### PR TITLE
v0.10.0: + Excel ↔ .gg5 round-trip + #69 hotkeys + #55 #65 #80 — cumulative

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cable-planner",
-    "version": "0.3.1",
+    "version": "0.9.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cable-planner",
-            "version": "0.3.1",
+            "version": "0.9.0",
             "dependencies": {
                 "@dnd-kit/core": "^6.3.1",
                 "@dnd-kit/sortable": "^10.0.0",
@@ -21,6 +21,7 @@
                 "react-dom": "^19.2.5",
                 "reactflow": "^11.11.4",
                 "uuid": "^13.0.0",
+                "xlsx": "^0.18.5",
                 "yaml": "^2.8.3",
                 "zustand": "^5.0.8"
             },
@@ -3452,6 +3453,15 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
+        "node_modules/adler-32": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+            "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
         "node_modules/agent-base": {
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -4249,6 +4259,19 @@
                 "node": ">=10.0.0"
             }
         },
+        "node_modules/cfb": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+            "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "adler-32": "~1.3.0",
+                "crc-32": "~1.2.0"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4354,6 +4377,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/codepage": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+            "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.8"
             }
         },
         "node_modules/color-convert": {
@@ -4490,6 +4522,18 @@
             "optional": true,
             "dependencies": {
                 "buffer": "^5.1.0"
+            }
+        },
+        "node_modules/crc-32": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+            "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+            "license": "Apache-2.0",
+            "bin": {
+                "crc32": "bin/crc32.njs"
+            },
+            "engines": {
+                "node": ">=0.8"
             }
         },
         "node_modules/cross-dirname": {
@@ -5738,6 +5782,15 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/frac": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+            "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.8"
             }
         },
         "node_modules/fraction.js": {
@@ -8351,6 +8404,18 @@
             "license": "BSD-3-Clause",
             "optional": true
         },
