### PR TITLE
fix(lint): resolve react-hooks/set-state-in-effect

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -303,6 +303,7 @@ export default function App() {
   }, [libraryReady, projectVersion])
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- PDF-Export öffnet → Theme einmalig auf hell setzen
     if (pdfExportOpen) setPdfTheme('light')
   }, [pdfExportOpen])
 

--- a/src/renderer/components/Atem/AtemAudioRouterDialog.tsx
+++ b/src/renderer/components/Atem/AtemAudioRouterDialog.tsx
@@ -69,6 +69,7 @@ export const AtemAudioRouterDialog = () => {
   // {sources,outputs} shape into the new {matrix:{...}} wrapper.
   useEffect(() => {
     if (!open) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Draft beim Dialog-Öffnen aus equipment seeden (keyed sync)
     setErrorMsg('')
     const stored = equipment?.atemAudioConfig
     if (!stored) {

--- a/src/renderer/components/Atem/AtemMvConfigDialog.tsx
+++ b/src/renderer/components/Atem/AtemMvConfigDialog.tsx
@@ -658,6 +658,7 @@ export const AtemMvConfigDialog = () => {
 
   useEffect(() => {
     if (!slot.open || !equipment) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Draft beim Dialog-Öffnen seeden/zurücksetzen (keyed sync)
     setStatus('')
     setPicker(null)
     // v7.9.4 — Migration auf Quadranten-Modell. Falls ein MV noch das

--- a/src/renderer/components/Atem/MultiviewerLayoutView.tsx
+++ b/src/renderer/components/Atem/MultiviewerLayoutView.tsx
@@ -266,6 +266,7 @@ export const MultiviewerLayoutView = ({ onClose }: MultiviewerLayoutViewProps) =
   }
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Initial-Refresh + ATEM-Event-Subscription (externer Store)
     void refresh()
     // Live updates: the main process pushes ATEM state events; refresh on each.
     const unsubscribe = cablePlannerApi.atem.onEvent(() => {

--- a/src/renderer/components/Canvas/CableContextMenu.tsx
+++ b/src/renderer/components/Canvas/CableContextMenu.tsx
@@ -117,6 +117,7 @@ export const CableContextMenu = () => {
   // strand the menu at the old coordinates).
   useEffect(() => {
     if (!menu.open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Submenu beim Schließen zurücksetzen (neben Outside-Click/Escape-Listener)
       setSubmenu(null)
       return
     }

--- a/src/renderer/components/Canvas/PendingCableOverlay.tsx
+++ b/src/renderer/components/Canvas/PendingCableOverlay.tsx
@@ -20,6 +20,7 @@ export const PendingCableOverlay = () => {
 
   useEffect(() => {
     if (!pendingCable) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Reset beim Clear neben dem window-mousemove-Listener
       setMouseFlow(null)
       return
     }

--- a/src/renderer/components/Layout/FloatingPanelShell.tsx
+++ b/src/renderer/components/Layout/FloatingPanelShell.tsx
@@ -81,6 +81,7 @@ export const FloatingPanelShell = ({
   // panel where the user can't see it. clamp() uses the current
   // viewport bounds.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Persistierte Position in den aktuellen Viewport clampen
     setPos((current) => {
       const clamped = clamp(position, width)
       if (

--- a/src/renderer/components/Library/LibraryPanel.tsx
+++ b/src/renderer/components/Library/LibraryPanel.tsx
@@ -185,6 +185,7 @@ export const LibraryPanel = () => {
       })),
       cables: [],
     }
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- One-shot Store-Trigger (Rack-Builder seeden), danach Trigger clearen
     setSeedPreset(synthesized)
     setEditingRackPresetId(null)
     setShowRackBuilderDialog(true)
@@ -197,6 +198,7 @@ export const LibraryPanel = () => {
   // feuert auch wenn der vorherige schon abgewickelt ist.
   useEffect(() => {
     if (!newRackBuilderTrigger) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- One-shot Store-Trigger (leeren Rack-Builder öffnen), danach clearen
     setSeedPreset(null)
     setEditingRackPresetId(null)
     setEditingCanvasRackEquipmentId(null)
@@ -276,6 +278,7 @@ export const LibraryPanel = () => {
           standard: 'unbekannt',
         })),
       }
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- One-shot Store-Trigger (Rack aus Black-Box editieren), danach clearen
       setSeedPreset(synth)
       setEditingRackPresetId(null)
       // Merken: Save geht in dieses Canvas-Equipment zurueck, nicht in
@@ -300,6 +303,7 @@ export const LibraryPanel = () => {
   const clearEmptyDeviceDrop = useUiStore((s) => s.clearEmptyDeviceDrop)
   useEffect(() => {
     if (!pendingEmptyDeviceDrop) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- One-shot Store-Trigger (Empty-Device-Drop), danach clearen
     setName(pendingEmptyDeviceDrop.name || t('library.create.defaultName', 'Neues Gerät'))
     if (pendingEmptyDeviceDrop.category) setCategory(pendingEmptyDeviceDrop.category)
     setPendingDropOnSave({ x: pendingEmptyDeviceDrop.x, y: pendingEmptyDeviceDrop.y })

--- a/src/renderer/components/Library/TemplateMergeDialog.tsx
+++ b/src/renderer/components/Library/TemplateMergeDialog.tsx
@@ -48,6 +48,7 @@ export const TemplateMergeDialog = ({
     for (const port of localTemplate.outputs) {
       defaults.add(makePortKey('local', 'out', port.id))
     }
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Auswahl/Kategorie beim Dialog-Öffnen seeden (keyed sync)
     setSelectedKeys(defaults)
     setCategory(initialCategory ?? localTemplate.category ?? categoryOptions[0] ?? '')
   }, [open, localTemplate, initialCategory, categoryOptions])

--- a/src/renderer/components/Library/tabs/LocalEquipmentTab.tsx
+++ b/src/renderer/components/Library/tabs/LocalEquipmentTab.tsx
@@ -99,6 +99,7 @@ export const LocalEquipmentTab = ({
     const allCats = new Set([...knownCategories, ...usedCats])
     if (allCats.size === 0) return
     collapsedInitRef.current = true
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Einmalige Initialisierung der eingeklappten Kategorien
     setCollapsedCats(allCats)
   }, [customLibrary, knownCategories])
 

--- a/src/renderer/components/MobileShare/MobileShareDialog.tsx
+++ b/src/renderer/components/MobileShare/MobileShareDialog.tsx
@@ -87,6 +87,7 @@ export const MobileShareDialog = () => {
   // Pick + render the primary URL whenever the server state changes.
   useEffect(() => {
     if (status.urls.length === 0) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- QR/URL aus dem asynchronen Server-Status ableiten/zurücksetzen
       setQrDataUrl('')
       setSelectedUrl('')
       return

--- a/src/renderer/components/Onboarding/OnboardingTour.tsx
+++ b/src/renderer/components/Onboarding/OnboardingTour.tsx
@@ -89,6 +89,7 @@ export const OnboardingTour = ({ open, onClose }: OnboardingTourProps) => {
   const STEPS = stepsForLang(t)
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Beim Öffnen auf den ersten Schritt zurücksetzen
     if (open) setStep(0)
   }, [open])
 

--- a/src/renderer/components/Properties/ModeEditorDialog.tsx
+++ b/src/renderer/components/Properties/ModeEditorDialog.tsx
@@ -70,6 +70,7 @@ export const ModeEditorDialog = ({
   useEffect(() => {
     if (!open) return
     if (editingMode) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Draft beim Dialog-Öffnen seeden (keyed sync)
       setName(editingMode.name)
       setDescription(editingMode.description ?? '')
       setInputs(editingMode.inputs.map(toDraft))

--- a/src/renderer/components/Properties/TemplateProperties.tsx
+++ b/src/renderer/components/Properties/TemplateProperties.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useSyncedState } from '../../hooks/useSyncedState'
 import { useCanvasProjectStore as useProjectStore } from '../../store/projectStoreContext'
 import { nextPlacementPosition } from '../../lib/library'
 import { CategorySelect } from '../shared/CategorySelect'
@@ -18,14 +18,8 @@ export const TemplateProperties = () => {
 
   const template = customLibrary.find((tpl) => tpl.name === selectedTemplateName)
 
-  const [name, setName] = useState(template?.name ?? '')
-  const [category, setCategory] = useState(template?.category ?? '')
-
-  // Sync local state when selected template changes
-  useEffect(() => {
-    setName(template?.name ?? '')
-    setCategory(template?.category ?? '')
-  }, [template?.name, template?.category])
+  const [name, setName] = useSyncedState(template?.name ?? '')
+  const [category, setCategory] = useSyncedState(template?.category ?? '')
 
   if (!template) {
     return (

--- a/src/renderer/components/Rack/Rack3DView.tsx
+++ b/src/renderer/components/Rack/Rack3DView.tsx
@@ -215,6 +215,7 @@ const useImageTexture = (url?: string): THREE.Texture | null => {
   )
   useEffect(() => {
     if (!url) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Textur für die URL laden/leeren (asynchrone Ressource)
       setTex(null)
       return
     }

--- a/src/renderer/components/Rack/RackBuilderDialog.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialog.tsx
@@ -442,6 +442,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
     // so existing autosaves of an unrelated "new rack" don't leak in.
     if (initialPreset) {
       const seeded = normalizeDraft(draftFromPreset(initialPreset))
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Draft beim Dialog-Öffnen seeden (keyed sync)
       setDraft(seeded)
       setLastSavedSnapshot(JSON.stringify(seeded))
       setSelectedPlacementId(seeded.placements[0]?.id ?? null)

--- a/src/renderer/components/Rack/RackImageCropDialog.tsx
+++ b/src/renderer/components/Rack/RackImageCropDialog.tsx
@@ -91,6 +91,7 @@ export const RackImageCropDialog = ({
 
   useEffect(() => {
     if (open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Crop-Draft beim Dialog-Öffnen seeden (keyed sync)
       setCrop(defaultCrop(rackUnits, imgAspect))
       setZoom(1)
       setAspectLock(true)

--- a/src/renderer/components/Rentman/NewRentmanDeviceWizard.tsx
+++ b/src/renderer/components/Rentman/NewRentmanDeviceWizard.tsx
@@ -75,6 +75,7 @@ export const NewRentmanDeviceWizard = ({
 
   useEffect(() => {
     if (!current) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Draft aus dem aktuellen Item seeden (keyed sync)
     setName(current.name)
     setCategory(current.category || 'Custom')
     setGroups(hintsToDrafts(suggestPortGroups(current.name, current.category)))

--- a/src/renderer/components/Rentman/RentmanCableExportDialog.tsx
+++ b/src/renderer/components/Rentman/RentmanCableExportDialog.tsx
@@ -103,6 +103,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
   // dem Zugriff sieht (react-hooks/immutability).
   useEffect(() => {
     if (!open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- State beim Schließen zurücksetzen / Katalog beim Öffnen laden
       setStatusByKey({})
       setPickerKey(null)
       setPickerQuery('')

--- a/src/renderer/components/Settings/tabs/ProjectTab.tsx
+++ b/src/renderer/components/Settings/tabs/ProjectTab.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
+import { useSyncedState } from '../../../hooks/useSyncedState'
 import { Download, Upload, Loader2, X } from 'lucide-react'
 import { Icon } from '../../shared/Icon'
 import { useProjectStore } from '../../../store/projectStore'
@@ -360,9 +361,8 @@ const LengthEstimationSection = () => {
 export const ProjectTab = ({ onClose: _onClose }: { onClose: () => void }) => {
   const metadata = useProjectStore((s) => s.project.metadata)
   const updateProjectMetadata = useProjectStore((s) => s.updateProjectMetadata)
-  const [draftMeta, setDraftMeta] = useState(metadata)
+  const [draftMeta, setDraftMeta] = useSyncedState(metadata)
   const t = useTranslation()
-  useEffect(() => setDraftMeta(metadata), [metadata])
 
   const persistMeta = () =>
     updateProjectMetadata({

--- a/src/renderer/components/Settings/tabs/SyncTab.tsx
+++ b/src/renderer/components/Settings/tabs/SyncTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useSyncedState } from '../../../hooks/useSyncedState'
 import { useSettingsStore } from '../../../store/settingsStore'
 import { useTranslation } from '../../../lib/i18n'
 import { hasDesktopBridge } from '../../../lib/bridge'
@@ -12,14 +12,9 @@ export const SyncTab = () => {
   const sharedSyncUser = useSettingsStore((s) => s.sharedSyncUser)
   const setSyncPath = useSettingsStore((s) => s.setSyncPath)
   const setSyncUser = useSettingsStore((s) => s.setSyncUser)
-  const [draftSyncPath, setDraftSyncPath] = useState(sharedSyncPath)
-  const [draftSyncUser, setDraftSyncUser] = useState(sharedSyncUser)
+  const [draftSyncPath, setDraftSyncPath] = useSyncedState(sharedSyncPath)
+  const [draftSyncUser, setDraftSyncUser] = useSyncedState(sharedSyncUser)
   const t = useTranslation()
-
-  useEffect(() => {
-    setDraftSyncPath(sharedSyncPath)
-    setDraftSyncUser(sharedSyncUser)
-  }, [sharedSyncPath, sharedSyncUser])
 
   return (
     <div className="space-y-3 text-sm">

--- a/src/renderer/hooks/useDraggablePosition.ts
+++ b/src/renderer/hooks/useDraggablePosition.ts
@@ -27,6 +27,7 @@ export const useDraggablePosition = (storageKey: string, open: boolean) => {
       if (!raw) return
       const parsed = JSON.parse(raw) as { x: number; y: number }
       if (typeof parsed?.x === 'number' && typeof parsed?.y === 'number') {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- Persistierten Offset beim Öffnen aus localStorage hydrieren
         setOffset(parsed)
       }
     } catch {

--- a/src/renderer/hooks/useSyncedState.ts
+++ b/src/renderer/hooks/useSyncedState.ts
@@ -1,0 +1,23 @@
+import { useState, type Dispatch, type SetStateAction } from 'react'
+
+/**
+ * Local state that re-initialises from `source` whenever `source` changes —
+ * without a sync effect. Uses React's recommended "adjust state during render"
+ * pattern (remembering the previous source) instead of
+ * `useEffect(() => setDraft(source), [source])`, so there are no cascading
+ * effect renders (react-hooks/set-state-in-effect).
+ *
+ * Use for an editable draft seeded from a prop/store value: local edits persist
+ * until `source` changes, then the draft resets to the new source.
+ *
+ * See https://react.dev/reference/react/useState#storing-information-from-previous-renders
+ */
+export function useSyncedState<T>(source: T): [T, Dispatch<SetStateAction<T>>] {
+  const [value, setValue] = useState(source)
+  const [prevSource, setPrevSource] = useState(source)
+  if (prevSource !== source) {
+    setPrevSource(source)
+    setValue(source)
+  }
+  return [value, setValue]
+}


### PR DESCRIPTION
- Neuer Hook useSyncedState (Render-Adjust-Pattern statt Sync-Effect) für reine "Draft = Source"-Fälle: ProjectTab, SyncTab, TemplateProperties
- Übrige Effekte (Seed-on-open, Async-Load, Event-Listener-Setup, One-shot-Store-Trigger, localStorage-Hydration) per gezieltem Disable mit Begründung — legitime Effekt-Pattern, Verhalten bleibt unverändert; Regel bleibt als Error aktiv, fängt also neue Verstöße weiter ab