### PR TITLE
feat(rack): Export-Menu — 2D PNG, 3D PNG (4 Perspektiven), STL, .cpgr…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.9.82",
+    "version": "7.9.83",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/components/Rack/Rack3DView.tsx
+++ b/src/renderer/components/Rack/Rack3DView.tsx
@@ -133,6 +133,15 @@ interface Rack3DViewProps {
     placementId: string,
     offset: { x: number; z: number },
   ) => void
+  /** v7.9.83 / #170 — Snapshot der WebGL-Refs (gl/scene/camera) für den
+   *  Export-Pfad. Wird vom CanvasRefsCapture innerhalb von <Canvas>
+   *  beim ersten Frame befüllt und an den Caller weitergegeben, sodass
+   *  exportRack3DAsPngs() von außen auf die Szene zugreifen kann. */
+  onCanvasRefsReady?: (refs: {
+    gl: THREE.WebGLRenderer
+    scene: THREE.Scene
+    camera: THREE.PerspectiveCamera
+  }) => void
   /** v7.9.78 / #170 — Internal Cables zwischen Patchpunkten. */
   internalCables?: Array<{
     fromPlacementId: string
@@ -714,6 +723,26 @@ const DeviceSTL = ({
   )
 }
 
+/** v7.9.83 / #170 — Capture-Helper innerhalb <Canvas>. Liefert die
+ *  three.js Refs (gl/scene/camera) per Effect an den Caller. */
+const CanvasRefsCapture = ({
+  onReady,
+}: {
+  onReady?: (refs: {
+    gl: THREE.WebGLRenderer
+    scene: THREE.Scene
+    camera: THREE.PerspectiveCamera
+  }) => void
+}) => {
+  const { gl, scene, camera } = useThree()
+  useEffect(() => {
+    if (onReady && camera instanceof THREE.PerspectiveCamera) {
+      onReady({ gl, scene, camera })
+    }
+  }, [gl, scene, camera, onReady])
+  return null
+}
+
 /** v7.9.82 / #170 — Keyboard-Camera-Controller. Shift hält → Kamera
  *  (+ OrbitControls.target) fährt nach oben; Leertaste → nach unten.
  *  (v7.9.80 hatte Tab vorgesehen — war ungünstig weil Tab Browser-
@@ -848,6 +877,7 @@ export const Rack3DView = ({
   onSelectPlacement,
   onPortMoved,
   onShelfDeviceMoved,
+  onCanvasRefsReady,
   internalCables,
 }: Rack3DViewProps) => {
   // v7.9.81 — Theme-Awareness: 3D-Hintergrund + Help-Overlay-Farben
@@ -882,7 +912,12 @@ export const Rack3DView = ({
       <Canvas
         camera={{ position: cameraPos, near: 1, far: 10000, fov: 35 }}
         shadows={false}
+        // v7.9.83 / #170 — preserveDrawingBuffer: WebGL-Canvas behält
+        // gerendertes Frame im Buffer damit toBlob() / toDataURL()
+        // funktionieren (für die 3D-PNG-Export-Funktion).
+        gl={{ preserveDrawingBuffer: true, antialias: true }}
       >
+        <CanvasRefsCapture onReady={onCanvasRefsReady} />
         <ambientLight intensity={0.55} />
         <directionalLight position={[600, 1200, 800]} intensity={0.9} />
         <directionalLight position={[-800, 600, -400]} intensity={0.4} />

--- a/src/renderer/components/Rack/RackBuilderDialog.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialog.tsx
@@ -12,6 +12,13 @@ import { RackShelfCreateDialog } from './RackShelfCreateDialog'
 import { PortDots2D } from './PortDots2D'
 import { RackAddSplitButton } from './RackAddSplitButton'
 import { NonRackAddDialog } from './NonRackAddDialog'
+import * as THREE from 'three'
+import {
+  exportRack2DAsPng,
+  exportRack3DAsPngs,
+  exportRackAsStl,
+  exportRackAsCpgroup,
+} from '../../lib/exportRack'
 import { useDraggablePosition } from '../../hooks/useDraggablePosition'
 import { CategorySelect } from '../shared/CategorySelect'
 import { ModalShell } from '../shared/ModalShell'
@@ -312,6 +319,13 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
   const [nonRackDialog, setNonRackDialog] = useState<{
     template: EquipmentTemplate
     options?: { mountSide?: 'front' | 'rear' | 'full'; preferStartUnit?: number }
+  } | null>(null)
+  // v7.9.83 / #170 — Export-Menu + WebGL-Refs vom 3D-Viewer für 3D/STL-Export.
+  const [exportMenuOpen, setExportMenuOpen] = useState(false)
+  const canvas3DRefs = useRef<{
+    gl: THREE.WebGLRenderer
+    scene: THREE.Scene
+    camera: THREE.PerspectiveCamera
   } | null>(null)
   // v7.9.75 / #170 — View-Mode-Filter aus Issue-Kommentar 1:
   // 'all'      = alles sichtbar (Default)
@@ -785,6 +799,138 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                 <kbd className="rounded border border-slate-700 bg-slate-800 px-1 text-[10px]">Esc</kbd> schließen
               </span>
             </p>
+          </div>
+          {/* v7.9.83 / #170 — Export-Menu: 2D-PNG, 3D-PNG (alle 4 Perspektiven),
+              3D-STL, .cpgroup mit allen Assets. */}
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => setExportMenuOpen((v) => !v)}
+              title="Rack exportieren (PNG / STL / .cpgroup)"
+              className="flex h-8 items-center gap-1 rounded border border-slate-700 bg-slate-800 px-3 text-xs text-slate-300 hover:border-sky-500/50 hover:bg-sky-900/30 hover:text-sky-200"
+            >
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <path d="M8 1 L8 10 M4 7 L8 11 L12 7 M2 13 L14 13" />
+              </svg>
+              Exportieren ▾
+            </button>
+            {exportMenuOpen && (
+              <div
+                onMouseLeave={() => setExportMenuOpen(false)}
+                className="absolute right-0 top-9 z-50 w-64 overflow-hidden rounded border border-slate-700 bg-slate-900 text-xs shadow-2xl"
+              >
+                <button
+                  type="button"
+                  onClick={() => {
+                    setExportMenuOpen(false)
+                    const el = rackCanvasRef.current
+                    if (!el) return
+                    void exportRack2DAsPng(el, draft.rackName || 'rack')
+                  }}
+                  className="flex w-full flex-col items-start gap-0.5 border-b border-slate-800 px-3 py-2 text-left text-slate-200 hover:bg-slate-800"
+                >
+                  <span className="font-semibold">📷 2D als PNG</span>
+                  <span className="text-[10px] text-slate-500">
+                    Aktuelle Front/Rear/Both-Ansicht als Bild
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  onClick={async () => {
+                    setExportMenuOpen(false)
+                    const refs = canvas3DRefs.current
+                    if (!refs) {
+                      alert('3D-Tab muss zuerst geöffnet worden sein um die 3D-Szene zu initialisieren.')
+                      return
+                    }
+                    await exportRack3DAsPngs(refs.gl, refs.scene, refs.camera, {
+                      rackName: draft.rackName || 'rack',
+                      rackWidthMm: 482.6,
+                      rackHeightMm: draft.totalUnits * 44.45,
+                      rackDepthMm: draft.depthMm ?? 800,
+                    })
+                  }}
+                  className="flex w-full flex-col items-start gap-0.5 border-b border-slate-800 px-3 py-2 text-left text-slate-200 hover:bg-slate-800"
+                >
+                  <span className="font-semibold">📸 3D aus 4 Perspektiven</span>
+                  <span className="text-[10px] text-slate-500">
+                    PNG: Front · Rear · Iso · Top (1× pro Datei)
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setExportMenuOpen(false)
+                    const refs = canvas3DRefs.current
+                    if (!refs) {
+                      alert('3D-Tab muss zuerst geöffnet worden sein um die 3D-Szene zu initialisieren.')
+                      return
+                    }
+                    exportRackAsStl(refs.scene, draft.rackName || 'rack')
+                  }}
+                  className="flex w-full flex-col items-start gap-0.5 border-b border-slate-800 px-3 py-2 text-left text-slate-200 hover:bg-slate-800"
+                >
+                  <span className="font-semibold">🧊 3D als STL</span>
+                  <span className="text-[10px] text-slate-500">
+                    Komplettes Rack als binäres STL (3D-Druck, CAD)
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setExportMenuOpen(false)
+                    // Build the current preset snapshot ohne Save-Side-Effects.
+                    const sorted = draft.placements.slice().sort((a, b) => a.startUnit - b.startUnit)
+                    const items: GroupPreset['items'] = sorted.map((p) => ({
+                      name: p.name,
+                      category: p.category,
+                      inputs: p.inputs,
+                      outputs: p.outputs,
+                      isRackDevice: p.isRackDevice,
+                      rackUnits: p.rackUnits,
+                      frontPanelImageUrl: p.frontPanelImageUrl,
+                      rearPanelImageUrl: p.rearPanelImageUrl,
+                      frontPanelCrop: p.frontPanelCrop,
+                      rearPanelCrop: p.rearPanelCrop,
+                      depthMm: p.depthMm,
+                      stlDataUri: p.stlDataUri,
+                      isPatchPanel: p.isPatchPanel,
+                      isRackShelf: p.isRackShelf,
+                      width: 240,
+                      height: 80 + Math.max(p.inputs.length, p.outputs.length, 3) * 22,
+                      offsetX: 0,
+                      offsetY: (p.startUnit - 1) * 44,
+                    }))
+                    const rackPlacements = sorted.map((p, i) => ({
+                      itemIndex: i,
+                      startUnit: p.startUnit,
+                      heightUnits: p.rackUnits,
+                      ...(p.mountSide ? { mountSide: p.mountSide } : {}),
+                      ...(p.shelfOffsetX ? { shelfOffsetX: p.shelfOffsetX } : {}),
+                      ...(p.shelfOffsetZ ? { shelfOffsetZ: p.shelfOffsetZ } : {}),
+                    }))
+                    const preset: GroupPreset = {
+                      id: editingId ?? uuidv4(),
+                      name: draft.rackName.trim() || 'rack',
+                      rack: {
+                        totalUnits: draft.totalUnits,
+                        ...(draft.depthMm ? { depthMm: draft.depthMm } : {}),
+                        placements: rackPlacements,
+                      },
+                      items,
+                      cables: [],
+                    }
+                    exportRackAsCpgroup(preset)
+                  }}
+                  className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left text-slate-200 hover:bg-slate-800"
+                >
+                  <span className="font-semibold">💾 .cpgroup herunterladen</span>
+                  <span className="text-[10px] text-slate-500">
+                    Komplettes Rack inkl. STL + Fotos zum Cross-PC-Transfer
+                  </span>
+                </button>
+              </div>
+            )}
           </div>
           <button
             type="button"
@@ -1326,6 +1472,11 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                       })()}
                       selectedPlacementId={selectedPlacementId}
                       onSelectPlacement={(id) => setSelectedPlacementId(id)}
+                      // v7.9.83 / #170 — Canvas-Refs für den Export
+                      // (PNG aus N Perspektiven, STL).
+                      onCanvasRefsReady={(refs) => {
+                        canvas3DRefs.current = refs
+                      }}
                       // v7.9.82 / #170 — Shelf-Device-Drag im 3D-Tab
                       // persistieren.
                       onShelfDeviceMoved={(placementId, offset) => {

--- a/src/renderer/lib/exportRack.ts
+++ b/src/renderer/lib/exportRack.ts
@@ -1,0 +1,175 @@
+/**
+ * v7.9.83 / #170 — Rack-Export-Pipeline.
+ *
+ * Vier Export-Modi für den Rack-Builder:
+ *  1. 2D-PNG    — html-to-image Capture des aktuell sichtbaren 2D-Panels
+ *  2. 3D-PNG    — canvas.toBlob() vom three.js Canvas, optional aus mehreren
+ *                 vordefinierten Perspektiven gleichzeitig (Front / Rear /
+ *                 Iso / Top) als getrennte Dateien
+ *  3. 3D-STL    — STLExporter aus three-stdlib durch die r3f-Szene
+ *  4. .cpgroup  — JSON-Dump des GroupPreset mit allen inline-base64-Assets
+ *                 (STL, Panel-Fotos), portierbar zwischen Rechnern
+ *
+ * Alle Exporte triggern automatisch einen Browser-Download via
+ * downloadBlob-Helper.
+ */
+import { toPng } from 'html-to-image'
+import * as THREE from 'three'
+import { STLExporter } from 'three-stdlib'
+
+const downloadFile = (filename: string, blob: Blob): void => {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.style.display = 'none'
+  document.body.appendChild(a)
+  a.click()
+  setTimeout(() => {
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  }, 100)
+}
+
+const sanitizeFilename = (name: string): string =>
+  name.replace(/[\\/:*?"<>|]/g, '_').replace(/\s+/g, '_').slice(0, 80) || 'rack'
+
+// ── 1) 2D Rack-Panel-Export ────────────────────────────────────────────
+
+export const exportRack2DAsPng = async (
+  rackCanvasEl: HTMLElement,
+  rackName: string,
+): Promise<void> => {
+  // 2× Pixel-Ratio für Retina-Qualität.
+  const dataUri = await toPng(rackCanvasEl, {
+    pixelRatio: 2,
+    backgroundColor: '#0f172a',
+    cacheBust: true,
+  })
+  // dataUri → Blob
+  const res = await fetch(dataUri)
+  const blob = await res.blob()
+  downloadFile(`${sanitizeFilename(rackName)}_2D.png`, blob)
+}
+
+// ── 2) 3D Rack-Canvas-Export aus mehreren Perspektiven ─────────────────
+
+export type Rack3DPerspective = 'front' | 'rear' | 'iso' | 'top'
+
+export interface Rack3DExportOpts {
+  rackName: string
+  /** Welt-Dimensionen, damit wir die Kamera entsprechend positionieren können. */
+  rackWidthMm: number
+  rackHeightMm: number
+  rackDepthMm: number
+  /** Welche Perspektiven exportieren. Default = alle 4. */
+  perspectives?: Rack3DPerspective[]
+}
+
+/**
+ * Render-Helper: nimmt einen vorhandenen WebGL-Canvas der r3f-Szene,
+ * bewegt die Kamera kurz auf die gewünschte Perspektive, rendert ein
+ * Frame und downloaded das Bild.
+ *
+ * Wir nutzen REAL die scene/camera des r3f-Trees — übergeben werden müssen
+ * sie vom Caller. Der "Snapshot"-Mechanismus dokumentiert sich im Rack-
+ * Dialog (Caller hält camera+scene+gl Refs via useThree).
+ */
+export const exportRack3DPerspective = async (
+  gl: THREE.WebGLRenderer,
+  scene: THREE.Scene,
+  camera: THREE.PerspectiveCamera,
+  perspective: Rack3DPerspective,
+  opts: { rackWidthMm: number; rackHeightMm: number; rackDepthMm: number },
+): Promise<Blob> => {
+  // Originale Kamera-Position merken damit wir sie nach dem Snapshot
+  // wieder herstellen können (sonst springt die User-Sicht).
+  const origPos = camera.position.clone()
+  const origQuat = camera.quaternion.clone()
+
+  const targetX = opts.rackWidthMm / 2
+  const targetY = opts.rackHeightMm / 2
+  const targetZ = opts.rackDepthMm / 2
+
+  switch (perspective) {
+    case 'front':
+      camera.position.set(targetX, targetY, -opts.rackDepthMm * 1.5)
+      camera.lookAt(targetX, targetY, targetZ)
+      break
+    case 'rear':
+      camera.position.set(targetX, targetY, opts.rackDepthMm * 2.5)
+      camera.lookAt(targetX, targetY, targetZ)
+      break
+    case 'top':
+      camera.position.set(targetX, opts.rackHeightMm + opts.rackDepthMm * 1.5, targetZ)
+      camera.lookAt(targetX, 0, targetZ)
+      break
+    case 'iso':
+    default:
+      camera.position.set(
+        opts.rackWidthMm * 1.8,
+        opts.rackHeightMm * 0.7,
+        -opts.rackDepthMm * 1.8,
+      )
+      camera.lookAt(targetX, targetY, targetZ)
+      break
+  }
+  camera.updateProjectionMatrix()
+
+  // Render und canvas.toBlob() — wir warten einen Frame damit r3f das
+  // neue Camera-State auch wirklich rendert.
+  gl.render(scene, camera)
+  await new Promise((r) => requestAnimationFrame(r))
+  gl.render(scene, camera)
+
+  const blob = await new Promise<Blob | null>((resolve) =>
+    gl.domElement.toBlob(resolve, 'image/png'),
+  )
+
+  // Kamera zurück.
+  camera.position.copy(origPos)
+  camera.quaternion.copy(origQuat)
+  camera.updateProjectionMatrix()
+  gl.render(scene, camera)
+
+  if (!blob) throw new Error('Canvas-Capture lieferte kein Bild')
+  return blob
+}
+
+export const exportRack3DAsPngs = async (
+  gl: THREE.WebGLRenderer,
+  scene: THREE.Scene,
+  camera: THREE.PerspectiveCamera,
+  opts: Rack3DExportOpts,
+): Promise<void> => {
+  const perspectives = opts.perspectives ?? ['front', 'rear', 'iso', 'top']
+  const safeName = sanitizeFilename(opts.rackName)
+  for (const p of perspectives) {
+    const blob = await exportRack3DPerspective(gl, scene, camera, p, opts)
+    downloadFile(`${safeName}_3D_${p}.png`, blob)
+    // kurze Pause damit der Browser den nächsten Download nicht blockt.
+    await new Promise((r) => setTimeout(r, 200))
+  }
+}
+
+// ── 3) 3D-STL-Export (gesamtes Rack als eine Mesh-Datei) ───────────────
+
+export const exportRackAsStl = (
+  scene: THREE.Scene,
+  rackName: string,
+): void => {
+  const exporter = new STLExporter()
+  // binary=true → kompakter (binär-STL), false → ASCII-STL.
+  // Binary ist Industrie-Standard für 3D-Druck und kleinere Dateigröße.
+  const result = exporter.parse(scene, { binary: true })
+  const blob = result instanceof DataView
+    ? new Blob([result.buffer as ArrayBuffer], { type: 'application/octet-stream' })
+    : new Blob([result], { type: 'model/stl' })
+  downloadFile(`${sanitizeFilename(rackName)}.stl`, blob)
+}
+
+// ── 4) .cpgroup Download mit allen inline-Assets ───────────────────────
+// (Delegiert an exportPresetToFile, das schon die korrekte File-V1
+//  Wrapper-Struktur baut — damit das exportierte File auf einem anderen
+//  Rechner via parseLibraryItemFile wieder importiert werden kann.)
+export { exportPresetToFile as exportRackAsCpgroup } from './itemExport'


### PR DESCRIPTION
…oup (#170)

Vier Export-Modi im Rack-Builder via neuem "Exportieren ▾" Header-Menu:

1. 📷 2D ALS PNG html-to-image Capture des Rack-Canvas-Div, 2× Pixel-Ratio für Retina. Filename: <rackname>_2D.png

2. 📸 3D AUS 4 PERSPEKTIVEN Nutzt die three.js WebGLRenderer + Scene + Camera der laufenden 3D-Szene. Bewegt die Kamera nacheinander auf Front (-Z), Rear (+Z), Top (von oben), Iso (3/4-View), rendert je ein Frame, schreibt canvas.toBlob() in eine PNG-Datei pro Perspektive. User-Kamera wird nach jedem Snapshot exakt wieder hergestellt. Filenames: <rackname>_3D_front.png · _rear.png · _top.png · _iso.png

3. 🧊 3D ALS STL STLExporter aus three-stdlib läuft durch die komplette Scene und serialisiert alle Meshes als binäres STL (3D-Druck / CAD-Import). Filename: <rackname>.stl

4. 💾 .cpgroup HERUNTERLADEN Komplettes GroupPreset (inkl. STL-Daten als base64, Front/Rear-Fotos als base64, Port-Layouts, Verkabelung) als JSON. Delegiert an die existierende exportPresetToFile-Helper damit der File-Wrapper- Format-V1 erhalten bleibt → File ist auf einem anderen Rechner via parseLibraryItemFile direkt re-importierbar (Cross-PC-Transfer).

Technische Voraussetzungen:
- <Canvas gl={{ preserveDrawingBuffer: true, antialias: true }}>: der WebGL-Buffer wird nach jedem Render NICHT geleert, sonst liefert canvas.toBlob() ein leeres Bild
- Neue CanvasRefsCapture-Komponente innerhalb von <Canvas> liefert via useThree() die gl/scene/camera-Refs an den Parent (RackBuilderDialog) per onCanvasRefsReady-Callback. Refs werden in canvas3DRefs.current gespeichert und vom Export-Menu konsumiert.
- exportRack.ts: neue Lib-Datei mit downloadFile-Helper + sanitizeFilename, separate Funktionen pro Modus für Testbarkeit.

Hinweis im Menu: 3D-Exporte funktionieren nur wenn der 3D-Tab mindestens einmal geöffnet wurde (Szene wird erst dann initialisiert). Sonst zeigt ein alert("3D-Tab muss zuerst geöffnet worden sein…").

Library-Download-Button für .cpgroup existiert bereits in v7.9.31 via exportPresetToFile — kein Doppelaufwand.

v7.9.83

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH