### PR TITLE
feat(rack): Adapter-Patchblende + Port-Dots + Drag + Internal-Cables …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.9.76",
+    "version": "7.9.78",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/components/Rack/PatchPanelCreateDialog.tsx
+++ b/src/renderer/components/Rack/PatchPanelCreateDialog.tsx
@@ -15,7 +15,7 @@
  */
 import { useMemo, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
-import { ALL_CONNECTOR_TYPES, type ConnectorType, type EquipmentTemplate, type Port } from '../../types/equipment'
+import { ALL_CONNECTOR_TYPES, type ConnectorType, type EquipmentTemplate } from '../../types/equipment'
 import { useUiStore } from '../../store/uiStore'
 
 interface PatchPanelCreateDialogProps {
@@ -27,7 +27,8 @@ interface PatchPanelCreateDialogProps {
 interface PortDraft {
   id: string
   label: string
-  connectorType: ConnectorType
+  frontConnectorType: ConnectorType
+  rearConnectorType: ConnectorType
 }
 
 const COMMON_PORT_COUNTS = [12, 16, 24, 32, 48]
@@ -36,9 +37,16 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
   const [name, setName] = useState('Patchblende')
   const [heightUnits, setHeightUnits] = useState(1)
   const [portCount, setPortCount] = useState(24)
-  const [defaultConnector, setDefaultConnector] = useState<ConnectorType>('BNC')
+  // v7.9.77 / #170 — Adapter-Patchblende: Front und Rear können
+  // unterschiedliche Connector-Typen haben (z.B. BNC vorne, RJ45 hinten).
+  // Wenn beide gleich sind, ist es eine klassische Patchblende ohne Adapter.
+  const [frontConnector, setFrontConnector] = useState<ConnectorType>('BNC')
+  const [rearConnector, setRearConnector] = useState<ConnectorType>('BNC')
+  const [adapterMode, setAdapterMode] = useState(false)
   const [tab, setTab] = useState<'basics' | 'ports'>('basics')
-  const [perPortOverrides, setPerPortOverrides] = useState<Record<number, { label?: string; connector?: ConnectorType }>>({})
+  const [perPortOverrides, setPerPortOverrides] = useState<
+    Record<number, { label?: string; front?: ConnectorType; rear?: ConnectorType }>
+  >({})
   const [mountSide, setMountSide] = useState<'front' | 'rear' | 'full'>('full')
   // v7.9.75 — Custom Connector-Typen sind in uiStore.customConnectorTypes
   // hinterlegt und sollen im Patch-Builder ebenfalls verfügbar sein.
@@ -56,43 +64,52 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
         return {
           id: uuidv4(),
           label: override?.label ?? `P${idx + 1}`,
-          connectorType: override?.connector ?? defaultConnector,
+          frontConnectorType: override?.front ?? frontConnector,
+          rearConnectorType: override?.rear ?? (adapterMode ? rearConnector : frontConnector),
         }
       }),
-    [portCount, defaultConnector, perPortOverrides],
+    [portCount, frontConnector, rearConnector, adapterMode, perPortOverrides],
   )
 
   if (!open) return null
 
   const handleCreate = () => {
-    const built: Port[] = ports.map((p) => ({
-      id: p.id,
-      name: p.label,
-      type: p.connectorType,
-      connectorType: p.connectorType,
-    }))
-    // Patchblenden sind klassisch passive Crossfields — beide Seiten sind
-    // gleichberechtigt. Wir legen alle Ports als BOTH-Sides an, indem wir
-    // sie sowohl in inputs als auch in outputs spiegeln. So zeigt das 2D-
-    // Panel die Ports vorne UND hinten an, was der Realität entspricht.
+    // v7.9.77 / #170 — Adapter-Patchblende: inputs (Front-Seite) und
+    // outputs (Rear-Seite) bekommen unabhängige Connector-Typen.
+    // Klassische Patchblende: frontConnector === rearConnector (= adapterMode false).
     const template: EquipmentTemplate = {
       name: name.trim() || 'Patchblende',
-      category: 'Patchblende',
-      inputs: built.map((p) => ({ ...p, id: uuidv4(), name: `${p.name} (Front)` })),
-      outputs: built.map((p) => ({ ...p, id: uuidv4(), name: `${p.name} (Rear)` })),
+      category: adapterMode ? 'Patchblende (Adapter)' : 'Patchblende',
+      inputs: ports.map((p) => ({
+        id: uuidv4(),
+        name: `${p.label} (Front)`,
+        type: p.frontConnectorType,
+        connectorType: p.frontConnectorType,
+      })),
+      outputs: ports.map((p) => ({
+        id: uuidv4(),
+        name: `${p.label} (Rear)`,
+        type: p.rearConnectorType,
+        connectorType: p.rearConnectorType,
+      })),
       isRackDevice: true,
       isPatchPanel: true,
       rackUnits: heightUnits,
       depthMm: 50,
       width: 240,
       height: 80 + Math.max(heightUnits, 1) * 22,
-      notes: `${portCount}-fach Patchfeld, default ${defaultConnector}.${mountSide !== 'full' ? ` Mount: ${mountSide}.` : ''}`,
+      notes: adapterMode
+        ? `${portCount}-fach Adapter-Patchfeld: Front ${frontConnector} ↔ Rear ${rearConnector}.${mountSide !== 'full' ? ` Mount: ${mountSide}.` : ''}`
+        : `${portCount}-fach Patchfeld, ${frontConnector}.${mountSide !== 'full' ? ` Mount: ${mountSide}.` : ''}`,
     }
     onCreated(template)
     onClose()
   }
 
-  const setOverride = (idx: number, patch: { label?: string; connector?: ConnectorType }) => {
+  const setOverride = (
+    idx: number,
+    patch: { label?: string; front?: ConnectorType; rear?: ConnectorType },
+  ) => {
     setPerPortOverrides((prev) => ({
       ...prev,
       [idx]: { ...prev[idx], ...patch },
@@ -206,23 +223,65 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
                 </div>
               </div>
             </label>
-            <label className="block">
-              <span className="mb-1 block text-xs text-slate-400">Default Connector-Typ</span>
-              <select
-                value={defaultConnector}
-                onChange={(e) => setDefaultConnector(e.target.value as ConnectorType)}
-                className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1.5"
-              >
-                {allConnectors.map((c) => (
-                  <option key={c} value={c}>
-                    {c}
-                  </option>
-                ))}
-              </select>
-              <span className="mt-1 block text-[10px] text-slate-500">
-                Wirkt auf alle {portCount} Ports. Einzeln im Tab "Per-Port-Detail" anpassbar.
+            {/* v7.9.77 / #170 — Adapter-Toggle: bei eingeschalteter
+                Adapter-Mode zeigt der Dialog zwei separate Connector-
+                Selects (Front + Rear). Ohne Adapter-Mode wird der Rear-
+                Connector automatisch dem Front gleichgesetzt — klassische
+                Patchblende. */}
+            <label className="flex items-center gap-2 rounded border border-slate-700 bg-slate-950/40 px-2 py-1.5 text-xs">
+              <input
+                type="checkbox"
+                checked={adapterMode}
+                onChange={(e) => setAdapterMode(e.target.checked)}
+                className="accent-sky-500"
+              />
+              <span className="flex-1">
+                <span className="font-medium text-slate-200">Adapter-Patchblende</span>
+                <span className="ml-1 text-[10px] text-slate-500">
+                  (Front ≠ Rear Stecker, mit internem Adapterkabel)
+                </span>
               </span>
             </label>
+            <div className={`grid gap-2 ${adapterMode ? 'grid-cols-2' : 'grid-cols-1'}`}>
+              <label className="block">
+                <span className="mb-1 block text-xs text-slate-400">
+                  {adapterMode ? 'Front-Connector' : 'Connector-Typ (beide Seiten)'}
+                </span>
+                <select
+                  value={frontConnector}
+                  onChange={(e) => setFrontConnector(e.target.value as ConnectorType)}
+                  className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1.5"
+                >
+                  {allConnectors.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              {adapterMode && (
+                <label className="block">
+                  <span className="mb-1 block text-xs text-slate-400">Rear-Connector</span>
+                  <select
+                    value={rearConnector}
+                    onChange={(e) => setRearConnector(e.target.value as ConnectorType)}
+                    className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1.5"
+                  >
+                    {allConnectors.map((c) => (
+                      <option key={c} value={c}>
+                        {c}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
+            </div>
+            <span className="block text-[10px] text-slate-500">
+              Wirkt auf alle {portCount} Ports. Einzeln im Tab "Per-Port-Detail" anpassbar.
+              {adapterMode
+                ? ` Jeder Front-Port koppelt intern via Adapterkabel auf den gleichnamigen Rear-Port.`
+                : ''}
+            </span>
           </div>
         )}
 
@@ -230,6 +289,7 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
           <div className="space-y-2">
             <div className="text-[10px] text-slate-500">
               Pro Port Label und Connector-Typ überschreibbar. Leerlassen = Default.
+              {adapterMode && ' Bei Adapter-Patchblende sind Front- und Rear-Connector unabhängig wählbar.'}
             </div>
             <div className="max-h-[40vh] overflow-y-auto rounded border border-slate-800">
               <table className="w-full text-xs">
@@ -237,7 +297,8 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
                   <tr>
                     <th className="px-2 py-1 text-left">#</th>
                     <th className="px-2 py-1 text-left">Label</th>
-                    <th className="px-2 py-1 text-left">Connector</th>
+                    <th className="px-2 py-1 text-left">Front</th>
+                    {adapterMode && <th className="px-2 py-1 text-left">Rear</th>}
                   </tr>
                 </thead>
                 <tbody>
@@ -254,9 +315,9 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
                       </td>
                       <td className="px-2 py-0.5">
                         <select
-                          value={perPortOverrides[idx]?.connector ?? defaultConnector}
+                          value={perPortOverrides[idx]?.front ?? frontConnector}
                           onChange={(e) =>
-                            setOverride(idx, { connector: e.target.value as ConnectorType })
+                            setOverride(idx, { front: e.target.value as ConnectorType })
                           }
                           className="w-full rounded border border-slate-700 bg-slate-950 px-1.5 py-0.5"
                         >
@@ -267,6 +328,23 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
                           ))}
                         </select>
                       </td>
+                      {adapterMode && (
+                        <td className="px-2 py-0.5">
+                          <select
+                            value={perPortOverrides[idx]?.rear ?? rearConnector}
+                            onChange={(e) =>
+                              setOverride(idx, { rear: e.target.value as ConnectorType })
+                            }
+                            className="w-full rounded border border-slate-700 bg-slate-950 px-1.5 py-0.5"
+                          >
+                            {allConnectors.map((c) => (
+                              <option key={c} value={c}>
+                                {c}
+                              </option>
+                            ))}
+                          </select>
+                        </td>
+                      )}
                     </tr>
                   ))}
                 </tbody>

--- a/src/renderer/components/Rack/Rack3DView.tsx
+++ b/src/renderer/components/Rack/Rack3DView.tsx
@@ -33,6 +33,15 @@ const RACK_MOUNT_WIDTH_MM = 450
 const DEFAULT_RACK_DEPTH_MM = 800
 const DEFAULT_DEVICE_DEPTH_MM = 400
 
+interface Rack3DPort {
+  id: string
+  name: string
+  connectorType: string
+  /** Normalized 0..1 across panel face, or undefined for auto-layout. */
+  panelPosX?: number
+  panelPosY?: number
+}
+
 interface Rack3DPlacement {
   id: string
   name: string
@@ -48,6 +57,43 @@ interface Rack3DPlacement {
   portCount?: number
   isPatchPanel?: boolean
   isRackShelf?: boolean
+  /** v7.9.77 / #170 — Front + Rear Port-Listen für 3D-Dot-Rendering.
+   *  Front entspricht inputs[], Rear entspricht outputs[]. */
+  frontPorts?: Rack3DPort[]
+  rearPorts?: Rack3DPort[]
+}
+
+/** v7.9.77 / #170 — Port-Connector-Type → Dot-Farbe. Vereinheitlicht mit
+ *  dem 2D-Canvas port-by-type Color-Scheme. */
+const PORT_DOT_COLORS: Record<string, string> = {
+  BNC: '#fbbf24',
+  HDMI: '#a855f7',
+  'Ethernet/RJ45': '#10b981',
+  Fiber: '#3b82f6',
+  SFP: '#06b6d4',
+  'SFP+': '#06b6d4',
+  XLR: '#ef4444',
+  Custom: '#94a3b8',
+}
+
+const portDotColor = (connectorType: string): string =>
+  PORT_DOT_COLORS[connectorType] ?? '#94a3b8'
+
+/** v7.9.77 / #170 — Default-Port-Position (Grid-Layout) wenn der User
+ *  keine manuelle Position gesetzt hat. Ports werden in einer Spalten-
+ *  Grid auf der Panel-Face verteilt. Vermeidet Überlapp bei vielen Ports.
+ */
+const computeDefaultPortPosition = (index: number, total: number): { x: number; y: number } => {
+  if (total <= 1) return { x: 0.5, y: 0.5 }
+  // Choose column count so layout stays ungefähr square-ish.
+  const cols = Math.ceil(Math.sqrt(total * 2.5)) // mehr Spalten als Zeilen weil Panel breit ist
+  const rows = Math.ceil(total / cols)
+  const col = index % cols
+  const row = Math.floor(index / cols)
+  return {
+    x: (col + 0.5) / cols,
+    y: (row + 0.5) / rows,
+  }
 }
 
 interface Rack3DViewProps {
@@ -56,6 +102,26 @@ interface Rack3DViewProps {
   placements: Rack3DPlacement[]
   selectedPlacementId: string | null
   onSelectPlacement: (id: string | null) => void
+  /** v7.9.77 / #170 — Drag-Callback wenn der User einen Port-Dot
+   *  verschoben hat. Übergibt placement-id, port-id, side und die neue
+   *  normalisierte Position. Lokales State-Tracking während des Drags
+   *  passiert intern; Persistierung erst beim Drag-End. */
+  onPortMoved?: (
+    placementId: string,
+    portId: string,
+    side: 'front' | 'rear',
+    pos: { x: number; y: number },
+  ) => void
+  /** v7.9.78 / #170 — Internal Cables zwischen Patchpunkten. */
+  internalCables?: Array<{
+    fromPlacementId: string
+    fromPortId: string
+    fromSide: 'front' | 'rear'
+    toPlacementId: string
+    toPortId: string
+    toSide: 'front' | 'rear'
+    color?: string
+  }>
 }
 
 const Chassis = ({
@@ -159,12 +225,14 @@ const DeviceBox = ({
   totalUnits,
   selected,
   onClick,
+  onPortMoved,
 }: {
   placement: Rack3DPlacement
   rackDepthMm: number
   totalUnits: number
   selected: boolean
   onClick: () => void
+  onPortMoved?: Rack3DViewProps['onPortMoved']
 }) => {
   const mountSide = placement.mountSide ?? 'full'
   const depthMm = Math.max(20, placement.depthMm ?? DEFAULT_DEVICE_DEPTH_MM)
@@ -237,6 +305,33 @@ const DeviceBox = ({
         <boxGeometry args={[widthMm, heightMm, depthMm]} />
         <Edges color={selected ? '#0ea5e9' : '#020617'} threshold={15} />
       </mesh>
+      {/* v7.9.77 / #170 — Port-Dots auf Front-Face (-Z) und Rear-Face (+Z).
+          Werden minimal nach außen versetzt (zOffset ±1 mm) damit sie
+          immer vor dem Panel-Foto sichtbar bleiben. */}
+      {placement.frontPorts && placement.frontPorts.length > 0 && (
+        <PortDots
+          ports={placement.frontPorts}
+          side="front"
+          placementId={placement.id}
+          faceCenter={[xCenter, yCenter, zStart - 1]}
+          widthMm={widthMm * 0.95}
+          heightMm={heightMm * 0.85}
+          zOffset={0}
+          onPortMoved={onPortMoved}
+        />
+      )}
+      {placement.rearPorts && placement.rearPorts.length > 0 && (
+        <PortDots
+          ports={placement.rearPorts}
+          side="rear"
+          placementId={placement.id}
+          faceCenter={[xCenter, yCenter, zStart + depthMm + 1]}
+          widthMm={widthMm * 0.95}
+          heightMm={heightMm * 0.85}
+          zOffset={0}
+          onPortMoved={onPortMoved}
+        />
+      )}
       <Html
         position={[xCenter, yCenter, mountSide === 'rear' ? zStart - 5 : zStart + depthMm + 5]}
         center
@@ -254,6 +349,118 @@ const DeviceBox = ({
       >
         {placement.name} ({placement.rackUnits}HE)
       </Html>
+    </group>
+  )
+}
+
+/** v7.9.77 / #170 — Port-Dots auf einer Panel-Face (Front oder Rear).
+ *  Rendert kleine Kugeln, deren Position normiert auf der Face liegt.
+ *  Drag: onPointerDown auf einer Kugel → onPointerMove raycaster
+ *  schneidet wieder die Face → neue normierte Position → onPortMoved.
+ *
+ *  Face-Koordinaten:
+ *   - Face liegt in der XY-Ebene des Geräts (W × H)
+ *   - x ∈ [0..1] mappt auf widthMm
+ *   - y ∈ [0..1] mappt auf heightMm
+ *   - z = 0 (auf der Face) — wir lupen die Dots minimal nach außen
+ *     damit sie auf dem Foto sichtbar sind (zOffset = +0.5 mm)
+ */
+const PortDots = ({
+  ports,
+  side,
+  placementId,
+  faceCenter,
+  widthMm,
+  heightMm,
+  zOffset,
+  onPortMoved,
+}: {
+  ports: Rack3DPort[]
+  side: 'front' | 'rear'
+  placementId: string
+  faceCenter: [number, number, number] // world center of the face plane
+  widthMm: number
+  heightMm: number
+  /** Outward offset from face center along normal (positive = outside-of-box). */
+  zOffset: number
+  onPortMoved?: Rack3DViewProps['onPortMoved']
+}) => {
+  // Während eines Drags speichern wir lokal die neue Position, damit der
+  // Dot beim Slide live folgt (statt erst nach Drop neu zu rendern).
+  const [dragOverride, setDragOverride] = useState<{ id: string; x: number; y: number } | null>(null)
+  const draggingRef = useRef<{ id: string; pointerId: number } | null>(null)
+  const meshRefs = useRef<Map<string, THREE.Mesh>>(new Map())
+
+  // Sichere Höhe für Dot-Geometrie: ~6mm Radius, aber max 1/3 der HE-Höhe
+  // damit sie bei kleinen 1HE-Boxen nicht den ganzen Bereich überdecken.
+  const dotRadius = Math.min(6, heightMm * 0.18)
+
+  return (
+    <group>
+      {ports.map((port, idx) => {
+        const override = dragOverride?.id === port.id ? dragOverride : null
+        const px = override?.x ?? port.panelPosX ?? computeDefaultPortPosition(idx, ports.length).x
+        const py = override?.y ?? port.panelPosY ?? computeDefaultPortPosition(idx, ports.length).y
+        // Face-X: 0..1 → -widthMm/2 .. +widthMm/2 (in face local space).
+        // Y wird invertiert (oben=0 fühlt sich natürlicher an): py=0 → +heightMm/2.
+        const faceX = (px - 0.5) * widthMm
+        const faceY = (0.5 - py) * heightMm
+        // World: faceCenter ist bereits world-position. Für Front (-Z normal)
+        // schieben wir den Dot in -Z Richtung (zOffset negativ); für Rear
+        // in +Z. Der zOffset-Param trägt das schon vorzeichenrichtig.
+        const worldX = faceCenter[0] + faceX
+        const worldY = faceCenter[1] + faceY
+        const worldZ = faceCenter[2] + zOffset
+        return (
+          <mesh
+            key={port.id}
+            ref={(m) => {
+              if (m) meshRefs.current.set(port.id, m)
+              else meshRefs.current.delete(port.id)
+            }}
+            position={[worldX, worldY, worldZ]}
+            onPointerDown={(e) => {
+              if (!onPortMoved) return
+              e.stopPropagation()
+              ;(e.target as Element).setPointerCapture?.(e.pointerId)
+              draggingRef.current = { id: port.id, pointerId: e.pointerId }
+            }}
+            onPointerMove={(e) => {
+              const drag = draggingRef.current
+              if (!drag || drag.id !== port.id || drag.pointerId !== e.pointerId) return
+              // Raycast-Trick: e.point ist der getroffene World-Punkt
+              // (r3f setzt das beim pointer event). Wir konvertieren zurück
+              // in Face-Local (faceCenter abziehen, durch w/h teilen).
+              const hit = e.point as THREE.Vector3
+              const localX = hit.x - faceCenter[0]
+              const localY = hit.y - faceCenter[1]
+              const nx = Math.max(0, Math.min(1, localX / widthMm + 0.5))
+              const ny = Math.max(0, Math.min(1, 0.5 - localY / heightMm))
+              setDragOverride({ id: port.id, x: nx, y: ny })
+            }}
+            onPointerUp={(e) => {
+              const drag = draggingRef.current
+              if (!drag || drag.id !== port.id) return
+              ;(e.target as Element).releasePointerCapture?.(e.pointerId)
+              const override = dragOverride?.id === port.id ? dragOverride : null
+              if (override && onPortMoved) {
+                onPortMoved(placementId, port.id, side, { x: override.x, y: override.y })
+              }
+              draggingRef.current = null
+              setDragOverride(null)
+            }}
+          >
+            <sphereGeometry args={[dotRadius, 12, 12]} />
+            <meshStandardMaterial
+              color={portDotColor(port.connectorType)}
+              emissive={portDotColor(port.connectorType)}
+              emissiveIntensity={0.3}
+              roughness={0.4}
+              metalness={0.5}
+            />
+          </mesh>
+        )
+      })}
     </group>
   )
 }
@@ -376,12 +583,92 @@ const DeviceSTL = ({
   )
 }
 
+/** v7.9.78 / #170 — Rack-interne Verkabelung als 3D-Linien. Berechnet
+ *  pro Cable die Welt-Position des From- und To-Ports, baut eine
+ *  BufferGeometry mit 2 (oder mehr für Kurven) Punkten und rendert sie
+ *  als <line>. Farbe aus cable.color oder Connector-Default.
+ */
+const InternalCables3D = ({
+  placements,
+  totalUnits,
+  rackDepthMm,
+  cables,
+}: {
+  placements: Rack3DPlacement[]
+  totalUnits: number
+  rackDepthMm: number
+  cables: NonNullable<Rack3DViewProps['internalCables']>
+}) => {
+  // Helper: berechne World-Position eines bestimmten Port-Dots auf einer
+  // Face. Identisch zur PortDots-Mathe; dupliziert hier weil wir die
+  // Position OHNE Mesh-Render brauchen.
+  const portWorldPos = (
+    placement: Rack3DPlacement,
+    portId: string,
+    side: 'front' | 'rear',
+  ): THREE.Vector3 | null => {
+    const ports = side === 'front' ? placement.frontPorts : placement.rearPorts
+    if (!ports) return null
+    const idx = ports.findIndex((p) => p.id === portId)
+    if (idx < 0) return null
+    const p = ports[idx]
+    const depthMm = Math.max(20, placement.depthMm ?? DEFAULT_DEVICE_DEPTH_MM)
+    const mountSide = placement.mountSide ?? 'full'
+    const yBottom = (totalUnits - placement.startUnit - placement.rackUnits + 1) * HE_HEIGHT_MM
+    const heightMm = placement.rackUnits * HE_HEIGHT_MM
+    const widthMm = RACK_MOUNT_WIDTH_MM * 0.95
+    const heightActiveMm = heightMm * 0.85
+    const zStart = mountSide === 'rear' ? rackDepthMm - depthMm : 0
+    const xCenter = RACK_OUTER_WIDTH_MM / 2
+    const yCenter = yBottom + heightMm / 2
+    const faceZ = side === 'front' ? zStart - 1 : zStart + depthMm + 1
+    const px = p.panelPosX ?? computeDefaultPortPosition(idx, ports.length).x
+    const py = p.panelPosY ?? computeDefaultPortPosition(idx, ports.length).y
+    const faceX = (px - 0.5) * widthMm
+    const faceY = (0.5 - py) * heightActiveMm
+    return new THREE.Vector3(xCenter + faceX, yCenter + faceY, faceZ)
+  }
+
+  return (
+    <group>
+      {cables.map((c, idx) => {
+        const fromPl = placements.find((p) => p.id === c.fromPlacementId)
+        const toPl = placements.find((p) => p.id === c.toPlacementId)
+        if (!fromPl || !toPl) return null
+        const fromPos = portWorldPos(fromPl, c.fromPortId, c.fromSide)
+        const toPos = portWorldPos(toPl, c.toPortId, c.toSide)
+        if (!fromPos || !toPos) return null
+        // Kurze Out-of-Face-Strecke (Stub) damit das Kabel nicht direkt
+        // im Port verschwindet. 30mm außerhalb der Face entlang Normal.
+        const stubLen = 30
+        const fromStub = fromPos.clone()
+        fromStub.z += c.fromSide === 'front' ? -stubLen : stubLen
+        const toStub = toPos.clone()
+        toStub.z += c.toSide === 'front' ? -stubLen : stubLen
+        const points = [fromPos, fromStub, toStub, toPos]
+        const geom = new THREE.BufferGeometry().setFromPoints(points)
+        const color = c.color ?? '#22d3ee'
+        return (
+          <primitive key={`${c.fromPlacementId}-${c.fromPortId}-${idx}`} object={
+            new THREE.Line(
+              geom,
+              new THREE.LineBasicMaterial({ color, linewidth: 2 }),
+            )
+          } />
+        )
+      })}
+    </group>
+  )
+}
+
 export const Rack3DView = ({
   totalUnits,
   rackDepthMm,
   placements,
   selectedPlacementId,
   onSelectPlacement,
+  onPortMoved,
+  internalCables,
 }: Rack3DViewProps) => {
   const depthMm = rackDepthMm ?? DEFAULT_RACK_DEPTH_MM
   const orbitRef = useRef<unknown>(null)
@@ -439,9 +726,20 @@ export const Rack3DView = ({
                 totalUnits={totalUnits}
                 selected={selectedPlacementId === p.id}
                 onClick={() => onSelectPlacement(p.id)}
+                onPortMoved={onPortMoved}
               />
             )
           })}
+          {/* v7.9.78 / #170 — Rack-interne Verkabelung als Linien zwischen
+              den jeweiligen Port-Dots. Vereinfachte gerade Linie — wer
+              schöne Routing-Kurven will, kann später CatmullRomCurve3
+              dazwischen ziehen. */}
+          <InternalCables3D
+            placements={placements}
+            totalUnits={totalUnits}
+            rackDepthMm={depthMm}
+            cables={internalCables ?? []}
+          />
         </Suspense>
         <OrbitControls
           ref={orbitRef as never}

--- a/src/renderer/components/Rack/RackBuilderDialog.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialog.tsx
@@ -1283,12 +1283,6 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                             const totalPorts = (p.inputs?.length ?? 0) + (p.outputs?.length ?? 0)
                             const hasFreePort = usedSet.size < totalPorts
                             if (renderMode === 'free') return hasFreePort
-                            // 'released': Items mit AUSSCHLIESSLICH zu
-                            // Patchblenden verkabelten Ports gelten als
-                            // released (die Patchblende ist der externe
-                            // Übergang). Vereinfachte Approximation:
-                            // wenn alle Ports intern verbunden sind,
-                            // gelten sie als nicht-released (versteckt).
                             return hasFreePort
                           })
                           .map((p) => ({
@@ -1304,10 +1298,72 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                             portCount: (p.inputs?.length ?? 0) + (p.outputs?.length ?? 0),
                             isPatchPanel: p.isPatchPanel,
                             isRackShelf: p.isRackShelf,
+                            // v7.9.77 / #170 — inputs = Front-Ports,
+                            // outputs = Rear-Ports (Builder-Konvention).
+                            frontPorts: (p.inputs ?? []).map((port) => ({
+                              id: port.id,
+                              name: port.name,
+                              connectorType: port.connectorType,
+                              panelPosX: port.panelPosX,
+                              panelPosY: port.panelPosY,
+                            })),
+                            rearPorts: (p.outputs ?? []).map((port) => ({
+                              id: port.id,
+                              name: port.name,
+                              connectorType: port.connectorType,
+                              panelPosX: port.panelPosX,
+                              panelPosY: port.panelPosY,
+                            })),
                           }))
                       })()}
                       selectedPlacementId={selectedPlacementId}
                       onSelectPlacement={(id) => setSelectedPlacementId(id)}
+                      // v7.9.77 / #170 — Port-Dot-Drag persistieren: setzt
+                      // panelPosX/Y am Port (in inputs ODER outputs je
+                      // nach side) im Draft.
+                      onPortMoved={(placementId, portId, side, pos) => {
+                        setDraft((current) => ({
+                          ...current,
+                          placements: current.placements.map((p) => {
+                            if (p.id !== placementId) return p
+                            const key = side === 'front' ? 'inputs' : 'outputs'
+                            return {
+                              ...p,
+                              [key]: p[key].map((port) =>
+                                port.id === portId
+                                  ? { ...port, panelPosX: pos.x, panelPosY: pos.y }
+                                  : port,
+                              ),
+                            }
+                          }),
+                        }))
+                      }}
+                      // v7.9.78 / #170 — Internal cables: portName aus
+                      // dem Cable-Eintrag → portId-Lookup + side-Ableitung
+                      // (im input → Front, im output → Rear).
+                      internalCables={draft.internalCables
+                        .map((c) => {
+                          const fromP = draft.placements.find((x) => x.id === c.fromPlacementId)
+                          const toP = draft.placements.find((x) => x.id === c.toPlacementId)
+                          if (!fromP || !toP) return null
+                          const fromInput = fromP.inputs.find((p) => p.name === c.fromPortName)
+                          const fromOutput = fromP.outputs.find((p) => p.name === c.fromPortName)
+                          const toInput = toP.inputs.find((p) => p.name === c.toPortName)
+                          const toOutput = toP.outputs.find((p) => p.name === c.toPortName)
+                          const fromPort = fromInput ?? fromOutput
+                          const toPort = toInput ?? toOutput
+                          if (!fromPort || !toPort) return null
+                          return {
+                            fromPlacementId: c.fromPlacementId,
+                            fromPortId: fromPort.id,
+                            fromSide: (fromInput ? 'front' : 'rear') as 'front' | 'rear',
+                            toPlacementId: c.toPlacementId,
+                            toPortId: toPort.id,
+                            toSide: (toInput ? 'front' : 'rear') as 'front' | 'rear',
+                            color: c.color,
+                          }
+                        })
+                        .filter((c): c is NonNullable<typeof c> => c !== null)}
                     />
                   </div>
                 ) : (

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -91,6 +91,16 @@ export interface Port {
    * For Fiber ports: module vendor (e.g. "Cisco", "Aruba", "Ubiquiti", "FS.com").
    */
   sfpVendor?: string
+  /**
+   * v7.9.77 / #170 — Manual position override of the port-dot on the
+   * device's rack-panel (front oder rear). Normalized 0..1 across the
+   * panel face (0=links/oben, 1=rechts/unten). Wenn nicht gesetzt,
+   * verteilt der Renderer die Ports gleichmäßig (Default-Layout).
+   * Wird interaktiv per Drag in 2D-Rack-Preview / 3D-View gesetzt, damit
+   * die Dots zu importierten Front-/Rear-Panel-Fotos passen.
+   */
+  panelPosX?: number
+  panelPosY?: number
 }
 
 /** v7.5.0 — a named operating mode for a device whose port layout


### PR DESCRIPTION
…in 3D (#170)

Vier zusammenhängende Erweiterungen am 3D-Rack:

1. ADAPTER-PATCHBLENDE (v7.9.77) PatchPanelCreateDialog hat eine neue Checkbox "Adapter-Patchblende". Aktiv: Front- und Rear-Connector sind unabhängig wählbar (z.B. BNC vorne, RJ45 hinten — typisch für Patch-Adapter mit internem Adapterkabel). Per-Port-Tab zeigt eine zusätzliche Rear-Spalte, damit pro Port beide Stecker einzeln änderbar sind. Die generierte EquipmentTemplate bekommt category="Patchblende (Adapter)" damit Library und Plan-BOM die Adapter-Variante separat zählen können.

2. PORT-DOTS IN DER 3D-ANSICHT (v7.9.77) Jedes Gerät rendert jetzt kleine farbige Kugeln auf seiner Front- und Rear-Face — jeweils inputs (Front) und outputs (Rear) aus dem Placement. Farbe folgt dem Connector-Typ (BNC=amber, HDMI=lila, Ethernet=grün, Fiber=blau, XLR=rot, …) — analog zum 2D-Canvas. Default-Layout: Spalten-Grid auf der Face (cols ≈ √(2.5·N) damit Panel-Breite vs. -Höhe Berücksichtigung findet).

3. PORT-DOT DRAG (v7.9.77) Pointer-Down auf einem Dot startet einen Drag; r3f's event.point liefert den Welt-Schnittpunkt, den wir zurück in Face-Local rechnen und als normalisierte 0..1-Position auf Port.panelPosX/Y schreiben. Damit kann der User die Dots auf hochgeladene Front-/Rear-Fotos ausrichten (Dot landet exakt auf dem echten Stecker im Foto). Live-Override während des Drags rendert smooth, Persistierung erst onPointerUp via onPortMoved-Callback in den Draft.

4. INTERNE VERKABELUNG IM 3D (v7.9.78) InternalCables3D rendert für jeden internalCable eine THREE.Line zwischen den Welt-Positionen der beiden Port-Dots — mit kurzem 30mm Stub außerhalb der Face damit das Kabel nicht IN den Port verschwindet. Kabel-Farbe aus cable.color (default cyan). side-Ableitung: portName-Match in inputs → Front, in outputs → Rear.

Neuer Port-Typ-Feld panelPosX/Y (optional, normalisiert 0..1) auf src/renderer/types/equipment.ts. Default beim Render: gleichmäßig verteiltes Grid.

v7.9.78

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH