### PR TITLE
fix(menubar): Dropdown-Menüs nicht mehr von header overflow-hidden abgeschnitten

### DIFF
--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -110,7 +110,7 @@ export const MenuBar = ({
     projectHistory.canRedo,
   )
   return (
-    <header className="flex shrink-0 items-center justify-between gap-3 overflow-hidden border-b border-[var(--cp-border)] bg-[var(--cp-surface-3)] px-3 py-1.5 text-cp-xs shadow-sm">
+    <header className="flex shrink-0 items-center justify-between gap-3 border-b border-[var(--cp-border)] bg-[var(--cp-surface-3)] px-3 py-1.5 text-cp-xs shadow-sm">
       <div className="flex shrink-0 items-center gap-2">
         <span className="hidden select-none font-semibold tracking-wide text-slate-300 lg:inline">
           {t('app.title', 'Cable Planner')}


### PR DESCRIPTION
## Bug

Die Dropdown-Menüs der Top-Bar (**Datei / Ansicht / Werkzeuge / …**) öffneten sich nicht mehr sichtbar — Klick öffnete das Menü (State `open=true`), aber man sah nichts.

## Ursache

Commit `e17f9d7` (*MenuBar overflow/token cleanup, UX #5/#7*) setzte `overflow-hidden` auf das MenuBar-`<header>`. Die Dropdowns rendern per `absolute top-full` **unterhalb** der Leiste; ihr Containing-Block liegt innerhalb des Headers, daher hat `overflow-hidden` sie **komplett abgeschnitten**.

## Fix

`overflow-hidden` am `<header>` entfernt (1 Zeile).

Das responsive Verhalten hängt **nicht** davon ab:
- Center-Gruppe: `min-w-0 flex-1` + `truncate` (Projektname zusätzlich `max-w-[42ch] truncate`)
- Seiten-Gruppen: `shrink-0`

Die Leiste läuft also weiter nicht über, und die Dropdowns (out-of-flow, `absolute`) lassen sie nicht wachsen.

## Verifikation
- `npx tsc -p tsconfig.app.json --noEmit` → **0 Errors**
- `npx vite build` → **exit 0**

---
_Generated by [Claude Code](https://claude.ai/code/session_015uS2viCVSEK6YvJUGyRUQ9)_