### PR TITLE
feat(rentman): Kombination als Rack importieren (#335)

### DIFF
--- a/src/renderer/components/Rack/RackBuilderDialog.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialog.tsx
@@ -182,6 +182,8 @@ const draftFromPreset = (preset: GroupPreset): RackDraft => {
       isRackShelf: item.isRackShelf,
       shelfOffsetX: shelfOffsetByIndex.get(index)?.x,
       shelfOffsetZ: shelfOffsetByIndex.get(index)?.z,
+      // #335 — Rentman-ID des Inhalts über Reload erhalten.
+      rentmanId: item.rentmanId,
     }
   })
   // Hydrate internal cables: cables in the stored preset reference items
@@ -214,6 +216,8 @@ const draftFromPreset = (preset: GroupPreset): RackDraft => {
     rackName: preset.name,
     totalUnits: preset.rack?.totalUnits ?? 42,
     depthMm: preset.rack?.depthMm,
+    // #335 — Kombi-ID des Racks über Reload erhalten.
+    rentmanId: preset.rack?.rentmanId,
     viewMode: 'front',
     placements,
     internalCables,
@@ -641,6 +645,8 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
       // v7.9.75 / #170 — Patchblende-/Shelf-Marker persistieren.
       isPatchPanel: placement.isPatchPanel,
       isRackShelf: placement.isRackShelf,
+      // #335 — Rentman-ID des Inhalts erhalten (nur wenn gesetzt).
+      ...(placement.rentmanId ? { rentmanId: placement.rentmanId } : {}),
       width: 240,
       height: 80 + Math.max(placement.inputs.length, placement.outputs.length, 3) * 22,
       offsetX: 0,
@@ -704,6 +710,8 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
       name: draft.rackName.trim(),
       rack: {
         totalUnits: draft.totalUnits,
+        // #335 — Kombi-ID des Racks erhalten (nur wenn aus Rentman-Import).
+        ...(draft.rentmanId ? { rentmanId: draft.rentmanId } : {}),
         // v7.9.73 / #170 — Rack-Tiefe nur persistieren wenn vom User gesetzt.
         ...(draft.depthMm ? { depthMm: draft.depthMm } : {}),
         placements: rackPlacements,

--- a/src/renderer/components/Rack/rackBuilderTypes.ts
+++ b/src/renderer/components/Rack/rackBuilderTypes.ts
@@ -41,6 +41,10 @@ export interface RackPlacementDraft {
   shelfOffsetX?: number
   /** v7.9.82 / #170 — Shelf-Device depth-Offset (mm von vorne). */
   shelfOffsetZ?: number
+  /** #335 — Rentman-ID dieses Geräts (wenn es aus einer Rentman-Kombination
+   *  als Rack-Inhalt importiert wurde). Bleibt über Save/Reload erhalten und
+   *  landet beim Platzieren auf dem EquipmentItem. */
+  rentmanId?: string
 }
 
 export interface InternalCableDraft {
@@ -61,6 +65,10 @@ export interface InternalCableDraft {
 export interface RackDraft {
   rackName: string
   totalUnits: number
+  /** #335 — Rentman-Equipment-ID der Kombination, falls dieses Rack aus einer
+   *  Rentman-Kombination importiert wurde. Round-trips über das GroupPreset
+   *  (preset.rack.rentmanId). */
+  rentmanId?: string
   viewMode: 'front' | 'rear' | 'both' | 'side'
   /** v7.9.73 / #170 — Rack-Tiefe in mm. Default 800 mm. */
   depthMm?: number

--- a/src/renderer/components/Rentman/EquipmentChecklist.tsx
+++ b/src/renderer/components/Rentman/EquipmentChecklist.tsx
@@ -33,6 +33,14 @@ interface EquipmentChecklistProps {
   onQtyChange?: (id: string, qty: number) => void
   onSetAllChildren?: (parentId: string, checked: boolean) => void
   /**
+   * #335: Per-Kombination "Als Rack importieren". Markierte Sets werden beim
+   * Import zu einem Cable-Planner-Rack (Kombi-Name = Rack-Name, Kombi-ID am
+   * Rack, Inhalte als Rack-Geräte mit eigenen Rentman-IDs) statt zu einzelnen
+   * Templates.
+   */
+  rackSetIds?: Set<string>
+  onSetAsRack?: (parentId: string, asRack: boolean) => void
+  /**
    * Issue #33: Per-row "link to existing local device" mapping. When
    * provided, each row gets a dropdown of local equipment (without a
    * Rentman ID yet). Selecting one writes that Rentman id onto the
@@ -51,6 +59,8 @@ export const EquipmentChecklist = ({
   onSetAll,
   onQtyChange,
   onSetAllChildren,
+  rackSetIds,
+  onSetAsRack,
   linkableEquipment,
   onLinkExisting,
   linkedMap,
@@ -195,6 +205,29 @@ export const EquipmentChecklist = ({
                         {item.name}
                         {isSet && (
                           <span className="ml-1 text-[10px] text-slate-400">[set · {children!.length}]</span>
+                        )}
+                        {isSet && onSetAsRack && (
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.preventDefault()
+                              e.stopPropagation()
+                              onSetAsRack(item.id, !rackSetIds?.has(item.id))
+                            }}
+                            className={`ml-2 rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                              rackSetIds?.has(item.id)
+                                ? 'bg-sky-700/70 text-sky-100'
+                                : 'bg-slate-700/60 text-slate-300 hover:bg-slate-600/60'
+                            }`}
+                            title={t(
+                              'rentman.checklist.asRackTitle',
+                              'Diese Kombination beim Import als Rack übernehmen (Inhalte behalten ihre Rentman-IDs).',
+                            )}
+                          >
+                            {rackSetIds?.has(item.id)
+                              ? t('rentman.checklist.asRackOn', '✓ als Rack')
+                              : t('rentman.checklist.asRackOff', '+ als Rack')}
+                          </button>
                         )}
                         {item.templateMatch && (() => {
                           // v7.9.128 — Drei verschiedene Badge-Styles

--- a/src/renderer/components/Rentman/RentmanImportDialog.tsx
+++ b/src/renderer/components/Rentman/RentmanImportDialog.tsx
@@ -15,6 +15,7 @@ import { matchGreenGoTemplate } from '../../lib/greengoCatalog'
 import { getCachedRentmanTemplate } from '../../lib/rentmanTemplateCache'
 import type { EquipmentTemplate, Port } from '../../types/equipment'
 import type { CableType } from '../../types/cable'
+import { buildRackPresetFromCombination } from '../../lib/rentmanRack'
 import { EquipmentChecklist } from './EquipmentChecklist'
 import { NewRentmanDeviceWizard, type UnknownCandidate } from './NewRentmanDeviceWizard'
 import { ProjectSelector } from './ProjectSelector'
@@ -276,6 +277,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
   }
   const updateEquipment = useProjectStore((state) => state.updateEquipment)
   const addCustomTemplate = useProjectStore((state) => state.addCustomTemplate)
+  const addGroupPreset = useProjectStore((state) => state.addGroupPreset)
   const addKnownCategories = useProjectStore((state) => state.addKnownCategories)
   const knownCategories = useProjectStore((state) => state.knownCategories)
   const updateProjectMetadata = useProjectStore((state) => state.updateProjectMetadata)
@@ -286,6 +288,8 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
   const [projectQuery, setProjectQuery] = useState('')
   const [selectedProjectId, setSelectedProjectId] = useState('')
   const [items, setItems] = useState<RentmanEquipment[]>([])
+  // #335 — Kombinationen (Sets), die als Rack importiert werden sollen.
+  const [rackSetIds, setRackSetIds] = useState<Set<string>>(new Set())
   const [selectedCategories, setSelectedCategories] = useState<Set<string>>(new Set())
   const [error, setError] = useState('')
   const [warning, setWarning] = useState('')
@@ -736,7 +740,32 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
     // One library template per unique device name — quantity is irrelevant for the template.
     const seen = new Set<string>()
     let addedCount = 0
+
+    // #335 — Sets, die als Rack markiert sind, werden zu einem GroupPreset
+    // (Rack) statt zu einzelnen Templates. Das Rack trägt die Kombi-ID, die
+    // Inhalte behalten ihre eigenen Rentman-IDs. Konsumierte Rows (Parent +
+    // Children) werden unten in der Template-Schleife übersprungen.
+    const rackConsumedIds = new Set<string>()
+    if (rackSetIds.size > 0) {
+      for (const parent of selected) {
+        if (!rackSetIds.has(parent.id)) continue
+        const children = selected.filter((c) => c.parentId === parent.id)
+        if (children.length === 0) continue
+        const rackChildren = children.map((child) => ({
+          template: buildImportedBaseTemplate(child, templatesByEquipmentId, categoryByName),
+          rentmanId: child.equipmentId,
+        }))
+        addGroupPreset(buildRackPresetFromCombination(parent.name, parent.equipmentId, rackChildren))
+        rackConsumedIds.add(parent.id)
+        for (const c of children) rackConsumedIds.add(c.id)
+        addedCount++
+      }
+    }
+
     selected.forEach((item) => {
+      // #335 — Rows, die schon in einem Rack-GroupPreset gelandet sind, nicht
+      // zusätzlich als Einzel-Template importieren.
+      if (rackConsumedIds.has(item.id)) return
       if (seen.has(item.name)) return
       seen.add(item.name)
 
@@ -1596,6 +1625,23 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                 children.forEach((child) => {
                   if (child.checked !== checked) toggleItem(child.id)
                 })
+              }}
+              rackSetIds={rackSetIds}
+              onSetAsRack={(parentId, asRack) => {
+                setRackSetIds((prev) => {
+                  const next = new Set(prev)
+                  if (asRack) next.add(parentId)
+                  else next.delete(parentId)
+                  return next
+                })
+                // #335 — Beim Markieren als Rack die Kinder gleich mitselektieren,
+                // damit der Rack-Inhalt vollständig importiert wird.
+                if (asRack) {
+                  const children = items.filter((i) => i.parentId === parentId)
+                  children.forEach((child) => {
+                    if (!child.checked) toggleItem(child.id)
+                  })
+                }
               }}
               linkableEquipment={projectEquipment
                 .filter((e) => !e.rentmanId)

--- a/src/renderer/lib/i18n.ts
+++ b/src/renderer/lib/i18n.ts
@@ -1633,6 +1633,11 @@ const en: Dict = {
   'rentman.checklist.deselectChildren': 'Deselect all children',
   'rentman.checklist.childrenAllOff': 'all',
   'rentman.checklist.childrenAllOn': 'all',
+  // #335 — import a Rentman combination as a rack
+  'rentman.checklist.asRackOn': '✓ as rack',
+  'rentman.checklist.asRackOff': '+ as rack',
+  'rentman.checklist.asRackTitle':
+    'Import this combination as a rack (contents keep their Rentman IDs).',
 
   // Rentman — RentmanImportDialog body
   'rentman.import.busyTitle': 'Import operations still running',

--- a/src/renderer/lib/rentmanRack.ts
+++ b/src/renderer/lib/rentmanRack.ts
@@ -1,0 +1,63 @@
+import { v4 as uuidv4 } from 'uuid'
+import type { EquipmentTemplate, GroupPreset } from '../types/equipment'
+
+/**
+ * #335 — Rentman physische Kombination → Cable-Planner Rack.
+ *
+ * Eine Rentman-Kombination besteht aus mehreren einzelnen Equipment-IDs.
+ * Beim Import „als Rack" wird daraus ein GroupPreset mit Rack-Metadaten:
+ *
+ * - `rack.rentmanId` = Equipment-ID der Kombination → das Rack trägt als
+ *   Einheit die Kombi-ID.
+ * - jedes Item trägt seine eigene `rentmanId` → die Inhalte behalten ihre
+ *   individuellen Rentman-IDs (genau die Invariante aus Issue #335).
+ *
+ * Höhen kommen aus `rackUnits` der Kind-Templates (Default 1 HE, da Rentman
+ * keine HE-Höhe liefert); die Inhalte werden von unten nach oben gestapelt.
+ * Im Rack-Builder kann der User Höhe/Position danach frei nachjustieren.
+ */
+export interface RackChildInput {
+  /** Fertig aufgebautes Kind-Template (z. B. via buildImportedBaseTemplate). */
+  template: EquipmentTemplate
+  /** Rentman-Equipment-ID dieses Inhalts. */
+  rentmanId: string
+}
+
+export const buildRackPresetFromCombination = (
+  name: string,
+  combinationRentmanId: string,
+  children: RackChildInput[],
+): GroupPreset => {
+  let unit = 1
+  const items: GroupPreset['items'] = []
+  const placements: NonNullable<GroupPreset['rack']>['placements'] = []
+
+  children.forEach((child, index) => {
+    const he = Math.max(1, Math.round(child.template.rackUnits ?? 1))
+    items.push({
+      ...child.template,
+      // Rack-Inhalte sind per Definition Rack-Geräte.
+      isRackDevice: true,
+      rackUnits: he,
+      rentmanId: child.rentmanId,
+      offsetX: 0,
+      offsetY: (unit - 1) * 44,
+    })
+    placements.push({ itemIndex: index, startUnit: unit, heightUnits: he })
+    unit += he
+  })
+
+  const totalUnits = Math.max(1, unit - 1)
+
+  return {
+    id: uuidv4(),
+    name: name.trim() || 'Rentman Rack',
+    rack: {
+      totalUnits,
+      rentmanId: combinationRentmanId,
+      placements,
+    },
+    items,
+    cables: [],
+  }
+}

--- a/src/renderer/store/slices/groupPresetSpawnSlice.ts
+++ b/src/renderer/store/slices/groupPresetSpawnSlice.ts
@@ -87,6 +87,8 @@ const buildRackInternalSnapshot = (preset: import('../../types/equipment').Group
         preset.rack?.placements?.find((pl) => pl.itemIndex === idx)?.heightUnits ??
         item.rackUnits ??
         1,
+      // #335 — Rentman-ID des Inhalts mitschnappen (für späteren Sync/Export).
+      ...(item.rentmanId ? { rentmanId: item.rentmanId } : {}),
     })),
     cables: preset.cables.map((c) => ({
       fromItemIndex: c.fromItemIndex,
@@ -221,6 +223,10 @@ export const createGroupPresetSpawnSlice: StateCreator<
         height: 0,
         icon: '🗄',
         notes: `Black-Box-Rack: ${preset.items.length} Geräte, ${preset.cables.length} interne Verbindungen.`,
+        // #335 — Wenn das Rack aus einer Rentman-Kombination stammt, trägt das
+        // Rack als Einheit die Kombi-ID; die Inhalte behalten ihre eigenen IDs
+        // im Snapshot.
+        ...(preset.rack?.rentmanId ? { rentmanId: preset.rack.rentmanId } : {}),
         rackInternalSnapshot: buildRackInternalSnapshot(preset),
       }
       const updated = touchProject({

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -269,7 +269,9 @@ export interface EquipmentItem {
    *  GroupPreset-Strukturen. Read-only — die echte Quelle ist nach wie
    *  vor der GroupPreset im projectStore. */
   rackInternalSnapshot?: {
-    items: Array<{ name: string; startUnit: number; rackUnits: number }>
+    /** #335 — `rentmanId` pro Inhalt: ein als Rack importiertes Black-Box-Rack
+     *  behält die individuellen Rentman-IDs seiner Geräte im Snapshot. */
+    items: Array<{ name: string; startUnit: number; rackUnits: number; rentmanId?: string }>
     cables: Array<{
       fromItemIndex: number
       fromPortName: string
@@ -677,6 +679,10 @@ export interface GroupPreset {
   /** Optional rack metadata when this group was authored in the 2D rack builder. */
   rack?: {
     totalUnits: number
+    /** #335 — Rentman-Equipment-ID der physischen Kombination, aus der dieses
+     *  Rack importiert wurde. Das Rack als Einheit trägt die Kombi-ID; die
+     *  einzelnen Inhalte behalten ihre eigene `rentmanId` (siehe items). */
+    rentmanId?: string
     /** v7.9.73 / #170 — Rack-Tiefe in mm (Default 800 mm beim Rendering).
      *  Wird vom 3D/Split-Builder genutzt um zu prüfen ob Patchblenden hinter
      *  full-depth-Geräten passen. */
@@ -708,6 +714,10 @@ export interface GroupPreset {
     EquipmentTemplate & {
       offsetX: number
       offsetY: number
+      /** #335 — Rentman-ID dieses Rack-Inhalts. Beim Platzieren (placeGroupPreset)
+       *  per Spread auf das EquipmentItem übernommen, sodass jedes Gerät im Rack
+       *  seine individuelle Rentman-ID behält. */
+      rentmanId?: string
     }
   >
   cables: Array<{


### PR DESCRIPTION
Rentman physische Kombination → Cable-Planner Rack. Das Rack trägt als Einheit die Equipment-ID der Kombination, die Inhalte behalten ihre einzelnen Rentman-IDs (die Kern-Invariante aus #335).

Datenmodell (additiv, optional):
- GroupPreset.rack.rentmanId (Kombi-ID am Rack) + items[].rentmanId (jeder Inhalt seine eigene ID).
- RackPlacementDraft/RackDraft.rentmanId — round-trips durch den Rack-Builder (saveRack ↔ draftFromPreset).
- rackInternalSnapshot.items[].rentmanId — Black-Box-Rack behält die Inhalts-IDs; insertBlackBoxRack stempelt die Kombi-ID aufs Rack. placeGroupPreset reicht item.rentmanId per Spread aufs EquipmentItem durch.

Import:
- lib/rentmanRack.ts: reine Transform buildRackPresetFromCombination (Inhalte 1 HE gestapelt, im Builder nachjustierbar).
- EquipmentChecklist: per-Kombination Toggle „+ als Rack".
- RentmanImportDialog: markierte Sets werden zu einem GroupPreset (addGroupPreset) statt zu Einzel-Templates; Kinder werden mitselektiert und nicht doppelt importiert.

Verifiziert: tsc/Build/i18n grün. End-to-end (5/5 headless): seed-Preset mit Kombi-/Inhalts-IDs → über Racks-Tab platziert → Rack trägt COMBO-ID, Snapshot behält CHILD-A/CHILD-B. Der Live-Rentman-Importpfad (Feldnamen der Kombination) ist mangels API-Zugang nur am Desktop prüfbar.