### PR TITLE
feat(videohub): VideoHubSim-Komplett-Adoption (v7.9.128)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.9.126",
+    "version": "7.9.128",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/src/main/ipc/videohubIpc.ts
+++ b/src/main/ipc/videohubIpc.ts
@@ -1,6 +1,156 @@
 import { ipcMain } from 'electron'
 import net from 'net'
 
+/**
+ * v7.9.128 — Parser fuer Videohub-Protokoll-State-Dumps.
+ *
+ * Bei Connect schickt jeder Blackmagic Videohub einen vollstaendigen
+ * State-Dump in mehreren Bloecken, getrennt durch Leerzeilen:
+ *
+ *   PROTOCOL PREAMBLE:
+ *   Version: 2.8
+ *
+ *   VIDEOHUB DEVICE:
+ *   Device present: true
+ *   Model name: Blackmagic Smart Videohub 12G 40 x 40
+ *   Video inputs: 40
+ *   Video outputs: 40
+ *
+ *   INPUT LABELS:
+ *   0 SDI In 1
+ *   1 Cam Stage
+ *   ...
+ *
+ *   OUTPUT LABELS:
+ *   0 PGM
+ *   1 PVW
+ *   ...
+ *
+ *   VIDEO OUTPUT LOCKS:
+ *   0 U         ← U=unlocked, L=locked-by-other, O=locked-by-self
+ *   1 L
+ *   ...
+ *
+ *   VIDEO OUTPUT ROUTING:
+ *   0 5         ← Output 0 wird gespeist von Input 5
+ *   1 0
+ *   ...
+ *
+ *   CONFIGURATION:
+ *   Take Mode: false
+ *
+ * Diese Funktion parsed den kompletten Dump in ein strukturiertes Objekt.
+ * Unbekannte Blocks werden ignoriert.
+ */
+export interface VideohubState {
+  protocolVersion?: string
+  modelName?: string
+  friendlyName?: string
+  uniqueId?: string
+  videoInputs?: number
+  videoOutputs?: number
+  inputLabels: Record<number, string>
+  outputLabels: Record<number, string>
+  outputLocks: Record<number, 'unlocked' | 'locked-other' | 'locked-self'>
+  routing: Record<number, number>
+  takeMode?: boolean
+}
+
+const emptyState = (): VideohubState => ({
+  inputLabels: {},
+  outputLabels: {},
+  outputLocks: {},
+  routing: {},
+})
+
+const parseVideohubDump = (buffer: string): VideohubState => {
+  const state = emptyState()
+  // Bloecke sind durch Leerzeilen getrennt. Jede Block beginnt mit
+  // einer "HEADER:" Zeile gefolgt von 1..N Datenzeilen.
+  const blocks = buffer.split(/\r?\n\r?\n/)
+  for (const block of blocks) {
+    const lines = block.split(/\r?\n/).filter((l) => l.length > 0)
+    if (lines.length === 0) continue
+    const header = lines[0].replace(/:\s*$/, '').toUpperCase()
+    const data = lines.slice(1)
+    switch (header) {
+      case 'PROTOCOL PREAMBLE': {
+        for (const line of data) {
+          const m = line.match(/^Version:\s*(.+)$/i)
+          if (m) state.protocolVersion = m[1].trim()
+        }
+        break
+      }
+      case 'VIDEOHUB DEVICE': {
+        for (const line of data) {
+          const [key, ...rest] = line.split(':')
+          const value = rest.join(':').trim()
+          switch (key.trim().toLowerCase()) {
+            case 'model name':
+              state.modelName = value
+              break
+            case 'friendly name':
+              state.friendlyName = value
+              break
+            case 'unique id':
+              state.uniqueId = value
+              break
+            case 'video inputs':
+              state.videoInputs = parseInt(value, 10) || undefined
+              break
+            case 'video outputs':
+              state.videoOutputs = parseInt(value, 10) || undefined
+              break
+          }
+        }
+        break
+      }
+      case 'INPUT LABELS': {
+        for (const line of data) {
+          const m = line.match(/^(\d+)\s+(.*)$/)
+          if (m) state.inputLabels[parseInt(m[1], 10)] = m[2]
+        }
+        break
+      }
+      case 'OUTPUT LABELS': {
+        for (const line of data) {
+          const m = line.match(/^(\d+)\s+(.*)$/)
+          if (m) state.outputLabels[parseInt(m[1], 10)] = m[2]
+        }
+        break
+      }
+      case 'VIDEO OUTPUT LOCKS': {
+        for (const line of data) {
+          const m = line.match(/^(\d+)\s+([ULO])\s*$/i)
+          if (m) {
+            const idx = parseInt(m[1], 10)
+            const code = m[2].toUpperCase()
+            state.outputLocks[idx] =
+              code === 'L' ? 'locked-other' : code === 'O' ? 'locked-self' : 'unlocked'
+          }
+        }
+        break
+      }
+      case 'VIDEO OUTPUT ROUTING': {
+        for (const line of data) {
+          const m = line.match(/^(\d+)\s+(\d+)\s*$/)
+          if (m) state.routing[parseInt(m[1], 10)] = parseInt(m[2], 10)
+        }
+        break
+      }
+      case 'CONFIGURATION': {
+        for (const line of data) {
+          const m = line.match(/^Take Mode:\s*(true|false)$/i)
+          if (m) state.takeMode = m[1].toLowerCase() === 'true'
+        }
+        break
+      }
+      // Unknown blocks (e.g. VIDEO MONITORING OUTPUT LABELS, SERIAL PORT DIRECTIONS) — ignored.
+    }
+  }
+  return state
+}
+
 export function registerVideohubIpc() {
   /**
    * Send a Videohub protocol command block to a real Blackmagic Videohub via TCP.
@@ -68,6 +218,90 @@ export function registerVideohubIpc() {
           }
         })
       })
+    },
+  )
+
+  /**
+   * v7.9.128 — Read full state dump from a Videohub.
+   *
+   * Strategie: Verbinden, alle Bloecke (PROTOCOL PREAMBLE,
+   * VIDEOHUB DEVICE, INPUT LABELS, OUTPUT LABELS, VIDEO OUTPUT LOCKS,
+   * VIDEO OUTPUT ROUTING, CONFIGURATION) sammeln bis 600ms keine
+   * Daten mehr kommen (= initialer Dump abgeschlossen), dann
+   * disconnect + parsen + zurueckgeben.
+   *
+   * Verwendung im Renderer: User klickt "Status laden" -> bekommt
+   * echte Labels + aktuelles Routing + Lock-State vom Hub statt
+   * Defaults aus dem Canvas. Auch fuer den UI-Stand "was steht
+   * gerade im Hub vs. was hat der User in der Matrix konfiguriert"
+   * wichtig.
+   */
+  ipcMain.handle(
+    'videohub:read-state',
+    (_, { host, port }: { host: string; port: number }) => {
+      return new Promise<{ ok: boolean; message: string; state: VideohubState | null }>(
+        (resolve) => {
+          if (!host || !/^[\w.\-:]+$/.test(host)) {
+            resolve({ ok: false, message: 'Ungueltige IP-Adresse', state: null })
+            return
+          }
+          if (!Number.isInteger(port) || port < 1 || port > 65535) {
+            resolve({ ok: false, message: 'Ungueltiger Port', state: null })
+            return
+          }
+
+          const socket = new net.Socket()
+          let buffer = ''
+          let settled = false
+          // Silence-Detector: nach 600ms ohne neue Daten ist der
+          // initiale State-Dump fertig. Wert ist konservativ — selbst
+          // 288x288 Hubs schicken alles in < 200ms ueber LAN.
+          let silenceTimer: NodeJS.Timeout | null = null
+
+          const done = (ok: boolean, message: string, state: VideohubState | null) => {
+            if (settled) return
+            settled = true
+            clearTimeout(connectTimer)
+            if (silenceTimer) clearTimeout(silenceTimer)
+            socket.destroy()
+            resolve({ ok, message, state })
+          }
+
+          const connectTimer = setTimeout(() => {
+            done(false, 'Timeout: keine Verbindung zum Videohub (5 s)', null)
+          }, 5000)
+
+          const scheduleParse = () => {
+            if (silenceTimer) clearTimeout(silenceTimer)
+            silenceTimer = setTimeout(() => {
+              const state = parseVideohubDump(buffer)
+              done(true, 'Status erfolgreich gelesen', state)
+            }, 600)
+          }
+
+          socket.connect(port, host)
+
+          socket.on('error', (err) => {
+            done(false, `Verbindungsfehler: ${err.message}`, null)
+          })
+
+          socket.on('data', (data) => {
+            buffer += data.toString()
+            scheduleParse()
+          })
+
+          socket.on('close', () => {
+            // Verbindung selbst-aktiv beendet vom Hub? Wenn wir
+            // schon Daten haben, ausparsen, sonst Fehler.
+            if (buffer.length > 0) {
+              const state = parseVideohubDump(buffer)
+              done(true, 'Status erfolgreich gelesen (Verbindung getrennt)', state)
+            } else if (!settled) {
+              done(false, 'Verbindung vom Hub getrennt ohne Daten', null)
+            }
+          })
+        },
+      )
     },
   )
 }

--- a/src/main/preload.cts
+++ b/src/main/preload.cts
@@ -117,6 +117,24 @@ contextBridge.exposeInMainWorld('cablePlanner', {
   videohub: {
     sendRouting: (params: { host: string; port: number; block: string }) =>
       ipcRenderer.invoke('videohub:send', params) as Promise<{ ok: boolean; message: string }>,
+    readState: (params: { host: string; port: number }) =>
+      ipcRenderer.invoke('videohub:read-state', params) as Promise<{
+        ok: boolean
+        message: string
+        state: {
+          protocolVersion?: string
+          modelName?: string
+          friendlyName?: string
+          uniqueId?: string
+          videoInputs?: number
+          videoOutputs?: number
+          inputLabels: Record<number, string>
+          outputLabels: Record<number, string>
+          outputLocks: Record<number, 'unlocked' | 'locked-other' | 'locked-self'>
+          routing: Record<number, number>
+          takeMode?: boolean
+        } | null
+      }>,
   },
   logs: {
     rendererError: (payload: { message: string; stack?: string; source?: string }) =>

--- a/src/renderer/components/Export/VideohubExportDialog.tsx
+++ b/src/renderer/components/Export/VideohubExportDialog.tsx
@@ -1,4 +1,4 @@
-﻿import { useMemo, useState } from 'react'
+﻿import { useEffect, useMemo, useState } from 'react'
 import { useProjectStore } from '../../store/projectStore'
 import { guessVideohubPresetKey } from '../../lib/deviceKind'
 import { downloadBlob } from '../../lib/downloadBlob'
@@ -10,7 +10,7 @@ import {
   videohubPresets,
 } from '../../lib/exportVideohub'
 import { VideohubRoutingMatrix } from './VideohubRoutingMatrix'
-import { cablePlannerApi, hasDesktopBridge } from '../../lib/bridge'
+import { cablePlannerApi, hasDesktopBridge, type VideohubState } from '../../lib/bridge'
 
 interface Props {
   onClose: () => void
@@ -59,6 +59,137 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
   const [vhPort, setVhPort] = useState('9990')
   const [sendStatus, setSendStatus] = useState<SendStatus>('idle')
   const [sendMessage, setSendMessage] = useState('')
+
+  // v7.9.128 — VideoHubSim-inspired UI-Features:
+  //
+  // 1) Activity-Log: jede Sende-Aktion (Routing-Push, Salvo-Apply,
+  //    Verbindungs-Versuch) wird zeit-gestempelt protokolliert.
+  //    State only — wird nicht persistiert, frisch pro Dialog-Open.
+  type LogEntry = { ts: number; text: string; ok: boolean }
+  const [activityLog, setActivityLog] = useState<LogEntry[]>([])
+  const logEvent = (text: string, ok = true) =>
+    setActivityLog((prev) => [{ ts: Date.now(), text, ok }, ...prev].slice(0, 50))
+
+  // 2) Connection-History: zuletzt benutzte IP/Port-Kombinationen.
+  //    LocalStorage, max 8 Eintraege, frischeste oben.
+  type ConnEntry = { host: string; port: string; lastUsed: number }
+  const CONN_HISTORY_KEY = 'cable-planner.videohub.connections'
+  const [connHistory, setConnHistory] = useState<ConnEntry[]>(() => {
+    try {
+      const raw = localStorage.getItem(CONN_HISTORY_KEY)
+      if (!raw) return []
+      const parsed = JSON.parse(raw) as ConnEntry[]
+      if (!Array.isArray(parsed)) return []
+      return parsed.slice(0, 8)
+    } catch {
+      return []
+    }
+  })
+  const persistConnHistory = (list: ConnEntry[]) => {
+    try {
+      localStorage.setItem(CONN_HISTORY_KEY, JSON.stringify(list.slice(0, 8)))
+    } catch {
+      /* ignore quota */
+    }
+  }
+  const recordConnection = (host: string, port: string) => {
+    setConnHistory((prev) => {
+      const filtered = prev.filter((c) => !(c.host === host && c.port === port))
+      const next = [{ host, port, lastUsed: Date.now() }, ...filtered].slice(0, 8)
+      persistConnHistory(next)
+      return next
+    })
+  }
+
+  // 3) Salvos: benannte Routing-Snapshots zum spaeteren Wiederherstellen.
+  //    Pro Device gespeichert (key: deviceId), in localStorage.
+  type Salvo = { id: string; name: string; routing: Record<number, number>; createdAt: number }
+  const salvoKey = `cable-planner.videohub.salvos.${deviceId || '_'}`
+  const [salvos, setSalvos] = useState<Salvo[]>([])
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(salvoKey)
+      const parsed = raw ? (JSON.parse(raw) as Salvo[]) : []
+      setSalvos(Array.isArray(parsed) ? parsed : [])
+    } catch {
+      setSalvos([])
+    }
+  }, [salvoKey])
+  const persistSalvos = (list: Salvo[]) => {
+    try {
+      localStorage.setItem(salvoKey, JSON.stringify(list))
+    } catch {
+      /* ignore quota */
+    }
+  }
+  const saveSalvo = () => {
+    const name = window.prompt('Salvo-Name (= Routing-Snapshot speichern):')?.trim()
+    if (!name) return
+    const next: Salvo[] = [
+      { id: crypto.randomUUID(), name, routing: { ...routing }, createdAt: Date.now() },
+      ...salvos.filter((s) => s.name !== name),
+    ]
+    setSalvos(next)
+    persistSalvos(next)
+    logEvent(`Salvo gespeichert: "${name}" (${Object.keys(routing).length} Routen)`)
+  }
+  const recallSalvo = (s: Salvo) => {
+    setRouting({ ...s.routing })
+    logEvent(`Salvo geladen: "${s.name}"`)
+  }
+  const deleteSalvo = (id: string) => {
+    const next = salvos.filter((s) => s.id !== id)
+    setSalvos(next)
+    persistSalvos(next)
+  }
+
+  // v7.9.128 — Live-State vom Hub (Labels + Routing + Locks). Wird per
+  // "Status laden"-Button gefuellt. Wenn vorhanden, gewinnen die echten
+  // Hub-Labels gegenueber den Canvas-Defaults.
+  const [hubState, setHubState] = useState<VideohubState | null>(null)
+  const [readingState, setReadingState] = useState(false)
+
+  const handleReadState = async () => {
+    if (!device) return
+    const port = parseInt(vhPort, 10)
+    if (!vhHost.trim() || isNaN(port)) {
+      logEvent('Status-Read abgebrochen: ungueltige IP/Port', false)
+      return
+    }
+    setReadingState(true)
+    logEvent(`Status-Read von ${vhHost.trim()}:${port} …`)
+    try {
+      const result = await cablePlannerApi.videohub.readState({
+        host: vhHost.trim(),
+        port,
+      })
+      if (result.ok && result.state) {
+        setHubState(result.state)
+        // Aktuelles Routing vom Hub uebernehmen
+        if (Object.keys(result.state.routing).length > 0) {
+          setRouting({ ...result.state.routing })
+        }
+        const labels = Object.keys(result.state.inputLabels).length
+        const locks = Object.values(result.state.outputLocks).filter(
+          (v) => v !== 'unlocked',
+        ).length
+        logEvent(
+          `Status geladen: ${result.state.modelName ?? 'Unbekannt'} · ` +
+            `${labels} Labels · ${locks} Locks · Routing ${Object.keys(result.state.routing).length}`,
+        )
+        recordConnection(vhHost.trim(), String(port))
+      } else {
+        logEvent(`Status-Read Fehler: ${result.message}`, false)
+      }
+    } catch (e) {
+      logEvent(
+        `Exception bei Status-Read: ${e instanceof Error ? e.message : String(e)}`,
+        false,
+      )
+    } finally {
+      setReadingState(false)
+    }
+  }
 
   const device = equipment.find((e) => e.id === deviceId)
   const preset = videohubPresets.find((p) => p.key === presetKey) ?? videohubPresets[0]
@@ -178,10 +309,12 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
     if (!vhHost.trim() || isNaN(port)) {
       setSendStatus('error')
       setSendMessage('Bitte gültige IP und Port angeben.')
+      logEvent('Send abgebrochen: ungueltige IP/Port', false)
       return
     }
     setSendStatus('sending')
     setSendMessage('')
+    logEvent(`Senden an ${vhHost.trim()}:${port} …`)
     const block = buildVideohubRoutingCommand(routing, preset.outputs)
     try {
       const result = await cablePlannerApi.videohub.sendRouting({
@@ -191,9 +324,16 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
       })
       setSendStatus(result.ok ? 'ok' : 'error')
       setSendMessage(result.message)
+      logEvent(
+        `${result.ok ? 'OK' : 'Fehler'}: ${result.message}`,
+        result.ok,
+      )
+      if (result.ok) recordConnection(vhHost.trim(), String(port))
     } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Unbekannter Fehler'
       setSendStatus('error')
-      setSendMessage(e instanceof Error ? e.message : 'Unbekannter Fehler')
+      setSendMessage(msg)
+      logEvent(`Exception: ${msg}`, false)
     }
   }
 
@@ -318,23 +458,89 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                 totalInputs={preset.inputs}
                 totalOutputs={preset.outputs}
                 inputLabels={Array.from({ length: preset.inputs }, (_, i) => {
+                  // v7.9.128 — Hub-Labels gewinnen wenn vom Hub geladen
+                  // ("Status laden"). Sonst Canvas-Port-Name + (wenn
+                  // verkabelt) die Source aus dem Canvas (v7.9.119).
+                  const hubLabel = hubState?.inputLabels?.[i]
+                  if (hubLabel) return hubLabel
                   const portName = device?.inputs[i]?.name ?? `In ${i + 1}`
-                  // v7.9.119 — Label um die Source aus dem Canvas ergaenzen.
                   const conn = connections.inputConn.get(i)
                   return conn
                     ? `${portName} ← ${conn.sourceName}`
                     : portName
                 })}
                 outputLabels={Array.from({ length: preset.outputs }, (_, i) => {
+                  const hubLabel = hubState?.outputLabels?.[i]
+                  const lockState = hubState?.outputLocks?.[i]
+                  const lockBadge =
+                    lockState === 'locked-self'
+                      ? ' 🔒'
+                      : lockState === 'locked-other'
+                        ? ' 🔒❗'
+                        : ''
+                  if (hubLabel) return `${hubLabel}${lockBadge}`
                   const portName = device?.outputs[i]?.name ?? `Out ${i + 1}`
                   const conn = connections.outputConn.get(i)
                   return conn
-                    ? `${portName} → ${conn.destName}`
-                    : portName
+                    ? `${portName} → ${conn.destName}${lockBadge}`
+                    : `${portName}${lockBadge}`
                 })}
                 routing={routing}
                 onRoute={(output, input) => setRouting((r) => ({ ...r, [output]: input }))}
               />
+            )}
+          </div>
+        )}
+
+        {/* v7.9.128 — Salvos: benannte Routing-Snapshots speichern/laden.
+            Inspiriert von VideoHubSim. Pro Device + Preset gespeichert in
+            localStorage. */}
+        {format === 'routing' && showMatrix && (
+          <div className="mb-3 rounded border border-cyan-700/40 bg-cyan-950/20 p-2">
+            <div className="mb-2 flex items-center justify-between">
+              <div className="text-[10px] uppercase tracking-wide text-cyan-300">
+                Salvos (Routing-Snapshots)
+              </div>
+              <button
+                type="button"
+                onClick={saveSalvo}
+                className="rounded bg-cyan-700 px-2 py-0.5 text-[11px] text-white hover:bg-cyan-600"
+                title="Aktuelles Routing als benannten Snapshot speichern"
+              >
+                + Aktuelles Routing speichern
+              </button>
+            </div>
+            {salvos.length === 0 ? (
+              <div className="text-[11px] text-slate-500">
+                Noch keine Salvos. Speichere die aktuelle Crosspoint-Verteilung
+                und ruf sie spaeter mit einem Klick zurueck.
+              </div>
+            ) : (
+              <div className="flex flex-wrap gap-1">
+                {salvos.map((s) => (
+                  <div
+                    key={s.id}
+                    className="flex items-center gap-1 rounded border border-cyan-800/60 bg-cyan-950/40 px-1.5 py-0.5 text-[11px]"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => recallSalvo(s)}
+                      className="text-cyan-100 hover:text-white"
+                      title={`Salvo "${s.name}" laden (${Object.keys(s.routing).length} Routen, ${new Date(s.createdAt).toLocaleString('de-DE')})`}
+                    >
+                      📋 {s.name}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => deleteSalvo(s.id)}
+                      className="text-slate-500 hover:text-red-400"
+                      title="Salvo loeschen"
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+              </div>
             )}
           </div>
         )}
@@ -351,15 +557,44 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
             <div className="flex items-end gap-2">
               <label className="block flex-1 text-xs">
                 IP-Adresse
-                <input
-                  value={vhHost}
-                  onChange={(e) => {
-                    setVhHost(e.target.value)
-                    setSendStatus('idle')
-                  }}
-                  placeholder="192.168.1.1"
-                  className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-1.5 font-mono text-xs"
-                />
+                <div className="mt-1 flex items-stretch gap-1">
+                  <input
+                    value={vhHost}
+                    onChange={(e) => {
+                      setVhHost(e.target.value)
+                      setSendStatus('idle')
+                    }}
+                    placeholder="192.168.1.1"
+                    className="flex-1 rounded border border-slate-700 bg-slate-950 p-1.5 font-mono text-xs"
+                  />
+                  {/* v7.9.128 — Connection-History: zuletzt benutzte
+                      IP/Port-Kombinationen. Wird beim erfolgreichen Send
+                      automatisch gepflegt. */}
+                  {connHistory.length > 0 && (
+                    <select
+                      value=""
+                      onChange={(e) => {
+                        const idx = parseInt(e.target.value, 10)
+                        if (isNaN(idx)) return
+                        const pick = connHistory[idx]
+                        if (pick) {
+                          setVhHost(pick.host)
+                          setVhPort(pick.port)
+                          setSendStatus('idle')
+                        }
+                      }}
+                      title="Zuletzt benutzte Verbindungen"
+                      className="w-10 rounded border border-slate-700 bg-slate-950 px-1 text-xs"
+                    >
+                      <option value="">▼</option>
+                      {connHistory.map((c, i) => (
+                        <option key={`${c.host}-${c.port}-${c.lastUsed}`} value={i}>
+                          {c.host}:{c.port}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                </div>
               </label>
               <label className="block w-20 text-xs">
                 Port
@@ -375,6 +610,15 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
               </label>
               <button
                 type="button"
+                onClick={() => { void handleReadState() }}
+                disabled={!device || !hasDesktopBridge || readingState}
+                title="Aktuellen Hub-Status holen: Labels + Routing + Locks. Routing wird in die Matrix uebernommen, Labels in den Spalten/Zeilen angezeigt."
+                className="rounded bg-sky-700 px-3 py-1.5 text-xs hover:bg-sky-600 disabled:opacity-40"
+              >
+                {readingState ? '⏳ Laden…' : '⬇ Status laden'}
+              </button>
+              <button
+                type="button"
                 onClick={() => { void handleSend() }}
                 disabled={!device || !hasDesktopBridge || sendStatus === 'sending'}
                 className="rounded bg-purple-700 px-3 py-1.5 text-xs hover:bg-purple-600 disabled:opacity-40"
@@ -382,6 +626,28 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                 {sendStatus === 'sending' ? '⏳ Senden…' : '⬆ Routing übertragen'}
               </button>
             </div>
+            {hubState && (
+              <div className="mt-1.5 rounded border border-sky-700/40 bg-sky-950/30 p-1.5 text-[11px] text-sky-100">
+                <span className="font-semibold">Hub-Status:</span>{' '}
+                {hubState.modelName ?? 'Unbekannt'}{' '}
+                {hubState.friendlyName && `("${hubState.friendlyName}")`}
+                {hubState.videoInputs && hubState.videoOutputs && (
+                  <span className="ml-1 text-sky-300">
+                    {' '}· {hubState.videoInputs}×{hubState.videoOutputs}
+                  </span>
+                )}
+                {(() => {
+                  const lockedCount = Object.values(hubState.outputLocks).filter(
+                    (v) => v !== 'unlocked',
+                  ).length
+                  return lockedCount > 0 ? (
+                    <span className="ml-2 rounded bg-amber-900/40 px-1 py-0.5 text-amber-200">
+                      🔒 {lockedCount} Output{lockedCount !== 1 ? 's' : ''} gesperrt
+                    </span>
+                  ) : null
+                })()}
+              </div>
+            )}
             {sendStatus !== 'idle' && (
               <div
                 className={`mt-1.5 rounded p-1.5 text-xs ${
@@ -396,6 +662,32 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                 {sendStatus === 'error' && '✗ '}
                 {sendMessage}
               </div>
+            )}
+            {/* v7.9.128 — Activity-Log (VideoHubSim-Style): rolling list
+                der letzten 50 Events (Sende-Versuche, Salvos, Connection-
+                Wechsel). Hilft beim Debuggen ("warum sagt Hub jetzt
+                NAK"). Wird beim Dialog-Close vergessen. */}
+            {activityLog.length > 0 && (
+              <details className="mt-2 text-[11px]">
+                <summary className="cursor-pointer text-slate-400 hover:text-slate-200">
+                  Activity-Log ({activityLog.length})
+                </summary>
+                <div className="mt-1 max-h-32 space-y-0.5 overflow-auto rounded border border-slate-800 bg-slate-950/60 p-1.5 font-mono">
+                  {activityLog.map((e, i) => (
+                    <div
+                      key={`${e.ts}-${i}`}
+                      className={`whitespace-nowrap ${
+                        e.ok ? 'text-slate-300' : 'text-red-300'
+                      }`}
+                    >
+                      <span className="text-slate-500">
+                        {new Date(e.ts).toLocaleTimeString('de-DE')}
+                      </span>{' '}
+                      {e.text}
+                    </div>
+                  ))}
+                </div>
+              </details>
             )}
           </div>
         )}

--- a/src/renderer/components/Export/VideohubRoutingMatrix.tsx
+++ b/src/renderer/components/Export/VideohubRoutingMatrix.tsx
@@ -56,6 +56,11 @@ export const VideohubRoutingMatrix = ({
   const useGrid = cellCount <= 100_000
 
   const [hover, setHover] = useState<{ row: number; col: number } | null>(null)
+  // v7.9.128 — Drag-to-route: User klickt + zieht ueber Cells, jede
+  // ueberfahrene Cell wird geroutet. Diagonal-Drag (Out N -> In N,
+  // N+1 -> N+1, ...) ergibt sequenzielles 1:1. Vertikaler Drag
+  // (mehrere Outs auf denselben In) ergibt Multicast.
+  const [dragging, setDragging] = useState(false)
   const rowRefs = useRef<Array<HTMLTableRowElement | null>>([])
 
   // List-Mode bei riesigen Matrizen — DOM wuerde sonst kollabieren.
@@ -135,6 +140,7 @@ export const VideohubRoutingMatrix = ({
       className="overflow-auto rounded border border-slate-700 bg-slate-950"
       style={{ maxHeight }}
       onMouseLeave={() => setHover(null)}
+      onMouseUp={() => setDragging(false)}
     >
       <table className="border-collapse" style={{ fontSize: fontPx }}>
         <thead>
@@ -278,12 +284,20 @@ export const VideohubRoutingMatrix = ({
                       className={`p-0 text-center ${groupBreak ? 'border-l border-slate-700' : ''} ${
                         inCol && !rowOn ? 'bg-sky-900/30' : ''
                       }`}
-                      onMouseEnter={() => setHover({ row: oi, col: ii })}
+                      onMouseEnter={() => {
+                        setHover({ row: oi, col: ii })
+                        // Drag-Mode: jede ueberfahrene Cell routen.
+                        if (dragging) onRoute(oi, ii)
+                      }}
                     >
                       <button
                         type="button"
-                        onClick={() => onRoute(oi, ii)}
-                        title={`${outLabelTip[oi]} ← ${inLabelTip[ii]}`}
+                        onMouseDown={(e) => {
+                          e.preventDefault()
+                          setDragging(true)
+                          onRoute(oi, ii)
+                        }}
+                        title={`${outLabelTip[oi]} ← ${inLabelTip[ii]} (klick + ziehen fuer 1:1-Routing)`}
                         aria-label={`Set Output ${oi + 1} (${outLabel}) to Input ${ii + 1} (${inLabel})`}
                         className={
                           active

--- a/src/renderer/lib/bridge.ts
+++ b/src/renderer/lib/bridge.ts
@@ -14,6 +14,21 @@ export interface AtemInputSummary {
   sourceAvailability?: number
 }
 
+/** v7.9.128 — Vollstaendiger State-Dump eines Videohubs (parsed). */
+export interface VideohubState {
+  protocolVersion?: string
+  modelName?: string
+  friendlyName?: string
+  uniqueId?: string
+  videoInputs?: number
+  videoOutputs?: number
+  inputLabels: Record<number, string>
+  outputLabels: Record<number, string>
+  outputLocks: Record<number, 'unlocked' | 'locked-other' | 'locked-self'>
+  routing: Record<number, number>
+  takeMode?: boolean
+}
+
 export interface AtemMultiviewerWindow {
   windowIndex: number
   sourceId: number
@@ -162,6 +177,11 @@ type CablePlannerApi = {
   }
   videohub: {
     sendRouting: (params: { host: string; port: number; block: string }) => Promise<{ ok: boolean; message: string }>
+    readState: (params: { host: string; port: number }) => Promise<{
+      ok: boolean
+      message: string
+      state: VideohubState | null
+    }>
   }
   logs: {
     rendererError: (payload: { message: string; stack?: string; source?: string }) => void
@@ -606,6 +626,11 @@ const webFallbackApi: CablePlannerApi = {
     sendRouting: async () => ({
       ok: false,
       message: 'TCP-Übertragung erfordert die Desktop-App.',
+    }),
+    readState: async () => ({
+      ok: false,
+      message: 'TCP-Lese-Zugriff erfordert die Desktop-App.',
+      state: null,
     }),
   },
   logs: {


### PR DESCRIPTION
User: "sehr gut. uebernehme alle features" (= alle Features von VideoHubSim die fuer einen CLIENT statt einem SIMULATOR sinnvoll sind).

UI im VideohubExportDialog + VideohubRoutingMatrix:

1) **Drag-to-Route**: Klick+Ziehen in der Matrix routet jede
   ueberfahrene Cell. Diagonal-Drag = 1:1-Sequential, vertikal =
   Multicast (mehrere Outs auf denselben In). mouseUp am Wrapper
   schliesst die Drag-Session auch wenn der User ausserhalb der
   Matrix loslaesst.

2) **Salvos** (Routing-Snapshots): pro Device gespeichert in
   localStorage. Neuer Cyan-Block unter der Matrix mit Knopf
   "+ Aktuelles Routing speichern" und Chip-Liste der vorhandenen
   Salvos mit Klick zum Wiederherstellen, "×" zum Loeschen.
   Prompt fuer den Namen, Timestamp wird mitgespeichert.

3) **Activity-Log**: rolling-list der letzten 50 Events (Sende-
   Versuche, Salvo-Operations, Status-Reads). Eingeklappt als
   <details>, Zeitstempel + ok/error-Color. State only, wird beim
   Dialog-Close vergessen.

4) **Connection-History**: bei jedem erfolgreichen Send wird die
   benutzte IP+Port-Kombi in localStorage (max 8) gespeichert.
   Klein-Dropdown direkt neben dem IP-Input erlaubt 1-Klick-
   Wiederherstellung zuletzt benutzter Verbindungen.

Backend videohubIpc.ts (Phase 2):

5) **State-Reader**: neuer 'videohub:read-state'-IPC. Verbindet,
   sammelt alle Bloecke (PROTOCOL PREAMBLE, VIDEOHUB DEVICE,
   INPUT LABELS, OUTPUT LABELS, VIDEO OUTPUT LOCKS, VIDEO OUTPUT
   ROUTING, CONFIGURATION), wartet 600ms Silence-Detector bis
   der initiale Dump fertig ist, dann disconnect + parsen.
   Liefert strukturiertes VideohubState-Objekt zurueck.

6) **Lock-State-Visualisierung**: wenn Hub-State geladen ist,
   zeigen die Output-Labels in der Matrix jetzt 🔒 (self-locked)
   oder 🔒❗ (other-locked) je nach Status. Status-Zeile ueber
   dem Send-Block zeigt Modellname, Friendly-Name, Dimensions
   und Lock-Count auf einen Blick.

7) **Hub-Labels uebernehmen**: nach Status-Read werden die ECHTEN
   Labels des Hubs in die Matrix gerendert statt der Canvas-
   Defaults. Aktuelles Routing vom Hub wird auch direkt in die
   Matrix-State uebernommen.

Bridge + Preload entsprechend erweitert (sendRouting + readState). Web-Fallback liefert 'erfordert Desktop-App'.

Type-Check: 0 neue Fehler in app/main/preload, Baseline 36 unveraendert.

VideoHubSim-Patterns die wir NICHT uebernommen haben:
- Multi-Protocol (SW-P-08, GV Native) — wir reden nur mit Blackmagic-Hubs, andere Protokolle out-of-scope.
- Multi-Client (Simulator-Pattern) — wir sind Client, nicht Server.
- Persistent multi-command TCP — aktuell weiter one-shot, ist bei den paar Routen pro Send-Vorgang kein Bottleneck.
- Minimap fuer grosse Matrizen — separates Folge-Issue, das Matrix-Re-Layout zu aufwendig fuer diesen Commit.
- Right-click Label-Rename — separates Folge-Issue, Storage-Ort fuer ueberschriebene Labels muss noch designed werden.

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH