### PR TITLE
fix(rack): Display-Glitch beim ersten Kabel — exakte Node-Vorab-Größe (#528)

### DIFF
--- a/src/renderer/components/Rack/RackInternalCanvas.tsx
+++ b/src/renderer/components/Rack/RackInternalCanvas.tsx
@@ -29,6 +29,7 @@ import { useCanvasProjectStore } from '../../store/projectStoreContext'
 import { ProjectStoreProvider } from '../../store/ProjectStoreProvider'
 import { createProjectStoreInstance } from '../../store/projectStore'
 import { routeCable } from '../../lib/canvasViewport'
+import { computeEquipmentLayout } from '../../lib/equipmentLayout'
 import type {
   EquipmentItem,
   EquipmentTemplate,
@@ -112,16 +113,7 @@ const buildScratchEquipment = (
   placements: RackPlacementForCanvas[],
 ): EquipmentItem[] =>
   placements.map((p) => {
-    // v7.9.84 / #206 — Sinnvolle Default-Höhe statt 0. Vorher konnte
-    // hasOverlap mit eq.height=0 vor dem ersten ReactFlow-Measure
-    // false-positive "Ghost-Blocking" liefern (Bug 2 in #206). Wir
-    // schätzen die Höhe aus header + max(inputs, outputs) Port-Rows;
-    // beim ersten Measure überschreibt onNodesChange den Wert exakt.
-    const HEADER = 48
-    const ROW = 22
-    const PADDING = 8
-    const portRows = Math.max(p.inputs.length, p.outputs.length, 1)
-    return {
+    const eq: EquipmentItem = {
       id: p.id,
       name: p.name,
       category: p.category,
@@ -132,10 +124,25 @@ const buildScratchEquipment = (
       x: p.canvasX ?? X_OFFSET,
       y: p.canvasY ?? Y_OFFSET + (p.startUnit - 1) * HE_TO_PX,
       width: NODE_WIDTH,
-      height: HEADER + portRows * ROW + PADDING,
+      height: 0,
       isRackDevice: p.isRackDevice,
       rackUnits: p.rackUnits,
     }
+    // #528 / #206 — Initiale Node-Dimensionen EXAKT so berechnen wie der
+    // spätere ReactFlow-Measure: über computeEquipmentLayout, dieselbe Quelle
+    // aus der auch EquipmentNode rendert. Vorher stand hier eine grobe
+    // HEADER/ROW/PADDING-Schätzung, die vom gemessenen Wert abwich — beim
+    // ersten Measure (onNodesChange dimensions) sprangen Node- und damit
+    // Handle-Positionen dann einen Frame weit. Das war der "Display-Bug beim
+    // ersten Kabel" während des Verkabelns: die in-progress-Connection-Line
+    // (und die frisch gemessenen Handles) verschoben sich kurz, ehe sich der
+    // Wert stabilisierte. Mit exakter Vorab-Größe ist estimate == measured →
+    // der onNodesChange-Diff bleibt unter der 2px-Schwelle, kein Sprung. Hält
+    // auch den hasOverlap-Check (#206) von Anfang an stabil.
+    const layout = computeEquipmentLayout(eq)
+    eq.width = layout.width
+    eq.height = layout.height
+    return eq
   })
 
 /** Map GroupPreset.cables → Cable[]. Port-Refs werden von Index+Name


### PR DESCRIPTION
## Behebt #528 (statt es liegen zu lassen)
Der „Display-Bug beim ersten Kabel" während des Rack-Verkabelns — Darstellung springt beim **ersten** Kabel kurz, ab dem zweiten nicht mehr.

## Root Cause (jetzt konkret, nicht spekulativ)
`buildScratchEquipment` (in `RackInternalCanvas`) legte die Node-Größe mit einer **groben Schätzung** an: `width = NODE_WIDTH = 280`, `height = 48 + rows·22 + 8`. `EquipmentNode` rendert seine Maße aber über **`computeEquipmentLayout`**, und das snapped die Breite aufs 11px-Grid: **280 → 286**. Die gespeicherten 280 wichen also um **6px** vom gemessenen Wert ab — über der **2px-Schwelle** in `onNodesChange`. Folge: beim **ersten** ReactFlow-Measure wurde `eq.width` auf 286 korrigiert → die Output-Handles (rechte Kante) verschoben sich einen Frame → die in-progress-Connection-Line des ersten Kabels „sprang". Ab dem zweiten Kabel war der Wert stabil. (Höhe war nur 1px daneben → unter Schwelle → nie das Problem.)

## Fix
`buildScratchEquipment` berechnet `width`/`height` jetzt über **dieselbe `computeEquipmentLayout`-Funktion**, aus der auch `EquipmentNode` rendert → `estimate == measured` → Diff 0 → kein Sprung. Das ist exakt die Invariante, auf die sich `CanvasArea.routeOne` (A\*-Handle-Platzierung) ohnehin verlässt — die Schätzung war die einzige Stelle, die sie verletzte.

## Verifikation (mit der **echten** Funktion, nicht Replik)
Per esbuild-Bundle die produktive `computeEquipmentLayout` in node ausgeführt:

| Port-Rows | echte Funktion | alte Schätzung | Δw | Δh |
|---|---|---|---|---|
| 1 | 286×77 | 280×78 | **6** | 1 |
| 2 | 286×99 | 280×100 | **6** | 1 |
| 4 | 286×143 | 280×144 | **6** | 1 |

Δw=6px lag immer über der 2px-Schwelle → Sprung bewiesen; nach dem Fix Δ0. Headless-Boot: react-flow mountet, **0 Console-Errors**. tsc 0 · eslint 0 · build 0.

Closes #528

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_