### PR TITLE
v0.5.0: 6 issue closures (#59 #62 #66 #67 #70 #72)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "0.4.2",
+    "version": "0.5.0",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -539,6 +539,11 @@ const makeCustomCableSpec = (connectorType: ConnectorType, color: string): Cable
 })
 
 const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoFormat, onCancel, onCreate }: CableDialogProps) => {
+  // Issue #70: optional global override of connector-mismatch warnings.
+  // When enabled, the dialog still SHOWS the warning banner so the user
+  // sees what's happening, but the submit path skips the modal confirm
+  // so the cable can be created in one click.
+  const overrideWarnings = useUiStore((s) => s.overrideConnectionWarnings)
   // Build list of cables ranked by compatibility with the two ports.
   const ranked = useMemo(() => {
     if (!fromPort || !toPort) {
@@ -642,7 +647,7 @@ const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoFormat, onC
       : null
 
   const submit = () => {
-    if (connectorMismatch === 'error') {
+    if (connectorMismatch === 'error' && !overrideWarnings) {
       if (
         !window.confirm(
           `${connectorMessage}\n\nAdd this connection anyway (marked as needing a converter)?`,

--- a/src/renderer/components/Canvas/CableEdge.tsx
+++ b/src/renderer/components/Canvas/CableEdge.tsx
@@ -278,8 +278,15 @@ export const CableEdge = ({
   const isWireless = cable?.wireless === true
   const dashArray = (cable?.dashed || isWireless) ? '6 4' : undefined
 
-  const markerEnd = cable?.arrowEnd === false ? undefined : 'url(#cable-planner-arrow-end)'
-  const markerStart = cable?.arrowStart ? 'url(#cable-planner-arrow-start)' : undefined
+  // Bidirectional cables (USB, Ethernet, Fibre, …) get arrow markers on
+  // BOTH ends to communicate two-way signal flow. The user can still
+  // override per-end with the arrowStart / arrowEnd toggles, but the
+  // bidirectional flag is the easier single switch (issue #67).
+  const bidi = cable?.bidirectional === true
+  const markerEnd =
+    bidi || cable?.arrowEnd !== false ? 'url(#cable-planner-arrow-end)' : undefined
+  const markerStart =
+    bidi || cable?.arrowStart ? 'url(#cable-planner-arrow-start)' : undefined
 
   const mergedStyle: React.CSSProperties = {
     ...style,

--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -10,6 +10,7 @@ import ReactFlow, {
   useReactFlow,
   useUpdateNodeInternals,
   ConnectionMode,
+  SelectionMode,
   type Connection,
   type Edge,
   type Node,
@@ -1029,7 +1030,14 @@ const CanvasContent = () => {
         zoomOnDoubleClick={!interactionLocked}
         selectNodesOnDrag={false}
         multiSelectionKeyCode={['Control', 'Meta']}
-        selectionKeyCode={null}
+        // Hold Shift and drag on empty canvas to draw a marquee selection
+        // box (issue #66). Plain drag still pans the viewport, so the
+        // user's normal pan workflow is untouched.
+        selectionKeyCode={interactionLocked ? null : 'Shift'}
+        // 'Partial' = any node touching the marquee is selected. The
+        // alternative ('Full' / SelectionMode.Full) requires the whole
+        // node to fit inside the box, which is annoying for big devices.
+        selectionMode={SelectionMode.Partial}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
         connectionMode={ConnectionMode.Loose}

--- a/src/renderer/components/Canvas/CanvasToolbar.tsx
+++ b/src/renderer/components/Canvas/CanvasToolbar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useReactFlow } from 'reactflow'
 import { useUiStore } from '../../store/uiStore'
 import { useProjectStore } from '../../store/projectStore'
@@ -33,6 +33,18 @@ export const CanvasToolbar = () => {
   const { getNodes } = useReactFlow()
   const [namingGroup, setNamingGroup] = useState(false)
   const [groupName, setGroupName] = useState('')
+  // Issue #59: the toolbar's group-name input sometimes ignored keystrokes
+  // until app restart. autoFocus alone is unreliable when another component
+  // (e.g. ReactFlow's pane after a click) steals focus on the same tick.
+  // Hold a ref and re-focus explicitly each time the form opens.
+  const groupNameRef = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    if (namingGroup) {
+      // Defer one frame so the input is in the DOM before .focus() runs.
+      const id = requestAnimationFrame(() => groupNameRef.current?.focus())
+      return () => cancelAnimationFrame(id)
+    }
+  }, [namingGroup])
 
   /**
    * Align the currently selected equipment nodes along the requested axis.
@@ -323,9 +335,17 @@ export const CanvasToolbar = () => {
               }}
             >
               <input
+                ref={groupNameRef}
                 autoFocus
                 value={groupName}
                 onChange={(e) => setGroupName(e.target.value)}
+                // ReactFlow's pane swallows pointer events on its children
+                // unless we stop propagation here. Without this the click
+                // that focuses the input also bubbles to the pane, which
+                // can immediately re-focus itself and steal the caret
+                // (issue #59: "manchmal lässt sich kein text eingeben").
+                onMouseDown={(e) => e.stopPropagation()}
+                onClick={(e) => e.stopPropagation()}
                 placeholder="Gruppenname…"
                 style={{
                   width: 140,

--- a/src/renderer/components/Canvas/EquipmentNode.tsx
+++ b/src/renderer/components/Canvas/EquipmentNode.tsx
@@ -32,6 +32,10 @@ export const EquipmentNode = ({ id, data, selected }: NodeProps<EquipmentNodeDat
   const clearPendingCable = useUiStore((s) => s.clearPendingCable)
   const canvasTheme = useUiStore((s) => s.canvasTheme)
   const colorPortsByType = useUiStore((s) => s.colorPortsByType)
+  // Issue #62: user-editable per-connector-type colour overrides.
+  // The override map is sparse — empty/missing entries fall back to
+  // the built-in palette inside colorForConnector().
+  const connectorTypeColors = useUiStore((s) => s.connectorTypeColors)
   const isLight = (data.exportThemeOverride ?? canvasTheme) === 'light'
   const queueConnection = useProjectStore((s) => s.queueConnection)
   const updateNodeInternals = useUpdateNodeInternals()
@@ -439,7 +443,7 @@ export const EquipmentNode = ({ id, data, selected }: NodeProps<EquipmentNodeDat
         const side = placement.side
         const pos = side === 'left' ? Position.Left : Position.Right
         const dotColor = colorPortsByType
-          ? colorForConnector(port.connectorType)
+          ? colorForConnector(port.connectorType, connectorTypeColors)
           : (bi ? '#a855f7' : '#0ea5e9')
         return (
           <Fragment key={`h-in-${port.id}`}>
@@ -534,7 +538,7 @@ export const EquipmentNode = ({ id, data, selected }: NodeProps<EquipmentNodeDat
         const side = placement.side
         const pos = side === 'left' ? Position.Left : Position.Right
         const dotColor = colorPortsByType
-          ? colorForConnector(port.connectorType)
+          ? colorForConnector(port.connectorType, connectorTypeColors)
           : (bi ? '#a855f7' : '#22c55e')
         return (
           <Fragment key={`h-out-${port.id}`}>

--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import { SharedSyncPanel } from '../Sync/SharedSyncPanel'
 import { useTranslation } from '../../lib/i18n'
+import { projectHistory } from '../../store/projectHistory'
 
 interface MenuBarProps {
   onNewProject: () => void
@@ -58,6 +59,15 @@ export const MenuBar = ({
   hasToken = false,
 }: MenuBarProps) => {
   const t = useTranslation()
+  // Re-render whenever the projectHistory store changes so the undo/redo
+  // buttons reflect the current canUndo/canRedo state. Keyboard shortcuts
+  // (Strg+Z / Strg+Umsch+Z / Strg+Y) live in useUndoRedoShortcuts; these
+  // buttons exist because users couldn't tell that history was working
+  // (issue #72: "Redo geht noch nicht. muss auch in die oberste topbar").
+  useSyncExternalStore(projectHistory.subscribe, () => projectHistory.canUndo() ? 'u' : '', () => '')
+  useSyncExternalStore(projectHistory.subscribe, () => projectHistory.canRedo() ? 'r' : '', () => '')
+  const canUndo = projectHistory.canUndo()
+  const canRedo = projectHistory.canRedo()
   return (
     <header className="flex shrink-0 items-center justify-between gap-3 border-b border-slate-700 bg-slate-950 px-3 py-1.5 text-xs shadow-sm">
       <div className="flex items-center gap-2">
@@ -158,6 +168,29 @@ export const MenuBar = ({
       </div>
 
       <div className="flex items-center gap-2">
+        <div className="flex items-center rounded border border-slate-700 bg-slate-900">
+          <button
+            type="button"
+            onClick={() => projectHistory.undo()}
+            disabled={!canUndo}
+            title={t('app.undo', 'Rückgängig (Strg+Z)')}
+            aria-label={t('app.undo', 'Rückgängig (Strg+Z)')}
+            className="px-2 py-1 text-slate-200 hover:bg-slate-800 disabled:cursor-not-allowed disabled:text-slate-600 disabled:hover:bg-transparent"
+          >
+            ⟲
+          </button>
+          <span className="h-4 w-px bg-slate-700" aria-hidden="true" />
+          <button
+            type="button"
+            onClick={() => projectHistory.redo()}
+            disabled={!canRedo}
+            title={t('app.redo', 'Wiederherstellen (Strg+Y)')}
+            aria-label={t('app.redo', 'Wiederherstellen (Strg+Y)')}
+            className="px-2 py-1 text-slate-200 hover:bg-slate-800 disabled:cursor-not-allowed disabled:text-slate-600 disabled:hover:bg-transparent"
+          >
+            ⟳
+          </button>
+        </div>
         <SharedSyncPanel />
         {onChangeVideoFormat && (
           <label className="flex items-center gap-1 text-[11px] text-slate-400">

--- a/src/renderer/components/Properties/CableProperties.tsx
+++ b/src/renderer/components/Properties/CableProperties.tsx
@@ -299,6 +299,17 @@ export const CableProperties = () => {
           />
           Arrow ►
         </label>
+        <label
+          className="flex items-center gap-1"
+          title="Bidirektionales Kabel (z.B. USB, Ethernet, LWL) — Pfeile auf beiden Seiten"
+        >
+          <input
+            type="checkbox"
+            checked={cable.bidirectional ?? false}
+            onChange={(event) => updateCable(cable.id, { bidirectional: event.target.checked })}
+          />
+          Bidirektional ⇌
+        </label>
       </div>
 
       <div className="rounded border border-slate-700 bg-slate-950/50 p-2 space-y-2">

--- a/src/renderer/components/Settings/SettingsDialog.tsx
+++ b/src/renderer/components/Settings/SettingsDialog.tsx
@@ -11,6 +11,8 @@ import { promptDialog } from '../../lib/promptDialog'
 import { getGeminiApiKey, setGeminiApiKey } from '../../lib/aiSuggestions'
 import { format, useTranslation } from '../../lib/i18n'
 import type { Language } from '../../store/uiStore'
+import { ALL_CONNECTOR_TYPES } from '../../types/equipment'
+import { DEFAULT_CONNECTOR_TYPE_COLORS } from '../../lib/cableColors'
 
 interface SettingsDialogProps {
   open: boolean
@@ -336,6 +338,11 @@ const AppearanceTab = () => {
   const cableColorMode = useUiStore((s) => s.cableColorMode)
   const setCableColorMode = useUiStore((s) => s.setCableColorMode)
   const defaultArrow = useUiStore((s) => s.defaultArrow)
+  const overrideConnectionWarnings = useUiStore((s) => s.overrideConnectionWarnings)
+  const setOverrideConnectionWarnings = useUiStore((s) => s.setOverrideConnectionWarnings)
+  const connectorTypeColors = useUiStore((s) => s.connectorTypeColors)
+  const setConnectorTypeColor = useUiStore((s) => s.setConnectorTypeColor)
+  const resetConnectorTypeColors = useUiStore((s) => s.resetConnectorTypeColors)
   const setDefaultArrow = useUiStore((s) => s.setDefaultArrow)
   const language = useUiStore((s) => s.language)
   const setLanguage = useUiStore((s) => s.setLanguage)
@@ -498,6 +505,71 @@ const AppearanceTab = () => {
             'Pfeil am Ziel-Ende anzeigen (Signalflussrichtung)',
           )}
         </label>
+      </SettingsCard>
+
+      <SettingsCard
+        title={t('settings.connections.title', 'Verbindungs-Warnungen')}
+        description={t(
+          'settings.connections.overrideDesc',
+          'Steckertyp-Konflikt erzeugt normalerweise eine Bestätigungs-Abfrage. Mit Override wird die Verbindung trotzdem ohne Rückfrage angelegt (als Adapter/Konverter markiert).',
+        )}
+      >
+        <label className="flex items-center gap-2 text-sm text-slate-200">
+          <input
+            type="checkbox"
+            checked={overrideConnectionWarnings}
+            onChange={(e) => setOverrideConnectionWarnings(e.target.checked)}
+          />
+          {t(
+            'settings.connections.override.label',
+            'Beliebige Inputs und Outputs ohne Warnung verbinden',
+          )}
+        </label>
+      </SettingsCard>
+
+      <SettingsCard
+        title={t('settings.connectorColors.title', 'Steckertyp-Farben')}
+        description={t(
+          'settings.connectorColors.desc',
+          'Eigene Farbe pro Stecker-Typ — nur sichtbar wenn "Ports nach Typ" oben aktiv ist. Leeres Feld setzt zurück auf Standard.',
+        )}
+      >
+        <div className="grid grid-cols-2 gap-x-3 gap-y-2 text-sm md:grid-cols-3">
+          {ALL_CONNECTOR_TYPES.map((ct) => {
+            const override = connectorTypeColors[ct] ?? ''
+            const effective = override || DEFAULT_CONNECTOR_TYPE_COLORS[ct]
+            return (
+              <label key={ct} className="flex items-center gap-2 text-slate-200" title={`Default: ${DEFAULT_CONNECTOR_TYPE_COLORS[ct]}`}>
+                <input
+                  type="color"
+                  value={effective}
+                  onChange={(e) => setConnectorTypeColor(ct, e.target.value)}
+                  className="h-6 w-8 cursor-pointer rounded border border-slate-700 bg-slate-900 p-0.5"
+                />
+                <span className="flex-1 truncate text-xs">{ct}</span>
+                {override && (
+                  <button
+                    type="button"
+                    onClick={() => setConnectorTypeColor(ct, null)}
+                    className="rounded bg-slate-700 px-1 py-0.5 text-[10px] text-slate-300 hover:bg-slate-600"
+                    title="Auf Default zurücksetzen"
+                  >
+                    ↺
+                  </button>
+                )}
+              </label>
+            )
+          })}
+        </div>
+        <div className="mt-3 flex justify-end">
+          <button
+            type="button"
+            onClick={() => resetConnectorTypeColors()}
+            className="rounded bg-slate-800 px-2 py-1 text-xs text-slate-300 hover:bg-slate-700"
+          >
+            {t('settings.connectorColors.resetAll', 'Alle zurücksetzen')}
+          </button>
+        </div>
       </SettingsCard>
     </div>
   )

--- a/src/renderer/lib/cableColors.ts
+++ b/src/renderer/lib/cableColors.ts
@@ -47,7 +47,7 @@ import type { ConnectorType } from '../types/equipment'
  * ports at a glance on equipment nodes. Values match the cable catalog
  * defaults where possible (e.g. SDI = amber, HDMI = purple).
  */
-export const CONNECTOR_TYPE_COLORS: Record<ConnectorType, string> = {
+export const DEFAULT_CONNECTOR_TYPE_COLORS: Record<ConnectorType, string> = {
   XLR: '#38bdf8',
   BNC: '#f59e0b',
   HDMI: '#a855f7',
@@ -68,5 +68,18 @@ export const CONNECTOR_TYPE_COLORS: Record<ConnectorType, string> = {
   Custom: '#94a3b8',
 }
 
-export const colorForConnector = (connectorType: ConnectorType): string =>
-  CONNECTOR_TYPE_COLORS[connectorType] ?? CONNECTOR_TYPE_COLORS.Custom
+/** Backwards-compat alias for older imports. Prefer
+ *  `useUiStore.getState().connectorTypeColors` or the colorForConnector
+ *  helper below — both honour user overrides made in Settings. */
+export const CONNECTOR_TYPE_COLORS = DEFAULT_CONNECTOR_TYPE_COLORS
+
+/** Resolve a colour for a connector type, preferring user overrides if a
+ *  map is provided (read from the UI store). Falls back to the built-in
+ *  default palette, then to the Custom colour. */
+export const colorForConnector = (
+  connectorType: ConnectorType,
+  overrides?: Partial<Record<ConnectorType, string>>,
+): string =>
+  overrides?.[connectorType] ??
+  DEFAULT_CONNECTOR_TYPE_COLORS[connectorType] ??
+  DEFAULT_CONNECTOR_TYPE_COLORS.Custom

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -313,6 +313,17 @@ interface ProjectState {
 
 const now = () => new Date().toISOString()
 
+/** Cable types that physically carry signal in both directions. Newly
+ *  created cables of these types get cable.bidirectional = true by
+ *  default so CableEdge draws arrow markers on both ends (issue #67). */
+const BIDIRECTIONAL_CABLE_TYPES = new Set<Cable['type']>([
+  'Ethernet/RJ45',
+  'Fiber',
+  'SFP',
+  'SFP+',
+  'USB-C',
+])
+
 const defaultProject = (): CablePlannerProject => ({
   metadata: {
     name: 'Untitled Project',
@@ -918,6 +929,10 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         needsConverter: draft.needsConverter,
         routing: ui.defaultRouting,
         arrowEnd: ui.defaultArrow,
+        // Inherently two-way cable types get the bidirectional flag set
+        // by default (issue #67). The user can still untick it in
+        // CableProperties if they want to show a one-way arrow anyway.
+        bidirectional: BIDIRECTIONAL_CABLE_TYPES.has(draft.type),
         strokeWidth: 2.5,
         waypoints: state.pendingWaypoints,
       }

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -27,6 +27,17 @@ interface PersistedUiState {
   /** UI language. Coverage is partial today — see lib/i18n.ts. Defaults to
    *  German because that's the historical UI language of the codebase. */
   language: Language
+  /** Issue #70: When true the cable dialog will not block creation on
+   *  connector-type incompatibilities — the user can connect any input
+   *  to any output without the "needs converter" confirmation prompt.
+   *  The cable is still flagged needsConverter for downstream warnings,
+   *  it just doesn't interrupt the user mid-flow. */
+  overrideConnectionWarnings: boolean
+  /** Issue #62: per-connector-type colour overrides. When a connector
+   *  type is missing or its value is an empty string the built-in
+   *  default from DEFAULT_CONNECTOR_TYPE_COLORS applies. Stored sparsely
+   *  so we don't bloat localStorage with the full default palette. */
+  connectorTypeColors: Record<string, string>
 }
 
 const defaults: PersistedUiState = {
@@ -42,6 +53,8 @@ const defaults: PersistedUiState = {
   canvasTheme: 'dark',
   colorPortsByType: false,
   language: 'de',
+  overrideConnectionWarnings: false,
+  connectorTypeColors: {},
 }
 
 const load = (): PersistedUiState => {
@@ -75,6 +88,9 @@ interface UiState extends PersistedUiState {
   setCanvasTheme: (value: 'dark' | 'light') => void
   setColorPortsByType: (value: boolean) => void
   setLanguage: (value: Language) => void
+  setOverrideConnectionWarnings: (value: boolean) => void
+  setConnectorTypeColor: (connectorType: string, color: string | null) => void
+  resetConnectorTypeColors: () => void
   pdfExportThemeOverride: 'dark' | 'light' | null
   setPdfExportThemeOverride: (value: 'dark' | 'light' | null) => void
   cableEdit: { open: boolean; cableId?: string }
@@ -142,6 +158,15 @@ const applyPatch =
       cableColorMode: state.cableColorMode,
       canvasTheme: state.canvasTheme,
       colorPortsByType: state.colorPortsByType,
+      // The two fields below were missing from the explicit list — any
+      // call through applyPatch was silently dropping them when writing
+      // to localStorage. Result: the next time the user toggled a
+      // different setting their language / override choice got reset to
+      // the default. (Fixed as part of issue #70 which added the
+      // override toggle.)
+      language: state.language,
+      overrideConnectionWarnings: state.overrideConnectionWarnings,
+      connectorTypeColors: state.connectorTypeColors,
       ...patch,
     }
     persist(next)
@@ -166,6 +191,15 @@ export const useUiStore = create<UiState>((set) => ({
   setCanvasTheme: (value) => set(applyPatch({ canvasTheme: value })),
   setColorPortsByType: (value) => set(applyPatch({ colorPortsByType: value })),
   setLanguage: (value) => set(applyPatch({ language: value })),
+  setOverrideConnectionWarnings: (value) => set(applyPatch({ overrideConnectionWarnings: value })),
+  setConnectorTypeColor: (connectorType, color) =>
+    set((state) => {
+      const next = { ...state.connectorTypeColors }
+      if (!color) delete next[connectorType]
+      else next[connectorType] = color
+      return applyPatch({ connectorTypeColors: next })(state)
+    }),
+  resetConnectorTypeColors: () => set(applyPatch({ connectorTypeColors: {} })),
   pdfExportThemeOverride: null,
   setPdfExportThemeOverride: (value) => set({ pdfExportThemeOverride: value }),
   cableEdit: { open: false },

--- a/src/renderer/types/cable.ts
+++ b/src/renderer/types/cable.ts
@@ -37,6 +37,11 @@ export interface Cable {
   arrowStart?: boolean
   /** Draw arrow marker at end (default true). */
   arrowEnd?: boolean
+  /** Marks the cable as carrying signal in both directions (USB, Ethernet,
+   *  Fibre, …). When true the CableEdge renders arrow markers on BOTH
+   *  ends regardless of arrowStart/arrowEnd. Auto-enabled for inherently
+   *  bidirectional cable types (issue #67). */
+  bidirectional?: boolean
   /** Optional user-placed bend points (flow coordinates). */
   waypoints?: CableWaypoint[]
   /** Where to show the cable label. Defaults to 'center'. */


### PR DESCRIPTION
#72 Redo + Undo buttons in the topbar (logic already existed in
    projectHistory.ts — only the visible controls were missing).
    The buttons subscribe to projectHistory.subscribe via
    useSyncExternalStore so the disabled state tracks canUndo/canRedo
    live, and the existing Strg+Z / Strg+Umsch+Z / Strg+Y shortcuts
    still work unchanged.

#67 Bidirectional cables. Adds Cable.bidirectional. CableEdge renders
    arrow markers on BOTH ends when set. CableProperties grows a
    "Bidirektional ⇌" checkbox alongside the existing per-end arrow
    toggles. createCableFromPending auto-enables the flag for
    inherently two-way cable types (Ethernet/RJ45, Fiber, SFP, SFP+,
    USB-C) — the user can still untick it per cable.

#70 Override connection warnings. New setting
    `overrideConnectionWarnings` (Einstellungen → Verbindungs-
    Warnungen) skips the "Add anyway / Cancel" confirm prompt when
    the chosen cable doesn't match both ports. The cable still gets
    needsConverter:true so the downstream BOM/PDF can still flag it.

#66 Marquee selection. ReactFlow shipped marquee selection out of
    the box, the app was passing `selectionKeyCode={null}` which
    explicitly suppressed it. Switched to `'Shift'` + SelectionMode.
    Partial so Shift+drag on an empty canvas draws a rectangle that
    selects any touched node.

#59 Sporadic text-field lock-up (e.g. group-name input on the canvas
    toolbar). Defensive fixes:
      - explicit ref.focus() in a requestAnimationFrame after namingGroup goes true, on top of autoFocus
      - onMouseDown / onClick stopPropagation on the input so ReactFlow's pane click handler doesn't immediately re-focus the pane and steal the caret

#62 Per-connector-type colour overrides. The hardcoded
    CONNECTOR_TYPE_COLORS palette is now the DEFAULT, with a sparse
    user-override map in uiStore.connectorTypeColors. Settings grows
    a "Steckertyp-Farben" card with a colour picker per ConnectorType
    plus an "↺" reset-to-default button per entry and "Alle
    zurücksetzen". EquipmentNode resolves colours through
    colorForConnector(type, overrides) which falls back to the
    default palette for any unset key. The earlier "first XLR
    cable wins" CableDialog fallback was already fixed in v0.4.0
    (now falls back to Custom Cable when no catalog match) so the
    second half of #62 lands here.

Bonus: applyPatch in uiStore was silently dropping `language` and the new `overrideConnectionWarnings` / `connectorTypeColors` fields when persisting to localStorage. Fixed.

Closes #57 (already shipped via PR #58 / v0.4.1, comment+state update done at merge time).

Also opened PR #75 separately to ship v0.4.2 with the React #310 startup-crash fix — that needs to merge BEFORE this one so the release pointer moves forward.