### PR TITLE
refactor(theme): migrate 3 components slate-* → cp-tokens (#449)

### DIFF
--- a/src/renderer/components/Project/WelcomeDialog.tsx
+++ b/src/renderer/components/Project/WelcomeDialog.tsx
@@ -52,7 +52,7 @@ export const WelcomeDialog = ({ open, onNew, onOpen, onClose }: WelcomeDialogPro
           <button
             type="button"
             onClick={onClose}
-            className="rounded bg-slate-800 px-3 py-1 text-cp-xs text-slate-400 hover:bg-slate-700 hover:text-slate-200"
+            className="rounded bg-cp-surface-2 px-3 py-1 text-cp-xs text-cp-text-muted hover:bg-slate-700 hover:text-slate-200"
             title={t(
               'project.welcome.laterTitle',
               'Ohne Auswahl fortfahren — bitte denke daran, manuell zu speichern.',
@@ -63,7 +63,7 @@ export const WelcomeDialog = ({ open, onNew, onOpen, onClose }: WelcomeDialogPro
         </div>
       }
     >
-      <p className="mb-3 text-cp-xs text-slate-400">
+      <p className="mb-3 text-cp-xs text-cp-text-muted">
         {t(
           'project.welcome.intro',
           'Lege ein neues Projekt an oder öffne ein bestehendes, damit deine Arbeit zuverlässig gespeichert wird.',
@@ -77,14 +77,14 @@ export const WelcomeDialog = ({ open, onNew, onOpen, onClose }: WelcomeDialogPro
             onNew()
             onClose()
           }}
-          className="flex w-full items-start gap-3 rounded border border-slate-700 bg-slate-800 px-3 py-2.5 text-left hover:border-emerald-500 hover:bg-slate-700"
+          className="flex w-full items-start gap-3 rounded border border-cp-border bg-cp-surface-2 px-3 py-2.5 text-left hover:border-emerald-500 hover:bg-slate-700"
         >
           <Icon icon={FileText} size="lg" className="mt-0.5 text-emerald-400" />
           <span className="flex-1">
             <span className="block text-cp-base font-semibold">
               {t('project.welcome.newTitle', 'Neues Projekt')}
             </span>
-            <span className="block text-[11px] text-slate-400">
+            <span className="block text-[11px] text-cp-text-muted">
               {t('project.welcome.newSubtitle', 'Mit Projektname, Auftraggeber und Planer starten.')}
             </span>
           </span>
@@ -96,16 +96,16 @@ export const WelcomeDialog = ({ open, onNew, onOpen, onClose }: WelcomeDialogPro
             onOpen()
             onClose()
           }}
-          className="flex w-full items-start gap-3 rounded border border-slate-700 bg-slate-800 px-3 py-2.5 text-left hover:border-sky-500 hover:bg-slate-700"
+          className="flex w-full items-start gap-3 rounded border border-cp-border bg-cp-surface-2 px-3 py-2.5 text-left hover:border-sky-500 hover:bg-slate-700"
         >
           <Icon icon={FolderOpen} size="lg" className="mt-0.5 text-sky-400" />
           <span className="flex-1">
             <span className="block text-cp-base font-semibold">
               {t('project.welcome.openTitle', 'Projekt öffnen…')}
             </span>
-            <span className="block text-[11px] text-slate-400">
+            <span className="block text-[11px] text-cp-text-muted">
               {t('project.welcome.openSubtitle1', 'Eine vorhandene')}{' '}
-              <code className="rounded bg-slate-950 px-1">.cableplan</code>
+              <code className="rounded bg-cp-surface-3 px-1">.cableplan</code>
               {t('project.welcome.openSubtitle2', '-Datei laden.')}
             </span>
           </span>
@@ -113,14 +113,14 @@ export const WelcomeDialog = ({ open, onNew, onOpen, onClose }: WelcomeDialogPro
 
         {recents.length > 0 && (
           <div className="pt-2">
-            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-slate-400">
+            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-cp-text-muted">
               {t('project.welcome.recents', 'Zuletzt verwendet')}
             </div>
             <div className="max-h-32 space-y-1 overflow-auto">
               {recents.slice(0, 6).map((path) => (
                 <div
                   key={path}
-                  className="flex items-center gap-2 rounded border border-slate-800 bg-slate-950/40 px-2 py-1 text-[11px] text-slate-400"
+                  className="flex items-center gap-2 rounded border border-cp-border-muted bg-cp-surface-3/40 px-2 py-1 text-[11px] text-cp-text-muted"
                   title={path}
                 >
                   <Icon icon={Clock} size="sm" />
@@ -128,7 +128,7 @@ export const WelcomeDialog = ({ open, onNew, onOpen, onClose }: WelcomeDialogPro
                 </div>
               ))}
             </div>
-            <p className="mt-1 text-[10px] text-slate-400">
+            <p className="mt-1 text-[10px] text-cp-text-muted">
               {t(
                 'project.welcome.recentsHint',
                 'Klick „Projekt öffnen…“ und wähle eine der Dateien im Datei-Dialog.',

--- a/src/renderer/components/Properties/sections/DisplayFlagsSection.tsx
+++ b/src/renderer/components/Properties/sections/DisplayFlagsSection.tsx
@@ -20,7 +20,7 @@ export const DisplayFlagsSection = ({ equipment }: { equipment: EquipmentItem })
   return (
     <SortableSection id="flags" title={t('flags.title', 'Darstellung & Flags')} subtitle={t('flags.subtitle', 'kompakt · Farbe · gepackt')}>
       <div className="space-y-2">
-        <label className="flex items-center gap-2 text-[12px] text-slate-300">
+        <label className="flex items-center gap-2 text-[12px] text-cp-text-secondary">
           <input
             type="checkbox"
             checked={!!equipment.collapsed}
@@ -29,7 +29,7 @@ export const DisplayFlagsSection = ({ equipment }: { equipment: EquipmentItem })
             }
           />
           {t('eq.field.compact', 'Kompakte Darstellung')}{' '}
-          <span className="text-slate-500">({t('eq.field.compactHint', 'nur Icon + Name, Ports als Punkte')})</span>
+          <span className="text-cp-text-faint">({t('eq.field.compactHint', 'nur Icon + Name, Ports als Punkte')})</span>
         </label>
 
         <ColorField
@@ -44,7 +44,7 @@ export const DisplayFlagsSection = ({ equipment }: { equipment: EquipmentItem })
         {/* #419 — "Ports spiegeln" gehoert zur Inputs-&-Outputs-Sektion
             (siehe PortsSection); nicht mehr hier. */}
         <label
-          className="flex items-center gap-2 text-[11px] text-slate-300"
+          className="flex items-center gap-2 text-[11px] text-cp-text-secondary"
           title={t('flags.packedTitle', 'Markiert das Gerät als gepackt. Erscheint als ✓ auf dem Canvas und als eigene Spalte in der Geräte-BOM.')}
         >
           <input
@@ -60,7 +60,7 @@ export const DisplayFlagsSection = ({ equipment }: { equipment: EquipmentItem })
             eindeutige 1-In/1-Out-Wandler relevant; bei mehrdeutigen
             Geraeten wird trotzdem ohne Pass-Through angezeigt. */}
         <label
-          className="flex items-center gap-2 text-[11px] text-slate-300"
+          className="flex items-center gap-2 text-[11px] text-cp-text-secondary"
           title={t('flags.converterTitle', 'Wandler-Marker: in der Patchliste wird dieses Gerät übersprungen und das nächste echte Ziel direkt angezeigt. Sinnvoll für SDI-HDMI-Konverter, Format-Wandler, Embedder/De-Embedder etc.')}
         >
           <input
@@ -75,7 +75,7 @@ export const DisplayFlagsSection = ({ equipment }: { equipment: EquipmentItem })
           Wandler (Patchliste folgt Durchgangskabel)
         </label>
         <label
-          className="flex items-center gap-2 text-[11px] text-slate-300"
+          className="flex items-center gap-2 text-[11px] text-cp-text-secondary"
           title={t('flags.daTitle', 'Verteilverstärker: 1 Eingang wird aktiv auf mehrere Ausgänge derselben Quelle verteilt (1→N).')}
         >
           <input
@@ -90,9 +90,9 @@ export const DisplayFlagsSection = ({ equipment }: { equipment: EquipmentItem })
           {t('flags.da', 'Verteilverstärker (1→N)')}
         </label>
         {/* #359/#360/#366 — Signal-Flow-Rollen (Timecode / Tally / Embedding). */}
-        <div className="grid grid-cols-3 gap-1 border-t border-slate-800 pt-2">
+        <div className="grid grid-cols-3 gap-1 border-t border-cp-border-muted pt-2">
           <label className="block text-[10px]">
-            <span className="mb-0.5 block text-slate-400">{t('roles.tc', 'Timecode')}</span>
+            <span className="mb-0.5 block text-cp-text-muted">{t('roles.tc', 'Timecode')}</span>
             <select
               value={equipment.tcRole ?? ''}
               onChange={(event) =>
@@ -100,7 +100,7 @@ export const DisplayFlagsSection = ({ equipment }: { equipment: EquipmentItem })
                   tcRole: (event.target.value || undefined) as 'source' | 'sink' | undefined,
                 })
               }
-              className="w-full rounded border border-slate-700 bg-slate-950 p-1"
+              className="w-full rounded border border-cp-border bg-cp-surface-3 p-1"
             >
               <option value="">—</option>
               <option value="source">{t('roles.source', 'Quelle')}</option>
@@ -108,7 +108,7 @@ export const DisplayFlagsSection = ({ equipment }: { equipment: EquipmentItem })
             </select>
           </label>
           <label className="block text-[10px]">
-            <span className="mb-0.5 block text-slate-400">{t('roles.tally', 'Tally')}</span>
+            <span className="mb-0.5 block text-cp-text-muted">{t('roles.tally', 'Tally')}</span>
             <select
               value={equipment.tallyRole ?? ''}
               onChange={(event) =>
@@ -116,7 +116,7 @@ export const DisplayFlagsSection = ({ equipment }: { equipment: EquipmentItem })
                   tallyRole: (event.target.value || undefined) as 'source' | 'sink' | undefined,
                 })
               }
-              className="w-full rounded border border-slate-700 bg-slate-950 p-1"
+              className="w-full rounded border border-cp-border bg-cp-surface-3 p-1"
             >
               <option value="">—</option>
               <option value="source">{t('roles.source', 'Quelle')}</option>
@@ -124,7 +124,7 @@ export const DisplayFlagsSection = ({ equipment }: { equipment: EquipmentItem })
             </select>
           </label>
           <label className="block text-[10px]">
-            <span className="mb-0.5 block text-slate-400">{t('roles.embed', 'Embedding')}</span>
+            <span className="mb-0.5 block text-cp-text-muted">{t('roles.embed', 'Embedding')}</span>
             <select
               value={equipment.embedderRole ?? ''}
               onChange={(event) =>
@@ -135,7 +135,7 @@ export const DisplayFlagsSection = ({ equipment }: { equipment: EquipmentItem })
                     | undefined,
                 })
               }
-              className="w-full rounded border border-slate-700 bg-slate-950 p-1"
+              className="w-full rounded border border-cp-border bg-cp-surface-3 p-1"
             >
               <option value="">—</option>
               <option value="embedder">{t('roles.embedder', 'Embedder')}</option>

--- a/src/renderer/components/Properties/sections/NetworkAccessSection.tsx
+++ b/src/renderer/components/Properties/sections/NetworkAccessSection.tsx
@@ -29,62 +29,62 @@ export const NetworkAccessSection = ({ equipment }: { equipment: EquipmentItem }
     >
       <div className="grid grid-cols-2 gap-2">
         <label className="block">
-          <span className="mb-1 block text-slate-300">IP Address</span>
+          <span className="mb-1 block text-cp-text-secondary">IP Address</span>
           <input
             value={equipment.ipAddress ?? ''}
             onChange={(event) =>
               updateEquipment(equipment.id, { ipAddress: event.target.value })
             }
             placeholder="192.168.1.10"
-            className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono"
+            className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
           />
         </label>
         <label className="block">
-          <span className="mb-1 block text-slate-300">{t('eq.field.serial', 'Seriennummer')}</span>
+          <span className="mb-1 block text-cp-text-secondary">{t('eq.field.serial', 'Seriennummer')}</span>
           <input
             value={equipment.serialNumber ?? ''}
             onChange={(event) =>
               updateEquipment(equipment.id, { serialNumber: event.target.value || undefined })
             }
             placeholder={t('eq.field.serialPlaceholder', 'S/N')}
-            className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono"
+            className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
           />
         </label>
         <label className="block">
-          <span className="mb-1 block text-slate-300">{t('eq.field.subnet', 'Subnet Mask')}</span>
+          <span className="mb-1 block text-cp-text-secondary">{t('eq.field.subnet', 'Subnet Mask')}</span>
           <input
             value={equipment.subnetMask ?? ''}
             onChange={(event) =>
               updateEquipment(equipment.id, { subnetMask: event.target.value })
             }
             placeholder={t('eq.field.subnetPlaceholder', '255.255.255.0 oder /24')}
-            className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono"
+            className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
           />
         </label>
         <label className="block">
-          <span className="mb-1 block text-slate-300">{t('eq.field.mac', 'MAC-Adresse')}</span>
+          <span className="mb-1 block text-cp-text-secondary">{t('eq.field.mac', 'MAC-Adresse')}</span>
           <input
             value={equipment.macAddress ?? ''}
             onChange={(event) =>
               updateEquipment(equipment.id, { macAddress: event.target.value || undefined })
             }
             placeholder="00:1A:2B:3C:4D:5E"
-            className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono"
+            className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
           />
         </label>
         <label className="block">
-          <span className="mb-1 block text-slate-300">{t('eq.field.username', 'Username')}</span>
+          <span className="mb-1 block text-cp-text-secondary">{t('eq.field.username', 'Username')}</span>
           <input
             value={equipment.username ?? ''}
             onChange={(event) =>
               updateEquipment(equipment.id, { username: event.target.value })
             }
             autoComplete="off"
-            className="w-full rounded border border-slate-700 bg-slate-900 p-2"
+            className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
           />
         </label>
         <label className="block">
-          <span className="mb-1 block text-slate-300">{t('eq.field.password', 'Password')}</span>
+          <span className="mb-1 block text-cp-text-secondary">{t('eq.field.password', 'Password')}</span>
           <div className="relative">
             <input
               type={showPassword ? 'text' : 'password'}
@@ -93,7 +93,7 @@ export const NetworkAccessSection = ({ equipment }: { equipment: EquipmentItem }
                 updateEquipment(equipment.id, { password: event.target.value })
               }
               autoComplete="new-password"
-              className="w-full rounded border border-slate-700 bg-slate-900 p-2 pr-10"
+              className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 pr-10"
             />
             <button
               type="button"
@@ -108,7 +108,7 @@ export const NetworkAccessSection = ({ equipment }: { equipment: EquipmentItem }
                   ? t('eq.field.passwordHide', 'Passwort verbergen')
                   : t('eq.field.passwordShow', 'Passwort anzeigen')
               }
-              className="absolute inset-y-0 right-0 flex items-center px-2 text-slate-400 hover:text-slate-200"
+              className="absolute inset-y-0 right-0 flex items-center px-2 text-cp-text-muted hover:text-slate-200"
             >
               <Icon icon={showPassword ? EyeOff : Eye} size="sm" />
             </button>
@@ -116,13 +116,13 @@ export const NetworkAccessSection = ({ equipment }: { equipment: EquipmentItem }
         </label>
       </div>
       <label className="mt-2 block">
-        <span className="mb-1 block text-slate-300">{t('cable.field.notes', 'Notes')}</span>
+        <span className="mb-1 block text-cp-text-secondary">{t('cable.field.notes', 'Notes')}</span>
         <textarea
           value={equipment.notes ?? ''}
           onChange={(event) => updateEquipment(equipment.id, { notes: event.target.value })}
           rows={3}
           placeholder={t('netAccess.notesPlaceholder', 'Web UI URL, firmware version, wiring notes, …')}
-          className="w-full rounded border border-slate-700 bg-slate-900 p-2"
+          className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
         />
       </label>
     </SortableSection>


### PR DESCRIPTION
## Zweck
Zweiter Migrations-Batch für #449, aufbauend auf dem in #525 gelegten Fundament (Dark-`--cp-*`-Tokens sind jetzt an Tailwinds `--color-slate-*` gebunden → **jedes ersetzte slate-↔cp-Paar ist pixelgleich**). Damit ist diese Migration appearance-neutral *by construction*.

## Änderung
- **`Project/WelcomeDialog`** — rohe `slate-*` → `cp-*`-Token-Utilities
- **`Properties/sections/DisplayFlagsSection`** — vollständig migriert (100% der slate-Klassen)
- **`Properties/sections/NetworkAccessSection`** — 22/23 Klassen migriert

Bewusst **roh belassen** (kein exakter Token vorhanden): `hover:bg-slate-700`, `hover:text-slate-200` — `slate-700`-als-Surface bzw. `slate-200` haben keine `cp-`Entsprechung; gehört in eine spätere Token-Erweiterung, nicht in eine „pixelgleich"-Migration.

## Verifikation (headless)
Die App headless gerendert (`vite preview` + Chromium), Theme faithful über den persistierten Store-Key geseedet (flippt CSS **und** die `isLight`-Props). WelcomeDialog in **dark + light** vor/nach der Migration gescreenshottet und per Canvas-`getImageData` pixelweise gedifft:
- **Dialog: appearance-neutral** — kein Pixel über Schwelle.
- Einzige messbare Abweichung: der Versions-Chip in der Statusleiste (`v24e184b` → `v24e184b-dirty`) — ein **git-describe-Build-Artefakt** der uncommitteten Arbeitskopie, kein UI-Effekt. Außerhalb nur Subpixel-AA-Rauschen (≤6/Pixel).

tsc 0 · eslint 0 · build 0. Console-Errors beim Boot: keine.

Inkrementell (schließt #449 nicht). Refs #449

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_