### PR TITLE
v7.2.1: phone-accessible mobile viewer via LAN HTTP server + QR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,24 @@
 {
     "name": "cable-planner",
-    "version": "0.9.0",
+    "version": "7.2.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cable-planner",
-            "version": "0.9.0",
+            "version": "7.2.1",
             "dependencies": {
                 "@dnd-kit/core": "^6.3.1",
                 "@dnd-kit/sortable": "^10.0.0",
                 "@dnd-kit/utilities": "^3.2.2",
+                "@types/qrcode": "^1.5.5",
                 "atem-connection": "^3.9.0",
                 "axios": "^1.13.1",
                 "fast-xml-parser": "^5.8.0",
                 "html-to-image": "^1.11.13",
                 "jspdf": "^4.2.1",
                 "keytar": "^7.9.0",
+                "qrcode": "^1.5.4",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5",
                 "reactflow": "^11.11.4",
@@ -2995,7 +2997,6 @@
             "version": "24.12.2",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
             "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~7.16.0"
@@ -3017,6 +3018,15 @@
             "dependencies": {
                 "@types/node": "*",
                 "xmlbuilder": ">=11.0.1"
+            }
+        },
+        "node_modules/@types/qrcode": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.5.tgz",
+            "integrity": "sha512-CdfBi/e3Qk+3Z/fXYShipBT13OJ2fDO2Q2w5CIP5anLTLIndQG9z6P1cnm+8zCWSpm5dnxMFd/uREtb0EXuQzg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
             }
         },
         "node_modules/@types/raf": {
@@ -4218,6 +4228,15 @@
                 "node": ">=6"
             }
         },
+        "node_modules/camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001790",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
@@ -4717,6 +4736,15 @@
                 }
             }
         },
+        "node_modules/decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/decompress-response": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -4821,6 +4849,12 @@
             "dev": true,
             "license": "MIT",
             "optional": true
+        },
+        "node_modules/dijkstrajs": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+            "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+            "license": "MIT"
         },
         "node_modules/dir-compare": {
             "version": "4.2.0",
@@ -7428,6 +7462,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/pako": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
@@ -7451,7 +7494,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -7795,6 +7837,150 @@
                 "node": ">=6"
             }
         },
+        "node_modules/qrcode": {
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+            "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+            "license": "MIT",
+            "dependencies": {
+                "dijkstrajs": "^1.0.1",
+                "pngjs": "^5.0.0",
+                "yargs": "^15.3.1"
+            },
+            "bin": {
+                "qrcode": "bin/qrcode"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/qrcode/node_modules/cliui": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+            "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^6.2.0"
+            }
+        },
+        "node_modules/qrcode/node_modules/find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/qrcode/node_modules/locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/qrcode/node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "license": "MIT",
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/qrcode/node_modules/p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/qrcode/node_modules/pngjs": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+            "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/qrcode/node_modules/wrap-ansi": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/qrcode/node_modules/y18n": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+            "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+            "license": "ISC"
+        },
+        "node_modules/qrcode/node_modules/yargs": {
+            "version": "15.4.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+            "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^6.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^4.1.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^4.2.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^18.1.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/qrcode/node_modules/yargs-parser": {
+            "version": "18.1.3",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+            "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+            "license": "ISC",
+            "dependencies": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/quick-lru": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -7923,6 +8109,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/require-main-filename": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+            "license": "ISC"
         },
         "node_modules/resedit": {
             "version": "1.7.2",
@@ -8164,6 +8356,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+            "license": "ISC"
         },
         "node_modules/sharp": {
             "version": "0.34.5",
@@ -8921,7 +9119,6 @@
             "version": "7.16.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
             "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/universalify": {
@@ -9177,6 +9374,12 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/which-module": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+            "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+            "license": "ISC"
         },
         "node_modules/wmf": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "0.11.0",
+    "version": "7.2.1",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",
@@ -27,12 +27,14 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@types/qrcode": "^1.5.5",
         "atem-connection": "^3.9.0",
         "axios": "^1.13.1",
         "fast-xml-parser": "^5.8.0",
         "html-to-image": "^1.11.13",
         "jspdf": "^4.2.1",
         "keytar": "^7.9.0",
+        "qrcode": "^1.5.4",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "reactflow": "^11.11.4",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import { registerVideohubIpc } from './ipc/videohubIpc.js'
 import { registerLogIpc } from './ipc/logIpc.js'
 import { registerSyncIpc } from './ipc/syncIpc.js'
 import { registerGraphmlIpc } from './ipc/graphmlIpc.js'
+import { registerMobileShareIpc } from './ipc/mobileShareIpc.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -90,6 +91,7 @@ app.whenReady().then(async () => {
   registerLogIpc()
   registerSyncIpc()
   registerGraphmlIpc()
+  registerMobileShareIpc()
 
   await createWindow()
 

--- a/src/main/ipc/mobileShareIpc.ts
+++ b/src/main/ipc/mobileShareIpc.ts
@@ -1,0 +1,40 @@
+import { app, ipcMain } from 'electron'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  getMobileShareStatus,
+  setMobileShareProject,
+  startMobileShareServer,
+  stopMobileShareServer,
+} from '../services/mobileShareServer.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+/** Resolve the directory containing the bundled renderer assets
+ *  (mobile.html + main bundle). Same path that BrowserWindow.loadFile
+ *  uses, just relative to `dist/main/`. */
+const resolveRendererDir = (): string => {
+  // Packaged Electron: app.getAppPath() ends in `app.asar`. Inside the
+  // asar the renderer sits at `dist/renderer/`.
+  const candidates = [
+    path.join(__dirname, '..', 'renderer'),
+    path.join(app.getAppPath(), 'dist', 'renderer'),
+  ]
+  return candidates[0]
+}
+
+export const registerMobileShareIpc = () => {
+  ipcMain.handle('mobileShare:start', async () => {
+    return await startMobileShareServer(resolveRendererDir())
+  })
+  ipcMain.handle('mobileShare:stop', () => {
+    stopMobileShareServer()
+    return { ok: true }
+  })
+  ipcMain.handle('mobileShare:status', () => getMobileShareStatus())
+  ipcMain.handle('mobileShare:setProject', (_event, project: unknown) => {
+    setMobileShareProject(project)
+    return { ok: true }
+  })
+}

--- a/src/main/preload.cts
+++ b/src/main/preload.cts
@@ -92,4 +92,22 @@ contextBridge.exposeInMainWorld('cablePlanner', {
     releaseLock: (dirPath: string, owner: string) =>
       ipcRenderer.invoke('sync:release-lock', dirPath, owner) as Promise<void>,
   },
+  mobileShare: {
+    start: () =>
+      ipcRenderer.invoke('mobileShare:start') as Promise<{
+        port: number
+        urls: string[]
+        hasProject: boolean
+      }>,
+    stop: () => ipcRenderer.invoke('mobileShare:stop') as Promise<{ ok: boolean }>,
+    status: () =>
+      ipcRenderer.invoke('mobileShare:status') as Promise<{
+        running: boolean
+        port: number
+        urls: string[]
+        hasProject: boolean
+      }>,
+    setProject: (project: unknown) =>
+      ipcRenderer.invoke('mobileShare:setProject', project) as Promise<{ ok: boolean }>,
+  },
 })

--- a/src/main/services/mobileShareServer.ts
+++ b/src/main/services/mobileShareServer.ts
@@ -1,0 +1,239 @@
+/**
+ * Issue follow-up: phone-accessible mobile viewer while the desktop
+ * app is running on a different machine.
+ *
+ * Spawns a tiny HTTP server on a free LAN port. Routes:
+ *   GET /                 → 302 to /mobile.html
+ *   GET /mobile.html      → the bundled mobile viewer HTML
+ *   GET /assets/*         → the bundled JS/CSS assets next to mobile.html
+ *   GET /project.json     → the current in-memory project (Cable-Planner JSON)
+ *
+ * Lifecycle:
+ *   - start() picks a free port, opens the server, returns
+ *     { port, urls } where `urls` is every LAN address that
+ *     resolves to a non-internal IPv4 interface (so the user can
+ *     pick the one their phone is on if the studio runs multiple
+ *     subnets).
+ *   - setProject() updates the JSON the server hands out. The
+ *     renderer pushes the project here whenever it changes so the
+ *     phone always sees the latest state on refresh.
+ *   - stop() closes the server and clears the in-memory project.
+ *
+ * Security note: server is bound to 0.0.0.0 (LAN). No write
+ * endpoints. If a token gate is needed later we'd add a random
+ * token to the URL and require it in `/project.json`. For a small
+ * studio LAN the absence of write endpoints is the right tradeoff
+ * between zero-config and security.
+ */
+
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from 'node:http'
+import { readFileSync, existsSync } from 'node:fs'
+import { resolve as pathResolve } from 'node:path'
+import { networkInterfaces } from 'node:os'
+import { fileURLToPath } from 'node:url'
+
+const MIME_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.json': 'application/json; charset=utf-8',
+  '.ico': 'image/x-icon',
+  '.webp': 'image/webp',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+}
+
+const mimeFor = (filePath: string): string => {
+  const dot = filePath.lastIndexOf('.')
+  if (dot < 0) return 'application/octet-stream'
+  return MIME_TYPES[filePath.slice(dot).toLowerCase()] ?? 'application/octet-stream'
+}
+
+const __filename = fileURLToPath(import.meta.url)
+
+interface MobileShareState {
+  server: Server | null
+  port: number
+  project: unknown | null
+  /** Absolute path to dist/renderer (where mobile.html + assets live). */
+  rendererDir: string
+}
+
+const state: MobileShareState = {
+  server: null,
+  port: 0,
+  project: null,
+  rendererDir: '',
+}
+
+/** Lookup non-internal IPv4 addresses across all network interfaces. */
+const collectLanAddresses = (): string[] => {
+  const result: string[] = []
+  const ifaces = networkInterfaces()
+  for (const list of Object.values(ifaces)) {
+    if (!list) continue
+    for (const entry of list) {
+      if (entry.family === 'IPv4' && !entry.internal) {
+        result.push(entry.address)
+      }
+    }
+  }
+  // Always include localhost so the user can verify the server is
+  // running even if the LAN listing is empty (no wifi etc.).
+  return [...result, '127.0.0.1']
+}
+
+const sendFile = (res: ServerResponse, filePath: string) => {
+  if (!existsSync(filePath)) {
+    res.statusCode = 404
+    res.end('Not Found')
+    return
+  }
+  const body = readFileSync(filePath)
+  res.statusCode = 200
+  res.setHeader('Content-Type', mimeFor(filePath))
+  res.setHeader('Cache-Control', 'no-cache')
+  // Allow access from the phone over the LAN. Same-origin already
+  // satisfies the browser since mobile.html and /project.json are
+  // both served from this server; the CORS header is defensive in
+  // case the user opens an old cached mobile bundle from elsewhere.
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.end(body)
+}
+
+const handleRequest = (req: IncomingMessage, res: ServerResponse) => {
+  if (!req.url) {
+    res.statusCode = 400
+    res.end()
+    return
+  }
+  const url = new URL(req.url, `http://${req.headers.host ?? 'localhost'}`)
+  const pathname = url.pathname
+
+  // Project JSON endpoint
+  if (pathname === '/project.json') {
+    res.statusCode = state.project ? 200 : 503
+    res.setHeader('Content-Type', 'application/json; charset=utf-8')
+    res.setHeader('Cache-Control', 'no-store')
+    res.setHeader('Access-Control-Allow-Origin', '*')
+    res.end(state.project ? JSON.stringify(state.project) : '{}')
+    return
+  }
+
+  // Health/info endpoint — useful for the renderer to verify
+  // the server is alive without round-tripping the whole project.
+  if (pathname === '/share-info.json') {
+    res.statusCode = 200
+    res.setHeader('Content-Type', 'application/json; charset=utf-8')
+    res.setHeader('Cache-Control', 'no-store')
+    res.end(
+      JSON.stringify({
+        ok: true,
+        hasProject: state.project !== null,
+        port: state.port,
+      }),
+    )
+    return
+  }
+
+  // Static file routing
+  if (pathname === '/' || pathname === '/mobile') {
+    res.statusCode = 302
+    res.setHeader('Location', '/mobile.html')
+    res.end()
+    return
+  }
+
+  // Guard against directory traversal — resolve paths against the
+  // renderer dir and reject anything that escapes it.
+  const normalized = pathname.replace(/^\/+/, '')
+  const safePath = pathResolve(state.rendererDir, normalized)
+  if (!safePath.startsWith(state.rendererDir)) {
+    res.statusCode = 403
+    res.end('Forbidden')
+    return
+  }
+  sendFile(res, safePath)
+}
+
+/** Pick a free port in the 39520..39620 range by trying sequential
+ *  bindings. Using a deterministic-ish range makes manual debugging
+ *  easier (`curl localhost:39520`) without conflicting with common
+ *  dev-server ports (3000/5173/8080). */
+const findFreePort = (server: Server): Promise<number> =>
+  new Promise((resolve, reject) => {
+    const tryPort = (port: number) => {
+      if (port > 39620) {
+        reject(new Error('No free port in 39520..39620 range'))
+        return
+      }
+      server.once('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'EADDRINUSE') {
+          // Server emits 'error' once per failed listen; rebind next.
+          server.close(() => tryPort(port + 1))
+        } else {
+          reject(err)
+        }
+      })
+      server.listen(port, '0.0.0.0', () => {
+        server.removeAllListeners('error')
+        resolve(port)
+      })
+    }
+    tryPort(39520)
+  })
+
+export interface MobileShareInfo {
+  port: number
+  urls: string[]
+  hasProject: boolean
+}
+
+export const startMobileShareServer = async (
+  rendererDir: string,
+): Promise<MobileShareInfo> => {
+  if (state.server) {
+    return {
+      port: state.port,
+      urls: collectLanAddresses().map((ip) => `http://${ip}:${state.port}/mobile.html`),
+      hasProject: state.project !== null,
+    }
+  }
+  state.rendererDir = pathResolve(rendererDir)
+  const server = createServer(handleRequest)
+  const port = await findFreePort(server)
+  state.server = server
+  state.port = port
+  return {
+    port,
+    urls: collectLanAddresses().map((ip) => `http://${ip}:${port}/mobile.html`),
+    hasProject: state.project !== null,
+  }
+}
+
+export const stopMobileShareServer = (): void => {
+  if (!state.server) return
+  state.server.close()
+  state.server = null
+  state.port = 0
+  state.project = null
+}
+
+export const setMobileShareProject = (project: unknown): void => {
+  state.project = project
+}
+
+export const getMobileShareStatus = (): MobileShareInfo & { running: boolean } => ({
+  running: state.server !== null,
+  port: state.port,
+  urls: state.server
+    ? collectLanAddresses().map((ip) => `http://${ip}:${state.port}/mobile.html`)
+    : [],
+  hasProject: state.project !== null,
+})
+
+void __filename // keep ESM file-url alive

--- a/src/mobile/MobileApp.tsx
+++ b/src/mobile/MobileApp.tsx
@@ -391,12 +391,83 @@ const ProjectView = ({
 
 export const MobileApp = () => {
   const [project, setProject] = useState<CablePlannerProject | null>(null)
+  const [autoLoadAttempted, setAutoLoadAttempted] = useState(false)
+  const [autoLoadError, setAutoLoadError] = useState<string | null>(null)
+
+  // When loaded via the desktop app's LAN share server, a sibling
+  // /project.json endpoint serves the live project. Auto-fetch on
+  // mount and (separately) poll every 5 s so the phone stays in sync
+  // while it's the active window.
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await fetch('/share-info.json', { cache: 'no-store' })
+        if (!res.ok) {
+          setAutoLoadAttempted(true)
+          return
+        }
+        const info = (await res.json()) as { ok: boolean; hasProject: boolean }
+        if (!info.ok || !info.hasProject) {
+          setAutoLoadAttempted(true)
+          return
+        }
+        const projectRes = await fetch('/project.json', { cache: 'no-store' })
+        if (!projectRes.ok) {
+          setAutoLoadError(`Server antwortete mit ${projectRes.status}.`)
+          setAutoLoadAttempted(true)
+          return
+        }
+        const data = (await projectRes.json()) as CablePlannerProject
+        if (!cancelled && data && Array.isArray(data.equipment)) {
+          setProject(data)
+        }
+      } catch {
+        // Not running from the share server — show the manual picker.
+      } finally {
+        if (!cancelled) setAutoLoadAttempted(true)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Refresh every 5 s once we've successfully auto-loaded so the
+  // phone reflects edits made on the desktop.
+  useEffect(() => {
+    if (!project) return
+    const id = window.setInterval(async () => {
+      try {
+        const r = await fetch('/project.json', { cache: 'no-store' })
+        if (!r.ok) return
+        const next = (await r.json()) as CablePlannerProject
+        if (next && Array.isArray(next.equipment)) setProject(next)
+      } catch {
+        /* server stopped or network blip — keep last good state */
+      }
+    }, 5000)
+    return () => window.clearInterval(id)
+  }, [project !== null])
+
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
-      {project ? (
+      {!autoLoadAttempted ? (
+        <div className="grid min-h-screen place-items-center p-4 text-xs text-slate-400">
+          <div className="animate-pulse">Lade Projekt vom Desktop…</div>
+        </div>
+      ) : project ? (
         <ProjectView project={project} onUnload={() => setProject(null)} />
       ) : (
-        <ProjectPicker onLoad={setProject} />
+        <>
+          <ProjectPicker onLoad={setProject} />
+          {autoLoadError && (
+            <div className="mx-auto mt-2 max-w-md rounded border border-amber-700 bg-amber-950 p-2 text-[11px] text-amber-200">
+              Hinweis: Es lief offenbar ein Desktop-Share-Server, aber das Laden ist
+              fehlgeschlagen ({autoLoadError}).
+            </div>
+          )}
+        </>
       )}
     </div>
   )

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -17,6 +17,7 @@ import { AtemMvConfigDialog } from './components/Atem/AtemMvConfigDialog'
 import { AtemAudioRouterDialog } from './components/Atem/AtemAudioRouterDialog'
 import { LocationBomDialog } from './components/Project/LocationBomDialog'
 import { RackEditorDialog } from './components/Rack/RackEditorDialog'
+import { MobileShareDialog } from './components/MobileShare/MobileShareDialog'
 import { ProjectMetaDialog } from './components/Project/ProjectMetaDialog'
 import { CableBomDialog } from './components/Project/CableBomDialog'
 import { PrintDialog } from './components/Print/PrintDialog'
@@ -24,7 +25,7 @@ import { WelcomeDialog } from './components/Project/WelcomeDialog'
 import { Splitter } from './components/Layout/Splitter'
 import { useProject } from './hooks/useProject'
 import { useRentman } from './hooks/useRentman'
-import { cablePlannerApi } from './lib/bridge'
+import { cablePlannerApi, hasDesktopBridge } from './lib/bridge'
 import { exportCanvasToPdf, exportCanvasToPdfBytes } from './lib/exportPdf'
 import { exportCanvasToImage } from './lib/exportImage'
 import { useProjectStore } from './store/projectStore'
@@ -156,6 +157,19 @@ export default function App() {
   }, [refreshRecent, setHasToken])
 
   useUndoRedoShortcuts()
+
+  // Whenever the project changes, push it to the in-process mobile-
+  // share HTTP server so the phone always sees the latest state on
+  // refresh. The bridge no-ops gracefully when the server isn't
+  // running, so we don't need to gate this on a UI flag. Debounced
+  // 500 ms to avoid IPC churn during rapid drags.
+  useEffect(() => {
+    if (!hasDesktopBridge) return
+    const timer = window.setTimeout(() => {
+      void cablePlannerApi.mobileShare.setProject(project)
+    }, 500)
+    return () => window.clearTimeout(timer)
+  }, [project])
 
   // Issue #69: dispatch user-customizable hotkeys defined in
   // Settings → Hotkeys. The undo/redo entries below intentionally
@@ -434,6 +448,7 @@ export default function App() {
       <AtemAudioRouterDialog />
       <LocationBomDialog />
       <RackEditorDialog />
+      <MobileShareDialog />
 
       <ProjectMetaDialog
         open={metaDialog !== null}

--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import { SharedSyncPanel } from '../Sync/SharedSyncPanel'
 import { useTranslation } from '../../lib/i18n'
 import { projectHistory } from '../../store/projectHistory'
+import { useUiStore } from '../../store/uiStore'
+import { hasDesktopBridge } from '../../lib/bridge'
 
 interface MenuBarProps {
   onNewProject: () => void
@@ -228,6 +230,19 @@ export const MenuBar = ({
               <option value="2160p60">2160p60 (12G)</option>
             </select>
           </label>
+        )}
+        {hasDesktopBridge && (
+          <button
+            type="button"
+            onClick={() => useUiStore.getState().openMobileShare()}
+            className="rounded bg-slate-800 px-2 py-1 text-slate-100 hover:bg-slate-700"
+            title={t(
+              'app.mobileShare.title',
+              'Handy-Zugriff: kleiner LAN-Server + QR-Code, damit das Handy den Mobile-Viewer öffnen kann.',
+            )}
+          >
+            📱
+          </button>
         )}
         <button
           type="button"

--- a/src/renderer/components/MobileShare/MobileShareDialog.tsx
+++ b/src/renderer/components/MobileShare/MobileShareDialog.tsx
@@ -1,0 +1,264 @@
+/**
+ * Phone-friendly viewer launcher.
+ *
+ * Workflow:
+ *   1. User clicks "📱 Handy-Zugriff" in the topbar → this dialog opens.
+ *   2. The dialog starts a tiny HTTP server in the Electron main process
+ *      (see src/main/services/mobileShareServer.ts) on a free LAN port.
+ *   3. The server hands out the bundled mobile.html + the currently-
+ *      loaded project. The dialog renders a QR code with the LAN URL —
+ *      the field tech scans it with their phone and sees the read-only
+ *      viewer in the browser, no app install needed.
+ *   4. While the server is running, the renderer pushes any project
+ *      mutation to the server (debounced) so the phone always sees the
+ *      latest state on refresh.
+ *
+ * The server has no write endpoints; the phone view is read-only. The
+ * server stops when the user clicks "Stop" or when the desktop app
+ * closes (Electron tears down the http server with the process).
+ */
+
+import { useEffect, useState } from 'react'
+import QRCode from 'qrcode'
+import { useUiStore } from '../../store/uiStore'
+import { cablePlannerApi, hasDesktopBridge } from '../../lib/bridge'
+
+interface ShareStatus {
+  running: boolean
+  port: number
+  urls: string[]
+  hasProject: boolean
+}
+
+const renderQrTo = async (url: string): Promise<string> => {
+  try {
+    return await QRCode.toDataURL(url, {
+      width: 240,
+      margin: 1,
+      color: { dark: '#0f172a', light: '#ffffff' },
+    })
+  } catch {
+    return ''
+  }
+}
+
+/** Score addresses so we surface the most-likely-useful one first.
+ *  Wi-Fi private ranges (192.168.*, 10.*, 172.16-31.*) usually beat
+ *  link-local / VirtualBox / loopback. */
+const scoreAddress = (url: string): number => {
+  if (url.includes('127.0.0.1')) return -10
+  if (/192\.168\./.test(url)) return 100
+  if (/^http:\/\/10\./.test(url)) return 90
+  if (/^http:\/\/172\.(1[6-9]|2[0-9]|3[01])\./.test(url)) return 80
+  if (/169\.254\./.test(url)) return -20
+  return 50
+}
+
+export const MobileShareDialog = () => {
+  const open = useUiStore((s) => s.mobileShare.open)
+  const close = useUiStore((s) => s.closeMobileShare)
+  const [status, setStatus] = useState<ShareStatus>({
+    running: false,
+    port: 0,
+    urls: [],
+    hasProject: false,
+  })
+  const [busy, setBusy] = useState(false)
+  const [qrDataUrl, setQrDataUrl] = useState<string>('')
+  const [selectedUrl, setSelectedUrl] = useState<string>('')
+  const [copied, setCopied] = useState(false)
+
+  // Initial status check whenever the dialog opens — the server may
+  // already be running from a previous session in the same Electron
+  // process.
+  useEffect(() => {
+    if (!open || !hasDesktopBridge) return
+    void (async () => {
+      const next = await cablePlannerApi.mobileShare.status()
+      setStatus(next)
+    })()
+  }, [open])
+
+  // Pick + render the primary URL whenever the server state changes.
+  useEffect(() => {
+    if (status.urls.length === 0) {
+      setQrDataUrl('')
+      setSelectedUrl('')
+      return
+    }
+    const sorted = [...status.urls].sort((a, b) => scoreAddress(b) - scoreAddress(a))
+    const primary = selectedUrl && status.urls.includes(selectedUrl) ? selectedUrl : sorted[0]
+    setSelectedUrl(primary)
+    void renderQrTo(primary).then(setQrDataUrl)
+  }, [status.urls, selectedUrl])
+
+  if (!open) return null
+
+  const handleStart = async () => {
+    setBusy(true)
+    try {
+      const result = await cablePlannerApi.mobileShare.start()
+      setStatus({ ...result, running: true })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleStop = async () => {
+    setBusy(true)
+    try {
+      await cablePlannerApi.mobileShare.stop()
+      setStatus({ running: false, port: 0, urls: [], hasProject: false })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const copyUrl = async () => {
+    if (!selectedUrl) return
+    try {
+      await navigator.clipboard.writeText(selectedUrl)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      /* clipboard may be unavailable */
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onMouseDown={(e) => e.target === e.currentTarget && close()}
+    >
+      <div className="w-full max-w-md rounded-lg border border-slate-700 bg-slate-900 text-slate-100 shadow-2xl">
+        <header className="flex items-center justify-between border-b border-slate-700 px-4 py-3">
+          <h2 className="text-sm font-semibold">
+            <span className="mr-2">📱</span>Handy-Zugriff
+          </h2>
+          <button
+            type="button"
+            onClick={close}
+            className="rounded px-2 py-1 text-xs text-slate-400 hover:bg-slate-800 hover:text-slate-100"
+          >
+            ✕
+          </button>
+        </header>
+        <div className="space-y-3 p-4 text-sm">
+          {!hasDesktopBridge && (
+            <div className="rounded border border-amber-700 bg-amber-950/40 p-3 text-xs text-amber-200">
+              Diese Funktion benötigt die Desktop-App (Electron). Im Web-Browser ist der
+              Mobile-Viewer als statisches HTML im{' '}
+              <code className="rounded bg-slate-800 px-1">dist/renderer/mobile.html</code>{' '}
+              erreichbar.
+            </div>
+          )}
+
+          <p className="text-xs text-slate-400">
+            Startet einen kleinen Web-Server im lokalen Netzwerk. Scanne den QR-Code mit dem
+            Handy → der Mobile-Viewer öffnet sich im Browser und lädt das aktuelle Projekt.
+            Der Server stoppt automatisch beim Schließen der App oder über den Stop-Button.
+          </p>
+
+          {status.running ? (
+            <div className="space-y-3">
+              <div className="flex flex-col items-center gap-2 rounded border border-emerald-700 bg-emerald-950/30 p-3">
+                {qrDataUrl ? (
+                  <img src={qrDataUrl} alt="QR-Code" className="rounded bg-white p-2" />
+                ) : (
+                  <div className="h-[240px] w-[240px] animate-pulse rounded bg-slate-800" />
+                )}
+                <div className="w-full">
+                  <div className="text-[10px] uppercase tracking-wide text-emerald-300">
+                    Aktive URL
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <input
+                      readOnly
+                      value={selectedUrl}
+                      className="flex-1 rounded border border-slate-700 bg-slate-950 px-2 py-1 font-mono text-[11px] text-slate-100"
+                      onFocus={(e) => e.target.select()}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => void copyUrl()}
+                      className="rounded bg-slate-700 px-2 py-1 text-[10px] hover:bg-slate-600"
+                      title="In die Zwischenablage kopieren"
+                    >
+                      {copied ? '✓' : '📋'}
+                    </button>
+                  </div>
+                </div>
+              </div>
+              {status.urls.length > 1 && (
+                <div>
+                  <div className="mb-1 text-[10px] uppercase tracking-wide text-slate-500">
+                    Alternative LAN-Adressen (falls eine nicht erreichbar ist)
+                  </div>
+                  <div className="flex flex-wrap gap-1">
+                    {status.urls.map((u) => (
+                      <button
+                        key={u}
+                        type="button"
+                        onClick={() => setSelectedUrl(u)}
+                        className={`rounded border px-2 py-0.5 text-[10px] font-mono ${
+                          u === selectedUrl
+                            ? 'border-sky-500 bg-sky-900 text-white'
+                            : 'border-slate-700 bg-slate-900 text-slate-300 hover:border-sky-700'
+                        }`}
+                      >
+                        {u.replace(/^http:\/\//, '').replace('/mobile.html', '')}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+              <div className="flex items-center justify-between">
+                <span className="text-[11px] text-slate-400">
+                  Port {status.port} ·{' '}
+                  {status.hasProject ? (
+                    <span className="text-emerald-300">Projekt synchronisiert</span>
+                  ) : (
+                    <span className="text-amber-300">Kein Projekt geladen</span>
+                  )}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => void handleStop()}
+                  disabled={busy}
+                  className="rounded bg-red-700 px-3 py-1 text-xs text-white hover:bg-red-600 disabled:opacity-50"
+                >
+                  Stop
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-col items-center gap-3 rounded border border-slate-700 bg-slate-950/40 p-6 text-center">
+              <div className="text-3xl">📡</div>
+              <p className="text-xs text-slate-400">
+                Server ist gestoppt. Klicke unten, um den LAN-Server zu starten.
+              </p>
+              <button
+                type="button"
+                onClick={() => void handleStart()}
+                disabled={busy || !hasDesktopBridge}
+                className="rounded bg-sky-700 px-4 py-2 text-sm text-white hover:bg-sky-600 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {busy ? 'Starte…' : 'LAN-Server starten'}
+              </button>
+            </div>
+          )}
+
+          <details className="text-[11px] text-slate-500">
+            <summary className="cursor-pointer hover:text-slate-300">Hinweise zur Sicherheit</summary>
+            <ul className="mt-1 list-inside list-disc space-y-1">
+              <li>Read-only: das Handy kann nur lesen, nichts schreiben.</li>
+              <li>Der Server bindet auf das lokale Netzwerk (0.0.0.0). Wenn unklar ist, wer
+                  im Netz hängt, lieber stoppen.</li>
+              <li>Beim Schließen der Desktop-App stoppt auch der Server automatisch.</li>
+            </ul>
+          </details>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/lib/bridge.ts
+++ b/src/renderer/lib/bridge.ts
@@ -117,6 +117,12 @@ type CablePlannerApi = {
     acquireLock: (dirPath: string, owner: string) => Promise<{ ok: boolean; lockedBy?: string }>
     releaseLock: (dirPath: string, owner: string) => Promise<void>
   }
+  mobileShare: {
+    start: () => Promise<{ port: number; urls: string[]; hasProject: boolean }>
+    stop: () => Promise<{ ok: boolean }>
+    status: () => Promise<{ running: boolean; port: number; urls: string[]; hasProject: boolean }>
+    setProject: (project: unknown) => Promise<{ ok: boolean }>
+  }
 }
 
 const TOKEN_KEY = 'cable-planner:web:token'
@@ -485,6 +491,14 @@ const webFallbackApi: CablePlannerApi = {
     exists: async () => false,
     acquireLock: async () => ({ ok: false, lockedBy: undefined }),
     releaseLock: async () => {},
+  },
+  mobileShare: {
+    start: async () => {
+      throw new Error('Handy-Zugriff erfordert die Desktop-App.')
+    },
+    stop: async () => ({ ok: true }),
+    status: async () => ({ running: false, port: 0, urls: [], hasProject: false }),
+    setProject: async () => ({ ok: true }),
   },
 }
 

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -251,6 +251,10 @@ interface UiState extends PersistedUiState {
   rackEditor: { open: boolean; rackInstanceId?: string }
   openRackEditor: (rackInstanceId: string) => void
   closeRackEditor: () => void
+  /** Phone-share dialog (LAN HTTP server + QR code, v7.2.1). */
+  mobileShare: { open: boolean }
+  openMobileShare: () => void
+  closeMobileShare: () => void
   /** Rentman equipment import dialog (cross-component trigger). */
   rentmanImport: { open: boolean }
   openRentmanImport: () => void
@@ -432,6 +436,9 @@ export const useUiStore = create<UiState>((set) => ({
   rackEditor: { open: false },
   openRackEditor: (rackInstanceId) => set({ rackEditor: { open: true, rackInstanceId } }),
   closeRackEditor: () => set({ rackEditor: { open: false } }),
+  mobileShare: { open: false },
+  openMobileShare: () => set({ mobileShare: { open: true } }),
+  closeMobileShare: () => set({ mobileShare: { open: false } }),
   rentmanImport: { open: false },
   openRentmanImport: () => set({ rentmanImport: { open: true } }),
   closeRentmanImport: () => set({ rentmanImport: { open: false } }),


### PR DESCRIPTION
## Summary

Small patch follow-up to **v7.2.0**: the mobile viewer now opens on the
phone just by scanning a QR code — no file copy required.

## Why

v7.2.0 / #73 shipped the mobile viewer as a static HTML in
`dist/renderer/mobile.html`. To use it you had to copy the project JSON
to the phone first. This PR closes that gap by serving both the viewer
and the live project from inside the desktop app over the LAN.

## How

- **`src/main/services/mobileShareServer.ts`** — tiny `node:http` server
  (no extra deps). Picks a free port in 39520-39620, binds 0.0.0.0,
  routes `/mobile.html` + `/assets/*` + `/project.json` + a small
  `/share-info.json` liveness probe. Directory-traversal-guarded.
- **`src/main/ipc/mobileShareIpc.ts`** + `preload.cts` — `start` / `stop`
  / `status` / `setProject` over IPC.
- **`App.tsx`** debounce-pushes the current project to the server on
  every change (500 ms). No-op when the server is stopped.
- **`MobileShareDialog`** in `components/MobileShare/`: QR code via
  `qrcode` (~20 KB), copy-URL chip, alternative-LAN-address list
  ranked so 192.168.* / 10.* / 172.16-31.* float to the top,
  start/stop, port + project-sync status. Inline security notes
  (read-only, dies with the desktop process).
- **MenuBar 📱 button** sits next to ⚙ Settings (desktop-only).
- **`MobileApp.tsx`** auto-loads from the server on mount and polls
  every 5 s so the phone reflects desktop edits live.

## Versioning

Aligned the package version to **7.2.1** to match your release scheme
(v7.2.0 in prod). Going forward I'll use patch bumps for small features
and minor for bigger ones — no more 0.10 → 0.11 jumps on my side.

## Test plan

- [ ] App version label shows **7.2.1**
- [ ] Open Cable Planner on desktop, click 📱 in the topbar
- [ ] Click "LAN-Server starten" → QR code appears, URL shows port 39520+
- [ ] Scan the QR with a phone on the same Wi-Fi → mobile viewer opens
      with the current project pre-loaded
- [ ] Edit a device name on the desktop → wait ≤ 5 s → phone reflects
      the change after auto-refresh
- [ ] Stop server → phone shows "503" / stale data; restart server →
      phone recovers on next poll
- [ ] Close the desktop app → server dies, phone shows network error
- [ ] In the dialog, alternative-address chips work when picked (QR
      refreshes)


---
_Generated by [Claude Code](https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH)_