### PR TITLE
v7.2.2: About dialog + Patchliste + 3 Werkzeuge + #60 accordion + #53 collision shift

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.2.1",
+    "version": "7.2.2",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -18,6 +18,9 @@ import { AtemAudioRouterDialog } from './components/Atem/AtemAudioRouterDialog'
 import { LocationBomDialog } from './components/Project/LocationBomDialog'
 import { RackEditorDialog } from './components/Rack/RackEditorDialog'
 import { MobileShareDialog } from './components/MobileShare/MobileShareDialog'
+import { AboutDialog } from './components/About/AboutDialog'
+import { PatchListDialog } from './components/Patch/PatchListDialog'
+import { CalculatorsDialog } from './components/Calculators/CalculatorsDialog'
 import { ProjectMetaDialog } from './components/Project/ProjectMetaDialog'
 import { CableBomDialog } from './components/Project/CableBomDialog'
 import { PrintDialog } from './components/Print/PrintDialog'
@@ -449,6 +452,9 @@ export default function App() {
       <LocationBomDialog />
       <RackEditorDialog />
       <MobileShareDialog />
+      <AboutDialog />
+      <PatchListDialog />
+      <CalculatorsDialog />
 
       <ProjectMetaDialog
         open={metaDialog !== null}

--- a/src/renderer/components/About/AboutDialog.tsx
+++ b/src/renderer/components/About/AboutDialog.tsx
@@ -1,0 +1,96 @@
+/**
+ * About dialog — surfaces the running app version + build info so the
+ * user can tell their installed version apart from what's in a github
+ * release. Triggered from the Help menu and from the version chip in
+ * the StatusBar.
+ */
+
+import { useUiStore } from '../../store/uiStore'
+import {
+  APP_AUTHOR,
+  APP_BUILD_DATE,
+  APP_DESCRIPTION,
+  APP_REPO_URL,
+  APP_VERSION,
+} from '../../lib/appInfo'
+
+const buildDateLocal = (() => {
+  try {
+    return new Date(APP_BUILD_DATE).toLocaleString()
+  } catch {
+    return APP_BUILD_DATE
+  }
+})()
+
+export const AboutDialog = () => {
+  const open = useUiStore((s) => s.aboutDialog.open)
+  const close = useUiStore((s) => s.closeAboutDialog)
+  if (!open) return null
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onMouseDown={(e) => e.target === e.currentTarget && close()}
+    >
+      <div className="w-full max-w-md rounded-lg border border-slate-700 bg-slate-900 text-slate-100 shadow-2xl">
+        <header className="flex items-center justify-between border-b border-slate-700 px-4 py-3">
+          <h2 className="text-sm font-semibold">
+            <span className="mr-2">ⓘ</span>Über Cable Planner
+          </h2>
+          <button
+            type="button"
+            onClick={close}
+            className="rounded px-2 py-1 text-xs text-slate-400 hover:bg-slate-800 hover:text-slate-100"
+          >
+            ✕
+          </button>
+        </header>
+        <div className="space-y-3 p-4 text-sm">
+          <div className="flex items-center gap-3 rounded border border-slate-800 bg-slate-950/40 p-3">
+            <div className="text-3xl">🔌</div>
+            <div className="min-w-0">
+              <div className="font-semibold text-slate-100">Cable Planner</div>
+              <div className="text-[11px] text-slate-400">{APP_DESCRIPTION}</div>
+            </div>
+            <div className="ml-auto shrink-0 rounded bg-emerald-700 px-2 py-1 font-mono text-xs text-white">
+              v{APP_VERSION}
+            </div>
+          </div>
+
+          <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs">
+            <dt className="text-slate-500">Version</dt>
+            <dd className="font-mono text-slate-100">{APP_VERSION}</dd>
+            <dt className="text-slate-500">Build</dt>
+            <dd className="font-mono text-slate-100">{buildDateLocal}</dd>
+            {APP_AUTHOR && (
+              <>
+                <dt className="text-slate-500">Autor</dt>
+                <dd className="text-slate-100">{APP_AUTHOR}</dd>
+              </>
+            )}
+            <dt className="text-slate-500">Repository</dt>
+            <dd>
+              <a
+                href={APP_REPO_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sky-400 underline hover:text-sky-300"
+              >
+                {APP_REPO_URL.replace(/^https?:\/\//, '')}
+              </a>
+            </dd>
+            <dt className="text-slate-500">Plattform</dt>
+            <dd className="text-slate-100">
+              Electron + React + ReactFlow + Vite + Tailwind
+            </dd>
+          </dl>
+
+          <div className="rounded border border-slate-800 bg-slate-950/40 p-3 text-[11px] text-slate-400">
+            Issues + Feature-Wünsche bitte direkt auf GitHub melden. Der Release-Workflow
+            baut Windows EXE + macOS DMG automatisch, sobald ein <code>v*</code>-Tag auf{' '}
+            <code>main</code> gepusht wird.
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/Calculators/CalculatorsDialog.tsx
+++ b/src/renderer/components/Calculators/CalculatorsDialog.tsx
@@ -1,0 +1,377 @@
+/**
+ * Roadmap #76 follow-up — three small standalone utility calculators:
+ *   • Cable-Length: Euclidean + vertical-rise + slack reserve
+ *   • Bandwidth: video format → Mbps + SDI-tier check
+ *   • Power Consumption: sum of equipment watts → kW + amps + breaker
+ *
+ * All three live in one dialog with tabs so we don't clutter the topbar
+ * with three more menu items.
+ */
+
+import { useMemo, useState } from 'react'
+import { useUiStore } from '../../store/uiStore'
+import { useProjectStore } from '../../store/projectStore'
+
+type Tab = 'length' | 'bandwidth' | 'power'
+
+const TAB_LABEL: Record<Tab, string> = {
+  length: '📐 Kabel-Länge',
+  bandwidth: '📡 Bandbreite',
+  power: '⚡ Stromverbrauch',
+}
+
+const TabBar = ({
+  active,
+  onChange,
+}: {
+  active: Tab
+  onChange: (next: Tab) => void
+}) => (
+  <div className="flex gap-1 border-b border-slate-800 px-4 py-2">
+    {(Object.keys(TAB_LABEL) as Tab[]).map((t) => (
+      <button
+        key={t}
+        type="button"
+        onClick={() => onChange(t)}
+        className={`rounded px-3 py-1 text-xs ${
+          active === t
+            ? 'bg-sky-700 text-white'
+            : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+        }`}
+      >
+        {TAB_LABEL[t]}
+      </button>
+    ))}
+  </div>
+)
+
+// ─── Cable Length ──────────────────────────────────────────────────────────
+
+const LengthTab = () => {
+  const [horizontal, setHorizontal] = useState(10)
+  const [vertical, setVertical] = useState(2)
+  const [slackPercent, setSlackPercent] = useState(15)
+  const [bendCount, setBendCount] = useState(2)
+  const bendReserve = 0.3 // m per bend
+  const straight = Math.sqrt(horizontal * horizontal + vertical * vertical)
+  const withBends = straight + bendCount * bendReserve
+  const total = withBends * (1 + slackPercent / 100)
+  return (
+    <div className="space-y-3 p-4 text-sm">
+      <p className="text-[11px] text-slate-400">
+        Schätzt die benötigte Kabel-Länge aus horizontaler Distanz, vertikaler Steigung,
+        Anzahl der 90°-Bögen und einem prozentualen Reserve-Slack. Reserve pro Bogen: 0,3 m.
+      </p>
+      <div className="grid grid-cols-2 gap-3">
+        <label className="block">
+          <span className="mb-1 block text-xs text-slate-400">Horizontal (m)</span>
+          <input
+            type="number"
+            step={0.1}
+            value={horizontal}
+            onChange={(e) => setHorizontal(Math.max(0, Number(e.target.value) || 0))}
+            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs text-slate-400">Vertikal (m)</span>
+          <input
+            type="number"
+            step={0.1}
+            value={vertical}
+            onChange={(e) => setVertical(Math.max(0, Number(e.target.value) || 0))}
+            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs text-slate-400">Anzahl Bögen</span>
+          <input
+            type="number"
+            min={0}
+            value={bendCount}
+            onChange={(e) => setBendCount(Math.max(0, Number(e.target.value) || 0))}
+            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs text-slate-400">Slack-Reserve (%)</span>
+          <input
+            type="number"
+            min={0}
+            step={5}
+            value={slackPercent}
+            onChange={(e) => setSlackPercent(Math.max(0, Number(e.target.value) || 0))}
+            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+          />
+        </label>
+      </div>
+      <div className="rounded border border-sky-700 bg-sky-950/40 p-3">
+        <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs">
+          <dt className="text-slate-500">Direkte Distanz</dt>
+          <dd className="font-mono text-slate-200">{straight.toFixed(2)} m</dd>
+          <dt className="text-slate-500">+ Bogen-Reserve</dt>
+          <dd className="font-mono text-slate-200">{withBends.toFixed(2)} m</dd>
+          <dt className="text-slate-500">+ Slack ({slackPercent}%)</dt>
+          <dd className="font-mono text-lg font-semibold text-sky-200">{total.toFixed(2)} m</dd>
+        </dl>
+        <p className="mt-2 text-[10px] text-slate-500">
+          Empfehlung: nächst-größere Standard-Länge nehmen (z. B. {Math.ceil(total)} m oder{' '}
+          {Math.ceil(total / 5) * 5} m als 5-m-Raster).
+        </p>
+      </div>
+    </div>
+  )
+}
+
+// ─── Bandwidth ─────────────────────────────────────────────────────────────
+
+const SDI_TIERS: { label: string; mbps: number }[] = [
+  { label: 'HD-SDI (1.5G)', mbps: 1485 },
+  { label: '3G-SDI', mbps: 2970 },
+  { label: '6G-SDI', mbps: 5940 },
+  { label: '12G-SDI', mbps: 11880 },
+]
+
+const RESOLUTION_PRESETS: { label: string; w: number; h: number }[] = [
+  { label: '720p', w: 1280, h: 720 },
+  { label: '1080p', w: 1920, h: 1080 },
+  { label: '1440p', w: 2560, h: 1440 },
+  { label: '2160p / 4K UHD', w: 3840, h: 2160 },
+  { label: '4096 DCI', w: 4096, h: 2160 },
+  { label: '8K UHD', w: 7680, h: 4320 },
+]
+
+const FPS_PRESETS = [23.976, 24, 25, 29.97, 30, 50, 59.94, 60]
+
+const SAMPLING_PRESETS: { label: string; factor: number }[] = [
+  { label: '4:2:0 8-bit', factor: 12 },
+  { label: '4:2:2 8-bit', factor: 16 },
+  { label: '4:2:2 10-bit', factor: 20 },
+  { label: '4:4:4 8-bit', factor: 24 },
+  { label: '4:4:4 10-bit', factor: 30 },
+  { label: '4:4:4 12-bit', factor: 36 },
+]
+
+const BandwidthTab = () => {
+  const [resolution, setResolution] = useState(RESOLUTION_PRESETS[1])
+  const [fps, setFps] = useState(50)
+  const [sampling, setSampling] = useState(SAMPLING_PRESETS[2])
+  const bpsRaw = resolution.w * resolution.h * fps * sampling.factor
+  const mbps = bpsRaw / 1_000_000
+  const fittingTier = SDI_TIERS.find((t) => mbps <= t.mbps)
+  return (
+    <div className="space-y-3 p-4 text-sm">
+      <p className="text-[11px] text-slate-400">
+        Brutto-Datenrate eines Video-Streams (vor Kompression) und der kleinste SDI-Tier der
+        sie tragen kann. Pixel × Zeilen × fps × Bits-pro-Pixel.
+      </p>
+      <div className="grid grid-cols-3 gap-3">
+        <label className="block">
+          <span className="mb-1 block text-xs text-slate-400">Auflösung</span>
+          <select
+            value={resolution.label}
+            onChange={(e) =>
+              setResolution(
+                RESOLUTION_PRESETS.find((r) => r.label === e.target.value) ?? RESOLUTION_PRESETS[1],
+              )
+            }
+            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+          >
+            {RESOLUTION_PRESETS.map((r) => (
+              <option key={r.label} value={r.label}>
+                {r.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs text-slate-400">FPS</span>
+          <select
+            value={fps}
+            onChange={(e) => setFps(Number(e.target.value))}
+            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+          >
+            {FPS_PRESETS.map((f) => (
+              <option key={f} value={f}>
+                {f}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs text-slate-400">Sampling / Tiefe</span>
+          <select
+            value={sampling.label}
+            onChange={(e) =>
+              setSampling(
+                SAMPLING_PRESETS.find((s) => s.label === e.target.value) ?? SAMPLING_PRESETS[2],
+              )
+            }
+            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+          >
+            {SAMPLING_PRESETS.map((s) => (
+              <option key={s.label} value={s.label}>
+                {s.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div className="rounded border border-amber-700 bg-amber-950/30 p-3">
+        <div className="text-[10px] uppercase tracking-wide text-amber-300">Datenrate</div>
+        <div className="font-mono text-lg text-amber-100">{mbps.toLocaleString(undefined, { maximumFractionDigits: 1 })} Mbps</div>
+        <div className="mt-1 text-xs text-amber-200">
+          {fittingTier
+            ? `Passt in ${fittingTier.label} (${fittingTier.mbps} Mbps).`
+            : `Überschreitet 12G-SDI — nur über IP-Transport (ST 2110, NDI, JPEG-XS …) möglich.`}
+        </div>
+      </div>
+      <details className="rounded border border-slate-800 bg-slate-950/40">
+        <summary className="cursor-pointer px-3 py-1.5 text-[11px] uppercase tracking-wide text-slate-400">
+          SDI-Tiers
+        </summary>
+        <ul className="space-y-0.5 px-3 py-2 text-xs">
+          {SDI_TIERS.map((t) => (
+            <li key={t.label}>
+              <span className="inline-block w-28">{t.label}</span>
+              <span className="font-mono text-slate-400">≤ {t.mbps} Mbps</span>
+            </li>
+          ))}
+        </ul>
+      </details>
+    </div>
+  )
+}
+
+// ─── Power Consumption ─────────────────────────────────────────────────────
+
+const PowerTab = () => {
+  const equipment = useProjectStore((s) => s.project.equipment)
+  const [voltage, setVoltage] = useState(230)
+  const [marginPercent, setMarginPercent] = useState(20)
+  const totals = useMemo(() => {
+    let totalW = 0
+    let countedDevices = 0
+    let missingDevices = 0
+    const devices: { name: string; watts: number }[] = []
+    for (const e of equipment) {
+      const w = e.powerConsumptionWatts ?? 0
+      if (w > 0) {
+        totalW += w
+        countedDevices += 1
+        devices.push({ name: e.name, watts: w })
+      } else {
+        missingDevices += 1
+      }
+    }
+    devices.sort((a, b) => b.watts - a.watts)
+    return { totalW, countedDevices, missingDevices, devices }
+  }, [equipment])
+  const totalWithMargin = totals.totalW * (1 + marginPercent / 100)
+  const amps = totalWithMargin / Math.max(1, voltage)
+  const recommendedBreaker = amps > 0 ? [16, 25, 32, 63, 80, 125].find((b) => amps * 1.25 <= b) ?? '> 125' : '—'
+  return (
+    <div className="space-y-3 p-4 text-sm">
+      <p className="text-[11px] text-slate-400">
+        Summe der Verbrauchsangaben aus den Geräte-Eigenschaften
+        (<code className="rounded bg-slate-800 px-1">powerConsumptionWatts</code>). Geräte ohne Wert
+        zählen nicht mit; trage sie in den Properties nach, damit die Summe stimmt.
+      </p>
+      <div className="grid grid-cols-2 gap-3">
+        <label className="block">
+          <span className="mb-1 block text-xs text-slate-400">Netzspannung (V)</span>
+          <select
+            value={voltage}
+            onChange={(e) => setVoltage(Number(e.target.value))}
+            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+          >
+            <option value={230}>230 V (EU)</option>
+            <option value={120}>120 V (US)</option>
+            <option value={400}>400 V (3-Phasen)</option>
+          </select>
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs text-slate-400">Sicherheits-Reserve (%)</span>
+          <input
+            type="number"
+            min={0}
+            value={marginPercent}
+            onChange={(e) => setMarginPercent(Math.max(0, Number(e.target.value) || 0))}
+            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+          />
+        </label>
+      </div>
+      <div className="rounded border border-emerald-700 bg-emerald-950/30 p-3">
+        <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs">
+          <dt className="text-slate-500">Erfasste Geräte</dt>
+          <dd className="font-mono text-slate-200">
+            {totals.countedDevices} von {totals.countedDevices + totals.missingDevices}
+            {totals.missingDevices > 0 && (
+              <span className="ml-2 text-amber-300">({totals.missingDevices} ohne Wert)</span>
+            )}
+          </dd>
+          <dt className="text-slate-500">Gesamtverbrauch</dt>
+          <dd className="font-mono text-slate-200">{totals.totalW.toFixed(0)} W</dd>
+          <dt className="text-slate-500">+ Reserve ({marginPercent}%)</dt>
+          <dd className="font-mono text-emerald-200 text-lg">
+            {totalWithMargin.toFixed(0)} W · {(totalWithMargin / 1000).toFixed(2)} kW
+          </dd>
+          <dt className="text-slate-500">Stromstärke @ {voltage} V</dt>
+          <dd className="font-mono text-slate-200">{amps.toFixed(1)} A</dd>
+          <dt className="text-slate-500">Empfohlene Absicherung</dt>
+          <dd className="font-mono text-slate-200">
+            {typeof recommendedBreaker === 'number' ? `B${recommendedBreaker}` : recommendedBreaker}
+          </dd>
+        </dl>
+      </div>
+      {totals.devices.length > 0 && (
+        <details className="rounded border border-slate-800 bg-slate-950/40">
+          <summary className="cursor-pointer px-3 py-1.5 text-[11px] uppercase tracking-wide text-slate-400">
+            Top-Verbraucher
+          </summary>
+          <ul className="px-3 py-2 text-xs">
+            {totals.devices.slice(0, 12).map((d) => (
+              <li key={d.name} className="flex justify-between border-b border-slate-800 py-0.5">
+                <span className="truncate">{d.name}</span>
+                <span className="font-mono text-slate-400">{d.watts} W</span>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  )
+}
+
+export const CalculatorsDialog = () => {
+  const open = useUiStore((s) => s.calculators.open)
+  const close = useUiStore((s) => s.closeCalculators)
+  const initialTab = useUiStore((s) => s.calculators.tab) ?? 'length'
+  const [tab, setTab] = useState<Tab>(initialTab)
+  if (!open) return null
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onMouseDown={(e) => e.target === e.currentTarget && close()}
+    >
+      <div className="w-full max-w-2xl rounded-lg border border-slate-700 bg-slate-900 text-slate-100 shadow-2xl">
+        <header className="flex items-center justify-between border-b border-slate-700 px-4 py-3">
+          <h2 className="text-sm font-semibold">
+            <span className="mr-2">🧮</span>Werkzeuge / Rechner
+          </h2>
+          <button
+            type="button"
+            onClick={close}
+            className="rounded px-2 py-1 text-xs text-slate-400 hover:bg-slate-800 hover:text-slate-100"
+          >
+            ✕
+          </button>
+        </header>
+        <TabBar active={tab} onChange={setTab} />
+        {tab === 'length' && <LengthTab />}
+        {tab === 'bandwidth' && <BandwidthTab />}
+        {tab === 'power' && <PowerTab />}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/Canvas/CableEdge.tsx
+++ b/src/renderer/components/Canvas/CableEdge.tsx
@@ -178,6 +178,20 @@ const resolveOrthogonalWaypoints = (
     : rawWaypoints
 }
 
+/** Issue #53: deterministic small offset for the midline of a cable
+ *  so two cables that would compute the same midX/midY don't perfectly
+ *  overlap. Hash the cable id to a stable jitter in -10..+10 px. */
+const midlineJitter = (cableId: string): number => {
+  let hash = 0
+  for (let i = 0; i < cableId.length; i++) {
+    hash = (hash * 31 + cableId.charCodeAt(i)) | 0
+  }
+  // Map to -10, -6, -2, +2, +6, +10 — six discrete lanes so even
+  // many overlapping cables space out predictably.
+  const lanes = [-10, -6, -2, 2, 6, 10]
+  return lanes[Math.abs(hash) % lanes.length]
+}
+
 const buildPath = (
   cable: Cable,
   args: {
@@ -251,16 +265,22 @@ const buildPath = (
 
     // Compose intermediate points between sStub and tStub. The exact shape
     // depends on whether the two stubs share an axis after stub-out.
+    // Issue #53: when the user enabled `orthogonalCollisionShift` we
+    // jitter the midline so cables that would compute identical
+    // midX/midY don't perfectly overlap. The jitter is hashed from the
+    // cable id so it's stable across re-renders.
+    const collisionShiftOn = useUiStore.getState().orthogonalCollisionShift
+    const jitter = collisionShiftOn ? midlineJitter(cable.id) : 0
     const points: { x: number; y: number }[] = [{ x: sx, y: sy }, sStub]
     if (Math.abs(sStub.x - tStub.x) < 2 || Math.abs(sStub.y - tStub.y) < 2) {
       // Stubs are collinear: src → sStub → tStub → tgt is already orthogonal.
     } else if (sHorizontal && tHorizontal) {
       // Both handles horizontal (typical port-to-port): bend at midX.
-      const midX = (sStub.x + tStub.x) / 2
+      const midX = (sStub.x + tStub.x) / 2 + jitter
       points.push({ x: midX, y: sStub.y }, { x: midX, y: tStub.y })
     } else if (!sHorizontal && !tHorizontal) {
       // Both handles vertical: bend at midY.
-      const midY = (sStub.y + tStub.y) / 2
+      const midY = (sStub.y + tStub.y) / 2 + jitter
       points.push({ x: sStub.x, y: midY }, { x: tStub.x, y: midY })
     } else if (sHorizontal) {
       // Source horizontal → target vertical: single bend at (tStub.x, sStub.y).

--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -157,13 +157,46 @@ export const MenuBar = ({
           )}
         </Menu>
 
-        {onOpenTour && (
-          <Menu label={t('app.menu.help', 'Hilfe')}>
+        <Menu label={t('app.menu.tools', 'Werkzeuge')}>
+          <MenuItem
+            onClick={() => useUiStore.getState().openPatchList()}
+            icon="🪢"
+          >
+            {t('app.menu.tools.patchList', 'Patchliste…')}
+          </MenuItem>
+          <MenuItem
+            onClick={() => useUiStore.getState().openCalculators('length')}
+            icon="📐"
+          >
+            {t('app.menu.tools.cableLength', 'Kabel-Länge berechnen…')}
+          </MenuItem>
+          <MenuItem
+            onClick={() => useUiStore.getState().openCalculators('bandwidth')}
+            icon="📡"
+          >
+            {t('app.menu.tools.bandwidth', 'Bandbreite berechnen…')}
+          </MenuItem>
+          <MenuItem
+            onClick={() => useUiStore.getState().openCalculators('power')}
+            icon="⚡"
+          >
+            {t('app.menu.tools.power', 'Stromverbrauch berechnen…')}
+          </MenuItem>
+        </Menu>
+
+        <Menu label={t('app.menu.help', 'Hilfe')}>
+          {onOpenTour && (
             <MenuItem onClick={onOpenTour} icon="💡">
               {t('app.menu.help.tour', 'Erste-Schritte-Tour…')}
             </MenuItem>
-          </Menu>
-        )}
+          )}
+          <MenuItem
+            onClick={() => useUiStore.getState().openAboutDialog()}
+            icon="ⓘ"
+          >
+            {t('app.menu.help.about', 'Über Cable Planner…')}
+          </MenuItem>
+        </Menu>
       </div>
 
       <div className="flex min-w-0 flex-1 items-center justify-center gap-2">

--- a/src/renderer/components/Layout/StatusBar.tsx
+++ b/src/renderer/components/Layout/StatusBar.tsx
@@ -1,3 +1,6 @@
+import { APP_VERSION } from '../../lib/appInfo'
+import { useUiStore } from '../../store/uiStore'
+
 interface StatusBarProps {
   projectName: string
   zoom: number
@@ -69,6 +72,14 @@ export const StatusBar = ({
           Rentman: {rentmanProjectName ?? (hasToken ? 'Token bereit' : 'Standalone')}
         </span>
         <span>Zoom: {(zoom * 100).toFixed(0)}%</span>
+        <button
+          type="button"
+          onClick={() => useUiStore.getState().openAboutDialog()}
+          className="rounded bg-slate-800 px-1.5 py-0.5 font-mono text-[10px] text-slate-400 hover:bg-slate-700 hover:text-slate-200"
+          title="Über Cable Planner"
+        >
+          v{APP_VERSION}
+        </button>
       </div>
     </footer>
   )

--- a/src/renderer/components/Patch/PatchListDialog.tsx
+++ b/src/renderer/components/Patch/PatchListDialog.tsx
@@ -1,0 +1,222 @@
+/**
+ * Roadmap #76 follow-up — "Patchliste als eigene Ansicht".
+ *
+ * The Cable-BOM dialog already aggregates cables by (type, length). The
+ * Patchliste differs: one row per physical cable showing the full
+ * routing, sorted alphabetically by source device. Use case: hand the
+ * field tech a printable list of every individual patch to make.
+ */
+
+import { useMemo, useState } from 'react'
+import { useUiStore } from '../../store/uiStore'
+import { useProjectStore } from '../../store/projectStore'
+import { downloadBlob } from '../../lib/downloadBlob'
+
+type SortKey = 'fromDevice' | 'toDevice' | 'type' | 'length' | 'color'
+
+interface PatchRow {
+  cableId: string
+  fromDevice: string
+  fromPort: string
+  toDevice: string
+  toPort: string
+  type: string
+  length: number
+  color: string
+  cableName: string
+  notes: string
+}
+
+export const PatchListDialog = () => {
+  const open = useUiStore((s) => s.patchList.open)
+  const close = useUiStore((s) => s.closePatchList)
+  const equipment = useProjectStore((s) => s.project.equipment)
+  const cables = useProjectStore((s) => s.project.cables)
+  const projectName = useProjectStore((s) => s.project.metadata.name)
+  const [filter, setFilter] = useState('')
+  const [sortKey, setSortKey] = useState<SortKey>('fromDevice')
+
+  const rows = useMemo<PatchRow[]>(() => {
+    if (!open) return []
+    const eqById = new Map(equipment.map((e) => [e.id, e]))
+    const list = cables.map<PatchRow>((c) => {
+      const from = eqById.get(c.fromEquipmentId)
+      const to = eqById.get(c.toEquipmentId)
+      const fromPort =
+        from?.outputs.find((p) => p.id === c.fromPortId) ??
+        from?.inputs.find((p) => p.id === c.fromPortId)
+      const toPort =
+        to?.inputs.find((p) => p.id === c.toPortId) ??
+        to?.outputs.find((p) => p.id === c.toPortId)
+      return {
+        cableId: c.id,
+        fromDevice: from?.name ?? '?',
+        fromPort: fromPort?.name ?? c.fromPortId,
+        toDevice: to?.name ?? '?',
+        toPort: toPort?.name ?? c.toPortId,
+        type: c.type,
+        length: c.length,
+        color: c.color || '#64748b',
+        cableName: c.name,
+        notes: c.notes ?? '',
+      }
+    })
+    const cmp = (a: PatchRow, b: PatchRow): number => {
+      switch (sortKey) {
+        case 'fromDevice':
+          return a.fromDevice.localeCompare(b.fromDevice) || a.fromPort.localeCompare(b.fromPort)
+        case 'toDevice':
+          return a.toDevice.localeCompare(b.toDevice) || a.toPort.localeCompare(b.toPort)
+        case 'type':
+          return a.type.localeCompare(b.type) || a.length - b.length
+        case 'length':
+          return a.length - b.length
+        case 'color':
+          return a.color.localeCompare(b.color)
+      }
+    }
+    return list.sort(cmp)
+  }, [cables, equipment, open, sortKey])
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase()
+    if (!q) return rows
+    return rows.filter((r) =>
+      [r.fromDevice, r.fromPort, r.toDevice, r.toPort, r.type, r.cableName, r.notes].some(
+        (v) => v.toLowerCase().includes(q),
+      ),
+    )
+  }, [rows, filter])
+
+  if (!open) return null
+
+  const exportCsv = () => {
+    const header = ['Von Gerät', 'Von Port', 'Nach Gerät', 'Nach Port', 'Typ', 'Länge (m)', 'Farbe', 'Kabelname', 'Notizen']
+    const escape = (v: string) => `"${v.replace(/"/g, '""')}"`
+    const lines = [
+      header.join(';'),
+      ...filtered.map((r) =>
+        [
+          escape(r.fromDevice),
+          escape(r.fromPort),
+          escape(r.toDevice),
+          escape(r.toPort),
+          escape(r.type),
+          String(r.length),
+          escape(r.color),
+          escape(r.cableName),
+          escape(r.notes),
+        ].join(';'),
+      ),
+    ]
+    downloadBlob(
+      `${projectName || 'cable-planner'}-patchliste.csv`,
+      '﻿' + lines.join('\r\n'),
+      'text/csv;charset=utf-8',
+    )
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onMouseDown={(e) => e.target === e.currentTarget && close()}
+    >
+      <div className="flex h-[85vh] w-full max-w-5xl flex-col overflow-hidden rounded-lg border border-slate-700 bg-slate-900 text-slate-100 shadow-2xl">
+        <header className="flex items-center justify-between border-b border-slate-700 px-4 py-3">
+          <div>
+            <h2 className="text-sm font-semibold">
+              <span className="mr-2">🪢</span>Patchliste
+            </h2>
+            <p className="text-[10px] text-slate-400">
+              Jedes Kabel als eigene Zeile, sortiert für die Patch-Reihenfolge auf dem Set.
+              CSV-Export für Excel/Druck enthält die aktuell gefilterten Zeilen.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={exportCsv}
+              disabled={filtered.length === 0}
+              className="rounded bg-emerald-700 px-3 py-1 text-xs hover:bg-emerald-600 disabled:opacity-40"
+            >
+              ⬇ CSV exportieren
+            </button>
+            <button
+              type="button"
+              onClick={close}
+              className="rounded bg-slate-800 px-2 py-1 text-xs hover:bg-slate-700"
+            >
+              Schließen
+            </button>
+          </div>
+        </header>
+        <div className="flex items-center gap-2 border-b border-slate-800 px-4 py-2">
+          <input
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Suchen (Gerät, Port, Typ, Farbe, Notiz …)"
+            className="flex-1 rounded border border-slate-700 bg-slate-950 px-2 py-1 text-xs"
+          />
+          <span className="text-[11px] text-slate-400">
+            {filtered.length} / {rows.length}
+          </span>
+        </div>
+        <div className="flex-1 overflow-auto">
+          <table className="w-full text-xs">
+            <thead className="sticky top-0 bg-slate-950 text-slate-400">
+              <tr>
+                {[
+                  { k: 'fromDevice' as const, label: 'Von Gerät' },
+                  { k: 'fromDevice' as const, label: 'Port' },
+                  { k: 'toDevice' as const, label: 'Nach Gerät' },
+                  { k: 'toDevice' as const, label: 'Port' },
+                  { k: 'type' as const, label: 'Typ' },
+                  { k: 'length' as const, label: 'Länge (m)' },
+                  { k: 'color' as const, label: 'Farbe' },
+                ].map((col, i) => (
+                  <th
+                    key={`${col.k}-${i}`}
+                    className="cursor-pointer px-2 py-1 text-left hover:text-slate-200"
+                    onClick={() => setSortKey(col.k)}
+                  >
+                    {col.label}
+                    {sortKey === col.k && <span className="ml-1 text-[9px]">▲</span>}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((r) => (
+                <tr key={r.cableId} className="border-t border-slate-800 hover:bg-slate-900">
+                  <td className="px-2 py-1 font-medium text-slate-100">{r.fromDevice}</td>
+                  <td className="px-2 py-1 text-slate-300">{r.fromPort}</td>
+                  <td className="px-2 py-1 font-medium text-slate-100">{r.toDevice}</td>
+                  <td className="px-2 py-1 text-slate-300">{r.toPort}</td>
+                  <td className="px-2 py-1 text-slate-300">{r.type}</td>
+                  <td className="px-2 py-1 text-right text-slate-300">{r.length}</td>
+                  <td className="px-2 py-1">
+                    <span
+                      className="inline-block h-3 w-8 rounded"
+                      style={{ background: r.color }}
+                      title={r.color}
+                    />
+                  </td>
+                </tr>
+              ))}
+              {filtered.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={7}
+                    className="px-2 py-6 text-center text-[11px] text-slate-500"
+                  >
+                    Keine Kabel passen zum Filter.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/Properties/EquipmentProperties.tsx
+++ b/src/renderer/components/Properties/EquipmentProperties.tsx
@@ -989,6 +989,11 @@ export const EquipmentProperties = () => {
         />
       </label>
 
+      <details className="rounded border border-slate-800 bg-slate-950/40 [&_summary]:cursor-pointer">
+        <summary className="px-2 py-1.5 text-[11px] uppercase tracking-wide text-slate-400 hover:text-slate-200">
+          Optionale Felder (Hersteller-Link, Referenzbild, Icon)
+        </summary>
+        <div className="space-y-3 border-t border-slate-800 p-2">
       <label className="block">
         <span className="mb-1 block text-slate-300">
           {t('eq.field.manufacturerUrl', 'Hersteller-Link')}{' '}
@@ -1109,6 +1114,8 @@ export const EquipmentProperties = () => {
           )}
         </div>
       </label>
+        </div>
+      </details>
 
       <label className="flex items-center gap-2 text-[12px] text-slate-300">
         <input
@@ -1279,6 +1286,28 @@ export const EquipmentProperties = () => {
             className="w-full rounded border border-slate-700 bg-slate-900 p-2"
           />
         </label>
+        <label className="mt-2 block">
+          <span className="mb-1 block text-slate-300">
+            Stromverbrauch (W)
+            <span className="ml-1 text-slate-500">(continuous; vom Datenblatt)</span>
+          </span>
+          <input
+            type="number"
+            min={0}
+            step={1}
+            value={equipment.powerConsumptionWatts ?? ''}
+            placeholder="optional"
+            onChange={(event) =>
+              updateEquipment(equipment.id, {
+                powerConsumptionWatts: event.target.value
+                  ? Math.max(0, Number(event.target.value))
+                  : undefined,
+              })
+            }
+            className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono"
+            title="Wird im Werkzeuge → Stromverbrauch-Rechner aufsummiert."
+          />
+        </label>
       </fieldset>
 
       {hasSdiPorts(equipment) && (
@@ -1300,8 +1329,14 @@ export const EquipmentProperties = () => {
         onChange={(outputs) => updateEquipment(equipment.id, { outputs })}
       />
 
-      <fieldset className="rounded border border-slate-700 p-2">
-        <legend className="px-1 text-[11px] uppercase tracking-wide text-slate-400">Rack / 19" Einstellungen</legend>
+      <details
+        className="rounded border border-slate-700 [&_summary]:cursor-pointer"
+        open={!!equipment.isRackDevice}
+      >
+        <summary className="px-2 py-1.5 text-[11px] uppercase tracking-wide text-slate-400 hover:text-slate-200">
+          Rack / 19" Einstellungen {equipment.isRackDevice ? `(${equipment.rackUnits ?? 1} HE)` : ''}
+        </summary>
+        <fieldset className="border-t border-slate-800 p-2">
         <label className="mb-2 flex items-center gap-2 text-xs">
           <input
             type="checkbox"
@@ -1386,7 +1421,8 @@ export const EquipmentProperties = () => {
             <RackFacePreview equipment={equipment} viewMode={rackViewMode} />
           </>
         )}
-      </fieldset>
+        </fieldset>
+      </details>
 
       <div className="rounded border border-slate-700 bg-slate-900/40 p-2">
         <div className="mb-1 text-[10px] uppercase tracking-wide text-slate-400">

--- a/src/renderer/lib/appInfo.ts
+++ b/src/renderer/lib/appInfo.ts
@@ -1,0 +1,28 @@
+/** Build-time app metadata. The constants are injected by Vite from
+ *  `package.json` so the renderer can show them without an IPC round-
+ *  trip. Falls back to safe defaults if the consts aren't defined (e.g.
+ *  unit tests, story-book, or a stripped-down web build). */
+
+const safe = (value: unknown, fallback: string): string =>
+  typeof value === 'string' && value.length > 0 ? value : fallback
+
+const tryGet = <T>(get: () => T, fallback: T): T => {
+  try {
+    return get()
+  } catch {
+    return fallback
+  }
+}
+
+export const APP_VERSION = tryGet(() => safe(__APP_VERSION__, '0.0.0'), '0.0.0')
+export const APP_DESCRIPTION = tryGet(
+  () => safe(__APP_DESCRIPTION__, 'Cable Planner'),
+  'Cable Planner',
+)
+export const APP_AUTHOR = tryGet(() => safe(__APP_AUTHOR__, ''), '')
+export const APP_BUILD_DATE = tryGet(
+  () => safe(__APP_BUILD_DATE__, new Date().toISOString()),
+  new Date().toISOString(),
+)
+
+export const APP_REPO_URL = 'https://github.com/larszu/cable-planner'

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -255,6 +255,15 @@ interface UiState extends PersistedUiState {
   mobileShare: { open: boolean }
   openMobileShare: () => void
   closeMobileShare: () => void
+  aboutDialog: { open: boolean }
+  openAboutDialog: () => void
+  closeAboutDialog: () => void
+  patchList: { open: boolean }
+  openPatchList: () => void
+  closePatchList: () => void
+  calculators: { open: boolean; tab?: 'length' | 'bandwidth' | 'power' }
+  openCalculators: (tab?: 'length' | 'bandwidth' | 'power') => void
+  closeCalculators: () => void
   /** Rentman equipment import dialog (cross-component trigger). */
   rentmanImport: { open: boolean }
   openRentmanImport: () => void
@@ -439,6 +448,15 @@ export const useUiStore = create<UiState>((set) => ({
   mobileShare: { open: false },
   openMobileShare: () => set({ mobileShare: { open: true } }),
   closeMobileShare: () => set({ mobileShare: { open: false } }),
+  aboutDialog: { open: false },
+  openAboutDialog: () => set({ aboutDialog: { open: true } }),
+  closeAboutDialog: () => set({ aboutDialog: { open: false } }),
+  patchList: { open: false },
+  openPatchList: () => set({ patchList: { open: true } }),
+  closePatchList: () => set({ patchList: { open: false } }),
+  calculators: { open: false },
+  openCalculators: (tab) => set({ calculators: { open: true, tab } }),
+  closeCalculators: () => set({ calculators: { open: false } }),
   rentmanImport: { open: false },
   openRentmanImport: () => set({ rentmanImport: { open: true } }),
   closeRentmanImport: () => set({ rentmanImport: { open: false } }),

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -163,6 +163,10 @@ export interface EquipmentItem {
    *  Visualised on the canvas with a small ✓ marker on the header and
    *  surfaced as a column in the equipment BOM. (H2R parity.) */
   packed?: boolean
+  /** Roadmap #76 follow-up: rated power consumption in watts (continuous).
+   *  Fed into the Power-Consumption calculator and the equipment BOM
+   *  totals row. Optional — only the user/data-sheet fills this in. */
+  powerConsumptionWatts?: number
   /**
    * Native display resolution (for monitors, multiviewers, displays).
    * Format example: "1920x1080", "3840x2160".

--- a/src/renderer/vite-env.d.ts
+++ b/src/renderer/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+/** Build-time constants injected by `vite.config.ts` via `define`. They
+ *  come from package.json so the renderer can show them in the About
+ *  dialog and StatusBar without an IPC round-trip. */
+declare const __APP_VERSION__: string
+declare const __APP_DESCRIPTION__: string
+declare const __APP_AUTHOR__: string
+declare const __APP_BUILD_DATE__: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,26 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { resolve } from 'node:path'
+import { readFileSync } from 'node:fs'
+
+// Read version from package.json at build time so the renderer can show
+// it in the About dialog + StatusBar without an IPC round-trip. Build
+// timestamp is also injected — handy for QA when comparing build hashes.
+const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8')) as {
+  version: string
+  description?: string
+  author?: { name?: string; email?: string } | string
+}
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+    __APP_DESCRIPTION__: JSON.stringify(pkg.description ?? ''),
+    __APP_AUTHOR__: JSON.stringify(
+      typeof pkg.author === 'string' ? pkg.author : pkg.author?.name ?? '',
+    ),
+    __APP_BUILD_DATE__: JSON.stringify(new Date().toISOString()),
+  },
   plugins: [
     react(),
     // Remove crossorigin attribute so file:// loading works in packaged Electron


### PR DESCRIPTION
## Summary

Roadmap #76 follow-up — clears the remaining "open-issue-but-can-do-now"
items plus the user's About-section request.

**Closes #60, closes #53.** Also delivers all four "no-ticket-yet" items
from the analysis section of #76: Patchliste, three calculators, About,
power-consumption field.

Still deferred (need external input):
- **#52 / #63** ATEM Fairlight Audio Router — needs a real Fairlight XML
  sample before any code is worth writing.
- **#79** Input-side arrow direction — would break straight/curved-mode
  semantics; orthogonal already has the 18 px stub.

---

## What's new in v7.2.2

### Visible version
- `vite.config.ts` injects `__APP_VERSION__` etc. from `package.json` at
  build time. New `lib/appInfo.ts` wraps the constants with safe
  fallbacks.
- **`components/About/AboutDialog.tsx`** shows version + build date +
  author + repo + platform stack. Reachable from **Hilfe → ⓘ Über Cable
  Planner…** and from the new **version chip in the StatusBar** (right
  side, monospace, click-to-open).

### #60 — EquipmentProperties accordion
- Hersteller-Link / Referenzbild / Icon-Picker — the user's exact
  "unwichtige Felder" example — now collapse into one `<details>` block
  at the top of the panel.
- Rack/19" Einstellungen fieldset is also wrapped in `<details>`;
  defaults to open only for actual rack devices.

### Patchliste als eigene Ansicht
- **`components/Patch/PatchListDialog`**: one row per cable, sortable
  by source/target/type/length/color. Live filter + CSV export
  (semicolon + UTF-8 BOM so Excel opens it correctly).

### Three calculators
- **`components/Calculators/CalculatorsDialog`** with three tabs:
  - 📐 **Kabel-Länge** — horizontal + vertikal + Bogen-Reserve +
    Slack-%.
  - 📡 **Bandbreite** — Auflösung × FPS × Sampling → Mbps, mapped to
    smallest fitting SDI tier (HD/3G/6G/12G).
  - ⚡ **Stromverbrauch** — sums `equipment.powerConsumptionWatts`,
    applies margin %, computes amps at chosen voltage, recommends
    breaker (B16…B125). Top-12 verbrauchers list.
- New **Werkzeuge** menu in the topbar with deep-links to each tab.
- New `equipment.powerConsumptionWatts` field + Watt input next to
  Notes in EquipmentProperties.

### #53 — Orthogonal collision shift (functional now)
- The v0.10.0 toggle now does something. When on, every orthogonal
  cable's midline is jittered by a deterministic ±2/±6/±10 px hashed
  from the cable id (six lanes). Stable across renders. Cables that
  would compute identical midX/midY now fan out predictably instead
  of perfectly overlapping. Full per-frame collision routing remains
  a larger future change.

## What you do

1. Merge this PR.
2. Tag `v7.2.2` on `main` via the GitHub UI — `release.yml` builds
   Windows EXE + macOS DMG.

## Test plan

- [ ] Open the app → version chip in the bottom-right reads `v7.2.2`
- [ ] Click the chip → About dialog shows build date + repo link
- [ ] Open any device → Hersteller-Link/Referenzbild/Icon are hidden
      under a single collapsed accordion at the top
- [ ] Werkzeuge → Patchliste → all cables listed; click a column header
      to re-sort; type in the filter box; click "CSV exportieren"
- [ ] Werkzeuge → Kabel-Länge → values respond live; default config
      shows ~12.8 m for 10/2/2 with 15 % slack
- [ ] Werkzeuge → Bandbreite → 1080p × 50 fps × 4:2:2 10-bit reports
      ~2073 Mbps and "passt in 3G-SDI"
- [ ] Set `powerConsumptionWatts` on a couple of devices → Werkzeuge →
      Stromverbrauch totals them, suggests a breaker
- [ ] Settings → Bearbeiten → enable "Mittellinien automatisch
      versetzen" → place two cables that previously overlapped → they
      now sit side by side


---
_Generated by [Claude Code](https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH)_