### PR TITLE
feat(atem): mDNS-Auto-Discovery für ATEM-Switcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cable-planner",
-    "version": "7.9.4",
+    "version": "7.9.52",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cable-planner",
-            "version": "7.9.4",
+            "version": "7.9.52",
             "dependencies": {
                 "@dnd-kit/core": "^6.3.1",
                 "@dnd-kit/sortable": "^10.0.0",
@@ -14,6 +14,7 @@
                 "@types/qrcode": "^1.5.5",
                 "atem-connection": "^3.9.0",
                 "axios": "^1.13.1",
+                "bonjour-service": "^1.3.0",
                 "fast-xml-parser": "^5.8.0",
                 "html-to-image": "^1.11.13",
                 "jspdf": "^4.2.1",
@@ -1707,6 +1708,12 @@
             "engines": {
                 "node": ">=14.15"
             }
+        },
+        "node_modules/@leichtgewicht/ip-codec": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+            "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+            "license": "MIT"
         },
         "node_modules/@malept/cross-spawn-promise": {
             "version": "2.0.0",
@@ -3929,6 +3936,16 @@
                 "readable-stream": "^3.4.0"
             }
         },
+        "node_modules/bonjour-service": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.3.0.tgz",
+            "integrity": "sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "multicast-dns": "^7.2.5"
+            }
+        },
         "node_modules/boolean": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
@@ -4961,6 +4978,18 @@
                 "node": ">=8"
             }
         },
+        "node_modules/dns-packet": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+            "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+            "license": "MIT",
+            "dependencies": {
+                "@leichtgewicht/ip-codec": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/dompurify": {
             "version": "3.4.3",
             "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
@@ -5634,7 +5663,6 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-json-stable-stringify": {
@@ -7203,6 +7231,19 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
+        },
+        "node_modules/multicast-dns": {
+            "version": "7.2.5",
+            "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+            "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+            "license": "MIT",
+            "dependencies": {
+                "dns-packet": "^5.2.2",
+                "thunky": "^1.0.2"
+            },
+            "bin": {
+                "multicast-dns": "cli.js"
+            }
         },
         "node_modules/nanoid": {
             "version": "3.3.12",
@@ -8957,6 +8998,12 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "license": "0BSD"
+        },
+        "node_modules/thunky": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+            "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+            "license": "MIT"
         },
         "node_modules/tiny-async-pool": {
             "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.9.52",
+    "version": "7.9.53",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",
@@ -30,6 +30,7 @@
         "@types/qrcode": "^1.5.5",
         "atem-connection": "^3.9.0",
         "axios": "^1.13.1",
+        "bonjour-service": "^1.3.0",
         "fast-xml-parser": "^5.8.0",
         "html-to-image": "^1.11.13",
         "jspdf": "^4.2.1",

--- a/src/main/ipc/atemIpc.ts
+++ b/src/main/ipc/atemIpc.ts
@@ -1,5 +1,6 @@
 import { ipcMain, BrowserWindow } from 'electron'
 import { Atem, AtemConnectionStatus } from 'atem-connection'
+import { Bonjour, type Service } from 'bonjour-service'
 
 /**
  * Singleton ATEM session. Only one device at a time is supported - matches the
@@ -408,6 +409,56 @@ export const registerAtemIpc = () => {
         `Applied audio config: matrix=${matrixApplied}, classic=${classicApplied}, labels=${labelsApplied}`,
       )
       return { matrixApplied, classicApplied, labelsApplied }
+    },
+  )
+
+  // v7.9.53 — mDNS-Auto-Discovery für ATEM-Switcher.
+  //
+  // ATEMs broadcasten sich selbst als "_blackmagic._tcp.local"-Service.
+  // Wir starten einen Bonjour-Browser für 3 s, sammeln alle "up"-Events
+  // und liefern die Liste {name, ip, port} zurück. Renderer kann das
+  // dann z.B. als Picker-UI anzeigen.
+  //
+  // Bewusst kein langlebiger Browser — Discovery ist ein User-getriggerter
+  // One-Shot ("Suchen"-Button), damit wir nicht im Hintergrund einen
+  // mDNS-Listener auf der CPU haben.
+  ipcMain.handle(
+    'atem:discover',
+    async (
+      _event,
+      params?: { timeoutMs?: number },
+    ): Promise<Array<{ name: string; ip: string; port: number; model?: string }>> => {
+      const timeoutMs = Math.max(500, Math.min(15000, params?.timeoutMs ?? 3000))
+      const bonjour = new Bonjour()
+      const found = new Map<string, { name: string; ip: string; port: number; model?: string }>()
+      const browser = bonjour.find({ type: 'blackmagic' })
+      const onUp = (svc: Service) => {
+        // ATEM antwortet typisch mit fqdn wie "<HostName>._blackmagic._tcp.local"
+        // und addresses=[<IPv4>]. Wir bevorzugen referer.address (= UDP-Reply-
+        // Quelle) weil das die garantiert erreichbare Adresse ist, fallen
+        // sonst auf addresses[0] zurück.
+        const ip = svc.referer?.address ?? svc.addresses?.[0]
+        if (!ip) return
+        const key = svc.fqdn || svc.name || ip
+        if (found.has(key)) return
+        found.set(key, {
+          name: svc.name || svc.fqdn || ip,
+          ip,
+          port: svc.port ?? 9910,
+          // TXT-Records: ATEM tagged z.B. "model=ATEM Mini Pro"
+          model:
+            (svc.txt && typeof svc.txt === 'object' && 'model' in (svc.txt as Record<string, unknown>)
+              ? String((svc.txt as Record<string, unknown>).model)
+              : undefined) ?? undefined,
+        })
+      }
+      browser.on('up', onUp)
+      await new Promise<void>((resolve) => setTimeout(resolve, timeoutMs))
+      browser.stop()
+      bonjour.destroy()
+      const result = [...found.values()].sort((a, b) => a.name.localeCompare(b.name))
+      pushEvent(`Discovery scan: ${result.length} ATEM(s) gefunden`)
+      return result
     },
   )
 }

--- a/src/main/preload.cts
+++ b/src/main/preload.cts
@@ -92,6 +92,13 @@ contextBridge.exposeInMainWorld('cablePlanner', {
       ipcRenderer.on('atem:event', listener)
       return () => ipcRenderer.removeListener('atem:event', listener)
     },
+    /** v7.9.53 — mDNS-Auto-Discovery für ATEM-Switcher. Liefert nach
+     *  timeoutMs (Default 3000) eine Liste aller _blackmagic._tcp-Services
+     *  im lokalen Netzwerk. */
+    discover: (params?: { timeoutMs?: number }) =>
+      ipcRenderer.invoke('atem:discover', params) as Promise<
+        Array<{ name: string; ip: string; port: number; model?: string }>
+      >,
   },
   videohub: {
     sendRouting: (params: { host: string; port: number; block: string }) =>

--- a/src/renderer/components/Atem/AtemDialog.tsx
+++ b/src/renderer/components/Atem/AtemDialog.tsx
@@ -37,6 +37,12 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
   const [ip, setIp] = useState(equipment?.ipAddress ?? '')
   const [status, setStatus] = useState<'idle' | 'connecting' | 'connected' | 'error'>('idle')
   const [error, setError] = useState<string | null>(null)
+  // v7.9.53 — mDNS Auto-Discovery State
+  const [discovering, setDiscovering] = useState(false)
+  const [discovered, setDiscovered] = useState<
+    Array<{ name: string; ip: string; port: number; model?: string }>
+  >([])
+  const [discoveryDone, setDiscoveryDone] = useState(false)
   const [state, setState] = useState<AtemStateSummary | null>(null)
   const [events, setEvents] = useState<string[]>([])
   const [drafts, setDrafts] = useState<Record<number, { long: string; short: string }>>({})
@@ -62,6 +68,24 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
     })
     return () => unsubscribe()
   }, [])
+
+  // v7.9.53 — mDNS-Discovery: scannt 3s lang nach "_blackmagic._tcp"
+  // Services im lokalen Netz. Ergebnis erscheint als Klick-Liste die
+  // den IP-Input auto-füllt.
+  const discover = async () => {
+    setDiscovering(true)
+    setDiscoveryDone(false)
+    setDiscovered([])
+    try {
+      const list = await cablePlannerApi.atem.discover({ timeoutMs: 3000 })
+      setDiscovered(list)
+    } catch {
+      setDiscovered([])
+    } finally {
+      setDiscovering(false)
+      setDiscoveryDone(true)
+    }
+  }
 
   const connect = async () => {
     setStatus('connecting')
@@ -171,6 +195,17 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
             {status !== 'connected' && (
               <button
                 type="button"
+                onClick={discover}
+                disabled={discovering || status === 'connecting'}
+                className="rounded bg-purple-700 px-3 py-2 text-sm hover:bg-purple-600 disabled:opacity-50"
+                title="ATEM-Switcher per mDNS (Bonjour) im lokalen Netzwerk suchen"
+              >
+                {discovering ? '🔍 Suche…' : '🔍 Suchen'}
+              </button>
+            )}
+            {status !== 'connected' && (
+              <button
+                type="button"
                 onClick={connect}
                 disabled={status === 'connecting' || !ip.trim()}
                 className="rounded bg-sky-700 px-3 py-2 text-sm hover:bg-sky-600 disabled:opacity-50"
@@ -198,6 +233,42 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
               </button>
             )}
           </div>
+          {/* v7.9.53 — Discovery-Result-Liste. Erscheint nach dem ersten
+              "Suchen"-Klick. Klick auf eine Zeile füllt den IP-Input. */}
+          {discoveryDone && status !== 'connected' && (
+            <div className="mt-2">
+              {discovered.length === 0 ? (
+                <div className="rounded border border-dashed border-slate-700 bg-slate-950/40 p-2 text-[11px] text-slate-500">
+                  Kein ATEM-Switcher per mDNS im lokalen Netzwerk gefunden. (Manche
+                  Modelle / Firewall-Setups blocken mDNS — dann IP manuell eingeben.)
+                </div>
+              ) : (
+                <div className="space-y-1">
+                  <div className="text-[10px] uppercase tracking-wide text-slate-500">
+                    Gefunden ({discovered.length}) — Klick übernimmt die IP:
+                  </div>
+                  {discovered.map((dev) => (
+                    <button
+                      key={dev.ip}
+                      type="button"
+                      onClick={() => setIp(dev.ip)}
+                      className="flex w-full items-center justify-between gap-2 rounded border border-slate-700 bg-slate-950 px-2 py-1.5 text-left text-xs hover:border-purple-500 hover:bg-slate-900"
+                    >
+                      <span className="font-medium text-slate-100">
+                        {dev.name}
+                        {dev.model && (
+                          <span className="ml-2 text-[10px] text-slate-400">
+                            ({dev.model})
+                          </span>
+                        )}
+                      </span>
+                      <span className="font-mono text-[11px] text-purple-300">{dev.ip}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
           {status === 'connected' && state && (
             <div className="mt-2 text-[11px] text-slate-400">
               {state.productIdentifier}

--- a/src/renderer/lib/bridge.ts
+++ b/src/renderer/lib/bridge.ts
@@ -142,6 +142,11 @@ type CablePlannerApi = {
       inputLabels?: Record<number, { shortName: string; longName: string }>
     }) => Promise<{ matrixApplied: number; classicApplied: number; labelsApplied: number }>
     onEvent: (cb: (line: string) => void) => () => void
+    /** v7.9.53 — mDNS-Auto-Discovery für ATEM-Switcher im lokalen Netz.
+     *  Sucht für timeoutMs (Default 3000) nach "_blackmagic._tcp"-Services. */
+    discover: (params?: { timeoutMs?: number }) => Promise<
+      Array<{ name: string; ip: string; port: number; model?: string }>
+    >
   }
   videohub: {
     sendRouting: (params: { host: string; port: number; block: string }) => Promise<{ ok: boolean; message: string }>
@@ -560,6 +565,7 @@ const webFallbackApi: CablePlannerApi = {
       throw new Error('ATEM control requires the desktop app.')
     },
     onEvent: () => () => {},
+    discover: async () => [],
   },
   videohub: {
     sendRouting: async () => ({


### PR DESCRIPTION
ATEMs broadcasten sich selbst als _blackmagic._tcp-Service via mDNS. LibAtem (.NET) macht das via Makaretu.Dns; wir nutzen bonjour-service (pure-JS, ~50KB, keine native Deps).

Implementierung:
- bonjour-service als dependency (^1.3.0)
- atemIpc.ts: neuer IPC-Handler atem:discover
  - User-getriggerter One-Shot-Scan (3 s Default-Timeout)
  - Liefert [{name, ip, port, model?}] sortiert nach Name
  - Bevorzugt referer.address (UDP-Reply-Quelle) für IP, fallback auf addresses[0]; TXT-Records werden für model-Tag gescannt
  - Bewusst nicht langlebig (Browser wird nach jedem Scan destroyed) — kein dauerhafter mDNS-Listener auf der CPU
- preload.cts + bridge.ts: API durchgereicht; Web-Fallback liefert []
- AtemDialog.tsx: neuer "🔍 Suchen"-Button (lila, neben "Verbinden"); Ergebnis-Liste darunter mit Klick-zum-Übernehmen der IP. Wenn nichts gefunden, klarer Hinweis-Text (mDNS-Blocker durch Firewall / WLAN- Isolation häufig).

Bumps version 7.9.52 → 7.9.53.

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH