### PR TITLE
ui(videohub): Matrix-Restyle — sauberer Header, Group-Stripes, breite…

### DIFF
--- a/src/renderer/components/Export/VideohubExportDialog.tsx
+++ b/src/renderer/components/Export/VideohubExportDialog.tsx
@@ -385,7 +385,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-6">
-      <div className="flex max-h-[90vh] w-full max-w-3xl flex-col overflow-hidden rounded border border-slate-700 bg-slate-900 p-4 text-slate-100">
+      <div className="flex max-h-[95vh] w-full max-w-6xl flex-col overflow-hidden rounded border border-slate-700 bg-slate-900 p-4 text-slate-100">
         <div className="mb-3 flex items-center justify-between">
           <h3 className="text-base font-semibold">🎚 Videohub konfigurieren · Labels + Routing</h3>
           <button

--- a/src/renderer/components/Export/VideohubRoutingMatrix.tsx
+++ b/src/renderer/components/Export/VideohubRoutingMatrix.tsx
@@ -12,37 +12,29 @@ interface Props {
 /**
  * Interactive routing crosspoint matrix for Blackmagic Videohub.
  *
- * v7.9.128 — UI-Lift inspiriert vom open-source VideoHubSim
- * (https://github.com/videojedi/VideoHubSim). Wesentliche
- * Aenderungen gegenueber dem alten Grid:
+ * v7.9.128 — UI im Stil von VideoHubSim
+ * (https://github.com/videojedi/VideoHubSim) — explizite Trennung von
+ * Index-Spalte vs. Label-Spalte, klare Grid-Linien, broadcast-typische
+ * 8er-Gruppierung, dezent abwechselnde Group-Backgrounds, grosse
+ * Klick-Targets bei kleinen Hubs.
  *
- * 1. **Index-Spalten/-Zeilen**: links neben den Output-Labels und
- *    ueber den Input-Labels steht jetzt die laufende Port-Nummer
- *    (1-N), was bei grossen Matrizen das Auffinden eines konkreten
- *    Slots dramatisch vereinfacht.
+ *   ┌─ Outputs ───────────────────────────────────────────────┐
+ *   │  #   Label                ║  In  1  2  3  4  ┃  5  6  7  8 │
+ *   │  ─── ──────────────────── ╫  ───────────────────────────── │
+ *   │  1   Resolume IN 1        ║       ●                       │
+ *   │  2   Resolume IN 2        ║          ●                    │
+ *   │  …                                                        │
+ *   └───────────────────────────────────────────────────────────┘
  *
- * 2. **Crosshair-Hover**: beim Mouseover ueber einer Zelle werden
- *    die zugehoerige Output-Zeile UND die Input-Spalte komplett
- *    eingefaerbt (sky-blue Tint) — der User sieht direkt welcher
- *    Input zu welchem Output geroutet wuerde, ohne den Finger
- *    abzaehlen zu muessen. Header werden zusaetzlich hervorgehoben.
+ * Drei Visualisierungs-Hilfen:
+ *  1) **Crosshair-Hover**: gesamte Zeile + Spalte werden eingefaerbt.
+ *  2) **Drag-to-Route**: Klick + Ziehen ueber Cells routet jede.
+ *  3) **Group-Stripes**: alle 8 Slots wechselt der Background-Tint,
+ *     plus 1-px Trennlinie — typisch Broadcast-Layout, schnell
+ *     "Out 24 oder 25?" auf einen Blick.
  *
- * 3. **Sichtbare Gruppierung alle 8**: subtile vertikale + horizontale
- *    Trennlinien jeden 8. Port (klassische Broadcast-Konvention) —
- *    erleichtert das Schaetzen "ist das jetzt Output 24 oder 25?".
- *
- * 4. **Groessere Klick-Targets bei kleinen Hubs**: 22 px bis 40er,
- *    16 px fuer 40-80er, 12 px fuer 80-200er, 9 px ab 200er. Active-
- *    Crosspoint mit Emerald-Highlight + leichten Schatten — leichter
- *    zu sehen.
- *
- * 5. **Klickbare Indizes** zur Schnell-Navigation: Klick auf eine
- *    Output-Zeilennummer fokussiert die Zeile (scrollt sie in den
- *    Sichtbereich), Klick auf eine Input-Spalten-Nummer analog.
- *    Nuetzlich bei 288×288 wo der scrollende Bereich riesig ist.
- *
- * 6. **List-Mode-Fallback** bleibt — bei extrem grossen Matrizen
- *    (>100k Crosspoints) wuerde der DOM den Browser blockieren.
+ *  Cell-Sizing dynamisch je Hub-Groesse — 28 px bis 20er, 20 px bis
+ *  40er, 14 px bis 80er, 10 px bis 200er, 7 px ab 200er.
  */
 export const VideohubRoutingMatrix = ({
   totalInputs,
@@ -56,14 +48,9 @@ export const VideohubRoutingMatrix = ({
   const useGrid = cellCount <= 100_000
 
   const [hover, setHover] = useState<{ row: number; col: number } | null>(null)
-  // v7.9.128 — Drag-to-route: User klickt + zieht ueber Cells, jede
-  // ueberfahrene Cell wird geroutet. Diagonal-Drag (Out N -> In N,
-  // N+1 -> N+1, ...) ergibt sequenzielles 1:1. Vertikaler Drag
-  // (mehrere Outs auf denselben In) ergibt Multicast.
   const [dragging, setDragging] = useState(false)
   const rowRefs = useRef<Array<HTMLTableRowElement | null>>([])
 
-  // List-Mode bei riesigen Matrizen — DOM wuerde sonst kollabieren.
   if (!useGrid) {
     return (
       <div className="overflow-auto max-h-64 rounded border border-slate-700 bg-slate-950 p-2">
@@ -96,25 +83,30 @@ export const VideohubRoutingMatrix = ({
     )
   }
 
-  // Cell-Sizing nach Groesse — kleinere Cells fuer groessere Hubs,
-  // damit 288×288 noch passabel scrollt.
-  const big = totalInputs <= 40 && totalOutputs <= 40
-  const medium = !big && totalInputs <= 80 && totalOutputs <= 80
-  const small = !big && !medium && totalInputs <= 200 && totalOutputs <= 200
-  const cellPx = big ? 22 : medium ? 16 : small ? 12 : 9
-  const fontPx = big ? 11 : medium ? 9 : 8
-  const labelMaxRem = big ? '7rem' : medium ? '6rem' : '5rem'
-  const indexColPx = big ? 28 : 24
-  const labelColPx = big ? 130 : medium ? 110 : 90
+  // Dynamische Cell-Groesse + Schrift.
+  const tier =
+    totalInputs <= 20 && totalOutputs <= 20
+      ? 'xl'
+      : totalInputs <= 40 && totalOutputs <= 40
+        ? 'lg'
+        : totalInputs <= 80 && totalOutputs <= 80
+          ? 'md'
+          : totalInputs <= 200 && totalOutputs <= 200
+            ? 'sm'
+            : 'xs'
 
-  // Stilkonstanten fuer Crosshair-Highlight (Cell-Hover faerbt
-  // die gesamte Spalte + Zeile ein).
+  const cellPx = tier === 'xl' ? 28 : tier === 'lg' ? 20 : tier === 'md' ? 14 : tier === 'sm' ? 10 : 7
+  const fontPx = tier === 'xl' ? 12 : tier === 'lg' ? 10 : tier === 'md' ? 9 : tier === 'sm' ? 8 : 7
+  const labelColPx = tier === 'xl' ? 200 : tier === 'lg' ? 160 : tier === 'md' ? 130 : 100
+  const indexColPx = tier === 'xl' ? 36 : tier === 'lg' ? 30 : 24
+  const labelRowHeightRem = tier === 'xl' ? '9rem' : tier === 'lg' ? '8rem' : tier === 'md' ? '7rem' : '6rem'
+
   const colHighlight = hover?.col
   const rowHighlight = hover?.row
 
-  // groupBreak: true wenn die Linie zwischen index-1 und index eine
-  // 8er-Gruppen-Grenze ist (z.B. nach Port 8, 16, 24 ...). Verwendet
-  // fuer subtle border-Effects.
+  // Alternierender Group-Stripe (8er) — wirkt subtil und macht das
+  // Zaehlen im 40x40 viel einfacher.
+  const isGroupStripe = (index: number) => Math.floor(index / 8) % 2 === 1
   const isGroupBreak = (index: number) => index > 0 && index % 8 === 0
 
   const focusRow = (oi: number) => {
@@ -122,8 +114,6 @@ export const VideohubRoutingMatrix = ({
     if (el) el.scrollIntoView({ block: 'center', behavior: 'smooth' })
   }
 
-  // Pre-compute Labels mit Index-Suffix — verwendet als Title-Tooltip
-  // an den Cells.
   const inLabelTip = useMemo(
     () => inputLabels.map((l, i) => `In ${i + 1} · ${l}`),
     [inputLabels],
@@ -133,90 +123,79 @@ export const VideohubRoutingMatrix = ({
     [outputLabels],
   )
 
-  const maxHeight = big ? '22rem' : medium ? '24rem' : '28rem'
+  const maxHeight = tier === 'xl' || tier === 'lg' ? '28rem' : '32rem'
 
   return (
     <div
-      className="overflow-auto rounded border border-slate-700 bg-slate-950"
+      className="overflow-auto rounded-md border border-slate-700 bg-slate-950"
       style={{ maxHeight }}
       onMouseLeave={() => setHover(null)}
       onMouseUp={() => setDragging(false)}
     >
-      <table className="border-collapse" style={{ fontSize: fontPx }}>
+      <table
+        className="border-collapse"
+        style={{ fontSize: fontPx, minWidth: '100%' }}
+      >
         <thead>
+          {/* Reihe 1: "Inputs ↓" + Output-Label-Spalte + Index + Input-Labels horizontal */}
           <tr>
-            {/* corner: Out-Label-Col-Header */}
             <th
-              className="sticky left-0 top-0 z-30 bg-slate-900 px-2 py-1 text-left text-[10px] font-medium text-slate-400"
+              className="sticky left-0 top-0 z-30 border-b border-r border-slate-700 bg-slate-900 px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-wide text-slate-400"
               style={{ width: labelColPx, minWidth: labelColPx }}
             >
-              Output ↓
+              Outputs ↓
             </th>
-            {/* index-row-header */}
             <th
-              className="sticky top-0 z-20 bg-slate-900 text-center text-[10px] font-mono text-slate-500"
+              className="sticky top-0 z-20 border-b border-r border-slate-700 bg-slate-900 text-center text-[10px] font-mono text-slate-500"
               style={{ width: indexColPx, minWidth: indexColPx }}
-              title="Output-Nummer (Klick zum Scrollen)"
+              title="Output-Nummer"
             >
               #
             </th>
-            {/* Input column index row */}
-            {inputLabels.map((_, i) => (
-              <th
-                key={`idx-${i}`}
-                className={`sticky top-0 z-10 bg-slate-900 p-0 font-mono text-slate-500 ${
-                  isGroupBreak(i) ? 'border-l border-slate-700' : ''
-                } ${colHighlight === i ? 'bg-sky-900/60 text-sky-200' : ''}`}
-                style={{ width: cellPx, minWidth: cellPx, textAlign: 'center' }}
-              >
-                <button
-                  type="button"
-                  onClick={() => {
-                    // Klick auf Index = scroll-into-view fuer die
-                    // VERTIKALE Achse koennen wir hier zwar nicht
-                    // direkt machen (kein Element pro Spalte), aber
-                    // wir setzen einen Hover-Highlight als Visual-Aid.
-                    setHover((h) => (h?.col === i ? null : { row: 0, col: i }))
-                  }}
-                  className="block w-full text-center hover:text-sky-300"
-                  style={{ fontSize: fontPx - 1, padding: 0 }}
-                >
-                  {i + 1}
-                </button>
-              </th>
-            ))}
-          </tr>
-          <tr>
-            {/* corner cell — sticky both axes */}
             <th
-              className="sticky left-0 top-[1.5rem] z-30 bg-slate-900 px-2 py-1 text-left text-[10px] font-medium text-slate-400"
-              style={{ minWidth: labelColPx }}
+              className="sticky top-0 z-20 border-b border-slate-700 bg-slate-800/80 px-2 py-2 text-left text-[11px] font-semibold uppercase tracking-wide text-slate-300"
+              colSpan={totalInputs}
+              style={{
+                position: 'sticky',
+                top: 0,
+                left: 0,
+              }}
             >
-              Input →
+              Inputs →
             </th>
+          </tr>
+
+          {/* Reihe 2: Input-Labels (rotiert) */}
+          <tr>
             <th
-              className="sticky top-[1.5rem] z-20 bg-slate-900"
+              className="sticky left-0 top-[2.5rem] z-30 border-r border-slate-700 bg-slate-900"
+              style={{ width: labelColPx, minWidth: labelColPx }}
+            />
+            <th
+              className="sticky left-[var(--label-w)] top-[2.5rem] z-20 border-r border-slate-700 bg-slate-900"
               style={{ width: indexColPx, minWidth: indexColPx }}
             />
-            {/* Input labels (rotated) */}
             {inputLabels.map((label, i) => (
               <th
                 key={`lbl-${i}`}
-                className={`sticky top-[1.5rem] z-10 bg-slate-900 p-0 ${
-                  isGroupBreak(i) ? 'border-l border-slate-700' : ''
-                } ${colHighlight === i ? 'bg-sky-900/60' : ''}`}
-                style={{ width: cellPx, minWidth: cellPx }}
+                className={`sticky top-[2.5rem] z-10 p-0 ${
+                  isGroupStripe(i) ? 'bg-slate-900/80' : 'bg-slate-900'
+                } ${isGroupBreak(i) ? 'border-l border-slate-700' : ''} ${
+                  colHighlight === i ? 'bg-sky-900/70' : ''
+                }`}
+                style={{ width: cellPx, minWidth: cellPx, height: labelRowHeightRem }}
               >
                 <div
                   className={`overflow-hidden text-center ${
-                    colHighlight === i ? 'text-sky-100' : 'text-slate-400'
+                    colHighlight === i ? 'text-sky-100' : 'text-slate-300'
                   }`}
                   style={{
                     writingMode: 'vertical-lr',
                     transform: 'rotate(180deg)',
-                    maxHeight: labelMaxRem,
-                    padding: '2px 0',
-                    fontSize: fontPx,
+                    height: '100%',
+                    padding: '4px 0',
+                    fontSize: fontPx + 1,
+                    fontWeight: 500,
                   }}
                   title={inLabelTip[i]}
                 >
@@ -225,42 +204,97 @@ export const VideohubRoutingMatrix = ({
               </th>
             ))}
           </tr>
+
+          {/* Reihe 3: Input-Index-Nummern */}
+          <tr>
+            <th
+              className="sticky left-0 top-[calc(2.5rem+var(--lbl-h))] z-30 border-b border-r border-slate-700 bg-slate-900 px-3 py-1 text-left text-[10px] uppercase text-slate-500"
+              style={{ width: labelColPx, minWidth: labelColPx, top: `calc(2.5rem + ${labelRowHeightRem})` }}
+            >
+              Label
+            </th>
+            <th
+              className="sticky z-20 border-b border-r border-slate-700 bg-slate-900 text-center text-[10px] font-mono text-slate-500"
+              style={{
+                left: labelColPx,
+                top: `calc(2.5rem + ${labelRowHeightRem})`,
+                width: indexColPx,
+                minWidth: indexColPx,
+              }}
+            >
+              #
+            </th>
+            {inputLabels.map((_, i) => (
+              <th
+                key={`idx-${i}`}
+                className={`sticky z-10 border-b border-slate-700 font-mono text-slate-500 ${
+                  isGroupStripe(i) ? 'bg-slate-900/80' : 'bg-slate-900'
+                } ${isGroupBreak(i) ? 'border-l border-slate-700' : ''} ${
+                  colHighlight === i ? 'bg-sky-900/70 text-sky-200' : ''
+                }`}
+                style={{
+                  top: `calc(2.5rem + ${labelRowHeightRem})`,
+                  width: cellPx,
+                  minWidth: cellPx,
+                  textAlign: 'center',
+                  fontSize: fontPx,
+                }}
+              >
+                {i + 1}
+              </th>
+            ))}
+          </tr>
         </thead>
+
         <tbody>
           {outputLabels.map((outLabel, oi) => {
             const rowOn = rowHighlight === oi
+            const rowStripe = isGroupStripe(oi)
             const routedIdx = routing[oi]
             const groupRowBreak = isGroupBreak(oi)
             return (
               <tr
                 key={oi}
                 ref={(el) => { rowRefs.current[oi] = el }}
-                className={`${rowOn ? 'bg-sky-900/30' : 'hover:bg-slate-800/40'} ${
-                  groupRowBreak ? 'border-t border-slate-700' : ''
-                }`}
+                className={`${
+                  rowOn
+                    ? 'bg-sky-900/40'
+                    : rowStripe
+                      ? 'bg-slate-900/60 hover:bg-slate-800/60'
+                      : 'hover:bg-slate-800/40'
+                } ${groupRowBreak ? 'border-t border-slate-700' : ''}`}
               >
-                {/* Output label cell — sticky left */}
                 <td
-                  className={`sticky left-0 z-10 truncate px-2 py-0.5 text-right ${
+                  className={`sticky left-0 z-10 truncate border-r border-slate-800 px-3 py-1 text-left ${
                     rowOn
-                      ? 'bg-sky-900/60 text-sky-100'
-                      : 'bg-slate-950 text-slate-300'
+                      ? 'bg-sky-900/70 text-sky-100'
+                      : rowStripe
+                        ? 'bg-slate-900/90 text-slate-200'
+                        : 'bg-slate-950 text-slate-200'
                   }`}
-                  style={{ maxWidth: labelColPx, fontSize: fontPx }}
+                  style={{
+                    maxWidth: labelColPx,
+                    minWidth: labelColPx,
+                    fontSize: fontPx + 1,
+                    fontWeight: 500,
+                  }}
                   title={outLabelTip[oi]}
                 >
                   {outLabel}
                 </td>
-                {/* Output index cell */}
                 <td
-                  className={`sticky left-[${labelColPx}px] z-10 text-center font-mono ${
-                    rowOn ? 'bg-sky-900/60 text-sky-200' : 'bg-slate-900 text-slate-500'
+                  className={`sticky z-10 border-r border-slate-800 text-center font-mono ${
+                    rowOn
+                      ? 'bg-sky-900/70 text-sky-200'
+                      : rowStripe
+                        ? 'bg-slate-900/95 text-slate-400'
+                        : 'bg-slate-900 text-slate-500'
                   }`}
                   style={{
                     left: labelColPx,
                     width: indexColPx,
                     minWidth: indexColPx,
-                    fontSize: fontPx - 1,
+                    fontSize: fontPx,
                   }}
                 >
                   <button
@@ -272,21 +306,26 @@ export const VideohubRoutingMatrix = ({
                     {oi + 1}
                   </button>
                 </td>
-                {/* Crosspoint cells */}
                 {inputLabels.map((inLabel, ii) => {
                   const active = routedIdx === ii
                   const inCol = colHighlight === ii
+                  const colStripe = isGroupStripe(ii)
                   const inCross = rowOn || inCol
                   const groupBreak = isGroupBreak(ii)
+                  // Hintergrund-Tint per Group-Stripe; overrides bei Hover.
+                  const tdBg = inCross
+                    ? inCol && !rowOn
+                      ? 'bg-sky-900/40'
+                      : ''
+                    : colStripe
+                      ? 'bg-slate-900/40'
+                      : ''
                   return (
                     <td
                       key={ii}
-                      className={`p-0 text-center ${groupBreak ? 'border-l border-slate-700' : ''} ${
-                        inCol && !rowOn ? 'bg-sky-900/30' : ''
-                      }`}
+                      className={`p-0 text-center ${groupBreak ? 'border-l border-slate-800' : ''} ${tdBg}`}
                       onMouseEnter={() => {
                         setHover({ row: oi, col: ii })
-                        // Drag-Mode: jede ueberfahrene Cell routen.
                         if (dragging) onRoute(oi, ii)
                       }}
                     >
@@ -301,10 +340,10 @@ export const VideohubRoutingMatrix = ({
                         aria-label={`Set Output ${oi + 1} (${outLabel}) to Input ${ii + 1} (${inLabel})`}
                         className={
                           active
-                            ? 'mx-auto my-0.5 block rounded-sm bg-emerald-500 shadow-[0_0_4px_rgba(16,185,129,0.55)]'
+                            ? 'mx-auto my-0.5 block rounded-sm bg-emerald-500 shadow-[0_0_5px_rgba(16,185,129,0.7)] ring-1 ring-emerald-300/50'
                             : inCross
-                              ? 'mx-auto my-0.5 block rounded-sm bg-sky-500/40 hover:bg-sky-400'
-                              : 'mx-auto my-0.5 block rounded-sm bg-slate-700 hover:bg-slate-500'
+                              ? 'mx-auto my-0.5 block rounded-sm bg-sky-500/50 hover:bg-sky-400'
+                              : 'mx-auto my-0.5 block rounded-sm bg-slate-700/80 hover:bg-slate-500'
                         }
                         style={{ width: cellPx - 4, height: cellPx - 4 }}
                       />


### PR DESCRIPTION
…rer Dialog

User-Screenshot zeigt: Matrix war zwar funktional aber die Input-Labels rotiert+gequetscht im engen 3xl-Dialog, kaum broadcast-mässig.

Visuelle Aufbesserung — Patterns von VideoHubSim adaptiert:

1) **Dialog jetzt 6xl breit** (statt 3xl) und max-h:95vh — mehr
   Raum fuer die Matrix, der haupt-Use-Case dieses Dialogs.

2) **Drei separate Header-Rows** in der Matrix:
   - Row 1: "Outputs ↓" + "#" + "Inputs →" als Top-Label-Bar
   - Row 2: rotierte Input-Labels (jetzt 12 px statt 9 px, fontWeight 500, leicht groesser fuer Lesbarkeit)
   - Row 3: Input-Index-Nummern (1-N) als eigene Reihe Plus links die "Label / #" Ecke fuer die Output-Spalte. Statt zwei verschachtelte Spalten in einer Reihe = klar getrennt + sticky-aware.

3) **Group-Stripes alle 8 Slots**: alternierender dezenter
   Slate-Tint horizontal UND vertikal. Plus die existierenden
   1-px-Trennlinien — Konvention von Broadcast-Crosspoint-Panels
   damit "Out 25" auf einen Blick im 3. 8er-Block sichtbar ist.

4) **Vergroesserte Cell-Sizes**: 28 px bis 20er Hubs (vorher 22),
   20 px bis 40er (vorher 16), 14 px bis 80er (vorher 12), 10 px
   bis 200er (vorher 9), 7 px ab 200er (neu). Insgesamt mehr
   Klick-Target + bessere Aktiv-Sichtbarkeit.

5) **Active-Crosspoint klarer**: Emerald-Hintergrund + groesseren
   Glow (0_0_5px) + 1-px Emerald-Ring. Inactive-Cells leicht
   transparenter (slate-700/80 statt 700) damit der Active-Punkt
   visuell heraus pop.

6) **Crosshair-Hover** weiter aktiv aber mit verbesserten
   Tints — Group-Stripes werden vom Hover overridden.

Funktional unveraendert: gleiche Drag-To-Route, gleiches onRoute-Callback, gleiches Lock-Badge-Format wenn vom Aufrufer geliefert. Performance bei 288x288 weiter im List-Mode-Fallback.

Bekannte VideoHubSim-Patterns die noch fehlen:
- Minimap fuer >40er Hubs (Folge-Issue)
- Inline-Label-Edit per Doppelklick (Folge-Issue)
- Alle Inputs/Outputs gleichzeitig per Drag-Rect routen (heute cell-by-cell)

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH