### PR TITLE
feat(collab): kollaboratives Undo/Redo via Y.UndoManager — schließt #413

### DIFF
--- a/scripts/crdt-convergence-check.mjs
+++ b/scripts/crdt-convergence-check.mjs
@@ -405,6 +405,41 @@ const scenario7 = async () => {
   tb.dispose()
 }
 
+// Szenario 8: Kollaboratives Undo (#413) — Y.UndoManager auf LOCAL_ORIGIN
+// beschränkt. Spiegelt projectCrdt.getUndoManager(): Undo nimmt NUR die
+// eigenen Edits zurück, fremde (remote) Änderungen bleiben unangetastet.
+const scenario8 = () => {
+  console.log('Szenario 8: kollaboratives Undo — nur eigene Edits zurücknehmen')
+  const a = new Y.Doc()
+  const b = new Y.Doc()
+  // Kopplung wie SyncManager: lokale Updates beim Peer als remote anwenden.
+  const link = (src, dst) =>
+    src.on('update', (u, origin) => {
+      if (origin !== REMOTE) Y.applyUpdate(dst, u, REMOTE)
+    })
+  link(a, b)
+  link(b, a)
+  const eqA = a.getMap('equipment')
+  const eqB = b.getMap('equipment')
+  // UndoManager von A: nur LOCAL_ORIGIN (wie ProjectCrdt.getUndoManager).
+  const um = new Y.UndoManager([eqA, a.getMap('cables'), a.getMap('locations')], {
+    trackedOrigins: new Set([LOCAL]),
+  })
+
+  a.transact(() => eqA.set('a1', { id: 'a1', name: 'A' }), LOCAL)
+  b.transact(() => eqB.set('b1', { id: 'b1', name: 'B' }), LOCAL)
+  assert(eqA.has('a1') && eqA.has('b1'), 'A sieht eigenes a1 + fremdes b1')
+  assert(um.undoStack.length === 1, `A-Undo-Stack hat nur den eigenen Edit (len=${um.undoStack.length})`)
+
+  um.undo()
+  assert(!eqA.has('a1'), 'A.undo(): eigenes a1 entfernt')
+  assert(eqA.has('b1'), 'A.undo(): fremdes b1 bleibt (kein Clobbering der Peer-Edits)')
+  assert(eqB.has('b1') && !eqB.has('a1'), 'B konvergiert nach A.undo()')
+
+  um.redo()
+  assert(eqA.has('a1') && eqA.has('b1'), 'A.redo(): a1 zurück, b1 unberührt')
+}
+
 // ── Runner ──────────────────────────────────────────────────────────────────
 const run = async () => {
   scenario1()
@@ -414,6 +449,7 @@ const run = async () => {
   scenario5()
   scenario6()
   await scenario7()
+  scenario8()
 
   console.log('')
   if (failures === 0) {

--- a/src/renderer/lib/crdt/collab.ts
+++ b/src/renderer/lib/crdt/collab.ts
@@ -47,6 +47,14 @@ export interface CollabOptions {
 export interface CollabSession {
   readonly mode: CollabMode
   readonly room: string
+  /** #413 — Kollaboratives Undo/Redo: nimmt NUR die eigenen Edits zurück
+   *  (Y.UndoManager auf LOCAL_ORIGIN beschränkt), ohne fremde Änderungen
+   *  anzutasten. projectHistory delegiert hierher, solange eine Session
+   *  aktiv ist. */
+  undo: () => void
+  redo: () => void
+  canUndo: () => boolean
+  canRedo: () => boolean
   /** Beendet die Session: Transport/Provider trennen, Bindung lösen, Doc
    *  freigeben. Der Store behält den zuletzt synchronisierten Stand. */
   stop: () => void
@@ -91,9 +99,18 @@ export const startCollaboration = async (opts: CollabOptions): Promise<CollabSes
     throw err
   }
 
+  // #413 — Undo-Manager NACH dem Seed/Connect erzeugen, damit der initiale
+  // Seed (und eingehende Remote-Stände) nicht auf dem Undo-Stack landen —
+  // nur ab jetzt getätigte EIGENE Edits sind undobar.
+  crdt.getUndoManager()
+
   return {
     mode: opts.mode,
     room,
+    undo: () => crdt.undo(),
+    redo: () => crdt.redo(),
+    canUndo: () => crdt.canUndo(),
+    canRedo: () => crdt.canRedo(),
     stop: () => {
       presence?.stop()
       manager?.stop()

--- a/src/renderer/lib/crdt/projectCrdt.ts
+++ b/src/renderer/lib/crdt/projectCrdt.ts
@@ -39,12 +39,47 @@ export class ProjectCrdt {
   private readonly equipment: Y.Map<EquipmentItem>
   private readonly cables: Y.Map<Cable>
   private readonly locations: Y.Map<LocationFrame>
+  /** #413 — Undo-Manager über die drei Collections. Lazy erzeugt (erst beim
+   *  ersten getUndoManager-Aufruf), damit er NUR Edits ab Session-Start
+   *  erfasst und nicht den Initial-Seed. */
+  private undoManager: Y.UndoManager | null = null
 
   constructor(doc: Y.Doc = new Y.Doc()) {
     this.doc = doc
     this.equipment = doc.getMap<EquipmentItem>(EQUIPMENT_MAP)
     this.cables = doc.getMap<Cable>(CABLES_MAP)
     this.locations = doc.getMap<LocationFrame>(LOCATIONS_MAP)
+  }
+
+  // ── Undo/Redo (Stufe: #413-Akzeptanzkriterium) ───────────────────────
+
+  /** Liefert (und erzeugt bei Bedarf) einen Y.UndoManager, der NUR die
+   *  lokalen Edits dieses Peers erfasst — `trackedOrigins` ist auf
+   *  LOCAL_ORIGIN beschränkt, also die Origin, mit der die Store-Bindung
+   *  via `transactLocal` schreibt. Dadurch nimmt Undo ausschließlich die
+   *  EIGENEN Änderungen zurück und lässt die Edits anderer Teilnehmer
+   *  unangetastet — genau das Verhalten, das kollaboratives Undo braucht. */
+  getUndoManager(): Y.UndoManager {
+    if (!this.undoManager) {
+      this.undoManager = new Y.UndoManager(
+        [this.equipment, this.cables, this.locations],
+        { trackedOrigins: new Set([LOCAL_ORIGIN]) },
+      )
+    }
+    return this.undoManager
+  }
+
+  undo(): void {
+    this.getUndoManager().undo()
+  }
+  redo(): void {
+    this.getUndoManager().redo()
+  }
+  canUndo(): boolean {
+    return this.getUndoManager().undoStack.length > 0
+  }
+  canRedo(): boolean {
+    return this.getUndoManager().redoStack.length > 0
   }
 
   // ── Voll-Projekt-Sync ────────────────────────────────────────────────
@@ -161,6 +196,8 @@ export class ProjectCrdt {
   }
 
   destroy(): void {
+    this.undoManager?.destroy()
+    this.undoManager = null
     this.doc.destroy()
   }
 }

--- a/src/renderer/store/collabStore.ts
+++ b/src/renderer/store/collabStore.ts
@@ -11,6 +11,7 @@ import { colorForId, type PresencePeer } from '../lib/crdt/presence'
 import { cablePlannerApi, hasDesktopBridge, type DiscoveredCollabSession } from '../lib/bridge'
 import { useUiStore } from './uiStore'
 import { useProjectStore } from './projectStore'
+import { setUndoDelegate } from './projectHistory'
 
 export type { CollabMode } from '../lib/crdt/collab'
 export type { PresencePeer } from '../lib/crdt/presence'
@@ -228,6 +229,14 @@ export const useCollabStore = create<CollabState>((set, get) => ({
         return
       }
       set({ session: s, status: 'on', localSignaling })
+      // #413 — Undo/Redo im Collab-Modus an den Session-UndoManager delegieren
+      // (nimmt nur die eigenen Edits zurück). Wird in stop() wieder gelöst.
+      setUndoDelegate({
+        undo: s.undo,
+        redo: s.redo,
+        canUndo: s.canUndo,
+        canRedo: s.canRedo,
+      })
       // Nur der Host bewirbt die Session — mit der effektiven Signaling-Adresse
       // (lokaler Server-URL falls gestartet, sonst die manuelle Eingabe).
       if (mode === 'webrtc' && !adopt) {
@@ -247,6 +256,7 @@ export const useCollabStore = create<CollabState>((set, get) => ({
 
   stop: () => {
     const { session, localSignaling } = get()
+    setUndoDelegate(null) // #413 — zurück auf lokale History
     session?.stop()
     unadvertiseSession()
     if (localSignaling) void cablePlannerApi.signaling.stop().catch(() => {})

--- a/src/renderer/store/projectHistory.ts
+++ b/src/renderer/store/projectHistory.ts
@@ -107,9 +107,26 @@ useProjectStore.subscribe((state) => {
   notify()
 })
 
+/** #413 — Optionaler Undo/Redo-Delegat für den Kollaborations-Modus. Solange
+ *  eine Live-Session aktiv ist, registriert der collabStore hier den
+ *  Y.UndoManager der Session; projectHistory leitet Undo/Redo/canUndo/canRedo
+ *  dann dorthin um, damit nur die EIGENEN CRDT-Edits zurückgenommen werden
+ *  (nicht die der anderen Teilnehmer). Bei null gilt die lokale History. */
+interface UndoDelegate {
+  undo: () => void
+  redo: () => void
+  canUndo: () => boolean
+  canRedo: () => boolean
+}
+let undoDelegate: UndoDelegate | null = null
+export const setUndoDelegate = (d: UndoDelegate | null): void => {
+  undoDelegate = d
+  notify()
+}
+
 export const projectHistory = {
-  canUndo: () => past.length > 0,
-  canRedo: () => future.length > 0,
+  canUndo: () => (undoDelegate ? undoDelegate.canUndo() : past.length > 0),
+  canRedo: () => (undoDelegate ? undoDelegate.canRedo() : future.length > 0),
 
   /** v7.9.92 — Start einer expliziten Transaktion. Bis zum
    *  endTransaction() werden alle Project-Mutationen NICHT als
@@ -144,6 +161,11 @@ export const projectHistory = {
   },
 
   undo: () => {
+    if (undoDelegate) {
+      undoDelegate.undo()
+      notify()
+      return
+    }
     if (past.length === 0) return
     const prev = past.pop()!
     future.push(lastProject)
@@ -171,6 +193,11 @@ export const projectHistory = {
     notify()
   },
   redo: () => {
+    if (undoDelegate) {
+      undoDelegate.redo()
+      notify()
+      return
+    }
     if (future.length === 0) return
     const next = future.pop()!
     past.push(lastProject)


### PR DESCRIPTION
## Zweck
Erfüllt das letzte offene Akzeptanzkriterium von #413 — **„Undo/Redo bleibt nutzbar"** im Live-Kollaborations-Modus. Das andere Kriterium („zwei Instanzen editieren live denselben Plan") ist bereits in `main` (CRDT-Stack + Transports + Presence).

## Lösung
- **`ProjectCrdt`**: `Y.UndoManager` über `equipment`/`cables`/`locations`, per `trackedOrigins` auf `LOCAL_ORIGIN` beschränkt → Undo nimmt **nur die eigenen** Edits zurück, fremde (remote) Änderungen bleiben unangetastet. Lazy erzeugt **nach** dem Seed (Initial-Stand ist nicht undobar). `undo/redo/canUndo/canRedo` + Cleanup in `destroy()`.
- **`collab.ts`**: `CollabSession` exponiert `undo/redo/canUndo/canRedo`.
- **`projectHistory`**: optionaler Undo-Delegat. Solange eine Session aktiv ist, leiten `undo/redo/canUndo/canRedo` dorthin um; sonst lokale History wie bisher. **Ein** Indirektionspunkt deckt Shortcuts (Strg+Z/Y), Menü-Buttons und App ab — keine aufruferseitige Änderung nötig.
- **`collabStore`**: registriert den Delegaten bei Status `on`, löst ihn in `stop()`.

## Verifikation (headless, deterministisch)
Konvergenz-Beweis um **Szenario 8** erweitert (`npm run test:crdt`): zwei gekoppelte Y.Docs, A's UndoManager nur auf `LOCAL_ORIGIN`. Bewiesen:
- A sieht eigenes `a1` + fremdes `b1`; A-Undo-Stack enthält **nur** den eigenen Edit.
- `A.undo()` entfernt `a1`, **`b1` (fremd) bleibt** — kein Clobbering der Peer-Edits; B konvergiert.
- `A.redo()` stellt `a1` her, `b1` unberührt.

tsc 0 · eslint 0 · build 0 · Proof grün.

Closes #413

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_