### PR TITLE
fix(pdf-vector): Skalierung via printToPDF.scale statt CSS-Transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.9.103",
+    "version": "7.9.104",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/main/ipc/printIpc.ts
+++ b/src/main/ipc/printIpc.ts
@@ -32,9 +32,20 @@ export const registerPrintIpc = (): void => {
     'canvas:export-pdf-vector',
     async (
       _event,
-      params: { html: string; widthMicrons: number; heightMicrons: number },
+      params: {
+        html: string
+        widthMicrons: number
+        heightMicrons: number
+        /** v7.9.104 — printToPDF.scale 0..1. Skaliert die ganze Page
+         *  vektoriell, statt CSS-Transform auf den Content. */
+        scale?: number
+      },
     ): Promise<Uint8Array> => {
       const { html, widthMicrons, heightMicrons } = params
+      const scale =
+        typeof params.scale === 'number' && params.scale > 0 && params.scale <= 2
+          ? params.scale
+          : 1
       if (!html) throw new Error('printToPDF: leeres HTML')
       const tmpFile = path.join(tmpdir(), `cable-planner-pdf-vec-${Date.now()}.html`)
       await writeFile(tmpFile, html, 'utf-8')
@@ -75,12 +86,20 @@ export const registerPrintIpc = (): void => {
         const buffer = await win.webContents.printToPDF({
           pageSize: { width: widthMicrons, height: heightMicrons },
           printBackground: true,
-          preferCSSPageSize: true,
+          // v7.9.104 — preferCSSPageSize: false, damit der API-Wert wins.
+          // Mit scale<1 + @page CSS in body-natural-size haetten die zwei
+          // sich gestritten. Jetzt: API-pageSize = Paper, body = natural,
+          // scale skaliert beim Render-Pass die ganze Page in die
+          // Paper-Box rein.
+          preferCSSPageSize: false,
           margins: { marginType: 'none' },
           displayHeaderFooter: false,
           landscape: widthMicrons > heightMicrons,
-          // generateTaggedPDF=false bricht bei einigen Chromium-Versionen
-          // den Render. Default lassen wir weg.
+          // Vektorielle Skalierung: Chromium schreibt das als
+          // PDF-Transformations-Matrix → Text bleibt selektierbar +
+          // scharf bei jedem Zoom. CSS-Transform haette einen GPU-Layer
+          // erzwungen → Bitmap.
+          scale,
         })
         if (!buffer || buffer.byteLength < 1000) {
           throw new Error(

--- a/src/main/preload.cts
+++ b/src/main/preload.cts
@@ -133,11 +133,13 @@ contextBridge.exposeInMainWorld('cablePlanner', {
     /** v7.9.97 — Vektor-PDF: Renderer schickt fertiges HTML mit
      *  foreignObject-SVG-Canvas + Page-Size in microns, Main rendert
      *  via Chromium printToPDF. Liefert die PDF-Bytes zurück. Text
-     *  bleibt vektoriell und durchsuchbar. */
+     *  bleibt vektoriell und durchsuchbar.
+     *  v7.9.104 — optional `scale` 0..1 fuer Paper-Fit. */
     canvasPdfVector: (params: {
       html: string
       widthMicrons: number
       heightMicrons: number
+      scale?: number
     }) =>
       ipcRenderer.invoke('canvas:export-pdf-vector', params) as Promise<Uint8Array>,
   },

--- a/src/renderer/lib/exportPdfVector.ts
+++ b/src/renderer/lib/exportPdfVector.ts
@@ -56,6 +56,9 @@ interface CablePlannerPrintApi {
     html: string
     widthMicrons: number
     heightMicrons: number
+    /** v7.9.104 — printToPDF.scale: skaliert die ganze Page vektoriell,
+     *  statt CSS-Transform der Content. Vermeidet Layer-Rasterung. */
+    scale?: number
   }) => Promise<Uint8Array>
 }
 
@@ -194,50 +197,42 @@ const collectAllCss = (): string => {
 }
 
 /** Klont nur das `.react-flow`-Element — also die ReactFlow-Renderflaeche
- *  ohne den umgebenden Toolbar/Banner-Chrome. Setzt anschliessend den
- *  Viewport-Transform so um, dass das natural-size Content-Rechteck bei
- *  (0,0) sitzt UND optional skaliert wird.
+ *  ohne den umgebenden Toolbar/Banner-Chrome. Viewport-Transform wird auf
+ *  Identity + Translation gesetzt, sodass das natural-Content-Rechteck
+ *  bei (0,0) sitzt.
  *
- *  v7.9.101: Wir klonten frueher das ganze #cable-planner-canvas (Wrapper
- *  mit CanvasToolbar/Banner) — Toolbar landete dann oben im PDF. Jetzt
- *  greifen wir das innere .react-flow.
- *  v7.9.103: Scale jetzt direkt im Viewport-Transform statt als CSS
- *  transform: scale auf einem Outer-Wrapper. Microsoft Edge's PDF-
- *  Viewer rendert Wrapper-Scale-Transforms anders als Acrobat — manche
- *  Inhalte werden gar nicht angezeigt. ReactFlow nutzt das gleiche
- *  Transform-Pattern im Normalbetrieb (translate+scale auf .viewport)
- *  → Edge kennt das Output-Pattern und rendert es zuverlaessig. */
+ *  v7.9.101: nur .react-flow klonen statt #cable-planner-canvas
+ *  (sonst landet die CanvasToolbar oben im PDF).
+ *  v7.9.104: KEIN CSS-transform-scale mehr. Skalierung passiert via
+ *  printToPDF's eigenem `scale`-Parameter — Chromium schreibt das als
+ *  PDF-Transformations-Matrix statt auf einen GPU-Layer zu rastern.
+ *  Vorher: Text wurde matschig bei A0-Cap, weil scale<1 auf der
+ *  Viewport-Transform Chromium dazu brachte, Layer-zu-Bitmap zu flatten.
+ *  Jetzt: Body bleibt natural-size, printToPDF skaliert die GESAMTE
+ *  Page vektoriell beim Render. */
 const cloneCanvasForPrint = (
   canvasEl: HTMLElement,
   bbox: BoundingBox,
-  scale: number,
 ): HTMLElement => {
   const reactFlowEl = canvasEl.querySelector('.react-flow') as HTMLElement | null
   const source = reactFlowEl ?? canvasEl
   const clone = source.cloneNode(true) as HTMLElement
   clone.removeAttribute('id')
-  // Clone-Outer auf DISPLAYED (skaliert) sizen — der Viewport drin macht
-  // den Scale selber.
-  const displayedW = bbox.contentW * scale
-  const displayedH = bbox.contentH * scale
-  clone.style.width = `${displayedW}px`
-  clone.style.height = `${displayedH}px`
+  // Clone auf Natural-Content-Groesse. Kein scale-Transform.
+  clone.style.width = `${bbox.contentW}px`
+  clone.style.height = `${bbox.contentH}px`
   clone.style.position = 'relative'
   clone.style.overflow = 'hidden'
 
-  // ReactFlow-Viewport: kombiniert translate + scale wie ReactFlow es im
-  // Normalbetrieb tut. translate kommt VOR scale (CSS-Konvention), also
-  // sind die translate-Werte in pre-scale-Koordinaten:
-  //   ein Child bei flow-coord (bbox.contentX, bbox.contentY) landet
-  //   nach Transform bei (0, 0) der DISPLAYED-Wrap.
+  // Viewport: nur Translation, KEIN scale. printToPDF skaliert spaeter
+  // die ganze Page einheitlich.
   const viewport = clone.querySelector('.react-flow__viewport') as HTMLElement | null
   if (viewport) {
-    viewport.style.transform = `translate(${-bbox.contentX * scale}px, ${-bbox.contentY * scale}px) scale(${scale})`
+    viewport.style.transform = `translate(${-bbox.contentX}px, ${-bbox.contentY}px)`
     viewport.style.transformOrigin = '0 0'
   }
 
-  // Edge-Path-SVG-Container auf natural sizen — Scale wird vom Viewport-
-  // Transform auf dieses SVG drauf-angewandt.
+  // Edge-Path-SVG-Container auf natural sizen.
   const edgesSvg = clone.querySelector('.react-flow__edges') as SVGElement | null
   if (edgesSvg) {
     edgesSvg.style.width = `${bbox.contentW}px`
@@ -449,38 +444,43 @@ export const exportCanvasToPdfVector = async (
   const headerHeight = 28
   const titleBlockReserve = metadata ? 12 : 0
 
-  // v7.9.103 — Page-Size auswerten:
-  //   'original'  → kein Cap, Natural-Canvas-Groesse stehen lassen
-  //                 (fuer Plotter-Drucke, kann in Edge weiss erscheinen)
-  //   'auto'      → A0-Landscape-Cap (Default, max. Viewer-Kompatibilitaet)
-  //   'a0'/'a1'/… → harte Festlegung auf das Standard-Format
-  // Wenn der natural Canvas groesser ist als das gewaehlte Format,
-  // wird er vektoriell runterskaliert (transform auf .react-flow__viewport).
+  // v7.9.104 — Body bleibt IMMER natural-size. Skalierung passiert via
+  // printToPDF's `scale`-Parameter beim Render — das emittiert eine
+  // PDF-Transformations-Matrix statt auf einen Layer zu rastern, also
+  // bleibt Text scharf bei jedem Zoom.
+  // Page-Size-Pref:
+  //   'original'  → Paper = Body natural size (kein Cap)
+  //   'auto'      → A0-Landscape Paper, Content scale-to-fit
+  //   'a0'/'a1'/… → konkretes Format, Content scale-to-fit
   const pageSizePref: PdfPageSize = options?.pageSize ?? 'auto'
-  let maxCanvasWidthPx: number | null
-  let maxCanvasHeightPx: number | null
+  const bodyWidthPx = bbox.contentW + margin * 2
+  const bodyHeightPx = bbox.contentH + margin * 2 + headerHeight + titleBlockReserve
+
+  let paperWidthPx: number
+  let paperHeightPx: number
   if (pageSizePref === 'original') {
-    maxCanvasWidthPx = null
-    maxCanvasHeightPx = null
+    paperWidthPx = bodyWidthPx
+    paperHeightPx = bodyHeightPx
   } else {
     const key = pageSizePref === 'auto' ? 'a0' : pageSizePref
     const [longMm, shortMm] = PAGE_SIZE_MM[key]
-    // Landscape per default
-    maxCanvasWidthPx = longMm / PX_TO_MM - margin * 2
-    maxCanvasHeightPx = shortMm / PX_TO_MM - margin * 2 - headerHeight - titleBlockReserve
+    paperWidthPx = longMm / PX_TO_MM
+    paperHeightPx = shortMm / PX_TO_MM
   }
-  const canvasScale =
-    maxCanvasWidthPx == null || maxCanvasHeightPx == null
-      ? 1
-      : Math.min(1, maxCanvasWidthPx / bbox.contentW, maxCanvasHeightPx / bbox.contentH)
-  const displayedCanvasWidth = Math.ceil(bbox.contentW * canvasScale)
-  const displayedCanvasHeight = Math.ceil(bbox.contentH * canvasScale)
-  const pageWidthPx = displayedCanvasWidth + margin * 2
-  const pageHeightPx =
-    displayedCanvasHeight + margin * 2 + headerHeight + titleBlockReserve
 
-  onProgress('capture', `Canvas-DOM klonen (scale ${(canvasScale * 100).toFixed(0)}%)…`)
-  const canvasClone = cloneCanvasForPrint(canvasEl, bbox, canvasScale)
+  // Print-Scale: kleinstes Verhaeltnis Paper/Body, damit Body in
+  // einer Page Platz hat. <=1, vektoriell.
+  const printScale = Math.min(
+    1,
+    paperWidthPx / bodyWidthPx,
+    paperHeightPx / bodyHeightPx,
+  )
+
+  onProgress(
+    'capture',
+    `Canvas-DOM klonen (Body ${bodyWidthPx}×${bodyHeightPx}px → Paper ${Math.round(paperWidthPx)}×${Math.round(paperHeightPx)}px, scale ${(printScale * 100).toFixed(0)}%)…`,
+  )
+  const canvasClone = cloneCanvasForPrint(canvasEl, bbox)
   const canvasOuterHtml = canvasClone.outerHTML
   if (canvasOuterHtml.length < 1000) {
     throw new Error(
@@ -496,10 +496,10 @@ export const exportCanvasToPdfVector = async (
     appCss,
     canvasOuterHtml,
     projectName,
-    pageWidthPx,
-    pageHeightPx,
-    canvasWidthPx: displayedCanvasWidth,
-    canvasHeightPx: displayedCanvasHeight,
+    pageWidthPx: bodyWidthPx,
+    pageHeightPx: bodyHeightPx,
+    canvasWidthPx: bbox.contentW,
+    canvasHeightPx: bbox.contentH,
     headerHeight,
     margin,
     bgFallback,
@@ -508,10 +508,12 @@ export const exportCanvasToPdfVector = async (
     themeDark,
   })
 
-  onProgress('render', 'Chromium printToPDF…')
-  const widthMicrons = Math.round(pageWidthPx * PX_TO_MICRONS)
-  const heightMicrons = Math.round(pageHeightPx * PX_TO_MICRONS)
-  const bytes = await handler({ html, widthMicrons, heightMicrons })
+  onProgress('render', `Chromium printToPDF (scale ${(printScale * 100).toFixed(0)}%)…`)
+  // Paper-Size in microns. Body in der HTML ist natural-size, scale
+  // skaliert den ganzen Body in die Paper-Seite.
+  const widthMicrons = Math.round(paperWidthPx * PX_TO_MICRONS)
+  const heightMicrons = Math.round(paperHeightPx * PX_TO_MICRONS)
+  const bytes = await handler({ html, widthMicrons, heightMicrons, scale: printScale })
 
   onProgress('save', 'Datei speichern…')
   if (!bytes || bytes.byteLength < 1000) {


### PR DESCRIPTION
A0-Vektor-Export war unleserlich matschig: Text in Geraete-Boxen war gerastert obwohl wir Vektor-PDF wollten. Ursache: CSS transform: scale auf dem Viewport zwang Chromium dazu, den ganzen Layer zu rastern (GPU-Layer-Flattening), bevor er ins PDF emittiert wurde.

Fix:
- KEIN CSS scale mehr auf dem Clone/Viewport. Body bleibt natural-size.
- Skalierung via printToPDF.scale (0..1). Chromium emittiert das als PDF-Transformations-Matrix → Text bleibt selektierbar + scharf bei jedem Zoom.
- preferCSSPageSize: false, damit API-pageSize wins (war mit scale<1 konfliktanfaellig).
- IPC-Schnittstelle um optionalen `scale`-Parameter erweitert (preload
  + main + renderer).

Test: A0-PDF in Acrobat oeffnen, in einer Geraete-Box auf Text doppel-klicken — sollte sich das Wort markieren lassen (= echter Text, nicht Bitmap). Zoom auf 400% → Text bleibt crisp.

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH