### PR TITLE
feat(rack): 2D Port-Dots Overlay mit Drag (#170)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.9.78",
+    "version": "7.9.79",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/components/Rack/PortDots2D.tsx
+++ b/src/renderer/components/Rack/PortDots2D.tsx
@@ -1,0 +1,121 @@
+/**
+ * v7.9.78 / #170 — 2D-Port-Dot Overlay für den Rack-Builder.
+ *
+ * Zeigt pro Port ein kleines farbiges Kreis-Overlay auf der Front- bzw.
+ * Rear-Seite des Geräts im 2D-Rack-Editor. Position ist normalisiert
+ * 0..1 über die Block-Fläche (panelPosX/Y am Port). Wenn nicht gesetzt,
+ * verteilt der Renderer die Dots gleichmäßig in einem Spalten-Grid.
+ *
+ * Drag: onPointerDown auf Dot startet Drag, onPointerMove updated
+ * pos.x/y aus der Position relativ zum Parent-Block. Drop persistiert
+ * via updatePlacement(panelPosX/Y) — entweder auf inputs (Front) oder
+ * outputs (Rear).
+ *
+ * Synchronisiert sich mit den 3D-Dots: derselbe panelPosX/Y-Wert wird
+ * dort genutzt, sodass ein 2D-Drag sofort die 3D-Position ändert.
+ */
+import { useRef, useState } from 'react'
+import type { Port } from '../../types/equipment'
+
+interface Props {
+  ports: Port[]
+  placementId: string
+  placementWidth: number
+  placementHeight: number
+  updatePlacement: (id: string, patch: Partial<{ inputs: Port[]; outputs: Port[] }>) => void
+  side: 'front' | 'rear'
+}
+
+const PORT_DOT_COLORS: Record<string, string> = {
+  BNC: '#fbbf24',
+  HDMI: '#a855f7',
+  'Ethernet/RJ45': '#10b981',
+  Fiber: '#3b82f6',
+  SFP: '#06b6d4',
+  'SFP+': '#06b6d4',
+  XLR: '#ef4444',
+  Custom: '#94a3b8',
+}
+
+const computeDefault = (idx: number, total: number): { x: number; y: number } => {
+  if (total <= 1) return { x: 0.5, y: 0.5 }
+  const cols = Math.ceil(Math.sqrt(total * 2.5))
+  const rows = Math.ceil(total / cols)
+  return { x: ((idx % cols) + 0.5) / cols, y: (Math.floor(idx / cols) + 0.5) / rows }
+}
+
+export const PortDots2D = ({
+  ports,
+  placementId,
+  placementWidth,
+  placementHeight,
+  updatePlacement,
+  side,
+}: Props) => {
+  const [dragOverride, setDragOverride] = useState<{ id: string; x: number; y: number } | null>(null)
+  const draggingRef = useRef<{ id: string; pointerId: number } | null>(null)
+
+  const dotPx = Math.min(14, Math.max(8, placementHeight * 0.15))
+
+  return (
+    <div className="pointer-events-none absolute inset-0">
+      {ports.map((port, idx) => {
+        const override = dragOverride?.id === port.id ? dragOverride : null
+        const px = override?.x ?? port.panelPosX ?? computeDefault(idx, ports.length).x
+        const py = override?.y ?? port.panelPosY ?? computeDefault(idx, ports.length).y
+        const color = PORT_DOT_COLORS[port.connectorType] ?? '#94a3b8'
+        return (
+          <div
+            key={port.id}
+            // stopPropagation auf den Pointer-Events, sonst greift der
+            // Placement-Drag-Handler (vertikales Verschieben des Blocks)
+            // und der Dot wird nie selber bewegt.
+            onPointerDown={(e) => {
+              e.stopPropagation()
+              e.preventDefault()
+              ;(e.currentTarget as Element).setPointerCapture?.(e.pointerId)
+              draggingRef.current = { id: port.id, pointerId: e.pointerId }
+            }}
+            onPointerMove={(e) => {
+              const drag = draggingRef.current
+              if (!drag || drag.id !== port.id || drag.pointerId !== e.pointerId) return
+              e.stopPropagation()
+              const host = (e.currentTarget as HTMLElement).parentElement
+              if (!host) return
+              const rect = host.getBoundingClientRect()
+              const nx = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width))
+              const ny = Math.max(0, Math.min(1, (e.clientY - rect.top) / rect.height))
+              setDragOverride({ id: port.id, x: nx, y: ny })
+            }}
+            onPointerUp={(e) => {
+              const drag = draggingRef.current
+              if (!drag || drag.id !== port.id) return
+              e.stopPropagation()
+              ;(e.currentTarget as Element).releasePointerCapture?.(e.pointerId)
+              const override = dragOverride?.id === port.id ? dragOverride : null
+              if (override) {
+                const key = side === 'front' ? 'inputs' : 'outputs'
+                const updated = ports.map((p) =>
+                  p.id === port.id ? { ...p, panelPosX: override.x, panelPosY: override.y } : p,
+                )
+                updatePlacement(placementId, { [key]: updated })
+              }
+              draggingRef.current = null
+              setDragOverride(null)
+            }}
+            onClick={(e) => e.stopPropagation()}
+            title={`${port.name} · ${port.connectorType}\n(ziehen zum Verschieben auf das Panel-Foto)`}
+            className="pointer-events-auto absolute -translate-x-1/2 -translate-y-1/2 cursor-grab rounded-full border-2 border-white/80 shadow-md active:cursor-grabbing"
+            style={{
+              left: `${px * placementWidth}px`,
+              top: `${py * placementHeight}px`,
+              width: dotPx,
+              height: dotPx,
+              background: color,
+            }}
+          />
+        )
+      })}
+    </div>
+  )
+}

--- a/src/renderer/components/Rack/RackBuilderDialog.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialog.tsx
@@ -9,6 +9,7 @@ import { RackLivePreview } from './RackLivePreview'
 import { Rack3DView } from './Rack3DView'
 import { PatchPanelCreateDialog } from './PatchPanelCreateDialog'
 import { RackShelfCreateDialog } from './RackShelfCreateDialog'
+import { PortDots2D } from './PortDots2D'
 import { useDraggablePosition } from '../../hooks/useDraggablePosition'
 import { CategorySelect } from '../shared/CategorySelect'
 import { ModalShell } from '../shared/ModalShell'
@@ -1530,6 +1531,21 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                           ) : (
                             <div className="pointer-events-none flex h-full items-center justify-center px-2 text-center text-[10px] font-semibold text-sky-100">{item.name}</div>
                           )}
+                          {/* v7.9.78 / #170 — Port-Dots-Overlay im 2D
+                              Rack-Editor. Front-Side zeigt inputs[],
+                              Rear-Side zeigt outputs[]. Dots sind via
+                              Pointer-Drag positionierbar — Position als
+                              normalisierte 0..1 auf den Port persistiert
+                              (panelPosX/Y). Default-Verteilung wenn kein
+                              Override gesetzt. */}
+                          <PortDots2D
+                            ports={side === 'front' ? item.inputs : item.outputs}
+                            placementId={item.id}
+                            placementWidth={rowHeight * RACK_PANEL_ASPECT_PER_1HE}
+                            placementHeight={height}
+                            updatePlacement={updatePlacement}
+                            side={side as 'front' | 'rear'}
+                          />
                           <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-black/50 px-1 py-0.5 text-[9px] text-white">
                             {item.inputs.length} In · {item.outputs.length} Out
                           </div>


### PR DESCRIPTION
Symmetrisch zu den 3D-Port-Dots aus v7.9.77: jetzt hat auch der 2D Rack-Editor einen Dot-Overlay pro Placement-Block. Front-Side zeigt inputs[] als farbige Dots auf dem hochgeladenen Frontfoto (oder auf dem blauen Default-Hintergrund), Rear-Side zeigt outputs[].

Drag-Mechanik (PortDots2D.tsx):
- Pointer-Down auf Dot → setPointerCapture + draggingRef
- onPointerMove → normalisiert auf 0..1 relativ zum Placement-Block
- onPointerUp → persistiert via updatePlacement({inputs|outputs}: ...) und schreibt panelPosX/Y auf den entsprechenden Port
- stopPropagation auf allen Events, damit der existierende Block- Vertical-Drag (HE-Reposition) nicht beim Dot-Drag mit ausgelöst wird

Dot-Größe skaliert mit der Block-Höhe (8-14 px), Farbe folgt dem Connector-Typ (analog 2D-Canvas + 3D-View). Default-Layout: Spalten- Grid wenn panelPosX/Y nicht gesetzt — identisch zur 3D-Default-Logik, damit die 2D-Anordnung mit der 3D-Anordnung übereinstimmt bis der User manuell zieht.

Folge: User kann die Dots im 2D direkt auf die Stecker eines importierten Frontfotos schieben (z.B. exakt auf die 12 BNCs eines Switchers). Die Position ist sofort in 3D synchron, weil beide Views denselben panelPosX/Y-Wert lesen.

v7.9.79

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH