### PR TITLE
v7.3.2: React #185 boot-loop — 3 defensive layers + auto-recovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.3.1",
+    "version": "7.3.2",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/ErrorBoundary.tsx
+++ b/src/renderer/ErrorBoundary.tsx
@@ -3,22 +3,52 @@ import { cablePlannerApi } from './lib/bridge'
 
 interface State {
   error: Error | null
+  autoRecovered: boolean
 }
 
 interface Props {
   children: ReactNode
 }
 
+/** Boot-loop tracker — persists across the auto-reload. If the same
+ *  ErrorBoundary fires twice within RECOVERY_WINDOW ms, we wipe the
+ *  cable-planner localStorage entries (which is the most common
+ *  trigger for a render-loop on mount: a corrupt autosaved project or
+ *  ui-store schema mismatch). The user no longer has to click the
+ *  "reset" button — the app self-recovers and reloads. */
+const BOOT_ERROR_KEY = 'cable-planner:boot-error-ts'
+const RECOVERY_WINDOW_MS = 10_000
+
+const wipeLocalState = () => {
+  try {
+    const drop: string[] = []
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i)
+      if (k && k.startsWith('cable-planner:')) drop.push(k)
+    }
+    for (const k of drop) localStorage.removeItem(k)
+  } catch {
+    /* ignore */
+  }
+}
+
 /**
  * Catches any uncaught render-time errors (including React #185 / #300) so
  * the user sees a readable message instead of a black screen, and reports
  * details to the main process for `renderer-error.log`.
+ *
+ * Auto-recovery: when the boundary catches an error and one was already
+ * caught in the last 10 s (tracked in `cable-planner:boot-error-ts`),
+ * we wipe the cable-planner localStorage entries and reload. This breaks
+ * the boot loop that a corrupt autosave / ui-store can cause. The user
+ * still sees the error screen on the SINGLE crash so we don't silently
+ * eat reports.
  */
 export class ErrorBoundary extends Component<Props, State> {
-  state: State = { error: null }
+  state: State = { error: null, autoRecovered: false }
 
   static getDerivedStateFromError(error: Error): State {
-    return { error }
+    return { error, autoRecovered: false }
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
@@ -28,6 +58,23 @@ export class ErrorBoundary extends Component<Props, State> {
         stack: `${error.stack ?? ''}\n--- componentStack ---\n${info.componentStack ?? ''}`,
         source: 'ErrorBoundary',
       })
+    } catch {
+      /* ignore */
+    }
+    // Boot-loop detection.
+    try {
+      const now = Date.now()
+      const previousStr = localStorage.getItem(BOOT_ERROR_KEY)
+      const previous = previousStr ? parseInt(previousStr, 10) : 0
+      if (previous && now - previous < RECOVERY_WINDOW_MS) {
+        // Second crash in the recovery window — wipe and reload.
+        wipeLocalState()
+        localStorage.removeItem(BOOT_ERROR_KEY)
+        this.setState({ autoRecovered: true })
+        window.setTimeout(() => location.reload(), 200)
+        return
+      }
+      localStorage.setItem(BOOT_ERROR_KEY, String(now))
     } catch {
       /* ignore */
     }
@@ -46,6 +93,19 @@ export class ErrorBoundary extends Component<Props, State> {
           overflow: 'auto',
         }}>
           <h1 style={{ color: '#fca5a5', marginBottom: 12 }}>Cable Planner – Fehler beim Start</h1>
+          {this.state.autoRecovered && (
+            <div style={{
+              marginBottom: 12,
+              padding: 12,
+              borderRadius: 6,
+              background: '#0f3a30',
+              border: '1px solid #047857',
+              color: '#a7f3d0',
+            }}>
+              ⚙ Boot-Loop erkannt — lokale Cable-Planner-Daten wurden automatisch
+              zurückgesetzt. Die App lädt gleich neu.
+            </div>
+          )}
           <p style={{ marginBottom: 8 }}>
             Ein unerwarteter Fehler ist aufgetreten. Details wurden in
             <code style={{ margin: '0 4px' }}>%APPDATA%\cable-planner\renderer-error.log</code>

--- a/src/renderer/components/Layout/FloatingPanelShell.tsx
+++ b/src/renderer/components/Layout/FloatingPanelShell.tsx
@@ -68,7 +68,16 @@ export const FloatingPanelShell = ({
     offsetY: number
   } | null>(null)
 
-  useEffect(() => setPos(position), [position])
+  // Sync local pos with prop ONLY when the actual coordinates change.
+  // Without the value-comparison guard, a parent re-render that passes
+  // a fresh {x,y} object with the same values would still trigger
+  // setPos → re-render → fresh prop ref → setPos → loop. This is a
+  // textbook React #185 "max update depth" recipe.
+  useEffect(() => {
+    setPos((current) =>
+      current.x === position.x && current.y === position.y ? current : position,
+    )
+  }, [position.x, position.y])
 
   // Re-clamp on resize so a previously valid position doesn't leave the
   // panel off-screen on smaller viewports.

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -121,20 +121,30 @@ const loadAutosavedProject = (): CablePlannerProject | null => {
     if (!raw) return null
     const parsed = JSON.parse(raw) as CablePlannerProject
     if (!parsed || !Array.isArray(parsed.equipment) || !Array.isArray(parsed.cables)) return null
-    // Repair equipment that was seeded with empty port ids (old library
-    // templates used `id: ''` and relied on the store to fill them in — see
-    // sanitizePort). Without this, every handle on the node would share an
-    // empty string id and ReactFlow would always snap new cables to port 1.
+    // Defensive: ensure each equipment item has valid inputs+outputs
+    // arrays. A corrupt autosave (older schema, partial write, or
+    // hand-edited localStorage) where `item.inputs` is null/undefined
+    // crashes the renderer downstream with `cannot read .map of undefined`
+    // — which surfaces as React #185 boot loops via the ErrorBoundary
+    // re-mount. Repair-on-load is cheaper than a try/catch in every
+    // PortList / cable-routing code path.
     let mutated = false
     parsed.equipment = parsed.equipment.map((item) => {
-      const fixInputs = item.inputs?.some((p) => !p.id) ?? false
-      const fixOutputs = item.outputs?.some((p) => !p.id) ?? false
-      if (!fixInputs && !fixOutputs) return item
+      const inputs = Array.isArray(item.inputs) ? item.inputs : []
+      const outputs = Array.isArray(item.outputs) ? item.outputs : []
+      const needsArrayRepair = inputs !== item.inputs || outputs !== item.outputs
+      const fixInputs = inputs.some((p) => !p || !p.id)
+      const fixOutputs = outputs.some((p) => !p || !p.id)
+      if (!needsArrayRepair && !fixInputs && !fixOutputs) return item
       mutated = true
       return {
         ...item,
-        inputs: (item.inputs ?? []).map((p) => (p.id ? p : { ...p, id: uuidv4() })),
-        outputs: (item.outputs ?? []).map((p) => (p.id ? p : { ...p, id: uuidv4() })),
+        inputs: inputs
+          .filter((p): p is NonNullable<typeof p> => Boolean(p))
+          .map((p) => (p.id ? p : { ...p, id: uuidv4() })),
+        outputs: outputs
+          .filter((p): p is NonNullable<typeof p> => Boolean(p))
+          .map((p) => (p.id ? p : { ...p, id: uuidv4() })),
       }
     })
     if (mutated) {


### PR DESCRIPTION
## Summary

Patch fix for the recurring React #185 startup crash. Three independent
defensive layers so the next variant doesn't strand the user again.

**Honest answer to "ist der Bug mit dem neuen build weg?":** my
v7.2.4 patch fixed ONE trigger (a render-time `useUiStore.getState()`
in CableEdge), but the error came back with a different bundle hash —
which means there's at least one more trigger I missed. This PR
addresses two more, plus adds an auto-recovery so the user can't get
stuck in a boot loop anymore.

## Layer 1 — FloatingPanelShell position-sync loop

```js
// before
useEffect(() => setPos(position), [position])
```

`position` comes from `useUiStore(s => s.libraryFloatingPos)`. Every
parent re-render that passes a fresh `{x,y}` reference (even with the
same values) triggered:

setPos → re-render → fresh prop ref → setPos → loop

Textbook React #185 recipe. Fixed by comparing values, not
references:

```js
useEffect(() => {
  setPos(current =>
    current.x === position.x && current.y === position.y ? current : position,
  )
}, [position.x, position.y])
```

## Layer 2 — corrupt autosave hardening

`loadAutosavedProject()` only checked top-level arrays. If
`item.inputs` was `null` (older schema, partial write, hand-edited
localStorage), the downstream `inputs.map(...)` crashed and the
ErrorBoundary caught it on every mount → boot loop.

Fix: per-item array repair on load — ensure `inputs` and `outputs`
are always arrays, drop null entries, generate fresh port ids for
entries missing one. Mutated copies persist back to localStorage so
subsequent loads are stable.

## Layer 3 — boot-loop auto-recovery

The existing "Lokale Daten zurücksetzen und neu laden" button only
helped if the user knew to click it. Now: ErrorBoundary tracks a
timestamp in localStorage; if the SAME boundary fires **twice within
10 s**, the app **auto-wipes** `cable-planner:*` localStorage entries
and reloads itself. A green "Auto-Recovery" banner explains what
happened.

Single crashes still surface the error UI normally so genuine
reports aren't silently eaten.

## What you do

1. Merge.
2. Tag `v7.3.2` on `main` — `release.yml` builds Win EXE + macOS DMG.

## Test plan

- [ ] Install v7.3.2; if the previous boot-loop user re-opens the app
      it boots — or, if their state is too corrupted, the second
      crash auto-wipes and recovers
- [ ] Detach + re-dock a panel repeatedly → no console errors,
      no #185
- [ ] Open the app with intentionally-corrupted
      `cable-planner:projectAutosave` (e.g. `{"equipment":[{"id":"x"}],"cables":[]}`)
      → load doesn't crash, app comes up normally with a single
      device whose inputs/outputs arrays were synthesised
- [ ] Force two crashes within 10 s (e.g. via DevTools): green
      banner appears, app self-recovers


---
_Generated by [Claude Code](https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH)_