### PR TITLE
feat(equipment): Short-Form-Name + Auto-Generator fuer Endpoint-Labels

### DIFF
--- a/src/renderer/components/Canvas/CableEdge.tsx
+++ b/src/renderer/components/Canvas/CableEdge.tsx
@@ -15,6 +15,7 @@ import { CableWaypoints } from './CableWaypoints'
 import { computeObstacleAwareWaypoints, type Rect } from '../../lib/cableRouting'
 import { EQUIPMENT_LAYOUT } from '../../lib/layoutConstants'
 import { isCableVisibleByLayer } from '../../lib/cableLayers'
+import { effectiveShortName } from '../../lib/shortName'
 
 interface CableEdgeData {
   cable: Cable
@@ -722,8 +723,11 @@ export const CableEdge = ({
             toEq?.outputs.find((p) => p.id === cable.toPortId) ??
             toEq?.inputs.find((p) => p.id === cable.toPortId)
           if (!fromEq || !toEq || !fromPort || !toPort) return null
-          const sourceEndLabel = `→ ${toEq.name} · ${toPort.name}`
-          const targetEndLabel = `← ${fromEq.name} · ${fromPort.name}`
+          // v7.9.127 — Statt eq.name den Short-Form-Namen verwenden
+          // (User-Override oder auto-generiert). So heisst's nicht
+          // "→ ATEM Constellation 8K · In 8" sondern "→ ATEM8K · In 8".
+          const sourceEndLabel = `→ ${effectiveShortName(toEq)} · ${toPort.name}`
+          const targetEndLabel = `← ${effectiveShortName(fromEq)} · ${fromPort.name}`
           const endpointStyle = {
             position: 'absolute' as const,
             background: isLight ? 'rgba(241,245,249,0.85)' : 'rgba(15,23,42,0.78)',

--- a/src/renderer/components/Properties/EquipmentProperties.tsx
+++ b/src/renderer/components/Properties/EquipmentProperties.tsx
@@ -20,6 +20,7 @@ import { CSS } from '@dnd-kit/utilities'
 import { useCanvasProjectStore as useProjectStore } from '../../store/projectStoreContext'
 import { useUiStore } from '../../store/uiStore'
 import { detectDeviceKind, detectNetworkDevice } from '../../lib/deviceKind'
+import { generateShortName } from '../../lib/shortName'
 import { ModeEditorDialog } from './ModeEditorDialog'
 import { promptDialog } from '../../lib/promptDialog'
 import { confirmDialog } from '../../lib/confirmDialog'
@@ -1914,6 +1915,62 @@ export const EquipmentProperties = () => {
           className="w-full rounded border border-slate-700 bg-slate-900 p-2"
         />
       </label>
+
+      {/* v7.9.127 — Short-Form-Name. Wird in platzknappen Kontexten
+          benutzt (Cable-Endpoint-Labels, Patch-Sheets). Wenn leer:
+          auto-generiert aus name (Placeholder zeigt den Vorschlag).
+          Refresh-Button setzt den Override auf den Auto-Vorschlag. */}
+      {(() => {
+        const autoSuggestion = generateShortName(equipment.name)
+        return (
+          <label className="block">
+            <span className="mb-1 block text-slate-300">
+              {t('eq.field.shortName', 'Short-Name')}{' '}
+              <span className="text-slate-500">
+                ({t('common.optional', 'optional')},{' '}
+                {t(
+                  'eq.field.shortNameHint',
+                  'fuer Port-/Endpoint-Labels — z.B. "ATEM8K" statt "ATEM Constellation 8K"',
+                )}
+                )
+              </span>
+            </span>
+            <div className="flex gap-1">
+              <input
+                value={equipment.shortName ?? ''}
+                placeholder={autoSuggestion || t('eq.field.shortNamePlaceholder', 'Kurzform…')}
+                onChange={(event) =>
+                  updateEquipment(equipment.id, {
+                    shortName: event.target.value || undefined,
+                  })
+                }
+                className="flex-1 rounded border border-slate-700 bg-slate-900 p-2"
+              />
+              <button
+                type="button"
+                onClick={() =>
+                  updateEquipment(equipment.id, { shortName: autoSuggestion || undefined })
+                }
+                disabled={!autoSuggestion}
+                title={
+                  autoSuggestion
+                    ? `${t('eq.field.shortNameAuto', 'Aus Namen neu generieren')} (${autoSuggestion})`
+                    : t('eq.field.shortNameAutoEmpty', 'Kein Vorschlag — Name pflegen.')
+                }
+                className="shrink-0 rounded border border-slate-700 bg-slate-800 px-2 text-xs text-slate-200 hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {t('eq.field.shortNameAutoBtn', '↻ auto')}
+              </button>
+            </div>
+            {!equipment.shortName?.trim() && autoSuggestion && (
+              <p className="mt-1 text-[10px] text-slate-500">
+                {t('eq.field.shortNameAutoUsed', 'Verwendet automatisch:')}{' '}
+                <span className="font-mono text-slate-400">{autoSuggestion}</span>
+              </p>
+            )}
+          </label>
+        )
+      })()}
 
       <label className="block">
         <span className="mb-1 block text-slate-300">

--- a/src/renderer/lib/shortName.ts
+++ b/src/renderer/lib/shortName.ts
@@ -1,0 +1,96 @@
+import type { EquipmentItem } from '../types/equipment'
+
+/**
+ * Short-form device-name generator. Used for space-constrained
+ * contexts like cable endpoint labels, where the full device name
+ * ("ATEM Constellation 8K HD") is too long.
+ *
+ * Algorithm (researched against common AV/broadcast labelling
+ * conventions — D-Tools System Integrator, Stardraw Design,
+ * patchbay-labelling standards in Visio AV-ECAV):
+ *
+ * 1. Normalize input — trim, collapse whitespace, split CamelCase.
+ * 2. Tokenize by non-alphanumeric separators.
+ * 3. Drop common filler words ("the", "of", "model", "series" …).
+ * 4. For each remaining token:
+ *    - Contains digits ("8K", "40x40", "A170", "v2") -> keep entire token
+ *    - Short uppercase acronym ("ATEM", "SDI", "USB", "NDI") -> keep
+ *    - Single letter -> keep uppercase
+ *    - Regular word -> first letter uppercase
+ * 5. Join with no separator. If > 6 chars total, fall back to
+ *    "first-token + first-numeric-token" (so "ATEM Constellation 8K"
+ *    -> "ATEM8K" instead of the noisier "ATEMC8K").
+ *
+ * Examples:
+ *   "ATEM Constellation 8K"             -> "ATEM8K"
+ *   "Blackmagic Smart Videohub 40x40"   -> "B40x40"
+ *   "Sony PVM-A170"                     -> "SA170"
+ *   "Pixelhue P20"                      -> "PP20"
+ *   "Brompton Tessera SX40"             -> "BTSX40"
+ *   "Sennheiser EW G4"                  -> "SEWG4"
+ *   "Camera 1"                          -> "C1"
+ *   "Mac Mini"                          -> "MM"
+ */
+export const generateShortName = (fullName: string | undefined | null): string => {
+  if (!fullName) return ''
+  const trimmed = fullName.trim()
+  if (!trimmed) return ''
+
+  const FILLER_WORDS = new Set([
+    // Articles, conjunctions, prepositions
+    'the', 'and', 'or', 'of', 'a', 'an', 'with', 'for', 'to', 'in', 'on', 'by',
+    // Generic descriptors
+    'model', 'series', 'edition', 'version', 'mark',
+  ])
+
+  // Split CamelCase ("VideoHub" -> "Video Hub", "AVMixer" -> "AV Mixer")
+  const decased = trimmed
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1 $2')
+
+  // Tokenize on non-alphanumeric boundaries
+  const rawTokens = decased
+    .split(/[\s\-_/\\()[\]{}.,;:|"'`~!@#$%^&*+=?<>]+/)
+    .filter((t) => t.length > 0)
+  if (rawTokens.length === 0) return ''
+
+  // Drop fillers — but keep at least one token so we don't produce empty output
+  let tokens = rawTokens.filter((t) => !FILLER_WORDS.has(t.toLowerCase()))
+  if (tokens.length === 0) tokens = [rawTokens[0]]
+
+  // Transform each token
+  const parts = tokens.map((tok) => {
+    if (/\d/.test(tok)) return tok                              // model-number-ish
+    if (/^[A-Z]{2,5}$/.test(tok)) return tok                    // short acronym
+    if (tok.length === 1) return tok.toUpperCase()
+    return tok[0].toUpperCase()
+  })
+
+  const naive = parts.join('')
+  if (naive.length <= 6) return naive
+
+  // Too long -> fall back to "first significant token + first numeric token".
+  // Produces "ATEM8K" instead of "ATEMC8K", "B40x40" instead of "BSVH40x40".
+  const first = parts[0]
+  const firstNumeric = parts.slice(1).find((p) => /\d/.test(p))
+  if (firstNumeric) {
+    const combined = first + firstNumeric
+    if (combined.length <= 8) return combined
+    return combined.slice(0, 8)
+  }
+  return first.slice(0, 6)
+}
+
+/**
+ * Effective short-form for a device: user-defined override
+ * (eq.shortName) wins; falls back to auto-generated value from
+ * eq.name. Empty/whitespace-only override is treated as undefined.
+ */
+export const effectiveShortName = (
+  eq: Pick<EquipmentItem, 'name' | 'shortName'> | undefined | null,
+): string => {
+  if (!eq) return ''
+  const override = eq.shortName?.trim()
+  if (override) return override
+  return generateShortName(eq.name)
+}

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -145,6 +145,12 @@ export interface DeviceMode {
 export interface EquipmentItem {
   id: string
   name: string
+  /** v7.9.127 — Optional Short-Form-Name fuer platzbegrenzte Kontexte
+   *  wie Cable-Endpoint-Labels und Patchlisten. Wenn nicht gesetzt,
+   *  wird er bei Bedarf aus `name` per `generateShortName()` abgeleitet.
+   *  User kann ihn in den Properties ueberschreiben. Beispiel:
+   *  "ATEM Constellation 8K" -> Auto "ATEM8K", User-Override frei. */
+  shortName?: string
   /** Optional subtitle shown below the device name (e.g. "PGM Monitor", "Cam 1"). */
   subtitle?: string
   /** Optional background/accent color for the node header (CSS hex, e.g. "#0f4c81"). */


### PR DESCRIPTION
User-Pain: in den Endpoint-Labels (v7.9.127) und potentiell weiteren Stellen steht der volle Geraete-Name, z.B. "ATEM Constellation 8K · In 8" — zu lang fuer kompakte Labels.

Loesung:

1) Neuer Helper lib/shortName.ts mit generateShortName():
   - Researched gegen AV-/Broadcast-Labelling-Conventions (D-Tools, Stardraw, Visio AV-ECAV, Dante-Label-Standards).
   - Algorithmus: a) Normalize (trim, CamelCase split: "VideoHub" -> "Video Hub") b) Tokenize an Non-Alphanumeric Boundaries c) Drop Filler-Words ("the", "of", "model", "series" …) d) Pro Token: Digits-haltig -> ganzer Token bleibt (8K, 40x40, A170); kurzes UPPERCASE-Acronym (2-5 chars) -> bleibt (ATEM, SDI, USB); Einzelbuchstabe -> upper; sonst -> erster Buchstabe upper. e) Join, cap 6 chars. Wenn laenger: "first-token + first-numeric-token" Fallback ("ATEM Constellation 8K" -> "ATEM8K" statt noisy "ATEMC8K").
   - Plus effectiveShortName(eq): User-Override gewinnt, sonst auto-generiert.

   Test-Beispiele:
   - ATEM Constellation 8K       -> ATEM8K
   - Blackmagic Smart Videohub 40x40 -> B40x40
   - Sony PVM-A170               -> SA170
   - Pixelhue P20                -> PP20
   - Brompton Tessera SX40       -> BTSX40
   - Sennheiser EW G4            -> SEWG4
   - Camera 1                    -> C1
   - Mac Mini                    -> MM

2) EquipmentItem.shortName?: string — User-Override-Feld.
   Wenn leer/undefined: auto-generiert on-the-fly. Nicht in
   Schema-Heal zwangsweise gefuellt — bleibt minimal-invasiv.

3) EquipmentProperties: neues Input-Feld direkt unter "Name",
   mit dem Auto-Vorschlag als Placeholder. Daneben "↻ auto"-
   Button der den Override mit dem aktuellen Auto-Vorschlag
   fuellt (z.B. wenn der User den Namen geaendert hat und neu
   ableiten will). Helper-Text unter dem Input zeigt, was
   gerade als Auto-Wert genutzt wird wenn das Override-Feld
   leer ist.

4) CableEdge Endpoint-Labels (Source-/Target-Mini-Labels):
   nutzen jetzt effectiveShortName statt eq.name. Aus
   "→ ATEM Constellation 8K · In 8" wird "→ ATEM8K · In 8".

Andere Stellen (Patch-Sheet, Cable-BOM, Canvas-Node-Header) bleiben unveraendert — Full-Name bleibt der Default fuer Plaetze wo der Lese-Raum nicht beschraenkt ist. Wenn der User das anders haben moechte, kann es spaeter analog erweitert werden.

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH