### PR TITLE
feat(atem): OpenSwitcher-style Live-Read/Write für Audio-Routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.9.51",
+    "version": "7.9.52",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/main/ipc/atemIpc.ts
+++ b/src/main/ipc/atemIpc.ts
@@ -237,4 +237,177 @@ export const registerAtemIpc = () => {
       return { applied }
     },
   )
+
+  // v7.9.52 — OpenSwitcher-style Live-Audio-Routing.
+  //
+  // Liest den vollständigen Audio-State live aus dem aktuellen Switcher und
+  // gibt ihn im AtemAudioConfig-Format zurück (kompatibel zum XML-Flow,
+  // sodass das gleiche UI beide Quellen verarbeiten kann). Anders als
+  // der XML-Pfad, der nur eine offline gespeicherte ATEM-Profile-XML
+  // patcht, holt das hier den TATSÄCHLICHEN aktuellen Zustand.
+  //
+  // atem-connection legt den State unter atem.state.audio (Classic) /
+  // atem.state.fairlight + atem.state.fairlight.audioRouting (Matrix
+  // auf Extreme/Constellation). Wir mappen direkt darauf.
+  ipcMain.handle('atem:read-audio-config', async () => {
+    if (!atem || atem.status !== AtemConnectionStatus.CONNECTED) {
+      throw new Error('ATEM not connected')
+    }
+    const state = atem.state
+    if (!state) return null
+
+    // Input-Labels (gleiche Quelle wie summarizeState)
+    const inputLabels: Record<number, { shortName: string; longName: string; externalPortType?: string }> = {}
+    for (const [idStr, input] of Object.entries(state.inputs ?? {})) {
+      if (!input) continue
+      const id = Number(idStr)
+      inputLabels[id] = {
+        shortName: input.shortName ?? '',
+        longName: input.longName ?? '',
+        externalPortType: input.internalPortType?.toString(),
+      }
+    }
+
+    // Classic Mixer (state.audio.channels)
+    let classic:
+      | {
+          programOutGain: number
+          programOutBalance: number
+          programOutFollowFadeToBlack: boolean
+          audioFollowVideoCrossfadeTransition: boolean
+          inputs: Array<{
+            id: number
+            mixOption: 'Off' | 'On' | 'AudioFollowVideo'
+            gain: number | null
+            balance: number
+          }>
+        }
+      | undefined
+    if (state.audio?.channels) {
+      const inputs: Array<{ id: number; mixOption: 'Off' | 'On' | 'AudioFollowVideo'; gain: number | null; balance: number }> = []
+      for (const [idStr, channel] of Object.entries(state.audio.channels)) {
+        if (!channel) continue
+        const mixOption = channel.mixOption === 0 ? 'Off' : channel.mixOption === 1 ? 'On' : 'AudioFollowVideo'
+        inputs.push({
+          id: Number(idStr),
+          mixOption,
+          gain: Number.isFinite(channel.gain) ? channel.gain : null,
+          balance: channel.balance,
+        })
+      }
+      classic = {
+        programOutGain: state.audio.master?.gain ?? 0,
+        programOutBalance: state.audio.master?.balance ?? 0,
+        programOutFollowFadeToBlack: state.audio.master?.followFadeToBlack ?? false,
+        audioFollowVideoCrossfadeTransition:
+          (state.audio as unknown as { audioFollowVideoCrossfadeTransition?: boolean })
+            .audioFollowVideoCrossfadeTransition ?? false,
+        inputs,
+      }
+    }
+
+    // Fairlight Audio Routing Matrix (Extreme/Constellation)
+    let matrix: { sources: Array<{ id: number; name: string }>; outputs: Array<{ id: number; sourceId: number; name: string }> } | undefined
+    const routing = state.fairlight?.audioRouting
+    if (routing) {
+      const sources = Object.entries(routing.sources ?? {}).map(([id, s]) => ({
+        id: Number(id),
+        name: (s as { name?: string })?.name ?? `Source ${id}`,
+      }))
+      const outputs = Object.entries(routing.outputs ?? {}).map(([id, o]) => {
+        const out = o as { sourceId?: number | bigint; name?: string }
+        const srcId = typeof out.sourceId === 'bigint' ? Number(out.sourceId) : out.sourceId ?? 0
+        return { id: Number(id), sourceId: srcId, name: out.name ?? `Output ${id}` }
+      })
+      matrix = { sources, outputs }
+    }
+
+    return {
+      classicMixer: classic,
+      matrix,
+      inputLabels,
+    }
+  })
+
+  // v7.9.52 — Sendet ein bearbeitetes AtemAudioConfig an den Switcher.
+  // Nur die jeweils befüllten Sections werden gepusht (Matrix UND/ODER
+  // Classic UND/ODER Labels). Keine Validierung gegen Mixer-Capabilities —
+  // wenn etwas nicht unterstützt wird, fängt atem-connection den Fehler
+  // und wir loggen ihn ins event-Log; gesendet wird trotzdem alles.
+  ipcMain.handle(
+    'atem:apply-audio-config',
+    async (
+      _event,
+      config: {
+        matrix?: { outputs: Array<{ id: number; sourceId: number }> }
+        classicMixer?: {
+          inputs: Array<{
+            id: number
+            mixOption: 'Off' | 'On' | 'AudioFollowVideo'
+            gain: number | null
+            balance: number
+          }>
+        }
+        inputLabels?: Record<number, { shortName: string; longName: string }>
+      },
+    ): Promise<{ matrixApplied: number; classicApplied: number; labelsApplied: number }> => {
+      if (!atem || atem.status !== AtemConnectionStatus.CONNECTED) {
+        throw new Error('ATEM not connected')
+      }
+      let matrixApplied = 0
+      let classicApplied = 0
+      let labelsApplied = 0
+
+      if (config.inputLabels) {
+        for (const [idStr, label] of Object.entries(config.inputLabels)) {
+          try {
+            await atem.setInputSettings(
+              { longName: label.longName.slice(0, 20), shortName: label.shortName.slice(0, 4) },
+              Number(idStr),
+            )
+            labelsApplied += 1
+          } catch (err) {
+            pushEvent(`Label-Push ${idStr} failed: ${(err as Error).message}`)
+          }
+        }
+      }
+
+      if (config.classicMixer) {
+        for (const input of config.classicMixer.inputs) {
+          try {
+            await atem.setClassicAudioMixerInputProps(input.id, {
+              mixOption: input.mixOption === 'Off' ? 0 : input.mixOption === 'On' ? 1 : 2,
+              gain: input.gain ?? -Infinity,
+              balance: input.balance,
+            })
+            classicApplied += 1
+          } catch (err) {
+            pushEvent(`Classic input ${input.id} failed: ${(err as Error).message}`)
+          }
+        }
+      }
+
+      if (config.matrix) {
+        for (const output of config.matrix.outputs) {
+          try {
+            // setFairlightAudioRoutingOutputProperties nimmt outputId als
+            // erstes Argument; das war historisch die "sourceId" — der
+            // Parameter-Name in der atem-connection API ist verwirrend
+            // benannt, gemeint ist die ID des Outputs (= AROC index).
+            await atem.setFairlightAudioRoutingOutputProperties(output.id, {
+              sourceId: BigInt(output.sourceId),
+            } as unknown as Partial<{ sourceId: number; name: string }>)
+            matrixApplied += 1
+          } catch (err) {
+            pushEvent(`Matrix output ${output.id} failed: ${(err as Error).message}`)
+          }
+        }
+      }
+
+      pushEvent(
+        `Applied audio config: matrix=${matrixApplied}, classic=${classicApplied}, labels=${labelsApplied}`,
+      )
+      return { matrixApplied, classicApplied, labelsApplied }
+    },
+  )
 }

--- a/src/main/preload.cts
+++ b/src/main/preload.cts
@@ -70,6 +70,23 @@ contextBridge.exposeInMainWorld('cablePlanner', {
       ipcRenderer.invoke('atem:get-status') as Promise<{ connected: boolean; ip: string | null }>,
     applyMvConfig: (config: unknown) =>
       ipcRenderer.invoke('atem:apply-mv-config', config) as Promise<{ applied: number }>,
+    /** v7.9.52 — Liest Live-Audio-State (Fairlight Matrix + Classic Mixer
+     *  + Input-Labels) als AtemAudioConfig vom verbundenen ATEM. */
+    readAudioConfig: () =>
+      ipcRenderer.invoke('atem:read-audio-config') as Promise<{
+        matrix?: { sources: Array<{ id: number; name: string }>; outputs: Array<{ id: number; sourceId: number; name: string }> }
+        classicMixer?: unknown
+        inputLabels?: Record<number, { shortName: string; longName: string; externalPortType?: string }>
+      } | null>,
+    /** v7.9.52 — Push einer kompletten oder partiellen AtemAudioConfig
+     *  zurück an den verbundenen ATEM. Zählt erfolgreich gesendete
+     *  Commands pro Sektion. */
+    applyAudioConfig: (config: unknown) =>
+      ipcRenderer.invoke('atem:apply-audio-config', config) as Promise<{
+        matrixApplied: number
+        classicApplied: number
+        labelsApplied: number
+      }>,
     onEvent: (cb: (line: string) => void) => {
       const listener = (_event: unknown, line: string) => cb(line)
       ipcRenderer.on('atem:event', listener)

--- a/src/renderer/components/Atem/AtemAudioRouterDialog.tsx
+++ b/src/renderer/components/Atem/AtemAudioRouterDialog.tsx
@@ -4,6 +4,8 @@ import { useProjectStore } from '../../store/projectStore'
 import { useDraggablePosition } from '../../hooks/useDraggablePosition'
 import { downloadBlob } from '../../lib/downloadBlob'
 import { LIMITS } from '../../lib/layoutConstants'
+import { cablePlannerApi, hasDesktopBridge } from '../../lib/bridge'
+import { infoDialog } from '../../lib/infoDialog'
 import type {
   AtemAudioConfig,
   AtemClassicAudioInput,
@@ -75,6 +77,28 @@ export const AtemAudioRouterDialog = () => {
     setActiveTab('matrix')
   }, [open, equipment])
 
+  // v7.9.52 — Live-Connection-Status für die OpenSwitcher-style
+  // Read/Push-Buttons. Wird beim Dialog-Open + alle 4s gepollt.
+  const [atemConnected, setAtemConnected] = useState(false)
+  useEffect(() => {
+    if (!open) return
+    let stopped = false
+    const refresh = async () => {
+      try {
+        const st = await cablePlannerApi.atem.getStatus()
+        if (!stopped) setAtemConnected(!!st?.connected)
+      } catch {
+        if (!stopped) setAtemConnected(false)
+      }
+    }
+    void refresh()
+    const id = window.setInterval(refresh, 4000)
+    return () => {
+      stopped = true
+      window.clearInterval(id)
+    }
+  }, [open])
+
   if (!open || !equipment) return null
 
   const handleLoadXml = () => {
@@ -123,6 +147,100 @@ export const AtemAudioRouterDialog = () => {
     if (!draft) return
     updateEquipment(equipment.id, { atemAudioConfig: draft })
     close()
+  }
+
+  // v7.9.52 — OpenSwitcher-Style: liest den aktuellen Audio-Zustand
+  // direkt vom verbundenen ATEM (Matrix + Classic + Input-Labels), ohne
+  // Umweg über das Profile-XML.
+  const handleReadFromAtem = async () => {
+    if (!atemConnected) {
+      await infoDialog('ATEM nicht verbunden', {
+        body: 'Verbinde dich zuerst mit dem ATEM (Hauptdialog "ATEM Mischer").',
+        tone: 'warning',
+      })
+      return
+    }
+    setBusy(true)
+    setErrorMsg('')
+    try {
+      const live = await cablePlannerApi.atem.readAudioConfig()
+      if (!live || (!live.matrix && !live.classicMixer)) {
+        await infoDialog('Keine Audio-Daten', {
+          body: 'Der verbundene ATEM hat weder eine Routing-Matrix noch einen Classic-Mixer im State. Manche Mini-Modelle haben gar kein editierbares Audio-Routing.',
+          tone: 'warning',
+        })
+        return
+      }
+      // raws aus Draft beibehalten (XML-Round-Trip kompatibilität), nur
+      // matrix/classicMixer/inputLabels überschreiben.
+      const merged: AtemAudioConfig = {
+        ...(draft ?? {}),
+        matrix: live.matrix ?? draft?.matrix,
+        classicMixer: live.classicMixer ?? draft?.classicMixer,
+        inputLabels: live.inputLabels ?? draft?.inputLabels,
+      }
+      setDraft(merged)
+      setActiveTab('matrix')
+      await infoDialog('Audio-Config vom ATEM geladen', {
+        body: [
+          live.matrix ? `Matrix: ${live.matrix.outputs.length} Outputs × ${live.matrix.sources.length} Sources` : null,
+          live.classicMixer ? `Classic-Mixer: ${live.classicMixer.inputs.length} Inputs` : null,
+          live.inputLabels ? `Input-Labels: ${Object.keys(live.inputLabels).length}` : null,
+        ].filter(Boolean).join('\n'),
+        tone: 'success',
+      })
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handlePushToAtem = async () => {
+    if (!draft) return
+    if (!atemConnected) {
+      await infoDialog('ATEM nicht verbunden', {
+        body: 'Verbinde dich zuerst mit dem ATEM (Hauptdialog "ATEM Mischer").',
+        tone: 'warning',
+      })
+      return
+    }
+    const confirmed = await confirmDialog(
+      'Audio-Konfiguration an ATEM senden?',
+      {
+        body: 'Die geladene Routing-Matrix / Classic-Mixer-Werte werden direkt an den verbundenen Switcher geschickt. Änderungen sind sofort wirksam und werden NICHT als Startup-State persistiert — dazu musst du in ATEM Software Control "Save Startup State" aufrufen.',
+        okLabel: 'Senden',
+      },
+    )
+    if (!confirmed) return
+    setBusy(true)
+    setErrorMsg('')
+    try {
+      const result = await cablePlannerApi.atem.applyAudioConfig({
+        matrix: draft.matrix
+          ? { outputs: draft.matrix.outputs.map((o) => ({ id: o.id, sourceId: o.sourceId })) }
+          : undefined,
+        classicMixer: draft.classicMixer
+          ? { inputs: draft.classicMixer.inputs }
+          : undefined,
+        inputLabels: draft.inputLabels
+          ? Object.fromEntries(
+              Object.entries(draft.inputLabels).map(([id, l]) => [
+                id,
+                { shortName: l.shortName, longName: l.longName },
+              ]),
+            )
+          : undefined,
+      })
+      await infoDialog('Konfiguration gesendet', {
+        body: `Matrix: ${result.matrixApplied} · Classic: ${result.classicApplied} · Labels: ${result.labelsApplied}\n\nNicht vergessen: in ATEM Software Control "Save Startup State" um die Werte persistent zu machen.`,
+        tone: 'success',
+      })
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
   }
 
   /** Build a fresh AtemAudioConfig with the ATEM-default Crosspoint
@@ -218,6 +336,41 @@ export const AtemAudioRouterDialog = () => {
           >
             {t('atem.audio.action.saveXml', '💾 XML speichern')}
           </button>
+          {/* v7.9.52 — OpenSwitcher-style Live-Direct-Pfad. Sichtbar nur
+              wenn Desktop-Bridge verfügbar; Aktiv nur wenn ATEM gerade
+              verbunden ist. Funktioniert OHNE XML-Datei — liest und
+              schreibt direkt aus/in den Switcher-State. */}
+          {hasDesktopBridge && (
+            <>
+              <span className="ml-2 text-slate-600">|</span>
+              <button
+                type="button"
+                onClick={handleReadFromAtem}
+                disabled={!atemConnected || busy}
+                className="rounded bg-purple-700 px-3 py-1 hover:bg-purple-600 disabled:opacity-50"
+                title={
+                  atemConnected
+                    ? 'Live-State vom verbundenen ATEM lesen (Matrix + Classic-Mixer + Labels)'
+                    : 'ATEM nicht verbunden — im Haupt-Dialog "ATEM Mischer" verbinden'
+                }
+              >
+                {atemConnected ? '🔌 Vom ATEM lesen' : '🔌 Lesen (offline)'}
+              </button>
+              <button
+                type="button"
+                onClick={handlePushToAtem}
+                disabled={!atemConnected || !draft || busy}
+                className="rounded bg-orange-700 px-3 py-1 hover:bg-orange-600 disabled:opacity-50"
+                title={
+                  atemConnected
+                    ? 'Aktuelle Konfiguration direkt an den ATEM senden (kein XML-Umweg)'
+                    : 'ATEM nicht verbunden — im Haupt-Dialog "ATEM Mischer" verbinden'
+                }
+              >
+                {atemConnected ? '📤 An ATEM senden' : '📤 Senden (offline)'}
+              </button>
+            </>
+          )}
           {draft?.matrix && (
             <>
               <span className="ml-2 text-slate-500">|</span>

--- a/src/renderer/lib/bridge.ts
+++ b/src/renderer/lib/bridge.ts
@@ -106,6 +106,41 @@ type CablePlannerApi = {
         windows: { windowIndex: number; sourceId: number }[]
       }[]
     }) => Promise<{ applied: number }>
+    /** v7.9.52 — OpenSwitcher-style Live-Audio-State lesen. */
+    readAudioConfig: () => Promise<{
+      matrix?: {
+        sources: Array<{ id: number; name: string }>
+        outputs: Array<{ id: number; sourceId: number; name: string }>
+      }
+      classicMixer?: {
+        programOutGain: number
+        programOutBalance: number
+        programOutFollowFadeToBlack: boolean
+        audioFollowVideoCrossfadeTransition: boolean
+        inputs: Array<{
+          id: number
+          mixOption: 'Off' | 'On' | 'AudioFollowVideo'
+          gain: number | null
+          balance: number
+        }>
+      }
+      inputLabels?: Record<number, { shortName: string; longName: string; externalPortType?: string }>
+    } | null>
+    /** v7.9.52 — OpenSwitcher-style: Push einer kompletten oder partiellen
+     *  AtemAudioConfig direkt an den verbundenen Switcher. Umgeht den
+     *  XML-Import-Schritt von ATEM Software Control. */
+    applyAudioConfig: (config: {
+      matrix?: { outputs: Array<{ id: number; sourceId: number }> }
+      classicMixer?: {
+        inputs: Array<{
+          id: number
+          mixOption: 'Off' | 'On' | 'AudioFollowVideo'
+          gain: number | null
+          balance: number
+        }>
+      }
+      inputLabels?: Record<number, { shortName: string; longName: string }>
+    }) => Promise<{ matrixApplied: number; classicApplied: number; labelsApplied: number }>
     onEvent: (cb: (line: string) => void) => () => void
   }
   videohub: {
@@ -518,6 +553,10 @@ const webFallbackApi: CablePlannerApi = {
     getEvents: async () => [],
     getStatus: async () => ({ connected: false, ip: null }),
     applyMvConfig: async () => {
+      throw new Error('ATEM control requires the desktop app.')
+    },
+    readAudioConfig: async () => null,
+    applyAudioConfig: async () => {
       throw new Error('ATEM control requires the desktop app.')
     },
     onEvent: () => () => {},


### PR DESCRIPTION
Ergänzt den existierenden XML-Hin-und-Her-Flow (Profile-XML laden → editieren → Profile-XML zurück in ATEM Software Control importieren) um einen direkten IP-Pfad zum verbundenen Mischer — analog zu wie openswitcher/pyatem den State direkt liest/schreibt.

XML-Flow bleibt unverändert für Offline-Editing / Versand an andere.

Implementierung:
- atemIpc.ts: zwei neue IPC-Handler
  - atem:read-audio-config — liest state.audio (Classic) + state.fairlight (Master + audioRouting-Matrix auf Extreme/Constellation) + state.inputs (Labels) und gibt sie als AtemAudioConfig zurück
  - atem:apply-audio-config — sendet jede Sektion via atem.setClassicAudioMixerInputProps / setFairlightAudioRoutingOutput Properties / setInputSettings; counted pro Sektion
- preload.cts: readAudioConfig + applyAudioConfig im atem-Block
- bridge.ts: TypeScript-Signatures + Web-Fallback (throws)
- AtemAudioRouterDialog.tsx:
  - Live-Connection-Status-Polling alle 4s
  - Zwei neue Buttons in der Action-Bar: "🔌 Vom ATEM lesen" — überschreibt Matrix/Classic/Labels im Draft "📤 An ATEM senden" — pushed Draft nach Confirm-Dialog
  - Buttons sind disabled wenn nicht verbunden + zeigen klaren Hinweis
  - Push-Confirm erinnert daran, "Save Startup State" in ATEM Software Control aufzurufen damit die Werte beim Reboot bleiben (RAM-only)

Alle Commands kommen aus atem-connection (npm) das schon im Projekt ist — keine zusätzlichen Dependencies, kein Byte-Buffer-Handcoding. pyatem-Source (PyPI sdist) als Referenz für Mask-/Offset-Verifikation hinzugezogen.

Bumps version 7.9.51 → 7.9.52.

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH