### PR TITLE
feat(cable): Endpoint-Labels — Pfeile zeigen wohin das andere Kabelen…

### DIFF
--- a/src/renderer/components/Canvas/CableEdge.tsx
+++ b/src/renderer/components/Canvas/CableEdge.tsx
@@ -363,6 +363,7 @@ export const CableEdge = ({
   // aus. Wirkt zusammen mit dem per-Kabel labelPosition='none' / legacy
   // labelHidden=true (zwei Wege zum gleichen Ziel waehrend der Migration).
   const hideAllCableLabels = useUiStore((s) => s.hideAllCableLabels)
+  const showCableEndpointLabels = useUiStore((s) => s.showCableEndpointLabels)
   const collisionShiftOn = useUiStore((s) => s.orthogonalCollisionShift)
   // v7.9.85 / #123 — Layer-Filter. Wenn das Kabel einen Layer hat
   // (z.B. 'network') und der Layer-Toggle in der Toolbar AUS ist,
@@ -694,6 +695,68 @@ export const CableEdge = ({
           </div>
         </EdgeLabelRenderer>
       )}
+      {/* v7.9.127 — Endpoint-Labels: an jedem Kabelende ein kleines
+          Mini-Label das anzeigt zu welchem Geraet/Port das ANDERE
+          Ende geht. Greift nur wenn der Settings-Toggle an ist und
+          alle anderen Hide-Bedingungen (globaler Hide, per-Kabel
+          'none', layerHidden) nicht zuschlagen. Pfeile (→ ←)
+          markieren die Lese-Richtung "fuehrt zu". */}
+      {showCableEndpointLabels &&
+        !hideAllCableLabels &&
+        cable?.labelPosition !== 'none' &&
+        !cable?.labelHidden &&
+        cable && (() => {
+          const fromEq = equipment.find((e) => e.id === cable.fromEquipmentId)
+          const toEq = equipment.find((e) => e.id === cable.toEquipmentId)
+          const fromPort =
+            fromEq?.outputs.find((p) => p.id === cable.fromPortId) ??
+            fromEq?.inputs.find((p) => p.id === cable.fromPortId)
+          const toPort =
+            toEq?.outputs.find((p) => p.id === cable.toPortId) ??
+            toEq?.inputs.find((p) => p.id === cable.toPortId)
+          if (!fromEq || !toEq || !fromPort || !toPort) return null
+          const sourceEndLabel = `→ ${toEq.name} · ${toPort.name}`
+          const targetEndLabel = `← ${fromEq.name} · ${fromPort.name}`
+          const endpointStyle = {
+            position: 'absolute' as const,
+            background: isLight ? 'rgba(241,245,249,0.85)' : 'rgba(15,23,42,0.78)',
+            color: isLight ? '#475569' : '#94a3b8',
+            border: `1px dashed ${isLight ? '#cbd5e1' : '#475569'}`,
+            padding: '1px 4px',
+            borderRadius: 3,
+            fontSize: 9,
+            lineHeight: 1.2,
+            pointerEvents: 'none' as const,
+            whiteSpace: 'nowrap' as const,
+            maxWidth: 180,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }
+          return (
+            <EdgeLabelRenderer>
+              <div
+                style={{
+                  ...endpointStyle,
+                  transform: `translate(-50%, -130%) translate(${sourceX}px, ${sourceY}px)`,
+                }}
+                className="nodrag nopan"
+                title={sourceEndLabel}
+              >
+                {sourceEndLabel}
+              </div>
+              <div
+                style={{
+                  ...endpointStyle,
+                  transform: `translate(-50%, -130%) translate(${targetX}px, ${targetY}px)`,
+                }}
+                className="nodrag nopan"
+                title={targetEndLabel}
+              >
+                {targetEndLabel}
+              </div>
+            </EdgeLabelRenderer>
+          )
+        })()}
     </>
   )
 }

--- a/src/renderer/components/Settings/SettingsDialog.tsx
+++ b/src/renderer/components/Settings/SettingsDialog.tsx
@@ -1126,8 +1126,41 @@ const EditingTab = () => {
 
       <CableReconnectOptionsCard />
       <CableInheritTypeCard />
+      <CableEndpointLabelsCard />
       <CableVisualOptionsCard />
     </div>
+  )
+}
+
+/** v7.9.127 — Endpoint-Labels: an jedem Kabelende ein kleines Label
+ *  das zeigt, zu welchem Geraet/Port das ANDERE Ende des Kabels geht.
+ *  Hilft beim Verfolgen von Kabeln in dichten Plaenen. */
+const CableEndpointLabelsCard = () => {
+  const t = useTranslation()
+  const showCableEndpointLabels = useUiStore((s) => s.showCableEndpointLabels)
+  const setShowCableEndpointLabels = useUiStore((s) => s.setShowCableEndpointLabels)
+  return (
+    <SettingsCard
+      title={t('settings.editing.endpointLabels', 'Endpoint-Labels an Kabelenden')}
+      description={t(
+        'settings.editing.endpointLabelsDesc',
+        'Zeigt an jedem Kabelende ein kleines Label das anzeigt, wohin das andere Ende geht — am Source-Ende "→ Ziel-Geraet · Ziel-Port", am Target-Ende "← Quell-Geraet · Quell-Port". Hilft beim Verfolgen von Kabeln ohne ihnen visuell folgen zu muessen.',
+      )}
+    >
+      <label className="flex items-center gap-2 text-sm text-slate-200">
+        <input
+          type="checkbox"
+          checked={showCableEndpointLabels}
+          onChange={(e) => setShowCableEndpointLabels(e.target.checked)}
+        />
+        {t('settings.editing.endpointLabelsLabel', 'Endpoint-Labels einblenden')}
+      </label>
+      <p className="mt-2 text-[11px] text-slate-500">
+        Default aus — gibt zusaetzlichen Visual-Noise. Wirkt
+        zusammen mit dem globalen "Alle Labels ausblenden"-Toggle
+        und respektiert per-Kabel labelPosition='none'.
+      </p>
+    </SettingsCard>
   )
 }
 

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -197,6 +197,13 @@ interface PersistedUiState {
    *  fuer aufgeraeumte Plan-Ansicht beim Praesentieren ohne dass jedes
    *  Kabel einzeln umgestellt werden muss. */
   hideAllCableLabels: boolean
+  /** v7.9.127 — Endpoint-Labels: an jedem Kabelende ein kleines Label
+   *  das zeigt zu welchem Geraet/Port das ANDERE Ende des Kabels geht.
+   *  Am Source-Ende steht "→ Target-Device · Target-Port", am Target-
+   *  Ende "← Source-Device · Source-Port". Nuetzlich um auf einen
+   *  Blick zu sehen wohin ein Kabel zieht, ohne ihm visuell folgen
+   *  zu muessen. Default off — gibt zusaetzliches Visual-Noise. */
+  showCableEndpointLabels: boolean
   /** v7.9.113 / Issue #232 — Wenn aktiv, wird beim Cable-Reconnect der
    *  vom User vergebene Port-Name mit dem Kabel mitgenommen: alter Port
    *  bekommt seinen Template-default-Namen zurueck, neuer Port bekommt
@@ -283,6 +290,7 @@ const defaults: PersistedUiState = {
   deviceConfigLibrary: [],
   cableBumps: false,
   hideAllCableLabels: false,
+  showCableEndpointLabels: false,
   swapLabelsOnReconnect: false,
   inheritCableTypeFromPort: true,
   orthogonalCollisionShift: false,
@@ -586,6 +594,7 @@ interface UiState extends PersistedUiState {
   replaceDeviceConfigLibrary: (entries: DeviceConfigEntry[]) => void
   setCableBumps: (value: boolean) => void
   setHideAllCableLabels: (value: boolean) => void
+  setShowCableEndpointLabels: (value: boolean) => void
   setSwapLabelsOnReconnect: (value: boolean) => void
   setInheritCableTypeFromPort: (value: boolean) => void
   setOrthogonalCollisionShift: (value: boolean) => void
@@ -797,6 +806,7 @@ const applyPatch =
       deviceConfigLibrary: state.deviceConfigLibrary,
       cableBumps: state.cableBumps,
       inheritCableTypeFromPort: state.inheritCableTypeFromPort,
+      showCableEndpointLabels: state.showCableEndpointLabels,
       orthogonalCollisionShift: state.orthogonalCollisionShift,
       hotkeys: state.hotkeys,
       libraryFloating: state.libraryFloating,
@@ -982,6 +992,7 @@ export const useUiStore = create<UiState>((set) => ({
     set((state) => applyPatch({ deviceConfigLibrary: entries })(state)),
   setCableBumps: (value) => set(applyPatch({ cableBumps: value })),
   setHideAllCableLabels: (value) => set(applyPatch({ hideAllCableLabels: value })),
+  setShowCableEndpointLabels: (value) => set(applyPatch({ showCableEndpointLabels: value })),
   setSwapLabelsOnReconnect: (value) => set(applyPatch({ swapLabelsOnReconnect: value })),
   setInheritCableTypeFromPort: (value) => set(applyPatch({ inheritCableTypeFromPort: value })),
   setOrthogonalCollisionShift: (value) => set(applyPatch({ orthogonalCollisionShift: value })),


### PR DESCRIPTION
…de geht

User-Wunsch: an jedem Kabelende ein kleines Label das anzeigt, wohin das andere Ende geht — am Source-Ende "→ Ziel-Geraet · Ziel-Port", am Target-Ende "← Quell-Geraet · Quell-Port". Hilft beim Verfolgen von Kabeln in dichten Plaenen, ohne dass man der Linie visuell bis ans andere Ende folgen muss.

Implementation:
- uiStore: neues showCableEndpointLabels (default off, persistiert in localStorage wie alle anderen Editing-Settings).
- Settings -> Editing: neue Card "Endpoint-Labels an Kabelenden" mit Checkbox + Hilfetext.
- CableEdge: zusaetzlich zum bestehenden Center-Label rendert zwei zusaetzliche kleinere Labels an (sourceX/Y) und (targetX/Y), jeweils 130% nach oben verschoben damit sie ueber dem Kabel haengen statt es zu ueberlagern. Stil: dashed-Border, gedaempfte Farben (kleinere Schrift 9px), pointer-events:none, max-width mit ellipsis bei langen Namen.

Greift nur wenn:
- showCableEndpointLabels aktiv
- hideAllCableLabels NICHT aktiv (globaler Override)
- per-Kabel labelPosition != 'none'
- legacy labelHidden != true

Wenn Ports/Geraete orphaned sind (geloescht/umgenannt), wird nichts gerendert.

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH