### PR TITLE
feat(rack+canvas): Port-Side-Default, Location-Move-Contents, Theme-A…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.9.80",
+    "version": "7.9.81",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/components/Canvas/CableContextMenu.tsx
+++ b/src/renderer/components/Canvas/CableContextMenu.tsx
@@ -91,6 +91,9 @@ const MENU_WIDTH = 240
 export const CableContextMenu = () => {
   const menu = useUiStore((s) => s.cableContextMenu)
   const close = useUiStore((s) => s.closeCableContextMenu)
+  // v7.9.81 — Theme-Awareness: Menu folgt jetzt canvasTheme.
+  const canvasTheme = useUiStore((s) => s.canvasTheme)
+  const isLight = canvasTheme === 'light'
   const globalCableBumps = useUiStore((s) => s.cableBumps)
   const updateCable = useProjectStore((s) => s.updateCable)
   const deleteCable = useProjectStore((s) => s.deleteCable)
@@ -221,11 +224,19 @@ export const CableContextMenu = () => {
     <div
       ref={containerRef}
       style={{ position: 'fixed', left, top, width: MENU_WIDTH, zIndex: 9999 }}
-      className="rounded border border-slate-700 bg-slate-900/98 text-slate-100 shadow-2xl backdrop-blur-sm"
+      className={`rounded border shadow-2xl backdrop-blur-sm ${
+        isLight
+          ? 'border-slate-300 bg-white/98 text-slate-900'
+          : 'border-slate-700 bg-slate-900/98 text-slate-100'
+      }`}
       onContextMenu={(e) => e.preventDefault()}
     >
-      <div className="border-b border-slate-800 px-3 py-1.5 text-[10px] uppercase tracking-wide text-slate-400">
-        Kabel: <span className="font-semibold text-slate-200">{cable.name}</span>
+      <div
+        className={`border-b px-3 py-1.5 text-[10px] uppercase tracking-wide ${
+          isLight ? 'border-slate-200 text-slate-500' : 'border-slate-800 text-slate-400'
+        }`}
+      >
+        Kabel: <span className={`font-semibold ${isLight ? 'text-slate-700' : 'text-slate-200'}`}>{cable.name}</span>
       </div>
       <Item onClick={renameLabel} icon="✎">Bezeichnung ändern…</Item>
       <Separator />
@@ -257,7 +268,7 @@ export const CableContextMenu = () => {
         <span className="ml-auto text-slate-500">{submenu === 'routing' ? '▾' : '▸'}</span>
       </Item>
       {submenu === 'routing' && (
-        <div className="border-l-2 border-sky-700 bg-slate-950/50">
+        <div className={`border-l-2 border-sky-700 ${isLight ? 'bg-slate-100' : 'bg-slate-950/50'}`}>
           {(['orthogonal', 'straight', 'curved'] as const).map((r) => (
             <Item
               key={r}

--- a/src/renderer/components/Rack/PortDots2D.tsx
+++ b/src/renderer/components/Rack/PortDots2D.tsx
@@ -18,7 +18,15 @@ import { useRef, useState } from 'react'
 import type { Port } from '../../types/equipment'
 
 interface Props {
+  /** Ports die auf dieser Face gerendert werden sollen (bereits gefiltert
+   *  nach rackSide oder Patchblende-Konvention). Können aus inputs oder
+   *  outputs des Placements stammen — das wird in der Drag-Persist-Logik
+   *  jeweils richtig zurückgeschrieben. */
   ports: Port[]
+  /** Vollständige Listen, damit wir beim Drag das Original updaten können
+   *  egal aus welcher der beiden Listen der Port kommt. */
+  allInputs: Port[]
+  allOutputs: Port[]
   placementId: string
   placementWidth: number
   placementHeight: number
@@ -46,11 +54,12 @@ const computeDefault = (idx: number, total: number): { x: number; y: number } =>
 
 export const PortDots2D = ({
   ports,
+  allInputs,
+  allOutputs,
   placementId,
   placementWidth,
   placementHeight,
   updatePlacement,
-  side,
 }: Props) => {
   const [dragOverride, setDragOverride] = useState<{ id: string; x: number; y: number } | null>(null)
   const draggingRef = useRef<{ id: string; pointerId: number } | null>(null)
@@ -94,11 +103,22 @@ export const PortDots2D = ({
               ;(e.currentTarget as Element).releasePointerCapture?.(e.pointerId)
               const override = dragOverride?.id === port.id ? dragOverride : null
               if (override) {
-                const key = side === 'front' ? 'inputs' : 'outputs'
-                const updated = ports.map((p) =>
-                  p.id === port.id ? { ...p, panelPosX: override.x, panelPosY: override.y } : p,
-                )
-                updatePlacement(placementId, { [key]: updated })
+                // v7.9.81 / #170 — Port kann aus inputs ODER outputs kommen.
+                // Wir suchen ihn in beiden Listen und updaten die richtige.
+                const inInputs = allInputs.some((p) => p.id === port.id)
+                if (inInputs) {
+                  updatePlacement(placementId, {
+                    inputs: allInputs.map((p) =>
+                      p.id === port.id ? { ...p, panelPosX: override.x, panelPosY: override.y } : p,
+                    ),
+                  })
+                } else {
+                  updatePlacement(placementId, {
+                    outputs: allOutputs.map((p) =>
+                      p.id === port.id ? { ...p, panelPosX: override.x, panelPosY: override.y } : p,
+                    ),
+                  })
+                }
               }
               draggingRef.current = null
               setDragOverride(null)

--- a/src/renderer/components/Rack/Rack3DView.tsx
+++ b/src/renderer/components/Rack/Rack3DView.tsx
@@ -26,6 +26,7 @@ import { Canvas, useFrame, useThree, useLoader } from '@react-three/fiber'
 import { OrbitControls, Edges, Html } from '@react-three/drei'
 import { STLLoader } from 'three-stdlib'
 import * as THREE from 'three'
+import { useUiStore } from '../../store/uiStore'
 
 const HE_HEIGHT_MM = 44.45
 const RACK_OUTER_WIDTH_MM = 482.6
@@ -133,39 +134,44 @@ interface Rack3DViewProps {
 const Chassis = ({
   totalUnits,
   depthMm,
+  isLight,
 }: {
   totalUnits: number
   depthMm: number
+  isLight: boolean
 }) => {
   const heightMm = totalUnits * HE_HEIGHT_MM
-  // Solid grau-transparente Wände + Edges damit man die Geräte drin sieht.
+  // v7.9.81 — Theme-Awareness: helles Rack-Chassis im Light-Mode (graue
+  // Töne mit höherer Helligkeit), klassisches Dark-Chassis im Dark-Mode.
+  const chassisColor = isLight ? '#94a3b8' : '#1f2937'
+  const railColor = isLight ? '#64748b' : '#475569'
   return (
     <group>
       {/* Boden */}
       <mesh position={[RACK_OUTER_WIDTH_MM / 2, 0, depthMm / 2]} receiveShadow>
         <boxGeometry args={[RACK_OUTER_WIDTH_MM, 4, depthMm]} />
-        <meshStandardMaterial color="#1f2937" opacity={0.9} transparent />
+        <meshStandardMaterial color={chassisColor} opacity={0.9} transparent />
       </mesh>
       {/* Linke Wand */}
       <mesh position={[2, heightMm / 2, depthMm / 2]}>
         <boxGeometry args={[4, heightMm, depthMm]} />
-        <meshStandardMaterial color="#1f2937" opacity={0.4} transparent />
+        <meshStandardMaterial color={chassisColor} opacity={0.4} transparent />
       </mesh>
       {/* Rechte Wand */}
       <mesh position={[RACK_OUTER_WIDTH_MM - 2, heightMm / 2, depthMm / 2]}>
         <boxGeometry args={[4, heightMm, depthMm]} />
-        <meshStandardMaterial color="#1f2937" opacity={0.4} transparent />
+        <meshStandardMaterial color={chassisColor} opacity={0.4} transparent />
       </mesh>
       {/* Decke */}
       <mesh position={[RACK_OUTER_WIDTH_MM / 2, heightMm, depthMm / 2]}>
         <boxGeometry args={[RACK_OUTER_WIDTH_MM, 4, depthMm]} />
-        <meshStandardMaterial color="#1f2937" opacity={0.4} transparent />
+        <meshStandardMaterial color={chassisColor} opacity={0.4} transparent />
       </mesh>
       {/* HE-Markierungen an der linken Schiene */}
       {Array.from({ length: totalUnits + 1 }, (_, i) => (
         <mesh key={i} position={[16, i * HE_HEIGHT_MM, 1]}>
           <boxGeometry args={[2, 0.6, 2]} />
-          <meshStandardMaterial color="#475569" />
+          <meshStandardMaterial color={railColor} />
         </mesh>
       ))}
     </group>
@@ -739,6 +745,15 @@ export const Rack3DView = ({
   onPortMoved,
   internalCables,
 }: Rack3DViewProps) => {
+  // v7.9.81 — Theme-Awareness: 3D-Hintergrund + Help-Overlay-Farben
+  // folgen jetzt dem globalen canvasTheme.
+  const canvasTheme = useUiStore((s) => s.canvasTheme)
+  const isLight = canvasTheme === 'light'
+  const bgColor = isLight ? '#e2e8f0' : '#0f172a'
+  const overlayBg = isLight ? 'rgba(248,250,252,0.92)' : 'rgba(15,23,42,0.85)'
+  const overlayText = isLight ? '#334155' : '#94a3b8'
+  const overlayLegendText = isLight ? '#475569' : '#cbd5e1'
+  const kbdBg = isLight ? '#cbd5e1' : '#1e293b'
   const depthMm = rackDepthMm ?? DEFAULT_RACK_DEPTH_MM
   // v7.9.80 / #170 — OrbitControls ref für den CameraKeyboardController:
   // wir mutieren controls.target.y zusammen mit camera.y, sonst tilted
@@ -753,7 +768,7 @@ export const Rack3DView = ({
   ]
   return (
     <div
-      style={{ width: '100%', height: '100%', position: 'relative', background: '#0f172a' }}
+      style={{ width: '100%', height: '100%', position: 'relative', background: bgColor }}
       onClick={() => onSelectPlacement(null)}
     >
       <Canvas
@@ -763,7 +778,7 @@ export const Rack3DView = ({
         <ambientLight intensity={0.55} />
         <directionalLight position={[600, 1200, 800]} intensity={0.9} />
         <directionalLight position={[-800, 600, -400]} intensity={0.4} />
-        <Chassis totalUnits={totalUnits} depthMm={depthMm} />
+        <Chassis totalUnits={totalUnits} depthMm={depthMm} isLight={isLight} />
         <Suspense fallback={null}>
           {placements.map((p) => {
             if (p.isRackShelf) {
@@ -824,7 +839,12 @@ export const Rack3DView = ({
         />
         <CameraKeyboardController orbitTargetRef={orbitRef} />
         <gridHelper
-          args={[2000, 20, '#334155', '#1e293b']}
+          args={[
+            2000,
+            20,
+            isLight ? '#94a3b8' : '#334155',
+            isLight ? '#cbd5e1' : '#1e293b',
+          ]}
           position={[RACK_OUTER_WIDTH_MM / 2, -1, depthMm / 2]}
         />
       </Canvas>
@@ -834,11 +854,11 @@ export const Rack3DView = ({
           position: 'absolute',
           bottom: 8,
           left: 8,
-          background: 'rgba(15,23,42,0.85)',
+          background: overlayBg,
           padding: '6px 8px',
           borderRadius: 4,
           fontSize: 10,
-          color: '#cbd5e1',
+          color: overlayLegendText,
           pointerEvents: 'none',
         }}
       >
@@ -860,17 +880,17 @@ export const Rack3DView = ({
           position: 'absolute',
           top: 8,
           right: 8,
-          background: 'rgba(15,23,42,0.85)',
+          background: overlayBg,
           padding: '4px 8px',
           borderRadius: 4,
           fontSize: 10,
-          color: '#94a3b8',
+          color: overlayText,
           pointerEvents: 'none',
           lineHeight: 1.4,
         }}
       >
         🖱 Drehen: links · Pannen: rechts · Zoom: scroll<br />
-        ⌨ Höhe: <kbd style={{ background: '#1e293b', padding: '0 3px', borderRadius: 2 }}>Shift</kbd> hoch · <kbd style={{ background: '#1e293b', padding: '0 3px', borderRadius: 2 }}>Tab</kbd> runter
+        ⌨ Höhe: <kbd style={{ background: kbdBg, padding: '0 3px', borderRadius: 2 }}>Shift</kbd> hoch · <kbd style={{ background: kbdBg, padding: '0 3px', borderRadius: 2 }}>Tab</kbd> runter
       </div>
     </div>
   )

--- a/src/renderer/components/Rack/RackBuilderDialog.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialog.tsx
@@ -1262,22 +1262,41 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                             portCount: (p.inputs?.length ?? 0) + (p.outputs?.length ?? 0),
                             isPatchPanel: p.isPatchPanel,
                             isRackShelf: p.isRackShelf,
-                            // v7.9.77 / #170 — inputs = Front-Ports,
-                            // outputs = Rear-Ports (Builder-Konvention).
-                            frontPorts: (p.inputs ?? []).map((port) => ({
-                              id: port.id,
-                              name: port.name,
-                              connectorType: port.connectorType,
-                              panelPosX: port.panelPosX,
-                              panelPosY: port.panelPosY,
-                            })),
-                            rearPorts: (p.outputs ?? []).map((port) => ({
-                              id: port.id,
-                              name: port.name,
-                              connectorType: port.connectorType,
-                              panelPosX: port.panelPosX,
-                              panelPosY: port.panelPosY,
-                            })),
+                            // v7.9.81 / #170 — Port-Side aus port.rackSide
+                            // (Default 'rear' wenn nicht gesetzt). Inputs UND
+                            // Outputs werden in einen Topf geworfen und nach
+                            // rackSide aufgesplittet. Patchblenden sind die
+                            // Ausnahme: dort wandert input → front, output →
+                            // rear (klassisches Crossfield-Layout).
+                            frontPorts: [...(p.inputs ?? []), ...(p.outputs ?? [])]
+                              .filter((port) => {
+                                if (p.isPatchPanel) {
+                                  // Patchblende: inputs = front, outputs = rear
+                                  return (p.inputs ?? []).some((i) => i.id === port.id)
+                                }
+                                return (port.rackSide ?? 'rear') === 'front'
+                              })
+                              .map((port) => ({
+                                id: port.id,
+                                name: port.name,
+                                connectorType: port.connectorType,
+                                panelPosX: port.panelPosX,
+                                panelPosY: port.panelPosY,
+                              })),
+                            rearPorts: [...(p.inputs ?? []), ...(p.outputs ?? [])]
+                              .filter((port) => {
+                                if (p.isPatchPanel) {
+                                  return (p.outputs ?? []).some((o) => o.id === port.id)
+                                }
+                                return (port.rackSide ?? 'rear') === 'rear'
+                              })
+                              .map((port) => ({
+                                id: port.id,
+                                name: port.name,
+                                connectorType: port.connectorType,
+                                panelPosX: port.panelPosX,
+                                panelPosY: port.panelPosY,
+                              })),
                           }
                           })
                       })()}
@@ -1532,7 +1551,18 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                               (panelPosX/Y). Default-Verteilung wenn kein
                               Override gesetzt. */}
                           <PortDots2D
-                            ports={side === 'front' ? item.inputs : item.outputs}
+                            // v7.9.81 / #170 — Filter nach port.rackSide
+                            // (Default 'rear'). Patchblende = Sonderfall:
+                            // inputs auf front, outputs auf rear.
+                            ports={[...item.inputs, ...item.outputs].filter((port) => {
+                              if (item.isPatchPanel) {
+                                const isInput = item.inputs.some((i) => i.id === port.id)
+                                return side === 'front' ? isInput : !isInput
+                              }
+                              return (port.rackSide ?? 'rear') === side
+                            })}
+                            allInputs={item.inputs}
+                            allOutputs={item.outputs}
                             placementId={item.id}
                             placementWidth={rowHeight * RACK_PANEL_ASPECT_PER_1HE}
                             placementHeight={height}
@@ -1829,9 +1859,121 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                       : 'Ohne STL wird das Gerät als Box mit Front-/Rear-Foto dargestellt.'}
                   </span>
                 </div>
-                <div className="rounded border border-slate-800 bg-slate-900/40 p-2 text-[11px] text-slate-400">
-                  Ports sichtbar: {selectedPlacement.inputs.length} Inputs / {selectedPlacement.outputs.length} Outputs
-                </div>
+                {/* v7.9.81 / #170 — Port-Side-Editor.
+                    Default-Annahme: alle Ports hinten. User kann einzelne
+                    Ports auf vorne flippen oder alle in einer Aktion
+                    spiegeln. */}
+                <details className="rounded border border-slate-800 bg-slate-900/40 p-2" open>
+                  <summary className="cursor-pointer text-[11px] font-semibold text-slate-300">
+                    Port-Seite (Front/Rear)
+                    <span className="ml-1 text-slate-500">
+                      ({selectedPlacement.inputs.length} Inputs / {selectedPlacement.outputs.length} Outputs)
+                    </span>
+                  </summary>
+                  {/* Bulk-Buttons */}
+                  <div className="mt-2 grid grid-cols-3 gap-1 text-[10px]">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        updatePlacement(selectedPlacement.id, {
+                          inputs: selectedPlacement.inputs.map((p) => ({ ...p, rackSide: 'rear' as const })),
+                          outputs: selectedPlacement.outputs.map((p) => ({ ...p, rackSide: 'rear' as const })),
+                        })
+                      }}
+                      className="rounded bg-purple-900/40 px-2 py-1 text-purple-200 hover:bg-purple-900/60"
+                      title="Alle Ports nach hinten (Default für klassische Server-Geräte)"
+                    >
+                      ⏬ alle nach hinten
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        updatePlacement(selectedPlacement.id, {
+                          inputs: selectedPlacement.inputs.map((p) => ({
+                            ...p,
+                            rackSide: (p.rackSide ?? 'rear') === 'front' ? ('rear' as const) : ('front' as const),
+                          })),
+                          outputs: selectedPlacement.outputs.map((p) => ({
+                            ...p,
+                            rackSide: (p.rackSide ?? 'rear') === 'front' ? ('rear' as const) : ('front' as const),
+                          })),
+                        })
+                      }}
+                      className="rounded bg-slate-700 px-2 py-1 text-slate-100 hover:bg-slate-600"
+                      title="Front-Ports werden zu Rear-Ports und umgekehrt"
+                    >
+                      ↔ spiegeln
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        updatePlacement(selectedPlacement.id, {
+                          inputs: selectedPlacement.inputs.map((p) => ({ ...p, rackSide: 'front' as const })),
+                          outputs: selectedPlacement.outputs.map((p) => ({ ...p, rackSide: 'front' as const })),
+                        })
+                      }}
+                      className="rounded bg-green-900/40 px-2 py-1 text-green-200 hover:bg-green-900/60"
+                      title="Alle Ports nach vorne (z.B. Frontpanel-Geräte)"
+                    >
+                      ⏫ alle nach vorne
+                    </button>
+                  </div>
+                  {/* Per-Port-Toggle-Liste */}
+                  <div className="mt-2 max-h-48 overflow-y-auto rounded border border-slate-800">
+                    {[
+                      ...selectedPlacement.inputs.map((p) => ({ port: p, dir: 'in' as const })),
+                      ...selectedPlacement.outputs.map((p) => ({ port: p, dir: 'out' as const })),
+                    ].map(({ port, dir }) => {
+                      const side: 'front' | 'rear' = port.rackSide ?? 'rear'
+                      return (
+                        <div
+                          key={port.id}
+                          className="flex items-center justify-between gap-2 border-t border-slate-800/60 px-2 py-0.5 text-[10px] first:border-t-0"
+                        >
+                          <span className="flex min-w-0 items-center gap-1">
+                            <span
+                              className={`shrink-0 rounded px-1 text-[8px] font-bold uppercase ${
+                                dir === 'in' ? 'bg-cyan-900/60 text-cyan-200' : 'bg-emerald-900/60 text-emerald-200'
+                              }`}
+                              title={dir === 'in' ? 'Input (Signal-Eingang)' : 'Output (Signal-Ausgang)'}
+                            >
+                              {dir}
+                            </span>
+                            <span className="truncate text-slate-300">{port.name}</span>
+                            <span className="shrink-0 text-slate-500">· {port.connectorType}</span>
+                          </span>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              const newSide: 'front' | 'rear' = side === 'front' ? 'rear' : 'front'
+                              if (dir === 'in') {
+                                updatePlacement(selectedPlacement.id, {
+                                  inputs: selectedPlacement.inputs.map((p) =>
+                                    p.id === port.id ? { ...p, rackSide: newSide } : p,
+                                  ),
+                                })
+                              } else {
+                                updatePlacement(selectedPlacement.id, {
+                                  outputs: selectedPlacement.outputs.map((p) =>
+                                    p.id === port.id ? { ...p, rackSide: newSide } : p,
+                                  ),
+                                })
+                              }
+                            }}
+                            className={`shrink-0 rounded border px-1.5 py-0.5 font-semibold transition ${
+                              side === 'front'
+                                ? 'border-green-700 bg-green-900/40 text-green-200 hover:bg-green-900/60'
+                                : 'border-purple-700 bg-purple-900/40 text-purple-200 hover:bg-purple-900/60'
+                            }`}
+                            title={`Port-Seite umschalten (aktuell: ${side === 'front' ? 'vorne' : 'hinten'})`}
+                          >
+                            {side === 'front' ? '⏫ vorne' : '⏬ hinten'}
+                          </button>
+                        </div>
+                      )
+                    })}
+                  </div>
+                </details>
                 <div className="space-y-2">
                   <div className="flex items-center justify-between">
                     <div className="text-[11px] font-semibold text-slate-400">Panel-Bilder (Import + Zuschneiden)</div>

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -103,6 +103,32 @@ body,
 [data-theme="light"] .bg-slate-700      { background-color: #cbd5e1; }
 [data-theme="light"] .bg-slate-600      { background-color: #b8c4d0; }
 
+/* v7.9.81 — Opacity-modified slate-Backgrounds (z.B. bg-slate-900/98,
+ * bg-slate-950/50, bg-black/60) wurden vom obigen Mapping NICHT erfasst,
+ * weil Tailwind sie als eigene Klassen mit rgb()-Werten generiert. Hier
+ * explizit für die häufigsten Opacity-Varianten überschreiben damit die
+ * Context-Menüs, Modal-Overlays und Sub-Karten im Light-Mode nicht
+ * dunkel bleiben. */
+[data-theme="light"] .bg-slate-950\/30   { background-color: rgba(240,244,248,0.7); }
+[data-theme="light"] .bg-slate-950\/40   { background-color: rgba(240,244,248,0.7); }
+[data-theme="light"] .bg-slate-950\/50   { background-color: rgba(240,244,248,0.75); }
+[data-theme="light"] .bg-slate-950\/60   { background-color: rgba(240,244,248,0.8); }
+[data-theme="light"] .bg-slate-950\/70   { background-color: rgba(240,244,248,0.85); }
+[data-theme="light"] .bg-slate-900\/40   { background-color: rgba(234,239,245,0.7); }
+[data-theme="light"] .bg-slate-900\/50   { background-color: rgba(234,239,245,0.75); }
+[data-theme="light"] .bg-slate-900\/60   { background-color: rgba(234,239,245,0.8); }
+[data-theme="light"] .bg-slate-900\/70   { background-color: rgba(234,239,245,0.85); }
+[data-theme="light"] .bg-slate-900\/98   { background-color: rgba(234,239,245,0.98); }
+[data-theme="light"] .bg-slate-800\/40   { background-color: rgba(221,228,238,0.7); }
+[data-theme="light"] .bg-slate-800\/50   { background-color: rgba(221,228,238,0.75); }
+[data-theme="light"] .bg-slate-800\/60   { background-color: rgba(221,228,238,0.8); }
+/* Modal-Backdrop: im Light-Mode statt schwarz ein helles Grau mit
+ * Transparenz, damit Modals "weiches Glas" auf hellem Hintergrund sind. */
+[data-theme="light"] .bg-black\/40       { background-color: rgba(15,23,42,0.15); }
+[data-theme="light"] .bg-black\/50       { background-color: rgba(15,23,42,0.20); }
+[data-theme="light"] .bg-black\/60       { background-color: rgba(15,23,42,0.25); }
+[data-theme="light"] .bg-black\/70       { background-color: rgba(15,23,42,0.30); }
+
 [data-theme="light"] .border-slate-50   { border-color: #e2e8f0; }
 [data-theme="light"] .border-slate-100  { border-color: #cbd5e1; }
 [data-theme="light"] .border-slate-200  { border-color: #cbd5e1; }

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -1145,6 +1145,12 @@ const buildProjectStore = (
         width: partial?.width ?? 360,
         height: partial?.height ?? 240,
         color: partial?.color ?? '#38bdf8',
+        // v7.9.81 / #194 — Default ist jetzt 'Inhalt mitbewegen' = true.
+        // Erwartung: wenn ich eine Location verschiebe, geht der Inhalt
+        // mit (Equipment, Cable-Waypoints). User kann das pro Location
+        // in den Properties wieder ausschalten falls gewünscht. Resize
+        // ist davon unberührt — der zieht nur den Rahmen.
+        moveContents: partial?.moveContents ?? true,
       }
       return {
         project: touchProject({
@@ -1183,6 +1189,8 @@ const buildProjectStore = (
         color: partial?.color ?? '#38bdf8',
         ...(partial?.width ? { width: partial.width } : {}),
         ...(partial?.height ? { height: partial.height } : {}),
+        // v7.9.81 / #194 — Default Move-Contents = true (siehe addLocation).
+        moveContents: partial?.moveContents ?? true,
       }
       return {
         project: touchProject({

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -101,6 +101,16 @@ export interface Port {
    */
   panelPosX?: number
   panelPosY?: number
+  /**
+   * v7.9.81 / #170 — Auf welcher Rack-Face (Front/Rear) der Port
+   * physisch sitzt. Unabhängig davon ob Input/Output (das ist die
+   * Signal-Richtung). Default-Annahme bei fehlendem Wert: 'rear' —
+   * weil bei den meisten Rack-Geräten ALLE Anschlüsse hinten sind
+   * (Patchblenden + 2-seitige Geräte sind die Ausnahme).
+   * User kann Ports einzeln oder in Bulk auf die andere Seite flippen
+   * (Rack-Builder Placement-Properties).
+   */
+  rackSide?: 'front' | 'rear'
 }
 
 /** v7.5.0 — a named operating mode for a device whose port layout


### PR DESCRIPTION
…udit (#170, #194)

DREI Themen in einem Commit:

═══════════════════════════════════════════════════════
1. PORT-SIDE-DEFAULT + FLIP-UI (#170) ═══════════════════════════════════════════════════════

Vorher: inputs → Front, outputs → Rear (Builder-Konvention). Falsch für die meisten Rack-Geräte, wo ALLE Anschlüsse hinten sind.

Jetzt: Neues optionales Feld Port.rackSide ∈ {'front','rear'}. Default
bei fehlendem Wert: 'rear' (Realität: 95% der Server-Geräte). Patchblenden
bleiben Sonderfall: dort weiterhin inputs=front, outputs=rear.

UI im Placement-Properties-Panel (RackBuilderDialog): • <details>-Block "Port-Seite (Front/Rear)" mit Live-Counts • Bulk: drei Buttons "⏬ alle nach hinten" · "↔ spiegeln" · "⏫ alle nach vorne" • Per-Port-Liste mit Direction-Badge (in/out), Name, Connector, und
  einem grün/lila gefärbten Side-Toggle pro Port

PortDots2D + 3D-View nutzen [...inputs, ...outputs].filter(p.rackSide===side) statt der starren input→front/output→rear-Mapping. Drag-Persist findet den Port jetzt in beiden Listen via allInputs/allOutputs-Props.

═══════════════════════════════════════════════════════
2. LOCATION INHALT MITBEWEGEN (#194) ═══════════════════════════════════════════════════════

addLocation + addLocationAroundEquipment setzen moveContents jetzt default = true. Erwartung des Issues: wenn ich eine Location verschiebe, geht der Inhalt mit (Equipment + Cable-Waypoints). User kann es pro Location in den Properties wieder ausschalten falls gewünscht.

Resize ist davon unberührt — der existierende Pfad updateLocation({x,y, width,height}) bei Resize-Position-Changes berührt die contained-Liste nicht, weil locationDragRef nur in onNodeDragStart befüllt wird. ✓

Alte Locations mit explizitem moveContents=false bleiben unverändert.

═══════════════════════════════════════════════════════
3. THEME-AUDIT: Rack 3D-Viewer + CableContextMenu (+ CSS-Map) ═══════════════════════════════════════════════════════

Rack3DView.tsx:
• Background-Color, Chassis (Boden/Wände/Decke), HE-Rails und
  gridHelper-Farben respektieren jetzt canvasTheme. Chassis bekommt
  isLight als Prop und wählt entsprechende Slate-Töne.
• Help/Legend-Overlays nutzen overlayBg/overlayText state-driven.

CableContextMenu.tsx:
• Menu-Container + Header lesen canvasTheme; in light mode weiße
  Glas-Optik mit dunklem Text. Sub-Menu-Container ebenfalls.

src/renderer/index.css:
• Systematische Erweiterung des [data-theme="light"]-Mappings auf
  opacity-modified Slate-Klassen (bg-slate-900/98, bg-slate-950/40,
  bg-slate-900/60 etc.) und Modal-Backdrops (bg-black/40-70). Vorher
  hat Tailwind die opacity-Variante als eigene Klasse mit rgb()-
  Hardcoded-Werten generiert die das Mapping nicht erfasst hat. Damit
  werden ALLE Modal-Overlays, Sub-Karten in Properties-Panels und
  Right-Click-Menüs auf einen Schlag theme-aware — ohne dass jede
  Komponente individuell gepatcht werden muss.

v7.9.81

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH