### PR TITLE
feat(mobile): Offline-Cache + Kabel-Hinzufügen vor Ort

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.9.53",
+    "version": "7.9.54",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/main/ipc/mobileShareIpc.ts
+++ b/src/main/ipc/mobileShareIpc.ts
@@ -6,6 +6,7 @@ import {
   getMobileShareStatus,
   setMobileShareProject,
   setMobileShareChecksHandler,
+  setMobileShareCableAddedHandler,
   startMobileShareServer,
   stopMobileShareServer,
 } from '../services/mobileShareServer.js'
@@ -59,6 +60,16 @@ export const registerMobileShareIpc = () => {
     for (const win of BrowserWindow.getAllWindows()) {
       if (win.isDestroyed()) continue
       win.webContents.send('mobileShare:checksUpdate', checks)
+    }
+  })
+
+  // v7.9.54 — Mobile-User hat ein Kabel via Dropdown-UI hinzugefügt.
+  // Broadcast an alle Renderer; ProjectStore fügt es mit
+  // addedFromMobile=true ein.
+  setMobileShareCableAddedHandler((cable) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (win.isDestroyed()) continue
+      win.webContents.send('mobileShare:cableAdded', cable)
     }
   })
 

--- a/src/main/preload.cts
+++ b/src/main/preload.cts
@@ -189,5 +189,37 @@ contextBridge.exposeInMainWorld('cablePlanner', {
       ipcRenderer.on('mobileShare:checksUpdate', listener)
       return () => ipcRenderer.removeListener('mobileShare:checksUpdate', listener)
     },
+    // v7.9.54 — Mobile-User hat ein Kabel via Dropdown-UI im Phone
+    // hinzugefügt. Renderer fügt es ins Projekt ein mit addedFromMobile=true.
+    onCableAdded: (
+      cb: (cable: {
+        fromEquipmentId: string
+        fromPortId: string
+        toEquipmentId: string
+        toPortId: string
+        name?: string
+        type?: string
+        length?: number
+        color?: string
+        notes?: string
+      }) => void,
+    ) => {
+      const listener = (
+        _event: unknown,
+        cable: {
+          fromEquipmentId: string
+          fromPortId: string
+          toEquipmentId: string
+          toPortId: string
+          name?: string
+          type?: string
+          length?: number
+          color?: string
+          notes?: string
+        },
+      ) => cb(cable)
+      ipcRenderer.on('mobileShare:cableAdded', listener)
+      return () => ipcRenderer.removeListener('mobileShare:cableAdded', listener)
+    },
   },
 })

--- a/src/main/services/mobileShareServer.ts
+++ b/src/main/services/mobileShareServer.ts
@@ -70,6 +70,24 @@ interface MobileShareState {
    *  POST /checks-Handler aufgerufen sobald das Handy einen Port
    *  als gesteckt markiert. */
   onChecksUpdate: ((checks: { ports: Record<string, boolean>; cables: Record<string, boolean> }) => void) | null
+  /** v7.9.54 — Callback für vom Mobile-Viewer hinzugefügte Kabel.
+   *  Der User steht vor Ort am Gerät, merkt dass ein Patch fehlt und
+   *  trägt das fehlende Kabel über die Dropdown-UI im Phone ein.
+   *  Server reicht das hier rein, Renderer fügt es ins Projekt mit
+   *  addedFromMobile=true ein. */
+  onCableAdded:
+    | ((cable: {
+        fromEquipmentId: string
+        fromPortId: string
+        toEquipmentId: string
+        toPortId: string
+        name?: string
+        type?: string
+        length?: number
+        color?: string
+        notes?: string
+      }) => void)
+    | null
 }
 
 const state: MobileShareState = {
@@ -79,6 +97,7 @@ const state: MobileShareState = {
   rendererDir: '',
   devProxyUrl: undefined,
   onChecksUpdate: null,
+  onCableAdded: null,
 }
 
 /** Lookup non-internal IPv4 addresses across all network interfaces. */
@@ -217,6 +236,64 @@ const handleRequest = (req: IncomingMessage, res: ServerResponse) => {
     return
   }
 
+  // v7.9.54 — POST /cables: das Mobile-View schickt nach Hinzufügen eines
+  // neuen Kabels via Dropdown-UI eine Cable-Spec. Wir validieren minimal
+  // (alle 4 IDs vorhanden) und leiten an den Renderer-Callback weiter.
+  if (pathname === '/cables' && req.method === 'POST') {
+    let body = ''
+    req.on('data', (chunk) => {
+      body += chunk
+      if (body.length > 100_000) {
+        res.statusCode = 413
+        res.end('Payload too large')
+        req.destroy()
+      }
+    })
+    req.on('end', () => {
+      try {
+        const parsed = JSON.parse(body) as Record<string, unknown>
+        const fromEquipmentId = String(parsed.fromEquipmentId ?? '').trim()
+        const fromPortId = String(parsed.fromPortId ?? '').trim()
+        const toEquipmentId = String(parsed.toEquipmentId ?? '').trim()
+        const toPortId = String(parsed.toPortId ?? '').trim()
+        if (!fromEquipmentId || !fromPortId || !toEquipmentId || !toPortId) {
+          res.statusCode = 400
+          res.setHeader('Access-Control-Allow-Origin', '*')
+          res.end('{"error":"missing endpoint ids"}')
+          return
+        }
+        const cable = {
+          fromEquipmentId,
+          fromPortId,
+          toEquipmentId,
+          toPortId,
+          name: typeof parsed.name === 'string' ? parsed.name : undefined,
+          type: typeof parsed.type === 'string' ? parsed.type : undefined,
+          length: typeof parsed.length === 'number' ? parsed.length : undefined,
+          color: typeof parsed.color === 'string' ? parsed.color : undefined,
+          notes: typeof parsed.notes === 'string' ? parsed.notes : undefined,
+        }
+        state.onCableAdded?.(cable)
+        res.statusCode = 200
+        res.setHeader('Access-Control-Allow-Origin', '*')
+        res.end('{"ok":true}')
+      } catch {
+        res.statusCode = 400
+        res.setHeader('Access-Control-Allow-Origin', '*')
+        res.end('{"error":"invalid json"}')
+      }
+    })
+    return
+  }
+  if (pathname === '/cables' && req.method === 'OPTIONS') {
+    res.statusCode = 204
+    res.setHeader('Access-Control-Allow-Origin', '*')
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+    res.end()
+    return
+  }
+
   // Health/info endpoint — useful for the renderer to verify
   // the server is alive without round-tripping the whole project.
   if (pathname === '/share-info.json') {
@@ -344,6 +421,26 @@ export const setMobileShareChecksHandler = (
   handler: ((checks: { ports: Record<string, boolean>; cables: Record<string, boolean> }) => void) | null,
 ): void => {
   state.onChecksUpdate = handler
+}
+
+/** v7.9.54 — Registrierung des Callbacks für vom Mobile-Viewer
+ *  hinzugefügte Kabel (POST /cables). */
+export const setMobileShareCableAddedHandler = (
+  handler:
+    | ((cable: {
+        fromEquipmentId: string
+        fromPortId: string
+        toEquipmentId: string
+        toPortId: string
+        name?: string
+        type?: string
+        length?: number
+        color?: string
+        notes?: string
+      }) => void)
+    | null,
+): void => {
+  state.onCableAdded = handler
 }
 
 export const getMobileShareStatus = (): MobileShareInfo & { running: boolean } => ({

--- a/src/mobile/MobileApp.tsx
+++ b/src/mobile/MobileApp.tsx
@@ -20,10 +20,22 @@
  * familiar; Tailwind classes carry over from the shared index.css.
  */
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { CablePlannerProject } from '../renderer/types/project'
 
 const CHECK_KEY = (projectName: string) => `cable-planner-mobile:checks:${projectName}`
+// v7.9.54 — Offline-Cache des kompletten Projekts. Ein Eintrag pro
+// Hostname/Port-Origin, damit verschiedene Geräte-Sessions sich nicht
+// gegenseitig überschreiben. So überlebt eine Session den
+// Funkverbindungs-Verlust und der Techniker kann lokal weiter haken
+// setzen, die beim nächsten Re-Connect automatisch synchronisiert werden.
+const PROJECT_CACHE_KEY = `cable-planner-mobile:project-cache:${
+  typeof window !== 'undefined' ? window.location.host : 'unknown'
+}`
+interface ProjectCacheEnvelope {
+  cachedAt: string
+  project: unknown
+}
 
 interface CheckState {
   cables: Record<string, boolean>
@@ -46,6 +58,30 @@ const saveChecks = (projectName: string, state: CheckState) => {
   } catch {
     /* ignore quota */
   }
+}
+
+// v7.9.54 — Cache-Helpers für das Offline-Survival des Projekts.
+const cacheProject = (project: unknown): void => {
+  try {
+    const env: ProjectCacheEnvelope = { cachedAt: new Date().toISOString(), project }
+    localStorage.setItem(PROJECT_CACHE_KEY, JSON.stringify(env))
+  } catch {
+    /* quota / private-mode → einfach skippen, ist nur ein Cache */
+  }
+}
+
+const loadCachedProject = (): { cachedAt: string; project: unknown } | null => {
+  try {
+    const raw = localStorage.getItem(PROJECT_CACHE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<ProjectCacheEnvelope>
+    if (parsed && typeof parsed.cachedAt === 'string' && parsed.project) {
+      return { cachedAt: parsed.cachedAt, project: parsed.project }
+    }
+  } catch {
+    /* corrupted cache → ignore */
+  }
+  return null
 }
 
 const portKey = (deviceId: string, portId: string) => `${deviceId}|${portId}`
@@ -325,9 +361,13 @@ const PortList = ({
 
 const ProjectView = ({
   project,
+  online,
+  cachedAt,
   onUnload,
 }: {
   project: CablePlannerProject
+  online?: boolean
+  cachedAt?: string | null
   onUnload: () => void
 }) => {
   const projectName = project.metadata?.name || 'cable-planner'
@@ -359,6 +399,27 @@ const ProjectView = ({
       body: JSON.stringify(checks),
     }).catch(() => {})
   }, [projectName, checks])
+
+  // v7.9.54 — Reconnect-Resync. Wenn der Online-Status von false → true
+  // wechselt (= Funkverbindung wieder da), schicken wir EINMAL den
+  // gesamten lokalen Check-State an /checks damit alle offline
+  // gesetzten Häkchen ans Desktop syncen. Ohne diesen explizten Push
+  // wären Offline-Toggles nur in localStorage; das Canvas am Desktop
+  // würde sie erst beim nächsten regulären Toggle sehen.
+  const wasOnlineRef = useRef(online ?? true)
+  useEffect(() => {
+    const wasOnline = wasOnlineRef.current
+    wasOnlineRef.current = online ?? true
+    if (online && !wasOnline) {
+      void fetch('/checks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(checks),
+      }).catch(() => {})
+    }
+  }, [online, checks])
+
+  const [showAddCable, setShowAddCable] = useState(false)
 
   // v7.7.3 — Toggling a port toggles BOTH endpoints of the cable that's
   // plugged into it (and the cable itself), because physically plugging
@@ -465,8 +526,32 @@ const ProjectView = ({
             />
             offen
           </label>
+          <button
+            type="button"
+            onClick={() => setShowAddCable(true)}
+            className="rounded bg-sky-700 px-2 py-1 text-[11px] text-white hover:bg-sky-600"
+            title="Kabel vor Ort hinzufügen (Dropdowns)"
+          >
+            + Kabel
+          </button>
         </div>
+        {/* v7.9.54 — Offline-Banner. Erscheint sobald der Poll fehlschlägt
+            oder der initiale Load aus dem Cache kam. Klar erkennbar in
+            Amber, damit der User weiß dass seine Checks gerade nur
+            lokal sind und beim Re-Connect automatisch syncen. */}
+        {online === false && (
+          <div className="mt-2 rounded border border-amber-700/60 bg-amber-900/30 px-2 py-1 text-[10px] text-amber-200">
+            ⚠ Offline · Cache vom {cachedAt ? new Date(cachedAt).toLocaleString() : '?'} · Checks
+            werden bei Re-Connect synchronisiert
+          </div>
+        )}
       </header>
+      {showAddCable && (
+        <AddCableModal
+          project={project}
+          onClose={() => setShowAddCable(false)}
+        />
+      )}
       <div className="space-y-2 pb-8">
         {filteredDevices.length === 0 ? (
           <div className="rounded border border-dashed border-slate-700 bg-slate-900 p-6 text-center text-xs text-slate-500">
@@ -493,37 +578,52 @@ export const MobileApp = () => {
   const [project, setProject] = useState<CablePlannerProject | null>(null)
   const [autoLoadAttempted, setAutoLoadAttempted] = useState(false)
   const [autoLoadError, setAutoLoadError] = useState<string | null>(null)
+  // v7.9.54 — Online/Cache-Status. `online === false` zeigt das Banner
+  // "Offline — letzter Cache vom DATE" über der UI. Erste-Load-Versuch
+  // setzt online basierend auf dem Ergebnis. Spätere Polls toggeln es.
+  const [online, setOnline] = useState(true)
+  const [cachedAt, setCachedAt] = useState<string | null>(null)
 
   // When loaded via the desktop app's LAN share server, a sibling
   // /project.json endpoint serves the live project. Auto-fetch on
-  // mount and (separately) poll every 5 s so the phone stays in sync
-  // while it's the active window.
+  // mount; bei Fehlschlag fallback auf den lokalen Offline-Cache damit
+  // der Techniker auch ohne Funkverbindung weiter haken setzen kann.
   useEffect(() => {
     let cancelled = false
     void (async () => {
       try {
         const res = await fetch('/share-info.json', { cache: 'no-store' })
-        if (!res.ok) {
-          setAutoLoadAttempted(true)
-          return
-        }
+        if (!res.ok) throw new Error(`share-info ${res.status}`)
         const info = (await res.json()) as { ok: boolean; hasProject: boolean }
         if (!info.ok || !info.hasProject) {
           setAutoLoadAttempted(true)
           return
         }
         const projectRes = await fetch('/project.json', { cache: 'no-store' })
-        if (!projectRes.ok) {
-          setAutoLoadError(`Server antwortete mit ${projectRes.status}.`)
-          setAutoLoadAttempted(true)
-          return
-        }
+        if (!projectRes.ok) throw new Error(`project ${projectRes.status}`)
         const data = (await projectRes.json()) as CablePlannerProject
         if (!cancelled && data && Array.isArray(data.equipment)) {
           setProject(data)
+          setOnline(true)
+          cacheProject(data)
+          setCachedAt(new Date().toISOString())
         }
       } catch {
-        // Not running from the share server — show the manual picker.
+        // Live-Server nicht erreichbar — Offline-Cache versuchen damit
+        // die App nicht komplett tot ist.
+        const cached = loadCachedProject()
+        if (!cancelled && cached) {
+          const data = cached.project as CablePlannerProject
+          if (data && Array.isArray(data.equipment)) {
+            setProject(data)
+            setOnline(false)
+            setCachedAt(cached.cachedAt)
+          }
+        } else if (!cancelled) {
+          // Kein Cache → manueller File-Picker. autoLoadError nur setzen
+          // wenn wir zumindest weiter versucht haben (kein hard error).
+          setAutoLoadError(null)
+        }
       } finally {
         if (!cancelled) setAutoLoadAttempted(true)
       }
@@ -533,18 +633,23 @@ export const MobileApp = () => {
     }
   }, [])
 
-  // Refresh every 5 s once we've successfully auto-loaded so the
-  // phone reflects edits made on the desktop.
+  // Refresh every 5 s. Erfolgreiche Pulls aktualisieren den Cache UND
+  // den Online-Status; Fehler markieren als offline (UI zeigt Banner).
   useEffect(() => {
     if (!project) return
     const id = window.setInterval(async () => {
       try {
         const r = await fetch('/project.json', { cache: 'no-store' })
-        if (!r.ok) return
+        if (!r.ok) throw new Error(`project ${r.status}`)
         const next = (await r.json()) as CablePlannerProject
-        if (next && Array.isArray(next.equipment)) setProject(next)
+        if (next && Array.isArray(next.equipment)) {
+          setProject(next)
+          setOnline(true)
+          cacheProject(next)
+          setCachedAt(new Date().toISOString())
+        }
       } catch {
-        /* server stopped or network blip — keep last good state */
+        setOnline(false)
       }
     }, 5000)
     return () => window.clearInterval(id)
@@ -557,7 +662,12 @@ export const MobileApp = () => {
           <div className="animate-pulse">Lade Projekt vom Desktop…</div>
         </div>
       ) : project ? (
-        <ProjectView project={project} onUnload={() => setProject(null)} />
+        <ProjectView
+          project={project}
+          online={online}
+          cachedAt={cachedAt}
+          onUnload={() => setProject(null)}
+        />
       ) : (
         <>
           <ProjectPicker onLoad={setProject} />
@@ -569,6 +679,233 @@ export const MobileApp = () => {
           )}
         </>
       )}
+    </div>
+  )
+}
+
+// v7.9.54 — Add-Cable-Modal für den Mobile-Viewer.
+//
+// Use-Case: Techniker steht vor Ort am Gerät, sieht dass das Patch im
+// Plan fehlt, will es schnell nachpflegen ohne zum Planer-Laptop zu
+// rennen. UI ist bewusst kein Canvas (= 2D-Drag würde am Phone tap-
+// freundlich nicht funktionieren) sondern 4 sequentielle Dropdowns:
+// Von Gerät → Von Port → Zu Gerät → Zu Port. Optional Name + Typ +
+// Länge. POST /cables → Renderer fügt es mit addedFromMobile=true ein.
+const AddCableModal = ({
+  project,
+  onClose,
+}: {
+  project: CablePlannerProject
+  onClose: () => void
+}) => {
+  const [fromEqId, setFromEqId] = useState('')
+  const [fromPortId, setFromPortId] = useState('')
+  const [toEqId, setToEqId] = useState('')
+  const [toPortId, setToPortId] = useState('')
+  const [name, setName] = useState('')
+  const [cableType, setCableType] = useState('')
+  const [length, setLength] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const [done, setDone] = useState(false)
+
+  const sortedEquipment = useMemo(
+    () => [...project.equipment].sort((a, b) => a.name.localeCompare(b.name)),
+    [project.equipment],
+  )
+  const fromEq = sortedEquipment.find((e) => e.id === fromEqId)
+  const toEq = sortedEquipment.find((e) => e.id === toEqId)
+  const fromPorts = fromEq ? [...fromEq.outputs, ...fromEq.inputs] : []
+  const toPorts = toEq ? [...toEq.inputs, ...toEq.outputs] : []
+
+  const canSubmit =
+    !!fromEqId && !!fromPortId && !!toEqId && !!toPortId && !busy
+
+  const submit = async () => {
+    if (!canSubmit) return
+    setBusy(true)
+    setErr(null)
+    try {
+      const res = await fetch('/cables', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          fromEquipmentId: fromEqId,
+          fromPortId,
+          toEquipmentId: toEqId,
+          toPortId,
+          name: name.trim() || undefined,
+          type: cableType.trim() || undefined,
+          length: length ? Number(length) : undefined,
+        }),
+      })
+      if (!res.ok) throw new Error(`Server ${res.status}`)
+      setDone(true)
+      window.setTimeout(onClose, 1200)
+    } catch (e) {
+      setErr(
+        e instanceof Error
+          ? `Konnte Kabel nicht senden: ${e.message}. Verbindung zum Desktop prüfen.`
+          : 'Konnte Kabel nicht senden.',
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-20 flex items-end justify-center bg-black/60 p-2"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div className="w-full max-w-md rounded-t-lg border border-slate-700 bg-slate-900 text-slate-100 shadow-2xl">
+        <header className="flex items-center justify-between border-b border-slate-700 px-3 py-2">
+          <h2 className="text-sm font-semibold">📱 Kabel hinzufügen</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded px-2 py-0.5 text-xs text-slate-400 hover:bg-slate-800"
+          >
+            ✕
+          </button>
+        </header>
+        <div className="space-y-3 p-3 text-xs">
+          {done ? (
+            <div className="rounded border border-emerald-700 bg-emerald-900/30 p-3 text-center text-emerald-200">
+              ✓ Kabel gesendet — wird am Desktop mit 📱-Marker eingefügt
+            </div>
+          ) : (
+            <>
+              <p className="text-[10px] italic text-slate-400">
+                Wird im Plan mit 📱-Badge markiert, damit der Planer sieht dass das
+                Kabel vor Ort nachgepflegt wurde.
+              </p>
+              <label className="block">
+                <span className="mb-1 block text-slate-300">Von Gerät</span>
+                <select
+                  value={fromEqId}
+                  onChange={(e) => {
+                    setFromEqId(e.target.value)
+                    setFromPortId('')
+                  }}
+                  className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+                >
+                  <option value="">— wählen —</option>
+                  {sortedEquipment.map((eq) => (
+                    <option key={eq.id} value={eq.id}>
+                      {eq.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="block">
+                <span className="mb-1 block text-slate-300">Von Port</span>
+                <select
+                  value={fromPortId}
+                  onChange={(e) => setFromPortId(e.target.value)}
+                  disabled={!fromEq}
+                  className="w-full rounded border border-slate-700 bg-slate-950 p-2 disabled:opacity-40"
+                >
+                  <option value="">— wählen —</option>
+                  {fromPorts.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name} ({p.connectorType})
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="block">
+                <span className="mb-1 block text-slate-300">Zu Gerät</span>
+                <select
+                  value={toEqId}
+                  onChange={(e) => {
+                    setToEqId(e.target.value)
+                    setToPortId('')
+                  }}
+                  className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+                >
+                  <option value="">— wählen —</option>
+                  {sortedEquipment.map((eq) => (
+                    <option key={eq.id} value={eq.id}>
+                      {eq.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="block">
+                <span className="mb-1 block text-slate-300">Zu Port</span>
+                <select
+                  value={toPortId}
+                  onChange={(e) => setToPortId(e.target.value)}
+                  disabled={!toEq}
+                  className="w-full rounded border border-slate-700 bg-slate-950 p-2 disabled:opacity-40"
+                >
+                  <option value="">— wählen —</option>
+                  {toPorts.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name} ({p.connectorType})
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <div className="grid grid-cols-2 gap-2">
+                <label className="block">
+                  <span className="mb-1 block text-slate-300">Typ (opt.)</span>
+                  <input
+                    value={cableType}
+                    onChange={(e) => setCableType(e.target.value)}
+                    placeholder="SDI / XLR / …"
+                    className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+                  />
+                </label>
+                <label className="block">
+                  <span className="mb-1 block text-slate-300">Länge in m (opt.)</span>
+                  <input
+                    type="number"
+                    inputMode="decimal"
+                    value={length}
+                    onChange={(e) => setLength(e.target.value)}
+                    className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+                  />
+                </label>
+              </div>
+              <label className="block">
+                <span className="mb-1 block text-slate-300">Name (opt.)</span>
+                <input
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Auto: 'Gerät A → Gerät B'"
+                  className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+                />
+              </label>
+              {err && (
+                <div className="rounded border border-red-700/60 bg-red-900/30 p-2 text-[11px] text-red-200">
+                  ⚠ {err}
+                </div>
+              )}
+              <div className="flex justify-end gap-2 pt-1">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="rounded bg-slate-700 px-3 py-1.5 text-xs text-slate-200 hover:bg-slate-600"
+                >
+                  Abbrechen
+                </button>
+                <button
+                  type="button"
+                  onClick={submit}
+                  disabled={!canSubmit}
+                  className="rounded bg-sky-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-sky-500 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  {busy ? 'Sende…' : '📤 An Desktop senden'}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -375,6 +375,17 @@ export default function App() {
     })
   }, [setCheckState])
 
+  // v7.9.54 — Mobile-User hat ein Kabel via Dropdown-UI hinzugefügt.
+  // ProjectStore fügt es mit addedFromMobile=true ein → Canvas zeigt
+  // sofort ein 📱-Badge am neuen Edge.
+  const addCableFromMobile = useProjectStore((s) => s.addCableFromMobile)
+  useEffect(() => {
+    if (!hasDesktopBridge) return
+    return cablePlannerApi.mobileShare.onCableAdded((cable) => {
+      addCableFromMobile(cable)
+    })
+  }, [addCableFromMobile])
+
   // Issue #69: dispatch user-customizable hotkeys defined in
   // Settings → Hotkeys. The undo/redo entries below intentionally
   // overlap with useUndoRedoShortcuts() — only the first matching

--- a/src/renderer/components/Canvas/CableEdge.tsx
+++ b/src/renderer/components/Canvas/CableEdge.tsx
@@ -527,7 +527,17 @@ export const CableEdge = ({
   const wirelessSuffix = isWireless
     ? ` 〜${cable?.frequency ? ` ${cable.frequency}` : ''}${cable?.wifiChannel ? ` CH${cable.wifiChannel}` : ''}`
     : ''
-  const displayLabel = label ? `${label}${wirelessSuffix}` : (wirelessSuffix.trim() ? wirelessSuffix.trim() : undefined)
+  // v7.9.54 — Kabel die vom Mobile-Viewer hinzugefügt wurden (Techniker
+  // vor Ort) kriegen ein 📱-Prefix damit der Planer sie auf einen Blick
+  // erkennt.
+  const mobilePrefix = cable?.addedFromMobile ? '📱 ' : ''
+  const displayLabel = label
+    ? `${mobilePrefix}${label}${wirelessSuffix}`
+    : wirelessSuffix.trim()
+      ? `${mobilePrefix}${wirelessSuffix.trim()}`
+      : mobilePrefix
+        ? mobilePrefix.trim()
+        : undefined
 
   return (
     <>

--- a/src/renderer/lib/bridge.ts
+++ b/src/renderer/lib/bridge.ts
@@ -200,6 +200,20 @@ type CablePlannerApi = {
     onChecksUpdate: (
       cb: (checks: { ports: Record<string, boolean>; cables: Record<string, boolean> }) => void,
     ) => () => void
+    /** v7.9.54 — Listener für Mobile-Cable-Add-Events. */
+    onCableAdded: (
+      cb: (cable: {
+        fromEquipmentId: string
+        fromPortId: string
+        toEquipmentId: string
+        toPortId: string
+        name?: string
+        type?: string
+        length?: number
+        color?: string
+        notes?: string
+      }) => void,
+    ) => () => void
   }
 }
 
@@ -610,6 +624,7 @@ const webFallbackApi: CablePlannerApi = {
     status: async () => ({ running: false, port: 0, urls: [], hasProject: false }),
     setProject: async () => ({ ok: true }),
     onChecksUpdate: () => () => {},
+    onCableAdded: () => () => {},
   },
 }
 

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -405,6 +405,19 @@ export interface ProjectState {
    *  Komplettes Objekt-Replace damit gelöschte Checks (false → kein
    *  key) auch übernommen werden. */
   setCheckState: (checks: { ports: Record<string, boolean>; cables: Record<string, boolean> }) => void
+  /** v7.9.54 — Vom Mobile-Viewer hinzugefügtes Kabel ins Projekt. Wird
+   *  mit addedFromMobile=true markiert (Canvas zeigt 📱-Badge). */
+  addCableFromMobile: (input: {
+    fromEquipmentId: string
+    fromPortId: string
+    toEquipmentId: string
+    toPortId: string
+    name?: string
+    type?: string
+    length?: number
+    color?: string
+    notes?: string
+  }) => void
   /** v7.9.3 — Planungs-Status: 'editing' (default), 'finalized' (Canvas
    *  read-only, vom Plan-Eigentümer setzbar), 'viewer' (durch Import
    *  einer .cpviewer-Datei, permanent read-only). */
@@ -1847,6 +1860,46 @@ const buildProjectStore = (
       const updated = { ...state.project, checkState: checks }
       scheduleProjectAutosave(updated)
       return { project: updated }
+    }),
+  addCableFromMobile: (input) =>
+    set((state) => {
+      // v7.9.54 — Kabel-Add vom Mobile-Viewer. Validiert dass beide
+      // Endpoints (Equipment+Port-Pair) im aktuellen Projekt existieren;
+      // sonst silently skip (Mobile zeigt eh nur das was im Projekt war).
+      const fromEq = state.project.equipment.find((e) => e.id === input.fromEquipmentId)
+      const toEq = state.project.equipment.find((e) => e.id === input.toEquipmentId)
+      if (!fromEq || !toEq) return {}
+      const fromPort =
+        [...fromEq.inputs, ...fromEq.outputs].find((p) => p.id === input.fromPortId) ?? null
+      const toPort =
+        [...toEq.inputs, ...toEq.outputs].find((p) => p.id === input.toPortId) ?? null
+      if (!fromPort || !toPort) return {}
+      // Doppelte verhindern: gleiche Port-Combo schon mal verbunden? skip.
+      const dupe = state.project.cables.some(
+        (c) =>
+          (c.fromPortId === input.fromPortId && c.toPortId === input.toPortId) ||
+          (c.fromPortId === input.toPortId && c.toPortId === input.fromPortId),
+      )
+      if (dupe) return {}
+      const cable: Cable = {
+        id: uuidv4(),
+        name: input.name?.trim() || `${fromEq.name} → ${toEq.name}`,
+        type: (input.type as Cable['type']) || 'unbekannt',
+        length: input.length ?? 0,
+        color: input.color ?? '#64748b',
+        fromEquipmentId: input.fromEquipmentId,
+        fromPortId: input.fromPortId,
+        toEquipmentId: input.toEquipmentId,
+        toPortId: input.toPortId,
+        notes: input.notes ?? '',
+        addedFromMobile: true,
+      }
+      const updated = touchProject({
+        ...state.project,
+        cables: [...state.project.cables, cable],
+      })
+      scheduleProjectAutosave(updated)
+      return { project: updated, projectVersion: state.projectVersion + 1 }
     }),
   setProjectMode: (mode) =>
     set((state) => {

--- a/src/renderer/types/cable.ts
+++ b/src/renderer/types/cable.ts
@@ -62,4 +62,10 @@ export interface Cable {
    *  Kabel. Legacy-Daten mit bumpStyle: 'auto' werden wie undefined
    *  behandelt. Set via the right-click context menu on the cable. */
   bumpStyle?: 'on' | 'off'
+  /** v7.9.54 — Marker für Kabel, die NICHT vom Planer am Desktop, sondern
+   *  spontan vor Ort über die Mobile-Viewer-App hinzugefügt wurden (z.B.
+   *  weil der Techniker am Gerät steht und merkt dass ein Patch fehlt).
+   *  Canvas rendert dafür ein "📱"-Badge, damit der Planer sieht welche
+   *  Verbindungen aus dem Feld nachgepflegt wurden. */
+  addedFromMobile?: boolean
 }


### PR DESCRIPTION
Zwei non-destruktive Erweiterungen am Mobile-Viewer:

1) Offline-Cache des kompletten Projekts
   - Erfolgreicher /project.json-Fetch wird in localStorage gecached (Key: cable-planner-mobile:project-cache:<host>; mit Timestamp)
   - Wenn der initiale Server-Fetch fehlschlägt: Fallback auf Cache; App startet im Offline-Mode statt komplett leer zu sein
   - Poll alle 5s: bei Fehler wird online=false gesetzt, bei Erfolg wird Cache + Online-Status aktualisiert
   - Amber-Banner zeigt "⚠ Offline · Cache vom DATE · Checks werden bei Re-Connect synchronisiert"
   - Reconnect-Resync: wenn online false → true wechselt, wird der komplette lokale CheckState einmal an /checks gepushed, damit offline gesetzte Häkchen automatisch ans Desktop syncen

2) Kabel hinzufügen vor Ort
   - Neuer "+ Kabel"-Button in der Mobile-Toolbar
   - AddCableModal mit vier sequentiellen Dropdowns: Von Gerät → Von Port → Zu Gerät → Zu Port Plus optional: Name, Typ, Länge
   - POST /cables → neuer Server-Endpoint im mobileShareServer
   - Validiert Endpoint-IDs minimal, leitet via Callback an Renderer
   - Renderer (App.tsx) hängt an mobileShare.onCableAdded, ruft ProjectStore.addCableFromMobile (validiert Equipment+Port-Refs, prüft Duplikate, fügt mit addedFromMobile=true ein)
   - CableEdge rendert ein 📱-Prefix am Label damit der Planer erkennt welche Kabel vor Ort nachgepflegt wurden

Cable-Type bekommt neues optionales Feld:
  addedFromMobile?: boolean

Bewusst kein 2D-Canvas-Drag auf dem Phone — wäre tap-feindlich. Die Dropdown-UI ist schnell, eindeutig, und am Smartphone bedienbar.

Bumps version 7.9.53 → 7.9.54.

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH