### PR TITLE
feat(videohub+ports): #234 Label-Toggle-Pattern + #251 Port-Numbering…

### DIFF
--- a/src/renderer/components/Export/VideohubExportDialog.tsx
+++ b/src/renderer/components/Export/VideohubExportDialog.tsx
@@ -66,6 +66,31 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
       return 'matrix'
     }
   })
+  // v7.9.130 — Toggle "Verkabelung anzeigen". Wenn an (Default), wird
+  // an jedes Input/Output-Label das angeschlossene Geraet aus den
+  // Canvas-Kabeln angehaengt (z.B. "1 SDI In ← Sony PMW-F5").
+  // Wenn aus, sieht der User nur die nackten Port-Namen — sinnvoll
+  // wenn die Connection-Info schon redundant ist (Hub-Labels eh
+  // gleich beschriftet) oder die Spalten zu voll werden.
+  const [showConnections, setShowConnections] = useState<boolean>(() => {
+    try {
+      return sessionStorage.getItem('cable-planner.videohub.show-connections') !== 'off'
+    } catch {
+      return true
+    }
+  })
+  const toggleShowConnections = () => {
+    const next = !showConnections
+    setShowConnections(next)
+    try {
+      sessionStorage.setItem(
+        'cable-planner.videohub.show-connections',
+        next ? 'on' : 'off',
+      )
+    } catch {
+      /* ignore */
+    }
+  }
   const setAndPersistRoutingView = (v: 'matrix' | 'list') => {
     setRoutingView(v)
     try {
@@ -536,6 +561,24 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
               <span className="text-xs text-slate-500">
                 {preset.inputs} Eing. × {preset.outputs} Ausg.
               </span>
+              {/* v7.9.130 — Verkabelung-Toggle. Zeigt/versteckt das
+                  "← Verbundenes Geraet"-Suffix in den Labels. */}
+              <button
+                type="button"
+                onClick={toggleShowConnections}
+                title={
+                  showConnections
+                    ? 'Connection-Info ausblenden (nur Port-Name)'
+                    : 'Connection-Info einblenden (← angeschlossenes Geraet)'
+                }
+                className={`rounded border px-2 py-1 text-xs ${
+                  showConnections
+                    ? 'border-sky-700 bg-sky-900/40 text-sky-200'
+                    : 'border-slate-700 bg-slate-900 text-slate-400 hover:bg-slate-800'
+                }`}
+              >
+                {showConnections ? '🔗 Verkabelung an' : '🔗 Verkabelung aus'}
+              </button>
               {/* v7.9.119 / Issue #237 — Smart-Routing Vorschlag aus
                   Canvas-Verbindungen. Heuristik: pro Output das beste
                   Token-Match in den Input-Sources. Fallback: Diagonal. */}
@@ -566,7 +609,10 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                 if (hubLabel) return hubLabel
                 const portName = device?.inputs[i]?.name ?? `In ${i + 1}`
                 const conn = connections.inputConn.get(i)
-                return conn ? `${portName} ← ${conn.sourceName}` : portName
+                // v7.9.130 — Connection-Suffix nur wenn Toggle an.
+                return conn && showConnections
+                  ? `${portName} ← ${conn.sourceName}`
+                  : portName
               })
               const outputLabelArr = Array.from({ length: preset.outputs }, (_, i) => {
                 const hubLabel = hubState?.outputLabels?.[i]
@@ -580,7 +626,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                 if (hubLabel) return `${hubLabel}${lockBadge}`
                 const portName = device?.outputs[i]?.name ?? `Out ${i + 1}`
                 const conn = connections.outputConn.get(i)
-                return conn
+                return conn && showConnections
                   ? `${portName} → ${conn.destName}${lockBadge}`
                   : `${portName}${lockBadge}`
               })

