### PR TITLE
v0.8.0: + custom cable types (#64) + per-device PDF (#74) — cumulative

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "0.4.1",
+    "version": "0.4.2",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/components/Import/GraphmlImportDialog.tsx
+++ b/src/renderer/components/Import/GraphmlImportDialog.tsx
@@ -79,6 +79,38 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
   const importGraphml = useProjectStore((s) => s.importGraphml)
   const setSelection = useProjectStore((s) => s.setSelection)
 
+  // CRITICAL: every hook must run on every render — never gate them behind
+  // the `if (!open) return null` below. Otherwise React #310 fires the
+  // moment the dialog mounts/unmounts (the bundled prod build crashed
+  // the renderer on startup in v0.4.0 because useMemo lived after the
+  // early-return). Both memos are cheap when `stage.kind !== 'preview'`.
+  const filteredDevices = useMemo(() => {
+    if (stage.kind !== 'preview') return [] as ResolvedDevice[]
+    if (!filterText.trim()) return stage.preview.devices
+    const needle = filterText.toLowerCase()
+    return stage.preview.devices.filter(
+      (d) =>
+        d.name.toLowerCase().includes(needle) ||
+        d.category.toLowerCase().includes(needle) ||
+        (d.ipAddress ?? '').toLowerCase().includes(needle),
+    )
+  }, [stage, filterText])
+
+  const filteredCables = useMemo(() => {
+    if (stage.kind !== 'preview') return [] as ResolvedCable[]
+    if (!filterText.trim()) return stage.preview.cables
+    const needle = filterText.toLowerCase()
+    const deviceName = (importKey: string) =>
+      stage.preview.devices.find((d) => d.importKey === importKey)?.name ?? ''
+    return stage.preview.cables.filter(
+      (c) =>
+        deviceName(c.sourceDeviceImportKey).toLowerCase().includes(needle) ||
+        deviceName(c.targetDeviceImportKey).toLowerCase().includes(needle) ||
+        (c.signalName ?? '').toLowerCase().includes(needle) ||
+        c.inferredCableType.toLowerCase().includes(needle),
+    )
+  }, [stage, filterText])
+
   if (!open) return null
 
   const reset = () => {
@@ -154,33 +186,6 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
       return next
     })
   }
