### PR TITLE
feat(rack): 5 UX-Fixes — STL-Button, Mount-Split, View-Toggle, Cam-Ke…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.9.79",
+    "version": "7.9.80",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/components/Rack/NonRackAddDialog.tsx
+++ b/src/renderer/components/Rack/NonRackAddDialog.tsx
@@ -1,0 +1,242 @@
+/**
+ * v7.9.80 / #170 — Add-Dialog für Non-Rack-Geräte.
+ *
+ * Vor 7.9.80 fragte addTemplate() nur "Wieviele HE?" was für Shelf-
+ * Geräte (Mac mini, Encoder-Box, Splitter…) Unsinn ist — die haben
+ * keine sinnvolle HE-Höhe, sondern echte physikalische Maße W×H×D
+ * in mm. Dieser Dialog gibt dem User zwei Pfade:
+ *
+ *  • "Als 19""-Gerät" → wie bisher, HE-Eingabe
+ *  • "Auf Shelf"     → W/H/D in mm + optional Persist aufs Template
+ *
+ * Im Shelf-Pfad: HE wird auf 1 gesetzt (Geräte sitzen oben in einer
+ * HE-Reihe auf einem Shelf), und widthMm/heightMm/depthMm wandern aufs
+ * Template → bleiben mit dem Gerät verbunden und werden vom 3D-Renderer
+ * (Phase B+1) als kleinere Box innerhalb der HE gerendert.
+ */
+import { useState } from 'react'
+import type { EquipmentTemplate } from '../../types/equipment'
+
+interface Props {
+  open: boolean
+  templateName: string
+  initialDimensions?: { widthMm?: number; heightMm?: number; depthMm?: number }
+  onCancel: () => void
+  /** Returns { rackUnits, mountSide?, dimensions? } and whether to persist back to template. */
+  onConfirm: (result: {
+    mode: 'rack' | 'shelf'
+    rackUnits: number
+    widthMm?: number
+    heightMm?: number
+    depthMm?: number
+    persistToTemplate: boolean
+  }) => void
+}
+
+const DEFAULT_SHELF_DEVICE = { widthMm: 200, heightMm: 50, depthMm: 200 }
+
+export const NonRackAddDialog = ({
+  open,
+  templateName,
+  initialDimensions,
+  onCancel,
+  onConfirm,
+}: Props) => {
+  const [mode, setMode] = useState<'rack' | 'shelf'>('rack')
+  const [rackUnits, setRackUnits] = useState(1)
+  const [widthMm, setWidthMm] = useState(initialDimensions?.widthMm ?? DEFAULT_SHELF_DEVICE.widthMm)
+  const [heightMm, setHeightMm] = useState(initialDimensions?.heightMm ?? DEFAULT_SHELF_DEVICE.heightMm)
+  const [depthMm, setDepthMm] = useState(initialDimensions?.depthMm ?? DEFAULT_SHELF_DEVICE.depthMm)
+  const [persistFlag, setPersistFlag] = useState(true)
+
+  if (!open) return null
+
+  const submit = () => {
+    if (mode === 'rack') {
+      onConfirm({
+        mode: 'rack',
+        rackUnits: Math.max(1, Math.min(20, Math.round(rackUnits) || 1)),
+        persistToTemplate: persistFlag,
+      })
+    } else {
+      onConfirm({
+        mode: 'shelf',
+        rackUnits: 1,
+        widthMm: Math.max(20, Math.min(450, widthMm)),
+        heightMm: Math.max(10, Math.min(400, heightMm)),
+        depthMm: Math.max(20, Math.min(1500, depthMm)),
+        persistToTemplate: persistFlag,
+      })
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[200] flex items-center justify-center bg-black/70 backdrop-blur-sm"
+      onClick={onCancel}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="w-[480px] max-w-[95vw] rounded-lg border border-slate-700 bg-slate-900 p-4 text-sm text-slate-100 shadow-2xl"
+      >
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-base font-semibold">
+            "{templateName}" hinzufügen
+          </h2>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded p-1 text-slate-400 hover:bg-slate-800 hover:text-white"
+            aria-label="Schließen"
+          >
+            ✕
+          </button>
+        </div>
+        <div className="mb-3 text-[11px] text-slate-400">
+          Das Gerät ist nicht als 19″-Rack-Gerät markiert. Wähle wie es im Rack
+          platziert werden soll:
+        </div>
+
+        <div className="mb-3 grid grid-cols-2 gap-2">
+          <button
+            type="button"
+            onClick={() => setMode('rack')}
+            className={`rounded border p-3 text-left transition ${
+              mode === 'rack'
+                ? 'border-sky-500 bg-sky-900/40 text-sky-100'
+                : 'border-slate-700 bg-slate-950/50 text-slate-400 hover:bg-slate-900'
+            }`}
+          >
+            <div className="font-semibold">📏 Als 19″-Gerät</div>
+            <div className="mt-0.5 text-[10px] text-slate-500">
+              Belegt N HE auf den Rack-Schienen
+            </div>
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode('shelf')}
+            className={`rounded border p-3 text-left transition ${
+              mode === 'shelf'
+                ? 'border-emerald-500 bg-emerald-900/40 text-emerald-100'
+                : 'border-slate-700 bg-slate-950/50 text-slate-400 hover:bg-slate-900'
+            }`}
+          >
+            <div className="font-semibold">🪑 Auf Shelf</div>
+            <div className="mt-0.5 text-[10px] text-slate-500">
+              Eigene Maße in mm, sitzt auf einem Rack-Shelf
+            </div>
+          </button>
+        </div>
+
+        {mode === 'rack' && (
+          <div className="mb-3 space-y-2">
+            <label className="block">
+              <span className="mb-1 block text-xs text-slate-400">HE-Höhe</span>
+              <input
+                type="number"
+                min={1}
+                max={20}
+                value={rackUnits}
+                onChange={(e) => setRackUnits(Math.max(1, Math.min(20, Number(e.target.value) || 1)))}
+                className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1.5"
+                autoFocus
+              />
+            </label>
+          </div>
+        )}
+
+        {mode === 'shelf' && (
+          <div className="mb-3 space-y-2">
+            <div className="grid grid-cols-3 gap-2">
+              <label className="block">
+                <span className="mb-1 block text-xs text-slate-400">Breite (mm)</span>
+                <input
+                  type="number"
+                  min={20}
+                  max={450}
+                  step={5}
+                  value={widthMm}
+                  onChange={(e) => setWidthMm(Number(e.target.value) || 0)}
+                  className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1.5"
+                  autoFocus
+                />
+              </label>
+              <label className="block">
+                <span className="mb-1 block text-xs text-slate-400">Höhe (mm)</span>
+                <input
+                  type="number"
+                  min={10}
+                  max={400}
+                  step={5}
+                  value={heightMm}
+                  onChange={(e) => setHeightMm(Number(e.target.value) || 0)}
+                  className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1.5"
+                />
+              </label>
+              <label className="block">
+                <span className="mb-1 block text-xs text-slate-400">Tiefe (mm)</span>
+                <input
+                  type="number"
+                  min={20}
+                  max={1500}
+                  step={5}
+                  value={depthMm}
+                  onChange={(e) => setDepthMm(Number(e.target.value) || 0)}
+                  className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1.5"
+                />
+              </label>
+            </div>
+            <div className="rounded border border-slate-800 bg-slate-950/50 p-2 text-[10px] text-slate-400">
+              Lege das Gerät auf ein vorhandenes Rack-Shelf, indem du es auf
+              derselben Start-HE einfügst. Maße werden im 3D-Tab als reale
+              Boxen-Größe visualisiert.
+            </div>
+          </div>
+        )}
+
+        <label className="mb-3 flex items-start gap-2 rounded border border-slate-800 bg-slate-950/40 p-2 text-[11px]">
+          <input
+            type="checkbox"
+            checked={persistFlag}
+            onChange={(e) => setPersistFlag(e.target.checked)}
+            className="mt-0.5 accent-sky-500"
+          />
+          <span className="flex-1">
+            <span className="font-medium text-slate-200">Maße permanent ans Template speichern</span>
+            <span className="ml-1 text-slate-500">
+              (beim nächsten Hinzufügen wird nicht mehr gefragt)
+            </span>
+          </span>
+        </label>
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded bg-slate-700 px-3 py-1.5 text-xs hover:bg-slate-600"
+          >
+            Abbrechen
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            className="rounded bg-emerald-700 px-3 py-1.5 text-xs font-semibold hover:bg-emerald-600"
+          >
+            Hinzufügen
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Helper signature for the parent's stamper that injects template-level
+ *  dimensions (W/H/D) when the user opts in. Used by RackBuilderDialog
+ *  to persist the chosen dims back to the library template. */
+export type NonRackPersistFn = (template: EquipmentTemplate, patch: {
+  isRackDevice?: boolean
+  rackUnits?: number
+  widthMm?: number
+  heightMm?: number
+  depthMm?: number
+}) => void

--- a/src/renderer/components/Rack/Rack3DView.tsx
+++ b/src/renderer/components/Rack/Rack3DView.tsx
@@ -22,7 +22,7 @@
  * STLLoader geladen und in die HE-Box eingepasst. Sonst prozedurale Box.
  */
 import { Suspense, useEffect, useMemo, useRef, useState } from 'react'
-import { Canvas, useLoader } from '@react-three/fiber'
+import { Canvas, useFrame, useThree, useLoader } from '@react-three/fiber'
 import { OrbitControls, Edges, Html } from '@react-three/drei'
 import { STLLoader } from 'three-stdlib'
 import * as THREE from 'three'
@@ -61,6 +61,12 @@ interface Rack3DPlacement {
    *  Front entspricht inputs[], Rear entspricht outputs[]. */
   frontPorts?: Rack3DPort[]
   rearPorts?: Rack3DPort[]
+  /** v7.9.80 / #170 — Physische Maße in mm für Non-19″-Shelf-Geräte.
+   *  Wenn gesetzt, rendert DeviceBox mit diesen Maßen statt der vollen
+   *  Rack-Mount-Breite — und positioniert das Gerät zentriert auf dem
+   *  Bodenrand der HE-Reihe (= "steht auf dem Shelf darunter"). */
+  widthMm?: number
+  heightMm?: number
 }
 
 /** v7.9.77 / #170 — Port-Connector-Type → Dot-Farbe. Vereinheitlicht mit
@@ -237,12 +243,23 @@ const DeviceBox = ({
   const mountSide = placement.mountSide ?? 'full'
   const depthMm = Math.max(20, placement.depthMm ?? DEFAULT_DEVICE_DEPTH_MM)
   const yBottom = (totalUnits - placement.startUnit - placement.rackUnits + 1) * HE_HEIGHT_MM
-  const heightMm = placement.rackUnits * HE_HEIGHT_MM
-  const widthMm = RACK_MOUNT_WIDTH_MM
+  // v7.9.80 / #170 — Wenn das Template eigene mm-Maße trägt (Shelf-
+  // Device), nehmen wir die statt der HE × Rack-Mount-Breite. Geräte
+  // sitzen dann zentriert auf dem unteren Bodenrand der HE-Reihe
+  // (dort wo das Shelf liegt). Klassische Rack-Geräte: HE × volle Breite.
+  const isShelfDevice = !!(placement.widthMm && placement.heightMm)
+  const heightMm = isShelfDevice
+    ? Math.min(placement.heightMm!, placement.rackUnits * HE_HEIGHT_MM)
+    : placement.rackUnits * HE_HEIGHT_MM
+  const widthMm = isShelfDevice
+    ? Math.min(placement.widthMm!, RACK_MOUNT_WIDTH_MM)
+    : RACK_MOUNT_WIDTH_MM
 
   const zStart = mountSide === 'rear' ? rackDepthMm - depthMm : 0
   const xCenter = (RACK_OUTER_WIDTH_MM - widthMm) / 2 + widthMm / 2
-  const yCenter = yBottom + heightMm / 2
+  // Shelf-Geräte ruhen auf dem unteren Rand der HE-Reihe (yBottom + heightMm/2)
+  // statt mittig in der HE-Reihe. Bei Rack-Geräten ist beides identisch.
+  const yCenter = isShelfDevice ? yBottom + heightMm / 2 : yBottom + heightMm / 2
   const zCenter = zStart + depthMm / 2
 
   // v7.9.75 / #170 — Patchblenden bekommen eine eigene Farbe damit der
@@ -583,6 +600,58 @@ const DeviceSTL = ({
   )
 }
 
+/** v7.9.80 / #170 — Keyboard-Camera-Controller. Solange der User
+ *  Shift hält, fährt die Kamera (samt OrbitControls.target) nach oben;
+ *  Tab hält → nach unten. Damit kann der User die Höhe seines Blicks
+ *  ändern UND gerade auf eine bestimmte HE-Reihe schauen, ohne mit der
+ *  Maus um den Rack-Body kreisen zu müssen. Tab-Default (Focus-Wechsel)
+ *  wird verhindert. */
+const CameraKeyboardController = ({
+  orbitTargetRef,
+}: {
+  orbitTargetRef: React.RefObject<{ target: THREE.Vector3; update: () => void } | null>
+}) => {
+  const { camera } = useThree()
+  const keys = useRef({ shift: false, tab: false })
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      // Nur capturen wenn der Fokus nicht in einem Input/Textarea ist —
+      // sonst killt Shift Text-Selektion und Tab den Form-Wechsel.
+      const tag = (e.target as HTMLElement | null)?.tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
+      if (e.key === 'Shift') keys.current.shift = true
+      if (e.key === 'Tab') {
+        keys.current.tab = true
+        e.preventDefault()
+      }
+    }
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') keys.current.shift = false
+      if (e.key === 'Tab') keys.current.tab = false
+    }
+    window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('keyup', onKeyUp)
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('keyup', onKeyUp)
+    }
+  }, [])
+  useFrame((_, delta) => {
+    if (!keys.current.shift && !keys.current.tab) return
+    // 800 mm pro Sekunde Kamera-Vertikalgeschwindigkeit — schnell genug
+    // um schnell durch ein 42HE-Rack zu scrollen, langsam genug für
+    // präzise Höheneinstellung.
+    const speed = 800 * delta
+    const dy = keys.current.shift ? speed : -speed
+    camera.position.y += dy
+    if (orbitTargetRef.current?.target) {
+      orbitTargetRef.current.target.y += dy
+      orbitTargetRef.current.update?.()
+    }
+  })
+  return null
+}
+
 /** v7.9.78 / #170 — Rack-interne Verkabelung als 3D-Linien. Berechnet
  *  pro Cable die Welt-Position des From- und To-Ports, baut eine
  *  BufferGeometry mit 2 (oder mehr für Kurven) Punkten und rendert sie
@@ -671,7 +740,10 @@ export const Rack3DView = ({
   internalCables,
 }: Rack3DViewProps) => {
   const depthMm = rackDepthMm ?? DEFAULT_RACK_DEPTH_MM
-  const orbitRef = useRef<unknown>(null)
+  // v7.9.80 / #170 — OrbitControls ref für den CameraKeyboardController:
+  // wir mutieren controls.target.y zusammen mit camera.y, sonst tilted
+  // die Kamera statt zu pannen.
+  const orbitRef = useRef<{ target: THREE.Vector3; update: () => void } | null>(null)
   const rackHeightMm = totalUnits * HE_HEIGHT_MM
   // Set initial camera so the rack is fully visible.
   const cameraPos: [number, number, number] = [
@@ -750,6 +822,7 @@ export const Rack3DView = ({
           minDistance={150}
           maxDistance={4000}
         />
+        <CameraKeyboardController orbitTargetRef={orbitRef} />
         <gridHelper
           args={[2000, 20, '#334155', '#1e293b']}
           position={[RACK_OUTER_WIDTH_MM / 2, -1, depthMm / 2]}
@@ -793,9 +866,11 @@ export const Rack3DView = ({
           fontSize: 10,
           color: '#94a3b8',
           pointerEvents: 'none',
+          lineHeight: 1.4,
         }}
       >
-        🖱 Linke Maustaste: drehen · Rechte: pannen · Scroll: zoom
+        🖱 Drehen: links · Pannen: rechts · Zoom: scroll<br />
+        ⌨ Höhe: <kbd style={{ background: '#1e293b', padding: '0 3px', borderRadius: 2 }}>Shift</kbd> hoch · <kbd style={{ background: '#1e293b', padding: '0 3px', borderRadius: 2 }}>Tab</kbd> runter
       </div>
     </div>
   )

--- a/src/renderer/components/Rack/RackAddSplitButton.tsx
+++ b/src/renderer/components/Rack/RackAddSplitButton.tsx
@@ -1,0 +1,137 @@
+/**
+ * v7.9.80 / #170 — Split-Button für den Rack-Builder Library-Add.
+ *
+ * UI-Design-Rationale: Statt drei gleichberechtigter Buttons (F / Beide / R)
+ * ein primärer "+ Ins Rack" Button (= Full-Depth, Default-Verhalten in 95%
+ * der Fälle) mit anliegendem Chevron, das ein Mini-Menü mit den Alternativen
+ * "Vorne" und "Hinten" öffnet. Klare visuelle Hierarchie: häufigster Klick
+ * ist groß und beschriftet, seltenere Optionen sind im Dropdown.
+ *
+ * Klick auf den Haupt-Button → Full-Depth Add.
+ * Klick auf den Chevron → öffnet das Dropdown mit "Vorne (Front-Mount)" und
+ * "Hinten (Rear-Mount, z.B. Patchblende)".
+ * Außenklick / Escape schließt das Dropdown.
+ */
+import { useEffect, useRef, useState } from 'react'
+
+interface Props {
+  onAddFull: () => void
+  onAddFront: () => void
+  onAddRear: () => void
+  primaryLabel?: string
+}
+
+export const RackAddSplitButton = ({
+  onAddFull,
+  onAddFront,
+  onAddRear,
+  primaryLabel = '+ Ins Rack',
+}: Props) => {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onDoc = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDoc)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDoc)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  return (
+    <div ref={rootRef} className="relative shrink-0">
+      <div className="flex overflow-hidden rounded-md shadow-sm">
+        <button
+          type="button"
+          onClick={onAddFull}
+          className="bg-emerald-600 px-2.5 py-1.5 text-[11px] font-semibold text-white transition hover:bg-emerald-500"
+          title="Gerät full-depth (vorne + hinten) ins Rack hinzufügen"
+        >
+          {primaryLabel}
+        </button>
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className={`border-l border-emerald-700/60 px-1.5 py-1.5 text-[10px] font-bold text-white transition ${
+            open ? 'bg-emerald-700' : 'bg-emerald-600 hover:bg-emerald-500'
+          }`}
+          aria-expanded={open}
+          aria-haspopup="menu"
+          title="Mount-Optionen (Vorne / Hinten)"
+        >
+          ▾
+        </button>
+      </div>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 z-30 mt-1 w-44 overflow-hidden rounded-md border border-slate-700 bg-slate-900 text-[11px] shadow-2xl"
+        >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setOpen(false)
+              onAddFront()
+            }}
+            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-slate-200 hover:bg-slate-800"
+          >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+              <rect x="2" y="3" width="12" height="10" rx="1" stroke="#475569" strokeWidth="1" />
+              <rect x="2" y="3" width="12" height="3" fill="#22c55e" />
+            </svg>
+            <div className="flex flex-col">
+              <span className="font-semibold text-emerald-300">Nur vorne</span>
+              <span className="text-[9px] text-slate-500">Front-Mount</span>
+            </div>
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setOpen(false)
+              onAddFull()
+            }}
+            className="flex w-full items-center gap-2 border-t border-slate-800 bg-slate-800/50 px-3 py-1.5 text-left text-slate-200 hover:bg-slate-800"
+          >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+              <rect x="2" y="3" width="12" height="10" rx="1" fill="#64748b" />
+            </svg>
+            <div className="flex flex-col">
+              <span className="font-semibold text-slate-100">Full-Depth</span>
+              <span className="text-[9px] text-slate-500">vorne + hinten (Default)</span>
+            </div>
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setOpen(false)
+              onAddRear()
+            }}
+            className="flex w-full items-center gap-2 border-t border-slate-800 px-3 py-1.5 text-left text-slate-200 hover:bg-slate-800"
+          >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+              <rect x="2" y="3" width="12" height="10" rx="1" stroke="#475569" strokeWidth="1" />
+              <rect x="2" y="10" width="12" height="3" fill="#a855f7" />
+            </svg>
+            <div className="flex flex-col">
+              <span className="font-semibold text-purple-300">Nur hinten</span>
+              <span className="text-[9px] text-slate-500">Rear-Mount (z.B. Patchblende)</span>
+            </div>
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/Rack/RackBuilderDialog.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialog.tsx
@@ -10,12 +10,13 @@ import { Rack3DView } from './Rack3DView'
 import { PatchPanelCreateDialog } from './PatchPanelCreateDialog'
 import { RackShelfCreateDialog } from './RackShelfCreateDialog'
 import { PortDots2D } from './PortDots2D'
+import { RackAddSplitButton } from './RackAddSplitButton'
+import { NonRackAddDialog } from './NonRackAddDialog'
 import { useDraggablePosition } from '../../hooks/useDraggablePosition'
 import { CategorySelect } from '../shared/CategorySelect'
 import { ModalShell } from '../shared/ModalShell'
 import { pickImageAsDataUri } from '../../lib/readImageAsDataUri'
 import { confirmDialog } from '../../lib/confirmDialog'
-import { promptDialog } from '../../lib/promptDialog'
 import { STORAGE_KEYS } from '../../lib/storageKeys'
 import { LIMITS } from '../../lib/layoutConstants'
 
@@ -255,6 +256,7 @@ const draftFromPreset = (preset: GroupPreset): RackDraft => {
 export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onSave }: RackBuilderDialogProps) => {
   // v7.9.13 — Permanent-Mark-As-Rack-Device action.
   const markTemplateAsRack = useProjectStore((s) => s.markTemplateAsRack)
+  const addCustomTemplate = useProjectStore((s) => s.addCustomTemplate)
   const autosaveIntervalMs = useSettingsStore((state) => state.autosaveIntervalMs)
   const editingId = initialPreset?.id
   const [draft, setDraft] = useState<RackDraft>({
@@ -287,6 +289,11 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
   // v7.9.75 / #170 — Patch-Panel-Creation-Dialog.
   const [patchPanelDialogOpen, setPatchPanelDialogOpen] = useState(false)
   const [shelfDialogOpen, setShelfDialogOpen] = useState(false)
+  // v7.9.80 / #170 — Non-Rack-Add-Dialog: Auswahl HE-Höhe vs. Shelf-Maße.
+  const [nonRackDialog, setNonRackDialog] = useState<{
+    template: EquipmentTemplate
+    options?: { mountSide?: 'front' | 'rear' | 'full'; preferStartUnit?: number }
+  } | null>(null)
   // v7.9.75 / #170 — View-Mode-Filter aus Issue-Kommentar 1:
   // 'all'      = alles sichtbar (Default)
   // 'free'     = nur freie Ports + Patchblenden + externe Patchfelder
@@ -524,35 +531,13 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
     // den Rack-Geräten ohne erneute HE-Abfrage.
     let effectiveTemplate = template
     if (!template.isRackDevice && !template.rackUnits) {
-      const answer = (
-        await promptDialog(
-          `Wieviele HE für "${template.name}" im Rack? (1-20, leer = Abbruch)`,
-          '1',
-        )
-      )?.trim()
-      if (!answer) return
-      const heightHE = Math.max(1, Math.min(LIMITS.MAX_PORT_HEIGHT_HE, Math.round(Number(answer))))
-      if (!Number.isFinite(heightHE) || heightHE < 1) {
-        setSaveError(`Ungültige HE-Eingabe für "${template.name}". Bitte 1–20 angeben.`)
-        return
-      }
-      const persistFlag = await confirmDialog(
-        `"${template.name}" permanent als 19"-Rack-Gerät markieren?`,
-        {
-          body:
-            `Empfohlen wenn dieses Gerät immer in Racks verbaut wird. Dann erscheint es künftig direkt unter den Rack-Geräten — ohne erneute HE-Abfrage. Du kannst die Markierung in den Geräte-Eigenschaften jederzeit wieder entfernen.\n\nHE-Höhe: ${heightHE}`,
-          okLabel: 'Ja, permanent markieren',
-          cancelLabel: 'Nur für dieses Rack',
-        },
-      )
-      if (persistFlag) {
-        markTemplateAsRack(template.name, heightHE)
-      }
-      effectiveTemplate = {
-        ...template,
-        isRackDevice: true,
-        rackUnits: heightHE,
-      }
+      // v7.9.80 / #170 — Statt einer simplen HE-Promptbox jetzt ein
+      // richtiger Dialog mit zwei Pfaden: 19″-Rack-Gerät (HE) oder
+      // Shelf-mounted (W/H/D in mm). Dialog stellt das Template asynchron
+      // bereit; addTemplate kehrt hier zurück und der Dialog ruft später
+      // selber wieder addTemplate auf — mit dem dimensionierten Template.
+      setNonRackDialog({ template, options })
+      return
     }
     const units = parseUnits(effectiveTemplate)
     let targetUnit = 1
@@ -795,7 +780,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
         {/* v7.9.11 — Control-Bar mit gewichteten Spalten. Name (Pflichtfeld
             + längster Inhalt) bekommt 2 Spalten, Höhe + Ansicht + Zoom je 1.
             Zoom hat jetzt explizite +/- Buttons für Tastatur/Maus-User. */}
-        <div className="mb-3 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-5">
+        <div className="mb-3 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-[2fr_1fr_1fr_1fr]">
           <label className="block text-xs font-medium text-slate-300 lg:col-span-2">
             Rack-Name *
             <input
@@ -851,20 +836,10 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
               title="Rack-Tiefe in mm. Standard: 800 mm. Gängige Werte: 350/450/600/800/1000/1200."
             />
           </label>
-          <label className="block text-xs font-medium text-slate-300">
-            Ansicht
-            <select
-              value={draft.viewMode}
-              onChange={(event) =>
-                setDraft((current) => ({ ...current, viewMode: event.target.value as 'front' | 'rear' | 'both' }))
-              }
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-2 py-1.5 text-sm font-normal text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
-            >
-              <option value="front">Nur vorne</option>
-              <option value="rear">Nur hinten</option>
-              <option value="both">Front + Rear</option>
-            </select>
-          </label>
+          {/* v7.9.80 / #170 — "Ansicht" (Front/Rear/Both) ist nach
+              unten in die 2D-Rack-Spalte gewandert (als Tab-Bar dort);
+              Grid hier ist auf 4 Spalten reduziert (Name=2fr, Höhe,
+              Tiefe, Zoom). */}
           <div className="block text-xs font-medium text-slate-300">
             <div className="flex items-baseline justify-between">
               <span>Zoom</span>
@@ -1089,37 +1064,17 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                         </div>
                         <div className="truncate text-[10px] text-slate-500">{template.category}</div>
                       </div>
-                      {/* v7.9.76 / #170 — Drei Mount-Side-Buttons statt
-                          einem "+ Rack": Vorne (front-mount), Beide
-                          (full-depth = Default), Hinten (rear-mount).
-                          Beide bleibt der prominent grüne Button — die
-                          gewünschte Wahl ist explizit. */}
-                      <div className="flex shrink-0 overflow-hidden rounded border border-slate-700">
-                        <button
-                          type="button"
-                          onClick={() => addTemplate(template, { mountSide: 'front' })}
-                          className="bg-green-700 px-1.5 py-1 text-[10px] font-semibold text-white hover:bg-green-600"
-                          title="Vorne im Rack montieren (front-mount, Default-Tiefe)"
-                        >
-                          F
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => addTemplate(template, { mountSide: 'full' })}
-                          className="bg-emerald-700 px-2 py-1 text-[10px] font-semibold text-white hover:bg-emerald-600"
-                          title={placedCount > 0 ? 'Weitere Instanz full-depth einfügen' : 'Full-depth ins Rack (vorne+hinten)'}
-                        >
-                          + Beide
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => addTemplate(template, { mountSide: 'rear' })}
-                          className="bg-purple-700 px-1.5 py-1 text-[10px] font-semibold text-white hover:bg-purple-600"
-                          title="Hinten im Rack montieren (rear-mount, z.B. Patchblende)"
-                        >
-                          R
-                        </button>
-                      </div>
+                      {/* v7.9.80 / #170 — Split-Button: Hauptaktion
+                          "+ Hinzufügen" (Default = full-depth) + kleines
+                          ▾ Chevron das die alternativen Mount-Optionen
+                          (Vorne / Hinten) zeigt. Cleanere Hierarchie als
+                          drei gleichberechtigte Buttons. */}
+                      <RackAddSplitButton
+                        onAddFull={() => void addTemplate(template, { mountSide: 'full' })}
+                        onAddFront={() => void addTemplate(template, { mountSide: 'front' })}
+                        onAddRear={() => void addTemplate(template, { mountSide: 'rear' })}
+                        primaryLabel={placedCount > 0 ? '+ Weitere' : '+ Ins Rack'}
+                      />
                     </div>
                     <div className="mt-1 text-[10px] text-slate-400">
                       {isRack ? `${parseUnits(template)} HE · ` : 'HE ? · '}
@@ -1286,12 +1241,20 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                             if (renderMode === 'free') return hasFreePort
                             return hasFreePort
                           })
-                          .map((p) => ({
+                          .map((p) => {
+                            // v7.9.80 / #170 — Shelf-Device-Maße aus dem
+                            // Template ziehen (sind im Builder nicht im
+                            // RackPlacementDraft, sondern auf dem Library-
+                            // Template gespeichert).
+                            const tpl = templates.find((t) => t.name === p.templateName)
+                            return {
                             id: p.id,
                             name: p.name,
                             startUnit: p.startUnit,
                             rackUnits: p.rackUnits,
-                            depthMm: p.depthMm,
+                            depthMm: p.depthMm ?? tpl?.depthMm,
+                            widthMm: tpl?.widthMm,
+                            heightMm: tpl?.heightMm,
                             mountSide: p.mountSide,
                             stlDataUri: p.stlDataUri,
                             frontPanelImageUrl: p.frontPanelImageUrl,
@@ -1315,7 +1278,8 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                               panelPosX: port.panelPosX,
                               panelPosY: port.panelPosY,
                             })),
-                          }))
+                          }
+                          })
                       })()}
                       selectedPlacementId={selectedPlacementId}
                       onSelectPlacement={(id) => setSelectedPlacementId(id)}
@@ -1373,6 +1337,35 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                   </div>
                 )}
               </>
+            )}
+            {/* v7.9.80 / #170 — Front/Rear/Both-Toggle ist jetzt Teil der
+                2D-Rack-Spalte (war vorher als Select im Header). */}
+            {viewTab === '2d' && (
+              <div className="mb-2 flex overflow-hidden rounded-md border border-slate-700 text-[11px]">
+                {([
+                  ['front', 'Nur vorne', '#22c55e'],
+                  ['both', 'Beide', '#64748b'],
+                  ['rear', 'Nur hinten', '#a855f7'],
+                ] as const).map(([mode, label, color]) => (
+                  <button
+                    key={mode}
+                    type="button"
+                    onClick={() => setDraft((cur) => ({ ...cur, viewMode: mode }))}
+                    className={`flex flex-1 items-center justify-center gap-1.5 px-2 py-1 font-medium transition ${
+                      draft.viewMode === mode
+                        ? 'bg-slate-800 text-white'
+                        : 'bg-slate-900/50 text-slate-400 hover:bg-slate-800/60'
+                    }`}
+                    aria-pressed={draft.viewMode === mode}
+                  >
+                    <span
+                      className="inline-block h-1.5 w-1.5 rounded-full"
+                      style={{ background: color }}
+                    />
+                    {label}
+                  </button>
+                ))}
+              </div>
             )}
             {/* v7.9.10 — max-h begrenzt den Rack-Canvas auf die
                 Viewport-Höhe minus Header/Footer; in Kombi mit dem
@@ -1760,50 +1753,82 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                     </select>
                   </label>
                 </div>
-                {/* STL-Upload für 3D-Modell */}
-                <label className="block">
-                  3D-Modell (STL, optional)
+                {/* STL-Upload für 3D-Modell.
+                    v7.9.80 / #170 — Eigener gestylter "Datei wählen…"-
+                    Button (statt nacktem <input type="file">, der je nach
+                    OS nur "Keine ausgewählt" zeigt). Speichert die STL
+                    zusätzlich aufs Template via addCustomTemplate, damit
+                    sie über librarySync in die zentrale .cpdevice-Datei
+                    landet und beim nächsten Mal aus der Library schon
+                    mit STL kommt. */}
+                <div className="block">
+                  <div className="mb-1 text-xs text-slate-300">3D-Modell (STL, optional)</div>
                   <div className="mt-1 flex items-center gap-2">
-                    <input
-                      type="file"
-                      accept=".stl,application/octet-stream"
-                      onChange={async (event) => {
-                        const file = event.target.files?.[0]
-                        if (!file) return
-                        if (file.size > 5 * 1024 * 1024) {
-                          await confirmDialog('Datei zu groß', {
-                            body: 'STL-Dateien über 5 MB werden nicht angenommen, sonst explodiert der Projekt-Save.',
-                            okLabel: 'OK',
-                          })
-                          return
-                        }
-                        const buf = await file.arrayBuffer()
-                        const b64 = btoa(
-                          String.fromCharCode(...new Uint8Array(buf)),
-                        )
-                        updatePlacement(selectedPlacement.id, {
-                          stlDataUri: `data:application/octet-stream;base64,${b64}`,
-                        })
-                      }}
-                      className="flex-1 text-[11px]"
-                    />
+                    <label
+                      className="inline-flex cursor-pointer items-center gap-1 rounded border border-slate-600 bg-sky-700 px-3 py-1 text-[11px] font-semibold text-white hover:bg-sky-600"
+                      title="STL-Datei (.stl, max 5 MB) zum Gerät hochladen"
+                    >
+                      <span>📁</span>
+                      <span>{selectedPlacement.stlDataUri ? 'STL ersetzen…' : 'STL auswählen…'}</span>
+                      <input
+                        type="file"
+                        accept=".stl,application/octet-stream"
+                        onChange={async (event) => {
+                          const file = event.target.files?.[0]
+                          if (!file) return
+                          if (file.size > 5 * 1024 * 1024) {
+                            await confirmDialog('Datei zu groß', {
+                              body: 'STL-Dateien über 5 MB werden nicht angenommen, sonst explodiert der Projekt-Save.',
+                              okLabel: 'OK',
+                            })
+                            event.target.value = ''
+                            return
+                          }
+                          const buf = await file.arrayBuffer()
+                          const b64 = btoa(String.fromCharCode(...new Uint8Array(buf)))
+                          const dataUri = `data:application/octet-stream;base64,${b64}`
+                          updatePlacement(selectedPlacement.id, { stlDataUri: dataUri })
+                          // Auch ins Template heften: librarySync schreibt
+                          // das .cpdevice (mit STL inline base64) in den
+                          // zentralen Library-Ordner — damit ist die STL
+                          // permanent ans Gerät gebunden.
+                          const tpl = templates.find(
+                            (t) => t.name === selectedPlacement.templateName,
+                          )
+                          if (tpl) {
+                            addCustomTemplate({ ...tpl, stlDataUri: dataUri })
+                          }
+                          event.target.value = '' // reset so user can re-upload same file
+                        }}
+                        className="hidden"
+                      />
+                    </label>
                     {selectedPlacement.stlDataUri && (
                       <button
                         type="button"
-                        onClick={() => updatePlacement(selectedPlacement.id, { stlDataUri: undefined })}
-                        className="rounded bg-slate-700 px-2 py-0.5 text-[10px] hover:bg-slate-600"
+                        onClick={() => {
+                          updatePlacement(selectedPlacement.id, { stlDataUri: undefined })
+                          // Auch im Template entfernen, falls dort gespeichert
+                          const tpl = templates.find(
+                            (t) => t.name === selectedPlacement.templateName,
+                          )
+                          if (tpl && tpl.stlDataUri) {
+                            addCustomTemplate({ ...tpl, stlDataUri: undefined })
+                          }
+                        }}
+                        className="rounded border border-slate-600 bg-slate-700 px-2 py-1 text-[11px] text-slate-200 hover:bg-slate-600"
                         title="STL entfernen — Gerät wird wieder als Box gerendert"
                       >
-                        ✕
+                        ✕ Entfernen
                       </button>
                     )}
                   </div>
-                  <span className="mt-0.5 block text-[10px] text-slate-500">
+                  <span className="mt-1 block text-[10px] text-slate-500">
                     {selectedPlacement.stlDataUri
-                      ? '✓ STL geladen — wird im 3D-Tab gerendert.'
-                      : 'Ohne STL wird das Gerät als Box dargestellt.'}
+                      ? '✓ STL geladen — wird im 3D-Tab gerendert und permanent am Gerät gespeichert (Library + Projekt).'
+                      : 'Ohne STL wird das Gerät als Box mit Front-/Rear-Foto dargestellt.'}
                   </span>
-                </label>
+                </div>
                 <div className="rounded border border-slate-800 bg-slate-900/40 p-2 text-[11px] text-slate-400">
                   Ports sichtbar: {selectedPlacement.inputs.length} Inputs / {selectedPlacement.outputs.length} Outputs
                 </div>
@@ -2111,6 +2136,48 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
           void addTemplate(template)
         }}
       />
+      {/* v7.9.80 / #170 — Non-Rack-Add-Dialog. Bei Confirm wird das
+          Template mit den gewählten Maßen angereichert und addTemplate
+          rekursiv neu aufgerufen — diesmal MIT isRackDevice + rackUnits
+          gesetzt, sodass der early-return nicht mehr greift. Optional
+          auch ins Library-Template-Storage geschrieben (persistFlag). */}
+      {nonRackDialog && (
+        <NonRackAddDialog
+          open
+          templateName={nonRackDialog.template.name}
+          initialDimensions={{
+            widthMm: nonRackDialog.template.widthMm,
+            heightMm: nonRackDialog.template.heightMm,
+            depthMm: nonRackDialog.template.depthMm,
+          }}
+          onCancel={() => setNonRackDialog(null)}
+          onConfirm={(result) => {
+            const base = nonRackDialog.template
+            const options = nonRackDialog.options
+            const enrichedTemplate: EquipmentTemplate = {
+              ...base,
+              isRackDevice: true,
+              rackUnits: result.rackUnits,
+              ...(result.mode === 'shelf'
+                ? {
+                    widthMm: result.widthMm,
+                    heightMm: result.heightMm,
+                    depthMm: result.depthMm,
+                  }
+                : {}),
+            }
+            if (result.persistToTemplate) {
+              if (result.mode === 'rack') {
+                markTemplateAsRack(base.name, result.rackUnits)
+              } else {
+                addCustomTemplate(enrichedTemplate)
+              }
+            }
+            setNonRackDialog(null)
+            void addTemplate(enrichedTemplate, options)
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -336,6 +336,12 @@ export interface EquipmentItem {
   /** Tiefe in mm. Wird vom 3D-Rack genutzt um zu prüfen ob ein Patchblende
    *  noch hinter das Gerät passt. Default beim Rendering: 400 mm. */
   depthMm?: number
+  /** v7.9.80 / #170 — Physische Breite in mm (für Non-19″-Geräte auf
+   *  Rack-Shelves). Wird vom 3D-Renderer als reale Box-Breite genutzt.
+   *  Unterscheidet sich von `width` (Pixel-Größe für Canvas-Rendering). */
+  widthMm?: number
+  /** v7.9.80 / #170 — Physische Höhe in mm (für Non-19″-Geräte auf Shelves). */
+  heightMm?: number
   /** v7.9.73 / #170 — Optionale STL-Datei (als data:application/octet-stream
    *  base64-URI) für das 3D-Modell des Geräts. Wenn vorhanden, rendert der
    *  3D-Rack-Builder die echte Geometrie statt einer prozeduralen Box.


### PR DESCRIPTION
…ys, Non-Rack-Dialog (#170)

Fünf User-Feedback-Punkte abgearbeitet:

1. STL-UPLOAD-BUTTON sichtbar gemacht — vorher zeigte das nackte <input type="file"> je nach Browser/OS nur "Keine ausgewählt" ohne sichtbaren "Datei wählen"-Button. Jetzt eigener gestylter Label- Button "📁 STL auswählen…" / "STL ersetzen…". Zusätzlich wird die STL beim Upload automatisch ans Library-Template gehängt (via addCustomTemplate) — damit landet sie über librarySync in der zentralen .cpdevice-Datei und ist beim nächsten Mal permanent dabei.

2. MOUNT-SIDE BUTTONS NEU DESIGNED — die alte Triple-Button-Reihe "F / +Beide / R" war flach und cryptisch. Ersetzt durch einen echten Split-Button (RackAddSplitButton.tsx): primärer "+ Ins Rack"- Button (= Full-Depth, häufigster Fall) plus ▾ Chevron, das ein Dropdown mit beschrifteten Alternativen "Nur vorne (Front-Mount)" / "Full-Depth" / "Nur hinten (Rear-Mount, z.B. Patchblende)" öffnet — jeweils mit kleinem SVG-Icon das den Mount-Bereich am Rack visualisiert. Klare Hierarchie statt 3 gleichberechtigter Buttons.

3. FRONT/REAR/BOTH SELECTOR aus dem Top-Header in die 2D-Rack-Spalte geschoben. Vorher: <select> im Settings-Grid neben Höhe/Tiefe/Zoom. Jetzt: visuell verbundenes Tab-Trio direkt über dem Rack-Layout mit farbigen Indikator-Dots (grün/grau/lila) und aktivem State.

4. CAMERA-KEYBOARD-CONTROLS für Rack3DView — neuer CameraKeyboard- Controller-Component nutzt useFrame um camera.y + orbit.target.y um 800 mm/sec zu verschieben solange Shift (hoch) bzw. Tab (runter) gedrückt ist. Tab-Default (Focus-Switch) wird verhindert; Input- Fokus wird respektiert (kein Hijack in Textfeldern). Help-Overlay zeigt jetzt die Shortcuts. Damit kann der User auf eine bestimmte HE-Reihe gerade drauf schauen.

5. NON-RACK-ADD-DIALOG (NonRackAddDialog.tsx) — ersetzt den simplen "Wieviele HE?"-Prompt durch ein richtiges Dialog mit zwei Pfaden: • "Als 19″-Gerät" → HE-Eingabe (alte Logik)
     • "Auf Shelf"     → physische W/H/D in mm
   Bei "Auf Shelf"-Wahl wandern widthMm/heightMm/depthMm aufs Template
   (via addCustomTemplate, optional persistent). 3D-Renderer (DeviceBox)
   nutzt die mm-Maße statt der HE × Rack-Mount-Breite, sodass Shelf-
   Geräte als kleinere Box auf dem Shelf-Boden ihrer HE sitzen.
   Zwei neue Felder auf EquipmentTemplate: widthMm + heightMm
   (depthMm gab es schon).

v7.9.80

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH