### PR TITLE
fix(rack): Auto-Routing beim Verkabeln — Router-Singleton entrennen (#515)

### DIFF
--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import ReactFlow, {
   Background,
   Controls,
@@ -65,6 +65,10 @@ type CanvasMode = 'main' | 'rack'
 
 const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
   const t = useTranslation()
+  // #515 — stabile ID dieser CanvasArea-Instanz für die A*-Router-Registry.
+  // Haupt- und Rack-Canvas teilen die Komponente, aber nicht die Instanz;
+  // die ID hält ihre Router im Stack auseinander (siehe setCableRouter).
+  const routerId = useId()
   // v7.9.9 — context-aware project store instance. Default = main store,
   // override = scratch store (z.B. RackInternalCanvas).
   const projectStoreInstance = useCanvasProjectStoreInstance()
@@ -279,9 +283,9 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
       return ok
     }
 
-    setCableRouter({ routeOne, routeAll })
-    return () => setCableRouter(null)
-  }, [project.equipment, updateCable])
+    setCableRouter(routerId, { routeOne, routeAll })
+    return () => setCableRouter(routerId, null)
+  }, [routerId, project.equipment, updateCable])
 
   // Restore saved viewport whenever a new project is loaded (projectVersion changes).
   // The initial render uses defaultViewport below; this effect handles

--- a/src/renderer/lib/canvasViewport.ts
+++ b/src/renderer/lib/canvasViewport.ts
@@ -151,10 +151,36 @@ export const triggerCanvasResetZoom = () => {
 // CanvasArea owns the live data (rfNodes for actual rendered handle
 // positions, full obstacle list, all cables for soft-obstacle
 // avoidance) and turns the request into the actual write.
-let cableRouter: ((cableId: string) => boolean) | null = null
-let allCablesRouter: (() => number) | null = null
+// #515 — Router-Registry als ID-gekeyter Stack statt einzelner Globals.
+// Grund: Die Rack-Verkabelung (RackInternalCanvas) rendert DIESELBE
+// <CanvasArea>-Komponente ein zweites Mal (mode='rack'), nur mit einem
+// eigenen Scratch-Store. Beide Instanzen registrierten ihren A*-Router
+// über EIN globales Slot — wer zuletzt seinen Effect laufen ließ, gewann.
+// Lief der Effect der Haupt-Canvas erneut (deps: project.equipment /
+// updateCable), während das Rack-Overlay offen war, zeigte das Slot
+// wieder auf die HAUPT-Canvas. routeCable(scratchCableId) suchte das
+// Kabel dann im Haupt-Projekt, fand es nicht und gab still `false`
+// zurück → "Auto-Routing beim Verkabeln defekt" (Issue #515).
+//
+// Fix: jede CanvasArea-Instanz registriert mit stabiler ID. Aktiv ist
+// die ZULETZT gemountete (oben auf dem Stack = das Rack-Overlay, solange
+// es offen ist). Re-Registrierung einer bekannten ID aktualisiert
+// in-place, OHNE die Stack-Position zu ändern — ein Re-Run des Haupt-
+// Effects kann das offene Rack-Overlay also nicht mehr verdrängen.
+// Schließt das Overlay (Cleanup → setCableRouter(id, null)), fällt der
+// Stack auf die Haupt-Canvas zurück.
+interface CableRouterEntry {
+  id: string
+  routeOne: (cableId: string) => boolean
+  routeAll: () => number
+}
+const cableRouterStack: CableRouterEntry[] = []
+
+const activeCableRouter = (): CableRouterEntry | null =>
+  cableRouterStack.length > 0 ? cableRouterStack[cableRouterStack.length - 1] : null
 
 export const setCableRouter = (
+  id: string,
   fns:
     | {
         routeOne: (cableId: string) => boolean
@@ -162,15 +188,26 @@ export const setCableRouter = (
       }
     | null,
 ) => {
-  cableRouter = fns?.routeOne ?? null
-  allCablesRouter = fns?.routeAll ?? null
+  const idx = cableRouterStack.findIndex((e) => e.id === id)
+  if (!fns) {
+    if (idx >= 0) cableRouterStack.splice(idx, 1)
+    return
+  }
+  if (idx >= 0) {
+    // In-place aktualisieren — Stack-Position (= "wer ist aktiv") bleibt.
+    cableRouterStack[idx] = { id, routeOne: fns.routeOne, routeAll: fns.routeAll }
+  } else {
+    cableRouterStack.push({ id, routeOne: fns.routeOne, routeAll: fns.routeAll })
+  }
 }
 
 /** Reroute a single cable using A*. Returns true if a path was found
- *  and written to the cable. */
+ *  and written to the cable. Nutzt den aktiven (zuletzt gemounteten)
+ *  Canvas-Router — im Rack-Overlay also dessen Scratch-Store-Router. */
 export const routeCable = (cableId: string): boolean => {
   try {
-    return cableRouter ? cableRouter(cableId) : false
+    const r = activeCableRouter()
+    return r ? r.routeOne(cableId) : false
   } catch {
     return false
   }
@@ -180,7 +217,8 @@ export const routeCable = (cableId: string): boolean => {
  *  successfully found a path. */
 export const routeAllCables = (): number => {
   try {
-    return allCablesRouter ? allCablesRouter() : 0
+    const r = activeCableRouter()
+    return r ? r.routeAll() : 0
   } catch {
     return 0
   }


### PR DESCRIPTION
## Antwort auf die Architektur-Frage
> „Warum ist das Canvas darin nicht dieselbe Canvas-Komponente wie im Haupt-Canvas?"

Es **ist** dieselbe Komponente: `RackInternalCanvas` rendert `<CanvasArea mode="rack" />` (gleicher Code) — nur mit einem **eigenen Scratch-Store** über den `ProjectStoreProvider`. Der Knackpunkt war nicht die Komponente, sondern dass der **A\*-Router über ein Prozess-globales Slot** (`let cableRouter` in `canvasViewport.ts`) veröffentlicht wurde, nicht pro Instanz.

## Root Cause (Auto-Routing defekt)
Beide `CanvasArea`-Instanzen (Haupt + Rack-Overlay) sind gleichzeitig gemountet und schrieben ihren Router in **dasselbe** globale Slot — wer zuletzt seinen `useEffect` laufen ließ, gewann. Lief der Haupt-Canvas-Effect erneut (deps `project.equipment`/`updateCable`), während das Rack-Overlay offen war, zeigte das Slot **wieder auf die Haupt-Canvas**. `routeCable(scratchKabelId)` suchte das Kabel dann im **Haupt-Projekt**, fand es nicht → `return false` (still verschluckt). Ergebnis: „Auto-Routing beim Verkabeln tut nichts".

## Fix
- **`canvasViewport.ts`** — Router-Registry ist jetzt ein **ID-gekeyter Stack** statt eines einzelnen Globals. Aktiv = zuletzt gemountete Canvas (= das Rack-Overlay, solange offen). Re-Registrierung einer bekannten ID **aktualisiert in-place**, ohne die Stack-Position zu ändern → ein Re-Run des Haupt-Effects kann das offene Rack-Overlay **nicht mehr verdrängen**. Overlay zu (Cleanup) → Stack fällt auf die Haupt-Canvas zurück.
- **`CanvasArea.tsx`** — jede Instanz registriert mit stabiler `useId()`-ID. **Keine Aufrufer-Änderung** (`routeCable`-Signatur unverändert).

## Verifikation
- **Stack-Invarianten 6/6** (Unit-Test der exakten Registry-Logik) — inkl. der Bug-Sequenz *„Haupt-Effect-Re-Run darf das offene Rack NICHT verdrängen"* und *„Overlay zu → zurück auf main"*.
- **Headless-Boot**: Haupt-Canvas mountet (`.react-flow` da), **0 Console-Errors** → neue `useId`-Registrierung trägt end-to-end, Haupt-Canvas nachweislich unberührt.
- tsc 0 · eslint 0 Errors (2 Baseline-Warnungen unverändert) · build 0.

**Ehrliche Grenze:** der eigentliche ReactFlow-Port-Drag im Modal ist headless nicht zuverlässig simulierbar — die **Fix-Logik ist aber bewiesen** und der Haupt-Pfad unberührt. Der separate *„Display-Bug beim ersten Kabel"* aus dem Issue ist **nicht** Teil dieses PRs (eigenes Issue, siehe Issue-Verlauf).

Refs #515

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_