### PR TITLE
fix(canvas): Drag-Connect zwischen Ports — Overlay-Handle nicht-conne…

### DIFF
--- a/src/renderer/components/Canvas/EquipmentNode.tsx
+++ b/src/renderer/components/Canvas/EquipmentNode.tsx
@@ -768,6 +768,16 @@ export const EquipmentNode = ({ id, data, selected }: NodeProps<EquipmentNodeDat
               type="source"
               id={port.id}
               position={pos}
+              // v7.9.128 — Overlay-Handle NICHT connectable. Vorher waren
+              // beide Stacked-Handles fuer ReactFlow connectable und
+              // teilten dieselbe handleId — die (nodeId, handleId)-
+              // Registry konnte den Drop nicht eindeutig aufloesen,
+              // onConnect feuerte mal nicht. Mit ConnectionMode.Loose
+              // genuegt das real-Handle alleine fuer beide Richtungen,
+              // das Overlay ist nur noch da damit Klicks UND Drags
+              // ueber den ganzen Port-Hit-Bereich gehen (onClick laeuft
+              // weiterhin unabhaengig vom isConnectable-Flag).
+              isConnectable={false}
               onClick={handlePortClick(port.id, 'input')}
               style={{
                 top: rowCenter(placement.slot),
@@ -893,6 +903,10 @@ export const EquipmentNode = ({ id, data, selected }: NodeProps<EquipmentNodeDat
               type="target"
               id={port.id}
               position={pos}
+              // v7.9.128 — siehe Input-Overlay oben: nicht-connectable
+              // damit ReactFlow's Drag-Detection eindeutig auf das
+              // real-Handle faellt. Click-Handler bleibt aktiv.
+              isConnectable={false}
               onClick={handlePortClick(port.id, 'output')}
               style={{
                 top: rowCenter(placement.slot),


### PR DESCRIPTION
…ctable

User-Report: "selbst wenn ich von port zu port ein kabel ziehe durch nur dragging, wird es nicht verbunden — schon lange vor 7.9.128 so".

Root-Cause: jeder Port in EquipmentNode rendert ZWEI Handle-Komponenten gestapelt:

  Input-Port:
    1) <Handle type="target" id={port.id} isConnectable={!rackInternal} />
    2) <Handle type="source" id={port.id} />   ← Overlay, transparent

  Output-Port analog (real source + overlay target).

Das Overlay-Pattern stammt aus der Zeit vor ConnectionMode.Loose und sollte Drag-in-beide-Richtungen ermoeglichen. Mit Loose-Mode ist es ueberfluessig — das echte Handle nimmt jetzt sowieso beide Richtungen.

PROBLEM: Beide Stacked-Handles haben dieselbe handleId (port.id). ReactFlow's interne (nodeId, handleId)-Registry hat also zwei Eintraege fuer denselben Schluessel. Beim Drop konnte ReactFlow nicht eindeutig aufloesen welches Handle gemeint war — onConnect ist deshalb teilweise gar nicht gefeuert, der Drag schweigend ins Leere gelaufen.

Fix: Overlay-Handles auf isConnectable={false} setzen. Damit ignoriert ReactFlow sie fuer's Drag-Routing, das echte Handle ist eindeutig der Drop-Target. Die onClick-Handler auf den Overlays bleiben aktiv (HTML-Event, unabhaengig von isConnectable) — Click-to-Connect ueber den gesamten Hit-Bereich des Ports funktioniert weiter wie bisher.

Rack-Internal-Ports bleiben unveraendert (real-Handle hat weiter isConnectable={!rackInternal}).

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH