### PR TITLE
v7.5.0: audio matrix-only + 3-phase power + device modes + per-port SDI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.4.0",
+    "version": "7.5.0",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/components/Atem/AtemAudioRouterDialog.tsx
+++ b/src/renderer/components/Atem/AtemAudioRouterDialog.tsx
@@ -43,7 +43,12 @@ export const AtemAudioRouterDialog = () => {
   const drag = useDraggablePosition('cable-planner:modal-pos:atem-audio', open)
 
   const [draft, setDraft] = useState<AtemAudioConfig | null>(null)
-  const [activeTab, setActiveTab] = useState<'matrix' | 'classic'>('matrix')
+  // v7.5.0 — the classic-mixer view was removed. The router now
+  // edits only the routing matrix (AudioMapping section). Imported
+  // XMLs that also contain a classic-mixer (AudioMixer) section keep
+  // that data in `draft.classicMixer` so save round-trips byte-for-
+  // byte, but the user-facing UI is matrix-only.
+  const [activeTab, setActiveTab] = useState<'matrix'>('matrix')
   const [busy, setBusy] = useState(false)
   const [errorMsg, setErrorMsg] = useState('')
 
@@ -66,8 +71,7 @@ export const AtemAudioRouterDialog = () => {
     }
     const value = stored as AtemAudioConfig
     setDraft(value)
-    if (value.matrix) setActiveTab('matrix')
-    else if (value.classicMixer) setActiveTab('classic')
+    setActiveTab('matrix')
   }, [open, equipment])
 
   if (!open || !equipment) return null
@@ -86,8 +90,7 @@ export const AtemAudioRouterDialog = () => {
           setDraft(config)
           setErrorMsg('')
           // Auto-pick a sensible default tab
-          if (config.matrix) setActiveTab('matrix')
-          else if (config.classicMixer) setActiveTab('classic')
+          setActiveTab('matrix')
         } catch (e) {
           setErrorMsg(e instanceof Error ? e.message : String(e))
         }
@@ -161,28 +164,6 @@ export const AtemAudioRouterDialog = () => {
     setErrorMsg('')
   }
 
-  /** Build a fresh AtemAudioConfig with the classic-mixer defaults —
-   *  8 channel strips, all On, 0 dB, centred. Matches the ATEM 2 M/E
-   *  Production Studio out-of-the-box state. */
-  const handleCreateClassic = () => {
-    setDraft({
-      classicMixer: {
-        programOutGain: 0,
-        programOutBalance: 0,
-        programOutFollowFadeToBlack: false,
-        audioFollowVideoCrossfadeTransition: false,
-        inputs: Array.from({ length: 8 }, (_, i) => ({
-          id: i + 1,
-          mixOption: 'On' as const,
-          gain: 0,
-          balance: 0,
-        })),
-      },
-    })
-    setActiveTab('classic')
-    setErrorMsg('')
-  }
-
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
       <div
@@ -236,34 +217,19 @@ export const AtemAudioRouterDialog = () => {
           >
             {t('atem.audio.action.saveXml', '💾 XML speichern')}
           </button>
-          {draft && (draft.matrix || draft.classicMixer) && (
+          {draft?.matrix && (
             <>
               <span className="ml-2 text-slate-500">|</span>
-              {draft.matrix && (
-                <button
-                  type="button"
-                  onClick={() => setActiveTab('matrix')}
-                  className={`rounded px-3 py-1 ${
-                    activeTab === 'matrix'
-                      ? 'bg-sky-800 text-white'
-                      : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
-                  }`}
-                >
-                  {t('atem.audio.tab.matrix', '🎚 Routing-Matrix')} ({draft.matrix.outputs.length}×{draft.matrix.sources.length})
-                </button>
-              )}
+              <span className="rounded bg-sky-800 px-3 py-1 text-white">
+                {t('atem.audio.tab.matrix', '🎚 Routing-Matrix')} ({draft.matrix.outputs.length}×{draft.matrix.sources.length})
+              </span>
               {draft.classicMixer && (
-                <button
-                  type="button"
-                  onClick={() => setActiveTab('classic')}
-                  className={`rounded px-3 py-1 ${
-                    activeTab === 'classic'
-                      ? 'bg-sky-800 text-white'
-                      : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
-                  }`}
+                <span
+                  className="text-[10px] text-slate-500"
+                  title="Das geladene XML enthält zusätzlich eine klassische AudioMixer-Sektion. Sie wird beim Speichern unverändert mit zurück ins XML geschrieben, ist aber hier nicht editierbar."
                 >
-                  {t('atem.audio.tab.classic', '🎛 Klassischer Mixer')} ({draft.classicMixer.inputs.length} Inputs)
-                </button>
+                  + AudioMixer-Sektion (read-only, round-trip)
+                </span>
               )}
             </>
           )}
@@ -280,13 +246,27 @@ export const AtemAudioRouterDialog = () => {
             <EmptyState
               onLoad={handleLoadXml}
               onCreateMatrix={handleCreateMatrix}
-              onCreateClassic={handleCreateClassic}
               equipmentName={equipment.name}
             />
-          ) : activeTab === 'matrix' && draft.matrix ? (
+          ) : draft.matrix ? (
             <MatrixView config={draft} setConfig={setDraft} />
-          ) : activeTab === 'classic' && draft.classicMixer ? (
-            <ClassicMixerView config={draft} setConfig={setDraft} />
+          ) : draft.classicMixer && !draft.matrix ? (
+            <div className="m-auto max-w-md text-center text-sm text-slate-400">
+              <p>
+                Dieses XML enthält nur eine klassische AudioMixer-Sektion und keine
+                Routing-Matrix. Die Sektion wird beim Speichern unverändert
+                zurückgeschrieben (Round-Trip), ist aber im Editor nicht editierbar.
+                Lege bei Bedarf via <strong>🎚 Matrix manuell</strong> oben eine
+                neue Crosspoint-Matrix an — beide Sektionen koexistieren dann im XML.
+              </p>
+              <button
+                type="button"
+                onClick={handleCreateMatrix}
+                className="mt-3 rounded bg-sky-700 px-3 py-1 text-xs text-white hover:bg-sky-600"
+              >
+                🎚 Matrix manuell anlegen
+              </button>
+            </div>
           ) : (
             <div className="m-auto text-sm text-slate-400">
               Kein {activeTab === 'matrix' ? 'Routing' : 'Klassischer Mixer'} im
@@ -371,34 +351,22 @@ const summarise = (
 const EmptyState = ({
   onLoad,
   onCreateMatrix,
-  onCreateClassic,
   equipmentName,
 }: {
   onLoad: () => void
   onCreateMatrix: () => void
-  onCreateClassic: () => void
   equipmentName: string
 }) => (
   <div className="m-auto max-w-md text-center text-sm text-slate-400">
-    <div className="mb-2 text-3xl">🎛</div>
+    <div className="mb-2 text-3xl">🎚</div>
     <div className="mb-3 text-base font-semibold text-slate-200">
-      ATEM Audio-Konfiguration
+      ATEM Audio-Routing
     </div>
     <p className="mb-3">
-      Lade ein bestehendes ATEM Profile-XML — oder fang manuell mit den Standard-Defaults
-      für deinen Mischer an. Beim Speichern erzeugen wir ein gültiges Profile-XML, das du
-      direkt im ATEM Software Control importieren kannst.
+      Lade ein bestehendes ATEM Profile-XML — oder fang manuell mit der Crosspoint-Matrix
+      an. Beim Speichern erzeugen wir ein gültiges Profile-XML, das du direkt im ATEM
+      Software Control importieren kannst.
     </p>
-    <ul className="mb-4 list-inside list-disc text-left text-xs text-slate-400">
-      <li>
-        Neuere Modelle (Constellation / 4 M/E) nutzen die{' '}
-        <strong>Crosspoint-Matrix</strong>.
-      </li>
-      <li>
-        Production Studio / Television Studio öffnen mit{' '}
-        <strong>klassischem Channel-Strip</strong> (Off/On/AFV + Gain).
-      </li>
-    </ul>
     <div className="flex flex-wrap items-center justify-center gap-2">
       <button
         type="button"
@@ -410,24 +378,15 @@ const EmptyState = ({
       <button
         type="button"
         onClick={onCreateMatrix}
-        title="Frische Crosspoint-Matrix mit den ATEM-Standard-Eingängen + 8 Output-Bussen (für Constellation / 4 M/E)."
+        title="Frische Crosspoint-Matrix mit den ATEM-Standard-Eingängen + 8 Output-Bussen."
         className="rounded border border-slate-700 bg-slate-800 px-4 py-2 text-sm text-slate-100 hover:border-sky-600 hover:bg-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
       >
         🎚 Matrix manuell
       </button>
-      <button
-        type="button"
-        onClick={onCreateClassic}
-        title="Frischer klassischer Mixer (8 Channel-Strips, alle On, 0 dB, mittig)."
-        className="rounded border border-slate-700 bg-slate-800 px-4 py-2 text-sm text-slate-100 hover:border-sky-600 hover:bg-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
-      >
-        🎛 Klassischer Mixer
-      </button>
     </div>
     <p className="mt-3 text-[10px] text-slate-500">
-      Für {equipmentName || 'das aktuelle Gerät'}. Die Defaults richten sich nach den
-      üblichen ATEM-Audio-Bus-Layouts; du kannst Quellen, Outputs + Mappings danach frei
-      bearbeiten.
+      Für {equipmentName || 'das aktuelle Gerät'}. 24 Standard-Quellen × 8 Output-Busse;
+      Quellen + Outputs + Mappings danach frei bearbeiten.
     </p>
   </div>
 )
@@ -928,208 +887,3 @@ const MatrixView = ({ config, setConfig }: ViewProps) => {
 
 // --- Classic mixer view -------------------------------------------------
 
-const ClassicMixerView = ({ config, setConfig }: ViewProps) => {
-  const mixer = config.classicMixer!
-  const [filter, setFilter] = useState('')
-
-  const labelFor = (id: number): string => {
-    const lbl = config.inputLabels?.[id]
-    if (lbl?.longName) return lbl.longName
-    if (lbl?.shortName) return lbl.shortName
-    // Special audio-only ids for older mixers
-    if (id === 1001) return 'Mic 1'
-    if (id === 1101) return 'Mic 2'
-    if (id === 1201) return 'RCA'
-    if (id === 1301) return 'XLR'
-    if (id >= 2001 && id <= 2099) return `Color ${id - 2000}`
-    if (id >= 3010 && id < 3050) return `Media Player ${Math.floor((id - 3010) / 10) + 1}`
-    return `Input ${id}`
-  }
-
-  const filteredInputs = useMemo(() => {
-    const q = filter.trim().toLowerCase()
-    if (!q) return mixer.inputs
-    return mixer.inputs.filter((inp) => {
-      if (String(inp.id).includes(q)) return true
-      return labelFor(inp.id).toLowerCase().includes(q)
-    })
-  }, [mixer.inputs, filter, config.inputLabels])
-
-  const setInput = (id: number, patch: Partial<AtemClassicAudioInput>) => {
-    setConfig({
-      ...config,
-      classicMixer: {
-        ...mixer,
-        inputs: mixer.inputs.map((i) =>
-          i.id === id ? { ...i, ...patch } : i,
-        ),
-      },
-    })
-  }
-
-  return (
-    <div className="flex flex-1 flex-col overflow-hidden">
-      <div className="flex flex-wrap items-center gap-3 border-b border-slate-800 bg-slate-950/30 px-4 py-2 text-xs">
-        <input
-          type="text"
-          value={filter}
-          onChange={(e) => setFilter(e.target.value)}
-          placeholder="Inputs filtern (Name oder ID)…"
-          title="Substring-Filter für Audio-Inputs"
-          aria-label="Inputs filtern"
-          className="rounded border border-slate-700 bg-slate-900 px-2 py-1 text-xs"
-        />
-        <span className="text-slate-500">
-          {filteredInputs.length} / {mixer.inputs.length} sichtbar
-        </span>
-        <span className="ml-auto text-slate-400">
-          Master: gain{' '}
-          <input
-            type="number"
-            step={0.1}
-            value={mixer.programOutGain}
-            onChange={(e) =>
-              setConfig({
-                ...config,
-                classicMixer: {
-                  ...mixer,
-                  programOutGain: Number(e.target.value),
-                },
-              })
-            }
-            className="w-16 rounded border border-slate-700 bg-slate-900 px-1 py-0.5 text-right font-mono"
-            title="programOutGain (dB)"
-            aria-label="Master Gain (dB)"
-          />{' '}
-          dB · balance{' '}
-          <input
-            type="number"
-            step={1}
-            min={-100}
-            max={100}
-            value={mixer.programOutBalance}
-            onChange={(e) =>
-              setConfig({
-                ...config,
-                classicMixer: {
-                  ...mixer,
-                  programOutBalance: Number(e.target.value),
-                },
-              })
-            }
-            className="w-14 rounded border border-slate-700 bg-slate-900 px-1 py-0.5 text-right font-mono"
-            title="programOutBalance (-100..+100)"
-            aria-label="Master Balance"
-          />
-        </span>
-      </div>
-
-      <div className="flex-1 overflow-auto">
-        <table className="w-full text-xs">
-          <thead className="sticky top-0 bg-slate-950 text-slate-300">
-            <tr className="border-b border-slate-700">
-              <th className="px-2 py-1 text-left">ID</th>
-              <th className="px-2 py-1 text-left">Bezeichnung</th>
-              <th className="px-2 py-1 text-left">Mix</th>
-              <th className="px-2 py-1 text-right">Gain (dB)</th>
-              <th className="px-2 py-1 text-right">Balance</th>
-            </tr>
-          </thead>
-          <tbody>
-            {filteredInputs.map((inp) => {
-              const lbl = config.inputLabels?.[inp.id]
-              const port = lbl?.externalPortType
-              return (
-                <tr
-                  key={inp.id}
-                  className={`border-b border-slate-800 ${
-                    inp.mixOption !== 'Off' ? 'bg-emerald-950/20' : ''
-                  }`}
-                >
-                  <td className="px-2 py-1 font-mono text-slate-500">
-                    {inp.id}
-                  </td>
-                  <td className="px-2 py-1">
-                    <span className="text-slate-100">{labelFor(inp.id)}</span>
-                    {lbl?.shortName && (
-                      <span className="ml-2 text-[10px] text-slate-500">
-                        ({lbl.shortName})
-                      </span>
-                    )}
-                    {port && (
-                      <span className="ml-2 rounded bg-slate-800 px-1.5 py-0.5 text-[10px] text-slate-400">
-                        {port}
-                      </span>
-                    )}
-                  </td>
-                  <td className="px-2 py-1">
-                    <div className="inline-flex overflow-hidden rounded border border-slate-700">
-                      {(['Off', 'On', 'AudioFollowVideo'] as const).map((m) => (
-                        <button
-                          key={m}
-                          type="button"
-                          onClick={() => setInput(inp.id, { mixOption: m })}
-                          className={`px-2 py-0.5 text-[10px] ${
-                            inp.mixOption === m
-                              ? m === 'Off'
-                                ? 'bg-slate-600 text-white'
-                                : m === 'On'
-                                  ? 'bg-emerald-700 text-white'
-                                  : 'bg-amber-700 text-white'
-                              : 'bg-slate-900 text-slate-400 hover:bg-slate-800'
-                          }`}
-                          title={
-                            m === 'Off'
-                              ? 'Stumm'
-                              : m === 'On'
-                                ? 'Immer aktiv (im Programm-Mix)'
-                                : 'Audio-Follow-Video'
-                          }
-                        >
-                          {m === 'AudioFollowVideo' ? 'AFV' : m}
-                        </button>
-                      ))}
-                    </div>
-                  </td>
-                  <td className="px-2 py-1 text-right">
-                    <input
-                      type="number"
-                      step={0.1}
-                      max={6}
-                      value={inp.gain ?? ''}
-                      placeholder="-inf"
-                      onChange={(e) => {
-                        const v = e.target.value
-                        setInput(inp.id, {
-                          gain: v === '' ? null : Number(v),
-                        })
-                      }}
-                      className="w-20 rounded border border-slate-700 bg-slate-950 px-1.5 py-0.5 text-right font-mono"
-                      title={`Gain für Input ${inp.id} in dB. Leer = -inf (stumm).`}
-                      aria-label={`Gain Input ${inp.id}`}
-                    />
-                  </td>
-                  <td className="px-2 py-1 text-right">
-                    <input
-                      type="number"
-                      step={1}
-                      min={-100}
-                      max={100}
-                      value={inp.balance}
-                      onChange={(e) =>
-                        setInput(inp.id, { balance: Number(e.target.value) })
-                      }
-                      className="w-16 rounded border border-slate-700 bg-slate-950 px-1.5 py-0.5 text-right font-mono"
-                      title={`Balance für Input ${inp.id} (-100..+100)`}
-                      aria-label={`Balance Input ${inp.id}`}
-                    />
-                  </td>
-                </tr>
-              )
-            })}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  )
-}

--- a/src/renderer/components/Calculators/CalculatorsDialog.tsx
+++ b/src/renderer/components/Calculators/CalculatorsDialog.tsx
@@ -13,10 +13,20 @@ import { useUiStore } from '../../store/uiStore'
 import { useProjectStore } from '../../store/projectStore'
 import { useDraggablePosition } from '../../hooks/useDraggablePosition'
 
-type Tab = 'length' | 'bandwidth' | 'power'
+// v7.5.0 — Cable-Length tab removed. The standalone calculator
+// can't produce meaningful estimates without inter-location distances
+// + per-device location membership. A proper "real-world cable length"
+// feature needs:
+//   1. Distance edges between Location frames on the canvas.
+//   2. Per-device location-tags (already implicit via the LocationFrame).
+//   3. A length-derivation that walks: source-device → source-location
+//      → distance(source-loc, dest-loc) → dest-location → dest-device,
+//      plus per-cable slack.
+// Until that lands, the existing per-cable `length` field captures
+// the truth the user knows best.
+type Tab = 'bandwidth' | 'power'
 
 const TAB_LABEL: Record<Tab, string> = {
-  length: '📐 Kabel-Länge',
   bandwidth: '📡 Bandbreite',
   power: '⚡ Stromverbrauch',
 }
@@ -45,84 +55,6 @@ const TabBar = ({
     ))}
   </div>
 )
-
-// ─── Cable Length ──────────────────────────────────────────────────────────
-
-const LengthTab = () => {
-  const [horizontal, setHorizontal] = useState(10)
-  const [vertical, setVertical] = useState(2)
-  const [slackPercent, setSlackPercent] = useState(15)
-  const [bendCount, setBendCount] = useState(2)
-  const bendReserve = 0.3 // m per bend
-  const straight = Math.sqrt(horizontal * horizontal + vertical * vertical)
-  const withBends = straight + bendCount * bendReserve
-  const total = withBends * (1 + slackPercent / 100)
-  return (
-    <div className="space-y-3 p-4 text-sm">
-      <p className="text-[11px] text-slate-400">
-        Schätzt die benötigte Kabel-Länge aus horizontaler Distanz, vertikaler Steigung,
-        Anzahl der 90°-Bögen und einem prozentualen Reserve-Slack. Reserve pro Bogen: 0,3 m.
-      </p>
-      <div className="grid grid-cols-2 gap-3">
-        <label className="block">
-          <span className="mb-1 block text-xs text-slate-400">Horizontal (m)</span>
-          <input
-            type="number"
-            step={0.1}
-            value={horizontal}
-            onChange={(e) => setHorizontal(Math.max(0, Number(e.target.value) || 0))}
-            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
-          />
-        </label>
-        <label className="block">
-          <span className="mb-1 block text-xs text-slate-400">Vertikal (m)</span>
-          <input
-            type="number"
-            step={0.1}
-            value={vertical}
-            onChange={(e) => setVertical(Math.max(0, Number(e.target.value) || 0))}
-            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
-          />
-        </label>
-        <label className="block">
-          <span className="mb-1 block text-xs text-slate-400">Anzahl Bögen</span>
-          <input
-            type="number"
-            min={0}
-            value={bendCount}
-            onChange={(e) => setBendCount(Math.max(0, Number(e.target.value) || 0))}
-            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
-          />
-        </label>
-        <label className="block">
-          <span className="mb-1 block text-xs text-slate-400">Slack-Reserve (%)</span>
-          <input
-            type="number"
-            min={0}
-            step={5}
-            value={slackPercent}
-            onChange={(e) => setSlackPercent(Math.max(0, Number(e.target.value) || 0))}
-            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
-          />
-        </label>
-      </div>
-      <div className="rounded border border-sky-700 bg-sky-950/40 p-3">
-        <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs">
-          <dt className="text-slate-500">Direkte Distanz</dt>
-          <dd className="font-mono text-slate-200">{straight.toFixed(2)} m</dd>
-          <dt className="text-slate-500">+ Bogen-Reserve</dt>
-          <dd className="font-mono text-slate-200">{withBends.toFixed(2)} m</dd>
-          <dt className="text-slate-500">+ Slack ({slackPercent}%)</dt>
-          <dd className="font-mono text-lg font-semibold text-sky-200">{total.toFixed(2)} m</dd>
-        </dl>
-        <p className="mt-2 text-[10px] text-slate-500">
-          Empfehlung: nächst-größere Standard-Länge nehmen (z. B. {Math.ceil(total)} m oder{' '}
-          {Math.ceil(total / 5) * 5} m als 5-m-Raster).
-        </p>
-      </div>
-    </div>
-  )
-}
 
 // ─── Bandwidth ─────────────────────────────────────────────────────────────
 
@@ -244,12 +176,83 @@ const BandwidthTab = () => {
   )
 }
 
-// ─── Power Consumption ─────────────────────────────────────────────────────
+// ─── Power Consumption (+ 3-phase distribution) ────────────────────────────
+
+/** Standard German/EU mains supply presets the user picks the cabling
+ *  from. Phase column count drives the bin-packer below: 1 for Schuko,
+ *  3 for CEE 16A/32A/63A. The per-phase amp limit is what one CEE
+ *  fuse trips at. */
+const SUPPLY_PRESETS = [
+  {
+    id: 'schuko' as const,
+    label: 'Schuko / Einphasig (16A)',
+    voltage: 230,
+    phases: 1,
+    perPhaseAmps: 16,
+  },
+  {
+    id: 'cee16' as const,
+    label: 'CEE 16A (3-Phasen, rot)',
+    voltage: 230,
+    phases: 3,
+    perPhaseAmps: 16,
+  },
+  {
+    id: 'cee32' as const,
+    label: 'CEE 32A (3-Phasen, rot)',
+    voltage: 230,
+    phases: 3,
+    perPhaseAmps: 32,
+  },
+  {
+    id: 'cee63' as const,
+    label: 'CEE 63A (3-Phasen, rot)',
+    voltage: 230,
+    phases: 3,
+    perPhaseAmps: 63,
+  },
+]
+type SupplyPresetId = (typeof SUPPLY_PRESETS)[number]['id']
+
+interface DeviceAssignment {
+  name: string
+  watts: number
+  phase: number // 1-indexed; 0 = no phase yet
+}
+
+/** Greedy bin-packing across N phases. Devices sorted by W desc;
+ *  each device drops on the currently-lightest phase. Best-fit-
+ *  decreasing is provably within 11/9 of optimal for this load-
+ *  balancing problem — good enough for stage power planning,
+ *  where the user can hand-tweak the result anyway. */
+const balancePhases = (
+  devices: { name: string; watts: number }[],
+  phases: number,
+): { perPhaseWatts: number[]; assignments: DeviceAssignment[] } => {
+  const sorted = [...devices].sort((a, b) => b.watts - a.watts)
+  const perPhaseWatts = Array.from({ length: phases }, () => 0)
+  const assignments: DeviceAssignment[] = []
+  for (const d of sorted) {
+    let lightest = 0
+    for (let i = 1; i < phases; i++) {
+      if (perPhaseWatts[i] < perPhaseWatts[lightest]) lightest = i
+    }
+    perPhaseWatts[lightest] += d.watts
+    assignments.push({ name: d.name, watts: d.watts, phase: lightest + 1 })
+  }
+  return { perPhaseWatts, assignments }
+}
+
+const PHASE_BG = ['bg-rose-900/40', 'bg-amber-900/40', 'bg-sky-900/40']
+const PHASE_TEXT = ['text-rose-200', 'text-amber-200', 'text-sky-200']
+const PHASE_BORDER = ['border-rose-700', 'border-amber-700', 'border-sky-700']
 
 const PowerTab = () => {
   const equipment = useProjectStore((s) => s.project.equipment)
-  const [voltage, setVoltage] = useState(230)
+  const [supplyId, setSupplyId] = useState<SupplyPresetId>('cee32')
   const [marginPercent, setMarginPercent] = useState(20)
+  const supply = SUPPLY_PRESETS.find((s) => s.id === supplyId) ?? SUPPLY_PRESETS[0]
+
   const totals = useMemo(() => {
     let totalW = 0
     let countedDevices = 0
@@ -268,27 +271,51 @@ const PowerTab = () => {
     devices.sort((a, b) => b.watts - a.watts)
     return { totalW, countedDevices, missingDevices, devices }
   }, [equipment])
+
   const totalWithMargin = totals.totalW * (1 + marginPercent / 100)
-  const amps = totalWithMargin / Math.max(1, voltage)
-  const recommendedBreaker = amps > 0 ? [16, 25, 32, 63, 80, 125].find((b) => amps * 1.25 <= b) ?? '> 125' : '—'
+  const ampsSinglePhase = totalWithMargin / supply.voltage
+  // For 3-phase symmetric load: I = P / (V·√3) ≈ P / 398 V.
+  const ampsThreePhase = totalWithMargin / (supply.voltage * Math.sqrt(3))
+
+  const distribution = useMemo(
+    () => balancePhases(totals.devices, supply.phases),
+    [totals.devices, supply.phases],
+  )
+
+  const perPhaseLoadFraction = distribution.perPhaseWatts.map(
+    (w) => (w / supply.voltage) / supply.perPhaseAmps,
+  )
+  const overloaded = perPhaseLoadFraction.some((f) => f > 1)
+  const maxImbalancePct =
+    distribution.perPhaseWatts.length > 0 && Math.max(...distribution.perPhaseWatts) > 0
+      ? Math.round(
+          ((Math.max(...distribution.perPhaseWatts) -
+            Math.min(...distribution.perPhaseWatts)) /
+            Math.max(...distribution.perPhaseWatts)) *
+            100,
+        )
+      : 0
+
   return (
     <div className="space-y-3 p-4 text-sm">
       <p className="text-[11px] text-slate-400">
         Summe der Verbrauchsangaben aus den Geräte-Eigenschaften
-        (<code className="rounded bg-slate-800 px-1">powerConsumptionWatts</code>). Geräte ohne Wert
-        zählen nicht mit; trage sie in den Properties nach, damit die Summe stimmt.
+        (<code className="rounded bg-slate-800 px-1">Leistung (W)</code>). Geräte ohne
+        Wert zählen nicht mit; in den Properties nachtragen damit die Verteilung stimmt.
       </p>
       <div className="grid grid-cols-2 gap-3">
         <label className="block">
-          <span className="mb-1 block text-xs text-slate-400">Netzspannung (V)</span>
+          <span className="mb-1 block text-xs text-slate-400">Anschluss-Typ</span>
           <select
-            value={voltage}
-            onChange={(e) => setVoltage(Number(e.target.value))}
+            value={supplyId}
+            onChange={(e) => setSupplyId(e.target.value as SupplyPresetId)}
             className="w-full rounded border border-slate-700 bg-slate-950 p-2"
           >
-            <option value={230}>230 V (EU)</option>
-            <option value={120}>120 V (US)</option>
-            <option value={400}>400 V (3-Phasen)</option>
+            {SUPPLY_PRESETS.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.label}
+              </option>
+            ))}
           </select>
         </label>
         <label className="block">
@@ -302,6 +329,7 @@ const PowerTab = () => {
           />
         </label>
       </div>
+
       <div className="rounded border border-emerald-700 bg-emerald-950/30 p-3">
         <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs">
           <dt className="text-slate-500">Erfasste Geräte</dt>
@@ -317,14 +345,116 @@ const PowerTab = () => {
           <dd className="font-mono text-emerald-200 text-lg">
             {totalWithMargin.toFixed(0)} W · {(totalWithMargin / 1000).toFixed(2)} kW
           </dd>
-          <dt className="text-slate-500">Stromstärke @ {voltage} V</dt>
-          <dd className="font-mono text-slate-200">{amps.toFixed(1)} A</dd>
-          <dt className="text-slate-500">Empfohlene Absicherung</dt>
-          <dd className="font-mono text-slate-200">
-            {typeof recommendedBreaker === 'number' ? `B${recommendedBreaker}` : recommendedBreaker}
-          </dd>
+          {supply.phases === 1 ? (
+            <>
+              <dt className="text-slate-500">Stromstärke (1-phasig)</dt>
+              <dd className="font-mono text-slate-200">
+                {ampsSinglePhase.toFixed(1)} A · max {supply.perPhaseAmps} A
+              </dd>
+            </>
+          ) : (
+            <>
+              <dt className="text-slate-500">Symmetrisch (3-phasig)</dt>
+              <dd className="font-mono text-slate-200">
+                {ampsThreePhase.toFixed(1)} A · max {supply.perPhaseAmps} A je Phase
+              </dd>
+            </>
+          )}
         </dl>
       </div>
+
+      {supply.phases === 3 && totals.devices.length > 0 && (
+        <div
+          className={`rounded border ${
+            overloaded ? 'border-red-700 bg-red-950/30' : 'border-sky-700 bg-sky-950/20'
+          } p-3`}
+        >
+          <div className="mb-2 flex items-center justify-between">
+            <div className="text-[11px] uppercase tracking-wide text-slate-300">
+              Phasen-Verteilung ({supply.label})
+            </div>
+            <div className="text-[10px] text-slate-500">
+              Unwucht: {maxImbalancePct}%
+              {overloaded && (
+                <span className="ml-2 rounded bg-red-700 px-1.5 py-0.5 text-[10px] text-white">
+                  ⚠ Phase überlastet
+                </span>
+              )}
+            </div>
+          </div>
+          <div className="grid grid-cols-3 gap-2">
+            {distribution.perPhaseWatts.map((watts, idx) => {
+              const amps = watts / supply.voltage
+              const fraction = amps / supply.perPhaseAmps
+              return (
+                <div
+                  key={idx}
+                  className={`rounded border ${PHASE_BORDER[idx]} ${PHASE_BG[idx]} p-2`}
+                >
+                  <div className={`text-[10px] uppercase tracking-wider ${PHASE_TEXT[idx]}`}>
+                    Phase L{idx + 1}
+                  </div>
+                  <div className="font-mono text-base text-slate-100">
+                    {watts.toFixed(0)} W
+                  </div>
+                  <div className="font-mono text-[11px] text-slate-300">
+                    {amps.toFixed(1)} A / {supply.perPhaseAmps} A
+                  </div>
+                  <div className="mt-1 h-1.5 overflow-hidden rounded bg-slate-800">
+                    <div
+                      className={`h-full ${
+                        fraction > 1
+                          ? 'bg-red-500'
+                          : fraction > 0.85
+                            ? 'bg-amber-500'
+                            : 'bg-emerald-500'
+                      }`}
+                      style={{ width: `${Math.min(100, fraction * 100)}%` }}
+                    />
+                  </div>
+                  <div className="mt-0.5 text-[10px] text-slate-400">
+                    {Math.round(fraction * 100)}% Last
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+          <details className="mt-2">
+            <summary className="cursor-pointer text-[11px] uppercase tracking-wide text-slate-400 hover:text-slate-200">
+              Geräte → Phase ({distribution.assignments.length})
+            </summary>
+            <table className="mt-1 w-full text-xs">
+              <thead className="text-slate-500">
+                <tr>
+                  <th className="text-left">Gerät</th>
+                  <th className="text-right">W</th>
+                  <th className="text-right pr-2">Phase</th>
+                </tr>
+              </thead>
+              <tbody>
+                {distribution.assignments.map((a, i) => (
+                  <tr key={`${a.name}-${i}`} className="border-t border-slate-800">
+                    <td className="truncate py-0.5">{a.name}</td>
+                    <td className="text-right font-mono text-slate-400">{a.watts}</td>
+                    <td
+                      className={`pr-2 text-right font-mono font-semibold ${PHASE_TEXT[a.phase - 1]}`}
+                    >
+                      L{a.phase}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </details>
+          <p className="mt-2 text-[10px] text-slate-500">
+            Greedy-Verteilung: sortiert nach Leistung, jedes Gerät auf die aktuell am
+            schwächsten belastete Phase. Bei symmetrischen Lasten zieht der Drehstrom
+            nur {ampsThreePhase.toFixed(1)} A je Phase; Unwucht erhöht den höchsten
+            Phasenstrom. Ziel: jede Phase &lt; 85% Last + Unwucht &lt; 20%.
+          </p>
+        </div>
+      )}
+
       {totals.devices.length > 0 && (
         <details className="rounded border border-slate-800 bg-slate-950/40">
           <summary className="cursor-pointer px-3 py-1.5 text-[11px] uppercase tracking-wide text-slate-400">
@@ -347,8 +477,13 @@ const PowerTab = () => {
 export const CalculatorsDialog = () => {
   const open = useUiStore((s) => s.calculators.open)
   const close = useUiStore((s) => s.closeCalculators)
-  const initialTab = useUiStore((s) => s.calculators.tab) ?? 'length'
-  const [tab, setTab] = useState<Tab>(initialTab)
+  // v7.5.0 — older shortcuts may still pass 'length'; coerce to bandwidth
+  // since the cable-length calculator was removed (no meaningful estimate
+  // without an inter-location distance graph).
+  const initialTab = useUiStore((s) => s.calculators.tab)
+  const [tab, setTab] = useState<Tab>(
+    initialTab === 'bandwidth' || initialTab === 'power' ? initialTab : 'bandwidth',
+  )
   const drag = useDraggablePosition('cable-planner:modal-pos:calculators', open)
   if (!open) return null
   return (
@@ -377,7 +512,6 @@ export const CalculatorsDialog = () => {
           </button>
         </header>
         <TabBar active={tab} onChange={setTab} />
-        {tab === 'length' && <LengthTab />}
         {tab === 'bandwidth' && <BandwidthTab />}
         {tab === 'power' && <PowerTab />}
       </div>

--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -165,12 +165,6 @@ export const MenuBar = ({
             {t('app.menu.tools.patchList', 'Patchliste…')}
           </MenuItem>
           <MenuItem
-            onClick={() => useUiStore.getState().openCalculators('length')}
-            icon="📐"
-          >
-            {t('app.menu.tools.cableLength', 'Kabel-Länge berechnen…')}
-          </MenuItem>
-          <MenuItem
             onClick={() => useUiStore.getState().openCalculators('bandwidth')}
             icon="📡"
           >

--- a/src/renderer/components/Properties/EquipmentProperties.tsx
+++ b/src/renderer/components/Properties/EquipmentProperties.tsx
@@ -320,6 +320,72 @@ const PortList = ({ title, ports, onChange }: PortListProps) => {
                 </div>
               </div>
             )}
+            {port.connectorType === 'BNC' && (
+              <div className="mt-1 rounded border border-amber-900/60 bg-amber-950/20 p-1.5">
+                <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-amber-300">
+                  SDI-Fähigkeiten (port-spezifisch)
+                </div>
+                <div className="grid grid-cols-2 gap-1 text-[10px]">
+                  <label className="flex items-center gap-1 text-slate-300">
+                    <input
+                      type="checkbox"
+                      checked={!!port.sdiCaps?.levelA}
+                      onChange={(e) =>
+                        updatePort(port.id, {
+                          sdiCaps: {
+                            ...(port.sdiCaps ?? {}),
+                            levelA: e.target.checked || undefined,
+                          },
+                        })
+                      }
+                    />
+                    3G Level A
+                  </label>
+                  <label className="flex items-center gap-1 text-slate-300">
+                    <input
+                      type="checkbox"
+                      checked={!!port.sdiCaps?.levelB}
+                      onChange={(e) =>
+                        updatePort(port.id, {
+                          sdiCaps: {
+                            ...(port.sdiCaps ?? {}),
+                            levelB: e.target.checked || undefined,
+                          },
+                        })
+                      }
+                    />
+                    3G Level B
+                  </label>
+                  <label className="col-span-2 block">
+                    <span className="text-slate-400">Max Single-Link</span>
+                    <select
+                      value={port.sdiCaps?.maxSingleLink ?? ''}
+                      onChange={(e) =>
+                        updatePort(port.id, {
+                          sdiCaps: {
+                            ...(port.sdiCaps ?? {}),
+                            maxSingleLink: (e.target.value || undefined) as NonNullable<
+                              NonNullable<typeof port.sdiCaps>['maxSingleLink']
+                            >,
+                          },
+                        })
+                      }
+                      className="mt-0.5 w-full rounded border border-slate-700 bg-slate-950 p-1 text-xs"
+                    >
+                      <option value="">(Geräte-Default)</option>
+                      <option value="SDI-HD">SDI-HD (1.5G)</option>
+                      <option value="SDI-3G">SDI-3G</option>
+                      <option value="SDI-6G">SDI-6G</option>
+                      <option value="SDI-12G">SDI-12G</option>
+                    </select>
+                  </label>
+                </div>
+                <div className="mt-1 text-[9px] text-slate-500">
+                  Überschreibt die Geräte-SDI-Fähigkeiten für diesen Port.
+                  Leer = Default vom Gerät.
+                </div>
+              </div>
+            )}
           </SortablePortItem>
         ))}
           </ul>
@@ -914,6 +980,58 @@ const DeviceConfigsBlock = ({ equipmentId }: { equipmentId: string }) => {
       )}
       <div className="mt-1 text-[10px] text-slate-500">
         Neue Konfigurationen über Einstellungen → Konfigurationen hochladen.
+      </div>
+    </div>
+  )
+}
+
+/**
+ * v7.5.0 — Operating-mode picker for multi-mode devices (media servers,
+ * modular processors like Pixelhue P20, Parco S3, Brompton Tessera).
+ * Each mode defines its own port layout; switching the active mode
+ * rewrites the equipment's live `inputs`/`outputs` so the canvas
+ * shows the correct ports for that mode.
+ *
+ * Out of scope for v7.5.0: an inline "edit modes" UI. Modes are
+ * created either (a) by the library author when shipping a multi-mode
+ * device template, or (b) via JSON import. The user can still pick
+ * between existing modes here.
+ */
+const DeviceModePicker = ({
+  equipment,
+}: {
+  equipment: import('../../types/equipment').EquipmentItem
+}) => {
+  const setActiveDeviceMode = useProjectStore((s) => s.setActiveDeviceMode)
+  const modes = equipment.modes ?? []
+  const active = equipment.activeModeId
+  return (
+    <div className="space-y-2 text-xs">
+      <p className="text-[10px] text-slate-500">
+        Wechselt das Port-Layout des Geräts. Bestehende Kabel an Ports, die im neuen
+        Modus nicht existieren, bleiben im Projekt, müssen aber neu gesteckt werden.
+      </p>
+      <div className="grid grid-cols-1 gap-1">
+        {modes.map((m) => (
+          <button
+            key={m.id}
+            type="button"
+            onClick={() => setActiveDeviceMode(equipment.id, m.id)}
+            className={`flex flex-col items-start rounded border px-2 py-1.5 text-left transition-colors ${
+              active === m.id
+                ? 'border-sky-500 bg-sky-900/40 text-sky-100'
+                : 'border-slate-700 bg-slate-900 text-slate-200 hover:border-sky-700'
+            }`}
+          >
+            <span className="font-medium">{m.name}</span>
+            {m.description && (
+              <span className="text-[10px] text-slate-400">{m.description}</span>
+            )}
+            <span className="mt-1 text-[10px] text-slate-500">
+              {m.inputs.length} In · {m.outputs.length} Out
+            </span>
+          </button>
+        ))}
       </div>
     </div>
   )
@@ -1527,6 +1645,20 @@ export const EquipmentProperties = () => {
             allPorts={[...equipment.inputs, ...equipment.outputs]}
             kind={networkKind}
           />
+        </SortableSection>
+      )}
+
+      {equipment.modes && equipment.modes.length > 0 && (
+        <SortableSection
+          id="modes"
+          title="Betriebsmodus"
+          subtitle={
+            equipment.modes.find((m) => m.id === equipment.activeModeId)?.name ??
+            'kein Modus aktiv'
+          }
+          defaultOpen
+        >
+          <DeviceModePicker equipment={equipment} />
         </SortableSection>
       )}
 

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -265,6 +265,12 @@ interface ProjectState {
     offset: { dx: number; dy: number },
   ) => string[]
   updateEquipment: (id: string, patch: Partial<EquipmentItem>) => void
+  /** v7.5.0 — activate a named DeviceMode on the given equipment.
+   *  Replaces the live `inputs`/`outputs` arrays with snapshots from
+   *  the mode definition so the canvas re-renders with the new port
+   *  set. Cables whose ports no longer exist stay in the project but
+   *  show as "orphaned" until the user re-routes them. */
+  setActiveDeviceMode: (equipmentId: string, modeId: string | null) => void
   setSelection: (equipmentId?: string, cableId?: string, locationId?: string) => void
   setSelectedTemplateName: (name?: string) => void
   addLocation: (partial?: Partial<LocationFrame>) => void
@@ -812,6 +818,32 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
           cables: nextCables,
         }),
       }
+    }),
+  setActiveDeviceMode: (equipmentId, modeId) =>
+    set((state) => {
+      const eq = state.project.equipment.find((e) => e.id === equipmentId)
+      if (!eq || !eq.modes || eq.modes.length === 0) return {}
+      const mode = modeId ? eq.modes.find((m) => m.id === modeId) : null
+      if (modeId && !mode) return {}
+      // Replace the live port arrays with the mode's snapshot (or
+      // leave them as-is when clearing the active mode — the user can
+      // still edit ports manually).
+      const nextEquipment = state.project.equipment.map((item) =>
+        item.id === equipmentId
+          ? {
+              ...item,
+              activeModeId: mode?.id,
+              inputs: mode ? mode.inputs.map((p) => ({ ...p })) : item.inputs,
+              outputs: mode ? mode.outputs.map((p) => ({ ...p })) : item.outputs,
+            }
+          : item,
+      )
+      const updated = touchProject({
+        ...state.project,
+        equipment: nextEquipment,
+      })
+      scheduleProjectAutosave(updated)
+      return { project: updated }
     }),
   setSelection: (equipmentId, cableId, locationId) =>
     set({

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -163,6 +163,7 @@ const defaults: PersistedUiState = {
   propertiesFloatingPos: { x: 80, y: 80 },
   customPalette: null,
   equipmentSectionOrder: [
+    'modes',
     'ports',
     'network',
     'sdi',
@@ -331,8 +332,8 @@ interface UiState extends PersistedUiState {
   patchList: { open: boolean }
   openPatchList: () => void
   closePatchList: () => void
-  calculators: { open: boolean; tab?: 'length' | 'bandwidth' | 'power' }
-  openCalculators: (tab?: 'length' | 'bandwidth' | 'power') => void
+  calculators: { open: boolean; tab?: 'bandwidth' | 'power' }
+  openCalculators: (tab?: 'bandwidth' | 'power') => void
   closeCalculators: () => void
   /** Rentman equipment import dialog (cross-component trigger). */
   rentmanImport: { open: boolean }

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -37,6 +37,12 @@ export interface Port {
   side?: 'left' | 'right'
   /** Optional signal standard declared for this port (e.g. SDI-12G on a camera out). */
   standard?: SignalStandard
+  /** v7.5.0 — per-port SDI capabilities. A device with a mixed SDI port
+   *  layout (e.g. some BNC are 12G level A, others 6G only, others
+   *  HD-SDI) can declare each port's spec individually here. The
+   *  device-level `equipment.sdiCaps` stays as a fallback default
+   *  when the port doesn't override it. */
+  sdiCaps?: import('./videoFormat').SdiCapabilities
   /**
    * Direction of the port. Defaults to the array it lives in (`inputs` → 'in',
    * `outputs` → 'out'). A port marked `bidirectional` (e.g. an RJ45 network
@@ -63,6 +69,21 @@ export interface Port {
   sfpVendor?: string
 }
 
+/** v7.5.0 — a named operating mode for a device whose port layout
+ *  changes depending on configuration (e.g. media-server boards,
+ *  modular processors). Each mode owns its own ports; switching the
+ *  active mode on an EquipmentItem rewrites its `inputs`/`outputs`
+ *  to the mode's snapshot. */
+export interface DeviceMode {
+  id: string
+  name: string
+  /** Optional description that surfaces in the mode picker, e.g.
+   *  "12G IN / 4× HDMI OUT" or "Standalone (1× SDI passthrough)". */
+  description?: string
+  inputs: Port[]
+  outputs: Port[]
+}
+
 export interface EquipmentItem {
   id: string
   name: string
@@ -75,6 +96,16 @@ export interface EquipmentItem {
   category: string
   inputs: Port[]
   outputs: Port[]
+  /** v7.5.0 — operating-mode-dependent port layouts (media servers,
+   *  modular processors like Pixelhue P20 / Parco S3 / Brompton Tessera).
+   *  Each mode carries its own `inputs` + `outputs`. When `activeModeId`
+   *  is set to a mode's id, the equipment's live `inputs`/`outputs`
+   *  arrays are replaced with that mode's port set — switching mode in
+   *  the UI swaps the visible ports on the canvas. Cables that no
+   *  longer find their port id are left orphaned (the user can
+   *  re-route them). */
+  modes?: DeviceMode[]
+  activeModeId?: string
   /** Explicit flag: true when this is a 19" rack device. */
   isRackDevice?: boolean
   /** Optional rack height in HE/U for future 2D rack layouts. */


### PR DESCRIPTION
## Summary

User-driven correction round across audio routing, power calculation,
and device modeling.

### ATEM Audio Router — matrix only

- `ClassicMixerView` (~200 LOC) removed. The user reported it
  "can do nothing useful" — only basic channel-strip params and not
  the workflow they needed.
- Imported XML's `<AudioMixer>` section is **retained as-is** on
  `draft.classicMixer` and round-trips on save (read-only), so no
  data loss. A small badge shows it's still in the XML.
- EmptyState: only **📂 XML laden** + **🎚 Matrix manuell** now.

### Cable-Length calculator removed

The standalone calculator only echoed numbers the user already had to
type. Removed:
- `LengthTab` (entire component)
- Werkzeuge → "Kabel-Länge berechnen…" menu entry
- 'length' from the calculator tab type

**Future proper implementation** (documented in code comment): 
distance edges between Location frames + device location-tags +
length derivation that walks `src-device → src-loc → dist(src-loc,
dst-loc) → dst-device + slack`. Needs a separate location-distance
model — slotted for v7.6+.

### Power calculator — 3-phase distribution

- Anschluss-Typ selector: **Schuko 16A**, **CEE 16A**, **CEE 32A**,
  **CEE 63A**. CEE flips the calculator into 3-phase mode.
- Greedy bin-packing (best-fit decreasing) distributes devices across
  L1/L2/L3 to minimise asymmetry. Within 11/9 of optimal for this
  problem in theory; in stage-power practice, perfect.
- Three colored per-phase cards (rosé L1 / amber L2 / sky L3) with
  kW + A + % of phase limit. Bar turns **red when a phase exceeds
  the fuse rating**.
- Expandable **"Geräte → Phase"** table so the user can see exactly
  which device plugs into which CEE pin.
- Unwucht-% indicator + overload warning.

### Device modes (per-mode port layouts) #61-follow-up

- New `DeviceMode { id, name, description, inputs, outputs }` +
  `EquipmentItem.modes` + `activeModeId`.
- New store action `setActiveDeviceMode(equipmentId, modeId)` —
  copies the mode's port arrays onto the equipment's live
  `inputs`/`outputs`. Cables whose ports vanish stay in the project
  as orphans (user re-routes them).
- New **Betriebsmodus** SortableSection in EquipmentProperties (only
  mounted when the device has ≥1 mode). Cards with name + description
  + in/out count; active mode highlights sky-500.
- Use case: Pixelhue P20, Parco S3, Brompton Tessera, etc.

### Per-port SDI capabilities

- New `Port.sdiCaps?: SdiCapabilities`. Overrides the
  `equipment.sdiCaps` fallback when set.
- Inline editor on every BNC-typed port row: 3G Level A / Level B
  checkboxes + Max Single-Link dropdown (Default · HD · 3G · 6G · 12G).
  Empty = use device-level default.
- Use case: mixed-spec devices where some BNC are 12G and others HD.

## What you do

1. Merge.
2. Tag `v7.5.0` on `main`.

## Test plan

- [ ] ATEM device → Audio-Router → EmptyState shows only 2 buttons;
      no "Klassischer Mixer"; import an XML with an AudioMixer
      section → "+ AudioMixer-Sektion (read-only)" badge appears;
      save → XML still contains AudioMixer
- [ ] Werkzeuge menu has 📡 Bandbreite + ⚡ Stromverbrauch only
- [ ] Power calc: pick "CEE 32A" → 3 phase cards show; total devices
      sort onto L1/L2/L3 with greedy balance; phases > 85% turn
      amber, > 100% red
- [ ] Equipment with `modes` → "Betriebsmodus" accordion shows cards;
      click a mode → canvas ports update
- [ ] Equipment with BNC ports → expand the port row → SDI section
      with 3G Level A/B + Single-Link override is visible


---
_Generated by [Claude Code](https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH)_