### PR TITLE
ui(export): "Beta"-Tag bei Vektor-PDF entfernen

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1058,7 +1058,7 @@ const PdfExportDialog = ({
                 onChange={() => onVectorChange(true)}
               />
               <span>
-                Vektor (Beta)
+                Vektor
                 <span className="block text-[10px] text-slate-500">
                   Chromium printToPDF. Text bleibt selektierbar &amp; scharf bei
                   jedem Zoom. Kleinere Dateigröße.

--- a/src/renderer/components/Export/ExportDialog.tsx
+++ b/src/renderer/components/Export/ExportDialog.tsx
@@ -302,9 +302,7 @@ const PlanSection = ({
                 className="mt-0.5"
               />
               <span>
-                <span className="block">
-                  ✨ Vektor <span className="rounded bg-sky-700 px-1 py-0.5 text-[9px] font-semibold text-white">Beta</span>
-                </span>
+                <span className="block">✨ Vektor</span>
                 <span className="block text-[10px] text-slate-400">
                   Chromium printToPDF. Text bleibt selektierbar &amp; scharf bei
                   jedem Zoom. Kleinere Dateigröße.


### PR DESCRIPTION
User-Request: Vektor-Pfad ist stabil genug, Beta-Label kann weg. Aenderung in beiden Export-Dialogen (ExportDialog + PdfExportDialog).

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH