### PR TITLE
fix(theme): Dark-Tokens an Tailwind-Palette binden, Migration pixelgleich (#449)

### DIFF
--- a/src/renderer/components/About/AboutDialog.tsx
+++ b/src/renderer/components/About/AboutDialog.tsx
@@ -41,12 +41,16 @@ export const AboutDialog = () => {
       maxWidth="md"
       draggableKey="cable-planner:modal-pos:about"
     >
+      {/* #449 — Demo-Migration roher slate-* → cp-Token-Utilities. Alle
+          ersetzten Paare sind headless als pixelgleich (dark+light) verifiziert.
+          bg-emerald-700 (Versions-Badge) + hover:text-sky-300 bleiben: dafür
+          gibt es (noch) keinen exakten Token. */}
       <div className="space-y-3 text-cp-base">
-        <div className="flex items-center gap-3 rounded border border-slate-800 bg-slate-950/40 p-3">
-          <Icon icon={Cable} size={28} className="text-sky-400" />
+        <div className="flex items-center gap-3 rounded border border-cp-border-muted bg-cp-surface-3/40 p-3">
+          <Icon icon={Cable} size={28} className="text-cp-accent" />
           <div className="min-w-0">
-            <div className="font-semibold text-slate-100">{t('app.title', 'Cable Planner')}</div>
-            <div className="text-[11px] text-slate-400">{APP_DESCRIPTION}</div>
+            <div className="font-semibold text-cp-text">{t('app.title', 'Cable Planner')}</div>
+            <div className="text-[11px] text-cp-text-muted">{APP_DESCRIPTION}</div>
           </div>
           <div className="ml-auto shrink-0 rounded bg-emerald-700 px-2 py-1 font-mono text-cp-xs text-white">
             v{APP_VERSION}
@@ -54,34 +58,34 @@ export const AboutDialog = () => {
         </div>
 
         <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-cp-xs">
-          <dt className="text-slate-500">{t('about.version', 'Version')}</dt>
-          <dd className="font-mono text-slate-100">{APP_VERSION}</dd>
-          <dt className="text-slate-500">{t('about.build', 'Build')}</dt>
-          <dd className="font-mono text-slate-100">{buildDateLocal}</dd>
+          <dt className="text-cp-text-faint">{t('about.version', 'Version')}</dt>
+          <dd className="font-mono text-cp-text">{APP_VERSION}</dd>
+          <dt className="text-cp-text-faint">{t('about.build', 'Build')}</dt>
+          <dd className="font-mono text-cp-text">{buildDateLocal}</dd>
           {APP_AUTHOR && (
             <>
-              <dt className="text-slate-500">{t('about.author', 'Autor')}</dt>
-              <dd className="text-slate-100">{APP_AUTHOR}</dd>
+              <dt className="text-cp-text-faint">{t('about.author', 'Autor')}</dt>
+              <dd className="text-cp-text">{APP_AUTHOR}</dd>
             </>
           )}
-          <dt className="text-slate-500">{t('about.repository', 'Repository')}</dt>
+          <dt className="text-cp-text-faint">{t('about.repository', 'Repository')}</dt>
           <dd>
             <a
               href={APP_REPO_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-sky-400 underline hover:text-sky-300"
+              className="text-cp-accent underline hover:text-sky-300"
             >
               {APP_REPO_URL.replace(/^https?:\/\//, '')}
             </a>
           </dd>
-          <dt className="text-slate-500">{t('about.platform', 'Plattform')}</dt>
-          <dd className="text-slate-100">
+          <dt className="text-cp-text-faint">{t('about.platform', 'Plattform')}</dt>
+          <dd className="text-cp-text">
             Electron + React + ReactFlow + Vite + Tailwind
           </dd>
         </dl>
 
-        <div className="rounded border border-slate-800 bg-slate-950/40 p-3 text-[11px] text-slate-400">
+        <div className="rounded border border-cp-border-muted bg-cp-surface-3/40 p-3 text-[11px] text-cp-text-muted">
           {t('about.issueHint', 'Issues + Feature-Wünsche bitte direkt auf GitHub melden.')}
         </div>
       </div>

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -88,19 +88,26 @@
    * Töne (bzw. deren Light-Remap), damit die Migration der zentralen
    * Shells auf var(--cp-*) appearance-neutral ist. Neue Komponenten
    * sollten diese Tokens statt roher slate-Klassen verwenden. */
-  --cp-bg: #0f172a; /* App-Hintergrund */
-  --cp-surface-1: #0f172a; /* slate-900 — Panels/Modals */
-  --cp-surface-2: #1e293b; /* slate-800 — raised/hover */
-  --cp-surface-3: #020617; /* slate-950 — sunken/Leisten/Inputs */
-  --cp-border: #334155; /* slate-700 */
-  --cp-border-muted: #1e293b; /* slate-800 */
-  --cp-text: #f1f5f9; /* slate-100 */
-  --cp-text-secondary: #cbd5e1; /* slate-300 */
-  --cp-text-muted: #94a3b8; /* slate-400 */
-  --cp-text-faint: #64748b; /* slate-500 */
-  --cp-accent: #38bdf8; /* sky-400 */
-  --cp-warn: #f59e0b; /* amber-500 */
-  --cp-danger: #ef4444; /* red-500 */
+  /* #449 — Dark-Tokens an Tailwinds eigene Palette-Variablen gebunden
+   * (statt hartcodierter Hex-Werte). Tailwind v4 rendert slate-* in oklch;
+   * die früheren Hex-Werte wichen davon um 1–2 RGB-Stufen ab, wodurch eine
+   * slate-*→cp-*-Migration NICHT pixelgleich war. Über var(--color-slate-N)
+   * sind die Tokens jetzt per Definition deckungsgleich mit den rohen
+   * slate-/sky-/amber-/red-Utilities — die Migration ist damit beweisbar
+   * appearance-neutral, und es gibt nur noch EINE Farbquelle. */
+  --cp-bg: var(--color-slate-900); /* App-Hintergrund */
+  --cp-surface-1: var(--color-slate-900); /* Panels/Modals */
+  --cp-surface-2: var(--color-slate-800); /* raised/hover */
+  --cp-surface-3: var(--color-slate-950); /* sunken/Leisten/Inputs */
+  --cp-border: var(--color-slate-700);
+  --cp-border-muted: var(--color-slate-800);
+  --cp-text: var(--color-slate-100);
+  --cp-text-secondary: var(--color-slate-300);
+  --cp-text-muted: var(--color-slate-400);
+  --cp-text-faint: var(--color-slate-500);
+  --cp-accent: var(--color-sky-400);
+  --cp-warn: var(--color-amber-500);
+  --cp-danger: var(--color-red-500);
 
   /* Spacing-Skala (Referenz; schrittweise Migration der Shells) */
   --cp-space-1: 0.25rem;
@@ -209,6 +216,10 @@ body,
   --cp-border: #94a3b8; /* = .border-slate-700 */
   --cp-border-muted: #b8c4d0; /* = .border-slate-800 */
   --cp-text: #0f172a; /* = .text-slate-100 */
+  /* #449 — fehlte im Light-Remap: --cp-text-secondary fiel auf den Dark-Wert
+   * zurück (heller Grauton auf hellem Grund → unlesbar). Jetzt = light
+   * .text-slate-300 (#1e293b), passt in die Ramp text(#0f172a) → muted(#334155). */
+  --cp-text-secondary: #1e293b; /* = .text-slate-300 (light) */
   --cp-text-muted: #334155; /* = .text-slate-400 */
   --cp-text-faint: #475569; /* = .text-slate-500 */
   --cp-accent: #0284c7; /* sky-600 */


### PR DESCRIPTION
## Zweck
Macht die in #449 vorgesehene slate-→cp-Token-Migration **beweisbar appearance-neutral** und liefert den ersten verschlankten Baustein. Adressiert außerdem einen echten Light-Mode-Kontrast-Bug.

## Hintergrund
Mein vorheriger Pixel-Vergleich (im Issue dokumentiert) zeigte: die `--cp-*`-Dark-Tokens trugen **hartcodierte Hex-Werte**, während Tailwind v4 die `slate-*`-Palette in **oklch** rendert → 1–2 RGB-Stufen Drift, also **nicht** pixelgleich. Ein Blind-Batch hätte minimale Farbverschiebungen gestreut.

## Änderung
1. **`index.css` — Dark-Tokens an die Palette gebunden:** `--cp-surface-*/border/text/accent…` → `var(--color-slate-N)` / `var(--color-sky-400)` etc. Token und rohe Utility teilen jetzt **dieselbe Quell-Variable** ⇒ definitionsgemäß identisch, nur noch eine Farbquelle, selbstwartend.
2. **`index.css` — Light-Remap-Lücke gefixt:** `--cp-text-secondary` fehlte und fiel auf den Dark-Wert zurück (heller Grauton auf hellem Grund → unlesbar). Ergänzt = light `slate-300`.
3. **`AboutDialog.tsx` — erste Komponenten-Migration** (Demo, dass das Fundament trägt): rohe `slate-*` → `cp-*`-Utilities. `bg-emerald-700` + `hover:text-sky-300` bewusst belassen (kein exakter Token).

## Verifikation (headless)
Chromium, echte gemalte Pixel via Canvas-`getImageData`: **alle 20 slate-↔cp-Paare PIXELGLEICH in dark UND light** (vorher 6–8 Abweichungen). tsc 0 · eslint 0 · build 0.

Inkrementell — schließt #449 nicht (Remap-Abbau läuft weiter über weitere Komponenten), aber das Fundament ist jetzt nachweisbar verlustfrei.

Refs #449

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_