### PR TITLE
fix(rack): Shelf-Placement-Crash bei fehlendem Template (#510)

### DIFF
--- a/src/renderer/components/Rack/RackBuilderDialog.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialog.tsx
@@ -1402,7 +1402,16 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                       // #506 — Shelf-Device unten-bündig rendern (wie im 3D: das
                       // Gerät ruht auf dem Boden seiner HE-Reihe). Vorher war es
                       // oben-bündig, was nicht zur 3D-Ansicht passte.
-                      const shelfBoxHeight = Math.min(rackTpl!.heightMm! * mmToPx, height)
+                      // #510 — NUR dereferenzieren wenn isShelfDevice (dann ist
+                      // rackTpl garantiert gesetzt, s. Definition oben). Sonst ist
+                      // rackTpl ggf. undefined (Placement referenziert ein Template
+                      // das NICHT in `templates` liegt: frisch erstelltes Rack-Shelf,
+                      // nicht-persistiertes Shelf-Device, oder veralteter Draft) —
+                      // ein unbedingter `rackTpl!.heightMm!` warf dann
+                      // "Cannot read properties of undefined (reading 'heightMm')".
+                      const shelfBoxHeight = isShelfDevice
+                        ? Math.min(rackTpl!.heightMm! * mmToPx, height)
+                        : height
                       const shelfStyle = isShelfDevice
                         ? {
                             top: top + (height - shelfBoxHeight),


### PR DESCRIPTION
- `rackTpl!.heightMm!` wurde seit #506 UNBEDINGT dereferenziert (aus dem isShelfDevice-Ternary herausgezogen). Bei einem Placement, dessen Template nicht in `templates` liegt — frisch erstelltes Rack-Shelf, nicht-persistiertes Shelf-Device oder veralteter rack-builder-Draft — ist rackTpl undefined → "Cannot read properties of undefined (reading 'heightMm')", was die ganze App über die ErrorBoundary lahmlegt.
- shelfBoxHeight wird jetzt nur bei isShelfDevice berechnet (dann ist rackTpl garantiert gesetzt), sonst = height. Stellt das graceful- degradation-Verhalten von 8.0.10 wieder her: unbekanntes Template rendert als normaler Block statt zu crashen.
- tsc app + eslint grün.