### PR TITLE
feat(rack): Space-Key, Doppel-Label, Shelf-Drag + korrektes 2D-Width …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.9.81",
+    "version": "7.9.82",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/components/Rack/Rack3DView.tsx
+++ b/src/renderer/components/Rack/Rack3DView.tsx
@@ -68,6 +68,12 @@ interface Rack3DPlacement {
    *  Bodenrand der HE-Reihe (= "steht auf dem Shelf darunter"). */
   widthMm?: number
   heightMm?: number
+  /** v7.9.82 / #170 — Shelf-Device horizontale Position innerhalb der
+   *  Rack-Mount-Breite (mm vom linken Rail). Default 0 = ganz links. */
+  shelfOffsetX?: number
+  /** v7.9.82 / #170 — Shelf-Device Tiefen-Position (mm von vorne).
+   *  Default 0 = ganz vorne. */
+  shelfOffsetZ?: number
 }
 
 /** v7.9.77 / #170 — Port-Connector-Type → Dot-Farbe. Vereinheitlicht mit
@@ -118,6 +124,14 @@ interface Rack3DViewProps {
     portId: string,
     side: 'front' | 'rear',
     pos: { x: number; y: number },
+  ) => void
+  /** v7.9.82 / #170 — Shelf-Device Position-Update (horizontale + Tiefen-
+   *  Position in mm). Wird vom User per Pointer-Drag direkt auf der Box
+   *  im 3D-Tab ausgelöst (Raycast auf die Box, e.point liefert Welt-
+   *  Koordinate die wir zurück in mm-Offsets übersetzen). */
+  onShelfDeviceMoved?: (
+    placementId: string,
+    offset: { x: number; z: number },
   ) => void
   /** v7.9.78 / #170 — Internal Cables zwischen Patchpunkten. */
   internalCables?: Array<{
@@ -238,6 +252,8 @@ const DeviceBox = ({
   selected,
   onClick,
   onPortMoved,
+  onShelfDeviceMoved,
+  orbitRef,
 }: {
   placement: Rack3DPlacement
   rackDepthMm: number
@@ -245,7 +261,17 @@ const DeviceBox = ({
   selected: boolean
   onClick: () => void
   onPortMoved?: Rack3DViewProps['onPortMoved']
+  onShelfDeviceMoved?: Rack3DViewProps['onShelfDeviceMoved']
+  /** v7.9.82 — Ref auf OrbitControls, damit wir bei Shelf-Drag das
+   *  Kamera-Drehen kurz deaktivieren können (sonst dreht/pannt der
+   *  Drag gleichzeitig die Kamera, schlimmes UX). */
+  orbitRef?: React.RefObject<{ enabled: boolean } | null>
 }) => {
+  // v7.9.82 / #170 — Shelf-Device-Drag-State. Solange aktiv: pointer-
+  // move-events auf der Mesh übersetzen e.point (World-Hit auf die Box-
+  // Geometrie) zurück in mm-Offsets innerhalb des Racks.
+  const shelfDragRef = useRef<{ pointerId: number; offsetX: number; offsetZ: number } | null>(null)
+  const [shelfDragOverride, setShelfDragOverride] = useState<{ x: number; z: number } | null>(null)
   const mountSide = placement.mountSide ?? 'full'
   const depthMm = Math.max(20, placement.depthMm ?? DEFAULT_DEVICE_DEPTH_MM)
   const yBottom = (totalUnits - placement.startUnit - placement.rackUnits + 1) * HE_HEIGHT_MM
@@ -261,11 +287,23 @@ const DeviceBox = ({
     ? Math.min(placement.widthMm!, RACK_MOUNT_WIDTH_MM)
     : RACK_MOUNT_WIDTH_MM
 
-  const zStart = mountSide === 'rear' ? rackDepthMm - depthMm : 0
-  const xCenter = (RACK_OUTER_WIDTH_MM - widthMm) / 2 + widthMm / 2
-  // Shelf-Geräte ruhen auf dem unteren Rand der HE-Reihe (yBottom + heightMm/2)
-  // statt mittig in der HE-Reihe. Bei Rack-Geräten ist beides identisch.
-  const yCenter = isShelfDevice ? yBottom + heightMm / 2 : yBottom + heightMm / 2
+  // v7.9.82 / #170 — Shelf-Devices nutzen zusätzlich shelfOffsetX (mm
+  // vom linken Rail) und shelfOffsetZ (mm von der Front) — beide vom
+  // User per Drag / Number-Input gesetzt. Bei klassischen Rack-Geräten
+  // sind die Offsets undefined → zentriert/vorne wie bisher.
+  // Während eines aktiven Drags hat shelfDragOverride Vorrang (smooth
+  // live-Render).
+  const railInnerOffset = (RACK_OUTER_WIDTH_MM - RACK_MOUNT_WIDTH_MM) / 2
+  const effectiveShelfX = shelfDragOverride?.x ?? placement.shelfOffsetX ?? 0
+  const effectiveShelfZ = shelfDragOverride?.z ?? placement.shelfOffsetZ ?? 0
+  const xLeftBase = isShelfDevice
+    ? railInnerOffset + effectiveShelfX
+    : (RACK_OUTER_WIDTH_MM - widthMm) / 2
+  const zStart = isShelfDevice
+    ? effectiveShelfZ
+    : (mountSide === 'rear' ? rackDepthMm - depthMm : 0)
+  const xCenter = xLeftBase + widthMm / 2
+  const yCenter = yBottom + heightMm / 2
   const zCenter = zStart + depthMm / 2
 
   // v7.9.75 / #170 — Patchblenden bekommen eine eigene Farbe damit der
@@ -324,6 +362,55 @@ const DeviceBox = ({
           e.stopPropagation()
           onClick()
         }}
+        // v7.9.82 / #170 — Shelf-Drag im 3D: Pointer-Down speichert den
+        // Maus-Offset relativ zur aktuellen Mesh-Position. Move-Events
+        // berechnen daraus die neue Welt-Position und konvertieren in
+        // shelfOffsetX/Z (mm). Up persistiert via onShelfDeviceMoved.
+        // Nicht-Shelf-Geräte ignorieren die Drag-Events (kein onShelfDeviceMoved).
+        onPointerDown={(e) => {
+          if (!isShelfDevice || !onShelfDeviceMoved) return
+          e.stopPropagation()
+          ;(e.target as Element).setPointerCapture?.(e.pointerId)
+          // v7.9.82 — OrbitControls aus, damit der gleiche Pointer-Drag
+          // nicht zusätzlich die Kamera dreht.
+          if (orbitRef?.current) orbitRef.current.enabled = false
+          const hitX = e.point.x
+          const hitZ = e.point.z
+          shelfDragRef.current = {
+            pointerId: e.pointerId,
+            offsetX: hitX - xCenter,
+            offsetZ: hitZ - zCenter,
+          }
+        }}
+        onPointerMove={(e) => {
+          const drag = shelfDragRef.current
+          if (!drag || drag.pointerId !== e.pointerId) return
+          if (!isShelfDevice) return
+          const newCenterX = e.point.x - drag.offsetX
+          const newCenterZ = e.point.z - drag.offsetZ
+          // Center → linke Vorderkante zurück
+          const newLeftX = newCenterX - widthMm / 2
+          const newZ = newCenterZ - depthMm / 2
+          // Klemmen auf rack-internen Bereich
+          const newOffsetX = Math.max(
+            0,
+            Math.min(RACK_MOUNT_WIDTH_MM - widthMm, newLeftX - railInnerOffset),
+          )
+          const newOffsetZ = Math.max(0, Math.min(rackDepthMm - depthMm, newZ))
+          setShelfDragOverride({ x: newOffsetX, z: newOffsetZ })
+        }}
+        onPointerUp={(e) => {
+          const drag = shelfDragRef.current
+          if (!drag) return
+          ;(e.target as Element).releasePointerCapture?.(e.pointerId)
+          if (shelfDragOverride && onShelfDeviceMoved) {
+            onShelfDeviceMoved(placement.id, shelfDragOverride)
+          }
+          shelfDragRef.current = null
+          setShelfDragOverride(null)
+          // OrbitControls wieder an
+          if (orbitRef?.current) orbitRef.current.enabled = true
+        }}
       >
         <boxGeometry args={[widthMm, heightMm, depthMm]} />
         <Edges color={selected ? '#0ea5e9' : '#020617'} threshold={15} />
@@ -355,13 +442,34 @@ const DeviceBox = ({
           onPortMoved={onPortMoved}
         />
       )}
+      {/* v7.9.82 / #170 — Gerätenamen jetzt SOWOHL vorne als auch hinten,
+          damit der User aus jeder Orbit-Richtung lesen kann welches Gerät
+          er anschaut. Ohne Doppellabel war beim Drehen-um-180° die
+          Beschriftung weg. */}
       <Html
-        position={[xCenter, yCenter, mountSide === 'rear' ? zStart - 5 : zStart + depthMm + 5]}
+        position={[xCenter, yCenter, zStart - 5]}
         center
         style={{
           color: '#e2e8f0',
           fontSize: 10,
-          background: 'rgba(15,23,42,0.7)',
+          background: 'rgba(15,23,42,0.78)',
+          padding: '2px 6px',
+          borderRadius: 3,
+          pointerEvents: 'none',
+          whiteSpace: 'nowrap',
+        }}
+        transform={false}
+        distanceFactor={300}
+      >
+        {placement.name} ({placement.rackUnits}HE)
+      </Html>
+      <Html
+        position={[xCenter, yCenter, zStart + depthMm + 5]}
+        center
+        style={{
+          color: '#e2e8f0',
+          fontSize: 10,
+          background: 'rgba(15,23,42,0.78)',
           padding: '2px 6px',
           borderRadius: 3,
           pointerEvents: 'none',
@@ -606,34 +714,33 @@ const DeviceSTL = ({
   )
 }
 
-/** v7.9.80 / #170 — Keyboard-Camera-Controller. Solange der User
- *  Shift hält, fährt die Kamera (samt OrbitControls.target) nach oben;
- *  Tab hält → nach unten. Damit kann der User die Höhe seines Blicks
- *  ändern UND gerade auf eine bestimmte HE-Reihe schauen, ohne mit der
- *  Maus um den Rack-Body kreisen zu müssen. Tab-Default (Focus-Wechsel)
- *  wird verhindert. */
+/** v7.9.82 / #170 — Keyboard-Camera-Controller. Shift hält → Kamera
+ *  (+ OrbitControls.target) fährt nach oben; Leertaste → nach unten.
+ *  (v7.9.80 hatte Tab vorgesehen — war ungünstig weil Tab Browser-
+ *  Default = Focus-Switch ist. Space ist intuitiver.) */
 const CameraKeyboardController = ({
   orbitTargetRef,
 }: {
   orbitTargetRef: React.RefObject<{ target: THREE.Vector3; update: () => void } | null>
 }) => {
   const { camera } = useThree()
-  const keys = useRef({ shift: false, tab: false })
+  const keys = useRef({ shift: false, space: false })
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      // Nur capturen wenn der Fokus nicht in einem Input/Textarea ist —
-      // sonst killt Shift Text-Selektion und Tab den Form-Wechsel.
+      // Nicht capturen wenn der Fokus in einem Input/Textarea ist —
+      // sonst killt Shift Text-Selektion und Space würde im Properties-
+      // Panel die Eingabe stören.
       const tag = (e.target as HTMLElement | null)?.tagName
       if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
       if (e.key === 'Shift') keys.current.shift = true
-      if (e.key === 'Tab') {
-        keys.current.tab = true
+      if (e.key === ' ' || e.code === 'Space') {
+        keys.current.space = true
         e.preventDefault()
       }
     }
     const onKeyUp = (e: KeyboardEvent) => {
       if (e.key === 'Shift') keys.current.shift = false
-      if (e.key === 'Tab') keys.current.tab = false
+      if (e.key === ' ' || e.code === 'Space') keys.current.space = false
     }
     window.addEventListener('keydown', onKeyDown)
     window.addEventListener('keyup', onKeyUp)
@@ -643,10 +750,7 @@ const CameraKeyboardController = ({
     }
   }, [])
   useFrame((_, delta) => {
-    if (!keys.current.shift && !keys.current.tab) return
-    // 800 mm pro Sekunde Kamera-Vertikalgeschwindigkeit — schnell genug
-    // um schnell durch ein 42HE-Rack zu scrollen, langsam genug für
-    // präzise Höheneinstellung.
+    if (!keys.current.shift && !keys.current.space) return
     const speed = 800 * delta
     const dy = keys.current.shift ? speed : -speed
     camera.position.y += dy
@@ -743,6 +847,7 @@ export const Rack3DView = ({
   selectedPlacementId,
   onSelectPlacement,
   onPortMoved,
+  onShelfDeviceMoved,
   internalCables,
 }: Rack3DViewProps) => {
   // v7.9.81 — Theme-Awareness: 3D-Hintergrund + Help-Overlay-Farben
@@ -758,7 +863,10 @@ export const Rack3DView = ({
   // v7.9.80 / #170 — OrbitControls ref für den CameraKeyboardController:
   // wir mutieren controls.target.y zusammen mit camera.y, sonst tilted
   // die Kamera statt zu pannen.
-  const orbitRef = useRef<{ target: THREE.Vector3; update: () => void } | null>(null)
+  // v7.9.82 / #170 — Plus 'enabled'-Toggle (Shelf-Drag schaltet
+  // OrbitControls kurz aus damit Pointer-Drag nicht gleichzeitig die
+  // Kamera dreht).
+  const orbitRef = useRef<{ target: THREE.Vector3; update: () => void; enabled: boolean } | null>(null)
   const rackHeightMm = totalUnits * HE_HEIGHT_MM
   // Set initial camera so the rack is fully visible.
   const cameraPos: [number, number, number] = [
@@ -814,6 +922,8 @@ export const Rack3DView = ({
                 selected={selectedPlacementId === p.id}
                 onClick={() => onSelectPlacement(p.id)}
                 onPortMoved={onPortMoved}
+                onShelfDeviceMoved={onShelfDeviceMoved}
+                orbitRef={orbitRef as React.RefObject<{ enabled: boolean } | null>}
               />
             )
           })}
@@ -890,7 +1000,7 @@ export const Rack3DView = ({
         }}
       >
         🖱 Drehen: links · Pannen: rechts · Zoom: scroll<br />
-        ⌨ Höhe: <kbd style={{ background: kbdBg, padding: '0 3px', borderRadius: 2 }}>Shift</kbd> hoch · <kbd style={{ background: kbdBg, padding: '0 3px', borderRadius: 2 }}>Tab</kbd> runter
+        ⌨ Höhe: <kbd style={{ background: kbdBg, padding: '0 3px', borderRadius: 2 }}>Shift</kbd> hoch · <kbd style={{ background: kbdBg, padding: '0 3px', borderRadius: 2 }}>Space</kbd> runter
       </div>
     </div>
   )

--- a/src/renderer/components/Rack/RackBuilderDialog.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialog.tsx
@@ -61,6 +61,10 @@ interface RackPlacementDraft {
   isPatchPanel?: boolean
   /** v7.9.75 / #170 — Rack-Shelf-Marker. */
   isRackShelf?: boolean
+  /** v7.9.82 / #170 — Shelf-Device horizontal-Offset (mm von links). */
+  shelfOffsetX?: number
+  /** v7.9.82 / #170 — Shelf-Device depth-Offset (mm von vorne). */
+  shelfOffsetZ?: number
 }
 
 interface RackDraft {
@@ -95,6 +99,11 @@ interface InternalCableDraft {
 // rowHeight in pixels from the measured panel width so the on-screen rack is
 // proportional to a real 19" rack, regardless of available screen space.
 const RACK_PANEL_ASPECT_PER_1HE = 10.857
+// v7.9.82 / #170 — geteilt mit Rack3DView.tsx: 19″ standardisierte
+// Außenbreite + Mounting-Raum (innen zwischen den Rails). Werden für
+// die Shelf-Device Horizontal-Positionierung in 2D gebraucht.
+const RACK_OUTER_WIDTH_MM = 482.6
+const RACK_MOUNT_WIDTH_MM = 450
 // v7.9.10 — MIN auf 6 px gesenkt damit bei kleinem Dialog + vielen HE
 // (42 HE) der Rack noch in den sichtbaren Bereich passt. Wer Details
 // sehen will dreht den Zoom hoch.
@@ -151,6 +160,9 @@ const toPlacement = (template: EquipmentTemplate, startUnit: number): RackPlacem
   stlDataUri: template.stlDataUri,
   isPatchPanel: template.isPatchPanel,
   isRackShelf: template.isRackShelf,
+  // v7.9.82 / #170 — Shelf-Offsets initial 0 (= linke vordere Ecke der HE).
+  shelfOffsetX: 0,
+  shelfOffsetZ: 0,
 })
 
 const normalizeDraft = (draft: RackDraft): RackDraft => {
@@ -191,8 +203,13 @@ const draftFromPreset = (preset: GroupPreset): RackDraft => {
   const savedPositions = preset.rack?.internalCanvasPositions ?? {}
   // v7.9.73 / #170 — mountSide aus preset.rack.placements[].mountSide hydraten
   const mountSideByIndex = new Map<number, 'front' | 'rear' | 'full' | undefined>()
+  // v7.9.82 / #170 — Shelf-Offsets dito.
+  const shelfOffsetByIndex = new Map<number, { x?: number; z?: number }>()
   for (const p of preset.rack?.placements ?? []) {
     if (p.mountSide) mountSideByIndex.set(p.itemIndex, p.mountSide)
+    if (p.shelfOffsetX != null || p.shelfOffsetZ != null) {
+      shelfOffsetByIndex.set(p.itemIndex, { x: p.shelfOffsetX, z: p.shelfOffsetZ })
+    }
   }
   const placements: RackPlacementDraft[] = preset.items.map((item, index) => {
     const meta = placementsByIndex.get(index)
@@ -219,6 +236,8 @@ const draftFromPreset = (preset: GroupPreset): RackDraft => {
       stlDataUri: item.stlDataUri,
       isPatchPanel: item.isPatchPanel,
       isRackShelf: item.isRackShelf,
+      shelfOffsetX: shelfOffsetByIndex.get(index)?.x,
+      shelfOffsetZ: shelfOffsetByIndex.get(index)?.z,
     }
   })
   // Hydrate internal cables: cables in the stored preset reference items
@@ -652,6 +671,9 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
       heightUnits: placement.rackUnits,
       // v7.9.73 / #170 — mountSide nur persistieren wenn explizit gesetzt.
       ...(placement.mountSide ? { mountSide: placement.mountSide } : {}),
+      // v7.9.82 / #170 — Shelf-Offsets nur wenn != 0.
+      ...(placement.shelfOffsetX ? { shelfOffsetX: placement.shelfOffsetX } : {}),
+      ...(placement.shelfOffsetZ ? { shelfOffsetZ: placement.shelfOffsetZ } : {}),
     }))
 
     // v7.8.5 — Map internal cables (referenced by placement id) onto the
@@ -1262,6 +1284,8 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                             portCount: (p.inputs?.length ?? 0) + (p.outputs?.length ?? 0),
                             isPatchPanel: p.isPatchPanel,
                             isRackShelf: p.isRackShelf,
+                            shelfOffsetX: p.shelfOffsetX,
+                            shelfOffsetZ: p.shelfOffsetZ,
                             // v7.9.81 / #170 — Port-Side aus port.rackSide
                             // (Default 'rear' wenn nicht gesetzt). Inputs UND
                             // Outputs werden in einen Topf geworfen und nach
@@ -1302,6 +1326,14 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                       })()}
                       selectedPlacementId={selectedPlacementId}
                       onSelectPlacement={(id) => setSelectedPlacementId(id)}
+                      // v7.9.82 / #170 — Shelf-Device-Drag im 3D-Tab
+                      // persistieren.
+                      onShelfDeviceMoved={(placementId, offset) => {
+                        updatePlacement(placementId, {
+                          shelfOffsetX: offset.x,
+                          shelfOffsetZ: offset.z,
+                        })
+                      }}
                       // v7.9.77 / #170 — Port-Dot-Drag persistieren: setzt
                       // panelPosX/Y am Port (in inputs ODER outputs je
                       // nach side) im Draft.
@@ -1488,16 +1520,36 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                       const top = (item.startUnit - 1) * rowHeight
                       const height = item.rackUnits * rowHeight
                       const image = side === 'front' ? item.frontPanelImageUrl : item.rearPanelImageUrl
+                      // v7.9.82 / #170 — Shelf-Device-Rendering: nutze die
+                      // physischen mm-Maße (widthMm) + shelfOffsetX statt
+                      // der vollen HE-Breite. Mapping: 1 mm = (rackWidthPx /
+                      // RACK_MOUNT_WIDTH_MM). Klassische 19″-Geräte:
+                      // full-width wie bisher (left:0, right:0).
+                      const rackTpl = templates.find((t) => t.name === item.templateName)
+                      const isShelfDevice = !!(rackTpl?.widthMm && rackTpl?.heightMm)
+                      const rackWidthPx = rowHeight * RACK_PANEL_ASPECT_PER_1HE
+                      const mmToPx = rackWidthPx / RACK_OUTER_WIDTH_MM
+                      const railInsetPx = ((RACK_OUTER_WIDTH_MM - RACK_MOUNT_WIDTH_MM) / 2) * mmToPx
+                      const shelfStyle = isShelfDevice
+                        ? {
+                            top,
+                            height: Math.min(rackTpl!.heightMm! * mmToPx, height),
+                            left: railInsetPx + (item.shelfOffsetX ?? 0) * mmToPx,
+                            width: rackTpl!.widthMm! * mmToPx,
+                          }
+                        : { top, height, left: 0, right: 0 }
                       return (
                         <div
                           key={`${side}-block-${item.id}`}
                           className={`absolute cursor-grab touch-none select-none overflow-hidden rounded border-2 active:cursor-grabbing ${
                             selectedPlacementId === item.id
                               ? 'border-amber-300 bg-amber-900/40 shadow-[0_0_0_2px_rgba(252,211,77,0.45)] ring-1 ring-amber-400/40'
-                              : 'border-sky-600/70 bg-sky-900/30 hover:border-sky-400/80 hover:bg-sky-900/40'
+                              : isShelfDevice
+                                ? 'border-emerald-600/70 bg-emerald-900/30 hover:border-emerald-400/80'
+                                : 'border-sky-600/70 bg-sky-900/30 hover:border-sky-400/80 hover:bg-sky-900/40'
                           }`}
-                          style={{ top, height, left: 0, right: 0 }}
-                          title={`${item.name} (${item.rackUnits} HE, Start HE${item.startUnit})`}
+                          style={shelfStyle}
+                          title={`${item.name} (${item.rackUnits} HE, Start HE${item.startUnit}${isShelfDevice ? `, Shelf-Device ${rackTpl!.widthMm}×${rackTpl!.heightMm} mm` : ''})`}
                           onPointerDown={(event) => {
                             // Capture so onPointerMove fires reliably even
                             // when the cursor leaves the small block.
@@ -1519,7 +1571,21 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                             const placement = draft.placements.find((p) => p.id === dragState.placementId)
                             if (!placement) return
                             const nextStart = Math.max(1, Math.min(draft.totalUnits - placement.rackUnits + 1, unitAtPointer - dragState.offsetUnits))
-                            updatePlacement(placement.id, { startUnit: nextStart })
+                            const patch: Partial<RackPlacementDraft> = { startUnit: nextStart }
+                            // v7.9.82 / #170 — Shelf-Devices auch horizontal
+                            // verschiebbar machen: Drop-X-Position relativ zum
+                            // Panel in mm umrechnen, in [0..(RACK_MOUNT_WIDTH_MM
+                            // - widthMm)] klemmen.
+                            if (isShelfDevice && rackTpl?.widthMm) {
+                              const mmToPxLocal = host.width / RACK_OUTER_WIDTH_MM
+                              const railInsetLocal =
+                                ((RACK_OUTER_WIDTH_MM - RACK_MOUNT_WIDTH_MM) / 2) * mmToPxLocal
+                              const x = clamp(event.clientX - host.left, 0, host.width)
+                              const offsetMm = (x - railInsetLocal) / mmToPxLocal - rackTpl.widthMm / 2
+                              const maxOffset = Math.max(0, RACK_MOUNT_WIDTH_MM - rackTpl.widthMm)
+                              patch.shelfOffsetX = clamp(offsetMm, 0, maxOffset)
+                            }
+                            updatePlacement(placement.id, patch)
                           }}
                           onPointerUp={(event) => {
                             event.currentTarget.releasePointerCapture?.(event.pointerId)
@@ -1859,6 +1925,72 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                       : 'Ohne STL wird das Gerät als Box mit Front-/Rear-Foto dargestellt.'}
                   </span>
                 </div>
+                {/* v7.9.82 / #170 — Shelf-Device-Position-Editor.
+                    Nur sichtbar wenn das Template echte mm-Maße hat
+                    (Shelf-Device). Erlaubt präzises Eingeben der
+                    horizontal- + Tiefen-Position innerhalb des Racks. */}
+                {(() => {
+                  const tpl = templates.find((t) => t.name === selectedPlacement.templateName)
+                  if (!tpl?.widthMm || !tpl?.heightMm) return null
+                  const maxX = Math.max(0, RACK_MOUNT_WIDTH_MM - tpl.widthMm)
+                  const rackDepthRender = draft.depthMm ?? 800
+                  const devDepth = tpl.depthMm ?? 400
+                  const maxZ = Math.max(0, rackDepthRender - devDepth)
+                  return (
+                    <details className="rounded border border-emerald-800 bg-emerald-900/20 p-2" open>
+                      <summary className="cursor-pointer text-[11px] font-semibold text-emerald-200">
+                        🪑 Shelf-Position
+                        <span className="ml-1 text-emerald-400">
+                          ({tpl.widthMm}×{tpl.heightMm}×{tpl.depthMm ?? 400} mm)
+                        </span>
+                      </summary>
+                      <div className="mt-2 grid grid-cols-2 gap-2">
+                        <label className="block text-[10px]">
+                          <span className="mb-0.5 block text-emerald-300/80">
+                            Horizontal (mm vom linken Rail)
+                          </span>
+                          <input
+                            type="number"
+                            min={0}
+                            max={maxX}
+                            step={5}
+                            value={Math.round(selectedPlacement.shelfOffsetX ?? 0)}
+                            onChange={(e) =>
+                              updatePlacement(selectedPlacement.id, {
+                                shelfOffsetX: Math.max(0, Math.min(maxX, Number(e.target.value) || 0)),
+                              })
+                            }
+                            className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1"
+                          />
+                          <span className="text-[9px] text-slate-500">max {Math.round(maxX)} mm</span>
+                        </label>
+                        <label className="block text-[10px]">
+                          <span className="mb-0.5 block text-emerald-300/80">
+                            Tiefe (mm von vorne)
+                          </span>
+                          <input
+                            type="number"
+                            min={0}
+                            max={maxZ}
+                            step={10}
+                            value={Math.round(selectedPlacement.shelfOffsetZ ?? 0)}
+                            onChange={(e) =>
+                              updatePlacement(selectedPlacement.id, {
+                                shelfOffsetZ: Math.max(0, Math.min(maxZ, Number(e.target.value) || 0)),
+                              })
+                            }
+                            className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1"
+                          />
+                          <span className="text-[9px] text-slate-500">max {Math.round(maxZ)} mm</span>
+                        </label>
+                      </div>
+                      <div className="mt-1 text-[10px] text-slate-500">
+                        Tipp: Im 2D-Tab kannst du das Gerät auch horizontal per Maus
+                        verschieben. Tiefen-Position nur hier oder im 3D-Tab editierbar.
+                      </div>
+                    </details>
+                  )
+                })()}
                 {/* v7.9.81 / #170 — Port-Side-Editor.
                     Default-Annahme: alle Ports hinten. User kann einzelne
                     Ports auf vorne flippen oder alle in einer Aktion

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -533,6 +533,12 @@ export interface GroupPreset {
        *  Patchblende hinter einem vorderen Gerät), 'full' = beide Tiefen
        *  belegt (Default für klassische Server). Fehlt → 'full'. */
       mountSide?: 'front' | 'rear' | 'full'
+      /** v7.9.82 / #170 — Shelf-Devices: horizontale Position innerhalb der
+       *  Rack-Mount-Breite (mm vom linken Rail, 0 = ganz links). Default 0. */
+      shelfOffsetX?: number
+      /** v7.9.82 / #170 — Shelf-Devices: Tiefen-Position innerhalb des Racks
+       *  (mm von der Front, 0 = ganz vorne). Default 0. */
+      shelfOffsetZ?: number
     }>
     /** v7.9.14 — Canvas-Positionen für den RackInternalCanvas. Wird
      *  vom Rack-Builder beim Speichern befüllt, falls der User Geräte


### PR DESCRIPTION
…(#170)

Drei User-Feedback-Punkte aus dem 3D-Rack:

1. TAB → LEERTASTE (Space) für Kamera-runter. Tab war ungünstig (Browser-Default = Focus-Switch). Space ist intuitiver und konflikt-frei mit dem natürlichen "Shift = hoch"-Mental- Model. CameraKeyboardController + Help-Overlay umgestellt.

2. GERÄTENAMEN AN FRONT UND REAR. Vorher: ein einzelnes <Html>-Label am sichtbaren Mount-End — bei Orbit-um-180° war die Beschriftung weg. Jetzt zwei Labels (eines pro Face), beide always-on, von jeder Orbit-Richtung lesbar.

3. SHELF-DEVICES VERSCHIEBBAR + KORREKT IN 2D. Bisher hat das 2D-Panel jedes Placement auf volle 19″-Breite gestreckt — auch Shelf-Geräte mit eigener widthMm. Falsch. Fix: 2D-Rendering nutzt jetzt template.widthMm/heightMm + shelfOffsetX für die echte Größe und Position (mit emerald-Border, damit Shelf- Devices visuell von normalen Rack-Geräten unterscheidbar sind).

   Zwei neue optionale Felder im GroupPreset + RackPlacementDraft:
   - shelfOffsetX (mm vom linken Rail)
   - shelfOffsetZ (mm von der Front)

   Drag-UX:
   • 2D-Tab: existing pointer-drag für vertikales HE-Verschieben hat
     jetzt für Shelf-Devices auch horizontale Berechnung dabei (clientX → mm via mmToPxLocal-Mapping, geklemmt auf [0..(RACK_MOUNT_WIDTH_MM - widthMm)]). • 3D-Tab: Pointer-Down auf einem Shelf-Device aktiviert Drag-Modus (OrbitControls.enabled = false damit Drehen pausiert), e.point liefert World-Hit, daraus errechnen wir neue Offset-Werte. Live- Override für smooth Render während Drag, onPointerUp persistiert. • Number-Inputs als Fallback im Placement-Properties-Panel (<details> "🪑 Shelf-Position") für präzise Eingabe.

3D-Renderer in DeviceBox: bei Shelf-Devices nutzt jetzt shelfOffsetX/Z für xLeftBase/zStart statt der zentrierten/vorderen Default-Position.

Round-Trip: shelfOffsetX/Z fließen via toPlacement, draftFromPreset und saveRack durch — bleiben mit dem Preset erhalten.

v7.9.82

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH