### PR TITLE
ui(videohub): Buttons + Label-Text in unterschiedlichen Farben

### DIFF
--- a/src/renderer/components/Export/VideohubExportDialog.tsx
+++ b/src/renderer/components/Export/VideohubExportDialog.tsx
@@ -604,9 +604,10 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                 {showConnections ? '🔗 Verkabelung an' : '🔗 Verkabelung aus'}
               </button>
               {/* v7.9.130 — Zusatztoggle "Input-Label" (Port-Name am
-                  angeschlossenen Geraet). Nur sichtbar wenn
-                  Verkabelung-Toggle an ist — ohne Connection-Info gibt
-                  es keinen Port am anderen Ende zum Anzeigen. */}
+                  angeschlossenen Geraet). Andere Farb-Palette als
+                  Verkabelung-Toggle damit User auf einen Blick sieht
+                  dass das zwei unabhaengige Toggles sind: Verkabelung
+                  -> sky, Input-Label -> emerald. */}
               {showConnections && (
                 <button
                   type="button"
@@ -618,7 +619,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                   }
                   className={`rounded border px-2 py-1 text-xs ${
                     showConnectionPorts
-                      ? 'border-sky-700 bg-sky-900/40 text-sky-200'
+                      ? 'border-emerald-700 bg-emerald-900/40 text-emerald-200'
                       : 'border-slate-700 bg-slate-900 text-slate-400 hover:bg-slate-800'
                   }`}
                 >
@@ -650,31 +651,24 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
               // Liste durchreichen. Hub-Labels gewinnen wenn vom Hub
               // geladen ("Status laden"). Sonst Canvas-Port-Name +
               // (wenn verkabelt) die Source/Dest aus dem Canvas.
-              // v7.9.130 — Connection-Suffix-Builder:
-              //   showConnections=off → kein Suffix (nur Port-Name)
-              //   showConnections=on, showConnectionPorts=off → "← DeviceName"
-              //   showConnections=on, showConnectionPorts=on  → "← DeviceName · DevicePort"
-              const connSuffix = (
-                arrow: '←' | '→',
-                deviceName: string,
-                devicePort: string,
-              ) => {
-                if (!showConnections) return ''
-                if (showConnectionPorts && devicePort && devicePort !== '?') {
-                  return ` ${arrow} ${deviceName} · ${devicePort}`
-                }
-                return ` ${arrow} ${deviceName}`
-              }
-              const inputLabelArr = Array.from({ length: preset.inputs }, (_, i) => {
+              // v7.9.130 — Connection-Suffix-Builder + parallel
+              // strukturierte Parts fuer farb-kodierte Anzeige.
+              const inputLabelParts = Array.from({ length: preset.inputs }, (_, i) => {
                 const hubLabel = hubState?.inputLabels?.[i]
-                if (hubLabel) return hubLabel
+                if (hubLabel) return { port: hubLabel }
                 const portName = device?.inputs[i]?.name ?? `In ${i + 1}`
                 const conn = connections.inputConn.get(i)
-                return conn
-                  ? `${portName}${connSuffix('←', conn.sourceName, conn.portName)}`
-                  : portName
+                if (!conn || !showConnections) return { port: portName }
+                return {
+                  port: portName,
+                  connDevice: conn.sourceName,
+                  connPort:
+                    showConnectionPorts && conn.portName && conn.portName !== '?'
+                      ? conn.portName
+                      : undefined,
+                }
               })
-              const outputLabelArr = Array.from({ length: preset.outputs }, (_, i) => {
+              const outputLabelParts = Array.from({ length: preset.outputs }, (_, i) => {
                 const hubLabel = hubState?.outputLabels?.[i]
                 const lockState = hubState?.outputLocks?.[i]
                 const lockBadge =
@@ -683,13 +677,36 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                     : lockState === 'locked-other'
                       ? ' 🔒❗'
                       : ''
-                if (hubLabel) return `${hubLabel}${lockBadge}`
+                if (hubLabel) return { port: hubLabel, lockBadge }
                 const portName = device?.outputs[i]?.name ?? `Out ${i + 1}`
                 const conn = connections.outputConn.get(i)
-                return conn
-                  ? `${portName}${connSuffix('→', conn.destName, conn.portName)}${lockBadge}`
-                  : `${portName}${lockBadge}`
+                if (!conn || !showConnections) return { port: portName, lockBadge }
+                return {
+                  port: portName,
+                  connDevice: conn.destName,
+                  connPort:
+                    showConnectionPorts && conn.portName && conn.portName !== '?'
+                      ? conn.portName
+                      : undefined,
+                  lockBadge,
+                }
               })
+              // Plain-Text-Variante fuer Tooltips / List-Mode-Fallback /
+              // Export-Filenamen.
+              const inputLabelArr = inputLabelParts.map((p) =>
+                p.connPort
+                  ? `${p.port} ← ${p.connDevice} · ${p.connPort}`
+                  : p.connDevice
+                    ? `${p.port} ← ${p.connDevice}`
+                    : p.port,
+              )
+              const outputLabelArr = outputLabelParts.map((p) =>
+                (p.connPort
+                  ? `${p.port} → ${p.connDevice} · ${p.connPort}`
+                  : p.connDevice
+                    ? `${p.port} → ${p.connDevice}`
+                    : p.port) + (p.lockBadge ?? ''),
+              )
               const onRoute = (output: number, input: number) =>
                 setRouting((r) => ({ ...r, [output]: input }))
               if (routingView === 'list') {
@@ -710,6 +727,8 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                   totalOutputs={preset.outputs}
                   inputLabels={inputLabelArr}
                   outputLabels={outputLabelArr}
+                  inputLabelParts={inputLabelParts}
+                  outputLabelParts={outputLabelParts}
                   routing={routing}
                   onRoute={onRoute}
                 />

--- a/src/renderer/components/Export/VideohubRoutingMatrix.tsx
+++ b/src/renderer/components/Export/VideohubRoutingMatrix.tsx
@@ -1,5 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 
+/** Struktur fuer farb-kodierte Label-Rendering. Wenn ein Eintrag
+ *  mehr als nur `port` enthaelt, rendert der Matrix-Header die Teile
+ *  farblich getrennt (Verkabelung = sky, Input-Label = emerald). */
+export interface LabelPart {
+  port: string
+  connDevice?: string
+  connPort?: string
+  lockBadge?: string
+}
+
 interface Props {
   totalInputs: number
   totalOutputs: number
@@ -7,7 +17,27 @@ interface Props {
   outputLabels: string[]
   routing: Record<number, number>
   onRoute: (output: number, input: number) => void
+  /** Optional: strukturierte Label-Teile fuer farb-kodierte Anzeige.
+   *  Wenn gesetzt, gewinnt's gegenueber inputLabels/outputLabels fuer
+   *  die Darstellung — der String wird nur noch fuer Tooltip/Title und
+   *  Filter genutzt. */
+  inputLabelParts?: LabelPart[]
+  outputLabelParts?: LabelPart[]
 }
+
+/** Rendert einen LabelPart mit Farb-Kodierung der Suffixe. */
+const renderLabelPart = (part: LabelPart) => (
+  <>
+    <span>{part.port}</span>
+    {part.connDevice && (
+      <span className="text-sky-300"> ← {part.connDevice}</span>
+    )}
+    {part.connPort && (
+      <span className="text-emerald-300"> · {part.connPort}</span>
+    )}
+    {part.lockBadge && <span>{part.lockBadge}</span>}
+  </>
+)
 
 /**
  * Interactive routing crosspoint matrix for Blackmagic Videohub.
@@ -70,6 +100,8 @@ export const VideohubRoutingMatrix = ({
   totalOutputs,
   inputLabels,
   outputLabels,
+  inputLabelParts,
+  outputLabelParts,
   routing,
   onRoute,
 }: Props) => {
@@ -353,10 +385,6 @@ export const VideohubRoutingMatrix = ({
                             fontWeight: 500,
                             letterSpacing: 0.2,
                             lineHeight: 1.15,
-                            // 2-Zeilen-Wrap statt Mid-Word-Truncation,
-                            // damit Labels wie "TBR ← SDI Out 1" voll
-                            // lesbar sind. Fallback Ellipsis nur wenn
-                            // die zweite Zeile auch nicht reicht.
                             display: '-webkit-box',
                             WebkitLineClamp: 2,
                             WebkitBoxOrient: 'vertical',
@@ -365,7 +393,9 @@ export const VideohubRoutingMatrix = ({
                           }}
                           title={inLabelTip[i]}
                         >
-                          {label}
+                          {inputLabelParts?.[i]
+                            ? renderLabelPart(inputLabelParts[i])
+                            : label}
                         </div>
                       ) : (
                         <div
@@ -384,7 +414,9 @@ export const VideohubRoutingMatrix = ({
                           }}
                           title={inLabelTip[i]}
                         >
-                          {label}
+                          {inputLabelParts?.[i]
+                            ? renderLabelPart(inputLabelParts[i])
+                            : label}
                         </div>
                       )}
                       {/* Resize-Handle rechts */}
@@ -481,8 +513,11 @@ export const VideohubRoutingMatrix = ({
                     title={outLabelTip[oi]}
                   >
                     <div style={{ position: 'relative' }}>
-                      <div className="truncate">{outLabel}</div>
-                      {/* Resize-Handle unten (verschoben weiter unten am tr) */}
+                      <div className="truncate">
+                        {outputLabelParts?.[oi]
+                          ? renderLabelPart(outputLabelParts[oi])
+                          : outLabel}
+                      </div>
                     </div>
                   </td>
                   <td


### PR DESCRIPTION
User-Request: "verkabelung an, und input label an muessen die buttons und auch die dazugehoerigen texte unterschiedliche farben haben wegen UI".

Zwei Aenderungen:

1) **Button-Farben unterscheiden**:
   - 🔗 Verkabelung an  → sky (Primary-Highlight-Farbe)
   - · Input-Label an  → emerald (gleiches Gruen wie active- routing-State, bewusst andere Farbe als sky) Beide haben gleichen Slate-Hintergrund wenn aus.

2) **Label-Text-Fragmente farbig**: Matrix rendert die drei
   Teile eines Labels jetzt mit verschiedenen Farben:
   - "PortName"            (slate-200/300 — neutral)
   - " ← DeviceName"       (sky-300        — passt zum
                             Verkabelung-Toggle)
   - " · ConnectionPort"   (emerald-300    — passt zum
                             Input-Label-Toggle)

   Neue Prop-Schnittstelle: inputLabelParts / outputLabelParts
   als optionales Array von { port, connDevice?, connPort?,
   lockBadge? }. Wenn vorhanden, rendert die Matrix die Teile
   per renderLabelPart() mit colored spans. Fallback auf den
   plain string wenn keine Parts. Tooltip nimmt weiter den
   Plain-String (Title kann kein HTML).

   Listen-View nutzt weiter Plain-Strings — Browser kann
   keine inline-Farben in <option>-Elementen rendern (HTML-
   Spec-Limit).

Damit ist auf einen Blick sichtbar welcher Toggle welchen Teil des Labels steuert: gleiche Farbe wie der Button, gleicher Effekt.

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH