### PR TITLE
ui(rentman): 1-Klick-Sync — Dialog laedt verknuepftes Projekt auto

### DIFF
--- a/src/renderer/components/Library/LibraryPanel.tsx
+++ b/src/renderer/components/Library/LibraryPanel.tsx
@@ -1927,6 +1927,19 @@ export const LibraryPanel = () => {
                     <span className="rounded bg-red-950/50 px-1.5 py-0.5 text-red-200">{removed.length} entfernt</span>
                   )}
                 </div>
+                {/* v7.9.128 — Prominente "Aus Rentman aktualisieren"-Action.
+                    Oeffnet den RentmanImportDialog, der dank Auto-Load das
+                    verknuepfte Projekt direkt vorausgewaehlt + dessen
+                    Equipment direkt gefetched zeigt. So sieht der User
+                    in einem Klick was neu in Rentman ist. */}
+                <button
+                  type="button"
+                  onClick={openRentmanImport}
+                  className="mt-2 w-full rounded bg-orange-600 px-2 py-1.5 text-xs font-semibold text-white hover:bg-orange-500"
+                  title="Aktuelle Equipment-Liste aus dem verknuepften Rentman-Projekt holen — neue oder geaenderte Items werden im Dialog angezeigt."
+                >
+                  🔄 Aus Rentman aktualisieren / neue Items importieren
+                </button>
                 {(() => {
                   // v7.9.70 / #171 — Re-Sync Button: zeige nur wenn Canvas
                   // Equipment mit rentmanId hat, die im aktuellen Library-Set
@@ -2458,6 +2471,20 @@ export const LibraryPanel = () => {
                   <h2 className="text-sm font-semibold text-amber-300">Abgleich Canvas ↔ Rentman</h2>
                   <span className="text-[10px] text-slate-500">{untracked.length} nicht erfasst</span>
                 </div>
+                {/* v7.9.128 — Auch im Sync-View ein prominenter Fetch-Knopf.
+                    Der User landet hier wenn er pruefen will, was neu in
+                    Rentman ist — ohne diesen Knopf musste er zurueck zu
+                    Importiert und den orangenen Sync-Button suchen. */}
+                {linkedRentmanProjectId && (
+                  <button
+                    type="button"
+                    onClick={openRentmanImport}
+                    className="mb-3 w-full rounded bg-orange-600 px-2 py-1.5 text-xs font-semibold text-white hover:bg-orange-500"
+                    title="Equipment-Liste aus dem verknuepften Rentman-Projekt jetzt laden. Neue Items koennen direkt importiert werden."
+                  >
+                    🔄 Aus Rentman aktualisieren / neue Items importieren
+                  </button>
+                )}
                 {removed.length > 0 && (
                   <div className="mb-2 space-y-1">
                     <div className="mb-1 text-[10px] text-red-400">Nicht mehr in Rentman vorhanden:</div>

--- a/src/renderer/components/Rentman/RentmanImportDialog.tsx
+++ b/src/renderer/components/Rentman/RentmanImportDialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import { useTranslation } from '../../lib/i18n'
 import { infoDialog } from '../../lib/infoDialog'
@@ -437,6 +437,34 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
       a.type === b.type ? a.length - b.length : a.type.localeCompare(b.type),
     )
   }, [detectedCableRows])
+
+  // v7.9.128 — Auto-Load wenn der Dialog mit einem bereits verknuepften
+  // Rentman-Projekt geoeffnet wird. Bisher musste der User "Projekte
+  // laden" klicken, das Projekt finden und auswaehlen — viel Klick-Arbeit
+  // fuer einen simplen Re-Sync. Jetzt: Dialog auf -> Projekte werden
+  // automatisch geladen, das verknuepfte Projekt vorausgewaehlt, dessen
+  // Equipment direkt gefetched. User sieht sofort den aktuellen Stand
+  // und kann importieren / neue Geraete uebernehmen.
+  useEffect(() => {
+    if (!open || !linkedProjectId) return
+    if (loading) return
+    // Projekte noch nicht geladen? -> laden, dann auto-select.
+    if (projects.length === 0) {
+      void (async () => {
+        await fetchProjects()
+      })()
+      return
+    }
+    // Projekte da, aber noch nichts ausgewaehlt: das verknuepfte Projekt
+    // direkt auswaehlen und Equipment fetchen.
+    if (!selectedProjectId) {
+      const linked = projects.find((p) => p.id === linkedProjectId)
+      if (linked) {
+        void fetchEquipment(linked.id, linked.name)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, linkedProjectId, projects.length, selectedProjectId])
 
   if (!open) {
     return null


### PR DESCRIPTION
User-Pain: um neue Rentman-Items zu fetchen muss der User:
  1) Rentman-Import-Dialog oeffnen
  2) "Projekte laden" klicken
  3) das verknuepfte Projekt in der Liste finden + auswaehlen
  4) auf "Equipment laden" warten
  -> 4 Klicks fuer einen simplen Re-Sync.

Zwei Verbesserungen die das zu 1 Klick reduzieren:

1) RentmanImportDialog: neuer useEffect der bei open=true UND
   linkedProjectId gesetzt automatisch:
   a) Projekte laedt (wenn noch nicht geladen)
   b) Das verknuepfte Projekt vorausgewaehlt + dessen Equipment
      direkt fetched
   So sieht der User sofort den aktuellen Stand des Rentman-
   Projekts inklusive aller neuen Items, ohne den Drei-Schritte-
   Pfad durchklicken zu muessen.

2) LibraryPanel: zwei neue prominente orange Aktions-Buttons
   "🔄 Aus Rentman aktualisieren / neue Items importieren":
   a) Im linked-Project-Stats-Block (Importiert-View) direkt
      unter den Counter-Chips
   b) Im Sync-View ganz oben — der User landet hier wenn er
      pruefen will was neu in Rentman ist, hier ist der Knopf
      jetzt direkt im Blickfeld statt zurueck zum anderen Tab
      zu muessen.
   Beide oeffnen den RentmanImportDialog, der dank (1) sofort
   den verknuepften Projekt-Stand zeigt.

Resultat: 1-Klick-Sync. Bisheriger manueller Import-Flow funktioniert unveraendert weiter wenn kein Projekt verknuepft ist (loadProjects-Button greift wie zuvor).

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH