### PR TITLE
feat(rentman): Stabiler Export in 'CablePlanner'-EquipmentGroup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.9.110",
+    "version": "7.9.111",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/main/ipc/rentmanIpc.ts
+++ b/src/main/ipc/rentmanIpc.ts
@@ -41,6 +41,23 @@ export const registerRentmanIpc = () => {
     },
   )
 
+  // v7.9.110 — High-level Export: legt im Rentman-Projekt eine
+  // EquipmentGroup namens 'CablePlanner' an (falls noch nicht vorhanden)
+  // und fuegt alle items dort ein. Idempotent: mehrfaches Ausfuehren
+  // fuegt in dieselbe Gruppe. Failure pro item bricht den Batch NICHT
+  // ab — der Renderer sieht im Ergebnis was geklappt hat + was nicht.
+  ipcMain.handle(
+    'rentman:export-to-cableplanner-group',
+    async (
+      _event,
+      projectId: string,
+      items: Array<{ equipmentId: string; quantity: number }>,
+    ) => {
+      const client = await getClient()
+      return client.exportEquipmentToCablePlannerGroup(projectId, items)
+    },
+  )
+
   ipcMain.handle(
     'rentman:add-project-file',
     async (

--- a/src/main/preload.cts
+++ b/src/main/preload.cts
@@ -19,6 +19,20 @@ contextBridge.exposeInMainWorld('cablePlanner', {
     getEquipmentFolders: () => ipcRenderer.invoke('rentman:get-equipment-folders') as Promise<unknown[]>,
     addProjectEquipment: (projectId: string, equipmentId: string, quantity?: number) =>
       ipcRenderer.invoke('rentman:add-project-equipment', projectId, equipmentId, quantity) as Promise<unknown>,
+    /** v7.9.110 — Batch-Export in eine 'CablePlanner'-EquipmentGroup im
+     *  Rentman-Projekt. Gruppe wird angelegt falls nicht vorhanden,
+     *  sonst wiederverwendet. */
+    exportToCablePlannerGroup: (
+      projectId: string,
+      items: Array<{ equipmentId: string; quantity: number }>,
+    ) =>
+      ipcRenderer.invoke('rentman:export-to-cableplanner-group', projectId, items) as Promise<{
+        added: number
+        failed: Array<{ equipmentId: string; quantity: number; error: string }>
+        groupId: string | null
+        groupCreated: boolean
+        subprojectId: string | null
+      }>,
     addProjectFile: (
       projectId: string,
       fileName: string,

--- a/src/main/services/rentmanApiClient.ts
+++ b/src/main/services/rentmanApiClient.ts
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import axios, { AxiosError } from 'axios'
 
 const BASE_URL = 'https://api.rentman.net'
 
@@ -33,6 +33,64 @@ const normalize = <T>(value: unknown): T => {
   return value as T
 }
 
+/**
+ * v7.9.110 — Convert Axios/Rentman errors into a clean Error with a German
+ * user-facing message. Rentman returns JSON like
+ * `{ "error": "Validation failed", "details": [{...}] }` on 4xx — we lift
+ * the most helpful string out and prefix with the HTTP status so triage
+ * via console logs is easier.
+ */
+const wrapRentmanError = (err: unknown, context: string): Error => {
+  if (axios.isAxiosError(err)) {
+    const ax = err as AxiosError<unknown>
+    const status = ax.response?.status
+    const data = ax.response?.data as Record<string, unknown> | undefined
+    const serverMsg =
+      (typeof data?.error === 'string' && data.error) ||
+      (typeof data?.message === 'string' && data.message) ||
+      (Array.isArray(data?.details) && data.details.length > 0
+        ? JSON.stringify(data.details[0])
+        : '') ||
+      ax.message
+    const hint =
+      status === 401
+        ? 'Token ungültig oder abgelaufen — Einstellungen → Rentman prüfen.'
+        : status === 403
+          ? 'Token hat keine Schreibrechte für diesen Endpoint (Rentman-Admin fragen).'
+          : status === 404
+            ? 'Resource nicht gefunden — Projekt-/Equipment-ID falsch oder gelöscht.'
+            : status === 422
+              ? 'Validation: ' + serverMsg
+              : status && status >= 500
+                ? 'Rentman-Server-Fehler — später erneut versuchen.'
+                : serverMsg
+    return new Error(`Rentman ${status ?? '??'} (${context}): ${hint}`)
+  }
+  if (err instanceof Error) return new Error(`${context}: ${err.message}`)
+  return new Error(`${context}: ${String(err)}`)
+}
+
+/**
+ * v7.9.110 — Fixed group-name for items that Cable-Planner exports to a
+ * Rentman project. Created on demand (if not present) and reused across
+ * exports — so all items from Cable-Planner end up in one well-named
+ * group rather than scattered through the project.
+ */
+const CABLE_PLANNER_GROUP_NAME = 'CablePlanner'
+
+export interface CablePlannerExportResult {
+  /** Number of items successfully added to the group. */
+  added: number
+  /** Items that failed with their error message. */
+  failed: Array<{ equipmentId: string; quantity: number; error: string }>
+  /** The Rentman equipmentgroup id that received the items. */
+  groupId: string | null
+  /** True if the group was created during this call (false: reused existing). */
+  groupCreated: boolean
+  /** Subproject the group lives in. */
+  subprojectId: string | null
+}
+
 export const createRentmanApiClient = (token: string) => {
   const client = axios.create({
     baseURL: BASE_URL,
@@ -58,6 +116,195 @@ export const createRentmanApiClient = (token: string) => {
     return all
   }
 
+  /** Robust id-extractor: Rentman responses sometimes use number ids, sometimes
+   *  stringified, sometimes nested in `data`. */
+  const pickId = (raw: unknown): string | null => {
+    if (raw == null) return null
+    if (typeof raw === 'string' || typeof raw === 'number') return String(raw)
+    if (typeof raw !== 'object') return null
+    const obj = raw as Record<string, unknown>
+    const data = (obj.data ?? obj) as Record<string, unknown>
+    const id = data.id ?? data.ID ?? data._id
+    if (id == null) return null
+    return String(id)
+  }
+
+  /** v7.9.110 — Subprojects einer Project-ID. Jedes Rentman-Projekt hat
+   *  >=1 Subproject (Standard: 'Initial'). Equipment + Groups haengen
+   *  immer an einem Subproject. */
+  const getProjectSubprojects = async (projectId: string): Promise<unknown[]> => {
+    try {
+      return await fetchAll(`/projects/${encodeURIComponent(projectId)}/subprojects`)
+    } catch (err) {
+      throw wrapRentmanError(err, `GET subprojects fuer Projekt ${projectId}`)
+    }
+  }
+
+  /** v7.9.110 — Liste aller EquipmentGroups in einem Subproject. Wird
+   *  genutzt um die 'CablePlanner'-Gruppe nachzuschlagen. */
+  const getEquipmentGroups = async (subprojectId: string): Promise<unknown[]> => {
+    try {
+      // Rentman erlaubt Filter via Query — wenn das nicht funktioniert,
+      // holen wir alle und filtern lokal.
+      return await fetchAll(
+        `/equipmentgroups?subproject=${encodeURIComponent(subprojectId)}`,
+      )
+    } catch (err) {
+      throw wrapRentmanError(err, `GET equipmentgroups fuer Subproject ${subprojectId}`)
+    }
+  }
+
+  /** v7.9.110 — Create new equipment group in a subproject. */
+  const createEquipmentGroup = async (params: {
+    name: string
+    subprojectId: string
+    order?: number
+  }): Promise<{ id: string }> => {
+    try {
+      const response = await client.post('/equipmentgroups', {
+        name: params.name,
+        subproject: params.subprojectId,
+        ...(typeof params.order === 'number' ? { order: params.order } : {}),
+      })
+      const id = pickId(response.data)
+      if (!id) {
+        throw new Error('Rentman lieferte beim Erstellen der Group keine id zurueck.')
+      }
+      return { id }
+    } catch (err) {
+      throw wrapRentmanError(err, `POST equipmentgroups (${params.name})`)
+    }
+  }
+
+  /** v7.9.110 — Add equipment to a specific group within a project.
+   *  Anders als der alte addProjectEquipment, der nur equipment+project+
+   *  quantity sendete (was Rentman teilweise mit 422 abwies weil
+   *  subproject fehlte), schickt diese Variante ALLE relevanten Refs:
+   *  project, subproject, equipmentgroup, equipment, quantity. */
+  const addEquipmentToGroup = async (params: {
+    projectId: string
+    subprojectId: string
+    equipmentGroupId: string
+    equipmentId: string
+    quantity: number
+  }): Promise<unknown> => {
+    try {
+      const response = await client.post('/projectequipment', {
+        project: params.projectId,
+        subproject: params.subprojectId,
+        equipmentgroup: params.equipmentGroupId,
+        equipment: params.equipmentId,
+        quantity: params.quantity,
+      })
+      return response.data
+    } catch (err) {
+      throw wrapRentmanError(
+        err,
+        `POST projectequipment (equipment=${params.equipmentId}, qty=${params.quantity})`,
+      )
+    }
+  }
+
+  /** v7.9.110 — Top-level export action. Stellt sicher, dass eine
+   *  Equipment-Gruppe namens 'CablePlanner' im (ersten/Standard-)
+   *  Subproject existiert und fuegt die items hinzu.
+   *
+   *  Idempotenz: wird die Action mehrfach ausgefuehrt, landen alle items
+   *  in derselben 'CablePlanner'-Gruppe (nicht in einer neuen). Wenn
+   *  Rentman bereits identische Equipment+Quantity-Eintraege hat, kommen
+   *  zusaetzliche dazu — Rentman dedupliziert nicht automatisch.
+   *
+   *  Fehler-Strategie: ein einzelner failed item bricht NICHT den
+   *  gesamten Export ab. Wir sammeln alle Failures und melden sie am
+   *  Ende via failed[]. So sieht der User welche items angekommen sind
+   *  und welche nicht. */
+  const exportEquipmentToCablePlannerGroup = async (
+    projectId: string,
+    items: Array<{ equipmentId: string; quantity: number }>,
+  ): Promise<CablePlannerExportResult> => {
+    if (items.length === 0) {
+      return { added: 0, failed: [], groupId: null, groupCreated: false, subprojectId: null }
+    }
+
+    // 1. Subprojects holen — wir brauchen mindestens eines.
+    const subprojectsRaw = await getProjectSubprojects(projectId)
+    if (subprojectsRaw.length === 0) {
+      throw new Error(`Rentman-Projekt #${projectId} hat keine Subprojects.`)
+    }
+    // Sortieren nach order (falls vorhanden), dann nach id — erstes ist
+    // der Default ("Initial").
+    const subprojects = (subprojectsRaw as Array<Record<string, unknown>>).slice().sort((a, b) => {
+      const oa = typeof a.order === 'number' ? a.order : 0
+      const ob = typeof b.order === 'number' ? b.order : 0
+      if (oa !== ob) return oa - ob
+      const ia = pickId(a) ?? ''
+      const ib = pickId(b) ?? ''
+      return ia.localeCompare(ib)
+    })
+    const subprojectId = pickId(subprojects[0])
+    if (!subprojectId) {
+      throw new Error(`Rentman-Projekt #${projectId}: Subproject hat keine id.`)
+    }
+
+    // 2. CablePlanner-Group finden oder erstellen.
+    const existingGroups = await getEquipmentGroups(subprojectId)
+    const existingGroup = (existingGroups as Array<Record<string, unknown>>).find(
+      (g) => typeof g.name === 'string' && g.name === CABLE_PLANNER_GROUP_NAME,
+    )
+    let groupId: string
+    let groupCreated = false
+    if (existingGroup) {
+      const id = pickId(existingGroup)
+      if (!id) {
+        throw new Error(`Existing '${CABLE_PLANNER_GROUP_NAME}'-Group hat keine id.`)
+      }
+      groupId = id
+    } else {
+      // Neue Gruppe: order = letzte+1 damit sie unten erscheint und nicht
+      // die bestehende Reihenfolge zerschiesst.
+      const maxOrder = (existingGroups as Array<Record<string, unknown>>).reduce(
+        (max, g) => (typeof g.order === 'number' && g.order > max ? g.order : max),
+        0,
+      )
+      const created = await createEquipmentGroup({
+        name: CABLE_PLANNER_GROUP_NAME,
+        subprojectId,
+        order: maxOrder + 1,
+      })
+      groupId = created.id
+      groupCreated = true
+    }
+
+    // 3. Items einzeln adden (sequentiell — Rentman rate-limits stark).
+    const result: CablePlannerExportResult = {
+      added: 0,
+      failed: [],
+      groupId,
+      groupCreated,
+      subprojectId,
+    }
+    for (const item of items) {
+      try {
+        await addEquipmentToGroup({
+          projectId,
+          subprojectId,
+          equipmentGroupId: groupId,
+          equipmentId: item.equipmentId,
+          quantity: item.quantity,
+        })
+        result.added++
+      } catch (err) {
+        result.failed.push({
+          equipmentId: item.equipmentId,
+          quantity: item.quantity,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+
+    return result
+  }
+
   return {
     async getProjects() {
       return fetchAll('/projects')
@@ -79,23 +326,26 @@ export const createRentmanApiClient = (token: string) => {
         throw error
       }
     },
+    getProjectSubprojects,
+    getEquipmentGroups,
+    createEquipmentGroup,
+    addEquipmentToGroup,
+    exportEquipmentToCablePlannerGroup,
     /**
-     * Add a master-catalog equipment item to a Rentman project.
-     * The Rentman v2 schema for /projectequipment expects `equipment`,
-     * `project` and `quantity` fields. Returns the API response so the UI
-     * can surface the new project-equipment id and any server-side defaults.
+     * @deprecated v7.9.110 — verwende exportEquipmentToCablePlannerGroup.
+     * Diese Methode bleibt aus Kompatibilitaet, routet aber jetzt auf den
+     * neuen Pfad (mit subproject + equipmentgroup gesetzt). Davor wurden
+     * nur equipment+project+quantity gesendet — Rentman wies das oft mit
+     * 422 ab, weshalb Exports lautlos kaputt waren.
      */
-    async addProjectEquipment(
-      projectId: string,
-      equipmentId: string,
-      quantity: number = 1,
-    ) {
-      const response = await client.post('/projectequipment', {
-        equipment: equipmentId,
-        project: projectId,
-        quantity,
-      })
-      return response.data
+    async addProjectEquipment(projectId: string, equipmentId: string, quantity = 1) {
+      const result = await exportEquipmentToCablePlannerGroup(projectId, [
+        { equipmentId, quantity },
+      ])
+      if (result.failed.length > 0) {
+        throw new Error(result.failed[0].error)
+      }
+      return { added: result.added, groupId: result.groupId, groupCreated: result.groupCreated }
     },
     /**
      * Upload a file (e.g. an exported PDF plan) and attach it to a Rentman
@@ -113,28 +363,23 @@ export const createRentmanApiClient = (token: string) => {
       fileBytes: Uint8Array,
       mimeType: string = 'application/pdf',
     ) {
-      // FormData is available in Node 18+ which Electron 42 ships with.
-      const form = new FormData()
-      // Node 25's @types/node tightened Uint8Array's buffer constraint,
-      // making Uint8Array<ArrayBufferLike> incompatible with the Blob
-      // ctor's Uint8Array<ArrayBuffer> expectation. Reconstruct from a
-      // fresh ArrayBuffer so the resulting view is strictly typed.
-      const buf = new Uint8Array(new ArrayBuffer(fileBytes.byteLength))
-      buf.set(fileBytes)
-      const blob = new Blob([buf], { type: mimeType })
-      form.append('file', blob, fileName)
-      form.append('name', fileName)
-      form.append('item', projectId)
-      form.append('itemtype', 'project')
-      // IMPORTANT: do NOT set Content-Type manually — axios 1.x autogenerates
-      // `multipart/form-data; boundary=...` from the FormData instance.
-      // Forcing the header strips the boundary and Rentman replies with
-      // "invalid key value pair missing equal sign".
-      const response = await client.post('/files', form, {
-        maxContentLength: 50 * 1024 * 1024,
-        maxBodyLength: 50 * 1024 * 1024,
-      })
-      return response.data
+      try {
+        const form = new FormData()
+        const buf = new Uint8Array(new ArrayBuffer(fileBytes.byteLength))
+        buf.set(fileBytes)
+        const blob = new Blob([buf], { type: mimeType })
+        form.append('file', blob, fileName)
+        form.append('name', fileName)
+        form.append('item', projectId)
+        form.append('itemtype', 'project')
+        const response = await client.post('/files', form, {
+          maxContentLength: 50 * 1024 * 1024,
+          maxBodyLength: 50 * 1024 * 1024,
+        })
+        return response.data
+      } catch (err) {
+        throw wrapRentmanError(err, `POST files (project ${projectId})`)
+      }
     },
   }
 }

--- a/src/renderer/components/Library/LibraryPanel.tsx
+++ b/src/renderer/components/Library/LibraryPanel.tsx
@@ -894,7 +894,12 @@ export const LibraryPanel = () => {
   // Rentman master catalog: every device available in the user's Rentman
   // account (not just the ones already in the active project). Loaded on
   // demand so we don't blow the API budget on every panel render.
-  const { loadEquipment: loadRentmanEquipment, loadFolders: loadRentmanFolders, addProjectEquipment } = useRentman()
+  const {
+    loadEquipment: loadRentmanEquipment,
+    loadFolders: loadRentmanFolders,
+    addProjectEquipment,
+    exportToCablePlannerGroup,
+  } = useRentman()
   const [rentmanCatalog, setRentmanCatalog] = useState<
     { id: string; name: string; category: string; folderId: string | null }[]
   >([])
@@ -1087,11 +1092,30 @@ export const LibraryPanel = () => {
     }
     setRentmanCatalogAddBusy(item.id)
     try {
-      await addProjectEquipment(linkedRentmanProjectId, item.id, 1)
-      await infoDialog(`"${item.name}" hinzugefügt`, {
-        body: `Wurde dem Rentman-Projekt "${projectName}" hinzugefügt.`,
-        tone: 'success',
-      })
+      // v7.9.110 — Nutze die neue Batch-Export-Action. Sie legt eine
+      // 'CablePlanner'-Group im Subproject an (oder verwendet die
+      // bestehende) und packt das item rein. Voraussetzung dass Rentman
+      // die Schreib-Anfrage akzeptiert: project + subproject + group +
+      // equipment + quantity — die alte addProjectEquipment-Variante hat
+      // subproject/group weggelassen und scheiterte deshalb oft mit 422.
+      const result = await exportToCablePlannerGroup(linkedRentmanProjectId, [
+        { equipmentId: item.id, quantity: 1 },
+      ])
+      if (result.failed.length > 0) {
+        const msg = result.failed.map((f) => `- ${f.error}`).join('\n')
+        await infoDialog('Hinzufuegen teilweise fehlgeschlagen', {
+          body: `${result.added} OK, ${result.failed.length} Fehler:\n${msg}`,
+          tone: 'warning',
+        })
+      } else {
+        const groupNote = result.groupCreated
+          ? ' (neue Gruppe "CablePlanner" angelegt)'
+          : ' (zur bestehenden Gruppe "CablePlanner" hinzugefuegt)'
+        await infoDialog(`"${item.name}" hinzugefügt`, {
+          body: `Wurde dem Rentman-Projekt "${projectName}" hinzugefügt${groupNote}.`,
+          tone: 'success',
+        })
+      }
     } catch (err) {
       await infoDialog('Fehler beim Hinzufügen zu Rentman', {
         body: err instanceof Error ? err.message : String(err),

--- a/src/renderer/components/Rentman/RentmanCableExportDialog.tsx
+++ b/src/renderer/components/Rentman/RentmanCableExportDialog.tsx
@@ -46,7 +46,7 @@ const keyOf = (c: Pick<Cable, 'type' | 'length'>): string => `${c.type}|${c.leng
 export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDialogProps) => {
   const project = useProjectStore((state) => state.project)
   const updateMeta = useProjectStore((state) => state.updateProjectMetadata)
-  const { loadEquipment, loadFolders, addProjectEquipment } = useRentman()
+  const { loadEquipment, loadFolders, exportToCablePlannerGroup } = useRentman()
 
   const [catalog, setCatalog] = useState<CatalogItem[]>([])
   const [catalogLoaded, setCatalogLoaded] = useState(false)
@@ -187,7 +187,19 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
     setBusyKey(bucket.key)
     setStatusByKey((prev) => ({ ...prev, [bucket.key]: 'Sende an Rentman…' }))
     try {
-      await addProjectEquipment(linkedProjectId, bucket.mappedId, bucket.delta)
+      // v7.9.110 — Nutzt die neue Batch-Export-Action. Landet in der
+      // 'CablePlanner'-EquipmentGroup im Subproject (wird angelegt
+      // falls nicht vorhanden). Vorher ging das via addProjectEquipment,
+      // das subproject/equipmentgroup nicht setzte — Rentman wies das
+      // mit 422 ab.
+      const result = await exportToCablePlannerGroup(linkedProjectId, [
+        { equipmentId: bucket.mappedId, quantity: bucket.delta },
+      ])
+      if (result.failed.length > 0) {
+        const msg = result.failed[0]?.error ?? 'Unbekannter Fehler'
+        setStatusByKey((prev) => ({ ...prev, [bucket.key]: `Fehler: ${msg}` }))
+        return
+      }
       const current = project.metadata.rentmanCableMap ?? {}
       updateMeta({
         rentmanCableMap: {
@@ -198,9 +210,10 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
           },
         },
       })
+      const groupNote = result.groupCreated ? ' (Gruppe angelegt)' : ''
       setStatusByKey((prev) => ({
         ...prev,
-        [bucket.key]: `✓ ${bucket.delta} an Rentman gesendet.`,
+        [bucket.key]: `✓ ${bucket.delta} an Rentman gesendet${groupNote}.`,
       }))
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)

--- a/src/renderer/hooks/useRentman.ts
+++ b/src/renderer/hooks/useRentman.ts
@@ -14,6 +14,20 @@ export const useRentman = () => {
       cablePlannerApi.rentman.addProjectEquipment(projectId, equipmentId, quantity),
     [],
   )
+  /**
+   * v7.9.110 — Batch-Export in eine 'CablePlanner'-EquipmentGroup im
+   * Rentman-Projekt. Gruppe wird angelegt falls noch nicht vorhanden,
+   * sonst wiederverwendet. Bevorzugt gegenueber addProjectEquipment fuer
+   * alles was Cable-Planner nach Rentman schiebt — landet sortiert in
+   * einer dedizierten Gruppe statt verstreut im Projekt.
+   */
+  const exportToCablePlannerGroup = useCallback(
+    (
+      projectId: string,
+      items: Array<{ equipmentId: string; quantity: number }>,
+    ) => cablePlannerApi.rentman.exportToCablePlannerGroup(projectId, items),
+    [],
+  )
   const addProjectFile = useCallback(
     (projectId: string, fileName: string, fileBytes: Uint8Array, mimeType?: string) =>
       cablePlannerApi.rentman.addProjectFile(projectId, fileName, fileBytes, mimeType),
@@ -26,6 +40,7 @@ export const useRentman = () => {
     loadFolders,
     loadEquipment,
     addProjectEquipment,
+    exportToCablePlannerGroup,
     addProjectFile,
   }
 }

--- a/src/renderer/lib/bridge.ts
+++ b/src/renderer/lib/bridge.ts
@@ -63,6 +63,18 @@ type CablePlannerApi = {
       equipmentId: string,
       quantity?: number,
     ) => Promise<unknown>
+    /** v7.9.110 — Batch-Export in eine 'CablePlanner'-Group im Rentman-
+     *  Projekt. Gruppe wird angelegt falls nicht vorhanden. */
+    exportToCablePlannerGroup: (
+      projectId: string,
+      items: Array<{ equipmentId: string; quantity: number }>,
+    ) => Promise<{
+      added: number
+      failed: Array<{ equipmentId: string; quantity: number; error: string }>
+      groupId: string | null
+      groupCreated: boolean
+      subprojectId: string | null
+    }>
     addProjectFile: (
       projectId: string,
       fileName: string,
@@ -446,6 +458,15 @@ const webFallbackApi: CablePlannerApi = {
       } catch {
         return text
       }
+    },
+    /** v7.9.110 — Web-Fallback: nicht verfuegbar in Browser-only-Builds
+     *  (Mobile-Share / Web-Viewer). Der Export braucht subproject- und
+     *  equipmentgroup-Lookups die mehrere API-Calls benoetigen — wenig
+     *  Mehrwert ohne Token-Management via Electron-Credentials-Store. */
+    exportToCablePlannerGroup: async () => {
+      throw new Error(
+        'Rentman-Export ist nur in der Electron-Desktop-App verfuegbar, nicht im Web-/Mobile-Build.',
+      )
     },
     addProjectFile: async (
       projectId: string,


### PR DESCRIPTION
Bisher: addProjectEquipment schickte nur { equipment, project, quantity } ohne subproject/equipmentgroup. Rentman weist das oft mit 422 ab — Exports liefen lautlos kaputt. Plus: Items landeten ungruppiert im Projekt.

Neuer Pfad — exportEquipmentToCablePlannerGroup (Main-API):
1. GET /projects/{id}/subprojects → erstes (Default 'Initial')
2. GET /equipmentgroups?subproject={id} → Suche nach Name 'CablePlanner'
3. Wenn nicht da: POST /equipmentgroups { name, subproject, order }
4. Fuer jedes Item: POST /projectequipment { project, subproject, equipmentgroup, equipment, quantity }

Verbesserungen:
- wrapRentmanError(): konvertiert Axios/Rentman-Errors in lesbare Messages mit HTTP-Status + Hint (401→Token, 403→Rights, 404→Resource, 422→Validation-Details, 5xx→Server). Statt 'AxiosError: Request failed with status code 422' gibt's jetzt klaren Text.
- Pro-Item-Failure bricht den Batch NICHT ab — Result enthaelt { added, failed[], groupId, groupCreated, subprojectId }.
- Idempotent: zweiter Export nutzt dieselbe Gruppe.
- pickId(): robust gegen number/string/nested-data Response-Shapes.

Caller umgestellt:
- LibraryPanel: Rentman-Katalog-Add nutzt jetzt exportToCablePlanner- Group statt addProjectEquipment. Info-Dialog zeigt 'neue Gruppe angelegt' vs 'bestehende Gruppe' damit der User Bescheid weiss.
- RentmanCableExportDialog: Cable-Bucket-Send analog. Status-Text zeigt '(Gruppe angelegt)' beim ersten Export.

Alt-API addProjectEquipment bleibt fuer Backward-Compat aber routet intern auch durch den neuen Pfad — der alte direkte Call mit fehlendem subproject war eh kaputt.

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH