### PR TITLE
build: Version aus git-tag ziehen statt package.json hardcoded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cable-planner",
     "private": true,
-    "version": "7.9.128",
+    "version": "8.0.10",
     "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
     "author": {
         "name": "Lars Zumpe",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { resolve } from 'node:path'
 import { readFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
 
 // Read version from package.json at build time so the renderer can show
 // it in the About dialog + StatusBar without an IPC round-trip. Build
@@ -12,9 +13,44 @@ const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8')
   author?: { name?: string; email?: string } | string
 }
 
+// Prefer git tag over package.json for the runtime version. CI release
+// flow taggt vor jedem Build (z.B. v8.0.10), und der User erwartet
+// dass die Hilfe-Menue-Version dem Tag entspricht. Fallback auf
+// package.json wenn git nicht verfuegbar ist (z.B. tarball-Build).
+const resolveAppVersion = (): string => {
+  try {
+    // `git describe --tags --abbrev=0` → letzter erreichbarer Tag wie "v8.0.10".
+    // Wenn HEAD genau auf dem Tag sitzt: nackter Tagname.
+    // Wenn HEAD ein paar Commits hinter dem Tag ist: pre-release-Suffix
+    // (z.B. "v8.0.10-3-gabcdef") damit man auf einen Blick sieht dass
+    // der Build *vor* dem Tag ist und nicht der Release selbst.
+    const exact = execSync('git describe --tags --exact-match HEAD', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim()
+    if (exact) return exact.replace(/^v/, '')
+  } catch {
+    /* HEAD ist kein exakter Tag — versuche nearest + suffix */
+  }
+  try {
+    const described = execSync('git describe --tags --always --dirty', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim()
+    if (described) return described.replace(/^v/, '')
+  } catch {
+    /* kein git verfuegbar — Fallback auf package.json */
+  }
+  return pkg.version
+}
+
+const appVersion = resolveAppVersion()
+
 export default defineConfig({
   define: {
-    __APP_VERSION__: JSON.stringify(pkg.version),
+    __APP_VERSION__: JSON.stringify(appVersion),
     __APP_DESCRIPTION__: JSON.stringify(pkg.description ?? ''),
     __APP_AUTHOR__: JSON.stringify(
       typeof pkg.author === 'string' ? pkg.author : pkg.author?.name ?? '',


### PR DESCRIPTION
User-Feedback: das Hilfe-Menue zeigte 7.9.128 obwohl der letzte Release-Tag schon v8.0.10 war. Jetzt:

1. Vite probiert zuerst 'git describe --tags --exact-match HEAD' -> wenn HEAD genau auf einem Tag steht, blanker Tagname (8.0.10).
2. Sonst 'git describe --tags --always --dirty' -> Pre-Release-Form (z.B. 8.0.10-3-gabcdef-dirty) damit man auf einen Blick sieht dass es kein Release-Build ist.
3. Fallback auf package.json wenn git nicht verfuegbar (z.B. wenn aus dem Tarball gebaut wird).

Zusaetzlich package.json-Version von 7.9.128 -> 8.0.10 gezogen damit der Fallback nicht stale ist.

https://claude.ai/code/session_01R5qdUcEdY5pUygUyKtc1gH