### PR TITLE
feat(properties): Display/Fachdaten/Konfigurationen ein-/ausklappbar

### DIFF
--- a/src/renderer/components/Properties/sections/CategoryPropsSection.tsx
+++ b/src/renderer/components/Properties/sections/CategoryPropsSection.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useProjectStore } from '../../../store/projectStore'
 import { useUiStore } from '../../../store/uiStore'
 import { useTranslation } from '../../../lib/i18n'
@@ -114,16 +115,28 @@ export const CategoryPropsSection = ({ equipment }: { equipment: EquipmentItem }
     })
   }
 
+  // Ein-/ausklappbar (wie SDI-Caps / Abmessungen). Default offen, wenn schon
+  // Fachdaten gesetzt sind, sonst eingeklappt. <summary> statt Form-Control,
+  // damit das Toggle auch im gesperrten (viewer/finalized) Fieldset geht.
+  const [open, setOpen] = useState(Object.keys(props).length > 0)
+
   return (
-    <fieldset className="rounded border border-slate-700 p-2">
-      <legend className="px-1 text-[11px] uppercase tracking-wide text-slate-400">
-        {t('catprops.title', 'Fachdaten')} — {equipment.category}
-      </legend>
-      <div className="grid grid-cols-2 gap-2">
+    <details
+      open={open}
+      onToggle={(e) => setOpen(e.currentTarget.open)}
+      className="rounded border border-slate-700 [&_summary]:cursor-pointer"
+    >
+      <summary className="flex items-center gap-1 px-2 py-1.5 text-[11px] uppercase tracking-wide text-slate-400 hover:text-slate-200 [&::-webkit-details-marker]:hidden">
+        <span className="text-slate-500">{open ? '▾' : '▸'}</span>
+        <span className="flex-1">
+          {t('catprops.title', 'Fachdaten')} — {equipment.category}
+        </span>
+      </summary>
+      <div className="grid grid-cols-2 gap-2 px-2 pb-2">
         {fields.map((f) => (
           <Field key={f.key} field={f} lang={lang} value={props[f.key]} onChange={(v) => setProp(f.key, v)} />
         ))}
       </div>
-    </fieldset>
+    </details>
   )
 }

--- a/src/renderer/components/Properties/sections/DeviceConfigsBlock.tsx
+++ b/src/renderer/components/Properties/sections/DeviceConfigsBlock.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useUiStore } from '../../../store/uiStore'
 import { useTranslation } from '../../../lib/i18n'
 
@@ -13,12 +14,27 @@ export const DeviceConfigsBlock = ({ equipmentId }: { equipmentId: string }) => 
   const updateDeviceConfig = useUiStore((s) => s.updateDeviceConfig)
   const assigned = library.filter((e) => e.equipmentId === equipmentId)
   const unassigned = library.filter((e) => !e.equipmentId)
+  // Ein-/ausklappbar (wie SDI-Caps / Abmessungen). Default offen, wenn dem
+  // Gerät schon Konfigurationen zugeordnet sind, sonst eingeklappt. <summary>
+  // statt Form-Control, damit das Toggle auch im gesperrten Fieldset geht.
+  const [open, setOpen] = useState(assigned.length > 0)
   if (library.length === 0) return null
   return (
-    <div className="rounded border border-slate-700 bg-slate-900/40 p-2">
-      <div className="mb-1 text-[10px] uppercase tracking-wide text-slate-400">
-        {t('props.deviceConfigs.title', 'Konfigurationen')}
-      </div>
+    <details
+      open={open}
+      onToggle={(e) => setOpen(e.currentTarget.open)}
+      className="rounded border border-slate-700 bg-slate-900/40 [&_summary]:cursor-pointer"
+    >
+      <summary className="flex items-center gap-1 px-2 py-1.5 text-[10px] uppercase tracking-wide text-slate-400 hover:text-slate-200 [&::-webkit-details-marker]:hidden">
+        <span className="text-slate-500">{open ? '▾' : '▸'}</span>
+        <span className="flex-1">{t('props.deviceConfigs.title', 'Konfigurationen')}</span>
+        {!open && assigned.length > 0 && (
+          <span className="rounded bg-slate-700/60 px-1 text-[9px] normal-case text-slate-200">
+            {assigned.length}
+          </span>
+        )}
+      </summary>
+      <div className="px-2 pb-2">
       {assigned.length === 0 ? (
         <div className="text-[11px] text-slate-500">
           {t('props.deviceConfigs.none', 'Keine Konfiguration zugeordnet.')}
@@ -67,6 +83,7 @@ export const DeviceConfigsBlock = ({ equipmentId }: { equipmentId: string }) => 
           'Neue Konfigurationen über Einstellungen → Konfigurationen hochladen.',
         )}
       </div>
-    </div>
+      </div>
+    </details>
   )
 }

--- a/src/renderer/components/Properties/sections/DisplayPropertiesBlock.tsx
+++ b/src/renderer/components/Properties/sections/DisplayPropertiesBlock.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useProjectStore } from '../../../store/projectStore'
 import { useTranslation } from '../../../lib/i18n'
 import type { EquipmentItem } from '../../../types/equipment'
@@ -29,11 +30,23 @@ export const DisplayPropertiesBlock = ({ equipment }: { equipment: EquipmentItem
     equipment.resolution !== undefined ||
     equipment.displaySizeInch !== undefined
   if (!looksLikeDisplay) return null
+  // Ein-/ausklappbar (wie SDI-Caps / Abmessungen). Default offen, wenn schon
+  // Werte gesetzt sind, sonst eingeklappt. <summary> statt Form-Control, damit
+  // das Toggle auch im gesperrten (viewer/finalized) Fieldset bedienbar bleibt.
+  const [open, setOpen] = useState(
+    equipment.resolution !== undefined || equipment.displaySizeInch !== undefined,
+  )
   return (
-    <fieldset className="rounded border border-slate-700 p-2">
-      <legend className="px-1 text-[11px] uppercase tracking-wide text-slate-400">
-        {t('display.title', 'Display')}
-      </legend>
+    <details
+      open={open}
+      onToggle={(e) => setOpen(e.currentTarget.open)}
+      className="rounded border border-slate-700 [&_summary]:cursor-pointer"
+    >
+      <summary className="flex items-center gap-1 px-2 py-1.5 text-[11px] uppercase tracking-wide text-slate-400 hover:text-slate-200 [&::-webkit-details-marker]:hidden">
+        <span className="text-slate-500">{open ? '▾' : '▸'}</span>
+        <span className="flex-1">{t('display.title', 'Display')}</span>
+      </summary>
+      <div className="px-2 pb-2">
       <div className="grid grid-cols-2 gap-2">
         <label className="block">
           <span className="mb-1 block text-slate-300">{t('display.resolution', 'Auflösung')}</span>
@@ -70,6 +83,7 @@ export const DisplayPropertiesBlock = ({ equipment }: { equipment: EquipmentItem
           />
         </label>
       </div>
-    </fieldset>
+      </div>
+    </details>
   )
 }


### PR DESCRIPTION
- DisplayPropertiesBlock, CategoryPropsSection, DeviceConfigsBlock von statischen Containern auf collapsible <details> umgestellt, gleiches ▾/▸-Muster wie SDI-Caps + Abmessungen.
- Smart default: aufgeklappt wenn bereits Werte/Zuordnungen gesetzt, sonst eingeklappt. DeviceConfigs zeigt Anzahl-Badge beim Einklappen.
- <summary> statt Form-Control, bleibt im gesperrten Properties- Fieldset (viewer/finalized) bedienbar.