### PR TITLE
feat(export): Ebenen-Chips im Plan-Export-Dialog unter Page-Size

### DIFF
--- a/src/renderer/components/Export/ExportDialog.tsx
+++ b/src/renderer/components/Export/ExportDialog.tsx
@@ -22,6 +22,7 @@ import { printPdfBlob } from '../../lib/printPdfBlob'
 import { sanitizeForPdf } from '../../lib/sanitizeForPdf'
 import { downloadBlob } from '../../lib/downloadBlob'
 import { buildExportFilenameWithSuffix } from '../../lib/exportFilename'
+import { LayerVisibilityChips } from '../Canvas/LayerVisibilityChips'
 import type { Cable } from '../../types/cable'
 
 export type ExportFormat = 'pdf' | 'png' | 'jpeg'
@@ -339,6 +340,21 @@ const PlanSection = ({
               </p>
             </fieldset>
           )}
+          {/* Ebenen-Filter — uebernimmt die Chip-Komponente aus der
+              Canvas-Toolbar. Same store, daher synchronisiert sich die
+              Auswahl bidirektional. "Nur Video drucken" = alle anderen
+              Chips ausschalten, exportieren, Chips wieder einschalten. */}
+          <fieldset className="space-y-1">
+            <legend className="mb-1 text-xs font-semibold text-slate-300">
+              Ebenen (im PDF enthalten)
+            </legend>
+            <div className="-mx-1 flex flex-wrap gap-1">
+              <LayerVisibilityChips />
+            </div>
+            <p className="text-[10px] text-slate-500">
+              Klick auf einen Chip schaltet die Ebene fuer Canvas UND PDF um.
+            </p>
+          </fieldset>
         </>
       )}
 


### PR DESCRIPTION
Pro User-Feedback: die Ebenen-Filter im ExportDialog (Datei ->
Exportieren & Drucken -> Plan) waren noch nicht sichtbar. Der fehlende Spot war direkt unter "Page-Size" — dort jetzt eine eigene Fieldset mit der LayerVisibilityChips-Komponente.

Sichtbar fuer alle PDF-Modi (Raster + Vektor); Page-Size selbst ist nur im Vektor-Modus sichtbar, die Layer-Chips daneben/darunter aber jederzeit waehrend "Plan" ausgewaehlt ist.

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH