### PR TITLE
fix(ui): Emoji in extrahierten Rack/Library-Komponenten auf lucide-Icons (UX #50)

### DIFF
--- a/src/renderer/components/Library/tabs/LocalEquipmentTab.tsx
+++ b/src/renderer/components/Library/tabs/LocalEquipmentTab.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { ChevronDown, ChevronRight, Pencil, X } from 'lucide-react'
+import { Icon } from '../../shared/Icon'
 import { useProjectStore } from '../../../store/projectStore'
 import { useUiStore } from '../../../store/uiStore'
 import { bilingualCategoryDialog } from '../../../lib/bilingualCategoryDialog'
@@ -134,9 +136,10 @@ export const LocalEquipmentTab = ({
               type="button"
               onClick={() => setLibrarySearch('')}
               title={t('library.search.clear', 'Suche löschen')}
+              aria-label={t('library.search.clear', 'Suche löschen')}
               className="absolute right-1 top-1/2 -translate-y-1/2 rounded px-1 py-0.5 text-xs text-slate-500 hover:bg-slate-700 hover:text-slate-200"
             >
-              ✕
+              <Icon icon={X} size="sm" />
             </button>
           ) : (
             <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[9px] uppercase tracking-wider text-slate-600">
@@ -218,8 +221,9 @@ export const LocalEquipmentTab = ({
             type="button"
             onClick={() => setShowNewGroup(false)}
             className="rounded bg-slate-700 px-2 text-xs hover:bg-slate-600"
+            aria-label={t('common.close', 'Schließen')}
           >
-            ✕
+            <Icon icon={X} size="sm" />
           </button>
         </form>
       )}
@@ -324,7 +328,7 @@ export const LocalEquipmentTab = ({
                     className="flex flex-1 min-w-0 items-center gap-1.5 text-left"
                   >
                     <span className="inline-block w-3 text-center text-slate-500">
-                      {collapsed ? '▸' : '▾'}
+                      <Icon icon={collapsed ? ChevronRight : ChevronDown} size="xs" />
                     </span>
                     <span className="flex-1 truncate normal-case tracking-normal">
                       {categoryDisplay(cat, lang, categoryTranslations)}
@@ -353,8 +357,9 @@ export const LocalEquipmentTab = ({
                     }}
                     className="hidden rounded bg-slate-700/80 px-1.5 py-0.5 text-[10px] font-normal normal-case text-slate-200 hover:bg-slate-600 group-hover/cat:block"
                     title={t('library.renameCategory', 'Kategorie umbenennen')}
+                    aria-label={t('library.renameCategory', 'Kategorie umbenennen')}
                   >
-                    ✎
+                    <Icon icon={Pencil} size="xs" />
                   </button>
                   <span className="rounded bg-slate-800 px-1.5 py-0.5 text-[10px] font-normal text-slate-400">
                     {items.length}
@@ -395,8 +400,9 @@ export const LocalEquipmentTab = ({
                             onClick={() => setSelectedTemplateName(item.name)}
                             className="absolute right-7 top-1 hidden rounded bg-slate-600 px-1 py-0.5 text-[10px] hover:bg-slate-500 group-hover/item:block"
                             title={t('library.template.editTitle', 'Vorlage bearbeiten (Name, Kategorie)')}
+                            aria-label={t('library.template.editTitle', 'Vorlage bearbeiten (Name, Kategorie)')}
                           >
-                            ✎
+                            <Icon icon={Pencil} size="xs" />
                           </button>
                         </div>
                       ))

--- a/src/renderer/components/Rack/RackBuilderDialogExportMenu.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialogExportMenu.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react'
+import { Box, Camera, ChevronDown, Save } from 'lucide-react'
+import { Icon } from '../shared/Icon'
 import { v4 as uuidv4 } from 'uuid'
 import * as THREE from 'three'
 import type { EquipmentTemplate, GroupPreset } from '../../types/equipment'
@@ -81,7 +83,7 @@ export const RackBuilderDialogExportMenu = ({
         <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
           <path d="M8 1 L8 10 M4 7 L8 11 L12 7 M2 13 L14 13" />
         </svg>
-        {t('rack.exportBtn', 'Exportieren')} ▾
+        {t('rack.exportBtn', 'Exportieren')}<Icon icon={ChevronDown} size="xs" className="ml-1 inline-block align-text-bottom" />
       </button>
       {open && (
         <div
@@ -97,7 +99,7 @@ export const RackBuilderDialogExportMenu = ({
             }}
             className="flex w-full flex-col items-start gap-0.5 border-b border-slate-800 px-3 py-2 text-left text-slate-200 hover:bg-slate-800"
           >
-            <span className="font-semibold">📷 {t('rack.export.png2d', '2D als PNG')}</span>
+            <span className="font-semibold"><Icon icon={Camera} size="xs" className="mr-1 inline-block align-text-bottom" />{t('rack.export.png2d', '2D als PNG')}</span>
             <span className="text-[10px] text-slate-500">
               {t('rack.export.png2dDesc', 'Aktuelle Front/Rear/Both-Ansicht als Bild')}
             </span>
@@ -119,7 +121,7 @@ export const RackBuilderDialogExportMenu = ({
             }}
             className="flex w-full flex-col items-start gap-0.5 border-b border-slate-800 px-3 py-2 text-left text-slate-200 hover:bg-slate-800"
           >
-            <span className="font-semibold">📸 {t('rack.export.png3d', '3D aus 4 Perspektiven')}</span>
+            <span className="font-semibold"><Icon icon={Camera} size="xs" className="mr-1 inline-block align-text-bottom" />{t('rack.export.png3d', '3D aus 4 Perspektiven')}</span>
             <span className="text-[10px] text-slate-500">
               {t('rack.export.png3dDesc', 'PNG: Front · Rear · Iso · Top (1× pro Datei)')}
             </span>
@@ -136,7 +138,7 @@ export const RackBuilderDialogExportMenu = ({
             }}
             className="flex w-full flex-col items-start gap-0.5 border-b border-slate-800 px-3 py-2 text-left text-slate-200 hover:bg-slate-800"
           >
-            <span className="font-semibold">🧊 {t('rack.export.stl', '3D als STL')}</span>
+            <span className="font-semibold"><Icon icon={Box} size="xs" className="mr-1 inline-block align-text-bottom" />{t('rack.export.stl', '3D als STL')}</span>
             <span className="text-[10px] text-slate-500">
               {t('rack.export.stlDesc', 'Komplettes Rack als binäres STL (3D-Druck, CAD)')}
             </span>
@@ -190,7 +192,7 @@ export const RackBuilderDialogExportMenu = ({
             }}
             className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left text-slate-200 hover:bg-slate-800"
           >
-            <span className="font-semibold">💾 {t('rack.export.cpgroup', '.cpgroup herunterladen')}</span>
+            <span className="font-semibold"><Icon icon={Save} size="xs" className="mr-1 inline-block align-text-bottom" />{t('rack.export.cpgroup', '.cpgroup herunterladen')}</span>
             <span className="text-[10px] text-slate-500">
               {t('rack.export.cpgroupDesc', 'Komplettes Rack inkl. STL + Fotos zum Cross-PC-Transfer')}
             </span>

--- a/src/renderer/components/Rack/RackBuilderFooter.tsx
+++ b/src/renderer/components/Rack/RackBuilderFooter.tsx
@@ -1,3 +1,5 @@
+import { AlertTriangle } from 'lucide-react'
+import { Icon } from '../shared/Icon'
 import { useTranslation } from '../../lib/i18n'
 
 /** v7.9.11 — Status-Footer mit drei klaren Zonen:
@@ -62,7 +64,7 @@ export const RackBuilderFooter = ({
         )}
         {conflictsCount > 0 && (
           <span className="inline-flex items-center gap-1 rounded bg-red-900/60 px-2 py-0.5 text-red-200">
-            <span>⚠</span>
+            <Icon icon={AlertTriangle} size="xs" />
             <strong>{conflictsCount}</strong>
             <span>{t('rack.conflictsWord', 'Konflikte')}</span>
           </span>


### PR DESCRIPTION
## Hintergrund

Der Refactor-PR #408 hat Sub-Komponenten aus dem Stand **vor** mains Emoji-Sweep (UX #50) ausgelagert. Beim Merge kamen dadurch 11 Emoji-Glyphs zurück auf main, die main an den ursprünglichen (nicht-extrahierten) Stellen längst auf lucide-`<Icon/>` umgestellt hatte. Dieser PR zieht den Sweep in den extrahierten Dateien nach — gleiche Icons/Patterns wie überall sonst.

## Änderungen
- **LocalEquipmentTab.tsx**: Such-/Close-Buttons `✕` → `X`, Rename/Edit `✎` → `Pencil`, Kategorie-Chevrons `▸/▾` → `ChevronRight/ChevronDown`; passende `aria-label`s ergänzt.
- **RackBuilderDialogExportMenu.tsx**: Export-Buttons `📷/📸` → `Camera`, `🧊` → `Box`, `💾` → `Save`, Dropdown-Caret `▾` → `ChevronDown`.
- **RackBuilderFooter.tsx**: Konflikt-Badge `⚠` → `AlertTriangle`.

## Verifikation
- `npx tsc -p tsconfig.app.json --noEmit` → **0 Errors**
- `npx vite build` → **exit 0**
- 0 Emoji-Glyphs mehr in den 3 Dateien

Closes UX #50 (Restbestand aus #408).

---
_Generated by [Claude Code](https://claude.ai/code/session_015uS2viCVSEK6YvJUGyRUQ9)_