### PR TITLE
fix(annotations): v7.9.4 — React #185 Render-Loop im AnnotationsPanel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.9.3",
+    "version": "7.9.4",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/components/Annotations/AnnotationsPanel.tsx
+++ b/src/renderer/components/Annotations/AnnotationsPanel.tsx
@@ -34,6 +34,8 @@ const ANCHOR_LABEL = (annotation: ProjectAnnotation, deviceNames: Map<string, st
   return ''
 }
 
+const EMPTY_ANNOTATIONS: ProjectAnnotation[] = []
+
 export const AnnotationsPanel = ({
   open,
   onClose,
@@ -41,7 +43,12 @@ export const AnnotationsPanel = ({
   open: boolean
   onClose: () => void
 }) => {
-  const annotations = useProjectStore((s) => s.project.annotations ?? [])
+  // v7.9.3-fix — `?? []` INSIDE der Selector-Funktion erzeugte ein
+  // neues Array bei jedem getSnapshot(); useSyncExternalStore sah
+  // jedes Mal "change" und triggerte Render-Loop (React-Error #185,
+  // gleiche Bug-Klasse wie v7.8.2 hoveredEndpointPortIds). Fix: das
+  // ?? im Component-Scope, mit stabilem Modul-Konstanten-Fallback.
+  const annotations = useProjectStore((s) => s.project.annotations) ?? EMPTY_ANNOTATIONS
   const equipment = useProjectStore((s) => s.project.equipment)
   const cables = useProjectStore((s) => s.project.cables)
   const updateAnnotation = useProjectStore((s) => s.updateAnnotation)


### PR DESCRIPTION
Crash-Report vom User: "React error #185" (Maximum update depth exceeded), ErrorBoundary hat 5 Backups in 11 Sekunden geschrieben.

Root-Cause: gleiche Bug-Klasse wie v7.8.2 hoveredEndpointPortIds — das `?? []` lag INNERHALB der zustand-Selector-Funktion:

    useProjectStore((s) => s.project.annotations ?? [])

`s.project.annotations` ist bei allen Projekten vor v7.9.3 undefined. Der `??` Fallback erzeugt bei jedem getSnapshot()-Aufruf ein neues leeres Array. React's useSyncExternalStore vergleicht den neuen Snapshot mit dem alten via Object.is — `[] !== []` ist true → React denkt der Store hat sich geändert → re-render → neuer Snapshot mit nochmal frischem [] → re-render → … → React #185.

Fix: das `??` ins Component-Scope ziehen, mit Modul-Konstanten- Fallback (stable reference):

    const EMPTY_ANNOTATIONS: ProjectAnnotation[] = []
    const annotations = useProjectStore((s) => s.project.annotations)
                        ?? EMPTY_ANNOTATIONS

Damit cached zustand `undefined` stabil, das `?? EMPTY_ANNOTATIONS` gibt jedes Mal dieselbe Modul-Referenz zurück — keine ghost-changes.

Andere `?? 'editing'` / `?? 0` Selectoren sind safe weil Primitives (String/Number) per Value verglichen werden.