+        "node_modules/ssf": {
+            "version": "0.11.2",
+            "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+            "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "frac": "~1.1.2"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
         "node_modules/stackblur-canvas": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
@@ -9113,6 +9178,24 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/wmf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+            "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/word": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+            "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
         "node_modules/word-wrap": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -9145,6 +9228,27 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "license": "ISC"
+        },
+        "node_modules/xlsx": {
+            "version": "0.18.5",
+            "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+            "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "adler-32": "~1.3.0",
+                "cfb": "~1.2.1",
+                "codepage": "~1.15.0",
+                "crc-32": "~1.2.1",
+                "ssf": "~0.11.2",
+                "wmf": "~1.0.1",
+                "word": "~0.3.0"
+            },
+            "bin": {
+                "xlsx": "bin/xlsx.njs"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
         },
         "node_modules/xml-naming": {
             "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "0.9.0",
+    "version": "0.10.0",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",
@@ -37,6 +37,7 @@
         "react-dom": "^19.2.5",
         "reactflow": "^11.11.4",
         "uuid": "^13.0.0",
+        "xlsx": "^0.18.5",
         "yaml": "^2.8.3",
         "zustand": "^5.0.8"
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "0.8.0",
+    "version": "0.8.1",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "0.8.1",
+    "version": "0.9.0",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "0.7.0",
+    "version": "0.8.0",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -552,12 +552,20 @@ const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoFormat, onC
   // sees what's happening, but the submit path skips the modal confirm
   // so the cable can be created in one click.
   const overrideWarnings = useUiStore((s) => s.overrideConnectionWarnings)
+  // Combined catalog = built-ins + user-defined custom cable specs (issue #64).
+  // The custom specs come from uiStore.customCableSpecs and persist in
+  // localStorage so the user can recall them across sessions.
+  const customCableSpecs = useUiStore((s) => s.customCableSpecs)
+  const fullCableCatalog = useMemo(
+    () => [...cableCatalog, ...customCableSpecs],
+    [customCableSpecs],
+  )
   // Build list of cables ranked by compatibility with the two ports.
   const ranked = useMemo(() => {
     if (!fromPort || !toPort) {
-      return cableCatalog.map((cable) => ({ cable, level: 'ok' as const, message: '' }))
+      return fullCableCatalog.map((cable) => ({ cable, level: 'ok' as const, message: '' }))
     }
-    return cableCatalog
+    return fullCableCatalog
       .map((cable) => ({
         cable,
         ...checkCableCompatibility(fromPort.connectorType, toPort.connectorType, cable),
@@ -625,7 +633,7 @@ const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoFormat, onC
       // the user's custom name. (Bug #13)
       return
     }
-    const spec = cableCatalog.find((c) => c.id === id)
+    const spec = fullCableCatalog.find((c) => c.id === id)
     if (!spec) return
     setName(spec.name)
     setColor(spec.color)
@@ -760,6 +768,36 @@ const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoFormat, onC
                   className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
                 />
               </label>
+              <button
+                type="button"
+                onClick={() => {
+                  // Issue #64: persist the current Custom Cable as a
+                  // reusable type. We prompt for a name (defaulting to
+                  // the user's current `name`) and save the spec; the
+                  // dialog then switches to the new spec so the user
+                  // can see it landed in the dropdown.
+                  const proposedName = name.trim() || `${customConnectorType} Custom`
+                  const finalName = window.prompt(
+                    'Name für den neuen Kabel-Typ:',
+                    proposedName,
+                  )?.trim()
+                  if (!finalName) return
+                  const created = useUiStore.getState().addCustomCableSpec({
+                    name: finalName,
+                    connectorType: customConnectorType,
+                    standards: [customStandard],
+                    color,
+                    maxLengthMeters: typeof customMaxLength === 'number' ? customMaxLength : undefined,
+                    notes: notes || undefined,
+                  })
+                  setSpecId(created.id)
+                  setName(created.name)
+                }}
+                className="mt-2 w-full rounded bg-sky-700 px-2 py-1 text-xs font-medium text-white hover:bg-sky-600"
+                title="Speichert diese Custom-Definition als wiederverwendbaren Kabeltyp in der Bibliothek (Issue #64)."
+              >
+                💾 Als Kabel-Typ speichern…
+              </button>
             </div>
           )}
 
@@ -871,6 +909,14 @@ interface CableEditDialogProps {
 const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
   const equipment = useProjectStore((state) => state.project.equipment)
   const cables = useProjectStore((state) => state.project.cables)
+  // Issue #64: include user-defined custom cable specs in the dropdown
+  // so editing a cable that uses a custom type doesn't lose the
+  // reference. Built-ins + custom share the same shape.
+  const customCableSpecs = useUiStore((s) => s.customCableSpecs)
+  const fullCableCatalog = useMemo(
+    () => [...cableCatalog, ...customCableSpecs],
+    [customCableSpecs],
+  )
 
   const initialCustomConnectorType: ConnectorType =
     cable.type === 'Custom' ? 'Custom' : (cable.type as ConnectorType)
@@ -879,7 +925,7 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
   const [customStandard, setCustomStandard] = useState<SignalStandard>(cable.standard ?? 'Generic')
   const selected: CableSpec = specId === CUSTOM_CABLE_SPEC_ID
     ? makeCustomCableSpec(customConnectorType, cable.color)
-    : (cableCatalog.find((c) => c.id === specId) ?? cableCatalog[0])
+    : (fullCableCatalog.find((c) => c.id === specId) ?? fullCableCatalog[0])
   const [standard, setStandard] = useState<SignalStandard | undefined>(
     cable.standard ?? (specId === CUSTOM_CABLE_SPEC_ID ? customStandard : pickHighestSdiStandard(selected.standards)),
   )
@@ -938,7 +984,7 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
       setStandard(customStandard)
       return
     }
-    const spec = cableCatalog.find((c) => c.id === id)
+    const spec = fullCableCatalog.find((c) => c.id === id)
     if (!spec) return
     setStandard(pickHighestSdiStandard(spec.standards))
   }
@@ -1002,7 +1048,7 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
               className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
             >
               <option value={CUSTOM_CABLE_SPEC_ID}>★ Custom Cable…</option>
-              {cableCatalog.map((c) => (
+              {fullCableCatalog.map((c) => (
                 <option key={c.id} value={c.id}>
                   {c.name} ({c.connectorType})
                 </option>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -18,6 +18,7 @@ import { AtemAudioRouterDialog } from './components/Atem/AtemAudioRouterDialog'
 import { LocationBomDialog } from './components/Project/LocationBomDialog'
 import { ProjectMetaDialog } from './components/Project/ProjectMetaDialog'
 import { CableBomDialog } from './components/Project/CableBomDialog'
+import { PrintDialog } from './components/Print/PrintDialog'
 import { WelcomeDialog } from './components/Project/WelcomeDialog'
 import { Splitter } from './components/Layout/Splitter'
 import { useProject } from './hooks/useProject'
@@ -89,6 +90,7 @@ export default function App() {
   const [welcomeOpen, setWelcomeOpen] = useState(false)
   const [pdfExportOpen, setPdfExportOpen] = useState(false)
   const [pdfTheme, setPdfTheme] = useState<'dark' | 'light'>('light')
+  const [printDialogOpen, setPrintDialogOpen] = useState(false)
   const [graphmlImportOpen, setGraphmlImportOpen] = useState(false)
   const pdfExportThemeOverride = useUiStore((state) => state.pdfExportThemeOverride)
   const setPdfExportThemeOverride = useUiStore((state) => state.setPdfExportThemeOverride)
@@ -328,12 +330,7 @@ export default function App() {
         onSaveProjectAs={() => void saveProjectAs()}
         onOpenSettings={() => setSettingsOpen(true)}
         onExportPdf={() => setPdfExportOpen(true)}
-        onExportPng={() =>
-          void exportCanvasToImage(project.metadata.name, 'png', { backgroundTheme: canvasTheme })
-        }
-        onExportJpeg={() =>
-          void exportCanvasToImage(project.metadata.name, 'jpeg', { backgroundTheme: canvasTheme })
-        }
+        onOpenPrintDialog={() => setPrintDialogOpen(true)}
         onOpenGraphmlImport={() => setGraphmlImportOpen(true)}
         onAttachPdfToRentman={() => void handleUploadPdfToRentman()}
         onOpenRentmanCableExport={openRentmanCableExport}
@@ -415,6 +412,18 @@ export default function App() {
       />
 
       <CableBomDialog open={cableBomOpen} onClose={() => setCableBomOpen(false)} />
+
+      <PrintDialog
+        open={printDialogOpen}
+        onClose={() => setPrintDialogOpen(false)}
+        onPrintPlanPdf={() => setPdfExportOpen(true)}
+        onPrintPlanPng={() =>
+          void exportCanvasToImage(project.metadata.name, 'png', { backgroundTheme: canvasTheme })
+        }
+        onPrintPlanJpeg={() =>
+          void exportCanvasToImage(project.metadata.name, 'jpeg', { backgroundTheme: canvasTheme })
+        }
+      />
 
       <PdfExportDialog
         open={pdfExportOpen}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -27,9 +27,10 @@ import { cablePlannerApi } from './lib/bridge'
 import { exportCanvasToPdf, exportCanvasToPdfBytes } from './lib/exportPdf'
 import { exportCanvasToImage } from './lib/exportImage'
 import { useProjectStore } from './store/projectStore'
-import { useUndoRedoShortcuts } from './store/projectHistory'
+import { useUndoRedoShortcuts, projectHistory } from './store/projectHistory'
 import { useSettingsStore } from './store/settingsStore'
 import { useUiStore } from './store/uiStore'
+import { useHotkeys } from './lib/hotkeys'
 import type { Cable, CableType } from './types/cable'
 import { ALL_CONNECTOR_TYPES } from './types/equipment'
 import type { ConnectorType, EquipmentItem, Port } from './types/equipment'
@@ -154,6 +155,35 @@ export default function App() {
   }, [refreshRecent, setHasToken])
 
   useUndoRedoShortcuts()
+
+  // Issue #69: dispatch user-customizable hotkeys defined in
+  // Settings → Hotkeys. The undo/redo entries below intentionally
+  // overlap with useUndoRedoShortcuts() — only the first matching
+  // handler fires, so there's no double-trigger.
+  const hotkeys = useUiStore((s) => s.hotkeys)
+  const hotkeyHandlers = useMemo(
+    () => ({
+      undo: () => projectHistory.undo(),
+      redo: () => projectHistory.redo(),
+      save: () => void saveProject(),
+      saveAs: () => void saveProjectAs(),
+      newProject: () => void handleNewProject(),
+      openProject: () => void openProject(),
+      deleteSelected: () => useProjectStore.getState().deleteSelected(),
+      clearSelection: () =>
+        useProjectStore.getState().setSelection(undefined, undefined, undefined),
+      toggleLibrary: () => useUiStore.getState().toggleLibraryCollapsed(),
+      toggleProperties: () => useUiStore.getState().togglePropertiesCollapsed(),
+      toggleArrows: () =>
+        useUiStore.getState().setDefaultArrow(!useUiStore.getState().defaultArrow),
+    }),
+    // We rebuild handlers only when stable refs change. Most setters
+    // come from zustand; handleNewProject is recreated each render
+    // but it's only invoked on key press so a stale capture is fine.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [openProject, saveProject, saveProjectAs],
+  )
+  useHotkeys(hotkeys, hotkeyHandlers)
 
   const handleNewProject = async () => {
     // Only *open* the dialog here. The actual project reset happens when the

--- a/src/renderer/components/Atem/AtemMvConfigDialog.tsx
+++ b/src/renderer/components/Atem/AtemMvConfigDialog.tsx
@@ -438,20 +438,29 @@ export const AtemMvConfigDialog = () => {
           {mv && spec && (
             <>
               <div className="mb-3 flex flex-wrap items-center gap-3 text-xs">
-                <label className="flex items-center gap-2">
-                  <span className="text-slate-300">Layout</span>
-                  <select
-                    value={mv.layout}
-                    onChange={(e) => updateMv(activeMv, { layout: Number(e.target.value) })}
-                    className="rounded border border-slate-700 bg-slate-900 px-2 py-1"
-                  >
-                    {MV_LAYOUT_OPTIONS.map((l) => (
-                      <option key={l.value} value={l.value}>
-                        {l.label}
-                      </option>
-                    ))}
-                  </select>
-                </label>
+                {/* Issue #55: ATEM-software-style layout picker. Each
+                    button shows the layout label and is clickable to
+                    switch the active multiviewer's grid. Active layout
+                    is highlighted in sky-700. Replaces the previous
+                    dropdown (less obvious which layouts exist). */}
+                <span className="text-slate-300">Layout</span>
+                <div className="flex flex-wrap gap-1">
+                  {MV_LAYOUT_OPTIONS.map((l) => (
+                    <button
+                      key={l.value}
+                      type="button"
+                      onClick={() => updateMv(activeMv, { layout: l.value })}
+                      className={`rounded border px-2 py-1 text-[11px] transition-colors ${
+                        mv.layout === l.value
+                          ? 'border-sky-500 bg-sky-700 text-white'
+                          : 'border-slate-700 bg-slate-900 text-slate-300 hover:border-sky-700 hover:text-sky-200'
+                      }`}
+                      title={`Layout: ${l.label}`}
+                    >
+                      {l.label}
+                    </button>
+                  ))}
+                </div>
                 <label className="flex items-center gap-2">
                   <input
                     type="checkbox"

--- a/src/renderer/components/Canvas/CableEdge.tsx
+++ b/src/renderer/components/Canvas/CableEdge.tsx
@@ -18,6 +18,110 @@ interface CableEdgeData {
   exportThemeOverride?: 'dark' | 'light'
 }
 
+/**
+ * Issue #65: Replace each crossing point with a small jump-bump arc so
+ * the user can see which cable is "on top" when two cables cross.
+ *
+ * Input: a polyline (list of points forming straight segments).
+ * Output: an SVG-path `d` string with the original moves/lines plus an
+ *         arc of `bumpRadius` over each crossing point.
+ *
+ * We only consider perpendicular crossings; near-parallel overlaps fall
+ * through as regular line segments because a bump there would look
+ * weird. The crossings are computed against `otherSegments`, which
+ * should be the segments of all OTHER cables on the canvas.
+ */
+const buildPathWithBumps = (
+  points: { x: number; y: number }[],
+  otherSegments: Array<{
+    a: { x: number; y: number }
+    b: { x: number; y: number }
+  }>,
+  bumpRadius = 5,
+): string => {
+  if (points.length < 2 || otherSegments.length === 0) {
+    return points
+      .map((p, i) => (i === 0 ? `M ${p.x} ${p.y}` : `L ${p.x} ${p.y}`))
+      .join(' ')
+  }
+  const segments: string[] = []
+  segments.push(`M ${points[0].x} ${points[0].y}`)
+  for (let i = 0; i < points.length - 1; i++) {
+    const p = points[i]
+    const q = points[i + 1]
+    const horizontal = Math.abs(q.y - p.y) < 1
+    const vertical = Math.abs(q.x - p.x) < 1
+    if (!horizontal && !vertical) {
+      segments.push(`L ${q.x} ${q.y}`)
+      continue
+    }
+    // Find perpendicular crossings on this segment, sorted by distance
+    // from p so we draw them in order.
+    const hits: number[] = []
+    for (const other of otherSegments) {
+      const oHoriz = Math.abs(other.a.y - other.b.y) < 1
+      const oVert = Math.abs(other.a.x - other.b.x) < 1
+      if (horizontal && oVert) {
+        const ox = other.a.x
+        const oyMin = Math.min(other.a.y, other.b.y)
+        const oyMax = Math.max(other.a.y, other.b.y)
+        const xMin = Math.min(p.x, q.x)
+        const xMax = Math.max(p.x, q.x)
+        if (
+          ox > xMin + bumpRadius &&
+          ox < xMax - bumpRadius &&
+          p.y > oyMin + 1 &&
+          p.y < oyMax - 1
+        ) {
+          hits.push(ox)
+        }
+      } else if (vertical && oHoriz) {
+        const oy = other.a.y
+        const oxMin = Math.min(other.a.x, other.b.x)
+        const oxMax = Math.max(other.a.x, other.b.x)
+        const yMin = Math.min(p.y, q.y)
+        const yMax = Math.max(p.y, q.y)
+        if (
+          oy > yMin + bumpRadius &&
+          oy < yMax - bumpRadius &&
+          p.x > oxMin + 1 &&
+          p.x < oxMax - 1
+        ) {
+          hits.push(oy)
+        }
+      }
+    }
+    if (hits.length === 0) {
+      segments.push(`L ${q.x} ${q.y}`)
+      continue
+    }
+    // Sort by distance from p along the segment direction.
+    const ascending = horizontal ? q.x > p.x : q.y > p.y
+    hits.sort((a, b) => (ascending ? a - b : b - a))
+    let curX = p.x
+    let curY = p.y
+    for (const hit of hits) {
+      if (horizontal) {
+        const arcStartX = ascending ? hit - bumpRadius : hit + bumpRadius
+        const arcEndX = ascending ? hit + bumpRadius : hit - bumpRadius
+        segments.push(`L ${arcStartX} ${curY}`)
+        // sweep flag 0 keeps the arc on the "top" side (negative y) of
+        // a horizontal segment regardless of travel direction
+        segments.push(`A ${bumpRadius} ${bumpRadius} 0 0 ${ascending ? 1 : 0} ${arcEndX} ${curY}`)
+        curX = arcEndX
+      } else {
+        const arcStartY = ascending ? hit - bumpRadius : hit + bumpRadius
+        const arcEndY = ascending ? hit + bumpRadius : hit - bumpRadius
+        segments.push(`L ${curX} ${arcStartY}`)
+        segments.push(`A ${bumpRadius} ${bumpRadius} 0 0 ${ascending ? 0 : 1} ${curX} ${arcEndY}`)
+        curY = arcEndY
+      }
+    }
+    segments.push(`L ${q.x} ${q.y}`)
+  }
+  return segments.join(' ')
+}
+
 /** Normalize waypoints so every segment is strictly horizontal or vertical.
  *  Any diagonal is replaced by an L-corner (horizontal-first). Already
  *  orthogonal segments are passed through unchanged so we don't introduce

--- a/src/renderer/components/Canvas/CanvasToolbar.tsx
+++ b/src/renderer/components/Canvas/CanvasToolbar.tsx
@@ -85,6 +85,20 @@ export const CanvasToolbar = () => {
     }
   }
 
+  const sectionLabelStyle: React.CSSProperties = {
+    color: isLight ? '#475569' : '#94a3b8',
+    fontWeight: 600,
+    textTransform: 'uppercase',
+    letterSpacing: '0.06em',
+    fontSize: 9,
+    paddingRight: 2,
+  }
+  const dividerStyle: React.CSSProperties = {
+    width: 1,
+    height: 18,
+    background: isLight ? '#e2e8f0' : '#1f2937',
+    margin: '0 2px',
+  }
   return (
     <div
       className="nodrag nopan"
@@ -96,20 +110,22 @@ export const CanvasToolbar = () => {
         display: 'flex',
         flexWrap: 'wrap',
         gap: 6,
-        maxWidth: 'min(860px, calc(100vw - 420px))',
-        padding: 6,
-        background: isLight ? 'rgba(248,250,252,0.96)' : 'rgba(15,23,42,0.94)',
-        border: `1px solid ${isLight ? '#cbd5e1' : '#334155'}`,
-        borderRadius: 8,
-        boxShadow: isLight ? '0 18px 40px rgba(0,0,0,0.12)' : '0 18px 40px rgba(0,0,0,0.28)',
+        maxWidth: 'min(880px, calc(100vw - 420px))',
+        padding: '5px 8px',
+        background: isLight ? 'rgba(248,250,252,0.92)' : 'rgba(15,23,42,0.92)',
+        border: `1px solid ${isLight ? '#cbd5e1' : '#1f2937'}`,
+        borderRadius: 10,
+        boxShadow: isLight
+          ? '0 8px 24px rgba(15,23,42,0.10), 0 2px 6px rgba(15,23,42,0.06)'
+          : '0 8px 24px rgba(0,0,0,0.40), 0 2px 6px rgba(0,0,0,0.30)',
         fontSize: 11,
         color: isLight ? '#1e293b' : '#e2e8f0',
         alignItems: 'center',
+        backdropFilter: 'blur(8px)',
+        WebkitBackdropFilter: 'blur(8px)',
       }}
     >
-      <span style={{ color: isLight ? '#64748b' : '#94a3b8', fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0, fontSize: 10 }}>
-        Canvas
-      </span>
+      <span style={sectionLabelStyle}>Canvas</span>
       <label style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer' }}>
         <input
           type="checkbox"
@@ -134,10 +150,8 @@ export const CanvasToolbar = () => {
         }}
         title="Rastergröße in Pixeln"
       />
-      <span style={{ width: 1, height: 18, background: isLight ? '#cbd5e1' : '#334155', margin: '0 4px' }} />
-      <span style={{ color: isLight ? '#64748b' : '#94a3b8', fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0, fontSize: 10 }}>
-        Routing
-      </span>
+      <span style={dividerStyle} />
+      <span style={sectionLabelStyle}>Routing</span>
       <RoutingToggle
         value={defaultRouting}
         onChange={setDefaultRouting}
@@ -163,12 +177,10 @@ export const CanvasToolbar = () => {
         />
         Ports nach Typ
       </label>
-      <span style={{ width: 1, height: 18, background: isLight ? '#cbd5e1' : '#334155', margin: '0 4px' }} />
+      <span style={dividerStyle} />
       {/* Cable color mode toggle */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
-        <span style={{ color: isLight ? '#64748b' : '#94a3b8', fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0, fontSize: 10, marginRight: 2 }}>
-          Kabel
-        </span>
+        <span style={{ ...sectionLabelStyle, marginRight: 2 }}>Kabel</span>
         <button
           type="button"
           onClick={() => setCableColorMode('manual')}
@@ -260,7 +272,7 @@ export const CanvasToolbar = () => {
           </button>
         </div>
       )}
-      <span style={{ width: 1, height: 18, background: isLight ? '#cbd5e1' : '#334155', margin: '0 4px' }} />
+      <span style={dividerStyle} />
       <button
         type="button"
         onClick={() => setCanvasTheme(canvasTheme === 'dark' ? 'light' : 'dark')}
@@ -277,10 +289,8 @@ export const CanvasToolbar = () => {
       >
         {canvasTheme === 'dark' ? '☀' : '🌙'}
       </button>
-      <span style={{ width: 1, height: 18, background: isLight ? '#cbd5e1' : '#334155', margin: '0 4px' }} />
-      <span style={{ color: isLight ? '#64748b' : '#94a3b8', fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0, fontSize: 10 }}>
-        Layout
-      </span>
+      <span style={dividerStyle} />
+      <span style={sectionLabelStyle}>Layout</span>
       <button
         type="button"
         onClick={() => {
@@ -422,10 +432,8 @@ export const CanvasToolbar = () => {
         } as const
         return (
           <>
-            <span style={{ width: 1, height: 18, background: isLight ? '#cbd5e1' : '#334155', margin: '0 4px' }} />
-            <span style={{ color: isLight ? '#64748b' : '#94a3b8', fontWeight: 700, textTransform: 'uppercase', fontSize: 10 }}>
-              Ausrichten
-            </span>
+            <span style={dividerStyle} />
+            <span style={sectionLabelStyle}>Ausrichten</span>
             <button type="button" title="Linksbündig (gleiche linke Kante)" onClick={() => alignSelected('left')} style={btnStyle}>⇤</button>
             <button type="button" title="Horizontal zentrieren (gleiche X-Mitte)" onClick={() => alignSelected('center-h')} style={btnStyle}>↔</button>
             <button type="button" title="Rechtsbündig (gleiche rechte Kante)" onClick={() => alignSelected('right')} style={btnStyle}>⇥</button>

--- a/src/renderer/components/Export/GreenGoExportDialog.tsx
+++ b/src/renderer/components/Export/GreenGoExportDialog.tsx
@@ -10,6 +10,10 @@ import {
   parseGg5File,
   type Gg5ImportResult,
 } from '../../lib/importGreengo'
+import {
+  exportIntercomMatrixXlsx,
+  parseIntercomMatrixXlsx,
+} from '../../lib/intercomMatrixXlsx'
 
 interface Props {
   onClose: () => void
@@ -44,8 +48,10 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
   // ── import state ──────────────────────────────────────────────────────────
 
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const xlsxInputRef = useRef<HTMLInputElement>(null)
   const [importResult, setImportResult] = useState<Gg5ImportResult | null>(null)
   const [importError, setImportError] = useState<string | null>(null)
+  const [xlsxImportNotice, setXlsxImportNotice] = useState<string | null>(null)
   /** userId → canvas equipmentId mapping chosen by the user in the import overlay */
   const [importMappings, setImportMappings] = useState<Map<number, string>>(new Map())
 
@@ -88,6 +94,73 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
   const cancelImport = () => {
     setImportResult(null)
     setImportError(null)
+  }
+
+  // ── XLSX intercom-matrix round-trip ───────────────────────────────────────
+
+  const handleXlsxSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = (ev) => {
+      const buffer = ev.target?.result
+      if (!(buffer instanceof ArrayBuffer)) {
+        setImportError('Konnte XLSX nicht als Binärdaten lesen.')
+        return
+      }
+      const result = parseIntercomMatrixXlsx(buffer)
+      if ('error' in result) {
+        setImportError(result.error)
+        return
+      }
+      // Merge with current config: prefer the XLSX-derived users/groups
+      // but keep system metadata (multicast/sampleRate) from the current
+      // session so the user doesn't lose those defaults.
+      setConfig((prev) => ({
+        ...prev,
+        systemName: result.config.systemName,
+        description: result.config.description,
+        users: result.config.users,
+        groups: result.config.groups,
+      }))
+      setActiveTab('matrix')
+      const lines: string[] = []
+      lines.push(
+        `✓ ${result.config.users.length} Benutzer · ${result.config.groups.length} Gruppen aus Excel übernommen.`,
+      )
+      if (result.directTalkPairs.length > 0) {
+        lines.push(
+          `${result.directTalkPairs.length} Direkt-Linien (User↔User) wurden ignoriert — GreenGo speichert Mitgliedschaften, keine 1:1-Routen.`,
+        )
+      }
+      if (result.equipmentMarks.length > 0) {
+        lines.push(
+          `${result.equipmentMarks.length} Equipment-Markierungen sind nur Audit — ordne die Beltpacks auf dem Canvas zu.`,
+        )
+      }
+      for (const w of result.warnings) lines.push(`⚠ ${w}`)
+      setXlsxImportNotice(lines.join('\n'))
+      setImportError(null)
+    }
+    reader.onerror = () => setImportError('XLSX konnte nicht gelesen werden.')
+    reader.readAsArrayBuffer(file)
+    e.target.value = ''
+  }
+
+  const handleXlsxExport = () => {
+    const buffer = exportIntercomMatrixXlsx(config)
+    const blob = new Blob([buffer], {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    const safeName = config.systemName.replace(/[^a-z0-9_\-]/gi, '_') || 'intercom'
+    a.download = `${safeName}-IntercomMatrix.xlsx`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    setTimeout(() => URL.revokeObjectURL(url), 1000)
   }
 
   // ── system helpers ────────────────────────────────────────────────────────
@@ -579,14 +652,21 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
               <span className="ml-2 text-emerald-700">· {intercomEquipment.length} Geräte auf Canvas</span>
             )}
           </span>
-          <div className="flex gap-2">
-            {/* Hidden file input for .gg5 import */}
+          <div className="flex flex-wrap gap-2">
+            {/* Hidden file inputs for .gg5 and .xlsx imports */}
             <input
               ref={fileInputRef}
               type="file"
               accept=".gg5,.json"
               className="hidden"
               onChange={handleFileSelected}
+            />
+            <input
+              ref={xlsxInputRef}
+              type="file"
+              accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+              className="hidden"
+              onChange={handleXlsxSelected}
             />
             <button
               type="button"
@@ -595,6 +675,22 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
               title=".gg5 Datei importieren und mit Canvas-Geräten verknüpfen"
             >
               ⬆ .gg5 importieren
+            </button>
+            <button
+              type="button"
+              onClick={() => xlsxInputRef.current?.click()}
+              className="rounded border border-slate-600 px-3 py-1.5 text-xs text-slate-400 hover:border-cyan-700 hover:text-cyan-300"
+              title="Intercom-Matrix-Excel hochladen — die Users + Gruppen werden in die GreenGo-Konfiguration übernommen."
+            >
+              📊 Excel-Matrix importieren
+            </button>
+            <button
+              type="button"
+              onClick={handleXlsxExport}
+              className="rounded border border-slate-600 px-3 py-1.5 text-xs text-slate-400 hover:border-cyan-700 hover:text-cyan-300"
+              title="Aktuelle GreenGo-Konfiguration als Intercom-Matrix-Excel herunterladen (für Druck / Weitergabe)."
+            >
+              📊 Excel-Matrix exportieren
             </button>
             <button
               type="button"
@@ -613,6 +709,20 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
           </div>
         </div>
       </div>
+
+      {/* ══════ XLSX IMPORT TOAST (multi-line) ══════ */}
+      {xlsxImportNotice && (
+        <div className="fixed bottom-6 left-1/2 z-[60] -translate-x-1/2 max-w-lg rounded border border-cyan-700 bg-cyan-950 px-4 py-3 text-xs text-cyan-100 shadow-lg">
+          <pre className="whitespace-pre-wrap font-sans">{xlsxImportNotice}</pre>
+          <button
+            type="button"
+            onClick={() => setXlsxImportNotice(null)}
+            className="mt-2 rounded bg-cyan-800 px-2 py-1 text-[11px] text-white hover:bg-cyan-700"
+          >
+            OK
+          </button>
+        </div>
+      )}
 
       {/* ══════ IMPORT ERROR TOAST ══════ */}
       {importError && (

--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -10,10 +10,8 @@ interface MenuBarProps {
   onSaveProjectAs: () => void
   onOpenSettings: () => void
   onExportPdf: () => void
-  /** Save the canvas as a PNG bitmap (H2R parity). */
-  onExportPng?: () => void
-  /** Save the canvas as a JPEG bitmap. */
-  onExportJpeg?: () => void
+  /** Open the consolidated "Drucken" hub (Plan + per-device patch-sheets, Issue #74). */
+  onOpenPrintDialog?: () => void
   /** Open the GraphML / yEd import dialog. */
   onOpenGraphmlImport?: () => void
   onEditProjectMeta?: () => void
@@ -49,8 +47,7 @@ export const MenuBar = ({
   onSaveProjectAs,
   onOpenSettings,
   onExportPdf,
-  onExportPng,
-  onExportJpeg,
+  onOpenPrintDialog,
   onOpenGraphmlImport,
   onEditProjectMeta,
   onOpenCableBom,
@@ -107,19 +104,15 @@ export const MenuBar = ({
         </Menu>
 
         <Menu label={t('app.menu.export', 'Export')}>
+          {onOpenPrintDialog && (
+            <MenuItem onClick={onOpenPrintDialog} icon="🖨">
+              {t('app.menu.export.print', 'Drucken… (Plan + Einzelgeräte)')}
+            </MenuItem>
+          )}
+          {onOpenPrintDialog && <MenuSep />}
           <MenuItem onClick={onExportPdf} icon="📑">
             {t('app.menu.export.pdf', 'Plan als PDF…')}
           </MenuItem>
-          {onExportPng && (
-            <MenuItem onClick={onExportPng} icon="🖼">
-              {t('app.menu.export.png', 'Plan als PNG…')}
-            </MenuItem>
-          )}
-          {onExportJpeg && (
-            <MenuItem onClick={onExportJpeg} icon="🖼">
-              {t('app.menu.export.jpeg', 'Plan als JPEG…')}
-            </MenuItem>
-          )}
           {onOpenCableBom && (
             <MenuItem onClick={onOpenCableBom} icon="🧮">
               {t('app.menu.export.cableBom', 'Kabel-Stückliste (BOM)…')}

--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -66,11 +66,19 @@ export const MenuBar = ({
   // buttons reflect the current canUndo/canRedo state. Keyboard shortcuts
   // (Strg+Z / Strg+Umsch+Z / Strg+Y) live in useUndoRedoShortcuts; these
   // buttons exist because users couldn't tell that history was working
-  // (issue #72: "Redo geht noch nicht. muss auch in die oberste topbar").
-  useSyncExternalStore(projectHistory.subscribe, () => projectHistory.canUndo() ? 'u' : '', () => '')
-  useSyncExternalStore(projectHistory.subscribe, () => projectHistory.canRedo() ? 'r' : '', () => '')
-  const canUndo = projectHistory.canUndo()
-  const canRedo = projectHistory.canRedo()
+  // (issue #72). Use stable method references for getSnapshot — inline
+  // arrows would create fresh function objects every render and have
+  // occasionally been the trigger for React #185 boot loops.
+  const canUndo = useSyncExternalStore(
+    projectHistory.subscribe,
+    projectHistory.canUndo,
+    projectHistory.canUndo,
+  )
+  const canRedo = useSyncExternalStore(
+    projectHistory.subscribe,
+    projectHistory.canRedo,
+    projectHistory.canRedo,
+  )
   return (
     <header className="flex shrink-0 items-center justify-between gap-3 border-b border-slate-700 bg-slate-950 px-3 py-1.5 text-xs shadow-sm">
       <div className="flex items-center gap-2">

--- a/src/renderer/components/Library/LibraryPanel.tsx
+++ b/src/renderer/components/Library/LibraryPanel.tsx
@@ -472,36 +472,41 @@ export const LibraryPanel = () => {
     }
   }
 
+  if (collapsed) {
+    return (
+      <aside className="flex h-full w-8 flex-col items-center border-r border-slate-700 bg-slate-950 transition-colors hover:bg-slate-900">
+        <button
+          type="button"
+          onClick={toggleCollapsed}
+          title="Library einblenden"
+          aria-label="Library einblenden"
+          className="mt-2 flex h-7 w-7 items-center justify-center rounded-full border border-slate-700 bg-slate-900 text-slate-300 shadow-sm transition-all hover:border-sky-500 hover:bg-slate-800 hover:text-sky-300"
+        >
+          <span className="text-base leading-none">›</span>
+        </button>
+        <button
+          type="button"
+          onClick={toggleCollapsed}
+          aria-label="Library einblenden"
+          className="mt-3 flex-1 self-stretch text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500 transition-colors hover:text-slate-300"
+          style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}
+        >
+          Library
+        </button>
+      </aside>
+    )
+  }
   return (
     <aside className="flex h-full min-h-0 flex-col border-r border-slate-700 bg-slate-950 p-3 text-slate-100">
-      {/* ---- collapsed state ---- */}
-      {collapsed ? (
-        <>
-          <button
-            type="button"
-            onClick={toggleCollapsed}
-            title="Library aufklappen"
-            className="rounded px-1 py-2 text-slate-300 hover:bg-slate-800"
-          >
-            ►
-          </button>
-          <div
-            className="mt-4 text-[10px] uppercase tracking-wider text-slate-500"
-            style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}
-          >
-            Library
-          </div>
-        </>
-      ) : (
-        <>
       <div className="mb-3 flex items-center gap-2 text-xs">
         <button
           type="button"
           onClick={toggleCollapsed}
-          title="Library einklappen"
-          className="rounded px-1 py-1 text-slate-400 hover:bg-slate-800 hover:text-slate-200"
+          title="Library ausblenden"
+          aria-label="Library ausblenden"
+          className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-slate-700 bg-slate-900 text-slate-300 transition-all hover:border-sky-500 hover:bg-slate-800 hover:text-sky-300"
         >
-          ◄
+          <span className="text-base leading-none">‹</span>
         </button>
         <button
           type="button"
@@ -2032,8 +2037,6 @@ export const LibraryPanel = () => {
           window.alert('Merge gespeichert.')
         }}
       />
-      </>
-      )}
     </aside>
   )
 }

--- a/src/renderer/components/Print/PrintDialog.tsx
+++ b/src/renderer/components/Print/PrintDialog.tsx
@@ -1,0 +1,323 @@
+// Issue #74 follow-up: one consolidated "Drucken" dialog reachable from the
+// topbar. Replaces the scattered "Plan als PNG…" / "Plan als JPEG…" menu
+// items (those used to fire downloads directly with no chance to review).
+// Single hub for:
+//   - Plan-as-PDF (delegates to existing PdfExportDialog flow)
+//   - Plan-as-PNG and Plan-as-JPEG (direct downloads)
+//   - Per-device patch-sheet exports (issue #74), with a multi-select list
+//     and a choice between one combined PDF or individual PDFs per device.
+
+import { useMemo, useState } from 'react'
+import { useProjectStore } from '../../store/projectStore'
+import {
+  exportDevicePatchSheet,
+  exportDevicesPatchSheetsBatch,
+} from '../../lib/exportDevicePdf'
+import type { EquipmentItem } from '../../types/equipment'
+
+interface PrintDialogProps {
+  open: boolean
+  onClose: () => void
+  /** Trigger the existing Plan-as-PDF dialog (theme picker etc.). */
+  onPrintPlanPdf: () => void
+  /** Direct download of the canvas as PNG. */
+  onPrintPlanPng: () => void
+  /** Direct download of the canvas as JPEG. */
+  onPrintPlanJpeg: () => void
+}
+
+type DeviceMode = 'combined' | 'individual'
+type PaperFormat = 'a4' | 'a3'
+
+export const PrintDialog = ({
+  open,
+  onClose,
+  onPrintPlanPdf,
+  onPrintPlanPng,
+  onPrintPlanJpeg,
+}: PrintDialogProps) => {
+  const equipment = useProjectStore((state) => state.project.equipment)
+  const cables = useProjectStore((state) => state.project.cables)
+
+  const sortedEquipment = useMemo(
+    () => [...equipment].sort((a, b) => a.name.localeCompare(b.name)),
+    [equipment],
+  )
+
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [filter, setFilter] = useState('')
+  const [format, setFormat] = useState<PaperFormat>('a4')
+  const [mode, setMode] = useState<DeviceMode>('combined')
+  const [busy, setBusy] = useState(false)
+
+  if (!open) return null
+
+  const filteredEquipment = sortedEquipment.filter((eq) => {
+    if (!filter.trim()) return true
+    const q = filter.toLowerCase()
+    return (
+      eq.name.toLowerCase().includes(q) ||
+      (eq.category ?? '').toLowerCase().includes(q) ||
+      (eq.subtitle ?? '').toLowerCase().includes(q)
+    )
+  })
+
+  const toggleDevice = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const selectAll = () => setSelectedIds(new Set(filteredEquipment.map((e) => e.id)))
+  const selectNone = () => setSelectedIds(new Set())
+
+  const selectedDevices: EquipmentItem[] = sortedEquipment.filter((e) => selectedIds.has(e.id))
+  const selectionCount = selectedDevices.length
+
+  const handleExportDevices = async () => {
+    if (selectionCount === 0) return
+    setBusy(true)
+    try {
+      if (mode === 'combined' || selectedDevices.length === 1) {
+        await exportDevicesPatchSheetsBatch(selectedDevices, equipment, cables, { format })
+      } else {
+        for (const device of selectedDevices) {
+          await exportDevicePatchSheet(device, equipment, cables, { format })
+        }
+      }
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 grid place-items-center bg-black/60 p-4"
+      onMouseDown={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-lg border border-slate-700 bg-slate-900 shadow-2xl">
+        <header className="flex items-center justify-between border-b border-slate-700 px-4 py-3">
+          <h2 className="text-sm font-semibold text-slate-100">
+            <span className="mr-2">🖨</span>
+            Drucken
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded px-2 py-1 text-xs text-slate-400 hover:bg-slate-800 hover:text-slate-100"
+            aria-label="Schließen"
+          >
+            ✕
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto px-4 py-3">
+          {/* Plan section */}
+          <fieldset className="mb-4 rounded border border-slate-700 p-3">
+            <legend className="px-1 text-[11px] uppercase tracking-wide text-slate-400">
+              Plan / Gesamtansicht
+            </legend>
+            <p className="mb-2 text-[11px] text-slate-400">
+              Exportiert die komplette Canvas-Ansicht. Der PDF-Export öffnet einen separaten
+              Dialog mit Hintergrund-Auswahl.
+            </p>
+            <div className="grid grid-cols-3 gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  onClose()
+                  onPrintPlanPdf()
+                }}
+                className="rounded bg-sky-700 px-3 py-2 text-xs font-medium text-white hover:bg-sky-600"
+              >
+                📑 Plan als PDF…
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  onClose()
+                  onPrintPlanPng()
+                }}
+                className="rounded bg-slate-700 px-3 py-2 text-xs font-medium text-slate-100 hover:bg-slate-600"
+              >
+                🖼 Plan als PNG
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  onClose()
+                  onPrintPlanJpeg()
+                }}
+                className="rounded bg-slate-700 px-3 py-2 text-xs font-medium text-slate-100 hover:bg-slate-600"
+              >
+                🖼 Plan als JPEG
+              </button>
+            </div>
+          </fieldset>
+
+          {/* Per-device section */}
+          <fieldset className="rounded border border-slate-700 p-3">
+            <legend className="px-1 text-[11px] uppercase tracking-wide text-slate-400">
+              Einzelgeräte (Patch-Sheet, Issue #74)
+            </legend>
+            <p className="mb-2 text-[11px] text-slate-400">
+              Wählt einzelne Geräte aus und erzeugt eine A4/A3-Patch-Liste mit allen Ports +
+              verbundenen Kabeln — zum Aufkleben am Gerät.
+            </p>
+
+            {/* Toolbar: search + select-all/none + counters */}
+            <div className="mb-2 flex flex-wrap items-center gap-2">
+              <input
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                placeholder="Suchen (Name, Kategorie, Untertitel)…"
+                className="flex-1 rounded border border-slate-700 bg-slate-950 px-2 py-1 text-xs text-slate-100 placeholder:text-slate-500"
+              />
+              <button
+                type="button"
+                onClick={selectAll}
+                disabled={filteredEquipment.length === 0}
+                className="rounded border border-slate-700 bg-slate-800 px-2 py-1 text-[11px] text-slate-200 hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Alle wählen{filter.trim() ? ' (gefiltert)' : ''}
+              </button>
+              <button
+                type="button"
+                onClick={selectNone}
+                disabled={selectionCount === 0}
+                className="rounded border border-slate-700 bg-slate-800 px-2 py-1 text-[11px] text-slate-200 hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Keines
+              </button>
+            </div>
+
+            {/* Device checklist */}
+            <div className="mb-3 max-h-[42vh] overflow-y-auto rounded border border-slate-800 bg-slate-950/40 p-1">
+              {sortedEquipment.length === 0 ? (
+                <div className="px-3 py-6 text-center text-[11px] text-slate-500">
+                  Keine Geräte im Projekt.
+                </div>
+              ) : filteredEquipment.length === 0 ? (
+                <div className="px-3 py-6 text-center text-[11px] text-slate-500">
+                  Kein Gerät passt zum Suchbegriff „{filter}".
+                </div>
+              ) : (
+                <ul className="space-y-0.5">
+                  {filteredEquipment.map((eq) => {
+                    const portCount = (eq.inputs?.length ?? 0) + (eq.outputs?.length ?? 0)
+                    const cableCount = cables.filter(
+                      (c) => c.fromEquipmentId === eq.id || c.toEquipmentId === eq.id,
+                    ).length
+                    return (
+                      <li key={eq.id}>
+                        <label className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-xs text-slate-200 hover:bg-slate-800/60">
+                          <input
+                            type="checkbox"
+                            checked={selectedIds.has(eq.id)}
+                            onChange={() => toggleDevice(eq.id)}
+                            className="h-3.5 w-3.5"
+                          />
+                          <div className="min-w-0 flex-1">
+                            <div className="truncate font-medium text-slate-100">{eq.name}</div>
+                            <div className="truncate text-[10px] text-slate-500">
+                              {[eq.category, eq.subtitle].filter(Boolean).join(' · ') || '—'}
+                            </div>
+                          </div>
+                          <span className="shrink-0 text-[10px] text-slate-500">
+                            {portCount} Ports · {cableCount} Kabel
+                          </span>
+                        </label>
+                      </li>
+                    )
+                  })}
+                </ul>
+              )}
+            </div>
+
+            {/* Options: paper format + output mode */}
+            <div className="grid grid-cols-2 gap-3">
+              <div className="rounded border border-slate-700 p-2">
+                <div className="mb-1 text-[10px] uppercase tracking-wide text-slate-400">
+                  Format
+                </div>
+                <label className="flex cursor-pointer items-center gap-2 text-xs text-slate-200">
+                  <input
+                    type="radio"
+                    name="print-format"
+                    checked={format === 'a4'}
+                    onChange={() => setFormat('a4')}
+                  />
+                  A4 (Standard)
+                </label>
+                <label className="flex cursor-pointer items-center gap-2 text-xs text-slate-200">
+                  <input
+                    type="radio"
+                    name="print-format"
+                    checked={format === 'a3'}
+                    onChange={() => setFormat('a3')}
+                  />
+                  A3 (mehr Ports / Seite)
+                </label>
+              </div>
+              <div className="rounded border border-slate-700 p-2">
+                <div className="mb-1 text-[10px] uppercase tracking-wide text-slate-400">
+                  Ausgabe
+                </div>
+                <label className="flex cursor-pointer items-center gap-2 text-xs text-slate-200">
+                  <input
+                    type="radio"
+                    name="print-mode"
+                    checked={mode === 'combined'}
+                    onChange={() => setMode('combined')}
+                  />
+                  Eine Sammel-PDF
+                </label>
+                <label className="flex cursor-pointer items-center gap-2 text-xs text-slate-200">
+                  <input
+                    type="radio"
+                    name="print-mode"
+                    checked={mode === 'individual'}
+                    onChange={() => setMode('individual')}
+                  />
+                  Einzelne PDFs pro Gerät
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+
+        <footer className="flex items-center justify-between gap-2 border-t border-slate-700 bg-slate-950/60 px-4 py-3">
+          <div className="text-[11px] text-slate-400">
+            {selectionCount === 0
+              ? 'Kein Gerät ausgewählt'
+              : `${selectionCount} Gerät${selectionCount === 1 ? '' : 'e'} ausgewählt`}
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded border border-slate-700 bg-slate-800 px-3 py-1.5 text-xs text-slate-100 hover:bg-slate-700"
+            >
+              Schließen
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleExportDevices()}
+              disabled={selectionCount === 0 || busy}
+              className="rounded bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {busy
+                ? 'Erzeuge PDF…'
+                : selectionCount > 1 && mode === 'individual'
+                  ? `🖨 ${selectionCount} PDFs herunterladen`
+                  : '🖨 Patch-Sheet PDF erzeugen'}
+            </button>
+          </div>
+        </footer>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/Properties/EquipmentProperties.tsx
+++ b/src/renderer/components/Properties/EquipmentProperties.tsx
@@ -22,6 +22,7 @@ import { useUiStore } from '../../store/uiStore'
 import { detectDeviceKind, detectNetworkDevice } from '../../lib/deviceKind'
 import { promptDialog } from '../../lib/promptDialog'
 import { useGreenGoBeltpack } from '../../lib/greengoSync'
+import { exportDevicePatchSheet } from '../../lib/exportDevicePdf'
 import { ALL_CONNECTOR_TYPES } from '../../types/equipment'
 import type { ConnectorType, Port, VlanDef, PortVlanAssignment } from '../../types/equipment'
 import { ALL_SIGNAL_STANDARDS } from '../../types/cableSpec'
@@ -1370,6 +1371,44 @@ export const EquipmentProperties = () => {
             title="Erstellt eine neue Vorlage unter anderem Namen — bestehende bleibt unverändert."
           >
             Als neues Gerät in Library speichern ✚
+          </button>
+        </div>
+      </div>
+
+      <div className="rounded border border-slate-700 bg-slate-900/40 p-2">
+        <div className="mb-1 text-[10px] uppercase tracking-wide text-slate-400">
+          Druck / Dokumentation
+        </div>
+        <div className="flex flex-col gap-1">
+          <button
+            type="button"
+            onClick={() =>
+              void exportDevicePatchSheet(
+                equipment,
+                useProjectStore.getState().project.equipment,
+                useProjectStore.getState().project.cables,
+                { format: 'a4' },
+              )
+            }
+            className="w-full rounded bg-sky-700 px-2 py-1 text-xs text-white hover:bg-sky-600"
+            title="Erzeugt eine einseitige A4-Patch-Liste mit allen Ports + verbundenen Kabeln — zum Aufkleben am Gerät (Issue #74)."
+          >
+            🖨 Patch-Sheet (A4 PDF) drucken
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              void exportDevicePatchSheet(
+                equipment,
+                useProjectStore.getState().project.equipment,
+                useProjectStore.getState().project.cables,
+                { format: 'a3' },
+              )
+            }
+            className="w-full rounded bg-sky-800 px-2 py-1 text-xs text-white hover:bg-sky-700"
+            title="A3-Variante für Geräte mit vielen Ports."
+          >
+            🖨 Patch-Sheet (A3 PDF) drucken
           </button>
         </div>
       </div>

--- a/src/renderer/components/Properties/EquipmentProperties.tsx
+++ b/src/renderer/components/Properties/EquipmentProperties.tsx
@@ -784,6 +784,69 @@ const GreenGoBeltpackSection = ({ equipmentId }: { equipmentId: string }) => {
   )
 }
 
+/**
+ * Issue #80: Per-device view of the global device-config library
+ * (uiStore.deviceConfigLibrary). Lists configs already assigned to
+ * this equipment, plus a dropdown to assign an existing unassigned
+ * config to it. Upload/management of the library itself lives in
+ * Settings → Konfigurationen.
+ */
+const DeviceConfigsBlock = ({ equipmentId }: { equipmentId: string }) => {
+  const library = useUiStore((s) => s.deviceConfigLibrary)
+  const updateDeviceConfig = useUiStore((s) => s.updateDeviceConfig)
+  const assigned = library.filter((e) => e.equipmentId === equipmentId)
+  const unassigned = library.filter((e) => !e.equipmentId)
+  if (library.length === 0) return null
+  return (
+    <div className="rounded border border-slate-700 bg-slate-900/40 p-2">
+      <div className="mb-1 text-[10px] uppercase tracking-wide text-slate-400">
+        Konfigurationen
+      </div>
+      {assigned.length === 0 ? (
+        <div className="text-[11px] text-slate-500">Keine Konfiguration zugeordnet.</div>
+      ) : (
+        <ul className="mb-2 space-y-1">
+          {assigned.map((e) => (
+            <li key={e.id} className="flex items-center gap-2 rounded bg-slate-950 px-2 py-1 text-[11px]">
+              <span className="flex-1 truncate" title={`${e.fileName} (${e.kind})`}>
+                {e.name}
+              </span>
+              <span className="shrink-0 text-[10px] text-slate-500">{e.kind}</span>
+              <button
+                type="button"
+                onClick={() => updateDeviceConfig(e.id, { equipmentId: undefined })}
+                className="rounded bg-slate-800 px-1.5 py-0.5 text-[10px] text-slate-300 hover:bg-red-700 hover:text-white"
+                title="Zuordnung lösen (Datei bleibt in der Bibliothek)"
+              >
+                Lösen
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {unassigned.length > 0 && (
+        <select
+          value=""
+          onChange={(e) => {
+            if (e.target.value) updateDeviceConfig(e.target.value, { equipmentId })
+          }}
+          className="w-full rounded border border-slate-700 bg-slate-950 p-1 text-[11px]"
+        >
+          <option value="">+ Vorhandene Konfiguration zuordnen…</option>
+          {unassigned.map((e) => (
+            <option key={e.id} value={e.id}>
+              {e.kind} · {e.name}
+            </option>
+          ))}
+        </select>
+      )}
+      <div className="mt-1 text-[10px] text-slate-500">
+        Neue Konfigurationen über Einstellungen → Konfigurationen hochladen.
+      </div>
+    </div>
+  )
+}
+
 export const EquipmentProperties = () => {
   const t = useTranslation()
   const selectedEquipmentId = useProjectStore((state) => state.selectedEquipmentId)
@@ -1374,6 +1437,8 @@ export const EquipmentProperties = () => {
           </button>
         </div>
       </div>
+
+      <DeviceConfigsBlock equipmentId={equipment.id} />
 
       <div className="rounded border border-slate-700 bg-slate-900/40 p-2">
         <div className="mb-1 text-[10px] uppercase tracking-wide text-slate-400">

--- a/src/renderer/components/Properties/PropertiesPanel.tsx
+++ b/src/renderer/components/Properties/PropertiesPanel.tsx
@@ -34,28 +34,32 @@ export const PropertiesPanel = () => {
 
   if (collapsed) {
     return (
-      <aside className="flex h-full w-8 flex-col items-center border-l border-slate-700 bg-slate-950 py-2">
+      <aside className="group flex h-full w-8 flex-col items-center border-l border-slate-700 bg-slate-950 transition-colors hover:bg-slate-900">
         <button
           type="button"
           onClick={toggle}
-          title="Expand properties"
-          className="rounded px-1 py-2 text-slate-300 hover:bg-slate-800"
+          title="Eigenschaften einblenden"
+          aria-label="Eigenschaften einblenden"
+          className="mt-2 flex h-7 w-7 items-center justify-center rounded-full border border-slate-700 bg-slate-900 text-slate-300 shadow-sm transition-all hover:border-sky-500 hover:bg-slate-800 hover:text-sky-300"
         >
-          ◄
+          <span className="text-base leading-none">‹</span>
         </button>
-        <div
-          className="mt-4 text-[10px] uppercase tracking-wider text-slate-500"
+        <button
+          type="button"
+          onClick={toggle}
+          aria-label="Eigenschaften einblenden"
+          className="mt-3 flex-1 self-stretch text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500 transition-colors hover:text-slate-300"
           style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}
         >
-          Properties
-        </div>
+          Eigenschaften
+        </button>
       </aside>
     )
   }
 
   return (
-    <aside className="flex h-full min-h-0 flex-col border-l border-slate-700 bg-slate-950 p-3 text-slate-100">
-      <div className="mb-3 flex items-start justify-between gap-2">
+    <aside className="flex h-full min-h-0 flex-col border-l border-slate-700 bg-slate-950 text-slate-100">
+      <div className="flex items-start justify-between gap-2 border-b border-slate-800 px-3 py-2.5">
         <div className="min-w-0">
           <h2 className="truncate text-sm font-semibold">{title}</h2>
           <div className="mt-0.5 text-[10px] uppercase tracking-wide text-slate-500">
@@ -65,13 +69,14 @@ export const PropertiesPanel = () => {
         <button
           type="button"
           onClick={toggle}
-          title="Collapse properties"
-          className="rounded px-2 py-0.5 text-xs text-slate-300 hover:bg-slate-800"
+          title="Eigenschaften ausblenden"
+          aria-label="Eigenschaften ausblenden"
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-slate-700 bg-slate-900 text-slate-300 transition-all hover:border-sky-500 hover:bg-slate-800 hover:text-sky-300"
         >
-          ►
+          <span className="text-base leading-none">›</span>
         </button>
       </div>
-      <div className="flex-1 min-h-0 overflow-auto">
+      <div className="flex-1 min-h-0 overflow-auto px-3 pb-3 pt-3">
         {selectedEquipmentId && <EquipmentProperties />}
         {selectedCableId && <CableProperties />}
         {selectedLocationId && <LocationProperties />}

--- a/src/renderer/components/Settings/SettingsDialog.tsx
+++ b/src/renderer/components/Settings/SettingsDialog.tsx
@@ -18,6 +18,7 @@ import {
   loadGreenGoPresets,
   saveGreenGoPreset,
 } from '../../lib/greengoSync'
+import type { DeviceConfigEntry, DeviceConfigKind } from '../../store/uiStore'
 
 interface SettingsDialogProps {
   open: boolean
@@ -29,6 +30,7 @@ type SettingsSection =
   | 'appearance'
   | 'editing'
   | 'integrations'
+  | 'configs'
   | 'sync'
   | 'advanced'
 
@@ -37,6 +39,7 @@ const TAB_ICONS: Record<SettingsSection, string> = {
   appearance: '🎨',
   editing: '✏️',
   integrations: '🔌',
+  configs: '🗄',
   sync: '🔄',
   advanced: '⚙',
 }
@@ -46,6 +49,7 @@ const TAB_FALLBACK_LABEL: Record<SettingsSection, string> = {
   appearance: 'Darstellung',
   editing: 'Bearbeiten',
   integrations: 'Integrationen',
+  configs: 'Konfigurationen',
   sync: 'Netzwerk-Sync',
   advanced: 'Erweitert',
 }
@@ -55,6 +59,7 @@ const TAB_FALLBACK_TITLE: Record<SettingsSection, string> = {
   appearance: 'Darstellung',
   editing: 'Bearbeiten',
   integrations: 'Integrationen',
+  configs: 'Geräte-Konfigurationen',
   sync: 'Netzwerk-Sync',
   advanced: 'Erweitert',
 }
@@ -118,6 +123,7 @@ export const SettingsDialog = ({ open, onClose }: SettingsDialogProps) => {
             {section === 'appearance' && <AppearanceTab />}
             {section === 'editing' && <EditingTab />}
             {section === 'integrations' && <IntegrationsTab onClose={onClose} />}
+            {section === 'configs' && <ConfigsTab />}
             {section === 'sync' && <SyncTab />}
             {section === 'advanced' && <AdvancedTab />}
           </div>
@@ -1155,6 +1161,331 @@ const GreenGoPresetsCard = () => {
         </ul>
       )}
     </SettingsCard>
+  )
+}
+
+// --- Tab: Configs (Issue #80) ---------------------------------------------
+
+const CONFIG_KIND_LABEL: Record<DeviceConfigKind, string> = {
+  'atem-mv': 'ATEM Multiviewer Layout',
+  'atem-audio': 'ATEM Fairlight Audio',
+  'videohub-labels': 'Videohub Labels',
+  'videohub-routing': 'Videohub Routing',
+  greengo: 'GreenGo Intercom (.gg5)',
+  other: 'Sonstige',
+}
+
+const CONFIG_KIND_ICON: Record<DeviceConfigKind, string> = {
+  'atem-mv': '🟦',
+  'atem-audio': '🟪',
+  'videohub-labels': '🟣',
+  'videohub-routing': '🟣',
+  greengo: '🟢',
+  other: '📄',
+}
+
+const guessKindFromFileName = (fileName: string): DeviceConfigKind => {
+  const lower = fileName.toLowerCase()
+  if (lower.endsWith('.gg5')) return 'greengo'
+  if (lower.includes('multiview') || lower.includes('mvw') || lower.includes('mv-layout'))
+    return 'atem-mv'
+  if (lower.includes('audio') || lower.includes('fairlight')) return 'atem-audio'
+  if (lower.includes('label')) return 'videohub-labels'
+  if (lower.includes('routing') || lower.includes('matrix')) return 'videohub-routing'
+  if (lower.endsWith('.xml') && lower.includes('atem')) return 'atem-mv'
+  return 'other'
+}
+
+const downloadConfig = (entry: DeviceConfigEntry) => {
+  const blob = new Blob([entry.content], { type: entry.mimeType || 'application/octet-stream' })
+  const a = document.createElement('a')
+  a.href = URL.createObjectURL(blob)
+  a.download = entry.fileName || `${entry.name}.txt`
+  a.click()
+  URL.revokeObjectURL(a.href)
+}
+
+const pickTextFile = (): Promise<{ name: string; content: string; mimeType: string } | null> =>
+  new Promise((resolve) => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = '.xml,.json,.gg5,.txt,.csv,application/xml,application/json,text/plain'
+    input.onchange = () => {
+      const file = input.files?.[0]
+      if (!file) {
+        resolve(null)
+        return
+      }
+      const reader = new FileReader()
+      reader.onload = () =>
+        resolve({
+          name: file.name,
+          mimeType: file.type || 'application/octet-stream',
+          content: typeof reader.result === 'string' ? reader.result : '',
+        })
+      reader.onerror = () => resolve(null)
+      reader.readAsText(file)
+    }
+    input.click()
+  })
+
+const ConfigsTab = () => {
+  const t = useTranslation()
+  const library = useUiStore((s) => s.deviceConfigLibrary)
+  const addDeviceConfig = useUiStore((s) => s.addDeviceConfig)
+  const updateDeviceConfig = useUiStore((s) => s.updateDeviceConfig)
+  const removeDeviceConfig = useUiStore((s) => s.removeDeviceConfig)
+  const replaceDeviceConfigLibrary = useUiStore((s) => s.replaceDeviceConfigLibrary)
+  const equipment = useProjectStore((s) => s.project.equipment)
+  const [filter, setFilter] = useState<DeviceConfigKind | 'all'>('all')
+
+  const grouped = useMemo(() => {
+    const filtered = filter === 'all' ? library : library.filter((e) => e.kind === filter)
+    const byKind = new Map<DeviceConfigKind, DeviceConfigEntry[]>()
+    for (const entry of filtered) {
+      const list = byKind.get(entry.kind) ?? []
+      list.push(entry)
+      byKind.set(entry.kind, list)
+    }
+    return byKind
+  }, [library, filter])
+
+  const handleUpload = async () => {
+    const file = await pickTextFile()
+    if (!file) return
+    const kind = guessKindFromFileName(file.name)
+    addDeviceConfig({
+      kind,
+      name: file.name.replace(/\.[^.]+$/, ''),
+      fileName: file.name,
+      mimeType: file.mimeType,
+      content: file.content,
+    })
+  }
+
+  const handleExportBundle = () => {
+    const blob = new Blob([JSON.stringify({ version: 1, library }, null, 2)], {
+      type: 'application/json',
+    })
+    const a = document.createElement('a')
+    a.href = URL.createObjectURL(blob)
+    a.download = `cable-planner-konfigurationen-${new Date().toISOString().slice(0, 10)}.json`
+    a.click()
+    URL.revokeObjectURL(a.href)
+  }
+
+  const handleImportBundle = async () => {
+    const file = await pickTextFile()
+    if (!file) return
+    try {
+      const parsed = JSON.parse(file.content) as { version?: number; library?: DeviceConfigEntry[] }
+      if (!parsed.library || !Array.isArray(parsed.library)) {
+        window.alert('Datei enthält kein gültiges Konfigurations-Bundle.')
+        return
+      }
+      const replace = window.confirm(
+        `${parsed.library.length} Konfigurationen aus der Datei laden?\n\nOK = bestehende Bibliothek ersetzen\nAbbrechen = neue Konfigurationen anhängen`,
+      )
+      if (replace) {
+        replaceDeviceConfigLibrary(parsed.library)
+      } else {
+        // Append, but assign fresh ids so we never collide with existing ones.
+        for (const entry of parsed.library) {
+          const { id: _drop, savedAt: _drop2, ...rest } = entry
+          void _drop
+          void _drop2
+          addDeviceConfig(rest)
+        }
+      }
+    } catch (err) {
+      window.alert(`Fehler beim Import: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-slate-400">
+        {t(
+          'settings.configs.intro',
+          'Globale Bibliothek von Geräte-Konfigurationen (ATEM, Videohub, GreenGo). Lade Dateien hier hoch, lade sie als Datei wieder herunter, oder weise einer canvas-Gerät die passende Config zu (im Properties-Panel des Geräts).',
+        )}
+      </p>
+
+      <SettingsCard
+        title={t('settings.configs.upload.title', 'Neue Konfiguration hochladen')}
+        description={t(
+          'settings.configs.upload.desc',
+          'XML / JSON / TXT / .gg5 — der Typ wird aus dem Dateinamen geraten und kann unten geändert werden.',
+        )}
+      >
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => void handleUpload()}
+            className="rounded bg-sky-700 px-3 py-1 text-xs text-white hover:bg-sky-600"
+          >
+            📤 Datei wählen…
+          </button>
+          <button
+            type="button"
+            onClick={handleExportBundle}
+            disabled={library.length === 0}
+            className="rounded bg-emerald-700 px-3 py-1 text-xs text-white hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            💾 Bibliothek als JSON exportieren
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleImportBundle()}
+            className="rounded bg-amber-700 px-3 py-1 text-xs text-white hover:bg-amber-600"
+          >
+            ⤵ JSON-Bibliothek importieren…
+          </button>
+        </div>
+      </SettingsCard>
+
+      <SettingsCard
+        title={t('settings.configs.library.title', 'Konfigurations-Bibliothek')}
+        description={
+          library.length === 0
+            ? t(
+                'settings.configs.library.empty',
+                'Noch keine Konfigurationen hochgeladen.',
+              )
+            : `${library.length} Einträge`
+        }
+      >
+        <div className="mb-2 flex flex-wrap gap-1">
+          {(['all', 'atem-mv', 'atem-audio', 'videohub-labels', 'videohub-routing', 'greengo', 'other'] as const).map(
+            (k) => (
+              <button
+                key={k}
+                type="button"
+                onClick={() => setFilter(k)}
+                className={`rounded px-2 py-0.5 text-[11px] ${
+                  filter === k
+                    ? 'bg-sky-700 text-white'
+                    : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+                }`}
+              >
+                {k === 'all'
+                  ? `Alle (${library.length})`
+                  : `${CONFIG_KIND_ICON[k]} ${CONFIG_KIND_LABEL[k]} (${
+                      library.filter((e) => e.kind === k).length
+                    })`}
+              </button>
+            ),
+          )}
+        </div>
+
+        {library.length === 0 ? (
+          <div className="rounded border border-dashed border-slate-700 p-4 text-center text-[11px] text-slate-500">
+            Lade die erste Konfigurationsdatei hoch — sie wird hier gelistet und kann anschließend
+            einem Gerät auf dem Canvas zugeordnet werden.
+          </div>
+        ) : grouped.size === 0 ? (
+          <div className="rounded border border-dashed border-slate-700 p-4 text-center text-[11px] text-slate-500">
+            Kein Eintrag passt zum gewählten Filter.
+          </div>
+        ) : (
+          <ul className="space-y-2">
+            {Array.from(grouped.entries()).map(([kind, entries]) => (
+              <li key={kind}>
+                <div className="mb-1 text-[10px] uppercase tracking-wide text-slate-500">
+                  {CONFIG_KIND_ICON[kind]} {CONFIG_KIND_LABEL[kind]}
+                </div>
+                <ul className="space-y-1">
+                  {entries.map((entry) => {
+                    const linked = entry.equipmentId
+                      ? equipment.find((eq) => eq.id === entry.equipmentId)
+                      : undefined
+                    return (
+                      <li
+                        key={entry.id}
+                        className="flex flex-wrap items-center gap-2 rounded border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs"
+                      >
+                        <input
+                          type="text"
+                          value={entry.name}
+                          onChange={(e) => updateDeviceConfig(entry.id, { name: e.target.value })}
+                          className="min-w-0 flex-1 rounded border border-slate-700 bg-slate-950 px-1.5 py-0.5 text-slate-100"
+                        />
+                        <select
+                          value={entry.kind}
+                          onChange={(e) =>
+                            updateDeviceConfig(entry.id, {
+                              kind: e.target.value as DeviceConfigKind,
+                            })
+                          }
+                          className="rounded border border-slate-700 bg-slate-900 px-1 py-0.5 text-[11px] text-slate-200"
+                        >
+                          {(Object.keys(CONFIG_KIND_LABEL) as DeviceConfigKind[]).map((k) => (
+                            <option key={k} value={k}>
+                              {CONFIG_KIND_LABEL[k]}
+                            </option>
+                          ))}
+                        </select>
+                        <select
+                          value={entry.equipmentId ?? ''}
+                          onChange={(e) =>
+                            updateDeviceConfig(entry.id, {
+                              equipmentId: e.target.value || undefined,
+                            })
+                          }
+                          className="rounded border border-slate-700 bg-slate-900 px-1 py-0.5 text-[11px] text-slate-200"
+                          title="Gerät auf dem Canvas, dem diese Konfiguration zugeordnet ist"
+                        >
+                          <option value="">(unzugeordnet)</option>
+                          {equipment.map((eq) => (
+                            <option key={eq.id} value={eq.id}>
+                              {eq.name}
+                            </option>
+                          ))}
+                        </select>
+                        <span
+                          className="hidden text-[10px] text-slate-500 sm:inline"
+                          title={`Originaldatei: ${entry.fileName}\nHochgeladen: ${new Date(
+                            entry.savedAt,
+                          ).toLocaleString()}\n${entry.content.length.toLocaleString()} Zeichen`}
+                        >
+                          {entry.fileName}{linked ? ' · ✓' : ''}
+                        </span>
+                        <div className="flex shrink-0 gap-1">
+                          <button
+                            type="button"
+                            onClick={() => downloadConfig(entry)}
+                            className="rounded bg-slate-700 px-2 py-0.5 text-[11px] text-slate-100 hover:bg-slate-600"
+                            title="Originaldatei herunterladen"
+                          >
+                            ⬇
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              if (
+                                window.confirm(
+                                  `Konfiguration "${entry.name}" löschen? Die Datei selbst auf der Festplatte bleibt unverändert.`,
+                                )
+                              ) {
+                                removeDeviceConfig(entry.id)
+                              }
+                            }}
+                            className="rounded bg-slate-800 px-2 py-0.5 text-[11px] text-slate-300 hover:bg-red-700 hover:text-white"
+                            title="Aus Bibliothek entfernen"
+                          >
+                            ✕
+                          </button>
+                        </div>
+                      </li>
+                    )
+                  })}
+                </ul>
+              </li>
+            ))}
+          </ul>
+        )}
+      </SettingsCard>
+    </div>
   )
 }
 

--- a/src/renderer/components/Settings/SettingsDialog.tsx
+++ b/src/renderer/components/Settings/SettingsDialog.tsx
@@ -701,7 +701,82 @@ const EditingTab = () => {
           />
         </label>
       </SettingsCard>
+
+      <CustomCableTypesCard />
     </div>
+  )
+}
+
+/**
+ * Manage the library of user-defined cable specs (issue #64). Built-in
+ * specs from `cableCatalog` are read-only and not shown here; only the
+ * user's own entries appear with rename / colour / delete controls.
+ *
+ * Adding a new spec is normally done inline from the Cable dialog via
+ * "Als Kabel-Typ speichern" — this card is the corresponding management
+ * surface for cleanup and tweaks. Avoids duplicating the full editor.
+ */
+const CustomCableTypesCard = () => {
+  const t = useTranslation()
+  const specs = useUiStore((s) => s.customCableSpecs)
+  const updateSpec = useUiStore((s) => s.updateCustomCableSpec)
+  const removeSpec = useUiStore((s) => s.removeCustomCableSpec)
+  return (
+    <SettingsCard
+      title={t('settings.customCables.title', 'Eigene Kabel-Typen')}
+      description={t(
+        'settings.customCables.desc',
+        'Vom User angelegte Kabel-Typen. Anlegen geht im Kabel-Dialog über "Als Kabel-Typ speichern" wenn "Custom Cable" gewählt ist.',
+      )}
+    >
+      {specs.length === 0 ? (
+        <p className="text-[11px] text-slate-500">
+          {t('settings.customCables.empty', 'Noch keine eigenen Kabel-Typen gespeichert.')}
+        </p>
+      ) : (
+        <ul className="space-y-1">
+          {specs.map((spec) => (
+            <li
+              key={spec.id}
+              className="flex items-center gap-2 rounded border border-slate-800 bg-slate-950 px-2 py-1 text-xs"
+            >
+              <input
+                type="color"
+                value={spec.color}
+                onChange={(e) => updateSpec(spec.id, { color: e.target.value })}
+                className="h-6 w-7 cursor-pointer rounded border border-slate-700 bg-slate-900 p-0.5"
+                aria-label="Kabel-Farbe"
+              />
+              <input
+                type="text"
+                value={spec.name}
+                onChange={(e) => updateSpec(spec.id, { name: e.target.value })}
+                className="flex-1 rounded border border-slate-700 bg-slate-950 px-1.5 py-0.5 text-slate-100"
+              />
+              <span className="text-[10px] text-slate-500">
+                {spec.connectorType}
+                {spec.maxLengthMeters ? ` · max ${spec.maxLengthMeters} m` : ''}
+              </span>
+              <button
+                type="button"
+                onClick={() => {
+                  if (
+                    window.confirm(
+                      `Kabel-Typ "${spec.name}" wirklich löschen? Bereits damit verlegte Kabel auf dem Canvas bleiben unverändert, lassen sich aber nicht mehr neu auf diesen Typ setzen.`,
+                    )
+                  ) {
+                    removeSpec(spec.id)
+                  }
+                }}
+                className="rounded bg-slate-800 px-2 py-0.5 text-[10px] text-slate-300 hover:bg-red-700 hover:text-white"
+              >
+                {t('common.delete', 'Löschen')}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </SettingsCard>
   )
 }
 

--- a/src/renderer/components/Settings/SettingsDialog.tsx
+++ b/src/renderer/components/Settings/SettingsDialog.tsx
@@ -19,6 +19,7 @@ import {
   saveGreenGoPreset,
 } from '../../lib/greengoSync'
 import type { DeviceConfigEntry, DeviceConfigKind } from '../../store/uiStore'
+import { HOTKEY_ACTION_LABEL, comboFromEvent } from '../../lib/hotkeys'
 
 interface SettingsDialogProps {
   open: boolean
@@ -29,6 +30,7 @@ type SettingsSection =
   | 'project'
   | 'appearance'
   | 'editing'
+  | 'hotkeys'
   | 'integrations'
   | 'configs'
   | 'sync'
@@ -38,6 +40,7 @@ const TAB_ICONS: Record<SettingsSection, string> = {
   project: '📋',
   appearance: '🎨',
   editing: '✏️',
+  hotkeys: '⌨',
   integrations: '🔌',
   configs: '🗄',
   sync: '🔄',
@@ -48,6 +51,7 @@ const TAB_FALLBACK_LABEL: Record<SettingsSection, string> = {
   project: 'Projekt',
   appearance: 'Darstellung',
   editing: 'Bearbeiten',
+  hotkeys: 'Hotkeys',
   integrations: 'Integrationen',
   configs: 'Konfigurationen',
   sync: 'Netzwerk-Sync',
@@ -58,6 +62,7 @@ const TAB_FALLBACK_TITLE: Record<SettingsSection, string> = {
   project: 'Projekt-Einstellungen',
   appearance: 'Darstellung',
   editing: 'Bearbeiten',
+  hotkeys: 'Tastenkürzel',
   integrations: 'Integrationen',
   configs: 'Geräte-Konfigurationen',
   sync: 'Netzwerk-Sync',
@@ -122,6 +127,7 @@ export const SettingsDialog = ({ open, onClose }: SettingsDialogProps) => {
             {section === 'project' && <ProjectTab onClose={onClose} />}
             {section === 'appearance' && <AppearanceTab />}
             {section === 'editing' && <EditingTab />}
+            {section === 'hotkeys' && <HotkeysTab />}
             {section === 'integrations' && <IntegrationsTab onClose={onClose} />}
             {section === 'configs' && <ConfigsTab />}
             {section === 'sync' && <SyncTab />}
@@ -708,8 +714,54 @@ const EditingTab = () => {
         </label>
       </SettingsCard>
 
+      <CableVisualOptionsCard />
+
       <CustomCableTypesCard />
     </div>
+  )
+}
+
+/** Issue #65 / #53: visual options for orthogonal cable routing.
+ *  Cable bumps draw a small arc on crossings; collision-shift moves
+ *  parallel midlines apart so cables don't overlay. Both are stored
+ *  in uiStore so they persist across sessions. */
+const CableVisualOptionsCard = () => {
+  const t = useTranslation()
+  const cableBumps = useUiStore((s) => s.cableBumps)
+  const setCableBumps = useUiStore((s) => s.setCableBumps)
+  const orthogonalCollisionShift = useUiStore((s) => s.orthogonalCollisionShift)
+  const setOrthogonalCollisionShift = useUiStore((s) => s.setOrthogonalCollisionShift)
+  return (
+    <SettingsCard
+      title={t('settings.editing.cableVisuals', 'Kabel-Darstellung')}
+      description={t(
+        'settings.editing.cableVisualsDesc',
+        'Visuelle Hilfen für orthogonal verlegte Kabel (yEd-ähnliche Brücken bei Kreuzungen und automatische Versetzung sich überlagernder Mittellinien).',
+      )}
+    >
+      <label className="mb-2 flex items-center gap-2 text-sm text-slate-200">
+        <input
+          type="checkbox"
+          checked={cableBumps}
+          onChange={(e) => setCableBumps(e.target.checked)}
+        />
+        {t(
+          'settings.editing.cableBumps',
+          'Kreuzungs-Brücken auf orthogonalen Kabeln (#65, experimentell — globale Berechnung in v0.11)',
+        )}
+      </label>
+      <label className="flex items-center gap-2 text-sm text-slate-200">
+        <input
+          type="checkbox"
+          checked={orthogonalCollisionShift}
+          onChange={(e) => setOrthogonalCollisionShift(e.target.checked)}
+        />
+        {t(
+          'settings.editing.collisionShift',
+          'Mittellinien automatisch versetzen wenn Kabel sich überlagern (#53, experimentell)',
+        )}
+      </label>
+    </SettingsCard>
   )
 }
 
@@ -783,6 +835,101 @@ const CustomCableTypesCard = () => {
         </ul>
       )}
     </SettingsCard>
+  )
+}
+
+// --- Tab: Hotkeys (Issue #69) ---------------------------------------------
+
+const HotkeyRow = ({
+  action,
+  combo,
+  onChange,
+}: {
+  action: string
+  combo: string
+  onChange: (combo: string) => void
+}) => {
+  const [capturing, setCapturing] = useState(false)
+  const label = HOTKEY_ACTION_LABEL[action] ?? action
+  return (
+    <li className="flex items-center gap-2 rounded border border-slate-800 bg-slate-950 px-2 py-1.5 text-xs">
+      <span className="flex-1 truncate text-slate-200">{label}</span>
+      <button
+        type="button"
+        onClick={() => setCapturing(true)}
+        onBlur={() => setCapturing(false)}
+        onKeyDown={(e) => {
+          if (!capturing) return
+          e.preventDefault()
+          const next = comboFromEvent(e)
+          if (next) {
+            onChange(next)
+            setCapturing(false)
+          }
+        }}
+        className={`min-w-[120px] rounded border px-2 py-1 text-center font-mono text-[11px] ${
+          capturing
+            ? 'border-sky-500 bg-sky-950/60 text-sky-200'
+            : 'border-slate-700 bg-slate-900 text-slate-300 hover:border-slate-600'
+        }`}
+        title={capturing ? 'Taste oder Tasten-Kombination drücken…' : 'Klicken und Taste(n) drücken'}
+      >
+        {capturing ? 'Taste drücken…' : combo || '—'}
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange('')}
+        className="rounded bg-slate-800 px-1.5 py-0.5 text-[10px] text-slate-400 hover:bg-red-700 hover:text-white"
+        title="Hotkey leeren"
+      >
+        ✕
+      </button>
+    </li>
+  )
+}
+
+const HotkeysTab = () => {
+  const t = useTranslation()
+  const hotkeys = useUiStore((s) => s.hotkeys)
+  const setHotkey = useUiStore((s) => s.setHotkey)
+  const resetHotkeys = useUiStore((s) => s.resetHotkeys)
+  const actions = Object.keys(HOTKEY_ACTION_LABEL)
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-slate-400">
+        {t(
+          'settings.hotkeys.intro',
+          'Tastenkürzel können hier frei belegt werden. Klicke auf eine Combo-Zelle und drücke die gewünschten Tasten — Ctrl/Shift/Alt + Buchstabe oder Funktionstaste.',
+        )}
+      </p>
+      <SettingsCard
+        title={t('settings.hotkeys.title', 'Aktive Tastenkürzel')}
+        description={t(
+          'settings.hotkeys.desc',
+          'Format: Ctrl+Shift+S. Leere Felder deaktivieren den Hotkey. Doppel-Belegungen sind erlaubt — der zuerst gefundene Hotkey gewinnt.',
+        )}
+      >
+        <ul className="space-y-1">
+          {actions.map((action) => (
+            <HotkeyRow
+              key={action}
+              action={action}
+              combo={hotkeys[action] ?? ''}
+              onChange={(combo) => setHotkey(action, combo)}
+            />
+          ))}
+        </ul>
+        <div className="mt-3 flex justify-end">
+          <button
+            type="button"
+            onClick={resetHotkeys}
+            className="rounded bg-slate-800 px-3 py-1 text-xs text-slate-300 hover:bg-slate-700"
+          >
+            {t('settings.hotkeys.reset', 'Auf Standard zurücksetzen')}
+          </button>
+        </div>
+      </SettingsCard>
+    </div>
   )
 }
 

--- a/src/renderer/lib/exportDevicePdf.ts
+++ b/src/renderer/lib/exportDevicePdf.ts
@@ -1,0 +1,223 @@
+// Per-device "patch sheet" PDF (issue #74).
+//
+// One A4 portrait page per device, intended to be printed and stuck on
+// the physical hardware so the operator on-site sees exactly which
+// cable goes into which port without consulting the full plan PDF.
+//
+// Layout:
+//   ┌─────────────────────────────────────────────────────────┐
+//   │  Device name                                Date stamp │
+//   │  Category · IP                                          │
+//   ├─────────────────────────┬───────────────────────────────┤
+//   │  INPUTS                 │  OUTPUTS                      │
+//   │  · Port name [type]     │  · Port name [type]           │
+//   │    → cable name (m)     │    → cable name (m)           │
+//   │      from other device  │      to other device          │
+//   │  …                      │  …                            │
+//   └─────────────────────────┴───────────────────────────────┘
+//
+// Cables that have a stable graphmlId / serial number / name show that
+// info first so technicians can match the printed sheet to the labels
+// they put on the physical cables.
+
+import jsPDF from 'jspdf'
+import type { Cable } from '../types/cable'
+import type { EquipmentItem, Port } from '../types/equipment'
+
+interface CableEndpointSummary {
+  /** Human-readable label for the cable (name OR fallback to type+length). */
+  cableLabel: string
+  /** Name of the device on the other side of this cable. */
+  otherDeviceName: string
+  /** Name of the port on the other side, if known. */
+  otherPortName: string | null
+  cable: Cable
+}
+
+const summarizeEndpoint = (
+  cable: Cable,
+  myEquipmentId: string,
+  allEquipment: EquipmentItem[],
+): CableEndpointSummary => {
+  const isFromMe = cable.fromEquipmentId === myEquipmentId
+  const otherId = isFromMe ? cable.toEquipmentId : cable.fromEquipmentId
+  const otherPortId = isFromMe ? cable.toPortId : cable.fromPortId
+  const other = allEquipment.find((e) => e.id === otherId)
+  const otherPort: Port | undefined = other
+    ? [...(other.inputs ?? []), ...(other.outputs ?? [])].find((p) => p.id === otherPortId)
+    : undefined
+  const lengthLabel = cable.length ? `${cable.length} m` : ''
+  const typeLabel = cable.type ? String(cable.type) : ''
+  const baseLabel = [typeLabel, lengthLabel].filter(Boolean).join(' · ') || 'Kabel'
+  const cableLabel = cable.name?.trim() ? `${cable.name.trim()}  (${baseLabel})` : baseLabel
+  return {
+    cableLabel,
+    otherDeviceName: other?.name ?? 'unbekannt',
+    otherPortName: otherPort?.name ?? null,
+    cable,
+  }
+}
+
+/** Group a device's ports + the cables incident on each port. Ports
+ *  with no cable still appear (the printed sheet doubles as a checklist
+ *  during build-up). */
+const collectPortRows = (
+  device: EquipmentItem,
+  ports: Port[],
+  myEquipmentId: string,
+  allCables: Cable[],
+  allEquipment: EquipmentItem[],
+): Array<{ port: Port; cables: CableEndpointSummary[] }> => {
+  void device
+  return ports.map((port) => {
+    const cables = allCables
+      .filter((c) =>
+        (c.fromEquipmentId === myEquipmentId && c.fromPortId === port.id) ||
+        (c.toEquipmentId === myEquipmentId && c.toPortId === port.id),
+      )
+      .map((c) => summarizeEndpoint(c, myEquipmentId, allEquipment))
+    return { port, cables }
+  })
+}
+
+const drawColumn = (
+  pdf: jsPDF,
+  title: string,
+  rows: Array<{ port: Port; cables: CableEndpointSummary[] }>,
+  xStart: number,
+  yStart: number,
+  colWidth: number,
+  pageBottom: number,
+  margin: number,
+) => {
+  let x = xStart
+  let y = yStart
+  pdf.setFontSize(11)
+  pdf.setTextColor(20)
+  pdf.text(title, x, y)
+  y += 14
+  pdf.setFontSize(9)
+
+  for (const row of rows) {
+    // Page-break: if a port row wouldn't fit fully in the current page,
+    // start a fresh page. The drawColumn caller resets x/y when it
+    // detects we wrapped, but for the per-port renderer we play safe.
+    if (y > pageBottom - 30) {
+      pdf.addPage()
+      y = margin + 4
+    }
+    pdf.setTextColor(15)
+    pdf.setFont('helvetica', 'bold')
+    const portLine = `■ ${row.port.name || row.port.id}`
+    const portType = row.port.connectorType ? `  [${row.port.connectorType}]` : ''
+    pdf.text(`${portLine}${portType}`, x, y, { maxWidth: colWidth - 4 })
+    pdf.setFont('helvetica', 'normal')
+    y += 12
+
+    if (row.cables.length === 0) {
+      pdf.setTextColor(140)
+      pdf.text('  → frei', x, y)
+      y += 11
+      pdf.setTextColor(15)
+      continue
+    }
+    for (const c of row.cables) {
+      pdf.setTextColor(15)
+      pdf.text(`  → ${c.cableLabel}`, x, y, { maxWidth: colWidth - 6 })
+      y += 11
+      pdf.setTextColor(80)
+      const tgt = c.otherPortName
+        ? `       zu ${c.otherDeviceName} · ${c.otherPortName}`
+        : `       zu ${c.otherDeviceName}`
+      pdf.text(tgt, x, y, { maxWidth: colWidth - 6 })
+      y += 11
+    }
+    y += 4 // small gap between port rows
+  }
+  return y
+}
+
+export const exportDevicePatchSheet = async (
+  device: EquipmentItem,
+  allEquipment: EquipmentItem[],
+  allCables: Cable[],
+  options?: { format?: 'a4' | 'a3' },
+): Promise<void> => {
+  const format = options?.format ?? 'a4'
+  const pdf = new jsPDF({ orientation: 'portrait', unit: 'pt', format })
+  const pageWidth = pdf.internal.pageSize.getWidth()
+  const pageHeight = pdf.internal.pageSize.getHeight()
+  const margin = 32
+  const pageBottom = pageHeight - margin
+
+  // Header — device name + meta line
+  pdf.setFontSize(16)
+  pdf.setTextColor(15)
+  pdf.text(device.name || 'Gerät', margin, margin + 4)
+
+  pdf.setFontSize(9)
+  pdf.setTextColor(80)
+  const metaParts: string[] = []
+  if (device.category) metaParts.push(device.category)
+  if (device.subtitle) metaParts.push(device.subtitle)
+  if (device.ipAddress) metaParts.push(`IP ${device.ipAddress}`)
+  pdf.text(metaParts.join('  ·  '), margin, margin + 20)
+  pdf.text(new Date().toLocaleString(), pageWidth - margin, margin + 20, { align: 'right' })
+
+  // Subtle horizontal rule below the header
+  pdf.setDrawColor(180)
+  pdf.line(margin, margin + 28, pageWidth - margin, margin + 28)
+
+  // Two-column layout for inputs (left) and outputs (right)
+  const gutter = 18
+  const colWidth = (pageWidth - margin * 2 - gutter) / 2
+  const inputRows = collectPortRows(
+    device,
+    device.inputs ?? [],
+    device.id,
+    allCables,
+    allEquipment,
+  )
+  const outputRows = collectPortRows(
+    device,
+    device.outputs ?? [],
+    device.id,
+    allCables,
+    allEquipment,
+  )
+
+  const colYStart = margin + 48
+  drawColumn(
+    pdf,
+    `INPUTS (${inputRows.length})`,
+    inputRows,
+    margin,
+    colYStart,
+    colWidth,
+    pageBottom,
+    margin,
+  )
+  drawColumn(
+    pdf,
+    `OUTPUTS (${outputRows.length})`,
+    outputRows,
+    margin + colWidth + gutter,
+    colYStart,
+    colWidth,
+    pageBottom,
+    margin,
+  )
+
+  // Footer — note about cable colour key
+  pdf.setFontSize(7)
+  pdf.setTextColor(140)
+  pdf.text(
+    `Cable Planner · ${device.name} · ${inputRows.length} In / ${outputRows.length} Out · automatisch erzeugte Patch-Liste`,
+    pageWidth / 2,
+    pageHeight - 12,
+    { align: 'center' },
+  )
+
+  const safeName = (device.name || 'device').replace(/[/\\?%*:|"<>]/g, '-').trim() || 'device'
+  pdf.save(`${safeName}-patch.pdf`)
+}

--- a/src/renderer/lib/exportDevicePdf.ts
+++ b/src/renderer/lib/exportDevicePdf.ts
@@ -137,14 +137,19 @@ const drawColumn = (
   return y
 }
 
-export const exportDevicePatchSheet = async (
+/**
+ * Render a single device's patch sheet onto the CURRENT page of `pdf`.
+ * Caller is responsible for creating the pdf, adding pages between
+ * devices in batch mode, and saving the file. Factored out from
+ * `exportDevicePatchSheet` so the new batch export can reuse it
+ * without duplicating layout logic.
+ */
+const drawDevicePage = (
+  pdf: jsPDF,
   device: EquipmentItem,
   allEquipment: EquipmentItem[],
   allCables: Cable[],
-  options?: { format?: 'a4' | 'a3' },
-): Promise<void> => {
-  const format = options?.format ?? 'a4'
-  const pdf = new jsPDF({ orientation: 'portrait', unit: 'pt', format })
+): void => {
   const pageWidth = pdf.internal.pageSize.getWidth()
   const pageHeight = pdf.internal.pageSize.getHeight()
   const margin = 32
@@ -217,7 +222,39 @@ export const exportDevicePatchSheet = async (
     pageHeight - 12,
     { align: 'center' },
   )
+}
 
+export const exportDevicePatchSheet = async (
+  device: EquipmentItem,
+  allEquipment: EquipmentItem[],
+  allCables: Cable[],
+  options?: { format?: 'a4' | 'a3' },
+): Promise<void> => {
+  const format = options?.format ?? 'a4'
+  const pdf = new jsPDF({ orientation: 'portrait', unit: 'pt', format })
+  drawDevicePage(pdf, device, allEquipment, allCables)
   const safeName = (device.name || 'device').replace(/[/\\?%*:|"<>]/g, '-').trim() || 'device'
   pdf.save(`${safeName}-patch.pdf`)
+}
+
+/**
+ * Combined patch-sheet PDF — one device per page in a single file.
+ * Used by the new "Drucken" dialog when the user picks several devices
+ * and wants a single PDF (instead of one download per device).
+ */
+export const exportDevicesPatchSheetsBatch = async (
+  devices: EquipmentItem[],
+  allEquipment: EquipmentItem[],
+  allCables: Cable[],
+  options?: { format?: 'a4' | 'a3'; fileName?: string },
+): Promise<void> => {
+  if (devices.length === 0) return
+  const format = options?.format ?? 'a4'
+  const pdf = new jsPDF({ orientation: 'portrait', unit: 'pt', format })
+  devices.forEach((device, idx) => {
+    if (idx > 0) pdf.addPage()
+    drawDevicePage(pdf, device, allEquipment, allCables)
+  })
+  const fileName = options?.fileName ?? 'cable-planner-patch-sammlung.pdf'
+  pdf.save(fileName)
 }

--- a/src/renderer/lib/hotkeys.ts
+++ b/src/renderer/lib/hotkeys.ts
@@ -1,0 +1,96 @@
+/**
+ * Issue #69: Hotkey dispatcher.
+ *
+ * The user-customizable hotkey map lives in uiStore.hotkeys. Each entry
+ * is `actionName → key-combo` (e.g. "undo" → "Ctrl+Z"). This module:
+ *   1. Provides `comboFromEvent` so the settings UI can capture a
+ *      keystroke and store it as a string.
+ *   2. Provides `useHotkeys()` — a hook that registers a global
+ *      keydown listener and dispatches a callback when a matching
+ *      combo is pressed.
+ *
+ * Combos use the syntax: modifier+modifier+key, modifiers in fixed
+ * order: Ctrl, Shift, Alt, Meta. The "key" half is the value of
+ * `event.key` (case-insensitive for printables; special keys keep
+ * their canonical name — "ArrowUp", "Delete", "Escape", "F1"…).
+ */
+
+import { useEffect } from 'react'
+
+export interface HotkeyHandlers {
+  [action: string]: () => void
+}
+
+/** Build a canonical combo string from a KeyboardEvent. */
+export const comboFromEvent = (event: KeyboardEvent | React.KeyboardEvent): string => {
+  const parts: string[] = []
+  if (event.ctrlKey || event.metaKey) parts.push(event.metaKey && !event.ctrlKey ? 'Meta' : 'Ctrl')
+  if (event.shiftKey) parts.push('Shift')
+  if (event.altKey) parts.push('Alt')
+  const key = event.key
+  // Exclude modifier-only keystrokes ("Shift", "Control" etc.) — those
+  // make no sense as a "completed" combo.
+  if (key === 'Control' || key === 'Shift' || key === 'Alt' || key === 'Meta') return ''
+  const printable = key.length === 1
+  parts.push(printable ? key.toUpperCase() : key)
+  return parts.join('+')
+}
+
+/** True when the user is currently typing in a text input — in which case
+ *  global hotkeys should NOT fire (so the user can still type Ctrl+A etc.
+ *  in form fields). */
+const isEditable = (target: EventTarget | null): boolean => {
+  if (!target || !(target instanceof HTMLElement)) return false
+  const tag = target.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
+  if (target.isContentEditable) return true
+  return false
+}
+
+/**
+ * React hook that wires a `map of action → combo` to a `map of action →
+ * callback`. Pass both; the hook attaches a single window listener and
+ * fires the matching callback when the key combo is detected. Edits in
+ * text fields are skipped.
+ */
+export const useHotkeys = (
+  map: Record<string, string>,
+  handlers: HotkeyHandlers,
+  enabled = true,
+) => {
+  useEffect(() => {
+    if (!enabled) return
+    const handler = (event: KeyboardEvent) => {
+      if (isEditable(event.target)) return
+      const combo = comboFromEvent(event)
+      if (!combo) return
+      // First exact match wins. Build a reverse lookup once per call.
+      for (const action of Object.keys(map)) {
+        if (map[action] === combo && handlers[action]) {
+          event.preventDefault()
+          handlers[action]!()
+          return
+        }
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [map, handlers, enabled])
+}
+
+export const HOTKEY_ACTION_LABEL: Record<string, string> = {
+  undo: 'Rückgängig',
+  redo: 'Wiederherstellen',
+  save: 'Projekt speichern',
+  saveAs: 'Projekt speichern unter…',
+  newProject: 'Neues Projekt',
+  openProject: 'Projekt öffnen',
+  deleteSelected: 'Auswahl löschen',
+  clearSelection: 'Auswahl aufheben',
+  toggleLibrary: 'Library ein-/ausblenden',
+  toggleProperties: 'Eigenschaften ein-/ausblenden',
+  showLegend: 'Längen-Legende anzeigen',
+  jumpToPatches: 'Zu Patches springen',
+  toggleArrows: 'Pfeil-Anzeige umschalten',
+  toggleRouting: 'Routing umschalten',
+}

--- a/src/renderer/lib/intercomMatrixXlsx.ts
+++ b/src/renderer/lib/intercomMatrixXlsx.ts
@@ -1,0 +1,409 @@
+/**
+ * Issue: Intercom-Excel ↔ GreenGo config round-trip.
+ *
+ * The user produces a planning spreadsheet (see PFIJUKO25 example) that
+ * lists every intercom user as a row and every reachable group/user as a
+ * column. Each "x" in the matrix means "user A talks to / belongs to
+ * resource B". We parse that into a GreenGoConfig (.gg5 logical shape)
+ * and can serialize a GreenGoConfig back into the same XLSX layout so the
+ * Excel file stays in sync with whatever the user edits in the matrix
+ * view inside the app.
+ *
+ * Layout assumptions (extracted from the supplied PFIJUKO25 file — the
+ * format is loose enough that we sniff section headers instead of
+ * hardcoding column numbers):
+ *
+ *   Row containing "Equipment", "Gruppen", "User" cells → column-group header
+ *   Row directly below it (numeric IDs 1.. and 101..) → ID row
+ *   Row directly below the ID row (BPX, PGM, V Bimi, …) → label row
+ *   All subsequent rows where col B has a numeric user-id and col D has a
+ *   non-empty name → user rows. "x" cells under group columns mean
+ *   user ∈ group; "x" cells under user columns are direct-talk entries
+ *   that we capture as a `directTalkUserIds` audit array (we don't
+ *   reflect them in .gg5 groupIds because GreenGo's data model lists
+ *   group memberships, not user-to-user shortcuts).
+ */
+
+import * as XLSX from 'xlsx'
+import type { GreenGoConfig, GreenGoGroup, GreenGoUser } from '../types/greengo'
+
+/** What a single cell can contain after we've stringified it. */
+type Cell = string
+
+const SECTION_HEADER_LABELS = ['Equipment', 'Gruppen', 'User'] as const
+type SectionHeader = (typeof SECTION_HEADER_LABELS)[number]
+
+interface SectionRange {
+  header: SectionHeader
+  startCol: number
+  /** Exclusive — the column where the next section starts (or sheet width). */
+  endCol: number
+}
+
+interface MatrixLayout {
+  sectionHeaderRow: number
+  idRow: number
+  labelRow: number
+  sections: SectionRange[]
+  /** First row of user data (1-based). */
+  firstUserRow: number
+  /** Width of the data area on the sheet. */
+  width: number
+  /** Height of the data area on the sheet. */
+  height: number
+}
+
+const cellAt = (rows: Cell[][], r: number, c: number): string =>
+  (rows[r] && rows[r][c]) ?? ''
+
+const isMark = (s: string): boolean => {
+  const t = s.trim().toLowerCase()
+  return t === 'x' || t === '✓' || t === 'y' || t === 'ja' || t === '1'
+}
+
+/** Trim and collapse whitespace inside a cell — the source spreadsheet
+ *  often contains leading/trailing spaces in shared strings. */
+const norm = (s: string): string => s.replace(/\s+/g, ' ').trim()
+
+/** Find a row whose cells contain at least two of the section header
+ *  labels (`Equipment`, `Gruppen`, `User`). Returns -1 if the file
+ *  doesn't look like an intercom matrix. */
+const findSectionHeaderRow = (rows: Cell[][]): number => {
+  for (let r = 0; r < rows.length; r++) {
+    const row = rows[r] ?? []
+    const hits = SECTION_HEADER_LABELS.filter((label) =>
+      row.some((cell) => norm(cell) === label),
+    ).length
+    if (hits >= 2) return r
+  }
+  return -1
+}
+
+const findSectionsInRow = (row: Cell[]): SectionRange[] => {
+  const found: { header: SectionHeader; col: number }[] = []
+  for (let c = 0; c < row.length; c++) {
+    const label = norm(row[c]) as SectionHeader
+    if (SECTION_HEADER_LABELS.includes(label)) {
+      found.push({ header: label, col: c })
+    }
+  }
+  found.sort((a, b) => a.col - b.col)
+  return found.map((f, i) => ({
+    header: f.header,
+    startCol: f.col,
+    endCol: i + 1 < found.length ? found[i + 1].col : row.length,
+  }))
+}
+
+const detectLayout = (rows: Cell[][]): MatrixLayout | { error: string } => {
+  const sectionHeaderRow = findSectionHeaderRow(rows)
+  if (sectionHeaderRow < 0) {
+    return {
+      error:
+        'Konnte keine Intercom-Matrix erkennen — es fehlt eine Zeile mit den Spaltenüberschriften "Equipment", "Gruppen" und "User".',
+    }
+  }
+  const headerCells = rows[sectionHeaderRow] ?? []
+  const sections = findSectionsInRow(headerCells)
+  if (sections.length === 0) {
+    return { error: 'Keine Spalten-Sektionen unterhalb der Header gefunden.' }
+  }
+  // ID row sits immediately below the header row; label row directly
+  // after it. Some templates may have one extra spacer row between
+  // header and id — we look for the first row that has at least 2
+  // numeric cells in the Group section to be robust.
+  let idRow = sectionHeaderRow + 1
+  const groupSection = sections.find((s) => s.header === 'Gruppen')
+  if (groupSection) {
+    for (let r = sectionHeaderRow + 1; r < Math.min(sectionHeaderRow + 4, rows.length); r++) {
+      const numericInGroupSection = rows[r]
+        ?.slice(groupSection.startCol, groupSection.endCol)
+        .filter((c) => /^\d+$/.test(norm(c))).length ?? 0
+      if (numericInGroupSection >= 2) {
+        idRow = r
+        break
+      }
+    }
+  }
+  const labelRow = idRow + 1
+  return {
+    sectionHeaderRow,
+    idRow,
+    labelRow,
+    sections,
+    firstUserRow: labelRow + 1,
+    width: Math.max(...rows.map((r) => r.length)),
+    height: rows.length,
+  }
+}
+
+export interface IntercomXlsxImportResult {
+  config: GreenGoConfig
+  /** Audit: user→user direct-talk marks that didn't map onto groups. */
+  directTalkPairs: Array<{ fromUserId: number; toUserId: number; note: string }>
+  /** Audit: equipment-section "x" marks — meaning the user uses a
+   *  particular hardware type (BPX, MCX, SI4WR…). Stored so the caller
+   *  can show "this user uses 3 hardware types" but we don't push it
+   *  into the .gg5 because GreenGo doesn't model that. */
+  equipmentMarks: Array<{ userId: number; label: string }>
+  /** Audit/warning strings to surface to the user. */
+  warnings: string[]
+}
+
+/**
+ * Parse an XLSX file into a GreenGoConfig. The first worksheet is used.
+ * Throws on malformed files; returns `{ error }` for unrecognised
+ * layouts.
+ */
+export const parseIntercomMatrixXlsx = (
+  data: ArrayBuffer | Uint8Array,
+): IntercomXlsxImportResult | { error: string } => {
+  let workbook: XLSX.WorkBook
+  try {
+    workbook = XLSX.read(data, { type: 'array' })
+  } catch (err) {
+    return { error: `XLSX konnte nicht gelesen werden: ${(err as Error).message}` }
+  }
+  const sheetName = workbook.SheetNames[0]
+  if (!sheetName) return { error: 'Keine Tabelle in der Datei gefunden.' }
+  const sheet = workbook.Sheets[sheetName]
+  // Get raw cell values as strings; XLSX returns a 2D array.
+  const rows: Cell[][] = XLSX.utils.sheet_to_json(sheet, {
+    header: 1,
+    raw: false,
+    defval: '',
+  }) as Cell[][]
+  if (rows.length === 0) return { error: 'Die erste Tabelle ist leer.' }
+
+  const layoutOrError = detectLayout(rows)
+  if ('error' in layoutOrError) return layoutOrError
+  const layout = layoutOrError
+
+  const groupSection = layout.sections.find((s) => s.header === 'Gruppen')
+  const userSection = layout.sections.find((s) => s.header === 'User')
+  const equipmentSection = layout.sections.find((s) => s.header === 'Equipment')
+
+  // ─── Build group list from the Gruppen section ────────────────────────────
+  const groups: GreenGoGroup[] = []
+  /** column → group id, so we can dereference x-marks in user rows. */
+  const groupColumnMap = new Map<number, number>()
+  if (groupSection) {
+    for (let c = groupSection.startCol; c < groupSection.endCol; c++) {
+      const idStr = norm(cellAt(rows, layout.idRow, c))
+      const label = norm(cellAt(rows, layout.labelRow, c))
+      if (!label) continue
+      const id = /^\d+$/.test(idStr) ? Number(idStr) : groups.length + 1
+      groups.push({ id, name: label })
+      groupColumnMap.set(c, id)
+    }
+  }
+
+  // ─── Build user list & memberships ────────────────────────────────────────
+  const users: GreenGoUser[] = []
+  const userColumnMap = new Map<number, number>() // column → user id
+  if (userSection) {
+    for (let c = userSection.startCol; c < userSection.endCol; c++) {
+      const idStr = norm(cellAt(rows, layout.idRow, c))
+      if (/^\d+$/.test(idStr)) userColumnMap.set(c, Number(idStr))
+    }
+  }
+
+  const directTalkPairs: IntercomXlsxImportResult['directTalkPairs'] = []
+  const equipmentMarks: IntercomXlsxImportResult['equipmentMarks'] = []
+  const warnings: string[] = []
+
+  for (let r = layout.firstUserRow; r < rows.length; r++) {
+    const row = rows[r] ?? []
+    // User-id column is usually 2 (column "B") but in the sample it's
+    // column index 1 (B). Be defensive: take the first numeric cell in
+    // the row before the equipment section, and the first non-empty
+    // label after it as the user name.
+    let idCol = -1
+    for (let c = 0; c < (equipmentSection?.startCol ?? 4); c++) {
+      if (/^\d+$/.test(norm(row[c] ?? ''))) {
+        idCol = c
+        break
+      }
+    }
+    if (idCol < 0) continue
+    const id = Number(norm(row[idCol]))
+    // Find user name: first non-empty cell after idCol but before the
+    // first matrix section.
+    let name = ''
+    for (let c = idCol + 1; c < (equipmentSection?.startCol ?? row.length); c++) {
+      const v = norm(row[c] ?? '')
+      if (v && !isMark(v)) {
+        name = v
+        break
+      }
+    }
+    if (!name) continue
+
+    const groupIds: number[] = []
+    if (groupSection) {
+      for (let c = groupSection.startCol; c < groupSection.endCol; c++) {
+        if (isMark(cellAt(rows, r, c))) {
+          const gid = groupColumnMap.get(c)
+          if (gid !== undefined && !groupIds.includes(gid)) groupIds.push(gid)
+        }
+      }
+    }
+    if (userSection) {
+      for (let c = userSection.startCol; c < userSection.endCol; c++) {
+        if (!isMark(cellAt(rows, r, c))) continue
+        const targetUserId = userColumnMap.get(c)
+        if (targetUserId !== undefined && targetUserId !== id) {
+          directTalkPairs.push({
+            fromUserId: id,
+            toUserId: targetUserId,
+            note: `Direkt-Linie: ${name} → User ${targetUserId}`,
+          })
+        }
+      }
+    }
+    if (equipmentSection) {
+      for (let c = equipmentSection.startCol; c < equipmentSection.endCol; c++) {
+        if (!isMark(cellAt(rows, r, c))) continue
+        const label = norm(cellAt(rows, layout.labelRow, c))
+        if (label) equipmentMarks.push({ userId: id, label })
+      }
+    }
+
+    users.push({ id, name, groupIds })
+  }
+
+  // Sanity warnings
+  if (groups.length === 0) {
+    warnings.push('Keine Gruppen erkannt — prüfe die "Gruppen"-Spalten im Sheet.')
+  }
+  if (users.length === 0) {
+    warnings.push('Keine Benutzer erkannt — prüfe die Benutzer-Zeilen unterhalb der Spaltenköpfe.')
+  }
+  if (users.length > 0 && users.every((u) => u.groupIds.length === 0)) {
+    warnings.push(
+      'Kein Benutzer ist einer Gruppe zugeordnet — bitte prüfen ob die Matrix-Markierungen ("x") korrekt erkannt wurden.',
+    )
+  }
+
+  // Pull the project title (workbook content above the matrix) for a
+  // sensible systemName.
+  let systemName = 'Intercom-Setup'
+  for (let r = 0; r < layout.sectionHeaderRow; r++) {
+    const cells = (rows[r] ?? []).map(norm).filter(Boolean)
+    if (cells.length > 0 && cells.some((c) => c.length > 4)) {
+      systemName = cells.find((c) => c.length > 4) ?? systemName
+      break
+    }
+  }
+
+  return {
+    config: {
+      systemName,
+      description: `Importiert aus XLSX (${new Date().toLocaleString()})`,
+      multicastAddress: '239.1.160.1',
+      sampleRate: 32000,
+      users,
+      groups,
+    },
+    directTalkPairs,
+    equipmentMarks,
+    warnings,
+  }
+}
+
+/* ────────────────────────────────────────────────────────────────────────── *\
+ *  Export: GreenGoConfig → XLSX                                              *
+\* ────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Render the given GreenGoConfig as an Excel matrix in the same layout
+ * the importer expects, so the round-trip is symmetric.
+ *
+ * Columns (1-based):
+ *   A: spacer / left margin
+ *   B: numeric user id
+ *   C: optional function (left blank in the basic export)
+ *   D: user display name
+ *   E…: one column per group (header in idRow, label in labelRow)
+ *
+ * The export omits the Equipment + per-user direct-line columns from
+ * the original spreadsheet — those weren't part of the .gg5 model. We
+ * document this with a banner row above the matrix so the user knows
+ * the Excel file is a faithful representation of what's stored in
+ * GreenGo, not a 1:1 copy of any uploaded source.
+ */
+export const exportIntercomMatrixXlsx = (config: GreenGoConfig): ArrayBuffer => {
+  const SPACER_COL = 0
+  const ID_COL = 1
+  const FN_COL = 2
+  const NAME_COL = 3
+  const FIRST_GROUP_COL = 4
+
+  const titleRow = 1
+  const sectionHeaderRow = 3
+  const idRow = 4
+  const labelRow = 5
+  const firstUserRow = 6
+
+  const numGroups = config.groups.length
+  const lastGroupCol = FIRST_GROUP_COL + Math.max(0, numGroups - 1)
+
+  // Build a 2D array of cells. XLSX.utils.aoa_to_sheet ingests this.
+  const rowCount = firstUserRow + config.users.length + 2
+  const colCount = Math.max(FIRST_GROUP_COL + numGroups, NAME_COL + 1) + 1
+  const aoa: (string | number)[][] = Array.from({ length: rowCount }, () =>
+    Array.from({ length: colCount }, () => ''),
+  )
+
+  aoa[titleRow][ID_COL] = `${config.systemName} — Intercom Matrix`
+  aoa[sectionHeaderRow][NAME_COL] = 'User'
+  if (numGroups > 0) aoa[sectionHeaderRow][FIRST_GROUP_COL] = 'Gruppen'
+
+  // Group ID/label row
+  config.groups.forEach((g, i) => {
+    aoa[idRow][FIRST_GROUP_COL + i] = g.id
+    aoa[labelRow][FIRST_GROUP_COL + i] = g.name
+  })
+
+  // User rows
+  const groupIdToCol = new Map<number, number>(
+    config.groups.map((g, i) => [g.id, FIRST_GROUP_COL + i]),
+  )
+  config.users.forEach((u, i) => {
+    const row = firstUserRow + i
+    aoa[row][ID_COL] = u.id
+    aoa[row][NAME_COL] = u.name
+    void aoa[row][FN_COL] // intentionally left blank
+    for (const gid of u.groupIds) {
+      const col = groupIdToCol.get(gid)
+      if (col !== undefined) aoa[row][col] = 'x'
+    }
+  })
+
+  // Footer note about scope
+  aoa[firstUserRow + config.users.length + 1][ID_COL] =
+    `Exportiert aus Cable Planner · ${new Date().toLocaleString()} · ${config.users.length} User × ${config.groups.length} Gruppen`
+
+  const sheet = XLSX.utils.aoa_to_sheet(aoa)
+
+  // Column widths so the export looks like the source on first open.
+  sheet['!cols'] = [
+    { wch: 3 },
+    { wch: 5 },
+    { wch: 16 },
+    { wch: 24 },
+    ...config.groups.map(() => ({ wch: 8 })),
+  ]
+  // Mark the matrix range so Excel doesn't auto-trim.
+  sheet['!ref'] = XLSX.utils.encode_range({
+    s: { c: 0, r: 0 },
+    e: {
+      c: Math.max(lastGroupCol, NAME_COL),
+      r: firstUserRow + config.users.length + 1,
+    },
+  })
+
+  const wb = XLSX.utils.book_new()
+  XLSX.utils.book_append_sheet(wb, sheet, 'Intercom Matrix')
+  return XLSX.write(wb, { type: 'array', bookType: 'xlsx' }) as ArrayBuffer
+}

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -85,6 +85,18 @@ interface PersistedUiState {
   /** Issue #80: global library of device-config files (ATEM, Videohub,
    *  GreenGo). Each entry can optionally be bound to one equipment id. */
   deviceConfigLibrary: DeviceConfigEntry[]
+  /** Issue #65: draw small jump-bumps when two orthogonal cables cross,
+   *  the way yEd does, so the user can visually trace which cable is on
+   *  top. The lower-id cable gets the bump. Off by default to preserve
+   *  the existing visual baseline. */
+  cableBumps: boolean
+  /** Issue #53: when two orthogonal cables share an X- or Y-midline,
+   *  shift one of them by a small offset so they're parallel instead of
+   *  perfectly overlapping. */
+  orthogonalCollisionShift: boolean
+  /** Issue #69: customizable keyboard shortcuts. Map of action → key
+   *  combo. Empty string disables the shortcut. */
+  hotkeys: Record<string, string>
 }
 
 const defaults: PersistedUiState = {
@@ -106,13 +118,53 @@ const defaults: PersistedUiState = {
   bgOpacity: 0.5,
   customCableSpecs: [],
   deviceConfigLibrary: [],
+  cableBumps: false,
+  orthogonalCollisionShift: false,
+  hotkeys: {
+    undo: 'Ctrl+Z',
+    redo: 'Ctrl+Y',
+    save: 'Ctrl+S',
+    saveAs: 'Ctrl+Shift+S',
+    newProject: 'Ctrl+N',
+    openProject: 'Ctrl+O',
+    deleteSelected: 'Delete',
+    clearSelection: 'Escape',
+    toggleLibrary: 'Ctrl+B',
+    toggleProperties: 'Ctrl+I',
+    showLegend: 'L',
+    jumpToPatches: 'P',
+    toggleArrows: 'A',
+    toggleRouting: 'R',
+  },
 }
 
 const load = (): PersistedUiState => {
   try {
     const raw = localStorage.getItem(KEY)
     if (!raw) return defaults
-    return { ...defaults, ...(JSON.parse(raw) as Partial<PersistedUiState>) }
+    const parsed = JSON.parse(raw) as Partial<PersistedUiState>
+    // Defensive: ensure every field has the right TYPE, otherwise React
+    // selectors that expect arrays/objects can crash on first render and
+    // trigger an infinite mount loop (React #185 / #310). Replace any
+    // field with the wrong type by the default. This protects users who
+    // updated from a much older version with a different schema.
+    const merged: PersistedUiState = { ...defaults, ...parsed }
+    if (!Array.isArray(merged.customCableSpecs)) merged.customCableSpecs = []
+    if (!Array.isArray(merged.deviceConfigLibrary)) merged.deviceConfigLibrary = []
+    if (typeof merged.cableBumps !== 'boolean') merged.cableBumps = defaults.cableBumps
+    if (typeof merged.orthogonalCollisionShift !== 'boolean')
+      merged.orthogonalCollisionShift = defaults.orthogonalCollisionShift
+    if (!merged.hotkeys || typeof merged.hotkeys !== 'object') merged.hotkeys = defaults.hotkeys
+    else merged.hotkeys = { ...defaults.hotkeys, ...merged.hotkeys }
+    if (merged.connectorTypeColors === null || typeof merged.connectorTypeColors !== 'object')
+      merged.connectorTypeColors = {}
+    if (typeof merged.bgOpacity !== 'number' || !Number.isFinite(merged.bgOpacity))
+      merged.bgOpacity = defaults.bgOpacity
+    if (typeof merged.gridSize !== 'number' || merged.gridSize < 2)
+      merged.gridSize = defaults.gridSize
+    if (typeof merged.libraryWidth !== 'number') merged.libraryWidth = defaults.libraryWidth
+    if (typeof merged.propertiesWidth !== 'number') merged.propertiesWidth = defaults.propertiesWidth
+    return merged
   } catch {
     return defaults
   }
@@ -161,6 +213,10 @@ interface UiState extends PersistedUiState {
   removeDeviceConfig: (id: string) => void
   /** Bulk-replace the entire library. Used by the JSON-bundle importer. */
   replaceDeviceConfigLibrary: (entries: DeviceConfigEntry[]) => void
+  setCableBumps: (value: boolean) => void
+  setOrthogonalCollisionShift: (value: boolean) => void
+  setHotkey: (action: string, combo: string) => void
+  resetHotkeys: () => void
   pdfExportThemeOverride: 'dark' | 'light' | null
   setPdfExportThemeOverride: (value: 'dark' | 'light' | null) => void
   cableEdit: { open: boolean; cableId?: string }
@@ -248,6 +304,9 @@ const applyPatch =
       bgOpacity: state.bgOpacity,
       customCableSpecs: state.customCableSpecs,
       deviceConfigLibrary: state.deviceConfigLibrary,
+      cableBumps: state.cableBumps,
+      orthogonalCollisionShift: state.orthogonalCollisionShift,
+      hotkeys: state.hotkeys,
       ...patch,
     }
     persist(next)
@@ -333,6 +392,11 @@ export const useUiStore = create<UiState>((set) => ({
     ),
   replaceDeviceConfigLibrary: (entries) =>
     set((state) => applyPatch({ deviceConfigLibrary: entries })(state)),
+  setCableBumps: (value) => set(applyPatch({ cableBumps: value })),
+  setOrthogonalCollisionShift: (value) => set(applyPatch({ orthogonalCollisionShift: value })),
+  setHotkey: (action, combo) =>
+    set((state) => applyPatch({ hotkeys: { ...state.hotkeys, [action]: combo } })(state)),
+  resetHotkeys: () => set(applyPatch({ hotkeys: defaults.hotkeys })),
   pdfExportThemeOverride: null,
   setPdfExportThemeOverride: (value) => set({ pdfExportThemeOverride: value }),
   cableEdit: { open: false },

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -45,6 +45,13 @@ interface PersistedUiState {
   /** Background grid opacity 0..1. Lower values make the dots/lines
    *  fainter — useful when zooming way out on large diagrams. */
   bgOpacity: number
+  /** Issue #64: user-defined cable specs persisted across sessions.
+   *  Each entry has the same shape as a built-in CableSpec but its
+   *  `id` is prefixed with 'custom-cable:' so the cable dialog can
+   *  visually distinguish them. They show up in the dropdown next
+   *  to the built-in catalog and can be re-edited / deleted from
+   *  Settings. */
+  customCableSpecs: import('../types/cableSpec').CableSpec[]
 }
 
 const defaults: PersistedUiState = {
@@ -64,6 +71,7 @@ const defaults: PersistedUiState = {
   connectorTypeColors: {},
   bgVariant: 'dots',
   bgOpacity: 0.5,
+  customCableSpecs: [],
 }
 
 const load = (): PersistedUiState => {
@@ -102,6 +110,17 @@ interface UiState extends PersistedUiState {
   resetConnectorTypeColors: () => void
   setBgVariant: (value: 'dots' | 'lines' | 'cross' | 'none') => void
   setBgOpacity: (value: number) => void
+  /** Add a new custom cable spec. The store assigns a `custom-cable:`
+   *  id automatically; if a spec with the same name already exists
+   *  it's replaced (so re-saving keeps the library clean). */
+  addCustomCableSpec: (spec: Omit<import('../types/cableSpec').CableSpec, 'id'>) => import('../types/cableSpec').CableSpec
+  /** Patch an existing custom spec in place. No-op if `id` doesn't
+   *  start with 'custom-cable:' — built-ins are read-only. */
+  updateCustomCableSpec: (
+    id: string,
+    patch: Partial<Omit<import('../types/cableSpec').CableSpec, 'id'>>,
+  ) => void
+  removeCustomCableSpec: (id: string) => void
   pdfExportThemeOverride: 'dark' | 'light' | null
   setPdfExportThemeOverride: (value: 'dark' | 'light' | null) => void
   cableEdit: { open: boolean; cableId?: string }
@@ -187,6 +206,7 @@ const applyPatch =
       connectorTypeColors: state.connectorTypeColors,
       bgVariant: state.bgVariant,
       bgOpacity: state.bgOpacity,
+      customCableSpecs: state.customCableSpecs,
       ...patch,
     }
     persist(next)
@@ -222,6 +242,29 @@ export const useUiStore = create<UiState>((set) => ({
   resetConnectorTypeColors: () => set(applyPatch({ connectorTypeColors: {} })),
   setBgVariant: (value) => set(applyPatch({ bgVariant: value })),
   setBgOpacity: (value) => set(applyPatch({ bgOpacity: Math.max(0, Math.min(1, value)) })),
+  addCustomCableSpec: (spec) => {
+    const id = `custom-cable:${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`
+    const entry = { ...spec, id }
+    set((state) => {
+      // Drop any existing spec with the same name so the user can re-save
+      // an edited definition without duplicating it in the dropdown.
+      const filtered = state.customCableSpecs.filter((s) => s.name !== spec.name)
+      return applyPatch({ customCableSpecs: [...filtered, entry] })(state)
+    })
+    return entry
+  },
+  updateCustomCableSpec: (id, patch) =>
+    set((state) => {
+      if (!id.startsWith('custom-cable:')) return state
+      const next = state.customCableSpecs.map((s) =>
+        s.id === id ? { ...s, ...patch, id: s.id } : s,
+      )
+      return applyPatch({ customCableSpecs: next })(state)
+    }),
+  removeCustomCableSpec: (id) =>
+    set((state) =>
+      applyPatch({ customCableSpecs: state.customCableSpecs.filter((s) => s.id !== id) })(state),
+    ),
   pdfExportThemeOverride: null,
   setPdfExportThemeOverride: (value) => set({ pdfExportThemeOverride: value }),
   cableEdit: { open: false },

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -3,6 +3,36 @@ import { create } from 'zustand'
 export type EdgeRouting = 'orthogonal' | 'straight' | 'curved'
 export type Language = 'de' | 'en'
 
+/** Issue #80: globally stored device-config files (ATEM MV/audio configs,
+ *  Videohub label & routing dumps, GreenGo .gg5 etc.) that the user can
+ *  upload once and then assign to a specific equipment node on the canvas.
+ *  Persisted in localStorage so the library survives across projects.
+ *
+ *  `kind` drives the upload picker and the icon in the list. `equipmentId`
+ *  is the binding to a canvas device; null/undefined means "in library
+ *  but not assigned". Content is stored as text — XML, JSON or plain
+ *  text payload — so we don't need to deal with binary blob storage
+ *  in localStorage. */
+export type DeviceConfigKind =
+  | 'atem-mv'
+  | 'atem-audio'
+  | 'videohub-labels'
+  | 'videohub-routing'
+  | 'greengo'
+  | 'other'
+
+export interface DeviceConfigEntry {
+  id: string
+  kind: DeviceConfigKind
+  name: string
+  fileName: string
+  mimeType: string
+  content: string
+  notes?: string
+  savedAt: string
+  equipmentId?: string
+}
+
 const KEY = 'cable-planner:ui'
 
 interface PersistedUiState {
@@ -52,6 +82,9 @@ interface PersistedUiState {
    *  to the built-in catalog and can be re-edited / deleted from
    *  Settings. */
   customCableSpecs: import('../types/cableSpec').CableSpec[]
+  /** Issue #80: global library of device-config files (ATEM, Videohub,
+   *  GreenGo). Each entry can optionally be bound to one equipment id. */
+  deviceConfigLibrary: DeviceConfigEntry[]
 }
 
 const defaults: PersistedUiState = {
@@ -72,6 +105,7 @@ const defaults: PersistedUiState = {
   bgVariant: 'dots',
   bgOpacity: 0.5,
   customCableSpecs: [],
+  deviceConfigLibrary: [],
 }
 
 const load = (): PersistedUiState => {
@@ -121,6 +155,12 @@ interface UiState extends PersistedUiState {
     patch: Partial<Omit<import('../types/cableSpec').CableSpec, 'id'>>,
   ) => void
   removeCustomCableSpec: (id: string) => void
+  /** Issue #80: device-config library (ATEM / Videohub / GreenGo configs). */
+  addDeviceConfig: (entry: Omit<DeviceConfigEntry, 'id' | 'savedAt'>) => DeviceConfigEntry
+  updateDeviceConfig: (id: string, patch: Partial<Omit<DeviceConfigEntry, 'id' | 'savedAt'>>) => void
+  removeDeviceConfig: (id: string) => void
+  /** Bulk-replace the entire library. Used by the JSON-bundle importer. */
+  replaceDeviceConfigLibrary: (entries: DeviceConfigEntry[]) => void
   pdfExportThemeOverride: 'dark' | 'light' | null
   setPdfExportThemeOverride: (value: 'dark' | 'light' | null) => void
   cableEdit: { open: boolean; cableId?: string }
@@ -207,6 +247,7 @@ const applyPatch =
       bgVariant: state.bgVariant,
       bgOpacity: state.bgOpacity,
       customCableSpecs: state.customCableSpecs,
+      deviceConfigLibrary: state.deviceConfigLibrary,
       ...patch,
     }
     persist(next)
@@ -265,6 +306,33 @@ export const useUiStore = create<UiState>((set) => ({
     set((state) =>
       applyPatch({ customCableSpecs: state.customCableSpecs.filter((s) => s.id !== id) })(state),
     ),
+  addDeviceConfig: (entry) => {
+    const id = `cfg:${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`
+    const created: DeviceConfigEntry = {
+      ...entry,
+      id,
+      savedAt: new Date().toISOString(),
+    }
+    set((state) =>
+      applyPatch({ deviceConfigLibrary: [...state.deviceConfigLibrary, created] })(state),
+    )
+    return created
+  },
+  updateDeviceConfig: (id, patch) =>
+    set((state) => {
+      const next = state.deviceConfigLibrary.map((e) =>
+        e.id === id ? { ...e, ...patch, id: e.id, savedAt: e.savedAt } : e,
+      )
+      return applyPatch({ deviceConfigLibrary: next })(state)
+    }),
+  removeDeviceConfig: (id) =>
+    set((state) =>
+      applyPatch({ deviceConfigLibrary: state.deviceConfigLibrary.filter((e) => e.id !== id) })(
+        state,
+      ),
+    ),
+  replaceDeviceConfigLibrary: (entries) =>
+    set((state) => applyPatch({ deviceConfigLibrary: entries })(state)),
   pdfExportThemeOverride: null,
   setPdfExportThemeOverride: (value) => set({ pdfExportThemeOverride: value }),
   cableEdit: { open: false },


### PR DESCRIPTION
## Summary

Cumulative release branch bumping cable-planner to **v0.10.0**. Combines three pushes since v0.7.0:

| Wave | Closes | Highlights |
|---|---|---|
| **v0.8.0** | #64 #74 | User-defined cable types + per-device patch-sheet PDF |
| **v0.8.1** | #74 follow-up | Consolidated Drucken-Dialog (Plan + Einzelgeräte) |
| **v0.9.0** | #80 | Device-config library (ATEM/Videohub/GreenGo upload+download), panel + toolbar polish |
| **v0.10.0** | #55 #65 #69 #82 | Intercom-Excel ↔ .gg5 round-trip, hotkeys, MV layout buttons, cable-bump toggle |

**Closes #55, #65, #69, #80, #82.** (#53 toggle landed; algorithm pending in v0.11.)

---

## v0.10.0 highlights

### Intercom-Excel ↔ .gg5 round-trip (user's main request)
- New `lib/intercomMatrixXlsx.ts` reads the Equipment / Gruppen / User columns
  out of an XLSX planning sheet and builds a `GreenGoConfig`.
- Symmetric export: the same matrix layout is regenerated from the current
  GreenGo config so the Excel plan always reflects what's stored.
- Two new buttons in the GreenGo dialog (📊 Excel-Matrix importieren /
  exportieren) plus a multi-line import-toast that surfaces ignored
  direct-talk pairs and equipment marks.

### Issue closures
- **#69 Hotkeys** — uiStore.hotkeys map (14 default actions) + new Settings →
  ⌨ Hotkeys tab with capture-keystroke editor. Wired into App.tsx so
  undo/redo/save/delete/clearSelection/etc. fire from the keyboard with
  user-chosen combos.
- **#55 ATEM MV** — layout dropdown replaced with a row of click-able layout
  buttons (active layout highlighted in sky-700).
- **#65 Cable bumps** — uiStore toggle + `buildPathWithBumps` helper.
  Marked experimental; full cross-cable segment cache follows in v0.11.
- **#53 Orthogonal collision** — toggle in Settings → Bearbeiten. Algorithm
  in cableRouting lands in v0.11.

### React #185 defensive fixes
- `uiStore.load()` now coerces every persisted field to the right type so a
  corrupt localStorage entry (array → string, etc.) can no longer crash
  startup with `filter is not a function`.
- MenuBar `useSyncExternalStore` switched to stable function references
  (`projectHistory.canUndo/canRedo`) — inline arrows can be misread as
  snapshot changes on aggressive React 19 builds.

---

## What you do

1. Merge this PR.
2. Create release `v0.10.0` (tag on `main`). `release.yml` builds Windows EXE
   + macOS DMG on Node 24.

## Test plan

- [ ] App version label shows **0.10.0**
- [ ] App launches cleanly on a corrupt-localStorage machine (delete
      `cable-planner:ui` first, then reload)
- [ ] GreenGo dialog → "📊 Excel-Matrix importieren" → pick the
      PFIJUKO25 sample → matrix view fills with users + group memberships
- [ ] GreenGo dialog → "📊 Excel-Matrix exportieren" with the freshly
      imported config → re-import the produced XLSX → users/groups
      identical (round-trip)
- [ ] Settings → ⌨ Hotkeys → change `save` to Ctrl+Shift+P → press
      Ctrl+Shift+P → save dialog opens; Ctrl+S no longer triggers it
- [ ] Settings → Konfigurationen → upload an XML, change name + binding,
      reload app → entry survives
- [ ] ATEM MV dialog → click each layout button → grid updates
- [ ] Settings → Bearbeiten → "Kreuzungs-Brücken" toggle persists
- [ ] All earlier features still work (yEd import, GreenGo beltpack, hover
      highlight, marquee, pack-status …)


---
_Generated by [Claude Code](https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH)_