### PR TITLE
feat(patch): Stecker-Katalog mit Symbolen im Patchblenden-Dialog

### DIFF
--- a/src/renderer/components/Rack/PatchPanelCreateDialog.tsx
+++ b/src/renderer/components/Rack/PatchPanelCreateDialog.tsx
@@ -20,6 +20,8 @@ import { ModalShell } from '../shared/ModalShell'
 import { ALL_CONNECTOR_TYPES, type ConnectorType, type EquipmentTemplate } from '../../types/equipment'
 import { useUiStore } from '../../store/uiStore'
 import { format, useTranslation } from '../../lib/i18n'
+import { ConnectorPicker } from '../shared/ConnectorPicker'
+import { connectorGender, connectorLabel } from '../../lib/connectorCatalog'
 
 interface PatchPanelCreateDialogProps {
   open: boolean
@@ -56,8 +58,11 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
   // hinterlegt und sollen im Patch-Builder ebenfalls verfügbar sein.
   const customConnectorTypes = useUiStore((s) => s.customConnectorTypes)
 
-  const allConnectors = useMemo<ConnectorType[]>(
-    () => [...ALL_CONNECTOR_TYPES, ...customConnectorTypes] as ConnectorType[],
+  // v7.9.75 — Legacy- + Custom-Typen, die der ConnectorPicker zusätzlich zum
+  // kategorisierten Katalog einblendet (unter "Allgemein"), damit nichts aus
+  // der bisherigen Auswahl verloren geht.
+  const extraConnectorTypes = useMemo<string[]>(
+    () => [...ALL_CONNECTOR_TYPES, ...customConnectorTypes],
     [customConnectorTypes],
   )
 
@@ -87,12 +92,16 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
         name: `${p.label} (Front)`,
         type: p.frontConnectorType,
         connectorType: p.frontConnectorType,
+        // #170 — Katalog-Stecker tragen ihr Geschlecht (XLR 3 Male/Female …);
+        // wird als ♂/♀ am Port gezeigt und in Patchliste/Etiketten genutzt.
+        gender: connectorGender(p.frontConnectorType),
       })),
       outputs: ports.map((p) => ({
         id: uuidv4(),
         name: `${p.label} (Rear)`,
         type: p.rearConnectorType,
         connectorType: p.rearConnectorType,
+        gender: connectorGender(p.rearConnectorType),
       })),
       isRackDevice: true,
       isPatchPanel: true,
@@ -101,8 +110,8 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
       width: 240,
       height: 80 + Math.max(heightUnits, 1) * 22,
       notes: adapterMode
-        ? `${portCount}-fach Adapter-Patchfeld: Front ${frontConnector} ↔ Rear ${rearConnector}.${mountSide !== 'full' ? ` Mount: ${mountSide}.` : ''}`
-        : `${portCount}-fach Patchfeld, ${frontConnector}.${mountSide !== 'full' ? ` Mount: ${mountSide}.` : ''}`,
+        ? `${portCount}-fach Adapter-Patchfeld: Front ${connectorLabel(frontConnector)} ↔ Rear ${connectorLabel(rearConnector)}.${mountSide !== 'full' ? ` Mount: ${mountSide}.` : ''}`
+        : `${portCount}-fach Patchfeld, ${connectorLabel(frontConnector)}.${mountSide !== 'full' ? ` Mount: ${mountSide}.` : ''}`,
     }
     onCreated(template)
     onClose()
@@ -246,32 +255,26 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
                 <span className="mb-1 block text-xs text-slate-400">
                   {adapterMode ? t('rack.patchPanel.frontConnector', 'Front-Connector') : t('rack.patchPanel.bothConnector', 'Connector-Typ (beide Seiten)')}
                 </span>
-                <select
+                <ConnectorPicker
                   value={frontConnector}
-                  onChange={(e) => setFrontConnector(e.target.value as ConnectorType)}
-                  className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1.5"
-                >
-                  {allConnectors.map((c) => (
-                    <option key={c} value={c}>
-                      {c}
-                    </option>
-                  ))}
-                </select>
+                  onChange={(id) => setFrontConnector(id as ConnectorType)}
+                  extraTypes={extraConnectorTypes}
+                  ariaLabel={
+                    adapterMode
+                      ? t('rack.patchPanel.frontConnector', 'Front-Connector')
+                      : t('rack.patchPanel.bothConnector', 'Connector-Typ (beide Seiten)')
+                  }
+                />
               </label>
               {adapterMode && (
                 <label className="block">
                   <span className="mb-1 block text-xs text-slate-400">{t('rack.patchPanel.rearConnector', 'Rear-Connector')}</span>
-                  <select
+                  <ConnectorPicker
                     value={rearConnector}
-                    onChange={(e) => setRearConnector(e.target.value as ConnectorType)}
-                    className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1.5"
-                  >
-                    {allConnectors.map((c) => (
-                      <option key={c} value={c}>
-                        {c}
-                      </option>
-                    ))}
-                  </select>
+                    onChange={(id) => setRearConnector(id as ConnectorType)}
+                    extraTypes={extraConnectorTypes}
+                    ariaLabel={t('rack.patchPanel.rearConnector', 'Rear-Connector')}
+                  />
                 </label>
               )}
             </div>
@@ -313,35 +316,23 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
                         />
                       </td>
                       <td className="px-2 py-0.5">
-                        <select
+                        <ConnectorPicker
                           value={perPortOverrides[idx]?.front ?? frontConnector}
-                          onChange={(e) =>
-                            setOverride(idx, { front: e.target.value as ConnectorType })
-                          }
-                          className="w-full rounded border border-slate-700 bg-slate-950 px-1.5 py-0.5"
-                        >
-                          {allConnectors.map((c) => (
-                            <option key={c} value={c}>
-                              {c}
-                            </option>
-                          ))}
-                        </select>
+                          onChange={(id) => setOverride(idx, { front: id as ConnectorType })}
+                          extraTypes={extraConnectorTypes}
+                          size="sm"
+                          ariaLabel={`${t('rack.patchPanel.col.front', 'Front')} ${idx + 1}`}
+                        />
                       </td>
                       {adapterMode && (
                         <td className="px-2 py-0.5">
-                          <select
+                          <ConnectorPicker
                             value={perPortOverrides[idx]?.rear ?? rearConnector}
-                            onChange={(e) =>
-                              setOverride(idx, { rear: e.target.value as ConnectorType })
-                            }
-                            className="w-full rounded border border-slate-700 bg-slate-950 px-1.5 py-0.5"
-                          >
-                            {allConnectors.map((c) => (
-                              <option key={c} value={c}>
-                                {c}
-                              </option>
-                            ))}
-                          </select>
+                            onChange={(id) => setOverride(idx, { rear: id as ConnectorType })}
+                            extraTypes={extraConnectorTypes}
+                            size="sm"
+                            ariaLabel={`${t('rack.patchPanel.col.rear', 'Rear')} ${idx + 1}`}
+                          />
                         </td>
                       )}
                     </tr>

--- a/src/renderer/components/shared/ConnectorPicker.tsx
+++ b/src/renderer/components/shared/ConnectorPicker.tsx
@@ -1,0 +1,230 @@
+/**
+ * #170 / Patchblende — Visueller Connector-Picker.
+ *
+ * Ersetzt das flache `<select>` im Patchblenden-Dialog durch ein
+ * Feld-mit-Popover: der Trigger zeigt das aktuell gewählte Steckersymbol +
+ * Label, das Popover eine durchsuchbare, nach Kategorie gruppierte Kachel-
+ * Palette (Audio / MIDI / Video / Data / Fiber / Power / …). Legacy- und
+ * Custom-Connector-Typen werden über `extraTypes` mit eingeblendet, damit
+ * nichts aus der bisherigen Auswahl verloren geht.
+ *
+ * Das Popover rendert via Portal an document.body (fixed positioniert aus
+ * dem Trigger-Rect), damit es nicht vom scrollenden Modal-Body geclippt wird.
+ */
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { ChevronDown, Search } from 'lucide-react'
+import {
+  buildConnectorGroups,
+  connectorColor,
+  connectorColorById,
+  connectorLabel,
+  findConnectorEntry,
+  type ConnectorCatalogEntry,
+} from '../../lib/connectorCatalog'
+import { useTranslation } from '../../lib/i18n'
+import { ConnectorSymbol } from './ConnectorSymbol'
+
+interface ConnectorPickerProps {
+  value: string
+  onChange: (id: string) => void
+  /** Zusätzliche Legacy-/Custom-Typen, die nicht im Katalog stehen. */
+  extraTypes?: string[]
+  /** 'sm' für die dichte Per-Port-Tabelle, 'md' (Default) für die Basics-Seite. */
+  size?: 'sm' | 'md'
+  ariaLabel?: string
+}
+
+const tileSymbolFor = (entry: ConnectorCatalogEntry) => (
+  <ConnectorSymbol
+    symbol={entry.symbol}
+    pins={entry.pins}
+    poles={entry.poles}
+    gender={entry.gender}
+    flow={entry.flow}
+    mini={entry.mini}
+    size={34}
+  />
+)
+
+export const ConnectorPicker = ({
+  value,
+  onChange,
+  extraTypes = [],
+  size = 'md',
+  ariaLabel,
+}: ConnectorPickerProps) => {
+  const t = useTranslation()
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const popRef = useRef<HTMLDivElement>(null)
+  const [pos, setPos] = useState<{ left: number; top: number; width: number } | null>(null)
+
+  const groups = useMemo(() => buildConnectorGroups(extraTypes), [extraTypes])
+  const selected = findConnectorEntry(value)
+
+  const filteredGroups = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return groups
+    return groups
+      .map((g) => ({
+        ...g,
+        entries: g.entries.filter(
+          (e) => e.label.toLowerCase().includes(q) || e.id.toLowerCase().includes(q),
+        ),
+      }))
+      .filter((g) => g.entries.length > 0)
+  }, [groups, query])
+
+  const place = () => {
+    const el = triggerRef.current
+    if (!el) return
+    const r = el.getBoundingClientRect()
+    const width = Math.max(r.width, 320)
+    const maxH = 360
+    const below = window.innerHeight - r.bottom
+    const top = below < maxH + 12 && r.top > below ? Math.max(8, r.top - maxH - 6) : r.bottom + 6
+    const left = Math.min(Math.max(8, r.left), window.innerWidth - width - 8)
+    setPos({ left, top, width })
+  }
+
+  useLayoutEffect(() => {
+    if (!open) return
+    place()
+    const onScroll = () => place()
+    window.addEventListener('scroll', onScroll, true)
+    window.addEventListener('resize', onScroll)
+    return () => {
+      window.removeEventListener('scroll', onScroll, true)
+      window.removeEventListener('resize', onScroll)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const onDoc = (e: MouseEvent) => {
+      const target = e.target as Node
+      if (popRef.current?.contains(target) || triggerRef.current?.contains(target)) return
+      setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onDoc)
+    document.addEventListener('keydown', onKey, true)
+    return () => {
+      document.removeEventListener('mousedown', onDoc)
+      document.removeEventListener('keydown', onKey, true)
+    }
+  }, [open])
+
+  const pick = (id: string) => {
+    onChange(id)
+    setOpen(false)
+    setQuery('')
+  }
+
+  const triggerColor = connectorColorById(value)
+
+  return (
+    <>
+      <button
+        type="button"
+        ref={triggerRef}
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        className={`flex w-full items-center gap-2 rounded border border-slate-700 bg-slate-950 text-left text-slate-200 hover:border-slate-500 ${
+          size === 'sm' ? 'px-1.5 py-1' : 'px-2 py-1.5'
+        }`}
+      >
+        <span
+          className="flex shrink-0 items-center justify-center rounded"
+          style={{ color: triggerColor }}
+        >
+          {selected ? (
+            tileSymbolFor(selected)
+          ) : (
+            <ConnectorSymbol symbol="generic" size={size === 'sm' ? 22 : 28} />
+          )}
+        </span>
+        <span className={`flex-1 truncate ${size === 'sm' ? 'text-[11px]' : 'text-sm'}`}>
+          {connectorLabel(value)}
+        </span>
+        <ChevronDown size={14} className="shrink-0 text-slate-500" />
+      </button>
+
+      {open &&
+        pos &&
+        createPortal(
+          <div
+            ref={popRef}
+            role="dialog"
+            className="fixed z-[300] flex max-h-[360px] flex-col overflow-hidden rounded-lg border border-slate-700 bg-slate-900 shadow-2xl"
+            style={{ left: pos.left, top: pos.top, width: pos.width }}
+          >
+            <div className="flex items-center gap-2 border-b border-slate-800 px-2 py-1.5">
+              <Search size={14} className="shrink-0 text-slate-500" />
+              <input
+                autoFocus
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder={t('connector.picker.search', 'Stecker suchen…')}
+                className="w-full bg-transparent text-sm text-slate-200 outline-none placeholder:text-slate-600"
+              />
+            </div>
+            <div className="flex-1 overflow-y-auto p-2">
+              {filteredGroups.length === 0 && (
+                <div className="px-2 py-6 text-center text-xs text-slate-500">
+                  {t('connector.picker.noResults', 'Kein Stecker gefunden')}
+                </div>
+              )}
+              {filteredGroups.map((g) => (
+                <div key={g.category.id} className="mb-2 last:mb-0">
+                  <div
+                    className="mb-1 flex items-center gap-1.5 px-1 text-[10px] font-semibold tracking-wide uppercase"
+                    style={{ color: g.category.color }}
+                  >
+                    <span
+                      className="inline-block h-2 w-2 rounded-full"
+                      style={{ background: g.category.color }}
+                    />
+                    {t(`connector.cat.${g.category.id}`, g.category.de)}
+                  </div>
+                  <div className="grid grid-cols-3 gap-1">
+                    {g.entries.map((e) => {
+                      const active = e.id === value
+                      return (
+                        <button
+                          key={e.id}
+                          type="button"
+                          onClick={() => pick(e.id)}
+                          title={e.label}
+                          className={`flex flex-col items-center gap-1 rounded border px-1 py-1.5 text-center transition ${
+                            active
+                              ? 'border-sky-500 bg-sky-500/10'
+                              : 'border-slate-800 bg-slate-950/40 hover:border-slate-600 hover:bg-slate-800/60'
+                          }`}
+                        >
+                          <span style={{ color: connectorColor(e) }}>{tileSymbolFor(e)}</span>
+                          <span className="w-full truncate text-[9px] leading-tight text-slate-300">
+                            {e.label}
+                          </span>
+                        </button>
+                      )
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>,
+          document.body,
+        )}
+    </>
+  )
+}

--- a/src/renderer/components/shared/ConnectorSymbol.tsx
+++ b/src/renderer/components/shared/ConnectorSymbol.tsx
@@ -1,0 +1,408 @@
+/**
+ * #170 / Patchblende — Schematische Steckersymbole.
+ *
+ * Zeichnet pro Connector-Familie ein einfaches Linien-Symbol (XLR-Pins,
+ * BNC-Ring, Klinke, RJ45-Keystone, D-Sub, Glasfaser …) angelehnt an die
+ * Symbolik von Patchbay-CAD-Tools. Vom ConnectorPicker / Patchblenden-Dialog
+ * genutzt, damit der User den Stecker visuell erkennt.
+ *
+ * Stil: stroke = currentColor (Tile/Parent setzt die Farbe), fill none außer
+ * für Kontakt-Pins. Männliche Pins sind gefüllt, weibliche hohl. Alle Symbole
+ * leben im viewBox 0 0 40 40 (Zentrum 20,20), damit sie frei skalieren.
+ */
+import type { ReactElement } from 'react'
+import type { ConnectorSymbolId } from '../../lib/connectorCatalog'
+
+interface ConnectorSymbolProps {
+  symbol: ConnectorSymbolId
+  pins?: number
+  poles?: number
+  gender?: 'male' | 'female'
+  flow?: 'in' | 'out'
+  mini?: boolean
+  /** Pixelgröße (quadratisch). Default 28. */
+  size?: number
+  className?: string
+  title?: string
+}
+
+/** Pin-Positionen gleichmäßig auf einem Kreis (Start oben). */
+const ringPins = (n: number, cx: number, cy: number, r: number) => {
+  const pts: Array<{ x: number; y: number }> = []
+  for (let i = 0; i < n; i++) {
+    const a = (-90 + (360 / n) * i) * (Math.PI / 180)
+    pts.push({ x: cx + r * Math.cos(a), y: cy + r * Math.sin(a) })
+  }
+  return pts
+}
+
+const xlrPins = (n: number) => {
+  if (n <= 6) {
+    const r = 3.5 + n * 0.8
+    return ringPins(n, 20, 20, r)
+  }
+  // 7-pol: 6 außen + 1 Mitte.
+  return [...ringPins(6, 20, 20, 8.5), { x: 20, y: 20 }]
+}
+
+const renderBody = (p: ConnectorSymbolProps): ReactElement => {
+  const pinFill = p.gender === 'male' ? 'currentColor' : 'none'
+  switch (p.symbol) {
+    case 'xlr': {
+      const pts = xlrPins(p.pins ?? 3)
+      return (
+        <g>
+          <circle cx={20} cy={20} r={15} />
+          {/* Key-Nase oben */}
+          <line x1={20} y1={5} x2={20} y2={8} />
+          {pts.map((pt, i) => (
+            <circle key={i} cx={pt.x} cy={pt.y} r={1.9} fill={pinFill} />
+          ))}
+        </g>
+      )
+    }
+    case 'jack': {
+      const poles = p.poles ?? 3
+      const outer = p.mini ? 12 : 15
+      const rings = Math.max(0, poles - 1)
+      return (
+        <g>
+          <circle cx={20} cy={20} r={outer} />
+          {Array.from({ length: rings }, (_, i) => (
+            <circle key={i} cx={20} cy={20} r={(p.mini ? 7 : 9) - i * (p.mini ? 3.5 : 4)} />
+          ))}
+          <circle cx={20} cy={20} r={2.4} fill="currentColor" />
+        </g>
+      )
+    }
+    case 'bantam':
+      return (
+        <g>
+          {/* schlanker TT-Stecker im Profil */}
+          <rect x={15} y={8} width={10} height={24} rx={4} />
+          <circle cx={20} cy={11} r={2.6} fill="currentColor" />
+          <line x1={15} y1={20} x2={25} y2={20} />
+        </g>
+      )
+    case 'combo':
+      return (
+        <g>
+          <circle cx={20} cy={20} r={15} />
+          {ringPins(3, 20, 20, 10).map((pt, i) => (
+            <circle key={i} cx={pt.x} cy={pt.y} r={1.7} fill={pinFill} />
+          ))}
+          <circle cx={20} cy={20} r={6} />
+          <circle cx={20} cy={20} r={2.2} fill="currentColor" />
+        </g>
+      )
+    case 'speakon': {
+      const poles = p.poles ?? 4
+      return (
+        <g>
+          <circle cx={20} cy={20} r={15} />
+          {/* Twist-Lock-Keyway als offener Innenring */}
+          <path d="M 20 11 A 9 9 0 1 1 13 25" fill="none" />
+          {ringPins(poles, 20, 20, 5).map((pt, i) => (
+            <circle key={i} cx={pt.x} cy={pt.y} r={1.5} fill="currentColor" />
+          ))}
+        </g>
+      )
+    }
+    case 'phono':
+      return (
+        <g>
+          <path d="M 31 17 A 13 13 0 1 1 31 23" fill="none" />
+          <circle cx={20} cy={20} r={6} />
+          <circle cx={20} cy={20} r={2.4} fill="currentColor" />
+        </g>
+      )
+    case 'binding-post':
+      return (
+        <g>
+          <circle cx={13} cy={20} r={6} />
+          <circle cx={13} cy={20} r={2} fill="currentColor" />
+          <circle cx={27} cy={20} r={6} />
+          <circle cx={27} cy={20} r={2} fill="currentColor" />
+        </g>
+      )
+    case 'midi':
+      return (
+        <g>
+          <circle cx={20} cy={20} r={15} />
+          {/* Key-Slot unten */}
+          <rect x={17} y={31} width={6} height={4} rx={1} />
+          {[
+            { x: 14, y: 25 },
+            { x: 26, y: 25 },
+            { x: 12, y: 18 },
+            { x: 28, y: 18 },
+            { x: 20, y: 13 },
+          ].map((pt, i) => (
+            <circle key={i} cx={pt.x} cy={pt.y} r={1.8} fill={pinFill} />
+          ))}
+        </g>
+      )
+    case 'bnc':
+      return (
+        <g>
+          <circle cx={20} cy={20} r={13} />
+          {/* Bajonett-Nasen */}
+          <line x1={5} y1={20} x2={8} y2={20} />
+          <line x1={32} y1={20} x2={35} y2={20} />
+          <circle cx={20} cy={20} r={6} />
+          <circle cx={20} cy={20} r={2.2} fill="currentColor" />
+        </g>
+      )
+    case 'vga':
+      return (
+        <g>
+          <path d="M 6 13 L 34 13 L 31 27 L 9 27 Z" />
+          {[17, 20, 23].map((y, row) =>
+            Array.from({ length: 5 }, (_, col) => (
+              <circle
+                key={`${row}-${col}`}
+                cx={11 + col * 4.5 + (row === 1 ? 2.25 : 0)}
+                cy={y}
+                r={1.1}
+                fill="currentColor"
+              />
+            )),
+          )}
+        </g>
+      )
+    case 'mini-din': {
+      const n = p.pins ?? 4
+      const layout =
+        n === 6
+          ? [
+              { x: 14, y: 17 },
+              { x: 26, y: 17 },
+              { x: 12, y: 22 },
+              { x: 28, y: 22 },
+              { x: 17, y: 25 },
+              { x: 23, y: 25 },
+            ]
+          : [
+              { x: 15, y: 17 },
+              { x: 25, y: 17 },
+              { x: 15, y: 23 },
+              { x: 25, y: 23 },
+            ]
+      return (
+        <g>
+          <circle cx={20} cy={20} r={13} />
+          <rect x={16} y={29} width={8} height={4} rx={1} />
+          {layout.map((pt, i) => (
+            <circle key={i} cx={pt.x} cy={pt.y} r={1.6} fill={pinFill} />
+          ))}
+        </g>
+      )
+    }
+    case 'hdmi':
+      return (
+        <g>
+          <path d="M 8 15 L 32 15 L 32 22 L 27 26 L 13 26 L 8 22 Z" />
+          <line x1={12} y1={19} x2={28} y2={19} />
+        </g>
+      )
+    case 'f-conn':
+      return (
+        <g>
+          {ringPins(6, 20, 20, 12).reduce<ReactElement[]>((acc, _, i, arr) => {
+            const a = arr[i]
+            const b = arr[(i + 1) % arr.length]
+            acc.push(<line key={i} x1={a.x} y1={a.y} x2={b.x} y2={b.y} />)
+            return acc
+          }, [])}
+          <circle cx={20} cy={20} r={6} />
+          <circle cx={20} cy={20} r={2.2} fill="currentColor" />
+        </g>
+      )
+    case 'displayport':
+      return (
+        <g>
+          <path d="M 8 15 L 32 15 L 32 25 L 14 25 L 8 20 Z" />
+          <line x1={13} y1={19} x2={29} y2={19} />
+        </g>
+      )
+    case 'dvi':
+      return (
+        <g>
+          <rect x={6} y={14} width={28} height={12} rx={1.5} />
+          {[16.5, 20, 23.5].map((y, row) =>
+            Array.from({ length: 6 }, (_, col) => (
+              <circle key={`${row}-${col}`} cx={9 + col * 3} cy={y} r={0.9} fill="currentColor" />
+            )),
+          )}
+          <rect x={29} y={16} width={3} height={8} />
+        </g>
+      )
+    case 'dsub': {
+      const n = p.pins ?? 9
+      const top = Math.ceil(n / 2)
+      const bottom = n - top
+      const r = n > 20 ? 0.7 : 1.1
+      const row = (count: number, y: number, offset: number) =>
+        Array.from({ length: count }, (_, i) => {
+          const span = 24
+          const step = span / Math.max(count - 1, 1)
+          return (
+            <circle key={`${y}-${i}`} cx={8 + offset + i * step} cy={y} r={r} fill="currentColor" />
+          )
+        })
+      return (
+        <g>
+          <path d="M 5 13 L 35 13 L 32 27 L 8 27 Z" />
+          {row(top, 18, 0)}
+          {row(bottom, 23, 1.5)}
+        </g>
+      )
+    }
+    case 'rj45':
+      return (
+        <g>
+          <path d="M 12 8 L 28 8 L 28 27 L 24 27 L 24 32 L 16 32 L 16 27 L 12 27 Z" />
+          {Array.from({ length: 8 }, (_, i) => (
+            <line key={i} x1={13.5 + i * 1.8} y1={10} x2={13.5 + i * 1.8} y2={15} />
+          ))}
+        </g>
+      )
+    case 'usb-a':
+      return (
+        <g>
+          <rect x={7} y={15} width={26} height={11} rx={1} />
+          <rect x={10} y={16.5} width={20} height={3.5} fill="currentColor" />
+        </g>
+      )
+    case 'usb-b':
+      return (
+        <g>
+          <path d="M 13 12 L 27 12 L 29 16 L 29 28 L 11 28 L 11 16 Z" />
+          <rect x={15} y={15} width={10} height={3.5} fill="currentColor" />
+        </g>
+      )
+    case 'firewire': {
+      const fw800 = (p.pins ?? 6) >= 9
+      return fw800 ? (
+        <g>
+          <path d="M 13 13 L 27 13 L 29 16 L 29 27 L 11 27 L 11 16 Z" />
+          <rect x={15} y={17} width={10} height={4} fill="currentColor" />
+        </g>
+      ) : (
+        <g>
+          <path d="M 11 16 L 25 16 L 29 20 L 25 24 L 11 24 Z" />
+          <rect x={13} y={18.5} width={9} height={3} fill="currentColor" />
+        </g>
+      )
+    }
+    case 'fiber-lc':
+      return (
+        <g>
+          {[12, 23].map((x, i) => (
+            <g key={i}>
+              <rect x={x} y={13} width={7} height={14} rx={1} />
+              <line x1={x + 1} y1={12} x2={x + 6} y2={12} />
+            </g>
+          ))}
+        </g>
+      )
+    case 'fiber-sc':
+      return (
+        <g>
+          <rect x={11} y={11} width={18} height={18} rx={1.5} />
+          <rect x={15} y={15} width={10} height={10} rx={1} />
+          <line x1={16} y1={11} x2={24} y2={11} />
+        </g>
+      )
+    case 'fiber-st':
+      return (
+        <g>
+          <circle cx={20} cy={20} r={12} />
+          <line x1={20} y1={6} x2={20} y2={9} />
+          <circle cx={20} cy={20} r={4.5} />
+          <circle cx={20} cy={20} r={1.6} fill="currentColor" />
+        </g>
+      )
+    case 'toslink':
+      return (
+        <g>
+          <path d="M 11 13 L 17 13 L 20 16 L 23 13 L 29 13 L 29 27 L 11 27 Z" />
+          <circle cx={20} cy={21} r={3} fill="currentColor" />
+        </g>
+      )
+    case 'powercon': {
+      const out = p.flow === 'out'
+      return (
+        <g>
+          {/* runder Body mit Flachseite */}
+          <path d="M 20 7 A 13 13 0 1 1 11 29 L 29 29 A 13 13 0 0 0 20 7 Z" fill="none" />
+          {ringPins(3, 20, 19, 5).map((pt, i) => (
+            <circle key={i} cx={pt.x} cy={pt.y} r={1.7} fill="currentColor" />
+          ))}
+          {/* In/Out-Pfeil */}
+          <line x1={20} y1={out ? 20 : 14} x2={20} y2={out ? 14 : 20} />
+          <path
+            d={out ? 'M 17 16 L 20 13 L 23 16' : 'M 17 17 L 20 20 L 23 17'}
+            fill="none"
+          />
+        </g>
+      )
+    }
+    case 'lemo':
+      return (
+        <g>
+          <circle cx={20} cy={20} r={12} />
+          <circle cx={20} cy={9} r={2} fill="currentColor" />
+          {ringPins(3, 20, 21, 4.5).map((pt, i) => (
+            <circle key={i} cx={pt.x} cy={pt.y} r={1.5} fill="currentColor" />
+          ))}
+        </g>
+      )
+    case 'generic':
+      return (
+        <g>
+          <rect x={8} y={8} width={24} height={24} rx={6} />
+          <circle cx={20} cy={20} r={4.5} />
+        </g>
+      )
+    case 'blank':
+      return (
+        <g>
+          <rect x={7} y={12} width={26} height={16} rx={2} />
+          {[12, 18, 24, 30].map((x, i) => (
+            <line key={i} x1={x} y1={28} x2={x + 6} y2={12} />
+          ))}
+        </g>
+      )
+    default:
+      return (
+        <g>
+          <rect x={8} y={8} width={24} height={24} rx={6} />
+        </g>
+      )
+  }
+}
+
+export const ConnectorSymbol = ({
+  size = 28,
+  className,
+  title,
+  ...rest
+}: ConnectorSymbolProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 40 40"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.6}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    role="img"
+    aria-label={title}
+  >
+    {title ? <title>{title}</title> : null}
+    {renderBody(rest)}
+  </svg>
+)

--- a/src/renderer/lib/connectorCatalog.ts
+++ b/src/renderer/lib/connectorCatalog.ts
@@ -1,0 +1,226 @@
+/**
+ * #170 / Patchblende — Kategorisierter Connector-Katalog mit Symbolen.
+ *
+ * Ergänzt die flache `ALL_CONNECTOR_TYPES`-Liste um eine nach Funktion
+ * gruppierte Auswahl (Audio / MIDI / Video / Data / Fiber / Power /
+ * Multifunction / General) mit je einem schematischen Steckersymbol —
+ * vorbildlich an Patchbay-CAD-Tools angelehnt. Genutzt vom
+ * Patchblenden-Dialog im Rack-Builder (ConnectorPicker), damit der User
+ * den Stecker visuell wählt statt aus einer langen Dropdown-Liste.
+ *
+ * WICHTIG: `id` ist der gespeicherte `connectorType`-String am Port. Wo ein
+ * sauberes 1:1 zu einem bestehenden `ConnectorType` existiert (BNC, HDMI,
+ * RJ45 …) wird die Legacy-ID wiederverwendet, damit Farb-Legende und
+ * Kabel/BOM-Matching den Stecker weiter erkennen. Neue Stecker bekommen
+ * eine eigene String-ID — `connectorType` ist eh ein freier String (vgl.
+ * Custom-Connector-Typen), sodass das ohne Union-Erweiterung trägt.
+ */
+import type { ConnectorType } from '../types/equipment'
+import { DEFAULT_CONNECTOR_TYPE_COLORS } from './cableColors'
+
+export type ConnectorCategory =
+  | 'audio'
+  | 'midi'
+  | 'video'
+  | 'data'
+  | 'fiber'
+  | 'power'
+  | 'multifunction'
+  | 'general'
+
+export interface ConnectorCategoryDef {
+  id: ConnectorCategory
+  /** Deutsche Quell-Bezeichnung (i18n-Fallback). */
+  de: string
+  /** Englische Bezeichnung. */
+  en: string
+  /** Akzentfarbe für Kategorie-Header / Tile-Rahmen. */
+  color: string
+}
+
+export const CONNECTOR_CATEGORIES: ConnectorCategoryDef[] = [
+  { id: 'audio', de: 'Audio', en: 'Audio', color: '#38bdf8' },
+  { id: 'midi', de: 'MIDI', en: 'MIDI', color: '#e879f9' },
+  { id: 'video', de: 'Video', en: 'Video', color: '#f59e0b' },
+  { id: 'data', de: 'Daten', en: 'Data', color: '#22c55e' },
+  { id: 'fiber', de: 'Glasfaser', en: 'Fibre', color: '#eab308' },
+  { id: 'power', de: 'Strom', en: 'Power', color: '#ef4444' },
+  { id: 'multifunction', de: 'Multifunktion', en: 'Multifunction', color: '#a78bfa' },
+  { id: 'general', de: 'Allgemein', en: 'General', color: '#94a3b8' },
+]
+
+/** Symbol-Familie, die `ConnectorSymbol` zeichnen kann. */
+export type ConnectorSymbolId =
+  | 'xlr'
+  | 'jack'
+  | 'bantam'
+  | 'combo'
+  | 'speakon'
+  | 'phono'
+  | 'binding-post'
+  | 'midi'
+  | 'bnc'
+  | 'vga'
+  | 'mini-din'
+  | 'hdmi'
+  | 'f-conn'
+  | 'displayport'
+  | 'dvi'
+  | 'dsub'
+  | 'rj45'
+  | 'usb-a'
+  | 'usb-b'
+  | 'firewire'
+  | 'fiber-lc'
+  | 'fiber-sc'
+  | 'fiber-st'
+  | 'toslink'
+  | 'powercon'
+  | 'lemo'
+  | 'generic'
+  | 'blank'
+
+export interface ConnectorCatalogEntry {
+  /** Gespeicherter `connectorType`-String (ggf. Legacy-ID zur Farb-/BOM-Wiederverwendung). */
+  id: string
+  /** Anzeige-Label (Patchbay-Schreibweise). Technischer Produktname — nicht lokalisiert. */
+  label: string
+  category: ConnectorCategory
+  symbol: ConnectorSymbolId
+  /** Pin-Anzahl (XLR 3-7, DIN/D-Sub) — vom Symbol ausgewertet. */
+  pins?: number
+  /** Pol-Anzahl (speakON 2/4, Klinke TS=2 / TRS=3). */
+  poles?: number
+  /** Steckverbinder-Geschlecht — wird beim Erzeugen auf den Port übernommen. */
+  gender?: 'male' | 'female'
+  /** Strom-Richtung (powerCON In/Out) — beeinflusst Symbol-Pfeil. */
+  flow?: 'in' | 'out'
+  /** Kompaktes Symbol (Mini-Klinke). */
+  mini?: boolean
+  /** Explizite Farb-Überschreibung (sonst Legacy-Farbe bzw. Kategorie-Farbe). */
+  color?: string
+}
+
+export const CONNECTOR_CATALOG: ConnectorCatalogEntry[] = [
+  // ---- Audio ----
+  { id: 'TT/Bantam', label: 'Bantam', category: 'audio', symbol: 'bantam' },
+  { id: 'TS Jack', label: 'TS Jack', category: 'audio', symbol: 'jack', poles: 2 },
+  { id: 'TRS Jack', label: 'TRS Jack', category: 'audio', symbol: 'jack', poles: 3 },
+  { id: 'XLR 3 Male', label: 'XLR 3 Male', category: 'audio', symbol: 'xlr', pins: 3, gender: 'male' },
+  { id: 'XLR 3 Female', label: 'XLR 3 Female', category: 'audio', symbol: 'xlr', pins: 3, gender: 'female' },
+  { id: 'Combo XLR/Jack', label: 'Combo', category: 'audio', symbol: 'combo' },
+  { id: 'Mini Jack', label: 'Mini Jack', category: 'audio', symbol: 'jack', poles: 3, mini: true },
+  { id: 'speakON 2 Pole', label: 'speakON 2 Pole', category: 'audio', symbol: 'speakon', poles: 2 },
+  { id: 'speakON 4 Pole', label: 'speakON 4 Pole', category: 'audio', symbol: 'speakon', poles: 4 },
+  { id: 'Cinch/RCA', label: 'Phono', category: 'audio', symbol: 'phono' },
+  { id: 'Binding Post', label: 'Binding Post', category: 'audio', symbol: 'binding-post' },
+  { id: 'XLR 4 Male', label: 'XLR 4 Male', category: 'audio', symbol: 'xlr', pins: 4, gender: 'male' },
+  { id: 'XLR 4 Female', label: 'XLR 4 Female', category: 'audio', symbol: 'xlr', pins: 4, gender: 'female' },
+  { id: 'XLR 5 Male', label: 'XLR 5 Male', category: 'audio', symbol: 'xlr', pins: 5, gender: 'male' },
+  { id: 'XLR 5 Female', label: 'XLR 5 Female', category: 'audio', symbol: 'xlr', pins: 5, gender: 'female' },
+  { id: 'XLR 6 Male', label: 'XLR 6 Male', category: 'audio', symbol: 'xlr', pins: 6, gender: 'male' },
+  { id: 'XLR 6 Female', label: 'XLR 6 Female', category: 'audio', symbol: 'xlr', pins: 6, gender: 'female' },
+  { id: 'XLR 7 Male', label: 'XLR 7 Male', category: 'audio', symbol: 'xlr', pins: 7, gender: 'male' },
+  { id: 'XLR 7 Female', label: 'XLR 7 Female', category: 'audio', symbol: 'xlr', pins: 7, gender: 'female' },
+
+  // ---- MIDI ----
+  { id: 'MIDI', label: 'MIDI', category: 'midi', symbol: 'midi', pins: 5 },
+
+  // ---- Video ----
+  { id: 'BNC', label: 'BNC', category: 'video', symbol: 'bnc' },
+  { id: 'VGA', label: 'VGA', category: 'video', symbol: 'vga' },
+  { id: 'S-Video', label: 'S-Video', category: 'video', symbol: 'mini-din', pins: 4 },
+  { id: 'S-VHS', label: 'SVHS', category: 'video', symbol: 'mini-din', pins: 4 },
+  { id: 'HDMI', label: 'HDMI', category: 'video', symbol: 'hdmi' },
+  { id: 'F-Connector', label: 'F', category: 'video', symbol: 'f-conn' },
+  { id: 'DisplayPort', label: 'Display Port', category: 'video', symbol: 'displayport' },
+  { id: 'DVI', label: 'DVI', category: 'video', symbol: 'dvi' },
+
+  // ---- Data ----
+  { id: 'DB9', label: 'Dsub 9', category: 'data', symbol: 'dsub', pins: 9 },
+  { id: 'Ethernet/RJ45', label: 'RJ45', category: 'data', symbol: 'rj45' },
+  { id: 'USB Type A', label: 'USB Type A', category: 'data', symbol: 'usb-a' },
+  { id: 'USB Type B', label: 'USB Type B', category: 'data', symbol: 'usb-b' },
+  { id: 'USB 3 Type A', label: 'USB 3 Type A', category: 'data', symbol: 'usb-a', color: '#3b82f6' },
+  { id: 'USB 3 Type B', label: 'USB 3 Type B', category: 'data', symbol: 'usb-b', color: '#3b82f6' },
+  { id: 'FireWire 400', label: 'FireWire 400', category: 'data', symbol: 'firewire', pins: 6 },
+  { id: 'FireWire 800', label: 'FireWire 800', category: 'data', symbol: 'firewire', pins: 9 },
+  { id: 'PS/2', label: 'PS/2', category: 'data', symbol: 'mini-din', pins: 6 },
+
+  // ---- Fiber ----
+  { id: 'Fiber Optic LC', label: 'Fiber Optic LC', category: 'fiber', symbol: 'fiber-lc' },
+  { id: 'Fiber Optic SC', label: 'Fibre Optic SC', category: 'fiber', symbol: 'fiber-sc' },
+  { id: 'Fiber Optic ST', label: 'Fiber Optic ST', category: 'fiber', symbol: 'fiber-st' },
+  { id: 'Toslink', label: 'Toslink', category: 'fiber', symbol: 'toslink' },
+
+  // ---- Power ----
+  { id: 'powerCON Input', label: 'powerCON Input', category: 'power', symbol: 'powercon', flow: 'in', color: '#0ea5e9' },
+  { id: 'powerCON Output', label: 'powerCON Output', category: 'power', symbol: 'powercon', flow: 'out', color: '#64748b' },
+
+  // ---- Multifunction ----
+  { id: 'Lemo', label: 'Lemo', category: 'multifunction', symbol: 'lemo' },
+  { id: 'Tourine 25', label: 'Tourine 25', category: 'multifunction', symbol: 'dsub', pins: 25 },
+  { id: 'Tourine 37', label: 'Tourine 37', category: 'multifunction', symbol: 'dsub', pins: 37 },
+
+  // ---- General ----
+  { id: 'Generic', label: 'Generic', category: 'general', symbol: 'generic' },
+  { id: 'Blanking Panel', label: 'Blanking Panel', category: 'general', symbol: 'blank' },
+]
+
+const CATALOG_BY_ID = new Map(CONNECTOR_CATALOG.map((e) => [e.id, e]))
+const CATEGORY_BY_ID = new Map(CONNECTOR_CATEGORIES.map((c) => [c.id, c]))
+
+/** Katalog-Eintrag zu einer gespeicherten connectorType-ID (oder undefined). */
+export const findConnectorEntry = (id: string): ConnectorCatalogEntry | undefined =>
+  CATALOG_BY_ID.get(id)
+
+/** Anzeige-Label für eine connectorType-ID — Katalog-Label oder die ID selbst. */
+export const connectorLabel = (id: string): string => CATALOG_BY_ID.get(id)?.label ?? id
+
+/** Geschlecht aus dem Katalog (für Port-Erzeugung). */
+export const connectorGender = (id: string): 'male' | 'female' | undefined =>
+  CATALOG_BY_ID.get(id)?.gender
+
+/** Farbe für einen Eintrag: explizit → Legacy-Palette → Kategorie-Akzent. */
+export const connectorColor = (entry: ConnectorCatalogEntry): string =>
+  entry.color ??
+  DEFAULT_CONNECTOR_TYPE_COLORS[entry.id as ConnectorType] ??
+  CATEGORY_BY_ID.get(entry.category)?.color ??
+  '#94a3b8'
+
+/** Farbe direkt zu einer connectorType-ID (Fallback grau für unbekannte). */
+export const connectorColorById = (id: string): string => {
+  const entry = CATALOG_BY_ID.get(id)
+  if (entry) return connectorColor(entry)
+  return DEFAULT_CONNECTOR_TYPE_COLORS[id as ConnectorType] ?? '#94a3b8'
+}
+
+export interface ConnectorGroup {
+  category: ConnectorCategoryDef
+  entries: ConnectorCatalogEntry[]
+}
+
+/**
+ * Katalog nach Kategorien gruppiert (in CONNECTOR_CATEGORIES-Reihenfolge),
+ * plus optional weitere/Legacy/Custom-Typen die NICHT im Katalog stehen.
+ * Letztere landen mit Generic-Symbol unter "Allgemein", damit nichts aus
+ * der bisherigen Auswahl verloren geht.
+ */
+export const buildConnectorGroups = (extraTypes: string[] = []): ConnectorGroup[] => {
+  const groups: ConnectorGroup[] = CONNECTOR_CATEGORIES.map((category) => ({
+    category,
+    entries: CONNECTOR_CATALOG.filter((e) => e.category === category.id),
+  }))
+  const seen = new Set(CONNECTOR_CATALOG.map((e) => e.id))
+  const extras: ConnectorCatalogEntry[] = []
+  for (const t of extraTypes) {
+    if (!t || seen.has(t)) continue
+    seen.add(t)
+    extras.push({ id: t, label: t, category: 'general', symbol: 'generic' })
+  }
+  if (extras.length) {
+    const general = groups.find((g) => g.category.id === 'general')
+    if (general) general.entries = [...general.entries, ...extras]
+  }
+  return groups.filter((g) => g.entries.length > 0)
+}

--- a/src/renderer/lib/i18n.ts
+++ b/src/renderer/lib/i18n.ts
@@ -1703,6 +1703,18 @@ const en: Dict = {
   'rack.patchPanel.col.rear': 'Rear',
   'rack.patchPanel.create': 'Create patch panel',
 
+  // Connector catalog — categories + visual picker (#170)
+  'connector.cat.audio': 'Audio',
+  'connector.cat.midi': 'MIDI',
+  'connector.cat.video': 'Video',
+  'connector.cat.data': 'Data',
+  'connector.cat.fiber': 'Fibre',
+  'connector.cat.power': 'Power',
+  'connector.cat.multifunction': 'Multifunction',
+  'connector.cat.general': 'General',
+  'connector.picker.search': 'Search connector…',
+  'connector.picker.noResults': 'No connector found',
+
   // Rack — RackShelfCreateDialog
   'rack.shelf.title': 'Create rack shelf',
   'rack.shelf.name': 'Name',


### PR DESCRIPTION
- Neuer kategorisierter Connector-Katalog (Audio / MIDI / Video / Daten / Glasfaser / Strom / Multifunktion / Allgemein) in lib/connectorCatalog.ts
- ConnectorSymbol: schematische SVG-Symbole je Steckerfamilie (XLR-Pins male/female, Klinke, Bantam, speakON, Phono, BNC, VGA, HDMI, RJ45, D-Sub, USB, FireWire, Glasfaser LC/SC/ST, Toslink, powerCON In/Out, …)
- ConnectorPicker: durchsuchbare Kachel-Palette (Popover via Portal), ersetzt die flachen Selects im Patchblenden-Dialog (Basics + Per-Port)
- Legacy- und Custom-Connector-Typen bleiben unter "Allgemein" erhalten; Katalog-IDs nutzen bestehende ConnectorType-Werte wo sinnvoll, damit Farb-Legende und Kabel/BOM-Matching den Stecker weiter erkennen
- Stecker-Geschlecht (XLR 3 Male/Female …) wandert auf die Port-Gender-Info
- i18n: EN-Keys fuer die acht Kategorien + Picker-UI