### PR TITLE
v7.2.4: fix React #185 boot crash + visible canvas patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.2.3",
+    "version": "7.2.4",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/components/Canvas/CableEdge.tsx
+++ b/src/renderer/components/Canvas/CableEdge.tsx
@@ -204,6 +204,7 @@ const buildPath = (
   },
   obstacles: Rect[],
   obstacleIds: string[],
+  collisionShiftOn: boolean,
   resolvedOrthogonalWaypoints?: { x: number; y: number }[],
 ): [string, number, number] => {
   const routing = cable.routing ?? 'orthogonal'
@@ -265,11 +266,10 @@ const buildPath = (
 
     // Compose intermediate points between sStub and tStub. The exact shape
     // depends on whether the two stubs share an axis after stub-out.
-    // Issue #53: when the user enabled `orthogonalCollisionShift` we
-    // jitter the midline so cables that would compute identical
-    // midX/midY don't perfectly overlap. The jitter is hashed from the
-    // cable id so it's stable across re-renders.
-    const collisionShiftOn = useUiStore.getState().orthogonalCollisionShift
+    // Issue #53: when `collisionShiftOn` is true (read from uiStore by
+    // the calling component) we jitter the midline so cables that would
+    // compute identical midX/midY don't perfectly overlap. The jitter
+    // is hashed from the cable id so it's stable across re-renders.
     const jitter = collisionShiftOn ? midlineJitter(cable.id) : 0
     const points: { x: number; y: number }[] = [{ x: sx, y: sy }, sStub]
     if (Math.abs(sStub.x - tStub.x) < 2 || Math.abs(sStub.y - tStub.y) < 2) {
@@ -356,6 +356,7 @@ export const CableEdge = ({
   // EquipmentNode reads the same store value to highlight the matching
   // port handles, so the entire connection visually pops at once.
   const hoveredCableId = useUiStore((s) => s.hoveredCableId)
+  const collisionShiftOn = useUiStore((s) => s.orthogonalCollisionShift)
   const hovered = hoveredCableId === id
   const isLight = (data?.exportThemeOverride ?? canvasTheme) === 'light'
 
@@ -387,7 +388,7 @@ export const CableEdge = ({
     ? resolveOrthogonalWaypoints(cable, routingArgs, obstacles, obstacleIds)
     : []
   const [path, centerX, centerY] = cable
-    ? buildPath(cable, routingArgs, obstacles, obstacleIds, orthogonalWaypoints)
+    ? buildPath(cable, routingArgs, obstacles, obstacleIds, collisionShiftOn, orthogonalWaypoints)
     : getSmoothStepPath(routingArgs)
 
   // Resolve label position: center (default), near source, near target.

--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -1109,20 +1109,40 @@ const CanvasContent = () => {
         {/* Issue #71: background pattern is user-configurable. When the
             user picked 'none' we omit the component entirely so React
             Flow falls back to its plain coloured canvas. */}
-        {bgVariant !== 'none' && (
-          <Background
-            variant={
-              bgVariant === 'lines'
-                ? BackgroundVariant.Lines
-                : bgVariant === 'cross'
-                  ? BackgroundVariant.Cross
-                  : BackgroundVariant.Dots
-            }
-            gap={gridSize > 0 ? gridSize : 20}
-            color={effectiveCanvasTheme === 'light' ? '#cbd5e1' : '#334155'}
-            style={{ opacity: bgOpacity }}
-          />
-        )}
+        {bgVariant !== 'none' && (() => {
+          // Background pattern. Earlier defaults rendered the dots at gap=
+          // gridSize (often 10 px) with a near-bg-color stroke at 50 %
+          // opacity — practically invisible. Lift the floor:
+          //   • gap snaps to a sensible minimum of 16 px so dots don't
+          //     blur into a solid wash on dense gridSize values.
+          //   • Lines/Cross get a slightly bigger gap (3× gridSize) so
+          //     they read as a grid, not noise.
+          //   • Stroke uses high-contrast slate-500 (dark) / slate-400
+          //     (light) and we floor the user's opacity at 0.35 — below
+          //     that the pattern was effectively gone.
+          const variant =
+            bgVariant === 'lines'
+              ? BackgroundVariant.Lines
+              : bgVariant === 'cross'
+                ? BackgroundVariant.Cross
+                : BackgroundVariant.Dots
+          const baseGap = gridSize > 0 ? gridSize : 20
+          const gap =
+            variant === BackgroundVariant.Dots
+              ? Math.max(16, baseGap)
+              : Math.max(20, baseGap * 3)
+          const color = effectiveCanvasTheme === 'light' ? '#94a3b8' : '#64748b'
+          const opacity = Math.max(0.35, bgOpacity)
+          return (
+            <Background
+              variant={variant}
+              gap={gap}
+              size={variant === BackgroundVariant.Dots ? 1.5 : 1}
+              color={color}
+              style={{ opacity }}
+            />
+          )
+        })()}
       </ReactFlow>
       <PendingCableOverlay />
     </div>


### PR DESCRIPTION
## Summary

Patch release fixing two reported regressions.

### React #185 startup crash

User reported the same `Dl→Ol→Dl→Ol` commit-loop pattern as previous
boot crashes (see earlier `index-C-RThqlX.js` report).

Root cause this time: **`useUiStore.getState()` called from inside
`buildPath()` in `CableEdge.tsx`.** Reading zustand state via
`getState()` during the render phase never subscribes — so the value
can be stale and force every cable edge to recompute with mismatched
data each commit. In a heavy project this is exactly the asymmetric
subscription / render mismatch that trips React's max-update-depth
guard.

Fix:
- CableEdge now subscribes to `orthogonalCollisionShift` via the
  proper `useUiStore` hook at the component top.
- `buildPath()` gained an explicit `collisionShiftOn` parameter so
  it's pure — no more render-time store reads.

### Canvas background patterns invisible

User reported dots / lines / crosses weren't visible. With a small
`gridSize` (10 px) the dots used to sit 10 px apart with a near-bg
color at 50 % opacity — practically gone.

Fix in `CanvasArea.tsx`:
- Gap floor: 16 px for Dots, max(20, gridSize·3) for Lines/Cross.
- Dot size = 1.5 (was the default 1) so each dot is visible.
- Brighter stroke colour: slate-500 (dark) / slate-400 (light).
- Opacity floor 0.35 so a user who set bgOpacity=0 can still see the
  pattern.

### Roadmap cleanup

- **#52** (ATEM Audio Router) closed as duplicate of #63 — both were
  about the ATEM-internal audio routing; the "needs a Fairlight XML
  sample" deferral note was wrong.
- **#79** (Pfeil-Stub on inputs) closed as not_planned — would break
  straight/curved cable-routing semantics; orthogonal already has the
  18-px stub.

## What you do

1. Merge.
2. Tag `v7.2.4` on `main` — `release.yml` builds Win EXE + macOS DMG.

## Test plan

- [ ] Install the new build → app starts without the #185 boot crash
- [ ] Open a project with many cables → toggle Settings → Bearbeiten →
      "Mittellinien automatisch versetzen" — cables rearrange
      immediately (previously the toggle silently did nothing for
      already-mounted edges)
- [ ] Default canvas now visibly shows dots; switch to Lines / Cross
      and they're also clearly visible at any zoom
- [ ] Settings → Darstellung → Canvas-Hintergrund: changing the slider
      below 0.35 doesn't hide the pattern (floor is 0.35)


---
_Generated by [Claude Code](https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH)_