### PR TITLE
fix(rack): Shelf-Offset X/Z bei Position 0 nicht mehr verloren (#521 Teil c)

### DIFF
--- a/src/renderer/components/Rack/RackBuilderDialog.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialog.tsx
@@ -680,9 +680,12 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
       heightUnits: placement.rackUnits,
       // v7.9.73 / #170 — mountSide nur persistieren wenn explizit gesetzt.
       ...(placement.mountSide ? { mountSide: placement.mountSide } : {}),
-      // v7.9.82 / #170 — Shelf-Offsets nur wenn != 0.
-      ...(placement.shelfOffsetX ? { shelfOffsetX: placement.shelfOffsetX } : {}),
-      ...(placement.shelfOffsetZ ? { shelfOffsetZ: placement.shelfOffsetZ } : {}),
+      // #521 — Shelf-Offsets persistieren wenn GESETZT (auch 0!). Vorher ein
+      // truthy-Check (`shelfOffsetX ? …`), der den gültigen Wert 0 (linke Kante
+      // / Front) verwarf → X/Z-Position ging beim Speichern verloren. `!= null`
+      // unterscheidet korrekt zwischen 0 (valide Position) und undefined.
+      ...(placement.shelfOffsetX != null ? { shelfOffsetX: placement.shelfOffsetX } : {}),
+      ...(placement.shelfOffsetZ != null ? { shelfOffsetZ: placement.shelfOffsetZ } : {}),
     }))
 
     // v7.8.5 — Map internal cables (referenced by placement id) onto the

--- a/src/renderer/components/Rack/RackBuilderDialogExportMenu.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialogExportMenu.tsx
@@ -179,8 +179,10 @@ export const RackBuilderDialogExportMenu = ({
                 startUnit: p.startUnit,
                 heightUnits: p.rackUnits,
                 ...(p.mountSide ? { mountSide: p.mountSide } : {}),
-                ...(p.shelfOffsetX ? { shelfOffsetX: p.shelfOffsetX } : {}),
-                ...(p.shelfOffsetZ ? { shelfOffsetZ: p.shelfOffsetZ } : {}),
+                // #521 — auch 0 persistieren (linke Kante/Front); `!= null`
+                // statt truthy, sonst geht Position 0 beim Export verloren.
+                ...(p.shelfOffsetX != null ? { shelfOffsetX: p.shelfOffsetX } : {}),
+                ...(p.shelfOffsetZ != null ? { shelfOffsetZ: p.shelfOffsetZ } : {}),
               }))
               const preset: GroupPreset = {
                 id: editingId ?? uuidv4(),


### PR DESCRIPTION
## Zweck
Behebt **Teil (c)** von #521: Die X/Z-Positionierung von Shelf-Geräten ging beim Speichern eines Racks verloren, wenn das Gerät an der **linken Kante** (`shelfOffsetX=0`) oder ganz **vorne** (`shelfOffsetZ=0`) platziert war.

## Ursache
Ein truthy-Check beim Persistieren — `placement.shelfOffsetX ? { … } : {}` — verwarf den **gültigen** Wert `0`, weil `0` in JS falsy ist. Der Offset wurde dadurch gar nicht erst in den `GroupPreset` geschrieben. Der Load-Pfad nutzte bereits korrekt `!= null` und hätte `0` wiederhergestellt — es kam nur nie an.

## Fix
`!= null` statt truthy an beiden Persistier-Stellen:
- `RackBuilderDialog.tsx` (`saveRack`)
- `RackBuilderDialogExportMenu.tsx` (Preset-Export)

## Verifikation (headless)
Save→Load-Round-Trip-Test, der beide Mapper 1:1 spiegelt:
- **reproduziert den Bug**: alt `X=0` → `undefined` nach dem Speichern
- **belegt den Fix**: neu `X=0` und `Z=0` überstehen den Round-Trip
- keine Regression für Werte `!= 0`, kein Phantom-`0` bei ungesetztem Offset

tsc 0 · eslint 0 · build 0.

## Scope-Hinweis
Dies schließt #521 **nicht** — die übrigen Punkte (b off-grid-Höhe, c2 Z-Achse-Raster, d Konflikt-Anzeige) sind ein Datenmodell-Umbau und bleiben offen. Daher `Refs #521`, kein `Closes`.

Backward-compat: bereits gespeicherte Racks mit verlorenem 0-Offset sind nicht rückholbar (die Daten wurden nie geschrieben); betrifft nur künftige Saves.

Refs #521

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_