### PR TITLE
ui(videohub): Slate/Sky-Palette + volle Namen in Labels

### DIFF
--- a/src/renderer/components/Export/VideohubExportDialog.tsx
+++ b/src/renderer/components/Export/VideohubExportDialog.tsx
@@ -14,7 +14,6 @@ import {
 import { VideohubRoutingMatrix } from './VideohubRoutingMatrix'
 import { VideohubRoutingList } from './VideohubRoutingList'
 import { cablePlannerApi, hasDesktopBridge, type VideohubState } from '../../lib/bridge'
-import { effectiveShortName } from '../../lib/shortName'
 
 interface Props {
   onClose: () => void
@@ -239,11 +238,10 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
           const sourceEq = equipment.find((e) => e.id === c.fromEquipmentId)
           const sourcePort = sourceEq?.outputs.find((p) => p.id === c.fromPortId)
           inputConn.set(idx, {
-            // Issue #251 / readability — Short-Form-Name wenn der User
-            // einen gesetzt hat, sonst auto-generiert aus name.
-            // Macht "Telecast Basestation Rack" zu "TBR" o.ae. damit
-            // die Spalten-Header im Routing-Matrix lesbar bleiben.
-            sourceName: sourceEq ? effectiveShortName(sourceEq) : '?',
+            // User-Request: volle Geraete-Namen in Videohub-Labels,
+            // nicht die Short-Form-Variante. ShortName ist
+            // weiterhin fuer Endpoint-Labels (Cable-Edge) reserviert.
+            sourceName: sourceEq?.name ?? '?',
             portName: sourcePort?.name ?? '?',
           })
         }
@@ -255,7 +253,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
           const destEq = equipment.find((e) => e.id === c.toEquipmentId)
           const destPort = destEq?.inputs.find((p) => p.id === c.toPortId)
           outputConn.set(idx, {
-            destName: destEq ? effectiveShortName(destEq) : '?',
+            destName: destEq?.name ?? '?',
             portName: destPort?.name ?? '?',
           })
         }

--- a/src/renderer/components/Export/VideohubRoutingList.tsx
+++ b/src/renderer/components/Export/VideohubRoutingList.tsx
@@ -52,16 +52,16 @@ export const VideohubRoutingList = ({
               key={oi}
               className="flex items-center gap-2 rounded border border-slate-800 bg-slate-900/40 px-2 py-1.5 hover:bg-slate-800/50"
             >
-              {/* Output-Nummer (rot, mono) */}
+              {/* Output-Nummer (mono, neutral) */}
               <span
-                className="w-9 shrink-0 text-right font-mono text-[12px] font-semibold text-red-300/80"
+                className="w-9 shrink-0 text-right font-mono text-[12px] font-semibold text-slate-400"
                 title={`Output ${oi + 1}`}
               >
                 {oi + 1}
               </span>
-              {/* Output-Label (rot, fett) */}
+              {/* Output-Label */}
               <span
-                className="w-48 shrink-0 truncate text-[13px] font-semibold text-red-300"
+                className="w-48 shrink-0 truncate text-[13px] font-semibold text-slate-200"
                 title={outLabel}
               >
                 {outLabel}
@@ -74,11 +74,11 @@ export const VideohubRoutingList = ({
               <select
                 value={routedIdx}
                 onChange={(e) => onRoute(oi, parseInt(e.target.value, 10))}
-                className="flex-1 min-w-0 rounded border border-slate-700 bg-slate-950 px-2 py-1 text-[13px] text-emerald-200 focus:border-emerald-500 focus:outline-none"
+                className="flex-1 min-w-0 rounded border border-slate-700 bg-slate-950 px-2 py-1 text-[13px] text-slate-200 focus:border-sky-500 focus:outline-none"
                 title={`Input fuer Output ${oi + 1} (${outLabel}) waehlen — aktuell: ${routedIdx + 1} ${routedLabel}`}
               >
                 {inputLabels.map((inLabel, ii) => (
-                  <option key={ii} value={ii} className="bg-slate-950 text-emerald-100">
+                  <option key={ii} value={ii} className="bg-slate-950 text-slate-100">
                     {ii + 1}: {inLabel}
                   </option>
                 ))}

--- a/src/renderer/components/Export/VideohubRoutingMatrix.tsx
+++ b/src/renderer/components/Export/VideohubRoutingMatrix.tsx
@@ -98,14 +98,14 @@ export const VideohubRoutingMatrix = ({
           {outputLabels.map((outLabel, oi) => (
             <div key={oi} className="flex items-center gap-2 text-sm">
               <span className="w-10 shrink-0 font-mono text-right text-slate-500">{oi + 1}</span>
-              <span className="w-40 shrink-0 truncate text-right font-medium text-red-300">
+              <span className="w-40 shrink-0 truncate text-right font-medium text-slate-200">
                 {outLabel}
               </span>
               <span className="text-slate-500">←</span>
               <select
                 value={routing[oi] ?? 0}
                 onChange={(e) => onRoute(oi, parseInt(e.target.value, 10))}
-                className="flex-1 rounded border border-slate-700 bg-slate-900 p-1 text-sm text-emerald-200"
+                className="flex-1 rounded border border-slate-700 bg-slate-900 p-1 text-sm text-sky-200"
               >
                 {inputLabels.map((inLabel, ii) => (
                   <option key={ii} value={ii}>
@@ -303,7 +303,7 @@ export const VideohubRoutingMatrix = ({
                 #
               </th>
               <th
-                className="sticky top-0 z-20 border-b border-slate-700 bg-slate-800/80 px-3 text-left uppercase tracking-wide text-emerald-300"
+                className="sticky top-0 z-20 border-b border-slate-700 bg-slate-800/80 px-3 text-left uppercase tracking-wide text-slate-300"
                 colSpan={totalInputs}
                 style={{ fontSize: 12, fontWeight: 600 }}
               >
@@ -333,7 +333,7 @@ export const VideohubRoutingMatrix = ({
                     key={`lbl-${i}`}
                     className={`sticky z-10 bg-slate-900 ${
                       isGroupBreak(i) ? 'border-l border-slate-700' : ''
-                    } ${colHighlight === i ? 'bg-emerald-900/60' : ''}`}
+                    } ${colHighlight === i ? 'bg-sky-900/40' : ''}`}
                     style={{
                       top: 32,
                       width: cw,
@@ -346,7 +346,7 @@ export const VideohubRoutingMatrix = ({
                       {useHorizontalLabels ? (
                         <div
                           className={`flex h-full items-center justify-center px-2 text-center ${
-                            colHighlight === i ? 'text-emerald-100' : 'text-emerald-300'
+                            colHighlight === i ? 'text-slate-100' : 'text-slate-300'
                           }`}
                           style={{
                             fontSize: labelFontPx,
@@ -370,7 +370,7 @@ export const VideohubRoutingMatrix = ({
                       ) : (
                         <div
                           className={`overflow-hidden text-center ${
-                            colHighlight === i ? 'text-emerald-100' : 'text-emerald-300'
+                            colHighlight === i ? 'text-slate-100' : 'text-slate-300'
                           }`}
                           style={{
                             writingMode: 'vertical-lr',
@@ -432,7 +432,7 @@ export const VideohubRoutingMatrix = ({
                     key={`idx-${i}`}
                     className={`sticky z-10 border-b border-slate-700 bg-slate-900 font-mono text-slate-400 ${
                       isGroupBreak(i) ? 'border-l border-slate-700' : ''
-                    } ${colHighlight === i ? 'bg-emerald-900/60 text-emerald-200' : ''}`}
+                    } ${colHighlight === i ? 'bg-sky-900/40 text-sky-200' : ''}`}
                     style={{
                       top: 32 + labelRowHeightPx,
                       width: cw,
@@ -460,14 +460,14 @@ export const VideohubRoutingMatrix = ({
                 <tr
                   key={oi}
                   ref={(el) => { rowRefs.current[oi] = el }}
-                  className={`${rowOn ? 'bg-red-950/40' : 'hover:bg-slate-800/40'} ${
+                  className={`${rowOn ? 'bg-slate-800/50' : 'hover:bg-slate-800/40'} ${
                     groupRowBreak ? 'border-t border-slate-700' : ''
                   }`}
                   style={{ height: rh }}
                 >
                   <td
                     className={`sticky left-0 z-10 truncate border-r border-slate-800 px-3 text-left ${
-                      rowOn ? 'bg-red-950/70 text-red-100' : 'bg-slate-950 text-red-300'
+                      rowOn ? 'bg-slate-800/80 text-slate-100' : 'bg-slate-950 text-slate-200'
                     }`}
                     style={{
                       width: labelColW,
@@ -487,7 +487,7 @@ export const VideohubRoutingMatrix = ({
                   </td>
                   <td
                     className={`sticky z-10 border-r border-slate-800 text-center font-mono ${
-                      rowOn ? 'bg-red-950/70 text-red-200' : 'bg-slate-900 text-slate-500'
+                      rowOn ? 'bg-slate-800/80 text-slate-200' : 'bg-slate-900 text-slate-500'
                     }`}
                     style={{
                       left: labelColW,
@@ -501,7 +501,7 @@ export const VideohubRoutingMatrix = ({
                       <button
                         type="button"
                         onClick={() => focusRow(oi)}
-                        className="block w-full hover:text-emerald-300"
+                        className="block w-full hover:text-slate-300"
                         title={`Output ${oi + 1} fokussieren`}
                       >
                         {oi + 1}
@@ -519,8 +519,8 @@ export const VideohubRoutingMatrix = ({
                     const inCol = colHighlight === ii
                     const groupBreak = isGroupBreak(ii)
                     let tdBg = ''
-                    if (rowOn && inCol) tdBg = 'bg-amber-900/30'
-                    else if (inCol) tdBg = 'bg-emerald-900/30'
+                    if (rowOn && inCol) tdBg = 'bg-sky-700/40'
+                    else if (inCol) tdBg = 'bg-sky-900/30'
                     const cw = colWidth(ii)
                     return (
                       <td
@@ -545,11 +545,11 @@ export const VideohubRoutingMatrix = ({
                             active
                               ? 'mx-auto block rounded-sm bg-emerald-400 shadow-[0_0_8px_rgba(74,222,128,0.85)] ring-1 ring-emerald-200/70'
                               : rowOn && inCol
-                                ? 'mx-auto block rounded-sm bg-amber-400/70 hover:bg-amber-300'
+                                ? 'mx-auto block rounded-sm bg-sky-400/80 hover:bg-sky-300'
                                 : rowOn
-                                  ? 'mx-auto block rounded-sm bg-red-400/60 hover:bg-red-300'
+                                  ? 'mx-auto block rounded-sm bg-slate-400/50 hover:bg-slate-300'
                                   : inCol
-                                    ? 'mx-auto block rounded-sm bg-emerald-500/60 hover:bg-emerald-400'
+                                    ? 'mx-auto block rounded-sm bg-sky-500/50 hover:bg-sky-400'
                                     : 'mx-auto block rounded-sm bg-slate-700/80 hover:bg-slate-500'
                           }
                           style={{


### PR DESCRIPTION
User-Feedback (zwei kombiniert):

1) "mache die farben an das sonstige css von der software
   angepasst" — Routing-Matrix + Liste hatten Coral/Rot
   fuer Outputs und Emerald/Gruen fuer Inputs, das passte
   nicht zur App-Konvention (slate fuer Text, sky fuer
   aktive UI, emerald nur fuer "aktiv-routing"-Status).

   Geaendert:
   - Output-Labels: red-300 -> slate-200
   - Output-Labels-Highlight: red-100 -> slate-100
   - Input-Labels: emerald-300 -> slate-300
   - Input-Labels-Highlight: emerald-100 -> slate-100
   - Row-Hover-Tint: red-950/40 -> slate-800/50
   - Col-Hover-Tint: emerald-900/60 -> sky-900/40
   - Crosshair-Intersection: amber-900/30 -> sky-700/40
   - Row-Hover-Cell: red-400/60 -> slate-400/50
   - Col-Hover-Cell: emerald-500/60 -> sky-500/50
   - Row+Col-Cell: amber-400/70 -> sky-400/80
   - Index-Highlight: emerald-200 -> sky-200
   - List-Dropdown: emerald -> slate/sky

   Beibehalten:
   - Active-Crosspoint: emerald-400 mit Glow — bleibt, "aktiv-routing" ist im Cable-Planner generell emerald (Cable-Edges, gerouteter Zustand).
   - Warnungen: amber-300 (List-Mode-Fallback-Hinweis).

2) "Input Label und Output label sollen nicht die short
   form label nutzen" — die letzte Aenderung hatte fuer
   die Videohub-Spalten/-Zeilen-Header automatisch den
   effectiveShortName (z.B. "TBR" statt "Telecast
   Basestation Rack") eingesetzt. Revertiert: voller
   Geraete-Name kommt jetzt wieder ins Label. Short-Form
   ist weiter fuer die Cable-Endpoint-Labels reserviert
   (anderer Kontext, weniger Platz).

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH