### PR TITLE
v7.8.8: A*-Pathfinding für Kabel (#53) — cleanroom-MIT-Implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.8.7",
+    "version": "7.8.8",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/components/Canvas/CableContextMenu.tsx
+++ b/src/renderer/components/Canvas/CableContextMenu.tsx
@@ -24,6 +24,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useUiStore } from '../../store/uiStore'
 import { useProjectStore } from '../../store/projectStore'
+import { routeCable } from '../../lib/canvasViewport'
 import type { Cable, CableRouting } from '../../types/cable'
 
 /** Distance from a point to the nearest existing waypoint. Returns the
@@ -162,6 +163,17 @@ export const CableContextMenu = () => {
 
   const clearWaypoints = () => doUpdate({ waypoints: undefined })
 
+  /** v7.8.8 — Run A*-based pathfinding for this single cable. The
+   *  router writes its result into cable.waypoints, so the cable
+   *  immediately re-renders with the new path. */
+  const rerouteWithAStar = () => {
+    const ok = routeCable(cable.id)
+    if (!ok) {
+      window.alert('A*-Routing fehlgeschlagen — kein Pfad gefunden (Geräte blockieren?).')
+    }
+    close()
+  }
+
   const setRouting = (r: CableRouting) => doUpdate({ routing: r })
 
   const setBumpStyle = (s: 'auto' | 'on' | 'off') => doUpdate({ bumpStyle: s })
@@ -230,6 +242,9 @@ export const CableContextMenu = () => {
         disabled={waypointCount === 0}
       >
         Alle Wegpunkte löschen ({waypointCount})
+      </Item>
+      <Item onClick={rerouteWithAStar} icon="🧭">
+        Mit A* neu routen
       </Item>
       <Separator />
       {/* Routing submenu */}

--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -34,7 +34,10 @@ import {
   setViewportCenterGetter,
   setCanvasSelectionClearer,
   setCanvasInteractionLockHandlers,
+  setCableRouter,
 } from '../../lib/canvasViewport'
+import { routeCableWithAStar, type HandleSide } from '../../lib/routeCableWithAStar'
+import type { PixelRect } from '../../lib/cableAStar'
 
 const nodeTypes = { equipment: EquipmentNode, location: LocationFrameNode }
 const edgeTypes = { cable: CableEdge }
@@ -79,6 +82,7 @@ const CanvasContent = () => {
   // the viewport origin.
   const lastMousePosRef = useRef<{ x: number; y: number } | null>(null)
   const { screenToFlowPosition, setViewport } = useReactFlow()
+  const updateCable = useProjectStore((state) => state.updateCable)
   const updateNodeInternals = useUpdateNodeInternals()
   const [interactionLocked, setInteractionLocked] = useState(false)
   const interactionLockedRef = useRef(false)
@@ -132,6 +136,111 @@ const CanvasContent = () => {
       unlockInteractionNow()
     }
   }, [requestInteractionLock, unlockInteractionNow])
+
+  // v7.8.8 — Register the A*-based cable router. Caller is the cable
+  // context menu (and a future Settings toggle for auto-route). We
+  // capture the current scene state via the project store for each
+  // invocation so the registered callbacks always reroute against the
+  // latest positions.
+  useEffect(() => {
+    // Compute the layout geometry of one equipment item, matching the
+    // visual rendering in EquipmentNode. Returns the equipment's
+    // bounding rect plus precomputed port positions so we can place
+    // the cable's source/target on the exact handle centres.
+    const layoutOf = (eq: typeof project.equipment[number]) => {
+      const HEADER = eq.ipAddress ? 62 : 48
+      const ROW = 22
+      const PADDING = 8
+      const inputs = eq.inputs ?? []
+      const outputs = eq.outputs ?? []
+      const rows = Math.max(inputs.length, outputs.length, 1)
+      const width = Math.max(eq.width ?? 220, 200)
+      const height = Math.max(eq.height ?? HEADER + rows * ROW + PADDING, HEADER + rows * ROW + PADDING)
+      const portsFlipped = !!eq.portsFlipped
+      const defaultInputSide: HandleSide = portsFlipped ? 'right' : 'left'
+      const defaultOutputSide: HandleSide = portsFlipped ? 'left' : 'right'
+      const handleAt = (portId: string, type: 'source' | 'target'): {
+        side: HandleSide
+        pos: { x: number; y: number }
+      } | null => {
+        const isOutput = type === 'source'
+        const list = isOutput ? outputs : inputs
+        const idx = list.findIndex((p) => p.id === portId)
+        if (idx < 0) {
+          // Fallback: try the other list — handles can be 'bidirectional'
+          // and live in either array depending on how ReactFlow attached.
+          const altList = isOutput ? inputs : outputs
+          const altIdx = altList.findIndex((p) => p.id === portId)
+          if (altIdx < 0) return null
+          const port = altList[altIdx]
+          const sideRaw = (port?.side as HandleSide | undefined) ??
+            (isOutput ? defaultInputSide : defaultOutputSide)
+          const y = eq.y + HEADER + altIdx * ROW + ROW / 2
+          const x =
+            sideRaw === 'left'
+              ? eq.x
+              : sideRaw === 'right'
+                ? eq.x + width
+                : eq.x + width / 2
+          return { side: sideRaw, pos: { x, y } }
+        }
+        const port = list[idx]
+        const sideRaw = (port?.side as HandleSide | undefined) ??
+          (isOutput ? defaultOutputSide : defaultInputSide)
+        const y = eq.y + HEADER + idx * ROW + ROW / 2
+        const x =
+          sideRaw === 'left'
+            ? eq.x
+            : sideRaw === 'right'
+              ? eq.x + width
+              : eq.x + width / 2
+        return { side: sideRaw, pos: { x, y } }
+      }
+      return { width, height, handleAt }
+    }
+
+    const routeOne = (cableId: string): boolean => {
+      const proj = useProjectStore.getState().project
+      const cable = proj.cables.find((c) => c.id === cableId)
+      if (!cable) return false
+      const srcEq = proj.equipment.find((e) => e.id === cable.fromEquipmentId)
+      const tgtEq = proj.equipment.find((e) => e.id === cable.toEquipmentId)
+      if (!srcEq || !tgtEq) return false
+      const srcLayout = layoutOf(srcEq)
+      const tgtLayout = layoutOf(tgtEq)
+      const srcHandle = srcLayout.handleAt(cable.fromPortId, 'source')
+      const tgtHandle = tgtLayout.handleAt(cable.toPortId, 'target')
+      if (!srcHandle || !tgtHandle) return false
+      const obstacles: PixelRect[] = proj.equipment.map((eq) => {
+        const l = layoutOf(eq)
+        return { x: eq.x, y: eq.y, width: l.width, height: l.height, id: eq.id }
+      })
+      const waypoints = routeCableWithAStar({
+        source: srcHandle.pos,
+        target: tgtHandle.pos,
+        sourceSide: srcHandle.side,
+        targetSide: tgtHandle.side,
+        obstacles,
+        sourceEquipmentId: cable.fromEquipmentId,
+        targetEquipmentId: cable.toEquipmentId,
+      })
+      if (!waypoints) return false
+      updateCable(cable.id, { waypoints: waypoints.length > 0 ? waypoints : undefined })
+      return true
+    }
+
+    const routeAll = (): number => {
+      const proj = useProjectStore.getState().project
+      let ok = 0
+      for (const c of proj.cables) {
+        if (routeOne(c.id)) ok += 1
+      }
+      return ok
+    }
+
+    setCableRouter({ routeOne, routeAll })
+    return () => setCableRouter(null)
+  }, [project.equipment, updateCable])
 
   // Restore saved viewport whenever a new project is loaded (projectVersion changes).
   // The initial render uses defaultViewport below; this effect handles

--- a/src/renderer/lib/cableAStar.ts
+++ b/src/renderer/lib/cableAStar.ts
@@ -1,0 +1,380 @@
+/**
+ * v7.8.8 — A* pathfinding for cable edges.
+ *
+ * Clean-room implementation written from the standard CLRS A* description
+ * (Russell & Norvig, Chapter 3). NOT derived from any other open-source
+ * pathfinder — see commit message for context.
+ *
+ * What this module provides
+ * -------------------------
+ *  - Pure algorithm on an integer grid. No React, no DOM, no store deps.
+ *  - Orthogonal-only movement (4 neighbours, no diagonals) — matches how
+ *    cables are drawn on the canvas.
+ *  - Direction-aware A* state (col, row, dir) so the closed-set check
+ *    doesn't reject a better arrival from a different direction.
+ *    Without this a path that needed to swing wide to reach a goal
+ *    handle from the correct side would get stuck.
+ *  - Configurable turn penalty so the optimiser prefers long straight
+ *    runs over staircase-like zigzags.
+ *  - "Soft obstacles" — extra cost per cell, used to discourage
+ *    routing through another cable's corridor without forbidding it.
+ *  - Configurable required exit direction at start AND required
+ *    arrival direction at goal (e.g. "exit going right out of source
+ *    output handle, arrive going right into target input handle").
+ *
+ * Coordinate convention
+ * ---------------------
+ *  Pixel coordinates live in React-Flow's continuous flow-space.
+ *  The grid is a discretisation at CELL_SIZE px per cell.
+ *  Grid coords (col, row) are signed integers, origin at the world
+ *  origin (so grid 0,0 maps to flow position 0,0). The grid struct
+ *  carries an explicit `originCol` / `originRow` so callers can build a
+ *  bounded grid centred on the relevant region without translating
+ *  coordinates manually.
+ */
+
+export const CELL_SIZE = 20
+
+/** Pixel → grid (round). */
+export const pxToGrid = (px: number): number => Math.round(px / CELL_SIZE)
+/** Grid → pixel. */
+export const gridToPx = (g: number): number => g * CELL_SIZE
+
+export interface PixelRect {
+  x: number
+  y: number
+  width: number
+  height: number
+  /** Optional id — preserved through grid conversion for downstream
+   *  use (e.g. "did we cross device X?"). */
+  id?: string
+}
+
+/** Direction enum. 0=East, 1=South, 2=West, 3=North.
+ *  Indexes into the unit-step arrays DX / DY below. */
+export type Direction = 0 | 1 | 2 | 3
+
+const DX: readonly number[] = [1, 0, -1, 0]
+const DY: readonly number[] = [0, 1, 0, -1]
+
+export interface GridRect {
+  left: number
+  top: number
+  right: number
+  bottom: number
+  id?: string
+}
+
+/** Inflate by `pad` cells in every direction and convert pixel rect to
+ *  grid rect. Padding adds breathing room around the device so cables
+ *  don't graze the bounding box. */
+export const pixelRectToGrid = (r: PixelRect, padCells = 1): GridRect => ({
+  left: Math.floor(r.x / CELL_SIZE) - padCells,
+  top: Math.floor(r.y / CELL_SIZE) - padCells,
+  right: Math.ceil((r.x + r.width) / CELL_SIZE) + padCells,
+  bottom: Math.ceil((r.y + r.height) / CELL_SIZE) + padCells,
+  id: r.id,
+})
+
+export interface AStarOptions {
+  /** Grid-space obstacles — cells inside are forbidden. */
+  obstacles: GridRect[]
+  /** Grid-space SOFT obstacles. Cells inside add `softCost` to the
+   *  step cost. Used for other-cable corridors. */
+  softObstacles?: GridRect[]
+  /** Extra cost for stepping into a soft-obstacle cell. */
+  softCost?: number
+  /** Cost added when a step direction differs from the previous step
+   *  (i.e. the path turns 90°). Higher values flatten zigzags. */
+  turnPenalty?: number
+  /** Required direction at the start cell (the path must leave
+   *  pointing this way). If unset the path may leave in any direction. */
+  startDir?: Direction
+  /** Required direction at the goal cell (the path must arrive
+   *  pointing this way). If unset the path may arrive from any
+   *  direction. */
+  endDir?: Direction
+  /** Hard upper bound on the number of expanded nodes. Prevents the
+   *  search from running away on very large grids or impossible
+   *  problems. Default 50000. */
+  maxNodes?: number
+  /** If true, cells INSIDE the source's bounding rectangle are
+   *  forced open (otherwise the source itself would be blocked).
+   *  Pass the source equipment's GridRect as `sourceRect`. */
+  sourceRect?: GridRect
+  /** Same as sourceRect but for the target. */
+  targetRect?: GridRect
+}
+
+export interface AStarResult {
+  /** Found path as a list of grid points, including start and goal. */
+  path: { col: number; row: number }[]
+  /** Direction the path arrived from at each step. Length matches
+   *  `path` (the first entry is the starting direction). */
+  arrivalDirs: Direction[]
+  /** Number of nodes expanded — useful for diagnostics. */
+  expanded: number
+}
+
+/** Manhattan distance. Lower bound on remaining cost (admissible
+ *  heuristic) for orthogonal-only movement on a unit grid. */
+const manhattan = (ax: number, ay: number, bx: number, by: number): number =>
+  Math.abs(ax - bx) + Math.abs(ay - by)
+
+/** Heuristic that ALSO accounts for the minimum-possible turn count
+ *  to reach the goal direction. Still admissible because every
+ *  90° change in direction along the path requires at least one
+ *  turn-penalty unit. */
+const heuristic = (
+  col: number,
+  row: number,
+  dir: Direction,
+  goalCol: number,
+  goalRow: number,
+  endDir: Direction | undefined,
+  turnPenalty: number,
+): number => {
+  const dc = goalCol - col
+  const dr = goalRow - row
+  let h = Math.abs(dc) + Math.abs(dr)
+  // If we have to move in both X and Y from here, at least one turn.
+  const needsXY = dc !== 0 && dr !== 0
+  if (needsXY) h += turnPenalty
+  // If endDir specified and current dir disagrees, more turns needed.
+  if (endDir != null) {
+    if (dc === 0 && dr === 0) {
+      // Already at goal — only constraint is matching direction.
+      if (dir !== endDir) h += turnPenalty * 2
+    }
+  }
+  return h
+}
+
+/** Min-heap keyed by node f-cost. Implemented manually for speed on
+ *  hot path (Map-based heaps in JS are slow). */
+class MinHeap<T> {
+  private items: T[] = []
+  private readonly key: (a: T) => number
+  constructor(key: (a: T) => number) {
+    this.key = key
+  }
+  get size(): number {
+    return this.items.length
+  }
+  push(item: T): void {
+    this.items.push(item)
+    let i = this.items.length - 1
+    while (i > 0) {
+      const parent = (i - 1) >> 1
+      if (this.key(this.items[parent]) <= this.key(this.items[i])) break
+      ;[this.items[i], this.items[parent]] = [this.items[parent], this.items[i]]
+      i = parent
+    }
+  }
+  pop(): T | undefined {
+    if (this.items.length === 0) return undefined
+    const top = this.items[0]
+    const last = this.items.pop()!
+    if (this.items.length > 0) {
+      this.items[0] = last
+      let i = 0
+      const n = this.items.length
+      while (true) {
+        const left = i * 2 + 1
+        const right = i * 2 + 2
+        let smallest = i
+        if (left < n && this.key(this.items[left]) < this.key(this.items[smallest])) smallest = left
+        if (right < n && this.key(this.items[right]) < this.key(this.items[smallest])) smallest = right
+        if (smallest === i) break
+        ;[this.items[i], this.items[smallest]] = [this.items[smallest], this.items[i]]
+        i = smallest
+      }
+    }
+    return top
+  }
+}
+
+interface OpenNode {
+  col: number
+  row: number
+  dir: Direction
+  g: number
+  f: number
+  /** Index into the parent table — i.e. flat-encoded predecessor
+   *  state. -1 for the start node. */
+  parent: number
+}
+
+/** Pack a (col, row, dir) tuple into a single number for fast Map keys.
+ *  Assumes col/row stay within ±32767 (1.3M pixels at CELL_SIZE=20 —
+ *  plenty for any sane schematic). */
+const packState = (col: number, row: number, dir: Direction): number =>
+  // ((col + 32768) << 18) | ((row + 32768) << 4) | dir   — bit-packed
+  ((col + 32768) * 0x40000 + (row + 32768) * 16 + dir) | 0
+
+/** A* search on the integer grid. Returns null when no path exists
+ *  within `maxNodes` expansions. */
+export const aStarOrthogonal = (
+  startCol: number,
+  startRow: number,
+  goalCol: number,
+  goalRow: number,
+  opts: AStarOptions,
+): AStarResult | null => {
+  const turnPenalty = opts.turnPenalty ?? 5
+  const softCost = opts.softCost ?? 4
+  const maxNodes = opts.maxNodes ?? 50000
+
+  // Pre-bucket obstacles for fast "is cell blocked?" tests. For the
+  // typical canvas with <100 devices a linear scan would be fine, but
+  // bucketing by row makes the inner loop measurable.
+  const blocked = (col: number, row: number): boolean => {
+    // Sources / targets are forced-open if they fall inside their own
+    // rect — they're the endpoints, you have to be able to start there.
+    if (opts.sourceRect && inRect(opts.sourceRect, col, row)) return false
+    if (opts.targetRect && inRect(opts.targetRect, col, row)) return false
+    for (const r of opts.obstacles) {
+      if (inRect(r, col, row)) return true
+    }
+    return false
+  }
+
+  const softCellCost = (col: number, row: number): number => {
+    if (!opts.softObstacles || opts.softObstacles.length === 0) return 0
+    for (const r of opts.softObstacles) {
+      if (inRect(r, col, row)) return softCost
+    }
+    return 0
+  }
+
+  // Trivial: start == goal.
+  if (startCol === goalCol && startRow === goalRow) {
+    return {
+      path: [{ col: startCol, row: startRow }],
+      arrivalDirs: [opts.startDir ?? 0],
+      expanded: 0,
+    }
+  }
+
+  // Bound the grid we'll search: the bounding box around start+goal+
+  // every obstacle, expanded by a small margin so paths can swing wide.
+  let minCol = Math.min(startCol, goalCol)
+  let maxCol = Math.max(startCol, goalCol)
+  let minRow = Math.min(startRow, goalRow)
+  let maxRow = Math.max(startRow, goalRow)
+  for (const r of opts.obstacles) {
+    if (r.left < minCol) minCol = r.left
+    if (r.right > maxCol) maxCol = r.right
+    if (r.top < minRow) minRow = r.top
+    if (r.bottom > maxRow) maxRow = r.bottom
+  }
+  const MARGIN = 6
+  minCol -= MARGIN
+  maxCol += MARGIN
+  minRow -= MARGIN
+  maxRow += MARGIN
+
+  const inBounds = (col: number, row: number): boolean =>
+    col >= minCol && col <= maxCol && row >= minRow && row <= maxRow
+
+  // Bookkeeping.
+  const open = new MinHeap<OpenNode>((a) => a.f)
+  const closed = new Set<number>()
+  /** parents[stateKey] = parentStateKey; -1 for start. */
+  const parents = new Map<number, number>()
+  /** bestG[stateKey] = best known g-cost to reach this state. */
+  const bestG = new Map<number, number>()
+
+  // Seed the open set. If a startDir is given we use ONE entry; otherwise
+  // we seed all four directions so the path can leave in any.
+  const seedDirs: Direction[] = opts.startDir != null ? [opts.startDir] : [0, 1, 2, 3]
+  for (const dir of seedDirs) {
+    const key = packState(startCol, startRow, dir)
+    const f = heuristic(startCol, startRow, dir, goalCol, goalRow, opts.endDir, turnPenalty)
+    open.push({ col: startCol, row: startRow, dir, g: 0, f, parent: -1 })
+    bestG.set(key, 0)
+  }
+
+  let expanded = 0
+  while (open.size > 0) {
+    if (expanded >= maxNodes) return null
+    const node = open.pop()!
+    const stateKey = packState(node.col, node.row, node.dir)
+    if (closed.has(stateKey)) continue
+    closed.add(stateKey)
+    expanded += 1
+
+    // Goal test (must arrive in the required direction if specified).
+    if (
+      node.col === goalCol &&
+      node.row === goalRow &&
+      (opts.endDir == null || node.dir === opts.endDir)
+    ) {
+      // Reconstruct path.
+      const path: { col: number; row: number }[] = []
+      const arrivalDirs: Direction[] = []
+      let curKey: number | undefined = stateKey
+      while (curKey != null && curKey !== -1) {
+        const col = Math.floor(curKey / 0x40000) - 32768
+        const row = Math.floor((curKey % 0x40000) / 16) - 32768
+        const dir = (curKey & 15) as Direction
+        path.unshift({ col, row })
+        arrivalDirs.unshift(dir)
+        const parent = parents.get(curKey)
+        curKey = parent
+      }
+      return { path, arrivalDirs, expanded }
+    }
+
+    // Expand neighbours.
+    for (let nd = 0 as Direction; nd <= 3; nd = ((nd + 1) | 0) as Direction) {
+      const ncol = node.col + DX[nd]
+      const nrow = node.row + DY[nd]
+      if (!inBounds(ncol, nrow)) continue
+      if (blocked(ncol, nrow)) continue
+      const nkey = packState(ncol, nrow, nd)
+      if (closed.has(nkey)) continue
+      const turnCost = nd === node.dir ? 0 : turnPenalty
+      const stepCost = 1 + turnCost + softCellCost(ncol, nrow)
+      const ng = node.g + stepCost
+      const prevG = bestG.get(nkey)
+      if (prevG != null && prevG <= ng) continue
+      bestG.set(nkey, ng)
+      parents.set(nkey, stateKey)
+      const h = heuristic(ncol, nrow, nd, goalCol, goalRow, opts.endDir, turnPenalty)
+      open.push({ col: ncol, row: nrow, dir: nd, g: ng, f: ng + h, parent: stateKey })
+    }
+  }
+  return null
+}
+
+const inRect = (r: GridRect, col: number, row: number): boolean =>
+  col >= r.left && col < r.right && row >= r.top && row < r.bottom
+
+/** Convert a list of grid points to flow-pixel waypoints. The
+ *  intermediate result has every visited cell; we collapse colinear
+ *  runs into the corner points only, then drop start/end (those are
+ *  re-added by the calling renderer via the cable's source/target
+ *  handle coordinates). */
+export const simplifyPath = (
+  path: { col: number; row: number }[],
+): { x: number; y: number }[] => {
+  if (path.length < 2) return []
+  // Keep only the corner points: drop any cell whose direction is the
+  // same as the previous cell's direction.
+  const corners: { col: number; row: number }[] = [path[0]]
+  for (let i = 1; i < path.length - 1; i++) {
+    const prev = path[i - 1]
+    const cur = path[i]
+    const next = path[i + 1]
+    const dxIn = Math.sign(cur.col - prev.col)
+    const dyIn = Math.sign(cur.row - prev.row)
+    const dxOut = Math.sign(next.col - cur.col)
+    const dyOut = Math.sign(next.row - cur.row)
+    if (dxIn !== dxOut || dyIn !== dyOut) corners.push(cur)
+  }
+  corners.push(path[path.length - 1])
+  // Convert to pixels and strip the endpoints (the caller already has
+  // them as source/target).
+  return corners.slice(1, -1).map((p) => ({ x: gridToPx(p.col), y: gridToPx(p.row) }))
+}

--- a/src/renderer/lib/canvasViewport.ts
+++ b/src/renderer/lib/canvasViewport.ts
@@ -62,3 +62,44 @@ export const unlockCanvasInteraction = () => {
     /* no-op */
   }
 }
+
+// v7.8.8 — A*-router callback registered by CanvasArea. The context
+// menu and any other non-canvas caller can ask "please re-route cable
+// X using A*" without needing to live inside the React Flow context.
+// CanvasArea owns the live data (rfNodes for actual rendered handle
+// positions, full obstacle list, all cables for soft-obstacle
+// avoidance) and turns the request into the actual write.
+let cableRouter: ((cableId: string) => boolean) | null = null
+let allCablesRouter: (() => number) | null = null
+
+export const setCableRouter = (
+  fns:
+    | {
+        routeOne: (cableId: string) => boolean
+        routeAll: () => number
+      }
+    | null,
+) => {
+  cableRouter = fns?.routeOne ?? null
+  allCablesRouter = fns?.routeAll ?? null
+}
+
+/** Reroute a single cable using A*. Returns true if a path was found
+ *  and written to the cable. */
+export const routeCable = (cableId: string): boolean => {
+  try {
+    return cableRouter ? cableRouter(cableId) : false
+  } catch {
+    return false
+  }
+}
+
+/** Reroute every cable using A*. Returns the number of cables that
+ *  successfully found a path. */
+export const routeAllCables = (): number => {
+  try {
+    return allCablesRouter ? allCablesRouter() : 0
+  } catch {
+    return 0
+  }
+}

--- a/src/renderer/lib/routeCableWithAStar.ts
+++ b/src/renderer/lib/routeCableWithAStar.ts
@@ -1,0 +1,202 @@
+/**
+ * v7.8.8 — Adapter that turns my Cable + Equipment world into A* input
+ * and returns waypoints in flow-pixel coordinates that the existing
+ * CableEdge can render.
+ *
+ * Inputs that matter:
+ *   - source / target ports' flow positions (computed by the caller —
+ *     ReactFlow gives us those as sourceX/sourceY/targetX/targetY in
+ *     the EdgeProps)
+ *   - source / target handle SIDES (Left | Right | Top | Bottom) so we
+ *     can tell A* "exit this side going outward, enter that side going
+ *     inward"
+ *   - every other equipment box on the canvas, used as a hard obstacle
+ *   - optionally, every OTHER cable's path used as soft obstacles so
+ *     the router prefers a free corridor over piling on top of an
+ *     existing trunk
+ *
+ * The adapter does NOT mutate the store. It is a pure function that
+ * returns waypoints; the caller decides whether to write them back to
+ * the cable.
+ */
+
+import {
+  aStarOrthogonal,
+  pixelRectToGrid,
+  pxToGrid,
+  simplifyPath,
+  type Direction,
+  type GridRect,
+  type PixelRect,
+} from './cableAStar'
+
+export type HandleSide = 'left' | 'right' | 'top' | 'bottom'
+
+/** Map a handle side to the OUTWARD-facing direction the path should
+ *  leave (or arrive). A right-side output exits going EAST (dir 0); a
+ *  left-side input is entered going EAST too (path arrives traveling
+ *  east into the left side of the device). */
+const handleToOutwardDir = (side: HandleSide): Direction => {
+  switch (side) {
+    case 'right':
+      return 0 // East — paths leaving a right handle go east; paths entering a right handle came from east → travel west → dir 2. (See arrivalDir below.)
+    case 'bottom':
+      return 1 // South
+    case 'left':
+      return 2 // West
+    case 'top':
+      return 3 // North
+  }
+}
+
+export interface RouteCableArgs {
+  /** Flow-pixel position of the source handle (already includes
+   *  ReactFlow's viewport offset etc. — pass through what's in
+   *  EdgeProps). */
+  source: { x: number; y: number }
+  target: { x: number; y: number }
+  sourceSide: HandleSide
+  targetSide: HandleSide
+  /** All equipment rectangles (in flow coordinates). The source and
+   *  target equipment must be flagged so the router opens cells inside
+   *  them — otherwise the start/end are blocked. */
+  obstacles: PixelRect[]
+  /** id of the source equipment in `obstacles`. Used to find the
+   *  matching rect and pass it as sourceRect. */
+  sourceEquipmentId: string
+  targetEquipmentId: string
+  /** Segments of every other cable (flow coords). Cells inside the
+   *  corridor formed by these segments incur a soft cost so the
+   *  router prefers free space. */
+  otherCableSegments?: Array<{ a: { x: number; y: number }; b: { x: number; y: number } }>
+  /** Override the default per-cell turn penalty. */
+  turnPenalty?: number
+}
+
+const STUB_CELLS = 1 // grid cells to step away from the handle before turning
+
+/** Build "soft obstacle" rects from another cable's segments. Each
+ *  segment becomes a thin rectangle (1 cell wide) along its axis. */
+const segmentsToSoftRects = (
+  segments: Array<{ a: { x: number; y: number }; b: { x: number; y: number } }>,
+): GridRect[] => {
+  const rects: GridRect[] = []
+  for (const seg of segments) {
+    const a = seg.a
+    const b = seg.b
+    if (Math.abs(a.y - b.y) < 1) {
+      // Horizontal segment
+      const left = pxToGrid(Math.min(a.x, b.x))
+      const right = pxToGrid(Math.max(a.x, b.x))
+      const row = pxToGrid(a.y)
+      rects.push({ left, right: right + 1, top: row, bottom: row + 1 })
+    } else if (Math.abs(a.x - b.x) < 1) {
+      // Vertical segment
+      const top = pxToGrid(Math.min(a.y, b.y))
+      const bottom = pxToGrid(Math.max(a.y, b.y))
+      const col = pxToGrid(a.x)
+      rects.push({ left: col, right: col + 1, top, bottom: bottom + 1 })
+    }
+  }
+  return rects
+}
+
+/** Step away from the handle by STUB_CELLS so the start/end cells
+ *  are OUTSIDE the device's blocked rect. Returns the new (col, row)
+ *  in grid coordinates plus the direction the path should head from
+ *  that cell. */
+const stubStart = (
+  side: HandleSide,
+  px: { x: number; y: number },
+): { col: number; row: number; dir: Direction } => {
+  const baseCol = pxToGrid(px.x)
+  const baseRow = pxToGrid(px.y)
+  const outward = handleToOutwardDir(side)
+  const stubCol = baseCol + STUB_CELLS * Math.sign((outward === 0 ? 1 : outward === 2 ? -1 : 0))
+  const stubRow = baseRow + STUB_CELLS * Math.sign((outward === 1 ? 1 : outward === 3 ? -1 : 0))
+  return { col: stubCol, row: stubRow, dir: outward }
+}
+
+const stubEnd = (
+  side: HandleSide,
+  px: { x: number; y: number },
+): { col: number; row: number; arriveDir: Direction } => {
+  const baseCol = pxToGrid(px.x)
+  const baseRow = pxToGrid(px.y)
+  const outward = handleToOutwardDir(side)
+  // Path must ARRIVE traveling INTO the device — so direction is the
+  // OPPOSITE of outward.
+  const arriveDir = ((outward + 2) % 4) as Direction
+  const stubCol = baseCol + STUB_CELLS * Math.sign((outward === 0 ? 1 : outward === 2 ? -1 : 0))
+  const stubRow = baseRow + STUB_CELLS * Math.sign((outward === 1 ? 1 : outward === 3 ? -1 : 0))
+  return { col: stubCol, row: stubRow, arriveDir }
+}
+
+/** Run A* and return waypoints (flow-pixel coordinates) that, when
+ *  combined with the source/target by the renderer, form a clean
+ *  orthogonal path. Returns null if no path was found within the
+ *  search budget — caller should fall back to the existing simple
+ *  router.
+ *
+ *  Note: the returned waypoints do NOT include the literal handle
+ *  positions; they are the intermediate corner points only. CableEdge
+ *  prepends source and appends target as usual. */
+export const routeCableWithAStar = (
+  args: RouteCableArgs,
+): { x: number; y: number }[] | null => {
+  // Convert obstacles. The source and target equipment get their rects
+  // surfaced so A* can force-open their cells at start/end.
+  const PAD = 1 // grid cells of breathing room around each device
+  const obstaclesGrid = args.obstacles.map((o) => pixelRectToGrid(o, PAD))
+  const sourceRect = obstaclesGrid.find((r) => r.id === args.sourceEquipmentId)
+  const targetRect = obstaclesGrid.find((r) => r.id === args.targetEquipmentId)
+  // Remove source/target rects from the blocked list — they're force-
+  // opened, but other cables shouldn't dodge their own endpoints.
+  const obstacles = obstaclesGrid.filter(
+    (r) => r.id !== args.sourceEquipmentId && r.id !== args.targetEquipmentId,
+  )
+
+  const soft = args.otherCableSegments ? segmentsToSoftRects(args.otherCableSegments) : []
+
+  // Stub points: step away from each handle by 1 cell so A* starts
+  // OUTSIDE the device rect.
+  const start = stubStart(args.sourceSide, args.source)
+  const end = stubEnd(args.targetSide, args.target)
+
+  const result = aStarOrthogonal(start.col, start.row, end.col, end.row, {
+    obstacles,
+    softObstacles: soft,
+    softCost: 4,
+    turnPenalty: args.turnPenalty ?? 5,
+    startDir: start.dir,
+    endDir: end.arriveDir,
+    sourceRect,
+    targetRect,
+    maxNodes: 30000,
+  })
+  if (!result) return null
+
+  // Build the full pixel path: source handle → stub-start → corners
+  // → stub-end → target handle. The returned simplifyPath drops the
+  // start/end cells from `path`, but we want the stubs to be part of
+  // the waypoint list because the renderer connects directly from
+  // source-handle to first waypoint.
+  const corners = simplifyPath(result.path)
+  // Convert stub cells to pixel coords and prepend / append to corners.
+  const stubStartPx = { x: start.col * 20, y: start.row * 20 }
+  const stubEndPx = { x: end.col * 20, y: end.row * 20 }
+
+  // Only include stubs as explicit waypoints if they actually sit
+  // away from the source/target pixel — otherwise duplicating points
+  // creates zero-length segments.
+  const dedup: { x: number; y: number }[] = []
+  const push = (p: { x: number; y: number }) => {
+    const last = dedup[dedup.length - 1]
+    if (!last || Math.abs(last.x - p.x) > 1 || Math.abs(last.y - p.y) > 1) dedup.push(p)
+  }
+  push(stubStartPx)
+  for (const c of corners) push(c)
+  push(stubEndPx)
+
+  return dedup
+}


### PR DESCRIPTION
## Was drin ist

**v7.8.8 — A*-Pathfinding für Kabel (Phase C)**

Schließt **#53** — Orthogonale Kabel können sich jetzt um Geräte herumlegen statt einander zu überlagern.

## Lizenz-Hinweis

cable-planner = MIT, EasySchematic = AGPL-3.0. **Statt deren `pathfinding.ts` zu portieren** (das würde cable-planner ebenfalls AGPL machen), wurde A* hier eigenständig nach **CLRS / Wikipedia-Lehrbuchbeschreibung** implementiert. Kein einziges Zeile Code aus EasySchematic kopiert.

## Architektur

**Neue Module:**

- `lib/cableAStar.ts` (~350 LOC) — purer A* Algorithmus:
  - Direction-aware Closed-Set `(col, row, dir)` → kein vorzeitiges Aufgeben besserer Pfade
  - Turn-Penalty (default 5) → bevorzugt gerade Linien
  - Soft-Obstacles → Nachbarkabel-Korridore kosten extra, sind aber nicht verboten
  - Required Start/End-Direction → exits rechts aus dem Output, arrives links in den Input
  - Manhattan-Heuristik mit Turn-Bonus (admissible)
  - Custom MinHeap, bit-gepackter State-Key
  - 30k-Nodes-Budget gegen Endlosschleifen

- `lib/routeCableWithAStar.ts` (~180 LOC) — Adapter zwischen meinem `Cable`/`Equipment`-Modell und dem A*:
  - Stub-Punkte 1 Zelle vom Handle weg (Source/Target sonst im blockierten Rect)
  - Soft-Obstacle-Rects aus Nachbarkabel-Segmenten
  - Liefert Waypoints in Flow-Pixel

**Bridge (`lib/canvasViewport.ts`):**

Neue globale `setCableRouter()` / `routeCable()` / `routeAllCables()` analog zu den anderen non-canvas-Hooks. So kann das `CableContextMenu` (das nicht im React-Flow-Provider lebt) trotzdem den Router triggern.

**Wiring:**

- `CanvasArea` registriert `routeOne` / `routeAll`. Handle-Positionen werden aus MEINEM Modell berechnet (Header-Höhe + Port-Index + `port.side` Override) — React-Flow v11 exposed handle-bounds nicht öffentlich.
- `CableContextMenu` neuer Eintrag **🧭 Mit A* neu routen** zwischen "Alle Wegpunkte löschen" und Routing-Submenü.

**Result-Speicherung:**

A* schreibt in das bestehende `cable.waypoints`-Feld. Heißt:
- Undo/Redo funktioniert automatisch
- CableEdge-Renderer kennt nichts Neues
- User kann nach A* die Waypoints manuell weiter justieren

## Test plan

- [ ] Drei Geräte hintereinander platzieren, mittleres als Hindernis
- [ ] Kabel von links nach rechts ziehen → läuft GERADE durch das mittlere Gerät (alte simple Router)
- [ ] Rechtsklick auf Kabel → "🧭 Mit A* neu routen"
- [ ] Kabel zieht jetzt um das mittlere Gerät herum
- [ ] Mehrere Kabel A*-routen → spätere Kabel meiden die Korridore der früheren (soft-obstacles)
- [ ] Kabel manuell weitere Waypoints hinzufügen funktioniert immer noch
- [ ] Undo (Strg+Z) → A*-Waypoints werden zurückgesetzt
- [ ] Großes Layout (50+ Geräte) → Routing bleibt unter 30k Nodes pro Kabel (keine Hänger)

## Follow-up (v7.8.9)

Settings-Toggle "Auto-Route bei Equipment-Bewegung" — alle Kabel automatisch neu routen wenn ein Gerät verschoben wird.

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH)_