### PR TITLE
v7.7.x: deferred items + canvas bg fixes + custom bg image + bug pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.7.1",
+    "version": "7.7.2",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.7.0",
+    "version": "7.7.1",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -59,6 +59,12 @@ import {
 export default function App() {
   const project = useProjectStore((state) => state.project)
   const canvasTheme = useUiStore((state) => state.canvasTheme)
+  // v7.7.1 — exporters now read the live canvas-background settings so the
+  // exported PDF / PNG / JPEG matches what the user sees on the canvas.
+  const exportBgVariant = useUiStore((state) => state.bgVariant)
+  const exportBgOpacity = useUiStore((state) => state.bgOpacity)
+  const exportGridSize = useUiStore((state) => state.gridSize)
+  const exportCustomPalette = useUiStore((state) => state.customPalette)
   const showCableDialog = useProjectStore((state) => state.showCableDialog)
   const pendingConnection = useProjectStore((state) => state.pendingConnection)
   const createCableFromPending = useProjectStore((state) => state.createCableFromPending)
@@ -244,6 +250,24 @@ export default function App() {
     setMetaDialog(null)
   }
 
+  // v7.7.1 — PNG / JPEG export (canvas only, no header / title block).
+  const handleExportImage = async (format: 'png' | 'jpeg') => {
+    try {
+      await exportCanvasToImage(project.metadata.name, format, {
+        backgroundTheme: canvasTheme,
+        bgVariant: exportBgVariant,
+        gridSize: exportGridSize,
+        bgOpacity: exportBgOpacity,
+        customPalette: exportCustomPalette,
+      })
+    } catch (error) {
+      console.error(`${format.toUpperCase()} export failed:`, error)
+      alert(
+        `${format.toUpperCase()} export failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      )
+    }
+  }
+
   const handleExportPdf = async (theme: 'dark' | 'light' = canvasTheme) => {
     setPdfExportThemeOverride(theme)
     await new Promise<void>((resolve) =>
@@ -252,6 +276,10 @@ export default function App() {
     try {
       await exportCanvasToPdf(project.metadata.name, project.metadata, 0.85, {
         backgroundTheme: theme,
+        bgVariant: exportBgVariant,
+        gridSize: exportGridSize,
+        bgOpacity: exportBgOpacity,
+        customPalette: exportCustomPalette,
       })
     } catch (error) {
       console.error('PDF export failed:', error)
@@ -281,7 +309,13 @@ export default function App() {
       return
     }
     try {
-      const bytes = await exportCanvasToPdfBytes(meta, 0.85, { backgroundTheme: canvasTheme })
+      const bytes = await exportCanvasToPdfBytes(meta, 0.85, {
+        backgroundTheme: canvasTheme,
+        bgVariant: exportBgVariant,
+        gridSize: exportGridSize,
+        bgOpacity: exportBgOpacity,
+        customPalette: exportCustomPalette,
+      })
       const baseName = (meta.name || 'cable-planner').replace(/[^a-z0-9\-_. ]/gi, '_')
       const stamp = new Date().toISOString().slice(0, 19).replace(/[:T]/g, '-')
       const fileName = `${baseName}_${stamp}.pdf`
@@ -380,6 +414,8 @@ export default function App() {
         onSaveProjectAs={() => void saveProjectAs()}
         onOpenSettings={() => setSettingsOpen(true)}
         onExportPdf={() => setPdfExportOpen(true)}
+        onExportPng={() => void handleExportImage('png')}
+        onExportJpeg={() => void handleExportImage('jpeg')}
         onOpenPrintDialog={() => setPrintDialogOpen(true)}
         onOpenGraphmlImport={() => setGraphmlImportOpen(true)}
         onAttachPdfToRentman={() => void handleUploadPdfToRentman()}
@@ -628,7 +664,7 @@ const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoFormat, onC
     [customCableSpecs],
   )
   // Build list of cables ranked by compatibility with the two ports.
-  const ranked = useMemo(() => {
+  const ranked = useMemo((): Array<{ cable: CableSpec; level: 'ok' | 'warn' | 'error'; message: string }> => {
     if (!fromPort || !toPort) {
       return fullCableCatalog.map((cable) => ({ cable, level: 'ok' as const, message: '' }))
     }
@@ -641,7 +677,7 @@ const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoFormat, onC
         const order = { ok: 0, warn: 1, error: 2 }
         return order[a.level] - order[b.level]
       })
-  }, [fromPort, toPort])
+  }, [fromPort, toPort, fullCableCatalog])
 
   // For SDI↔SDI connections, pick the cable that matches the project's default
   // video format (or 1080p50 fallback) and the two devices' SDI capabilities.
@@ -716,7 +752,8 @@ const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoFormat, onC
     return checkSdiStandardMismatch(fromPort.standard ?? standard, toPort.standard ?? standard)
   }, [fromPort, toPort, standard])
 
-  const connectorMismatch = specId === CUSTOM_CABLE_SPEC_ID ? 'ok' : selectedEntry.level
+  const connectorMismatch: 'ok' | 'warn' | 'error' =
+    specId === CUSTOM_CABLE_SPEC_ID ? 'ok' : selectedEntry.level
   const connectorMessage = specId === CUSTOM_CABLE_SPEC_ID ? '' : selectedEntry.message
 
   const needsConverter =
@@ -747,7 +784,9 @@ const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoFormat, onC
       notes,
       cableSpecId: specId === CUSTOM_CABLE_SPEC_ID ? undefined : selected.id,
       standard: specId === CUSTOM_CABLE_SPEC_ID ? customStandard : standard,
-      needsConverter: needsConverter || connectorMismatch === 'error',
+      // `needsConverter` already covers warn-level and error-level mismatch
+      // (see definition above), so no extra fall-through check needed.
+      needsConverter,
     })
   }
 

--- a/src/renderer/components/Atem/AtemMvConfigDialog.tsx
+++ b/src/renderer/components/Atem/AtemMvConfigDialog.tsx
@@ -613,7 +613,7 @@ export const AtemMvConfigDialog = () => {
                     relevant layouts (matching ATEM software's flip
                     between one big window and four small windows). */}
                 {(['TL', 'TR', 'BL', 'BR'] as const).map((q) => {
-                  const cycle = QUADRANT_LAYOUT_CYCLES[q]
+                  const cycle = QUADRANT_LAYOUT_CYCLES[q] as readonly number[]
                   const idx = cycle.indexOf(mv.layout)
                   const next = cycle[(idx + 1) % cycle.length] ?? cycle[0]
                   const style: React.CSSProperties = {

--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -60,6 +60,9 @@ const CanvasContent = () => {
   const bgVariant = useUiStore((state) => state.bgVariant)
   const bgOpacity = useUiStore((state) => state.bgOpacity)
   const customPalette = useUiStore((state) => state.customPalette)
+  const canvasBgImageDark = useUiStore((state) => state.canvasBgImageDark)
+  const canvasBgImageLight = useUiStore((state) => state.canvasBgImageLight)
+  const canvasBgImageFit = useUiStore((state) => state.canvasBgImageFit)
   const cableColorMode = useUiStore((state) => state.cableColorMode)
   const canvasTheme = useUiStore((state) => state.canvasTheme)
   const pdfExportThemeOverride = useUiStore((state) => state.pdfExportThemeOverride)
@@ -952,6 +955,8 @@ const CanvasContent = () => {
               outputs: [],
               x: flow.x,
               y: flow.y,
+              width: 240,
+              height: 80,
             })
           })()
           return
@@ -979,6 +984,32 @@ const CanvasContent = () => {
     getSelectedEquipmentIds,
   ])
 
+  // v7.7.1 — Custom canvas background image (Issue #71). When the user
+  // uploaded an image for the current theme, render it as the canvas
+  // backdrop in place of the radial gradient. The pattern overlay from
+  // ReactFlow's <Background> still draws on top so the grid remains
+  // visible. Fit mode maps to CSS `background-size`.
+  const canvasBgImage =
+    effectiveCanvasTheme === 'light' ? canvasBgImageLight : canvasBgImageDark
+  const canvasBgSize =
+    canvasBgImageFit === 'cover'
+      ? 'cover'
+      : canvasBgImageFit === 'contain'
+        ? 'contain'
+        : 'auto'
+  const canvasBgRepeat = canvasBgImageFit === 'tile' ? 'repeat' : 'no-repeat'
+  const canvasBgInlineStyle: React.CSSProperties = canvasBgImage
+    ? {
+        backgroundImage: `url(${canvasBgImage})`,
+        backgroundSize: canvasBgSize,
+        backgroundRepeat: canvasBgRepeat,
+        backgroundPosition: 'center center',
+        backgroundColor:
+          customPalette?.canvasBg ??
+          (effectiveCanvasTheme === 'light' ? '#e8edf4' : '#0f172a'),
+      }
+    : { background: customPalette?.canvasBg }
+
   return (
     <div
       ref={wrapperRef}
@@ -987,7 +1018,7 @@ const CanvasContent = () => {
         height: '100%',
         minHeight: 400,
         position: 'relative',
-        background: customPalette?.canvasBg,
+        ...canvasBgInlineStyle,
       }}
       id="cable-planner-canvas"
       className={effectiveCanvasTheme === 'light' ? 'canvas-theme-light' : ''}

--- a/src/renderer/components/Canvas/CanvasToolbar.tsx
+++ b/src/renderer/components/Canvas/CanvasToolbar.tsx
@@ -58,7 +58,7 @@ export const CanvasToolbar = () => {
    *  same visual defaults the equipment-node renderer uses (220 px
    *  wide; height derived from port count). Center alignments use
    *  device CENTERS as the reference, not corners. */
-  const measuredSize = (item: { width?: number; height?: number; inputs?: { length: number }[]; outputs?: { length: number }[]; ipAddress?: string }) => {
+  const measuredSize = (item: { width?: number; height?: number; inputs?: ReadonlyArray<unknown>; outputs?: ReadonlyArray<unknown>; ipAddress?: string }) => {
     const w = item.width && item.width > 0 ? item.width : 220
     if (item.height && item.height > 0) return { w, h: item.height }
     // Match EquipmentNode's intrinsic layout: header + N port rows + padding.

--- a/src/renderer/components/Canvas/PendingCableOverlay.tsx
+++ b/src/renderer/components/Canvas/PendingCableOverlay.tsx
@@ -206,12 +206,18 @@ const PendingCableSuggestions = ({
       },
     ])
     queueConnection({
-      fromEquipmentId: sourceIsOutput ? sourceNodeId : newId,
-      fromPortId: sourceIsOutput ? sourcePortId : newPortId,
-      toEquipmentId: sourceIsOutput ? newId : sourceNodeId,
-      toPortId: sourceIsOutput ? newPortId : sourcePortId,
+      source: sourceIsOutput ? sourceNodeId : newId,
+      sourceHandle: sourceIsOutput ? sourcePortId : newPortId,
+      target: sourceIsOutput ? newId : sourceNodeId,
+      targetHandle: sourceIsOutput ? newPortId : sourcePortId,
     })
-    createCableFromPending({ name: template.name })
+    createCableFromPending({
+      name: template.name,
+      type: 'Custom',
+      length: 1,
+      color: '#64748b',
+      notes: '',
+    })
     clearPendingCable()
   }
 

--- a/src/renderer/components/Import/GraphmlImportDialog.tsx
+++ b/src/renderer/components/Import/GraphmlImportDialog.tsx
@@ -400,6 +400,15 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
           />
         </div>
 
+        {/* Library-mode hint: cables are dropped (templates carry no cabling). */}
+        {destination === 'library' && (
+          <div className="border-b border-violet-800/60 bg-violet-950/40 px-4 py-2 text-[11px] text-violet-200">
+            📚 Library-Modus: Geräte werden als wiederverwendbare Vorlagen
+            in die lokale Library gespeichert. Kabel werden nicht
+            mit übernommen (Templates enthalten keine Verkabelung).
+          </div>
+        )}
+
         {/* Tabs */}
         <div className="flex border-b border-slate-800 text-xs">
           {([

--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -12,6 +12,10 @@ interface MenuBarProps {
   onSaveProjectAs: () => void
   onOpenSettings: () => void
   onExportPdf: () => void
+  /** v7.7.1 — export the canvas as a PNG image (uses live bg settings). */
+  onExportPng?: () => void
+  /** v7.7.1 — export the canvas as a JPEG image (uses live bg settings). */
+  onExportJpeg?: () => void
   /** Open the consolidated "Drucken" hub (Plan + per-device patch-sheets, Issue #74). */
   onOpenPrintDialog?: () => void
   /** Open the GraphML / yEd import dialog. */
@@ -49,6 +53,8 @@ export const MenuBar = ({
   onSaveProjectAs,
   onOpenSettings,
   onExportPdf,
+  onExportPng,
+  onExportJpeg,
   onOpenPrintDialog,
   onOpenGraphmlImport,
   onEditProjectMeta,
@@ -118,6 +124,16 @@ export const MenuBar = ({
           <MenuItem onClick={onExportPdf} icon="📑">
             {t('app.menu.file.exportPdf', 'Plan als PDF exportieren…')}
           </MenuItem>
+          {onExportPng && (
+            <MenuItem onClick={onExportPng} icon="🖼">
+              {t('app.menu.file.exportPng', 'Plan als PNG exportieren…')}
+            </MenuItem>
+          )}
+          {onExportJpeg && (
+            <MenuItem onClick={onExportJpeg} icon="🖼">
+              {t('app.menu.file.exportJpeg', 'Plan als JPEG exportieren…')}
+            </MenuItem>
+          )}
           {onOpenCableBom && (
             <MenuItem onClick={onOpenCableBom} icon="🧮">
               {t('app.menu.file.cableBom', 'Kabel-Stückliste (BOM) exportieren…')}

--- a/src/renderer/components/Library/LibraryPanel.tsx
+++ b/src/renderer/components/Library/LibraryPanel.tsx
@@ -1744,7 +1744,7 @@ export const LibraryPanel = () => {
             </div>
 
             <div className="mb-2 rounded border border-violet-800/60 bg-violet-950/30 p-2 text-xs">
-              <div className="mb-1 flex items-center justify-between">
+              <div className="mb-1 flex flex-wrap items-center justify-between gap-y-1 gap-x-2">
                 <span className="font-semibold text-violet-200">
                   Auto-Vorschlag aus Geräte-Name
                 </span>
@@ -1841,11 +1841,11 @@ export const LibraryPanel = () => {
               </div>
             )}
 
-            <div className="mb-2 flex items-center justify-between">
+            <div className="mb-2 flex flex-wrap items-center justify-between gap-y-1 gap-x-2">
               <div className="text-sm font-semibold">
                 {t('library.create.portGroups', 'Port-Gruppen')}
               </div>
-              <div className="flex gap-2 text-xs">
+              <div className="flex flex-wrap gap-2 text-xs">
                 <button
                   type="button"
                   onClick={() => addGroup('in')}

--- a/src/renderer/components/Properties/CableProperties.tsx
+++ b/src/renderer/components/Properties/CableProperties.tsx
@@ -461,14 +461,17 @@ const ConnectorMismatchHint = ({
                   })
                   // Add second cable: converter output → original target
                   queueConnection({
-                    fromEquipmentId: newId,
-                    fromPortId: newOutPortId,
-                    toEquipmentId,
-                    toPortId: toPort.id,
+                    source: newId,
+                    sourceHandle: newOutPortId,
+                    target: toEquipmentId,
+                    targetHandle: toPort.id,
                   })
                   createCableFromPending({
                     name: `${tpl.name} → ${toDev.name}`,
                     color: '#94a3b8',
+                    type: 'Custom',
+                    length: 1,
+                    notes: '',
                   })
                 }}
                 className="rounded bg-amber-800/60 px-1.5 py-0.5 text-amber-100 hover:bg-amber-700/80"

--- a/src/renderer/components/Properties/EquipmentProperties.tsx
+++ b/src/renderer/components/Properties/EquipmentProperties.tsx
@@ -24,7 +24,7 @@ import { promptDialog } from '../../lib/promptDialog'
 import { useGreenGoBeltpack } from '../../lib/greengoSync'
 import { exportDevicePatchSheet } from '../../lib/exportDevicePdf'
 import { ALL_CONNECTOR_TYPES } from '../../types/equipment'
-import type { ConnectorType, Port, VlanDef, PortVlanAssignment } from '../../types/equipment'
+import type { ConnectorType, EquipmentItem, Port, VlanDef, PortVlanAssignment } from '../../types/equipment'
 import { ALL_SIGNAL_STANDARDS } from '../../types/cableSpec'
 import type { SignalStandard } from '../../types/cableSpec'
 import { QUAD_LINK_LABEL, type QuadLinkMode } from '../../types/videoFormat'
@@ -433,7 +433,7 @@ const RackFacePreview = ({
                       src={imageUrl}
                       alt={`${equipment.name} ${side}`}
                       className="mx-auto rounded object-contain"
-                      style={{ width: panelWidth, height: Math.max(1, equipment.rackUnits) * unitHeight }}
+                      style={{ width: panelWidth, height: Math.max(1, equipment.rackUnits ?? 1) * unitHeight }}
                     />
                   ) : (
                     <>

--- a/src/renderer/components/Settings/SettingsDialog.tsx
+++ b/src/renderer/components/Settings/SettingsDialog.tsx
@@ -366,6 +366,12 @@ const AppearanceTab = () => {
   const setBgVariant = useUiStore((s) => s.setBgVariant)
   const bgOpacity = useUiStore((s) => s.bgOpacity)
   const setBgOpacity = useUiStore((s) => s.setBgOpacity)
+  // v7.7.1 — Custom canvas background image (Issue #71).
+  const canvasBgImageDark = useUiStore((s) => s.canvasBgImageDark)
+  const canvasBgImageLight = useUiStore((s) => s.canvasBgImageLight)
+  const canvasBgImageFit = useUiStore((s) => s.canvasBgImageFit)
+  const setCanvasBgImage = useUiStore((s) => s.setCanvasBgImage)
+  const setCanvasBgImageFit = useUiStore((s) => s.setCanvasBgImageFit)
   const setDefaultArrow = useUiStore((s) => s.setDefaultArrow)
   const language = useUiStore((s) => s.language)
   const setLanguage = useUiStore((s) => s.setLanguage)
@@ -586,6 +592,80 @@ const AppearanceTab = () => {
             <span className="w-10 text-right text-xs text-slate-400">
               {Math.round(bgOpacity * 100)}%
             </span>
+          </label>
+        </div>
+        {/* v7.7.1 — Custom canvas background image upload (Issue #71). */}
+        <div className="mt-4 border-t border-slate-800 pt-3">
+          <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+            {t('settings.canvasBg.imageTitle', 'Eigenes Hintergrundbild')}
+          </div>
+          <div className="mb-2 text-[11px] text-slate-500">
+            {t(
+              'settings.canvasBg.imageDesc',
+              'Lade ein eigenes Bild als Canvas-Hintergrund — getrennt für Dark- und Light-Mode. Das Rastermuster (Punkte/Linien/Kreuze) wird darüber gezeichnet.',
+            )}
+          </div>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            {([
+              ['dark', '🌙 Dark-Mode-Bild', canvasBgImageDark] as const,
+              ['light', '☀ Light-Mode-Bild', canvasBgImageLight] as const,
+            ]).map(([theme, label, current]) => (
+              <div key={theme} className="rounded border border-slate-800 bg-slate-950/40 p-2">
+                <div className="mb-1 text-[11px] font-semibold text-slate-300">{label}</div>
+                {current ? (
+                  <>
+                    <img
+                      src={current}
+                      alt={`${theme} background`}
+                      className="mb-2 h-20 w-full rounded border border-slate-700 object-cover"
+                    />
+                    <div className="flex gap-1">
+                      <button
+                        type="button"
+                        onClick={async () => {
+                          const dataUri = await pickImageAsDataUri()
+                          if (dataUri) setCanvasBgImage(theme, dataUri)
+                        }}
+                        className="flex-1 rounded bg-slate-700 px-2 py-1 text-[11px] hover:bg-slate-600"
+                      >
+                        {t('settings.canvasBg.replace', 'Ersetzen…')}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setCanvasBgImage(theme, null)}
+                        className="rounded bg-red-900/60 px-2 py-1 text-[11px] text-red-200 hover:bg-red-800"
+                        title={t('settings.canvasBg.remove', 'Bild entfernen')}
+                      >
+                        ✕
+                      </button>
+                    </div>
+                  </>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      const dataUri = await pickImageAsDataUri()
+                      if (dataUri) setCanvasBgImage(theme, dataUri)
+                    }}
+                    className="w-full rounded border border-dashed border-slate-700 bg-slate-900 px-2 py-4 text-[11px] text-slate-400 hover:border-slate-600 hover:text-slate-200"
+                  >
+                    {t('settings.canvasBg.upload', '+ Bild hochladen…')}
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+          <label className="mt-3 flex items-center gap-2 text-xs text-slate-300">
+            <span className="text-slate-400">{t('settings.canvasBg.fit', 'Skalierung')}</span>
+            <select
+              value={canvasBgImageFit}
+              onChange={(e) => setCanvasBgImageFit(e.target.value as 'cover' | 'contain' | 'tile')}
+              className="rounded border border-slate-700 bg-slate-900 p-1 text-xs"
+            >
+              <option value="cover">{t('settings.canvasBg.fit.cover', 'Cover (füllt komplett, beschneidet)')}</option>
+              <option value="contain">{t('settings.canvasBg.fit.contain', 'Contain (vollständig sichtbar, mit Rand)')}</option>
+              <option value="tile">{t('settings.canvasBg.fit.tile', 'Kacheln (wiederholt)')}</option>
+            </select>
           </label>
         </div>
       </SettingsCard>

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -24,20 +24,25 @@ body,
   height: 100%;
 }
 
+/* v7.7.1 — Gradient lives on the canvas container itself, NOT on
+ * `.react-flow__pane`. The pane sits on top of `.react-flow__background`
+ * (the SVG that draws the dots/lines pattern), so making the pane opaque
+ * obscures the user-configurable Background component entirely. The
+ * pane must stay transparent for the pattern to be visible. */
 #cable-planner-canvas {
-  background: #0f172a;
-}
-
-#cable-planner-canvas .react-flow__pane {
   background: radial-gradient(circle at 20% 10%, #1e293b 0%, #0f172a 45%, #020617 100%);
 }
 
+#cable-planner-canvas .react-flow__pane {
+  background: transparent;
+}
+
 #cable-planner-canvas.canvas-theme-light {
-  background: #e8edf4;
+  background: radial-gradient(circle at 30% 20%, #eef2f7 0%, #e8edf4 50%, #dde4ee 100%);
 }
 
 #cable-planner-canvas.canvas-theme-light .react-flow__pane {
-  background: radial-gradient(circle at 30% 20%, #eef2f7 0%, #e8edf4 50%, #dde4ee 100%);
+  background: transparent;
 }
 
 #cable-planner-canvas.canvas-theme-light .react-flow__controls {

--- a/src/renderer/lib/bridge.ts
+++ b/src/renderer/lib/bridge.ts
@@ -364,7 +364,9 @@ const webFallbackApi: CablePlannerApi = {
         throw new Error('Rentman token missing or malformed.')
       }
       const form = new FormData()
-      const blob = new Blob([fileBytes], { type: mimeType })
+      // Cast to BlobPart — Uint8Array<ArrayBufferLike> is structurally a
+      // BlobPart but TS 6 narrows the buffer type to disallow shared.
+      const blob = new Blob([fileBytes as unknown as BlobPart], { type: mimeType })
       form.append('file', blob, fileName)
       form.append('name', fileName)
       form.append('item', projectId)

--- a/src/renderer/lib/downloadBlob.ts
+++ b/src/renderer/lib/downloadBlob.ts
@@ -23,7 +23,9 @@ const inferType = (content: DownloadContent, override?: string): string => {
 const toBlob = (content: DownloadContent, mimeType: string): Blob => {
   if (content instanceof Blob) return content
   if (typeof content === 'string') return new Blob([content], { type: mimeType })
-  return new Blob([content], { type: mimeType })
+  // Cast — TS 6 disallows ArrayBufferLike-backed Uint8Array as BlobPart
+  // even though it's structurally fine for the runtime Blob constructor.
+  return new Blob([content as unknown as BlobPart], { type: mimeType })
 }
 
 /**

--- a/src/renderer/lib/exportBackground.ts
+++ b/src/renderer/lib/exportBackground.ts
@@ -1,0 +1,151 @@
+// v7.7.1 — Shared canvas-background composer used by PDF and image
+// exports. Mirrors the live canvas styling (gradient + ReactFlow
+// `<Background>` pattern) so the exported file matches what the user
+// sees — including their chosen variant (dots / lines / cross / none),
+// grid size, opacity and custom palette overrides.
+//
+// Before this file existed both exporters duplicated a hardcoded
+// dot-pattern CSS that ignored every UI setting, so any tweak in
+// Settings → Canvas-Hintergrund had no effect on PDF / PNG / JPEG
+// output. That's also why the user reported "always dotted regardless
+// of what I change in the settings".
+
+export type ExportBgVariant = 'dots' | 'lines' | 'cross' | 'none'
+
+export interface ExportBackgroundOptions {
+  theme: 'dark' | 'light'
+  variant: ExportBgVariant
+  /** Grid step in CSS pixels (matches the live ReactFlow gap). */
+  gridSize: number
+  /** Opacity of the pattern layer (0..1). */
+  opacity: number
+  /** Optional custom canvas color overrides. */
+  customPalette?: { canvasBg: string; gridColor: string } | null
+}
+
+export interface ComposedBackground {
+  /** Use as the captured element's `backgroundColor` (solid fallback for
+   *  capture libs that can't rasterise gradients). */
+  bgFallback: string
+  /** CSS to apply as the `style.background` shorthand. Includes both
+   *  the pattern layer (if any) and the underlying gradient. */
+  background: string
+  /** Companion `background-size` for the composed background. */
+  backgroundSize: string
+  /** Companion `background-repeat`. */
+  backgroundRepeat: string
+}
+
+/** Build the composed background style. Layering order (top to bottom):
+ *  1. Pattern (dots / lines / cross) — only if variant !== 'none'
+ *  2. Theme-appropriate radial gradient
+ *
+ *  The pattern is drawn at `gridSize` intervals and tiles infinitely
+ *  via `background-repeat: repeat`, so the exported file shows the
+ *  grid extending across the entire content area regardless of how
+ *  much padding the caller adds. */
+export const composeExportBackground = (
+  opts: ExportBackgroundOptions,
+): ComposedBackground => {
+  const { theme, variant, gridSize, opacity, customPalette } = opts
+  const bgFallback =
+    customPalette?.canvasBg ?? (theme === 'light' ? '#e8edf4' : '#0f172a')
+  const bgGradient = customPalette?.canvasBg
+    ? customPalette.canvasBg
+    : theme === 'light'
+      ? 'radial-gradient(circle at 30% 20%, #eef2f7 0%, #e8edf4 50%, #dde4ee 100%)'
+      : 'radial-gradient(circle at 20% 10%, #1e293b 0%, #0f172a 45%, #020617 100%)'
+  const themeGridColor = theme === 'light' ? '#94a3b8' : '#64748b'
+  const gridColor = customPalette?.gridColor ?? themeGridColor
+  // Encode opacity into the grid color so the CSS pattern fades
+  // independently of the gradient (using the `style.opacity` field
+  // would fade the gradient too, which the user didn't ask for).
+  const rgbaGrid = withOpacity(gridColor, Math.max(0, Math.min(1, opacity)))
+
+  // Variant-specific pattern values. Sizes echo the ReactFlow defaults
+  // (dot radius 1.5, line width 1, cross arm 6 px).
+  let pattern = ''
+  let patternSize = ''
+  switch (variant) {
+    case 'dots':
+      pattern = `radial-gradient(${rgbaGrid} 1.5px, transparent 1.6px)`
+      patternSize = `${gridSize}px ${gridSize}px`
+      break
+    case 'lines':
+      // Orthogonal lines, 1 px wide, every gridSize px on both axes.
+      pattern =
+        `linear-gradient(${rgbaGrid} 1px, transparent 1px),` +
+        ` linear-gradient(90deg, ${rgbaGrid} 1px, transparent 1px)`
+      patternSize = `${gridSize}px ${gridSize}px, ${gridSize}px ${gridSize}px`
+      break
+    case 'cross': {
+      // 6-px cross at each intersection — approximated with two short
+      // line segments. Using radial-gradient with stops to fake the
+      // cross arms keeps the markup simple while still tiling.
+      const arm = 6
+      pattern =
+        `linear-gradient(${rgbaGrid} 1px, transparent 1px),` +
+        ` linear-gradient(90deg, ${rgbaGrid} 1px, transparent 1px)`
+      patternSize = `${gridSize}px ${arm}px, ${arm}px ${gridSize}px`
+      break
+    }
+    case 'none':
+    default:
+      pattern = ''
+      patternSize = ''
+      break
+  }
+
+  if (!pattern) {
+    return {
+      bgFallback,
+      background: bgGradient,
+      backgroundSize: '100% 100%',
+      backgroundRepeat: 'no-repeat',
+    }
+  }
+  return {
+    bgFallback,
+    background: `${pattern}, ${bgGradient}`,
+    backgroundSize: variant === 'cross'
+      ? `${patternSize}, 100% 100%`
+      : variant === 'lines'
+        ? `${patternSize}, 100% 100%`
+        : `${patternSize}, 100% 100%`,
+    backgroundRepeat: variant === 'none' ? 'no-repeat' : 'repeat, no-repeat',
+  }
+}
+
+/** Convert a hex / named color to rgba() with the given opacity. Falls
+ *  back to opacity-via-color-mix style alpha so any input flavour
+ *  works. */
+const withOpacity = (color: string, alpha: number): string => {
+  // Already an rgba() / hsla() — patch the alpha in place.
+  const rgba = /^rgba?\(([^)]+)\)$/i.exec(color)
+  if (rgba) {
+    const parts = rgba[1].split(',').map((p) => p.trim())
+    return `rgba(${parts[0]}, ${parts[1]}, ${parts[2]}, ${alpha})`
+  }
+  // Hex (#rgb / #rrggbb / #rrggbbaa) — split into channels.
+  const hex = /^#([0-9a-f]{3,8})$/i.exec(color)
+  if (hex) {
+    const h = hex[1]
+    const expand = (s: string) => (s.length === 1 ? s + s : s)
+    if (h.length === 3 || h.length === 4) {
+      const r = parseInt(expand(h[0]), 16)
+      const g = parseInt(expand(h[1]), 16)
+      const b = parseInt(expand(h[2]), 16)
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`
+    }
+    if (h.length === 6 || h.length === 8) {
+      const r = parseInt(h.slice(0, 2), 16)
+      const g = parseInt(h.slice(2, 4), 16)
+      const b = parseInt(h.slice(4, 6), 16)
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`
+    }
+  }
+  // Last resort — return the original with a wrapping color-mix; not
+  // every renderer supports it but at least the call doesn't drop the
+  // alpha entirely.
+  return `color-mix(in srgb, ${color} ${Math.round(alpha * 100)}%, transparent)`
+}

--- a/src/renderer/lib/exportImage.ts
+++ b/src/renderer/lib/exportImage.ts
@@ -8,8 +8,17 @@
 // directly so the output skips jsPDF entirely.
 
 import { toJpeg, toPng } from 'html-to-image'
+import { composeExportBackground, type ExportBgVariant } from './exportBackground'
 
 export type ImageExportFormat = 'png' | 'jpeg'
+
+export interface ImageExportBackgroundOptions {
+  /** Canvas grid variant. Defaults to 'dots'. */
+  bgVariant?: ExportBgVariant
+  gridSize?: number
+  bgOpacity?: number
+  customPalette?: { canvasBg: string; gridColor: string } | null
+}
 
 interface ContentBox {
   contentX: number
@@ -91,7 +100,9 @@ const computeContentBox = (viewportEl: HTMLElement): ContentBox => {
     throw new Error('Konnte den Inhalt des Canvas nicht vermessen')
   }
 
-  const padding = 80
+  // v7.7.1 — generous padding so the exported image shows plenty of
+  // background pattern around the content. Mirrors exportPdf.ts.
+  const padding = 200
   return {
     contentX: minX - padding,
     contentY: minY - padding,
@@ -105,6 +116,7 @@ const captureViewport = async (
   backgroundTheme: 'dark' | 'light',
   pixelRatio: number,
   jpegQuality: number,
+  bgOptions: ImageExportBackgroundOptions,
 ): Promise<string> => {
   const viewportEl =
     (document.querySelector('.react-flow__viewport') as HTMLElement | null) ?? null
@@ -112,17 +124,16 @@ const captureViewport = async (
 
   const { contentX, contentY, contentW, contentH } = computeContentBox(viewportEl)
 
-  const bgFallback = backgroundTheme === 'light' ? '#e8edf4' : '#0f172a'
-  const bgGradient =
-    backgroundTheme === 'light'
-      ? 'radial-gradient(circle at 30% 20%, #eef2f7 0%, #e8edf4 50%, #dde4ee 100%)'
-      : 'radial-gradient(circle at 20% 10%, #1e293b 0%, #0f172a 45%, #020617 100%)'
-  const dotColor = backgroundTheme === 'light' ? '#cbd5e1' : '#334155'
-  const dotPattern = `radial-gradient(${dotColor} 1px, transparent 1px)`
-  const composedBackground = `${dotPattern}, ${bgGradient}`
+  const composed = composeExportBackground({
+    theme: backgroundTheme,
+    variant: bgOptions.bgVariant ?? 'dots',
+    gridSize: bgOptions.gridSize ?? 20,
+    opacity: bgOptions.bgOpacity ?? 0.5,
+    customPalette: bgOptions.customPalette ?? null,
+  })
 
   const captureOptions = {
-    backgroundColor: bgFallback,
+    backgroundColor: composed.bgFallback,
     pixelRatio,
     cacheBust: true,
     width: contentW,
@@ -130,10 +141,10 @@ const captureViewport = async (
     style: {
       width: `${contentW}px`,
       height: `${contentH}px`,
-      background: composedBackground,
-      backgroundSize: '20px 20px, 100% 100%',
-      backgroundRepeat: 'repeat, no-repeat',
-      backgroundColor: bgFallback,
+      background: composed.background,
+      backgroundSize: composed.backgroundSize,
+      backgroundRepeat: composed.backgroundRepeat,
+      backgroundColor: composed.bgFallback,
       transform: `translate(${-contentX}px, ${-contentY}px)`,
       transformOrigin: '0 0',
     },
@@ -165,13 +176,23 @@ const triggerDownload = (dataUrl: string, fileName: string) => {
 export const exportCanvasToImage = async (
   projectName: string,
   format: ImageExportFormat,
-  options?: { backgroundTheme?: 'dark' | 'light'; pixelRatio?: number; jpegQuality?: number },
+  options?: {
+    backgroundTheme?: 'dark' | 'light'
+    pixelRatio?: number
+    jpegQuality?: number
+  } & ImageExportBackgroundOptions,
 ): Promise<void> => {
   const dataUrl = await captureViewport(
     format,
     options?.backgroundTheme ?? 'dark',
     options?.pixelRatio ?? 2,
     options?.jpegQuality ?? 0.92,
+    {
+      bgVariant: options?.bgVariant,
+      gridSize: options?.gridSize,
+      bgOpacity: options?.bgOpacity,
+      customPalette: options?.customPalette,
+    },
   )
   const safeName = projectName.replace(/[/\\?%*:|"<>]/g, '-').trim() || 'cable-planner'
   triggerDownload(dataUrl, `${safeName}.${format === 'png' ? 'png' : 'jpg'}`)

--- a/src/renderer/lib/exportPdf.ts
+++ b/src/renderer/lib/exportPdf.ts
@@ -1,9 +1,18 @@
 import { toJpeg } from 'html-to-image'
 import jsPDF from 'jspdf'
 import type { ProjectMetadata } from '../types/project'
+import { composeExportBackground, type ExportBgVariant } from './exportBackground'
 
 export interface ExportPdfOptions {
   backgroundTheme?: 'dark' | 'light'
+  /** v7.7.1 — Canvas grid variant from the UI store. Defaults to 'dots'. */
+  bgVariant?: ExportBgVariant
+  /** Grid step in CSS pixels (UI default = 10). */
+  gridSize?: number
+  /** Pattern opacity 0..1 (UI default = 0.5). */
+  bgOpacity?: number
+  /** Custom palette overrides from Settings → Canvas-Hintergrund. */
+  customPalette?: { canvasBg: string; gridColor: string } | null
 }
 
 const fmtDate = (iso?: string): string => {
@@ -222,9 +231,10 @@ const buildCanvasPdf = async (
     throw new Error('Konnte den Inhalt des Canvas nicht vermessen')
   }
 
-  // Padding around the content (in flow pixels) so cable bends and labels
-  // near the edge aren't clipped.
-  const padding = 80
+  // v7.7.1 — padding bumped to 200 px so the exported file shows
+  // generous margin AROUND the content, making the grid pattern look
+  // like an extension of the live canvas instead of a tight crop.
+  const padding = 200
   const contentX = minX - padding
   const contentY = minY - padding
   const contentW = Math.ceil(maxX - minX + padding * 2)
@@ -235,25 +245,19 @@ const buildCanvasPdf = async (
   // requested rectangle and `style` overrides the captured element's style
   // during capture (does not mutate the live DOM).
   //
-  // Background must match the live canvas styling defined in `index.css`
-  // (`#cable-planner-canvas` / `.canvas-theme-light .react-flow__pane`) plus
-  // the React Flow `<Background />` dot pattern. The viewport itself is a
-  // sibling of `.react-flow__background` so dots aren't captured implicitly —
-  // we reproduce them here as a CSS background-image so the exported PDF
-  // matches what the user sees on screen.
-  const theme = options?.backgroundTheme ?? 'dark'
-  const bgFallback = theme === 'light' ? '#e8edf4' : '#0f172a'
-  const bgGradient =
-    theme === 'light'
-      ? 'radial-gradient(circle at 30% 20%, #eef2f7 0%, #e8edf4 50%, #dde4ee 100%)'
-      : 'radial-gradient(circle at 20% 10%, #1e293b 0%, #0f172a 45%, #020617 100%)'
-  const dotColor = theme === 'light' ? '#cbd5e1' : '#334155'
-  // React Flow `<Background />` defaults: dots, gap=20, size=1.
-  const dotPattern = `radial-gradient(${dotColor} 1px, transparent 1px)`
-  const composedBackground = `${dotPattern}, ${bgGradient}`
+  // Background must match the live canvas — including the user's current
+  // bgVariant / gridSize / opacity / palette settings. Compose via the
+  // shared helper so PNG / JPEG / PDF all stay in sync.
+  const composed = composeExportBackground({
+    theme: options?.backgroundTheme ?? 'dark',
+    variant: options?.bgVariant ?? 'dots',
+    gridSize: options?.gridSize ?? 20,
+    opacity: options?.bgOpacity ?? 0.5,
+    customPalette: options?.customPalette ?? null,
+  })
 
   const dataUrl = await toJpeg(viewportEl, {
-    backgroundColor: bgFallback,
+    backgroundColor: composed.bgFallback,
     pixelRatio: 1.5,
     quality,
     cacheBust: true,
@@ -262,10 +266,10 @@ const buildCanvasPdf = async (
     style: {
       width: `${contentW}px`,
       height: `${contentH}px`,
-      background: composedBackground,
-      backgroundSize: '20px 20px, 100% 100%',
-      backgroundRepeat: 'repeat, no-repeat',
-      backgroundColor: bgFallback,
+      background: composed.background,
+      backgroundSize: composed.backgroundSize,
+      backgroundRepeat: composed.backgroundRepeat,
+      backgroundColor: composed.bgFallback,
       transform: `translate(${-contentX}px, ${-contentY}px)`,
       transformOrigin: '0 0',
     },

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -118,6 +118,14 @@ interface PersistedUiState {
    *  default position so adding new sections in future versions
    *  doesn't lose the user's existing ordering. */
   equipmentSectionOrder: string[]
+  /** v7.7.1 — Custom canvas background image (Issue #71). Separate
+   *  uploads for dark and light theme so the user can tune visibility.
+   *  When set, the image replaces the radial gradient and tiles by
+   *  default ('cover'). `null` falls back to the theme gradient. */
+  canvasBgImageDark: string | null
+  canvasBgImageLight: string | null
+  /** How the custom image is sized on the canvas. */
+  canvasBgImageFit: 'cover' | 'contain' | 'tile'
 }
 
 const defaults: PersistedUiState = {
@@ -162,6 +170,9 @@ const defaults: PersistedUiState = {
   propertiesFloating: false,
   propertiesFloatingPos: { x: 80, y: 80 },
   customPalette: null,
+  canvasBgImageDark: null,
+  canvasBgImageLight: null,
+  canvasBgImageFit: 'cover',
   equipmentSectionOrder: [
     'modes',
     'ports',
@@ -229,6 +240,12 @@ const load = (): PersistedUiState => {
       merged.gridSize = defaults.gridSize
     if (typeof merged.libraryWidth !== 'number') merged.libraryWidth = defaults.libraryWidth
     if (typeof merged.propertiesWidth !== 'number') merged.propertiesWidth = defaults.propertiesWidth
+    if (merged.canvasBgImageDark != null && typeof merged.canvasBgImageDark !== 'string')
+      merged.canvasBgImageDark = null
+    if (merged.canvasBgImageLight != null && typeof merged.canvasBgImageLight !== 'string')
+      merged.canvasBgImageLight = null
+    if (!['cover', 'contain', 'tile'].includes(merged.canvasBgImageFit))
+      merged.canvasBgImageFit = defaults.canvasBgImageFit
     return merged
   } catch {
     return defaults
@@ -288,6 +305,8 @@ interface UiState extends PersistedUiState {
   setPropertiesFloatingPos: (pos: { x: number; y: number }) => void
   setCustomPalette: (palette: { canvasBg: string; gridColor: string; accent: string } | null) => void
   setEquipmentSectionOrder: (order: string[]) => void
+  setCanvasBgImage: (theme: 'dark' | 'light', dataUri: string | null) => void
+  setCanvasBgImageFit: (fit: 'cover' | 'contain' | 'tile') => void
   pdfExportThemeOverride: 'dark' | 'light' | null
   setPdfExportThemeOverride: (value: 'dark' | 'light' | null) => void
   cableEdit: { open: boolean; cableId?: string }
@@ -402,6 +421,9 @@ const applyPatch =
       propertiesFloating: state.propertiesFloating,
       propertiesFloatingPos: state.propertiesFloatingPos,
       customPalette: state.customPalette,
+      canvasBgImageDark: state.canvasBgImageDark,
+      canvasBgImageLight: state.canvasBgImageLight,
+      canvasBgImageFit: state.canvasBgImageFit,
       equipmentSectionOrder: state.equipmentSectionOrder,
       ...patch,
     }
@@ -499,6 +521,13 @@ export const useUiStore = create<UiState>((set) => ({
   setPropertiesFloatingPos: (pos) => set(applyPatch({ propertiesFloatingPos: pos })),
   setCustomPalette: (palette) => set(applyPatch({ customPalette: palette })),
   setEquipmentSectionOrder: (order) => set(applyPatch({ equipmentSectionOrder: order })),
+  setCanvasBgImage: (theme, dataUri) =>
+    set(applyPatch(
+      theme === 'dark'
+        ? { canvasBgImageDark: dataUri }
+        : { canvasBgImageLight: dataUri },
+    )),
+  setCanvasBgImageFit: (fit) => set(applyPatch({ canvasBgImageFit: fit })),
   pdfExportThemeOverride: null,
   setPdfExportThemeOverride: (value) => set({ pdfExportThemeOverride: value }),
   cableEdit: { open: false },


### PR DESCRIPTION
## Summary

Three releases on one branch, ready to tag:

### v7.7.0 — Deferred items from v7.6.0 PR
- **yEd Port-Namen-Labels**: `semantics.ts` jetzt mit `associateFloatingPortLabels` — kleine frei stehende Text-Nodes neben Port-Shapes werden über Proximity-Radius dem nächsten Port zugeordnet und als Port-Name übernommen.
- **yEd Canvas-vs-Library-Toggle**: Neuer 🗺 Canvas / 📚 Library-Schalter im Import-Dialog. Library-Modus speichert Geräte als wiederverwendbare `EquipmentTemplate`s ohne Canvas-Platzierung und ohne Kabel.
- **2D Rack-Builder Drag-Fix**: Root-Cause war natives Image-Drag, das die Pointer-Events stahl. `draggable={false}` auf `<img>` + `pointer-events-none` auf Kindern + `setPointerCapture` + `touch-none` + `overflow-x-auto` auf dem Rack-Canvas.
- **Library Narrow-Mode**: Tab-Leiste, Equipment-Header, Gruppen- und Racks-Header haben jetzt `flex-wrap`, sodass Buttons bei schmalem Panel unter den Titel rutschen statt das Suchfeld zu überdecken.
- **Light-Mode CSS-Audit**: 92 fehlende Farbklassen ergänzt; Re-Audit zeigt 0 unmapped Klassen.

### v7.7.1 — Canvas-Hintergrund jetzt richtig sichtbar
- **Canvas-Pattern wieder sichtbar**: `.react-flow__pane` hatte einen opaken Radial-Gradient, der die `<Background>`-SVG mit dem Pattern (Punkte/Linien/Kreuze) komplett verdeckte. Gradient ist jetzt auf `#cable-planner-canvas` selbst, der Pane ist transparent.
- **Export respektiert Settings**: Neuer gemeinsamer `lib/exportBackground.ts` baut den Hintergrund aus den Live-UI-Settings (`bgVariant` + `gridSize` + `bgOpacity` + `customPalette`). PDF/PNG/JPEG-Export nutzen es jetzt einheitlich. Padding 80→200 px, sodass das Pattern wie eine Erweiterung des Canvas wirkt.
- **PNG / JPEG im Datei-Menü**: Plan-als-PNG und Plan-als-JPEG sind jetzt im Datei-Menü und nutzen denselben Composer.
- **Custom Canvas-Hintergrundbild (#71)**: Settings → Canvas-Hintergrund hat zwei separate Upload-Boxen (Dark / Light) mit Vorschau, Replace, Remove und Fit-Selektor (Cover / Contain / Kacheln).
- **Bug-Pass durch die App**: EquipmentItem-Import, addEquipment width/height, queueConnection-Property-Namen, CableDraft-Pflichtfelder, measuredSize-Typ, redundante needsConverter-Bedingung, AtemMvConfigDialog-tuple-indexOf, Uint8Array→BlobPart.

### v7.7.2 — Polish pass
- GraphmlImportDialog: violet-Banner im Library-Modus, der explizit erklärt, dass Kabel nicht mit übernommen werden.
- LibraryPanel: zwei weitere flex-wrap-Konvertierungen (Port-Gruppen-Header und Auto-Vorschlag-Header) für noch schmaleres Layout.

## Test plan
- [ ] Canvas-Pattern (Punkte/Linien/Kreuze) bei verschiedenen Einstellungen sichtbar prüfen
- [ ] PDF/PNG/JPEG-Export — Pattern + Größe stimmen mit Settings überein
- [ ] yEd-Import: Datei mit Port-Namen als separate Text-Labels → Namen erscheinen am Port
- [ ] yEd-Import: Library-Ziel ausgewählt → nur Templates landen, keine Kabel
- [ ] Light-Mode umschalten, alle Dialoge durchklicken, keine schwarz-auf-schwarz
- [ ] 2D Rack-Builder bei schmalem Fenster → kein Überlauf; Geräte per Drag verschiebbar
- [ ] Library schmal skalieren → +Kategorie/+Gerät rutschen unter den Titel
- [ ] Custom Bg-Image hochladen → wird im Canvas angezeigt; bleibt nach Reload

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH)_