### PR TITLE
feat(rentman): Plan-Fallback ohne Gruppe + Rentman-Name in Kabel-BOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.9.116",
+    "version": "7.9.117",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/main/services/rentmanApiClient.ts
+++ b/src/main/services/rentmanApiClient.ts
@@ -164,25 +164,43 @@ export const createRentmanApiClient = (token: string) => {
   }
 
   /** v7.9.110 — Liste aller EquipmentGroups in einem Subproject. Wird
-   *  genutzt um die 'CablePlanner'-Gruppe nachzuschlagen. */
-  const getEquipmentGroups = async (subprojectId: string): Promise<unknown[]> => {
+   *  genutzt um die 'CablePlanner'-Gruppe nachzuschlagen.
+   *
+   *  v7.9.117 — Liefert null statt zu werfen, wenn der Endpoint nicht
+   *  verfuegbar ist (manche Rentman-Plaene exponieren equipmentgroups
+   *  schlicht nicht — typischerweise 403/404). Aufrufer faellt dann auf
+   *  Equipment-Add OHNE Gruppen-Bezug zurueck. */
+  const getEquipmentGroups = async (
+    subprojectId: string,
+  ): Promise<unknown[] | null> => {
     try {
-      // Rentman erlaubt Filter via Query — wenn das nicht funktioniert,
-      // holen wir alle und filtern lokal.
       return await fetchAll(
         `/equipmentgroups?subproject=${encodeURIComponent(subprojectId)}`,
       )
     } catch (err) {
+      if (axios.isAxiosError(err)) {
+        const status = err.response?.status
+        if (status === 403 || status === 404) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[rentman] /equipmentgroups nicht verfuegbar (${status}) — fallback auf Equipment-Add ohne Gruppe.`,
+          )
+          return null
+        }
+      }
       throw wrapRentmanError(err, `GET equipmentgroups fuer Subproject ${subprojectId}`)
     }
   }
 
-  /** v7.9.110 — Create new equipment group in a subproject. */
+  /** v7.9.110 — Create new equipment group in a subproject.
+   *
+   *  v7.9.117 — Liefert null bei 403/404 statt zu werfen (siehe
+   *  getEquipmentGroups). Aufrufer arbeitet dann gruppenlos weiter. */
   const createEquipmentGroup = async (params: {
     name: string
     subprojectId: string
     order?: number
-  }): Promise<{ id: string }> => {
+  }): Promise<{ id: string } | null> => {
     try {
       const response = await client.post('/equipmentgroups', {
         name: params.name,
@@ -195,6 +213,16 @@ export const createRentmanApiClient = (token: string) => {
       }
       return { id }
     } catch (err) {
+      if (axios.isAxiosError(err)) {
+        const status = err.response?.status
+        if (status === 403 || status === 404) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[rentman] POST /equipmentgroups nicht erlaubt (${status}) — fallback auf gruppenlosen Add.`,
+          )
+          return null
+        }
+      }
       throw wrapRentmanError(err, `POST equipmentgroups (${params.name})`)
     }
   }
