### PR TITLE
stability: Render-Loop + Rules-of-Hooks-Crashes fixen + ESLint-Guard (Properties/Revisions)

### DIFF
--- a/src/renderer/components/Project/RevisionsDialog.tsx
+++ b/src/renderer/components/Project/RevisionsDialog.tsx
@@ -25,7 +25,11 @@ export const RevisionsDialog = () => {
   const t = useTranslation()
   const open = useUiStore((s) => s.revisions.open)
   const close = useUiStore((s) => s.closeRevisions)
-  const revisions = useProjectStore((s) => s.project.revisions ?? [])
+  // WICHTIG: `?? []` MUSS ausserhalb des Selectors stehen. Ein Selector der
+  // `s.project.revisions ?? []` zurueckgibt liefert bei fehlendem Feld bei
+  // JEDEM Render ein neues leeres Array → zustand v5 (useSyncExternalStore)
+  // sieht den Snapshot als geaendert → "Maximum update depth exceeded".
+  const revisions = useProjectStore((s) => s.project.revisions) ?? []
   const commitRevision = useProjectStore((s) => s.commitRevision)
   const restoreRevision = useProjectStore((s) => s.restoreRevision)
   const deleteRevision = useProjectStore((s) => s.deleteRevision)


### PR DESCRIPTION
Sammel-PR für die Render-Crashes, die beim Arbeiten mit echten Projekten auftraten (alle „weißer Bildschirm"/Freeze). Drei unabhängige Fixes + ein Guardrail.

### 1) Render-Endlosschleife — RevisionsDialog (`?? []`-Selector)
`useProjectStore(s => s.project.revisions ?? [])` → bei fehlendem Feld neues Array pro Render → zustand v5 `useSyncExternalStore` → „Maximum update depth exceeded". Fix: `?? []` aus dem Selector heraus. (Gleiche Klasse wie #435 CanvasToolbar.)

### 2) Rules-of-Hooks-Crashes — Properties-Panel
„**Rendered more hooks than during the previous render**" beim Wechsel des selektierten Geräts: mehrere Sektionen riefen einen Hook **nach** einem frühen `return null` auf. Beim Gerätewechsel schlug die Bedingung um → Hook-Anzahl änderte sich → Crash. Hook jeweils **vor** den Early-Return gezogen (Verhalten unverändert):
- `DisplayPropertiesBlock` — `useState` vor `if (!looksLikeDisplay)` *(der gemeldete Crash)*
- `CategoryPropsSection` — `useState` vor `if (fields.length === 0)`
- `GreenGoBeltpackSection` — `useState` vor `if (!config)`
- `EquipmentProperties` — `sectionOrder`/`sensors`/`projectMode` vor `if (!equipment)`

### 3) Guardrail — ESLint-Regel gegen instabile zustand-Selektoren
Drei `no-restricted-syntax`-Selektoren fangen `?? []` / Literal-Body / `.map()` in `use*Store`-Selektoren zur Lint-Zeit ab (verifiziert: 0 Treffer auf aktuellem Code, 0 neue Lint-Errors).

### Noch offen (separat — brauchen Component-Split, kein Zeilen-Move)
Gleiche Rules-of-Hooks-Klasse, aber in selten genutzten Features: `Export/VideohubRoutingMatrix` (4 Hooks nach Early-Return) und `Rack/Rack3DView` `DeviceSTL` (`useLoader` nach `if (!stlDataUri) return null` — kann nicht hochgezogen werden, da es sonst `undefined` lädt → Split in Outer-Guard + Inner-Component nötig).

tsc 0 Errors, vite build grün.