--- a/src/renderer/components/Properties/CableProperties.tsx
+++ b/src/renderer/components/Properties/CableProperties.tsx
@@ -339,41 +339,44 @@ export const CableProperties = () => {
           <span className="text-slate-300">Label Position</span>
         </div>
         {(() => {
+          // Issue #234 — kein extra "Aus"-Button mehr. Wenn keine
+          // der drei Positionen aktiv ist, ist das Label ausgeblendet
+          // (labelPosition='none'). Klick auf aktiven Toggle deaktiviert
+          // ihn → Label verschwindet.
           const isHidden = cable.labelPosition === 'none'
           const activePos = cable.labelPosition ?? 'center'
           const positions = [
             { id: 'source' as const, label: '← Start' },
             { id: 'center' as const, label: 'Mitte' },
             { id: 'target' as const, label: 'End →' },
-            { id: 'none' as const, label: '∅ Aus' },
           ]
           return (
             <>
               <div className="flex gap-1">
                 {positions.map((p) => {
                   const isActive =
-                    p.id === 'none'
-                      ? isHidden
-                      : !isHidden && cable.labelT === undefined && activePos === p.id
+                    !isHidden && cable.labelT === undefined && activePos === p.id
                   return (
                     <button
                       key={p.id}
                       type="button"
                       onClick={() =>
                         updateCable(cable.id, {
-                          labelPosition: p.id,
-                          // labelT reset wenn explizite Position gewaehlt
-                          // wird; 'none' braucht's auch nicht.
+                          // Toggle: wenn schon aktiv → deaktivieren
+                          // (labelPosition='none' = Label aus).
+                          labelPosition: isActive ? 'none' : p.id,
                           labelT: undefined,
-                          // Legacy labelHidden raeumen
                           labelHidden: undefined,
                         })
                       }
+                      title={
+                        isActive
+                          ? `${p.label} — Klick zum Ausblenden des Labels`
+                          : `${p.label}`
+                      }
                       className={`flex-1 rounded border px-2 py-1 text-xs ${
                         isActive
-                          ? p.id === 'none'
-                            ? 'border-slate-500 bg-slate-700 text-slate-100'
-                            : 'border-sky-500 bg-sky-800 text-white'
+                          ? 'border-sky-500 bg-sky-800 text-white'
                           : 'border-slate-700 bg-slate-900 text-slate-300 hover:bg-slate-800'
                       }`}
                     >
@@ -382,6 +385,12 @@ export const CableProperties = () => {
                   )
                 })}
               </div>
+              {isHidden && (
+                <p className="mt-1 text-[10px] text-slate-500">
+                  Label ausgeblendet — Klick auf eine der drei Positionen
+                  zeigt es wieder an.
+                </p>
+              )}
               <div className={`mt-2 flex items-center gap-2 text-[11px] ${isHidden ? 'opacity-40' : ''}`}>
                 <span className="text-slate-500">Slider:</span>
                 <input

--- a/src/renderer/lib/portNumbering.ts
+++ b/src/renderer/lib/portNumbering.ts
@@ -1,0 +1,37 @@
+import type { Port } from '../types/equipment'
+
+/**
+ * v7.9.130 / Issue #251 — Effektive Anzeige-Nummer eines Ports.
+ *
+ * Standard ist `arrayIndex + 1` (1-basiert wie der User es liest).
+ * Wenn der User in den Properties einen `portNumber`-Override gesetzt
+ * hat, gewinnt der. Damit kann z.B. bei einem Patchpanel der Slot 3
+ * geloescht werden, ohne dass die uebrigen ihre Bezifferung verlieren —
+ * Port an Index 2 behaelt Anzeige-Nummer 4 wenn 3 weg ist.
+ *
+ * Achtung: das hat KEINE Auswirkung auf Wire-Protokolle (Videohub,
+ * ATEM). Die sprechen weiter ueber den Array-Index. `portNumber` ist
+ * rein fuer die UI-Darstellung + Beschriftungen.
+ */
+export const effectivePortNumber = (port: Port, arrayIndex: number): number => {
+  if (typeof port.portNumber === 'number' && port.portNumber > 0) {
+    return port.portNumber
+  }
+  return arrayIndex + 1
+}
+
+/**
+ * Pruefe ob in einer Port-Liste doppelte Anzeige-Nummern vorkommen.
+ * Wird in der UI als Warnung angezeigt damit der User nicht versehentlich
+ * zwei Ports mit gleicher Nummer hat — verwirrt die Geraete-Beschriftung.
+ */
+export const findDuplicatePortNumbers = (ports: Port[]): number[] => {
+  const seen = new Map<number, number>()
+  const duplicates = new Set<number>()
+  ports.forEach((p, idx) => {
+    const n = effectivePortNumber(p, idx)
+    if (seen.has(n)) duplicates.add(n)
+    else seen.set(n, idx)
+  })
+  return Array.from(duplicates).sort((a, b) => a - b)
+}

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -37,6 +37,17 @@ export interface Port {
    *  seinen originalName zurueckgesetzt, der vom User vergebene Name
    *  wandert mit dem Kabel auf den neuen Port. */
   originalName?: string
+  /** v7.9.130 / Issue #251 — Anzeige-Nummer unabhaengig vom Label.
+   *  Default ist die Position im Array (1-basiert), kann aber pro
+   *  Port ueberschrieben werden. Anwendungsfaelle:
+   *  - User loescht Port 3 — die uebrigen behalten ihre Original-
+   *    Nummern (4 wird nicht zu 3).
+   *  - Videohub-Hardware ist anders nummeriert als unser Slot-Array.
+   *  - Doppelte Nummern werden vermeidbar weil der User explizit
+   *    festlegt, was angezeigt wird.
+   *  WICHTIG: Das Wire-Protokoll (Videohub, ATEM) nutzt weiter den
+   *  Array-Index — `portNumber` ist nur fuer die ANZEIGE. */
+  portNumber?: number
   /** v7.9.124 / Bug-2 + Bug-3 — Optionale ATEM-Source-ID-Ueberschreibung.
    *  Wenn gesetzt: dieser CP-Port wird im MV-Config-Dialog mit dieser
    *  Source-ID adressiert (statt idx+1). Ermoeglicht offline-Setup


### PR DESCRIPTION
… + #130 Verkabelung-Toggle

Drei kleine Features die zusammen die Lesbarkeit deutlich verbessern:

ISSUE #234 (CableProperties Label-Position):
  Der 4. Button "∅ Aus" entfernt. Start/Mitte/End sind jetzt
  TOGGLE-Buttons — Klick auf den aktiven schaltet ihn aus →
  Label verschwindet (labelPosition='none'). Klick auf einen
  beliebigen anderen aktiviert ihn. Hilfetext erscheint
  wenn Label ausgeblendet ist.

ISSUE #251 (Port-Nummern unabhaengig vom Label):
  Foundation:
  - Port-Schema um optionales `portNumber: number` erweitert
  - Helper lib/portNumbering.ts:
    - effectivePortNumber(port, idx) → port.portNumber ?? idx+1
    - findDuplicatePortNumbers(ports) → fuer UI-Warnung
  - Wire-Protokolle (Videohub, ATEM) sprechen weiter ueber Array-Index — portNumber ist NUR fuer die UI-Darstellung. Folge-Arbeit: UI-Input + Verwendung in Matrix-Header, Patch- Liste, Cable-BOM (siehe Plan unten).

ISSUE #130 / User-Request (Verkabelung-Toggle im Videohub-Routing):
  Im Routing-Section-Header neuer Toggle "🔗 Verkabelung an/aus".
  Wenn an (Default): Labels zeigen "Port-Name ← Verbundenes
  Geraet". Wenn aus: nur der nackte Port-Name. Persistiert in
  sessionStorage. Gilt fuer Matrix + Listen-View.

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH