### PR TITLE
feat(crdt): SyncManager + Transport + Voll-Projekt-Sync (Stufe 2, #413)

### DIFF
--- a/scripts/crdt-convergence-check.mjs
+++ b/scripts/crdt-convergence-check.mjs
@@ -1,111 +1,209 @@
-// #413 — Konvergenz-Beweis für das CRDT-Fundament, in EINEM Prozess.
+// #413 — Konvergenz-Beweis für die CRDT-Synchronisation, in EINEM Prozess.
 //
 // Simuliert zwei Planer (A und B), die gleichzeitig am selben Plan arbeiten,
-// ihre Updates austauschen und garantiert auf denselben Stand konvergieren —
-// ohne Server, auch bei konkurrierenden Edits und out-of-order Zustellung.
+// ihre Updates über einen Transport austauschen und garantiert auf denselben
+// Stand konvergieren — ohne Server, auch bei konkurrierenden Edits, Offline-
+// Phasen und out-of-order Zustellung.
 //
-// Läuft ohne TS-Toolchain direkt gegen das installierte `yjs` (pure JS).
-// Nutzung:  node scripts/crdt-convergence-check.mjs
+// Spiegelt die App-Module (pure JS, da die .mjs keine TS importieren kann):
+//   • Stufe 1: Y.Doc-Merge-Garantien direkt (Szenarien 1–3).
+//   • Stufe 2: LoopbackTransport (syncTransport.ts, inkl. inbox-Puffer) +
+//     SyncManager-Protokoll (syncManager.ts) über das volle Projekt (4–5).
+// Die TS-Implementierung ist tsc-geprüft; dieser Beweis verifiziert das
+// Protokoll/den Algorithmus.
+//
+// Nutzung:  node scripts/crdt-convergence-check.mjs   (npm run test:crdt)
 // Exit 0 = alle Asserts grün, Exit 1 = Divergenz (CI-tauglich).
 
 import * as Y from 'yjs'
 
 let failures = 0
 const assert = (cond, msg) => {
-  if (cond) {
-    console.log('  ✓', msg)
-  } else {
-    console.error('  ✗', msg)
-    failures++
-  }
+  console.log(cond ? '  OK ' : '  XX ', msg)
+  if (!cond) failures++
 }
 
-const cablesOf = (doc) => {
-  const out = {}
-  for (const [k, v] of doc.getMap('cables')) out[k] = v
-  return out
+// Order-unabhängiger Vergleich einer Y.Map (Insertion-Order variiert je Doc).
+const mapSorted = (doc, name) => {
+  const o = {}
+  for (const [k, v] of doc.getMap(name)) o[k] = v
+  return Object.keys(o).sort().map((k) => [k, o[k]])
 }
-// Order-unabhängiger Vergleich: Y.Map iteriert je nach Insertion-Order
-// unterschiedlich, der INHALT ist aber gleich. Daher Keys sortieren.
-const canonical = (doc) => {
-  const obj = cablesOf(doc)
-  return JSON.stringify(Object.keys(obj).sort().map((k) => [k, obj[k]]))
+const cablesEqual = (a, b) =>
+  JSON.stringify(mapSorted(a, 'cables')) === JSON.stringify(mapSorted(b, 'cables'))
+const cableCount = (doc) => mapSorted(doc, 'cables').length
+
+const projOf = (doc) =>
+  JSON.stringify({
+    e: mapSorted(doc, 'equipment'),
+    c: mapSorted(doc, 'cables'),
+    l: mapSorted(doc, 'locations'),
+  })
+const sameProject = (a, b) => projOf(a) === projOf(b)
+
+// ── LoopbackTransport (spiegelt syncTransport.ts inkl. inbox-Puffer) ────────
+const makeLoopbackPair = () => {
+  const mk = () => ({ peer: null, receivers: new Set(), outbox: [], inbox: [], paused: false })
+  const a = mk()
+  const b = mk()
+  a.peer = b
+  b.peer = a
+  // Liefert an ep; puffert in ep.inbox falls noch kein Receiver da ist
+  // (sonst ginge der Initial-State eines früh sendenden Peers verloren).
+  const deliver = (ep, u) => {
+    if (ep.receivers.size === 0) {
+      ep.inbox.push(u)
+      return
+    }
+    for (const r of ep.receivers) r(u)
+  }
+  const api = (ep) => ({
+    send: (u) => {
+      if (ep.paused) ep.outbox.push(u)
+      else deliver(ep.peer, u)
+    },
+    onReceive: (cb) => {
+      ep.receivers.add(cb)
+      if (ep.inbox.length > 0) {
+        const q = ep.inbox
+        ep.inbox = []
+        for (const u of q) cb(u)
+      }
+      return () => ep.receivers.delete(cb)
+    },
+    pause: () => {
+      ep.paused = true
+    },
+    resume: () => {
+      ep.paused = false
+      const q = ep.outbox
+      ep.outbox = []
+      for (const u of q) deliver(ep.peer, u)
+    },
+  })
+  return [api(a), api(b)]
 }
-const sameCables = (a, b) => canonical(a) === canonical(b)
+
+// ── SyncManager (spiegelt syncManager.ts) ──────────────────────────────────
+const REMOTE = 'remote'
+const wireManager = (doc, transport, counter) => {
+  doc.on('update', (u, origin) => {
+    if (origin !== REMOTE) {
+      if (counter) counter.sends++
+      transport.send(u)
+    }
+  })
+  transport.onReceive((u) => {
+    Y.applyUpdate(doc, u, REMOTE)
+  })
+  if (counter) counter.sends++
+  transport.send(Y.encodeStateAsUpdate(doc))
+}
 
 // ── Szenario 1: konkurrierende Edits an VERSCHIEDENEN Kabeln ───────────────
-console.log('Szenario 1: A und B editieren verschiedene Kabel gleichzeitig')
-{
+const scenario1 = () => {
+  console.log('Szenario 1: A und B editieren verschiedene Kabel gleichzeitig')
   const a = new Y.Doc()
   const b = new Y.Doc()
-  // Gemeinsamer Ausgangsstand: ein Kabel.
   a.getMap('cables').set('c1', { id: 'c1', name: 'SDI 1', length: 5 })
-  Y.applyUpdate(b, Y.encodeStateAsUpdate(a)) // B bekommt A's Start.
-  assert(sameCables(a, b), 'gleicher Startstand nach initialem Sync')
+  Y.applyUpdate(b, Y.encodeStateAsUpdate(a))
+  assert(cablesEqual(a, b), 'gleicher Startstand nach initialem Sync')
 
-  // Offline divergieren: A legt c2 an, B legt c3 an.
   a.getMap('cables').set('c2', { id: 'c2', name: 'SDI 2', length: 10 })
   b.getMap('cables').set('c3', { id: 'c3', name: 'XLR 1', length: 3 })
-  assert(!sameCables(a, b), 'divergiert während offline (erwartet)')
+  assert(!cablesEqual(a, b), 'divergiert während offline (erwartet)')
 
-  // Updates austauschen (beide Richtungen).
-  const updA = Y.encodeStateAsUpdate(a)
-  const updB = Y.encodeStateAsUpdate(b)
-  Y.applyUpdate(a, updB)
-  Y.applyUpdate(b, updA)
-
-  assert(sameCables(a, b), 'konvergiert nach Austausch')
-  assert(Object.keys(cablesOf(a)).length === 3, 'alle 3 Kabel vorhanden (c1,c2,c3)')
+  Y.applyUpdate(a, Y.encodeStateAsUpdate(b))
+  Y.applyUpdate(b, Y.encodeStateAsUpdate(a))
+  assert(cablesEqual(a, b), 'konvergiert nach Austausch')
+  assert(cableCount(a) === 3, 'alle 3 Kabel vorhanden (c1,c2,c3)')
 }
 
 // ── Szenario 2: konkurrierende Edits am SELBEN Kabel (Konflikt) ────────────
-console.log('Szenario 2: A und B editieren DASSELBE Kabel (Last-Write-Wins/Doc)')
-{
+const scenario2 = () => {
+  console.log('Szenario 2: A und B editieren DASSELBE Kabel (deterministische Aufloesung)')
   const a = new Y.Doc()
   const b = new Y.Doc()
   a.getMap('cables').set('c1', { id: 'c1', name: 'orig', length: 1 })
   Y.applyUpdate(b, Y.encodeStateAsUpdate(a))
 
-  // Beide ändern c1 unterschiedlich.
   a.getMap('cables').set('c1', { id: 'c1', name: 'von-A', length: 7 })
   b.getMap('cables').set('c1', { id: 'c1', name: 'von-B', length: 9 })
 
-  // Kreuz-Austausch.
-  const updA = Y.encodeStateAsUpdate(a)
-  const updB = Y.encodeStateAsUpdate(b)
-  Y.applyUpdate(a, updB)
-  Y.applyUpdate(b, updA)
-
-  // Konflikt wird deterministisch aufgelöst → beide gleich (kein Crash,
-  // kein Split-Brain). Welcher gewinnt, ist durch die Yjs-Client-ID fix.
-  assert(sameCables(a, b), 'konfligierende Edits konvergieren deterministisch')
-  console.log('    aufgelöst zu:', JSON.stringify(cablesOf(a).c1))
+  Y.applyUpdate(a, Y.encodeStateAsUpdate(b))
+  Y.applyUpdate(b, Y.encodeStateAsUpdate(a))
+  assert(cablesEqual(a, b), 'konfligierende Edits konvergieren deterministisch')
 }
 
 // ── Szenario 3: Idempotenz + out-of-order Zustellung ───────────────────────
-console.log('Szenario 3: Doppel-Empfang und vertauschte Reihenfolge')
-{
+const scenario3 = () => {
+  console.log('Szenario 3: Doppel-Empfang und vertauschte Reihenfolge')
   const a = new Y.Doc()
   const b = new Y.Doc()
   a.getMap('cables').set('c1', { id: 'c1', name: 'A', length: 1 })
   a.getMap('cables').set('c2', { id: 'c2', name: 'B', length: 2 })
 
   const u1 = Y.encodeStateAsUpdate(a)
-  // Zweimal anwenden (Idempotenz) + nochmal in anderer Reihenfolge.
   Y.applyUpdate(b, u1)
   Y.applyUpdate(b, u1)
   Y.applyUpdate(b, u1)
-
-  assert(sameCables(a, b), 'mehrfaches Anwenden desselben Updates ist idempotent')
-  assert(Object.keys(cablesOf(b)).length === 2, 'kein Duplikat durch Doppel-Empfang')
+  assert(cablesEqual(a, b), 'mehrfaches Anwenden desselben Updates ist idempotent')
+  assert(cableCount(b) === 2, 'kein Duplikat durch Doppel-Empfang')
 }
 
-// ── Ergebnis ───────────────────────────────────────────────────────────────
+// ── Szenario 4: SyncManager-Loop (live), volles Projekt ────────────────────
+const scenario4 = () => {
+  console.log('Szenario 4: SyncManager-Loop (live), volles Projekt')
+  const counter = { sends: 0 }
+  const a = new Y.Doc()
+  const b = new Y.Doc()
+  a.getMap('equipment').set('e1', { id: 'e1', name: 'Switcher' })
+  const [ta, tb] = makeLoopbackPair()
+  wireManager(a, ta, counter)
+  wireManager(b, tb, counter)
+  assert(sameProject(a, b), 'beitretender Peer B erhaelt A-Initialstand')
+
+  a.getMap('cables').set('c1', { id: 'c1', name: 'SDI 1', length: 5 })
+  b.getMap('locations').set('l1', { id: 'l1', name: 'FOH' })
+  assert(sameProject(a, b), 'Live-Edits beider Seiten propagieren sofort')
+  assert(counter.sends < 50, `keine Echo-Schleife (sends=${counter.sends})`)
+}
+
+// ── Szenario 5: Offline-Divergenz + Reconnect über Transport ───────────────
+const scenario5 = () => {
+  console.log('Szenario 5: Offline-Divergenz + Reconnect ueber Transport')
+  const a = new Y.Doc()
+  const b = new Y.Doc()
+  const [ta, tb] = makeLoopbackPair()
+  wireManager(a, ta)
+  wireManager(b, tb)
+  a.getMap('equipment').set('e1', { id: 'e1', name: 'Cam 1' })
+  assert(sameProject(a, b), 'synchron vor Offline-Phase')
+
+  ta.pause()
+  tb.pause()
+  a.getMap('equipment').set('e2', { id: 'e2', name: 'Cam 2' })
+  b.getMap('cables').set('c9', { id: 'c9', name: 'Tri-Level', length: 2 })
+  assert(!sameProject(a, b), 'divergiert waehrend beide offline (erwartet)')
+
+  ta.resume()
+  tb.resume()
+  assert(sameProject(a, b), 'konvergiert nach Reconnect')
+  const merged = JSON.parse(projOf(a))
+  assert(merged.e.length === 2 && merged.c.length === 1, 'alle Offline-Edits erhalten (2 Geraete, 1 Kabel)')
+}
+
+scenario1()
+scenario2()
+scenario3()
+scenario4()
+scenario5()
+
 console.log('')
 if (failures === 0) {
-  console.log('ALLE KONVERGENZ-ASSERTS GRÜN ✓')
+  console.log('ALLE KONVERGENZ-ASSERTS GRUEN')
   process.exit(0)
 } else {
-  console.error(`${failures} ASSERT(S) FEHLGESCHLAGEN ✗`)
+  console.error(`${failures} ASSERT(S) FEHLGESCHLAGEN`)
   process.exit(1)
 }

--- a/src/renderer/lib/crdt/projectCrdt.ts
+++ b/src/renderer/lib/crdt/projectCrdt.ts
@@ -1,81 +1,113 @@
-// #413 — Echtzeit-Kollaboration: CRDT-Fundament (erste Stufe).
+// #413 — Echtzeit-Kollaboration: CRDT-Datenschicht.
 //
-// Dies ist die *Datenschicht* für die spätere Live-Kollaboration: ein
-// Yjs-`Y.Doc`, das den Plan als CRDT spiegelt. Zwei Instanzen, die ihre
+// Ein Yjs-`Y.Doc`, das den Plan als CRDT spiegelt. Zwei Instanzen, die ihre
 // Updates austauschen, konvergieren garantiert auf denselben Stand — ohne
 // zentralen Server, auch bei gleichzeitigen Edits.
 //
-// BEWUSST erste Stufe: nur die `cables`-Collection ist gespiegelt (der am
-// häufigsten gleichzeitig editierte Teil), und es ist noch KEIN Transport
-// angebunden (`y-webrtc`/`y-websocket` kommt als nächster Schritt). Die
-// Slice-Integration (Store ⇄ Y.Doc) und Presence folgen darauf. Der Pfad
-// ist in docs/architecture.md §9.4 skizziert.
+// Stufe 1 (erledigt): nur `cables`. Stufe 2 (hier): das ganze Projekt —
+// `equipment`, `cables`, `locations` als je eigene `Y.Map` (Key = id).
+// Objekte werden als Ganzes gehalten (Konflikt-Granularität „pro Element"),
+// was für die Praxis (zwei Planer bearbeiten verschiedene Geräte/Kabel)
+// ausreicht; feld-granulares CRDT pro Element ist eine spätere Optimierung.
 //
-// Verifizierbar OHNE zweite App-Instanz: `mergeUpdateInto` + `encodeState`
-// erlauben einen Konvergenz-Beweis in einem Prozess (siehe
-// scripts/crdt-convergence-check.mjs).
+// Transport (LoopbackTransport für Tests, später y-webrtc/y-websocket) und
+// die Live-Bindung an den Store liegen in syncTransport.ts / syncManager.ts.
+// Pfad: docs/architecture.md §9.4.
 
 import * as Y from 'yjs'
 import type { Cable } from '../../types/cable'
+import type { EquipmentItem } from '../../types/equipment'
+import type { LocationFrame } from '../../types/location'
 
-/** Name der Yjs-Top-Level-Map, unter der die Kabel liegen. */
+const EQUIPMENT_MAP = 'equipment'
 const CABLES_MAP = 'cables'
+const LOCATIONS_MAP = 'locations'
+
+/** Minimaler Plan-Ausschnitt, den der CRDT spiegelt. */
+export interface CrdtProjectSlice {
+  equipment: EquipmentItem[]
+  cables: Cable[]
+  locations: LocationFrame[]
+}
 
 /**
- * Wrappt ein `Y.Doc` und bietet eine kleine, plan-spezifische API. Die
- * Kabel liegen als `Y.Map<Cable>` (Key = cable.id). Cables werden als ganze
- * Objekte gehalten (nicht feld-granular) — das ist die pragmatische erste
- * Stufe: Konflikt-Granularität ist „pro Kabel", was für die Praxis (zwei
- * Planer ziehen verschiedene Kabel) ausreicht. Feld-granulares CRDT pro
- * Kabel ist eine spätere Optimierung.
+ * Wrappt ein `Y.Doc` und bietet eine plan-spezifische API. Equipment, Kabel
+ * und Locations liegen je als `Y.Map<…>` (Key = element.id).
  */
 export class ProjectCrdt {
   readonly doc: Y.Doc
+  private readonly equipment: Y.Map<EquipmentItem>
   private readonly cables: Y.Map<Cable>
+  private readonly locations: Y.Map<LocationFrame>
 
   constructor(doc: Y.Doc = new Y.Doc()) {
     this.doc = doc
+    this.equipment = doc.getMap<EquipmentItem>(EQUIPMENT_MAP)
     this.cables = doc.getMap<Cable>(CABLES_MAP)
+    this.locations = doc.getMap<LocationFrame>(LOCATIONS_MAP)
   }
 
-  /** Spiegelt eine Kabel-Liste in das Y.Doc (Initial-Load). Bestehende
-   *  Einträge, die nicht mehr in der Liste sind, werden entfernt. Läuft in
-   *  einer Transaction, damit Observer nur ein Update sehen. */
-  loadFromCables(list: Cable[]): void {
+  // ── Voll-Projekt-Sync ────────────────────────────────────────────────
+
+  /** Spiegelt einen Plan-Ausschnitt in das Y.Doc (Initial-Load / Resync).
+   *  Entfernte Elemente werden gelöscht, neue/geänderte gesetzt — alles in
+   *  EINER Transaction, damit Observer nur ein Update sehen. */
+  loadFromProject(slice: CrdtProjectSlice): void {
     this.doc.transact(() => {
-      const incoming = new Set(list.map((c) => c.id))
-      // Entfernte Kabel löschen.
-      for (const id of [...this.cables.keys()]) {
-        if (!incoming.has(id)) this.cables.delete(id)
-      }
-      // Neue/aktualisierte setzen.
-      for (const c of list) this.cables.set(c.id, c)
+      syncMap(this.equipment, slice.equipment)
+      syncMap(this.cables, slice.cables)
+      syncMap(this.locations, slice.locations)
     })
   }
 
-  /** Setzt/aktualisiert ein einzelnes Kabel. */
+  /** Aktueller Plan-Stand aus dem Y.Doc. */
+  toProject(): CrdtProjectSlice {
+    return {
+      equipment: [...this.equipment.values()],
+      cables: [...this.cables.values()],
+      locations: [...this.locations.values()],
+    }
+  }
+
+  // ── Einzel-Mutationen ────────────────────────────────────────────────
+
+  upsertEquipment(item: EquipmentItem): void {
+    this.equipment.set(item.id, item)
+  }
+  removeEquipment(id: string): void {
+    this.equipment.delete(id)
+  }
   upsertCable(cable: Cable): void {
     this.cables.set(cable.id, cable)
   }
-
-  /** Entfernt ein Kabel. */
   removeCable(id: string): void {
     this.cables.delete(id)
   }
+  upsertLocation(loc: LocationFrame): void {
+    this.locations.set(loc.id, loc)
+  }
+  removeLocation(id: string): void {
+    this.locations.delete(id)
+  }
 
-  /** Aktueller Kabel-Stand aus dem Y.Doc als plain-Array. */
+  /** Aktueller Kabel-Stand (Stufe-1-Kompatibilität). */
   toCables(): Cable[] {
     return [...this.cables.values()]
   }
 
-  /** Encodiert den gesamten Doc-State als binäres Update (für Transport
-   *  oder Persistenz). */
+  /** Spiegelt nur die Kabel (Stufe-1-Kompatibilität). */
+  loadFromCables(list: Cable[]): void {
+    this.doc.transact(() => syncMap(this.cables, list))
+  }
+
+  // ── Transport-Primitive ──────────────────────────────────────────────
+
+  /** Gesamter Doc-State als binäres Update (für Transport/Persistenz). */
   encodeState(): Uint8Array {
     return Y.encodeStateAsUpdate(this.doc)
   }
 
-  /** State-Vector für inkrementelle Diffs (nur das senden, was der Peer
-   *  noch nicht hat). */
+  /** State-Vector für inkrementelle Diffs. */
   encodeStateVector(): Uint8Array {
     return Y.encodeStateVector(this.doc)
   }
@@ -85,27 +117,26 @@ export class ProjectCrdt {
     return Y.encodeStateAsUpdate(this.doc, remoteStateVector)
   }
 
-  /** Wendet ein eingehendes Update (von einem Peer) an. CRDT-Merge ist
-   *  kommutativ + idempotent — Reihenfolge und Doppel-Empfang sind egal. */
+  /** Wendet ein eingehendes Update an. CRDT-Merge ist kommutativ +
+   *  idempotent — Reihenfolge und Doppel-Empfang sind egal. */
   applyUpdate(update: Uint8Array): void {
     Y.applyUpdate(this.doc, update)
   }
 
-  /** Registriert einen Listener für lokale UND remote Updates. Liefert das
-   *  binäre Update + ob es vom lokalen Doc stammt (origin). Rückgabe:
-   *  Unsubscribe-Funktion. */
+  /** Wendet ein Remote-Update mit Origin-Markierung an, damit `onUpdate`-
+   *  Listener es als nicht-lokal erkennen (keine Echo-Schleife). */
+  applyRemoteUpdate(update: Uint8Array): void {
+    Y.applyUpdate(this.doc, update, REMOTE_ORIGIN)
+  }
+
+  /** Listener für lokale UND remote Updates. cb bekommt das binäre Update
+   *  + ob es lokal entstand. Rückgabe: Unsubscribe-Funktion. */
   onUpdate(cb: (update: Uint8Array, isLocal: boolean) => void): () => void {
     const handler = (update: Uint8Array, origin: unknown) => {
-      cb(update, origin !== 'remote')
+      cb(update, origin !== REMOTE_ORIGIN)
     }
     this.doc.on('update', handler)
     return () => this.doc.off('update', handler)
-  }
-
-  /** Wendet ein Remote-Update mit korrekter Origin-Markierung an, damit
-   *  `onUpdate`-Listener es als nicht-lokal erkennen (keine Echo-Schleife). */
-  applyRemoteUpdate(update: Uint8Array): void {
-    Y.applyUpdate(this.doc, update, 'remote')
   }
 
   destroy(): void {
@@ -113,10 +144,22 @@ export class ProjectCrdt {
   }
 }
 
+/** Origin-Marker für angewandte Remote-Updates (Echo-Schutz). */
+export const REMOTE_ORIGIN = 'remote'
+
+/** Setzt eine Y.Map auf den Stand einer id-Liste: fehlende löschen, Rest
+ *  setzen. Erwartet, in einer Transaction aufgerufen zu werden. */
+const syncMap = <T extends { id: string }>(map: Y.Map<T>, list: T[]): void => {
+  const incoming = new Set(list.map((x) => x.id))
+  for (const id of [...map.keys()]) {
+    if (!incoming.has(id)) map.delete(id)
+  }
+  for (const x of list) map.set(x.id, x)
+}
+
 /**
  * Konvenienz: führt das Update von `source` in `target` zusammen. Nur für
- * Tests/Proofs — Produktion nutzt den Transport. Liefert true, wenn beide
- * danach denselben Kabel-Stand haben.
+ * Tests/Proofs — Produktion nutzt den Transport.
  */
 export const mergeUpdateInto = (source: ProjectCrdt, target: ProjectCrdt): void => {
   target.applyUpdate(source.encodeState())

--- a/src/renderer/lib/crdt/syncManager.ts
+++ b/src/renderer/lib/crdt/syncManager.ts
@@ -1,0 +1,67 @@
+// #413 — SyncManager: koppelt einen ProjectCrdt an einen Transport.
+//
+// Verantwortlich für die Live-Schleife:
+//   • lokale Doc-Updates → Transport.send (nur lokale, kein Echo)
+//   • eingehende Updates  → doc.applyRemoteUpdate (markiert als remote)
+//   • Initial-Sync beim Verbinden: eigenen Voll-State einmal senden, damit
+//     ein spät hinzukommender Peer den aktuellen Stand bekommt.
+//
+// Echo-Schutz: angewandte Remote-Updates lösen via applyRemoteUpdate ein
+// Doc-Event mit origin='remote' aus; onUpdate liefert isLocal=false → wir
+// senden sie NICHT zurück. So entsteht keine Endlosschleife zwischen zwei
+// Peers.
+//
+// CRDT-Konvergenz (kommutativ, idempotent) garantiert, dass beide Seiten
+// trotz Offline-Phasen und out-of-order Zustellung denselben Stand erreichen.
+
+import type { ProjectCrdt } from './projectCrdt'
+import type { SyncTransport } from './syncTransport'
+
+export interface SyncManagerOptions {
+  /** Beim Start den eigenen Voll-State senden (Default true). Für den
+   *  zweiten Peer nützlich, der einem laufenden „Raum" beitritt. */
+  sendInitialState?: boolean
+}
+
+export class SyncManager {
+  private readonly crdt: ProjectCrdt
+  private readonly transport: SyncTransport
+  private unsubDoc: (() => void) | null = null
+  private unsubTransport: (() => void) | null = null
+  private started = false
+
+  constructor(crdt: ProjectCrdt, transport: SyncTransport) {
+    this.crdt = crdt
+    this.transport = transport
+  }
+
+  /** Verbindet Doc ⇄ Transport und startet die Live-Schleife. */
+  start(opts: SyncManagerOptions = {}): void {
+    if (this.started) return
+    this.started = true
+
+    // Lokale Updates rausschicken (Remote-Updates NICHT — sonst Echo).
+    this.unsubDoc = this.crdt.onUpdate((update, isLocal) => {
+      if (isLocal) this.transport.send(update)
+    })
+
+    // Eingehende Updates als remote anwenden.
+    this.unsubTransport = this.transport.onReceive((update) => {
+      this.crdt.applyRemoteUpdate(update)
+    })
+
+    // Initial-State anbieten, damit ein beitretender Peer aufholt.
+    if (opts.sendInitialState !== false) {
+      this.transport.send(this.crdt.encodeState())
+    }
+  }
+
+  /** Trennt die Schleife (Listener ab); Doc + Transport bleiben bestehen. */
+  stop(): void {
+    this.unsubDoc?.()
+    this.unsubTransport?.()
+    this.unsubDoc = null
+    this.unsubTransport = null
+    this.started = false
+  }
+}

--- a/src/renderer/lib/crdt/syncTransport.ts
+++ b/src/renderer/lib/crdt/syncTransport.ts
@@ -1,0 +1,79 @@
+// #413 — Transport-Abstraktion für die CRDT-Synchronisation.
+//
+// Der SyncManager (syncManager.ts) kennt nur dieses Interface — der konkrete
+// Transport ist austauschbar:
+//   • LoopbackTransport: in-process, für Tests/Konvergenz-Beweis.
+//   • (später) y-webrtc / y-websocket: echtes LAN/Cloud.
+//
+// Binäre Yjs-Updates gehen rein/raus; der Transport interessiert sich nicht
+// für deren Inhalt.
+
+export interface SyncTransport {
+  /** Sendet ein binäres Update an den/die Peer(s). */
+  send(update: Uint8Array): void
+  /** Registriert einen Empfangs-Handler. Rückgabe: Unsubscribe. */
+  onReceive(cb: (update: Uint8Array) => void): () => void
+  /** Räumt Ressourcen/Listener auf. */
+  dispose(): void
+}
+
+/**
+ * In-Process-Transport zum Testen: zwei Endpunkte, die sich gegenseitig
+ * beliefern (was A sendet, empfängt B). Unterstützt `pause()`/`resume()`,
+ * um eine Offline-Phase (Divergenz) und das Wiederverbinden zu simulieren —
+ * genau der Fall, den ein CRDT lösen muss.
+ */
+class LoopbackEndpoint implements SyncTransport {
+  /** Gegenstelle — wird von createLoopbackPair gesetzt. */
+  peer!: LoopbackEndpoint
+  private receivers = new Set<(u: Uint8Array) => void>()
+  private outbox: Uint8Array[] = []
+  private paused = false
+
+  send(update: Uint8Array): void {
+    if (this.paused) {
+      this.outbox.push(update)
+      return
+    }
+    this.peer.deliver(update)
+  }
+
+  onReceive(cb: (update: Uint8Array) => void): () => void {
+    this.receivers.add(cb)
+    return () => this.receivers.delete(cb)
+  }
+
+  dispose(): void {
+    this.receivers.clear()
+    this.outbox = []
+  }
+
+  /** Intern: ein vom Peer gesendetes Update an die eigenen Empfänger geben. */
+  deliver(update: Uint8Array): void {
+    for (const r of this.receivers) r(update)
+  }
+
+  /** Ab jetzt ausgehende Sends puffern (Endpunkt „offline"). */
+  pause(): void {
+    this.paused = true
+  }
+
+  /** Online gehen und alle gepufferten Sends nachliefern. */
+  resume(): void {
+    this.paused = false
+    const queued = this.outbox
+    this.outbox = []
+    for (const u of queued) this.peer.deliver(u)
+  }
+}
+
+export type LoopbackTransport = LoopbackEndpoint
+
+/** Erzeugt ein verbundenes Transport-Paar. */
+export const createLoopbackPair = (): [LoopbackTransport, LoopbackTransport] => {
+  const a = new LoopbackEndpoint()
+  const b = new LoopbackEndpoint()
+  a.peer = b
+  b.peer = a
+  return [a, b]
+}


### PR DESCRIPTION
- ProjectCrdt deckt jetzt das ganze Projekt ab (equipment + cables + locations als je eigene Y.Map), nicht mehr nur cables; Stufe-1-API (loadFromCables/toCables) bleibt kompatibel
- syncTransport.ts: SyncTransport-Interface + LoopbackTransport mit pause/resume + inbox-Puffer (kein Verlust des Initial-State bei start()-Reihenfolge); in-process testbar
- syncManager.ts: koppelt Doc <-> Transport, Echo-Schutz via origin, Initial-State-Austausch beim Verbinden
- Konvergenz-Beweis um Szenario 4 (Live-Loop, volles Projekt) + 5 (Offline-Divergenz + Reconnect) erweitert; 14/14 Asserts gruen

Refs #413