@@ -203,22 +231,26 @@ export const createRentmanApiClient = (token: string) => {
    *  Anders als der alte addProjectEquipment, der nur equipment+project+
    *  quantity sendete (was Rentman teilweise mit 422 abwies weil
    *  subproject fehlte), schickt diese Variante ALLE relevanten Refs:
-   *  project, subproject, equipmentgroup, equipment, quantity. */
+   *  project, subproject, equipmentgroup, equipment, quantity.
+   *
+   *  v7.9.117 — equipmentGroupId darf null sein wenn der Plan keine
+   *  Gruppen erlaubt; das Feld wird dann im Body weggelassen. */
   const addEquipmentToGroup = async (params: {
     projectId: string
     subprojectId: string
-    equipmentGroupId: string
+    equipmentGroupId: string | null
     equipmentId: string
     quantity: number
   }): Promise<unknown> => {
     try {
-      const response = await client.post('/projectequipment', {
+      const body: Record<string, unknown> = {
         project: params.projectId,
         subproject: params.subprojectId,
-        equipmentgroup: params.equipmentGroupId,
         equipment: params.equipmentId,
         quantity: params.quantity,
-      })
+      }
+      if (params.equipmentGroupId) body.equipmentgroup = params.equipmentGroupId
+      const response = await client.post('/projectequipment', body)
       return response.data
     } catch (err) {
       throw wrapRentmanError(
@@ -270,32 +302,37 @@ export const createRentmanApiClient = (token: string) => {
     }
 
     // 2. CablePlanner-Group finden oder erstellen.
+    // v7.9.117 — Wenn der Plan/Token /equipmentgroups nicht erlaubt
+    // (Plan-Restriction), faellt getEquipmentGroups + createEquipmentGroup
+    // auf null zurueck. Wir adden dann ohne Gruppe — die Items landen
+    // im Default-Container des Subprojects. Weniger schoen, aber besser
+    // als ueberhaupt nicht zu syncen.
     const existingGroups = await getEquipmentGroups(subprojectId)
-    const existingGroup = (existingGroups as Array<Record<string, unknown>>).find(
-      (g) => typeof g.name === 'string' && g.name === CABLE_PLANNER_GROUP_NAME,
-    )
-    let groupId: string
+    let groupId: string | null = null
     let groupCreated = false
-    if (existingGroup) {
-      const id = pickId(existingGroup)
-      if (!id) {
-        throw new Error(`Existing '${CABLE_PLANNER_GROUP_NAME}'-Group hat keine id.`)
-      }
-      groupId = id
-    } else {
-      // Neue Gruppe: order = letzte+1 damit sie unten erscheint und nicht
-      // die bestehende Reihenfolge zerschiesst.
-      const maxOrder = (existingGroups as Array<Record<string, unknown>>).reduce(
-        (max, g) => (typeof g.order === 'number' && g.order > max ? g.order : max),
-        0,
+    if (existingGroups !== null) {
+      const existingGroup = (existingGroups as Array<Record<string, unknown>>).find(
+        (g) => typeof g.name === 'string' && g.name === CABLE_PLANNER_GROUP_NAME,
       )
-      const created = await createEquipmentGroup({
-        name: CABLE_PLANNER_GROUP_NAME,
-        subprojectId,
-        order: maxOrder + 1,
-      })
-      groupId = created.id
-      groupCreated = true
+      if (existingGroup) {
+        const id = pickId(existingGroup)
+        if (id) groupId = id
+      }
+      if (!groupId) {
+        const maxOrder = (existingGroups as Array<Record<string, unknown>>).reduce(
+          (max, g) => (typeof g.order === 'number' && g.order > max ? g.order : max),
+          0,
+        )
+        const created = await createEquipmentGroup({
+          name: CABLE_PLANNER_GROUP_NAME,
+          subprojectId,
+          order: maxOrder + 1,
+        })
+        if (created) {
+          groupId = created.id
+          groupCreated = true
+        }
+      }
     }
 
     // 3. Items einzeln adden (sequentiell — Rentman rate-limits stark).
@@ -311,6 +348,8 @@ export const createRentmanApiClient = (token: string) => {
         await addEquipmentToGroup({
           projectId,
           subprojectId,
+          // v7.9.117 — null = kein Gruppen-Bezug. addEquipmentToGroup
+          // unten laesst das Feld dann aus.
           equipmentGroupId: groupId,
           equipmentId: item.equipmentId,
           quantity: item.quantity,

--- a/src/renderer/components/Export/ExportDialog.tsx
+++ b/src/renderer/components/Export/ExportDialog.tsx
@@ -577,6 +577,9 @@ interface BomRow {
   planned: number
   diff: number
   sample?: Cable
+  /** v7.9.117 — Verknuepfter Rentman-Equipment-Name (siehe CableBomDialog). */
+  rentmanName?: string
+  rentmanId?: string
 }
 
 const bomKeyOf = (c: Pick<Cable, 'type' | 'length'>): string => `${c.type}|${c.length}`
@@ -588,6 +591,7 @@ const fmtSignFixed = (n: number): string => (n > 0 ? `+${n}` : String(n))
 
 const BomSection = () => {
   const project = useProjectStore((s) => s.project)
+  const customLibrary = useProjectStore((s) => s.customLibrary)
   const updateMeta = useProjectStore((s) => s.updateProjectMetadata)
   const [draftPlan, setDraftPlan] = useState<Record<string, number> | null>(null)
 
@@ -600,12 +604,21 @@ const BomSection = () => {
       else built.set(k, { count: 1, sample: c })
     }
     const planned = draftPlan ?? project.metadata.rentmanCablePlan ?? {}
+    const cableMap = project.metadata.rentmanCableMap ?? {}
+    // v7.9.117 — Rentman-Name-Lookup via customLibrary, gleicher Pattern
+    // wie im CableBomDialog.
+    const rentmanNameById = new Map<string, string>()
+    for (const tpl of customLibrary) {
+      if (tpl.rentmanId) rentmanNameById.set(String(tpl.rentmanId), tpl.name)
+    }
     const keys = new Set<string>([...built.keys(), ...Object.keys(planned)])
     const list: BomRow[] = []
     for (const k of keys) {
       const b = built.get(k)?.count ?? 0
       const p = planned[k] ?? 0
       const parsed = parseBomKey(k)
+      const mapping = cableMap[k]
+      const rentmanId = mapping?.rentmanEquipmentId
       list.push({
         key: k,
         type: parsed.type,
@@ -614,13 +627,21 @@ const BomSection = () => {
         planned: p,
         diff: b - p,
         sample: built.get(k)?.sample,
+        rentmanId,
+        rentmanName: rentmanId ? rentmanNameById.get(String(rentmanId)) : undefined,
       })
     }
     list.sort((a, b) =>
       a.type === b.type ? a.length - b.length : a.type.localeCompare(b.type),
     )
     return list
-  }, [project.cables, project.metadata.rentmanCablePlan, draftPlan])
+  }, [
+    project.cables,
+    project.metadata.rentmanCablePlan,
+    project.metadata.rentmanCableMap,
+    customLibrary,
+    draftPlan,
+  ])
 
   const currentPlan = draftPlan ?? project.metadata.rentmanCablePlan ?? {}
   const setPlanned = (key: string, value: number) => {
@@ -637,10 +658,20 @@ const BomSection = () => {
   const discardPlan = () => setDraftPlan(null)
 
   const exportCsv = () => {
-    const lines = [['Typ', 'Länge (m)', 'Verbaut', 'Rentman geplant', 'Differenz'].join(';')]
+    // v7.9.117 — Rentman-Name als eigene Spalte fuer den Abgleich.
+    const lines = [
+      ['Typ', 'Rentman-Name', 'Länge (m)', 'Verbaut', 'Rentman geplant', 'Differenz'].join(';'),
+    ]
     for (const r of rows) {
       lines.push(
-        [r.type, String(r.length), String(r.built), String(r.planned), fmtSignFixed(r.diff)].join(';'),
+        [
+          r.type,
+          r.rentmanName ?? '',
+          String(r.length),
+          String(r.built),
+          String(r.planned),
+          fmtSignFixed(r.diff),
+        ].join(';'),
       )
     }
     downloadBlob(
@@ -690,9 +721,19 @@ const BomSection = () => {
       else if (r.diff > 0) pdf.setTextColor(180, 80, 20)
       else pdf.setTextColor(180, 20, 20)
       pdf.text(sanitizeForPdf(fmtSignFixed(r.diff)), colX[4] + 2, y)
+      // v7.9.117 — Rentman-Name unter dem Typ (zweite Zeile pro Eintrag
+      // wenn Verknuepfung existiert).
+      let nextY = y + 14
+      if (r.rentmanName) {
+        pdf.setFontSize(7)
+        pdf.setTextColor(180, 90, 20)
+        pdf.text(sanitizeForPdf(`R: ${r.rentmanName}`), colX[0] + 8, y + 9)
+        pdf.setFontSize(9)
+        nextY = y + 22
+      }
       pdf.setDrawColor(220)
-      pdf.line(margin, y + 4, pageWidth - margin, y + 4)
-      y += 14
+      pdf.line(margin, nextY - 6, pageWidth - margin, nextY - 6)
+      y = nextY
     }
     // v7.9.116 — Einheitlicher Stempel.
     pdf.save(buildExportFilenameWithSuffix(project.metadata.name || 'cable-planner', 'kabel-bom', 'pdf'))
@@ -737,9 +778,19 @@ const BomSection = () => {
       else if (r.diff > 0) pdf.setTextColor(180, 80, 20)
       else pdf.setTextColor(180, 20, 20)
       pdf.text(sanitizeForPdf(fmtSignFixed(r.diff)), colX[4] + 2, y)
+      // v7.9.117 — Rentman-Name unter dem Typ (zweite Zeile pro Eintrag
+      // wenn Verknuepfung existiert).
+      let nextY = y + 14
+      if (r.rentmanName) {
+        pdf.setFontSize(7)
+        pdf.setTextColor(180, 90, 20)
+        pdf.text(sanitizeForPdf(`R: ${r.rentmanName}`), colX[0] + 8, y + 9)
+        pdf.setFontSize(9)
+        nextY = y + 22
+      }
       pdf.setDrawColor(220)
-      pdf.line(margin, y + 4, pageWidth - margin, y + 4)
-      y += 14
+      pdf.line(margin, nextY - 6, pageWidth - margin, nextY - 6)
+      y = nextY
     }
     const blob = pdf.output('blob') as Blob
     void printPdfBlob(blob)

--- a/src/renderer/components/Library/LibraryPanel.tsx
+++ b/src/renderer/components/Library/LibraryPanel.tsx
@@ -1108,9 +1108,15 @@ export const LibraryPanel = () => {
           tone: 'warning',
         })
       } else {
+        // v7.9.117 — Drei Faelle:
+        //   groupCreated=true  → neue 'CablePlanner'-Group angelegt
+        //   groupId set + !groupCreated → bestehende Group wiederverwendet
+        //   groupId=null       → Plan erlaubt keine Groups → ohne Gruppe geadded
         const groupNote = result.groupCreated
           ? ' (neue Gruppe "CablePlanner" angelegt)'
-          : ' (zur bestehenden Gruppe "CablePlanner" hinzugefuegt)'
+          : result.groupId
+            ? ' (zur bestehenden Gruppe "CablePlanner" hinzugefuegt)'
+            : ' (ohne Gruppe — dein Rentman-Plan erlaubt keine API-Gruppen)'
         await infoDialog(`"${item.name}" hinzugefügt`, {
           body: `Wurde dem Rentman-Projekt "${projectName}" hinzugefügt${groupNote}.`,
           tone: 'success',

--- a/src/renderer/components/Project/CableBomDialog.tsx
+++ b/src/renderer/components/Project/CableBomDialog.tsx
@@ -20,6 +20,11 @@ interface BomRow {
   planned: number
   diff: number
   sample?: Cable
+  /** v7.9.117 — Verknuepfter Rentman-Equipment-Name (falls verknuepft).
+   *  Macht den Abgleich gegen Rentman sauber, weil Rentman Kabel oft
+   *  unter ganz anderem Namen fuehrt als der Cable-Planner-Type. */
+  rentmanName?: string
+  rentmanId?: string
 }
 
 const keyOf = (c: Pick<Cable, 'type' | 'length'>): string => `${c.type}|${c.length}`
@@ -38,6 +43,7 @@ const fmtSignFixed = (n: number): string => (n > 0 ? `+${n}` : String(n))
  */
 export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
   const project = useProjectStore((s) => s.project)
+  const customLibrary = useProjectStore((s) => s.customLibrary)
   const updateMeta = useProjectStore((s) => s.updateProjectMetadata)
   const [draftPlan, setDraftPlan] = useState<Record<string, number> | null>(null)
   const drag = useDraggablePosition('cable-planner:modal-pos:cable-bom', open)
@@ -52,12 +58,22 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
       else built.set(k, { count: 1, sample: c })
     }
     const planned = draftPlan ?? project.metadata.rentmanCablePlan ?? {}
+    const cableMap = project.metadata.rentmanCableMap ?? {}
+    // v7.9.117 — Rentman-Equipment per ID nachschlagen via customLibrary.
+    // Library haelt rentmanId + name pro Template, das ist die direkte
+    // Quelle ohne weitere API-Anfrage.
+    const rentmanNameById = new Map<string, string>()
+    for (const tpl of customLibrary) {
+      if (tpl.rentmanId) rentmanNameById.set(String(tpl.rentmanId), tpl.name)
+    }
     const keys = new Set<string>([...built.keys(), ...Object.keys(planned)])
     const list: BomRow[] = []
     for (const k of keys) {
       const b = built.get(k)?.count ?? 0
       const p = planned[k] ?? 0
       const parsed = parseKey(k)
+      const mapping = cableMap[k]
+      const rentmanId = mapping?.rentmanEquipmentId
       list.push({
         key: k,
         type: parsed.type,
@@ -66,13 +82,22 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
         planned: p,
         diff: b - p,
         sample: built.get(k)?.sample,
+        rentmanId,
+        rentmanName: rentmanId ? rentmanNameById.get(String(rentmanId)) : undefined,
       })
     }
     list.sort((a, b) =>
       a.type === b.type ? a.length - b.length : a.type.localeCompare(b.type),
     )
     return list
-  }, [open, project.cables, project.metadata.rentmanCablePlan, draftPlan])
+  }, [
+    open,
+    project.cables,
+    project.metadata.rentmanCablePlan,
+    project.metadata.rentmanCableMap,
+    customLibrary,
+    draftPlan,
+  ])
 
   if (!open) return null
 
@@ -94,9 +119,21 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
   const discardPlan = () => setDraftPlan(null)
 
   const exportCsv = () => {
-    const lines = [['Typ', 'Länge (m)', 'Verbaut', 'Rentman geplant', 'Differenz'].join(';')]
+    // v7.9.117 — Rentman-Name als eigene Spalte fuer den Abgleich.
+    const lines = [
+      ['Typ', 'Rentman-Name', 'Länge (m)', 'Verbaut', 'Rentman geplant', 'Differenz'].join(';'),
+    ]
     for (const r of rows) {
-      lines.push([r.type, String(r.length), String(r.built), String(r.planned), fmtSignFixed(r.diff)].join(';'))
+      lines.push(
+        [
+          r.type,
+          r.rentmanName ?? '',
+          String(r.length),
+          String(r.built),
+          String(r.planned),
+          fmtSignFixed(r.diff),
+        ].join(';'),
+      )
     }
     downloadBlob(
       // v7.9.116 \u2014 Einheitlicher Stempel: YYYYMMDD_<name>_NNN_kabel-bom.csv
@@ -145,9 +182,23 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
       else if (r.diff > 0) pdf.setTextColor(180, 80, 20)
       else pdf.setTextColor(180, 20, 20)
       pdf.text(sanitizeForPdf(fmtSignFixed(r.diff)), colX[4] + 2, y)
+      // v7.9.117 — Rentman-Name unter dem Typ damit die PDF den
+      // Abgleich erlaubt. Zwei-Zeilen-Eintraege brauchen mehr Y-Vorschub.
+      let nextY = y + 14
+      if (r.rentmanName) {
+        pdf.setFontSize(7)
+        pdf.setTextColor(180, 90, 20)
+        pdf.text(
+          sanitizeForPdf(`R: ${r.rentmanName}`),
+          colX[0] + 8,
+          y + 9,
+        )
+        pdf.setFontSize(9)
+        nextY = y + 22
+      }
       pdf.setDrawColor(220)
-      pdf.line(margin, y + 4, pageWidth - margin, y + 4)
-      y += 14
+      pdf.line(margin, nextY - 6, pageWidth - margin, nextY - 6)
+      y = nextY
     }
 
     // v7.9.116 — Einheitlicher Stempel: YYYYMMDD_<name>_NNN_kabel-bom.pdf
@@ -234,11 +285,35 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
               {rows.map((r) => (
                 <tr key={r.key} className={`border-t border-slate-800 ${r.diff < 0 ? 'bg-red-950/30' : ''}`}>
                   <td className="px-3 py-1">
-                    <span className="font-medium text-slate-100">{r.type}</span>
-                    {r.sample && (
-                      <span className="ml-1 text-[10px] text-slate-500">
-                        ({r.sample.name})
-                      </span>
+                    <div className="font-medium text-slate-100">
+                      {r.type}
+                      {r.sample && (
+                        <span className="ml-1 text-[10px] text-slate-500">
+                          ({r.sample.name})
+                        </span>
+                      )}
+                    </div>
+                    {/* v7.9.117 — Rentman-Name unter dem Typ. Macht den
+                        Abgleich klar wenn Rentman das gleiche Kabel
+                        unter anderem Namen fuehrt. */}
+                    {r.rentmanName && (
+                      <div className="mt-0.5 text-[10px] text-orange-300/80">
+                        <span
+                          className="rounded bg-orange-700/30 px-1 py-0 font-mono text-[9px] text-orange-200"
+                          title="Verknuepfter Rentman-Equipment-Name"
+                        >
+                          R
+                        </span>{' '}
+                        {r.rentmanName}
+                      </div>
+                    )}
+                    {!r.rentmanName && r.rentmanId && (
+                      <div
+                        className="mt-0.5 text-[10px] text-slate-600"
+                        title="Verknuepft, aber Rentman-Template lokal nicht gefunden"
+                      >
+                        R #{r.rentmanId}
+                      </div>
                     )}
                   </td>
                   <td className="px-3 py-1 text-right font-mono">{r.length}</td>

--- a/src/renderer/components/Rentman/RentmanCableExportDialog.tsx
+++ b/src/renderer/components/Rentman/RentmanCableExportDialog.tsx
@@ -210,7 +210,12 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
           },
         },
       })
-      const groupNote = result.groupCreated ? ' (Gruppe angelegt)' : ''
+      // v7.9.117 — Drei Faelle (siehe rentmanApiClient).
+      const groupNote = result.groupCreated
+        ? ' (Gruppe angelegt)'
+        : result.groupId
+          ? ''
+          : ' (ohne Gruppe — Plan-Restriction)'
       setStatusByKey((prev) => ({
         ...prev,
         [bucket.key]: `✓ ${bucket.delta} an Rentman gesendet${groupNote}.`,


### PR DESCRIPTION
1. Rentman-Plan-Fallback (war: 403 auf /equipmentgroups blockierte den gesamten Export):
   - getEquipmentGroups + createEquipmentGroup liefern jetzt null bei 403/404 statt zu werfen. console.warn dokumentiert den Fallback.
   - exportEquipmentToCablePlannerGroup: wenn null, addEquipmentToGroup wird ohne equipmentgroup-Field aufgerufen — die Items landen im Default-Container des Subprojects.
   - addEquipmentToGroup laesst equipmentgroup weg wenn null.
   - UI (LibraryPanel + RentmanCableExportDialog) zeigt drei Faelle: groupCreated (neue Gruppe), groupId ohne created (bestehende), groupId null (Plan-Restriction, ohne Gruppe gesynct).

2. Rentman-Name in der Kabel-Stueckliste (#— User-Request):
   - CableBomDialog + ExportDialog/BomSection: BomRow um rentmanId + rentmanName erweitert. Lookup ueber project.metadata.rentmanCableMap -> rentmanId -> customLibrary[rentmanId].name.
   - UI: Zweizeiliger Typ-Eintrag — Cable-Planner-Type oben, Rentman- Name darunter in orange. Wenn nur ID aber kein Template lokal vorhanden: 'R #ID' Hinweis.
   - CSV-Export: neue Spalte 'Rentman-Name' zwischen Typ und Laenge.
   - PDF-Export: Rentman-Name in zweiter Zeile pro Eintrag (kleiner, orange) — Abgleich gegen Rentman wird damit moeglich auch wenn die Namen abweichen.

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH