### PR TITLE
fix(videohub+cable): Input-Label-Lesbarkeit + kuerzere Cable-Labels (…

### DIFF
--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -537,9 +537,20 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
           updatable: true,
           style: { stroke: strokeColor, strokeWidth: item.strokeWidth ?? 2.5, strokeDasharray: dashArray },
           data: { cable: item, exportThemeOverride: pdfExportThemeOverride },
-          label: item.needsConverter
-            ? `${item.name} (${item.length}m) ⚠ converter`
-            : `${item.name} (${item.length}m)`,
+          label: (() => {
+            // Issue #240 — kuerzere Kabel-Label-Texte:
+            // "SDI 3G (1080p50/60) (1m)" -> "SDI 3G (1m)". Format-
+            // Suffix in Klammern (Pattern (NNNpNN[/NN]) o.ae.) wird
+            // aus dem Anzeige-Namen entfernt, weil's eher um's Kabel
+            // geht als um's Signal. Voller Name + Standard sieht der
+            // User weiter in den Eigenschaften.
+            const shortName = item.name.replace(
+              /\s*\(\d{2,4}[pi]\d{2,3}(?:\/\d{2,3})?\)/gi,
+              '',
+            ).trim()
+            const base = `${shortName} (${item.length}m)`
+            return item.needsConverter ? `${base} ⚠ converter` : base
+          })(),
         }
       }),
     [project.cables, cableColorMode, pdfExportThemeOverride],

--- a/src/renderer/components/Export/VideohubExportDialog.tsx
+++ b/src/renderer/components/Export/VideohubExportDialog.tsx
@@ -14,6 +14,7 @@ import {
 import { VideohubRoutingMatrix } from './VideohubRoutingMatrix'
 import { VideohubRoutingList } from './VideohubRoutingList'
 import { cablePlannerApi, hasDesktopBridge, type VideohubState } from '../../lib/bridge'
+import { effectiveShortName } from '../../lib/shortName'
 
 interface Props {
   onClose: () => void
@@ -238,7 +239,11 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
           const sourceEq = equipment.find((e) => e.id === c.fromEquipmentId)
           const sourcePort = sourceEq?.outputs.find((p) => p.id === c.fromPortId)
           inputConn.set(idx, {
-            sourceName: sourceEq?.name ?? '?',
+            // Issue #251 / readability — Short-Form-Name wenn der User
+            // einen gesetzt hat, sonst auto-generiert aus name.
+            // Macht "Telecast Basestation Rack" zu "TBR" o.ae. damit
+            // die Spalten-Header im Routing-Matrix lesbar bleiben.
+            sourceName: sourceEq ? effectiveShortName(sourceEq) : '?',
             portName: sourcePort?.name ?? '?',
           })
         }
@@ -250,7 +255,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
           const destEq = equipment.find((e) => e.id === c.toEquipmentId)
           const destPort = destEq?.inputs.find((p) => p.id === c.toPortId)
           outputConn.set(idx, {
-            destName: destEq?.name ?? '?',
+            destName: destEq ? effectiveShortName(destEq) : '?',
             portName: destPort?.name ?? '?',
           })
         }

--- a/src/renderer/components/Export/VideohubRoutingMatrix.tsx
+++ b/src/renderer/components/Export/VideohubRoutingMatrix.tsx
@@ -136,19 +136,24 @@ export const VideohubRoutingMatrix = ({
             : 'xs'
 
   const useHorizontalLabels = tier === 'xl' || tier === 'lg' || tier === 'md'
+  // Breitere Cells fuer horizontal-Label-Tiers — User: "jetzt sind
+  // die output label lesbar aber nicht die input label". Cells
+  // mussten breiter werden damit die Input-Header-Texte (inkl.
+  // Source-Suffix wie "TBR ← SDI Out 1") in eine oder zwei Zeilen
+  // passen ohne Mid-Word-Truncation.
   const defaultCellW =
-    tier === 'xl' ? 110 : tier === 'lg' ? 90 : tier === 'md' ? 60 : tier === 'sm' ? 14 : 10
+    tier === 'xl' ? 150 : tier === 'lg' ? 120 : tier === 'md' ? 80 : tier === 'sm' ? 14 : 10
   const defaultRowH =
     tier === 'xl' ? 36 : tier === 'lg' ? 32 : tier === 'md' ? 28 : tier === 'sm' ? 16 : 12
-  const labelFontPx = tier === 'xl' ? 14 : tier === 'lg' ? 13 : tier === 'md' ? 12 : tier === 'sm' ? 9 : 8
+  const labelFontPx = tier === 'xl' ? 13 : tier === 'lg' ? 12 : tier === 'md' ? 11 : tier === 'sm' ? 9 : 8
   const indexFontPx = Math.max(labelFontPx - 1, 8)
   const defaultLabelColW =
     tier === 'xl' ? 240 : tier === 'lg' ? 200 : tier === 'md' ? 160 : 120
   const indexColPx = tier === 'xl' ? 42 : tier === 'lg' ? 36 : 28
   const labelColW = layout.labelColWidth ?? defaultLabelColW
-  // Hoehe der Header-Reihe fuer Input-Labels. Horizontal → klein
-  // (eine Zeile). Rotiert → groesser.
-  const labelRowHeightPx = useHorizontalLabels ? 40 : tier === 'sm' ? 110 : 80
+  // Hoehe der Header-Reihe fuer Input-Labels — bei horizontalem
+  // Layout etwas mehr Hoehe damit 2-Zeilen-Labels (wrap) Platz haben.
+  const labelRowHeightPx = useHorizontalLabels ? 56 : tier === 'sm' ? 110 : 80
 
   const colWidth = (i: number) => layout.colWidths[i] ?? defaultCellW
   const rowHeight = (i: number) => layout.rowHeights[i] ?? defaultRowH
@@ -347,10 +352,16 @@ export const VideohubRoutingMatrix = ({
                             fontSize: labelFontPx,
                             fontWeight: 500,
                             letterSpacing: 0.2,
-                            lineHeight: 1.2,
-                            whiteSpace: 'nowrap',
+                            lineHeight: 1.15,
+                            // 2-Zeilen-Wrap statt Mid-Word-Truncation,
+                            // damit Labels wie "TBR ← SDI Out 1" voll
+                            // lesbar sind. Fallback Ellipsis nur wenn
+                            // die zweite Zeile auch nicht reicht.
+                            display: '-webkit-box',
+                            WebkitLineClamp: 2,
+                            WebkitBoxOrient: 'vertical',
                             overflow: 'hidden',
-                            textOverflow: 'ellipsis',
+                            wordBreak: 'break-word',
                           }}
                           title={inLabelTip[i]}
                         >


### PR DESCRIPTION
…#240)

User-Pain: "jetzt sind die output label lesbar aber nicht die input label".

Drei Aenderungen die zusammen die Input-Header der Routing- Matrix lesbar machen:

1) **Short-Name fuer Source-/Dest-Geraete** im VideohubExportDialog:
   inputConn/outputConn nutzen jetzt effectiveShortName statt
   eq.name. "Telecast Basestation Rack" wird automatisch zu "TBR"
   (oder dem User-Override). Aus dem Label
   "1 SDI In ← Telecast Basestation Rack" wird
   "1 SDI In ← TBR" — passt in eine Spalten-Header-Zelle.

2) **Breitere Cells** bei horizontal-Label-Tiers:
   - tier 'xl' (<=20):  110 -> 150 px
   - tier 'lg' (<=40):   90 -> 120 px
   - tier 'md' (<=80):   60 ->  80 px
   Header-Hoehe 40 -> 56 px damit 2-Zeilen-Wrap reinpasst.

3) **2-Zeilen-Label-Wrap** statt Mid-Word-Truncation:
   `-webkit-line-clamp: 2` + word-break:break-word. Lange Labels
   brechen sauber an Word-Boundaries; Ellipsis erst wenn auch
   die 2. Zeile voll ist. Voller Text bleibt im title-Tooltip.

Zusaetzlich Issue #240 (Cable-Label kuerzen): in CanvasArea wird die Format-Suffix-Klammer aus dem Anzeige-Namen herausgefiltert — aus "SDI 3G (1080p50/60) (1m)" wird "SDI 3G (1m)" auf dem Canvas. Voller Name + Format bleibt in den Eigenschaften.

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH