### PR TITLE
ui(videohub): Volle Lesbarkeit der Input/Output-Labels

### DIFF
--- a/src/renderer/components/Export/VideohubRoutingMatrix.tsx
+++ b/src/renderer/components/Export/VideohubRoutingMatrix.tsx
@@ -12,29 +12,27 @@ interface Props {
 /**
  * Interactive routing crosspoint matrix for Blackmagic Videohub.
  *
- * v7.9.128 — UI im Stil von VideoHubSim
- * (https://github.com/videojedi/VideoHubSim) — explizite Trennung von
- * Index-Spalte vs. Label-Spalte, klare Grid-Linien, broadcast-typische
- * 8er-Gruppierung, dezent abwechselnde Group-Backgrounds, grosse
- * Klick-Targets bei kleinen Hubs.
+ * v7.9.129 — Lesbarkeit-Fokus. User-Pain: "die input und output namen
+ * kann ich nicht richtig lesen". Maßnahmen:
  *
- *   ┌─ Outputs ───────────────────────────────────────────────┐
- *   │  #   Label                ║  In  1  2  3  4  ┃  5  6  7  8 │
- *   │  ─── ──────────────────── ╫  ───────────────────────────── │
- *   │  1   Resolume IN 1        ║       ●                       │
- *   │  2   Resolume IN 2        ║          ●                    │
- *   │  …                                                        │
- *   └───────────────────────────────────────────────────────────┘
+ * 1) **Deutlich groessere Schrift** — Input-Header bei 14px (statt 11),
+ *    Output-Labels bei 14px (statt 12), Index bei 12px.
+ * 2) **Mehr vertikaler Raum** fuer rotierte Input-Labels (8-12rem
+ *    Hoehe) — bis zu ~16 Zeichen pro Label gut lesbar bevor truncated.
+ * 3) **Breitere Cells** fuer kleine/mittlere Hubs — 32px statt 28
+ *    bei <=20er, damit auch der Active-Crosspoint groesseren Touch-
+ *    Target hat.
+ * 4) **VideoHubSim-Farbsprache** (Inspiration von
+ *    github.com/videojedi/VideoHubSim):
+ *    - Outputs in CORAL/ROT (#fca5a5) — visuell von Inputs getrennt
+ *    - Inputs in EMERALD/GRUEN (#86efac) — folgt dem aktiven Signal
+ *    - Active-Crosspoint: gleiches Emerald wie Inputs, mit Glow
+ *    - Row-Hover (Output): coral-tint
+ *    - Col-Hover (Input): emerald-tint
+ *    Damit ist die Lese-Richtung "Output (rot) <- Input (gruen)"
+ *    farblich kodiert und sofort intuitiv.
  *
- * Drei Visualisierungs-Hilfen:
- *  1) **Crosshair-Hover**: gesamte Zeile + Spalte werden eingefaerbt.
- *  2) **Drag-to-Route**: Klick + Ziehen ueber Cells routet jede.
- *  3) **Group-Stripes**: alle 8 Slots wechselt der Background-Tint,
- *     plus 1-px Trennlinie — typisch Broadcast-Layout, schnell
- *     "Out 24 oder 25?" auf einen Blick.
- *
- *  Cell-Sizing dynamisch je Hub-Groesse — 28 px bis 20er, 20 px bis
- *  40er, 14 px bis 80er, 10 px bis 200er, 7 px ab 200er.
+ * Drag-to-Route + Crosshair + Group-Stripes alle 8 unveraendert.
  */
 export const VideohubRoutingMatrix = ({
   totalInputs,
@@ -61,14 +59,16 @@ export const VideohubRoutingMatrix = ({
         </div>
         <div className="space-y-0.5">
           {outputLabels.map((outLabel, oi) => (
-            <div key={oi} className="flex items-center gap-2 text-xs">
-              <span className="w-8 shrink-0 font-mono text-right text-slate-500">{oi + 1}</span>
-              <span className="w-32 shrink-0 truncate text-right text-slate-300">{outLabel}</span>
+            <div key={oi} className="flex items-center gap-2 text-sm">
+              <span className="w-10 shrink-0 font-mono text-right text-slate-500">{oi + 1}</span>
+              <span className="w-40 shrink-0 truncate text-right font-medium text-red-300">
+                {outLabel}
+              </span>
               <span className="text-slate-500">←</span>
               <select
                 value={routing[oi] ?? 0}
                 onChange={(e) => onRoute(oi, parseInt(e.target.value, 10))}
-                className="flex-1 rounded border border-slate-700 bg-slate-900 p-0.5 text-xs text-slate-100"
+                className="flex-1 rounded border border-slate-700 bg-slate-900 p-1 text-sm text-emerald-200"
               >
                 {inputLabels.map((inLabel, ii) => (
                   <option key={ii} value={ii}>
@@ -83,7 +83,9 @@ export const VideohubRoutingMatrix = ({
     )
   }
 
-  // Dynamische Cell-Groesse + Schrift.
+  // Dynamische Cell-Groesse. Bei kleinen Hubs DEUTLICH groesser fuer
+  // Lesbarkeit. Schrift bleibt fix relativ gross — wir akzeptieren
+  // hoehere Header-Reihen damit die rotierten Labels lesbar sind.
   const tier =
     totalInputs <= 20 && totalOutputs <= 20
       ? 'xl'
@@ -95,17 +97,21 @@ export const VideohubRoutingMatrix = ({
             ? 'sm'
             : 'xs'
 
-  const cellPx = tier === 'xl' ? 28 : tier === 'lg' ? 20 : tier === 'md' ? 14 : tier === 'sm' ? 10 : 7
-  const fontPx = tier === 'xl' ? 12 : tier === 'lg' ? 10 : tier === 'md' ? 9 : tier === 'sm' ? 8 : 7
-  const labelColPx = tier === 'xl' ? 200 : tier === 'lg' ? 160 : tier === 'md' ? 130 : 100
-  const indexColPx = tier === 'xl' ? 36 : tier === 'lg' ? 30 : 24
-  const labelRowHeightRem = tier === 'xl' ? '9rem' : tier === 'lg' ? '8rem' : tier === 'md' ? '7rem' : '6rem'
+  const cellPx = tier === 'xl' ? 32 : tier === 'lg' ? 24 : tier === 'md' ? 16 : tier === 'sm' ? 11 : 8
+  // Schrift-Groessen bewusst hoch — Lesbarkeit ist das User-Issue.
+  const labelFontPx = tier === 'xl' ? 14 : tier === 'lg' ? 13 : tier === 'md' ? 11 : tier === 'sm' ? 9 : 8
+  const indexFontPx = Math.max(labelFontPx - 1, 8)
+  const labelColPx = tier === 'xl' ? 220 : tier === 'lg' ? 180 : tier === 'md' ? 140 : 110
+  const indexColPx = tier === 'xl' ? 40 : tier === 'lg' ? 34 : 26
+  // Hoehe der Input-Header-Row in rem — viel Platz fuer rotierte
+  // Labels. Vorher 7rem, jetzt 11rem bei XL damit ~16-Zeichen-Labels
+  // ohne Truncation Platz haben.
+  const labelRowHeightRem =
+    tier === 'xl' ? '11rem' : tier === 'lg' ? '10rem' : tier === 'md' ? '8rem' : '6rem'
 
   const colHighlight = hover?.col
   const rowHighlight = hover?.row
 
-  // Alternierender Group-Stripe (8er) — wirkt subtil und macht das
-  // Zaehlen im 40x40 viel einfacher.
   const isGroupStripe = (index: number) => Math.floor(index / 8) % 2 === 1
   const isGroupBreak = (index: number) => index > 0 && index % 8 === 0
 
@@ -123,7 +129,7 @@ export const VideohubRoutingMatrix = ({
     [outputLabels],
   )
 
-  const maxHeight = tier === 'xl' || tier === 'lg' ? '28rem' : '32rem'
+  const maxHeight = tier === 'xl' || tier === 'lg' ? '34rem' : '38rem'
 
   return (
     <div
@@ -132,48 +138,45 @@ export const VideohubRoutingMatrix = ({
       onMouseLeave={() => setHover(null)}
       onMouseUp={() => setDragging(false)}
     >
-      <table
-        className="border-collapse"
-        style={{ fontSize: fontPx, minWidth: '100%' }}
-      >
+      <table className="border-collapse" style={{ minWidth: '100%' }}>
         <thead>
-          {/* Reihe 1: "Inputs ↓" + Output-Label-Spalte + Index + Input-Labels horizontal */}
+          {/* Reihe 1: Achsen-Beschriftungen ("Outputs ↓" + "Inputs →") */}
           <tr>
             <th
-              className="sticky left-0 top-0 z-30 border-b border-r border-slate-700 bg-slate-900 px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-wide text-slate-400"
-              style={{ width: labelColPx, minWidth: labelColPx }}
+              className="sticky left-0 top-0 z-30 border-b border-r border-slate-700 bg-slate-900 px-3 py-2 text-left uppercase tracking-wide text-slate-400"
+              style={{ width: labelColPx, minWidth: labelColPx, fontSize: 12, fontWeight: 600 }}
             >
               Outputs ↓
             </th>
             <th
-              className="sticky top-0 z-20 border-b border-r border-slate-700 bg-slate-900 text-center text-[10px] font-mono text-slate-500"
-              style={{ width: indexColPx, minWidth: indexColPx }}
+              className="sticky top-0 z-20 border-b border-r border-slate-700 bg-slate-900 text-center font-mono text-slate-500"
+              style={{ width: indexColPx, minWidth: indexColPx, fontSize: 11 }}
               title="Output-Nummer"
             >
               #
             </th>
             <th
-              className="sticky top-0 z-20 border-b border-slate-700 bg-slate-800/80 px-2 py-2 text-left text-[11px] font-semibold uppercase tracking-wide text-slate-300"
+              className="sticky top-0 z-20 border-b border-slate-700 bg-slate-800/80 px-3 py-2 text-left uppercase tracking-wide text-emerald-300"
               colSpan={totalInputs}
-              style={{
-                position: 'sticky',
-                top: 0,
-                left: 0,
-              }}
+              style={{ fontSize: 12, fontWeight: 600 }}
             >
               Inputs →
             </th>
           </tr>
 
-          {/* Reihe 2: Input-Labels (rotiert) */}
+          {/* Reihe 2: Input-Labels (rotiert, GRUEN) */}
           <tr>
             <th
               className="sticky left-0 top-[2.5rem] z-30 border-r border-slate-700 bg-slate-900"
               style={{ width: labelColPx, minWidth: labelColPx }}
             />
             <th
-              className="sticky left-[var(--label-w)] top-[2.5rem] z-20 border-r border-slate-700 bg-slate-900"
-              style={{ width: indexColPx, minWidth: indexColPx }}
+              className="sticky top-[2.5rem] z-20 border-r border-slate-700 bg-slate-900"
+              style={{
+                left: labelColPx,
+                width: indexColPx,
+                minWidth: indexColPx,
+              }}
             />
             {inputLabels.map((label, i) => (
               <th
@@ -181,21 +184,23 @@ export const VideohubRoutingMatrix = ({
                 className={`sticky top-[2.5rem] z-10 p-0 ${
                   isGroupStripe(i) ? 'bg-slate-900/80' : 'bg-slate-900'
                 } ${isGroupBreak(i) ? 'border-l border-slate-700' : ''} ${
-                  colHighlight === i ? 'bg-sky-900/70' : ''
+                  colHighlight === i ? 'bg-emerald-900/60' : ''
                 }`}
                 style={{ width: cellPx, minWidth: cellPx, height: labelRowHeightRem }}
               >
                 <div
                   className={`overflow-hidden text-center ${
-                    colHighlight === i ? 'text-sky-100' : 'text-slate-300'
+                    colHighlight === i ? 'text-emerald-100' : 'text-emerald-300'
                   }`}
                   style={{
                     writingMode: 'vertical-lr',
                     transform: 'rotate(180deg)',
                     height: '100%',
-                    padding: '4px 0',
-                    fontSize: fontPx + 1,
+                    padding: '6px 0',
+                    fontSize: labelFontPx,
                     fontWeight: 500,
+                    letterSpacing: 0.2,
+                    lineHeight: 1.2,
                   }}
                   title={inLabelTip[i]}
                 >
@@ -205,21 +210,27 @@ export const VideohubRoutingMatrix = ({
             ))}
           </tr>
 
-          {/* Reihe 3: Input-Index-Nummern */}
+          {/* Reihe 3: Input-Index-Nummern (mono, schaerfer) */}
           <tr>
             <th
-              className="sticky left-0 top-[calc(2.5rem+var(--lbl-h))] z-30 border-b border-r border-slate-700 bg-slate-900 px-3 py-1 text-left text-[10px] uppercase text-slate-500"
-              style={{ width: labelColPx, minWidth: labelColPx, top: `calc(2.5rem + ${labelRowHeightRem})` }}
+              className="sticky left-0 z-30 border-b border-r border-slate-700 bg-slate-900 px-3 py-1 text-left uppercase text-slate-500"
+              style={{
+                top: `calc(2.5rem + ${labelRowHeightRem})`,
+                width: labelColPx,
+                minWidth: labelColPx,
+                fontSize: 11,
+              }}
             >
               Label
             </th>
             <th
-              className="sticky z-20 border-b border-r border-slate-700 bg-slate-900 text-center text-[10px] font-mono text-slate-500"
+              className="sticky z-20 border-b border-r border-slate-700 bg-slate-900 text-center font-mono text-slate-500"
               style={{
                 left: labelColPx,
                 top: `calc(2.5rem + ${labelRowHeightRem})`,
                 width: indexColPx,
                 minWidth: indexColPx,
+                fontSize: 11,
               }}
             >
               #
@@ -227,17 +238,18 @@ export const VideohubRoutingMatrix = ({
             {inputLabels.map((_, i) => (
               <th
                 key={`idx-${i}`}
-                className={`sticky z-10 border-b border-slate-700 font-mono text-slate-500 ${
+                className={`sticky z-10 border-b border-slate-700 font-mono text-slate-400 ${
                   isGroupStripe(i) ? 'bg-slate-900/80' : 'bg-slate-900'
                 } ${isGroupBreak(i) ? 'border-l border-slate-700' : ''} ${
-                  colHighlight === i ? 'bg-sky-900/70 text-sky-200' : ''
+                  colHighlight === i ? 'bg-emerald-900/60 text-emerald-200' : ''
                 }`}
                 style={{
                   top: `calc(2.5rem + ${labelRowHeightRem})`,
                   width: cellPx,
                   minWidth: cellPx,
                   textAlign: 'center',
-                  fontSize: fontPx,
+                  fontSize: indexFontPx,
+                  padding: '2px 0',
                 }}
               >
                 {i + 1}
@@ -258,25 +270,27 @@ export const VideohubRoutingMatrix = ({
                 ref={(el) => { rowRefs.current[oi] = el }}
                 className={`${
                   rowOn
-                    ? 'bg-sky-900/40'
+                    ? 'bg-red-950/40'
                     : rowStripe
                       ? 'bg-slate-900/60 hover:bg-slate-800/60'
                       : 'hover:bg-slate-800/40'
                 } ${groupRowBreak ? 'border-t border-slate-700' : ''}`}
               >
+                {/* Output-Label-Zelle: CORAL/ROT, deutlich groesser */}
                 <td
-                  className={`sticky left-0 z-10 truncate border-r border-slate-800 px-3 py-1 text-left ${
+                  className={`sticky left-0 z-10 truncate border-r border-slate-800 px-3 py-1.5 text-left ${
                     rowOn
-                      ? 'bg-sky-900/70 text-sky-100'
+                      ? 'bg-red-950/70 text-red-100'
                       : rowStripe
-                        ? 'bg-slate-900/90 text-slate-200'
-                        : 'bg-slate-950 text-slate-200'
+                        ? 'bg-slate-900/90 text-red-300'
+                        : 'bg-slate-950 text-red-300'
                   }`}
                   style={{
                     maxWidth: labelColPx,
                     minWidth: labelColPx,
-                    fontSize: fontPx + 1,
+                    fontSize: labelFontPx,
                     fontWeight: 500,
+                    letterSpacing: 0.2,
                   }}
                   title={outLabelTip[oi]}
                 >
@@ -285,7 +299,7 @@ export const VideohubRoutingMatrix = ({
                 <td
                   className={`sticky z-10 border-r border-slate-800 text-center font-mono ${
                     rowOn
-                      ? 'bg-sky-900/70 text-sky-200'
+                      ? 'bg-red-950/70 text-red-200'
                       : rowStripe
                         ? 'bg-slate-900/95 text-slate-400'
                         : 'bg-slate-900 text-slate-500'
@@ -294,13 +308,13 @@ export const VideohubRoutingMatrix = ({
                     left: labelColPx,
                     width: indexColPx,
                     minWidth: indexColPx,
-                    fontSize: fontPx,
+                    fontSize: indexFontPx,
                   }}
                 >
                   <button
                     type="button"
                     onClick={() => focusRow(oi)}
-                    className="block w-full hover:text-sky-300"
+                    className="block w-full py-1 hover:text-emerald-300"
                     title={`Output ${oi + 1} fokussieren`}
                   >
                     {oi + 1}
@@ -310,16 +324,13 @@ export const VideohubRoutingMatrix = ({
                   const active = routedIdx === ii
                   const inCol = colHighlight === ii
                   const colStripe = isGroupStripe(ii)
-                  const inCross = rowOn || inCol
                   const groupBreak = isGroupBreak(ii)
-                  // Hintergrund-Tint per Group-Stripe; overrides bei Hover.
-                  const tdBg = inCross
-                    ? inCol && !rowOn
-                      ? 'bg-sky-900/40'
-                      : ''
-                    : colStripe
-                      ? 'bg-slate-900/40'
-                      : ''
+                  // Hintergrund je nach Crosshair / Group-Stripe.
+                  let tdBg = ''
+                  if (rowOn && inCol) tdBg = 'bg-amber-900/30'
+                  else if (rowOn) tdBg = '' // Row-Tint kommt vom <tr>
+                  else if (inCol) tdBg = 'bg-emerald-900/30'
+                  else if (colStripe) tdBg = 'bg-slate-900/40'
                   return (
                     <td
                       key={ii}
@@ -340,12 +351,16 @@ export const VideohubRoutingMatrix = ({
                         aria-label={`Set Output ${oi + 1} (${outLabel}) to Input ${ii + 1} (${inLabel})`}
                         className={
                           active
-                            ? 'mx-auto my-0.5 block rounded-sm bg-emerald-500 shadow-[0_0_5px_rgba(16,185,129,0.7)] ring-1 ring-emerald-300/50'
-                            : inCross
-                              ? 'mx-auto my-0.5 block rounded-sm bg-sky-500/50 hover:bg-sky-400'
-                              : 'mx-auto my-0.5 block rounded-sm bg-slate-700/80 hover:bg-slate-500'
+                            ? 'mx-auto my-1 block rounded-sm bg-emerald-400 shadow-[0_0_8px_rgba(74,222,128,0.85)] ring-1 ring-emerald-200/70'
+                            : rowOn && inCol
+                              ? 'mx-auto my-1 block rounded-sm bg-amber-400/70 hover:bg-amber-300'
+                              : rowOn
+                                ? 'mx-auto my-1 block rounded-sm bg-red-400/60 hover:bg-red-300'
+                                : inCol
+                                  ? 'mx-auto my-1 block rounded-sm bg-emerald-500/60 hover:bg-emerald-400'
+                                  : 'mx-auto my-1 block rounded-sm bg-slate-700/80 hover:bg-slate-500'
                         }
-                        style={{ width: cellPx - 4, height: cellPx - 4 }}
+                        style={{ width: cellPx - 6, height: cellPx - 6 }}
                       />
                     </td>
                   )


### PR DESCRIPTION
User-Pain: "die input und output namen kann ich nicht richtig lesen ist sehr stoerend. passe volle lesbarkeit an."

Visual-Sprache an VideoHubSim angelehnt (Inspiration — Re-Implementation in unserem React/Tailwind-Stack, nicht verbatim kopiert):

LESBARKEIT — die Hauptaenderung:

1) **Schriftgroessen DEUTLICH groesser**:
   - Input-Header (rotiert): 11→14 px bei <=20er Hubs (+27%), 13 px bei <=40er, 11 px bei <=80er.
   - Output-Labels (horizontal): 12→14 px bei XL/LG.
   - Index-Nummern: 11 px statt 9.
   - Letter-Spacing 0.2 fuer mehr Kontur.

2) **Mehr vertikaler Raum** fuer rotierte Input-Labels:
   7→11 rem Hoehe bei XL — ~16 Zeichen pro Label gut lesbar
   ohne Truncation. 10 rem LG, 8 rem MD.

3) **Breitere Cells**: 28→32 px (XL), 20→24 px (LG), 14→16 px
   (MD). Groesseres Klick-Target + sichtbar groessere Active-
   Crosspoints.

4) **Breitere Label-Spalte**: 200→220 px (XL), 160→180 px (LG)
   — Outputs koennen jetzt laengere Namen ohne Truncation
   anzeigen.

FARB-SPRACHE (VideoHubSim-Konvention):

5) **Outputs in CORAL/ROT** (red-300, mit red-950/70 als
   Row-Hover-Tint) — visuell von Inputs getrennt.

6) **Inputs in EMERALD/GRUEN** (emerald-300, mit
   emerald-900/60 als Col-Hover-Tint) — folgt der Signal-
   Richtung In→Out.

7) **Active-Crosspoint**: emerald-400 mit groesserem Glow
   (0_0_8px) + emerald-Ring — visuell viel deutlicher als
   vorher.

8) **Crosshair-Kreuzung** (Row+Col gleichzeitig hover):
   amber-tint (mischt rot+gruen). Reine Row → red-tint, reine
   Col → emerald-tint.

9) **Inactive-Cells**: heller dahinter (slate-700/80) damit
   das gruen mehr knallt.

Drag-to-Route, Group-Stripes alle 8, Sticky-Header, Crosshair-Hover, List-Mode-Fallback bei riesigen Matrizen — alles unveraendert.

Inspiration / Visual-Sprache: VideoHubSim
(github.com/videojedi/VideoHubSim, MIT-lizenziert).

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH