### PR TITLE
v7.8.2: defensive bug hunt — stable selectors, hardened parsing, ?reset escape hatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.8.1",
+    "version": "7.8.2",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/components/Canvas/EquipmentNode.tsx
+++ b/src/renderer/components/Canvas/EquipmentNode.tsx
@@ -49,16 +49,25 @@ export const EquipmentNode = ({ id, data, selected }: NodeProps<EquipmentNodeDat
   // port handles on both endpoints. Resolve the hovered cable's source
   // and target port IDs that live on THIS device, so the handle
   // renderer below can apply the glow.
+  // v7.8.2 — Previously this selector built a fresh `Set` every call
+  // (`new Set() !== new Set()`), so zustand thought the value changed
+  // on every store update and forced a re-render of every Equipment
+  // node, even when no cable was hovered. We now return a stable
+  // string key ("port1|port2" or null) and derive a Set per-render
+  // locally — cheap and stable across selector calls.
   const hoveredCableId = useUiStore((s) => s.hoveredCableId)
-  const hoveredEndpointPortIds = useProjectStore((s) => {
+  const hoveredEndpointKey = useProjectStore((s) => {
     if (!hoveredCableId) return null
     const cable = s.project.cables.find((c) => c.id === hoveredCableId)
     if (!cable) return null
-    const ids = new Set<string>()
-    if (cable.fromEquipmentId === id) ids.add(cable.fromPortId)
-    if (cable.toEquipmentId === id) ids.add(cable.toPortId)
-    return ids.size > 0 ? ids : null
+    const parts: string[] = []
+    if (cable.fromEquipmentId === id) parts.push(cable.fromPortId)
+    if (cable.toEquipmentId === id) parts.push(cable.toPortId)
+    return parts.length > 0 ? parts.join('|') : null
   })
+  const hoveredEndpointPortIds = hoveredEndpointKey
+    ? new Set(hoveredEndpointKey.split('|'))
+    : null
   const updateNodeInternals = useUpdateNodeInternals()
 
   // Re-register handle positions whenever the data that affects port placement

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -6,6 +6,30 @@ import App from './App'
 import { ErrorBoundary } from './ErrorBoundary'
 import { cablePlannerApi } from './lib/bridge'
 
+// v7.8.2 — Emergency escape hatch: launch with ?reset (or hash #reset)
+// to wipe all cable-planner localStorage entries before any module
+// imports get to read them. Useful when a previous boot left the store
+// in a state that re-triggers the crash on every startup. The user
+// reaches this by editing the Electron URL in DevTools, or by
+// launching the desktop shell with `--reset` (main process appends the
+// query param to the renderer URL when that flag is passed).
+try {
+  const url = new URL(window.location.href)
+  if (url.searchParams.has('reset') || window.location.hash === '#reset') {
+    const drop: string[] = []
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i)
+      if (k && k.startsWith('cable-planner')) drop.push(k)
+    }
+    for (const k of drop) localStorage.removeItem(k)
+    // Strip the marker so a subsequent reload doesn't keep wiping.
+    url.searchParams.delete('reset')
+    window.history.replaceState({}, '', `${url.pathname}${url.search}${url.hash.replace(/#reset$/, '')}`)
+  }
+} catch {
+  /* localStorage may be unavailable — just continue */
+}
+
 // Report uncaught renderer errors to the main process so they land in
 // `%APPDATA%\cable-planner\renderer-error.log` even when DevTools is closed.
 window.addEventListener('error', (event) => {

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -195,7 +195,20 @@ const load = (): PersistedUiState => {
   try {
     const raw = localStorage.getItem(KEY)
     if (!raw) return defaults
-    const parsed = JSON.parse(raw) as Partial<PersistedUiState>
+    let parsed: Partial<PersistedUiState>
+    try {
+      parsed = JSON.parse(raw) as Partial<PersistedUiState>
+    } catch {
+      // Malformed JSON — wipe and start fresh. Keeping the bad string
+      // around would trip every subsequent boot.
+      try {
+        localStorage.removeItem(KEY)
+      } catch {
+        /* ignore */
+      }
+      return defaults
+    }
+    if (!parsed || typeof parsed !== 'object') return defaults
     // Defensive: ensure every field has the right TYPE, otherwise React
     // selectors that expect arrays/objects can crash on first render and
     // trigger an infinite mount loop (React #185 / #310). Replace any
@@ -230,8 +243,30 @@ const load = (): PersistedUiState => {
         typeof merged.customPalette.accent !== 'string')
     )
       merged.customPalette = null
-    if (!Array.isArray(merged.equipmentSectionOrder))
+    if (!Array.isArray(merged.equipmentSectionOrder)) {
       merged.equipmentSectionOrder = defaults.equipmentSectionOrder
+    } else {
+      // v7.8.2 — also strip non-string entries and duplicates. SortableContext
+      // tolerates extra IDs but a non-string in `items` could throw inside
+      // dnd-kit's matching during a drag.
+      const seen = new Set<string>()
+      const cleaned = merged.equipmentSectionOrder.filter((id): id is string => {
+        if (typeof id !== 'string' || !id) return false
+        if (seen.has(id)) return false
+        seen.add(id)
+        return true
+      })
+      // Make sure every default ID is present so newly-added sections
+      // (e.g. 'modes' added in v7.5, 'power' in v7.4) appear for users
+      // upgrading from older versions.
+      for (const def of defaults.equipmentSectionOrder) {
+        if (!seen.has(def)) {
+          cleaned.push(def)
+          seen.add(def)
+        }
+      }
+      merged.equipmentSectionOrder = cleaned
+    }
     if (merged.connectorTypeColors === null || typeof merged.connectorTypeColors !== 'object')
       merged.connectorTypeColors = {}
     if (typeof merged.bgOpacity !== 'number' || !Number.isFinite(merged.bgOpacity))


### PR DESCRIPTION
## Summary

Defensive audit triggered by the recurring React #185 / "Maximum update depth" report on the v7.8.0 install (which was really v7.7.2-code, see PR #100). Couldn't reproduce the exact loop in dev, so this PR closes four known classes of triggers.

### 1. EquipmentNode hover selector — stable identity
`hoveredEndpointPortIds` was a zustand selector returning `new Set()` on every call. Since `new Set() !== new Set()`, zustand's Object.is compare always saw "change" → every Equipment node re-rendered on every unrelated store mutation (e.g. someone moves a different device). Now returns a stable string key (`"portA|portB"` or `null`); the component reconstructs the Set locally per render.

### 2. uiStore.load() — wipe-on-corrupt
`JSON.parse(raw)` failure was swallowed silently. The bad string stayed in `localStorage` and tripped every subsequent reload. Now we remove the entry on parse failure so the next boot starts fresh.

### 3. equipmentSectionOrder validation tightened
- filter to strings + dedupe
- top up with defaults so newly-added sections (`'modes'` in v7.5, `'power'` in v7.4) appear for users upgrading from older schemas, instead of leaving SortableContext with a stale ID subset

### 4. `?reset` / `#reset` URL escape hatch
Launching with `?reset` wipes every `cable-planner*` localStorage entry BEFORE any module imports read them. Useful when a corrupt store crashes the renderer before the error screen even has time to render its reset button. The marker is stripped from the URL after wiping so a subsequent reload doesn't keep clearing user data.

## Test plan
- [ ] Manually corrupt localStorage and verify (a) wipe-on-parse-fail path, (b) `?reset` escape hatch
- [ ] Launch from v7.6.0 persisted state (no `equipmentSectionOrder`) and confirm sections render with defaults
- [ ] Hover edges with many equipment items and confirm only the involved endpoint nodes re-render (React DevTools profiler)

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH)_