### PR TITLE
fix(print): native Electron-Print statt iframe.print() — repariert de…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.9.26",
+    "version": "7.9.27",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,6 +11,7 @@ import { registerLogIpc } from './ipc/logIpc.js'
 import { registerSyncIpc } from './ipc/syncIpc.js'
 import { registerGraphmlIpc } from './ipc/graphmlIpc.js'
 import { registerMobileShareIpc } from './ipc/mobileShareIpc.js'
+import { registerPrintIpc } from './ipc/printIpc.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -212,6 +213,7 @@ app.whenReady().then(async () => {
   registerSyncIpc()
   registerGraphmlIpc()
   registerMobileShareIpc()
+  registerPrintIpc()
 
   await createWindow()
 

--- a/src/main/ipc/printIpc.ts
+++ b/src/main/ipc/printIpc.ts
@@ -1,0 +1,64 @@
+// v7.9.27 — Native Print-IPC.
+//
+// Hintergrund: printPdfBlob() im Renderer lud das PDF in ein verstecktes
+// iframe und rief iframe.contentWindow.print(). Chromium's PDFium-
+// Viewer rendert manche PDFs im iframe nicht zuverlässig — Folge: der
+// Microsoft-Print-to-PDF Drucker bekommt einen leeren/kaputten Page-
+// Stream und schreibt eine nicht öffenbare Datei.
+//
+// Lösung: PDF-Bytes via IPC ins Main-Process schicken, dort in eine
+// neue Hidden-BrowserWindow laden und webContents.print() aufrufen.
+// Electrons print() steht im Hauptprozess und nutzt Chromium's
+// PrintBackend direkt — robuster als die iframe-Variante.
+
+import { BrowserWindow, app, ipcMain } from 'electron'
+import { writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+export const registerPrintIpc = (): void => {
+  ipcMain.handle('print:pdf-bytes', async (_event, bytes: Uint8Array): Promise<boolean> => {
+    if (!bytes || bytes.byteLength === 0) return false
+    // PDF in tempfile schreiben — file:-URL ist verlaesslicher als data: in Electron
+    const tmpFile = path.join(tmpdir(), `cable-planner-print-${Date.now()}.pdf`)
+    await writeFile(tmpFile, Buffer.from(bytes))
+    return await new Promise<boolean>((resolve) => {
+      const win = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          contextIsolation: true,
+          nodeIntegration: false,
+          // Plugins on damit das PDF im BrowserWindow durch PDFium gerendert wird
+          plugins: true,
+        },
+      })
+      let resolved = false
+      const settle = (ok: boolean) => {
+        if (resolved) return
+        resolved = true
+        try { win.destroy() } catch { /* ignore */ }
+        resolve(ok)
+      }
+      // Sicherheitsnetz: wenn die print-Pipeline hängt, nach 60 s aufgeben
+      const fallbackTimer = setTimeout(() => settle(false), 60_000)
+      win.webContents.on('did-finish-load', () => {
+        // Kurze Pause damit PDFium tatsächlich gerendert hat
+        setTimeout(() => {
+          win.webContents.print({ silent: false }, (success) => {
+            clearTimeout(fallbackTimer)
+            settle(success)
+          })
+        }, 250)
+      })
+      win.webContents.on('did-fail-load', () => {
+        clearTimeout(fallbackTimer)
+        settle(false)
+      })
+      win.loadURL(`file://${tmpFile.replace(/\\/g, '/')}`).catch(() => {
+        clearTimeout(fallbackTimer)
+        settle(false)
+      })
+    })
+  })
+  void app // keep app import — used by other handlers wenn der Pfad geändert wird
+}

--- a/src/main/preload.cts
+++ b/src/main/preload.cts
@@ -99,6 +99,14 @@ contextBridge.exposeInMainWorld('cablePlanner', {
     releaseLock: (dirPath: string, owner: string) =>
       ipcRenderer.invoke('sync:release-lock', dirPath, owner) as Promise<void>,
   },
+  print: {
+    /** v7.9.27 — PDF-Bytes ans Main schicken, das öffnet die in einer
+     *  Hidden-BrowserWindow und ruft webContents.print(). Robuster als
+     *  iframe.contentWindow.print() das Microsoft-Print-to-PDF in
+     *  manchen Fällen kaputte Dateien schreiben lässt. */
+    pdfBytes: (bytes: Uint8Array) =>
+      ipcRenderer.invoke('print:pdf-bytes', bytes) as Promise<boolean>,
+  },
   mobileShare: {
     start: () =>
       ipcRenderer.invoke('mobileShare:start') as Promise<{

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -439,7 +439,7 @@ export default function App() {
         customPalette: exportCustomPalette,
       })
       const blob = new Blob([new Uint8Array(bytes)], { type: 'application/pdf' })
-      printPdfBlob(blob)
+      void printPdfBlob(blob)
     } catch (error) {
       console.error('PDF print failed:', error)
       await infoDialog('PDF-Druck fehlgeschlagen', {

--- a/src/renderer/components/Export/ExportDialog.tsx
+++ b/src/renderer/components/Export/ExportDialog.tsx
@@ -325,7 +325,7 @@ const PatchSheetSection = ({ onClose }: { onClose: () => void }) => {
           devices.length === 1
             ? buildDevicePatchSheetBlob(devices[0], equipment, cables, { format: paper })
             : buildDevicesPatchSheetsBatchBlob(devices, equipment, cables, { format: paper })
-        if (blob) printPdfBlob(blob)
+        if (blob) void printPdfBlob(blob)
       }
       onClose()
     } finally {
@@ -642,7 +642,7 @@ const BomSection = () => {
       y += 14
     }
     const blob = pdf.output('blob') as Blob
-    printPdfBlob(blob)
+    void printPdfBlob(blob)
   }
 
   return (

--- a/src/renderer/components/Print/PrintDialog.tsx
+++ b/src/renderer/components/Print/PrintDialog.tsx
@@ -82,12 +82,12 @@ export const PrintDialog = ({ open, onClose }: PrintDialogProps) => {
             ? buildDevicesPatchSheetsBatchBlob(selectedDevices, equipment, cables, { format })
             : null
         if (blob) {
-          printPdfBlob(blob)
+          void printPdfBlob(blob)
         } else if (mode === 'individual') {
           // Individual prints: each device PDF in its own print job.
           for (const device of selectedDevices) {
             const each = buildDevicePatchSheetBlob(device, equipment, cables, { format })
-            printPdfBlob(each)
+            void printPdfBlob(each)
           }
         }
       } else {

--- a/src/renderer/lib/bridge.ts
+++ b/src/renderer/lib/bridge.ts
@@ -121,6 +121,13 @@ type CablePlannerApi = {
     acquireLock: (dirPath: string, owner: string) => Promise<{ ok: boolean; lockedBy?: string }>
     releaseLock: (dirPath: string, owner: string) => Promise<void>
   }
+  print: {
+    /** v7.9.27 — PDF nativ über Electron-Hauptprozess drucken statt
+     *  iframe.contentWindow.print(). Liefert true wenn der Print-
+     *  Dialog erfolgreich abgeschlossen wurde, false bei Cancel
+     *  oder Fehler. */
+    pdfBytes: (bytes: Uint8Array) => Promise<boolean>
+  }
   mobileShare: {
     start: () => Promise<{ port: number; urls: string[]; hasProject: boolean }>
     stop: () => Promise<{ ok: boolean }>
@@ -514,6 +521,9 @@ const webFallbackApi: CablePlannerApi = {
     exists: async () => false,
     acquireLock: async () => ({ ok: false, lockedBy: undefined }),
     releaseLock: async () => {},
+  },
+  print: {
+    pdfBytes: async () => false,
   },
   mobileShare: {
     start: async () => {

--- a/src/renderer/lib/printPdfBlob.ts
+++ b/src/renderer/lib/printPdfBlob.ts
@@ -1,9 +1,18 @@
-// v7.9.4 — Open a freshly built PDF blob in a hidden iframe and trigger the
-// browser/Electron print dialog. Closest we get to real native printing
-// without bundling a platform-specific print driver: the OS dialog appears
-// with the real printer list, paper sizes, copies + orientation.
+// v7.9.27 — Hybrid print: native Electron print path im Desktop, iframe-
+// Fallback im Browser. Hintergrund: iframe.contentWindow.print() bricht
+// bei manchen jsPDF-Outputs (z.B. wenn der Microsoft-Print-to-PDF
+// Drucker ausgewählt wird), weil Chromium's PDFium-Viewer im iframe
+// das PDF nicht zuverlässig an die Print-Pipeline weiterreicht und
+// eine leere/kaputte Datei rauskommt ("Die Datei kann nicht geöffnet
+// werden. Etwas hat nicht funktioniert.").
+// Lösung: In Electron schicken wir die PDF-Bytes per IPC ans Main-
+// Process, das lädt sie in eine Hidden-BrowserWindow und ruft
+// webContents.print() direkt — Chromium's Print-Backend bekommt das
+// PDF dann sauber gerendert.
 
-export const printPdfBlob = (pdfBlob: Blob): void => {
+import { cablePlannerApi, hasDesktopBridge } from './bridge'
+
+const printViaIframe = (pdfBlob: Blob): void => {
   const url = URL.createObjectURL(pdfBlob)
   const iframe = document.createElement('iframe')
   iframe.style.position = 'fixed'
@@ -21,10 +30,26 @@ export const printPdfBlob = (pdfBlob: Blob): void => {
     } catch {
       /* fall back silently */
     }
-    // Revoke after a delay so the print job isn't cut off mid-stream.
     window.setTimeout(() => {
       document.body.removeChild(iframe)
       URL.revokeObjectURL(url)
     }, 60_000)
   }
+}
+
+export const printPdfBlob = async (pdfBlob: Blob): Promise<void> => {
+  if (hasDesktopBridge) {
+    try {
+      const buffer = await pdfBlob.arrayBuffer()
+      const bytes = new Uint8Array(buffer)
+      await cablePlannerApi.print.pdfBytes(bytes)
+      return
+    } catch {
+      // Native path fehlgeschlagen — fallback auf iframe damit der User
+      // wenigstens irgendwie drucken kann.
+      printViaIframe(pdfBlob)
+      return
+    }
+  }
+  printViaIframe(pdfBlob)
 }


### PR DESCRIPTION
…fekte PDFs

Hintergrund: Über den Drucken-Dialog → "Microsoft Print to PDF" entstand eine kaputte PDF ("Die Datei kann nicht geöffnet werden. Etwas hat nicht funktioniert."). Ursache: printPdfBlob() lud das PDF in ein verstecktes iframe und rief iframe.contentWindow.print() — Chromium's PDFium-Viewer im iframe gibt das PDF nicht zuverlässig an die Print-Pipeline weiter, sodass der Microsoft-PDF-Drucker einen leeren/kaputten Page-Stream bekommt.

Lösung: Neuer IPC-Channel 'print:pdf-bytes' im Main-Process. Renderer schickt die PDF-Bytes, Main lädt sie in eine Hidden-BrowserWindow via file:-URL und ruft webContents.print() direkt — Chromium's Print-Backend bekommt das PDF dann sauber gerendert. Iframe-Pfad bleibt als Fallback für Browser/Web-Kontext erhalten.

Bumps version 7.9.26 → 7.9.27.

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH