### PR TITLE
fix(canvas): Drag-to-Open-End + Auto-A* fuer Click-Click-Kabel

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -46,6 +46,7 @@ import { exportCanvasToPdfVector } from './lib/exportPdfVector'
 import { printPdfBlob } from './lib/printPdfBlob'
 import { exportCanvasToImage } from './lib/exportImage'
 import { connectorToCableType } from './lib/cableInheritance'
+import { routeCable } from './lib/canvasViewport'
 import { useProjectStore } from './store/projectStore'
 import {
   scanLibraryFolder,
@@ -717,7 +718,31 @@ export default function App() {
         }
       }
     }
+    // v7.9.128 — Snapshot der Waypoints VOR createCableFromPending,
+    // weil die Action pendingWaypoints sofort zurueck auf undefined
+    // setzt. Wir brauchen den Vorher-Stand um zu entscheiden ob das
+    // Kabel auto-A*-geroutet werden soll oder ob der User schon manuell
+    // Wegpunkte gesetzt hat.
+    const hadManualWaypoints =
+      (stateBefore.pendingWaypoints?.length ?? 0) > 0
     createCableFromPending(draft)
+    // v7.9.128 — Auto-A*-Routing fuer einfaches Cable-Erstellen
+    // (Drag oder Click-Click ohne Wegpunkte) gemaess User-Request:
+    // "Wenn man nur Start und Ziel anklickt, soll automatisch mit A*
+    //  geroutet werden". Doppelter rAF damit ReactFlow den neuen Edge
+    // gemessen hat und die Equipment-Bounding-Boxes stabil sind — sonst
+    // hat A* keine validen Obstacle-Rects (Pattern aus
+    // RackInternalCanvas.tsx v7.9.118).
+    if (!hadManualWaypoints) {
+      const newCable = useProjectStore.getState().project.cables.slice(-1)[0]
+      if (newCable) {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            routeCable(newCable.id)
+          })
+        })
+      }
+    }
     const plan = useProjectStore.getState().project.metadata.rentmanCablePlan
     if (!plan) return
     const key = `${draft.type}|${draft.length}`

--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -316,6 +316,13 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
     handleId: string | null
     handleType: 'source' | 'target' | null
   } | null>(null)
+  // v7.9.128 — Flag das onConnect setzt wenn ein gueltiger Drop auf
+  // einem Handle stattgefunden hat. onConnectEnd nutzt es um zu
+  // entscheiden ob er einen Open-End-Stub erstellen soll oder nicht.
+  // Loest das Problem dass die alte strict 'react-flow__pane'-
+  // Detection bei Drops auf Edge-Labels / Grid-Pattern / etc. das
+  // Open-End-Verhalten "verschluckt" hat.
+  const connectMadeRef = useRef(false)
   // Group-drag support: when a location frame is being dragged, we remember
   // which equipment was inside at drag-start and the previous frame position,
   // so we can apply the delta to contained equipment live.
@@ -1147,6 +1154,9 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
       // way (Input → Output). Normalise here so the canonical signal flow
       // (output → input) is preserved regardless of which end the user
       // started from.
+      // v7.9.128 — Flag setzen damit onConnectEnd weiss: hier wurde
+      // eine echte Verbindung gemacht, KEIN Open-End-Stub mehr noetig.
+      connectMadeRef.current = true
       if (connection.source && connection.target && connection.sourceHandle && connection.targetHandle) {
         const sourceEq = project.equipment.find((e) => e.id === connection.source)
         const targetEq = project.equipment.find((e) => e.id === connection.target)
@@ -1218,6 +1228,9 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
       params: { nodeId: string | null; handleId: string | null; handleType: 'source' | 'target' | null },
     ) => {
       connectStartRef.current = params
+      // v7.9.128 — Reset flag fuer neue Drag-Session. Wird in onConnect
+      // gesetzt wenn der Drop auf einem gueltigen Handle landet.
+      connectMadeRef.current = false
     },
     [],
   )
@@ -1228,10 +1241,26 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
       connectStartRef.current = null
       if (!start || !start.nodeId || !start.handleId || !start.handleType) return
 
