### PR TITLE
v7.3.3: mobile other-end labels + patch-PDF ASCII-safe + MV thumbnails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.3.2",
+    "version": "7.3.3",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/mobile/MobileApp.tsx
+++ b/src/mobile/MobileApp.tsx
@@ -144,11 +144,13 @@ const DeviceCard = ({
   cables,
   checks,
   onTogglePort,
+  allEquipment,
 }: {
   device: CablePlannerProject['equipment'][number]
   cables: CablePlannerProject['cables']
   checks: CheckState
   onTogglePort: (deviceId: string, portId: string) => void
+  allEquipment: CablePlannerProject['equipment']
 }) => {
   const inputCables = useMemo(
     () => cables.filter((c) => c.toEquipmentId === device.id),
@@ -189,6 +191,7 @@ const DeviceCard = ({
           mode="in"
           checks={checks}
           onTogglePort={onTogglePort}
+          allEquipment={allEquipment}
         />
         <PortList
           label="Outputs"
@@ -198,6 +201,7 @@ const DeviceCard = ({
           mode="out"
           checks={checks}
           onTogglePort={onTogglePort}
+          allEquipment={allEquipment}
         />
       </div>
     </details>
@@ -212,6 +216,7 @@ const PortList = ({
   mode,
   checks,
   onTogglePort,
+  allEquipment,
 }: {
   label: string
   deviceId: string
@@ -220,6 +225,7 @@ const PortList = ({
   mode: 'in' | 'out'
   checks: CheckState
   onTogglePort: (deviceId: string, portId: string) => void
+  allEquipment: CablePlannerProject['equipment']
 }) => {
   if (ports.length === 0) return null
   return (
@@ -231,33 +237,66 @@ const PortList = ({
             (c) =>
               (mode === 'in' ? c.toPortId : c.fromPortId) === p.id,
           )
+          // Resolve the OTHER endpoint of the cable so the field tech
+          // sees "what plugs in here", not just the cable type — the
+          // user's main mobile-app feedback was that just "BNC 1m"
+          // wasn't useful when racking the gear.
+          let otherDevice: CablePlannerProject['equipment'][number] | undefined
+          let otherPort: CablePlannerProject['equipment'][number]['inputs'][number] | undefined
+          if (cable) {
+            const isFromMe = cable.fromEquipmentId === deviceId
+            const otherEqId = isFromMe ? cable.toEquipmentId : cable.fromEquipmentId
+            const otherPortId = isFromMe ? cable.toPortId : cable.fromPortId
+            otherDevice = allEquipment.find((e) => e.id === otherEqId)
+            otherPort =
+              otherDevice?.inputs?.find((q) => q.id === otherPortId) ??
+              otherDevice?.outputs?.find((q) => q.id === otherPortId)
+          }
           const checked = !!checks.ports[portKey(deviceId, p.id)]
           return (
             <li key={p.id}>
               <button
                 type="button"
                 onClick={() => onTogglePort(deviceId, p.id)}
-                className={`flex w-full items-center gap-2 rounded border px-2 py-1.5 text-left ${
+                className={`flex w-full items-start gap-2 rounded border px-2 py-1.5 text-left ${
                   checked
                     ? 'border-emerald-700 bg-emerald-900/30 text-emerald-100'
                     : 'border-slate-800 bg-slate-950 text-slate-200 hover:border-slate-700'
                 }`}
               >
                 <span
-                  className={`flex h-5 w-5 shrink-0 items-center justify-center rounded ${
+                  className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded ${
                     checked ? 'bg-emerald-600 text-white' : 'border border-slate-600 bg-slate-900'
                   }`}
                 >
                   {checked ? '✓' : ''}
                 </span>
-                <span className="flex-1 truncate">
-                  <span className="font-medium">{p.name}</span>
-                  <span className="ml-2 text-[10px] text-slate-500">
-                    {p.connectorType}
+                <span className="flex-1 min-w-0">
+                  <span className="block">
+                    <span className="font-medium">{p.name}</span>
+                    <span className="ml-2 text-[10px] text-slate-500">
+                      {p.connectorType}
+                    </span>
                   </span>
+                  {cable && otherDevice && (
+                    <span className="mt-0.5 block truncate text-[11px] text-sky-300">
+                      → {otherDevice.name}
+                      {otherPort && (
+                        <>
+                          <span className="mx-1 text-slate-500">·</span>
+                          <span>{otherPort.name}</span>
+                          {otherPort.connectorType && (
+                            <span className="ml-1 text-[10px] text-slate-500">
+                              ({otherPort.connectorType})
+                            </span>
+                          )}
+                        </>
+                      )}
+                    </span>
+                  )}
                 </span>
                 {cable && (
-                  <span className="shrink-0 text-[10px] text-sky-300">
+                  <span className="shrink-0 text-[10px] text-slate-400">
                     {cable.type} · {cable.length} m
                   </span>
                 )}
@@ -381,6 +420,7 @@ const ProjectView = ({
               cables={project.cables}
               checks={checks}
               onTogglePort={togglePort}
+              allEquipment={project.equipment}
             />
           ))
         )}

--- a/src/renderer/components/Atem/AtemMvConfigDialog.tsx
+++ b/src/renderer/components/Atem/AtemMvConfigDialog.tsx
@@ -10,6 +10,67 @@ import {
   getMvGridSpec,
 } from '../../lib/atemMvLayout'
 
+/** Issue #55 — visual ATEM-software-style "Ansichtsauswahl"
+ *  thumbnail. Renders the 4×4 grid of an MV layout as a small SVG
+ *  with the "big" windows shaded darker than the small cells, so
+ *  the user can recognise each layout by its silhouette without
+ *  reading the label. */
+const MvLayoutThumb = ({
+  layoutId,
+  active,
+}: {
+  layoutId: number
+  active: boolean
+}) => {
+  const spec = getMvGridSpec(layoutId)
+  const cell = 8 // px per 4x4 cell
+  const gap = 1
+  const dim = cell * 4 + gap * 3
+  // Build a "this cell is part of a big window" lookup by walking the
+  // spec's `big` rectangles. Cells not covered by any big rect are
+  // small.
+  const bigCells = new Set<string>()
+  for (const big of spec.big) {
+    for (let r = big.rowStart; r < big.rowStart + big.rowSpan; r++) {
+      for (let c = big.colStart; c < big.colStart + big.colSpan; c++) {
+        bigCells.add(`${r},${c}`)
+      }
+    }
+  }
+  const fillBig = active ? '#0ea5e9' : '#334155'
+  const fillSmall = active ? '#075985' : '#1e293b'
+  const stroke = active ? '#0c4a6e' : '#0f172a'
+  return (
+    <svg
+      width={dim}
+      height={dim * (9 / 16)}
+      viewBox={`0 0 ${dim} ${(dim * 9) / 16}`}
+      role="presentation"
+    >
+      {Array.from({ length: 4 }).map((_, ri) =>
+        Array.from({ length: 4 }).map((_, ci) => {
+          const isBig = bigCells.has(`${ri + 1},${ci + 1}`)
+          const x = ci * (cell + gap)
+          const y = (ri * (cell + gap)) * (9 / 16) + 0.5
+          return (
+            <rect
+              key={`${ri}-${ci}`}
+              x={x}
+              y={y}
+              width={cell}
+              height={cell * (9 / 16) - 0.5}
+              fill={isBig ? fillBig : fillSmall}
+              stroke={stroke}
+              strokeWidth={0.5}
+              rx={1}
+            />
+          )
+        }),
+      )}
+    </svg>
+  )
+}
+
 /** Issue #55 — per-quadrant layout cycle. Clicking on a quadrant
  *  steps through the layouts that affect that quadrant (between "1
  *  big window covering this quadrant" and "this quadrant split into
@@ -457,28 +518,39 @@ export const AtemMvConfigDialog = () => {
           {mv && spec && (
             <>
               <div className="mb-3 flex flex-wrap items-center gap-3 text-xs">
-                {/* Issue #55: ATEM-software-style layout picker. Each
-                    button shows the layout label and is clickable to
-                    switch the active multiviewer's grid. Active layout
-                    is highlighted in sky-700. Replaces the previous
-                    dropdown (less obvious which layouts exist). */}
-                <span className="text-slate-300">Layout</span>
-                <div className="flex flex-wrap gap-1">
-                  {MV_LAYOUT_OPTIONS.map((l) => (
-                    <button
-                      key={l.value}
-                      type="button"
-                      onClick={() => updateMv(activeMv, { layout: l.value })}
-                      className={`rounded border px-2 py-1 text-[11px] transition-colors ${
-                        mv.layout === l.value
-                          ? 'border-sky-500 bg-sky-700 text-white'
-                          : 'border-slate-700 bg-slate-900 text-slate-300 hover:border-sky-700 hover:text-sky-200'
-                      }`}
-                      title={`Layout: ${l.label}`}
-                    >
-                      {l.label}
-                    </button>
-                  ))}
+                {/* Issue #55: visual layout thumbnails like the
+                    Blackmagic ATEM software's "Ansichtsauswahl"
+                    picker. Each button renders a tiny 4x4 SVG preview
+                    of that layout's grid (big windows + small cells)
+                    so the user can pick by sight, not by reading. */}
+                <span className="text-slate-300">Ansichtsauswahl</span>
+                <div className="flex flex-wrap gap-1.5">
+                  {MV_LAYOUT_OPTIONS.map((l) => {
+                    const active = mv.layout === l.value
+                    return (
+                      <button
+                        key={l.value}
+                        type="button"
+                        onClick={() => updateMv(activeMv, { layout: l.value })}
+                        className={`flex flex-col items-center gap-0.5 rounded border p-1 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 ${
+                          active
+                            ? 'border-sky-500 bg-sky-950/50'
+                            : 'border-slate-700 bg-slate-900 hover:border-sky-700'
+                        }`}
+                        title={`Layout: ${l.label}`}
+                        aria-label={`Layout ${l.label}${active ? ' (aktiv)' : ''}`}
+                      >
+                        <MvLayoutThumb layoutId={l.value} active={active} />
+                        <span
+                          className={`max-w-[64px] truncate text-[9px] ${
+                            active ? 'text-sky-200' : 'text-slate-400'
+                          }`}
+                        >
+                          {l.label}
+                        </span>
+                      </button>
+                    )
+                  })}
                 </div>
                 <label className="flex items-center gap-2">
                   <input

--- a/src/renderer/lib/exportDevicePdf.ts
+++ b/src/renderer/lib/exportDevicePdf.ts
@@ -48,7 +48,10 @@ const summarizeEndpoint = (
     : undefined
   const lengthLabel = cable.length ? `${cable.length} m` : ''
   const typeLabel = cable.type ? String(cable.type) : ''
-  const baseLabel = [typeLabel, lengthLabel].filter(Boolean).join(' · ') || 'Kabel'
+  // ASCII separator — the middle-dot · (U+00B7) IS in latin-1 so it
+  // works, but for visual consistency with the rest of the PDF (now
+  // pure ASCII for safety) we use a plain dash.
+  const baseLabel = [typeLabel, lengthLabel].filter(Boolean).join(' - ') || 'Kabel'
   const cableLabel = cable.name?.trim() ? `${cable.name.trim()}  (${baseLabel})` : baseLabel
   return {
     cableLabel,
@@ -108,7 +111,12 @@ const drawColumn = (
     }
     pdf.setTextColor(15)
     pdf.setFont('helvetica', 'bold')
-    const portLine = `■ ${row.port.name || row.port.id}`
+    // Helvetica (jsPDF's built-in font) only ships ISO-8859-1 glyphs.
+    // The bullet ■ (U+25A0) and arrow → (U+2192) used to print as
+    // "%" and "!'" respectively, and any non-Latin char downstream
+    // got individually space-padded ("S D I I n 1") because jsPDF
+    // can't lay out unmapped glyphs. Switch to ASCII-safe markers.
+    const portLine = `> ${row.port.name || row.port.id}`
     const portType = row.port.connectorType ? `  [${row.port.connectorType}]` : ''
     pdf.text(`${portLine}${portType}`, x, y, { maxWidth: colWidth - 4 })
     pdf.setFont('helvetica', 'normal')
@@ -116,19 +124,19 @@ const drawColumn = (
 
     if (row.cables.length === 0) {
       pdf.setTextColor(140)
-      pdf.text('  → frei', x, y)
+      pdf.text('  -- frei --', x, y)
       y += 11
       pdf.setTextColor(15)
       continue
     }
     for (const c of row.cables) {
       pdf.setTextColor(15)
-      pdf.text(`  → ${c.cableLabel}`, x, y, { maxWidth: colWidth - 6 })
+      pdf.text(`  -> ${c.cableLabel}`, x, y, { maxWidth: colWidth - 6 })
       y += 11
       pdf.setTextColor(80)
       const tgt = c.otherPortName
-        ? `       zu ${c.otherDeviceName} · ${c.otherPortName}`
-        : `       zu ${c.otherDeviceName}`
+        ? `       an ${c.otherDeviceName} - ${c.otherPortName}`
+        : `       an ${c.otherDeviceName}`
       pdf.text(tgt, x, y, { maxWidth: colWidth - 6 })
       y += 11
     }
@@ -166,7 +174,7 @@ const drawDevicePage = (
   if (device.category) metaParts.push(device.category)
   if (device.subtitle) metaParts.push(device.subtitle)
   if (device.ipAddress) metaParts.push(`IP ${device.ipAddress}`)
-  pdf.text(metaParts.join('  ·  '), margin, margin + 20)
+  pdf.text(metaParts.join('  -'), margin, margin + 20)
   pdf.text(new Date().toLocaleString(), pageWidth - margin, margin + 20, { align: 'right' })
 
   // Subtle horizontal rule below the header
@@ -217,7 +225,7 @@ const drawDevicePage = (
   pdf.setFontSize(7)
   pdf.setTextColor(140)
   pdf.text(
-    `Cable Planner · ${device.name} · ${inputRows.length} In / ${outputRows.length} Out · automatisch erzeugte Patch-Liste`,
+    `Cable Planner - ${device.name} - ${inputRows.length} In / ${outputRows.length} Out - automatisch erzeugte Patch-Liste`,
     pageWidth / 2,
     pageHeight - 12,
     { align: 'center' },


### PR DESCRIPTION
## Summary

Three user-reported regressions fixed in one patch.

### 1. Mobile-Viewer — show the OTHER end of each cable

The mobile viewer only showed `BNC 1m` next to a port. Useless when
racking gear on-set; the field tech needs to see WHICH device + port
plugs in here.

`PortList` now resolves the other endpoint via the full equipment
array and renders a sky-tinted line:

```
SDI In 1   BNC
→ Camera 1 · SDI Out 3 (BNC)        BNC · 1 m
```

Cable type+length stays as a small grey badge on the right.

### 2. Patch-PDF text rendering broken (`%` instead of `■`, `S D I I n 1` letter-spaced)

Root cause: jsPDF's built-in **Helvetica only ships ISO-8859-1
glyphs**. The bullet ■ (U+25A0) and arrow → (U+2192) used by
`exportDevicePatchSheet` weren't in the font, and unmapped glyphs
trigger jsPDF's fallback that emits per-character positioning
operators — that's where `S D I I n 1` came from on copy-paste.

Fix: replace non-ISO-8859-1 chars with ASCII-safe equivalents.

| before | after |
|---|---|
| `■ SDI In 1` | `> SDI In 1` |
| `→ frei` | `-- frei --` |
| `→ Cable name` | `-> Cable name` |
| `·` separators | `-` |

Latin-1 chars (ä, ö, ü, ß) keep working.

### 3. #55 MV layout picker — proper visual thumbnails

User's "Ansichtsauswahl" reference screenshot shows an icon-style
layout picker like the real ATEM software. Replaced the text button
row with **small 4×4 SVG silhouettes** of each layout — `big` cells
darker, `small` cells lighter, active layout highlights in sky-500.
Tooltip + label still present for screen readers.

## What you do

1. Merge.
2. Tag `v7.3.3` on `main` — `release.yml` builds Win EXE + macOS DMG.

## Test plan

- [ ] Mobile viewer — open a project with cables → tap any port → row
      shows `→ <other device> · <other port>` line
- [ ] Equipment-Properties → Druck/Dokumentation → "Patch-Sheet (A4
      PDF)" → opens with `> SDI In 1 [BNC]` and `-> Cable name`,
      no `S D I I n 1` letter-spacing or `%` glyph artifacts
- [ ] ATEM MVW dialog → layout picker now shows 9 mini-grid
      thumbnails (not text buttons). Active layout outlined sky-500.
      Click a thumb → MV preview updates.


---
_Generated by [Claude Code](https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH)_