### PR TITLE
fix(properties): Rules-of-Hooks-Crashes im Properties-Panel

### DIFF
--- a/src/renderer/components/Properties/EquipmentProperties.tsx
+++ b/src/renderer/components/Properties/EquipmentProperties.tsx
@@ -68,22 +68,31 @@ export const EquipmentProperties = () => {
   // sich Verkabelung aendert.
   const updateEquipment = useProjectStore((state) => state.updateEquipment)
 
-  if (!equipment) {
-    return <div className="text-xs text-slate-400">{t('inspector.selectEquipment', 'Wähle ein Gerät auf dem Canvas.')}</div>
-  }
-
-
   // v7.4.0 — sortable accordion sections. The parent is `flex flex-col`
   // so CSS `order` works. Non-movable elements (device-kind cards,
   // Name, Category, Rentman badge) have no `order` declared → they
   // default to 0 → render first in JSX order. Each SortableSection
   // sets its own `order` based on the uiStore-persisted user order.
+  //
+  // WICHTIG: ALLE Hooks (sectionOrder/sensors/projectMode) MUESSEN vor dem
+  // `if (!equipment)`-Early-Return stehen (Rules of Hooks) — sonst aendert
+  // sich die Hook-Anzahl wenn die Auswahl zwischen "kein Geraet" und "Geraet"
+  // wechselt ("Rendered more hooks than during the previous render").
   const sectionOrder = useUiStore((s) => s.equipmentSectionOrder)
   const setSectionOrder = useUiStore((s) => s.setEquipmentSectionOrder)
   const dragSensors = useSensors(
     useSensor(PointerSensor, POINTER_SENSOR_OPTIONS),
     useSensor(KeyboardSensor, KEYBOARD_SENSOR_OPTIONS),
   )
+  // v7.9.5 — Property-Panel im Lock-Modus visuell + funktional sperren.
+  // fieldset/disabled blockiert ALLE Form-Controls darunter; das CSS
+  // greift dann mit grauerem Look (pointer-events:none + opacity).
+  const projectMode = useProjectStore((s) => s.project.mode ?? 'editing')
+
+  if (!equipment) {
+    return <div className="text-xs text-slate-400">{t('inspector.selectEquipment', 'Wähle ein Gerät auf dem Canvas.')}</div>
+  }
+
   const handleSectionDragEnd = (event: DragEndEvent) => {
     const { active, over } = event
     if (!over || active.id === over.id) return
@@ -93,10 +102,6 @@ export const EquipmentProperties = () => {
     setSectionOrder(arrayMove(sectionOrder, oldIndex, newIndex))
   }
 
-  // v7.9.5 — Property-Panel im Lock-Modus visuell + funktional sperren.
-  // fieldset/disabled blockiert ALLE Form-Controls darunter; das CSS
-  // greift dann mit grauerem Look (pointer-events:none + opacity).
-  const projectMode = useProjectStore((s) => s.project.mode ?? 'editing')
   const projectIsLocked = projectMode === 'finalized' || projectMode === 'viewer'
 
   return (

--- a/src/renderer/components/Properties/sections/CategoryPropsSection.tsx
+++ b/src/renderer/components/Properties/sections/CategoryPropsSection.tsx
@@ -102,9 +102,16 @@ export const CategoryPropsSection = ({ equipment }: { equipment: EquipmentItem }
   const updateEquipment = useProjectStore((s) => s.updateEquipment)
 
   const fields = schemaForCategory(equipment.category)
-  if (fields.length === 0) return null
-
   const props = equipment.categoryProps ?? {}
+
+  // Ein-/ausklappbar (wie SDI-Caps / Abmessungen). Default offen, wenn schon
+  // Fachdaten gesetzt sind, sonst eingeklappt. <summary> statt Form-Control,
+  // damit das Toggle auch im gesperrten (viewer/finalized) Fieldset geht.
+  // WICHTIG: useState MUSS vor dem `return null` stehen (Rules of Hooks) —
+  // sonst aendert sich die Hook-Anzahl wenn die Kategorie beim Geraetewechsel
+  // von "kein Schema" zu "Schema" wechselt.
+  const [open, setOpen] = useState(Object.keys(props).length > 0)
+  if (fields.length === 0) return null
 
   const setProp = (key: string, value: string | number | boolean | undefined) => {
     const next: Record<string, string | number | boolean> = { ...props }
@@ -114,11 +121,6 @@ export const CategoryPropsSection = ({ equipment }: { equipment: EquipmentItem }
       categoryProps: Object.keys(next).length ? next : undefined,
     })
   }
-
-  // Ein-/ausklappbar (wie SDI-Caps / Abmessungen). Default offen, wenn schon
-  // Fachdaten gesetzt sind, sonst eingeklappt. <summary> statt Form-Control,
-  // damit das Toggle auch im gesperrten (viewer/finalized) Fieldset geht.
-  const [open, setOpen] = useState(Object.keys(props).length > 0)
 
   return (
     <details

--- a/src/renderer/components/Properties/sections/DisplayPropertiesBlock.tsx
+++ b/src/renderer/components/Properties/sections/DisplayPropertiesBlock.tsx
@@ -29,13 +29,16 @@ export const DisplayPropertiesBlock = ({ equipment }: { equipment: EquipmentItem
     /monitor|display|screen|tv|oled|lcd|led\b|projector|beamer/.test(name) ||
     equipment.resolution !== undefined ||
     equipment.displaySizeInch !== undefined
-  if (!looksLikeDisplay) return null
   // Ein-/ausklappbar (wie SDI-Caps / Abmessungen). Default offen, wenn schon
   // Werte gesetzt sind, sonst eingeklappt. <summary> statt Form-Control, damit
   // das Toggle auch im gesperrten (viewer/finalized) Fieldset bedienbar bleibt.
+  // WICHTIG: useState MUSS vor dem `return null` stehen (Rules of Hooks) —
+  // sonst aendert sich die Hook-Anzahl wenn `looksLikeDisplay` beim Wechsel
+  // des selektierten Geraets umschlaegt ("Rendered more hooks than...").
   const [open, setOpen] = useState(
     equipment.resolution !== undefined || equipment.displaySizeInch !== undefined,
   )
+  if (!looksLikeDisplay) return null
   return (
     <details
       open={open}

--- a/src/renderer/components/Properties/sections/GreenGoBeltpackSection.tsx
+++ b/src/renderer/components/Properties/sections/GreenGoBeltpackSection.tsx
@@ -10,6 +10,13 @@ import { format, useTranslation } from '../../../lib/i18n'
 export const GreenGoBeltpackSection = ({ equipmentId }: { equipmentId: string }) => {
   const t = useTranslation()
   const { config, info, rename, assignUser } = useGreenGoBeltpack(equipmentId)
+  // Ein-/ausklappbar (wie die übrigen Properties-Blöcke). Default offen, wenn
+  // diesem Gerät ein Beltpack-Slot zugeordnet ist, sonst eingeklappt. <summary>
+  // statt Form-Control, damit das Toggle auch im gesperrten Fieldset geht.
+  // WICHTIG: useState MUSS vor dem `return` stehen (Rules of Hooks) — sonst
+  // aendert sich die Hook-Anzahl wenn beim Geraetewechsel `config` von leer
+  // zu gesetzt wechselt ("Rendered more hooks than during the previous render").
+  const [open, setOpen] = useState(!!info)
   if (!config || config.users.length === 0) {
     return (
       <div className="mb-2 text-[10px] text-emerald-300/60">
@@ -23,11 +30,6 @@ export const GreenGoBeltpackSection = ({ equipmentId }: { equipmentId: string })
   // List of all users for the assignment dropdown. We label them by name
   // and decorate with the linked equipment id if any (so the user can
   // see at a glance which slots are already taken).
-  //
-  // Ein-/ausklappbar (wie die übrigen Properties-Blöcke). Default offen, wenn
-  // diesem Gerät ein Beltpack-Slot zugeordnet ist, sonst eingeklappt. <summary>
-  // statt Form-Control, damit das Toggle auch im gesperrten Fieldset geht.
-  const [open, setOpen] = useState(!!info)
   return (
     <details
       open={open}


### PR DESCRIPTION
'Rendered more hooks than during the previous render' beim Wechsel des selektierten Geraets: mehrere Sektionen riefen einen Hook NACH einem fruehen `return null` auf. Beim Geraetewechsel schlug die Bedingung um → Hook-Anzahl aenderte sich → Crash.

Hook jeweils VOR den Early-Return gezogen (Verhalten unveraendert, Hooks haengen nicht von der Bedingung ab):
- DisplayPropertiesBlock: useState vor 'if (!looksLikeDisplay)'  (gemeldeter Crash)
- CategoryPropsSection:   useState vor 'if (fields.length === 0)'
- GreenGoBeltpackSection: useState vor 'if (!config)'
- EquipmentProperties:    sectionOrder/sensors/projectMode vor 'if (!equipment)'

tsc 0, build gruen. Noch offen (brauchen Component-Split, separat): VideohubRoutingMatrix, Rack3DView/DeviceSTL (useLoader nach Early-Return).