### PR TITLE
fix(hooks): letzte Rules-of-Hooks-Crashes (Rack3DView 3D-View + Videohub-Matrix)

### DIFF
--- a/src/renderer/components/Export/VideohubRoutingMatrix.tsx
+++ b/src/renderer/components/Export/VideohubRoutingMatrix.tsx
@@ -156,6 +156,55 @@ export const VideohubRoutingMatrix = ({
     saveLayout(layout)
   }, [layout])
 
+  // Rules of Hooks: diese Hooks MUESSEN vor dem `if (!useGrid)`-Early-Return
+  // laufen — sonst aendert sich die Hook-Anzahl wenn `useGrid` (Port-Anzahl)
+  // umschlaegt. Haengen nur an Props/fruehen Hooks, daher sicher vorzuziehen.
+  const inLabelTip = useMemo(
+    () => inputLabels.map((l, i) => `In ${i + 1} · ${l}`),
+    [inputLabels],
+  )
+  const outLabelTip = useMemo(
+    () => outputLabels.map((l, i) => `Out ${i + 1} · ${l}`),
+    [outputLabels],
+  )
+
+  // Excel-style Drag-Resize. State im Ref damit window-handler stable
+  // bleibt ueber re-renders.
+  const resizeRef = useRef<
+    | { kind: 'col'; index: number; startX: number; startW: number }
+    | { kind: 'row'; index: number; startY: number; startH: number }
+    | { kind: 'label'; startX: number; startW: number }
+    | null
+  >(null)
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      const s = resizeRef.current
+      if (!s) return
+      if (s.kind === 'col') {
+        const w = Math.max(24, Math.round(s.startW + (e.clientX - s.startX)))
+        setLayout((prev) => ({ ...prev, colWidths: { ...prev.colWidths, [s.index]: w } }))
+      } else if (s.kind === 'row') {
+        const h = Math.max(20, Math.round(s.startH + (e.clientY - s.startY)))
+        setLayout((prev) => ({ ...prev, rowHeights: { ...prev.rowHeights, [s.index]: h } }))
+      } else {
+        const w = Math.max(80, Math.round(s.startW + (e.clientX - s.startX)))
+        setLayout((prev) => ({ ...prev, labelColWidth: w }))
+      }
+    }
+    const onUp = () => {
+      if (resizeRef.current) {
+        resizeRef.current = null
+        document.body.style.cursor = ''
+      }
+    }
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+    return () => {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+    }
+  }, [])
+
   if (!useGrid) {
     return (
       <div className="overflow-auto max-h-64 rounded border border-slate-700 bg-slate-950 p-2">
@@ -244,52 +293,6 @@ export const VideohubRoutingMatrix = ({
     const el = rowRefs.current[oi]
     if (el) el.scrollIntoView({ block: 'center', behavior: 'smooth' })
   }
-
-  const inLabelTip = useMemo(
-    () => inputLabels.map((l, i) => `In ${i + 1} · ${l}`),
-    [inputLabels],
-  )
-  const outLabelTip = useMemo(
-    () => outputLabels.map((l, i) => `Out ${i + 1} · ${l}`),
-    [outputLabels],
-  )
-
-  // Excel-style Drag-Resize. State im Ref damit window-handler stable
-  // bleibt ueber re-renders.
-  const resizeRef = useRef<
-    | { kind: 'col'; index: number; startX: number; startW: number }
-    | { kind: 'row'; index: number; startY: number; startH: number }
-    | { kind: 'label'; startX: number; startW: number }
-    | null
-  >(null)
-  useEffect(() => {
-    const onMove = (e: MouseEvent) => {
-      const s = resizeRef.current
-      if (!s) return
-      if (s.kind === 'col') {
-        const w = Math.max(24, Math.round(s.startW + (e.clientX - s.startX)))
-        setLayout((prev) => ({ ...prev, colWidths: { ...prev.colWidths, [s.index]: w } }))
-      } else if (s.kind === 'row') {
-        const h = Math.max(20, Math.round(s.startH + (e.clientY - s.startY)))
-        setLayout((prev) => ({ ...prev, rowHeights: { ...prev.rowHeights, [s.index]: h } }))
-      } else {
-        const w = Math.max(80, Math.round(s.startW + (e.clientX - s.startX)))
-        setLayout((prev) => ({ ...prev, labelColWidth: w }))
-      }
-    }
-    const onUp = () => {
-      if (resizeRef.current) {
-        resizeRef.current = null
-        document.body.style.cursor = ''
-      }
-    }
-    window.addEventListener('mousemove', onMove)
-    window.addEventListener('mouseup', onUp)
-    return () => {
-      window.removeEventListener('mousemove', onMove)
-      window.removeEventListener('mouseup', onUp)
-    }
-  }, [])
 
   const startColResize = (index: number) => (e: React.MouseEvent) => {
     e.preventDefault()

--- a/src/renderer/components/Rack/Rack3DView.tsx
+++ b/src/renderer/components/Rack/Rack3DView.tsx
@@ -743,21 +743,33 @@ const Shelf = ({
 }
 
 /** STL-loaded device geometry. Auto-fits into the HE-box. */
-const DeviceSTL = ({
-  placement,
-  rackDepthMm,
-  totalUnits,
-  selected,
-  onClick,
-}: {
+type DeviceSTLProps = {
   placement: Rack3DPlacement
   rackDepthMm: number
   totalUnits: number
   selected: boolean
   onClick: () => void
-}) => {
-  if (!placement.stlDataUri) return null
-  const geometry = useLoader(STLLoader, placement.stlDataUri)
+}
+
+// Rules of Hooks: useLoader/useMemo duerfen NICHT hinter dem `return null`
+// stehen — beim Umschalten von "kein STL" zu "STL" (oder Geraetewechsel)
+// aendert sich sonst die Hook-Anzahl ("Rendered more hooks than..."). Loesung:
+// die Hooks in eine innere Komponente, die nur gerendert wird wenn die
+// stlDataUri existiert. useLoader bekommt damit immer eine gueltige URL.
+const DeviceSTL = (props: DeviceSTLProps) => {
+  if (!props.placement.stlDataUri) return null
+  return <DeviceSTLMesh {...props} stlDataUri={props.placement.stlDataUri} />
+}
+
+const DeviceSTLMesh = ({
+  placement,
+  rackDepthMm,
+  totalUnits,
+  selected,
+  onClick,
+  stlDataUri,
+}: DeviceSTLProps & { stlDataUri: string }) => {
+  const geometry = useLoader(STLLoader, stlDataUri)
   const yBottom = (totalUnits - placement.startUnit - placement.rackUnits + 1) * HE_HEIGHT_MM
   const heightMm = placement.rackUnits * HE_HEIGHT_MM
   const widthMm = RACK_MOUNT_WIDTH_MM


### PR DESCRIPTION
Behebt die **letzten zwei** „Rendered more hooks than during the previous render"-Crashes — gleiche Klasse wie die Properties-Sektionen aus #437, aber in selten genutzten Features und mit etwas mehr Struktur.

### `Rack/Rack3DView` → `DeviceSTL` (3D-Rack-Ansicht)
`useLoader(STLLoader, placement.stlDataUri)` + `useMemo` standen hinter `if (!placement.stlDataUri) return null`. `useLoader` lässt sich **nicht** einfach hochziehen — es würde sonst `undefined` laden. Lösung: Component-Split — `DeviceSTL` macht nur den Guard, die innere `DeviceSTLMesh` ruft die Hooks mit garantierter URL.

### `Export/VideohubRoutingMatrix` (Crosspoint-Matrix)
`useMemo`×2 / `useRef` / `useEffect` (Excel-Resize) standen hinter `if (!useGrid) return <Listen-Modus>`. Da sie nur an Props/frühe Hooks hängen, vor den Early-Return gezogen.

### Ergebnis
**0** `react-hooks/rules-of-hooks`-Verstöße codebase-weit (vorher 15 über 6 Dateien; Properties-Cluster in #437, diese zwei hier). tsc 0 Errors, vite build grün.

Damit ist die ganze „Dialog/Panel friert beim Öffnen/Wechseln ein"-Crash-Klasse abgeräumt.

---
_Generated by [Claude Code](https://claude.ai/code/session_015uS2viCVSEK6YvJUGyRUQ9)_