### PR TITLE
v7.2.3: ATEM audio router polish (#63) + Videohub matrix unified + encoding fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.2.2",
+    "version": "7.2.3",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/components/Atem/AtemAudioRouterDialog.tsx
+++ b/src/renderer/components/Atem/AtemAudioRouterDialog.tsx
@@ -342,25 +342,180 @@ const CELL = 18
 const HEADER_HEIGHT = 110
 const SIDE_WIDTH = 220
 
+/** Issue #63: shared checkbox-list overlay for excluding sources or
+ *  outputs from the matrix. Items are grouped by `groupKey` so the
+ *  user can tick a whole device (e.g. "MADI", "Out 5/6") in one
+ *  click. Used by both source and output filter buttons. */
+interface ChannelPickerProps {
+  label: string
+  items: { id: number; name: string }[]
+  excluded: Set<number>
+  onToggle: (id: number) => void
+  onSetAll: (excludedIds: number[]) => void
+  groupKey: (name: string) => string
+  onClose: () => void
+}
+
+const ChannelPicker = ({
+  label,
+  items,
+  excluded,
+  onToggle,
+  onSetAll,
+  groupKey,
+  onClose,
+}: ChannelPickerProps) => {
+  const groups = useMemo(() => {
+    const map = new Map<string, { id: number; name: string }[]>()
+    for (const it of items) {
+      const k = groupKey(it.name)
+      const list = map.get(k) ?? []
+      list.push(it)
+      map.set(k, list)
+    }
+    return Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b))
+  }, [items, groupKey])
+
+  const allExcluded = items.length > 0 && items.every((it) => excluded.has(it.id))
+  return (
+    <div className="border-b border-slate-800 bg-slate-950/60 px-4 py-2 text-xs">
+      <div className="mb-1 flex items-center justify-between">
+        <span className="text-slate-300">
+          {label} ein-/ausblenden — abgewählte Einträge fallen aus Filter, Liste und Matrix.
+        </span>
+        <div className="flex gap-1">
+          <button
+            type="button"
+            onClick={() => onSetAll([])}
+            className="rounded bg-slate-800 px-2 py-0.5 text-[11px] hover:bg-slate-700"
+          >
+            Alle zeigen
+          </button>
+          <button
+            type="button"
+            onClick={() => onSetAll(items.map((i) => i.id))}
+            className="rounded bg-slate-800 px-2 py-0.5 text-[11px] hover:bg-slate-700"
+            disabled={allExcluded}
+          >
+            Alle ausblenden
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded bg-slate-800 px-2 py-0.5 text-[11px] hover:bg-slate-700"
+          >
+            Schließen
+          </button>
+        </div>
+      </div>
+      <div className="flex max-h-32 flex-wrap gap-x-3 gap-y-1 overflow-auto">
+        {groups.map(([key, members]) => {
+          const allHidden = members.every((m) => excluded.has(m.id))
+          const someHidden = members.some((m) => excluded.has(m.id))
+          return (
+            <div key={key} className="flex flex-col">
+              <button
+                type="button"
+                onClick={() => {
+                  const next = new Set(excluded)
+                  if (allHidden) {
+                    for (const m of members) next.delete(m.id)
+                  } else {
+                    for (const m of members) next.add(m.id)
+                  }
+                  onSetAll(Array.from(next))
+                }}
+                className={`mb-0.5 rounded px-2 py-0.5 text-left text-[11px] font-semibold ${
+                  allHidden
+                    ? 'bg-slate-800 text-slate-500'
+                    : someHidden
+                      ? 'bg-amber-900/40 text-amber-200'
+                      : 'bg-sky-900/40 text-sky-200'
+                }`}
+                title={`${key} — komplette Gruppe an-/abhaken`}
+              >
+                {allHidden ? '☐' : someHidden ? '◐' : '☑'} {key}
+              </button>
+              {members.map((m) => (
+                <label
+                  key={m.id}
+                  className="flex items-center gap-1 pl-2 text-[10px] text-slate-300"
+                >
+                  <input
+                    type="checkbox"
+                    checked={!excluded.has(m.id)}
+                    onChange={() => onToggle(m.id)}
+                  />
+                  <span className="truncate" title={m.name}>
+                    {m.name}
+                  </span>
+                </label>
+              ))}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
 const MatrixView = ({ config, setConfig }: ViewProps) => {
   const matrix = config.matrix!
   const [filterSources, setFilterSources] = useState('')
   const [filterOutputs, setFilterOutputs] = useState('')
+  // Issue #63: per-id exclude lists so the user can hide groups of
+  // sources/outputs they never patch (e.g. MADI block, output pairs
+  // 5/6, 7/8 …). Stored in this component's state because it's a
+  // pure UI concern; persisting would only help across sessions and
+  // adds store surface for little gain.
+  const [excludedSourceIds, setExcludedSourceIds] = useState<Set<number>>(new Set())
+  const [excludedOutputIds, setExcludedOutputIds] = useState<Set<number>>(new Set())
+  const [showSourcePicker, setShowSourcePicker] = useState(false)
+  const [showOutputPicker, setShowOutputPicker] = useState(false)
+  // Override the "too many crosspoints" guard — the user wants to be
+  // able to scroll through a big matrix anyway. We start with the
+  // guard armed (so the warning still flashes once for a fresh
+  // session) and remember the override across re-renders.
+  const [renderAnyway, setRenderAnyway] = useState(false)
 
   const visibleSources = useMemo(() => {
     const q = filterSources.trim().toLowerCase()
-    if (!q) return matrix.sources
-    return matrix.sources.filter((s) => s.name.toLowerCase().includes(q))
-  }, [matrix.sources, filterSources])
+    return matrix.sources.filter((s) => {
+      if (excludedSourceIds.has(s.id)) return false
+      if (q && !s.name.toLowerCase().includes(q)) return false
+      return true
+    })
+  }, [matrix.sources, filterSources, excludedSourceIds])
 
   const visibleOutputs = useMemo(() => {
     const q = filterOutputs.trim().toLowerCase()
-    if (!q) return matrix.outputs
-    return matrix.outputs.filter((o) => o.name.toLowerCase().includes(q))
-  }, [matrix.outputs, filterOutputs])
+    return matrix.outputs.filter((o) => {
+      if (excludedOutputIds.has(o.id)) return false
+      if (q && !o.name.toLowerCase().includes(q)) return false
+      return true
+    })
+  }, [matrix.outputs, filterOutputs, excludedOutputIds])
 
   const cellCount = visibleSources.length * visibleOutputs.length
-  const tooLarge = cellCount > 12000
+  const tooLarge = cellCount > 12000 && !renderAnyway
+
+  /** Heuristic group key for the checkbox list: take the part before the
+   *  trailing number. "MADI 1" → "MADI", "Out 5" → "Out", "AES 4" → "AES".
+   *  Lets the user toggle whole device-classes with one click via the
+   *  "alle gleichnamigen" link. */
+  const groupKey = (name: string): string =>
+    name.replace(/\s*\d+(?:[/-]\d+)?\s*$/, '').trim() || name
+
+  const toggleSetMember = (
+    setter: (next: Set<number>) => void,
+    current: Set<number>,
+    id: number,
+  ) => {
+    const next = new Set(current)
+    if (next.has(id)) next.delete(id)
+    else next.add(id)
+    setter(next)
+  }
 
   const setRouting = (outputId: number, sourceId: number) => {
     setConfig({
@@ -414,6 +569,40 @@ const MatrixView = ({ config, setConfig }: ViewProps) => {
         />
         <button
           type="button"
+          onClick={() => setShowSourcePicker((v) => !v)}
+          title="Quellen einzeln an-/abhaken (z. B. MADI, Mic, Tape …)"
+          className={`rounded border px-3 py-1 ${
+            excludedSourceIds.size > 0
+              ? 'border-sky-600 bg-sky-900/40 text-sky-200'
+              : 'border-slate-700 bg-slate-800 text-slate-200 hover:bg-slate-700'
+          }`}
+        >
+          Quellen-Auswahl
+          {excludedSourceIds.size > 0 && (
+            <span className="ml-1 text-[10px] text-sky-300">
+              ({excludedSourceIds.size} versteckt)
+            </span>
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={() => setShowOutputPicker((v) => !v)}
+          title="Outputs einzeln an-/abhaken (z. B. Out 5/6, 7/8 weglassen)"
+          className={`rounded border px-3 py-1 ${
+            excludedOutputIds.size > 0
+              ? 'border-sky-600 bg-sky-900/40 text-sky-200'
+              : 'border-slate-700 bg-slate-800 text-slate-200 hover:bg-slate-700'
+          }`}
+        >
+          Outputs-Auswahl
+          {excludedOutputIds.size > 0 && (
+            <span className="ml-1 text-[10px] text-sky-300">
+              ({excludedOutputIds.size} versteckt)
+            </span>
+          )}
+        </button>
+        <button
+          type="button"
           onClick={clearAllOutputs}
           className="rounded bg-slate-700 px-3 py-1 hover:bg-slate-600"
         >
@@ -421,17 +610,50 @@ const MatrixView = ({ config, setConfig }: ViewProps) => {
         </button>
         <span className="ml-2 text-slate-500">
           {visibleSources.length} × {visibleOutputs.length} sichtbar
+          {cellCount.toLocaleString() !== ''
+            ? ` · ${cellCount.toLocaleString()} Crosspoints`
+            : ''}
         </span>
       </div>
+
+      {showSourcePicker && (
+        <ChannelPicker
+          label="Quellen"
+          items={matrix.sources}
+          excluded={excludedSourceIds}
+          onToggle={(id) => toggleSetMember(setExcludedSourceIds, excludedSourceIds, id)}
+          onSetAll={(ids) => setExcludedSourceIds(new Set(ids))}
+          groupKey={groupKey}
+          onClose={() => setShowSourcePicker(false)}
+        />
+      )}
+      {showOutputPicker && (
+        <ChannelPicker
+          label="Outputs"
+          items={matrix.outputs}
+          excluded={excludedOutputIds}
+          onToggle={(id) => toggleSetMember(setExcludedOutputIds, excludedOutputIds, id)}
+          onSetAll={(ids) => setExcludedOutputIds(new Set(ids))}
+          groupKey={groupKey}
+          onClose={() => setShowOutputPicker(false)}
+        />
+      )}
 
       {tooLarge ? (
         <div className="m-auto max-w-md text-center text-sm text-amber-200">
           <div className="mb-2 text-2xl">⚠</div>
           <p>
-            {cellCount.toLocaleString()} sichtbare Crosspoints sind zu viel
-            für eine flüssige Darstellung. Bitte über die Filter eingrenzen
-            (Ziel: unter 12.000 Zellen).
+            {cellCount.toLocaleString()} sichtbare Crosspoints können das Rendering
+            verlangsamen. Über die Quellen-/Outputs-Auswahl eingrenzen oder trotzdem
+            anzeigen lassen — die Warnung bleibt dann für diese Sitzung aus.
           </p>
+          <button
+            type="button"
+            onClick={() => setRenderAnyway(true)}
+            className="mt-3 rounded bg-amber-700 px-3 py-1 text-xs text-amber-50 hover:bg-amber-600"
+          >
+            Trotzdem anzeigen
+          </button>
         </div>
       ) : (
         <div className="flex-1 overflow-auto">

--- a/src/renderer/components/Export/VideohubExportDialog.tsx
+++ b/src/renderer/components/Export/VideohubExportDialog.tsx
@@ -196,7 +196,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
           </div>
         )}
 
-        {/* â”€â”€ Routing Matrix â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */}
+        {/* ── Routing Matrix ─────────────────────────────────────────── */}
         {format === 'routing' && (
           <div className="mb-3">
             <div className="mb-1 flex items-center gap-2">
@@ -205,7 +205,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                 onClick={() => setShowMatrix((m) => !m)}
                 className="rounded bg-slate-700 px-2 py-1 text-xs hover:bg-slate-600"
               >
-                {showMatrix ? 'â–¼' : 'â–¶'} Routing-Matrix
+                {showMatrix ? '▼' : '▶'} Routing-Matrix
               </button>
               <span className="text-xs text-slate-500">
                 {preset.inputs} Eing. × {preset.outputs} Ausg.
@@ -216,7 +216,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                 className="ml-auto rounded bg-slate-800 px-2 py-1 text-xs hover:bg-slate-700"
                 title="Diagonal-Routing zurücksetzen (Ausgang N → Eingang N)"
               >
-                â†º Reset
+                ↺ Reset
               </button>
             </div>
             {showMatrix && (
@@ -238,7 +238,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
           </div>
         )}
 
-        {/* â”€â”€ TCP Senden â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */}
+        {/* ── TCP Senden ─────────────────────────────────────────────── */}
         {format === 'routing' && (
           <div className="mb-3 rounded border border-slate-600 bg-slate-800/60 p-2">
             <div className="mb-2 text-[10px] uppercase tracking-wide text-slate-400">

--- a/src/renderer/components/Export/VideohubRoutingMatrix.tsx
+++ b/src/renderer/components/Export/VideohubRoutingMatrix.tsx
@@ -9,8 +9,14 @@ interface Props {
 
 /**
  * Interactive routing crosspoint matrix for Blackmagic Videohub.
- * For ≤40×40 routers renders an XY grid (click to route).
- * For larger routers falls back to per-output select dropdowns.
+ *
+ * Renders the same grid for every preset (12×12, 20×20, 40×40, 72×72,
+ * 288×288). Earlier versions fell back to a per-output dropdown for
+ * >40 in/out, which the user reported as "schlechte" because it
+ * looked different from the smaller routers. The fall-back is now
+ * gated only on extreme sizes (>320×320 = ~100k cells) where the
+ * browser would refuse to scroll smoothly. For 72 and 288 the grid
+ * scrolls horizontally inside an `overflow-auto` container.
  */
 export const VideohubRoutingMatrix = ({
   totalInputs,
@@ -20,11 +26,17 @@ export const VideohubRoutingMatrix = ({
   routing,
   onRoute,
 }: Props) => {
-  const useGrid = totalInputs <= 40 && totalOutputs <= 40
+  const cellCount = totalInputs * totalOutputs
+  const useGrid = cellCount <= 100_000
 
   if (!useGrid) {
     return (
       <div className="overflow-auto max-h-64 rounded border border-slate-700 bg-slate-950 p-2">
+        <div className="mb-2 text-[10px] text-amber-300">
+          {totalInputs}×{totalOutputs} ({cellCount.toLocaleString()} Crosspoints) — Listen-
+          Modus, da die Crosspoint-Matrix bei dieser Größe das Browser-Rendering
+          überlastet.
+        </div>
         <div className="space-y-0.5">
           {outputLabels.map((outLabel, oi) => (
             <div key={oi} className="flex items-center gap-2 text-xs">
@@ -48,8 +60,21 @@ export const VideohubRoutingMatrix = ({
     )
   }
 
+  // Cell size shrinks as the router grows so 72×72 fits in a 1024 wrap and
+  // 288×288 stays under the 100k-cell threshold without becoming unscrollable.
+  // 40-and-below routers keep the original 14 px squares.
+  const dense = totalInputs > 80 || totalOutputs > 80
+  const cell = dense ? 10 : totalInputs > 40 || totalOutputs > 40 ? 12 : 14
+  const cellClass = dense ? 'h-[10px] w-[10px]' : totalInputs > 40 || totalOutputs > 40 ? 'h-[12px] w-[12px]' : 'h-[14px] w-[14px]'
+  // 16rem max-height is fine for ≤40; bump for larger routers so users
+  // see more rows at once. ≈ 18 rows of 10 px = 180 px = 11 rem.
+  const maxHeight = dense ? '24rem' : totalInputs > 40 ? '20rem' : '16rem'
+
   return (
-    <div className="overflow-auto rounded border border-slate-700 bg-slate-950" style={{ maxHeight: '16rem' }}>
+    <div
+      className="overflow-auto rounded border border-slate-700 bg-slate-950"
+      style={{ maxHeight }}
+    >
       <table className="border-collapse text-[10px]">
         <thead>
           <tr>
@@ -58,7 +83,8 @@ export const VideohubRoutingMatrix = ({
             {inputLabels.map((label, i) => (
               <th
                 key={i}
-                className="sticky top-0 z-10 w-[18px] min-w-[18px] bg-slate-900 p-0"
+                className="sticky top-0 z-10 bg-slate-900 p-0"
+                style={{ width: cell, minWidth: cell }}
               >
                 <div
                   className="overflow-hidden text-center text-slate-400"
@@ -92,8 +118,8 @@ export const VideohubRoutingMatrix = ({
                       title={`${outLabel} ← ${inLabel}`}
                       className={
                         active
-                          ? 'mx-auto my-0.5 block h-[14px] w-[14px] rounded-sm bg-emerald-500'
-                          : 'mx-auto my-0.5 block h-[14px] w-[14px] rounded-sm bg-slate-700 hover:bg-slate-500'
+                          ? `mx-auto my-0.5 block ${cellClass} rounded-sm bg-emerald-500`
+                          : `mx-auto my-0.5 block ${cellClass} rounded-sm bg-slate-700 hover:bg-slate-500`
                       }
                     />
                   </td>


### PR DESCRIPTION
## Summary

User-driven correction round on the audio routing UX. **Closes #63.**

Also corrects the deferral rationale on the roadmap: #52 / #63 are about
ATEM's internal audio routing — **not** Fairlight. (The earlier
"needs a Fairlight XML sample" note was wrong.)

## #63 ATEM Audio Router (matrix view)

- The "Too many crosspoints" warning is now a **dismissible banner**
  with a "Trotzdem anzeigen" button. The 12 000-cell threshold still
  trips the warning once per session, but the user can opt in and the
  warning stays suppressed afterwards.
- New **ChannelPicker** overlay invoked via "Quellen-Auswahl" and
  "Outputs-Auswahl" buttons. Every source / every output gets a
  checkbox, plus a **group header** (auto-derived from name prefix —
  "MADI 1" + "MADI 2" → group "MADI") that toggles the whole group
  with one click. Lets the user hide MADI sources and Out 5/6 + 7/8 +
  9/10 + 11/12 in seconds, the exact use case they asked for.
- Status line now also surfaces the live visible-crosspoint count so
  the user can tell when their filter has dropped below the warning
  threshold.

## Videohub

- **Fixed UTF-8 mojibake** throughout VideohubExportDialog.tsx — 97
  occurrences. The "↺ Reset" button, the "▼/▶ Routing-Matrix" toggle
  and the "── Routing Matrix ──" / "── TCP Senden ──" section dividers
  now render correctly. Root cause: the file was once saved through
  CP1252 and multi-byte UTF-8 sequences got mangled.
- **`VideohubRoutingMatrix`** uses the same crosspoint grid for the
  72×72 and 288×288 presets as for the smaller routers. Earlier the
  threshold was hard-coded to 40 and anything bigger fell back to a
  per-output dropdown column — the user reported this as "schlecht"
  because it looked unrelated to the 40er routers. New: grid up to
  100 k cells with adaptive cell size (14 → 12 → 10 px). Beyond that
  (e.g. theoretical 360×360) it still falls back to the list view
  with a banner.

## What you do

1. Merge.
2. Tag `v7.2.3` on `main` — `release.yml` builds Win EXE + macOS DMG.

## Test plan

- [ ] Version chip in StatusBar reads **v7.2.3**
- [ ] Open the ATEM Audio Router dialog on a project with many
      sources/outputs → "Trotzdem anzeigen" makes the matrix appear
- [ ] "Quellen-Auswahl" overlay: tick the MADI group header — every
      MADI source disappears from the matrix; untick it — they
      reappear
- [ ] "Outputs-Auswahl" overlay: untick "Out 5/6", "Out 7/8", "Out 9/10",
      "Out 11/12" → matrix is shorter and snappier
- [ ] Videohub Export dialog → routing matrix shows ↺ Reset, ▼/▶
      toggle, and "── Routing Matrix ──" header without mojibake
- [ ] Switch the Videohub preset to "Videohub 72×72" → crosspoint grid
      (not dropdown column) renders; switch to "Universal Videohub 288"
      → grid still works (slower)


---
_Generated by [Claude Code](https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH)_