### PR TITLE
feat(pdf): Vektor-PDF-Export (Beta) via Chromium printToPDF

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.9.96",
+    "version": "7.9.97",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/main/ipc/printIpc.ts
+++ b/src/main/ipc/printIpc.ts
@@ -12,11 +12,80 @@
 // PrintBackend direkt — robuster als die iframe-Variante.
 
 import { BrowserWindow, app, ipcMain } from 'electron'
-import { writeFile } from 'node:fs/promises'
+import { writeFile, unlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
 export const registerPrintIpc = (): void => {
+  // v7.9.97 — Vektor-PDF-Export via Chromium printToPDF.
+  //
+  // Renderer schickt ein selbst-enthaltenes HTML-Dokument (mit dem
+  // Canvas als foreignObject-SVG) zusammen mit der gewünschten Page-
+  // Size in Mikrometern. Wir laden das HTML in eine Hidden-BrowserWindow
+  // und rufen webContents.printToPDF — Chromium emittiert das PDF mit
+  // echtem Text + Vektor-Pfaden statt JPEG-Embedding.
+  //
+  // 'preferCSSPageSize: true' damit @page in den Print-Styles die
+  // Papier-Größe bestimmt. 'printBackground: true' damit Hintergrund-
+  // Farben mitkommen (Chromium-Default fuer Print ist sonst aus).
+  ipcMain.handle(
+    'canvas:export-pdf-vector',
+    async (
+      _event,
+      params: { html: string; widthMicrons: number; heightMicrons: number },
+    ): Promise<Uint8Array> => {
+      const { html, widthMicrons, heightMicrons } = params
+      if (!html) throw new Error('printToPDF: leeres HTML')
+      const tmpFile = path.join(tmpdir(), `cable-planner-pdf-vec-${Date.now()}.html`)
+      await writeFile(tmpFile, html, 'utf-8')
+      const win = new BrowserWindow({
+        show: false,
+        // 1 px = 264.583 microns @ 96 DPI. Cap auf 2000 damit das
+        // Hidden-Window nicht riesig wird — printToPDF nimmt eh die
+        // @page-Size aus dem HTML, das Viewport-Format ist nur fuer
+        // Layout-Pass relevant.
+        width: Math.min(2000, Math.ceil(widthMicrons / 264.583)),
+        height: Math.min(2000, Math.ceil(heightMicrons / 264.583)),
+        webPreferences: {
+          contextIsolation: true,
+          nodeIntegration: false,
+          offscreen: false,
+        },
+      })
+      try {
+        await win.loadFile(tmpFile)
+        // Auf Font-Loading warten — sonst werden Glyphs fallback-gerendert.
+        await win.webContents
+          .executeJavaScript(
+            'document.fonts && document.fonts.ready ? document.fonts.ready.then(() => true) : true',
+          )
+          .catch(() => null)
+        // Kurze Layout-Stabilisierung (foreignObject braucht 1-2 Frames).
+        await new Promise<void>((r) => setTimeout(r, 250))
+        const buffer = await win.webContents.printToPDF({
+          pageSize: { width: widthMicrons, height: heightMicrons },
+          printBackground: true,
+          preferCSSPageSize: true,
+          margins: { marginType: 'none' },
+          displayHeaderFooter: false,
+          landscape: widthMicrons > heightMicrons,
+        })
+        return new Uint8Array(buffer)
+      } finally {
+        try {
+          win.destroy()
+        } catch {
+          // ignore
+        }
+        try {
+          await unlink(tmpFile)
+        } catch {
+          // ignore
+        }
+      }
+    },
+  )
+
   ipcMain.handle('print:pdf-bytes', async (_event, bytes: Uint8Array): Promise<boolean> => {
     if (!bytes || bytes.byteLength === 0) return false
     // PDF in tempfile schreiben — file:-URL ist verlaesslicher als data: in Electron

--- a/src/main/preload.cts
+++ b/src/main/preload.cts
@@ -130,6 +130,16 @@ contextBridge.exposeInMainWorld('cablePlanner', {
      *  manchen Fällen kaputte Dateien schreiben lässt. */
     pdfBytes: (bytes: Uint8Array) =>
       ipcRenderer.invoke('print:pdf-bytes', bytes) as Promise<boolean>,
+    /** v7.9.97 — Vektor-PDF: Renderer schickt fertiges HTML mit
+     *  foreignObject-SVG-Canvas + Page-Size in microns, Main rendert
+     *  via Chromium printToPDF. Liefert die PDF-Bytes zurück. Text
+     *  bleibt vektoriell und durchsuchbar. */
+    canvasPdfVector: (params: {
+      html: string
+      widthMicrons: number
+      heightMicrons: number
+    }) =>
+      ipcRenderer.invoke('canvas:export-pdf-vector', params) as Promise<Uint8Array>,
   },
   library: {
     /** v7.9.33 — Zentraler Library-Ordner (userData/library/). Jedes

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -42,6 +42,7 @@ import { useProject } from './hooks/useProject'
 import { useRentman } from './hooks/useRentman'
 import { cablePlannerApi, hasDesktopBridge } from './lib/bridge'
 import { exportCanvasToPdf, exportCanvasToPdfBytes } from './lib/exportPdf'
+import { exportCanvasToPdfVector } from './lib/exportPdfVector'
 import { printPdfBlob } from './lib/printPdfBlob'
 import { exportCanvasToImage } from './lib/exportImage'
 import { useProjectStore } from './store/projectStore'
@@ -129,6 +130,9 @@ export default function App() {
   const [welcomeOpen, setWelcomeOpen] = useState(false)
   const [pdfExportOpen, setPdfExportOpen] = useState(false)
   const [pdfTheme, setPdfTheme] = useState<'dark' | 'light'>('light')
+  // v7.9.97 — Beta-Option: Vektor-PDF statt Raster. Aus per Default,
+  // damit alle bestehenden Workflows unveraendert weiterlaufen.
+  const [pdfVectorMode, setPdfVectorMode] = useState(false)
   // v7.9.0 / Issue #110 — unified export dialog
   const [exportDialogOpen, setExportDialogOpen] = useState(false)
   const [printDialogOpen, setPrintDialogOpen] = useState(false)
@@ -537,22 +541,38 @@ export default function App() {
     })
   }
 
-  const handleExportPdf = async (theme: 'dark' | 'light' = canvasTheme) => {
+  const handleExportPdf = async (
+    theme: 'dark' | 'light' = canvasTheme,
+    vector = false,
+  ) => {
     setPdfExportThemeOverride(theme)
     setPdfProgress({ active: true, phase: 'Starte…' })
     await new Promise<void>((resolve) =>
       requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
     )
     try {
-      await exportCanvasToPdf(project.metadata.name, project.metadata, 0.85, {
-        backgroundTheme: theme,
-        bgVariant: exportBgVariant,
-        gridSize: exportGridSize,
-        bgOpacity: exportBgOpacity,
-        customPalette: exportCustomPalette,
-        onProgress: (phase, detail) =>
-          setPdfProgress({ active: true, phase, detail }),
-      })
+      if (vector) {
+        // v7.9.97 — Vektor-Pfad: Chromium printToPDF, Text bleibt Text.
+        await exportCanvasToPdfVector(project.metadata.name, project.metadata, {
+          backgroundTheme: theme,
+          bgVariant: exportBgVariant,
+          gridSize: exportGridSize,
+          bgOpacity: exportBgOpacity,
+          customPalette: exportCustomPalette,
+          onProgress: (phase, detail) =>
+            setPdfProgress({ active: true, phase, detail }),
+        })
+      } else {
+        await exportCanvasToPdf(project.metadata.name, project.metadata, 0.85, {
+          backgroundTheme: theme,
+          bgVariant: exportBgVariant,
+          gridSize: exportGridSize,
+          bgOpacity: exportBgOpacity,
+          customPalette: exportCustomPalette,
+          onProgress: (phase, detail) =>
+            setPdfProgress({ active: true, phase, detail }),
+        })
+      }
     } catch (error) {
       console.error('PDF export failed:', error)
       await infoDialog('PDF-Export fehlgeschlagen', {
@@ -857,10 +877,12 @@ export default function App() {
         open={pdfExportOpen}
         theme={pdfTheme}
         onThemeChange={setPdfTheme}
+        vector={pdfVectorMode}
+        onVectorChange={setPdfVectorMode}
         onClose={() => setPdfExportOpen(false)}
         onExport={() => {
           setPdfExportOpen(false)
-          void handleExportPdf(pdfTheme)
+          void handleExportPdf(pdfTheme, pdfVectorMode)
         }}
       />
 
@@ -911,6 +933,8 @@ interface PdfExportDialogProps {
   open: boolean
   theme: 'dark' | 'light'
   onThemeChange: (theme: 'dark' | 'light') => void
+  vector: boolean
+  onVectorChange: (vector: boolean) => void
   onClose: () => void
   onExport: () => void
 }
@@ -919,6 +943,8 @@ const PdfExportDialog = ({
   open,
   theme,
   onThemeChange,
+  vector,
+  onVectorChange,
   onClose,
   onExport,
 }: PdfExportDialogProps) => {
@@ -949,6 +975,45 @@ const PdfExportDialog = ({
                 onChange={() => onThemeChange('dark')}
               />
               Dunkel
+            </label>
+          </fieldset>
+          {/* v7.9.97 — Vektor-PDF Beta. Default aus, damit alle
+              bestehenden Workflows die bekannte Raster-Pipeline
+              nutzen. Wenn an: Text bleibt im PDF als echter Text,
+              keine Pixelung beim Zoom. */}
+          <fieldset className="rounded border border-slate-700 p-3">
+            <legend className="px-1 text-[11px] uppercase tracking-wide text-slate-400">
+              Render-Modus
+            </legend>
+            <label className="mb-2 flex cursor-pointer items-start gap-2 text-xs text-slate-200">
+              <input
+                type="radio"
+                name="pdf-render-mode"
+                checked={!vector}
+                onChange={() => onVectorChange(false)}
+              />
+              <span>
+                Raster (klassisch)
+                <span className="block text-[10px] text-slate-500">
+                  JPEG-Snapshot des Canvas. Zuverlässig, aber unscharf bei großem
+                  Zoom in der PDF.
+                </span>
+              </span>
+            </label>
+            <label className="flex cursor-pointer items-start gap-2 text-xs text-slate-200">
+              <input
+                type="radio"
+                name="pdf-render-mode"
+                checked={vector}
+                onChange={() => onVectorChange(true)}
+              />
+              <span>
+                Vektor (Beta)
+                <span className="block text-[10px] text-slate-500">
+                  Chromium printToPDF. Text bleibt selektierbar &amp; scharf bei
+                  jedem Zoom. Kleinere Dateigröße.
+                </span>
+              </span>
             </label>
           </fieldset>
         </div>

--- a/src/renderer/lib/exportPdfVector.ts
+++ b/src/renderer/lib/exportPdfVector.ts
@@ -1,0 +1,404 @@
+/**
+ * v7.9.97 — Vektor-PDF-Export (Beta).
+ *
+ * Alternative zur klassischen Raster-Pipeline in exportPdf.ts. Statt
+ * das Canvas zu rastern → JPEG → jsPDF.addImage, serialisieren wir es
+ * via html-to-image.toSvg() als SVG mit foreignObject und lassen
+ * Electrons webContents.printToPDF() das PDF erzeugen.
+ *
+ * Vorteile:
+ *  - Text bleibt echter Text im PDF (selektier-/suchbar)
+ *  - SVG-Pfade bleiben Vektor (ReactFlow-Edges sind eh SVG)
+ *  - Beim Zoom kein Pixel-Matsch
+ *  - Datei-Größe typisch 1-3 MB statt 5-10 MB (kein JPEG-Embedding)
+ *
+ * Nachteile / Caveats:
+ *  - Nur in Electron-Builds verfügbar (braucht main-process printToPDF)
+ *  - foreignObject mit komplexem CSS kann theoretisch andere Resultate
+ *    geben — Chromium rendert sie aber gleich wie im Live-Canvas
+ *  - Erstaufruf ist langsamer (~1-2 s Hidden-Window-Boot)
+ *
+ * Die Raster-Pipeline bleibt unverändert als Fallback bestehen.
+ */
+import { toSvg } from 'html-to-image'
+import type { ProjectMetadata } from '../types/project'
+import { composeExportBackground, type ExportBgVariant } from './exportBackground'
+
+export interface ExportPdfVectorOptions {
+  backgroundTheme?: 'dark' | 'light'
+  bgVariant?: ExportBgVariant
+  gridSize?: number
+  bgOpacity?: number
+  customPalette?: { canvasBg: string; gridColor: string } | null
+  onProgress?: (phase: string, detail?: string) => void
+}
+
+interface CablePlannerPrintApi {
+  canvasPdfVector?: (params: {
+    html: string
+    widthMicrons: number
+    heightMicrons: number
+  }) => Promise<Uint8Array>
+}
+
+interface CablePlannerWindow {
+  cablePlanner?: { print?: CablePlannerPrintApi }
+}
+
+// 96 DPI: 1 CSS-px = 1/96 inch = 25400/96 = 264.5833 microns
+const PX_TO_MICRONS = 25400 / 96
+// 1 CSS-px ≈ 0.264583 mm
+const PX_TO_MM = 25.4 / 96
+
+const fmtDate = (iso?: string): string => {
+  if (!iso) return '—'
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+
+const escapeHtml = (s: string): string =>
+  s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+
+interface BoundingBox {
+  contentX: number
+  contentY: number
+  contentW: number
+  contentH: number
+}
+
+/** Misst die Bounding-Box aller Nodes + Edges + Edge-Labels im
+ *  ReactFlow-Viewport. Selbe Logik wie in exportPdf.ts — duplikat ist
+ *  bewusst, damit der Vektor-Pfad isoliert testbar bleibt und ein
+ *  Refactor am Raster-Pfad nicht versehentlich diesen hier bricht. */
+const computeNaturalBbox = (viewportEl: HTMLElement): BoundingBox => {
+  const nodeEls = Array.from(
+    viewportEl.querySelectorAll<HTMLElement>('.react-flow__node'),
+  )
+  if (nodeEls.length === 0) {
+    throw new Error('Keine Geräte zum Exportieren vorhanden')
+  }
+  const parseTranslate = (el: HTMLElement): { x: number; y: number } => {
+    const transform = getComputedStyle(el).transform
+    if (transform && transform !== 'none') {
+      const match = /matrix.*\((.+)\)/.exec(transform)
+      if (match) {
+        const parts = match[1].split(',').map((v) => parseFloat(v.trim()))
+        if (parts.length === 6) return { x: parts[4], y: parts[5] }
+        if (parts.length === 16) return { x: parts[12], y: parts[13] }
+      }
+    }
+    return { x: 0, y: 0 }
+  }
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  for (const node of nodeEls) {
+    const { x, y } = parseTranslate(node)
+    const w = node.offsetWidth
+    const h = node.offsetHeight
+    if (x < minX) minX = x
+    if (y < minY) minY = y
+    if (x + w > maxX) maxX = x + w
+    if (y + h > maxY) maxY = y + h
+  }
+  const edgePathEls = viewportEl.querySelectorAll<SVGGraphicsElement>(
+    '.react-flow__edge .react-flow__edge-path, .react-flow__edge path',
+  )
+  for (const path of edgePathEls) {
+    try {
+      const bb = path.getBBox()
+      if (bb.width === 0 && bb.height === 0) continue
+      if (bb.x < minX) minX = bb.x
+      if (bb.y < minY) minY = bb.y
+      if (bb.x + bb.width > maxX) maxX = bb.x + bb.width
+      if (bb.y + bb.height > maxY) maxY = bb.y + bb.height
+    } catch {
+      // ignore zero-size paths
+    }
+  }
+  const edgeLabelEls = Array.from(
+    viewportEl.querySelectorAll<HTMLElement>(
+      '.react-flow__edge-textwrapper, .react-flow__edge-label',
+    ),
+  )
+  for (const label of edgeLabelEls) {
+    const { x, y } = parseTranslate(label)
+    const w = label.offsetWidth
+    const h = label.offsetHeight
+    const lx = x - w / 2
+    const ly = y - h / 2
+    if (lx < minX) minX = lx
+    if (ly < minY) minY = ly
+    if (lx + w > maxX) maxX = lx + w
+    if (ly + h > maxY) maxY = ly + h
+  }
+  if (!isFinite(minX) || !isFinite(minY) || !isFinite(maxX) || !isFinite(maxY)) {
+    throw new Error('Konnte den Inhalt des Canvas nicht vermessen')
+  }
+  const padding = 200
+  return {
+    contentX: minX - padding,
+    contentY: minY - padding,
+    contentW: Math.ceil(maxX - minX + padding * 2),
+    contentH: Math.ceil(maxY - minY + padding * 2),
+  }
+}
+
+/** Decode a `data:image/svg+xml;...` URL back to its raw SVG markup. */
+const decodeSvgDataUrl = (dataUrl: string): string => {
+  const idx = dataUrl.indexOf(',')
+  if (idx < 0) throw new Error('Ungültige SVG-Data-URL')
+  const head = dataUrl.slice(0, idx)
+  const body = dataUrl.slice(idx + 1)
+  if (head.includes(';base64')) {
+    return atob(body)
+  }
+  // URL-encoded (html-to-image's default for toSvg)
+  return decodeURIComponent(body)
+}
+
+/** Filter for html-to-image: skip overlay/UI-only elements that
+ *  shouldn't be in the export. */
+const baseFilter = (node: Node): boolean => {
+  if (!(node instanceof HTMLElement) && !(node instanceof SVGElement)) return true
+  const el = node as HTMLElement | SVGElement
+  if (el.classList.contains('react-flow__minimap')) return false
+  if (el.classList.contains('react-flow__controls')) return false
+  if (el.classList.contains('react-flow__background')) return false
+  return true
+}
+
+const renderTitleBlock = (meta: ProjectMetadata): string => {
+  const rows: [string, string][] = [
+    ['Projekt', meta.name || '—'],
+    ['Projekt-Nr.', meta.projectNumber || '—'],
+    ['Kunde', meta.client || '—'],
+    ['Auftragnehmer', meta.contractor || '—'],
+    ['Planer', meta.author || '—'],
+    ['Erstellt', fmtDate(meta.createdAt)],
+    ['Geändert', fmtDate(meta.updatedAt)],
+  ]
+  const hasLogos = !!(meta.companyLogo || meta.clientLogo)
+  const logos = hasLogos
+    ? `<div class="title-block-logos">
+        ${meta.companyLogo ? `<img src="${escapeHtml(meta.companyLogo)}" alt="" />` : '<div></div>'}
+        ${meta.clientLogo ? `<img src="${escapeHtml(meta.clientLogo)}" alt="" />` : '<div></div>'}
+      </div>`
+    : ''
+  const rowsHtml = rows
+    .map(
+      ([k, v]) =>
+        `<div class="title-block-row"><span class="k">${escapeHtml(k)}</span><span class="v">${escapeHtml(v)}</span></div>`,
+    )
+    .join('')
+  return `<div class="title-block">${logos}${rowsHtml}</div>`
+}
+
+const buildPrintHtml = (params: {
+  svg: string
+  projectName: string
+  pageWidthPx: number
+  pageHeightPx: number
+  canvasWidthPx: number
+  canvasHeightPx: number
+  headerHeight: number
+  margin: number
+  bgFallback: string
+  textColor: string
+  metadata?: ProjectMetadata
+}): string => {
+  const {
+    svg,
+    projectName,
+    pageWidthPx,
+    pageHeightPx,
+    canvasWidthPx,
+    canvasHeightPx,
+    headerHeight,
+    margin,
+    bgFallback,
+    textColor,
+    metadata,
+  } = params
+  const pageWmm = (pageWidthPx * PX_TO_MM).toFixed(3)
+  const pageHmm = (pageHeightPx * PX_TO_MM).toFixed(3)
+  const timestamp = new Date().toLocaleString()
+  return `<!doctype html>
+<html><head>
+<meta charset="utf-8">
+<style>
+  @page { size: ${pageWmm}mm ${pageHmm}mm; margin: 0; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    width: ${pageWidthPx}px;
+    height: ${pageHeightPx}px;
+    background: ${bgFallback};
+    color: ${textColor};
+    font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  .page {
+    position: relative;
+    width: ${pageWidthPx}px;
+    height: ${pageHeightPx}px;
+    box-sizing: border-box;
+    padding: ${margin}px;
+  }
+  .header { display: flex; justify-content: space-between; align-items: baseline; }
+  .header .title { font-size: 14px; font-weight: 600; }
+  .header .stamp { font-size: 9px; color: ${textColor === '#000' ? '#555' : '#94a3b8'}; }
+  .canvas-wrap {
+    position: absolute;
+    left: ${margin}px;
+    top: ${margin + headerHeight}px;
+    width: ${canvasWidthPx}px;
+    height: ${canvasHeightPx}px;
+    overflow: hidden;
+  }
+  .canvas-wrap > svg { width: 100%; height: 100%; display: block; }
+  .title-block {
+    position: absolute;
+    right: ${margin}px;
+    bottom: ${margin}px;
+    width: 300px;
+    border: 1px solid #444;
+    font-size: 8px;
+    background: ${bgFallback};
+  }
+  .title-block-row {
+    display: flex;
+    border-bottom: 1px solid #aaa;
+    padding: 4px 6px;
+    line-height: 1.3;
+  }
+  .title-block-row:last-child { border-bottom: none; }
+  .title-block-row .k { width: 85px; color: ${textColor === '#000' ? '#555' : '#64748b'}; }
+  .title-block-row .v { flex: 1; }
+  .title-block-logos {
+    display: flex;
+    gap: 8px;
+    padding: 4px;
+    border-bottom: 1px solid #aaa;
+    align-items: center;
+    justify-content: space-around;
+    min-height: 36px;
+  }
+  .title-block-logos img {
+    max-height: 32px;
+    max-width: 140px;
+    object-fit: contain;
+  }
+</style>
+</head><body>
+<div class="page">
+  <div class="header">
+    <div class="title">${escapeHtml(projectName || 'Cable Planner Project')}</div>
+    <div class="stamp">${escapeHtml(timestamp)}</div>
+  </div>
+  <div class="canvas-wrap">${svg}</div>
+  ${metadata ? renderTitleBlock(metadata) : ''}
+</div>
+</body></html>`
+}
+
+export const exportCanvasToPdfVector = async (
+  projectName: string,
+  metadata?: ProjectMetadata,
+  options?: ExportPdfVectorOptions,
+): Promise<void> => {
+  const w = window as unknown as CablePlannerWindow
+  const handler = w.cablePlanner?.print?.canvasPdfVector
+  if (!handler) {
+    throw new Error(
+      'Vektor-PDF braucht den Electron-Hauptprozess. In Browser-/Mobile-Build nicht verfügbar.',
+    )
+  }
+  const onProgress = options?.onProgress ?? (() => {})
+
+  const canvasEl = document.getElementById('cable-planner-canvas')
+  if (!canvasEl) throw new Error('Canvas nicht gefunden')
+  const viewportEl = canvasEl.querySelector('.react-flow__viewport') as HTMLElement | null
+  if (!viewportEl) throw new Error('ReactFlow-Viewport nicht gefunden')
+
+  onProgress('measure', 'Inhalt vermessen…')
+  const bbox = computeNaturalBbox(viewportEl)
+  const { contentX, contentY, contentW, contentH } = bbox
+
+  const composed = composeExportBackground({
+    theme: options?.backgroundTheme ?? 'dark',
+    variant: options?.bgVariant ?? 'dots',
+    gridSize: options?.gridSize ?? 20,
+    opacity: options?.bgOpacity ?? 0.5,
+    customPalette: options?.customPalette ?? null,
+  })
+  const bgFallback = composed.bgFallback
+  const textColor = options?.backgroundTheme === 'light' ? '#000' : '#fff'
+
+  onProgress('capture', `Canvas ${contentW}×${contentH}px als SVG serialisieren…`)
+  // toSvg liefert eine data:image/svg+xml;... URL. Wir dekodieren sie und
+  // betten das rohe SVG ins Print-HTML ein.
+  const svgDataUrl = await toSvg(viewportEl, {
+    width: contentW,
+    height: contentH,
+    cacheBust: true,
+    backgroundColor: bgFallback,
+    style: {
+      width: `${contentW}px`,
+      height: `${contentH}px`,
+      background: bgFallback,
+      backgroundColor: bgFallback,
+      transform: `translate(${-contentX}px, ${-contentY}px)`,
+      transformOrigin: '0 0',
+    },
+    filter: baseFilter,
+  })
+  const svg = decodeSvgDataUrl(svgDataUrl)
+
+  // Page-Layout: identisch zum Raster-Pfad, damit Header/Title-Block
+  // stehen wo Nutzer es gewohnt sind.
+  const margin = 24
+  const headerHeight = 28
+  const titleBlockReserve = metadata ? 12 : 0
+  const pageWidthPx = contentW + margin * 2
+  const pageHeightPx = contentH + margin * 2 + headerHeight + titleBlockReserve
+
+  const html = buildPrintHtml({
+    svg,
+    projectName,
+    pageWidthPx,
+    pageHeightPx,
+    canvasWidthPx: contentW,
+    canvasHeightPx: contentH,
+    headerHeight,
+    margin,
+    bgFallback,
+    textColor,
+    metadata,
+  })
+
+  onProgress('render', 'Chromium printToPDF…')
+  const widthMicrons = Math.round(pageWidthPx * PX_TO_MICRONS)
+  const heightMicrons = Math.round(pageHeightPx * PX_TO_MICRONS)
+  const bytes = await handler({ html, widthMicrons, heightMicrons })
+
+  onProgress('save', 'Datei speichern…')
+  const blob = new Blob([new Uint8Array(bytes)], { type: 'application/pdf' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `${(projectName || 'cable-planner').replace(/[^a-z0-9\-_. ]/gi, '_')}.pdf`
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(url)
+  onProgress('done', 'Fertig.')
+}


### PR DESCRIPTION
Neue Option im PDF-Export-Dialog ('Vektor (Beta)') — komplett additiv zur bestehenden Raster-Pipeline. Default bleibt Raster, damit nichts am bestehenden Workflow bricht.

Architektur:
- Renderer: exportPdfVector.ts serialisiert Canvas via html-to-image toSvg() (kein Rastern!) zu SVG-mit-foreignObject, baut ein selbstenthaltenes HTML-Dokument mit Header + DIN-Title-Block, schickt es via IPC an Main
- Main: neuer Handler canvas:export-pdf-vector laedt das HTML in eine Hidden-BrowserWindow, wartet auf document.fonts.ready, ruft webContents.printToPDF mit @page-CSS-Size-Hint (preferCSSPageSize)
- Preload: cablePlanner.print.canvasPdfVector als Bridge

Vorteile:
- Text bleibt echter Text (selektierbar, suchbar, scharf bei Zoom)
- SVG-Pfade bleiben Vektor
- Datei typisch 1-3 MB statt 5-10 MB
- Plattform-unabhaengig durch gebundeltes Chromium

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH