### PR TITLE
fix(canvas): CanvasToolbar-Endlosschleife beheben (zustand v5 instabiler Selector, #425)

### DIFF
--- a/src/renderer/components/Canvas/CanvasToolbar.tsx
+++ b/src/renderer/components/Canvas/CanvasToolbar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useOnSelectionChange, useReactFlow } from 'reactflow'
 import { useUiStore } from '../../store/uiStore'
 import { useCanvasProjectStore as useProjectStore } from '../../store/projectStoreContext'
@@ -54,13 +54,18 @@ export const CanvasToolbar = ({ mode = 'main' }: { mode?: CanvasToolbarMode } = 
     (state) => state.addLocationAroundEquipment,
   )
   const saveGroupPreset = useProjectStore((state) => state.saveGroupPreset)
-  // #425 — Liste der bestehenden Preset-Namen fuer Duplikat-Check beim
-  // Speichern einer neuen Geraetegruppe (case-insensitive).
-  const existingPresetNames = useProjectStore((state) =>
-    state.groupPresets.map((p) => p.name.trim().toLowerCase()),
-  )
   const deleteGroupPreset = useProjectStore((state) => state.deleteGroupPreset)
   const groupPresetsForOverwrite = useProjectStore((state) => state.groupPresets)
+  // #425 — Liste der bestehenden Preset-Namen fuer Duplikat-Check beim
+  // Speichern einer neuen Geraetegruppe (case-insensitive). WICHTIG: aus dem
+  // stabilen groupPresets-Array via useMemo ableiten. Ein Store-Selector der
+  // direkt `.map()` zurueckgibt liefert bei JEDEM Render eine neue Array-
+  // Referenz; unter zustand v5 (useSyncExternalStore) fuehrt das zu
+  // "Maximum update depth exceeded" — Endlos-Re-Render der CanvasToolbar.
+  const existingPresetNames = useMemo(
+    () => groupPresetsForOverwrite.map((p) => p.name.trim().toLowerCase()),
+    [groupPresetsForOverwrite],
+  )
   const canvasState = useProjectStore((state) => state.project.canvasState)
   const updateEquipment = useProjectStore((state) => state.updateEquipment)
   const equipmentList = useProjectStore((state) => state.project.equipment)


### PR DESCRIPTION
### Bug
„Maximum update depth exceeded" beim Öffnen eines Projekts mit Geräte-Vorlagen — der Canvas friert ein. Stack zeigt `CanvasToolbar` → reactflow-Store-Loop.

### Ursache
`#425` hat in `CanvasToolbar` einen instabilen zustand-Selector eingeführt:
```ts
const existingPresetNames = useProjectStore((state) =>
  state.groupPresets.map((p) => p.name.trim().toLowerCase()),
)
```
`.map()` liefert bei **jedem** Render eine neue Array-Referenz. Unter **zustand v5** (`useSyncExternalStore`) gilt der Snapshot damit immer als „geändert" → Endlos-Re-Render → Crash.

### Fix
`existingPresetNames` aus dem stabilen `groupPresets`-Array via `useMemo` ableiten (statt im Selector zu mappen).

### Scope
Codebase-weiter Scan: dies war der **einzige** instabile Store-Selector. Die übrigen folgen bereits dem stabilen-Key-Muster (z. B. `EquipmentNode`: String-Key im Selector + `useMemo` fürs `Set`). Keine `useShallow`-Umstellung nötig.

tsc 0 Errors, vite build grün.

---
_Generated by [Claude Code](https://claude.ai/code/session_015uS2viCVSEK6YvJUGyRUQ9)_