### PR TITLE
refactor(theme): migrate 4 Properties-Sektionen slate-* → cp-tokens (#449)

### DIFF
--- a/src/renderer/components/Properties/sections/DeviceModePicker.tsx
+++ b/src/renderer/components/Properties/sections/DeviceModePicker.tsx
@@ -139,7 +139,7 @@ export const DeviceModePicker = ({
 
   return (
     <div className="space-y-2 text-cp-xs">
-      <p className="text-[10px] text-slate-400">
+      <p className="text-[10px] text-cp-text-muted">
         {t(
           'modes.intro',
           'Wechselt das Port-Layout des Geräts. Bestehende Kabel an Ports, die im neuen Modus nicht existieren, bleiben im Projekt, müssen aber neu gesteckt werden.',
@@ -147,7 +147,7 @@ export const DeviceModePicker = ({
       </p>
       <div className="grid grid-cols-1 gap-1">
         {modes.length === 0 && (
-          <div className="rounded border border-dashed border-slate-700 p-3 text-center text-[11px] text-slate-400">
+          <div className="rounded border border-dashed border-cp-border p-3 text-center text-[11px] text-cp-text-muted">
             {t(
               'modes.emptyState',
               'Keine Modi definiert. Ports oben bearbeiten und anschließend mit "+ aus aktuellem Layout" als Modus speichern.',
@@ -158,13 +158,13 @@ export const DeviceModePicker = ({
           <div
             key={m.id}
             className={`rounded border ${
-              active === m.id ? 'border-sky-500 bg-sky-900/40' : 'border-slate-700 bg-slate-900'
+              active === m.id ? 'border-sky-500 bg-sky-900/40' : 'border-cp-border bg-cp-surface-1'
             }`}
           >
             <button
               type="button"
               onClick={() => setActiveDeviceMode(equipment.id, m.id)}
-              className="flex w-full flex-col items-start px-2 py-1.5 text-left text-slate-100"
+              className="flex w-full flex-col items-start px-2 py-1.5 text-left text-cp-text"
               title={active === m.id ? t('modes.active', 'Aktiv') : t('modes.activate', 'Aktivieren')}
             >
               <span className="font-medium">
@@ -172,13 +172,13 @@ export const DeviceModePicker = ({
                 {m.name}
               </span>
               {m.description && (
-                <span className="text-[10px] text-slate-400">{m.description}</span>
+                <span className="text-[10px] text-cp-text-muted">{m.description}</span>
               )}
-              <span className="mt-1 text-[10px] text-slate-400">
+              <span className="mt-1 text-[10px] text-cp-text-muted">
                 {m.inputs.length} In · {m.outputs.length} Out
               </span>
             </button>
-            <div className="flex gap-1 border-t border-slate-800 bg-slate-950/40 px-1 py-1 text-[10px]">
+            <div className="flex gap-1 border-t border-cp-border-muted bg-cp-surface-3/40 px-1 py-1 text-[10px]">
               <button
                 type="button"
                 onClick={() => setEditorState({ mode: 'edit', modeId: m.id })}
@@ -190,7 +190,7 @@ export const DeviceModePicker = ({
               <button
                 type="button"
                 onClick={() => renameMode(m.id)}
-                className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-slate-300 hover:bg-slate-800"
+                className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-cp-text-secondary hover:bg-cp-surface-2"
                 title={t('modes.renameTitle', 'Namen ändern')}
               >
                 <Icon icon={Pencil} size="xs" /> {t('modes.name', 'Name')}
@@ -198,7 +198,7 @@ export const DeviceModePicker = ({
               <button
                 type="button"
                 onClick={() => editDescription(m.id)}
-                className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-slate-300 hover:bg-slate-800"
+                className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-cp-text-secondary hover:bg-cp-surface-2"
                 title={t('modes.descTitle', 'Beschreibung ändern')}
               >
                 <Icon icon={Pencil} size="xs" /> {t('modes.desc', 'Beschreibung')}
@@ -216,7 +216,7 @@ export const DeviceModePicker = ({
               <button
                 type="button"
                 onClick={() => deleteMode(m.id)}
-                className="ml-auto rounded px-1.5 py-0.5 text-slate-400 hover:bg-red-700 hover:text-white"
+                className="ml-auto rounded px-1.5 py-0.5 text-cp-text-muted hover:bg-red-700 hover:text-white"
                 title={t('modes.deleteTitle', 'Modus löschen')}
                 aria-label={t('modes.deleteTitle', 'Modus löschen')}
               >

--- a/src/renderer/components/Properties/sections/DimensionsSection.tsx
+++ b/src/renderer/components/Properties/sections/DimensionsSection.tsx
@@ -28,7 +28,7 @@ export const DimensionsSection = ({ equipment }: { equipment: EquipmentItem }) =
     <SortableSection id="dimensions" title={t('dims.title', 'Dimensionen')} subtitle={summary}>
       <div className="grid grid-cols-3 gap-2 text-cp-xs">
         <label className="block">
-          <span className="mb-1 block text-slate-400">{t('dims.width', 'Breite (mm)')}</span>
+          <span className="mb-1 block text-cp-text-muted">{t('dims.width', 'Breite (mm)')}</span>
           <input
             type="number"
             min={0}
@@ -38,11 +38,11 @@ export const DimensionsSection = ({ equipment }: { equipment: EquipmentItem }) =
             onChange={(e) =>
               updateEquipment(equipment.id, { widthMm: parseMm(e.target.value) })
             }
-            className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono"
+            className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
           />
         </label>
         <label className="block">
-          <span className="mb-1 block text-slate-400">{t('dims.height', 'Höhe (mm)')}</span>
+          <span className="mb-1 block text-cp-text-muted">{t('dims.height', 'Höhe (mm)')}</span>
           <input
             type="number"
             min={0}
@@ -52,11 +52,11 @@ export const DimensionsSection = ({ equipment }: { equipment: EquipmentItem }) =
             onChange={(e) =>
               updateEquipment(equipment.id, { heightMm: parseMm(e.target.value) })
             }
-            className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono"
+            className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
           />
         </label>
         <label className="block">
-          <span className="mb-1 block text-slate-400">{t('dims.depth', 'Tiefe (mm)')}</span>
+          <span className="mb-1 block text-cp-text-muted">{t('dims.depth', 'Tiefe (mm)')}</span>
           <input
             type="number"
             min={0}
@@ -66,11 +66,11 @@ export const DimensionsSection = ({ equipment }: { equipment: EquipmentItem }) =
             onChange={(e) =>
               updateEquipment(equipment.id, { depthMm: parseMm(e.target.value) })
             }
-            className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono"
+            className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
           />
         </label>
       </div>
-      <p className="mt-2 text-[10px] text-slate-400">
+      <p className="mt-2 text-[10px] text-cp-text-muted">
         {t(
           'dims.hint',
           'Physische Aussenmaße. 19" Rack-Gerät: 1 HE = 44.45 mm, Standard-Breite 482 mm, typische Tiefe 400-600 mm. Wird vom 3D-Rack-Renderer + Logistik-Tools genutzt.',

--- a/src/renderer/components/Properties/sections/PortsSection.tsx
+++ b/src/renderer/components/Properties/sections/PortsSection.tsx
@@ -38,7 +38,7 @@ export const PortsSection = ({ equipment }: { equipment: EquipmentItem }) => {
             mehr zu "Darstellung & Flags"), weil es die Seiten-Zuordnung der
             Inputs/Outputs am Canvas-Knoten umdreht. */}
         <label
-          className="flex items-center gap-2 px-1 text-[11px] text-slate-300"
+          className="flex items-center gap-2 px-1 text-[11px] text-cp-text-secondary"
           title={t(
             'ports.flipTitle',
             'Inputs werden rechts, Outputs werden links am Geräte-Knoten gerendert.',
@@ -53,10 +53,10 @@ export const PortsSection = ({ equipment }: { equipment: EquipmentItem }) => {
           />
           {t('ports.flip', 'Ports spiegeln (Inputs rechts, Outputs links)')}
         </label>
-        <details open className="rounded border border-slate-800 bg-slate-950/30">
-          <summary className="cursor-pointer select-none px-2 py-1 text-cp-xs font-semibold text-slate-300 hover:text-slate-100">
+        <details open className="rounded border border-cp-border-muted bg-cp-surface-3/30">
+          <summary className="cursor-pointer select-none px-2 py-1 text-cp-xs font-semibold text-cp-text-secondary hover:text-cp-text">
             {t('ports.title.inputs', 'Inputs')}{' '}
-            <span className="text-slate-500">({equipment.inputs.length})</span>
+            <span className="text-cp-text-faint">({equipment.inputs.length})</span>
           </summary>
           <div className="px-2 pb-2">
             <PortList
@@ -68,10 +68,10 @@ export const PortsSection = ({ equipment }: { equipment: EquipmentItem }) => {
             />
           </div>
         </details>
-        <details open className="rounded border border-slate-800 bg-slate-950/30">
-          <summary className="cursor-pointer select-none px-2 py-1 text-cp-xs font-semibold text-slate-300 hover:text-slate-100">
+        <details open className="rounded border border-cp-border-muted bg-cp-surface-3/30">
+          <summary className="cursor-pointer select-none px-2 py-1 text-cp-xs font-semibold text-cp-text-secondary hover:text-cp-text">
             {t('ports.title.outputs', 'Outputs')}{' '}
-            <span className="text-slate-500">({equipment.outputs.length})</span>
+            <span className="text-cp-text-faint">({equipment.outputs.length})</span>
           </summary>
           <div className="px-2 pb-2">
             <PortList

--- a/src/renderer/components/Properties/sections/PowerConsumptionSection.tsx
+++ b/src/renderer/components/Properties/sections/PowerConsumptionSection.tsx
@@ -31,7 +31,7 @@ export const PowerConsumptionSection = ({ equipment }: { equipment: EquipmentIte
     <SortableSection id="power" title={t('power.title', 'Stromverbrauch')} subtitle={summary}>
       <div className="grid grid-cols-3 gap-2 text-cp-xs">
         <label className="block">
-          <span className="mb-1 block text-slate-400">{t('power.voltage', 'Spannung (V)')}</span>
+          <span className="mb-1 block text-cp-text-muted">{t('power.voltage', 'Spannung (V)')}</span>
           <input
             type="number"
             min={0}
@@ -56,11 +56,11 @@ export const PowerConsumptionSection = ({ equipment }: { equipment: EquipmentIte
                 powerConsumptionWatts: wAutoMatched ? newProduct : w,
               })
             }}
-            className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono"
+            className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
           />
         </label>
         <label className="block">
-          <span className="mb-1 block text-slate-400">{t('power.current', 'Stromstärke (A)')}</span>
+          <span className="mb-1 block text-cp-text-muted">{t('power.current', 'Stromstärke (A)')}</span>
           <input
             type="number"
             min={0}
@@ -80,11 +80,11 @@ export const PowerConsumptionSection = ({ equipment }: { equipment: EquipmentIte
                 powerConsumptionWatts: wAutoMatched ? newProduct : w,
               })
             }}
-            className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono"
+            className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
           />
         </label>
         <label className="block">
-          <span className="mb-1 block text-slate-400">
+          <span className="mb-1 block text-cp-text-muted">
             {t('power.watts', 'Leistung (W)')}
             {computedW !== undefined && (
               <span className="ml-1 inline-flex text-emerald-400/70" title={t('power.wattsComputed', 'Aus V × A berechnet')}>
@@ -109,12 +109,12 @@ export const PowerConsumptionSection = ({ equipment }: { equipment: EquipmentIte
                   : undefined,
               })
             }
-            className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono"
+            className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
             title={t('power.wattsTitle', 'Datenblatt-Wert. V × A wird vorgeschlagen, kann hier überschrieben werden.')}
           />
         </label>
       </div>
-      <p className="mt-2 text-[10px] text-slate-400">
+      <p className="mt-2 text-[10px] text-cp-text-muted">
         {t(
           'power.formulaHint',
           'Wenn Spannung und Stromstärke gesetzt sind, wird die Leistung automatisch berechnet (P = U × I). Werkzeuge → Stromverbrauch summiert das Leistungs-Feld über alle Geräte.',


### PR DESCRIPTION
## Zweck
Dritter Migrations-Batch für #449 auf dem Fundament aus #525 (Dark-`--cp-*`-Tokens an Tailwinds `--color-slate-*` gebunden → jeder ersetzte slate-↔cp-Paar ist **pixelgleich**, in #525 headless bewiesen). Setzt die Properties-Panel-Migration fort (nach DisplayFlagsSection + NetworkAccessSection in #526).

## Änderung — alle vier **vollständig** migriert (kein Rest-slate)
- `Properties/sections/DimensionsSection`
- `Properties/sections/PowerConsumptionSection`
- `Properties/sections/PortsSection`
- `Properties/sections/DeviceModePicker`

Alle vier nutzten ausschließlich **mappbare Shades** (kein `slate-200/600`, kein `bg-slate-700`) → 100 % migriert. Inklusive Opacity-Varianten (`bg-slate-950/30·/40` → `bg-cp-surface-3/30·/40`) und Hover (`hover:bg-slate-800` → `hover:bg-cp-surface-2`, gleiche bewiesene Basisfarbe).

## Verifikation
**Appearance-neutral by construction**: jeder verwendete slate→cp-Paar wurde in #525 per Canvas-`getImageData` als pixelgleich in **dark + light** nachgewiesen. tsc 0 · eslint 0 · build 0. (Kein eigener Screenshot — diese Sektionen sind nur mit selektiertem Gerät sichtbar; die Pixelgleichheit der Paare ist die stärkere, allgemeingültige Garantie.)

Inkrementell. Refs #449

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_