-      // Only act when dropped on the pane (not on a node/handle).
+      // v7.9.128 — Wenn onConnect schon eine Verbindung gemacht hat,
+      // KEIN Open-End-Stub mehr drueber legen. Der frueher hier
+      // verwendete strict 'react-flow__pane'-Check hatte das Problem,
+      // dass Drops auf Cable-Edge-Labels, Grid-Pattern-SVG, Layer-
+      // Overlay-Buttons, Location-Frame-Labels usw. ALLE als
+      // "nicht auf der Pane" galten und der Drag-To-Open-End
+      // schweigend nichts tat — obwohl der User klar einen Stub
+      // wollte. Stattdessen: Drop auf einen Port (handle) -> hat
+      // onConnect schon gemacht. Sonst (egal wo auf der Canvas) ->
+      // Open-End-Stub.
+      if (connectMadeRef.current) {
+        connectMadeRef.current = false
+        return
+      }
+      // Sicherheitscheck: trotzdem nicht stub'en, wenn das Mouse-Up
+      // direkt auf einem Handle landete (ReactFlow konnte's evtl.
+      // nicht als Connect interpretieren, soll aber auch kein Stub
+      // erzeugen — z.B. Drop auf inkompatiblen Handle-Typ).
       const target = event.target as HTMLElement | null
-      const targetIsPane = target?.classList.contains('react-flow__pane')
-      if (!targetIsPane) return
+      if (target?.closest('.react-flow__handle')) return
 
       // Resolve clientX/Y for mouse or touch.
       const pt =


### PR DESCRIPTION
User-Report: "das normale kabelziehen und zu open end ziehen ist nicht mehr gut nutzbar. wegpunkte setzen oder start anklicken und ziel anklicken geht aber gut. Wenn man nur den start port anklickt und dann den ziel port, soll automatisch mit A* geroutet werden."

ZWEI Problem-Vektoren:

1) Open-End-Drag (Drag-from-Port-to-empty-Pane) hat schweigend
   nichts gemacht wenn das Drop-Target nicht EXAKT die
   'react-flow__pane'-Klasse hatte. Tatsaechlich landen Drops
   aber oft auf:
   - Edge-Label-Wrapper (vom ReactFlow-EdgeLabelRenderer)
   - SVG-Background-Pattern (Grid-Dots)
   - Layer-Overlay-Bubbles (Toolbar-Chips ueber dem Canvas)
   - Location-Frame-Label (v7.9.127: Plate jetzt 2x so gross und faengt mehr Drops ab)
   - Cable-Endpoint-Labels (v7.9.127)

   Fix: Detection auf "neuer Flag connectMadeRef" umgestellt.
   onConnect setzt das Flag wenn der Drop auf einem gueltigen
   Handle landet -> echte Verbindung gemacht, kein Stub noetig.
   onConnectEnd liest das Flag: wenn nicht gesetzt UND das
   konkrete Drop-Target ist kein Handle -> Open-End-Stub
   erzeugen, egal wo genau gedropped wurde. Beim onConnectStart
   wird das Flag fuer die neue Drag-Session resettet.

2) Click-Click und einfaches Drag-to-Port erzeugten zwar das
   Kabel aber haben ReactFlow's Default-L-Routing genutzt
   (sah huebsch aus nur fuer kurze gerade Verbindungen).
   Sobald Geraete im Weg standen kreuzte sich das Kabel mit
   anderen, Korridore wurden ignoriert, etc.

   Fix: in createCableWithPlanCheck (App.tsx — der CableDialog-
   Submit-Wrapper) wird nach createCableFromPending geprueft ob
   der User WEGPUNKTE manuell gesetzt hatte. Wenn nicht (Drag
   oder Click-Click ohne Pane-Klicks) -> doppelter
   requestAnimationFrame -> routeCable(newCable.id) -> A*-Pfad
   um Obstacles. Pattern uebernommen aus RackInternalCanvas
   (v7.9.118 / #223) — dort schon erprobt fuer's Rack.

   Wenn der User selber Wegpunkte gesetzt hat, bleiben sie
   unberuehrt — sein Routing-Wunsch gewinnt.

Drag-from-Port-zu-anderem-Port (onConnect-Path) bleibt verhaltensmaessig gleich, kriegt aber jetzt zusaetzlich das Auto-A*-Routing.

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH