### PR TITLE
fix(canvas): #223 Cable-Bridge-Rendering auf eigenen ReactFlow-Viewpo…

### DIFF
--- a/src/renderer/components/Canvas/CableEdge.tsx
+++ b/src/renderer/components/Canvas/CableEdge.tsx
@@ -495,8 +495,20 @@ export const CableEdge = ({
     // Collect orthogonal segments from every OTHER cable's path in the
     // DOM. Parse only M and L commands — anything else (arcs, curves)
     // means the path is already bumped or non-orthogonal.
+    //
+    // #223 — Bug: vorher hat das ein document-weites querySelectorAll
+    // gemacht. Im Sub-Canvas (RackInternalCanvas, RackEditorDialog) hat
+    // das auch Pfade vom Haupt-Canvas dahinter aufgesammelt und das
+    // Bridge-Rendering hat Kabel über "nicht existierende" Kabel
+    // springen lassen. Jetzt scopen wir auf die naechste
+    // .react-flow__container vom myPath aus, damit nur Kabel im
+    // gleichen ReactFlow-Viewport beruecksichtigt werden.
     const otherSegments: Array<{ a: { x: number; y: number }; b: { x: number; y: number } }> = []
-    const allPaths = document.querySelectorAll<SVGPathElement>('path.react-flow__edge-path')
+    const scope =
+      myPath.closest<HTMLElement>('.react-flow') ??
+      myPath.closest<HTMLElement>('.react-flow__container') ??
+      document
+    const allPaths = scope.querySelectorAll<SVGPathElement>('path.react-flow__edge-path')
     allPaths.forEach((p) => {
       if (p === myPath) return
       const d = p.getAttribute('d')


### PR DESCRIPTION
…rt scopen

Root-Cause des 'Kabel springen ueber andere (nicht existierende Kabel)'-Bugs im Rack-internen Canvas:

Der Bridge-Renderer in CableEdge.tsx hat per
document.querySelectorAll('path.react-flow__edge-path') alle Kabel- Pfade in der KOMPLETTEN DOM gesucht. Wenn der RackBuilderDialog (oder RackEditorDialog) offen war, lag der Haupt-Canvas dahinter weiterhin im DOM — Kabel im Rack-Canvas haben dadurch Bridge-Bumps ueber Kabel gerendert die der User dort gar nicht sehen kann.

Jetzt:
  const scope = myPath.closest('.react-flow') ?? document
  scope.querySelectorAll(...)

Damit pickt der Bridge-Code nur noch Kabel aus dem GLEICHEN ReactFlow-Viewport auf. Wirkt fuer beide Sub-Canvases (RackInternal fuer Library-Side Rack-Design, RackEditor fuer Canvas-platzierte Rack-Instanzen).

Andere Bug-Reports aus #223 wurden bereits in frueheren Commits adressiert:
  - 'A*-Routing fehlgeschlagen'-Modal: v7.9.115 graceful fallback auf ReactFlow-Standard-Orthogonal-Routing
  - 'Geraete verlieren ihre Position': v7.9.14 GroupPreset.rack.internalCanvasPositions
  - 'Kabel verlieren ihre Position': v7.9.115 cables[].waypoints werden im Preset persistiert
  - 'Geraete lassen sich nicht positionieren': hasOverlap guard fuer eqW=0/eqH=0 (vor erstem Measure)

Build clean.