### PR TITLE
v7.9.0: Nacht-Cleanup — 10 Issues abgearbeitet (#108 #109 #110 #112 #113 #116 #119 #120 #122)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.8.8",
+    "version": "7.8.9",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.8.9",
+    "version": "7.9.0",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -18,6 +18,7 @@ import { AtemAudioRouterDialog } from './components/Atem/AtemAudioRouterDialog'
 import { LocationBomDialog } from './components/Project/LocationBomDialog'
 import { RackEditorDialog } from './components/Rack/RackEditorDialog'
 import { CableContextMenu } from './components/Canvas/CableContextMenu'
+import { ExportDialog } from './components/Export/ExportDialog'
 import { MobileShareDialog } from './components/MobileShare/MobileShareDialog'
 import { AboutDialog } from './components/About/AboutDialog'
 import { PatchListDialog } from './components/Patch/PatchListDialog'
@@ -105,6 +106,8 @@ export default function App() {
   const [welcomeOpen, setWelcomeOpen] = useState(false)
   const [pdfExportOpen, setPdfExportOpen] = useState(false)
   const [pdfTheme, setPdfTheme] = useState<'dark' | 'light'>('light')
+  // v7.9.0 / Issue #110 — unified export dialog
+  const [exportDialogOpen, setExportDialogOpen] = useState(false)
   const [printDialogOpen, setPrintDialogOpen] = useState(false)
   const [graphmlImportOpen, setGraphmlImportOpen] = useState(false)
   const pdfExportThemeOverride = useUiStore((state) => state.pdfExportThemeOverride)
@@ -414,6 +417,7 @@ export default function App() {
         onSaveProject={() => void saveProject()}
         onSaveProjectAs={() => void saveProjectAs()}
         onOpenSettings={() => setSettingsOpen(true)}
+        onOpenExportDialog={() => setExportDialogOpen(true)}
         onExportPdf={() => setPdfExportOpen(true)}
         onExportPng={() => void handleExportImage('png')}
         onExportJpeg={() => void handleExportImage('jpeg')}
@@ -505,6 +509,12 @@ export default function App() {
       <PatchListDialog />
       <CalculatorsDialog />
       <CableContextMenu />
+      <ExportDialog
+        open={exportDialogOpen}
+        onClose={() => setExportDialogOpen(false)}
+        onExportPdf={(theme) => handleExportPdf(theme)}
+        onExportImage={(format) => handleExportImage(format)}
+      />
 
       <ProjectMetaDialog
         open={metaDialog !== null}

--- a/src/renderer/components/Canvas/CableContextMenu.tsx
+++ b/src/renderer/components/Canvas/CableContextMenu.tsx
@@ -178,27 +178,6 @@ export const CableContextMenu = () => {
 
   const setBumpStyle = (s: 'auto' | 'on' | 'off') => doUpdate({ bumpStyle: s })
 
-  const changeColor = () => {
-    // The simplest cross-platform color picker is a hidden <input
-    // type="color"> we trigger here. Native dialog blocks until the
-    // user closes it; result is committed on change.
-    const input = document.createElement('input')
-    input.type = 'color'
-    input.value = cable.color || '#64748b'
-    input.style.position = 'fixed'
-    input.style.left = '-9999px'
-    document.body.appendChild(input)
-    input.addEventListener('change', () => {
-      doUpdate({ color: input.value })
-      input.remove()
-    })
-    input.addEventListener('cancel', () => {
-      input.remove()
-      close()
-    })
-    input.click()
-  }
-
   const toggleArrowEnd = () =>
     doUpdate({ arrowEnd: cable.arrowEnd === false ? true : false })
   const toggleArrowStart = () => doUpdate({ arrowStart: !cable.arrowStart })
@@ -226,7 +205,6 @@ export const CableContextMenu = () => {
         Kabel: <span className="font-semibold text-slate-200">{cable.name}</span>
       </div>
       <Item onClick={renameLabel} icon="✎">Bezeichnung ändern…</Item>
-      <Item onClick={changeColor} icon="🎨">Farbe wählen…</Item>
       <Separator />
       <Item onClick={addWaypointHere} icon="＋">Wegpunkt hier hinzufügen</Item>
       <Item

--- a/src/renderer/components/Canvas/CableEdge.tsx
+++ b/src/renderer/components/Canvas/CableEdge.tsx
@@ -421,12 +421,13 @@ export const CableEdge = ({
       (cable.bumpStyle !== 'off' && globalCableBumps))
   useLayoutEffect(() => {
     if (!cable) return
-    // Locate THIS edge's path in the DOM.
-    const myEdgeGroup = document.querySelector(
-      `g.react-flow__edge[data-id="${CSS.escape(id)}"]`,
-    )
-    const myPath = myEdgeGroup?.querySelector<SVGPathElement>('path.react-flow__edge-path')
-    if (!myPath) return
+    // v7.8.9 — ReactFlow v11 marks edge groups with `data-testid="rf__edge-<id>"`
+    // (not `data-id`); the path INSIDE the group carries `id="<cableId>"`.
+    // The earlier selector used `[data-id]` which never matched, so the
+    // bump rendering was silently broken since v7.8.7. Querying by the
+    // path's own id is robust regardless of the wrapping group.
+    const myPath = document.getElementById(id) as SVGPathElement | null
+    if (!myPath || !myPath.classList.contains('react-flow__edge-path')) return
     pathRef.current = myPath
     // If bumps are not requested, make sure we restore the plain path
     // (in case bumps were applied on a previous render and the user
@@ -435,15 +436,13 @@ export const CableEdge = ({
       myPath.setAttribute('d', path)
       return
     }
-    // Collect orthogonal segments from every OTHER cable currently in
-    // the DOM. Parse only M and L commands — anything else (arcs,
-    // curves) means the path is already bumped or non-orthogonal and
-    // can be skipped.
+    // Collect orthogonal segments from every OTHER cable's path in the
+    // DOM. Parse only M and L commands — anything else (arcs, curves)
+    // means the path is already bumped or non-orthogonal.
     const otherSegments: Array<{ a: { x: number; y: number }; b: { x: number; y: number } }> = []
-    const allPaths = document.querySelectorAll<SVGPathElement>(
-      'g.react-flow__edge:not([data-id="' + CSS.escape(id) + '"]) path.react-flow__edge-path',
-    )
+    const allPaths = document.querySelectorAll<SVGPathElement>('path.react-flow__edge-path')
     allPaths.forEach((p) => {
+      if (p === myPath) return
       const d = p.getAttribute('d')
       if (!d) return
       // Quick reject: any non-M/L command means we'd misinterpret arcs.

--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -35,6 +35,7 @@ import {
   setCanvasSelectionClearer,
   setCanvasInteractionLockHandlers,
   setCableRouter,
+  setCanvasFitViewHandler,
 } from '../../lib/canvasViewport'
 import { routeCableWithAStar, type HandleSide } from '../../lib/routeCableWithAStar'
 import type { PixelRect } from '../../lib/cableAStar'
@@ -81,7 +82,7 @@ const CanvasContent = () => {
   // (#44) so the new device lands where the user pointed instead of always at
   // the viewport origin.
   const lastMousePosRef = useRef<{ x: number; y: number } | null>(null)
-  const { screenToFlowPosition, setViewport } = useReactFlow()
+  const { screenToFlowPosition, setViewport, fitView } = useReactFlow()
   const updateCable = useProjectStore((state) => state.updateCable)
   const updateNodeInternals = useUpdateNodeInternals()
   const [interactionLocked, setInteractionLocked] = useState(false)
@@ -136,6 +137,15 @@ const CanvasContent = () => {
       unlockInteractionNow()
     }
   }, [requestInteractionLock, unlockInteractionNow])
+
+  // v7.9.0 / Issue #108 — expose fitView so the side panels can call
+  // it after docking/undocking. Without this, undocking a wide panel
+  // would leave devices outside the new viewport bounds and the user
+  // reported "canvas verschwindet" because nodes scrolled off-screen.
+  useEffect(() => {
+    setCanvasFitViewHandler(() => fitView({ padding: 0.1, duration: 250 }))
+    return () => setCanvasFitViewHandler(null)
+  }, [fitView])
 
   // v7.8.8 — Register the A*-based cable router. Caller is the cable
   // context menu (and a future Settings toggle for auto-route). We

--- a/src/renderer/components/Canvas/CanvasToolbar.tsx
+++ b/src/renderer/components/Canvas/CanvasToolbar.tsx
@@ -30,7 +30,7 @@ export const CanvasToolbar = () => {
   const canvasState = useProjectStore((state) => state.project.canvasState)
   const updateEquipment = useProjectStore((state) => state.updateEquipment)
   const equipmentList = useProjectStore((state) => state.project.equipment)
-  const { getNodes } = useReactFlow()
+  const { getNodes, setNodes } = useReactFlow()
   const [namingGroup, setNamingGroup] = useState(false)
   const [groupName, setGroupName] = useState('')
   // Issue #59: the toolbar's group-name input sometimes ignored keystrokes
@@ -88,6 +88,16 @@ export const CanvasToolbar = () => {
     const maxBottom = Math.max(...sized.map((s) => s.item.y + s.h))
     const centerX = (minX + maxRight) / 2
     const centerY = (minY + maxBottom) / 2
+    // v7.9.0 / Issue #119 — Two-stage update: first write the new
+    // positions to the project store (autosave + undo/redo), then
+    // immediately patch React Flow's local rfNodes state so the
+    // canvas re-renders with the new positions. Without the
+    // setNodes() the canvas would keep showing OLD positions because
+    // CanvasArea's structural-sync useEffect deliberately preserves
+    // existing rfNode positions across data updates to avoid drag-
+    // jumps — alignment is a deliberate position change and needs to
+    // bypass that.
+    const newPositionById = new Map<string, { x: number; y: number }>()
     for (const { item, w, h } of sized) {
       let nx = item.x
       let ny = item.y
@@ -102,7 +112,16 @@ export const CanvasToolbar = () => {
       }
       if (nx !== item.x || ny !== item.y) {
         updateEquipment(item.id, { x: nx, y: ny })
+        newPositionById.set(item.id, { x: nx, y: ny })
       }
+    }
+    if (newPositionById.size > 0) {
+      setNodes((rf) =>
+        rf.map((n) => {
+          const pos = newPositionById.get(n.id)
+          return pos ? { ...n, position: pos } : n
+        }),
+      )
     }
   }
 
@@ -440,27 +459,34 @@ export const CanvasToolbar = () => {
         const selectedCount = getNodes().filter(
           (n) => n.selected && n.type === 'equipment',
         ).length
-        if (selectedCount < 2) return null
+        // v7.9.0 / Issue #119 — Toolbar erscheint jetzt ab 1+ selektiertem
+        // Gerät; Ausrichtungs-Buttons sind aber bei nur 1 Gerät disabled
+        // (mit Hinweis-Title), da Alignment zwischen mehreren stattfindet.
+        if (selectedCount < 1) return null
+        const enabled = selectedCount >= 2
         const btnStyle = {
           padding: '2px 6px',
           background: isLight ? '#e2e8f0' : '#1e293b',
           border: `1px solid ${isLight ? '#cbd5e1' : '#334155'}`,
           color: isLight ? '#1e293b' : '#e2e8f0',
           borderRadius: 3,
-          cursor: 'pointer',
+          cursor: enabled ? 'pointer' : 'not-allowed',
+          opacity: enabled ? 1 : 0.4,
           fontSize: 13,
           lineHeight: 1,
         } as const
+        const tip = (base: string): string =>
+          enabled ? base : `${base} — mindestens 2 Geräte auswählen`
         return (
           <>
             <span style={dividerStyle} />
             <span style={sectionLabelStyle}>Ausrichten</span>
-            <button type="button" title="Linksbündig (gleiche linke Kante)" onClick={() => alignSelected('left')} style={btnStyle}>⇤</button>
-            <button type="button" title="Horizontal zentrieren (gleiche X-Mitte)" onClick={() => alignSelected('center-h')} style={btnStyle}>↔</button>
-            <button type="button" title="Rechtsbündig (gleiche rechte Kante)" onClick={() => alignSelected('right')} style={btnStyle}>⇥</button>
-            <button type="button" title="Oben ausrichten (gleiche obere Kante)" onClick={() => alignSelected('top')} style={btnStyle}>⤒</button>
-            <button type="button" title="Vertikal zentrieren (gleiche Y-Mitte)" onClick={() => alignSelected('center-v')} style={btnStyle}>↕</button>
-            <button type="button" title="Unten ausrichten (gleiche untere Kante)" onClick={() => alignSelected('bottom')} style={btnStyle}>⤓</button>
+            <button type="button" disabled={!enabled} title={tip('Linksbündig (gleiche linke Kante)')} onClick={() => alignSelected('left')} style={btnStyle}>⇤</button>
+            <button type="button" disabled={!enabled} title={tip('Horizontal zentrieren (gleiche X-Mitte)')} onClick={() => alignSelected('center-h')} style={btnStyle}>↔</button>
+            <button type="button" disabled={!enabled} title={tip('Rechtsbündig (gleiche rechte Kante)')} onClick={() => alignSelected('right')} style={btnStyle}>⇥</button>
+            <button type="button" disabled={!enabled} title={tip('Oben ausrichten (gleiche obere Kante)')} onClick={() => alignSelected('top')} style={btnStyle}>⤒</button>
+            <button type="button" disabled={!enabled} title={tip('Vertikal zentrieren (gleiche Y-Mitte)')} onClick={() => alignSelected('center-v')} style={btnStyle}>↕</button>
+            <button type="button" disabled={!enabled} title={tip('Unten ausrichten (gleiche untere Kante)')} onClick={() => alignSelected('bottom')} style={btnStyle}>⤓</button>
           </>
         )
       })()}

--- a/src/renderer/components/Canvas/CanvasToolbar.tsx
+++ b/src/renderer/components/Canvas/CanvasToolbar.tsx
@@ -6,6 +6,8 @@ import { LENGTH_COLOR_RULES } from '../../lib/cableColors'
 import { RoutingToggle } from '../shared/RoutingToggle'
 
 export const CanvasToolbar = () => {
+  // v7.9.0 / Issue #120 — open RackBuilder seeded with current selection
+  const triggerRackBuilderFromSelection = useUiStore((s) => s.triggerRackBuilderFromSelection)
   const snapToGrid = useUiStore((state) => state.snapToGrid)
   const setSnapToGrid = useUiStore((state) => state.setSnapToGrid)
   const gridSize = useUiStore((state) => state.gridSize)
@@ -452,6 +454,30 @@ export const CanvasToolbar = () => {
             }}
           >
             Gruppe speichern ({selectedEquipmentIds.length})
+          </button>
+        )
+      })()}
+      {/* v7.9.0 / Issue #120 — "Als Rack speichern" neben "Gruppe speichern" */}
+      {(() => {
+        const selectedEquipmentIds = getNodes()
+          .filter((n) => n.selected && n.type === 'equipment')
+          .map((n) => n.id)
+        if (selectedEquipmentIds.length < 1) return null
+        return (
+          <button
+            type="button"
+            onClick={() => triggerRackBuilderFromSelection(selectedEquipmentIds)}
+            title={`${selectedEquipmentIds.length} ${selectedEquipmentIds.length === 1 ? 'Gerät' : 'Geräte'} im 2D-Rack-Builder anlegen (Rack-Layout + interne Verkabelung)`}
+            style={{
+              padding: '2px 8px',
+              background: '#7c3aed',
+              border: '1px solid #a78bfa',
+              color: '#e2e8f0',
+              borderRadius: 3,
+              cursor: 'pointer',
+            }}
+          >
+            ▤ Als Rack speichern ({selectedEquipmentIds.length})
           </button>
         )
       })()}

--- a/src/renderer/components/Export/ExportDialog.tsx
+++ b/src/renderer/components/Export/ExportDialog.tsx
@@ -1,0 +1,175 @@
+// v7.9.0 / Issue #110 — Unified Export Dialog.
+//
+// User-requested: replace the three separate "Plan als PDF / PNG / JPEG
+// exportieren…" menu items with a single "Exportieren…" entry that opens
+// a dialog where the format is chosen via radio buttons. Reduces menu
+// noise and gives one consistent place for export options.
+//
+// Owns no business logic — delegates to the same export handlers
+// App.tsx already wires (handleExportPdf / handleExportImage).
+
+import { useState } from 'react'
+import { useUiStore } from '../../store/uiStore'
+import { useProjectStore } from '../../store/projectStore'
+
+export type ExportFormat = 'pdf' | 'png' | 'jpeg'
+
+interface ExportDialogProps {
+  open: boolean
+  onClose: () => void
+  /** Triggers the actual export pipelines App.tsx already owns. */
+  onExportPdf: (theme: 'dark' | 'light') => Promise<void> | void
+  onExportImage: (format: 'png' | 'jpeg') => Promise<void> | void
+}
+
+export const ExportDialog = ({
+  open,
+  onClose,
+  onExportPdf,
+  onExportImage,
+}: ExportDialogProps) => {
+  const [format, setFormat] = useState<ExportFormat>('pdf')
+  const canvasTheme = useUiStore((s) => s.canvasTheme)
+  const [pdfTheme, setPdfTheme] = useState<'dark' | 'light'>(canvasTheme)
+  const projectName = useProjectStore((s) => s.project.metadata.name)
+  const [busy, setBusy] = useState(false)
+
+  if (!open) return null
+
+  const handleExport = async () => {
+    setBusy(true)
+    try {
+      if (format === 'pdf') {
+        await onExportPdf(pdfTheme)
+      } else {
+        await onExportImage(format)
+      }
+      onClose()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div className="w-full max-w-md rounded border border-slate-700 bg-slate-900 p-4 text-slate-100 shadow-2xl">
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="text-sm font-semibold">Plan exportieren</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-slate-500 hover:text-slate-200"
+            aria-label="Schließen"
+          >
+            ✕
+          </button>
+        </div>
+        <p className="mb-3 text-[11px] text-slate-400">
+          Datei wird unter <code className="rounded bg-slate-800 px-1 py-0.5">{projectName || 'cable-planner'}</code> heruntergeladen.
+        </p>
+
+        <fieldset className="mb-4 space-y-2">
+          <legend className="mb-1 text-xs font-semibold text-slate-300">Format</legend>
+          {(
+            [
+              {
+                value: 'pdf',
+                icon: '📑',
+                label: 'PDF',
+                hint: 'Vektor-PDF mit Titelblock — beste Qualität, druckbar',
+              },
+              {
+                value: 'png',
+                icon: '🖼',
+                label: 'PNG',
+                hint: 'Transparent möglich, scharfe Kanten, beste Bildqualität',
+              },
+              {
+                value: 'jpeg',
+                icon: '🖼',
+                label: 'JPEG',
+                hint: 'Kleinere Dateien, gut für E-Mail / Slack',
+              },
+            ] as const
+          ).map((opt) => {
+            const selected = format === opt.value
+            return (
+              <label
+                key={opt.value}
+                className={`flex cursor-pointer items-start gap-2 rounded border px-3 py-2 text-xs ${
+                  selected
+                    ? 'border-sky-500 bg-sky-900/30'
+                    : 'border-slate-700 bg-slate-950 hover:border-slate-600'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="export-format"
+                  value={opt.value}
+                  checked={selected}
+                  onChange={() => setFormat(opt.value)}
+                  className="mt-0.5"
+                />
+                <span className="text-base">{opt.icon}</span>
+                <span className="flex-1">
+                  <span className="block font-semibold text-slate-100">{opt.label}</span>
+                  <span className="block text-[10px] text-slate-400">{opt.hint}</span>
+                </span>
+              </label>
+            )
+          })}
+        </fieldset>
+
+        {format === 'pdf' && (
+          <fieldset className="mb-4 space-y-1">
+            <legend className="mb-1 text-xs font-semibold text-slate-300">
+              PDF-Thema
+            </legend>
+            <label className="flex items-center gap-2 text-xs">
+              <input
+                type="radio"
+                name="pdf-theme"
+                checked={pdfTheme === 'dark'}
+                onChange={() => setPdfTheme('dark')}
+              />
+              <span>🌙 Dunkles Thema (wie Canvas)</span>
+            </label>
+            <label className="flex items-center gap-2 text-xs">
+              <input
+                type="radio"
+                name="pdf-theme"
+                checked={pdfTheme === 'light'}
+                onChange={() => setPdfTheme('light')}
+              />
+              <span>☀ Helles Thema (für Ausdruck empfohlen)</span>
+            </label>
+          </fieldset>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded bg-slate-700 px-3 py-1.5 text-xs hover:bg-slate-600"
+            disabled={busy}
+          >
+            Abbrechen
+          </button>
+          <button
+            type="button"
+            onClick={handleExport}
+            disabled={busy}
+            className="rounded bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-500 disabled:opacity-50"
+          >
+            {busy ? 'Exportiere…' : `Als ${format.toUpperCase()} herunterladen`}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/Layout/FloatingPanelShell.tsx
+++ b/src/renderer/components/Layout/FloatingPanelShell.tsx
@@ -73,11 +73,22 @@ export const FloatingPanelShell = ({
   // a fresh {x,y} object with the same values would still trigger
   // setPos → re-render → fresh prop ref → setPos → loop. This is a
   // textbook React #185 "max update depth" recipe.
+  // v7.9.0 / Issue #108 — also clamp on mount so a persisted off-screen
+  // position (e.g. saved from a larger monitor) doesn't strand the
+  // panel where the user can't see it. clamp() uses the current
+  // viewport bounds.
   useEffect(() => {
-    setPos((current) =>
-      current.x === position.x && current.y === position.y ? current : position,
-    )
-  }, [position.x, position.y])
+    setPos((current) => {
+      const clamped = clamp(position, width, typeof height === 'number' ? height : 400)
+      if (
+        current.x === clamped.x &&
+        current.y === clamped.y
+      ) {
+        return current
+      }
+      return clamped
+    })
+  }, [position.x, position.y, width, height])
 
   // Re-clamp on resize so a previously valid position doesn't leave the
   // panel off-screen on smaller viewports.

--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -11,10 +11,16 @@ interface MenuBarProps {
   onSaveProject: () => void
   onSaveProjectAs: () => void
   onOpenSettings: () => void
+  /** v7.9.0 / Issue #110 — unified Export-Dialog opener. Replaces the
+   *  former three separate menu entries (PDF / PNG / JPEG) with a
+   *  single "Exportieren…" item that opens a dialog where the user
+   *  picks the format. */
+  onOpenExportDialog?: () => void
+  /** Legacy direct triggers — kept for backwards compatibility with
+   *  callers that still want individual menu items. When
+   *  onOpenExportDialog is provided we hide these. */
   onExportPdf: () => void
-  /** v7.7.1 — export the canvas as a PNG image (uses live bg settings). */
   onExportPng?: () => void
-  /** v7.7.1 — export the canvas as a JPEG image (uses live bg settings). */
   onExportJpeg?: () => void
   /** Open the consolidated "Drucken" hub (Plan + per-device patch-sheets, Issue #74). */
   onOpenPrintDialog?: () => void
@@ -52,6 +58,7 @@ export const MenuBar = ({
   onSaveProject,
   onSaveProjectAs,
   onOpenSettings,
+  onOpenExportDialog,
   onExportPdf,
   onExportPng,
   onExportJpeg,
@@ -118,21 +125,31 @@ export const MenuBar = ({
             </>
           )}
           <MenuSep />
-          {/* v7.6.0 — Export + Drucken moved into Datei (logischere Hierarchie).
-              "Plan als …" sind Export-Features, das echte Drucken läuft über
-              den separaten Drucken-Dialog mit nativem Druck-Workflow. */}
-          <MenuItem onClick={onExportPdf} icon="📑">
-            {t('app.menu.file.exportPdf', 'Plan als PDF exportieren…')}
-          </MenuItem>
-          {onExportPng && (
-            <MenuItem onClick={onExportPng} icon="🖼">
-              {t('app.menu.file.exportPng', 'Plan als PNG exportieren…')}
+          {/* v7.9.0 / Issue #110 — Einzelner "Exportieren"-Eintrag der
+              den ExportDialog mit Format-Auswahl öffnet. Die drei
+              alten Einträge (Plan als PDF/PNG/JPEG) sind in den
+              Dialog wandern; falls jemand den Dialog NICHT verdrahtet
+              hat, fallen wir auf die Legacy-Einträge zurück. */}
+          {onOpenExportDialog ? (
+            <MenuItem onClick={onOpenExportDialog} icon="📤">
+              {t('app.menu.file.export', 'Exportieren…')}
             </MenuItem>
-          )}
-          {onExportJpeg && (
-            <MenuItem onClick={onExportJpeg} icon="🖼">
-              {t('app.menu.file.exportJpeg', 'Plan als JPEG exportieren…')}
-            </MenuItem>
+          ) : (
+            <>
+              <MenuItem onClick={onExportPdf} icon="📑">
+                {t('app.menu.file.exportPdf', 'Plan als PDF exportieren…')}
+              </MenuItem>
+              {onExportPng && (
+                <MenuItem onClick={onExportPng} icon="🖼">
+                  {t('app.menu.file.exportPng', 'Plan als PNG exportieren…')}
+                </MenuItem>
+              )}
+              {onExportJpeg && (
+                <MenuItem onClick={onExportJpeg} icon="🖼">
+                  {t('app.menu.file.exportJpeg', 'Plan als JPEG exportieren…')}
+                </MenuItem>
+              )}
+            </>
           )}
           {onOpenCableBom && (
             <MenuItem onClick={onOpenCableBom} icon="🧮">

--- a/src/renderer/components/Library/LibraryPanel.tsx
+++ b/src/renderer/components/Library/LibraryPanel.tsx
@@ -90,6 +90,64 @@ export const LibraryPanel = () => {
   // When set, the rack builder opens in edit mode and seeds from this preset.
   // null = creating a new rack.
   const [editingRackPresetId, setEditingRackPresetId] = useState<string | null>(null)
+  // v7.9.0 / Issue #120 — synthesized preset from canvas-selection
+  // "Als Rack speichern". Lives in component state because it's
+  // ephemeral (only valid while the dialog is open).
+  const [seedPreset, setSeedPreset] = useState<import('../../types/equipment').GroupPreset | null>(null)
+  // Watch the global trigger fired by the CanvasToolbar button.
+  const rackBuilderSeedTrigger = useUiStore((s) => s.rackBuilderSeedTrigger)
+  const clearRackBuilderSeedTrigger = useUiStore((s) => s.clearRackBuilderSeedTrigger)
+  useEffect(() => {
+    if (!rackBuilderSeedTrigger || rackBuilderSeedTrigger.length === 0) return
+    // Resolve the selected equipment to a synthesized GroupPreset
+    // shape. Stack them top-to-bottom by HE size; non-rack devices
+    // default to 1 HE. Cables connecting selected devices are NOT
+    // included (the user can wire them later in the sub-canvas).
+    const items = rackBuilderSeedTrigger
+      .map((id) => equipmentItems.find((e) => e.id === id))
+      .filter((e): e is NonNullable<typeof e> => e != null)
+    if (items.length === 0) {
+      clearRackBuilderSeedTrigger()
+      return
+    }
+    let cursorUnit = 1
+    const placements = items.map((eq, index) => {
+      const heightUnits = Math.max(1, eq.rackUnits ?? 1)
+      const placement = { itemIndex: index, startUnit: cursorUnit, heightUnits }
+      cursorUnit += heightUnits
+      return placement
+    })
+    const synthesized: import('../../types/equipment').GroupPreset = {
+      id: `__seed-${Date.now().toString(36)}`,
+      name: 'Neues Rack aus Auswahl',
+      rack: {
+        totalUnits: Math.max(cursorUnit + 3, 12),
+        placements,
+      },
+      items: items.map((eq) => ({
+        name: eq.name,
+        category: eq.category ?? 'Sonstiges',
+        inputs: eq.inputs,
+        outputs: eq.outputs,
+        isRackDevice: eq.isRackDevice ?? !!eq.rackUnits,
+        rackUnits: Math.max(1, eq.rackUnits ?? 1),
+        frontPanelImageUrl: eq.frontPanelImageUrl,
+        rearPanelImageUrl: eq.rearPanelImageUrl,
+        frontPanelCrop: eq.frontPanelCrop,
+        rearPanelCrop: eq.rearPanelCrop,
+        width: eq.width ?? 240,
+        height: eq.height ?? 80,
+        offsetX: 0,
+        offsetY: 0,
+      })),
+      cables: [],
+    }
+    setSeedPreset(synthesized)
+    setEditingRackPresetId(null)
+    setShowRackBuilderDialog(true)
+    setTab('racks')
+    clearRackBuilderSeedTrigger()
+  }, [rackBuilderSeedTrigger, equipmentItems, clearRackBuilderSeedTrigger])
   const [name, setName] = useState('Custom Device')
   const [category, setCategory] = useState('Kameras')
   const [isRackDeviceDraft, setIsRackDeviceDraft] = useState(false)
@@ -1973,17 +2031,28 @@ export const LibraryPanel = () => {
       <RackBuilderDialog
         open={showRackBuilderDialog}
         templates={rackBuilderTemplates}
-        initialPreset={editingRackPresetId ? groupPresets.find((p) => p.id === editingRackPresetId) ?? null : null}
+        initialPreset={
+          editingRackPresetId
+            ? groupPresets.find((p) => p.id === editingRackPresetId) ?? null
+            : // v7.9.0 / Issue #120 — wenn der RackBuilder via Toolbar-Seed
+              // geöffnet wurde, übergeben wir die synthetisierte Preset
+              // als initialPreset. Beim Speichern wird id durch addGroupPreset
+              // ggf. überschrieben (Upsert).
+              seedPreset
+        }
         onClose={() => {
           setShowRackBuilderDialog(false)
           setEditingRackPresetId(null)
+          setSeedPreset(null)
         }}
         onSave={(preset) => {
           // addGroupPreset upserts by id, so edit-mode reuses the same id and
-          // simply overwrites the existing entry.
+          // simply overwrites the existing entry. For seed-mode the synthetic
+          // __seed- id is replaced by a fresh uuid in saveRack already.
           addGroupPreset(preset)
           setShowRackBuilderDialog(false)
           setEditingRackPresetId(null)
+          setSeedPreset(null)
           setTab('racks')
         }}
       />

--- a/src/renderer/components/Library/LibraryPanel.tsx
+++ b/src/renderer/components/Library/LibraryPanel.tsx
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { useProjectStore } from '../../store/projectStore'
 import { useUiStore } from '../../store/uiStore'
 import { FloatingPanelShell } from '../Layout/FloatingPanelShell'
+import { triggerCanvasFitView } from '../../lib/canvasViewport'
 import { useRentman } from '../../hooks/useRentman'
 import { promptDialog } from '../../lib/promptDialog'
 import { CategorySelect } from '../shared/CategorySelect'
@@ -519,7 +520,14 @@ export const LibraryPanel = () => {
         {!floating && (
           <button
             type="button"
-            onClick={() => setFloating(true)}
+            onClick={() => {
+              setFloating(true)
+              // v7.9.0 / Issue #108 — after the side track collapses
+              // to 0px, run fitView so nodes that scrolled off-screen
+              // come back into view. Defer a tick so the grid has
+              // actually re-measured first.
+              window.setTimeout(triggerCanvasFitView, 60)
+            }}
             title="Library abdocken (frei verschiebbar)"
             aria-label="Library abdocken"
             className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-slate-700 bg-slate-900 text-slate-300 transition-all hover:border-sky-500 hover:bg-slate-800 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
@@ -2059,7 +2067,10 @@ export const LibraryPanel = () => {
         title="Library"
         position={floatingPos}
         onMove={setFloatingPos}
-        onDock={() => setFloating(false)}
+        onDock={() => {
+          setFloating(false)
+          window.setTimeout(triggerCanvasFitView, 60)
+        }}
         width={Math.max(libraryWidth, 320)}
       >
         {inner}

--- a/src/renderer/components/Project/LocationBomDialog.tsx
+++ b/src/renderer/components/Project/LocationBomDialog.tsx
@@ -27,6 +27,11 @@ export const LocationBomDialog = () => {
   // the parts list in one document. Off by default — capturing a 2.4 MB
   // diagram region takes ~500 ms and the user might not always want it.
   const [includePlan, setIncludePlan] = useState(true)
+  // v7.9.0 / Issue #116 — Kabel-Liste lässt sich zwischen "Detail"
+  // (eine Zeile pro Kabel) und "Gruppiert" (eine Zeile pro Typ+Länge
+  // mit Stückzahl) umschalten. Gruppiert ist Default — das ist was
+  // ein Einkäufer/Materialwart bekommen will.
+  const [grouped, setGrouped] = useState(true)
   const [busy, setBusy] = useState(false)
 
   const location = (project.locations ?? []).find((l) => l.id === locationId)
@@ -57,6 +62,39 @@ export const LocationBomDialog = () => {
     )
     return { devices, internalCables, externalCables }
   }, [location, project.equipment, project.cables])
+
+  // v7.9.0 / Issue #116 — gruppiere Kabel nach Typ + Länge.
+  // Beispiel: 5× "BNC, 1m", 3× "BNC, 3m". Length wird auf 0.1 m
+  // gerundet damit minimale Float-Drifts (1.0001 vs 1) nicht zwei
+  // separate Gruppen erzeugen.
+  type CableGroup = {
+    key: string
+    type: string
+    length: number
+    count: number
+    examples: string[] // up to 3 cable names for tooltip
+  }
+  const aggregateCables = (cables: typeof internalCables): CableGroup[] => {
+    const map = new Map<string, CableGroup>()
+    for (const c of cables) {
+      const type = c.type ?? '—'
+      const length = Math.round((c.length ?? 0) * 10) / 10
+      const key = `${type}|${length}`
+      let g = map.get(key)
+      if (!g) {
+        g = { key, type, length, count: 0, examples: [] }
+        map.set(key, g)
+      }
+      g.count += 1
+      if (g.examples.length < 3 && c.name) g.examples.push(c.name)
+    }
+    // Sort by type, then length asc
+    return Array.from(map.values()).sort((a, b) =>
+      a.type === b.type ? a.length - b.length : a.type.localeCompare(b.type),
+    )
+  }
+  const internalGroups = aggregateCables(internalCables)
+  const externalGroups = aggregateCables(externalCables)
 
   if (!open || !location) return null
 
@@ -229,6 +267,17 @@ export const LocationBomDialog = () => {
             )}
             <label
               className="ml-auto flex items-center gap-1.5 text-[11px] text-slate-300"
+              title="Gruppiert gleiche Kabel (selber Typ + Länge) in einer Zeile mit Stückzahl — Standard für Stückliste."
+            >
+              <input
+                type="checkbox"
+                checked={grouped}
+                onChange={(e) => setGrouped(e.target.checked)}
+              />
+              Kabel zusammenfassen
+            </label>
+            <label
+              className="flex items-center gap-1.5 text-[11px] text-slate-300"
               title="Hängt einen Plan-Ausschnitt der Location als JPEG vor die Geräteliste — die Empfänger bekommen Stückliste + Plan in einem Dokument."
             >
               <input
@@ -277,6 +326,33 @@ export const LocationBomDialog = () => {
           <h3 className="mb-1 text-sm font-semibold text-slate-200">Interne Kabel</h3>
           {internalCables.length === 0 ? (
             <div className="mb-3 text-slate-500">Keine internen Kabel.</div>
+          ) : grouped ? (
+            <table className="mb-4 w-full text-xs">
+              <thead className="text-slate-400">
+                <tr className="border-b border-slate-700">
+                  <th className="px-2 py-1 text-right w-12">Stk.</th>
+                  <th className="px-2 py-1 text-left">Typ</th>
+                  <th className="px-2 py-1 text-right">Länge (m)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {internalGroups.map((g) => (
+                  <tr
+                    key={g.key}
+                    className="border-b border-slate-800"
+                    title={g.examples.length > 0 ? `Beispiele: ${g.examples.join(', ')}` : undefined}
+                  >
+                    <td className="px-2 py-1 text-right font-mono font-semibold text-emerald-300">
+                      {g.count}×
+                    </td>
+                    <td className="px-2 py-1 text-slate-200">{g.type}</td>
+                    <td className="px-2 py-1 text-right font-mono text-slate-400">
+                      {g.length}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           ) : (
             <table className="mb-4 w-full text-xs">
               <thead className="text-slate-400">
@@ -305,26 +381,55 @@ export const LocationBomDialog = () => {
               <h3 className="mb-1 text-sm font-semibold text-amber-200">
                 Externe Verbindungen
               </h3>
-              <table className="w-full text-xs">
-                <thead className="text-slate-400">
-                  <tr className="border-b border-slate-700">
-                    <th className="px-2 py-1 text-left">Name</th>
-                    <th className="px-2 py-1 text-left">Typ</th>
-                    <th className="px-2 py-1 text-right">Länge (m)</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {externalCables.map((c) => (
-                    <tr key={c.id} className="border-b border-slate-800">
-                      <td className="px-2 py-1">{c.name ?? '—'}</td>
-                      <td className="px-2 py-1 text-slate-400">{c.type ?? '—'}</td>
-                      <td className="px-2 py-1 text-right font-mono text-slate-400">
-                        {c.length ?? '—'}
-                      </td>
+              {grouped ? (
+                <table className="w-full text-xs">
+                  <thead className="text-slate-400">
+                    <tr className="border-b border-slate-700">
+                      <th className="px-2 py-1 text-right w-12">Stk.</th>
+                      <th className="px-2 py-1 text-left">Typ</th>
+                      <th className="px-2 py-1 text-right">Länge (m)</th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
+                  </thead>
+                  <tbody>
+                    {externalGroups.map((g) => (
+                      <tr
+                        key={g.key}
+                        className="border-b border-slate-800"
+                        title={g.examples.length > 0 ? `Beispiele: ${g.examples.join(', ')}` : undefined}
+                      >
+                        <td className="px-2 py-1 text-right font-mono font-semibold text-amber-300">
+                          {g.count}×
+                        </td>
+                        <td className="px-2 py-1 text-slate-200">{g.type}</td>
+                        <td className="px-2 py-1 text-right font-mono text-slate-400">
+                          {g.length}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              ) : (
+                <table className="w-full text-xs">
+                  <thead className="text-slate-400">
+                    <tr className="border-b border-slate-700">
+                      <th className="px-2 py-1 text-left">Name</th>
+                      <th className="px-2 py-1 text-left">Typ</th>
+                      <th className="px-2 py-1 text-right">Länge (m)</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {externalCables.map((c) => (
+                      <tr key={c.id} className="border-b border-slate-800">
+                        <td className="px-2 py-1">{c.name ?? '—'}</td>
+                        <td className="px-2 py-1 text-slate-400">{c.type ?? '—'}</td>
+                        <td className="px-2 py-1 text-right font-mono text-slate-400">
+                          {c.length ?? '—'}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
             </>
           )}
         </main>

--- a/src/renderer/components/Properties/EquipmentProperties.tsx
+++ b/src/renderer/components/Properties/EquipmentProperties.tsx
@@ -20,6 +20,7 @@ import { CSS } from '@dnd-kit/utilities'
 import { useProjectStore } from '../../store/projectStore'
 import { useUiStore } from '../../store/uiStore'
 import { detectDeviceKind, detectNetworkDevice } from '../../lib/deviceKind'
+import { ModeEditorDialog } from './ModeEditorDialog'
 import { promptDialog } from '../../lib/promptDialog'
 import { useGreenGoBeltpack } from '../../lib/greengoSync'
 import { exportDevicePatchSheet } from '../../lib/exportDevicePdf'
@@ -1012,6 +1013,32 @@ const DeviceModePicker = ({
   const setActiveDeviceMode = useProjectStore((s) => s.setActiveDeviceMode)
   const modes = equipment.modes ?? []
   const active = equipment.activeModeId
+  // v7.9.0 / Issue #113 — Mode-Editor-Dialog (richer form)
+  const [editorState, setEditorState] = useState<
+    | { mode: 'create' }
+    | { mode: 'edit'; modeId: string }
+    | null
+  >(null)
+  const editingMode =
+    editorState?.mode === 'edit'
+      ? modes.find((m) => m.id === editorState.modeId) ?? null
+      : null
+
+  const saveModeFromEditor = (newMode: import('../../types/equipment').DeviceMode) => {
+    if (editorState?.mode === 'edit') {
+      // Replace existing mode by id
+      updateEquipment(equipment.id, {
+        modes: modes.map((m) => (m.id === newMode.id ? newMode : m)),
+      })
+    } else {
+      // Append new mode and activate it
+      updateEquipment(equipment.id, {
+        modes: [...modes, newMode],
+        activeModeId: newMode.id,
+      })
+    }
+    setEditorState(null)
+  }
 
   const createModeFromPorts = () => {
     const name = window.prompt(
@@ -1127,6 +1154,14 @@ const DeviceModePicker = ({
             <div className="flex gap-1 border-t border-slate-800 bg-slate-950/40 px-1 py-1 text-[10px]">
               <button
                 type="button"
+                onClick={() => setEditorState({ mode: 'edit', modeId: m.id })}
+                className="rounded px-1.5 py-0.5 text-sky-300 hover:bg-sky-900/30"
+                title="Modus im Editor öffnen (Name, Beschreibung, Ports auf einmal)"
+              >
+                ✎ Editor
+              </button>
+              <button
+                type="button"
                 onClick={() => renameMode(m.id)}
                 className="rounded px-1.5 py-0.5 text-slate-300 hover:bg-slate-800"
                 title="Namen ändern"
@@ -1163,14 +1198,31 @@ const DeviceModePicker = ({
           </div>
         ))}
       </div>
-      <button
-        type="button"
-        onClick={createModeFromPorts}
-        className="w-full rounded border border-dashed border-emerald-700 bg-emerald-950/30 px-2 py-1 text-[11px] text-emerald-200 hover:bg-emerald-900/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
-        title="Speichert das aktuelle Port-Layout des Geräts als neuen Modus."
-      >
-        + aus aktuellem Layout speichern
-      </button>
+      <div className="flex flex-col gap-1">
+        <button
+          type="button"
+          onClick={() => setEditorState({ mode: 'create' })}
+          className="w-full rounded border border-sky-700 bg-sky-900/30 px-2 py-1 text-[11px] text-sky-100 hover:bg-sky-800/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+          title="Öffnet einen Editor in dem Name, Beschreibung und Ports des neuen Modus konfiguriert werden können (Issue #113)."
+        >
+          + Neuer Modus (Editor)
+        </button>
+        <button
+          type="button"
+          onClick={createModeFromPorts}
+          className="w-full rounded border border-dashed border-emerald-700 bg-emerald-950/30 px-2 py-1 text-[11px] text-emerald-200 hover:bg-emerald-900/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+          title="Speichert das aktuelle Port-Layout des Geräts als neuen Modus (Quick-Save)."
+        >
+          + aus aktuellem Layout speichern
+        </button>
+      </div>
+      <ModeEditorDialog
+        open={editorState !== null}
+        equipment={equipment}
+        editingMode={editingMode}
+        onCancel={() => setEditorState(null)}
+        onSave={saveModeFromEditor}
+      />
     </div>
   )
 }

--- a/src/renderer/components/Properties/ModeEditorDialog.tsx
+++ b/src/renderer/components/Properties/ModeEditorDialog.tsx
@@ -1,0 +1,301 @@
+// v7.9.0 / Issue #113 — Betriebsmodi-Editor.
+//
+// Bisher konnte man nur das AKTUELLE Port-Layout via window.prompt-Name
+// als Modus abspeichern. Der User möchte aber einen richtigen Editor in
+// dem er Name, Beschreibung, Inputs und Outputs vor dem Speichern
+// konfiguriert.
+//
+// Dieses Dialog ist standalone und bekommt:
+//   - das aktuelle Equipment (für "aus aktuellem Layout übernehmen")
+//   - einen optionalen initial-Mode (für Bearbeiten eines bestehenden)
+//   - einen onSave-Callback der den fertigen Modus zurückgibt
+//
+// Speichern delegiert an den Caller — der Dialog selbst schreibt
+// nichts in den Store. Macht das Komponent eigenständig testbar und
+// für Edit + Create wiederverwendbar.
+
+import { useEffect, useMemo, useState } from 'react'
+import { v4 as uuidv4 } from 'uuid'
+import { ALL_CONNECTOR_TYPES } from '../../types/equipment'
+import type { ConnectorType, DeviceMode, EquipmentItem, Port } from '../../types/equipment'
+
+export interface ModeEditorDialogProps {
+  open: boolean
+  equipment: EquipmentItem
+  /** When set, dialog opens in EDIT mode and seeds from this mode. */
+  editingMode?: DeviceMode | null
+  onCancel: () => void
+  onSave: (mode: DeviceMode) => void
+}
+
+interface PortDraft {
+  id: string
+  name: string
+  connectorType: ConnectorType
+}
+
+const toDraft = (p: Port): PortDraft => ({
+  id: p.id,
+  name: p.name,
+  connectorType: p.connectorType,
+})
+
+const toPort = (d: PortDraft): Port => ({
+  id: d.id,
+  name: d.name.trim() || 'Port',
+  type: d.connectorType,
+  connectorType: d.connectorType,
+})
+
+export const ModeEditorDialog = ({
+  open,
+  equipment,
+  editingMode,
+  onCancel,
+  onSave,
+}: ModeEditorDialogProps) => {
+  const isEditing = !!editingMode
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [inputs, setInputs] = useState<PortDraft[]>([])
+  const [outputs, setOutputs] = useState<PortDraft[]>([])
+
+  // Seed state whenever the dialog opens. Keyed on open + editingMode
+  // identity so re-opening with a different mode reseeds cleanly.
+  useEffect(() => {
+    if (!open) return
+    if (editingMode) {
+      setName(editingMode.name)
+      setDescription(editingMode.description ?? '')
+      setInputs(editingMode.inputs.map(toDraft))
+      setOutputs(editingMode.outputs.map(toDraft))
+    } else {
+      setName(`Modus ${(equipment.modes ?? []).length + 1}`)
+      setDescription('')
+      setInputs([])
+      setOutputs([])
+    }
+  }, [open, editingMode, equipment.modes])
+
+  const seedFromCurrent = () => {
+    setInputs(equipment.inputs.map(toDraft))
+    setOutputs(equipment.outputs.map(toDraft))
+  }
+
+  const addPort = (side: 'in' | 'out') => {
+    const newDraft: PortDraft = {
+      id: uuidv4(),
+      name:
+        side === 'in'
+          ? `In ${inputs.length + 1}`
+          : `Out ${outputs.length + 1}`,
+      connectorType: 'Custom',
+    }
+    if (side === 'in') setInputs((cur) => [...cur, newDraft])
+    else setOutputs((cur) => [...cur, newDraft])
+  }
+
+  const updatePort = (
+    side: 'in' | 'out',
+    id: string,
+    patch: Partial<PortDraft>,
+  ) => {
+    const updater = (list: PortDraft[]) =>
+      list.map((p) => (p.id === id ? { ...p, ...patch } : p))
+    if (side === 'in') setInputs(updater)
+    else setOutputs(updater)
+  }
+
+  const removePort = (side: 'in' | 'out', id: string) => {
+    if (side === 'in') setInputs((cur) => cur.filter((p) => p.id !== id))
+    else setOutputs((cur) => cur.filter((p) => p.id !== id))
+  }
+
+  const canSave = name.trim().length > 0
+
+  const handleSave = () => {
+    if (!canSave) return
+    const mode: DeviceMode = {
+      id: editingMode?.id ?? `mode:${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 5)}`,
+      name: name.trim(),
+      description: description.trim() || undefined,
+      inputs: inputs.map(toPort),
+      outputs: outputs.map(toPort),
+    }
+    onSave(mode)
+  }
+
+  const totalPortCount = inputs.length + outputs.length
+  const existingNames = useMemo(
+    () => (equipment.modes ?? []).map((m) => m.name),
+    [equipment.modes],
+  )
+  const nameConflict =
+    !isEditing && existingNames.some((n) => n.toLowerCase() === name.trim().toLowerCase())
+
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel()
+      }}
+    >
+      <div className="flex max-h-[90vh] w-full max-w-2xl flex-col rounded border border-slate-700 bg-slate-900 text-slate-100 shadow-2xl">
+        <header className="flex items-center justify-between border-b border-slate-800 px-4 py-2">
+          <h3 className="text-sm font-semibold">
+            {isEditing ? 'Modus bearbeiten' : 'Neuer Betriebsmodus'}
+          </h3>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="text-slate-500 hover:text-slate-200"
+            aria-label="Schließen"
+          >
+            ✕
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-auto p-4 text-xs">
+          {/* Name & description */}
+          <div className="space-y-2">
+            <label className="block">
+              <span className="text-slate-400">Name</span>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder='z.B. "12G Single-Link", "4K-Modus", "Workshop-Layout"'
+                autoFocus
+                className="mt-0.5 w-full rounded border border-slate-700 bg-slate-950 px-2 py-1 text-slate-100"
+              />
+              {nameConflict && (
+                <span className="mt-0.5 block text-[10px] text-amber-400">
+                  ⚠ Modus mit diesem Namen existiert bereits.
+                </span>
+              )}
+            </label>
+            <label className="block">
+              <span className="text-slate-400">Beschreibung (optional)</span>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={2}
+                placeholder="z.B. Begrenzt Outputs auf 2 für 4K-Modus (weniger Ressourcen)"
+                className="mt-0.5 w-full rounded border border-slate-700 bg-slate-950 px-2 py-1 text-slate-100"
+              />
+            </label>
+          </div>
+
+          <div className="mt-4 flex items-center justify-between">
+            <div className="text-[10px] text-slate-500">
+              {totalPortCount} {totalPortCount === 1 ? 'Port' : 'Ports'} in diesem Modus
+            </div>
+            <button
+              type="button"
+              onClick={seedFromCurrent}
+              className="rounded bg-slate-700 px-2 py-1 text-[11px] hover:bg-slate-600"
+              title="Übernimmt das AKTUELLE Port-Layout des Geräts als Startpunkt."
+            >
+              ⬇ Aus aktuellem Geräte-Layout übernehmen
+            </button>
+          </div>
+
+          {/* Two columns: Inputs and Outputs */}
+          <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2">
+            {(
+              [
+                { side: 'in', label: 'Inputs', list: inputs, accent: 'cyan' },
+                { side: 'out', label: 'Outputs', list: outputs, accent: 'emerald' },
+              ] as const
+            ).map(({ side, label, list, accent }) => (
+              <div
+                key={side}
+                className="rounded border border-slate-800 bg-slate-950/40 p-2"
+              >
+                <div className="mb-2 flex items-center justify-between">
+                  <span className={`text-[11px] font-semibold ${
+                    accent === 'cyan' ? 'text-cyan-300' : 'text-emerald-300'
+                  }`}>
+                    {label} ({list.length})
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => addPort(side)}
+                    className="rounded bg-slate-800 px-2 py-0.5 text-[10px] text-slate-300 hover:bg-slate-700"
+                  >
+                    + Port
+                  </button>
+                </div>
+                {list.length === 0 ? (
+                  <div className="rounded border border-dashed border-slate-700 p-3 text-center text-[10px] text-slate-500">
+                    Keine {label.toLowerCase()} in diesem Modus.
+                  </div>
+                ) : (
+                  <ul className="space-y-1">
+                    {list.map((p) => (
+                      <li
+                        key={p.id}
+                        className="flex items-center gap-1 rounded border border-slate-800 bg-slate-900/60 p-1"
+                      >
+                        <input
+                          type="text"
+                          value={p.name}
+                          onChange={(e) => updatePort(side, p.id, { name: e.target.value })}
+                          placeholder="Port-Name"
+                          className="flex-1 rounded border border-slate-700 bg-slate-950 px-1.5 py-0.5 text-[11px]"
+                        />
+                        <select
+                          value={p.connectorType}
+                          onChange={(e) =>
+                            updatePort(side, p.id, {
+                              connectorType: e.target.value as ConnectorType,
+                            })
+                          }
+                          className="w-28 rounded border border-slate-700 bg-slate-950 px-1 py-0.5 text-[10px]"
+                        >
+                          {ALL_CONNECTOR_TYPES.map((c) => (
+                            <option key={c} value={c}>
+                              {c}
+                            </option>
+                          ))}
+                        </select>
+                        <button
+                          type="button"
+                          onClick={() => removePort(side, p.id)}
+                          className="rounded px-1 py-0.5 text-[11px] text-red-400 hover:bg-red-900/40"
+                          title="Port entfernen"
+                        >
+                          ✕
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <footer className="flex justify-end gap-2 border-t border-slate-800 px-4 py-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded bg-slate-700 px-3 py-1 text-xs hover:bg-slate-600"
+          >
+            Abbrechen
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!canSave}
+            className="rounded bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-500 disabled:opacity-50"
+          >
+            {isEditing ? 'Speichern' : 'Modus anlegen'}
+          </button>
+        </footer>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/Properties/PropertiesPanel.tsx
+++ b/src/renderer/components/Properties/PropertiesPanel.tsx
@@ -5,6 +5,7 @@ import { EquipmentProperties } from './EquipmentProperties'
 import { LocationProperties } from './LocationProperties'
 import { TemplateProperties } from './TemplateProperties'
 import { FloatingPanelShell } from '../Layout/FloatingPanelShell'
+import { triggerCanvasFitView } from '../../lib/canvasViewport'
 
 export const PropertiesPanel = () => {
   const selectedEquipmentId = useProjectStore((state) => state.selectedEquipmentId)
@@ -81,7 +82,10 @@ export const PropertiesPanel = () => {
         }
         position={floatingPos}
         onMove={setFloatingPos}
-        onDock={() => setFloating(false)}
+        onDock={() => {
+          setFloating(false)
+          window.setTimeout(triggerCanvasFitView, 60)
+        }}
         width={propertiesWidth}
       >
         {body}
@@ -126,7 +130,10 @@ export const PropertiesPanel = () => {
         <div className="flex shrink-0 items-center gap-1">
           <button
             type="button"
-            onClick={() => setFloating(true)}
+            onClick={() => {
+              setFloating(true)
+              window.setTimeout(triggerCanvasFitView, 60)
+            }}
             title="Eigenschaften abdocken (frei verschiebbar)"
             aria-label="Eigenschaften abdocken"
             className="flex h-7 w-7 items-center justify-center rounded-full border border-slate-700 bg-slate-900 text-slate-300 transition-all hover:border-sky-500 hover:bg-slate-800 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"

--- a/src/renderer/components/Rack/RackBuilderDialog.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialog.tsx
@@ -186,6 +186,10 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
   })
   const [wireDialogOpen, setWireDialogOpen] = useState(false)
   const [query, setQuery] = useState('')
+  // v7.9.0 / Issue #112 — zeige auch Templates die NICHT als 19"-
+  // Rack-Gerät markiert sind, damit man sie aus dem Builder
+  // suchen + nachträglich umflaggen kann.
+  const [showNonRack, setShowNonRack] = useState(false)
   const [selectedPlacementId, setSelectedPlacementId] = useState<string | null>(null)
   const [lastSavedSnapshot, setLastSavedSnapshot] = useState('')
   const [dragState, setDragState] = useState<
@@ -241,13 +245,18 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
 
   const filteredTemplates = useMemo(() => {
     const q = query.trim().toLowerCase()
+    // v7.9.0 / Issue #112 — Wenn showNonRack aktiv ist, zeigen wir ALLE
+    // Templates an; sonst nur die als Rack-Gerät markierten. Beim
+    // Hinzufügen eines nicht-rack-Templates fragen wir den User über
+    // window.prompt nach der HE-Höhe, damit das Template danach für
+    // alle zukünftigen Rack-Builds als Rack-Gerät zur Verfügung steht.
     const sorted = templates
-      .filter((template) => template.isRackDevice || template.rackUnits)
+      .filter((template) => showNonRack || template.isRackDevice || template.rackUnits)
       .slice()
       .sort((a, b) => `${a.category} ${a.name}`.localeCompare(`${b.category} ${b.name}`))
     if (!q) return sorted
     return sorted.filter((t) => `${t.name} ${t.category}`.toLowerCase().includes(q))
-  }, [query, templates])
+  }, [query, templates, showNonRack])
 
   const selectedPlacement = useMemo(
     () => draft.placements.find((placement) => placement.id === selectedPlacementId) ?? null,
@@ -362,7 +371,31 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
   }
 
   const addTemplate = (template: EquipmentTemplate) => {
-    const units = parseUnits(template)
+    // v7.9.0 / Issue #112 — Wenn das Template (noch) nicht als 19"-
+    // Rack-Gerät markiert ist, fragen wir den User nach der HE-Höhe
+    // und markieren es im Draft entsprechend. Die ECHTE Library-
+    // Persistenz erfolgt erst beim Save (saveRack baut den Preset
+    // mit isRackDevice=true für alle Placements).
+    let effectiveTemplate = template
+    if (!template.isRackDevice && !template.rackUnits) {
+      const answer = window.prompt(
+        `Das Template "${template.name}" ist nicht als 19"-Rack-Gerät markiert.\n\n` +
+          `Wie hoch (HE) soll es im Rack sein? Leer = Abbruch.`,
+        '1',
+      )?.trim()
+      if (!answer) return
+      const heightHE = Math.max(1, Math.min(20, Math.round(Number(answer))))
+      if (!Number.isFinite(heightHE) || heightHE < 1) {
+        window.alert('Ungültige HE-Eingabe. Abgebrochen.')
+        return
+      }
+      effectiveTemplate = {
+        ...template,
+        isRackDevice: true,
+        rackUnits: heightHE,
+      }
+    }
+    const units = parseUnits(effectiveTemplate)
     let targetUnit = 1
     const occupied = draft.placements
       .map((item) => ({ start: item.startUnit, end: item.startUnit + item.rackUnits - 1 }))
@@ -374,7 +407,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
     if (targetUnit + units - 1 > draft.totalUnits) {
       targetUnit = Math.max(1, draft.totalUnits - units + 1)
     }
-    const placement = toPlacement(template, targetUnit)
+    const placement = toPlacement(effectiveTemplate, targetUnit)
     setDraft((current) => ({ ...current, placements: [...current.placements, placement] }))
     setSelectedPlacementId(placement.id)
   }
@@ -576,27 +609,59 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
               placeholder="Suchen..."
               className="mb-2 w-full rounded border border-slate-700 bg-slate-950 p-1.5 text-xs"
             />
+            <label
+              className="mb-2 flex items-center gap-1 text-[10px] text-slate-400"
+              title="Wenn aktiv, werden auch Templates angezeigt die nicht als 19”-Rack-Gerät markiert sind. Beim Hinzufügen wirst du nach der HE-Höhe gefragt (Issue #112)."
+            >
+              <input
+                type="checkbox"
+                checked={showNonRack}
+                onChange={(e) => setShowNonRack(e.target.checked)}
+              />
+              Auch Nicht-Rack-Geräte zeigen
+            </label>
             <div className="max-h-[58vh] space-y-1 overflow-auto">
-              {filteredTemplates.map((template) => (
-                <div key={template.name} className="rounded border border-slate-800 bg-slate-900/60 p-2 text-xs">
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0">
-                      <div className="truncate font-medium text-slate-100">{template.name}</div>
-                      <div className="truncate text-[10px] text-slate-500">{template.category}</div>
+              {filteredTemplates.map((template) => {
+                const isRack = template.isRackDevice || !!template.rackUnits
+                return (
+                  <div
+                    key={template.name}
+                    className={`rounded border p-2 text-xs ${
+                      isRack
+                        ? 'border-slate-800 bg-slate-900/60'
+                        : 'border-amber-800/40 bg-amber-950/20'
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-1">
+                          <span className="truncate font-medium text-slate-100">{template.name}</span>
+                          {!isRack && (
+                            <span
+                              className="rounded bg-amber-800/60 px-1 text-[8px] font-semibold uppercase text-amber-200"
+                              title="Nicht als 19”-Rack-Gerät markiert — wird beim Hinzufügen abgefragt."
+                            >
+                              No-HE
+                            </span>
+                          )}
+                        </div>
+                        <div className="truncate text-[10px] text-slate-500">{template.category}</div>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => addTemplate(template)}
+                        className="rounded bg-emerald-700 px-2 py-0.5 text-[11px] hover:bg-emerald-600"
+                      >
+                        + Rack
+                      </button>
                     </div>
-                    <button
-                      type="button"
-                      onClick={() => addTemplate(template)}
-                      className="rounded bg-emerald-700 px-2 py-0.5 text-[11px] hover:bg-emerald-600"
-                    >
-                      + Rack
-                    </button>
+                    <div className="mt-1 text-[10px] text-slate-400">
+                      {isRack ? `${parseUnits(template)} HE · ` : 'HE ? · '}
+                      {template.inputs.length} In · {template.outputs.length} Out
+                    </div>
                   </div>
-                  <div className="mt-1 text-[10px] text-slate-400">
-                    {parseUnits(template)} HE · {template.inputs.length} In · {template.outputs.length} Out
-                  </div>
-                </div>
-              ))}
+                )
+              })}
             </div>
           </div>
 

--- a/src/renderer/components/Settings/SettingsDialog.tsx
+++ b/src/renderer/components/Settings/SettingsDialog.tsx
@@ -161,6 +161,128 @@ const SettingsCard = ({
 
 // --- Tab: Project ----------------------------------------------------------
 
+// v7.9.0 / Issue #122 — Library Export/Import. Erstes Stück eines
+// zentralen Library-Speichers: bisher leben customLibrary +
+// groupPresets in localStorage (pro Electron-Installation). Mit dem
+// Export kann der User die ganze Library als JSON-Datei speichern
+// (Dropbox-sync, Team-Backup, …) und auf einer anderen Installation
+// importieren. Eine echte Datei-pro-Gerät + Versions-Tracking
+// kommt in einer späteren Phase (#122 ist als Roadmap-Issue
+// offen markiert).
+interface LibraryExportFile {
+  type: 'cable-planner-library'
+  version: 1
+  exportedAt: string
+  customLibrary: import('../../types/equipment').EquipmentTemplate[]
+  groupPresets: import('../../types/equipment').GroupPreset[]
+  knownCategories: string[]
+}
+
+const LibraryExportSection = () => {
+  const customLibrary = useProjectStore((s) => s.customLibrary)
+  const groupPresets = useProjectStore((s) => s.groupPresets)
+  const knownCategories = useProjectStore((s) => s.knownCategories)
+  const addCustomTemplates = useProjectStore((s) => s.addCustomTemplates)
+  const setGroupPresets = useProjectStore((s) => s.setGroupPresets)
+  const addKnownCategories = useProjectStore((s) => s.addKnownCategories)
+  const [importBusy, setImportBusy] = useState(false)
+
+  const handleExport = () => {
+    const payload: LibraryExportFile = {
+      type: 'cable-planner-library',
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      customLibrary,
+      groupPresets,
+      knownCategories,
+    }
+    const blob = new Blob([JSON.stringify(payload, null, 2)], {
+      type: 'application/json',
+    })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    const ts = new Date().toISOString().slice(0, 10)
+    a.download = `cable-planner-library-${ts}.json`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  }
+
+  const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    e.target.value = '' // allow re-import of the same file
+    setImportBusy(true)
+    try {
+      const text = await file.text()
+      const data = JSON.parse(text) as LibraryExportFile
+      if (data?.type !== 'cable-planner-library') {
+        window.alert('Diese Datei ist keine cable-planner-Library (falscher type).')
+        return
+      }
+      // Merge-by-name: addCustomTemplates only adds entries whose name
+      // doesn't exist yet. Damit überschreibt der Import nie eigene
+      // Edits am gleichen Template.
+      if (Array.isArray(data.customLibrary)) {
+        addCustomTemplates(data.customLibrary)
+      }
+      if (Array.isArray(data.knownCategories)) {
+        addKnownCategories(data.knownCategories)
+      }
+      // Group-Presets dürfen ebenfalls nur ergänzt werden, nicht
+      // ersetzt — wir kombinieren.
+      if (Array.isArray(data.groupPresets)) {
+        const byId = new Map(groupPresets.map((p) => [p.id, p]))
+        for (const p of data.groupPresets) {
+          if (!byId.has(p.id)) byId.set(p.id, p)
+        }
+        setGroupPresets(Array.from(byId.values()))
+      }
+      window.alert(
+        `Library importiert: ${data.customLibrary?.length ?? 0} Geräte-Templates, ${
+          data.groupPresets?.length ?? 0
+        } Gruppen-Presets (nur neue Einträge — vorhandene wurden NICHT überschrieben).`,
+      )
+    } catch (err) {
+      window.alert(
+        `Import fehlgeschlagen:\n\n${err instanceof Error ? err.message : String(err)}`,
+      )
+    } finally {
+      setImportBusy(false)
+    }
+  }
+
+  return (
+    <SettingsCard
+      title="Library Export / Import (#122)"
+      description="Sichere deine eigenen Geräte-Templates, Gruppen und Rack-Presets als JSON-Datei. Beim Import werden bestehende Einträge mit gleichem Namen NICHT überschrieben (merge-by-name)."
+    >
+      <div className="flex flex-wrap items-center gap-2 text-xs text-slate-200">
+        <button
+          type="button"
+          onClick={handleExport}
+          className="rounded bg-emerald-700 px-3 py-1.5 hover:bg-emerald-600"
+          title={`${customLibrary.length} Geräte + ${groupPresets.length} Gruppen exportieren`}
+        >
+          ⬇ Library exportieren ({customLibrary.length} Geräte, {groupPresets.length} Gruppen)
+        </button>
+        <label className="rounded bg-sky-700 px-3 py-1.5 cursor-pointer hover:bg-sky-600">
+          {importBusy ? 'Importiere…' : '⬆ Library importieren…'}
+          <input
+            type="file"
+            accept="application/json,.json"
+            className="hidden"
+            onChange={handleImport}
+            disabled={importBusy}
+          />
+        </label>
+      </div>
+    </SettingsCard>
+  )
+}
+
 const ProjectTab = ({ onClose: _onClose }: { onClose: () => void }) => {
   const metadata = useProjectStore((s) => s.project.metadata)
   const updateProjectMetadata = useProjectStore((s) => s.updateProjectMetadata)
@@ -326,6 +448,8 @@ const ProjectTab = ({ onClose: _onClose }: { onClose: () => void }) => {
           </div>
         )}
       </SettingsCard>
+
+      <LibraryExportSection />
 
       <div className="flex justify-end gap-2 pt-2">
         <button

--- a/src/renderer/components/Settings/SettingsDialog.tsx
+++ b/src/renderer/components/Settings/SettingsDialog.tsx
@@ -95,14 +95,14 @@ export const SettingsDialog = ({ open, onClose }: SettingsDialogProps) => {
   )
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-6">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-2 sm:p-6">
       <div
         ref={drag.containerRef}
         style={drag.containerStyle}
-        className="flex w-full max-w-4xl overflow-hidden rounded border border-slate-700 bg-slate-900 text-slate-100 shadow-2xl"
+        className="flex max-h-[95vh] min-h-0 w-full max-w-4xl flex-col overflow-hidden rounded border border-slate-700 bg-slate-900 text-slate-100 shadow-2xl sm:flex-row"
       >
-        <aside className="flex w-52 shrink-0 flex-col gap-1 border-r border-slate-800 bg-slate-950/40 p-3">
-          <h3 className="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
+        <aside className="flex shrink-0 flex-row gap-1 overflow-x-auto border-b border-slate-800 bg-slate-950/40 p-3 sm:w-52 sm:flex-col sm:overflow-x-visible sm:border-b-0 sm:border-r">
+          <h3 className="mb-2 hidden px-2 text-xs font-semibold uppercase tracking-wider text-slate-500 sm:block">
             {t('settings.section', 'Einstellungen')}
           </h3>
           {(Object.keys(TAB_ICONS) as SettingsSection[]).map((id) => navItem(id))}

--- a/src/renderer/lib/cableAStar.ts
+++ b/src/renderer/lib/cableAStar.ts
@@ -207,10 +207,17 @@ interface OpenNode {
 
 /** Pack a (col, row, dir) tuple into a single number for fast Map keys.
  *  Assumes col/row stay within ±32767 (1.3M pixels at CELL_SIZE=20 —
- *  plenty for any sane schematic). */
+ *  plenty for any sane schematic).
+ *
+ *  IMPORTANT: do NOT `| 0` the result — bitwise ops truncate to 32-bit
+ *  signed integers (~2.1B). With (col+32768)*262144 the result regularly
+ *  exceeds 2^31 (e.g. col=100 → ~8.6B), which would silently wrap
+ *  around to a negative number, corrupting the closed-set membership
+ *  test and making A* return "no path" for nearly any input.
+ *  JS numbers are safe integers up to 2^53, so plain arithmetic
+ *  handles the packed value without precision loss. */
 const packState = (col: number, row: number, dir: Direction): number =>
-  // ((col + 32768) << 18) | ((row + 32768) << 4) | dir   — bit-packed
-  ((col + 32768) * 0x40000 + (row + 32768) * 16 + dir) | 0
+  (col + 32768) * 0x40000 + (row + 32768) * 16 + dir
 
 /** A* search on the integer grid. Returns null when no path exists
  *  within `maxNodes` expansions. */

--- a/src/renderer/lib/canvasViewport.ts
+++ b/src/renderer/lib/canvasViewport.ts
@@ -63,6 +63,26 @@ export const unlockCanvasInteraction = () => {
   }
 }
 
+// v7.9.0 / Issue #108 — fitView callback. Caller is the docking
+// toggle in LibraryPanel / PropertiesPanel (and in future the
+// floating-panel close button). When the user docks or undocks a
+// side panel the canvas track changes width abruptly; without
+// re-fitting, devices may shift out of view, which the user
+// reported as "canvas verschwindet beim abdocken".
+let fitViewHandler: (() => void) | null = null
+
+export const setCanvasFitViewHandler = (fn: (() => void) | null) => {
+  fitViewHandler = fn
+}
+
+export const triggerCanvasFitView = () => {
+  try {
+    fitViewHandler?.()
+  } catch {
+    /* no-op */
+  }
+}
+
 // v7.8.8 — A*-router callback registered by CanvasArea. The context
 // menu and any other non-canvas caller can ask "please re-route cable
 // X using A*" without needing to live inside the React Flow context.

--- a/src/renderer/lib/exportDevicePdf.ts
+++ b/src/renderer/lib/exportDevicePdf.ts
@@ -161,6 +161,100 @@ const drawColumn = (
  * `exportDevicePatchSheet` so the new batch export can reuse it
  * without duplicating layout logic.
  */
+/** v7.9.0 / Issue #109 — Draws the page header (device name + meta +
+ *  current date/time + horizontal rule). Called once on the first
+ *  page AND repeated on every subsequent page so users can identify
+ *  the printed sheet without flipping back to page 1. */
+const drawPageHeader = (pdf: jsPDF, device: EquipmentItem): number => {
+  const pageWidth = pdf.internal.pageSize.getWidth()
+  const margin = 32
+  pdf.setFontSize(16)
+  pdf.setTextColor(15)
+  pdf.setFont('helvetica', 'bold')
+  pdf.text(device.name || 'Gerät', margin, margin + 4)
+
+  pdf.setFontSize(9)
+  pdf.setFont('helvetica', 'normal')
+  pdf.setTextColor(80)
+  const metaParts: string[] = []
+  if (device.category) metaParts.push(device.category)
+  if (device.subtitle) metaParts.push(device.subtitle)
+  if (device.ipAddress) metaParts.push(`IP ${device.ipAddress}`)
+  pdf.text(metaParts.join('  -'), margin, margin + 20)
+  pdf.text(new Date().toLocaleString(), pageWidth - margin, margin + 20, { align: 'right' })
+
+  pdf.setDrawColor(180)
+  pdf.line(margin, margin + 28, pageWidth - margin, margin + 28)
+  // Return the y-position where content can start.
+  return margin + 48
+}
+
+/** v7.9.0 / Issue #109 — Draws ONE port row in BOTH columns so they
+ *  stay vertically aligned. Returns the y-position AFTER this row.
+ *  When a row would overflow the page, the caller is responsible for
+ *  starting a new page first; this helper just paints. */
+const drawPortRowPair = (
+  pdf: jsPDF,
+  leftRow: { port: Port; cables: CableEndpointSummary[] } | null,
+  rightRow: { port: Port; cables: CableEndpointSummary[] } | null,
+  y: number,
+  leftX: number,
+  rightX: number,
+  colWidth: number,
+): number => {
+  // Determine how tall this row will be on each side, then advance by
+  // the MAX so both sides stay aligned no matter how many cables each
+  // port has.
+  const sideRowHeight = (row: { port: Port; cables: CableEndpointSummary[] } | null): number => {
+    if (!row) return 0
+    let h = 12 // port-name line
+    if (row.cables.length === 0) {
+      h += 11
+    } else {
+      h += row.cables.length * 22 // cable label + target line
+    }
+    return h + 4 // small gap below the row
+  }
+  const rowHeight = Math.max(sideRowHeight(leftRow), sideRowHeight(rightRow))
+
+  const drawSide = (
+    row: { port: Port; cables: CableEndpointSummary[] } | null,
+    x: number,
+  ) => {
+    if (!row) return
+    let cy = y
+    pdf.setTextColor(15)
+    pdf.setFont('helvetica', 'bold')
+    const portLine = `> ${row.port.name || row.port.id}`
+    const portType = row.port.connectorType ? `  [${row.port.connectorType}]` : ''
+    pdf.text(`${portLine}${portType}`, x, cy, { maxWidth: colWidth - 4 })
+    pdf.setFont('helvetica', 'normal')
+    cy += 12
+
+    if (row.cables.length === 0) {
+      pdf.setTextColor(140)
+      pdf.text('  -- frei --', x, cy)
+      return
+    }
+    for (const c of row.cables) {
+      pdf.setTextColor(15)
+      pdf.text(`  -> ${c.cableLabel}`, x, cy, { maxWidth: colWidth - 6 })
+      cy += 11
+      pdf.setTextColor(80)
+      const otherSuffix = c.otherPortConnectorType ? ` [${c.otherPortConnectorType}]` : ''
+      const tgt = c.otherPortName
+        ? `       an ${c.otherDeviceName} - ${c.otherPortName}${otherSuffix}`
+        : `       an ${c.otherDeviceName}`
+      pdf.text(tgt, x, cy, { maxWidth: colWidth - 6 })
+      cy += 11
+    }
+  }
+
+  drawSide(leftRow, leftX)
+  drawSide(rightRow, rightX)
+  return y + rowHeight
+}
+
 const drawDevicePage = (
   pdf: jsPDF,
   device: EquipmentItem,
@@ -172,27 +266,14 @@ const drawDevicePage = (
   const margin = 32
   const pageBottom = pageHeight - margin
 
-  // Header — device name + meta line
-  pdf.setFontSize(16)
-  pdf.setTextColor(15)
-  pdf.text(device.name || 'Gerät', margin, margin + 4)
-
-  pdf.setFontSize(9)
-  pdf.setTextColor(80)
-  const metaParts: string[] = []
-  if (device.category) metaParts.push(device.category)
-  if (device.subtitle) metaParts.push(device.subtitle)
-  if (device.ipAddress) metaParts.push(`IP ${device.ipAddress}`)
-  pdf.text(metaParts.join('  -'), margin, margin + 20)
-  pdf.text(new Date().toLocaleString(), pageWidth - margin, margin + 20, { align: 'right' })
-
-  // Subtle horizontal rule below the header
-  pdf.setDrawColor(180)
-  pdf.line(margin, margin + 28, pageWidth - margin, margin + 28)
+  // Header on page 1
+  let y = drawPageHeader(pdf, device)
 
   // Two-column layout for inputs (left) and outputs (right)
   const gutter = 18
   const colWidth = (pageWidth - margin * 2 - gutter) / 2
+  const leftX = margin
+  const rightX = margin + colWidth + gutter
   const inputRows = collectPortRows(
     device,
     device.inputs ?? [],
@@ -208,27 +289,46 @@ const drawDevicePage = (
     allEquipment,
   )
 
-  const colYStart = margin + 48
-  drawColumn(
-    pdf,
-    `INPUTS (${inputRows.length})`,
-    inputRows,
-    margin,
-    colYStart,
-    colWidth,
-    pageBottom,
-    margin,
-  )
-  drawColumn(
-    pdf,
-    `OUTPUTS (${outputRows.length})`,
-    outputRows,
-    margin + colWidth + gutter,
-    colYStart,
-    colWidth,
-    pageBottom,
-    margin,
-  )
+  // Column titles
+  pdf.setFontSize(11)
+  pdf.setFont('helvetica', 'bold')
+  pdf.setTextColor(20)
+  pdf.text(`INPUTS (${inputRows.length})`, leftX, y)
+  pdf.text(`OUTPUTS (${outputRows.length})`, rightX, y)
+  pdf.setFont('helvetica', 'normal')
+  pdf.setFontSize(9)
+  y += 14
+
+  // Walk both columns in lock-step so inputs and outputs always start
+  // at the SAME y on every page (Issue #109).
+  const rowCount = Math.max(inputRows.length, outputRows.length)
+  for (let i = 0; i < rowCount; i++) {
+    const leftRow = inputRows[i] ?? null
+    const rightRow = outputRows[i] ?? null
+
+    // Estimate row height to decide page break.
+    const estHeight = Math.max(
+      leftRow ? 12 + (leftRow.cables.length === 0 ? 11 : leftRow.cables.length * 22) + 4 : 0,
+      rightRow ? 12 + (rightRow.cables.length === 0 ? 11 : rightRow.cables.length * 22) + 4 : 0,
+    )
+
+    if (y + estHeight > pageBottom) {
+      pdf.addPage()
+      // Repeat header on every new page (Issue #109)
+      y = drawPageHeader(pdf, device)
+      // Repeat column titles too so the user knows what's left/right
+      pdf.setFontSize(11)
+      pdf.setFont('helvetica', 'bold')
+      pdf.setTextColor(20)
+      pdf.text(`INPUTS (${inputRows.length}) - Forts.`, leftX, y)
+      pdf.text(`OUTPUTS (${outputRows.length}) - Forts.`, rightX, y)
+      pdf.setFont('helvetica', 'normal')
+      pdf.setFontSize(9)
+      y += 14
+    }
+
+    y = drawPortRowPair(pdf, leftRow, rightRow, y, leftX, rightX, colWidth)
+  }
 
   // Footer — note about cable colour key
   pdf.setFontSize(7)

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -401,6 +401,13 @@ interface UiState extends PersistedUiState {
   rackEditor: { open: boolean; rackInstanceId?: string }
   openRackEditor: (rackInstanceId: string) => void
   closeRackEditor: () => void
+  /** v7.9.0 / Issue #120 — Trigger that the RackBuilder should open
+   *  seeded with these equipment ids (converted to placements). Null
+   *  when no seed is pending. Set by the canvas "Als Rack speichern"
+   *  toolbar button, consumed by LibraryPanel's RackBuilder mount. */
+  rackBuilderSeedTrigger: string[] | null
+  triggerRackBuilderFromSelection: (equipmentIds: string[]) => void
+  clearRackBuilderSeedTrigger: () => void
   /** v7.8.7 / Issues #106 + #117 — context-menu state for cables.
    *  `cableId` identifies the right-clicked cable; `screenX/screenY` is
    *  where the menu pops up; `flowX/flowY` is the click position in
@@ -634,6 +641,10 @@ export const useUiStore = create<UiState>((set) => ({
   rackEditor: { open: false },
   openRackEditor: (rackInstanceId) => set({ rackEditor: { open: true, rackInstanceId } }),
   closeRackEditor: () => set({ rackEditor: { open: false } }),
+  rackBuilderSeedTrigger: null,
+  triggerRackBuilderFromSelection: (equipmentIds) =>
+    set({ rackBuilderSeedTrigger: equipmentIds.length > 0 ? equipmentIds : null }),
+  clearRackBuilderSeedTrigger: () => set({ rackBuilderSeedTrigger: null }),
   cableContextMenu: { open: false },
   openCableContextMenu: ({ cableId, screenX, screenY, flowX, flowY }) =>
     set({ cableContextMenu: { open: true, cableId, screenX, screenY, flowX, flowY } }),


### PR DESCRIPTION
## Nacht-Cleanup — 10 Issues abgearbeitet

Systematischer Durchlauf der offenen GitHub-Issues. Jedes Item als eigener Commit für saubere Reviewability.

### Bugs gefixt
- **#108** Library abdocken → Canvas verschwindet — FloatingPanelShell mounting clamping + automatischer fitView nach Dock/Undock
- **#119** Ausrichten-Bug — Alignment-Buttons funktionierten nicht (rfNodes-State nicht aktualisiert) + Toolbar erscheint jetzt ab 1+ Gerät (war 2+)

### Features
- **#109** Patch-Sheet Header auf jeder Seite + Inputs/Outputs auf gleicher Höhe gerendert (lock-step Row-Layout)
- **#110** Unified Export-Dialog statt drei einzelner Menüpunkte (Plan als PDF/PNG/JPEG → "Exportieren…" mit Format-Radio)
- **#112** RackBuilder zeigt auch Nicht-Rack-Geräte (mit HE-Prompt beim Hinzufügen)
- **#113** Echter Modi-Editor mit Popup-Dialog — Name + Beschreibung + Inputs/Outputs editierbar bevor gespeichert wird
- **#116** Location-BOM Kabel zusammenfassen — `5× BNC 1m`, `3× BNC 3m` statt einzelner Zeilen, toggle-bar
- **#120** "Als Rack speichern" Button neben "Gruppe speichern" — öffnet RackBuilder vorausgewählt mit Selektion
- **#122 Phase 1** Library Export/Import als JSON — `cable-planner-library-YYYY-MM-DD.json` mit customLibrary + groupPresets + knownCategories. Merge-by-name beim Import schützt eigene Edits.

### Issues geschlossen (per Comment dokumentiert)
- **#98** React #185 — bereits v7.8.1+ behoben mit ErrorBoundary-Hardening
- **#104** Settings nicht scrollbar — v7.8.9 (max-h + responsive Layout)
- **#106** Kabelbrücken — v7.8.9 (DOM-Selector-Fix)
- **#111** Cables in Library erstellen — v7.8.6
- **#117** Kabel-Wegpunkte Rechtsklick — v7.8.7
- **#124** Equipment-Ressourcen pro Mode — durch #113 Editor abgedeckt
- **#76** Roadmap — alle Original-Items erledigt oder eigene Tickets

### Bleibende größere Architektur-Issues (Design-Notiz im Issue)
- **#118** Inline-Toolbar (draw.io-style)
- **#121** Tabs für Rack-Editor (Sub-Projekt-Konzept)
- **#123** Ebenen-Feature (Layers)

Alle drei brauchen jeweils 1-3 Sessions konzentrierte Arbeit; #121 + #123 teilen sich vermutlich ein Multi-View-State-Modell.

## Geprüft

- TypeScript: `npx tsc -p tsconfig.app.json --noEmit` clean
- Vite build: `npx vite build` clean (655+ modules)
- jeder Commit baut für sich allein

## Test plan

Quick smoke test reichweite:
- [x] Settings öffnen → Tab wechseln, dialog passt in viewport, scrollt intern
- [x] Zwei Geräte selektieren → Toolbar zeigt Ausrichten-Buttons aktiv. Klick auf "links" → Geräte alignen sich visuell
- [x] Ein Gerät selektieren → Toolbar erscheint mit Ausrichten-Buttons disabled (Hint im Title)
- [x] Library abdocken → kein "canvas weg" mehr, fitView zeigt Devices
- [x] Patch-Sheet PDF eines Geräts mit vielen Ports → Header auf Seite 2, Inputs+Outputs starten gleich
- [x] Datei-Menü → "Exportieren…" → Dialog mit Format-Wahl + PDF-Theme
- [x] Geräte selektieren → "Als Rack speichern" → RackBuilder öffnet mit Selektion vorbefüllt
- [x] Geräte-Properties → "Betriebsmodi" → "+ Neuer Modus (Editor)" → Form mit Inputs/Outputs-Spalten
- [x] Location BOM → "Kabel zusammenfassen" Checkbox toggelt zwischen detailliert/gruppiert
- [x] RackBuilder → "Auch Nicht-Rack-Geräte zeigen" + Klick auf "+ Rack" → HE-Prompt
- [ ] Settings → Projekt → "⬇ Library exportieren" → JSON-Download
- [ ] Settings → Projekt → "⬆ Library importieren…" → vorhandene werden nicht überschrieben

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH)_