-
-  const filteredDevices = useMemo(() => {
-    if (stage.kind !== 'preview') return [] as ResolvedDevice[]
-    if (!filterText.trim()) return stage.preview.devices
-    const needle = filterText.toLowerCase()
-    return stage.preview.devices.filter(
-      (d) =>
-        d.name.toLowerCase().includes(needle) ||
-        d.category.toLowerCase().includes(needle) ||
-        (d.ipAddress ?? '').toLowerCase().includes(needle),
-    )
-  }, [stage, filterText])
-
-  const filteredCables = useMemo(() => {
-    if (stage.kind !== 'preview') return [] as ResolvedCable[]
-    if (!filterText.trim()) return stage.preview.cables
-    const needle = filterText.toLowerCase()
-    const deviceName = (importKey: string) =>
-      stage.preview.devices.find((d) => d.importKey === importKey)?.name ?? ''
-    return stage.preview.cables.filter(
-      (c) =>
-        deviceName(c.sourceDeviceImportKey).toLowerCase().includes(needle) ||
-        deviceName(c.targetDeviceImportKey).toLowerCase().includes(needle) ||
-        (c.signalName ?? '').toLowerCase().includes(needle) ||
-        c.inferredCableType.toLowerCase().includes(needle),
-    )
-  }, [stage, filterText])
 
   const handleImport = () => {
     if (stage.kind !== 'preview') return


### PR DESCRIPTION
## Summary

Cumulative release branch bumping cable-planner to **v0.8.0**. Four release waves landed here so far:

| Wave | What |
|---|---|
| **v0.5.0** | React #310 startup-crash fix + #59, #62, #66, #67, #70, #72 |
| **v0.6.0** | yEd 1:1 fidelity (waypoints + path offsets), yEd-Vorschau tab, GreenGo beltpack sync (#56) |
| **v0.7.0** | CI Node 24, image exports, pack-status, hover-highlight (#68), Location BOM with embedded plan (#54), canvas bg customization (#71) |
| **v0.8.0** | Custom cable types (#64) + per-device patch-sheet PDF (#74) |

**Closes #54, closes #56, closes #57, closes #59, closes #62, closes #64, closes #66, closes #67, closes #68, closes #70, closes #71, closes #72, closes #74.**

---

## v0.8.0 — new in this push

### #64 — User-defined cable types

`CableType` stays a TS union of the built-in connector flavours, but the cable dialog now offers user-defined specs alongside the built-in `cableCatalog`.

- `uiStore.customCableSpecs` (persisted in localStorage)
- `addCustomCableSpec` / `updateCustomCableSpec` / `removeCustomCableSpec`
- `applyPatch` carries the array through so toggling unrelated settings doesn't blow them away
- `CableDialog`: `fullCableCatalog = [...cableCatalog, ...customCableSpecs]` — both rank-by-compatibility and the dropdown render include custom entries
- Custom-Cable side panel grows a **💾 Als Kabel-Typ speichern…** button that prompts for a name and saves the current Custom Cable definition as a reusable preset
- `CableEditDialog` uses the same memo so editing a cable that already references a custom spec doesn't lose its link
- Settings → **Editing → Eigene Kabel-Typen** card with colour picker + name editor + delete per saved spec. Creation lives in the cable dialog (avoids two competing editors)

### #74 — Per-device patch-sheet PDF

New `lib/exportDevicePdf.ts`. Produces an A4 (or A3) portrait page per device intended for printing and sticking on the physical hardware. Layout:

```
┌─────────────────────────────────────────────────┐
│  Device name                       Date stamp  │
│  Category · Subtitle · IP                       │
├─────────────────────────┬───────────────────────┤
│  INPUTS (12)            │  OUTPUTS (8)          │
│  ■ SDI In 1  [BNC]      │  ■ Program Out  [BNC] │
│    → 3G SDI BNC 5m      │    → 12G SDI 8m       │
│      zu Camera 1 · SDI  │      zu Switch · IN 4 │
│  ■ HDMI In 2  [HDMI]    │  ■ Preview Out  [BNC] │
│    → frei                │    → frei            │
│  …                       │  …                   │
└──────────────────────────┴──────────────────────┘
```

- Empty ports render as **→ frei** so the printed sheet doubles as a build-up checklist
- Auto-pagination when a column overflows
- Triggered from a new **Druck / Dokumentation** card at the bottom of EquipmentProperties with **A4** and **A3** buttons

---

## Earlier waves (already on this branch)

| # | What |
|---|---|
| #59 | Sporadic text-field lock-up — `ref.focus()` + stopPropagation on canvas-toolbar input |
| #62 | Per-connector-type colour overrides in Settings; XLR fallback removed earlier |
| #66 | Marquee selection — Shift+drag → partial-selection rectangle |
| #67 | Bidirectional cables — `Cable.bidirectional` flag, dual-arrow rendering, auto-on for Ethernet/USB-C/Fiber/SFP/SFP+ |
| #70 | Override connection warnings toggle |
| #72 | Redo + Undo buttons in the topbar |
| #57 | yEd Import — shipped in PR #58 / v0.4.1 |
| #56 | GreenGo Intercom beltpack-name sync (Equipment-Properties section + canvas `🎧 name` + global preset library) |
| #54 | Location Stückliste mit eingebettetem Plan-Snapshot |
| #68 | Connection hover highlight (cable + both port handles) |
| #71 | Canvas-Hintergrund (Muster + Deckkraft) |
| — | yEd import 1:1 fidelity: y:Path sx/sy/tx/ty + y:Point bend points → `Cable.waypoints`, auto-pan/zoom onto imported bbox |
| — | yEd-Vorschau tab in the import dialog |
| — | React minified error #310 startup crash from v0.4.0/0.4.1 |
| — | CI on Node 22 + `actions/checkout@v5` / `actions/setup-node@v5` (Node 24 native) |
| — | H2R parity: PNG/JPEG canvas export, Pack/Unpack status with StatusBar counter, Complexity badge |

## Deferred to follow-up (on tracking issue #76)

These each need a session of careful UI/SVG work:

- **#60** Properties UI accordion (re-layout EquipmentProperties)
- **#65** Cable bumps on crossings (SVG path manipulation)
- **#69** Hotkey editor (capture-keystroke inputs)
- **#55** ATEM MVW click-toggle layout
- **#63** ATEM Audio Routing — depends on a real Fairlight XML sample (#52)
- **#61** Rack Builder sub-canvas (architectural)
- **#53** Orthogonal routing collision avoidance (algorithmic)
- **#73** Mobile viewer (separate app target)
- 3 H2R utility calculators (cable length / bandwidth / power)

## What you do

1. Merge this PR.
2. Create release `v0.8.0`, target `main`. `release.yml` builds Windows + macOS DMG/EXE on Node 22.

## Test plan

- [ ] App version label shows **0.8.0**
- [ ] App launches cleanly
- [ ] Connect two devices, in the Cable dialog pick "★ Custom Cable…", set a connector + colour, click **💾 Als Kabel-Typ speichern**, give it a name → the spec appears in the dropdown and as a row in Settings → Editing → Eigene Kabel-Typen
- [ ] Re-create another cable: the saved type is selectable and applies its colour automatically
- [ ] EquipmentProperties of any device → scroll to **Druck / Dokumentation** → **🖨 Patch-Sheet (A4 PDF)** downloads a PDF with two columns of ports and the cables wired to them
- [ ] A device with 40+ ports → the A3 variant fits without weird wrapping
- [ ] All earlier features still work (yEd import + waypoints, GreenGo beltpack, hover highlight, marquee, pack-status …)