### PR TITLE
fix(rack/canvas): Gerät löschen im Rechtsklick-Menü + 3D-Rack-Spiegelung & Drag (#519, #517)

### DIFF
--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -56,7 +56,7 @@ import {
   setCanvasSelectAllHandler,
 } from '../../lib/canvasViewport'
 import { routeCableWithAStar, type HandleSide, type PixelRect } from '../../lib/routeCableWithAStar'
-import { useTranslation } from '../../lib/i18n'
+import { format, useTranslation } from '../../lib/i18n'
 
 const nodeTypes = { equipment: EquipmentNode, location: LocationFrameNode }
 const edgeTypes = { cable: CableEdge }
@@ -74,6 +74,7 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
   const addEquipment = useProjectStore((state) => state.addEquipment)
   const pasteEquipment = useProjectStore((state) => state.pasteEquipment)
   const deleteEquipment = useProjectStore((state) => state.deleteEquipment)
+  const deleteLocation = useProjectStore((state) => state.deleteLocation)
   const deleteCable = useProjectStore((state) => state.deleteCable)
   const queueConnection = useProjectStore((state) => state.queueConnection)
   const setSelection = useProjectStore((state) => state.setSelection)
@@ -1966,6 +1967,48 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
           }
           setNodeContextMenu(null)
         }
+        // #519 — Löschen aus dem Rechtsklick-Menü. Equipment: löscht das Gerät
+        // + kaskadiert angeschlossene Kabel (deleteEquipment). Location: löscht
+        // nur den Rahmen, die enthaltenen Geräte bleiben (deleteLocation) —
+        // das ist die nicht-destruktive Variante. Beides hinter einer
+        // Bestätigung (destructive), analog zu LocationProperties.
+        const remove = async () => {
+          const okLabel = t('confirm.delete', 'Löschen')
+          const ok = isLocation
+            ? await confirmDialog(
+                format(t('canvas.nodeMenu.confirmDeleteLocation', 'Rahmen "{name}" löschen?'), {
+                  name: target.name,
+                }),
+                {
+                  body: t(
+                    'canvas.nodeMenu.confirmDeleteLocationBody',
+                    'Nur der Rahmen wird gelöscht. Die enthaltenen Geräte bleiben auf dem Canvas.',
+                  ),
+                  destructive: true,
+                  okLabel,
+                },
+              )
+            : await confirmDialog(
+                format(t('canvas.nodeMenu.confirmDeleteEquipment', 'Gerät "{name}" löschen?'), {
+                  name: target.name,
+                }),
+                {
+                  body: t(
+                    'canvas.nodeMenu.confirmDeleteEquipmentBody',
+                    'Das Gerät und alle daran angeschlossenen Kabel werden gelöscht.',
+                  ),
+                  destructive: true,
+                  okLabel,
+                },
+              )
+          if (!ok) {
+            setNodeContextMenu(null)
+            return
+          }
+          if (isLocation) deleteLocation(nodeContextMenu.nodeId)
+          else deleteEquipment(nodeContextMenu.nodeId)
+          setNodeContextMenu(null)
+        }
         return (
           <div
             onClick={(e) => e.stopPropagation()}
@@ -2011,6 +2054,35 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
                 {isLocked
                   ? t('canvas.area.unlockPosition', 'Position entsperren')
                   : t('canvas.area.lockPosition', 'Position sperren')}
+              </span>
+            </button>
+            <div style={{ height: 1, background: '#334155', margin: '4px 0' }} />
+            <button
+              type="button"
+              onClick={() => void remove()}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                width: '100%',
+                padding: '6px 10px',
+                background: 'transparent',
+                color: '#f87171',
+                border: 'none',
+                borderRadius: 4,
+                cursor: 'pointer',
+                textAlign: 'left',
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.background = '#334155')}
+              onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+            >
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <path d="M2.5 4h11M6 4V2.5h4V4M5 4l.5 9a1 1 0 0 0 1 1h3a1 1 0 0 0 1-1L11 4" />
+              </svg>
+              <span>
+                {isLocation
+                  ? t('canvas.nodeMenu.deleteLocation', 'Rahmen löschen')
+                  : t('canvas.nodeMenu.deleteEquipment', 'Gerät löschen')}
               </span>
             </button>
           </div>

--- a/src/renderer/components/Rack/Rack3DView.tsx
+++ b/src/renderer/components/Rack/Rack3DView.tsx
@@ -1071,6 +1071,18 @@ export const Rack3DView = ({
         <ambientLight intensity={0.55} />
         <directionalLight position={[600, 1200, 800]} intensity={0.9} />
         <directionalLight position={[-800, 600, -400]} intensity={0.4} />
+        {/* #517 — Die Frontblenden zeigen nach −Z; mit der #506-Kamera (vor
+            dem Rack) bildete world+X auf Bildschirm-LINKS ab → die 3D-Front
+            war links/rechts gespiegelt gegenüber der 2D-Front-Ansicht
+            (deterministisch über die Projektionsmatrix nachgewiesen). Statt
+            an jeder X-Koordinate einzeln zu spiegeln, spiegeln wir die GESAMTE
+            Rack-Szene an der vertikalen Mittelachse: group bei x=W + scale-x=−1
+            ⇒ jedes world-x wird zu (W − x). Geräte, Port-Dots, Hitboxen und
+            interne Kabel bleiben dadurch zueinander konsistent. Labels sind
+            <Html> (DOM-Overlay) und bleiben aufrecht/lesbar. Kamera +
+            OrbitControls liegen bewusst AUSSERHALB dieser Gruppe, damit die
+            Steuerung nicht mitspiegelt. */}
+        <group scale={[-1, 1, 1]} position={[RACK_OUTER_WIDTH_MM, 0, 0]}>
         <Chassis totalUnits={totalUnits} depthMm={depthMm} isLight={isLight} />
         <Suspense fallback={null}>
           {placements.map((p) => {
@@ -1125,6 +1137,7 @@ export const Rack3DView = ({
             cables={internalCables ?? []}
           />
         </Suspense>
+        </group>
         <OrbitControls
           ref={orbitRef as never}
           target={[RACK_OUTER_WIDTH_MM / 2, rackHeightMm / 2, depthMm / 2]}

--- a/src/renderer/components/Rack/Rack3DView.tsx
+++ b/src/renderer/components/Rack/Rack3DView.tsx
@@ -410,7 +410,12 @@ const DeviceBox = ({
           // v7.9.82 — OrbitControls aus, damit der gleiche Pointer-Drag
           // nicht zusätzlich die Kamera dreht.
           if (orbitRef?.current) orbitRef.current.enabled = false
-          const hitX = e.point.x
+          // #517 — Die Rack-Szene wird per <group scale-x=−1> gespiegelt.
+          // e.point ist WORLD-Space; xCenter/zCenter sind LOCAL. Die X-Achse
+          // muss daher von world→local zurückgerechnet werden (world_x =
+          // RACK_OUTER_WIDTH_MM − local_x), sonst läuft der Drag invertiert
+          // zum Cursor. Z ist von der X-Spiegelung unberührt.
+          const hitX = RACK_OUTER_WIDTH_MM - e.point.x
           const hitZ = e.point.z
           shelfDragRef.current = {
             pointerId: e.pointerId,
@@ -422,7 +427,8 @@ const DeviceBox = ({
           const drag = shelfDragRef.current
           if (!drag || drag.pointerId !== e.pointerId) return
           if (!isShelfDevice) return
-          const newCenterX = e.point.x - drag.offsetX
+          // #517 — world→local für X (siehe onPointerDown), Z unverändert.
+          const newCenterX = (RACK_OUTER_WIDTH_MM - e.point.x) - drag.offsetX
           const newCenterZ = e.point.z - drag.offsetZ
           // Center → linke Vorderkante zurück
           const newLeftX = newCenterX - widthMm / 2
@@ -639,7 +645,11 @@ const PortDots = ({
     raycaster.setFromCamera(pointer, camera)
     const hit = raycaster.ray.intersectPlane(facePlane, hitPoint)
     if (!hit) return null
-    return { x: hit.x - faceCenter[0], y: hit.y - faceCenter[1] }
+    // #517 — Szene per <group scale-x=−1> gespiegelt: hit.x ist WORLD,
+    // faceCenter LOCAL. X von world→local zurückrechnen, sonst läuft der
+    // Port-Dot-Drag horizontal invertiert. Y/Z sind unberührt.
+    const localHitX = RACK_OUTER_WIDTH_MM - hit.x
+    return { x: localHitX - faceCenter[0], y: hit.y - faceCenter[1] }
   }
 
   // Sichere Höhe für Dot-Geometrie: ~6mm Radius, aber max 1/3 der HE-Höhe

--- a/src/renderer/lib/i18n.ts
+++ b/src/renderer/lib/i18n.ts
@@ -2366,6 +2366,13 @@ const en: Dict = {
   'canvas.area.renameLocation': 'Rename location:',
   'canvas.area.lockPosition': 'Lock position',
   'canvas.area.unlockPosition': 'Unlock position',
+  // #519 — Delete from the node right-click menu
+  'canvas.nodeMenu.deleteEquipment': 'Delete device',
+  'canvas.nodeMenu.deleteLocation': 'Delete frame',
+  'canvas.nodeMenu.confirmDeleteEquipment': 'Delete device "{name}"?',
+  'canvas.nodeMenu.confirmDeleteEquipmentBody': 'The device and all cables connected to it will be deleted.',
+  'canvas.nodeMenu.confirmDeleteLocation': 'Delete frame "{name}"?',
+  'canvas.nodeMenu.confirmDeleteLocationBody': 'Only the frame is deleted. The devices inside stay on the canvas.',
 
   // Atem — MultiviewerLayoutView
   'atem.mvLayout.title': 'Multiviewer layout (live)',


### PR DESCRIPTION
## Übersicht
Zwei Bugfixes/Features, beide verifiziert (tsc 0, eslint 0, build 0). Branch sitzt direkt auf dem aktuellen `main`-Tip — konfliktfreier Merge.

### #519 — Löschen im Rechtsklick-Menü (`c576a24`)
Das Node-Kontextmenü auf dem Canvas hatte nur „Position sperren". Neu: ein **„Gerät löschen"**-Eintrag (rot, mit Trenner).
- Gerät → `deleteEquipment` (kaskadiert angeschlossene Kabel, wie die Entf-Taste)
- Rahmen/Location (dasselbe Menü) → `deleteLocation` (nur Rahmen, enthaltene Geräte bleiben)
- Beides hinter `confirmDialog` (destructive) mit Namen im Text
- i18n: deutsche Quell-Strings als `t()`-Fallback, EN im `en`-Dict (`canvas.nodeMenu.*`)

### #517 (a) — 3D-Rack links/rechts gespiegelt (`8633c19` + `41aa322`)
Die 3D-Frontansicht war gegenüber der 2D-Front gespiegelt (logisch-links erschien rechts). Ursache deterministisch über die Projektionsmatrix nachgewiesen: Frontblenden zeigen nach −Z, die #506-Kamera blickt von vorne → world+X bildet auf Bildschirm-links ab.
- **Fix `8633c19`:** gesamte Rack-Szene (Chassis + Geräte + Port-Dots + interne Kabel) per `<group scale-x=−1>` an der Mittelachse spiegeln. Labels sind `<Html>` (bleiben aufrecht), Kamera/OrbitControls liegen außerhalb der Gruppe.
- **Fix `41aa322`:** Folgefix — die Spiegelung hatte die World-Space-Drags (Shelf #204, Port-Dot #209) horizontal invertiert (World/Local-Mix). An den drei Drag-Eintrittspunkten `x` von world→local zurückgerechnet (`RACK_OUTER_WIDTH_MM − x`). Beide Drags folgen dem Cursor wieder (numerisch via three.js-Raycast in beide Richtungen verifiziert).

**Hinweis:** #517 (b) freie XY-/Off-Grid-Positionierung + Persistenz + Konflikt-Anzeige bleibt offen (Datenmodell-Umbau, Aufwand L) — separat zu behandeln. Daher schließt dieser PR #517 **nicht** vollständig.

Closes #519

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_