### PR TITLE
v0.6.0: yEd 1:1 fidelity + GreenGo beltpack sync (#56)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "0.5.0",
+    "version": "0.6.0",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/components/Canvas/EquipmentNode.tsx
+++ b/src/renderer/components/Canvas/EquipmentNode.tsx
@@ -5,6 +5,7 @@ import { useUiStore } from '../../store/uiStore'
 import { useProjectStore } from '../../store/projectStore'
 import { colorForConnector } from '../../lib/cableColors'
 import { defaultIconForEquipment } from '../../lib/deviceKind'
+import { findGreenGoUserForEquipment } from '../../lib/greengoSync'
 
 type EquipmentNodeData = EquipmentItem & {
   exportThemeOverride?: 'dark' | 'light'
@@ -38,6 +39,12 @@ export const EquipmentNode = ({ id, data, selected }: NodeProps<EquipmentNodeDat
   const connectorTypeColors = useUiStore((s) => s.connectorTypeColors)
   const isLight = (data.exportThemeOverride ?? canvasTheme) === 'light'
   const queueConnection = useProjectStore((s) => s.queueConnection)
+  // Issue #56: GreenGo beltpack name is the canvas-visible identifier
+  // for intercom devices. Reads from project.greengoConfig.users —
+  // same source the EquipmentProperties beltpack section and the GG
+  // dialog write to, so all three views stay in sync.
+  const greengoConfig = useProjectStore((s) => s.project.greengoConfig)
+  const greengoUser = findGreenGoUserForEquipment(id, greengoConfig)
   const updateNodeInternals = useUpdateNodeInternals()
 
   // Re-register handle positions whenever the data that affects port placement
@@ -143,9 +150,14 @@ export const EquipmentNode = ({ id, data, selected }: NodeProps<EquipmentNodeDat
   // Hover state for port rows — gives visual feedback before click
   const [hoveredPort, setHoveredPort] = useState<string | null>(null)
 
-  const headerHeight = data.ipAddress
-    ? (data.subtitle ? HEADER_HEIGHT_WITH_IP + 14 : HEADER_HEIGHT_WITH_IP)
-    : (data.subtitle ? HEADER_HEIGHT + 14 : HEADER_HEIGHT)
+  // Header layout grows by 14 px per optional line (subtitle, beltpack
+  // name, …) so ports never overlap with the device label area.
+  const beltpackLine = greengoUser ? 14 : 0
+  const headerHeight = (
+    data.ipAddress
+      ? (data.subtitle ? HEADER_HEIGHT_WITH_IP + 14 : HEADER_HEIGHT_WITH_IP)
+      : (data.subtitle ? HEADER_HEIGHT + 14 : HEADER_HEIGHT)
+  ) + beltpackLine
   const inputPlacement = new Map<string, { side: 'left' | 'right'; slot: number }>()
   const outputPlacement = new Map<string, { side: 'left' | 'right'; slot: number }>()
   const sideCounts: Record<'left' | 'right', number> = { left: 0, right: 0 }
@@ -361,6 +373,20 @@ export const EquipmentNode = ({ id, data, selected }: NodeProps<EquipmentNodeDat
         <div style={{ fontSize: 11, color: isLight ? '#64748b' : '#94a3b8', lineHeight: '14px' }}>{data.category}</div>
         {data.subtitle && (
           <div style={{ fontSize: 11, color: isLight ? '#475569' : '#cbd5e1', lineHeight: '14px', fontStyle: 'italic' }}>{data.subtitle}</div>
+        )}
+        {greengoUser && (
+          <div
+            style={{
+              fontSize: 10,
+              color: isLight ? '#047857' : '#34d399',
+              lineHeight: '13px',
+              fontWeight: 600,
+              marginTop: 1,
+            }}
+            title={`GreenGo Beltpack #${greengoUser.user.id}${greengoUser.groupNames.length > 0 ? ` · Gruppen: ${greengoUser.groupNames.join(', ')}` : ''}`}
+          >
+            🎧 {greengoUser.user.name}
+          </div>
         )}
         {data.ipAddress && (
           <div

--- a/src/renderer/components/Import/GraphmlImportDialog.tsx
+++ b/src/renderer/components/Import/GraphmlImportDialog.tsx
@@ -31,6 +31,9 @@ export interface GraphmlImportDialogProps {
   onClose: () => void
 }
 
+import type { GraphmlDocument } from '../../lib/graphml/types'
+import { GraphmlViewer } from './GraphmlViewer'
+
 type Stage =
   | { kind: 'empty' }
   | { kind: 'parsing'; fileName: string }
@@ -38,6 +41,9 @@ type Stage =
   | {
       kind: 'preview'
       fileName: string
+      /** Kept around for the yEd visual preview tab — rendering needs
+       *  the raw geometry, not the resolved cable-planner shapes. */
+      document: GraphmlDocument
       preview: ImportPreview
       warningsCount: number
     }
@@ -67,7 +73,7 @@ const formatBytes = (n: number) => {
 
 export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps) => {
   const [stage, setStage] = useState<Stage>({ kind: 'empty' })
-  const [tab, setTab] = useState<'devices' | 'cables' | 'skipped'>('devices')
+  const [tab, setTab] = useState<'preview' | 'devices' | 'cables' | 'skipped'>('preview')
   const [mode, setMode] = useState<'append' | 'replace'>('append')
   const [skipDevices, setSkipDevices] = useState<Set<string>>(new Set())
   const [skipCables, setSkipCables] = useState<Set<string>>(new Set())
@@ -143,6 +149,7 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
           setStage({
             kind: 'preview',
             fileName: result.fileName,
+            document: doc,
             preview,
             warningsCount: warnings.length,
           })
@@ -197,6 +204,9 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
     })
     const newIds = importGraphml({ ...payload, mode })
     // Select the first imported device on the canvas to draw attention.
+    // The store action also pans + zooms the viewport onto the imported
+    // bounding box so the user actually sees them — yEd diagrams sit
+    // far from (0,0) and the previous viewport stayed unchanged.
     if (newIds[0]) setSelection(newIds[0])
     reset()
     onClose()
@@ -336,6 +346,7 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
         {/* Tabs */}
         <div className="flex border-b border-slate-800 text-xs">
           {([
+            ['preview', 'yEd-Vorschau'],
             ['devices', `Geräte (${totalDevices})`],
             ['cables', `Kabel (${totalCables})`],
             ['skipped', `Übersprungen (${preview.skippedNodes.length + preview.unresolvedEdges.length})`],
@@ -357,6 +368,21 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
 
         {/* Tab body */}
         <div className="min-h-0 flex-1 overflow-auto">
+          {tab === 'preview' && (
+            // Live render of the parsed yEd document at original
+            // coordinates so the user can visually confirm cable-planner
+            // is reading the file correctly before committing the
+            // import. Highlights the nodes the resolver picked as
+            // import-worthy devices (faded ones are decorative / port
+            // shapes that won't become Equipment items).
+            <div className="h-full min-h-0">
+              <GraphmlViewer
+                document={s.document}
+                highlightNodes={new Set(preview.devices.map((d) => d.graphmlId))}
+                className="relative h-full w-full"
+              />
+            </div>
+          )}
           {tab === 'devices' && (
             <table className="w-full text-xs">
               <thead className="sticky top-0 bg-slate-900 text-slate-400">

--- a/src/renderer/components/Import/GraphmlViewer.tsx
+++ b/src/renderer/components/Import/GraphmlViewer.tsx
@@ -1,0 +1,290 @@
+// Visual preview of a parsed yEd / GraphML document. Draws every node
+// rectangle and every edge polyline at the original coordinates so the
+// user can compare side-by-side with what cable-planner will produce
+// after import. Used inside GraphmlImportDialog as a fourth tab.
+//
+// Constraints driving the design:
+//   - real files have 1000+ nodes; rendering each as an SVG element is
+//     fine in modern browsers, but interactive panning needs to stay
+//     responsive. We use a single <svg> with viewBox math instead of
+//     ReactFlow so we avoid the per-node React overhead.
+//   - the parsed coordinates can be huge (e.g. -1300 to +2500) and
+//     scattered. We compute the data bounding box once, then add a
+//     uniform 64-pixel margin so labels at the edges aren't clipped.
+//   - the viewer is read-only — no node dragging, no selection state.
+//     One simple wheel-to-zoom and drag-to-pan handler keep it usable
+//     for "is this what I expect?" verification without bringing in a
+//     full canvas library.
+
+import { useMemo, useRef, useState } from 'react'
+import type { GraphmlDocument, GraphmlEdge, GraphmlNode } from '../../lib/graphml/types'
+
+export interface GraphmlViewerProps {
+  document: GraphmlDocument
+  /** Optional set of node IDs to highlight (e.g. devices the resolver
+   *  classified as imports) — they get a slightly thicker outline. */
+  highlightNodes?: Set<string>
+  className?: string
+}
+
+interface Bbox {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+}
+
+const computeBbox = (nodes: GraphmlNode[], edges: GraphmlEdge[]): Bbox => {
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  for (const n of nodes) {
+    if (!n.geometry) continue
+    if (n.geometry.x < minX) minX = n.geometry.x
+    if (n.geometry.y < minY) minY = n.geometry.y
+    if (n.geometry.x + n.geometry.width > maxX) maxX = n.geometry.x + n.geometry.width
+    if (n.geometry.y + n.geometry.height > maxY) maxY = n.geometry.y + n.geometry.height
+  }
+  for (const e of edges) {
+    for (const w of e.waypoints) {
+      if (w.x < minX) minX = w.x
+      if (w.y < minY) minY = w.y
+      if (w.x > maxX) maxX = w.x
+      if (w.y > maxY) maxY = w.y
+    }
+  }
+  if (!Number.isFinite(minX)) return { minX: 0, minY: 0, maxX: 1, maxY: 1 }
+  return { minX, minY, maxX, maxY }
+}
+
+/** Resolve an edge's start/end points to actual coordinates: the centre
+ *  of the source / target node (offset by y:Path sx/sy/tx/ty as yEd
+ *  stores them). When either endpoint is missing we fall back to the
+ *  first / last waypoint so the line still renders. */
+const edgePoints = (
+  edge: GraphmlEdge,
+  nodeById: Map<string, GraphmlNode>,
+): Array<{ x: number; y: number }> => {
+  const src = nodeById.get(edge.sourceId)
+  const tgt = nodeById.get(edge.targetId)
+  const start = src?.geometry
+    ? {
+        x: src.geometry.x + src.geometry.width / 2 + edge.pathOffset.sx,
+        y: src.geometry.y + src.geometry.height / 2 + edge.pathOffset.sy,
+      }
+    : edge.waypoints[0]
+  const end = tgt?.geometry
+    ? {
+        x: tgt.geometry.x + tgt.geometry.width / 2 + edge.pathOffset.tx,
+        y: tgt.geometry.y + tgt.geometry.height / 2 + edge.pathOffset.ty,
+      }
+    : edge.waypoints[edge.waypoints.length - 1]
+  const pts: Array<{ x: number; y: number }> = []
+  if (start) pts.push(start)
+  for (const w of edge.waypoints) pts.push(w)
+  if (end) pts.push(end)
+  return pts
+}
+
+export const GraphmlViewer = ({ document, highlightNodes, className }: GraphmlViewerProps) => {
+  const nodeById = useMemo(
+    () => new Map(document.nodes.map((n) => [n.id, n])),
+    [document.nodes],
+  )
+
+  // Bounding box of the data; we reuse this on every render but it's a
+  // single pass over the arrays so the cost is negligible compared to
+  // rendering 1000+ shapes.
+  const bbox = useMemo(
+    () => computeBbox(document.nodes, document.edges),
+    [document.nodes, document.edges],
+  )
+
+  // Static initial viewBox covers the whole data bounds with a margin.
+  // The pan/zoom state lives on top — viewBox is recomputed from
+  // baseViewBox + the current pan/zoom transform.
+  const baseViewBox = useMemo(() => {
+    const margin = 64
+    return {
+      x: bbox.minX - margin,
+      y: bbox.minY - margin,
+      w: Math.max(1, bbox.maxX - bbox.minX + margin * 2),
+      h: Math.max(1, bbox.maxY - bbox.minY + margin * 2),
+    }
+  }, [bbox])
+
+  // 0 = baseViewBox, positive = zoomed in. We store the centre of the
+  // current view in graph coordinates plus a zoom scalar so panning
+  // around a zoomed view feels natural.
+  const [view, setView] = useState({
+    cx: baseViewBox.x + baseViewBox.w / 2,
+    cy: baseViewBox.y + baseViewBox.h / 2,
+    zoom: 1,
+  })
+
+  const viewBox = `${view.cx - baseViewBox.w / (2 * view.zoom)} ${view.cy - baseViewBox.h / (2 * view.zoom)} ${baseViewBox.w / view.zoom} ${baseViewBox.h / view.zoom}`
+
+  const svgRef = useRef<SVGSVGElement | null>(null)
+  const dragRef = useRef<{ startX: number; startY: number; startCx: number; startCy: number } | null>(null)
+
+  const onWheel = (event: React.WheelEvent<SVGSVGElement>) => {
+    event.preventDefault()
+    const factor = event.deltaY > 0 ? 1 / 1.15 : 1.15
+    setView((v) => ({
+      ...v,
+      zoom: Math.max(0.05, Math.min(20, v.zoom * factor)),
+    }))
+  }
+
+  const onPointerDown = (event: React.PointerEvent<SVGSVGElement>) => {
+    if (event.button !== 0) return
+    ;(event.currentTarget as SVGSVGElement).setPointerCapture(event.pointerId)
+    dragRef.current = {
+      startX: event.clientX,
+      startY: event.clientY,
+      startCx: view.cx,
+      startCy: view.cy,
+    }
+  }
+
+  const onPointerMove = (event: React.PointerEvent<SVGSVGElement>) => {
+    const drag = dragRef.current
+    if (!drag) return
+    const rect = svgRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const dxClient = event.clientX - drag.startX
+    const dyClient = event.clientY - drag.startY
+    // Convert client pixel delta to graph units via the current viewBox scale.
+    const scaleX = (baseViewBox.w / view.zoom) / rect.width
+    const scaleY = (baseViewBox.h / view.zoom) / rect.height
+    setView((v) => ({
+      ...v,
+      cx: drag.startCx - dxClient * scaleX,
+      cy: drag.startCy - dyClient * scaleY,
+    }))
+  }
+
+  const onPointerUp = (event: React.PointerEvent<SVGSVGElement>) => {
+    dragRef.current = null
+    try {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    } catch {
+      /* pointer may not be captured */
+    }
+  }
+
+  const resetView = () => {
+    setView({
+      cx: baseViewBox.x + baseViewBox.w / 2,
+      cy: baseViewBox.y + baseViewBox.h / 2,
+      zoom: 1,
+    })
+  }
+
+  return (
+    <div className={className ?? 'relative h-full w-full'}>
+      <svg
+        ref={svgRef}
+        viewBox={viewBox}
+        preserveAspectRatio="xMidYMid meet"
+        onWheel={onWheel}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+        className="h-full w-full select-none bg-slate-950"
+        style={{ touchAction: 'none', cursor: dragRef.current ? 'grabbing' : 'grab' }}
+      >
+        {/* Edges first so node rects render on top of them where they
+            cross — matches the way yEd composites the layers. */}
+        <g strokeLinejoin="round" strokeLinecap="round" fill="none">
+          {document.edges.map((edge) => {
+            const pts = edgePoints(edge, nodeById)
+            if (pts.length < 2) return null
+            const d = pts
+              .map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`)
+              .join(' ')
+            const stroke = edge.lineColor || '#94a3b8'
+            const dash = edge.lineType === 'dashed' ? '6 4' : edge.lineType === 'dotted' ? '2 3' : undefined
+            return (
+              <path
+                key={edge.id}
+                d={d}
+                stroke={stroke}
+                strokeWidth={1.5 / view.zoom}
+                strokeDasharray={dash}
+                opacity={0.85}
+              />
+            )
+          })}
+        </g>
+        <g>
+          {document.nodes.map((node) => {
+            if (!node.geometry) return null
+            const fill = node.fillColor ?? '#1e293b'
+            const stroke = node.borderColor ?? '#64748b'
+            const hi = highlightNodes?.has(node.id)
+            const mainLabel = node.labels.find((l) => l.text.trim().length > 0)?.text ?? null
+            return (
+              <g key={node.id}>
+                <rect
+                  x={node.geometry.x}
+                  y={node.geometry.y}
+                  width={node.geometry.width}
+                  height={node.geometry.height}
+                  rx={node.shapePrimitive === 'roundrectangle' || node.shapePrimitive === 'ellipse' ? 8 : 0}
+                  fill={fill}
+                  stroke={hi ? '#38bdf8' : stroke}
+                  strokeWidth={(hi ? 1.6 : 0.8) / view.zoom}
+                  opacity={0.9}
+                />
+                {mainLabel && view.zoom * (node.geometry.width / baseViewBox.w) > 0.001 && (
+                  <text
+                    x={node.geometry.x + 4}
+                    y={node.geometry.y + 12}
+                    fontSize={11 / view.zoom}
+                    fill="#e2e8f0"
+                    style={{ pointerEvents: 'none' }}
+                  >
+                    {mainLabel.length > 32 ? `${mainLabel.slice(0, 30)}…` : mainLabel}
+                  </text>
+                )}
+              </g>
+            )
+          })}
+        </g>
+      </svg>
+      <div className="absolute right-3 top-3 flex items-center gap-1 rounded bg-slate-900/85 px-2 py-1 text-xs text-slate-300 backdrop-blur">
+        <button
+          type="button"
+          onClick={() => setView((v) => ({ ...v, zoom: Math.min(20, v.zoom * 1.4) }))}
+          className="rounded px-1.5 hover:bg-slate-700"
+          aria-label="Zoom in"
+        >
+          ＋
+        </button>
+        <button
+          type="button"
+          onClick={() => setView((v) => ({ ...v, zoom: Math.max(0.05, v.zoom / 1.4) }))}
+          className="rounded px-1.5 hover:bg-slate-700"
+          aria-label="Zoom out"
+        >
+          −
+        </button>
+        <button
+          type="button"
+          onClick={resetView}
+          className="rounded px-1.5 text-[10px] hover:bg-slate-700"
+          aria-label="Reset"
+        >
+          Reset
+        </button>
+        <span className="ml-1 text-[10px] text-slate-500">{Math.round(view.zoom * 100)}%</span>
+      </div>
+      <div className="pointer-events-none absolute bottom-2 left-3 text-[10px] text-slate-500">
+        Mausrad zoomt · Ziehen verschiebt · {document.nodes.length} Nodes · {document.edges.length} Edges
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/Properties/EquipmentProperties.tsx
+++ b/src/renderer/components/Properties/EquipmentProperties.tsx
@@ -21,6 +21,7 @@ import { useProjectStore } from '../../store/projectStore'
 import { useUiStore } from '../../store/uiStore'
 import { detectDeviceKind, detectNetworkDevice } from '../../lib/deviceKind'
 import { promptDialog } from '../../lib/promptDialog'
+import { useGreenGoBeltpack } from '../../lib/greengoSync'
 import { ALL_CONNECTOR_TYPES } from '../../types/equipment'
 import type { ConnectorType, Port, VlanDef, PortVlanAssignment } from '../../types/equipment'
 import { ALL_SIGNAL_STANDARDS } from '../../types/cableSpec'
@@ -698,6 +699,90 @@ const DisplayPropertiesBlock = ({ equipment }: { equipment: import('../../types/
   )
 }
 
+/**
+ * GreenGo beltpack section embedded in EquipmentProperties for any
+ * device whose deviceKind === 'greengo'. The data flows from
+ * `project.greengoConfig.users` — same source the GreenGo Intercom
+ * dialog uses — so renaming the beltpack here updates it everywhere
+ * (canvas label, the GreenGo dialog, the .gg5 export). Issue #56.
+ */
+const GreenGoBeltpackSection = ({ equipmentId }: { equipmentId: string }) => {
+  const { config, info, rename, assignUser } = useGreenGoBeltpack(equipmentId)
+  if (!config || config.users.length === 0) {
+    return (
+      <div className="mb-2 text-[10px] text-emerald-300/60">
+        Keine GreenGo-Konfiguration im Projekt. Öffne den Intercom-Planer oder lade ein
+        Preset, um Beltpacks zu definieren.
+      </div>
+    )
+  }
+  // List of all users for the assignment dropdown. We label them by name
+  // and decorate with the linked equipment id if any (so the user can
+  // see at a glance which slots are already taken).
+  return (
+    <div className="mb-2 rounded bg-emerald-950/40 p-2">
+      <div className="mb-1 flex items-center justify-between text-[10px] uppercase tracking-wide text-emerald-300">
+        <span>Beltpack</span>
+        {info?.groupNames && info.groupNames.length > 0 && (
+          <span
+            className="font-normal normal-case text-emerald-400/80"
+            title={`Gruppen: ${info.groupNames.join(', ')}`}
+          >
+            {info.groupNames.length} Gruppe{info.groupNames.length === 1 ? '' : 'n'}
+          </span>
+        )}
+      </div>
+      <label className="block">
+        <span className="mb-1 block text-emerald-200/70">Name</span>
+        <input
+          type="text"
+          value={info?.user.name ?? ''}
+          disabled={!info}
+          placeholder={info ? '' : 'Erst zuordnen ↓'}
+          onChange={(event) => rename(event.target.value)}
+          className="w-full rounded border border-emerald-700 bg-emerald-950 p-1 text-xs text-emerald-50 disabled:opacity-50"
+          title="Änderungen werden sofort in den Intercom-Plan und das .gg5-Export geschrieben"
+        />
+      </label>
+      <label className="mt-2 block">
+        <span className="mb-1 block text-emerald-200/70">Zugewiesener User-Slot</span>
+        <select
+          value={info?.user.id ?? ''}
+          onChange={(event) => {
+            const v = event.target.value
+            assignUser(v === '' ? null : Number(v))
+          }}
+          className="w-full rounded border border-emerald-700 bg-emerald-950 p-1 text-xs text-emerald-50"
+        >
+          <option value="">(kein Slot zugewiesen)</option>
+          {config.users.map((u) => {
+            const takenBy = u.equipmentId && u.equipmentId !== equipmentId
+            return (
+              <option key={u.id} value={u.id}>
+                {u.id}. {u.name}
+                {takenBy ? ' (anderem Gerät zugewiesen)' : ''}
+              </option>
+            )
+          })}
+        </select>
+      </label>
+      {info?.groupNames && info.groupNames.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1 text-[10px]">
+          {info.groupNames.map((g) => (
+            <span
+              key={g}
+              className="rounded bg-emerald-700/40 px-1.5 py-0.5 text-emerald-100"
+              title="Gruppen werden im Intercom-Planer bearbeitet"
+            >
+              {g}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 export const EquipmentProperties = () => {
   const t = useTranslation()
   const selectedEquipmentId = useProjectStore((state) => state.selectedEquipmentId)
@@ -735,6 +820,7 @@ export const EquipmentProperties = () => {
           <div className="mb-1 text-[10px] uppercase tracking-wide text-emerald-300">
             GreenGo Intercom erkannt
           </div>
+          <GreenGoBeltpackSection equipmentId={equipment.id} />
           <button
             type="button"
             onClick={() => openGreenGoExport()}

--- a/src/renderer/components/Settings/SettingsDialog.tsx
+++ b/src/renderer/components/Settings/SettingsDialog.tsx
@@ -13,6 +13,11 @@ import { format, useTranslation } from '../../lib/i18n'
 import type { Language } from '../../store/uiStore'
 import { ALL_CONNECTOR_TYPES } from '../../types/equipment'
 import { DEFAULT_CONNECTOR_TYPE_COLORS } from '../../lib/cableColors'
+import {
+  deleteGreenGoPreset,
+  loadGreenGoPresets,
+  saveGreenGoPreset,
+} from '../../lib/greengoSync'
 
 interface SettingsDialogProps {
   open: boolean
@@ -912,7 +917,125 @@ const IntegrationsTab = ({ onClose }: { onClose: () => void }) => {
           erstellen.
         </div>
       </SettingsCard>
+
+      <GreenGoPresetsCard />
     </div>
+  )
+}
+
+/**
+ * Global library of GreenGo Intercom presets. Stored in localStorage —
+ * survives across projects, separate from the per-project
+ * greengoConfig. Lets the user keep a "house template" config and
+ * apply it to new projects with one click (issue #56).
+ */
+const GreenGoPresetsCard = () => {
+  const t = useTranslation()
+  const greengoConfig = useProjectStore((s) => s.project.greengoConfig)
+  const updateGreenGoConfig = useProjectStore((s) => s.updateGreenGoConfig)
+  const [presets, setPresets] = useState(() => loadGreenGoPresets())
+  const refreshPresets = () => setPresets(loadGreenGoPresets())
+  const usableConfig = greengoConfig && greengoConfig.users.length > 0
+
+  return (
+    <SettingsCard
+      title={t('settings.greengo.title', 'GreenGo Intercom Presets')}
+      description={t(
+        'settings.greengo.desc',
+        'Globale Bibliothek wiederverwendbarer Intercom-Konfigurationen. Speichere die aktuelle Projekt-Konfiguration als benannten Preset und lade ihn später in jedes neue Projekt — Beltpack-Namen, Gruppen und Routing inklusive.',
+      )}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          disabled={!usableConfig}
+          onClick={async () => {
+            if (!greengoConfig) return
+            const name = await promptDialog(
+              t('settings.greengo.savePromptTitle', 'Name des Presets:'),
+              greengoConfig.systemName || 'Intercom-Setup',
+            )
+            if (!name) return
+            saveGreenGoPreset(name, greengoConfig)
+            refreshPresets()
+          }}
+          className="rounded bg-emerald-700 px-3 py-1 text-xs text-white hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-50"
+          title={
+            usableConfig
+              ? undefined
+              : t('settings.greengo.saveDisabled', 'Aktuelles Projekt hat noch keine GreenGo-Konfiguration')
+          }
+        >
+          {t('settings.greengo.save', 'Aktuelle Konfiguration als Preset speichern')}
+        </button>
+      </div>
+      {presets.length === 0 ? (
+        <div className="mt-2 text-[11px] text-slate-500">
+          {t('settings.greengo.empty', 'Noch keine Presets gespeichert.')}
+        </div>
+      ) : (
+        <ul className="mt-3 space-y-1">
+          {presets.map((p) => (
+            <li
+              key={p.id}
+              className="flex items-center justify-between rounded border border-emerald-900/40 bg-emerald-950/30 px-2 py-1 text-xs"
+            >
+              <div className="min-w-0 flex-1 truncate">
+                <span className="font-medium text-emerald-100">{p.name}</span>
+                <span className="ml-2 text-[10px] text-emerald-400/60">
+                  {p.config.users.length} User · {p.config.groups.length} Gruppen ·{' '}
+                  {new Date(p.savedAt).toLocaleDateString()}
+                </span>
+              </div>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={async () => {
+                    const ok = await confirmDialog(
+                      t('settings.greengo.applyTitle', 'Preset anwenden?'),
+                      {
+                        body: t(
+                          'settings.greengo.applyBody',
+                          'Die aktuelle GreenGo-Konfiguration im Projekt wird durch das Preset ersetzt. Equipment-Zuordnungen aus dem Preset, die im aktuellen Projekt nicht existieren, werden ignoriert.',
+                        ),
+                        okLabel: t('settings.greengo.applyConfirm', 'Übernehmen'),
+                      },
+                    )
+                    if (!ok) return
+                    updateGreenGoConfig(p.config)
+                  }}
+                  className="rounded bg-emerald-700 px-2 py-0.5 text-[11px] text-white hover:bg-emerald-600"
+                >
+                  {t('settings.greengo.apply', 'Laden')}
+                </button>
+                <button
+                  type="button"
+                  onClick={async () => {
+                    const ok = await confirmDialog(
+                      t('settings.greengo.deleteTitle', 'Preset löschen?'),
+                      {
+                        body: format(
+                          t('settings.greengo.deleteBody', 'Preset "{name}" wirklich löschen?'),
+                          { name: p.name },
+                        ),
+                        okLabel: t('settings.greengo.deleteConfirm', 'Löschen'),
+                        destructive: true,
+                      },
+                    )
+                    if (!ok) return
+                    deleteGreenGoPreset(p.id)
+                    refreshPresets()
+                  }}
+                  className="rounded bg-slate-800 px-2 py-0.5 text-[11px] text-slate-300 hover:bg-red-700 hover:text-white"
+                >
+                  {t('settings.greengo.delete', 'Löschen')}
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </SettingsCard>
   )
 }
 

--- a/src/renderer/lib/graphml/parser.ts
+++ b/src/renderer/lib/graphml/parser.ts
@@ -346,10 +346,13 @@ const walkGraph = (
     )
 
     // Edge graphics (y:PolyLineEdge / y:BezierEdge / …) carries the
-    // visual labels and line style.
+    // visual labels, line style, AND the polyline waypoints + path
+    // offsets we need to recreate the original yEd routing 1:1.
     let labels: string[] = []
     let lineColor: string | null = null
     let lineType: string | null = null
+    let waypoints: { x: number; y: number }[] = []
+    let pathOffset = { sx: 0, sy: 0, tx: 0, ty: 0 }
     if (edgegraphics && typeof edgegraphics === 'object') {
       const eg = edgegraphics as RawAttrs
       // Pick whatever edge realizer is present.
@@ -366,13 +369,46 @@ const walkGraph = (
               .filter(Boolean)
             lineColor = readAttr(fr['y:LineStyle'], 'color')
             lineType = readAttr(fr['y:LineStyle'], 'type')
+            // y:Path holds the start/end offset attributes (sx/sy/tx/ty)
+            // AND any y:Point bend points the user dragged into the
+            // polyline. Both are needed to recreate the routing in
+            // cable-planner — otherwise the canvas auto-routes a
+            // straight or L-shaped path and the diagram looks nothing
+            // like the source.
+            const path = fr['y:Path']
+            if (path && typeof path === 'object') {
+              const p = path as RawAttrs
+              pathOffset = {
+                sx: readNumberAttr(p, 'sx') ?? 0,
+                sy: readNumberAttr(p, 'sy') ?? 0,
+                tx: readNumberAttr(p, 'tx') ?? 0,
+                ty: readNumberAttr(p, 'ty') ?? 0,
+              }
+              waypoints = toArray(p['y:Point'])
+                .map((pt) => {
+                  const x = readNumberAttr(pt, 'x')
+                  const y = readNumberAttr(pt, 'y')
+                  return x != null && y != null ? { x, y } : null
+                })
+                .filter((w): w is { x: number; y: number } => w != null)
+            }
             break
           }
         }
       }
     }
 
-    edges.push({ id, sourceId: source, targetId: target, labels, data, lineColor, lineType })
+    edges.push({
+      id,
+      sourceId: source,
+      targetId: target,
+      labels,
+      data,
+      lineColor,
+      lineType,
+      waypoints,
+      pathOffset,
+    })
   }
 }
 

--- a/src/renderer/lib/graphml/semantics.ts
+++ b/src/renderer/lib/graphml/semantics.ts
@@ -87,6 +87,11 @@ export interface ResolvedCable {
    *  so the UI can surface them; orphan = true means at least one end
    *  doesn't map to an imported device. */
   orphan: boolean
+  /** Polyline bend points the user drew in yEd between source and
+   *  target, in absolute flow coordinates. Carried verbatim from the
+   *  parsed edge — without these the cable-planner canvas auto-routes
+   *  and the import no longer looks like the source diagram. */
+  waypoints: { x: number; y: number }[]
 }
 
 export interface ImportPreview {
@@ -559,6 +564,7 @@ export const resolveGraphml = (doc: GraphmlDocument): ImportPreview => {
         rawData: edge.data,
         lineColor: edge.lineColor,
         orphan: false,
+        waypoints: edge.waypoints,
       })
       continue
     }
@@ -647,6 +653,7 @@ export const resolveGraphml = (doc: GraphmlDocument): ImportPreview => {
       rawData: edge.data,
       lineColor: edge.lineColor,
       orphan: false,
+      waypoints: edge.waypoints,
     }
   }
 
@@ -751,6 +758,10 @@ export const buildImportPayload = (
       notes: [c.rawCableType ? `CableType: ${c.rawCableType}` : '', c.videoStandard ? `Standard: ${c.videoStandard}` : '']
         .filter(Boolean)
         .join('\n') || undefined,
+      // Carry yEd's polyline bend points through so the store can apply
+      // them to Cable.waypoints — without this the canvas auto-routes
+      // every cable and the import no longer matches the source diagram.
+      waypoints: c.waypoints.map((w) => ({ x: Math.round(w.x), y: Math.round(w.y) })),
     }))
 
   return { devices, portIndex, cables }

--- a/src/renderer/lib/graphml/types.ts
+++ b/src/renderer/lib/graphml/types.ts
@@ -55,6 +55,14 @@ export interface GraphmlEdge {
   data: Record<string, string>
   lineColor: string | null
   lineType: string | null
+  /** Intermediate bend points the user drew in yEd between source and
+   *  target (absolute graph coordinates). Empty when the edge runs as
+   *  a straight line. */
+  waypoints: { x: number; y: number }[]
+  /** Offsets from source/target node center to the actual line endpoints
+   *  inside yEd (`y:Path sx/sy/tx/ty`). Used when re-creating the visual
+   *  start/end of the polyline. */
+  pathOffset: { sx: number; sy: number; tx: number; ty: number }
 }
 
 export type GraphmlKeyDomain = 'node' | 'edge' | 'graph' | 'graphml' | 'port' | 'all'

--- a/src/renderer/lib/greengoSync.ts
+++ b/src/renderer/lib/greengoSync.ts
@@ -1,0 +1,167 @@
+// Bidirectional sync between the GreenGo planner config in the project
+// store and the equipment properties / canvas labels (issue #56).
+//
+// Single source of truth: `project.greengoConfig.users` — each user has
+// an `equipmentId` pointing at the cable-planner device that physically
+// hosts that beltpack/station. We provide:
+//
+//   - findGreenGoUserForEquipment()  — look up the user assigned to a
+//     given device, plus the list of groups they belong to.
+//   - useGreenGoBeltpack()           — React hook returning the user
+//     and a renaming callback. Used by EquipmentProperties.
+//   - upsertEquipmentBeltpackName()  — atomic update applied by both
+//     the equipment-properties UI and the GreenGo dialog.
+//   - global preset slot helpers     — load/save named presets to
+//     localStorage so the user can keep a library of standard intercom
+//     configs independent of any single project.
+
+import { useCallback, useMemo } from 'react'
+import type { GreenGoConfig, GreenGoUser } from '../types/greengo'
+import { useProjectStore } from '../store/projectStore'
+
+const PRESETS_KEY = 'cable-planner:greengoPresets'
+
+export interface GreenGoBeltpackInfo {
+  user: GreenGoUser
+  /** Group entries the user belongs to. Sorted by group id. */
+  groupNames: string[]
+}
+
+export const findGreenGoUserForEquipment = (
+  equipmentId: string,
+  config: GreenGoConfig | undefined,
+): GreenGoBeltpackInfo | null => {
+  if (!config) return null
+  const user = config.users.find((u) => u.equipmentId === equipmentId)
+  if (!user) return null
+  const groupNames = (user.groupIds ?? [])
+    .map((gid) => config.groups.find((g) => g.id === gid)?.name)
+    .filter((n): n is string => !!n)
+    .sort()
+  return { user, groupNames }
+}
+
+/** React hook bundling the lookup + a renaming callback. The callback
+ *  patches `project.greengoConfig.users[*].name` (and `displayName` if
+ *  set) so the GreenGo dialog and the canvas pick up the new name
+ *  immediately. */
+export const useGreenGoBeltpack = (equipmentId: string) => {
+  const config = useProjectStore((s) => s.project.greengoConfig)
+  const updateGreenGoConfig = useProjectStore((s) => s.updateGreenGoConfig)
+
+  const info = useMemo(
+    () => findGreenGoUserForEquipment(equipmentId, config),
+    [equipmentId, config],
+  )
+
+  const rename = useCallback(
+    (newName: string) => {
+      if (!config) return
+      const trimmed = newName.trim()
+      const next: GreenGoConfig = {
+        ...config,
+        users: config.users.map((u) =>
+          u.equipmentId === equipmentId
+            ? {
+                ...u,
+                name: trimmed || u.name,
+                // Keep displayName in sync with `name` when the user
+                // hasn't customised the display variant separately.
+                displayName:
+                  u.displayName && u.displayName !== u.name
+                    ? u.displayName
+                    : trimmed || u.name,
+              }
+            : u,
+        ),
+      }
+      updateGreenGoConfig(next)
+    },
+    [config, updateGreenGoConfig, equipmentId],
+  )
+
+  /** Link a GreenGo user (by id) to the equipment we're currently
+   *  inspecting. Lets the user assign a beltpack inline without
+   *  jumping over to the GreenGo dialog. */
+  const assignUser = useCallback(
+    (userId: number | null) => {
+      if (!config) return
+      const next: GreenGoConfig = {
+        ...config,
+        users: config.users.map((u) => {
+          if (u.id === userId) return { ...u, equipmentId }
+          // If another user was previously linked to this equipment,
+          // unlink them — equipmentId is exclusive 1:1.
+          if (u.equipmentId === equipmentId && u.id !== userId) {
+            return { ...u, equipmentId: undefined }
+          }
+          return u
+        }),
+      }
+      updateGreenGoConfig(next)
+    },
+    [config, updateGreenGoConfig, equipmentId],
+  )
+
+  return { config, info, rename, assignUser }
+}
+
+// ── Global preset slots ────────────────────────────────────────────────
+
+export interface GreenGoPreset {
+  id: string
+  name: string
+  savedAt: string
+  config: GreenGoConfig
+}
+
+const safeParse = <T,>(raw: string | null, fallback: T): T => {
+  if (!raw) return fallback
+  try {
+    return JSON.parse(raw) as T
+  } catch {
+    return fallback
+  }
+}
+
+export const loadGreenGoPresets = (): GreenGoPreset[] => {
+  return safeParse<GreenGoPreset[]>(localStorage.getItem(PRESETS_KEY), [])
+}
+
+const persistPresets = (presets: GreenGoPreset[]) => {
+  try {
+    localStorage.setItem(PRESETS_KEY, JSON.stringify(presets))
+  } catch {
+    /* quota — non-fatal, the preset library is convenience-only */
+  }
+}
+
+export const saveGreenGoPreset = (name: string, config: GreenGoConfig): GreenGoPreset => {
+  const presets = loadGreenGoPresets()
+  // Replace by name if one already exists, otherwise append. Saves the
+  // user from accumulating duplicates when iterating on a config.
+  const trimmed = name.trim() || `Preset ${new Date().toLocaleString()}`
+  const id = `gg-preset-${Date.now()}`
+  const preset: GreenGoPreset = {
+    id,
+    name: trimmed,
+    savedAt: new Date().toISOString(),
+    config,
+  }
+  const next = [...presets.filter((p) => p.name !== trimmed), preset]
+  persistPresets(next)
+  return preset
+}
+
+export const deleteGreenGoPreset = (id: string) => {
+  const next = loadGreenGoPresets().filter((p) => p.id !== id)
+  persistPresets(next)
+}
+
+/** Replace the current project's GreenGo config with the named preset.
+ *  Equipment links from the preset are kept verbatim — if the preset
+ *  references equipment ids that don't exist in this project they're
+ *  simply ignored at render time. */
+export const applyGreenGoPreset = (preset: GreenGoPreset) => {
+  useProjectStore.getState().updateGreenGoConfig(preset.config)
+}

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -238,6 +238,7 @@ interface ProjectState {
       standard?: Cable['standard']
       cableSpecId?: string
       notes?: string
+      waypoints?: { x: number; y: number }[]
     }>
     mode: 'append' | 'replace'
   }) => string[]
@@ -599,11 +600,61 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
           notes: draft.notes ?? '',
           standard: draft.standard,
           cableSpecId: draft.cableSpecId,
-          routing: ui.defaultRouting,
+          // yEd-imported cables ship their original bend points so the
+          // canvas matches the source diagram 1:1. If there are no
+          // waypoints the auto-routing kicks in via the user's default
+          // routing mode (orthogonal / straight / curved).
+          routing: draft.waypoints && draft.waypoints.length > 0 ? 'straight' : ui.defaultRouting,
+          waypoints: draft.waypoints && draft.waypoints.length > 0 ? draft.waypoints : undefined,
           arrowEnd: ui.defaultArrow,
           strokeWidth: 2.5,
           graphmlEdgeId: draft.graphmlEdgeId,
         })
+      }
+
+      // Compute the bounding box of the just-inserted devices and pan
+      // the viewport onto it. Without this the user clicks Import and
+      // sees nothing — yEd diagrams typically sit at (-1400..+2500) on
+      // both axes, well outside the visible canvas. We bump
+      // projectVersion so the existing setViewport effect in
+      // CanvasArea picks the new canvasState up.
+      let minX = Infinity
+      let minY = Infinity
+      let maxX = -Infinity
+      let maxY = -Infinity
+      for (const d of insertedEquipment) {
+        if (d.x < minX) minX = d.x
+        if (d.y < minY) minY = d.y
+        const w = d.width ?? 240
+        const h = d.height ?? 120
+        if (d.x + w > maxX) maxX = d.x + w
+        if (d.y + h > maxY) maxY = d.y + h
+      }
+      // Approximate the visible canvas area. The real value depends on
+      // the user's library / properties panel widths, but the constants
+      // below produce a sensible default for both default and collapsed
+      // layouts.
+      const VIEWPORT_W = 1200
+      const VIEWPORT_H = 700
+      let canvasState = state.project.canvasState
+      if (Number.isFinite(minX)) {
+        const bboxW = Math.max(1, maxX - minX)
+        const bboxH = Math.max(1, maxY - minY)
+        // Fit-to-view zoom: pick whichever axis is more constraining,
+        // cap at 1 so we never zoom in past 100%, and add 10% margin
+        // on each side so labels at the edge stay readable.
+        const fitZoom = Math.min(
+          1,
+          (VIEWPORT_W * 0.9) / bboxW,
+          (VIEWPORT_H * 0.9) / bboxH,
+        )
+        const cx = (minX + maxX) / 2
+        const cy = (minY + maxY) / 2
+        canvasState = {
+          x: VIEWPORT_W / 2 - cx * fitZoom,
+          y: VIEWPORT_H / 2 - cy * fitZoom,
+          zoom: Math.max(0.1, fitZoom),
+        }
       }
 
       return {
@@ -611,7 +662,11 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
           ...state.project,
           equipment: [...baseEquipment, ...insertedEquipment],
           cables: [...baseCables, ...insertedCables],
+          canvasState,
         }),
+        // Triggers CanvasArea's setViewport effect so the user actually
+        // sees the imported devices instead of an empty canvas.
+        projectVersion: state.projectVersion + 1,
       }
     })
     return newIds


### PR DESCRIPTION
## yEd / GraphML import — geometry parity

Previously the import positioned devices correctly but auto-routed every cable as a straight or L-shape, so a diagram with deliberate bend points landed in cable-planner looking nothing like the source.

  - parser: extract y:Path sx/sy/tx/ty AND every y:Point waypoint from y:PolyLineEdge (and the other realizer flavours). In the Missionswerk reference file this captures 225 bend points across 73 of 194 edges that the old parser threw away.
  - semantics: GraphmlEdge.waypoints + pathOffset flow through to ResolvedCable.waypoints.
  - buildImportPayload: rounds each point and hands them to the store.
  - projectStore.importGraphml: applies waypoints onto Cable.waypoints and switches routing to 'straight' for cables that carry their own bends (so the polyline draws verbatim instead of being re-orthogonalised on top of the imported points).
  - projectStore.importGraphml: also pans and zooms the viewport onto the imported bounding box, with a fit-to-view zoom capped at 1.0 and a 10% margin. yEd diagrams typically sit at (-1400..+2500) on both axes; without this the user clicked Import and saw nothing because the canvas viewport stayed at (0,0).

## yEd visual preview tab

GraphmlImportDialog now opens on a new "yEd-Vorschau" tab that draws every node rectangle and every edge polyline at the original yEd coordinates, with mouse-wheel zoom and drag-to-pan. Nodes the resolver classified as device imports get a sky-blue outline; the rest stay grey so the user can spot decoration vs. data at a glance. Lets the user verify "this is the diagram I expected" BEFORE committing the import.

Rendered with a single <svg> + viewBox math (1000+ shapes in one React element) so it stays responsive on the 2.4 MB reference files.

## Issue #56 — GreenGo Intercom beltpack sync

Single source of truth: `project.greengoConfig.users`. The same map that the GreenGo dialog already reads/writes now also surfaces in:

  - EquipmentProperties: when a device is a greengo intercom (deviceKind === 'greengo'), a new section shows the assigned beltpack name, the user-slot dropdown, and the comma list of talk groups the user belongs to. Renaming in either place immediately reflects in the dialog, the canvas label, and the .gg5 export.
  - EquipmentNode (canvas): renders "🎧 [beltpack name]" below the device subtitle for any intercom node linked to a GG user. The header height grows by 14 px when present so port handles never overlap.
  - Einstellungen → Integrations: new GreenGoPresetsCard. Save the current project's intercom config as a named preset to a global localStorage slot, apply later to any project, delete from the library. Lets venues keep a "house template" config separate from any single show file.

New helpers in lib/greengoSync.ts:
  - findGreenGoUserForEquipment()
  - useGreenGoBeltpack() hook (rename / assignUser callbacks)
  - loadGreenGoPresets / saveGreenGoPreset / deleteGreenGoPreset / applyGreenGoPreset