### PR TITLE
refactor: zentrale Drag-MIME-Konstanten (lib/dragDropMimes.ts)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.9.40",
+    "version": "7.9.41",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/components/Annotations/AnnotationsPanel.tsx
+++ b/src/renderer/components/Annotations/AnnotationsPanel.tsx
@@ -16,9 +16,9 @@ import { promptDialog } from '../../lib/promptDialog'
 import { confirmDialog } from '../../lib/confirmDialog'
 import type { ProjectAnnotation } from '../../types/project'
 
-/** v7.9.5 — Custom-Mime-Type für Annotations-Drag-Drop. Canvas-Drop-
- *  Handler erkennt diesen Typ und re-anchort die Annotation. */
-export const ANNOTATION_DRAG_MIME = 'application/cable-planner-annotation'
+// v7.9.41 — Re-export für Backward-Kompatibilität. Source-of-Truth ist
+// jetzt lib/dragDropMimes.ts (alle Canvas-Drag-MIMEs zentral).
+export { MIME_ANNOTATION as ANNOTATION_DRAG_MIME } from '../../lib/dragDropMimes'
 
 /** v7.9.5 — Liefert den effektiven Author-Namen für neue Annotations.
  *  Promptet den User wenn noch keiner gesetzt ist (kein 'Anonym'!).

--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -26,7 +26,12 @@ import {
 import { confirmDialog } from '../../lib/confirmDialog'
 import { EQUIPMENT_LAYOUT } from '../../lib/layoutConstants'
 import { useUiStore } from '../../store/uiStore'
-import { ANNOTATION_DRAG_MIME } from '../Annotations/AnnotationsPanel'
+import {
+  MIME_ANNOTATION as ANNOTATION_DRAG_MIME,
+  MIME_EQUIPMENT,
+  MIME_GROUP_PRESET,
+  MIME_RACK_PRESET,
+} from '../../lib/dragDropMimes'
 import { AnnotationCanvasOverlay } from '../Annotations/AnnotationCanvasOverlay'
 import type { EquipmentItem, EquipmentTemplate } from '../../types/equipment'
 import type { Cable } from '../../types/cable'
@@ -994,7 +999,7 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
       // v7.9.15 — Rack-Preset-Drop. Wenn ein Black-Box-Rack aus der
       // Library-Racks-Tab gezogen wird, fügen wir es als ein einziges
       // Equipment-Item (Black-Box) am Drop-Punkt ein.
-      const rackPresetId = event.dataTransfer.getData('application/cable-planner-rack-preset')
+      const rackPresetId = event.dataTransfer.getData(MIME_RACK_PRESET)
       if (rackPresetId) {
         if (mode === 'rack') return
         const px = snapX(position.x)
@@ -1005,7 +1010,7 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
       // v7.9.16 — Group-Preset-Drop (Non-Rack-Gruppen). Funktioniert wie
       // der Platzieren-Button: spawn die Geräte mit Internal-Cables am
       // Drop-Punkt (placeGroupPreset).
-      const groupPresetId = event.dataTransfer.getData('application/cable-planner-group-preset')
+      const groupPresetId = event.dataTransfer.getData(MIME_GROUP_PRESET)
       if (groupPresetId) {
         if (mode === 'rack') return
         const px = snapX(position.x)
@@ -1014,7 +1019,7 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
         return
       }
 
-      const payload = event.dataTransfer.getData('application/cable-planner-equipment')
+      const payload = event.dataTransfer.getData(MIME_EQUIPMENT)
       if (!payload) {
         return
       }

--- a/src/renderer/components/Library/LibraryItem.tsx
+++ b/src/renderer/components/Library/LibraryItem.tsx
@@ -2,6 +2,7 @@ import type { EquipmentTemplate } from '../../types/equipment'
 import { useProjectStore } from '../../store/projectStore'
 import { clearCanvasSelection } from '../../lib/canvasViewport'
 import { stampDeviceLibraryRef } from '../../lib/librarySync'
+import { MIME_EQUIPMENT } from '../../lib/dragDropMimes'
 
 interface LibraryItemProps {
   item: EquipmentTemplate
@@ -33,7 +34,7 @@ export const LibraryItem = ({
     // platzierte Gerät. Update-Prompt beim Projekt-Öffnen vergleicht
     // gegen den dann aktuellen Folder-Stand.
     const payload = JSON.stringify(stampDeviceLibraryRef(item))
-    event.dataTransfer.setData('application/cable-planner-equipment', payload)
+    event.dataTransfer.setData(MIME_EQUIPMENT, payload)
     event.dataTransfer.effectAllowed = 'copy'
   }
 

--- a/src/renderer/components/Library/LibraryPanel.tsx
+++ b/src/renderer/components/Library/LibraryPanel.tsx
@@ -48,6 +48,11 @@ import {
 } from '../../lib/itemExport'
 import { openLibraryFolder, stampDeviceLibraryRef } from '../../lib/librarySync'
 import { hasDesktopBridge } from '../../lib/bridge'
+import {
+  MIME_EQUIPMENT,
+  MIME_GROUP_PRESET,
+  MIME_RACK_PRESET,
+} from '../../lib/dragDropMimes'
 import { CableLibraryPanel } from './CableLibraryPanel'
 
 const connectorOptions = ALL_CONNECTOR_TYPES
@@ -1485,13 +1490,13 @@ export const LibraryPanel = () => {
                     cat={cat}
                     manualSort={librarySortMode === 'manual'}
                     onDragOverTemplate={(event) => {
-                      if (event.dataTransfer.types.includes('application/cable-planner-equipment')) {
+                      if (event.dataTransfer.types.includes(MIME_EQUIPMENT)) {
                         event.preventDefault()
                         event.dataTransfer.dropEffect = 'move'
                       }
                     }}
                     onDropTemplate={(event) => {
-                      const raw = event.dataTransfer.getData('application/cable-planner-equipment')
+                      const raw = event.dataTransfer.getData(MIME_EQUIPMENT)
                       if (!raw) return
                       try {
                         const tpl = JSON.parse(raw) as EquipmentTemplate
@@ -1908,7 +1913,7 @@ export const LibraryPanel = () => {
                                 inputs: [],
                                 outputs: [],
                               }
-                              event.dataTransfer.setData('application/cable-planner-equipment', JSON.stringify(template))
+                              event.dataTransfer.setData(MIME_EQUIPMENT, JSON.stringify(template))
                               event.dataTransfer.effectAllowed = 'copy'
                             }
                             return (
@@ -2126,7 +2131,7 @@ export const LibraryPanel = () => {
                           key={preset.id}
                           id={preset.id}
                           nativeDragData={{
-                            mime: 'application/cable-planner-group-preset',
+                            mime: MIME_GROUP_PRESET,
                             data: preset.id,
                           }}
                           onCardClick={() => placeGroupPreset(preset.id, cx, cy)}
@@ -2228,7 +2233,7 @@ export const LibraryPanel = () => {
                       key={preset.id}
                       id={preset.id}
                       nativeDragData={{
-                        mime: 'application/cable-planner-rack-preset',
+                        mime: MIME_RACK_PRESET,
                         data: preset.id,
                       }}
                       onCardClick={() => insertBlackBoxRack(preset.id, cx, cy)}

--- a/src/renderer/lib/dragDropMimes.ts
+++ b/src/renderer/lib/dragDropMimes.ts
@@ -1,0 +1,19 @@
+// v7.9.41 — Zentrale Registry für HTML5-Drag-MIME-Types.
+//
+// Vorher waren die MIME-Strings an 5+ Stellen als String-Literal
+// dupliziert ("application/cable-planner-equipment" etc.). Tippfehler
+// in einem getData/setData hätten die Drop-Erkennung lautlos kaputt
+// gemacht ohne TypeScript-Fehler. Jetzt einmal hier definiert, überall
+// importieren.
+
+/** Equipment-Template aus der Library auf den Canvas droppen. */
+export const MIME_EQUIPMENT = 'application/cable-planner-equipment'
+
+/** Group-Preset (mehrere Geräte + interne Kabel) auf den Canvas droppen. */
+export const MIME_GROUP_PRESET = 'application/cable-planner-group-preset'
+
+/** Rack-Preset (= Group-Preset mit rack-Feld) auf den Canvas droppen. */
+export const MIME_RACK_PRESET = 'application/cable-planner-rack-preset'
+
+/** Annotation aus dem Annotations-Panel auf den Canvas droppen. */
+export const MIME_ANNOTATION = 'application/cable-planner-annotation'


### PR DESCRIPTION
Vorher waren die MIME-Strings ("application/cable-planner-equipment" etc.) an 5+ Stellen als String-Literal dupliziert. Tippfehler in einem getData/setData hätte die Drop-Erkennung lautlos kaputt gemacht ohne TypeScript-Fehler.

Jetzt: lib/dragDropMimes.ts exportiert MIME_EQUIPMENT, MIME_GROUP_PRESET, MIME_RACK_PRESET, MIME_ANNOTATION. Alle Call-Sites importieren von dort. ANNOTATION_DRAG_MIME bleibt als re-export erhalten damit die existierenden Imports nicht brechen.

Bumps version 7.9.40 → 7.9.41.

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH