### PR TITLE
fix(rack-routing): Obstacle-Padding klein + Auto-A* bei Cable-Create …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.9.117",
+    "version": "7.9.118",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -259,6 +259,14 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
         obstacles,
         sourceEquipmentId: cable.fromEquipmentId,
         targetEquipmentId: cable.toEquipmentId,
+        // v7.9.118 / Issue #223 — Im Rack-Mode kleineres Obstacle-
+        // Padding, weil Rack-Geraete in 1HE-Schritten direkt aneinander
+        // stehen. Default 2 (= 40 px) wuerde den Korridor zwischen
+        // benachbarten Geraeten komplett sperren → A* loopt ums Rack.
+        // 0 Padding ist akzeptabel hier — die Geraete-Aussenkanten
+        // sind Snap-Grid-aligned, ein Kabel direkt an der Kante stoert
+        // visuell weniger als ein Riesen-Umweg.
+        ...(mode === 'rack' ? { obstaclePadCells: 0 } : {}),
       })
       // v7.9.115 / Issue #223 — Wenn A* keinen Pfad findet (dichtes
       // Rack, blockierter Korridor), schweigend zurueck auf

--- a/src/renderer/components/Rack/RackInternalCanvas.tsx
+++ b/src/renderer/components/Rack/RackInternalCanvas.tsx
@@ -30,6 +30,7 @@ import {
   useCanvasProjectStore,
 } from '../../store/projectStoreContext'
 import { createProjectStoreInstance } from '../../store/projectStore'
+import { routeCable } from '../../lib/canvasViewport'
 import type {
   EquipmentItem,
   EquipmentTemplate,
@@ -327,6 +328,22 @@ export const RackInternalCanvas = ({
           length: 0.5,
           color: '#64748b',
           notes: '',
+        })
+        // v7.9.118 / Issue #223 — Auto-Route via A* fuer neu angelegtes
+        // Kabel. Im Rack-Mode hat ReactFlow's Standard-L-Routing dazu
+        // gefuehrt dass mehrere Kabel sich ueberlappen / durcheinander
+        // laufen. A* mit padding=0 (siehe CanvasArea-Branch fuer
+        // mode='rack') findet sauberere Pfade, weicht Geraeten aus.
+        //
+        // Zwei requestAnimationFrame: der erste damit ReactFlow das
+        // neue Edge gerendert + die Node-Layouts gemessen hat, der
+        // zweite damit das Layout ueber den render-Loop stabil ist.
+        // Sonst hat A* keine validen Obstacle-Rects.
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            const newCable = scratchStore.getState().project.cables.slice(-1)[0]
+            if (newCable) routeCable(newCable.id)
+          })
         })
       },
     })

--- a/src/renderer/lib/routeCableWithAStar.ts
+++ b/src/renderer/lib/routeCableWithAStar.ts
@@ -52,6 +52,13 @@ export interface RouteCableArgs {
   obstacles: PixelRect[]
   sourceEquipmentId: string
   targetEquipmentId: string
+  /** v7.9.118 — Padding in Grid-Zellen um jedes Hindernis. Default 2
+   *  (= 40 px) — angenehmer Abstand im Haupt-Canvas. In dichten Racks
+   *  (mode='rack'), wo Geraete vertikal direkt aufeinander gestapelt
+   *  sind, sperrt das den Korridor zwischen zwei benachbarten Geraeten
+   *  komplett → A* loopt um das ganze Rack. Caller darf den Wert
+   *  reduzieren (z.B. 0) um dichte Routen zuzulassen. */
+  obstaclePadCells?: number
 }
 
 /** v7.9.32 — Sichtbare Lücke um jedes Hindernis. 2 Grid-Cells = 40 px. */
@@ -102,11 +109,17 @@ export const routeCableWithAStar = (
   // v7.9.37 — ALLE Devices kommen mit Padding als Hard-Obstacles rein,
   // inklusive Source und Target. Damit kann A* den Pfad nicht mehr durch
   // den eigenen Source/Target-Body optimieren.
-  const obstacles: Rect[] = args.obstacles.map((r) => inflate(r, OBSTACLE_PAD_PX))
+  // v7.9.118 — Padding-Zellen ueberschreibbar fuer Rack-Mode (default 2).
+  const padCells = typeof args.obstaclePadCells === 'number' && args.obstaclePadCells >= 0
+    ? args.obstaclePadCells
+    : OBSTACLE_PAD_CELLS
+  const padPx = padCells * CELL_SIZE
+  const obstacles: Rect[] = args.obstacles.map((r) => inflate(r, padPx))
 
   // Stub-Distanz: muss past dem eigenen Padding liegen, sonst sitzt
   // der A*-Startpunkt im blockierten Padding-Bereich fest.
-  const stubCells = OBSTACLE_PAD_CELLS + 1
+  // Mind. 1 damit der Handle nicht unmittelbar im Padding-Bereich endet.
+  const stubCells = Math.max(1, padCells + 1)
 
   // Korridor force-open: vom Handle nach außen durch das eigene Padding,
   // damit der gerenderte erste Segment (Handle → erstes Waypoint = Stub)


### PR DESCRIPTION
…(#223)

Symptom aus #223: 'interne Verkabelung ist ein kompletter durcheinander'. Root-Cause-Analyse:

1. routeCableWithAStar hatte hartcoded OBSTACLE_PAD_CELLS=2 (= 40 px Padding um jedes Geraet). Im Rack-Builder stehen Geraete in 1HE- Schritten direkt aneinander → Padding sperrt den Korridor zwischen benachbarten Geraeten → A* findet nur Pfade die um das ganze Rack herum loopen.

2. Neu erstellte Kabel im Rack-Builder bekamen NUR ReactFlow's Default-L-Routing — kein A*. Mehrere Kabel = mehrere identische L-Shapes die sich ueberlappen.

Fix:
- routeCableWithAStar.args.obstaclePadCells optional (default 2). CanvasArea routeOne passt 0 im mode='rack' an. Im Haupt-Canvas bleibt alles wie bisher.
- RackInternalCanvas queueConnection-Override ruft nach createCableFromPending direkt routeCable(neueId) auf — via 2x requestAnimationFrame damit ReactFlow zuerst die neuen Layouts measured hat. So sind alle neuen Rack-Kabel direkt A*-geroutet, weichen sich gegenseitig aus.
- stubCells = Math.max(1, padCells+1) — bei padCells=0 muss der Stub trotzdem ≥1 Cell ausserhalb sein damit der Handle nicht im Inneren blockierten Bereich startet.

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH