### PR TITLE
feat(theme): cp-Token-Set erweitern + Settings-Panel komplett migrieren (#449)

### DIFF
--- a/src/renderer/components/Settings/EquipmentColorsSection.tsx
+++ b/src/renderer/components/Settings/EquipmentColorsSection.tsx
@@ -32,9 +32,9 @@ export const EquipmentColorsSection = () => {
     >
       <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
         {(['light', 'dark'] as const).map((theme) => (
-          <div key={theme} className="rounded border border-slate-700 bg-slate-950/40 p-2">
+          <div key={theme} className="rounded border border-cp-border bg-cp-surface-3/40 p-2">
             <div className="mb-2 flex items-center justify-between">
-              <h4 className="flex items-center gap-1 text-cp-xs font-semibold text-slate-200">
+              <h4 className="flex items-center gap-1 text-cp-xs font-semibold text-cp-text-bright">
                 <Icon icon={theme === 'light' ? Sun : Moon} size="xs" />
                 {theme === 'light'
                   ? t('settings.eqColors.themeLight', 'Hell')
@@ -43,7 +43,7 @@ export const EquipmentColorsSection = () => {
               <button
                 type="button"
                 onClick={() => resetEquipmentColors(theme)}
-                className="rounded bg-slate-700 px-2 py-0.5 text-[10px] hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-2 py-0.5 text-[10px] hover:bg-cp-surface-5"
                 title={t('settings.eqColors.resetTitle', 'Auf Default zurücksetzen')}
               >
                 {t('settings.eqColors.reset', '↺ Reset')}
@@ -52,16 +52,16 @@ export const EquipmentColorsSection = () => {
             <div className="space-y-1.5">
               {roles.map((r) => (
                 <label key={r.key} className="flex items-center justify-between gap-2 text-cp-xs">
-                  <span className="text-slate-300" title={r.hint}>{r.label}</span>
+                  <span className="text-cp-text-secondary" title={r.hint}>{r.label}</span>
                   <div className="flex items-center gap-1">
                     <input
                       type="color"
                       value={equipmentColors[theme][r.key]}
                       onChange={(e) => setEquipmentColors(theme, { [r.key]: e.target.value })}
-                      className="h-6 w-10 cursor-pointer rounded border border-slate-700 bg-slate-900 p-0.5"
+                      className="h-6 w-10 cursor-pointer rounded border border-cp-border bg-cp-surface-1 p-0.5"
                       title={r.hint}
                     />
-                    <span className="font-mono text-[10px] text-slate-400">
+                    <span className="font-mono text-[10px] text-cp-text-muted">
                       {equipmentColors[theme][r.key]}
                     </span>
                   </div>
@@ -71,19 +71,19 @@ export const EquipmentColorsSection = () => {
           </div>
         ))}
       </div>
-      <div className="mt-2 text-[10px] text-slate-400">
+      <div className="mt-2 text-[10px] text-cp-text-muted">
         {t(
           'settings.eqColors.note',
           'Hinweis: Geräte mit eigener Farbe (Properties → Gerätefarbe) überschreiben den Body-Wert weiterhin individuell.',
         )}
       </div>
       {/* v7.9.63 / #172 — Default-Farbe für NEU hinzugefügte Geräte. */}
-      <div className="mt-3 flex items-center justify-between gap-2 rounded border border-slate-700 bg-slate-950/40 p-2">
+      <div className="mt-3 flex items-center justify-between gap-2 rounded border border-cp-border bg-cp-surface-3/40 p-2">
         <div>
-          <div className="text-cp-xs font-semibold text-slate-200">
+          <div className="text-cp-xs font-semibold text-cp-text-bright">
             {t('settings.eqColors.defaultDeviceColor', 'Standard-Gerätefarbe')}
           </div>
-          <div className="text-[10px] text-slate-400">
+          <div className="text-[10px] text-cp-text-muted">
             {t(
               'settings.eqColors.defaultDeviceColorHint',
               'Neu hinzugefügte Geräte starten mit dieser Farbe (Properties → Gerätefarbe lässt sich danach individuell ändern). Wenn leer: nutzt die Theme-Body-Farbe.',
@@ -95,13 +95,13 @@ export const EquipmentColorsSection = () => {
             type="color"
             value={defaultDeviceColor ?? '#475569'}
             onChange={(e) => setDefaultDeviceColor(e.target.value)}
-            className="h-7 w-12 cursor-pointer rounded border border-slate-700 bg-slate-900 p-0.5"
+            className="h-7 w-12 cursor-pointer rounded border border-cp-border bg-cp-surface-1 p-0.5"
           />
           {defaultDeviceColor && (
             <button
               type="button"
               onClick={() => setDefaultDeviceColor(undefined)}
-              className="rounded bg-slate-700 px-2 py-0.5 text-[10px] hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-2 py-0.5 text-[10px] hover:bg-cp-surface-5"
             >
               {t('settings.eqColors.resetX', '✕ Reset')}
             </button>

--- a/src/renderer/components/Settings/SettingsBody.tsx
+++ b/src/renderer/components/Settings/SettingsBody.tsx
@@ -88,7 +88,7 @@ export const SettingsBody = ({ onClose, initialSection, headerProps, titleId, he
       type="button"
       onClick={() => setSection(id)}
       className={`flex w-full items-center gap-2 rounded px-3 py-2 text-left text-cp-base ${
-        section === id ? 'bg-sky-700 text-white' : 'text-slate-300 hover:bg-slate-800'
+        section === id ? 'bg-sky-700 text-white' : 'text-cp-text-secondary hover:bg-cp-surface-2'
       }`}
     >
       <Icon icon={TAB_ICONS[id]} size="sm" />
@@ -98,8 +98,8 @@ export const SettingsBody = ({ onClose, initialSection, headerProps, titleId, he
 
   return (
     <>
-      <aside className="flex shrink-0 flex-row gap-1 overflow-x-auto border-b border-slate-800 bg-slate-950/40 p-3 sm:w-52 sm:flex-col sm:overflow-x-visible sm:overflow-y-auto sm:border-b-0 sm:border-r">
-        <h3 className="mb-2 hidden px-2 text-cp-xs font-semibold uppercase tracking-wider text-slate-500 sm:block">
+      <aside className="flex shrink-0 flex-row gap-1 overflow-x-auto border-b border-cp-border-muted bg-cp-surface-3/40 p-3 sm:w-52 sm:flex-col sm:overflow-x-visible sm:overflow-y-auto sm:border-b-0 sm:border-r">
+        <h3 className="mb-2 hidden px-2 text-cp-xs font-semibold uppercase tracking-wider text-cp-text-faint sm:block">
           {t('settings.section', 'Einstellungen')}
         </h3>
         {(Object.keys(TAB_ICONS) as SettingsSection[]).map((id) => navItem(id))}
@@ -108,7 +108,7 @@ export const SettingsBody = ({ onClose, initialSection, headerProps, titleId, he
       <main className="flex min-w-0 min-h-0 flex-1 flex-col">
         <header
           {...headerProps}
-          className="flex shrink-0 items-center justify-between border-b border-slate-800 px-4 py-2 select-none"
+          className="flex shrink-0 items-center justify-between border-b border-cp-border-muted px-4 py-2 select-none"
         >
           <h2 id={titleId} className="text-cp-xl font-semibold">
             {t(`settings.tabTitle.${section}`, TAB_FALLBACK_TITLE[section])}

--- a/src/renderer/components/Settings/SettingsCard.tsx
+++ b/src/renderer/components/Settings/SettingsCard.tsx
@@ -13,7 +13,7 @@ export const SettingsCard = ({
   description?: string
   children: ReactNode
 }) => (
-  <div className="rounded border border-[var(--cp-border-muted)] bg-slate-950/40 p-3">
+  <div className="rounded border border-[var(--cp-border-muted)] bg-cp-surface-3/40 p-3">
     <div className="mb-2 text-cp-xs font-semibold text-[var(--cp-text-secondary)]">{title}</div>
     {description && <p className="mb-2 text-cp-xs text-[var(--cp-text-faint)]">{description}</p>}
     {children}

--- a/src/renderer/components/Settings/SettingsDialog.tsx
+++ b/src/renderer/components/Settings/SettingsDialog.tsx
@@ -31,7 +31,7 @@ export const SettingsDialog = ({ open, onClose, initialSection }: SettingsDialog
         style={drag.containerStyle}
         // v7.9.2 — Fix-große Höhe statt max-h, damit der Viewport nicht
         // pro Tab variabel groß ist. Inner-Scroll greift immer.
-        className="flex h-[85vh] min-h-0 w-full max-w-4xl flex-col overflow-hidden rounded border border-slate-700 bg-slate-900 text-slate-100 shadow-2xl outline-none sm:flex-row"
+        className="flex h-[85vh] min-h-0 w-full max-w-4xl flex-col overflow-hidden rounded border border-cp-border bg-cp-surface-1 text-cp-text shadow-2xl outline-none sm:flex-row"
       >
         <SettingsBody
           onClose={onClose}

--- a/src/renderer/components/Settings/tabs/AdvancedTab.tsx
+++ b/src/renderer/components/Settings/tabs/AdvancedTab.tsx
@@ -136,7 +136,7 @@ export const AdvancedTab = () => {
           'Wie oft das aktuelle Projekt automatisch in localStorage gespeichert wird. Standard: 400 ms.',
         )}
       >
-        <label className="block text-cp-base text-slate-300">
+        <label className="block text-cp-base text-cp-text-secondary">
           {t('settings.advanced.autosaveInterval', 'Autosave-Intervall (ms)')}
           <input
             type="number"
@@ -145,7 +145,7 @@ export const AdvancedTab = () => {
             step={100}
             value={autosaveIntervalMs}
             onChange={(e) => setAutosaveIntervalMs(Number(e.target.value) || 400)}
-            className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+            className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
           />
         </label>
       </SettingsCard>
@@ -157,9 +157,9 @@ export const AdvancedTab = () => {
           'Bibliothek-Kategorien umbenennen oder neue anlegen. Beim Umbenennen wandern alle zugeordneten Vorlagen mit.',
         )}
       >
-        <div className="max-h-56 overflow-auto rounded border border-slate-800 bg-slate-950/50">
+        <div className="max-h-56 overflow-auto rounded border border-cp-border-muted bg-cp-surface-3/50">
           <table className="w-full text-cp-xs">
-            <thead className="sticky top-0 bg-slate-900 text-slate-400">
+            <thead className="sticky top-0 bg-cp-surface-1 text-cp-text-muted">
               <tr>
                 <th className="px-2 py-1 text-left">
                   {t('settings.advanced.categories.col.name', 'Kategorie')}
@@ -175,19 +175,19 @@ export const AdvancedTab = () => {
                 const display = categoryDisplay(cat, lang, categoryTranslations)
                 const showCanonical = display !== cat
                 return (
-                  <tr key={cat} className="border-t border-slate-800">
-                    <td className="px-2 py-1 text-slate-100">
+                  <tr key={cat} className="border-t border-cp-border-muted">
+                    <td className="px-2 py-1 text-cp-text">
                       {display}
                       {showCanonical && (
-                        <span className="ml-1 text-[10px] text-slate-400">({cat})</span>
+                        <span className="ml-1 text-[10px] text-cp-text-muted">({cat})</span>
                       )}
                     </td>
-                    <td className="px-2 py-1 text-right text-slate-400">{usageCount(cat)}</td>
+                    <td className="px-2 py-1 text-right text-cp-text-muted">{usageCount(cat)}</td>
                     <td className="px-2 py-1 text-right">
                       <button
                         type="button"
                         onClick={() => handleRename(cat)}
-                        className="rounded bg-slate-700 px-2 py-0.5 text-[10px] hover:bg-slate-600"
+                        className="rounded bg-cp-surface-4 px-2 py-0.5 text-[10px] hover:bg-cp-surface-5"
                       >
                         {t('common.rename', 'Umbenennen')}
                       </button>
@@ -197,7 +197,7 @@ export const AdvancedTab = () => {
               })}
               {allCategories.length === 0 && (
                 <tr>
-                  <td colSpan={3} className="px-2 py-3 text-center text-slate-500">
+                  <td colSpan={3} className="px-2 py-3 text-center text-cp-text-faint">
                     {t('settings.advanced.categories.empty', 'Noch keine Kategorien.')}
                   </td>
                 </tr>
@@ -227,7 +227,7 @@ export const AdvancedTab = () => {
             onClick={() =>
               clearCache('cable-planner:rentmanTemplateCache:v1', 'Rentman-Template-Cache')
             }
-            className="rounded bg-slate-700 px-3 py-1 text-cp-xs text-left hover:bg-slate-600"
+            className="rounded bg-cp-surface-4 px-3 py-1 text-cp-xs text-left hover:bg-cp-surface-5"
           >
             {t('settings.advanced.caches.rentman', 'Rentman-Template-Cache leeren')}
           </button>
@@ -235,14 +235,14 @@ export const AdvancedTab = () => {
           <button
             type="button"
             onClick={() => clearCache('cable-planner:web:recents', 'Web-Suchverlauf')}
-            className="rounded bg-slate-700 px-3 py-1 text-cp-xs text-left hover:bg-slate-600"
+            className="rounded bg-cp-surface-4 px-3 py-1 text-cp-xs text-left hover:bg-cp-surface-5"
           >
             {t('settings.advanced.caches.web', 'Web-Suchverlauf leeren')}
           </button>
           <button
             type="button"
             onClick={resetWelcome}
-            className="rounded bg-slate-700 px-3 py-1 text-cp-xs text-left hover:bg-slate-600"
+            className="rounded bg-cp-surface-4 px-3 py-1 text-cp-xs text-left hover:bg-cp-surface-5"
           >
             {t('settings.advanced.caches.welcome', 'Willkommens-Dialog beim nächsten Start zeigen')}
           </button>

--- a/src/renderer/components/Settings/tabs/AppearanceTab.tsx
+++ b/src/renderer/components/Settings/tabs/AppearanceTab.tsx
@@ -42,7 +42,7 @@ const CustomPaletteCard = () => {
         'Eigene Farben für Canvas-Hintergrund, Raster und Akzent — überschreibt die Theme-Defaults (dark/light). Wirkt nur auf den Canvas; Dialoge bleiben themed.',
       )}
     >
-      <label className="mb-2 flex items-center gap-2 text-cp-base text-slate-200">
+      <label className="mb-2 flex items-center gap-2 text-cp-base text-cp-text-bright">
         <input
           type="checkbox"
           checked={enabled}
@@ -60,16 +60,16 @@ const CustomPaletteCard = () => {
             ] as const
           ).map((field) => (
             <label key={field.key} className="block">
-              <span className="mb-1 block text-slate-400">{field.label}</span>
+              <span className="mb-1 block text-cp-text-muted">{field.label}</span>
               <input
                 type="color"
                 value={current[field.key]}
                 onChange={(e) =>
                   setPalette({ ...current, [field.key]: e.target.value })
                 }
-                className="h-10 w-full cursor-pointer rounded border border-slate-700 bg-slate-900 p-1"
+                className="h-10 w-full cursor-pointer rounded border border-cp-border bg-cp-surface-1 p-1"
               />
-              <code className="mt-1 block text-[10px] text-slate-400">
+              <code className="mt-1 block text-[10px] text-cp-text-muted">
                 {current[field.key]}
               </code>
             </label>
@@ -170,14 +170,14 @@ export const AppearanceTab = () => {
               className={`flex-1 rounded px-3 py-1 text-cp-xs ${
                 language === opt.value
                   ? 'bg-sky-700 text-white'
-                  : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+                  : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
               }`}
             >
               {opt.flag} {opt.label}
             </button>
           ))}
         </div>
-        <p className="mt-2 text-[10px] text-slate-400">
+        <p className="mt-2 text-[10px] text-cp-text-muted">
           {t(
             'settings.appearance.coverage',
             'Aktuell übersetzt: Einstellungen, Top-Level-Menüs und gemeinsame Buttons. Properties-Panels, Bibliothek, Rentman, ATEM und Export-Dialoge bleiben einstweilen deutsch.',
@@ -201,7 +201,7 @@ export const AppearanceTab = () => {
               className={`inline-flex flex-1 items-center justify-center gap-1.5 rounded px-3 py-1 text-cp-xs ${
                 canvasTheme === mode
                   ? 'bg-sky-700 text-white'
-                  : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+                  : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
               }`}
             >
               {mode === 'dark' ? (
@@ -238,14 +238,14 @@ export const AppearanceTab = () => {
             onChange={(e) => setPortLabelFontSize(parseInt(e.target.value, 10))}
             className="flex-1"
           />
-          <span className="w-10 text-right font-mono text-cp-xs text-slate-300">
+          <span className="w-10 text-right font-mono text-cp-xs text-cp-text-secondary">
             {portLabelFontSize}px
           </span>
           <button
             type="button"
             onClick={() => setPortLabelFontSize(11)}
             disabled={portLabelFontSize === 11}
-            className="rounded bg-slate-800 px-2 py-0.5 text-[11px] text-slate-300 hover:bg-slate-700 disabled:opacity-50"
+            className="rounded bg-cp-surface-2 px-2 py-0.5 text-[11px] text-cp-text-secondary hover:bg-cp-surface-4 disabled:opacity-50"
             title={t('settings.fontSize.reset', 'Auf Default 11 px zurücksetzen')}
           >
             ↺
@@ -267,7 +267,7 @@ export const AppearanceTab = () => {
             className={`flex-1 rounded px-3 py-1 text-cp-xs ${
               !colorPortsByType
                 ? 'bg-sky-700 text-white'
-                : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+                : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
             }`}
             title={t(
               'settings.appearance.ports.byDirectionTitle',
@@ -282,7 +282,7 @@ export const AppearanceTab = () => {
             className={`flex-1 rounded px-3 py-1 text-cp-xs ${
               colorPortsByType
                 ? 'bg-sky-700 text-white'
-                : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+                : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
             }`}
             title={t(
               'settings.appearance.ports.byTypeTitle',
@@ -308,7 +308,7 @@ export const AppearanceTab = () => {
             className={`flex-1 rounded px-3 py-1 text-cp-xs ${
               cableColorMode === 'manual'
                 ? 'bg-sky-700 text-white'
-                : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+                : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
             }`}
           >
             {t('settings.appearance.cableColor.manual', 'Manuell')}
@@ -319,7 +319,7 @@ export const AppearanceTab = () => {
             className={`flex-1 rounded px-3 py-1 text-cp-xs ${
               cableColorMode === 'byLength'
                 ? 'bg-sky-700 text-white'
-                : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+                : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
             }`}
           >
             {t('settings.appearance.cableColor.byLength', 'Nach Länge')}
@@ -334,7 +334,7 @@ export const AppearanceTab = () => {
           'Standard für neu gezeichnete Kabel. Per Kabel im Properties-Panel überschreibbar.',
         )}
       >
-        <label className="flex items-center gap-2 text-cp-base text-slate-200">
+        <label className="flex items-center gap-2 text-cp-base text-cp-text-bright">
           <input
             type="checkbox"
             checked={defaultArrow}
@@ -354,7 +354,7 @@ export const AppearanceTab = () => {
           'Steckertyp-Konflikt erzeugt normalerweise eine Bestätigungs-Abfrage. Mit Override wird die Verbindung trotzdem ohne Rückfrage angelegt (als Adapter/Konverter markiert).',
         )}
       >
-        <label className="flex items-center gap-2 text-cp-base text-slate-200">
+        <label className="flex items-center gap-2 text-cp-base text-cp-text-bright">
           <input
             type="checkbox"
             checked={overrideConnectionWarnings}
@@ -374,13 +374,13 @@ export const AppearanceTab = () => {
           'Muster + Deckkraft des Canvas-Rasters. Bei großen Plänen reduziert eine niedrige Deckkraft die visuelle Unruhe. Rastergröße kommt aus dem Canvas-Toolbar oben.',
         )}
       >
-        <div className="flex flex-wrap items-center gap-3 text-cp-base text-slate-200">
+        <div className="flex flex-wrap items-center gap-3 text-cp-base text-cp-text-bright">
           <label className="flex items-center gap-2">
-            <span className="text-cp-xs text-slate-400">{t('settings.canvasBg.variant', 'Muster')}</span>
+            <span className="text-cp-xs text-cp-text-muted">{t('settings.canvasBg.variant', 'Muster')}</span>
             <select
               value={bgVariant}
               onChange={(e) => setBgVariant(e.target.value as 'dots' | 'lines' | 'cross' | 'none')}
-              className="rounded border border-slate-700 bg-slate-900 p-1 text-cp-xs"
+              className="rounded border border-cp-border bg-cp-surface-1 p-1 text-cp-xs"
             >
               <option value="dots">{t('settings.canvasBg.variant.dots', 'Punkte')}</option>
               <option value="lines">{t('settings.canvasBg.variant.lines', 'Linien')}</option>
@@ -389,7 +389,7 @@ export const AppearanceTab = () => {
             </select>
           </label>
           <label className="flex items-center gap-2">
-            <span className="text-cp-xs text-slate-400">{t('settings.canvasBg.opacity', 'Deckkraft')}</span>
+            <span className="text-cp-xs text-cp-text-muted">{t('settings.canvasBg.opacity', 'Deckkraft')}</span>
             <input
               type="range"
               min={0}
@@ -400,17 +400,17 @@ export const AppearanceTab = () => {
               className="w-32"
               disabled={bgVariant === 'none'}
             />
-            <span className="w-10 text-right text-cp-xs text-slate-400">
+            <span className="w-10 text-right text-cp-xs text-cp-text-muted">
               {Math.round(bgOpacity * 100)}%
             </span>
           </label>
         </div>
         {/* v7.7.1 — Custom canvas background image upload (Issue #71). */}
-        <div className="mt-4 border-t border-slate-800 pt-3">
-          <div className="mb-2 text-cp-xs font-semibold uppercase tracking-wide text-slate-400">
+        <div className="mt-4 border-t border-cp-border-muted pt-3">
+          <div className="mb-2 text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">
             {t('settings.canvasBg.imageTitle', 'Eigenes Hintergrundbild')}
           </div>
-          <div className="mb-2 text-[11px] text-slate-400">
+          <div className="mb-2 text-[11px] text-cp-text-muted">
             {t(
               'settings.canvasBg.imageDesc',
               'Lade ein eigenes Bild als Canvas-Hintergrund — getrennt für Dark- und Light-Mode. Das Rastermuster (Punkte/Linien/Kreuze) wird darüber gezeichnet.',
@@ -421,14 +421,14 @@ export const AppearanceTab = () => {
               ['dark', t('settings.canvasBg.darkImage', 'Dark-Mode-Bild'), canvasBgImageDark] as const,
               ['light', t('settings.canvasBg.lightImage', 'Light-Mode-Bild'), canvasBgImageLight] as const,
             ]).map(([theme, label, current]) => (
-              <div key={theme} className="rounded border border-slate-800 bg-slate-950/40 p-2">
-                <div className="mb-1 text-[11px] font-semibold text-slate-300">{label}</div>
+              <div key={theme} className="rounded border border-cp-border-muted bg-cp-surface-3/40 p-2">
+                <div className="mb-1 text-[11px] font-semibold text-cp-text-secondary">{label}</div>
                 {current ? (
                   <>
                     <img
                       src={current}
                       alt={`${theme} background`}
-                      className="mb-2 h-20 w-full rounded border border-slate-700 object-cover"
+                      className="mb-2 h-20 w-full rounded border border-cp-border object-cover"
                     />
                     <div className="flex gap-1">
                       <button
@@ -437,7 +437,7 @@ export const AppearanceTab = () => {
                           const dataUri = await pickImageAsDataUri()
                           if (dataUri) setCanvasBgImage(theme, dataUri)
                         }}
-                        className="flex-1 rounded bg-slate-700 px-2 py-1 text-[11px] hover:bg-slate-600"
+                        className="flex-1 rounded bg-cp-surface-4 px-2 py-1 text-[11px] hover:bg-cp-surface-5"
                       >
                         {t('settings.canvasBg.replace', 'Ersetzen…')}
                       </button>
@@ -459,7 +459,7 @@ export const AppearanceTab = () => {
                       const dataUri = await pickImageAsDataUri()
                       if (dataUri) setCanvasBgImage(theme, dataUri)
                     }}
-                    className="w-full rounded border border-dashed border-slate-700 bg-slate-900 px-2 py-4 text-[11px] text-slate-400 hover:border-slate-600 hover:text-slate-200"
+                    className="w-full rounded border border-dashed border-cp-border bg-cp-surface-1 px-2 py-4 text-[11px] text-cp-text-muted hover:border-cp-surface-5 hover:text-cp-text-bright"
                   >
                     {t('settings.canvasBg.upload', '+ Bild hochladen…')}
                   </button>
@@ -467,12 +467,12 @@ export const AppearanceTab = () => {
               </div>
             ))}
           </div>
-          <label className="mt-3 flex items-center gap-2 text-cp-xs text-slate-300">
-            <span className="text-slate-400">{t('settings.canvasBg.fit', 'Skalierung')}</span>
+          <label className="mt-3 flex items-center gap-2 text-cp-xs text-cp-text-secondary">
+            <span className="text-cp-text-muted">{t('settings.canvasBg.fit', 'Skalierung')}</span>
             <select
               value={canvasBgImageFit}
               onChange={(e) => setCanvasBgImageFit(e.target.value as 'cover' | 'contain' | 'tile')}
-              className="rounded border border-slate-700 bg-slate-900 p-1 text-cp-xs"
+              className="rounded border border-cp-border bg-cp-surface-1 p-1 text-cp-xs"
             >
               <option value="cover">{t('settings.canvasBg.fit.cover', 'Cover (füllt komplett, beschneidet)')}</option>
               <option value="contain">{t('settings.canvasBg.fit.contain', 'Contain (vollständig sichtbar, mit Rand)')}</option>
@@ -498,24 +498,24 @@ export const AppearanceTab = () => {
             return (
               <label
                 key={name}
-                className="flex items-center gap-2 text-slate-200"
+                className="flex items-center gap-2 text-cp-text-bright"
                 title={`Default: ${defaultColor}${isCustom ? ' (custom)' : ''}`}
               >
                 <input
                   type="color"
                   value={effective}
                   onChange={(e) => setConnectorTypeColor(name, e.target.value)}
-                  className="h-6 w-8 cursor-pointer rounded border border-slate-700 bg-slate-900 p-0.5"
+                  className="h-6 w-8 cursor-pointer rounded border border-cp-border bg-cp-surface-1 p-0.5"
                 />
                 <span className="flex-1 truncate text-cp-xs">
                   {name}
-                  {isCustom && <span className="ml-1 text-[11px] text-slate-400">(custom)</span>}
+                  {isCustom && <span className="ml-1 text-[11px] text-cp-text-muted">(custom)</span>}
                 </span>
                 {override && (
                   <button
                     type="button"
                     onClick={() => setConnectorTypeColor(name, null)}
-                    className="rounded bg-slate-700 px-1 py-0.5 text-[10px] text-slate-300 hover:bg-slate-600"
+                    className="rounded bg-cp-surface-4 px-1 py-0.5 text-[10px] text-cp-text-secondary hover:bg-cp-surface-5"
                     title={t('settings.colors.resetDefault', 'Auf Default zurücksetzen')}
                   >
                     ↺
@@ -529,7 +529,7 @@ export const AppearanceTab = () => {
           <button
             type="button"
             onClick={() => resetConnectorTypeColors()}
-            className="rounded bg-slate-800 px-2 py-1 text-cp-xs text-slate-300 hover:bg-slate-700"
+            className="rounded bg-cp-surface-2 px-2 py-1 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-4"
           >
             {t('settings.connectorColors.resetAll', 'Alle zurücksetzen')}
           </button>
@@ -544,7 +544,7 @@ export const AppearanceTab = () => {
         )}
       >
         {allKnownCategories.length === 0 ? (
-          <div className="text-[11px] text-slate-400">
+          <div className="text-[11px] text-cp-text-muted">
             Noch keine Kategorien bekannt. Wird gefuellt sobald Geraete im Plan oder in der Library Kategorien haben.
           </div>
         ) : (
@@ -553,19 +553,19 @@ export const AppearanceTab = () => {
               const override = categoryColors[cat] ?? ''
               const effective = override || '#94a3b8'
               return (
-                <label key={cat} className="flex items-center gap-2 text-slate-200">
+                <label key={cat} className="flex items-center gap-2 text-cp-text-bright">
                   <input
                     type="color"
                     value={effective}
                     onChange={(e) => setCategoryColor(cat, e.target.value)}
-                    className="h-6 w-8 cursor-pointer rounded border border-slate-700 bg-slate-900 p-0.5"
+                    className="h-6 w-8 cursor-pointer rounded border border-cp-border bg-cp-surface-1 p-0.5"
                   />
                   <span className="flex-1 truncate text-cp-xs" title={cat}>{cat}</span>
                   {override && (
                     <button
                       type="button"
                       onClick={() => setCategoryColor(cat, null)}
-                      className="rounded bg-slate-700 px-1 py-0.5 text-[10px] text-slate-300 hover:bg-slate-600"
+                      className="rounded bg-cp-surface-4 px-1 py-0.5 text-[10px] text-cp-text-secondary hover:bg-cp-surface-5"
                       title={t('settings.colors.resetDefault', 'Auf Default zurücksetzen')}
                     >
                       ↺
@@ -581,7 +581,7 @@ export const AppearanceTab = () => {
             <button
               type="button"
               onClick={() => resetCategoryColors()}
-              className="rounded bg-slate-800 px-2 py-1 text-cp-xs text-slate-300 hover:bg-slate-700"
+              className="rounded bg-cp-surface-2 px-2 py-1 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-4"
             >
               {t('settings.categoryColors.resetAll', 'Alle zuruecksetzen')}
             </button>

--- a/src/renderer/components/Settings/tabs/ConfigsTab.tsx
+++ b/src/renderer/components/Settings/tabs/ConfigsTab.tsx
@@ -149,7 +149,7 @@ export const ConfigsTab = () => {
 
   return (
     <div className="space-y-3">
-      <p className="text-cp-xs text-slate-400">
+      <p className="text-cp-xs text-cp-text-muted">
         {t(
           'settings.configs.intro',
           'Globale Bibliothek von Geräte-Konfigurationen (ATEM, Videohub, GreenGo). Lade Dateien hier hoch, lade sie als Datei wieder herunter, oder weise einer canvas-Gerät die passende Config zu (im Properties-Panel des Geräts).',
@@ -212,7 +212,7 @@ export const ConfigsTab = () => {
                 className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-[11px] ${
                   filter === k
                     ? 'bg-sky-700 text-white'
-                    : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+                    : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
                 }`}
               >
                 {k === 'all' ? (
@@ -230,21 +230,21 @@ export const ConfigsTab = () => {
         </div>
 
         {library.length === 0 ? (
-          <div className="rounded border border-dashed border-slate-700 p-4 text-center text-[11px] text-slate-400">
+          <div className="rounded border border-dashed border-cp-border p-4 text-center text-[11px] text-cp-text-muted">
             {t(
               'settings.configs.emptyHint',
               'Lade die erste Konfigurationsdatei hoch — sie wird hier gelistet und kann anschließend einem Gerät auf dem Canvas zugeordnet werden.',
             )}
           </div>
         ) : grouped.size === 0 ? (
-          <div className="rounded border border-dashed border-slate-700 p-4 text-center text-[11px] text-slate-400">
+          <div className="rounded border border-dashed border-cp-border p-4 text-center text-[11px] text-cp-text-muted">
             {t('settings.configs.noFilterMatch', 'Kein Eintrag passt zum gewählten Filter.')}
           </div>
         ) : (
           <ul className="space-y-2">
             {Array.from(grouped.entries()).map(([kind, entries]) => (
               <li key={kind}>
-                <div className="mb-1 flex items-center gap-1 text-[10px] uppercase tracking-wide text-slate-400">
+                <div className="mb-1 flex items-center gap-1 text-[10px] uppercase tracking-wide text-cp-text-muted">
                   <Icon icon={CONFIG_KIND_ICON[kind]} size="xs" />
                   {t(`settings.configs.kind.${kind}`, CONFIG_KIND_LABEL[kind])}
                 </div>
@@ -256,13 +256,13 @@ export const ConfigsTab = () => {
                     return (
                       <li
                         key={entry.id}
-                        className="flex flex-wrap items-center gap-2 rounded border border-slate-800 bg-slate-950 px-2 py-1.5 text-cp-xs"
+                        className="flex flex-wrap items-center gap-2 rounded border border-cp-border-muted bg-cp-surface-3 px-2 py-1.5 text-cp-xs"
                       >
                         <input
                           type="text"
                           value={entry.name}
                           onChange={(e) => updateDeviceConfig(entry.id, { name: e.target.value })}
-                          className="min-w-0 flex-1 rounded border border-slate-700 bg-slate-950 px-1.5 py-0.5 text-slate-100"
+                          className="min-w-0 flex-1 rounded border border-cp-border bg-cp-surface-3 px-1.5 py-0.5 text-cp-text"
                         />
                         <select
                           value={entry.kind}
@@ -271,7 +271,7 @@ export const ConfigsTab = () => {
                               kind: e.target.value as DeviceConfigKind,
                             })
                           }
-                          className="rounded border border-slate-700 bg-slate-900 px-1 py-0.5 text-[11px] text-slate-200"
+                          className="rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-[11px] text-cp-text-bright"
                         >
                           {(Object.keys(CONFIG_KIND_LABEL) as DeviceConfigKind[]).map((k) => (
                             <option key={k} value={k}>
@@ -286,7 +286,7 @@ export const ConfigsTab = () => {
                               equipmentId: e.target.value || undefined,
                             })
                           }
-                          className="rounded border border-slate-700 bg-slate-900 px-1 py-0.5 text-[11px] text-slate-200"
+                          className="rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-[11px] text-cp-text-bright"
                           title={t(
                             'settings.configs.assignTitle',
                             'Gerät auf dem Canvas, dem diese Konfiguration zugeordnet ist',
@@ -300,7 +300,7 @@ export const ConfigsTab = () => {
                           ))}
                         </select>
                         <span
-                          className="hidden text-[10px] text-slate-400 sm:inline"
+                          className="hidden text-[10px] text-cp-text-muted sm:inline"
                           title={format(
                             t(
                               'settings.configs.fileMeta',
@@ -319,7 +319,7 @@ export const ConfigsTab = () => {
                           <button
                             type="button"
                             onClick={() => downloadConfig(entry)}
-                            className="rounded bg-slate-700 px-2 py-0.5 text-[11px] text-slate-100 hover:bg-slate-600"
+                            className="rounded bg-cp-surface-4 px-2 py-0.5 text-[11px] text-cp-text hover:bg-cp-surface-5"
                             title={t('settings.configs.downloadTitle', 'Originaldatei herunterladen')}
                           >
                             <Icon icon={Download} size="xs" />
@@ -345,7 +345,7 @@ export const ConfigsTab = () => {
                                 removeDeviceConfig(entry.id)
                               }
                             }}
-                            className="rounded bg-slate-800 px-2 py-0.5 text-[11px] text-slate-300 hover:bg-red-700 hover:text-white"
+                            className="rounded bg-cp-surface-2 px-2 py-0.5 text-[11px] text-cp-text-secondary hover:bg-red-700 hover:text-white"
                             title={t('settings.configs.removeTitle', 'Aus Bibliothek entfernen')}
                           >
                             <Icon icon={X} size="sm" />

--- a/src/renderer/components/Settings/tabs/EditingTab.tsx
+++ b/src/renderer/components/Settings/tabs/EditingTab.tsx
@@ -27,7 +27,7 @@ const CableEndpointLabelsCard = () => {
         'Zeigt an jedem Kabelende ein kleines Label das anzeigt, wohin das andere Ende geht — am Source-Ende "→ Ziel-Geraet · Ziel-Port", am Target-Ende "← Quell-Geraet · Quell-Port". Hilft beim Verfolgen von Kabeln ohne ihnen visuell folgen zu muessen.',
       )}
     >
-      <label className="flex items-center gap-2 text-cp-base text-slate-200">
+      <label className="flex items-center gap-2 text-cp-base text-cp-text-bright">
         <input
           type="checkbox"
           checked={showCableEndpointLabels}
@@ -35,7 +35,7 @@ const CableEndpointLabelsCard = () => {
         />
         {t('settings.editing.endpointLabelsLabel', 'Endpoint-Labels einblenden')}
       </label>
-      <p className="mt-2 text-[11px] text-slate-400">
+      <p className="mt-2 text-[11px] text-cp-text-muted">
         Default aus — gibt zusaetzlichen Visual-Noise. Wirkt
         zusammen mit dem globalen "Alle Labels ausblenden"-Toggle
         und respektiert per-Kabel labelPosition='none'.
@@ -61,7 +61,7 @@ const CableInheritTypeCard = () => {
         'Wenn ein Port-Connector geaendert wird (z.B. BNC -> XLR), uebernehmen verbundene Kabel automatisch den neuen Typ. Gilt auch beim Umstecken auf einen Port mit anderem Connector. Kabel mit Konverter-Hinweis (needsConverter) bleiben unberuehrt.',
       )}
     >
-      <label className="flex items-center gap-2 text-cp-base text-slate-200">
+      <label className="flex items-center gap-2 text-cp-base text-cp-text-bright">
         <input
           type="checkbox"
           checked={inheritCableTypeFromPort}
@@ -69,7 +69,7 @@ const CableInheritTypeCard = () => {
         />
         {t('settings.editing.cableInheritLabel', 'Kabel-Typ aus Port-Connector ableiten')}
       </label>
-      <p className="mt-2 text-[11px] text-slate-400">
+      <p className="mt-2 text-[11px] text-cp-text-muted">
         {t(
           'settings.editing.cableInheritNote',
           'Default an: meistens sollen Kabel den physischen Anschluss-Typ ihrer Ports widerspiegeln. Abschalten, wenn Kabel-Typen unabhängig von Port-Typen verwaltet werden sollen.',
@@ -95,7 +95,7 @@ const CableReconnectOptionsCard = () => {
         'Beim Umstecken eines Kabels uebernimmt der neue Port den User-Namen vom alten Port. Der alte Port faellt auf seinen Template-default zurueck. Spart Copy-Paste vom Label.',
       )}
     >
-      <label className="flex items-center gap-2 text-cp-base text-slate-200">
+      <label className="flex items-center gap-2 text-cp-base text-cp-text-bright">
         <input
           type="checkbox"
           checked={swapLabelsOnReconnect}
@@ -103,7 +103,7 @@ const CableReconnectOptionsCard = () => {
         />
         {t('settings.editing.labelSwapLabel', 'Beim Reconnect Port-Labels mit-tauschen')}
       </label>
-      <p className="mt-2 text-[11px] text-slate-400">
+      <p className="mt-2 text-[11px] text-cp-text-muted">
         {t(
           'settings.editing.labelSwapNote',
           'Aus Sicherheit per default aus — sonst würden Test-Umsteckungen ungewollt Labels umbenennen. Wirkt nur bei Ports, die einen vom User editierten Namen haben (sonst gibts nichts zu tauschen).',
@@ -131,7 +131,7 @@ const CableVisualOptionsCard = () => {
         'Visuelle Hilfen für orthogonal verlegte Kabel (yEd-ähnliche Brücken bei Kreuzungen und automatische Versetzung sich überlagernder Mittellinien).',
       )}
     >
-      <label className="mb-2 flex items-center gap-2 text-cp-base text-slate-200">
+      <label className="mb-2 flex items-center gap-2 text-cp-base text-cp-text-bright">
         <input
           type="checkbox"
           checked={cableBumps}
@@ -142,7 +142,7 @@ const CableVisualOptionsCard = () => {
           'Kreuzungs-Brücken auf orthogonalen Kabeln',
         )}
       </label>
-      <label className="flex items-center gap-2 text-cp-base text-slate-200">
+      <label className="flex items-center gap-2 text-cp-base text-cp-text-bright">
         <input
           type="checkbox"
           checked={orthogonalCollisionShift}
@@ -199,7 +199,7 @@ export const EditingTab = () => {
               if (c.routing !== defaultRouting) updateCable(c.id, { routing: defaultRouting })
             })
           }}
-          className="mt-2 w-full rounded bg-slate-800 px-2 py-1 text-[11px] text-slate-300 hover:bg-slate-700 disabled:opacity-50"
+          className="mt-2 w-full rounded bg-cp-surface-2 px-2 py-1 text-[11px] text-cp-text-secondary hover:bg-cp-surface-4 disabled:opacity-50"
         >
           {format(
             t('settings.editing.routing.applyAll', 'Auf alle bestehenden Kabel anwenden ({count})'),
@@ -212,7 +212,7 @@ export const EditingTab = () => {
         title={t('settings.editing.grid', 'Raster (Grid)')}
         description={t('settings.editing.gridDesc', 'Snap-to-Grid und Rastergröße in Pixeln.')}
       >
-        <label className="flex items-center gap-2 text-cp-base text-slate-200">
+        <label className="flex items-center gap-2 text-cp-base text-cp-text-bright">
           <input
             type="checkbox"
             checked={snapToGrid}
@@ -220,7 +220,7 @@ export const EditingTab = () => {
           />
           {t('settings.editing.snapLabel', 'Geräte am Raster einrasten')}
         </label>
-        <label className="mt-2 block text-cp-base text-slate-300">
+        <label className="mt-2 block text-cp-base text-cp-text-secondary">
           {t('settings.editing.gridSize', 'Rastergröße (Pixel)')}
           <input
             type="number"
@@ -228,7 +228,7 @@ export const EditingTab = () => {
             max={100}
             value={gridSize}
             onChange={(e) => setGridSize(Number(e.target.value) || 10)}
-            className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+            className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
           />
         </label>
       </SettingsCard>

--- a/src/renderer/components/Settings/tabs/HotkeysTab.tsx
+++ b/src/renderer/components/Settings/tabs/HotkeysTab.tsx
@@ -23,8 +23,8 @@ const HotkeyRow = ({
   const [capturing, setCapturing] = useState(false)
   const label = t(`hotkeys.action.${action}`, HOTKEY_ACTION_LABEL[action] ?? action)
   return (
-    <li className="flex items-center gap-2 rounded border border-slate-800 bg-slate-950 px-2 py-1.5 text-cp-xs">
-      <span className="flex-1 truncate text-slate-200">{label}</span>
+    <li className="flex items-center gap-2 rounded border border-cp-border-muted bg-cp-surface-3 px-2 py-1.5 text-cp-xs">
+      <span className="flex-1 truncate text-cp-text-bright">{label}</span>
       <button
         type="button"
         onClick={() => setCapturing(true)}
@@ -41,7 +41,7 @@ const HotkeyRow = ({
         className={`min-w-[120px] rounded border px-2 py-1 text-center font-mono text-[11px] ${
           capturing
             ? 'border-sky-500 bg-sky-950/60 text-sky-200'
-            : 'border-slate-700 bg-slate-900 text-slate-300 hover:border-slate-600'
+            : 'border-cp-border bg-cp-surface-1 text-cp-text-secondary hover:border-cp-surface-5'
         }`}
         title={
           capturing
@@ -54,7 +54,7 @@ const HotkeyRow = ({
       <button
         type="button"
         onClick={() => onChange('')}
-        className="rounded bg-slate-800 px-1.5 py-0.5 text-[10px] text-slate-400 hover:bg-red-700 hover:text-white"
+        className="rounded bg-cp-surface-2 px-1.5 py-0.5 text-[10px] text-cp-text-muted hover:bg-red-700 hover:text-white"
         title={t('settings.hotkeys.clear', 'Hotkey leeren')}
         aria-label={t('settings.hotkeys.clear', 'Hotkey leeren')}
       >
@@ -72,7 +72,7 @@ export const HotkeysTab = () => {
   const actions = Object.keys(HOTKEY_ACTION_LABEL)
   return (
     <div className="space-y-3">
-      <p className="text-cp-xs text-slate-400">
+      <p className="text-cp-xs text-cp-text-muted">
         {t(
           'settings.hotkeys.intro',
           'Tastenkürzel können hier frei belegt werden. Klicke auf eine Combo-Zelle und drücke die gewünschten Tasten — Ctrl/Shift/Alt + Buchstabe oder Funktionstaste.',
@@ -99,7 +99,7 @@ export const HotkeysTab = () => {
           <button
             type="button"
             onClick={resetHotkeys}
-            className="rounded bg-slate-800 px-3 py-1 text-cp-xs text-slate-300 hover:bg-slate-700"
+            className="rounded bg-cp-surface-2 px-3 py-1 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-4"
           >
             {t('settings.hotkeys.reset', 'Auf Standard zurücksetzen')}
           </button>

--- a/src/renderer/components/Settings/tabs/IntegrationsTab.tsx
+++ b/src/renderer/components/Settings/tabs/IntegrationsTab.tsx
@@ -121,7 +121,7 @@ const AiProvidersCard = () => {
                 <button
                   type="button"
                   onClick={() => setRevealed((r) => ({ ...r, [id]: !r[id] }))}
-                  className="rounded bg-cp-surface-2 px-2 py-1 text-cp-text-muted hover:bg-slate-700"
+                  className="rounded bg-cp-surface-2 px-2 py-1 text-cp-text-muted hover:bg-cp-surface-4"
                   title={revealed[id] ? t('common.hide', 'Verbergen') : t('common.show', 'Anzeigen')}
                   aria-label={revealed[id] ? t('common.hide', 'Verbergen') : t('common.show', 'Anzeigen')}
                 >

--- a/src/renderer/components/Settings/tabs/ProjectTab.tsx
+++ b/src/renderer/components/Settings/tabs/ProjectTab.tsx
@@ -128,7 +128,7 @@ const LibraryExportSection = () => {
         'Sichere deine eigenen Geräte-Templates, Gruppen und Rack-Presets als JSON-Datei. Beim Import werden bestehende Einträge mit gleichem Namen NICHT überschrieben (merge-by-name).',
       )}
     >
-      <div className="flex flex-wrap items-center gap-2 text-cp-xs text-slate-200">
+      <div className="flex flex-wrap items-center gap-2 text-cp-xs text-cp-text-bright">
         <button
           type="button"
           onClick={handleExport}
@@ -188,7 +188,7 @@ const CableNumberingSection = () => {
         'Automatische, kollisionsfreie Kabel-IDs nach festem Schema — sichtbar auf dem Canvas, in der Patchliste und auf den Etiketten.',
       )}
     >
-      <div className="space-y-2 text-cp-xs text-slate-200">
+      <div className="space-y-2 text-cp-xs text-cp-text-bright">
         <label className="flex items-center gap-2">
           <input
             type="checkbox"
@@ -199,45 +199,45 @@ const CableNumberingSection = () => {
         </label>
         <div className="grid grid-cols-2 gap-2">
           <label className="block">
-            <span className="mb-1 block text-slate-400">{t('settings.project.numbering.prefix', 'Präfix')}</span>
+            <span className="mb-1 block text-cp-text-muted">{t('settings.project.numbering.prefix', 'Präfix')}</span>
             <input
               type="text"
               value={eff.prefix}
               onChange={(e) => patch({ prefix: e.target.value })}
-              className="w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+              className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
               placeholder="C"
             />
           </label>
           <label className="block">
-            <span className="mb-1 block text-slate-400">{t('settings.project.numbering.separator', 'Trennzeichen')}</span>
+            <span className="mb-1 block text-cp-text-muted">{t('settings.project.numbering.separator', 'Trennzeichen')}</span>
             <input
               type="text"
               value={eff.separator}
               maxLength={2}
               onChange={(e) => patch({ separator: e.target.value })}
-              className="w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+              className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
               placeholder="-"
             />
           </label>
           <label className="block">
-            <span className="mb-1 block text-slate-400">{t('settings.project.numbering.padding', 'Stellen')}</span>
+            <span className="mb-1 block text-cp-text-muted">{t('settings.project.numbering.padding', 'Stellen')}</span>
             <input
               type="number"
               min={1}
               max={6}
               value={eff.padding}
               onChange={(e) => patch({ padding: Math.max(1, Math.min(6, Number(e.target.value) || 1)) })}
-              className="w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+              className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
             />
           </label>
           <label className="block">
-            <span className="mb-1 block text-slate-400">{t('settings.project.numbering.start', 'Start-Nummer')}</span>
+            <span className="mb-1 block text-cp-text-muted">{t('settings.project.numbering.start', 'Start-Nummer')}</span>
             <input
               type="number"
               min={0}
               value={eff.start}
               onChange={(e) => patch({ start: Math.max(0, Number(e.target.value) || 0) })}
-              className="w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+              className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
             />
           </label>
         </div>
@@ -250,7 +250,7 @@ const CableNumberingSection = () => {
           {t('settings.project.numbering.perLayer', 'Eigener Zähler je Layer (V/A/N/P …)')}
         </label>
         <div className="flex items-center justify-between gap-2 pt-1">
-          <span className="text-slate-400">
+          <span className="text-cp-text-muted">
             {t('settings.project.numbering.example', 'Beispiel')}:{' '}
             <span className="font-mono text-sky-300">{cableNumberExample(eff)}</span>
           </span>
@@ -304,10 +304,10 @@ const LengthEstimationSection = () => {
         'Schätzt die Kabellängen aus der Canvas-Distanz der Geräte (Luftlinie × Maßstab + Reserve). Überschreibt vorhandene Längen.',
       )}
     >
-      <div className="space-y-2 text-cp-xs text-slate-200">
+      <div className="space-y-2 text-cp-xs text-cp-text-bright">
         <div className="grid grid-cols-2 gap-2">
           <label className="block">
-            <span className="mb-1 block text-slate-400">
+            <span className="mb-1 block text-cp-text-muted">
               {t('settings.project.lengthEst.scale', 'Meter pro 100 px')}
             </span>
             <input
@@ -316,11 +316,11 @@ const LengthEstimationSection = () => {
               step={0.1}
               value={eff.metersPer100px}
               onChange={(e) => patch({ metersPer100px: Math.max(0.1, Number(e.target.value) || 0.1) })}
-              className="w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+              className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
             />
           </label>
           <label className="block">
-            <span className="mb-1 block text-slate-400">
+            <span className="mb-1 block text-cp-text-muted">
               {t('settings.project.lengthEst.slack', 'Reserve (%)')}
             </span>
             <input
@@ -329,7 +329,7 @@ const LengthEstimationSection = () => {
               max={200}
               value={eff.slackPercent}
               onChange={(e) => patch({ slackPercent: Math.max(0, Number(e.target.value) || 0) })}
-              className="w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+              className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
             />
           </label>
         </div>
@@ -381,15 +381,15 @@ const PlanDefaultsSection = () => {
         'Technische Vorgaben für diesen Plan, je nach Gewerk. Das Video-Format steuert die SDI-Standardverkabelung, der Strom-/Netz-Standard die Spannung im Stromrechner (Watt ↔ Ampere).',
       )}
     >
-      <div className="grid grid-cols-1 gap-3 text-cp-xs text-slate-200 sm:grid-cols-2">
+      <div className="grid grid-cols-1 gap-3 text-cp-xs text-cp-text-bright sm:grid-cols-2">
         <label className="block">
-          <span className="mb-1 block text-slate-400">
+          <span className="mb-1 block text-cp-text-muted">
             {t('settings.project.defaults.video', 'Video-Format (SDI)')}
           </span>
           <select
             value={videoFormat ?? DEFAULT_VIDEO_FORMAT}
             onChange={(e) => setDefaultVideoFormat(e.target.value)}
-            className="w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+            className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
           >
             {VIDEO_FORMATS.map((f) => (
               <option key={f.id} value={f.id}>
@@ -399,7 +399,7 @@ const PlanDefaultsSection = () => {
           </select>
         </label>
         <label className="block">
-          <span className="mb-1 block text-slate-400">
+          <span className="mb-1 block text-cp-text-muted">
             {t('settings.project.defaults.power', 'Strom-/Netz-Standard')}
           </span>
           <select
@@ -407,7 +407,7 @@ const PlanDefaultsSection = () => {
             onChange={(e) =>
               updateProjectMetadata({ defaultPowerStandard: e.target.value as PowerStandardId })
             }
-            className="w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+            className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
           >
             {POWER_STANDARDS.map((s) => (
               <option key={s.id} value={s.id}>
@@ -417,7 +417,7 @@ const PlanDefaultsSection = () => {
           </select>
         </label>
         <label className="block">
-          <span className="mb-1 block text-slate-400">
+          <span className="mb-1 block text-cp-text-muted">
             {t('settings.project.defaults.lighting', 'Licht-Steuerung (Default)')}
           </span>
           <select
@@ -427,7 +427,7 @@ const PlanDefaultsSection = () => {
                 defaultLightingControl: e.target.value as 'dmx512' | 'artnet' | 'sacn',
               })
             }
-            className="w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+            className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
           >
             <option value="dmx512">DMX512 / RDM (5-pin XLR)</option>
             <option value="artnet">Art-Net (Ethernet)</option>
@@ -464,7 +464,7 @@ export const ProjectTab = ({ onClose: _onClose }: { onClose: () => void }) => {
 
   return (
     <div className="space-y-3">
-      <p className="text-cp-xs text-slate-400">
+      <p className="text-cp-xs text-cp-text-muted">
         {t(
           'settings.project.intro',
           'Projekt-Metadaten — werden mit der Cable-Planner-Datei gespeichert.',
@@ -476,7 +476,7 @@ export const ProjectTab = ({ onClose: _onClose }: { onClose: () => void }) => {
           type="text"
           value={draftMeta.name}
           onChange={(e) => setDraftMeta({ ...draftMeta, name: e.target.value })}
-          className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2 text-cp-base"
+          className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2 text-cp-base"
           placeholder={t('settings.project.name', 'Projektname')}
         />
       </label>
@@ -486,7 +486,7 @@ export const ProjectTab = ({ onClose: _onClose }: { onClose: () => void }) => {
           value={draftMeta.description ?? ''}
           onChange={(e) => setDraftMeta({ ...draftMeta, description: e.target.value })}
           rows={3}
-          className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2 text-cp-base"
+          className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2 text-cp-base"
           placeholder={t(
             'settings.project.descriptionPlaceholder',
             'Optionale Projektbeschreibung',
@@ -500,7 +500,7 @@ export const ProjectTab = ({ onClose: _onClose }: { onClose: () => void }) => {
             type="text"
             value={draftMeta.client ?? ''}
             onChange={(e) => setDraftMeta({ ...draftMeta, client: e.target.value })}
-            className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2 text-cp-base"
+            className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2 text-cp-base"
             placeholder={t('settings.project.clientPlaceholder', 'Endkunde')}
           />
         </label>
@@ -510,7 +510,7 @@ export const ProjectTab = ({ onClose: _onClose }: { onClose: () => void }) => {
             type="text"
             value={draftMeta.contractor ?? ''}
             onChange={(e) => setDraftMeta({ ...draftMeta, contractor: e.target.value })}
-            className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2 text-cp-base"
+            className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2 text-cp-base"
             placeholder={t('settings.project.contractorPlaceholder', 'Ausführende Firma')}
           />
         </label>
@@ -522,7 +522,7 @@ export const ProjectTab = ({ onClose: _onClose }: { onClose: () => void }) => {
             type="text"
             value={draftMeta.author ?? ''}
             onChange={(e) => setDraftMeta({ ...draftMeta, author: e.target.value })}
-            className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2 text-cp-base"
+            className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2 text-cp-base"
             placeholder={t('settings.project.authorPlaceholder', 'Dein Name')}
           />
         </label>
@@ -532,7 +532,7 @@ export const ProjectTab = ({ onClose: _onClose }: { onClose: () => void }) => {
             type="text"
             value={draftMeta.projectNumber ?? ''}
             onChange={(e) => setDraftMeta({ ...draftMeta, projectNumber: e.target.value })}
-            className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2 text-cp-base"
+            className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2 text-cp-base"
             placeholder={t('settings.project.numberPlaceholder', 'z. B. 2026-042')}
           />
         </label>
@@ -556,18 +556,18 @@ export const ProjectTab = ({ onClose: _onClose }: { onClose: () => void }) => {
             const current = draftMeta[field]
             return (
               <div key={field} className="flex flex-col items-center gap-2">
-                <div className="flex h-16 w-full items-center justify-center overflow-hidden rounded border border-slate-700 bg-white/5">
+                <div className="flex h-16 w-full items-center justify-center overflow-hidden rounded border border-cp-border bg-white/5">
                   {current ? (
                     <img src={current} alt={label} className="max-h-16 max-w-full object-contain" />
                   ) : (
-                    <span className="text-[10px] text-slate-400">{label}</span>
+                    <span className="text-[10px] text-cp-text-muted">{label}</span>
                   )}
                 </div>
                 <div className="flex w-full gap-1">
                   <button
                     type="button"
                     onClick={() => pickLogo(field)}
-                    className="flex-1 rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+                    className="flex-1 rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
                   >
                     {t('common.choose', 'Wählen…')}
                   </button>
@@ -577,7 +577,7 @@ export const ProjectTab = ({ onClose: _onClose }: { onClose: () => void }) => {
                       onClick={() => setDraftMeta((prev) => ({ ...prev, [field]: undefined }))}
                       title={t('common.remove', 'Entfernen')}
                       aria-label={t('common.remove', 'Entfernen')}
-                      className="rounded bg-slate-800 px-2 py-1 text-cp-xs text-slate-400 hover:bg-red-700 hover:text-white"
+                      className="rounded bg-cp-surface-2 px-2 py-1 text-cp-xs text-cp-text-muted hover:bg-red-700 hover:text-white"
                     >
                       <Icon icon={X} size="sm" />
                     </button>
@@ -591,14 +591,14 @@ export const ProjectTab = ({ onClose: _onClose }: { onClose: () => void }) => {
 
       <SettingsCard title={t('settings.project.linkedRentman', 'Verknüpftes Rentman-Projekt')}>
         {metadata.rentmanProjectId ? (
-          <div className="text-cp-xs text-slate-400">
+          <div className="text-cp-xs text-cp-text-muted">
             <span className="text-orange-300">
               {metadata.rentmanProjectName ?? `Projekt #${metadata.rentmanProjectId}`}
             </span>
-            <span className="ml-2 text-slate-500">(ID: {metadata.rentmanProjectId})</span>
+            <span className="ml-2 text-cp-text-faint">(ID: {metadata.rentmanProjectId})</span>
           </div>
         ) : (
-          <div className="text-cp-xs text-slate-500">
+          <div className="text-cp-xs text-cp-text-faint">
             {t(
               'settings.project.notLinked',
               'Kein Rentman-Projekt verknüpft. Verknüpfung im Tab „Integrationen" herstellen.',
@@ -616,7 +616,7 @@ export const ProjectTab = ({ onClose: _onClose }: { onClose: () => void }) => {
         <button
           type="button"
           onClick={() => setDraftMeta(metadata)}
-          className="rounded bg-slate-700 px-3 py-1 text-cp-base hover:bg-slate-600"
+          className="rounded bg-cp-surface-4 px-3 py-1 text-cp-base hover:bg-cp-surface-5"
         >
           {t('common.reset', 'Zurücksetzen')}
         </button>

--- a/src/renderer/components/Settings/tabs/SyncTab.tsx
+++ b/src/renderer/components/Settings/tabs/SyncTab.tsx
@@ -44,7 +44,7 @@ const SharedLibrarySyncSection = ({ syncPath }: { syncPath: string }) => {
         'Gleicht Geräte-Templates, Gruppen und Kategorien mit der Datei cable-planner.library.json im Sync-Verzeichnis ab. Merge nach Name — lokale Templates werden nie überschrieben.',
       )}
     >
-      <div className="flex flex-wrap items-center gap-2 text-cp-xs text-slate-300">
+      <div className="flex flex-wrap items-center gap-2 text-cp-xs text-cp-text-secondary">
         <button
           type="button"
           onClick={run}
@@ -56,7 +56,7 @@ const SharedLibrarySyncSection = ({ syncPath }: { syncPath: string }) => {
             : t('settings.sharedLib.syncNow', 'Bibliothek jetzt synchronisieren')}
         </button>
         {!syncPath.trim() && (
-          <span className="text-[11px] text-slate-400">
+          <span className="text-[11px] text-cp-text-muted">
             {t('settings.sharedLib.needPath', 'Erst oben ein Sync-Verzeichnis setzen.')}
           </span>
         )}
@@ -118,29 +118,29 @@ export const SyncTab = () => {
           )}
         </div>
       )}
-      <p className="text-cp-xs text-slate-400">
+      <p className="text-cp-xs text-cp-text-muted">
         {t(
           'settings.sync.intro',
           'Gemeinsames Verzeichnis (FTP-Laufwerk, Netzwerkpfad oder lokaler Ordner), in dem Projekt, Bibliothek und Presets als JSON-Dateien geteilt werden.',
         )}
       </p>
-      <label className="block text-cp-base text-slate-300">
+      <label className="block text-cp-base text-cp-text-secondary">
         {t('settings.sync.path', 'Sync-Verzeichnis')}
         <input
           type="text"
           value={draftSyncPath}
           onChange={(e) => setDraftSyncPath(e.target.value)}
-          className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2 font-mono text-cp-xs"
+          className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2 font-mono text-cp-xs"
           placeholder={t('settings.sync.pathPlaceholder', 'Z:\\Projekte\\CablePlanner oder \\\\server\\share\\cable-planner')}
         />
       </label>
-      <label className="block text-cp-base text-slate-300">
+      <label className="block text-cp-base text-cp-text-secondary">
         {t('settings.sync.user', 'Benutzername (für Lock-Anzeige)')}
         <input
           type="text"
           value={draftSyncUser}
           onChange={(e) => setDraftSyncUser(e.target.value)}
-          className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2 text-cp-base"
+          className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2 text-cp-base"
           placeholder={t('settings.sync.userPlaceholder', 'z. B. Max Mustermann')}
         />
       </label>
@@ -151,7 +151,7 @@ export const SyncTab = () => {
             setDraftSyncPath(sharedSyncPath)
             setDraftSyncUser(sharedSyncUser)
           }}
-          className="rounded bg-slate-700 px-3 py-1 text-cp-base hover:bg-slate-600"
+          className="rounded bg-cp-surface-4 px-3 py-1 text-cp-base hover:bg-cp-surface-5"
         >
           {t('common.reset', 'Zurücksetzen')}
         </button>
@@ -169,7 +169,7 @@ export const SyncTab = () => {
       <SharedLibrarySyncSection syncPath={sharedSyncPath} />
 
       <SettingsCard title={t('settings.sync.notes', 'Hinweise')}>
-        <ul className="list-inside list-disc space-y-1 text-cp-xs text-slate-400">
+        <ul className="list-inside list-disc space-y-1 text-cp-xs text-cp-text-muted">
           <li>
             {t(
               'settings.sync.notes.push',

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -67,9 +67,12 @@
   --color-cp-surface-1: var(--cp-surface-1);
   --color-cp-surface-2: var(--cp-surface-2);
   --color-cp-surface-3: var(--cp-surface-3);
+  --color-cp-surface-4: var(--cp-surface-4);
+  --color-cp-surface-5: var(--cp-surface-5);
   --color-cp-border: var(--cp-border);
   --color-cp-border-muted: var(--cp-border-muted);
   --color-cp-text: var(--cp-text);
+  --color-cp-text-bright: var(--cp-text-bright);
   --color-cp-text-secondary: var(--cp-text-secondary);
   --color-cp-text-muted: var(--cp-text-muted);
   --color-cp-text-faint: var(--cp-text-faint);
@@ -99,9 +102,15 @@
   --cp-surface-1: var(--color-slate-900); /* Panels/Modals */
   --cp-surface-2: var(--color-slate-800); /* raised/hover */
   --cp-surface-3: var(--color-slate-950); /* sunken/Leisten/Inputs */
+  /* #449 — interaktive Button-Surfaces (heller als border). Erlauben die
+   * Migration der schweren Settings-Tabs, die slate-700/600 als Knopf-BG +
+   * slate-200 als helleren Text nutzen — wofür es bisher keinen Token gab. */
+  --cp-surface-4: var(--color-slate-700); /* Button-/Chip-Surface */
+  --cp-surface-5: var(--color-slate-600); /* heller, z.B. surface-4-Hover */
   --cp-border: var(--color-slate-700);
   --cp-border-muted: var(--color-slate-800);
   --cp-text: var(--color-slate-100);
+  --cp-text-bright: var(--color-slate-200); /* zwischen text und secondary */
   --cp-text-secondary: var(--color-slate-300);
   --cp-text-muted: var(--color-slate-400);
   --cp-text-faint: var(--color-slate-500);
@@ -213,9 +222,14 @@ body,
   --cp-surface-1: #eaeff5; /* = .bg-slate-900 light remap */
   --cp-surface-2: #dde4ee; /* = .bg-slate-800 */
   --cp-surface-3: #f0f4f8; /* = .bg-slate-950 */
+  /* #449 — Light-Werte = exakt der bestehende 340-Zeilen-Remap der rohen
+   * Klassen, damit bg-cp-surface-4/5 pixelgleich zu .bg-slate-700/600 bleiben. */
+  --cp-surface-4: #cbd5e1; /* = .bg-slate-700 (light) */
+  --cp-surface-5: #b8c4d0; /* = .bg-slate-600 (light) */
   --cp-border: #94a3b8; /* = .border-slate-700 */
   --cp-border-muted: #b8c4d0; /* = .border-slate-800 */
   --cp-text: #0f172a; /* = .text-slate-100 */
+  --cp-text-bright: #1e293b; /* = .text-slate-200 (light) */
   /* #449 — fehlte im Light-Remap: --cp-text-secondary fiel auf den Dark-Wert
    * zurück (heller Grauton auf hellem Grund → unlesbar). Jetzt = light
    * .text-slate-300 (#1e293b), passt in die Ramp text(#0f172a) → muted(#334155). */


### PR DESCRIPTION
## Zweck
Erweitert das cp-Token-Set um die fehlenden hellen Surface-/Text-Töne und migriert damit das **komplette Settings-Panel** — der in #531 dokumentierte Blocker für die schweren Tabs.

## Token-Erweiterung (`index.css`)
3 neue Tokens; dark an Tailwinds Palette gebunden, light = exakt der bestehende 340-Zeilen-Remap-Wert der rohen Klasse (→ pixelgleich):
| Token | = slate | Zweck |
|---|---|---|
| `--cp-surface-4` | slate-700 | Button-/Chip-Surface |
| `--cp-surface-5` | slate-600 | heller, z. B. surface-4-Hover |
| `--cp-text-bright` | slate-200 | Text zwischen `text` und `secondary` |

Damit ist die **gesamte slate-Rampe (100–950)** token-abgedeckt.

## Migration (12 Settings-Dateien)
Alle 8 Tabs (Appearance, Project, Configs, Editing, Hotkeys, Sync, Advanced, Integrations) + `SettingsBody`/`SettingsDialog`/`SettingsCard` + `EquipmentColorsSection` → **0 rohe slate-Klassen**. Regex-Migration erhält Opacity- (`/40`) und State-Prefixes (`hover:`/`focus:`).

## Verifikation (headless)
- **Neue Tokens: 6/6 Paare PIXELGLEICH** (dark+light) via Canvas-`getImageData` (`bg-cp-surface-4`↔`bg-slate-700` etc.).
- **Screenshots** Settings → Appearance (74 Klassen, schwerste Datei) + Project in **light**: theme-korrekt, Text dunkel auf hell, **0 Console-Errors**.
- Ersetzte Paare sind in #525 als pixelgleich bewiesen → appearance-neutral by construction.
- tsc 0 · eslint 0 · build 0.

Refs #449

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_