### PR TITLE
v7.3.4: patch-PDF target line includes other-port connector type (mirror mobile)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.3.3",
+    "version": "7.3.4",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/lib/exportDevicePdf.ts
+++ b/src/renderer/lib/exportDevicePdf.ts
@@ -31,6 +31,10 @@ interface CableEndpointSummary {
   otherDeviceName: string
   /** Name of the port on the other side, if known. */
   otherPortName: string | null
+  /** Connector type of the port on the other side (e.g. "BNC"), if known.
+   *  Mirrors what the mobile viewer prints next to each port so the
+   *  patch sheet and the phone screen match. */
+  otherPortConnectorType: string | null
   cable: Cable
 }
 
@@ -57,6 +61,7 @@ const summarizeEndpoint = (
     cableLabel,
     otherDeviceName: other?.name ?? 'unbekannt',
     otherPortName: otherPort?.name ?? null,
+    otherPortConnectorType: otherPort?.connectorType ? String(otherPort.connectorType) : null,
     cable,
   }
 }
@@ -134,8 +139,12 @@ const drawColumn = (
       pdf.text(`  -> ${c.cableLabel}`, x, y, { maxWidth: colWidth - 6 })
       y += 11
       pdf.setTextColor(80)
+      // Mirror the mobile viewer's "Camera 1 · SDI Out 3 (BNC)"
+      // line — device name + port name + connector type — so the
+      // printed sheet and the phone match exactly.
+      const otherSuffix = c.otherPortConnectorType ? ` [${c.otherPortConnectorType}]` : ''
       const tgt = c.otherPortName
-        ? `       an ${c.otherDeviceName} - ${c.otherPortName}`
+        ? `       an ${c.otherDeviceName} - ${c.otherPortName}${otherSuffix}`
         : `       an ${c.otherDeviceName}`
       pdf.text(tgt, x, y, { maxWidth: colWidth - 6 })
       y += 11


### PR DESCRIPTION
## Summary

Patch follow-up to v7.3.3 — the patch-PDF now mirrors the same
other-end info that the mobile viewer shows. Pre-check on the phone
and read the printed sheet → same labels in the same order.

## Change

`exportDevicePatchSheet` summarises each cable endpoint as a
`CableEndpointSummary`. The summary now carries an
`otherPortConnectorType` field. The PDF's "target line" picks it up:

**before**
```
> SDI In 1 [BNC]
  -> 3G SDI BNC 5m
       an Camera 1 - SDI Out 3
```

**after**
```
> SDI In 1 [BNC]
  -> 3G SDI BNC 5m
       an Camera 1 - SDI Out 3 [BNC]
```

Same brackets `[BNC]` as the bullet line above so the visual is
consistent. ASCII-safe — no jsPDF font-fallback risk.

## What you do

1. Merge.
2. Tag `v7.3.4` on `main`.

## Test plan

- [ ] Pick a device with at least one wired port → Properties → Druck
      → A4 PDF → cable target line reads
      `an <device> - <port> [<connector>]`
- [ ] Open the same device in the mobile viewer → the row shows
      `→ <device> · <port> (<connector>)` — same connector, same
      info, just slightly different separator style for each medium


---
_Generated by [Claude Code](https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH)_