### PR TITLE
feat(ui): alle System-Popups durch themed Dialoge ersetzt + About-Cle…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.9.21",
+    "version": "7.9.22",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -68,6 +68,9 @@ import {
   videoFormatById,
   type VideoFormatId,
 } from './types/videoFormat'
+import { confirmDialog } from './lib/confirmDialog'
+import { promptDialog } from './lib/promptDialog'
+import { infoDialog } from './lib/infoDialog'
 
 export default function App() {
   const project = useProjectStore((state) => state.project)
@@ -331,9 +334,10 @@ export default function App() {
       })
     } catch (error) {
       console.error(`${format.toUpperCase()} export failed:`, error)
-      alert(
-        `${format.toUpperCase()} export failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      )
+      await infoDialog(`${format.toUpperCase()}-Export fehlgeschlagen`, {
+        body: error instanceof Error ? error.message : 'Unbekannter Fehler',
+        tone: 'error',
+      })
     }
   }
 
@@ -342,21 +346,26 @@ export default function App() {
   // Planner und werden beim ersten Mal nach ihrem Namen gefragt.
   const handleExportViewer = async () => {
     if (!hasDesktopBridge) {
-      window.alert('Viewer-Export erfordert die Desktop-App.')
+      await infoDialog('Viewer-Export erfordert die Desktop-App.', { tone: 'warning' })
       return
     }
     try {
       const path = await cablePlannerApi.project.exportViewer(project)
       if (path) {
-        window.alert(
-          `Viewer-Datei gespeichert:\n\n${path}\n\n` +
-            'Sende sie an deine Freelancer/Helfer. Beim Öffnen werden sie nach\n' +
+        await infoDialog('Viewer-Datei gespeichert', {
+          body:
+            `${path}\n\n` +
+            'Sende sie an deine Freelancer/Helfer. Beim Öffnen werden sie nach ' +
             'ihrem Namen gefragt — Anmerkungen sind dann automatisch attributiert.',
-        )
+          tone: 'success',
+        })
       }
     } catch (error) {
       console.error('Viewer export failed:', error)
-      window.alert(`Viewer-Export fehlgeschlagen: ${(error as Error).message}`)
+      await infoDialog('Viewer-Export fehlgeschlagen', {
+        body: (error as Error).message,
+        tone: 'error',
+      })
     }
   }
 
@@ -365,7 +374,7 @@ export default function App() {
   // project.annotations[] hinzu (ID-basierte De-Duplikation).
   const handleImportAnnotations = async () => {
     if (!hasDesktopBridge) {
-      window.alert('Annotations-Re-Import erfordert die Desktop-App.')
+      await infoDialog('Annotations-Re-Import erfordert die Desktop-App.', { tone: 'warning' })
       return
     }
     const result = await cablePlannerApi.project.importAnnotations()
@@ -381,10 +390,12 @@ export default function App() {
       addAnnotation(a as import('./types/project').ProjectAnnotation)
       imported++
     }
-    window.alert(
-      `${imported} neue Anmerkung${imported === 1 ? '' : 'en'} importiert.\n` +
-        `(${incoming.length - imported} bereits vorhanden, übersprungen.)`,
-    )
+    await infoDialog('Annotations importiert', {
+      body:
+        `${imported} neue Anmerkung${imported === 1 ? '' : 'en'} importiert.\n` +
+        `${incoming.length - imported} bereits vorhanden — übersprungen.`,
+      tone: 'success',
+    })
   }
 
   const handleExportPdf = async (theme: 'dark' | 'light' = canvasTheme) => {
@@ -402,7 +413,10 @@ export default function App() {
       })
     } catch (error) {
       console.error('PDF export failed:', error)
-      alert(`PDF export failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
+      await infoDialog('PDF-Export fehlgeschlagen', {
+        body: error instanceof Error ? error.message : 'Unbekannter Fehler',
+        tone: 'error',
+      })
     } finally {
       setPdfExportThemeOverride(null)
     }
@@ -428,7 +442,10 @@ export default function App() {
       printPdfBlob(blob)
     } catch (error) {
       console.error('PDF print failed:', error)
-      alert(`PDF print failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
+      await infoDialog('PDF-Druck fehlgeschlagen', {
+        body: error instanceof Error ? error.message : 'Unbekannter Fehler',
+        tone: 'error',
+      })
     } finally {
       setPdfExportThemeOverride(null)
     }
@@ -446,11 +463,14 @@ export default function App() {
     const meta = project.metadata
     const linkedId = meta.rentmanProjectId
     if (!linkedId) {
-      window.alert('Kein Rentman-Projekt verknüpft. Bitte zuerst in den Einstellungen verknüpfen.')
+      await infoDialog('Kein Rentman-Projekt verknüpft', {
+        body: 'Bitte zuerst in den Einstellungen verknüpfen.',
+        tone: 'warning',
+      })
       return
     }
     const targetName = meta.rentmanProjectName ?? `Projekt #${linkedId}`
-    if (!window.confirm(`Aktuellen Plan als PDF an Rentman-Projekt "${targetName}" anhängen?`)) {
+    if (!(await confirmDialog(`Aktuellen Plan als PDF an Rentman-Projekt "${targetName}" anhängen?`))) {
       return
     }
     try {
@@ -465,11 +485,14 @@ export default function App() {
       const stamp = new Date().toISOString().slice(0, 19).replace(/[:T]/g, '-')
       const fileName = `${baseName}_${stamp}.pdf`
       await addProjectFile(linkedId, fileName, bytes, 'application/pdf')
-      window.alert(`✓ ${fileName} an Rentman angehängt.`)
+      await infoDialog('An Rentman angehängt', {
+        body: `${fileName} wurde dem Projekt "${targetName}" als Anhang hinzugefügt.`,
+        tone: 'success',
+      })
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       console.error('PDF upload to Rentman failed:', err)
-      window.alert(`Fehler beim PDF-Upload:\n\n${msg}`)
+      await infoDialog('Fehler beim PDF-Upload', { body: msg, tone: 'error' })
     }
   }
 
@@ -479,7 +502,7 @@ export default function App() {
    * Rentman quantity. The plan comes from `metadata.rentmanCablePlan`, which
    * is populated by the Rentman import dialog.
    */
-  const createCableWithPlanCheck: typeof createCableFromPending = (draft) => {
+  const createCableWithPlanCheck: typeof createCableFromPending = async (draft) => {
     // Issue #43: warn when either endpoint already has a cable plugged in
     // and offer to delete the existing cable(s) before adding the new one.
     const stateBefore = useProjectStore.getState()
@@ -505,11 +528,14 @@ export default function App() {
         const list = conflicts
           .map((c) => `• ${c.name || `${c.type} ${c.length} m`}`)
           .join('\n')
-        const replace = window.confirm(
-          `An mindestens einem der Ports steckt bereits ein Kabel:\n\n${list}\n\n` +
-            `OK = bestehendes Kabel löschen und neue Verbindung anlegen.\n` +
-            `Abbrechen = neue Verbindung verwerfen, alles bleibt wie es ist.`,
-        )
+        const replace = await confirmDialog('Port bereits belegt', {
+          body:
+            `An mindestens einem der Ports steckt bereits ein Kabel:\n\n${list}\n\n` +
+            `"Ersetzen" = bestehendes Kabel löschen und neue Verbindung anlegen.\n` +
+            `"Abbrechen" = neue Verbindung verwerfen, alles bleibt wie es ist.`,
+          okLabel: 'Ersetzen',
+          destructive: true,
+        })
         if (!replace) {
           stateBefore.closeCableDialog()
           return
@@ -529,9 +555,13 @@ export default function App() {
       .getState()
       .project.cables.filter((c) => c.type === draft.type && c.length === draft.length).length
     if (built > planned) {
-      window.alert(
-        `Warnung: Es sind jetzt ${built} × ${draft.type} ${draft.length} m verbaut, aber nur ${planned} laut Rentman-Plan vorhanden. Bitte zusätzliche Kabel in Rentman buchen oder die Verkabelung anpassen.`,
-      )
+      await infoDialog('Ueber Rentman-Plan hinaus', {
+        body:
+          `Es sind jetzt ${built} x ${draft.type} ${draft.length} m verbaut, ` +
+          `aber nur ${planned} laut Rentman-Plan vorhanden. ` +
+          `Bitte zusaetzliche Kabel in Rentman buchen oder die Verkabelung anpassen.`,
+        tone: 'warning',
+      })
     }
   }
 
@@ -954,13 +984,14 @@ const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoFormat, onC
       ? `Length exceeds recommended maximum of ${effectiveMaxLength} m for ${selected.name}.`
       : null
 
-  const submit = () => {
+  const submit = async () => {
     if (connectorMismatch === 'error' && !overrideWarnings) {
-      if (
-        !window.confirm(
-          `${connectorMessage}\n\nAdd this connection anyway (marked as needing a converter)?`,
-        )
-      ) {
+      const proceed = await confirmDialog('Stecker-Kompatibilität', {
+        body: `${connectorMessage}\n\nVerbindung trotzdem anlegen (markiert als "braucht Konverter")?`,
+        okLabel: 'Trotzdem anlegen',
+        destructive: true,
+      })
+      if (!proceed) {
         return
       }
     }
@@ -1026,10 +1057,10 @@ const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoFormat, onC
                   Connector Type
                   <select
                     value={customConnectorType}
-                    onChange={(e) => {
+                    onChange={async (e) => {
                       const v = e.target.value
                       if (v === '__new__') {
-                        const name = window.prompt('Neuer Stecker-Typ (z.B. "Speakon NL4"):')?.trim()
+                        const name = (await promptDialog('Neuer Stecker-Typ (z.B. "Speakon NL4"):'))?.trim()
                         if (name) {
                           useUiStore.getState().addCustomConnectorType(name)
                           setCustomConnectorType(name as ConnectorType)
@@ -1053,10 +1084,10 @@ const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoFormat, onC
                   Signal Standard
                   <select
                     value={customStandard}
-                    onChange={(e) => {
+                    onChange={async (e) => {
                       const v = e.target.value
                       if (v === '__new__') {
-                        const name = window.prompt('Neuer Signal-Standard (z.B. "Madi 64ch"):')?.trim()
+                        const name = (await promptDialog('Neuer Signal-Standard (z.B. "Madi 64ch"):'))?.trim()
                         if (name) {
                           useUiStore.getState().addCustomSignalStandard(name)
                           setCustomStandard(name as SignalStandard)
@@ -1093,17 +1124,17 @@ const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoFormat, onC
               </label>
               <button
                 type="button"
-                onClick={() => {
+                onClick={async () => {
                   // Issue #64: persist the current Custom Cable as a
                   // reusable type. We prompt for a name (defaulting to
                   // the user's current `name`) and save the spec; the
                   // dialog then switches to the new spec so the user
                   // can see it landed in the dropdown.
                   const proposedName = name.trim() || `${customConnectorType} Custom`
-                  const finalName = window.prompt(
+                  const finalName = (await promptDialog(
                     'Name für den neuen Kabel-Typ:',
                     proposedName,
-                  )?.trim()
+                  ))?.trim()
                   if (!finalName) return
                   const created = useUiStore.getState().addCustomCableSpec({
                     name: finalName,
@@ -1410,10 +1441,10 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
                 Connector Type
                 <select
                   value={customConnectorType}
-                  onChange={(e) => {
+                  onChange={async (e) => {
                     const v = e.target.value
                     if (v === '__new__') {
-                      const name = window.prompt('Neuer Stecker-Typ (z.B. "Speakon NL4"):')?.trim()
+                      const name = (await promptDialog('Neuer Stecker-Typ (z.B. "Speakon NL4"):'))?.trim()
                       if (name) {
                         useUiStore.getState().addCustomConnectorType(name)
                         setCustomConnectorType(name as ConnectorType)
@@ -1437,10 +1468,10 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
                 Signalstandard
                 <select
                   value={customStandard}
-                  onChange={(e) => {
+                  onChange={async (e) => {
                     const v = e.target.value
                     if (v === '__new__') {
-                      const name = window.prompt('Neuer Signal-Standard (z.B. "Madi 64ch"):')?.trim()
+                      const name = (await promptDialog('Neuer Signal-Standard (z.B. "Madi 64ch"):'))?.trim()
                       if (name) {
                         useUiStore.getState().addCustomSignalStandard(name)
                         setCustomStandard(name as SignalStandard)

--- a/src/renderer/ErrorBoundary.tsx
+++ b/src/renderer/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react'
 import { cablePlannerApi } from './lib/bridge'
+import { confirmDialog } from './lib/confirmDialog'
 
 interface State {
   error: Error | null
@@ -347,14 +348,16 @@ export class ErrorBoundary extends Component<Props, State> {
             </button>
             <button
               type="button"
-              onClick={() => {
+              onClick={async () => {
                 if (
-                  !window.confirm(
-                    'WARNUNG: Lokale Daten werden zurückgesetzt.\n\n' +
-                      '✅ Vorher wird eine Sicherheitskopie deines Projekts angelegt\n' +
-                      '   (cable-planner:projectBackup:<Zeit> in localStorage).\n\n' +
-                      'Wirklich zurücksetzen und neu laden?',
-                  )
+                  !(await confirmDialog('Lokale Daten zurücksetzen?', {
+                    body:
+                      'Eine Sicherheitskopie deines Projekts wird vorher angelegt ' +
+                      '(cable-planner:projectBackup:<Zeit> in localStorage).\n\n' +
+                      'Soll wirklich zurückgesetzt und neu geladen werden?',
+                    okLabel: 'Zurücksetzen',
+                    destructive: true,
+                  }))
                 ) {
                   return
                 }

--- a/src/renderer/components/About/AboutDialog.tsx
+++ b/src/renderer/components/About/AboutDialog.tsx
@@ -94,9 +94,7 @@ export const AboutDialog = () => {
           </dl>
 
           <div className="rounded border border-slate-800 bg-slate-950/40 p-3 text-[11px] text-slate-400">
-            Issues + Feature-Wünsche bitte direkt auf GitHub melden. Der Release-Workflow
-            baut Windows EXE + macOS DMG automatisch, sobald ein <code>v*</code>-Tag auf{' '}
-            <code>main</code> gepusht wird.
+            Issues + Feature-Wünsche bitte direkt auf GitHub melden.
           </div>
         </div>
       </div>

--- a/src/renderer/components/Annotations/AnnotationsPanel.tsx
+++ b/src/renderer/components/Annotations/AnnotationsPanel.tsx
@@ -13,6 +13,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { useProjectStore } from '../../store/projectStore'
 import { useUiStore } from '../../store/uiStore'
 import { promptDialog } from '../../lib/promptDialog'
+import { confirmDialog } from '../../lib/confirmDialog'
 import type { ProjectAnnotation } from '../../types/project'
 
 /** v7.9.5 — Custom-Mime-Type für Annotations-Drag-Drop. Canvas-Drop-
@@ -329,8 +330,11 @@ export const AnnotationsPanel = ({
                         </select>
                         <button
                           type="button"
-                          onClick={() => {
-                            if (window.confirm('Anmerkung löschen?')) removeAnnotation(a.id)
+                          onClick={async () => {
+                            if (await confirmDialog('Anmerkung löschen?', {
+                              okLabel: 'Löschen',
+                              destructive: true,
+                            })) removeAnnotation(a.id)
                           }}
                           className="rounded bg-red-900/60 px-1 py-0.5 text-[10px] text-red-200 hover:bg-red-800"
                           title="Anmerkung löschen"

--- a/src/renderer/components/Canvas/CableContextMenu.tsx
+++ b/src/renderer/components/Canvas/CableContextMenu.tsx
@@ -25,6 +25,9 @@ import { useEffect, useRef, useState } from 'react'
 import { useUiStore } from '../../store/uiStore'
 import { useCanvasProjectStore as useProjectStore } from '../../store/projectStoreContext'
 import { routeCable } from '../../lib/canvasViewport'
+import { confirmDialog } from '../../lib/confirmDialog'
+import { promptDialog } from '../../lib/promptDialog'
+import { infoDialog } from '../../lib/infoDialog'
 import type { Cable, CableRouting } from '../../types/cable'
 
 /** Distance from a point to the nearest existing waypoint. Returns the
@@ -140,8 +143,8 @@ export const CableContextMenu = () => {
     close()
   }
 
-  const renameLabel = () => {
-    const next = window.prompt('Kabel-Bezeichnung', cable.name)
+  const renameLabel = async () => {
+    const next = await promptDialog('Kabel-Bezeichnung', cable.name)
     if (next != null && next.trim() !== cable.name) {
       doUpdate({ name: next.trim() })
     } else {
@@ -170,7 +173,10 @@ export const CableContextMenu = () => {
   const rerouteWithAStar = () => {
     const ok = routeCable(cable.id)
     if (!ok) {
-      window.alert('A*-Routing fehlgeschlagen — kein Pfad gefunden (Geräte blockieren?).')
+      void infoDialog('A*-Routing fehlgeschlagen', {
+        body: 'Kein Pfad gefunden — möglicherweise blockieren andere Geräte den Korridor.',
+        tone: 'warning',
+      })
     }
     close()
   }
@@ -195,8 +201,11 @@ export const CableContextMenu = () => {
   const toggleArrowStart = () => doUpdate({ arrowStart: !cable.arrowStart })
   const toggleBidirectional = () => doUpdate({ bidirectional: !cable.bidirectional })
 
-  const removeCable = () => {
-    if (window.confirm(`Kabel "${cable.name}" löschen?`)) {
+  const removeCable = async () => {
+    if (await confirmDialog(`Kabel "${cable.name}" löschen?`, {
+      okLabel: 'Löschen',
+      destructive: true,
+    })) {
       deleteCable(cable.id)
     }
     close()

--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -23,6 +23,7 @@ import {
   useCanvasProjectStore as useProjectStore,
   useCanvasProjectStoreInstance,
 } from '../../store/projectStoreContext'
+import { confirmDialog } from '../../lib/confirmDialog'
 import { useUiStore } from '../../store/uiStore'
 import { ANNOTATION_DRAG_MIME } from '../Annotations/AnnotationsPanel'
 import { AnnotationCanvasOverlay } from '../Annotations/AnnotationCanvasOverlay'
@@ -1254,12 +1255,12 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
           {projectMode === 'finalized' && (
             <button
               type="button"
-              onClick={() => {
+              onClick={async () => {
                 if (
-                  window.confirm(
-                    'Planung wieder zur Bearbeitung freigeben?\n\n' +
-                      'Geräte, Kabel und Layout können dann wieder verändert werden.',
-                  )
+                  await confirmDialog('Planung wieder zur Bearbeitung freigeben?', {
+                    body: 'Geräte, Kabel und Layout können dann wieder verändert werden.',
+                    okLabel: 'Freigeben',
+                  })
                 ) {
                   projectStoreInstance.getState().setProjectMode('editing')
                 }

--- a/src/renderer/components/Canvas/CanvasToolbar.tsx
+++ b/src/renderer/components/Canvas/CanvasToolbar.tsx
@@ -5,6 +5,7 @@ import { useCanvasProjectStore as useProjectStore } from '../../store/projectSto
 import { LENGTH_COLOR_RULES } from '../../lib/cableColors'
 import { RoutingToggle } from '../shared/RoutingToggle'
 import { useDraggablePosition } from '../../hooks/useDraggablePosition'
+import { confirmDialog } from '../../lib/confirmDialog'
 
 type CanvasToolbarMode = 'main' | 'rack'
 
@@ -527,20 +528,21 @@ export const CanvasToolbar = ({ mode = 'main' }: { mode?: CanvasToolbarMode } = 
       <span style={{ ...dividerStyle, marginLeft: 'auto' }} />
       <button
         type="button"
-        onClick={() => {
+        onClick={async () => {
           if (projectMode === 'viewer') return
           if (projectMode === 'finalized') {
-            const ok = window.confirm(
-              'Planung wieder zur Bearbeitung freigeben?\n\n' +
-                'Geräte, Kabel und Layout können dann wieder verändert werden.',
-            )
+            const ok = await confirmDialog('Planung wieder zur Bearbeitung freigeben?', {
+              body: 'Geräte, Kabel und Layout können dann wieder verändert werden.',
+              okLabel: 'Freigeben',
+            })
             if (ok) setProjectMode('editing')
           } else {
-            const ok = window.confirm(
-              'Planung abschließen?\n\n' +
+            const ok = await confirmDialog('Planung abschließen?', {
+              body:
                 'Das Canvas wird gesperrt — keine Verschiebungen, neue Verbindungen ' +
                 'oder Löschungen möglich. Du kannst die Sperre jederzeit wieder aufheben.',
-            )
+              okLabel: 'Abschließen',
+            })
             if (ok) setProjectMode('finalized')
           }
         }}

--- a/src/renderer/components/Library/CableLibraryPanel.tsx
+++ b/src/renderer/components/Library/CableLibraryPanel.tsx
@@ -24,6 +24,7 @@ import { useProjectStore } from '../../store/projectStore'
 import { useUiStore } from '../../store/uiStore'
 import { videoFormatById, pickCableStandardForFormat } from '../../types/videoFormat'
 import { confirmDialog } from '../../lib/confirmDialog'
+import { promptDialog } from '../../lib/promptDialog'
 
 /** v7.8.6 — Editor dialog for creating / editing custom cable specs.
  *  Lives at the bottom of this file. Pure controlled form, no store
@@ -141,8 +142,8 @@ const CableTypeEditor = ({
                 <span>Stecker-Typ</span>
                 <button
                   type="button"
-                  onClick={() => {
-                    const n = window.prompt('Neuer Stecker-Typ (z.B. "Speakon NL4"):')?.trim()
+                  onClick={async () => {
+                    const n = (await promptDialog('Neuer Stecker-Typ (z.B. "Speakon NL4"):'))?.trim()
                     if (n) {
                       addCustomConnectorType(n)
                       setConnectorType(n as ConnectorType)
@@ -208,8 +209,8 @@ const CableTypeEditor = ({
               <span>Signal-Standards</span>
               <button
                 type="button"
-                onClick={() => {
-                  const n = window.prompt('Neuer Signal-Standard (z.B. "Dante Primary"):')?.trim()
+                onClick={async () => {
+                  const n = (await promptDialog('Neuer Signal-Standard (z.B. "Dante Primary"):'))?.trim()
                   if (n) {
                     addCustomSignalStandard(n)
                     setStandards((prev) => [...prev, n as SignalStandard])

--- a/src/renderer/components/Library/LibraryPanel.tsx
+++ b/src/renderer/components/Library/LibraryPanel.tsx
@@ -24,6 +24,7 @@ import { useRentman } from '../../hooks/useRentman'
 import { promptDialog } from '../../lib/promptDialog'
 import { CategorySelect } from '../shared/CategorySelect'
 import { confirmDialog } from '../../lib/confirmDialog'
+import { infoDialog } from '../../lib/infoDialog'
 import { format, useTranslation } from '../../lib/i18n'
 import { suggestPortGroups, type PortGroupHint } from '../../lib/portSuggestions'
 import { getGeminiApiKey, setGeminiApiKey, suggestFromAI } from '../../lib/aiSuggestions'
@@ -808,20 +809,25 @@ export const LibraryPanel = () => {
     if (!linkedRentmanProjectId) return
     const projectName = linkedRentmanProjectName ?? 'aktivem Rentman-Projekt'
     if (
-      !window.confirm(
-        `Gerät "${item.name}" wirklich dem ${projectName} in Rentman hinzufügen?\n\nDas ändert dein Rentman-Projekt und ist nicht automatisch reversibel.`,
-      )
+      !(await confirmDialog(`"${item.name}" zu Rentman hinzufügen?`, {
+        body: `Das ändert dein ${projectName} und ist nicht automatisch reversibel.`,
+        okLabel: 'Hinzufügen',
+      }))
     ) {
       return
     }
     setRentmanCatalogAddBusy(item.id)
     try {
       await addProjectEquipment(linkedRentmanProjectId, item.id, 1)
-      window.alert(`"${item.name}" wurde zu Rentman-Projekt hinzugefügt.`)
+      await infoDialog(`"${item.name}" hinzugefügt`, {
+        body: `Wurde dem Rentman-Projekt "${projectName}" hinzugefügt.`,
+        tone: 'success',
+      })
     } catch (err) {
-      window.alert(
-        `Fehler beim Hinzufügen zu Rentman:\n\n${err instanceof Error ? err.message : String(err)}`,
-      )
+      await infoDialog('Fehler beim Hinzufügen zu Rentman', {
+        body: err instanceof Error ? err.message : String(err),
+        tone: 'error',
+      })
     } finally {
       setRentmanCatalogAddBusy(null)
     }
@@ -1022,7 +1028,10 @@ export const LibraryPanel = () => {
       persistCategory(template)
       addCustomTemplate(template)
       setNetBoxResults((current) => current.filter((entry) => entry.path !== item.path))
-      window.alert(`✓ ${template.name} aus NetBox importiert.`)
+      await infoDialog(`${template.name} importiert`, {
+        body: 'Aus NetBox in die Library übernommen.',
+        tone: 'success',
+      })
     } catch (error) {
       setNetBoxError(error instanceof Error ? error.message : String(error))
     } finally {
@@ -2594,9 +2603,12 @@ export const LibraryPanel = () => {
               </button>
               <button
                 type="button"
-                onClick={() => {
+                onClick={async () => {
                   setNetBoxConflict(null)
-                  window.alert('Lokale Version bleibt unverandert.')
+                  await infoDialog('Lokale Version beibehalten', {
+                    body: 'Die bestehende Library-Version bleibt unverändert.',
+                    tone: 'info',
+                  })
                 }}
                 className="rounded bg-slate-700 px-3 py-1 text-sm hover:bg-slate-600"
               >
@@ -2604,10 +2616,13 @@ export const LibraryPanel = () => {
               </button>
               <button
                 type="button"
-                onClick={() => {
+                onClick={async () => {
                   addCustomTemplate(netBoxConflict.incoming)
                   setNetBoxConflict(null)
-                  window.alert('NetBox-Version wurde ubernommen.')
+                  await infoDialog('NetBox-Version übernommen', {
+                    body: 'Die lokale Version wurde durch die NetBox-Version ersetzt.',
+                    tone: 'success',
+                  })
                 }}
                 className="rounded bg-amber-700 px-3 py-1 text-sm hover:bg-amber-600"
               >
@@ -2636,10 +2651,13 @@ export const LibraryPanel = () => {
         categoryOptions={existingCategoryOptions}
         initialCategory={netBoxMergePair?.incoming.category}
         onCancel={() => setNetBoxMergePair(null)}
-        onConfirm={(merged) => {
+        onConfirm={async (merged) => {
           addCustomTemplate(merged)
           setNetBoxMergePair(null)
-          window.alert('Merge gespeichert.')
+          await infoDialog('Merge gespeichert', {
+            body: 'Die zusammengeführte Version wurde in der Library gespeichert.',
+            tone: 'success',
+          })
         }}
       />
     </aside>

--- a/src/renderer/components/Library/TemplateMergeDialog.tsx
+++ b/src/renderer/components/Library/TemplateMergeDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import type { EquipmentTemplate, Port } from '../../types/equipment'
+import { infoDialog } from '../../lib/infoDialog'
 
 interface TemplateMergeDialogProps {
   open: boolean
@@ -244,11 +245,17 @@ export const TemplateMergeDialog = ({
               const merged = buildMergedTemplate()
               if (!merged) return
               if (!category) {
-                window.alert('Bitte Zielkategorie auswählen.')
+                void infoDialog('Kategorie wählen', {
+                  body: 'Bitte Zielkategorie auswählen.',
+                  tone: 'warning',
+                })
                 return
               }
               if (merged.inputs.length === 0 && merged.outputs.length === 0) {
-                window.alert('Bitte mindestens einen Port auswählen.')
+                void infoDialog('Port wählen', {
+                  body: 'Bitte mindestens einen Port auswählen.',
+                  tone: 'warning',
+                })
                 return
               }
               onConfirm(merged)

--- a/src/renderer/components/Properties/EquipmentProperties.tsx
+++ b/src/renderer/components/Properties/EquipmentProperties.tsx
@@ -23,6 +23,7 @@ import { detectDeviceKind, detectNetworkDevice } from '../../lib/deviceKind'
 import { ModeEditorDialog } from './ModeEditorDialog'
 import { promptDialog } from '../../lib/promptDialog'
 import { confirmDialog } from '../../lib/confirmDialog'
+import { infoDialog } from '../../lib/infoDialog'
 import { useGreenGoBeltpack } from '../../lib/greengoSync'
 import { exportDevicePatchSheet } from '../../lib/exportDevicePdf'
 import { ALL_CONNECTOR_TYPES } from '../../types/equipment'
@@ -222,9 +223,10 @@ const PortList = ({ title, ports, onChange }: PortListProps) => {
       (p) => p.id !== sourcePortId && p.connectorType === 'BNC' && !p.quadLinkGroup,
     )
     if (freeBncPorts.length === 0) {
-      alert(
-        `Quad-Link Set ${g} hat nur ${haveCount}/4 Ports. Es sind keine weiteren freien BNC-Ports verfügbar — bitte zuerst BNC-Ports hinzufügen oder bestehende freigeben.`,
-      )
+      await infoDialog(`Quad-Link Set ${g} unvollständig`, {
+        body: `Hat nur ${haveCount}/4 Ports. Keine weiteren freien BNC-Ports verfügbar — bitte zuerst BNC-Ports hinzufügen oder bestehende freigeben.`,
+        tone: 'warning',
+      })
       return
     }
     const ok = await confirmDialog(
@@ -278,9 +280,10 @@ const PortList = ({ title, ports, onChange }: PortListProps) => {
           )
         }
       } else if (needed > 0) {
-        alert(
-          `Quad-Link Set ${newId} hat ${haveCount}/4 Ports. Bitte weitere BNC-Ports anlegen und ebenfalls dem Set zuweisen.`,
-        )
+        await infoDialog(`Quad-Link Set ${newId} angelegt`, {
+          body: `Hat aktuell ${haveCount}/4 Ports. Bitte weitere BNC-Ports anlegen und ebenfalls dem Set zuweisen.`,
+          tone: 'info',
+        })
       }
       return
     }
@@ -335,10 +338,10 @@ const PortList = ({ title, ports, onChange }: PortListProps) => {
                 <select
                   aria-label="Connector type"
                   value={port.connectorType}
-                  onChange={(event) => {
+                  onChange={async (event) => {
                     const v = event.target.value
                     if (v === '__new__') {
-                      const name = window.prompt('Neuer Stecker-Typ (z.B. "Speakon NL4"):')?.trim()
+                      const name = (await promptDialog('Neuer Stecker-Typ (z.B. "Speakon NL4"):'))?.trim()
                       if (name) {
                         addCustomConnectorType(name)
                         updatePort(port.id, { connectorType: name as ConnectorType, type: name })
@@ -365,10 +368,10 @@ const PortList = ({ title, ports, onChange }: PortListProps) => {
                 <select
                   aria-label="Signal standard"
                   value={port.standard ?? ''}
-                  onChange={(event) => {
+                  onChange={async (event) => {
                     const v = event.target.value
                     if (v === '__new__') {
-                      const name = window.prompt('Neuer Signal-Standard (z.B. "Dante Primary"):')?.trim()
+                      const name = (await promptDialog('Neuer Signal-Standard (z.B. "Dante Primary"):'))?.trim()
                       if (name) {
                         addCustomSignalStandard(name)
                         updatePort(port.id, { standard: name as SignalStandard })
@@ -1150,11 +1153,11 @@ const DeviceModePicker = ({
     setEditorState(null)
   }
 
-  const createModeFromPorts = () => {
-    const name = window.prompt(
+  const createModeFromPorts = async () => {
+    const name = (await promptDialog(
       'Name des neuen Modus (z. B. "12G Single-Link" / "HDMI Output Mode"):',
       `Modus ${modes.length + 1}`,
-    )?.trim()
+    ))?.trim()
     if (!name) return
     const newMode = {
       id: `mode:${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 5)}`,
@@ -1168,21 +1171,21 @@ const DeviceModePicker = ({
     })
   }
 
-  const renameMode = (modeId: string) => {
+  const renameMode = async (modeId: string) => {
     const mode = modes.find((m) => m.id === modeId)
     if (!mode) return
-    const name = window.prompt('Modus-Name:', mode.name)?.trim()
+    const name = (await promptDialog('Modus-Name:', mode.name))?.trim()
     if (!name) return
     updateEquipment(equipment.id, {
       modes: modes.map((m) => (m.id === modeId ? { ...m, name } : m)),
     })
   }
 
-  const editDescription = (modeId: string) => {
+  const editDescription = async (modeId: string) => {
     const mode = modes.find((m) => m.id === modeId)
     if (!mode) return
-    const desc = window.prompt(
-      'Kurze Beschreibung (z. B. "1× 12G IN, 4× HDMI OUT"):',
+    const desc = await promptDialog(
+      'Kurze Beschreibung (z. B. "1x 12G IN, 4x HDMI OUT"):',
       mode.description ?? '',
     )
     if (desc === null) return
@@ -1191,23 +1194,27 @@ const DeviceModePicker = ({
     })
   }
 
-  const deleteMode = (modeId: string) => {
+  const deleteMode = async (modeId: string) => {
     const mode = modes.find((m) => m.id === modeId)
     if (!mode) return
-    if (!window.confirm(`Modus "${mode.name}" löschen? Die zugehörigen Ports bleiben am Gerät erhalten.`)) return
+    if (!(await confirmDialog(`Modus "${mode.name}" löschen?`, {
+      body: 'Die zugehörigen Ports bleiben am Gerät erhalten.',
+      okLabel: 'Löschen',
+      destructive: true,
+    }))) return
     updateEquipment(equipment.id, {
       modes: modes.filter((m) => m.id !== modeId),
       activeModeId: active === modeId ? undefined : active,
     })
   }
 
-  const captureCurrentPortsToMode = (modeId: string) => {
+  const captureCurrentPortsToMode = async (modeId: string) => {
     const mode = modes.find((m) => m.id === modeId)
     if (!mode) return
     if (
-      !window.confirm(
-        `Aktuelles Port-Layout (${equipment.inputs.length} In, ${equipment.outputs.length} Out) als neue Definition für "${mode.name}" speichern?`,
-      )
+      !(await confirmDialog(`Aktuelles Port-Layout als Definition für "${mode.name}" speichern?`, {
+        body: `${equipment.inputs.length} Inputs · ${equipment.outputs.length} Outputs`,
+      }))
     )
       return
     updateEquipment(equipment.id, {
@@ -2093,12 +2100,18 @@ export const EquipmentProperties = () => {
         <div className="flex flex-col gap-1">
           <button
             type="button"
-            onClick={() => {
+            onClick={async () => {
               const existing = customLibrary.find((t) => t.name === equipment.name)
-              const msg = existing
-                ? `"${equipment.name}" existiert bereits in der Bibliothek. Mit den aktuellen Einstellungen dieses Geräts überschreiben?`
-                : `"${equipment.name}" als neue Standard-Vorlage in der Bibliothek speichern?`
-              if (window.confirm(msg)) {
+              const ok = existing
+                ? await confirmDialog(`"${equipment.name}" überschreiben?`, {
+                    body: 'Existiert bereits in der Bibliothek. Mit den aktuellen Einstellungen dieses Geräts überschreiben?',
+                    okLabel: 'Überschreiben',
+                    destructive: true,
+                  })
+                : await confirmDialog(`"${equipment.name}" speichern?`, {
+                    body: 'Als neue Standard-Vorlage in der Bibliothek speichern.',
+                  })
+              if (ok) {
                 saveEquipmentAsTemplate(equipment.id)
               }
             }}
@@ -2121,9 +2134,10 @@ export const EquipmentProperties = () => {
               const trimmed = input.trim()
               if (!trimmed) return
               if (customLibrary.some((t) => t.name === trimmed)) {
-                window.alert(
-                  `"${trimmed}" existiert bereits. Bitte einen anderen Namen wählen oder die bestehende Vorlage überschreiben.`,
-                )
+                await infoDialog(`"${trimmed}" existiert bereits`, {
+                  body: 'Bitte einen anderen Namen wählen oder die bestehende Vorlage überschreiben.',
+                  tone: 'warning',
+                })
                 return
               }
               saveEquipmentAsNewTemplate(equipment.id, trimmed, equipment.category)

--- a/src/renderer/components/Rentman/RentmanImportDialog.tsx
+++ b/src/renderer/components/Rentman/RentmanImportDialog.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import { useTranslation } from '../../lib/i18n'
+import { infoDialog } from '../../lib/infoDialog'
 import { useRentman } from '../../hooks/useRentman'
 import { useProjectStore } from '../../store/projectStore'
 import { matchBlackmagicTemplate } from '../../lib/blackmagicCatalog'
@@ -213,7 +214,10 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
   // (fixes race condition when user clicks back/close before import completes)
   const safeClose = () => {
     if (loading || wizardQueue !== null || mergeQueue.length > 0 || categoryAssignments !== null || conflictItems !== null) {
-      window.alert('Importvorgänge laufen noch. Bitte warten Sie auf den Abschluss.')
+      void infoDialog('Importvorgänge laufen noch', {
+        body: 'Bitte warten Sie auf den Abschluss.',
+        tone: 'info',
+      })
       return
     }
     onClose()
@@ -1222,7 +1226,10 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
               onClick={() => {
                 const hasMissing = categoryAssignments.some((row) => !row.targetCategory.trim())
                 if (hasMissing) {
-                  window.alert('Bitte für jedes Gerät eine bestehende Kategorie wählen.')
+                  void infoDialog('Kategorie fehlt', {
+                    body: 'Bitte für jedes Gerät eine bestehende Kategorie wählen.',
+                    tone: 'warning',
+                  })
                   return
                 }
                 const categoryByName: Record<string, string> = {}

--- a/src/renderer/components/Settings/SettingsDialog.tsx
+++ b/src/renderer/components/Settings/SettingsDialog.tsx
@@ -7,6 +7,7 @@ import { useDraggablePosition } from '../../hooks/useDraggablePosition'
 import { RoutingToggle } from '../shared/RoutingToggle'
 import { pickImageAsDataUri } from '../../lib/readImageAsDataUri'
 import { confirmDialog } from '../../lib/confirmDialog'
+import { infoDialog } from '../../lib/infoDialog'
 import { promptDialog } from '../../lib/promptDialog'
 import { getGeminiApiKey, setGeminiApiKey } from '../../lib/aiSuggestions'
 import { format, useTranslation } from '../../lib/i18n'
@@ -225,7 +226,10 @@ const LibraryExportSection = () => {
       const text = await file.text()
       const data = JSON.parse(text) as LibraryExportFile
       if (data?.type !== 'cable-planner-library') {
-        window.alert('Diese Datei ist keine cable-planner-Library (falscher type).')
+        await infoDialog('Falsches Dateiformat', {
+          body: 'Diese Datei ist keine cable-planner-Library.',
+          tone: 'error',
+        })
         return
       }
       // Merge-by-name: addCustomTemplates only adds entries whose name
@@ -246,15 +250,18 @@ const LibraryExportSection = () => {
         }
         setGroupPresets(Array.from(byId.values()))
       }
-      window.alert(
-        `Library importiert: ${data.customLibrary?.length ?? 0} Geräte-Templates, ${
-          data.groupPresets?.length ?? 0
-        } Gruppen-Presets (nur neue Einträge — vorhandene wurden NICHT überschrieben).`,
-      )
+      await infoDialog('Library importiert', {
+        body:
+          `${data.customLibrary?.length ?? 0} Geräte-Templates · ` +
+          `${data.groupPresets?.length ?? 0} Gruppen-Presets\n\n` +
+          'Nur neue Einträge wurden hinzugefügt — vorhandene Templates bleiben unverändert.',
+        tone: 'success',
+      })
     } catch (err) {
-      window.alert(
-        `Import fehlgeschlagen:\n\n${err instanceof Error ? err.message : String(err)}`,
-      )
+      await infoDialog('Import fehlgeschlagen', {
+        body: err instanceof Error ? err.message : String(err),
+        tone: 'error',
+      })
     } finally {
       setImportBusy(false)
     }
@@ -1654,12 +1661,20 @@ const ConfigsTab = () => {
     try {
       const parsed = JSON.parse(file.content) as { version?: number; library?: DeviceConfigEntry[] }
       if (!parsed.library || !Array.isArray(parsed.library)) {
-        window.alert('Datei enthält kein gültiges Konfigurations-Bundle.')
+        await infoDialog('Ungültiges Konfigurations-Bundle', {
+          body: 'Die Datei enthält kein cable-planner-Konfigurations-Bundle.',
+          tone: 'error',
+        })
         return
       }
-      const replace = window.confirm(
-        `${parsed.library.length} Konfigurationen aus der Datei laden?\n\nOK = bestehende Bibliothek ersetzen\nAbbrechen = neue Konfigurationen anhängen`,
-      )
+      const replace = await confirmDialog(`${parsed.library.length} Konfigurationen laden`, {
+        body:
+          '"Ersetzen" = bestehende Bibliothek wird überschrieben.\n' +
+          '"Anhängen" = neue Konfigurationen werden hinzugefügt, bestehende bleiben.',
+        okLabel: 'Ersetzen',
+        cancelLabel: 'Anhängen',
+        destructive: true,
+      })
       if (replace) {
         replaceDeviceConfigLibrary(parsed.library)
       } else {
@@ -1672,7 +1687,10 @@ const ConfigsTab = () => {
         }
       }
     } catch (err) {
-      window.alert(`Fehler beim Import: ${err instanceof Error ? err.message : String(err)}`)
+      await infoDialog('Fehler beim Import', {
+        body: err instanceof Error ? err.message : String(err),
+        tone: 'error',
+      })
     }
   }
 
@@ -1835,11 +1853,13 @@ const ConfigsTab = () => {
                           </button>
                           <button
                             type="button"
-                            onClick={() => {
+                            onClick={async () => {
                               if (
-                                window.confirm(
-                                  `Konfiguration "${entry.name}" löschen? Die Datei selbst auf der Festplatte bleibt unverändert.`,
-                                )
+                                await confirmDialog(`Konfiguration "${entry.name}" löschen?`, {
+                                  body: 'Die Datei selbst auf der Festplatte bleibt unverändert.',
+                                  okLabel: 'Löschen',
+                                  destructive: true,
+                                })
                               ) {
                                 removeDeviceConfig(entry.id)
                               }
@@ -2013,14 +2033,15 @@ const AdvancedTab = () => {
       return
     try {
       localStorage.removeItem(key)
-      window.alert(
+      await infoDialog(
         format(
-          t(
-            'settings.advanced.caches.cleared',
-            '{label} geleert. Beim nächsten Start wird neu geladen.',
-          ),
+          t('settings.advanced.caches.cleared', '{label} geleert.'),
           { label },
         ),
+        {
+          body: 'Beim nächsten Start wird neu geladen.',
+          tone: 'success',
+        },
       )
     } catch {
       /* ignore */

--- a/src/renderer/hooks/useProject.ts
+++ b/src/renderer/hooks/useProject.ts
@@ -3,6 +3,8 @@ import { cablePlannerApi } from '../lib/bridge'
 import { useProjectStore } from '../store/projectStore'
 import { projectHistory } from '../store/projectHistory'
 import type { CablePlannerProject } from '../types/project'
+import { promptDialog } from '../lib/promptDialog'
+import { infoDialog } from '../lib/infoDialog'
 
 interface OpenProjectResponse {
   filePath: string
@@ -67,12 +69,12 @@ export const useProject = () => {
       if (isViewer) {
         const oldAuthor =
           (incoming as { viewerSession?: { author?: string } })?.viewerSession?.author ?? ''
-        const author = window.prompt(
-          'Du öffnest eine Viewer-Datei zum Begutachten.\n\n' +
-            'Bitte gib deinen Namen ein — er wird allen Anmerkungen\n' +
-            'angeheftet, die du in dieser Session erstellst.',
+        const author = (await promptDialog(
+          'Viewer-Datei — Name eingeben\n\n' +
+            'Du öffnest eine Viewer-Datei zum Begutachten. Bitte gib deinen Namen ' +
+            'ein — er wird allen Anmerkungen angeheftet, die du in dieser Session erstellst.',
           oldAuthor,
-        )?.trim()
+        ))?.trim()
         if (author) {
           ;(incoming as Record<string, unknown>).viewerSession = {
             author,
@@ -80,9 +82,10 @@ export const useProject = () => {
           }
           ;(incoming as Record<string, unknown>).mode = 'viewer'
         } else {
-          window.alert(
-            'Ohne Namen können keine Anmerkungen gemacht werden. Datei wird nicht geladen.',
-          )
+          await infoDialog('Name fehlt', {
+            body: 'Ohne Namen können keine Anmerkungen gemacht werden. Die Datei wird nicht geladen.',
+            tone: 'warning',
+          })
           return
         }
       }

--- a/src/renderer/lib/infoDialog.tsx
+++ b/src/renderer/lib/infoDialog.tsx
@@ -1,0 +1,159 @@
+// v7.9.22 — Promise-basierter Replacement für window.alert().
+// Verwendet das gleiche Modal-Styling wie confirmDialog/promptDialog
+// damit Info-Meldungen sich nicht aus dem dunklen Theme rausreißen.
+//
+//   await infoDialog('Datei gespeichert', { body: 'Pfad: …' })
+//
+// Optional kann `tone` auf 'info' | 'success' | 'warning' | 'error'
+// gesetzt werden — dann wird das Icon + die Accent-Farbe angepasst.
+
+import { useEffect, useRef } from 'react'
+import { createRoot } from 'react-dom/client'
+import { useTranslation } from './i18n'
+
+export type InfoDialogTone = 'info' | 'success' | 'warning' | 'error'
+
+export interface InfoDialogOptions {
+  body?: string
+  /** Body kann auch React-Content sein (z.B. <code>, Links). */
+  bodyNode?: React.ReactNode
+  okLabel?: string
+  tone?: InfoDialogTone
+}
+
+const TONE_ACCENT: Record<InfoDialogTone, { bg: string; border: string; icon: string }> = {
+  info: { bg: '#0ea5e9', border: '#0369a1', icon: 'ℹ' },
+  success: { bg: '#10b981', border: '#059669', icon: '✓' },
+  warning: { bg: '#f59e0b', border: '#b45309', icon: '⚠' },
+  error: { bg: '#dc2626', border: '#991b1b', icon: '⛌' },
+}
+
+export function infoDialog(title: string, options: InfoDialogOptions = {}): Promise<void> {
+  return new Promise((resolve) => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    const done = () => {
+      root.unmount()
+      container.remove()
+      resolve()
+    }
+    root.render(<InfoDialog title={title} options={options} onDone={done} />)
+  })
+}
+
+interface Props {
+  title: string
+  options: InfoDialogOptions
+  onDone: () => void
+}
+
+const InfoDialog = ({ title, options, onDone }: Props) => {
+  const okRef = useRef<HTMLButtonElement>(null)
+  const t = useTranslation()
+  const tone = options.tone ?? 'info'
+  const accent = TONE_ACCENT[tone]
+
+  useEffect(() => {
+    okRef.current?.focus()
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' || e.key === 'Enter') {
+        e.preventDefault()
+        onDone()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onDone])
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 10000,
+      }}
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onDone()
+      }}
+    >
+      <div
+        style={{
+          background: '#1e293b',
+          color: '#e2e8f0',
+          border: `1px solid ${accent.border}`,
+          borderLeft: `4px solid ${accent.bg}`,
+          borderRadius: 8,
+          padding: 16,
+          minWidth: 360,
+          maxWidth: 560,
+          boxShadow: '0 10px 40px rgba(0,0,0,0.5)',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 10,
+            marginBottom: options.body || options.bodyNode ? 8 : 16,
+          }}
+        >
+          <span
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 22,
+              height: 22,
+              borderRadius: '50%',
+              background: accent.bg,
+              color: '#0f172a',
+              fontWeight: 700,
+              fontSize: 12,
+              flexShrink: 0,
+            }}
+          >
+            {accent.icon}
+          </span>
+          <div style={{ fontSize: 14, fontWeight: 600, lineHeight: '22px' }}>{title}</div>
+        </div>
+        {(options.body || options.bodyNode) && (
+          <div
+            style={{
+              marginBottom: 16,
+              fontSize: 13,
+              color: '#cbd5e1',
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+            }}
+          >
+            {options.bodyNode ?? options.body}
+          </div>
+        )}
+        <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <button
+            ref={okRef}
+            type="button"
+            onClick={onDone}
+            style={{
+              padding: '6px 16px',
+              background: accent.bg,
+              border: 'none',
+              borderRadius: 4,
+              color: '#0f172a',
+              cursor: 'pointer',
+              fontSize: 13,
+              fontWeight: 600,
+            }}
+          >
+            {options.okLabel ?? t('common.ok', 'OK')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
…anup

User-Request: "es gibt noch system popup dialoge die nicht dem design entsprechen. passe alle davon dem design an."

Neuer infoDialog (lib/infoDialog.tsx) — Promise-basierter Replacement für window.alert(). Optional tone: 'info' | 'success' | 'warning' | 'error' steuert Akzent-Farbe + Icon (ℹ ✓ ⚠ ⛌), gleicher Styling- Aufbau wie confirmDialog/promptDialog (slate-900, Sky-Border, ESC/ Enter, Backdrop-Click).

Ersetzt ~40 native Popups quer durch die App:

- App.tsx: PDF-Export-Fehler, Viewer-Export, Annotations-Import, Rentman-Upload, Cable-Plan-Warnung, Stecker/Signal-Prompts, Kabel-Typ-Speichern, Port-Replace-Confirm.
- EquipmentProperties.tsx: Quad-Link-Set-Warnings, Stecker-/Signal- Prompts, Modus-CRUD (Create/Rename/Description/Delete/Capture), Library-Save (Standard / Neu), Template-Konflikt.
- SettingsDialog.tsx: Library-Import-Validation + Erfolg/Fehler, Konfig-Bundle-Import (Replace/Append), Cache-Cleared.
- Library/CableLibraryPanel.tsx: Stecker-/Signal-Standard-Prompts.
- Library/LibraryPanel.tsx: Rentman-Hinzufuegen-Confirm + Erfolg/ Fehler, NetBox-Import-Success, NetBox-Konflikt-Resolution (Lokal behalten / NetBox uebernehmen / Merge), Merge-Save-Success.
- Library/TemplateMergeDialog.tsx: Kategorie+Port-Validation.
- Canvas/CableContextMenu.tsx: Rename-Prompt, A*-Failure-Warning, Delete-Confirm.
- Canvas/CanvasArea.tsx: Plan-Unlock-Confirm.
- Canvas/CanvasToolbar.tsx: Plan-Lock + Unlock-Confirms.
- Annotations/AnnotationsPanel.tsx: Delete-Confirm.
- Rentman/RentmanImportDialog.tsx: Busy-Warning, Category-Required.
- ErrorBoundary.tsx: Reset-localStorage-Confirm.
- hooks/useProject.ts: Viewer-Datei-Author-Prompt + Missing-Name-Warning.

Async-Konvertierungen ueberall wo native sync-Popups in non-async Handlern saßen — onClick wird zu async, Aufrufe nutzen await. Bei fire-and-forget infoDialogs (z.B. nach Click) wurde void infoDialog(...) verwendet damit kein unhandled-promise-warning entsteht.

About-Dialog: Release-Workflow-Hinweis entfernt (User-Request).

Version: 7.9.22.

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH