### PR TITLE
refactor(theme): migrate dialogs + panels slate-* → cp-tokens (#449)

### DIFF
--- a/src/renderer/components/Analysis/PlanCheckPanel.tsx
+++ b/src/renderer/components/Analysis/PlanCheckPanel.tsx
@@ -56,7 +56,7 @@ export const PlanCheckPanel = () => {
       scrollBody={false}
     >
       <div className="flex h-full flex-col">
-        <div className="flex items-center gap-3 border-b border-slate-800 py-2 text-cp-xs">
+        <div className="flex items-center gap-3 border-b border-cp-border-muted py-2 text-cp-xs">
           <span className="inline-flex items-center gap-1 text-red-400">
             <Icon icon={AlertCircle} size="xs" /> {errorCount}
           </span>
@@ -66,7 +66,7 @@ export const PlanCheckPanel = () => {
           <span className="inline-flex items-center gap-1 text-sky-400">
             <Icon icon={Info} size="xs" /> {infoCount}
           </span>
-          <span className="ml-auto text-slate-500">
+          <span className="ml-auto text-cp-text-faint">
             {format(t('planCheck.summary', '{count} Hinweise'), { count: findings.length })}
           </span>
         </div>
@@ -77,7 +77,7 @@ export const PlanCheckPanel = () => {
               <span className="text-cp-base">{t('planCheck.allClear', 'Keine Auffälligkeiten gefunden.')}</span>
             </div>
           ) : (
-            <ul className="divide-y divide-slate-800/60">
+            <ul className="divide-y divide-cp-surface-2/60">
               {findings.map((f) => {
                 const meta = SEVERITY_META[f.severity]
                 const clickable = !!(f.cableId || f.equipmentId)
@@ -94,7 +94,7 @@ export const PlanCheckPanel = () => {
                       <Icon icon={meta.icon} size="xs" className={`mt-0.5 shrink-0 ${meta.tone}`} />
                       <span className="min-w-0">
                         <span className={`mr-1 font-semibold ${meta.tone}`}>{f.category}:</span>
-                        <span className="text-slate-300">{f.message}</span>
+                        <span className="text-cp-text-secondary">{f.message}</span>
                       </span>
                     </button>
                   </li>
@@ -103,7 +103,7 @@ export const PlanCheckPanel = () => {
             </ul>
           )}
         </div>
-        <p className="border-t border-slate-800 py-1.5 text-[10px] text-slate-400">
+        <p className="border-t border-cp-border-muted py-1.5 text-[10px] text-cp-text-muted">
           {t(
             'planCheck.footerHint',
             'Live-Validierung des Plans. Klick auf einen Hinweis selektiert das betroffene Element.',

--- a/src/renderer/components/Annotations/AnnotationsPanel.tsx
+++ b/src/renderer/components/Annotations/AnnotationsPanel.tsx
@@ -160,7 +160,7 @@ export const AnnotationsPanel = ({
 
   const body = (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="border-b border-slate-800 bg-slate-950/40 px-3 py-2">
+      <div className="border-b border-cp-border-muted bg-cp-surface-3/40 px-3 py-2">
         <div className="mb-2 flex gap-1">
           {(['all', 'open', 'built', 'resolved'] as const).map((s) => (
             <button
@@ -170,7 +170,7 @@ export const AnnotationsPanel = ({
               className={`rounded px-2 py-0.5 text-[10px] ${
                 statusFilter === s
                   ? 'bg-sky-700 text-white'
-                  : 'bg-slate-800 text-slate-400 hover:bg-slate-700'
+                  : 'bg-cp-surface-2 text-cp-text-muted hover:bg-cp-surface-4'
               }`}
             >
               {s === 'all'
@@ -191,7 +191,7 @@ export const AnnotationsPanel = ({
                   ? format(t('annotations.placeholderAs', 'Anmerkung als {name}…'), { name: currentAuthor })
                   : t('annotations.placeholderEmpty', 'Anmerkung… (Name wird einmalig abgefragt)')
               }
-              className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1 text-cp-xs"
+              className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-xs"
             />
             <div className="flex gap-1">
               <button
@@ -223,7 +223,7 @@ export const AnnotationsPanel = ({
                   setDraftText('')
                   setCreating(false)
                 }}
-                className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
               >
                 {t('annotations.cancel', 'Abbruch')}
               </button>
@@ -242,7 +242,7 @@ export const AnnotationsPanel = ({
 
       <div className="flex-1 overflow-y-auto p-3">
         {grouped.length === 0 ? (
-          <p className="text-[11px] text-slate-400">
+          <p className="text-[11px] text-cp-text-muted">
             {t(
               'annotations.empty',
               'Noch keine Anmerkungen. Klicke „+ Neue Anmerkung" oder mache einen Rechtsklick auf ein Gerät / Kabel.',
@@ -251,7 +251,7 @@ export const AnnotationsPanel = ({
         ) : (
           grouped.map(([authorName, items]) => (
             <div key={authorName} className="mb-3">
-              <h4 className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+              <h4 className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-cp-text-muted">
                 {authorName} ({items.length})
               </h4>
               <ul className="space-y-1">
@@ -297,7 +297,7 @@ export const AnnotationsPanel = ({
                           /* setDragImage nicht supported — egal, Drop funktioniert trotzdem */
                         }
                       }}
-                      className="cursor-grab rounded border border-slate-700 bg-slate-950/40 p-2 text-cp-xs active:cursor-grabbing"
+                      className="cursor-grab rounded border border-cp-border bg-cp-surface-3/40 p-2 text-cp-xs active:cursor-grabbing"
                       title={t('annotations.dragTitle', 'Ziehen, um diese Anmerkung auf dem Canvas zu platzieren oder einem Gerät zuzuweisen')}
                     >
                       <div className="mb-1 flex items-center justify-between gap-2">
@@ -314,7 +314,7 @@ export const AnnotationsPanel = ({
                         >
                           {t(`annotations.status.${a.status}`, STATUS_LABEL[a.status])}
                         </span>
-                        <span className="truncate text-[10px] text-slate-400" title={a.createdAt}>
+                        <span className="truncate text-[10px] text-cp-text-muted" title={a.createdAt}>
                           {new Date(a.createdAt).toLocaleString()}
                         </span>
                       </div>
@@ -323,7 +323,7 @@ export const AnnotationsPanel = ({
                           value={a.text}
                           onChange={(e) => updateAnnotation(a.id, { text: e.target.value })}
                           rows={3}
-                          className="w-full rounded border border-slate-700 bg-slate-900 px-2 py-1 text-cp-xs"
+                          className="w-full rounded border border-cp-border bg-cp-surface-1 px-2 py-1 text-cp-xs"
                           onBlur={() => setEditingId(null)}
                           autoFocus
                         />
@@ -336,7 +336,7 @@ export const AnnotationsPanel = ({
                           {a.text}
                         </p>
                       )}
-                      <div className="mt-1 text-[10px] text-slate-400">
+                      <div className="mt-1 text-[10px] text-cp-text-muted">
                         {ANCHOR_LABEL(a, deviceNames, cableNames)}
                       </div>
                       <div className="mt-1 flex gap-1">
@@ -347,7 +347,7 @@ export const AnnotationsPanel = ({
                               status: e.target.value as ProjectAnnotation['status'],
                             })
                           }
-                          className="rounded border border-slate-700 bg-slate-900 px-1 py-0.5 text-[10px]"
+                          className="rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-[10px]"
                         >
                           <option value="open">{t('annotations.status.open', 'offen')}</option>
                           <option value="built">{t('annotations.status.built', 'gebaut')}</option>
@@ -368,7 +368,7 @@ export const AnnotationsPanel = ({
                                 setAnnotationsVisible(true)
                               }
                             }}
-                            className="inline-flex items-center gap-1 rounded bg-slate-800 px-1.5 py-0.5 text-[10px] text-slate-200 hover:bg-slate-700"
+                            className="inline-flex items-center gap-1 rounded bg-cp-surface-2 px-1.5 py-0.5 text-[10px] text-cp-text-bright hover:bg-cp-surface-4"
                             aria-label={t('annotations.placeCenter', 'Auf Canvas-Mitte platzieren (Tastatur-Alternative zum Ziehen)')}
                           >
                             <Icon icon={MapPin} size="xs" />
@@ -403,11 +403,11 @@ export const AnnotationsPanel = ({
 
   const headerTitle = (
     <span className="flex flex-col">
-      <span className="text-cp-base font-semibold text-slate-100">
+      <span className="text-cp-base font-semibold text-cp-text">
         <Icon icon={MessageSquare} size="sm" /> {t('annotations.title', 'Anmerkungen')} ({annotations.length})
       </span>
       {viewerSession && (
-        <span className="text-[10px] text-slate-400">
+        <span className="text-[10px] text-cp-text-muted">
           {format(t('annotations.reviewer', 'Reviewer: {name}'), { name: viewerSession.author })}
         </span>
       )}
@@ -439,17 +439,17 @@ export const AnnotationsPanel = ({
     <div
       className={
         inPopout
-          ? 'relative flex h-full w-full min-h-0 flex-col bg-slate-900 text-slate-100'
-          : 'fixed right-0 top-0 z-40 flex h-screen w-full max-w-[95vw] flex-col border-l border-slate-700 bg-slate-900 text-slate-100 shadow-2xl sm:w-96'
+          ? 'relative flex h-full w-full min-h-0 flex-col bg-cp-surface-1 text-cp-text'
+          : 'fixed right-0 top-0 z-40 flex h-screen w-full max-w-[95vw] flex-col border-l border-cp-border bg-cp-surface-1 text-cp-text shadow-2xl sm:w-96'
       }
     >
-      <header className="flex items-center justify-between gap-2 border-b border-slate-800 px-3 py-2">
+      <header className="flex items-center justify-between gap-2 border-b border-cp-border-muted px-3 py-2">
         <div className="flex min-w-0 flex-col">
           <h3 className="truncate text-cp-base font-semibold">
             <Icon icon={MessageSquare} size="sm" /> {t('annotations.title', 'Anmerkungen')} ({annotations.length})
           </h3>
           {viewerSession && (
-            <span className="text-[10px] text-slate-400">
+            <span className="text-[10px] text-cp-text-muted">
               {format(t('annotations.reviewer', 'Reviewer: {name}'), { name: viewerSession.author })}
             </span>
           )}
@@ -470,7 +470,7 @@ export const AnnotationsPanel = ({
               }}
               title={t('annotations.float.title', 'Abdocken (klicken oder herausziehen)')}
               aria-label={t('annotations.float.aria', 'Anmerkungen abdocken')}
-              className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
               style={{ touchAction: 'none' }}
             >
               <span className="pointer-events-none">⤢</span>
@@ -482,7 +482,7 @@ export const AnnotationsPanel = ({
               onClick={() => openPanelPopout('annotations')}
               title={t('panel.popoutTitle', 'In separates Fenster auslagern (weiterer Monitor)')}
               aria-label={t('panel.popout', 'Auslagern')}
-              className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
             >
               <Icon icon={ExternalLink} size="xs" />
             </button>
@@ -490,7 +490,7 @@ export const AnnotationsPanel = ({
           <button
             type="button"
             onClick={onClose}
-            className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+            className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
           >
             {t('common.close', 'Schließen')}
           </button>

--- a/src/renderer/components/Atem/AtemDialog.tsx
+++ b/src/renderer/components/Atem/AtemDialog.tsx
@@ -305,17 +305,17 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
       maxWidth="3xl"
       scrollBody={false}
     >
-      <div className="flex max-h-[80vh] flex-col text-slate-100">
-        <div className="border-b border-slate-700 px-4 py-3">
+      <div className="flex max-h-[80vh] flex-col text-cp-text">
+        <div className="border-b border-cp-border px-4 py-3">
           <div className="flex items-end gap-2">
             <label className="flex-1 text-cp-xs">
-              <span className="mb-1 block text-slate-300">ATEM IP-Adresse</span>
+              <span className="mb-1 block text-cp-text-secondary">ATEM IP-Adresse</span>
               <input
                 value={ip}
                 onChange={(event) => setIp(event.target.value)}
                 placeholder="192.168.10.240"
                 disabled={status === 'connected' || status === 'connecting'}
-                className="w-full rounded border border-slate-700 bg-slate-950 p-2 font-mono text-cp-base"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 p-2 font-mono text-cp-base"
               />
             </label>
             {status !== 'connected' && (
@@ -344,7 +344,7 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
               <button
                 type="button"
                 onClick={disconnect}
-                className="rounded bg-slate-700 px-3 py-2 text-cp-base hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-3 py-2 text-cp-base hover:bg-cp-surface-5"
               >
                 Trennen
               </button>
@@ -365,7 +365,7 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
           {discoveryDone && status !== 'connected' && (
             <div className="mt-2">
               {discovered.length === 0 ? (
-                <div className="rounded border border-dashed border-slate-700 bg-slate-950/40 p-2 text-[11px] text-slate-400">
+                <div className="rounded border border-dashed border-cp-border bg-cp-surface-3/40 p-2 text-[11px] text-cp-text-muted">
                   {t(
                     'atem.dialog.noneFound',
                     'Kein ATEM-Switcher per mDNS im lokalen Netzwerk gefunden. (Manche Modelle / Firewall-Setups blocken mDNS — dann IP manuell eingeben.)',
@@ -373,7 +373,7 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
                 </div>
               ) : (
                 <div className="space-y-1">
-                  <div className="text-[10px] uppercase tracking-wide text-slate-400">
+                  <div className="text-[10px] uppercase tracking-wide text-cp-text-muted">
                     {format(t('atem.dialog.foundCount', 'Gefunden ({n}) — Klick übernimmt die IP:'), {
                       n: discovered.length,
                     })}
@@ -383,12 +383,12 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
                       key={dev.ip}
                       type="button"
                       onClick={() => setIp(dev.ip)}
-                      className="flex w-full items-center justify-between gap-2 rounded border border-slate-700 bg-slate-950 px-2 py-1.5 text-left text-cp-xs hover:border-purple-500 hover:bg-slate-900"
+                      className="flex w-full items-center justify-between gap-2 rounded border border-cp-border bg-cp-surface-3 px-2 py-1.5 text-left text-cp-xs hover:border-purple-500 hover:bg-cp-surface-1"
                     >
-                      <span className="font-medium text-slate-100">
+                      <span className="font-medium text-cp-text">
                         {dev.name}
                         {dev.model && (
-                          <span className="ml-2 text-[10px] text-slate-400">
+                          <span className="ml-2 text-[10px] text-cp-text-muted">
                             ({dev.model})
                           </span>
                         )}
@@ -401,7 +401,7 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
             </div>
           )}
           {status === 'connected' && state && (
-            <div className="mt-2 text-[11px] text-slate-400">
+            <div className="mt-2 text-[11px] text-cp-text-muted">
               {state.productIdentifier}
               {state.apiVersion ? ` · API ${state.apiVersion.major}.${state.apiVersion.minor}` : ''}
               {state.mixEffects ? ` · ${state.mixEffects} M/E` : ''}
@@ -416,7 +416,7 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
         {status === 'connected' && state && (
           <div className="flex-1 overflow-auto px-4 py-3">
             <div className="mb-2 flex items-center justify-between">
-              <h3 className="text-cp-xs font-semibold uppercase tracking-wide text-slate-300">
+              <h3 className="text-cp-xs font-semibold uppercase tracking-wide text-cp-text-secondary">
                 Input-Namen ({rows.length})
               </h3>
               <button
@@ -429,7 +429,7 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
               </button>
             </div>
             <table className="w-full table-fixed text-cp-xs">
-              <thead className="text-left text-slate-400">
+              <thead className="text-left text-cp-text-muted">
                 <tr>
                   <th className="w-12 py-1">ID</th>
                   <th className="w-20 py-1">{t('atem.col.type', 'Typ')}</th>
@@ -443,11 +443,11 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
                   <tr
                     key={row.inputId}
                     title={row.lockReason}
-                    className={`border-t border-slate-800 ${
+                    className={`border-t border-cp-border-muted ${
                       row.locked ? 'opacity-60' : row.changed ? 'bg-amber-950/30' : ''
                     }`}
                   >
-                    <td className="py-1 font-mono text-slate-400">{row.inputId}</td>
+                    <td className="py-1 font-mono text-cp-text-muted">{row.inputId}</td>
                     <td className="py-1 text-[10px] uppercase tracking-wide">
                       <span
                         className={
@@ -463,7 +463,7 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
                                     ? 'text-amber-400'
                                     : row.category === 'mediaplayer'
                                       ? 'text-pink-400'
-                                      : 'text-slate-500'
+                                      : 'text-cp-text-faint'
                         }
                       >
                         {row.category === 'video-input'
@@ -481,9 +481,9 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
                                     : 'int.'}
                       </span>
                     </td>
-                    <td className="py-1 text-slate-300">
+                    <td className="py-1 text-cp-text-secondary">
                       <span className="font-mono">{row.liveLong}</span>{' '}
-                      <span className="text-slate-500">({row.liveShort})</span>
+                      <span className="text-cp-text-faint">({row.liveShort})</span>
                     </td>
                     <td className="py-1 pr-1">
                       <input
@@ -491,7 +491,7 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
                         maxLength={20}
                         disabled={row.locked}
                         onChange={(event) => setDraft(row.inputId, { long: event.target.value })}
-                        className="w-full rounded border border-slate-700 bg-slate-950 p-1 font-mono disabled:cursor-not-allowed disabled:bg-slate-900 disabled:text-slate-500"
+                        className="w-full rounded border border-cp-border bg-cp-surface-3 p-1 font-mono disabled:cursor-not-allowed disabled:bg-cp-surface-1 disabled:text-cp-text-faint"
                       />
                     </td>
                     <td className="py-1">
@@ -502,14 +502,14 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
                         onChange={(event) =>
                           setDraft(row.inputId, { short: event.target.value.toUpperCase() })
                         }
-                        className="w-full rounded border border-slate-700 bg-slate-950 p-1 font-mono uppercase disabled:cursor-not-allowed disabled:bg-slate-900 disabled:text-slate-500"
+                        className="w-full rounded border border-cp-border bg-cp-surface-3 p-1 font-mono uppercase disabled:cursor-not-allowed disabled:bg-cp-surface-1 disabled:text-cp-text-faint"
                       />
                     </td>
                   </tr>
                 ))}
               </tbody>
             </table>
-            <p className="mt-3 text-[11px] text-slate-400">
+            <p className="mt-3 text-[11px] text-cp-text-muted">
               {t(
                 'atem.dialog.changesNote',
                 'Hinweis: Änderungen gehen direkt an den Switcher (RAM). Damit sie einen Reboot überleben, in der Blackmagic ATEM Software „Save Startup State" auslösen. Audio-Eingaenge (XLR/RJ45-Talkback), Mediaplayer und interne Quellen sind gesperrt — der ATEM verwaltet die selbst.',
@@ -518,9 +518,9 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
           </div>
         )}
 
-        <details className="border-t border-slate-700 px-4 py-2 text-[11px]">
-          <summary className="cursor-pointer text-slate-400">{t('atem.eventLog', 'Event-Log')} ({events.length})</summary>
-          <pre className="mt-2 max-h-40 overflow-auto rounded bg-slate-950 p-2 font-mono text-[10px] text-slate-300">
+        <details className="border-t border-cp-border px-4 py-2 text-[11px]">
+          <summary className="cursor-pointer text-cp-text-muted">{t('atem.eventLog', 'Event-Log')} ({events.length})</summary>
+          <pre className="mt-2 max-h-40 overflow-auto rounded bg-cp-surface-3 p-2 font-mono text-[10px] text-cp-text-secondary">
             {events.join('\n') || '(noch keine Events)'}
           </pre>
         </details>

--- a/src/renderer/components/Atem/AtemMvConfigDialog.tsx
+++ b/src/renderer/components/Atem/AtemMvConfigDialog.tsx
@@ -144,7 +144,7 @@ const MvLayoutPicker = ({
   return (
     <div className="relative" style={{ width: 'min(240px, 70vw)', aspectRatio: '16 / 9' }}>
       <div
-        className="absolute inset-0 grid gap-[2px] rounded border border-slate-700 bg-slate-950 p-[2px]"
+        className="absolute inset-0 grid gap-[2px] rounded border border-cp-border bg-cp-surface-3 p-[2px]"
         style={{ gridTemplateColumns: 'repeat(4, 1fr)', gridTemplateRows: 'repeat(4, 1fr)' }}
       >
         {QUADRANTS.map((q) => (
@@ -444,20 +444,20 @@ const SourcePicker = ({
     <div
       ref={ref}
       onClick={(e) => e.stopPropagation()}
-      className="fixed z-[60] max-h-[60vh] w-64 overflow-auto rounded border border-slate-600 bg-slate-900 shadow-2xl"
+      className="fixed z-[60] max-h-[60vh] w-64 overflow-auto rounded border border-cp-surface-5 bg-cp-surface-1 shadow-2xl"
       style={{
         left: Math.min(anchor.x, window.innerWidth - 280),
         top: Math.min(anchor.y, window.innerHeight - 400),
       }}
     >
-      <div className="sticky top-0 z-10 border-b border-slate-700 bg-slate-900 p-2">
+      <div className="sticky top-0 z-10 border-b border-cp-border bg-cp-surface-1 p-2">
         <input
           autoFocus
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
           placeholder={t('common.search', 'Suche…')}
           aria-label={t('common.search', 'Suche…')}
-          className="mb-1 w-full rounded border border-slate-700 bg-slate-800 px-2 py-1 text-cp-xs"
+          className="mb-1 w-full rounded border border-cp-border bg-cp-surface-2 px-2 py-1 text-cp-xs"
         />
         <div className="flex gap-1">
           <input
@@ -465,7 +465,7 @@ const SourcePicker = ({
             value={custom}
             onChange={(e) => setCustom(e.target.value)}
             placeholder={t('atem.mv.idPlaceholder', 'ID')}
-            className="w-20 rounded border border-slate-700 bg-slate-800 px-2 py-1 text-cp-xs"
+            className="w-20 rounded border border-cp-border bg-cp-surface-2 px-2 py-1 text-cp-xs"
           />
           <button
             type="button"
@@ -482,7 +482,7 @@ const SourcePicker = ({
       <div className="p-1 text-cp-xs">
         {grouped.map(([group, items]) => (
           <div key={group} className="mb-1">
-            <div className="px-1 py-0.5 text-[10px] uppercase tracking-wider text-slate-400">
+            <div className="px-1 py-0.5 text-[10px] uppercase tracking-wider text-cp-text-muted">
               {group}
             </div>
             {items.map((item) => (
@@ -490,12 +490,12 @@ const SourcePicker = ({
                 key={`${group}-${item.id}`}
                 type="button"
                 onClick={() => onPick(item.id)}
-                className={`flex w-full items-center justify-between rounded px-2 py-1 text-left hover:bg-slate-800 ${
-                  item.id === currentId ? 'bg-slate-700 text-emerald-300' : 'text-slate-200'
+                className={`flex w-full items-center justify-between rounded px-2 py-1 text-left hover:bg-cp-surface-2 ${
+                  item.id === currentId ? 'bg-cp-surface-4 text-emerald-300' : 'text-cp-text-bright'
                 }`}
               >
                 <span className="truncate">{item.label}</span>
-                <span className="ml-2 text-[10px] text-slate-400">{item.id}</span>
+                <span className="ml-2 text-[10px] text-cp-text-muted">{item.id}</span>
               </button>
             ))}
           </div>
@@ -541,15 +541,15 @@ const CapabilitiesPanel = ({
     onOverride({ ...caps, supportedLayouts: Array.from(set).sort((a, b) => a - b) })
   }
   return (
-    <div className="border-t border-slate-800 bg-slate-950/40 px-3 py-1.5 text-[10px] text-slate-400">
+    <div className="border-t border-cp-border-muted bg-cp-surface-3/40 px-3 py-1.5 text-[10px] text-cp-text-muted">
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
-        className="flex w-full items-center gap-2 text-left hover:text-slate-200"
+        className="flex w-full items-center gap-2 text-left hover:text-cp-text-bright"
       >
         <span>{open ? '▾' : '▸'}</span>
         <span>
-          Modell-Capabilities: <span className="text-slate-300">{equipmentName}</span> ·{' '}
+          Modell-Capabilities: <span className="text-cp-text-secondary">{equipmentName}</span> ·{' '}
           {caps.mvCount} MV{caps.mvCount === 1 ? '' : 's'} ·{' '}
           {caps.supportedLayouts.length} Layouts{' '}
           {hasOverride && (
@@ -559,7 +559,7 @@ const CapabilitiesPanel = ({
       </button>
       {open && (
         <div className="mt-1 space-y-1.5 pl-4">
-          <p className="text-slate-500">
+          <p className="text-cp-text-faint">
             {t(
               'atem.mv.layoutsHint',
               'Heuristik basierend auf dem Geräte-Namen. Falls dein Modell ein Layout unterstützt das die Heuristik nicht erkennt (oder umgekehrt), Häkchen hier setzen — die Auswahl überschreibt das Default und bleibt beim Projekt.',
@@ -576,7 +576,7 @@ const CapabilitiesPanel = ({
                   className={`rounded px-2 py-0.5 text-[10px] ${
                     on
                       ? 'bg-sky-900 text-sky-200'
-                      : 'bg-slate-800 text-slate-500 hover:bg-slate-700'
+                      : 'bg-cp-surface-2 text-cp-text-faint hover:bg-cp-surface-4'
                   }`}
                   title={`${l.label} (${l.value})`}
                 >
@@ -599,7 +599,7 @@ const CapabilitiesPanel = ({
                     mvCount: Math.max(0, Math.min(4, Number(e.target.value) || 0)),
                   })
                 }
-                className="w-12 rounded border border-slate-700 bg-slate-900 px-1 py-0.5"
+                className="w-12 rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5"
               />
             </label>
             <label className="flex items-center gap-1">
@@ -615,7 +615,7 @@ const CapabilitiesPanel = ({
                     maxWindowsPerMv: Math.max(0, Math.min(32, Number(e.target.value) || 0)),
                   })
                 }
-                className="w-14 rounded border border-slate-700 bg-slate-900 px-1 py-0.5"
+                className="w-14 rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5"
               />
             </label>
             {hasOverride && (
@@ -653,17 +653,17 @@ const AtemMvDevicePicker = () => {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={close}>
       <div
-        className="flex max-h-[80vh] w-[440px] max-w-[95vw] flex-col rounded-cp-card border border-slate-700 bg-slate-900 shadow-2xl"
+        className="flex max-h-[80vh] w-[440px] max-w-[95vw] flex-col rounded-cp-card border border-cp-border bg-cp-surface-1 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between border-b border-slate-700 px-4 py-2">
-          <h2 className="flex items-center gap-2 text-cp-base font-semibold text-slate-200">
+        <div className="flex items-center justify-between border-b border-cp-border px-4 py-2">
+          <h2 className="flex items-center gap-2 text-cp-base font-semibold text-cp-text-bright">
             <Icon icon={Monitor} size="sm" />
             {t('atemMv.picker.title', 'ATEM Multiviewer — Gerät wählen')}
           </h2>
           <button
             onClick={close}
-            className="text-slate-400 hover:text-slate-200"
+            className="text-cp-text-muted hover:text-cp-text-bright"
             aria-label={t('common.close', 'Schließen')}
           >
             ×
@@ -671,7 +671,7 @@ const AtemMvDevicePicker = () => {
         </div>
         <div className="overflow-auto p-4 text-cp-base">
           {atemDevices.length === 0 ? (
-            <p className="text-slate-400">
+            <p className="text-cp-text-muted">
               {t(
                 'atemMv.picker.empty',
                 'Kein ATEM-Mischer im Plan. Lege zuerst einen ATEM aus der Bibliothek an — danach ist hier seine Multiviewer-Konfiguration wählbar.',
@@ -679,7 +679,7 @@ const AtemMvDevicePicker = () => {
             </p>
           ) : (
             <>
-              <p className="mb-2 text-[11px] text-slate-400">
+              <p className="mb-2 text-[11px] text-cp-text-muted">
                 {t('atemMv.picker.intro', 'Welchen ATEM-Mischer-Multiviewer möchtest du konfigurieren?')}
               </p>
               <ul className="space-y-1">
@@ -687,7 +687,7 @@ const AtemMvDevicePicker = () => {
                   <li key={e.id}>
                     <button
                       onClick={() => openAtemMvConfig(e.id)}
-                      className="flex w-full items-center gap-2 rounded border border-slate-700 bg-slate-800 px-3 py-2 text-left text-slate-100 hover:bg-slate-700"
+                      className="flex w-full items-center gap-2 rounded border border-cp-border bg-cp-surface-2 px-3 py-2 text-left text-cp-text hover:bg-cp-surface-4"
                     >
                       <Icon icon={Monitor} size="sm" />
                       {e.name}
@@ -1050,7 +1050,7 @@ export const AtemMvConfigDialog = () => {
           boxShadow: highlight ? `inset 0 0 0 3px ${highlight}` : undefined,
           color: sid === 0 ? '#cbd5e1' : '#0f172a',
         }}
-        className="group relative flex flex-col items-center justify-center overflow-hidden border border-slate-900/40 text-center hover:brightness-95"
+        className="group relative flex flex-col items-center justify-center overflow-hidden border border-cp-surface-1/40 text-center hover:brightness-95"
         title={`${quad.name} groß: ${label} (ID ${sid}) — klicken zum Ändern`}
       >
         {role !== 'other' && (
@@ -1092,7 +1092,7 @@ export const AtemMvConfigDialog = () => {
           boxShadow: highlight ? `inset 0 0 0 2px ${highlight}` : undefined,
           color: sid === 0 ? '#cbd5e1' : '#0f172a',
         }}
-        className="group relative flex flex-col items-center justify-center overflow-hidden border border-slate-900/40 text-center hover:brightness-95"
+        className="group relative flex flex-col items-center justify-center overflow-hidden border border-cp-surface-1/40 text-center hover:brightness-95"
         title={`${quad.name} klein #${cellIdx + 1}: ${label} (ID ${sid}) — klicken zum Ändern`}
       >
         <div className="truncate px-1 text-[10px] font-medium leading-tight">{label}</div>
@@ -1107,23 +1107,23 @@ export const AtemMvConfigDialog = () => {
       onClick={close}
     >
       <div
-        className="flex max-h-[95vh] w-[960px] max-w-[95vw] flex-col rounded-cp-card border border-slate-700 bg-slate-900 shadow-2xl"
+        className="flex max-h-[95vh] w-[960px] max-w-[95vw] flex-col rounded-cp-card border border-cp-border bg-cp-surface-1 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between border-b border-slate-700 px-4 py-2">
-          <h2 className="text-cp-base font-semibold text-slate-100">
+        <div className="flex items-center justify-between border-b border-cp-border px-4 py-2">
+          <h2 className="text-cp-base font-semibold text-cp-text">
             {format(t('atem.mv.dialogTitle', 'Multiviewer-Layout · {name}'), { name: equipment.name })}
           </h2>
           <button
             type="button"
             onClick={close}
-            className="rounded bg-slate-800 px-2 py-1 text-cp-xs hover:bg-slate-700"
+            className="rounded bg-cp-surface-2 px-2 py-1 text-cp-xs hover:bg-cp-surface-4"
           >
             {t('common.close', 'Schließen')}
           </button>
         </div>
 
-        <div className="flex items-center gap-1 border-b border-slate-800 px-3 py-2">
+        <div className="flex items-center gap-1 border-b border-cp-border-muted px-3 py-2">
           {config.multiViewers.map((mvItem, i) => (
             <button
               key={mvItem.index}
@@ -1132,7 +1132,7 @@ export const AtemMvConfigDialog = () => {
               className={`rounded px-3 py-1 text-cp-xs ${
                 i === activeMv
                   ? 'bg-sky-700 text-white'
-                  : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+                  : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
               }`}
             >
               MV {i + 1}
@@ -1143,7 +1143,7 @@ export const AtemMvConfigDialog = () => {
               type="button"
               onClick={addMv}
               disabled={config.multiViewers.length >= 4}
-              className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600 disabled:opacity-50"
+              className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5 disabled:opacity-50"
               title={t('atem.mv.addMv', 'Multiviewer hinzufügen')}
             >
               +
@@ -1152,13 +1152,13 @@ export const AtemMvConfigDialog = () => {
               type="button"
               onClick={removeMv}
               disabled={config.multiViewers.length <= 1}
-              className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600 disabled:opacity-50"
+              className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5 disabled:opacity-50"
               title={t('atem.mv.removeMv', 'Letzten Multiviewer entfernen')}
             >
               −
             </button>
           </div>
-          <span className="ml-auto text-[10px] text-slate-400">
+          <span className="ml-auto text-[10px] text-cp-text-muted">
             {config.multiViewers.length} MV — Klick auf ein Fenster ändert die Quelle.
           </span>
         </div>
@@ -1171,9 +1171,9 @@ export const AtemMvConfigDialog = () => {
 
             Steht außerhalb von mvGridRef → PNG-Export bleibt clean. */}
         {mv && (
-          <div className="flex flex-wrap items-center gap-4 border-b border-slate-800 px-3 py-2">
+          <div className="flex flex-wrap items-center gap-4 border-b border-cp-border-muted px-3 py-2">
             <div className="flex items-center gap-2">
-              <span className="text-[11px] text-slate-300">{t('atem.mv.layoutLabel', 'Layout')}</span>
+              <span className="text-[11px] text-cp-text-secondary">{t('atem.mv.layoutLabel', 'Layout')}</span>
               <MvLayoutPicker
                 quadrants={quadrants}
                 windows={Array.isArray(mv.windows) ? mv.windows : []}
@@ -1181,7 +1181,7 @@ export const AtemMvConfigDialog = () => {
                 onToggleQuadrant={toggleQuadrant}
                 canvasPortNames={canvasPortNames}
               />
-              <span className="text-[10px] text-slate-400">
+              <span className="text-[10px] text-cp-text-muted">
                 {t('atem.mv.quadrantHint1', 'Klick auf einen Quadranten:')}<br />
                 {t('atem.mv.quadrantHint2', 'groß ↔ 4 kleine')}
               </span>
@@ -1198,7 +1198,7 @@ export const AtemMvConfigDialog = () => {
           {mv && (
             <div className="relative w-full" style={{ aspectRatio: '16 / 9' }}>
               <div
-                className="absolute inset-0 grid gap-[2px] rounded border border-slate-700 bg-slate-950 p-1"
+                className="absolute inset-0 grid gap-[2px] rounded border border-cp-border bg-cp-surface-3 p-1"
                 style={{
                   gridTemplateColumns: 'repeat(4, 1fr)',
                   gridTemplateRows: 'repeat(4, 1fr)',
@@ -1225,8 +1225,8 @@ export const AtemMvConfigDialog = () => {
           }
         />
 
-        <div className="flex items-center justify-between border-t border-slate-700 px-4 py-2">
-          <span className="text-[11px] text-slate-400">
+        <div className="flex items-center justify-between border-t border-cp-border px-4 py-2">
+          <span className="text-[11px] text-cp-text-muted">
             {savedFlash ? (
               <span className="font-semibold text-emerald-400">✓ {t('atem.mv.saved', 'Gespeichert')}</span>
             ) : (
@@ -1248,7 +1248,7 @@ export const AtemMvConfigDialog = () => {
             <button
               type="button"
               onClick={handleSave}
-              className="rounded bg-slate-700 px-3 py-1 text-cp-xs hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-3 py-1 text-cp-xs hover:bg-cp-surface-5"
             >
               {t('atem.mv.saveDraft', 'Zwischenspeichern')}
             </button>

--- a/src/renderer/components/Atem/MultiviewerLayoutView.tsx
+++ b/src/renderer/components/Atem/MultiviewerLayoutView.tsx
@@ -185,8 +185,8 @@ const MultiviewerPanel = ({ mv }: { mv: AtemMultiviewer }) => {
   const pgmIndex = mv.programPreviewSwapped ? 0 : 1
   const prvIndex = mv.programPreviewSwapped ? 1 : 0
   return (
-    <div className="rounded border border-slate-600 bg-slate-950 p-2">
-      <div className="mb-1 text-center text-[11px] font-semibold uppercase tracking-wider text-slate-300">
+    <div className="rounded border border-cp-surface-5 bg-cp-surface-3 p-2">
+      <div className="mb-1 text-center text-[11px] font-semibold uppercase tracking-wider text-cp-text-secondary">
         MV {mv.index + 1}
       </div>
       <div
@@ -281,14 +281,14 @@ export const MultiviewerLayoutView = ({ onClose }: MultiviewerLayoutViewProps) =
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
-      <div className="flex max-h-[95vh] w-full max-w-6xl flex-col rounded border border-slate-600 bg-slate-900 text-slate-100">
-        <header className="flex items-center justify-between border-b border-slate-700 px-4 py-2">
+      <div className="flex max-h-[95vh] w-full max-w-6xl flex-col rounded border border-cp-surface-5 bg-cp-surface-1 text-cp-text">
+        <header className="flex items-center justify-between border-b border-cp-border px-4 py-2">
           <div>
             <h2 className="text-cp-xl font-semibold text-sky-300">
               {t('atem.mvLayout.title', 'Multiviewer Layout (Live)')}
             </h2>
             {state && (
-              <p className="text-[11px] text-slate-400">
+              <p className="text-[11px] text-cp-text-muted">
                 {state.productIdentifier} · {mvs.length} MV
                 {mvs.length === 1 ? '' : 's'}
               </p>
@@ -298,14 +298,14 @@ export const MultiviewerLayoutView = ({ onClose }: MultiviewerLayoutViewProps) =
             <button
               type="button"
               onClick={() => void refresh()}
-              className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
             >
               {t('atem.mvLayout.refresh', '↻ Aktualisieren')}
             </button>
             <button
               type="button"
               onClick={onClose}
-              className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
             >
               {t('atem.mvLayout.close', '✕ Schließen')}
             </button>
@@ -326,7 +326,7 @@ export const MultiviewerLayoutView = ({ onClose }: MultiviewerLayoutViewProps) =
           )}
 
           {connected && mvs.length === 0 && (
-            <div className="text-cp-xs text-slate-400">
+            <div className="text-cp-xs text-cp-text-muted">
               {t('atem.mvLayout.noMv', 'Der verbundene ATEM meldet keine Multiviewer.')}
             </div>
           )}
@@ -345,8 +345,8 @@ export const MultiviewerLayoutView = ({ onClose }: MultiviewerLayoutViewProps) =
           )}
         </div>
 
-        <footer className="flex flex-wrap items-center gap-4 border-t border-slate-700 px-4 py-2 text-[11px] text-slate-300">
-          <span className="font-semibold uppercase tracking-wider text-slate-400">
+        <footer className="flex flex-wrap items-center gap-4 border-t border-cp-border px-4 py-2 text-[11px] text-cp-text-secondary">
+          <span className="font-semibold uppercase tracking-wider text-cp-text-muted">
             {t('atem.mvLayout.legend', 'Legende')}
           </span>
           <LegendSwatch label={t('atem.mvLayout.camera', 'Kamera')} category="camera" />

--- a/src/renderer/components/Cable/CableDialog.tsx
+++ b/src/renderer/components/Cable/CableDialog.tsx
@@ -255,12 +255,12 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
         ref={panelRef}
         aria-labelledby={titleId}
         {...dialogProps}
-        className="w-full max-w-lg rounded border border-slate-700 bg-slate-900 p-4 text-slate-100 outline-none"
+        className="w-full max-w-lg rounded border border-cp-border bg-cp-surface-1 p-4 text-cp-text outline-none"
       >
         <h3 id={titleId} className="mb-2 text-cp-2xl font-semibold">{t('cable.dialog.title', 'Neues Kabel')}</h3>
 
         {fromPort && toPort && (
-          <div className="mb-3 rounded bg-slate-950 p-2 text-cp-xs">
+          <div className="mb-3 rounded bg-cp-surface-3 p-2 text-cp-xs">
             <div>
               {t('cable.dialog.from', 'Von:')} <span className="font-medium">{fromPort.name}</span> ({fromPort.connectorType}
               {fromPort.standard ? `, ${fromPort.standard}` : ''})
@@ -278,7 +278,7 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
             <select
               value={specId}
               onChange={(e) => onSelectSpec(e.target.value)}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+              className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
             >
               <option value={CUSTOM_CABLE_SPEC_ID}>★ Custom Cable…</option>
               {ranked.map(({ cable, level }) => {
@@ -293,8 +293,8 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
           </label>
 
           {specId === CUSTOM_CABLE_SPEC_ID && (
-            <div className="rounded border border-slate-700 bg-slate-950/60 p-2">
-              <div className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+            <div className="rounded border border-cp-border bg-cp-surface-3/60 p-2">
+              <div className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-cp-text-muted">
                 Custom Cable Definition
               </div>
               <div className="grid grid-cols-2 gap-2">
@@ -314,7 +314,7 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
                       }
                       setCustomConnectorType(v as ConnectorType)
                     }}
-                    className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+                    className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
                   >
                     {allConnectorOptions.map((type) => (
                       <option key={type} value={type}>
@@ -344,7 +344,7 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
                       setCustomStandard(next)
                       setStandard(next)
                     }}
-                    className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+                    className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
                   >
                     {allStandardOptions.map((item) => (
                       <option key={item} value={item}>
@@ -364,7 +364,7 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
                   value={customMaxLength}
                   onChange={(e) => setCustomMaxLength(e.target.value ? Number(e.target.value) : '')}
                   placeholder={t('common.optional', 'Optional')}
-                  className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+                  className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
                 />
               </label>
               <button
@@ -406,7 +406,7 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
               <select
                 value={standard ?? ''}
                 onChange={(e) => setStandard(e.target.value as SignalStandard)}
-                className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+                className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
               >
                 {selected.standards.map((s) => (
                   <option key={s} value={s}>
@@ -422,7 +422,7 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
             <input
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+              className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
             />
           </label>
 
@@ -434,7 +434,7 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
                 min={0}
                 value={length}
                 onChange={(e) => setLength(Number(e.target.value))}
-                className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+                className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
               />
             </label>
             <label className="block">
@@ -443,7 +443,7 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
                 type="color"
                 value={color}
                 onChange={(e) => setColor(e.target.value)}
-                className="mt-1 h-10 w-full rounded border border-slate-700 bg-slate-950 p-1"
+                className="mt-1 h-10 w-full rounded border border-cp-border bg-cp-surface-3 p-1"
               />
             </label>
           </div>
@@ -453,7 +453,7 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
             <textarea
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+              className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
               rows={2}
             />
           </label>
@@ -509,7 +509,7 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
           <button
             type="button"
             onClick={onCancel}
-            className="rounded bg-slate-700 px-3 py-1 hover:bg-slate-600"
+            className="rounded bg-cp-surface-4 px-3 py-1 hover:bg-cp-surface-5"
           >
             {t('common.cancel', 'Abbrechen')}
           </button>

--- a/src/renderer/components/Calculators/CalculatorsDialog.tsx
+++ b/src/renderer/components/Calculators/CalculatorsDialog.tsx
@@ -120,7 +120,7 @@ const BandwidthTab = () => {
   const fittingTier = SDI_TIERS.find((t) => mbps <= t.mbps)
   return (
     <div className="space-y-3 p-4 text-cp-base">
-      <p className="text-[11px] text-slate-400">
+      <p className="text-[11px] text-cp-text-muted">
         {t(
           'calc.bandwidth.intro',
           'Brutto-Datenrate eines Video-Streams (vor Kompression) und der kleinste SDI-Tier der sie tragen kann. Pixel × Zeilen × fps × Bits-pro-Pixel.',
@@ -128,7 +128,7 @@ const BandwidthTab = () => {
       </p>
       <div className="grid grid-cols-3 gap-3">
         <label className="block">
-          <span className="mb-1 block text-cp-xs text-slate-400">{t('calc.resolution', 'Auflösung')}</span>
+          <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('calc.resolution', 'Auflösung')}</span>
           <select
             value={resolution.label}
             onChange={(e) =>
@@ -136,7 +136,7 @@ const BandwidthTab = () => {
                 RESOLUTION_PRESETS.find((r) => r.label === e.target.value) ?? RESOLUTION_PRESETS[1],
               )
             }
-            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+            className="w-full rounded border border-cp-border bg-cp-surface-3 p-2"
           >
             {RESOLUTION_PRESETS.map((r) => (
               <option key={r.label} value={r.label}>
@@ -146,11 +146,11 @@ const BandwidthTab = () => {
           </select>
         </label>
         <label className="block">
-          <span className="mb-1 block text-cp-xs text-slate-400">FPS</span>
+          <span className="mb-1 block text-cp-xs text-cp-text-muted">FPS</span>
           <select
             value={fps}
             onChange={(e) => setFps(Number(e.target.value))}
-            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+            className="w-full rounded border border-cp-border bg-cp-surface-3 p-2"
           >
             {FPS_PRESETS.map((f) => (
               <option key={f} value={f}>
@@ -160,7 +160,7 @@ const BandwidthTab = () => {
           </select>
         </label>
         <label className="block">
-          <span className="mb-1 block text-cp-xs text-slate-400">{t('calc.sampling', 'Sampling / Tiefe')}</span>
+          <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('calc.sampling', 'Sampling / Tiefe')}</span>
           <select
             value={sampling.label}
             onChange={(e) =>
@@ -168,7 +168,7 @@ const BandwidthTab = () => {
                 SAMPLING_PRESETS.find((s) => s.label === e.target.value) ?? SAMPLING_PRESETS[2],
               )
             }
-            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+            className="w-full rounded border border-cp-border bg-cp-surface-3 p-2"
           >
             {SAMPLING_PRESETS.map((s) => (
               <option key={s.label} value={s.label}>
@@ -192,28 +192,28 @@ const BandwidthTab = () => {
               )}
         </div>
       </div>
-      <details className="rounded border border-slate-800 bg-slate-950/40">
-        <summary className="cursor-pointer px-3 py-1.5 text-[11px] uppercase tracking-wide text-slate-400">
+      <details className="rounded border border-cp-border-muted bg-cp-surface-3/40">
+        <summary className="cursor-pointer px-3 py-1.5 text-[11px] uppercase tracking-wide text-cp-text-muted">
           SDI-Tiers
         </summary>
         <ul className="space-y-0.5 px-3 py-2 text-cp-xs">
           {SDI_TIERS.map((t) => (
             <li key={t.label}>
               <span className="inline-block w-28">{t.label}</span>
-              <span className="font-mono text-slate-400">≤ {t.mbps} Mbps</span>
+              <span className="font-mono text-cp-text-muted">≤ {t.mbps} Mbps</span>
             </li>
           ))}
         </ul>
       </details>
-      <details className="rounded border border-slate-800 bg-slate-950/40">
-        <summary className="cursor-pointer px-3 py-1.5 text-[11px] uppercase tracking-wide text-slate-400">
+      <details className="rounded border border-cp-border-muted bg-cp-surface-3/40">
+        <summary className="cursor-pointer px-3 py-1.5 text-[11px] uppercase tracking-wide text-cp-text-muted">
           {t('calc.bandwidth.signalStds', 'IP-/Digital-Signalstandards')}
         </summary>
         <ul className="space-y-0.5 px-3 py-2 text-cp-xs">
           {SIGNAL_STD_BANDWIDTH.map((s) => (
             <li key={s.label}>
               <span className="inline-block w-56">{s.label}</span>
-              <span className="font-mono text-slate-400">{s.mbps} Mbps</span>
+              <span className="font-mono text-cp-text-muted">{s.mbps} Mbps</span>
             </li>
           ))}
         </ul>
@@ -223,38 +223,38 @@ const BandwidthTab = () => {
       {netBudget.count > 0 && (
         <div className="rounded border border-sky-700 bg-sky-950/20 p-3">
           <div className="mb-2 flex items-center justify-between">
-            <div className="text-[11px] uppercase tracking-wide text-slate-300">
+            <div className="text-[11px] uppercase tracking-wide text-cp-text-secondary">
               {t('calc.bandwidth.netBudget', 'Projekt-Netzwerk-Budget')}
             </div>
-            <div className="text-[10px] text-slate-400">
+            <div className="text-[10px] text-cp-text-muted">
               {netBudget.count} {t('calc.bandwidth.netLinks', 'IP-Signale')}
             </div>
           </div>
           <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-cp-xs">
-            <dt className="text-slate-500 font-semibold">{t('calc.bandwidth.netTotal', 'Gesamt-Bandbreite')}</dt>
+            <dt className="text-cp-text-faint font-semibold">{t('calc.bandwidth.netTotal', 'Gesamt-Bandbreite')}</dt>
             <dd className="font-mono text-cp-xl text-sky-200">
               {netBudget.totalMbps >= 1000
                 ? `${(netBudget.totalMbps / 1000).toFixed(2)} Gbps`
                 : `${netBudget.totalMbps} Mbps`}
             </dd>
-            <dt className="text-slate-500">{t('calc.bandwidth.netLink', 'Kleinster Link')}</dt>
-            <dd className="font-mono text-slate-200">
+            <dt className="text-cp-text-faint">{t('calc.bandwidth.netLink', 'Kleinster Link')}</dt>
+            <dd className="font-mono text-cp-text-bright">
               {netBudget.tier
                 ? netBudget.tier.label
                 : t('calc.bandwidth.netExceeds', '> 100 GbE — aufteilen / Spine-Leaf')}
             </dd>
           </dl>
-          <ul className="mt-2 space-y-0.5 border-t border-slate-800 pt-2 text-cp-xs">
+          <ul className="mt-2 space-y-0.5 border-t border-cp-border-muted pt-2 text-cp-xs">
             {netBudget.rows.map((r) => (
               <li key={r.std} className="flex justify-between">
-                <span className="text-slate-300">
-                  {r.std} <span className="text-slate-500">×{r.count}</span>
+                <span className="text-cp-text-secondary">
+                  {r.std} <span className="text-cp-text-faint">×{r.count}</span>
                 </span>
-                <span className="font-mono text-slate-400">{r.mbps} Mbps</span>
+                <span className="font-mono text-cp-text-muted">{r.mbps} Mbps</span>
               </li>
             ))}
           </ul>
-          <p className="mt-2 text-[10px] text-slate-400">
+          <p className="mt-2 text-[10px] text-cp-text-muted">
             {t(
               'calc.bandwidth.netNote',
               'Summe der Brutto-Bandbreiten aller Kabel mit IP-/Netzwerk-Signalstandard (NDI, Dante/AES67, ST 2110, Ethernet). Richtwerte; ST 2110-20 stark formatabhängig.',
@@ -285,15 +285,15 @@ const PHASE_COLORS = {
     dot: '#92400e' /* brown */,
   },
   L2: {
-    bg: 'bg-slate-800/80',
+    bg: 'bg-cp-surface-2/80',
     border: 'border-slate-500',
-    text: 'text-slate-200',
+    text: 'text-cp-text-bright',
     dot: '#0f172a' /* black */,
   },
   L3: {
-    bg: 'bg-slate-700/60',
+    bg: 'bg-cp-surface-4/60',
     border: 'border-slate-400',
-    text: 'text-slate-100',
+    text: 'text-cp-text',
     dot: '#94a3b8' /* grey */,
   },
   N: {
@@ -587,12 +587,12 @@ const PowerTab = () => {
 
   return (
     <div className="space-y-3 p-4 text-cp-base">
-      <p className="text-[11px] text-slate-400">
+      <p className="text-[11px] text-cp-text-muted">
         {t(
           'calc.power.intro1',
           'Summe der Verbrauchsangaben aus den Geräte-Eigenschaften',
         )}{' '}
-        (<code className="rounded bg-slate-800 px-1">{t('calc.power.wattsField', 'Leistung (W)')}</code>).{' '}
+        (<code className="rounded bg-cp-surface-2 px-1">{t('calc.power.wattsField', 'Leistung (W)')}</code>).{' '}
         {t(
           'calc.power.intro2',
           'Geräte ohne Wert zählen nicht mit; in den Properties nachtragen damit die Verteilung stimmt.',
@@ -600,11 +600,11 @@ const PowerTab = () => {
       </p>
       <div className="grid grid-cols-2 gap-3">
         <label className="block">
-          <span className="mb-1 block text-cp-xs text-slate-400">{t('calc.connectionType', 'Anschluss-Typ')}</span>
+          <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('calc.connectionType', 'Anschluss-Typ')}</span>
           <select
             value={supplyId}
             onChange={(e) => setSupplyId(e.target.value as SupplyPresetId)}
-            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+            className="w-full rounded border border-cp-border bg-cp-surface-3 p-2"
           >
             {supplies.map((p) => (
               <option key={p.id} value={p.id}>
@@ -614,49 +614,49 @@ const PowerTab = () => {
           </select>
         </label>
         <label className="block">
-          <span className="mb-1 block text-cp-xs text-slate-400">{t('calc.safetyReserve', 'Sicherheits-Reserve (%)')}</span>
+          <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('calc.safetyReserve', 'Sicherheits-Reserve (%)')}</span>
           <input
             type="number"
             min={0}
             value={marginPercent}
             onChange={(e) => setMarginPercent(Math.max(0, Number(e.target.value) || 0))}
-            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+            className="w-full rounded border border-cp-border bg-cp-surface-3 p-2"
           />
         </label>
       </div>
 
       <div className="rounded border border-emerald-700 bg-emerald-950/30 p-3">
         <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-cp-xs">
-          <dt className="text-slate-500">{t('calc.devicesCounted', 'Erfasste Geräte')}</dt>
-          <dd className="font-mono text-slate-200">
+          <dt className="text-cp-text-faint">{t('calc.devicesCounted', 'Erfasste Geräte')}</dt>
+          <dd className="font-mono text-cp-text-bright">
             {totals.countedDevices} {t('calc.outOf', 'von')} {totals.countedDevices + totals.missingDevices}
             {totals.missingDevices > 0 && (
               <span className="ml-2 text-amber-300">({totals.missingDevices} {t('calc.withoutValue', 'ohne Wert')})</span>
             )}
           </dd>
-          <dt className="text-slate-500">{t('calc.totalUsage', 'Gesamtverbrauch')}</dt>
-          <dd className="font-mono text-slate-200">{totals.totalW.toFixed(0)} W</dd>
-          <dt className="text-slate-500">+ {t('calc.reserve', 'Reserve')} ({marginPercent}%)</dt>
+          <dt className="text-cp-text-faint">{t('calc.totalUsage', 'Gesamtverbrauch')}</dt>
+          <dd className="font-mono text-cp-text-bright">{totals.totalW.toFixed(0)} W</dd>
+          <dt className="text-cp-text-faint">+ {t('calc.reserve', 'Reserve')} ({marginPercent}%)</dt>
           <dd className="font-mono text-emerald-200 text-cp-xl">
             {totalWithMargin.toFixed(0)} W · {(totalWithMargin / 1000).toFixed(2)} kW
           </dd>
           {supply.phases === 1 ? (
             <>
-              <dt className="text-slate-500">{t('calc.current1phase', 'Stromstärke (1-phasig)')}</dt>
-              <dd className="font-mono text-slate-200">
+              <dt className="text-cp-text-faint">{t('calc.current1phase', 'Stromstärke (1-phasig)')}</dt>
+              <dd className="font-mono text-cp-text-bright">
                 {ampsSinglePhase.toFixed(1)} A · max {supply.perPhaseAmps} A
               </dd>
             </>
           ) : (
             <>
-              <dt className="text-slate-500">{t('calc.current3phase', 'Symmetrisch (3-phasig)')}</dt>
-              <dd className="font-mono text-slate-200">
+              <dt className="text-cp-text-faint">{t('calc.current3phase', 'Symmetrisch (3-phasig)')}</dt>
+              <dd className="font-mono text-cp-text-bright">
                 {ampsThreePhase.toFixed(1)} A · max {supply.perPhaseAmps} A {t('calc.perPhase', 'je Phase')}
               </dd>
             </>
           )}
-          <dt className="text-slate-500">{t('calc.generator', 'Generator (cosφ 0,8)')}</dt>
-          <dd className="font-mono text-slate-200">
+          <dt className="text-cp-text-faint">{t('calc.generator', 'Generator (cosφ 0,8)')}</dt>
+          <dd className="font-mono text-cp-text-bright">
             {generatorKva.toFixed(1)} kVA ·{' '}
             <span className="text-emerald-200">
               {t('calc.generatorRec', 'empf.')} ≥ {generatorKvaRecommended.toFixed(1)} kVA
@@ -664,10 +664,10 @@ const PowerTab = () => {
           </dd>
           {/* Wärmelast → Kühlbedarf: die el. Leistung wird praktisch komplett
               in Wärme umgesetzt. AC-Einheiten zu je 12.000 BTU/h. */}
-          <dt className="text-slate-500">{t('calc.power.cooling', 'Wärme / Kühlung')}</dt>
-          <dd className="font-mono text-slate-200">
+          <dt className="text-cp-text-faint">{t('calc.power.cooling', 'Wärme / Kühlung')}</dt>
+          <dd className="font-mono text-cp-text-bright">
             {totalBtu} BTU/h
-            <span className="ml-2 text-slate-500">
+            <span className="ml-2 text-cp-text-faint">
               ≈ {(totals.totalW / 1000).toFixed(1)} kW · {Math.max(1, Math.ceil(totalBtu / 12000))}× 12k-BTU-AC
             </span>
           </dd>
@@ -677,7 +677,7 @@ const PowerTab = () => {
       {/* Distro-Vergleich: welcher Anschluss trägt die Last? */}
       {totals.totalW > 0 && (
         <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
-          <span className="font-semibold uppercase tracking-wide text-slate-500">
+          <span className="font-semibold uppercase tracking-wide text-cp-text-faint">
             {t('calc.power.fitsOn', 'Passt auf')}:
           </span>
           {supplies.map((p) => {
@@ -703,10 +703,10 @@ const PowerTab = () => {
           } p-3`}
         >
           <div className="mb-2 flex items-center justify-between">
-            <div className="text-[11px] uppercase tracking-wide text-slate-300">
+            <div className="text-[11px] uppercase tracking-wide text-cp-text-secondary">
               {t('calc.phaseDistribution', 'Phasen-Verteilung')} ({supply.label})
             </div>
-            <div className="text-[10px] text-slate-400">
+            <div className="text-[10px] text-cp-text-muted">
               {t('calc.imbalance', 'Unwucht')}: {maxImbalancePct}%
               {overloaded && (
                 <span className="ml-2 inline-flex items-center gap-1 rounded bg-red-700 px-1.5 py-0.5 text-[10px] text-white">
@@ -735,13 +735,13 @@ const PowerTab = () => {
                     />
                     {t('calc.phaseLabel', 'Phase')} L{idx + 1}
                   </div>
-                  <div className="font-mono text-cp-lg text-slate-100">
+                  <div className="font-mono text-cp-lg text-cp-text">
                     {watts.toFixed(0)} W
                   </div>
-                  <div className="font-mono text-[11px] text-slate-300">
+                  <div className="font-mono text-[11px] text-cp-text-secondary">
                     {amps.toFixed(1)} A / {supply.perPhaseAmps} A
                   </div>
-                  <div className="mt-1 h-1.5 overflow-hidden rounded bg-slate-800">
+                  <div className="mt-1 h-1.5 overflow-hidden rounded bg-cp-surface-2">
                     <div
                       className={`h-full ${
                         fraction > 1
@@ -753,7 +753,7 @@ const PowerTab = () => {
                       style={{ width: `${Math.min(100, fraction * 100)}%` }}
                     />
                   </div>
-                  <div className="mt-0.5 text-[10px] text-slate-400">
+                  <div className="mt-0.5 text-[10px] text-cp-text-muted">
                     {Math.round(fraction * 100)}% {t('calc.load', 'Last')}
                   </div>
                 </div>
@@ -766,11 +766,11 @@ const PowerTab = () => {
               className="inline-block h-2 w-2 shrink-0 rounded-full"
               style={{ background: PHASE_COLORS.N.dot }}
             />
-            <span className="text-slate-300">
+            <span className="text-cp-text-secondary">
               {t('calc.neutralCurrent', 'Neutralleiter (geschätzt)')}:
             </span>
             <span className="font-mono text-sky-200">{neutralAmps.toFixed(1)} A</span>
-            <span className="ml-auto text-[10px] text-slate-400">
+            <span className="ml-auto text-[10px] text-cp-text-muted">
               {neutralAmps < 0.05 * supply.perPhaseAmps
                 ? t('calc.neutralOk', 'gut balanciert')
                 : neutralAmps > 0.25 * supply.perPhaseAmps
@@ -779,14 +779,14 @@ const PowerTab = () => {
             </span>
           </div>
           <details className="mt-2">
-            <summary className="cursor-pointer text-[11px] uppercase tracking-wide text-slate-400 hover:text-slate-200">
+            <summary className="cursor-pointer text-[11px] uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright">
               {t('calc.devicesToPhase', 'Geräte → Phase')} ({distribution.assignments.length})
             </summary>
-            <div className="mb-1 mt-1 text-[10px] text-slate-400">
+            <div className="mb-1 mt-1 text-[10px] text-cp-text-muted">
               {t('calc.phasePinHint', 'Phase wählen = fest zuordnen; „Auto" = der Balancer verteilt automatisch.')}
             </div>
             <table className="w-full text-cp-xs">
-              <thead className="text-slate-500">
+              <thead className="text-cp-text-faint">
                 <tr>
                   <th className="text-left">{t('calc.col.device', 'Gerät')}</th>
                   <th className="text-right">W</th>
@@ -795,14 +795,14 @@ const PowerTab = () => {
               </thead>
               <tbody>
                 {distribution.assignments.map((a, i) => (
-                  <tr key={a.id ?? `${a.name}-${i}`} className="border-t border-slate-800">
+                  <tr key={a.id ?? `${a.name}-${i}`} className="border-t border-cp-border-muted">
                     <td className="truncate py-0.5">
                       {a.name}
                       {a.pinned && (
-                        <span className="ml-1 text-[11px] text-slate-400" title={t('calc.phasePinned', 'Fest zugeordnet')}>📌</span>
+                        <span className="ml-1 text-[11px] text-cp-text-muted" title={t('calc.phasePinned', 'Fest zugeordnet')}>📌</span>
                       )}
                     </td>
-                    <td className="text-right font-mono text-slate-400">{a.watts}</td>
+                    <td className="text-right font-mono text-cp-text-muted">{a.watts}</td>
                     <td className="pr-2 text-right">
                       {a.id ? (
                         <select
@@ -813,7 +813,7 @@ const PowerTab = () => {
                               powerPhase: v === 0 ? undefined : (v as 1 | 2 | 3),
                             })
                           }}
-                          className={`rounded border border-slate-700 bg-slate-950 py-0.5 pl-1 font-mono ${PHASE_COLORS[PHASE_KEYS[a.phase - 1]].text}`}
+                          className={`rounded border border-cp-border bg-cp-surface-3 py-0.5 pl-1 font-mono ${PHASE_COLORS[PHASE_KEYS[a.phase - 1]].text}`}
                           title={t('calc.col.phase', 'Phase')}
                         >
                           <option value={0}>{t('calc.phaseAuto', 'Auto')} (L{a.phase})</option>
@@ -832,8 +832,8 @@ const PowerTab = () => {
               </tbody>
             </table>
           </details>
-          <div className="mt-2 flex flex-wrap items-center gap-3 text-[10px] text-slate-400">
-            <span className="font-semibold uppercase tracking-wide text-slate-500">
+          <div className="mt-2 flex flex-wrap items-center gap-3 text-[10px] text-cp-text-muted">
+            <span className="font-semibold uppercase tracking-wide text-cp-text-faint">
               {t('calc.euColorTitle', 'EU-Farbcode (DIN VDE 0293-308)')}:
             </span>
             {(['L1', 'L2', 'L3', 'N', 'PE'] as const).map((key) => (
@@ -846,16 +846,16 @@ const PowerTab = () => {
               </span>
             ))}
           </div>
-          <p className="mt-2 text-[10px] text-slate-400">
+          <p className="mt-2 text-[10px] text-cp-text-muted">
             {t(
               'calc.greedyExplain',
               'Greedy-Verteilung: sortiert nach Leistung, jedes Gerät auf die aktuell am schwächsten belastete Phase. Bei symmetrischen Lasten zieht der Drehstrom nur {amps} A je Phase; Unwucht erhöht den höchsten Phasenstrom. Ziel: jede Phase < 85% Last + Unwucht < 20%.',
             ).replace('{amps}', ampsThreePhase.toFixed(1))}
           </p>
           <div className="mt-3 flex items-center justify-between text-[11px]">
-            <span className="text-slate-400">
+            <span className="text-cp-text-muted">
               {t('calc.power.heat', 'Wärme (BTU/h)')}:{' '}
-              <span className="font-mono text-slate-200">{totalBtu}</span>
+              <span className="font-mono text-cp-text-bright">{totalBtu}</span>
             </span>
             <button
               type="button"
@@ -877,15 +877,15 @@ const PowerTab = () => {
 
       {/* #345 ff. — USV / Notstrom-Puffer-Rechner. Nutzt die Gesamtlast der
           Geräte (oben) und schätzt USV-Größe + Pufferzeit. */}
-      <details className="rounded border border-slate-800 bg-slate-950/40" open={totals.totalW > 0}>
-        <summary className="flex cursor-pointer items-center gap-1.5 px-3 py-1.5 text-[11px] uppercase tracking-wide text-slate-400">
+      <details className="rounded border border-cp-border-muted bg-cp-surface-3/40" open={totals.totalW > 0}>
+        <summary className="flex cursor-pointer items-center gap-1.5 px-3 py-1.5 text-[11px] uppercase tracking-wide text-cp-text-muted">
           <Icon icon={BatteryCharging} size="xs" />
           {t('calc.ups.title', 'USV / Notstrom-Puffer')}
         </summary>
         <div className="space-y-3 px-3 py-2">
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
             <label className="block">
-              <span className="mb-1 block text-[10px] text-slate-400">
+              <span className="mb-1 block text-[10px] text-cp-text-muted">
                 {t('calc.ups.va', 'USV-Scheinleistung (VA)')}
               </span>
               <input
@@ -893,17 +893,17 @@ const PowerTab = () => {
                 min={0}
                 value={upsVa}
                 onChange={(e) => setUpsVa(Math.max(0, Number(e.target.value) || 0))}
-                className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-xs"
               />
             </label>
             <label className="block">
-              <span className="mb-1 block text-[10px] text-slate-400">
+              <span className="mb-1 block text-[10px] text-cp-text-muted">
                 {t('calc.ups.pf', 'Leistungsfaktor')}
               </span>
               <select
                 value={upsPf}
                 onChange={(e) => setUpsPf(Number(e.target.value))}
-                className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-xs"
               >
                 {[0.6, 0.7, 0.8, 0.9, 1.0].map((pf) => (
                   <option key={pf} value={pf}>
@@ -913,10 +913,10 @@ const PowerTab = () => {
               </select>
             </label>
             <div className="block">
-              <span className="mb-1 block text-[10px] text-slate-400">
+              <span className="mb-1 block text-[10px] text-cp-text-muted">
                 {t('calc.ups.capacity', 'Kapazität (W)')}
               </span>
-              <div className="rounded border border-slate-800 bg-slate-900 px-2 py-1 font-mono text-cp-xs text-slate-200">
+              <div className="rounded border border-cp-border-muted bg-cp-surface-1 px-2 py-1 font-mono text-cp-xs text-cp-text-bright">
                 {Math.round(upsCapacityW)} W
               </div>
             </div>
@@ -924,7 +924,7 @@ const PowerTab = () => {
 
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
             <label className="block">
-              <span className="mb-1 block text-[10px] text-slate-400">
+              <span className="mb-1 block text-[10px] text-cp-text-muted">
                 {t('calc.ups.battV', 'Akku (V)')}
               </span>
               <input
@@ -932,11 +932,11 @@ const PowerTab = () => {
                 min={0}
                 value={battV}
                 onChange={(e) => setBattV(Math.max(0, Number(e.target.value) || 0))}
-                className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-xs"
               />
             </label>
             <label className="block">
-              <span className="mb-1 block text-[10px] text-slate-400">
+              <span className="mb-1 block text-[10px] text-cp-text-muted">
                 {t('calc.ups.battAh', 'Kapazität (Ah)')}
               </span>
               <input
@@ -944,11 +944,11 @@ const PowerTab = () => {
                 min={0}
                 value={battAh}
                 onChange={(e) => setBattAh(Math.max(0, Number(e.target.value) || 0))}
-                className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-xs"
               />
             </label>
             <label className="block">
-              <span className="mb-1 block text-[10px] text-slate-400">
+              <span className="mb-1 block text-[10px] text-cp-text-muted">
                 {t('calc.ups.battCount', 'Anzahl Akkus')}
               </span>
               <input
@@ -956,11 +956,11 @@ const PowerTab = () => {
                 min={1}
                 value={battCount}
                 onChange={(e) => setBattCount(Math.max(1, Number(e.target.value) || 1))}
-                className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-xs"
               />
             </label>
             <label className="block">
-              <span className="mb-1 block text-[10px] text-slate-400">
+              <span className="mb-1 block text-[10px] text-cp-text-muted">
                 {t('calc.ups.usable', 'Nutzbar (%)')}
               </span>
               <input
@@ -971,7 +971,7 @@ const PowerTab = () => {
                 onChange={(e) =>
                   setUsablePercent(Math.min(100, Math.max(1, Number(e.target.value) || 1)))
                 }
-                className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-xs"
               />
             </label>
           </div>
@@ -982,11 +982,11 @@ const PowerTab = () => {
             }`}
           >
             <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-cp-xs">
-              <dt className="text-slate-500">{t('calc.ups.load', 'Last (gemessen)')}</dt>
-              <dd className="font-mono text-slate-200">{upsLoadW.toFixed(0)} W</dd>
-              <dt className="text-slate-500">{t('calc.ups.utilization', 'USV-Auslastung')}</dt>
+              <dt className="text-cp-text-faint">{t('calc.ups.load', 'Last (gemessen)')}</dt>
+              <dd className="font-mono text-cp-text-bright">{upsLoadW.toFixed(0)} W</dd>
+              <dt className="text-cp-text-faint">{t('calc.ups.utilization', 'USV-Auslastung')}</dt>
               <dd className="font-mono">
-                <span className={upsOverloaded ? 'text-red-300' : 'text-slate-200'}>
+                <span className={upsOverloaded ? 'text-red-300' : 'text-cp-text-bright'}>
                   {Math.round(upsLoadFraction * 100)}%
                 </span>
                 {upsOverloaded && (
@@ -996,13 +996,13 @@ const PowerTab = () => {
                   </span>
                 )}
               </dd>
-              <dt className="text-slate-500">{t('calc.ups.recommended', 'Empfohlene USV')}</dt>
+              <dt className="text-cp-text-faint">{t('calc.ups.recommended', 'Empfohlene USV')}</dt>
               <dd className="font-mono text-emerald-200">≥ {recommendedVa} VA</dd>
-              <dt className="text-slate-500">{t('calc.ups.battery', 'Akku-Energie')}</dt>
-              <dd className="font-mono text-slate-200">
+              <dt className="text-cp-text-faint">{t('calc.ups.battery', 'Akku-Energie')}</dt>
+              <dd className="font-mono text-cp-text-bright">
                 {Math.round(batteryWh)} Wh · {Math.round(usableWh)} Wh {t('calc.ups.usableShort', 'nutzbar')}
               </dd>
-              <dt className="text-slate-500">{t('calc.ups.runtime', 'Pufferzeit (geschätzt)')}</dt>
+              <dt className="text-cp-text-faint">{t('calc.ups.runtime', 'Pufferzeit (geschätzt)')}</dt>
               <dd className="font-mono text-cp-xl text-emerald-200">
                 {upsLoadW <= 0
                   ? '—'
@@ -1011,22 +1011,22 @@ const PowerTab = () => {
                     : `${runtimeMin.toFixed(0)} min`}
               </dd>
             </dl>
-            <div className="mt-2 flex items-center gap-2 border-t border-slate-800 pt-2 text-[11px]">
-              <span className="text-slate-400">{t('calc.ups.target', 'Ziel-Pufferzeit')}</span>
+            <div className="mt-2 flex items-center gap-2 border-t border-cp-border-muted pt-2 text-[11px]">
+              <span className="text-cp-text-muted">{t('calc.ups.target', 'Ziel-Pufferzeit')}</span>
               <input
                 type="number"
                 min={1}
                 value={targetMinutes}
                 onChange={(e) => setTargetMinutes(Math.max(1, Number(e.target.value) || 1))}
-                className="w-16 rounded border border-slate-700 bg-slate-950 px-1.5 py-0.5 text-cp-xs"
+                className="w-16 rounded border border-cp-border bg-cp-surface-3 px-1.5 py-0.5 text-cp-xs"
               />
-              <span className="text-slate-400">min →</span>
-              <span className="font-mono text-slate-200">
+              <span className="text-cp-text-muted">min →</span>
+              <span className="font-mono text-cp-text-bright">
                 {Math.round(requiredWhForTarget)} Wh {t('calc.ups.needed', 'Akku nötig')}
               </span>
             </div>
           </div>
-          <p className="text-[10px] text-slate-400">
+          <p className="text-[10px] text-cp-text-muted">
             {t(
               'calc.ups.note',
               'USV-Kapazität (W) = VA × Leistungsfaktor. Pufferzeit ≈ nutzbare Akku-Energie / Last. Lineare Näherung — reale Laufzeit hängt von Entladekurve, Alter und Temperatur ab; im Zweifel die Hersteller-Runtime-Tabelle prüfen.',
@@ -1036,14 +1036,14 @@ const PowerTab = () => {
       </details>
 
       {/* #345 ff. — Spannungsfall auf der Zuleitung (Distro-Strecke). */}
-      <details className="rounded border border-slate-800 bg-slate-950/40">
-        <summary className="flex cursor-pointer items-center gap-1.5 px-3 py-1.5 text-[11px] uppercase tracking-wide text-slate-400">
+      <details className="rounded border border-cp-border-muted bg-cp-surface-3/40">
+        <summary className="flex cursor-pointer items-center gap-1.5 px-3 py-1.5 text-[11px] uppercase tracking-wide text-cp-text-muted">
           {t('calc.vdrop.title', 'Spannungsfall (Zuleitung)')}
         </summary>
         <div className="space-y-3 px-3 py-2">
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
             <label className="block">
-              <span className="mb-1 block text-[10px] text-slate-400">
+              <span className="mb-1 block text-[10px] text-cp-text-muted">
                 {t('calc.vdrop.length', 'Leitungslänge (m)')}
               </span>
               <input
@@ -1051,17 +1051,17 @@ const PowerTab = () => {
                 min={0}
                 value={runLength}
                 onChange={(e) => setRunLength(Math.max(0, Number(e.target.value) || 0))}
-                className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-xs"
               />
             </label>
             <label className="block">
-              <span className="mb-1 block text-[10px] text-slate-400">
+              <span className="mb-1 block text-[10px] text-cp-text-muted">
                 {t('calc.vdrop.cross', 'Querschnitt (mm²)')}
               </span>
               <select
                 value={crossSection}
                 onChange={(e) => setCrossSection(Number(e.target.value))}
-                className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-xs"
               >
                 {[1.5, 2.5, 4, 6, 10, 16, 25, 35, 50].map((mm) => (
                   <option key={mm} value={mm}>
@@ -1071,10 +1071,10 @@ const PowerTab = () => {
               </select>
             </label>
             <div className="block">
-              <span className="mb-1 block text-[10px] text-slate-400">
+              <span className="mb-1 block text-[10px] text-cp-text-muted">
                 {t('calc.vdrop.current', 'Laststrom')}
               </span>
-              <div className="rounded border border-slate-800 bg-slate-900 px-2 py-1 font-mono text-cp-xs text-slate-200">
+              <div className="rounded border border-cp-border-muted bg-cp-surface-1 px-2 py-1 font-mono text-cp-xs text-cp-text-bright">
                 {vdropCurrent.toFixed(1)} A
               </div>
             </div>
@@ -1089,11 +1089,11 @@ const PowerTab = () => {
             }`}
           >
             <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-cp-xs">
-              <dt className="text-slate-500">{t('calc.vdrop.drop', 'Spannungsfall')}</dt>
-              <dd className="font-mono text-slate-200">
+              <dt className="text-cp-text-faint">{t('calc.vdrop.drop', 'Spannungsfall')}</dt>
+              <dd className="font-mono text-cp-text-bright">
                 {vdropVolts.toFixed(1)} V
               </dd>
-              <dt className="text-slate-500">{t('calc.vdrop.percent', 'Relativ')}</dt>
+              <dt className="text-cp-text-faint">{t('calc.vdrop.percent', 'Relativ')}</dt>
               <dd className="font-mono text-cp-xl">
                 <span
                   className={
@@ -1106,7 +1106,7 @@ const PowerTab = () => {
                 >
                   {vdropPercent.toFixed(1)} %
                 </span>
-                <span className="ml-2 text-[10px] text-slate-400">
+                <span className="ml-2 text-[10px] text-cp-text-muted">
                   {vdropPercent > 5
                     ? t('calc.vdrop.bad', '> 5 % — Querschnitt erhöhen')
                     : vdropPercent > 3
@@ -1114,13 +1114,13 @@ const PowerTab = () => {
                       : t('calc.vdrop.ok', '≤ 3 % — ok')}
                 </span>
               </dd>
-              <dt className="text-slate-500">{t('calc.vdrop.atLoad', 'Spannung am Ende')}</dt>
-              <dd className="font-mono text-slate-200">
+              <dt className="text-cp-text-faint">{t('calc.vdrop.atLoad', 'Spannung am Ende')}</dt>
+              <dd className="font-mono text-cp-text-bright">
                 ≈ {(supply.voltage - vdropVolts).toFixed(0)} V
               </dd>
             </dl>
           </div>
-          <p className="text-[10px] text-slate-400">
+          <p className="text-[10px] text-cp-text-muted">
             {t(
               'calc.vdrop.note',
               'Kupfer, ρ ≈ 0,0175 Ω·mm²/m. 1-phasig ΔU = 2·L·I·ρ/A, 3-phasig ΔU = √3·L·I·ρ/A. Richtwert: ≤ 3 % an Endgeräten. Laststrom = symmetrischer Strom inkl. Reserve.',
@@ -1130,15 +1130,15 @@ const PowerTab = () => {
       </details>
 
       {totals.devices.length > 0 && (
-        <details className="rounded border border-slate-800 bg-slate-950/40">
-          <summary className="cursor-pointer px-3 py-1.5 text-[11px] uppercase tracking-wide text-slate-400">
+        <details className="rounded border border-cp-border-muted bg-cp-surface-3/40">
+          <summary className="cursor-pointer px-3 py-1.5 text-[11px] uppercase tracking-wide text-cp-text-muted">
             {t('calc.topConsumers', 'Top-Verbraucher')}
           </summary>
           <ul className="px-3 py-2 text-cp-xs">
             {totals.devices.slice(0, 12).map((d) => (
-              <li key={d.name} className="flex justify-between border-b border-slate-800 py-0.5">
+              <li key={d.name} className="flex justify-between border-b border-cp-border-muted py-0.5">
                 <span className="truncate">{d.name}</span>
-                <span className="font-mono text-slate-400">{d.watts} W</span>
+                <span className="font-mono text-cp-text-muted">{d.watts} W</span>
               </li>
             ))}
           </ul>

--- a/src/renderer/components/Calculators/ProjectionCalculatorDialog.tsx
+++ b/src/renderer/components/Calculators/ProjectionCalculatorDialog.tsx
@@ -53,7 +53,7 @@ const NumField = ({
   suffix?: string
 }) => (
   <label className="block">
-    <span className="mb-1 block text-cp-xs text-slate-400">{label}</span>
+    <span className="mb-1 block text-cp-xs text-cp-text-muted">{label}</span>
     <div className="flex items-center gap-1">
       <input
         type="number"
@@ -61,16 +61,16 @@ const NumField = ({
         min={min}
         step={step}
         onChange={(e) => onChange(Number(e.target.value))}
-        className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-base"
+        className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-base"
       />
-      {suffix && <span className="text-cp-xs text-slate-500">{suffix}</span>}
+      {suffix && <span className="text-cp-xs text-cp-text-faint">{suffix}</span>}
     </div>
   </label>
 )
 
 const Result = ({ label, value }: { label: string; value: string }) => (
-  <div className="flex items-baseline justify-between rounded border border-slate-800 bg-slate-900/50 px-3 py-1.5">
-    <span className="text-cp-xs text-slate-400">{label}</span>
+  <div className="flex items-baseline justify-between rounded border border-cp-border-muted bg-cp-surface-1/50 px-3 py-1.5">
+    <span className="text-cp-xs text-cp-text-muted">{label}</span>
     <span className="font-mono text-cp-base text-sky-300">{value}</span>
   </div>
 )
@@ -121,7 +121,7 @@ const ProjectionCalcCore = () => {
       type="button"
       onClick={() => setTab(id)}
       className={`flex-1 rounded px-2 py-1 text-cp-xs ${
-        tab === id ? 'bg-sky-700 text-white' : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+        tab === id ? 'bg-sky-700 text-white' : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
       }`}
     >
       {label}
@@ -129,7 +129,7 @@ const ProjectionCalcCore = () => {
   )
 
   return (
-    <div className="space-y-3 text-slate-200">
+    <div className="space-y-3 text-cp-text-bright">
       <div className="flex gap-1">
         {tabBtn('throw', t('calc.projection.tab.throw', 'Projektionsabstand'))}
         {tabBtn('screen', t('calc.projection.tab.screen', 'Bildgröße & Sitzabstand'))}
@@ -138,7 +138,7 @@ const ProjectionCalcCore = () => {
 
       {tab === 'throw' && (
         <div className="space-y-3">
-          <p className="text-cp-xs text-slate-400">
+          <p className="text-cp-xs text-cp-text-muted">
             {t(
               'calc.projection.throw.intro',
               'Projektionsabstand = Throw-Ratio × Bildbreite. Die Throw-Ratio steht im Datenblatt des Objektivs (z. B. 1.2–1.8).',
@@ -161,11 +161,11 @@ const ProjectionCalcCore = () => {
           <div className="grid grid-cols-2 gap-3">
             <NumField label={t('calc.projection.diagonal', 'Diagonale')} value={diagonalIn} onChange={setDiagonalIn} step={1} suffix="″" />
             <label className="block">
-              <span className="mb-1 block text-cp-xs text-slate-400">{t('calc.projection.aspect', 'Seitenverhältnis')}</span>
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('calc.projection.aspect', 'Seitenverhältnis')}</span>
               <select
                 value={aspectId}
                 onChange={(e) => setAspectId(e.target.value)}
-                className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-base"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-base"
               >
                 {ASPECTS.map((a) => (
                   <option key={a.id} value={a.id}>{a.label}</option>
@@ -179,7 +179,7 @@ const ProjectionCalcCore = () => {
             <Result label={t('calc.projection.viewThx', 'Min. Sitzabstand (THX 36°)')} value={`${screen.thx.toFixed(2)} m`} />
             <Result label={t('calc.projection.viewSmpte', 'Optimaler Sitzabstand (SMPTE 30°)')} value={`${screen.smpte.toFixed(2)} m`} />
           </div>
-          <p className="text-[11px] text-slate-400">
+          <p className="text-[11px] text-cp-text-muted">
             {t('calc.projection.screen.note', 'Sitzabstände nach horizontalem Blickwinkel: THX empfiehlt max. 36°, SMPTE EG-18 ca. 30°.')}
           </p>
         </div>
@@ -187,7 +187,7 @@ const ProjectionCalcCore = () => {
 
       {tab === 'led' && (
         <div className="space-y-3">
-          <p className="text-cp-xs text-slate-400">
+          <p className="text-cp-xs text-cp-text-muted">
             {t('calc.projection.led.intro', 'Auflösung einer LED-Wand aus Pixel-Pitch und physischer Größe.')}
           </p>
           <div className="grid grid-cols-3 gap-3">
@@ -199,7 +199,7 @@ const ProjectionCalcCore = () => {
             <Result label={t('calc.projection.resolution', 'Auflösung')} value={`${led.pxW} × ${led.pxH} px`} />
             <Result label={t('calc.projection.totalPixels', 'Pixel gesamt')} value={`${led.total.toLocaleString()} (${led.mp.toFixed(1)} MP)`} />
           </div>
-          <p className="text-[11px] text-slate-400">
+          <p className="text-[11px] text-cp-text-muted">
             {t('calc.projection.led.note', 'Faustregel Mindest-Betrachtungsabstand (m) ≈ Pixel-Pitch (mm). Bei 2.6 mm also ab ~2.6 m ohne sichtbares Pixelraster.')}
           </p>
         </div>

--- a/src/renderer/components/Calculators/RecordingStorageCalculatorDialog.tsx
+++ b/src/renderer/components/Calculators/RecordingStorageCalculatorDialog.tsx
@@ -101,7 +101,7 @@ export const RecordingStorageCalcCore = ({
 
   return (
     <div className="space-y-3 p-4 text-cp-base">
-      <p className="text-[11px] text-slate-400">
+      <p className="text-[11px] text-cp-text-muted">
         {t(
           'recStorage.intro',
           'Berechnet den Speicherplatzbedarf für eine Aufzeichnung: Codec-Bitrate × Dauer × Kanäle. Werte sind Richtwerte ohne Filesystem-Overhead.',
@@ -109,11 +109,11 @@ export const RecordingStorageCalcCore = ({
       </p>
 
       <label className="block">
-        <span className="mb-1 block text-cp-xs text-slate-400">{t('recStorage.codec', 'Codec / Bitrate-Preset')}</span>
+        <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('recStorage.codec', 'Codec / Bitrate-Preset')}</span>
         <select
           value={codecId}
           onChange={(e) => setCodecId(e.target.value)}
-          className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+          className="w-full rounded border border-cp-border bg-cp-surface-3 p-2"
         >
           {CODEC_PRESETS.map((c) => (
             <option key={c.id} value={c.id}>
@@ -125,43 +125,43 @@ export const RecordingStorageCalcCore = ({
 
       {codecId === 'custom' && (
         <label className="block">
-          <span className="mb-1 block text-cp-xs text-slate-400">{t('recStorage.customMbps', 'Eigene Bitrate (Mbps)')}</span>
+          <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('recStorage.customMbps', 'Eigene Bitrate (Mbps)')}</span>
           <input
             type="number"
             min={1}
             max={10000}
             value={customMbps}
             onChange={(e) => setCustomMbps(Math.max(1, Number(e.target.value) || 100))}
-            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+            className="w-full rounded border border-cp-border bg-cp-surface-3 p-2"
           />
         </label>
       )}
 
       <div className="grid grid-cols-3 gap-2">
         <label className="block">
-          <span className="mb-1 block text-cp-xs text-slate-400">{t('recStorage.hours', 'Stunden')}</span>
+          <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('recStorage.hours', 'Stunden')}</span>
           <input
             type="number"
             min={0}
             max={9999}
             value={hours}
             onChange={(e) => setHours(Math.max(0, Number(e.target.value) || 0))}
-            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+            className="w-full rounded border border-cp-border bg-cp-surface-3 p-2"
           />
         </label>
         <label className="block">
-          <span className="mb-1 block text-cp-xs text-slate-400">{t('recStorage.minutes', 'Minuten')}</span>
+          <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('recStorage.minutes', 'Minuten')}</span>
           <input
             type="number"
             min={0}
             max={59}
             value={minutes}
             onChange={(e) => setMinutes(Math.max(0, Math.min(59, Number(e.target.value) || 0)))}
-            className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+            className="w-full rounded border border-cp-border bg-cp-surface-3 p-2"
           />
         </label>
         <label className="block">
-          <span className="mb-1 block text-cp-xs text-slate-400">{t('recStorage.channels', 'Kanäle')}</span>
+          <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('recStorage.channels', 'Kanäle')}</span>
           <input
             type="number"
             min={1}
@@ -169,10 +169,10 @@ export const RecordingStorageCalcCore = ({
             value={channels}
             disabled={fixedChannels !== undefined}
             onChange={(e) => setChannels(Math.max(1, Math.min(256, Number(e.target.value) || 1)))}
-            className="w-full rounded border border-slate-700 bg-slate-950 p-2 disabled:opacity-50"
+            className="w-full rounded border border-cp-border bg-cp-surface-3 p-2 disabled:opacity-50"
           />
           {fixedChannels !== undefined && (
-            <span className="mt-0.5 block text-[10px] text-slate-400">
+            <span className="mt-0.5 block text-[10px] text-cp-text-muted">
               {t('recStorage.fixedFromDevice', 'aus Gerät übernommen')}
             </span>
           )}
@@ -181,23 +181,23 @@ export const RecordingStorageCalcCore = ({
 
       <div className="rounded border border-emerald-700 bg-emerald-950/30 p-3">
         <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-cp-xs">
-          <dt className="text-slate-500">{t('recStorage.effectiveBitrate', 'Effektive Bitrate')}</dt>
-          <dd className="font-mono text-slate-200">{effectiveMbps} Mbps</dd>
-          <dt className="text-slate-500">{t('recStorage.duration', 'Dauer')}</dt>
-          <dd className="font-mono text-slate-200">
+          <dt className="text-cp-text-faint">{t('recStorage.effectiveBitrate', 'Effektive Bitrate')}</dt>
+          <dd className="font-mono text-cp-text-bright">{effectiveMbps} Mbps</dd>
+          <dt className="text-cp-text-faint">{t('recStorage.duration', 'Dauer')}</dt>
+          <dd className="font-mono text-cp-text-bright">
             {hours}h {minutes}min ({totalDurationHours.toFixed(2)} h)
           </dd>
-          <dt className="text-slate-500">{t('recStorage.perChannel', 'Pro Kanal')}</dt>
-          <dd className="font-mono text-slate-200">{formatGb(result.perChannel)}</dd>
-          <dt className="text-slate-500 font-semibold">
+          <dt className="text-cp-text-faint">{t('recStorage.perChannel', 'Pro Kanal')}</dt>
+          <dd className="font-mono text-cp-text-bright">{formatGb(result.perChannel)}</dd>
+          <dt className="text-cp-text-faint font-semibold">
             {t('recStorage.total', 'Gesamt')} ({channels}× {t('recStorage.channels', 'Kanäle')})
           </dt>
           <dd className="font-mono text-cp-xl text-emerald-200">{formatGb(result.total)}</dd>
           {/* Schreib-Durchsatz: kann der Datenträger das mitschreiben? */}
-          <dt className="text-slate-500">{t('recStorage.throughput', 'Schreibrate')}</dt>
-          <dd className="font-mono text-slate-200">
+          <dt className="text-cp-text-faint">{t('recStorage.throughput', 'Schreibrate')}</dt>
+          <dd className="font-mono text-cp-text-bright">
             {((effectiveMbps * channels) / 8).toFixed(0)} MB/s
-            <span className="ml-2 text-[10px] text-slate-400">
+            <span className="ml-2 text-[10px] text-cp-text-muted">
               {(effectiveMbps * channels) / 8 > 2000
                 ? t('recStorage.tpNvmeArray', '→ NVMe-RAID nötig')
                 : (effectiveMbps * channels) / 8 > 450
@@ -212,16 +212,16 @@ export const RecordingStorageCalcCore = ({
 
       {/* Array-Dimensionierung: wie viele Laufwerke brauche ich? */}
       <div className="rounded border border-sky-700 bg-sky-950/20 p-3">
-        <div className="mb-2 text-[11px] uppercase tracking-wide text-slate-300">
+        <div className="mb-2 text-[11px] uppercase tracking-wide text-cp-text-secondary">
           {t('recStorage.sizing', 'Array-Dimensionierung')}
         </div>
         <div className="grid grid-cols-3 gap-2">
           <label className="block">
-            <span className="mb-1 block text-[10px] text-slate-400">{t('recStorage.redundancy', 'Redundanz')}</span>
+            <span className="mb-1 block text-[10px] text-cp-text-muted">{t('recStorage.redundancy', 'Redundanz')}</span>
             <select
               value={redundancy}
               onChange={(e) => setRedundancy(e.target.value as typeof redundancy)}
-              className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+              className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
             >
               <option value="none">{t('recStorage.redNone', 'Keine (JBOD)')}</option>
               <option value="raid5">RAID 5 (+1)</option>
@@ -230,46 +230,46 @@ export const RecordingStorageCalcCore = ({
             </select>
           </label>
           <label className="block">
-            <span className="mb-1 block text-[10px] text-slate-400">{t('recStorage.headroom', 'Reserve (%)')}</span>
+            <span className="mb-1 block text-[10px] text-cp-text-muted">{t('recStorage.headroom', 'Reserve (%)')}</span>
             <input
               type="number"
               min={0}
               max={90}
               value={headroomPercent}
               onChange={(e) => setHeadroomPercent(Math.min(90, Math.max(0, Number(e.target.value) || 0)))}
-              className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+              className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
             />
           </label>
           <label className="block">
-            <span className="mb-1 block text-[10px] text-slate-400">{t('recStorage.driveTb', 'Laufwerk (TB)')}</span>
+            <span className="mb-1 block text-[10px] text-cp-text-muted">{t('recStorage.driveTb', 'Laufwerk (TB)')}</span>
             <input
               type="number"
               min={0.5}
               step={0.5}
               value={driveTb}
               onChange={(e) => setDriveTb(Math.max(0.5, Number(e.target.value) || 0.5))}
-              className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+              className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
             />
           </label>
         </div>
         <dl className="mt-2 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-cp-xs">
-          <dt className="text-slate-500">{t('recStorage.usableNeeded', 'Nutzbedarf inkl. Reserve')}</dt>
-          <dd className="font-mono text-slate-200">{sizing.usableNeededTb.toFixed(2)} TB</dd>
-          <dt className="text-slate-500 font-semibold">{t('recStorage.drivesNeeded', 'Laufwerke nötig')}</dt>
+          <dt className="text-cp-text-faint">{t('recStorage.usableNeeded', 'Nutzbedarf inkl. Reserve')}</dt>
+          <dd className="font-mono text-cp-text-bright">{sizing.usableNeededTb.toFixed(2)} TB</dd>
+          <dt className="text-cp-text-faint font-semibold">{t('recStorage.drivesNeeded', 'Laufwerke nötig')}</dt>
           <dd className="font-mono text-cp-xl text-sky-200">
             {sizing.totalDrives} × {driveTb} TB
-            <span className="ml-2 text-[10px] text-slate-400">
+            <span className="ml-2 text-[10px] text-cp-text-muted">
               ({t('recStorage.rawCapacity', 'roh')} {sizing.rawTb.toFixed(1)} TB)
             </span>
           </dd>
         </dl>
       </div>
 
-      <details className="rounded border border-slate-800 bg-slate-950/40">
-        <summary className="cursor-pointer px-3 py-1.5 text-[11px] uppercase tracking-wide text-slate-400">
+      <details className="rounded border border-cp-border-muted bg-cp-surface-3/40">
+        <summary className="cursor-pointer px-3 py-1.5 text-[11px] uppercase tracking-wide text-cp-text-muted">
           {t('recStorage.formulaHeader', 'Formel')}
         </summary>
-        <code className="block px-3 py-2 text-[11px] text-slate-300">
+        <code className="block px-3 py-2 text-[11px] text-cp-text-secondary">
           (Mbps × 3600 s × Stunden) ÷ 8 ÷ 1024 = GB pro Kanal
           <br />
           GB pro Kanal × Kanäle = Gesamt

--- a/src/renderer/components/Export/ExportDialog.tsx
+++ b/src/renderer/components/Export/ExportDialog.tsx
@@ -117,10 +117,10 @@ export const ExportDialog = ({
         ref={panelRef}
         aria-labelledby={titleId}
         {...dialogProps}
-        className="flex h-[85vh] w-full max-w-5xl flex-col overflow-hidden rounded border border-slate-700 bg-slate-900 text-slate-100 shadow-2xl outline-none sm:flex-row"
+        className="flex h-[85vh] w-full max-w-5xl flex-col overflow-hidden rounded border border-cp-border bg-cp-surface-1 text-cp-text shadow-2xl outline-none sm:flex-row"
       >
-        <aside className="flex shrink-0 flex-row gap-1 overflow-x-auto border-b border-slate-800 bg-slate-950/40 p-3 sm:w-52 sm:flex-col sm:overflow-x-visible sm:overflow-y-auto sm:border-b-0 sm:border-r">
-          <h3 className="mb-2 hidden px-2 text-cp-xs font-semibold uppercase tracking-wider text-slate-500 sm:block">
+        <aside className="flex shrink-0 flex-row gap-1 overflow-x-auto border-b border-cp-border-muted bg-cp-surface-3/40 p-3 sm:w-52 sm:flex-col sm:overflow-x-visible sm:overflow-y-auto sm:border-b-0 sm:border-r">
+          <h3 className="mb-2 hidden px-2 text-cp-xs font-semibold uppercase tracking-wider text-cp-text-faint sm:block">
             {t('export.title', 'Exportieren & Drucken')}
           </h3>
           {(Object.keys(SECTION_LABEL) as Section[]).map((id) => (
@@ -131,7 +131,7 @@ export const ExportDialog = ({
               className={`flex items-center gap-2 rounded px-3 py-2 text-left text-cp-base ${
                 section === id
                   ? 'bg-sky-700 text-white'
-                  : 'text-slate-300 hover:bg-slate-800'
+                  : 'text-cp-text-secondary hover:bg-cp-surface-2'
               }`}
             >
               <Icon icon={SECTION_ICON[id]} size="sm" />
@@ -141,7 +141,7 @@ export const ExportDialog = ({
         </aside>
 
         <main className="flex min-h-0 min-w-0 flex-1 flex-col">
-          <header className="flex shrink-0 items-center justify-between border-b border-slate-800 px-4 py-2">
+          <header className="flex shrink-0 items-center justify-between border-b border-cp-border-muted px-4 py-2">
             <h2 id={titleId} className="flex items-center gap-2 text-cp-2xl font-semibold">
               <Icon icon={SECTION_ICON[section]} size="sm" />{' '}
               {t(`export.section.${section}`, SECTION_LABEL[section])}
@@ -149,7 +149,7 @@ export const ExportDialog = ({
             <button
               type="button"
               onClick={onClose}
-              className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
             >
               {t('common.close', 'Schließen')}
             </button>
@@ -161,7 +161,7 @@ export const ExportDialog = ({
               "Standard-Viewport von Kabel-Stückliste ist so groß
               dass man scrollen muss um Drucken-Button zu sehen". */}
           <div className="flex min-h-0 flex-1 flex-col p-4">
-            <p className="mb-3 shrink-0 text-cp-xs text-slate-400">{t(`export.desc.${section}`, SECTION_DESC[section])}</p>
+            <p className="mb-3 shrink-0 text-cp-xs text-cp-text-muted">{t(`export.desc.${section}`, SECTION_DESC[section])}</p>
             <div className="flex min-h-0 flex-1 flex-col">
               {section === 'plan' && (
                 <PlanSection
@@ -248,7 +248,7 @@ const PlanSection = ({
   return (
     <div className="space-y-4">
       <fieldset className="space-y-2">
-        <legend className="mb-1 text-cp-xs font-semibold text-slate-300">{t('export.format', 'Format')}</legend>
+        <legend className="mb-1 text-cp-xs font-semibold text-cp-text-secondary">{t('export.format', 'Format')}</legend>
         {FORMAT_OPTIONS.map((opt) => {
           const selected = format === opt.value
           return (
@@ -257,7 +257,7 @@ const PlanSection = ({
               className={`flex cursor-pointer items-start gap-2 rounded border px-3 py-2 text-cp-xs ${
                 selected
                   ? 'border-sky-500 bg-sky-900/30'
-                  : 'border-slate-700 bg-slate-950 hover:border-slate-600'
+                  : 'border-cp-border bg-cp-surface-3 hover:border-cp-surface-5'
               }`}
             >
               <input
@@ -270,8 +270,8 @@ const PlanSection = ({
               />
               <Icon icon={opt.icon} size="sm" />
               <span className="flex-1">
-                <span className="block font-semibold text-slate-100">{opt.label}</span>
-                <span className="block text-[10px] text-slate-400">{opt.hint}</span>
+                <span className="block font-semibold text-cp-text">{opt.label}</span>
+                <span className="block text-[10px] text-cp-text-muted">{opt.hint}</span>
               </span>
             </label>
           )
@@ -281,7 +281,7 @@ const PlanSection = ({
       {format === 'pdf' && (
         <>
           <fieldset className="space-y-1">
-            <legend className="mb-1 text-cp-xs font-semibold text-slate-300">{t('export.pdfTheme', 'PDF-Thema')}</legend>
+            <legend className="mb-1 text-cp-xs font-semibold text-cp-text-secondary">{t('export.pdfTheme', 'PDF-Thema')}</legend>
             <label className="flex items-center gap-2 text-cp-xs">
               <input
                 type="radio"
@@ -306,7 +306,7 @@ const PlanSection = ({
               Text, scharf bei jedem Zoom, kleinere Dateigröße. Default
               ist Raster damit nichts am bestehenden Workflow bricht. */}
           <fieldset className="space-y-1">
-            <legend className="mb-1 text-cp-xs font-semibold text-slate-300">{t('export.renderMode', 'Render-Modus')}</legend>
+            <legend className="mb-1 text-cp-xs font-semibold text-cp-text-secondary">{t('export.renderMode', 'Render-Modus')}</legend>
             <label className="flex cursor-pointer items-start gap-2 text-cp-xs">
               <input
                 type="radio"
@@ -317,7 +317,7 @@ const PlanSection = ({
               />
               <span>
                 <span className="flex items-center gap-1"><Icon icon={Camera} size="xs" /> {t('export.render.raster', 'Raster (klassisch)')}</span>
-                <span className="block text-[10px] text-slate-400">
+                <span className="block text-[10px] text-cp-text-muted">
                   {t(
                     'export.render.rasterHint',
                     'JPEG-Snapshot. Zuverlässig, aber Text wird unscharf bei großem Zoom in der PDF.',
@@ -335,7 +335,7 @@ const PlanSection = ({
               />
               <span>
                 <span className="flex items-center gap-1"><Icon icon={Sparkles} size="xs" /> {t('export.render.vector', 'Vektor')}</span>
-                <span className="block text-[10px] text-slate-400">
+                <span className="block text-[10px] text-cp-text-muted">
                   {t(
                     'export.render.vectorHint',
                     'Chromium printToPDF. Text bleibt selektierbar & scharf bei jedem Zoom. Kleinere Dateigröße.',
@@ -348,13 +348,13 @@ const PlanSection = ({
               Raster ist das fix-bestimmt durch die natural Canvas-Groesse. */}
           {pdfVector && (
             <fieldset className="space-y-1">
-              <legend className="mb-1 text-cp-xs font-semibold text-slate-300">
+              <legend className="mb-1 text-cp-xs font-semibold text-cp-text-secondary">
                 {t('export.pageSize', 'Page-Size')}
               </legend>
               <select
                 value={pdfPageSize}
                 onChange={(e) => setPdfPageSize(e.target.value as PdfPageSizeOpt)}
-                className="w-full rounded border border-slate-700 bg-slate-900 px-2 py-1 text-cp-xs text-slate-100"
+                className="w-full rounded border border-cp-border bg-cp-surface-1 px-2 py-1 text-cp-xs text-cp-text"
               >
                 <option value="auto">{t('export.page.auto', 'Auto — A0 Landscape (kompatibel mit allen Viewern)')}</option>
                 <option value="a4">A4 Landscape (297×210 mm)</option>
@@ -365,7 +365,7 @@ const PlanSection = ({
                 <option value="a0plus">A0+ Plotter (1682×1189 mm)</option>
                 <option value="original">{t('export.page.original', 'Original — volle Canvas-Groesse fuer Plotter')}</option>
               </select>
-              <p className="text-[10px] text-slate-400">
+              <p className="text-[10px] text-cp-text-muted">
                 {pdfPageSize === 'original'
                   ? t('export.page.originalHint', 'Achtung: Edge / Preview zeigen Pages über A0 manchmal weiss an. Acrobat + Plotter-Software drucken trotzdem.')
                   : t('export.page.scaleHint', 'Canvas wird vektoriell auf die Page-Groesse skaliert. Text bleibt scharf.')}
@@ -377,21 +377,21 @@ const PlanSection = ({
               Auswahl bidirektional. "Nur Video drucken" = alle anderen
               Chips ausschalten, exportieren, Chips wieder einschalten. */}
           <fieldset className="space-y-1">
-            <legend className="mb-1 text-cp-xs font-semibold text-slate-300">
+            <legend className="mb-1 text-cp-xs font-semibold text-cp-text-secondary">
               {t('export.layersInPdf', 'Ebenen (im PDF enthalten)')}
             </legend>
             <div className="-mx-1 flex flex-wrap gap-1">
               <LayerVisibilityChips />
             </div>
-            <p className="text-[10px] text-slate-400">
+            <p className="text-[10px] text-cp-text-muted">
               {t('export.layersHint', 'Klick auf einen Chip schaltet die Ebene für Canvas UND PDF um.')}
             </p>
           </fieldset>
         </>
       )}
 
-      <div className="rounded border border-slate-800 bg-slate-950/40 p-2 text-[11px] text-slate-400">
-        {t('export.savedAs', 'Wird gespeichert als')} <code className="rounded bg-slate-800 px-1 py-0.5">{projectName || 'cable-planner'}</code>
+      <div className="rounded border border-cp-border-muted bg-cp-surface-3/40 p-2 text-[11px] text-cp-text-muted">
+        {t('export.savedAs', 'Wird gespeichert als')} <code className="rounded bg-cp-surface-2 px-1 py-0.5">{projectName || 'cable-planner'}</code>
       </div>
 
       <div className="flex justify-end gap-2">
@@ -520,19 +520,19 @@ const PatchSheetSection = ({ onClose }: { onClose: () => void }) => {
         <span className="text-emerald-300">→</span>
       </button>
 
-      <div className="mb-1 text-[11px] text-slate-400">
+      <div className="mb-1 text-[11px] text-cp-text-muted">
         {t('export.patch.perDeviceHint', '— oder pro-Gerät Patch-Sheet erzeugen:')}
       </div>
 
       <div>
         <div className="mb-1 flex items-center justify-between">
-          <span className="text-cp-xs font-semibold text-slate-300">
+          <span className="text-cp-xs font-semibold text-cp-text-secondary">
             {t('export.patch.devicesCount', 'Geräte')} ({selectedIds.size} / {filtered.length})
           </span>
           <button
             type="button"
             onClick={toggleAll}
-            className="rounded bg-slate-800 px-2 py-0.5 text-[10px] hover:bg-slate-700"
+            className="rounded bg-cp-surface-2 px-2 py-0.5 text-[10px] hover:bg-cp-surface-4"
           >
             {selectedIds.size === filtered.length
               ? t('export.patch.deselectAll', 'Alle abwählen')
@@ -545,15 +545,15 @@ const PatchSheetSection = ({ onClose }: { onClose: () => void }) => {
           onChange={(e) => setFilter(e.target.value)}
           placeholder={t('export.patch.filterPlaceholder', 'Filtern…')}
           aria-label={t('export.patch.filterPlaceholder', 'Filtern…')}
-          className="mb-2 w-full rounded border border-slate-700 bg-slate-950 px-2 py-1 text-cp-xs"
+          className="mb-2 w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-xs"
         />
-        <div className="max-h-64 space-y-0.5 overflow-y-auto rounded border border-slate-800 bg-slate-950/50 p-1">
+        <div className="max-h-64 space-y-0.5 overflow-y-auto rounded border border-cp-border-muted bg-cp-surface-3/50 p-1">
           {filtered.map((d) => {
             const on = selectedIds.has(d.id)
             return (
               <label
                 key={d.id}
-                className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-cp-xs hover:bg-slate-800"
+                className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-cp-xs hover:bg-cp-surface-2"
               >
                 <input
                   type="checkbox"
@@ -568,12 +568,12 @@ const PatchSheetSection = ({ onClose }: { onClose: () => void }) => {
                   }}
                 />
                 <span className="flex-1 truncate">{d.name}</span>
-                <span className="text-[10px] text-slate-400">{d.category}</span>
+                <span className="text-[10px] text-cp-text-muted">{d.category}</span>
               </label>
             )
           })}
           {filtered.length === 0 && (
-            <div className="px-2 py-3 text-center text-[11px] text-slate-400">
+            <div className="px-2 py-3 text-center text-[11px] text-cp-text-muted">
               {t('export.patch.noDevices', 'Keine Geräte im Projekt.')}
             </div>
           )}
@@ -588,7 +588,7 @@ const PatchSheetSection = ({ onClose }: { onClose: () => void }) => {
             type="button"
             onClick={() => setPendingAction('individual')}
             disabled={busy || selectedIds.size === 0}
-            className="rounded bg-slate-700 px-3 py-1.5 text-cp-xs hover:bg-slate-600 disabled:opacity-50"
+            className="rounded bg-cp-surface-4 px-3 py-1.5 text-cp-xs hover:bg-cp-surface-5 disabled:opacity-50"
             title={t('export.patch.perDevice', 'Eine PDF pro selektiertem Gerät')}
           >
             {t('export.patch.individualPdf', 'Einzel-PDF ({n})').replace('{n}', String(selectedIds.size))}
@@ -597,7 +597,7 @@ const PatchSheetSection = ({ onClose }: { onClose: () => void }) => {
             type="button"
             onClick={() => setPendingAction('batch')}
             disabled={busy || selectedIds.size === 0}
-            className="rounded bg-slate-700 px-3 py-1.5 text-cp-xs hover:bg-slate-600 disabled:opacity-50"
+            className="rounded bg-cp-surface-4 px-3 py-1.5 text-cp-xs hover:bg-cp-surface-5 disabled:opacity-50"
             title={t('export.patch.batchPdf', 'Eine Sammel-PDF — ein Gerät pro Seite')}
           >
             {t('export.patch.combinedPdf', 'Sammel-PDF ({n})').replace('{n}', String(selectedIds.size))}
@@ -614,7 +614,7 @@ const PatchSheetSection = ({ onClose }: { onClose: () => void }) => {
         </div>
       ) : (
         <div className="flex flex-wrap items-center justify-end gap-2 rounded border border-sky-700/60 bg-sky-950/40 px-3 py-2">
-          <span className="mr-auto text-cp-xs text-slate-300">
+          <span className="mr-auto text-cp-xs text-cp-text-secondary">
             <span className="font-semibold text-sky-200">{actionLabel[pendingAction]}</span>
             {' '}— {t('export.patch.pickPaper', 'Papier-Format wählen:')}
           </span>
@@ -638,7 +638,7 @@ const PatchSheetSection = ({ onClose }: { onClose: () => void }) => {
             type="button"
             disabled={busy}
             onClick={() => setPendingAction(null)}
-            className="rounded bg-slate-700 px-3 py-1.5 text-cp-xs text-slate-200 hover:bg-slate-600 disabled:opacity-50"
+            className="rounded bg-cp-surface-4 px-3 py-1.5 text-cp-xs text-cp-text-bright hover:bg-cp-surface-5 disabled:opacity-50"
           >
             Abbrechen
           </button>
@@ -947,10 +947,10 @@ const BomSection = () => {
       {/* v7.9.4 — Status-Zeile oben (shrink-0), Tabelle nimmt flex-1 mit
           eigenem overflow-auto, Footer + Action-Buttons sind shrink-0
           → bleiben IMMER sichtbar, egal wie groß der Dialog ist. */}
-      <div className="flex shrink-0 flex-wrap items-center gap-2 text-[11px] text-slate-400">
+      <div className="flex shrink-0 flex-wrap items-center gap-2 text-[11px] text-cp-text-muted">
         <span>
           {t('export.installedCables', 'Verbaute Kabel:')}{' '}
-          <b className="text-slate-200">{project.cables.length}</b>
+          <b className="text-cp-text-bright">{project.cables.length}</b>
         </span>
         {rows.some((r) => r.diff < 0) && (
           <span className="inline-flex items-center gap-1 rounded bg-red-900/50 px-2 py-0.5 font-semibold text-red-300">
@@ -968,9 +968,9 @@ const BomSection = () => {
         )}
       </div>
 
-      <div className="min-h-0 flex-1 overflow-auto rounded border border-slate-800 bg-slate-950/40">
+      <div className="min-h-0 flex-1 overflow-auto rounded border border-cp-border-muted bg-cp-surface-3/40">
         <table className="w-full text-cp-xs">
-          <thead className="sticky top-0 bg-slate-950 text-slate-300">
+          <thead className="sticky top-0 bg-cp-surface-3 text-cp-text-secondary">
             <tr>
               <th className="px-3 py-2 text-left">{t('export.bom.col.type', 'Typ')}</th>
               <th className="px-3 py-2 text-right">{t('export.bom.col.length', 'Länge (m)')}</th>
@@ -983,7 +983,7 @@ const BomSection = () => {
           <tbody>
             {rows.length === 0 && (
               <tr>
-                <td className="px-3 py-4 text-center text-slate-500" colSpan={6}>
+                <td className="px-3 py-4 text-center text-cp-text-faint" colSpan={6}>
                   Keine Kabel im Projekt.
                 </td>
               </tr>
@@ -991,17 +991,17 @@ const BomSection = () => {
             {rows.map((r) => (
               <tr
                 key={r.key}
-                className={`border-t border-slate-800 ${r.diff < 0 ? 'bg-red-950/30' : ''}`}
+                className={`border-t border-cp-border-muted ${r.diff < 0 ? 'bg-red-950/30' : ''}`}
               >
                 <td className="px-3 py-1">
-                  <span className="font-medium text-slate-100">{r.type}</span>
+                  <span className="font-medium text-cp-text">{r.type}</span>
                   {r.sample && (
-                    <span className="ml-1 text-[10px] text-slate-400">({r.sample.name})</span>
+                    <span className="ml-1 text-[10px] text-cp-text-muted">({r.sample.name})</span>
                   )}
                 </td>
                 <td className="px-3 py-1 text-right font-mono">{r.length}</td>
                 <td className="px-3 py-1 text-right font-mono">{r.built}</td>
-                <td className="px-3 py-1 text-right font-mono text-slate-300">
+                <td className="px-3 py-1 text-right font-mono text-cp-text-secondary">
                   {Number((r.built * r.length).toFixed(1))}
                 </td>
                 <td className="px-3 py-1 text-right">
@@ -1010,7 +1010,7 @@ const BomSection = () => {
                     min={0}
                     value={r.planned}
                     onChange={(e) => setPlanned(r.key, Number(e.target.value))}
-                    className="w-16 rounded border border-slate-700 bg-slate-950 px-1 py-0.5 text-right font-mono"
+                    className="w-16 rounded border border-cp-border bg-cp-surface-3 px-1 py-0.5 text-right font-mono"
                   />
                 </td>
                 <td
@@ -1035,8 +1035,8 @@ const BomSection = () => {
             ))}
           </tbody>
           {rows.length > 0 && (
-            <tfoot className="sticky bottom-0 bg-slate-950">
-              <tr className="border-t-2 border-slate-700 font-semibold text-slate-200">
+            <tfoot className="sticky bottom-0 bg-cp-surface-3">
+              <tr className="border-t-2 border-cp-border font-semibold text-cp-text-bright">
                 <td className="px-3 py-2 text-left" colSpan={2}>{t('bom.cable.total', 'Gesamt')}</td>
                 <td className="px-3 py-2 text-right font-mono">{rows.reduce((s, r) => s + r.built, 0)}</td>
                 <td className="px-3 py-2 text-right font-mono text-emerald-300">
@@ -1051,27 +1051,27 @@ const BomSection = () => {
 
       {/* Per-Gewerk-Zusammenfassung (Anzahl + Meter je Layer). */}
       {layerSummary.length > 0 && (
-        <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-slate-400">
-          <span className="font-semibold uppercase tracking-wide text-slate-500">
+        <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-cp-text-muted">
+          <span className="font-semibold uppercase tracking-wide text-cp-text-faint">
             {t('export.bom.byLayer', 'Je Gewerk')}:
           </span>
           {layerSummary.map((l) => (
             <span key={l.layer}>
               {t(`layer.${l.layer}`, LAYER_LABEL_DE[l.layer] ?? l.layer)}:{' '}
-              <b className="text-slate-200">{l.count}×</b>{' '}
+              <b className="text-cp-text-bright">{l.count}×</b>{' '}
               <span className="font-mono">{Number(l.meters.toFixed(1))} m</span>
             </span>
           ))}
         </div>
       )}
       {connectorSummary.length > 0 && (
-        <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-slate-400">
-          <span className="font-semibold uppercase tracking-wide text-slate-500">
+        <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-cp-text-muted">
+          <span className="font-semibold uppercase tracking-wide text-cp-text-faint">
             {t('export.bom.connectors', 'Steckverbinder (Enden)')}:
           </span>
           {connectorSummary.map((c) => (
             <span key={c.type}>
-              {c.type} <b className="text-slate-200">×{c.count}</b>
+              {c.type} <b className="text-cp-text-bright">×{c.count}</b>
             </span>
           ))}
         </div>
@@ -1079,7 +1079,7 @@ const BomSection = () => {
 
       {/* Rentman-Planung-Save (shrink-0, pinned). */}
       <div className="flex shrink-0 items-center justify-between text-[11px]">
-        <span className="text-slate-400">
+        <span className="text-cp-text-muted">
           {draftPlan
             ? t('export.bom.rentmanDirty', 'Nicht gespeicherte Änderungen an der Rentman-Planung.')
             : t('export.bom.rentmanClean', 'Rentman-Planung wird im Projekt gespeichert.')}
@@ -1089,7 +1089,7 @@ const BomSection = () => {
             <button
               type="button"
               onClick={discardPlan}
-              className="rounded bg-slate-700 px-3 py-1 text-cp-xs hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-3 py-1 text-cp-xs hover:bg-cp-surface-5"
             >
               {t('common.discard', 'Verwerfen')}
             </button>
@@ -1109,11 +1109,11 @@ const BomSection = () => {
           Patch-Sheets. CSV / PDF / Drucken sind die Export-Outputs der
           Sektion. Tabelle nimmt flex-1, diese Zeile shrink-0 → immer
           sichtbar ohne scrollen. */}
-      <div className="flex shrink-0 justify-end gap-2 border-t border-slate-800 pt-2">
+      <div className="flex shrink-0 justify-end gap-2 border-t border-cp-border-muted pt-2">
         <button
           type="button"
           onClick={exportCsv}
-          className="rounded bg-slate-700 px-3 py-1.5 text-cp-xs hover:bg-slate-600"
+          className="rounded bg-cp-surface-4 px-3 py-1.5 text-cp-xs hover:bg-cp-surface-5"
           title={t('export.bom.csvTitle', 'Tabelle als CSV (UTF-8 mit BOM für Excel) herunterladen')}
         >
           {t('export.bom.csv', 'Als CSV herunterladen')}

--- a/src/renderer/components/Export/GreenGoExportDialog.tsx
+++ b/src/renderer/components/Export/GreenGoExportDialog.tsx
@@ -262,18 +262,18 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
-      <div className="flex max-h-[92vh] w-full max-w-4xl flex-col overflow-hidden rounded border border-emerald-700 bg-slate-900 text-slate-100">
+      <div className="flex max-h-[92vh] w-full max-w-4xl flex-col overflow-hidden rounded border border-emerald-700 bg-cp-surface-1 text-cp-text">
 
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-slate-700 px-4 py-3">
+        <div className="flex items-center justify-between border-b border-cp-border px-4 py-3">
           <div>
             <h3 className="text-cp-xl font-semibold text-emerald-300">{t('greengo.title', 'GreenGo Intercom-Planung')}</h3>
-            <p className="text-[11px] text-slate-400">{config.systemName}</p>
+            <p className="text-[11px] text-cp-text-muted">{config.systemName}</p>
           </div>
           <button
             type="button"
             onClick={onClose}
-            className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+            className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
             aria-label={t('common.close', 'Schließen')}
           >
             <Icon icon={X} size="sm" />
@@ -281,7 +281,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
         </div>
 
         {/* Tabs */}
-        <div className="flex border-b border-slate-700 text-cp-xs">
+        <div className="flex border-b border-cp-border text-cp-xs">
           {([
             ['matrix',  t('greengo.tab.matrix', 'Übersicht')],
             ['users',   `${t('greengo.tab.users', 'Stationen')} (${config.users.length})`],
@@ -295,7 +295,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
               className={`px-4 py-2 font-medium transition-colors ${
                 activeTab === tab
                   ? 'border-b-2 border-emerald-400 text-emerald-300'
-                  : 'text-slate-400 hover:text-slate-200'
+                  : 'text-cp-text-muted hover:text-cp-text-bright'
               }`}
             >
               {label}
@@ -323,11 +323,11 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                 <div className="overflow-x-auto">
                   <table className="w-full border-collapse text-cp-xs">
                     <thead>
-                      <tr className="bg-slate-800">
-                        <th className="w-8 px-2 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-slate-400">#</th>
-                        <th className="min-w-[130px] px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-slate-400">{t('greengo.col.station', 'Station')}</th>
-                        <th className="min-w-[70px] px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-slate-400">{t('greengo.col.type', 'Typ')}</th>
-                        <th className="min-w-[160px] px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-slate-400">{t('greengo.col.deviceCanvas', 'Gerät (Canvas)')}</th>
+                      <tr className="bg-cp-surface-2">
+                        <th className="w-8 px-2 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-cp-text-muted">#</th>
+                        <th className="min-w-[130px] px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-cp-text-muted">{t('greengo.col.station', 'Station')}</th>
+                        <th className="min-w-[70px] px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-cp-text-muted">{t('greengo.col.type', 'Typ')}</th>
+                        <th className="min-w-[160px] px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-cp-text-muted">{t('greengo.col.deviceCanvas', 'Gerät (Canvas)')}</th>
                         {config.groups.map((group) => (
                           <th key={group.id} className="px-2 py-2 text-center text-[10px] font-semibold uppercase tracking-wide text-emerald-400 whitespace-nowrap">
                             {group.name}
@@ -341,33 +341,33 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                         const deviceType = getDeviceType(user.equipmentId)
                         return (
                           <tr key={user.id}
-                            className={`border-t border-slate-800 ${idx % 2 === 0 ? 'bg-slate-900' : 'bg-slate-800/30'} hover:bg-slate-800/70`}>
-                            <td className="px-2 py-1.5 text-center text-[10px] text-slate-400 font-mono">{user.id}</td>
+                            className={`border-t border-cp-border-muted ${idx % 2 === 0 ? 'bg-cp-surface-1' : 'bg-cp-surface-2/30'} hover:bg-cp-surface-2/70`}>
+                            <td className="px-2 py-1.5 text-center text-[10px] text-cp-text-muted font-mono">{user.id}</td>
                             <td className="px-2 py-1">
                               <input
                                 value={user.name}
                                 onChange={(e) => updateUser(user.id, { name: e.target.value })}
-                                className="w-full rounded border border-transparent bg-transparent px-1 py-0.5 text-cp-xs text-slate-100 hover:border-slate-700 focus:border-slate-600 focus:bg-slate-950 focus:outline-none"
+                                className="w-full rounded border border-transparent bg-transparent px-1 py-0.5 text-cp-xs text-cp-text hover:border-cp-border focus:border-cp-surface-5 focus:bg-cp-surface-3 focus:outline-none"
                               />
                             </td>
                             <td className="px-3 py-1.5 whitespace-nowrap">
                               {deviceType
                                 ? <span className="rounded bg-emerald-900/60 px-1.5 py-0.5 text-[10px] font-mono text-emerald-300">{deviceType}</span>
-                                : <span className="text-[10px] text-slate-400">—</span>}
+                                : <span className="text-[10px] text-cp-text-muted">—</span>}
                             </td>
                             <td className="px-2 py-1">
                               {intercomEquipment.length > 0 ? (
                                 <select
                                   value={user.equipmentId ?? ''}
                                   onChange={(e) => updateUser(user.id, { equipmentId: e.target.value || undefined })}
-                                  className="w-full rounded border border-slate-800 bg-slate-950 px-1 py-0.5 text-[11px] text-slate-300 hover:border-slate-600 focus:outline-none">
+                                  className="w-full rounded border border-cp-border-muted bg-cp-surface-3 px-1 py-0.5 text-[11px] text-cp-text-secondary hover:border-cp-surface-5 focus:outline-none">
                                   <option value="">{t('greengo.option.unassigned', '— nicht zugewiesen —')}</option>
                                   {intercomEquipment.map((eq) => (
                                     <option key={eq.id} value={eq.id}>{eq.name}</option>
                                   ))}
                                 </select>
                               ) : (
-                                <span className="text-[10px] text-slate-400">{t('greengo.noIntercomCanvas', 'kein Intercom auf Canvas')}</span>
+                                <span className="text-[10px] text-cp-text-muted">{t('greengo.noIntercomCanvas', 'kein Intercom auf Canvas')}</span>
                               )}
                             </td>
                             {config.groups.map((group) => {
@@ -383,7 +383,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                                     className={`h-7 w-7 rounded text-cp-base transition-colors ${
                                       active
                                         ? 'bg-emerald-600 text-white hover:bg-emerald-500'
-                                        : 'bg-slate-800 text-slate-600 hover:bg-slate-700 hover:text-slate-300'
+                                        : 'bg-cp-surface-2 text-slate-600 hover:bg-cp-surface-4 hover:text-cp-text-secondary'
                                     }`}>
                                     {active ? '●' : '○'}
                                   </button>
@@ -392,15 +392,15 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                             })}
                             <td className="px-1 py-1 text-center">
                               <button type="button" onClick={() => removeUser(user.id)}
-                                className="rounded px-1 py-0.5 text-[10px] text-slate-400 hover:bg-red-900/60 hover:text-red-300">×</button>
+                                className="rounded px-1 py-0.5 text-[10px] text-cp-text-muted hover:bg-red-900/60 hover:text-red-300">×</button>
                             </td>
                           </tr>
                         )
                       })}
                     </tbody>
                     <tfoot>
-                      <tr className="border-t border-slate-700 bg-slate-800/80">
-                        <td colSpan={4} className="px-3 py-1.5 text-[10px] text-slate-400">{t('greengo.members', 'Mitglieder')}</td>
+                      <tr className="border-t border-cp-border bg-cp-surface-2/80">
+                        <td colSpan={4} className="px-3 py-1.5 text-[10px] text-cp-text-muted">{t('greengo.members', 'Mitglieder')}</td>
                         {config.groups.map((group) => (
                           <td key={group.id} className="px-2 py-1.5 text-center text-[10px] font-bold text-emerald-400">
                             {config.users.filter((u) => u.groupIds.includes(group.id)).length}
@@ -416,7 +416,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
               {config.users.length > 0 && config.users.length < MAX_USERS && (
                 <div className="mt-2">
                   <button type="button" onClick={addUser}
-                    className="rounded border border-dashed border-slate-700 px-3 py-1.5 text-cp-xs text-slate-500 hover:border-emerald-700 hover:text-emerald-400">
+                    className="rounded border border-dashed border-cp-border px-3 py-1.5 text-cp-xs text-cp-text-faint hover:border-emerald-700 hover:text-emerald-400">
                     {t('greengo.addStationLong', '+ Station hinzufügen')}
                   </button>
                 </div>
@@ -424,7 +424,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
 
               {intercomEquipment.length > 0 && (
                 <div className="mt-5">
-                  <div className="mb-1.5 text-[10px] uppercase tracking-wide text-slate-400">{t('greengo.devicesOnCanvas', 'GreenGo-Geräte auf dem Canvas')}</div>
+                  <div className="mb-1.5 text-[10px] uppercase tracking-wide text-cp-text-muted">{t('greengo.devicesOnCanvas', 'GreenGo-Geräte auf dem Canvas')}</div>
                   <div className="flex flex-wrap gap-2">
                     {intercomEquipment.map((eq) => {
                       const assignedTo = config.users.find((u) => u.equipmentId === eq.id)
@@ -433,12 +433,12 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                           className={`rounded border px-2 py-1 text-[11px] ${
                             assignedTo
                               ? 'border-emerald-800 bg-emerald-950/40 text-emerald-300'
-                              : 'border-slate-700 bg-slate-800/60 text-slate-400'
+                              : 'border-cp-border bg-cp-surface-2/60 text-cp-text-muted'
                           }`}>
                           <span className="font-medium">{eq.name}</span>
                           {assignedTo
-                            ? <span className="ml-1.5 text-[10px] text-slate-400">→ {assignedTo.name}</span>
-                            : <span className="ml-1.5 text-[10px] text-slate-400">{t('greengo.unassigned', 'nicht zugewiesen')}</span>}
+                            ? <span className="ml-1.5 text-[10px] text-cp-text-muted">→ {assignedTo.name}</span>
+                            : <span className="ml-1.5 text-[10px] text-cp-text-muted">{t('greengo.unassigned', 'nicht zugewiesen')}</span>}
                         </div>
                       )
                     })}
@@ -452,7 +452,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
           {activeTab === 'users' && (
             <div>
               <div className="mb-2 flex items-center justify-between">
-                <span className="text-cp-xs text-slate-400">
+                <span className="text-cp-xs text-cp-text-muted">
                   {t('greengo.users.intro', 'Bis zu {max} Stationen. Gruppen im Tab „Übersicht" per Klick zuweisen.').replace('{max}', String(MAX_USERS))}
                 </span>
                 <button
@@ -466,7 +466,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
               </div>
 
               {config.users.length === 0 && (
-                <div className="rounded border border-dashed border-slate-700 p-6 text-center text-cp-xs text-slate-500">
+                <div className="rounded border border-dashed border-cp-border p-6 text-center text-cp-xs text-cp-text-faint">
                   {t('greengo.users.empty', 'Noch keine Stationen. Klicke „+ Station" um zu beginnen.')}
                 </div>
               )}
@@ -475,17 +475,17 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                 {config.users.map((user) => (
                   <div
                     key={user.id}
-                    className="rounded border border-slate-700 bg-slate-800/60 p-3"
+                    className="rounded border border-cp-border bg-cp-surface-2/60 p-3"
                   >
                     <div className="mb-2 flex items-center gap-2">
-                      <span className="w-6 text-center text-[10px] font-bold text-slate-400">
+                      <span className="w-6 text-center text-[10px] font-bold text-cp-text-muted">
                         #{user.id}
                       </span>
                       <input
                         value={user.name}
                         onChange={(e) => updateUser(user.id, { name: e.target.value })}
                         placeholder={t('greengo.users.namePlaceholder', 'Stationsname (z.B. Regie)')}
-                        className="flex-1 rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+                        className="flex-1 rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
                       />
                       {intercomEquipment.length > 0 && (
                         <select
@@ -493,7 +493,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                           onChange={(e) =>
                             updateUser(user.id, { equipmentId: e.target.value || undefined })
                           }
-                          className="w-44 rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+                          className="w-44 rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
                           title={t('greengo.users.assignTitle', 'Gerät auf dem Canvas zuweisen')}
                         >
                           <option value="">{t('greengo.users.deviceShort', '— Gerät —')}</option>
@@ -534,7 +534,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
           {activeTab === 'groups' && (
             <div>
               <div className="mb-2 flex items-center justify-between">
-                <span className="text-cp-xs text-slate-400">
+                <span className="text-cp-xs text-cp-text-muted">
                   {t('greengo.groups.intro', 'Bis zu {max} Kommunikationsgruppen (Talk Groups).').replace('{max}', String(MAX_GROUPS))}
                 </span>
                 <button
@@ -548,7 +548,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
               </div>
 
               {config.groups.length === 0 && (
-                <div className="rounded border border-dashed border-slate-700 p-6 text-center text-cp-xs text-slate-500">
+                <div className="rounded border border-dashed border-cp-border p-6 text-center text-cp-xs text-cp-text-faint">
                   {t('greengo.groups.empty', 'Noch keine Gruppen. Klicke „+ Gruppe" um eine Talk Group anzulegen.')}
                 </div>
               )}
@@ -565,19 +565,19 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                   return (
                     <div
                       key={group.id}
-                      className="rounded border border-slate-700 bg-slate-800/60 p-3"
+                      className="rounded border border-cp-border bg-cp-surface-2/60 p-3"
                     >
                       <div className="flex items-center gap-2">
-                        <span className="w-6 text-center text-[10px] font-bold text-slate-400">
+                        <span className="w-6 text-center text-[10px] font-bold text-cp-text-muted">
                           #{group.id}
                         </span>
                         <input
                           value={group.name}
                           onChange={(e) => updateGroup(group.id, { name: e.target.value })}
                           placeholder={t('greengo.groups.namePlaceholder', 'Gruppenname (z.B. CAM)')}
-                          className="flex-1 rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+                          className="flex-1 rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
                         />
-                        <span className="text-[10px] text-slate-400">
+                        <span className="text-[10px] text-cp-text-muted">
                           {memberCount} {t('greengo.members', 'Mitglieder')}
                         </span>
                         <button
@@ -589,7 +589,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                         </button>
                       </div>
                       {memberNames && (
-                        <p className="mt-1 pl-8 text-[10px] text-slate-400">{memberNames}</p>
+                        <p className="mt-1 pl-8 text-[10px] text-cp-text-muted">{memberNames}</p>
                       )}
                     </div>
                   )
@@ -602,48 +602,48 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
           {activeTab === 'system' && (
             <div className="max-w-md space-y-3 text-cp-base">
               <label className="block">
-                <span className="mb-1 block text-cp-xs text-slate-400">{t('greengo.system.systemName', 'System-Name')}</span>
+                <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('greengo.system.systemName', 'System-Name')}</span>
                 <input
                   value={config.systemName}
                   onChange={(e) => setField('systemName', e.target.value)}
                   placeholder={t('greengo.system.systemNamePlaceholder', 'Produktion')}
-                  className="w-full rounded border border-slate-700 bg-slate-950 p-2 text-cp-base"
+                  className="w-full rounded border border-cp-border bg-cp-surface-3 p-2 text-cp-base"
                 />
               </label>
 
               <label className="block">
-                <span className="mb-1 block text-cp-xs text-slate-400">{t('greengo.system.description', 'Beschreibung')}</span>
+                <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('greengo.system.description', 'Beschreibung')}</span>
                 <input
                   value={config.description ?? ''}
                   onChange={(e) => setField('description', e.target.value)}
                   placeholder={t('greengo.system.descriptionPlaceholder', 'optional')}
-                  className="w-full rounded border border-slate-700 bg-slate-950 p-2 text-cp-base"
+                  className="w-full rounded border border-cp-border bg-cp-surface-3 p-2 text-cp-base"
                 />
               </label>
 
               <label className="block">
-                <span className="mb-1 block text-cp-xs text-slate-400">
+                <span className="mb-1 block text-cp-xs text-cp-text-muted">
                   {t('greengo.system.multicast', 'Multicast-Adresse')}
                 </span>
                 <input
                   value={config.multicastAddress}
                   onChange={(e) => setField('multicastAddress', e.target.value)}
                   placeholder="239.1.160.1"
-                  className="w-full rounded border border-slate-700 bg-slate-950 p-2 font-mono text-cp-base"
+                  className="w-full rounded border border-cp-border bg-cp-surface-3 p-2 font-mono text-cp-base"
                 />
-                <span className="mt-0.5 block text-[10px] text-slate-400">
+                <span className="mt-0.5 block text-[10px] text-cp-text-muted">
                   {t('greengo.system.multicastHint', 'Standard: 239.1.160.1 — muss im Netzwerk eindeutig sein.')}
                 </span>
               </label>
 
               <label className="block">
-                <span className="mb-1 block text-cp-xs text-slate-400">{t('greengo.system.sampleRate', 'Sample Rate')}</span>
+                <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('greengo.system.sampleRate', 'Sample Rate')}</span>
                 <select
                   value={config.sampleRate}
                   onChange={(e) =>
                     setField('sampleRate', Number(e.target.value) as 32000 | 48000)
                   }
-                  className="w-full rounded border border-slate-700 bg-slate-950 p-2 text-cp-base"
+                  className="w-full rounded border border-cp-border bg-cp-surface-3 p-2 text-cp-base"
                 >
                   <option value={32000}>{t('greengo.system.sampleRate32', '32000 Hz (Standard GreenGo)')}</option>
                   <option value={48000}>{t('greengo.system.sampleRate48', '48000 Hz')}</option>
@@ -654,8 +654,8 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between border-t border-slate-700 px-4 py-3">
-          <span className="text-[11px] text-slate-400">
+        <div className="flex items-center justify-between border-t border-cp-border px-4 py-3">
+          <span className="text-[11px] text-cp-text-muted">
             {config.users.length} {t('greengo.footer.stations', 'Stationen')} · {config.groups.length} {t('greengo.footer.groups', 'Gruppen')}
             {intercomEquipment.length > 0 && (
               <span className="ml-2 text-emerald-700">· {intercomEquipment.length} {t('greengo.footer.devicesOnCanvas', 'Geräte auf Canvas')}</span>
@@ -680,7 +680,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
             <button
               type="button"
               onClick={() => fileInputRef.current?.click()}
-              className="rounded border border-slate-600 px-3 py-1.5 text-cp-xs text-slate-400 hover:border-emerald-700 hover:text-emerald-300"
+              className="rounded border border-cp-surface-5 px-3 py-1.5 text-cp-xs text-cp-text-muted hover:border-emerald-700 hover:text-emerald-300"
               title={t('greengo.import.gg5Title', '.gg5 Datei importieren und mit Canvas-Geräten verknüpfen')}
             >
               <Icon icon={Upload} size="xs" className="mr-1 inline-block align-text-bottom" />{t('greengo.import.gg5', '.gg5 importieren')}
@@ -688,7 +688,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
             <button
               type="button"
               onClick={() => xlsxInputRef.current?.click()}
-              className="rounded border border-slate-600 px-3 py-1.5 text-cp-xs text-slate-400 hover:border-cyan-700 hover:text-cyan-300"
+              className="rounded border border-cp-surface-5 px-3 py-1.5 text-cp-xs text-cp-text-muted hover:border-cyan-700 hover:text-cyan-300"
               title={t('greengo.import.xlsxTitle', 'Intercom-Matrix-Excel hochladen — die Users + Gruppen werden in die GreenGo-Konfiguration übernommen.')}
             >
               <Icon icon={FileSpreadsheet} size="xs" className="mr-1 inline-block align-text-bottom" />
@@ -697,7 +697,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
             <button
               type="button"
               onClick={handleXlsxExport}
-              className="rounded border border-slate-600 px-3 py-1.5 text-cp-xs text-slate-400 hover:border-cyan-700 hover:text-cyan-300"
+              className="rounded border border-cp-surface-5 px-3 py-1.5 text-cp-xs text-cp-text-muted hover:border-cyan-700 hover:text-cyan-300"
               title={t('greengo.export.xlsxTitle', 'Aktuelle GreenGo-Konfiguration als Intercom-Matrix-Excel herunterladen (für Druck / Weitergabe).')}
             >
               <Icon icon={FileSpreadsheet} size="xs" className="mr-1 inline-block align-text-bottom" />
@@ -706,7 +706,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
             <button
               type="button"
               onClick={handleSave}
-              className="rounded bg-slate-700 px-3 py-1.5 text-cp-xs hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-3 py-1.5 text-cp-xs hover:bg-cp-surface-5"
             >
               {t('greengo.saveProject', 'Im Projekt speichern')}
             </button>
@@ -746,24 +746,24 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
       {/* ══════ IMPORT MAPPING OVERLAY ══════ */}
       {importResult && (
         <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/70 p-4">
-          <div className="flex max-h-[88vh] w-full max-w-3xl flex-col overflow-hidden rounded border border-emerald-700 bg-slate-900 text-slate-100 shadow-2xl">
+          <div className="flex max-h-[88vh] w-full max-w-3xl flex-col overflow-hidden rounded border border-emerald-700 bg-cp-surface-1 text-cp-text shadow-2xl">
 
             {/* Header */}
-            <div className="flex items-center justify-between border-b border-slate-700 px-4 py-3">
+            <div className="flex items-center justify-between border-b border-cp-border px-4 py-3">
               <div>
                 <h3 className="text-cp-base font-semibold text-emerald-300">
                   {t('greengo.importOverlay.title', '.gg5 importieren — Geräte verknüpfen')}
                 </h3>
-                <p className="text-[11px] text-slate-400">
-                  {t('greengo.importOverlay.system', 'System:')} <span className="text-slate-200">{importResult.config.systemName}</span>
+                <p className="text-[11px] text-cp-text-muted">
+                  {t('greengo.importOverlay.system', 'System:')} <span className="text-cp-text-bright">{importResult.config.systemName}</span>
                   {importResult.config.multicastAddress && (
-                    <span className="ml-2 font-mono text-slate-500">{importResult.config.multicastAddress}</span>
+                    <span className="ml-2 font-mono text-cp-text-faint">{importResult.config.multicastAddress}</span>
                   )}
                 </p>
               </div>
               <button type="button" onClick={cancelImport}
                 aria-label={t('common.close', 'Schließen')}
-                className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"><Icon icon={X} size="sm" /></button>
+                className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"><Icon icon={X} size="sm" /></button>
             </div>
 
             <div className="flex-1 overflow-y-auto p-4 space-y-4">
@@ -771,7 +771,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
               {/* Groups summary */}
               {importResult.config.groups.length > 0 && (
                 <div>
-                  <div className="mb-1.5 text-[10px] uppercase tracking-wide text-slate-400">
+                  <div className="mb-1.5 text-[10px] uppercase tracking-wide text-cp-text-muted">
                     {t('greengo.importOverlay.importedGroups', 'Importierte Gruppen')} ({importResult.config.groups.length})
                   </div>
                   <div className="flex flex-wrap gap-1.5">
@@ -786,18 +786,18 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
 
               {/* User → Equipment mapping table */}
               <div>
-                <div className="mb-1.5 text-[10px] uppercase tracking-wide text-slate-400">
+                <div className="mb-1.5 text-[10px] uppercase tracking-wide text-cp-text-muted">
                   {t('greengo.importOverlay.linkStations', 'Stationen → Canvas-Geräte verknüpfen')} ({importResult.config.users.length})
                 </div>
-                <p className="mb-2 text-[11px] text-slate-400">
+                <p className="mb-2 text-[11px] text-cp-text-muted">
                   {t('greengo.importOverlay.linkHint', 'Wähle für jede importierte Station das entsprechende Gerät auf dem Canvas. Automatisch erkannte Zuordnungen sind vorausgefüllt.')}
                 </p>
                 <table className="w-full border-collapse text-cp-xs">
                   <thead>
-                    <tr className="bg-slate-800">
-                      <th className="px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-slate-400">{t('greengo.importOverlay.col.nameFromGg5', 'Name (aus .gg5)')}</th>
-                      <th className="px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-slate-400">{t('greengo.col.type', 'Typ')}</th>
-                      <th className="px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-slate-400">{t('greengo.importOverlay.col.groups', 'Gruppen')}</th>
+                    <tr className="bg-cp-surface-2">
+                      <th className="px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-cp-text-muted">{t('greengo.importOverlay.col.nameFromGg5', 'Name (aus .gg5)')}</th>
+                      <th className="px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-cp-text-muted">{t('greengo.col.type', 'Typ')}</th>
+                      <th className="px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-cp-text-muted">{t('greengo.importOverlay.col.groups', 'Gruppen')}</th>
                       <th className="min-w-[180px] px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-emerald-400">{t('greengo.importOverlay.col.deviceCanvas', 'Gerät auf Canvas')}</th>
                     </tr>
                   </thead>
@@ -810,8 +810,8 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                         .filter(Boolean)
                       return (
                         <tr key={user.id}
-                          className={`border-t border-slate-800 ${idx % 2 === 0 ? 'bg-slate-900' : 'bg-slate-800/30'}`}>
-                          <td className="px-3 py-2 font-medium text-slate-200">{user.name}</td>
+                          className={`border-t border-cp-border-muted ${idx % 2 === 0 ? 'bg-cp-surface-1' : 'bg-cp-surface-2/30'}`}>
+                          <td className="px-3 py-2 font-medium text-cp-text-bright">{user.name}</td>
                           <td className="px-3 py-2">
                             {typeHint
                               ? <span className="rounded bg-emerald-900/60 px-1.5 py-0.5 text-[10px] font-mono text-emerald-300">{typeHint}</span>
@@ -819,8 +819,8 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                           </td>
                           <td className="px-3 py-2">
                             {userGroups.length > 0
-                              ? <span className="text-[10px] text-slate-400">{userGroups.join(', ')}</span>
-                              : <span className="text-[10px] text-slate-400">{t('greengo.importOverlay.noGroups', 'keine')}</span>}
+                              ? <span className="text-[10px] text-cp-text-muted">{userGroups.join(', ')}</span>
+                              : <span className="text-[10px] text-cp-text-muted">{t('greengo.importOverlay.noGroups', 'keine')}</span>}
                           </td>
                           <td className="px-3 py-2">
                             {intercomEquipment.length > 0 ? (
@@ -835,7 +835,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                                 className={`w-full rounded border px-1.5 py-1 text-[11px] focus:outline-none ${
                                   assignedId
                                     ? 'border-emerald-800 bg-emerald-950/40 text-emerald-200'
-                                    : 'border-slate-700 bg-slate-950 text-slate-400'
+                                    : 'border-cp-border bg-cp-surface-3 text-cp-text-muted'
                                 }`}>
                                 <option value="">{t('greengo.importOverlay.dontLink', '— nicht verknüpfen —')}</option>
                                 {intercomEquipment.map((eq) => (
@@ -843,7 +843,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                                 ))}
                               </select>
                             ) : (
-                              <span className="text-[10px] text-slate-400">{t('greengo.importOverlay.noIntercomCanvas', 'Kein Intercom auf Canvas')}</span>
+                              <span className="text-[10px] text-cp-text-muted">{t('greengo.importOverlay.noIntercomCanvas', 'Kein Intercom auf Canvas')}</span>
                             )}
                           </td>
                         </tr>
@@ -856,13 +856,13 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
             </div>
 
             {/* Footer */}
-            <div className="flex items-center justify-between border-t border-slate-700 px-4 py-3">
-              <span className="text-[11px] text-slate-400">
+            <div className="flex items-center justify-between border-t border-cp-border px-4 py-3">
+              <span className="text-[11px] text-cp-text-muted">
                 {t('greengo.importOverlay.linkedCount', '{linked} von {total} Stationen verknüpft').replace('{linked}', String(importMappings.size)).replace('{total}', String(importResult.config.users.length))}
               </span>
               <div className="flex gap-2">
                 <button type="button" onClick={cancelImport}
-                  className="rounded bg-slate-700 px-3 py-1.5 text-cp-xs hover:bg-slate-600">
+                  className="rounded bg-cp-surface-4 px-3 py-1.5 text-cp-xs hover:bg-cp-surface-5">
                   {t('greengo.importOverlay.cancel', 'Abbrechen')}
                 </button>
                 <button type="button" onClick={applyImport}

--- a/src/renderer/components/Export/VideohubExportDialog.tsx
+++ b/src/renderer/components/Export/VideohubExportDialog.tsx
@@ -685,13 +685,13 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-6">
-      <div className="flex max-h-[95vh] w-full max-w-6xl flex-col overflow-hidden rounded border border-slate-700 bg-slate-900 p-4 text-slate-100">
+      <div className="flex max-h-[95vh] w-full max-w-6xl flex-col overflow-hidden rounded border border-cp-border bg-cp-surface-1 p-4 text-cp-text">
         <div className="mb-3 flex items-center justify-between">
           <h3 className="flex items-center gap-2 text-cp-xl font-semibold"><Icon icon={SlidersHorizontal} size="sm" /> Videohub konfigurieren · Labels + Routing</h3>
           <button
             type="button"
             onClick={onClose}
-            className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+            className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
             aria-label={t('common.close', 'Schließen')}
           >
             <Icon icon={X} size="sm" />
@@ -704,7 +704,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
             <select
               value={deviceId}
               onChange={(e) => setDeviceId(e.target.value)}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+              className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
             >
               <option value="">— {t('videohub.pickDevice', 'Gerät wählen')} —</option>
               {equipment.map((e) => (
@@ -729,7 +729,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                   setRouting(buildDefaultRouting(p.inputs, p.outputs))
                 }
               }}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+              className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
             >
               {videohubPresets.map((p) => (
                 <option key={p.key} value={p.key}>
@@ -742,7 +742,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
           {/* #387 — Custom-Mode: User-spezifische Inputs/Outputs Anzahl. */}
           {presetKey === 'custom' && (
             <div className="col-span-2 grid grid-cols-2 gap-2 rounded border border-sky-700/40 bg-sky-950/20 p-2">
-              <label className="block text-cp-xs text-slate-300">
+              <label className="block text-cp-xs text-cp-text-secondary">
                 Inputs
                 <input
                   type="number"
@@ -754,10 +754,10 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                     setCustomInputs(v)
                     setRouting(buildDefaultRouting(v, customOutputs))
                   }}
-                  className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+                  className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
                 />
               </label>
-              <label className="block text-cp-xs text-slate-300">
+              <label className="block text-cp-xs text-cp-text-secondary">
                 Outputs
                 <input
                   type="number"
@@ -769,7 +769,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                     setCustomOutputs(v)
                     setRouting(buildDefaultRouting(customInputs, v))
                   }}
-                  className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+                  className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
                 />
               </label>
             </div>
@@ -780,7 +780,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
             <select
               value={format}
               onChange={(e) => setFormat(e.target.value as Format)}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+              className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
               title={t('videohub.formatTitle', 'Bestimmt nur das Format der Vorschau-/Datei-Ausgabe unten. Der direkte TCP-Push (Labels/Routing-Buttons) ist davon unabhängig.')}
             >
               <option value="routing">{t('videohub.optFullRouting', 'Voller Routing-Dump (Protokoll 2.5)')}</option>
@@ -789,12 +789,12 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
           </label>
 
           <label className="block">
-            Friendly Name {format === 'labels' && <span className="text-slate-500">(ignoriert)</span>}
+            Friendly Name {format === 'labels' && <span className="text-cp-text-faint">(ignoriert)</span>}
             <input
               value={friendlyName}
               placeholder={device?.name ?? ''}
               onChange={(e) => setFriendlyName(e.target.value)}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+              className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
             />
           </label>
         </div>
@@ -816,20 +816,20 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
             <button
               type="button"
               onClick={() => setShowMatrix((m) => !m)}
-              className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
             >
               {showMatrix ? '▼' : '▶'} Routing-Ansicht
             </button>
             {/* v7.9.129 — View-Mode-Switch: Matrix oder Liste */}
             {showMatrix && (
-              <div className="flex overflow-hidden rounded border border-slate-700 text-cp-xs">
+              <div className="flex overflow-hidden rounded border border-cp-border text-cp-xs">
                 <button
                   type="button"
                   onClick={() => setAndPersistRoutingView('matrix')}
                   className={`px-2 py-1 ${
                     routingView === 'matrix'
                       ? 'bg-sky-700 text-white'
-                      : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+                      : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
                   }`}
                   title={t('videohub.matrixView', 'Crosspoint-Matrix')}
                 >
@@ -841,7 +841,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                   className={`px-2 py-1 ${
                     routingView === 'list'
                       ? 'bg-sky-700 text-white'
-                      : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+                      : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
                   }`}
                   title={t('videohub.listView', 'Listen-Ansicht mit Dropdown pro Output')}
                 >
@@ -849,7 +849,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                 </button>
               </div>
             )}
-            <span className="text-cp-xs text-slate-500">
+            <span className="text-cp-xs text-cp-text-faint">
               {preset.inputs} Eing. × {preset.outputs} Ausg.
             </span>
             {/* v7.9.131 — Achsen-Swap. Toggle zwischen "Outputs links/
@@ -863,7 +863,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                   ? 'Achsen tauschen: Inputs links, Outputs oben/als Picker'
                   : 'Achsen tauschen: Outputs links, Inputs oben/als Picker'
               }
-              className="rounded border border-slate-700 bg-slate-800 px-2 py-1 text-cp-xs text-slate-200 hover:bg-slate-700"
+              className="rounded border border-cp-border bg-cp-surface-2 px-2 py-1 text-cp-xs text-cp-text-bright hover:bg-cp-surface-4"
             >
               {axisOrientation === 'outputs-rows'
                 ? '⇅ Out·In tauschen'
@@ -882,7 +882,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
               className={`rounded border px-2 py-1 text-cp-xs ${
                 showConnections
                   ? 'border-sky-700 bg-sky-900/40 text-sky-200'
-                  : 'border-slate-700 bg-slate-900 text-slate-400 hover:bg-slate-800'
+                  : 'border-cp-border bg-cp-surface-1 text-cp-text-muted hover:bg-cp-surface-2'
               }`}
             >
               <Icon icon={Link} size="xs" className="mr-1 inline-block align-text-bottom" />{showConnections ? 'Verkabelung an' : 'Verkabelung aus'}
@@ -904,7 +904,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                 className={`rounded border px-2 py-1 text-cp-xs ${
                   showConnectionPorts
                     ? 'border-emerald-700 bg-emerald-900/40 text-emerald-200'
-                    : 'border-slate-700 bg-slate-900 text-slate-400 hover:bg-slate-800'
+                    : 'border-cp-border bg-cp-surface-1 text-cp-text-muted hover:bg-cp-surface-2'
                 }`}
               >
                 {showConnectionPorts ? '· Input-Label an' : '· Input-Label aus'}
@@ -924,7 +924,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
             <button
               type="button"
               onClick={() => setRouting(buildDefaultRouting(preset.inputs, preset.outputs))}
-              className="rounded bg-slate-800 px-2 py-1 text-cp-xs hover:bg-slate-700"
+              className="rounded bg-cp-surface-2 px-2 py-1 text-cp-xs hover:bg-cp-surface-4"
               title={t('videohub.resetDiag', 'Diagonal-Routing zurücksetzen (Ausgang N → Eingang N)')}
             >
               ↺ Reset
@@ -1073,7 +1073,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
             </button>
           </div>
           {salvos.length === 0 ? (
-            <div className="text-[11px] text-slate-400">
+            <div className="text-[11px] text-cp-text-muted">
               Noch keine Salvos. Speichere die aktuelle Crosspoint-Verteilung
               und ruf sie spaeter mit einem Klick zurueck.
             </div>
@@ -1095,7 +1095,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                   <button
                     type="button"
                     onClick={() => deleteSalvo(s.id)}
-                    className="text-slate-500 hover:text-red-400"
+                    className="text-cp-text-faint hover:text-red-400"
                     title={t('videohub.deleteSalvo', 'Salvo löschen')}
                   >
                     ×
@@ -1112,8 +1112,8 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
             pusht das ans Hub wenn er im richtigen Netz ist — ggf. nur
             Teilmengen (z.B. nur Labels nach Re-Labelling, ohne Routing
             zu touchen). */}
-        <div className="mb-3 rounded border border-slate-600 bg-slate-800/60 p-2">
-          <div className="mb-2 text-[10px] uppercase tracking-wide text-slate-400">
+        <div className="mb-3 rounded border border-cp-surface-5 bg-cp-surface-2/60 p-2">
+          <div className="mb-2 text-[10px] uppercase tracking-wide text-cp-text-muted">
             An Videohub senden (TCP) — offline editieren, hier pushen wenn online
             {!hasDesktopBridge && (
               <span className="ml-2 text-amber-400">· nur in Desktop-App verfügbar</span>
@@ -1130,7 +1130,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                     setSendStatus('idle')
                   }}
                   placeholder="192.168.1.1"
-                  className="flex-1 rounded border border-slate-700 bg-slate-950 p-1.5 font-mono text-cp-xs"
+                  className="flex-1 rounded border border-cp-border bg-cp-surface-3 p-1.5 font-mono text-cp-xs"
                 />
                 {/* v7.9.128 — Connection-History: zuletzt benutzte
                     IP/Port-Kombinationen. Wird beim erfolgreichen Send
@@ -1149,7 +1149,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                       }
                     }}
                     title={t('videohub.recentConns', 'Zuletzt benutzte Verbindungen')}
-                    className="w-10 rounded border border-slate-700 bg-slate-950 px-1 text-cp-xs"
+                    className="w-10 rounded border border-cp-border bg-cp-surface-3 px-1 text-cp-xs"
                   >
                     <option value="">▼</option>
                     {connHistory.map((c, i) => (
@@ -1170,7 +1170,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                   setSendStatus('idle')
                 }}
                 placeholder="9990"
-                className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-1.5 font-mono text-cp-xs"
+                className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 font-mono text-cp-xs"
               />
             </label>
             <button
@@ -1197,7 +1197,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
           {discovered !== null && (
             <div className="mt-2 rounded border border-teal-800 bg-teal-950/30 p-2 text-cp-xs">
               {discovered.length === 0 ? (
-                <div className="text-slate-400">
+                <div className="text-cp-text-muted">
                   Kein Videohub per mDNS gefunden. (Firewalls oder andere Subnetze
                   blocken Bonjour — dann IP manuell eintragen.)
                 </div>
@@ -1215,17 +1215,17 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                         setVhPort(String(d.port))
                         setSendStatus('idle')
                       }}
-                      className="flex items-center justify-between gap-2 rounded border border-slate-700 bg-slate-900 px-2 py-1 text-left hover:border-teal-500 hover:bg-slate-800"
+                      className="flex items-center justify-between gap-2 rounded border border-cp-border bg-cp-surface-1 px-2 py-1 text-left hover:border-teal-500 hover:bg-cp-surface-2"
                     >
-                      <span className="truncate font-semibold text-slate-100">
+                      <span className="truncate font-semibold text-cp-text">
                         {d.name}
                         {d.model && (
-                          <span className="ml-1 text-[10px] font-normal text-slate-400">
+                          <span className="ml-1 text-[10px] font-normal text-cp-text-muted">
                             · {d.model}
                           </span>
                         )}
                       </span>
-                      <span className="shrink-0 font-mono text-slate-300">
+                      <span className="shrink-0 font-mono text-cp-text-secondary">
                         {d.ip}:{d.port}
                       </span>
                     </button>
@@ -1294,7 +1294,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                   ? 'bg-emerald-950 text-emerald-300'
                   : sendStatus === 'error'
                     ? 'bg-red-950 text-red-300'
-                    : 'bg-slate-700 text-slate-300'
+                    : 'bg-cp-surface-4 text-cp-text-secondary'
               }`}
             >
               {sendStatus === 'ok' && '✓ '}
@@ -1308,18 +1308,18 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
               NAK"). Wird beim Dialog-Close vergessen. */}
           {activityLog.length > 0 && (
             <details className="mt-2 text-[11px]">
-              <summary className="cursor-pointer text-slate-400 hover:text-slate-200">
+              <summary className="cursor-pointer text-cp-text-muted hover:text-cp-text-bright">
                 Activity-Log ({activityLog.length})
               </summary>
-              <div className="mt-1 max-h-32 space-y-0.5 overflow-auto rounded border border-slate-800 bg-slate-950/60 p-1.5 font-mono">
+              <div className="mt-1 max-h-32 space-y-0.5 overflow-auto rounded border border-cp-border-muted bg-cp-surface-3/60 p-1.5 font-mono">
                 {activityLog.map((e, i) => (
                   <div
                     key={`${e.ts}-${i}`}
                     className={`whitespace-nowrap ${
-                      e.ok ? 'text-slate-300' : 'text-red-300'
+                      e.ok ? 'text-cp-text-secondary' : 'text-red-300'
                     }`}
                   >
-                    <span className="text-slate-500">
+                    <span className="text-cp-text-faint">
                       {new Date(e.ts).toLocaleTimeString('de-DE')}
                     </span>{' '}
                     {e.text}
@@ -1330,11 +1330,11 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
           )}
         </div>
 
-        <div className="mb-2 text-cp-xs text-slate-400">{t('videohub.preview', 'Vorschau')}</div>
+        <div className="mb-2 text-cp-xs text-cp-text-muted">{t('videohub.preview', 'Vorschau')}</div>
         <textarea
           readOnly
           value={preview}
-          className="flex-1 min-h-[150px] rounded border border-slate-700 bg-slate-950 p-2 font-mono text-[11px] text-slate-200"
+          className="flex-1 min-h-[150px] rounded border border-cp-border bg-cp-surface-3 p-2 font-mono text-[11px] text-cp-text-bright"
         />
 
         <div className="mt-3 flex justify-end gap-2">
@@ -1342,7 +1342,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
             type="button"
             onClick={handleCopy}
             disabled={!device}
-            className="rounded bg-slate-700 px-3 py-1 text-cp-base hover:bg-slate-600 disabled:opacity-50"
+            className="rounded bg-cp-surface-4 px-3 py-1 text-cp-base hover:bg-cp-surface-5 disabled:opacity-50"
           >
             In Zwischenablage
           </button>

--- a/src/renderer/components/Export/VideohubRoutingList.tsx
+++ b/src/renderer/components/Export/VideohubRoutingList.tsx
@@ -39,8 +39,8 @@ export const VideohubRoutingList = ({
 }: Props) => {
   const t = useTranslation()
   return (
-    <div className="rounded-cp-control border border-slate-700 bg-slate-950">
-      <div className="border-b border-slate-800 bg-slate-900 px-3 py-2 text-[11px] uppercase tracking-wide text-slate-400">
+    <div className="rounded-cp-control border border-cp-border bg-cp-surface-3">
+      <div className="border-b border-cp-border-muted bg-cp-surface-1 px-3 py-2 text-[11px] uppercase tracking-wide text-cp-text-muted">
         Routing-Liste · {totalOutputs} Outputs · {totalInputs} Inputs verfuegbar
       </div>
       <div
@@ -53,35 +53,35 @@ export const VideohubRoutingList = ({
           return (
             <div
               key={oi}
-              className="flex items-center gap-2 rounded border border-slate-800 bg-slate-900/40 px-2 py-1.5 hover:bg-slate-800/50"
+              className="flex items-center gap-2 rounded border border-cp-border-muted bg-cp-surface-1/40 px-2 py-1.5 hover:bg-cp-surface-2/50"
             >
               {/* Output-Nummer (mono, neutral) */}
               <span
-                className="w-9 shrink-0 text-right font-mono text-[12px] font-semibold text-slate-400"
+                className="w-9 shrink-0 text-right font-mono text-[12px] font-semibold text-cp-text-muted"
                 title={`Output ${oi + 1}`}
               >
                 {oi + 1}
               </span>
               {/* Output-Label */}
               <span
-                className="w-48 shrink-0 truncate text-[13px] font-semibold text-slate-200"
+                className="w-48 shrink-0 truncate text-[13px] font-semibold text-cp-text-bright"
                 title={outLabel}
               >
                 {outLabel}
               </span>
               {/* Lese-Richtung */}
-              <span className="text-slate-500" aria-hidden>
+              <span className="text-cp-text-faint" aria-hidden>
                 ←
               </span>
               {/* Input-Dropdown */}
               <select
                 value={routedIdx}
                 onChange={(e) => onRoute(oi, parseInt(e.target.value, 10))}
-                className="flex-1 min-w-0 rounded border border-slate-700 bg-slate-950 px-2 py-1 text-[13px] text-slate-200 focus:border-sky-500 focus:outline-none"
+                className="flex-1 min-w-0 rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-[13px] text-cp-text-bright focus:border-sky-500 focus:outline-none"
                 title={`Input fuer Output ${oi + 1} (${outLabel}) waehlen — aktuell: ${routedIdx + 1} ${routedLabel}`}
               >
                 {inputLabels.map((inLabel, ii) => (
-                  <option key={ii} value={ii} className="bg-slate-950 text-slate-100">
+                  <option key={ii} value={ii} className="bg-cp-surface-3 text-cp-text">
                     {ii + 1}: {inLabel}
                   </option>
                 ))}

--- a/src/renderer/components/Export/VideohubRoutingMatrix.tsx
+++ b/src/renderer/components/Export/VideohubRoutingMatrix.tsx
@@ -207,7 +207,7 @@ export const VideohubRoutingMatrix = ({
 
   if (!useGrid) {
     return (
-      <div className="overflow-auto max-h-64 rounded border border-slate-700 bg-slate-950 p-2">
+      <div className="overflow-auto max-h-64 rounded border border-cp-border bg-cp-surface-3 p-2">
         <div className="mb-2 text-[10px] text-amber-300">
           {totalInputs}×{totalOutputs} ({cellCount.toLocaleString()} Crosspoints) —
           Listen-Modus, da die Crosspoint-Matrix bei dieser Groesse das
@@ -216,15 +216,15 @@ export const VideohubRoutingMatrix = ({
         <div className="space-y-0.5">
           {outputLabels.map((outLabel, oi) => (
             <div key={oi} className="flex items-center gap-2 text-cp-base">
-              <span className="w-10 shrink-0 font-mono text-right text-slate-500">{oi + 1}</span>
-              <span className="w-40 shrink-0 truncate text-right font-medium text-slate-200">
+              <span className="w-10 shrink-0 font-mono text-right text-cp-text-faint">{oi + 1}</span>
+              <span className="w-40 shrink-0 truncate text-right font-medium text-cp-text-bright">
                 {outLabel}
               </span>
-              <span className="text-slate-500">←</span>
+              <span className="text-cp-text-faint">←</span>
               <select
                 value={routing[oi] ?? 0}
                 onChange={(e) => onRoute(oi, parseInt(e.target.value, 10))}
-                className="flex-1 rounded border border-slate-700 bg-slate-900 p-1 text-cp-base text-sky-200"
+                className="flex-1 rounded border border-cp-border bg-cp-surface-1 p-1 text-cp-base text-sky-200"
               >
                 {inputLabels.map((inLabel, ii) => (
                   <option key={ii} value={ii}>
@@ -333,7 +333,7 @@ export const VideohubRoutingMatrix = ({
 
   return (
     <div className="space-y-1">
-      <div className="flex items-center justify-between text-[11px] text-slate-400">
+      <div className="flex items-center justify-between text-[11px] text-cp-text-muted">
         <span>
           Tipp: rechte Kante einer Spalte / untere Kante einer Zeile ziehen wie in Excel.
         </span>
@@ -343,14 +343,14 @@ export const VideohubRoutingMatrix = ({
           <button
             type="button"
             onClick={resetLayout}
-            className="rounded bg-slate-800 px-2 py-0.5 text-[11px] text-slate-300 hover:bg-slate-700"
+            className="rounded bg-cp-surface-2 px-2 py-0.5 text-[11px] text-cp-text-secondary hover:bg-cp-surface-4"
           >
             ↺ Layout zuruecksetzen
           </button>
         )}
       </div>
       <div
-        className="overflow-auto rounded-cp-control border border-slate-700 bg-slate-950"
+        className="overflow-auto rounded-cp-control border border-cp-border bg-cp-surface-3"
         style={{ maxHeight }}
         onMouseLeave={() => setHover(null)}
         onMouseUp={() => setDragging(false)}
@@ -360,7 +360,7 @@ export const VideohubRoutingMatrix = ({
             {/* Achsenbeschriftungs-Bar */}
             <tr style={{ height: 32 }}>
               <th
-                className="sticky left-0 top-0 z-30 border-b border-r border-slate-700 bg-slate-900 px-3 text-left uppercase tracking-wide text-slate-400"
+                className="sticky left-0 top-0 z-30 border-b border-r border-cp-border bg-cp-surface-1 px-3 text-left uppercase tracking-wide text-cp-text-muted"
                 style={{ width: labelColW, minWidth: labelColW, fontSize: 12, fontWeight: 600, position: 'relative' }}
               >
                 {rowAxisLabel}
@@ -372,7 +372,7 @@ export const VideohubRoutingMatrix = ({
                 />
               </th>
               <th
-                className="sticky top-0 z-20 border-b border-r border-slate-700 bg-slate-900 text-center font-mono text-slate-500"
+                className="sticky top-0 z-20 border-b border-r border-cp-border bg-cp-surface-1 text-center font-mono text-cp-text-faint"
                 style={{
                   left: labelColW,
                   width: indexColPx,
@@ -383,7 +383,7 @@ export const VideohubRoutingMatrix = ({
                 #
               </th>
               <th
-                className="sticky top-0 z-20 border-b border-slate-700 bg-slate-800/80 px-3 text-left uppercase tracking-wide text-slate-300"
+                className="sticky top-0 z-20 border-b border-cp-border bg-cp-surface-2/80 px-3 text-left uppercase tracking-wide text-cp-text-secondary"
                 colSpan={totalInputs}
                 style={{ fontSize: 12, fontWeight: 600 }}
               >
@@ -394,11 +394,11 @@ export const VideohubRoutingMatrix = ({
             {/* Input-Label-Reihe — horizontal bei kleinen Hubs, rotiert sonst */}
             <tr style={{ height: labelRowHeightPx }}>
               <th
-                className="sticky left-0 z-30 border-r border-slate-700 bg-slate-900"
+                className="sticky left-0 z-30 border-r border-cp-border bg-cp-surface-1"
                 style={{ top: 32, width: labelColW, minWidth: labelColW }}
               />
               <th
-                className="sticky z-20 border-r border-slate-700 bg-slate-900"
+                className="sticky z-20 border-r border-cp-border bg-cp-surface-1"
                 style={{
                   top: 32,
                   left: labelColW,
@@ -411,8 +411,8 @@ export const VideohubRoutingMatrix = ({
                 return (
                   <th
                     key={`lbl-${i}`}
-                    className={`sticky z-10 bg-slate-900 ${
-                      isGroupBreak(i) ? 'border-l border-slate-700' : ''
+                    className={`sticky z-10 bg-cp-surface-1 ${
+                      isGroupBreak(i) ? 'border-l border-cp-border' : ''
                     } ${colHighlight === i ? 'bg-sky-900/40' : ''}`}
                     style={{
                       top: 32,
@@ -426,7 +426,7 @@ export const VideohubRoutingMatrix = ({
                       {useHorizontalLabels ? (
                         <div
                           className={`flex h-full items-center justify-center px-2 text-center ${
-                            colHighlight === i ? 'text-slate-100' : 'text-slate-300'
+                            colHighlight === i ? 'text-cp-text' : 'text-cp-text-secondary'
                           }`}
                           style={{
                             fontSize: labelFontPx,
@@ -448,7 +448,7 @@ export const VideohubRoutingMatrix = ({
                       ) : (
                         <div
                           className={`overflow-hidden text-center ${
-                            colHighlight === i ? 'text-slate-100' : 'text-slate-300'
+                            colHighlight === i ? 'text-cp-text' : 'text-cp-text-secondary'
                           }`}
                           style={{
                             writingMode: 'vertical-lr',
@@ -483,7 +483,7 @@ export const VideohubRoutingMatrix = ({
             {/* Input-Index-Reihe */}
             <tr style={{ height: 24 }}>
               <th
-                className="sticky left-0 z-30 border-b border-r border-slate-700 bg-slate-900 px-3 text-left uppercase text-slate-500"
+                className="sticky left-0 z-30 border-b border-r border-cp-border bg-cp-surface-1 px-3 text-left uppercase text-cp-text-faint"
                 style={{
                   top: 32 + labelRowHeightPx,
                   width: labelColW,
@@ -494,7 +494,7 @@ export const VideohubRoutingMatrix = ({
                 Label
               </th>
               <th
-                className="sticky z-20 border-b border-r border-slate-700 bg-slate-900 text-center font-mono text-slate-500"
+                className="sticky z-20 border-b border-r border-cp-border bg-cp-surface-1 text-center font-mono text-cp-text-faint"
                 style={{
                   top: 32 + labelRowHeightPx,
                   left: labelColW,
@@ -510,8 +510,8 @@ export const VideohubRoutingMatrix = ({
                 return (
                   <th
                     key={`idx-${i}`}
-                    className={`sticky z-10 border-b border-slate-700 bg-slate-900 font-mono text-slate-400 ${
-                      isGroupBreak(i) ? 'border-l border-slate-700' : ''
+                    className={`sticky z-10 border-b border-cp-border bg-cp-surface-1 font-mono text-cp-text-muted ${
+                      isGroupBreak(i) ? 'border-l border-cp-border' : ''
                     } ${colHighlight === i ? 'bg-sky-900/40 text-sky-200' : ''}`}
                     style={{
                       top: 32 + labelRowHeightPx,
@@ -540,14 +540,14 @@ export const VideohubRoutingMatrix = ({
                 <tr
                   key={oi}
                   ref={(el) => { rowRefs.current[oi] = el }}
-                  className={`${rowOn ? 'bg-slate-800/50' : 'hover:bg-slate-800/40'} ${
-                    groupRowBreak ? 'border-t border-slate-700' : ''
+                  className={`${rowOn ? 'bg-cp-surface-2/50' : 'hover:bg-cp-surface-2/40'} ${
+                    groupRowBreak ? 'border-t border-cp-border' : ''
                   }`}
                   style={{ height: rh }}
                 >
                   <td
-                    className={`sticky left-0 z-10 truncate border-r border-slate-800 px-3 text-left ${
-                      rowOn ? 'bg-slate-800/80 text-slate-100' : 'bg-slate-950 text-slate-200'
+                    className={`sticky left-0 z-10 truncate border-r border-cp-border-muted px-3 text-left ${
+                      rowOn ? 'bg-cp-surface-2/80 text-cp-text' : 'bg-cp-surface-3 text-cp-text-bright'
                     }`}
                     style={{
                       width: labelColW,
@@ -569,8 +569,8 @@ export const VideohubRoutingMatrix = ({
                     </div>
                   </td>
                   <td
-                    className={`sticky z-10 border-r border-slate-800 text-center font-mono ${
-                      rowOn ? 'bg-slate-800/80 text-slate-200' : 'bg-slate-900 text-slate-500'
+                    className={`sticky z-10 border-r border-cp-border-muted text-center font-mono ${
+                      rowOn ? 'bg-cp-surface-2/80 text-cp-text-bright' : 'bg-cp-surface-1 text-cp-text-faint'
                     }`}
                     style={{
                       left: labelColW,
@@ -584,7 +584,7 @@ export const VideohubRoutingMatrix = ({
                       <button
                         type="button"
                         onClick={() => focusRow(oi)}
-                        className="block w-full hover:text-slate-300"
+                        className="block w-full hover:text-cp-text-secondary"
                         title={`Output ${oi + 1} fokussieren`}
                       >
                         {oi + 1}
@@ -608,7 +608,7 @@ export const VideohubRoutingMatrix = ({
                     return (
                       <td
                         key={ii}
-                        className={`p-0 text-center ${groupBreak ? 'border-l border-slate-800' : ''} ${tdBg}`}
+                        className={`p-0 text-center ${groupBreak ? 'border-l border-cp-border-muted' : ''} ${tdBg}`}
                         style={{ width: cw, minWidth: cw, maxWidth: cw }}
                         onMouseEnter={() => {
                           setHover({ row: oi, col: ii })
@@ -633,7 +633,7 @@ export const VideohubRoutingMatrix = ({
                                   ? 'mx-auto block rounded-sm bg-slate-400/50 hover:bg-slate-300'
                                   : inCol
                                     ? 'mx-auto block rounded-sm bg-sky-500/50 hover:bg-sky-400'
-                                    : 'mx-auto block rounded-sm bg-slate-700/80 hover:bg-slate-500'
+                                    : 'mx-auto block rounded-sm bg-cp-surface-4/80 hover:bg-slate-500'
                           }
                           style={{
                             width: Math.min(cw - 8, rh - 10),

--- a/src/renderer/components/Import/GraphmlImportDialog.tsx
+++ b/src/renderer/components/Import/GraphmlImportDialog.tsx
@@ -257,12 +257,12 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
   }
 
   const renderEmpty = () => (
-    <div className="flex flex-1 flex-col items-center justify-center gap-4 p-12 text-center text-slate-300">
-      <Icon icon={Ruler} size={40} className="text-slate-400" />
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 p-12 text-center text-cp-text-secondary">
+      <Icon icon={Ruler} size={40} className="text-cp-text-muted" />
       <div className="max-w-md text-cp-base">
-        <p className="mb-2 font-semibold text-slate-100">{t('graphml.dialog.importerTitle', 'yEd / GraphML Importer')}</p>
+        <p className="mb-2 font-semibold text-cp-text">{t('graphml.dialog.importerTitle', 'yEd / GraphML Importer')}</p>
         <p>
-          {t('graphml.dialog.empty.intro1', 'Wähle eine')} <code className="text-slate-200">.graphml</code> {t('graphml.dialog.empty.intro2', 'Datei. Cable Planner erkennt Geräte, Ports und Kabel automatisch — du bekommst eine Vorschau und kannst einzelne Einträge ein- oder ausschließen, bevor sie ins Projekt übernommen werden.')}
+          {t('graphml.dialog.empty.intro1', 'Wähle eine')} <code className="text-cp-text-bright">.graphml</code> {t('graphml.dialog.empty.intro2', 'Datei. Cable Planner erkennt Geräte, Ports und Kabel automatisch — du bekommst eine Vorschau und kannst einzelne Einträge ein- oder ausschließen, bevor sie ins Projekt übernommen werden.')}
         </p>
       </div>
       <button
@@ -277,11 +277,11 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
   )
 
   const renderParsing = (fileName: string) => (
-    <div className="flex flex-1 flex-col items-center justify-center gap-3 p-12 text-center text-slate-300">
-      <div className="h-8 w-8 animate-spin rounded-full border-4 border-slate-600 border-t-sky-400" />
+    <div className="flex flex-1 flex-col items-center justify-center gap-3 p-12 text-center text-cp-text-secondary">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-cp-surface-5 border-t-sky-400" />
       <div className="text-cp-base">
         <p className="font-medium">{fileName}</p>
-        <p className="text-slate-500">{t('graphml.dialog.parsing', 'Parser läuft (~ 250 ms pro MB)…')}</p>
+        <p className="text-cp-text-faint">{t('graphml.dialog.parsing', 'Parser läuft (~ 250 ms pro MB)…')}</p>
       </div>
     </div>
   )
@@ -290,14 +290,14 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
     <div className="flex flex-1 flex-col items-center justify-center gap-3 p-12 text-center">
       <div className="flex justify-center text-red-300"><Icon icon={AlertTriangle} size={32} /></div>
       <p className="text-cp-base font-medium text-red-300">{t('graphml.dialog.importFailed', 'Import fehlgeschlagen')}</p>
-      {fileName && <p className="text-cp-xs text-slate-400">{fileName}</p>}
-      <pre className="max-w-full whitespace-pre-wrap rounded bg-slate-950 p-3 text-cp-xs text-red-200">
+      {fileName && <p className="text-cp-xs text-cp-text-muted">{fileName}</p>}
+      <pre className="max-w-full whitespace-pre-wrap rounded bg-cp-surface-3 p-3 text-cp-xs text-red-200">
         {message}
       </pre>
       <button
         type="button"
         onClick={reset}
-        className="rounded bg-slate-700 px-3 py-1 text-cp-xs hover:bg-slate-600"
+        className="rounded bg-cp-surface-4 px-3 py-1 text-cp-xs hover:bg-cp-surface-5"
       >
         {t('graphml.dialog.pickOther', 'Andere Datei wählen')}
       </button>
@@ -313,12 +313,12 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
     return (
       <div className="flex min-h-0 flex-1 flex-col">
         {/* Header summary */}
-        <div className="border-b border-slate-700 px-4 py-2">
+        <div className="border-b border-cp-border px-4 py-2">
           <div className="flex flex-wrap items-baseline justify-between gap-2">
             <div>
-              <span className="text-cp-xs uppercase tracking-wide text-slate-400">{t('graphml.dialog.file', 'Datei')}</span>{' '}
-              <span className="font-medium text-slate-100">{s.fileName}</span>
-              <span className="ml-2 text-cp-xs text-slate-500">
+              <span className="text-cp-xs uppercase tracking-wide text-cp-text-muted">{t('graphml.dialog.file', 'Datei')}</span>{' '}
+              <span className="font-medium text-cp-text">{s.fileName}</span>
+              <span className="ml-2 text-cp-xs text-cp-text-faint">
                 {formatBytes(preview.meta.fileSize)} • {preview.meta.nodeCount} {t('graphml.dialog.nodes', 'Nodes')} •{' '}
                 {preview.meta.edgeCount} {t('graphml.dialog.edges', 'Edges')}
               </span>
@@ -326,13 +326,13 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
             <button
               type="button"
               onClick={reset}
-              className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
               title={t('graphml.dialog.pickOther', 'Andere Datei wählen')}
             >
               {t('graphml.dialog.otherFile', '↻ Andere Datei')}
             </button>
           </div>
-          <div className="mt-2 flex flex-wrap items-center gap-3 text-cp-xs text-slate-300">
+          <div className="mt-2 flex flex-wrap items-center gap-3 text-cp-xs text-cp-text-secondary">
             <span>
               {t('graphml.dialog.devices', 'Geräte')}: <strong>{includedDevices}/{totalDevices}</strong>
             </span>
@@ -340,7 +340,7 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
               {t('graphml.dialog.cables', 'Kabel')}: <strong>{includedCables}/{totalCables}</strong>
             </span>
             {preview.skippedNodes.length > 0 && (
-              <span className="text-slate-500">
+              <span className="text-cp-text-faint">
                 {t('graphml.dialog.skipped', 'Übersprungen')}: {preview.skippedNodes.length}
               </span>
             )}
@@ -356,14 +356,14 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
         </div>
 
         {/* Destination + Mode + filter row */}
-        <div className="flex flex-wrap items-center justify-between gap-2 border-b border-slate-800 bg-slate-950/70 px-4 py-2 text-cp-xs">
+        <div className="flex flex-wrap items-center justify-between gap-2 border-b border-cp-border-muted bg-cp-surface-3/70 px-4 py-2 text-cp-xs">
           <div className="flex flex-wrap items-center gap-3">
             <div className="flex items-center gap-1">
-              <span className="text-slate-400">{t('graphml.dialog.target', 'Ziel:')}</span>
+              <span className="text-cp-text-muted">{t('graphml.dialog.target', 'Ziel:')}</span>
               <button
                 type="button"
                 onClick={() => setDestination('canvas')}
-                className={`rounded px-2 py-0.5 ${destination === 'canvas' ? 'bg-emerald-700 text-white' : 'bg-slate-800 text-slate-300 hover:bg-slate-700'}`}
+                className={`rounded px-2 py-0.5 ${destination === 'canvas' ? 'bg-emerald-700 text-white' : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'}`}
                 title={t('graphml.dialog.canvasTitle', 'Geräte direkt auf dem Canvas platzieren (inkl. Kabel).')}
               >
                 <Icon icon={Map} size="xs" className="mr-1 inline-block align-text-bottom" />{t('graphml.dialog.canvas', 'Canvas')}
@@ -371,7 +371,7 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
               <button
                 type="button"
                 onClick={() => setDestination('library')}
-                className={`rounded px-2 py-0.5 ${destination === 'library' ? 'bg-violet-700 text-white' : 'bg-slate-800 text-slate-300 hover:bg-slate-700'}`}
+                className={`rounded px-2 py-0.5 ${destination === 'library' ? 'bg-violet-700 text-white' : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'}`}
                 title={t('graphml.dialog.libraryTitle', 'Nur als wiederverwendbare Geräte-Vorlagen in die Library übernehmen (ohne Kabel, ohne Canvas-Platzierung).')}
               >
                 <Icon icon={Library} size="xs" className="mr-1 inline-block align-text-bottom" />{t('graphml.dialog.library', 'Library')}
@@ -379,18 +379,18 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
             </div>
             {destination === 'canvas' && (
               <div className="flex items-center gap-1">
-                <span className="text-slate-400">{t('graphml.dialog.mode', 'Modus:')}</span>
+                <span className="text-cp-text-muted">{t('graphml.dialog.mode', 'Modus:')}</span>
                 <button
                   type="button"
                   onClick={() => setMode('append')}
-                  className={`rounded px-2 py-0.5 ${mode === 'append' ? 'bg-sky-700 text-white' : 'bg-slate-800 text-slate-300 hover:bg-slate-700'}`}
+                  className={`rounded px-2 py-0.5 ${mode === 'append' ? 'bg-sky-700 text-white' : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'}`}
                 >
                   {t('graphml.dialog.appendProject', 'An Projekt anhängen')}
                 </button>
                 <button
                   type="button"
                   onClick={() => setMode('replace')}
-                  className={`rounded px-2 py-0.5 ${mode === 'replace' ? 'bg-amber-700 text-white' : 'bg-slate-800 text-slate-300 hover:bg-slate-700'}`}
+                  className={`rounded px-2 py-0.5 ${mode === 'replace' ? 'bg-amber-700 text-white' : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'}`}
                   title={t('graphml.dialog.replaceTitle', 'Ersetzt nur GraphML-importierte Geräte; manuell hinzugefügte bleiben unangetastet.')}
                 >
                   {t('graphml.dialog.replaceImport', 'GraphML-Import ersetzen')}
@@ -403,7 +403,7 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
             value={filterText}
             onChange={(e) => setFilterText(e.target.value)}
             placeholder={t('graphml.dialog.filterPlaceholder', 'Filter: Name / IP / Kategorie / Kabeltyp')}
-            className="w-64 rounded border border-slate-700 bg-slate-950 px-2 py-1 text-cp-xs text-slate-100"
+            className="w-64 rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-xs text-cp-text"
           />
         </div>
 
@@ -415,7 +415,7 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
         )}
 
         {/* Tabs */}
-        <div className="flex border-b border-slate-800 text-cp-xs">
+        <div className="flex border-b border-cp-border-muted text-cp-xs">
           {([
             ['preview', t('graphml.dialog.tab.preview', 'yEd-Vorschau')],
             ['devices', `${t('graphml.dialog.tab.devices', 'Geräte')} (${totalDevices})`],
@@ -428,8 +428,8 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
               onClick={() => setTab(key)}
               className={`px-4 py-2 ${
                 tab === key
-                  ? 'border-b-2 border-sky-500 bg-slate-900 text-slate-100'
-                  : 'text-slate-400 hover:text-slate-200'
+                  ? 'border-b-2 border-sky-500 bg-cp-surface-1 text-cp-text'
+                  : 'text-cp-text-muted hover:text-cp-text-bright'
               }`}
             >
               {label}
@@ -456,7 +456,7 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
           )}
           {tab === 'devices' && (
             <table className="w-full text-cp-xs">
-              <thead className="sticky top-0 bg-slate-900 text-slate-400">
+              <thead className="sticky top-0 bg-cp-surface-1 text-cp-text-muted">
                 <tr>
                   <th className="px-3 py-2 text-left w-6"></th>
                   <th className="px-3 py-2 text-left">{t('graphml.dialog.col.name', 'Name')}</th>
@@ -472,7 +472,7 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
                   return (
                     <tr
                       key={dev.importKey}
-                      className={`border-t border-slate-800 ${skipped ? 'opacity-40' : ''}`}
+                      className={`border-t border-cp-border-muted ${skipped ? 'opacity-40' : ''}`}
                     >
                       <td className="px-3 py-1">
                         <input
@@ -489,10 +489,10 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
                           onChange={(e) =>
                             setNameOverrides((p) => ({ ...p, [dev.importKey]: e.target.value }))
                           }
-                          className="w-full rounded border border-slate-700 bg-slate-950 px-1.5 py-0.5 text-slate-100"
+                          className="w-full rounded border border-cp-border bg-cp-surface-3 px-1.5 py-0.5 text-cp-text"
                         />
                         {dev.subtitle && (
-                          <div className="px-1.5 text-[10px] text-slate-400">{dev.subtitle}</div>
+                          <div className="px-1.5 text-[10px] text-cp-text-muted">{dev.subtitle}</div>
                         )}
                       </td>
                       <td className="px-3 py-1">
@@ -502,17 +502,17 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
                           onChange={(e) =>
                             setCategoryOverrides((p) => ({ ...p, [dev.importKey]: e.target.value }))
                           }
-                          className="w-32 rounded border border-slate-700 bg-slate-950 px-1.5 py-0.5 text-slate-100"
+                          className="w-32 rounded border border-cp-border bg-cp-surface-3 px-1.5 py-0.5 text-cp-text"
                         />
                       </td>
-                      <td className="px-3 py-1 text-slate-400">{dev.ipAddress ?? '—'}</td>
-                      <td className="px-3 py-1 text-right text-slate-300">
+                      <td className="px-3 py-1 text-cp-text-muted">{dev.ipAddress ?? '—'}</td>
+                      <td className="px-3 py-1 text-right text-cp-text-secondary">
                         {dev.inputs.length}/{dev.outputs.length}
                       </td>
                       <td className="px-3 py-1">
                         {confidenceBadge(dev.confidence)}
                         {dev.notes[0] && (
-                          <span className="ml-1 text-[10px] text-slate-400" title={dev.notes.join('\n')}>
+                          <span className="ml-1 text-[10px] text-cp-text-muted" title={dev.notes.join('\n')}>
                             {dev.notes[0].length > 50 ? `${dev.notes[0].slice(0, 47)}…` : dev.notes[0]}
                           </span>
                         )}
@@ -526,7 +526,7 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
 
           {tab === 'cables' && (
             <table className="w-full text-cp-xs">
-              <thead className="sticky top-0 bg-slate-900 text-slate-400">
+              <thead className="sticky top-0 bg-cp-surface-1 text-cp-text-muted">
                 <tr>
                   <th className="px-3 py-2 text-left w-6"></th>
                   <th className="px-3 py-2 text-left">{t('graphml.dialog.col.source', 'Quelle')}</th>
@@ -548,7 +548,7 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
                   return (
                     <tr
                       key={c.importKey}
-                      className={`border-t border-slate-800 ${skipped ? 'opacity-40' : ''}`}
+                      className={`border-t border-cp-border-muted ${skipped ? 'opacity-40' : ''}`}
                     >
                       <td className="px-3 py-1">
                         <input
@@ -558,11 +558,11 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
                           aria-label={t('graphml.dialog.toggleCableAria', 'Toggle cable')}
                         />
                       </td>
-                      <td className="px-3 py-1 text-slate-300">{src?.name ?? c.sourceDeviceImportKey}</td>
-                      <td className="px-3 py-1 text-slate-300">{tgt?.name ?? c.targetDeviceImportKey}</td>
-                      <td className="px-3 py-1 text-slate-100">{c.inferredCableType}</td>
-                      <td className="px-3 py-1 text-slate-400">{c.videoStandard ?? '—'}</td>
-                      <td className="px-3 py-1 text-right text-slate-400">
+                      <td className="px-3 py-1 text-cp-text-secondary">{src?.name ?? c.sourceDeviceImportKey}</td>
+                      <td className="px-3 py-1 text-cp-text-secondary">{tgt?.name ?? c.targetDeviceImportKey}</td>
+                      <td className="px-3 py-1 text-cp-text">{c.inferredCableType}</td>
+                      <td className="px-3 py-1 text-cp-text-muted">{c.videoStandard ?? '—'}</td>
+                      <td className="px-3 py-1 text-right text-cp-text-muted">
                         {c.cableLengthMeters != null ? `${c.cableLengthMeters} m` : '—'}
                       </td>
                     </tr>
@@ -575,28 +575,28 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
           {tab === 'skipped' && (
             <div className="space-y-4 p-3 text-cp-xs">
               <div>
-                <h4 className="mb-1 font-semibold text-slate-300">
+                <h4 className="mb-1 font-semibold text-cp-text-secondary">
                   {t('graphml.dialog.nodesSkipped', 'Nodes übersprungen')} ({preview.skippedNodes.length})
                 </h4>
-                <ul className="space-y-0.5 text-slate-400">
+                <ul className="space-y-0.5 text-cp-text-muted">
                   {preview.skippedNodes.slice(0, 50).map((s) => (
                     <li key={s.id}>
-                      <code className="text-slate-500">{s.id}</code> — {s.reason}
+                      <code className="text-cp-text-faint">{s.id}</code> — {s.reason}
                     </li>
                   ))}
                   {preview.skippedNodes.length > 50 && (
-                    <li className="text-slate-500">{t('graphml.dialog.moreEllipsis', '… ({count} weitere)').replace('{count}', String(preview.skippedNodes.length - 50))}</li>
+                    <li className="text-cp-text-faint">{t('graphml.dialog.moreEllipsis', '… ({count} weitere)').replace('{count}', String(preview.skippedNodes.length - 50))}</li>
                   )}
                 </ul>
               </div>
               <div>
-                <h4 className="mb-1 font-semibold text-slate-300">
+                <h4 className="mb-1 font-semibold text-cp-text-secondary">
                   {t('graphml.dialog.unresolvedEdges', 'Edges ohne aufgelöste Ports')} ({preview.unresolvedEdges.length})
                 </h4>
-                <ul className="space-y-0.5 text-slate-400">
+                <ul className="space-y-0.5 text-cp-text-muted">
                   {preview.unresolvedEdges.slice(0, 50).map((e) => (
                     <li key={e.id}>
-                      <code className="text-slate-500">{e.id}</code>: {e.sourceId} → {e.targetId}
+                      <code className="text-cp-text-faint">{e.id}</code>: {e.sourceId} → {e.targetId}
                       {Object.keys(e.data).length > 0 && (
                         <span className="ml-1 text-slate-600">
                           [{Object.entries(e.data).map(([k, v]) => `${k}=${v}`).join(', ')}]
@@ -605,7 +605,7 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
                     </li>
                   ))}
                   {preview.unresolvedEdges.length > 50 && (
-                    <li className="text-slate-500">{t('graphml.dialog.moreEllipsis', '… ({count} weitere)').replace('{count}', String(preview.unresolvedEdges.length - 50))}</li>
+                    <li className="text-cp-text-faint">{t('graphml.dialog.moreEllipsis', '… ({count} weitere)').replace('{count}', String(preview.unresolvedEdges.length - 50))}</li>
                   )}
                 </ul>
               </div>
@@ -614,14 +614,14 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
         </div>
 
         {/* Footer actions */}
-        <div className="flex items-center justify-end gap-2 border-t border-slate-700 px-4 py-3">
+        <div className="flex items-center justify-end gap-2 border-t border-cp-border px-4 py-3">
           <button
             type="button"
             onClick={() => {
               reset()
               onClose()
             }}
-            className="rounded bg-slate-700 px-3 py-1 text-cp-xs hover:bg-slate-600"
+            className="rounded bg-cp-surface-4 px-3 py-1 text-cp-xs hover:bg-cp-surface-5"
           >
             {t('graphml.dialog.cancel', 'Abbrechen')}
           </button>
@@ -642,8 +642,8 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-6">
-      <div className="flex h-[80vh] w-[min(1100px,95vw)] flex-col overflow-hidden rounded border border-slate-700 bg-slate-900 text-slate-100">
-        <div className="flex items-center justify-between border-b border-slate-700 px-4 py-2">
+      <div className="flex h-[80vh] w-[min(1100px,95vw)] flex-col overflow-hidden rounded border border-cp-border bg-cp-surface-1 text-cp-text">
+        <div className="flex items-center justify-between border-b border-cp-border px-4 py-2">
           <h3 className="text-cp-base font-semibold">{t('graphml.dialog.heading', 'yEd / GraphML importieren')}</h3>
           <button
             type="button"
@@ -651,7 +651,7 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
               reset()
               onClose()
             }}
-            className="text-slate-500 hover:text-slate-200"
+            className="text-cp-text-faint hover:text-cp-text-bright"
             aria-label={t('graphml.dialog.closeAria', 'Schließen')}
           >
             <Icon icon={X} size="sm" />

--- a/src/renderer/components/Import/GraphmlViewer.tsx
+++ b/src/renderer/components/Import/GraphmlViewer.tsx
@@ -200,7 +200,7 @@ export const GraphmlViewer = ({ document, highlightNodes, className }: GraphmlVi
         onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}
         onPointerCancel={onPointerUp}
-        className="h-full w-full select-none bg-slate-950"
+        className="h-full w-full select-none bg-cp-surface-3"
         style={{ touchAction: 'none', cursor: isDragging ? 'grabbing' : 'grab' }}
       >
         {/* Edges first so node rects render on top of them where they
@@ -262,11 +262,11 @@ export const GraphmlViewer = ({ document, highlightNodes, className }: GraphmlVi
           })}
         </g>
       </svg>
-      <div className="absolute right-3 top-3 flex items-center gap-1 rounded bg-slate-900/85 px-2 py-1 text-cp-xs text-slate-300 backdrop-blur">
+      <div className="absolute right-3 top-3 flex items-center gap-1 rounded bg-cp-surface-1/85 px-2 py-1 text-cp-xs text-cp-text-secondary backdrop-blur">
         <button
           type="button"
           onClick={() => setView((v) => ({ ...v, zoom: Math.min(20, v.zoom * 1.4) }))}
-          className="rounded px-1.5 hover:bg-slate-700"
+          className="rounded px-1.5 hover:bg-cp-surface-4"
           aria-label={t('graphmlViewer.zoomIn', 'Zoom in')}
         >
           ＋
@@ -274,7 +274,7 @@ export const GraphmlViewer = ({ document, highlightNodes, className }: GraphmlVi
         <button
           type="button"
           onClick={() => setView((v) => ({ ...v, zoom: Math.max(0.05, v.zoom / 1.4) }))}
-          className="rounded px-1.5 hover:bg-slate-700"
+          className="rounded px-1.5 hover:bg-cp-surface-4"
           aria-label={t('graphmlViewer.zoomOut', 'Zoom out')}
         >
           −
@@ -282,14 +282,14 @@ export const GraphmlViewer = ({ document, highlightNodes, className }: GraphmlVi
         <button
           type="button"
           onClick={resetView}
-          className="rounded px-1.5 text-[10px] hover:bg-slate-700"
+          className="rounded px-1.5 text-[10px] hover:bg-cp-surface-4"
           aria-label={t('graphmlViewer.reset', 'Reset')}
         >
           {t('graphmlViewer.reset', 'Reset')}
         </button>
-        <span className="ml-1 text-[10px] text-slate-400">{Math.round(view.zoom * 100)}%</span>
+        <span className="ml-1 text-[10px] text-cp-text-muted">{Math.round(view.zoom * 100)}%</span>
       </div>
-      <div className="pointer-events-none absolute bottom-2 left-3 text-[10px] text-slate-400">
+      <div className="pointer-events-none absolute bottom-2 left-3 text-[10px] text-cp-text-muted">
         {format(
           t(
             'graphmlViewer.statusBar',

--- a/src/renderer/components/Layout/FloatingPanelShell.tsx
+++ b/src/renderer/components/Layout/FloatingPanelShell.tsx
@@ -279,7 +279,7 @@ export const FloatingPanelShell = ({
       )}
       <aside
         ref={containerRef}
-        className="pointer-events-auto fixed z-40 flex flex-col rounded-cp-modal border border-[var(--cp-border)] bg-slate-950/95 text-[var(--cp-text)] shadow-2xl backdrop-blur-md"
+        className="pointer-events-auto fixed z-40 flex flex-col rounded-cp-modal border border-[var(--cp-border)] bg-cp-surface-3/95 text-[var(--cp-text)] shadow-2xl backdrop-blur-md"
         style={{
           left: pos.x,
           top: pos.y,
@@ -290,7 +290,7 @@ export const FloatingPanelShell = ({
         }}
       >
         <header
-          className="flex shrink-0 items-center justify-between border-b border-[var(--cp-border-muted)] bg-slate-900/80 px-2 py-1.5 text-cp-xs"
+          className="flex shrink-0 items-center justify-between border-b border-[var(--cp-border-muted)] bg-cp-surface-1/80 px-2 py-1.5 text-cp-xs"
           style={{ cursor: 'move', touchAction: 'none' }}
           onPointerDown={onPointerDown}
           onPointerMove={onPointerMove}
@@ -299,7 +299,7 @@ export const FloatingPanelShell = ({
         >
           <div className="flex min-w-0 flex-1 items-center gap-2">
             <Icon icon={GripVertical} size="sm" className="shrink-0 text-[var(--cp-text-faint)]" />
-            <span className="truncate font-medium text-slate-200">{title}</span>
+            <span className="truncate font-medium text-cp-text-bright">{title}</span>
           </div>
           <div className="flex shrink-0 items-center gap-1">
             {onPopout && (

--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -122,7 +122,7 @@ export const MenuBar = ({
   return (
     <header className="flex shrink-0 items-center justify-between gap-3 border-b border-[var(--cp-border)] bg-[var(--cp-surface-3)] px-3 py-1.5 text-cp-xs shadow-sm">
       <div className="flex shrink-0 items-center gap-2">
-        <span className="hidden select-none font-semibold tracking-wide text-slate-300 lg:inline">
+        <span className="hidden select-none font-semibold tracking-wide text-cp-text-secondary lg:inline">
           {t('app.title', 'Cable Planner')}
         </span>
         <span className="hidden text-slate-700 lg:inline">│</span>
@@ -493,12 +493,12 @@ export const MenuBar = ({
             type="button"
             onClick={onEditProjectMeta}
             disabled={!onEditProjectMeta}
-            className="group flex max-w-[42ch] items-center gap-1 truncate rounded px-2 py-0.5 text-slate-200 hover:bg-slate-800 hover:text-white disabled:cursor-default disabled:hover:bg-transparent"
+            className="group flex max-w-[42ch] items-center gap-1 truncate rounded px-2 py-0.5 text-cp-text-bright hover:bg-cp-surface-2 hover:text-white disabled:cursor-default disabled:hover:bg-transparent"
             title={onEditProjectMeta ? t('app.editProjectMeta', 'Projektdaten bearbeiten') : projectName}
           >
             <span className="truncate font-medium">{projectName}</span>
             {onEditProjectMeta && (
-              <span className="text-slate-500 opacity-0 transition-opacity group-hover:opacity-100">
+              <span className="text-cp-text-faint opacity-0 transition-opacity group-hover:opacity-100">
                 <Icon icon={Pencil} size="xs" />
               </span>
             )}
@@ -508,25 +508,25 @@ export const MenuBar = ({
       </div>
 
       <div className="flex shrink-0 items-center gap-2">
-        <div className="flex items-center rounded border border-slate-700 bg-slate-900">
+        <div className="flex items-center rounded border border-cp-border bg-cp-surface-1">
           <button
             type="button"
             onClick={() => projectHistory.undo()}
             disabled={!canUndo}
             title={t('app.undo', 'Rückgängig (Strg+Z)')}
             aria-label={t('app.undo', 'Rückgängig (Strg+Z)')}
-            className="px-2 py-1 text-slate-200 hover:bg-slate-800 disabled:cursor-not-allowed disabled:text-slate-600 disabled:hover:bg-transparent"
+            className="px-2 py-1 text-cp-text-bright hover:bg-cp-surface-2 disabled:cursor-not-allowed disabled:text-slate-600 disabled:hover:bg-transparent"
           >
             <Icon icon={Undo2} size="sm" />
           </button>
-          <span className="h-4 w-px bg-slate-700" aria-hidden="true" />
+          <span className="h-4 w-px bg-cp-surface-4" aria-hidden="true" />
           <button
             type="button"
             onClick={() => projectHistory.redo()}
             disabled={!canRedo}
             title={t('app.redo', 'Wiederherstellen (Strg+Y)')}
             aria-label={t('app.redo', 'Wiederherstellen (Strg+Y)')}
-            className="px-2 py-1 text-slate-200 hover:bg-slate-800 disabled:cursor-not-allowed disabled:text-slate-600 disabled:hover:bg-transparent"
+            className="px-2 py-1 text-cp-text-bright hover:bg-cp-surface-2 disabled:cursor-not-allowed disabled:text-slate-600 disabled:hover:bg-transparent"
           >
             <Icon icon={Redo2} size="sm" />
           </button>
@@ -536,7 +536,7 @@ export const MenuBar = ({
           <button
             type="button"
             onClick={() => useUiStore.getState().openMobileShare()}
-            className="rounded bg-slate-800 px-2 py-1 text-slate-100 hover:bg-slate-700"
+            className="rounded bg-cp-surface-2 px-2 py-1 text-cp-text hover:bg-cp-surface-4"
             aria-label={t('app.mobileShare.ariaLabel', 'Handy-Zugriff')}
             title={t(
               'app.mobileShare.title',
@@ -549,7 +549,7 @@ export const MenuBar = ({
         <button
           type="button"
           onClick={onOpenSettings}
-          className="inline-flex items-center gap-1 rounded bg-slate-800 px-2 py-1 text-slate-100 hover:bg-slate-700"
+          className="inline-flex items-center gap-1 rounded bg-cp-surface-2 px-2 py-1 text-cp-text hover:bg-cp-surface-4"
           title={t('settings.title', 'Einstellungen')}
         >
           <Icon icon={Settings} size="sm" />
@@ -645,10 +645,10 @@ const Menu = ({ label, children }: MenuProps) => {
         }}
         aria-haspopup="menu"
         aria-expanded={open}
-        className={`rounded px-2 py-1 text-slate-200 hover:bg-slate-800 ${open ? 'bg-slate-800' : ''}`}
+        className={`rounded px-2 py-1 text-cp-text-bright hover:bg-cp-surface-2 ${open ? 'bg-cp-surface-2' : ''}`}
       >
         {label}
-        <span className="ml-1 text-[11px] text-slate-400" aria-hidden="true">▾</span>
+        <span className="ml-1 text-[11px] text-cp-text-muted" aria-hidden="true">▾</span>
       </button>
       {open && (
         <div
@@ -678,7 +678,7 @@ const MenuItem = ({ onClick, icon, shortcut, disabled, children }: MenuItemProps
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-cp-xs text-slate-200 hover:bg-slate-700/70 disabled:cursor-not-allowed disabled:text-[var(--cp-text-faint)] disabled:hover:bg-transparent"
+      className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-cp-xs text-cp-text-bright hover:bg-cp-surface-4/70 disabled:cursor-not-allowed disabled:text-[var(--cp-text-faint)] disabled:hover:bg-transparent"
       role="menuitem"
     >
       <span className="inline-flex w-4 shrink-0 items-center justify-center text-[var(--cp-text-muted)]">{icon}</span>
@@ -692,7 +692,7 @@ const MenuItem = ({ onClick, icon, shortcut, disabled, children }: MenuItemProps
   )
 }
 
-const MenuSep = () => <div className="my-1 border-t border-slate-700" />
+const MenuSep = () => <div className="my-1 border-t border-cp-border" />
 
 /** Kleiner, nicht-interaktiver Gruppen-Titel innerhalb eines Menüs. Gliedert
  *  lange Menüs (z. B. Werkzeuge) optisch, ohne echte Flyout-Submenüs. */

--- a/src/renderer/components/Layout/PopoutApp.tsx
+++ b/src/renderer/components/Layout/PopoutApp.tsx
@@ -34,7 +34,7 @@ export const PopoutApp = ({ panel }: { panel: PopoutPanel }) => {
   // schließt das OS-Fenster. Layout entspricht dem Modal-Panel.
   if (panel === 'settings') {
     return (
-      <div className="flex h-full w-full min-h-0 flex-col overflow-hidden bg-slate-900 text-slate-100 sm:flex-row">
+      <div className="flex h-full w-full min-h-0 flex-col overflow-hidden bg-cp-surface-1 text-cp-text sm:flex-row">
         <SettingsBody onClose={() => window.close()} />
       </div>
     )

--- a/src/renderer/components/Layout/Splitter.tsx
+++ b/src/renderer/components/Layout/Splitter.tsx
@@ -49,7 +49,7 @@ export const Splitter = ({ side, onResize }: SplitterProps) => {
     <div
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
-      className="h-full w-1 cursor-col-resize bg-slate-800 hover:bg-sky-600"
+      className="h-full w-1 cursor-col-resize bg-cp-surface-2 hover:bg-sky-600"
       title={t('splitter.resize', 'Spalte verbreitern')}
     />
   )

--- a/src/renderer/components/Layout/StatusBar.tsx
+++ b/src/renderer/components/Layout/StatusBar.tsx
@@ -31,7 +31,7 @@ const complexityFor = (
   if (score >= 80) return { label: t('statusbar.complexity.large', 'Groß'), tone: 'bg-amber-600 text-amber-50' }
   if (score >= 30) return { label: t('statusbar.complexity.medium', 'Mittel'), tone: 'bg-sky-700 text-sky-50' }
   if (score >= 8) return { label: t('statusbar.complexity.small', 'Klein'), tone: 'bg-emerald-700 text-emerald-50' }
-  return { label: t('statusbar.complexity.new', 'Neu'), tone: 'bg-slate-700 text-slate-200' }
+  return { label: t('statusbar.complexity.new', 'Neu'), tone: 'bg-cp-surface-4 text-cp-text-bright' }
 }
 
 /** #471 — Macht eine laufende Live-Session im Haupt-UI sichtbar. Klick öffnet
@@ -94,7 +94,7 @@ export const StatusBar = ({
                 ? 'text-emerald-300'
                 : packedCount > 0
                   ? 'text-amber-300'
-                  : 'text-slate-500'
+                  : 'text-cp-text-faint'
             }`}
             title={t('statusbar.packedTitle', "Geräte, die in den Eigenschaften als 'gepackt' markiert sind")}
           >

--- a/src/renderer/components/Library/CableLibraryPanel.tsx
+++ b/src/renderer/components/Library/CableLibraryPanel.tsx
@@ -109,7 +109,7 @@ const CableTypeEditor = ({
 
   return (
     <div className="fixed inset-0 z-[80] flex items-center justify-center bg-black/70 p-4">
-      <div className="w-full max-w-md rounded border border-slate-700 bg-slate-900 p-4 text-slate-100 shadow-2xl">
+      <div className="w-full max-w-md rounded border border-cp-border bg-cp-surface-1 p-4 text-cp-text shadow-2xl">
         <div className="mb-3 flex items-center justify-between">
           <h3 className="text-cp-base font-semibold">
             {isEditing ? 'Kabeltyp bearbeiten' : 'Neuer Kabeltyp'}
@@ -117,7 +117,7 @@ const CableTypeEditor = ({
           <button
             type="button"
             onClick={onCancel}
-            className="text-slate-500 hover:text-slate-200"
+            className="text-cp-text-faint hover:text-cp-text-bright"
             aria-label={t('common.close', 'Schließen')}
           >
             <Icon icon={X} size="sm" />
@@ -125,14 +125,14 @@ const CableTypeEditor = ({
         </div>
         <div className="space-y-2 text-cp-xs">
           <label className="block">
-            <span className="text-slate-400">{t('common.name', 'Name')}</span>
+            <span className="text-cp-text-muted">{t('common.name', 'Name')}</span>
             <input
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder={t('cableLib.namePlaceholder', 'z.B. CAT6a Patch 5m')}
               autoFocus
-              className="mt-0.5 w-full rounded border border-slate-700 bg-slate-950 px-2 py-1 text-slate-100"
+              className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-text"
             />
             {conflictsWithExisting && (
               <span className="mt-0.5 flex items-center gap-1 text-[10px] text-amber-400">
@@ -143,7 +143,7 @@ const CableTypeEditor = ({
           </label>
           <div className="grid grid-cols-2 gap-2">
             <label className="block">
-              <span className="flex items-center justify-between text-slate-400">
+              <span className="flex items-center justify-between text-cp-text-muted">
                 <span>{t('cableLib.connectorType', 'Stecker-Typ')}</span>
                 <button
                   type="button"
@@ -163,7 +163,7 @@ const CableTypeEditor = ({
               <select
                 value={connectorType}
                 onChange={(e) => setConnectorType(e.target.value as ConnectorType)}
-                className="mt-0.5 w-full rounded border border-slate-700 bg-slate-950 px-2 py-1"
+                className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1"
               >
                 {allConnectorTypeOptions.map((c) => (
                   <option key={c} value={c}>
@@ -174,18 +174,18 @@ const CableTypeEditor = ({
               </select>
             </label>
             <label className="block">
-              <span className="text-slate-400">{t('cableLib.color', 'Kabel-Farbe')}</span>
+              <span className="text-cp-text-muted">{t('cableLib.color', 'Kabel-Farbe')}</span>
               <input
                 type="color"
                 value={color}
                 onChange={(e) => setColor(e.target.value)}
-                className="mt-0.5 h-7 w-full cursor-pointer rounded border border-slate-700 bg-slate-950 p-0.5"
+                className="mt-0.5 h-7 w-full cursor-pointer rounded border border-cp-border bg-cp-surface-3 p-0.5"
               />
             </label>
           </div>
           <div>
-            <span className="text-slate-400">{t('cableLib.compatibleWith', 'Auch kompatibel mit (optional)')}</span>
-            <div className="mt-1 flex max-h-24 flex-wrap gap-1 overflow-auto rounded border border-slate-700 bg-slate-950 p-1.5">
+            <span className="text-cp-text-muted">{t('cableLib.compatibleWith', 'Auch kompatibel mit (optional)')}</span>
+            <div className="mt-1 flex max-h-24 flex-wrap gap-1 overflow-auto rounded border border-cp-border bg-cp-surface-3 p-1.5">
               {allConnectorTypeOptions.filter((c) => c !== connectorType).map((c) => {
                 const on = compatible.includes(c)
                 return (
@@ -200,7 +200,7 @@ const CableTypeEditor = ({
                     className={`rounded px-1.5 py-0.5 text-[10px] ${
                       on
                         ? 'bg-emerald-700 text-white'
-                        : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+                        : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
                     }`}
                   >
                     {c}
@@ -210,7 +210,7 @@ const CableTypeEditor = ({
             </div>
           </div>
           <div>
-            <span className="flex items-center justify-between text-slate-400">
+            <span className="flex items-center justify-between text-cp-text-muted">
               <span>{t('cableLib.signalStandards', 'Signal-Standards')}</span>
               <button
                 type="button"
@@ -227,7 +227,7 @@ const CableTypeEditor = ({
                 + Standard
               </button>
             </span>
-            <div className="mt-1 flex max-h-32 flex-wrap gap-1 overflow-auto rounded border border-slate-700 bg-slate-950 p-1.5">
+            <div className="mt-1 flex max-h-32 flex-wrap gap-1 overflow-auto rounded border border-cp-border bg-cp-surface-3 p-1.5">
               {allSignalStandardOptions.map((s) => {
                 const on = standards.includes(s)
                 return (
@@ -242,7 +242,7 @@ const CableTypeEditor = ({
                     className={`rounded px-1.5 py-0.5 text-[10px] ${
                       on
                         ? 'bg-sky-700 text-white'
-                        : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+                        : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
                     } ${customSignalStandards.includes(s as string) ? 'italic' : ''}`}
                   >
                     {s}
@@ -257,7 +257,7 @@ const CableTypeEditor = ({
             )}
           </div>
           <label className="block">
-            <span className="text-slate-400">{t('cableLib.maxLength', 'Max. Länge (m) – optional')}</span>
+            <span className="text-cp-text-muted">{t('cableLib.maxLength', 'Max. Länge (m) – optional')}</span>
             <input
               type="number"
               min={0}
@@ -268,17 +268,17 @@ const CableTypeEditor = ({
                 setMaxLength(v === '' ? '' : Math.max(0, Number(v)))
               }}
               placeholder={t('cable.field.maxReachPlaceholder', 'z.B. 100')}
-              className="mt-0.5 w-full rounded border border-slate-700 bg-slate-950 px-2 py-1"
+              className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1"
             />
           </label>
           <label className="block">
-            <span className="text-slate-400">{t('cableLib.note', 'Notiz (optional)')}</span>
+            <span className="text-cp-text-muted">{t('cableLib.note', 'Notiz (optional)')}</span>
             <textarea
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
               rows={2}
               placeholder={t('cableLib.notePlaceholder', 'z.B. nur für indoor, geschirmt, …')}
-              className="mt-0.5 w-full rounded border border-slate-700 bg-slate-950 px-2 py-1"
+              className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1"
             />
           </label>
         </div>
@@ -286,7 +286,7 @@ const CableTypeEditor = ({
           <button
             type="button"
             onClick={onCancel}
-            className="rounded bg-slate-700 px-3 py-1 text-cp-xs hover:bg-slate-600"
+            className="rounded bg-cp-surface-4 px-3 py-1 text-cp-xs hover:bg-cp-surface-5"
           >
             Abbrechen
           </button>
@@ -348,7 +348,7 @@ const SortableCableGroup = ({
     position: 'relative',
   }
   return (
-    <div ref={setNodeRef} style={style} className="rounded border border-slate-700 bg-slate-900">
+    <div ref={setNodeRef} style={style} className="rounded border border-cp-border bg-cp-surface-1">
       <span
         {...attributes}
         {...listeners}
@@ -356,7 +356,7 @@ const SortableCableGroup = ({
         title={t('cableLib.groupReorderTitle', 'Per Drag&Drop verschieben')}
         role="button"
         tabIndex={0}
-        className="absolute left-0.5 top-0.5 z-10 flex h-5 w-3 cursor-grab items-center justify-center text-slate-500 hover:text-slate-200 active:cursor-grabbing"
+        className="absolute left-0.5 top-0.5 z-10 flex h-5 w-3 cursor-grab items-center justify-center text-cp-text-faint hover:text-cp-text-bright active:cursor-grabbing"
       >
         <svg width="6" height="12" viewBox="0 0 6 12" fill="currentColor">
           <circle cx="1.5" cy="2" r="1" />
@@ -496,7 +496,7 @@ export const CableLibraryPanel = () => {
       <div className="mb-2 flex flex-wrap items-center justify-between gap-y-1 gap-x-2">
         <div className="flex items-center gap-2">
           <h2 className="text-cp-base font-semibold">{t('cableLib.title', 'Kabel-Library')}</h2>
-          <span className="text-[10px] text-slate-400">{cables.length} verbaut</span>
+          <span className="text-[10px] text-cp-text-muted">{cables.length} verbaut</span>
         </div>
         <button
           type="button"
@@ -507,7 +507,7 @@ export const CableLibraryPanel = () => {
           + Neuer Kabeltyp
         </button>
       </div>
-      <p className="mb-2 text-[11px] text-slate-400">
+      <p className="mb-2 text-[11px] text-cp-text-muted">
         Presets mit Stecker- und Signalinfos.
         {customCableSpecs.length > 0 && (
           <> {customCableSpecs.length} eigene{customCableSpecs.length === 1 ? 'r' : ''} Kabeltyp{customCableSpecs.length === 1 ? '' : 'en'}.</>
@@ -530,27 +530,27 @@ export const CableLibraryPanel = () => {
               <button
                 type="button"
                 onClick={() => toggle(group)}
-                className="flex w-full items-center justify-between px-2 py-1.5 pl-5 text-left text-cp-xs font-semibold hover:bg-slate-800"
+                className="flex w-full items-center justify-between px-2 py-1.5 pl-5 text-left text-cp-xs font-semibold hover:bg-cp-surface-2"
               >
                 <span className="flex items-center gap-1.5">
                   {group}
-                  <span className="text-[10px] font-normal text-slate-400">({specs.length})</span>
+                  <span className="text-[10px] font-normal text-cp-text-muted">({specs.length})</span>
                   {groupBuilt > 0 && (
                     <span className={`rounded px-1.5 py-0.5 text-[11px] font-bold ${
                       groupPlanned > 0
                         ? groupBuilt >= groupPlanned
                           ? 'bg-emerald-900/60 text-emerald-300'
                           : 'bg-red-900/60 text-red-300'
-                        : 'bg-slate-700 text-slate-300'
+                        : 'bg-cp-surface-4 text-cp-text-secondary'
                     }`}>
                       {groupBuilt}{groupPlanned > 0 ? `/${groupPlanned}` : ''}
                     </span>
                   )}
                 </span>
-                <span className="text-slate-500">{isOpen ? '▾' : '▸'}</span>
+                <span className="text-cp-text-faint">{isOpen ? '▾' : '▸'}</span>
               </button>
               {isOpen && (
-                <div className="space-y-1 border-t border-slate-800 p-1.5">
+                <div className="space-y-1 border-t border-cp-border-muted p-1.5">
                   {specs.map((cable) => {
                     const isRecommended =
                       preferredSdi !== undefined &&
@@ -569,7 +569,7 @@ export const CableLibraryPanel = () => {
                             ? 'border-emerald-500 bg-emerald-950/40'
                             : isCustom
                               ? 'border-violet-700/60 bg-violet-950/30'
-                              : 'border-slate-700 bg-slate-950'
+                              : 'border-cp-border bg-cp-surface-3'
                         }`}
                         title={cable.notes ?? ''}
                       >
@@ -606,7 +606,7 @@ export const CableLibraryPanel = () => {
                                 ? built >= planned
                                   ? 'bg-emerald-900/60 text-emerald-300'
                                   : 'bg-red-900/60 text-red-300'
-                                : 'bg-slate-700/80 text-slate-300'
+                                : 'bg-cp-surface-4/80 text-cp-text-secondary'
                             }`}
                               title={planned > 0 ? `${built} verbaut / ${planned} Rentman geplant` : `${built} verbaut`}
                             >
@@ -616,7 +616,7 @@ export const CableLibraryPanel = () => {
                           <button
                             type="button"
                             onClick={() => setEditing(cable)}
-                            className="rounded bg-slate-700 px-1.5 py-0.5 text-[10px] text-slate-200 hover:bg-slate-600"
+                            className="rounded bg-cp-surface-4 px-1.5 py-0.5 text-[10px] text-cp-text-bright hover:bg-cp-surface-5"
                             title={isCustom
                               ? t('cableLib.edit', 'Kabeltyp bearbeiten')
                               : t('cableLib.editOverride', 'Kabeltyp lokal anpassen (Override)')}
@@ -687,18 +687,18 @@ export const CableLibraryPanel = () => {
                             </button>
                           )}
                         </div>
-                        <div className="mt-0.5 text-[11px] text-slate-400">
+                        <div className="mt-0.5 text-[11px] text-cp-text-muted">
                           {cable.connectorType}
                           {cable.compatibleConnectors?.length
                             ? ` (+ ${cable.compatibleConnectors.join(', ')})`
                             : ''}
                           {cable.maxLengthMeters ? ` · max ${cable.maxLengthMeters} m` : ''}
                         </div>
-                        <div className="text-[11px] text-slate-400">
+                        <div className="text-[11px] text-cp-text-muted">
                           {cable.standards.join(' · ')}
                         </div>
                         {cable.notes && (
-                          <div className="mt-1 rounded bg-slate-900 p-1 text-[10px] italic text-slate-300">
+                          <div className="mt-1 rounded bg-cp-surface-1 p-1 text-[10px] italic text-cp-text-secondary">
                             {cable.notes}
                           </div>
                         )}

--- a/src/renderer/components/Library/LibraryItem.tsx
+++ b/src/renderer/components/Library/LibraryItem.tsx
@@ -88,8 +88,8 @@ export const LibraryItem = ({
       }}
       className={`group flex w-full cursor-grab items-start justify-between gap-2 rounded border ${accentClass} px-2 py-2 text-left text-cp-base active:cursor-grabbing ${
         item.hidden
-          ? 'border-slate-800 bg-slate-950 opacity-60 hover:opacity-100'
-          : 'border-slate-700 bg-slate-900 hover:bg-slate-800'
+          ? 'border-cp-border-muted bg-cp-surface-3 opacity-60 hover:opacity-100'
+          : 'border-cp-border bg-cp-surface-1 hover:bg-cp-surface-2'
       }`}
       title={
         isFromActiveRentman
@@ -131,7 +131,7 @@ export const LibraryItem = ({
           )}
           {isFromOtherRentman && (
             <span
-              className="mr-1 rounded bg-slate-600 px-1 text-[11px] font-bold text-slate-200"
+              className="mr-1 rounded bg-cp-surface-5 px-1 text-[11px] font-bold text-cp-text-bright"
               title={format(
                 t('library.item.badgeOtherRentman', 'Aus Rentman-Projekt{suffix}'),
                 { suffix: item.rentmanProjectName ? `: ${item.rentmanProjectName}` : '' },
@@ -150,10 +150,10 @@ export const LibraryItem = ({
           )}
           {item.name}
         </div>
-        <div className="truncate text-cp-xs text-slate-400">
+        <div className="truncate text-cp-xs text-cp-text-muted">
           {item.category} · {item.inputs.length} in / {item.outputs.length} out
           {isFromOtherRentman && item.rentmanProjectName && (
-            <span className="ml-1 text-slate-500">· {item.rentmanProjectName}</span>
+            <span className="ml-1 text-cp-text-faint">· {item.rentmanProjectName}</span>
           )}
         </div>
       </div>
@@ -175,7 +175,7 @@ export const LibraryItem = ({
               className={`rounded px-1 text-[11px] ${
                 item.favorite
                   ? 'bg-amber-700 text-amber-100 hover:bg-amber-600'
-                  : 'bg-slate-700 text-slate-300 hover:bg-slate-600'
+                  : 'bg-cp-surface-4 text-cp-text-secondary hover:bg-cp-surface-5'
               }`}
               aria-label={
                 item.favorite
@@ -203,8 +203,8 @@ export const LibraryItem = ({
               }}
               className={`rounded px-1 text-[11px] ${
                 item.hidden
-                  ? 'bg-slate-600 text-slate-200 hover:bg-slate-500'
-                  : 'bg-slate-700 text-slate-300 hover:bg-slate-600'
+                  ? 'bg-cp-surface-5 text-cp-text-bright hover:bg-slate-500'
+                  : 'bg-cp-surface-4 text-cp-text-secondary hover:bg-cp-surface-5'
               }`}
               aria-label={
                 item.hidden
@@ -229,7 +229,7 @@ export const LibraryItem = ({
                 event.stopPropagation()
                 onExport()
               }}
-              className="rounded bg-slate-700 px-1 text-[11px] text-slate-300 hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-1 text-[11px] text-cp-text-secondary hover:bg-cp-surface-5"
               aria-label={t('library.item.exportAria', 'Exportieren')}
             >
               <Icon icon={Download} size="xs" />

--- a/src/renderer/components/Library/LibraryMenus.tsx
+++ b/src/renderer/components/Library/LibraryMenus.tsx
@@ -52,7 +52,7 @@ export const PlusMenu = ({
       {open && (
         <div
           role="menu"
-          className="absolute right-0 top-full z-10 mt-1 min-w-[160px] rounded border border-slate-700 bg-slate-900 py-1 text-cp-xs shadow-xl"
+          className="absolute right-0 top-full z-10 mt-1 min-w-[160px] rounded border border-cp-border bg-cp-surface-1 py-1 text-cp-xs shadow-xl"
         >
           <button
             type="button"
@@ -61,7 +61,7 @@ export const PlusMenu = ({
               setOpen(false)
               onNewDevice()
             }}
-            className="block w-full px-3 py-1.5 text-left hover:bg-slate-800"
+            className="block w-full px-3 py-1.5 text-left hover:bg-cp-surface-2"
           >
             {t('library.menus.newDevice', 'Neues Gerät…')}
           </button>
@@ -72,11 +72,11 @@ export const PlusMenu = ({
               setOpen(false)
               onNewCategory()
             }}
-            className="block w-full px-3 py-1.5 text-left hover:bg-slate-800"
+            className="block w-full px-3 py-1.5 text-left hover:bg-cp-surface-2"
           >
             {t('library.menus.newCategory', 'Neue Kategorie…')}
           </button>
-          <div className="my-1 border-t border-slate-800" />
+          <div className="my-1 border-t border-cp-border-muted" />
           <button
             type="button"
             role="menuitem"
@@ -84,7 +84,7 @@ export const PlusMenu = ({
               setOpen(false)
               onImportFile()
             }}
-            className="block w-full px-3 py-1.5 text-left hover:bg-slate-800"
+            className="block w-full px-3 py-1.5 text-left hover:bg-cp-surface-2"
             title={t('library.menus.importFileTitle', '.cpdevice oder .cpgroup-Datei importieren')}
           >
             {t('library.menus.importFile', 'Datei importieren…')}
@@ -97,7 +97,7 @@ export const PlusMenu = ({
                 setOpen(false)
                 onOpenFolder()
               }}
-              className="block w-full px-3 py-1.5 text-left hover:bg-slate-800"
+              className="block w-full px-3 py-1.5 text-left hover:bg-cp-surface-2"
               title={t('library.menus.openFolderTitle', 'Library-Ordner im Datei-Manager öffnen')}
             >
               {t('library.menus.openFolder', 'Bibliotheks-Ordner öffnen…')}
@@ -152,7 +152,7 @@ export const LibraryFiltersMenu = ({
         title={t('library.menus.filterTitle', 'Filter und Ansichtsoptionen')}
         aria-haspopup="menu"
         aria-expanded={open}
-        className="flex h-7 w-7 items-center justify-center rounded border border-slate-700 bg-slate-900 text-slate-400 hover:bg-slate-800 hover:text-slate-200"
+        className="flex h-7 w-7 items-center justify-center rounded border border-cp-border bg-cp-surface-1 text-cp-text-muted hover:bg-cp-surface-2 hover:text-cp-text-bright"
       >
         <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
           <circle cx="3" cy="8" r="1.4" />
@@ -163,24 +163,24 @@ export const LibraryFiltersMenu = ({
       {open && (
         <div
           role="menu"
-          className="absolute right-0 top-full z-10 mt-1 min-w-[210px] rounded border border-slate-700 bg-slate-900 py-1 text-cp-xs shadow-xl"
+          className="absolute right-0 top-full z-10 mt-1 min-w-[210px] rounded border border-cp-border bg-cp-surface-1 py-1 text-cp-xs shadow-xl"
         >
           <button
             type="button"
             role="menuitemcheckbox"
             aria-checked={!allCollapsed}
             onClick={() => onToggleAllCats(allCollapsed)}
-            className="block w-full px-3 py-1.5 text-left hover:bg-slate-800"
+            className="block w-full px-3 py-1.5 text-left hover:bg-cp-surface-2"
           >
-            <span className="mr-2 inline-block w-4 text-center text-slate-400">
+            <span className="mr-2 inline-block w-4 text-center text-cp-text-muted">
               {allCollapsed ? '▸' : '▾'}
             </span>
             {allCollapsed
               ? t('library.menus.expandAll', 'Alle Kategorien ausklappen')
               : t('library.menus.collapseAll', 'Alle Kategorien einklappen')}
           </button>
-          <div className="my-1 border-t border-slate-800" />
-          <div className="px-3 py-1 text-[10px] uppercase tracking-wider text-slate-400">
+          <div className="my-1 border-t border-cp-border-muted" />
+          <div className="px-3 py-1 text-[10px] uppercase tracking-wider text-cp-text-muted">
             {t('library.menus.sorting', 'Sortierung')}
           </div>
           {(
@@ -196,7 +196,7 @@ export const LibraryFiltersMenu = ({
               role="menuitemradio"
               aria-checked={sortMode === opt.value}
               onClick={() => setSortMode(opt.value)}
-              className="block w-full px-3 py-1.5 text-left hover:bg-slate-800"
+              className="block w-full px-3 py-1.5 text-left hover:bg-cp-surface-2"
             >
               <span className="mr-2 inline-block w-4 text-center">
                 {sortMode === opt.value ? '●' : '○'}
@@ -204,13 +204,13 @@ export const LibraryFiltersMenu = ({
               {opt.label}
             </button>
           ))}
-          <div className="my-1 border-t border-slate-800" />
+          <div className="my-1 border-t border-cp-border-muted" />
           <button
             type="button"
             role="menuitemcheckbox"
             aria-checked={showHidden}
             onClick={() => setShowHidden(!showHidden)}
-            className="block w-full px-3 py-1.5 text-left hover:bg-slate-800"
+            className="block w-full px-3 py-1.5 text-left hover:bg-cp-surface-2"
           >
             <span className="mr-2 inline-flex w-4 justify-center"><Icon icon={showHidden ? SquareCheck : Square} size="xs" /></span>
             {t('library.menus.showHidden', 'Versteckte zeigen')}
@@ -221,7 +221,7 @@ export const LibraryFiltersMenu = ({
             role="menuitemcheckbox"
             aria-checked={showEmpty}
             onClick={() => setShowEmpty(!showEmpty)}
-            className="block w-full px-3 py-1.5 text-left hover:bg-slate-800"
+            className="block w-full px-3 py-1.5 text-left hover:bg-cp-surface-2"
           >
             <span className="mr-2 inline-flex w-4 justify-center"><Icon icon={showEmpty ? SquareCheck : Square} size="xs" /></span>
             {t('library.menus.showEmpty', 'Leere Kategorien zeigen')}

--- a/src/renderer/components/Library/LibraryPanel.tsx
+++ b/src/renderer/components/Library/LibraryPanel.tsx
@@ -704,13 +704,13 @@ export const LibraryPanel = () => {
 
   if (collapsed && !floating) {
     return (
-      <aside className="flex h-full w-8 flex-col items-center border-r border-slate-700 bg-slate-950 transition-colors hover:bg-slate-900">
+      <aside className="flex h-full w-8 flex-col items-center border-r border-cp-border bg-cp-surface-3 transition-colors hover:bg-cp-surface-1">
         <button
           type="button"
           onClick={toggleCollapsed}
           title={t('library.show', 'Library einblenden')}
           aria-label={t('library.show', 'Library einblenden')}
-          className="mt-2 flex h-7 w-7 items-center justify-center rounded-full border border-slate-700 bg-slate-900 text-slate-300 shadow-sm transition-all hover:border-sky-500 hover:bg-slate-800 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+          className="mt-2 flex h-7 w-7 items-center justify-center rounded-full border border-cp-border bg-cp-surface-1 text-cp-text-secondary shadow-sm transition-all hover:border-sky-500 hover:bg-cp-surface-2 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
         >
           <span className="text-cp-lg leading-none">›</span>
         </button>
@@ -718,7 +718,7 @@ export const LibraryPanel = () => {
           type="button"
           onClick={toggleCollapsed}
           aria-label={t('library.show', 'Library einblenden')}
-          className="mt-3 flex-1 self-stretch text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400 transition-colors hover:text-slate-300 focus-visible:outline-none focus-visible:text-sky-300"
+          className="mt-3 flex-1 self-stretch text-[10px] font-semibold uppercase tracking-[0.18em] text-cp-text-muted transition-colors hover:text-cp-text-secondary focus-visible:outline-none focus-visible:text-sky-300"
           style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}
         >
           {t('library.title', 'Library')}
@@ -727,7 +727,7 @@ export const LibraryPanel = () => {
     )
   }
   const inner = (
-    <aside className={`flex h-full min-h-0 flex-col ${floating ? 'bg-transparent p-3' : 'border-r border-slate-700 bg-slate-950 p-3'} text-slate-100`}>
+    <aside className={`flex h-full min-h-0 flex-col ${floating ? 'bg-transparent p-3' : 'border-r border-cp-border bg-cp-surface-3 p-3'} text-cp-text`}>
       {/* v7.9.5 — Kompakte Tab-Strip mit SVG-Icons (keine Emojis) und
           konsistent deutschen Labels (Geräte/Kabel/Gruppen/Racks).
           Counts NUR an der kleinsten Granularität — der R-Badge am
@@ -740,7 +740,7 @@ export const LibraryPanel = () => {
             onClick={toggleCollapsed}
             title={t('library.hide', 'Library ausblenden')}
             aria-label={t('library.hide', 'Library ausblenden')}
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-slate-700 bg-slate-900 text-slate-300 transition-all hover:border-sky-500 hover:bg-slate-800 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-cp-border bg-cp-surface-1 text-cp-text-secondary transition-all hover:border-sky-500 hover:bg-cp-surface-2 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
           >
             <span className="text-cp-lg leading-none">‹</span>
           </button>
@@ -759,7 +759,7 @@ export const LibraryPanel = () => {
             }}
             title={t('library.float.title', 'Library abdocken (klicken oder herausziehen)')}
             aria-label={t('library.float.aria', 'Library abdocken')}
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-slate-700 bg-slate-900 text-slate-300 transition-all hover:border-sky-500 hover:bg-slate-800 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-cp-border bg-cp-surface-1 text-cp-text-secondary transition-all hover:border-sky-500 hover:bg-cp-surface-2 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
             style={{ touchAction: 'none' }}
           >
             <span className="pointer-events-none text-[11px] leading-none">⤢</span>
@@ -771,7 +771,7 @@ export const LibraryPanel = () => {
             onClick={() => openPanelPopout('library')}
             title={t('panel.popoutTitle', 'In separates Fenster auslagern (weiterer Monitor)')}
             aria-label={t('panel.popout', 'Auslagern')}
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-slate-700 bg-slate-900 text-slate-300 transition-all hover:border-sky-500 hover:bg-slate-800 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-cp-border bg-cp-surface-1 text-cp-text-secondary transition-all hover:border-sky-500 hover:bg-cp-surface-2 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
           >
             <Icon icon={ExternalLink} size="xs" />
           </button>
@@ -836,20 +836,20 @@ export const LibraryPanel = () => {
         <>
           {/* Sub-section toggle: Lokal vs. Rentman, both inside the Equipment tab.
               v7.9.4: nur sichtbar wenn rentmanEnabled — sonst gibt's nur Lokal. */}
-          <div className="mb-2 flex gap-1 rounded bg-slate-950/40 p-1">
+          <div className="mb-2 flex gap-1 rounded bg-cp-surface-3/40 p-1">
             <button
               type="button"
               onClick={() => setEquipmentSection('local')}
               className={`flex-1 rounded px-2 py-1 text-cp-xs ${
                 equipmentSection === 'local'
                   ? 'bg-sky-700 text-white'
-                  : 'text-slate-300 hover:bg-slate-800'
+                  : 'text-cp-text-secondary hover:bg-cp-surface-2'
               }`}
               title={t('library.section.localTitle', 'Eigene und importierte Vorlagen, lokal in dieser Installation')}
             >
               <span className="mr-1 rounded bg-sky-900/80 px-1 text-[11px] font-bold text-sky-100">L</span>
               {t('library.section.local', 'Lokal')}
-              <span className="ml-1 text-[10px] text-slate-400">
+              <span className="ml-1 text-[10px] text-cp-text-muted">
                 ({customLibrary.filter((t) => !t.rentmanSource).length})
               </span>
             </button>
@@ -859,13 +859,13 @@ export const LibraryPanel = () => {
               className={`flex-1 rounded px-2 py-1 text-cp-xs ${
                 equipmentSection === 'rentman'
                   ? 'bg-orange-600 text-white'
-                  : 'text-slate-300 hover:bg-slate-800'
+                  : 'text-cp-text-secondary hover:bg-cp-surface-2'
               }`}
               title={t('library.section.rentmanTitle', 'Aus Rentman importierte Geräte und Account-Katalog')}
             >
               <span className="mr-1 rounded bg-orange-900/80 px-1 text-[11px] font-bold text-orange-100">R</span>
               Rentman
-              <span className="ml-1 text-[10px] text-slate-400">
+              <span className="ml-1 text-[10px] text-cp-text-muted">
                 ({customLibrary.filter((t) => t.rentmanSource).length})
               </span>
             </button>
@@ -899,11 +899,11 @@ export const LibraryPanel = () => {
 
       {showNetBoxDialog && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-6">
-          <div className="max-h-[90vh] w-full max-w-3xl overflow-auto rounded border border-slate-700 bg-slate-900 p-4">
+          <div className="max-h-[90vh] w-full max-w-3xl overflow-auto rounded border border-cp-border bg-cp-surface-1 p-4">
             <div className="mb-3 flex items-start justify-between gap-3">
               <div>
                 <h3 className="text-cp-xl font-semibold">{t('library.netbox.title', 'NetBox Import')}</h3>
-                <p className="mt-1 text-cp-xs text-slate-400">
+                <p className="mt-1 text-cp-xs text-cp-text-muted">
                   {t(
                     'library.netbox.intro',
                     'Importiert Geräte aus der NetBox device-type-library in die lokale Library. Nicht-destruktiv: bestehende Geräte auf dem Canvas bleiben unverändert.',
@@ -913,7 +913,7 @@ export const LibraryPanel = () => {
               <button
                 type="button"
                 onClick={() => setShowNetBoxDialog(false)}
-                className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
               >
                 {t('common.close', 'Schließen')}
               </button>
@@ -931,7 +931,7 @@ export const LibraryPanel = () => {
                 }}
                 placeholder={t('library.netbox.searchPlaceholder', 'z.B. blackmagic atem, cisco catalyst, yamaha ql5')}
                 aria-label={t('library.netbox.searchPlaceholder', 'z.B. blackmagic atem, cisco catalyst, yamaha ql5')}
-                className="flex-1 rounded border border-slate-700 bg-slate-950 p-2 text-cp-base"
+                className="flex-1 rounded border border-cp-border bg-cp-surface-3 p-2 text-cp-base"
               />
               <button
                 type="button"
@@ -947,7 +947,7 @@ export const LibraryPanel = () => {
                   clearNetBoxIndexCache()
                   setNetBoxResults([])
                 }}
-                className="rounded bg-slate-700 px-3 py-2 text-cp-base hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-3 py-2 text-cp-base hover:bg-cp-surface-5"
                 title={t('library.netbox.refreshTitle', 'GitHub-Index neu laden')}
               >
                 Cache leeren
@@ -960,12 +960,12 @@ export const LibraryPanel = () => {
               </div>
             )}
 
-            <div className="mb-2 text-[11px] uppercase tracking-wide text-slate-400">
+            <div className="mb-2 text-[11px] uppercase tracking-wide text-cp-text-muted">
               Treffer {netBoxResults.length > 0 ? `(${netBoxResults.length})` : ''}
             </div>
             <div className="space-y-2">
               {netBoxResults.length === 0 ? (
-                <div className="rounded border border-slate-700 bg-slate-950/50 p-3 text-cp-xs text-slate-400">
+                <div className="rounded border border-cp-border bg-cp-surface-3/50 p-3 text-cp-xs text-cp-text-muted">
                   Hersteller + Modell suchen. Beispiel: „blackmagic atem", „yamaha ql5", „cisco catalyst 9300".
                 </div>
               ) : (
@@ -974,15 +974,15 @@ export const LibraryPanel = () => {
                   return (
                     <div
                       key={item.path}
-                      className="flex items-center justify-between gap-3 rounded border border-slate-700 bg-slate-950/50 p-3 text-cp-base"
+                      className="flex items-center justify-between gap-3 rounded border border-cp-border bg-cp-surface-3/50 p-3 text-cp-base"
                     >
                       <div className="min-w-0 flex-1">
-                        <div className="truncate font-medium text-slate-100">
+                        <div className="truncate font-medium text-cp-text">
                           {item.manufacturer} {item.model}
                         </div>
-                        <div className="truncate text-[11px] text-slate-400">{item.path}</div>
+                        <div className="truncate text-[11px] text-cp-text-muted">{item.path}</div>
                         <div className="mt-2 flex max-w-[340px] items-center gap-2">
-                          <span className="text-[11px] text-slate-400">{t('library.netbox.categoryLabel', 'Kategorie:')}</span>
+                          <span className="text-[11px] text-cp-text-muted">{t('library.netbox.categoryLabel', 'Kategorie:')}</span>
                           <select
                             value={netBoxCategoryByPath[item.path] ?? ''}
                             onChange={(event) =>
@@ -991,7 +991,7 @@ export const LibraryPanel = () => {
                                 [item.path]: event.target.value,
                               }))
                             }
-                            className="min-w-0 flex-1 rounded border border-slate-700 bg-slate-900 px-2 py-1 text-cp-xs"
+                            className="min-w-0 flex-1 rounded border border-cp-border bg-cp-surface-1 px-2 py-1 text-cp-xs"
                           >
                             <option value="">{t('library.netbox.pickCategory', 'Bitte auswählen...')}</option>
                             {existingCategoryOptions.map((cat) => (
@@ -1021,7 +1021,7 @@ export const LibraryPanel = () => {
 
       {showCreateDialog && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-6">
-          <div className="max-h-[90vh] w-full max-w-2xl overflow-auto rounded border border-slate-700 bg-slate-900 p-4">
+          <div className="max-h-[90vh] w-full max-w-2xl overflow-auto rounded border border-cp-border bg-cp-surface-1 p-4">
             <h3 className="mb-3 text-cp-xl font-semibold">
               {t('library.create.title', 'Eigenes Gerät anlegen')}
             </h3>
@@ -1031,7 +1031,7 @@ export const LibraryPanel = () => {
                 <input
                   value={name}
                   onChange={(event) => setName(event.target.value)}
-                  className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+                  className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
                 />
               </label>
               <label className="block">
@@ -1039,7 +1039,7 @@ export const LibraryPanel = () => {
                 <CategorySelect
                   value={category}
                   onChange={setCategory}
-                  className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+                  className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
                 />
               </label>
               <label className="block">
@@ -1060,7 +1060,7 @@ export const LibraryPanel = () => {
                     value={rackUnitsDraft}
                     onChange={(event) => setRackUnitsDraft(event.target.value ? Number(event.target.value) : '')}
                     placeholder={t('library.create.hePlaceholder', 'HE')}
-                    className="mt-2 w-full rounded border border-slate-700 bg-slate-950 p-2"
+                    className="mt-2 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
                   />
                 )}
               </label>
@@ -1087,7 +1087,7 @@ export const LibraryPanel = () => {
                 <button
                   type="button"
                   onClick={handleHeuristicSuggest}
-                  className="rounded bg-slate-700 px-2 py-1 hover:bg-slate-600"
+                  className="rounded bg-cp-surface-4 px-2 py-1 hover:bg-cp-surface-5"
                   title={t('library.create.suggest.heuristicTitle', 'Aus eingebauten Heuristik-Mustern (Camera, ATEM, Konverter, ...)')}
                 >
                   <Icon icon={Ruler} size="xs" className="mr-1 inline-block align-text-bottom" />Heuristik
@@ -1120,15 +1120,15 @@ export const LibraryPanel = () => {
             </div>
 
             {aiSettingsOpen && (
-              <div className="mb-2 rounded border border-slate-700 bg-slate-950 p-2 text-cp-xs">
-                <div className="mb-1 font-semibold text-slate-200">{t('library.create.aiKey.label', 'Gemini API-Key')}</div>
+              <div className="mb-2 rounded border border-cp-border bg-cp-surface-3 p-2 text-cp-xs">
+                <div className="mb-1 font-semibold text-cp-text-bright">{t('library.create.aiKey.label', 'Gemini API-Key')}</div>
                 <div className="flex gap-1">
                   <input
                     type="password"
                     value={aiKeyDraft}
                     onChange={(e) => setAiKeyDraft(e.target.value)}
                     placeholder={t('library.create.aiKey.placeholder', 'AIza…')}
-                    className="flex-1 rounded border border-slate-700 bg-slate-900 px-2 py-1 font-mono"
+                    className="flex-1 rounded border border-cp-border bg-cp-surface-1 px-2 py-1 font-mono"
                   />
                   <button
                     type="button"
@@ -1144,12 +1144,12 @@ export const LibraryPanel = () => {
                   <button
                     type="button"
                     onClick={() => setAiSettingsOpen(false)}
-                    className="rounded bg-slate-700 px-2 py-1 hover:bg-slate-600"
+                    className="rounded bg-cp-surface-4 px-2 py-1 hover:bg-cp-surface-5"
                   >
                     Abbrechen
                   </button>
                 </div>
-                <div className="mt-1 text-[10px] text-slate-400">
+                <div className="mt-1 text-[10px] text-cp-text-muted">
                   Gespeichert nur lokal in localStorage. Key bei{' '}
                   <a
                     href="https://aistudio.google.com/app/apikey"
@@ -1190,14 +1190,14 @@ export const LibraryPanel = () => {
               {groups.map((group) => (
                 <div
                   key={group.id}
-                  className="grid grid-cols-[80px_70px_1fr_1fr_40px] items-center gap-2 rounded border border-slate-700 bg-slate-950 p-2 text-cp-xs"
+                  className="grid grid-cols-[80px_70px_1fr_1fr_40px] items-center gap-2 rounded border border-cp-border bg-cp-surface-3 p-2 text-cp-xs"
                 >
                   <select
                     value={group.direction}
                     onChange={(event) =>
                       updateGroup(group.id, { direction: event.target.value as 'in' | 'out' })
                     }
-                    className="rounded border border-slate-700 bg-slate-900 p-1"
+                    className="rounded border border-cp-border bg-cp-surface-1 p-1"
                   >
                     <option value="in">Input</option>
                     <option value="out">Output</option>
@@ -1209,7 +1209,7 @@ export const LibraryPanel = () => {
                     onChange={(event) =>
                       updateGroup(group.id, { count: Number(event.target.value) })
                     }
-                    className="rounded border border-slate-700 bg-slate-900 p-1"
+                    className="rounded border border-cp-border bg-cp-surface-1 p-1"
                   />
                   <select
                     value={group.connectorType}
@@ -1218,7 +1218,7 @@ export const LibraryPanel = () => {
                         connectorType: event.target.value as ConnectorType,
                       })
                     }
-                    className="rounded border border-slate-700 bg-slate-900 p-1"
+                    className="rounded border border-cp-border bg-cp-surface-1 p-1"
                   >
                     {connectorOptions.map((item) => (
                       <option key={item} value={item}>
@@ -1230,7 +1230,7 @@ export const LibraryPanel = () => {
                     value={group.label}
                     onChange={(event) => updateGroup(group.id, { label: event.target.value })}
                     placeholder={t('library.create.groupLabelPrefix', 'Label prefix')}
-                    className="rounded border border-slate-700 bg-slate-900 p-1"
+                    className="rounded border border-cp-border bg-cp-surface-1 p-1"
                   />
                   <button
                     type="button"
@@ -1243,7 +1243,7 @@ export const LibraryPanel = () => {
                 </div>
               ))}
               {groups.length === 0 && (
-                <div className="text-cp-xs text-slate-400">No port groups yet. Add one above.</div>
+                <div className="text-cp-xs text-cp-text-muted">No port groups yet. Add one above.</div>
               )}
             </div>
 
@@ -1258,7 +1258,7 @@ export const LibraryPanel = () => {
                   setPendingDropOnSave(null)
                   resetDialog()
                 }}
-                className="rounded bg-slate-700 px-3 py-1 text-cp-base hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-3 py-1 text-cp-base hover:bg-cp-surface-5"
               >
                 {t('common.cancel', 'Abbrechen')}
               </button>
@@ -1331,15 +1331,15 @@ export const LibraryPanel = () => {
 
       {netBoxConflict && (
         <div className="fixed inset-0 z-[75] flex items-center justify-center bg-black/70 p-6">
-          <div className="w-full max-w-xl rounded border border-amber-600 bg-slate-900 p-4 text-slate-100">
+          <div className="w-full max-w-xl rounded border border-amber-600 bg-cp-surface-1 p-4 text-cp-text">
             <h3 className="mb-2 text-cp-xl font-semibold text-amber-300">{t('library.duplicate.title', 'Gerät existiert bereits')}</h3>
-            <p className="mb-3 text-cp-base text-slate-300">
+            <p className="mb-3 text-cp-base text-cp-text-secondary">
               {format(
                 t('library.netbox.duplicateIntro', '{name} ist bereits in der lokalen Library. Wahlen, wie importiert werden soll.'),
                 { name: netBoxConflict.incoming.name },
               )}
             </p>
-            <div className="mb-3 rounded border border-slate-700 bg-slate-950/40 p-2 text-cp-xs text-slate-400">
+            <div className="mb-3 rounded border border-cp-border bg-cp-surface-3/40 p-2 text-cp-xs text-cp-text-muted">
               {t('library.netbox.localCount', 'Lokal')}: {netBoxConflict.existing.inputs.length} In / {netBoxConflict.existing.outputs.length} Out
               <br />
               NetBox: {netBoxConflict.incoming.inputs.length} In / {netBoxConflict.incoming.outputs.length} Out
@@ -1348,7 +1348,7 @@ export const LibraryPanel = () => {
               <button
                 type="button"
                 onClick={() => setNetBoxConflict(null)}
-                className="rounded bg-slate-700 px-3 py-1 text-cp-base hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-3 py-1 text-cp-base hover:bg-cp-surface-5"
               >
                 {t('common.cancel', 'Abbrechen')}
               </button>
@@ -1361,7 +1361,7 @@ export const LibraryPanel = () => {
                     tone: 'info',
                   })
                 }}
-                className="rounded bg-slate-700 px-3 py-1 text-cp-base hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-3 py-1 text-cp-base hover:bg-cp-surface-5"
               >
                 {t('library.netbox.keepLocalBtn', 'Lokal behalten')}
               </button>
@@ -1430,7 +1430,7 @@ export const LibraryPanel = () => {
         <div aria-hidden className="min-h-0" />
         <FloatingPanelShell
           title={
-            <span className="text-cp-base font-semibold text-slate-100">
+            <span className="text-cp-base font-semibold text-cp-text">
               {t('library.title', 'Library')}
             </span>
           }

--- a/src/renderer/components/Library/LibrarySortables.tsx
+++ b/src/renderer/components/Library/LibrarySortables.tsx
@@ -44,7 +44,7 @@ export const SortableCategorySection = ({
       style={style}
       onDragOver={onDragOverTemplate}
       onDrop={onDropTemplate}
-      className="rounded border border-slate-800"
+      className="rounded border border-cp-border-muted"
     >
       {manualSort && (
         <span
@@ -54,7 +54,7 @@ export const SortableCategorySection = ({
           title={t('library.sortables.dragTitle', 'Per Drag&Drop verschieben')}
           role="button"
           tabIndex={0}
-          className="absolute left-0.5 top-0.5 z-10 flex h-5 w-3 cursor-grab items-center justify-center text-slate-500 hover:text-slate-200 active:cursor-grabbing"
+          className="absolute left-0.5 top-0.5 z-10 flex h-5 w-3 cursor-grab items-center justify-center text-cp-text-faint hover:text-cp-text-bright active:cursor-grabbing"
         >
           <svg width="6" height="12" viewBox="0 0 6 12" fill="currentColor">
             <circle cx="1.5" cy="2" r="1" />
@@ -107,8 +107,8 @@ export const SortablePresetCard = ({
     <div
       ref={setNodeRef}
       style={style}
-      className={`group rounded border border-slate-700 bg-slate-900 p-2 pl-5 text-cp-xs ${
-        onCardClick ? 'cursor-grab hover:bg-slate-800 active:cursor-grabbing' : ''
+      className={`group rounded border border-cp-border bg-cp-surface-1 p-2 pl-5 text-cp-xs ${
+        onCardClick ? 'cursor-grab hover:bg-cp-surface-2 active:cursor-grabbing' : ''
       }`}
       draggable={!!nativeDragData}
       onDragStart={(event) => {
@@ -148,7 +148,7 @@ export const SortablePresetCard = ({
         title={t('library.sortables.dragTitle', 'Per Drag&Drop verschieben')}
         role="button"
         tabIndex={0}
-        className="absolute left-0.5 top-0.5 z-10 flex h-5 w-3 cursor-grab items-center justify-center text-slate-500 hover:text-slate-200 active:cursor-grabbing"
+        className="absolute left-0.5 top-0.5 z-10 flex h-5 w-3 cursor-grab items-center justify-center text-cp-text-faint hover:text-cp-text-bright active:cursor-grabbing"
       >
         <svg width="6" height="12" viewBox="0 0 6 12" fill="currentColor">
           <circle cx="1.5" cy="2" r="1" />

--- a/src/renderer/components/Library/TabButton.tsx
+++ b/src/renderer/components/Library/TabButton.tsx
@@ -25,15 +25,15 @@ export const TabButton = ({
     onClick={onClick}
     title={title}
     className={`flex items-center gap-1 rounded px-2 py-1 ${
-      active ? 'bg-sky-700 text-white' : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+      active ? 'bg-sky-700 text-white' : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
     }`}
   >
-    <span className={active ? 'text-white' : 'text-slate-400'}>{icon}</span>
+    <span className={active ? 'text-white' : 'text-cp-text-muted'}>{icon}</span>
     <span>{label}</span>
     {count != null && count > 0 && (
       <span
         className={`ml-1 rounded-full px-1 text-[10px] ${
-          active ? 'bg-sky-900/70 text-sky-100' : 'bg-slate-900 text-slate-400'
+          active ? 'bg-sky-900/70 text-sky-100' : 'bg-cp-surface-1 text-cp-text-muted'
         }`}
       >
         {count}

--- a/src/renderer/components/Library/TemplateMergeDialog.tsx
+++ b/src/renderer/components/Library/TemplateMergeDialog.tsx
@@ -152,7 +152,7 @@ export const TemplateMergeDialog = ({
         </div>
       }
     >
-      <p className="mb-3 text-cp-xs text-slate-400">
+      <p className="mb-3 text-cp-xs text-cp-text-muted">
         {format(
           t(
             'templateMerge.intro',
@@ -168,7 +168,7 @@ export const TemplateMergeDialog = ({
             <select
               value={category}
               onChange={(event) => setCategory(event.target.value)}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+              className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
             >
               <option value="">{t('templateMerge.pleaseSelect', 'Bitte wählen...')}</option>
               {categoryOptions.map((cat) => (
@@ -178,13 +178,13 @@ export const TemplateMergeDialog = ({
               ))}
             </select>
           </label>
-          <div className="rounded border border-slate-700 bg-slate-950/50 p-2">
-            <div className="text-slate-400">{t('templateMerge.selectedPorts', 'Gewählte Ports')}</div>
-            <div className="mt-1 text-cp-base font-semibold text-slate-100">{selectedCount}</div>
+          <div className="rounded border border-cp-border bg-cp-surface-3/50 p-2">
+            <div className="text-cp-text-muted">{t('templateMerge.selectedPorts', 'Gewählte Ports')}</div>
+            <div className="mt-1 text-cp-base font-semibold text-cp-text">{selectedCount}</div>
           </div>
-          <div className="rounded border border-slate-700 bg-slate-950/50 p-2">
-            <div className="text-slate-400">{t('templateMerge.preview', 'Vorschau')}</div>
-            <div className="mt-1 text-cp-base font-semibold text-slate-100">
+          <div className="rounded border border-cp-border bg-cp-surface-3/50 p-2">
+            <div className="text-cp-text-muted">{t('templateMerge.preview', 'Vorschau')}</div>
+            <div className="mt-1 text-cp-base font-semibold text-cp-text">
               {format(t('templateMerge.previewCounts', '{in} In / {out} Out'), {
                 in: selectedTemplatePreview.inputs,
                 out: selectedTemplatePreview.outputs,
@@ -194,37 +194,37 @@ export const TemplateMergeDialog = ({
         </div>
 
         <div className="grid grid-cols-2 gap-3">
-          <div className="rounded border border-slate-700 bg-slate-950/50 p-2">
-            <div className="mb-2 text-cp-xs font-semibold uppercase tracking-wide text-slate-400">
+          <div className="rounded border border-cp-border bg-cp-surface-3/50 p-2">
+            <div className="mb-2 text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">
               {t('templateMerge.local', 'Lokal')}
             </div>
-            <div className="mb-1 text-[11px] text-slate-400">{localTemplate.name}</div>
+            <div className="mb-1 text-[11px] text-cp-text-muted">{localTemplate.name}</div>
             <div className="space-y-2">
               <div>
-                <div className="mb-1 text-[11px] font-semibold text-slate-300">{t('templateMerge.inputs', 'Inputs')}</div>
+                <div className="mb-1 text-[11px] font-semibold text-cp-text-secondary">{t('templateMerge.inputs', 'Inputs')}</div>
                 <div className="space-y-1">
                   {localTemplate.inputs.map((port) => {
                     const key = makePortKey('local', 'in', port.id)
                     return (
-                      <label key={key} className="flex items-center gap-2 rounded px-1 py-0.5 text-cp-xs hover:bg-slate-900">
+                      <label key={key} className="flex items-center gap-2 rounded px-1 py-0.5 text-cp-xs hover:bg-cp-surface-1">
                         <input type="checkbox" checked={selectedKeys.has(key)} onChange={() => toggle(key)} />
                         <span className="truncate">{port.name}</span>
-                        <span className="ml-auto text-[10px] text-slate-400">{port.connectorType}</span>
+                        <span className="ml-auto text-[10px] text-cp-text-muted">{port.connectorType}</span>
                       </label>
                     )
                   })}
                 </div>
               </div>
               <div>
-                <div className="mb-1 text-[11px] font-semibold text-slate-300">{t('templateMerge.outputs', 'Outputs')}</div>
+                <div className="mb-1 text-[11px] font-semibold text-cp-text-secondary">{t('templateMerge.outputs', 'Outputs')}</div>
                 <div className="space-y-1">
                   {localTemplate.outputs.map((port) => {
                     const key = makePortKey('local', 'out', port.id)
                     return (
-                      <label key={key} className="flex items-center gap-2 rounded px-1 py-0.5 text-cp-xs hover:bg-slate-900">
+                      <label key={key} className="flex items-center gap-2 rounded px-1 py-0.5 text-cp-xs hover:bg-cp-surface-1">
                         <input type="checkbox" checked={selectedKeys.has(key)} onChange={() => toggle(key)} />
                         <span className="truncate">{port.name}</span>
-                        <span className="ml-auto text-[10px] text-slate-400">{port.connectorType}</span>
+                        <span className="ml-auto text-[10px] text-cp-text-muted">{port.connectorType}</span>
                       </label>
                     )
                   })}
@@ -233,35 +233,35 @@ export const TemplateMergeDialog = ({
             </div>
           </div>
 
-          <div className="rounded border border-slate-700 bg-slate-950/50 p-2">
-            <div className="mb-2 text-cp-xs font-semibold uppercase tracking-wide text-slate-400">{incomingLabel}</div>
-            <div className="mb-1 text-[11px] text-slate-400">{incomingTemplate.name}</div>
+          <div className="rounded border border-cp-border bg-cp-surface-3/50 p-2">
+            <div className="mb-2 text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">{incomingLabel}</div>
+            <div className="mb-1 text-[11px] text-cp-text-muted">{incomingTemplate.name}</div>
             <div className="space-y-2">
               <div>
-                <div className="mb-1 text-[11px] font-semibold text-slate-300">{t('templateMerge.inputs', 'Inputs')}</div>
+                <div className="mb-1 text-[11px] font-semibold text-cp-text-secondary">{t('templateMerge.inputs', 'Inputs')}</div>
                 <div className="space-y-1">
                   {incomingTemplate.inputs.map((port) => {
                     const key = makePortKey('incoming', 'in', port.id)
                     return (
-                      <label key={key} className="flex items-center gap-2 rounded px-1 py-0.5 text-cp-xs hover:bg-slate-900">
+                      <label key={key} className="flex items-center gap-2 rounded px-1 py-0.5 text-cp-xs hover:bg-cp-surface-1">
                         <input type="checkbox" checked={selectedKeys.has(key)} onChange={() => toggle(key)} />
                         <span className="truncate">{port.name}</span>
-                        <span className="ml-auto text-[10px] text-slate-400">{port.connectorType}</span>
+                        <span className="ml-auto text-[10px] text-cp-text-muted">{port.connectorType}</span>
                       </label>
                     )
                   })}
                 </div>
               </div>
               <div>
-                <div className="mb-1 text-[11px] font-semibold text-slate-300">{t('templateMerge.outputs', 'Outputs')}</div>
+                <div className="mb-1 text-[11px] font-semibold text-cp-text-secondary">{t('templateMerge.outputs', 'Outputs')}</div>
                 <div className="space-y-1">
                   {incomingTemplate.outputs.map((port) => {
                     const key = makePortKey('incoming', 'out', port.id)
                     return (
-                      <label key={key} className="flex items-center gap-2 rounded px-1 py-0.5 text-cp-xs hover:bg-slate-900">
+                      <label key={key} className="flex items-center gap-2 rounded px-1 py-0.5 text-cp-xs hover:bg-cp-surface-1">
                         <input type="checkbox" checked={selectedKeys.has(key)} onChange={() => toggle(key)} />
                         <span className="truncate">{port.name}</span>
-                        <span className="ml-auto text-[10px] text-slate-400">{port.connectorType}</span>
+                        <span className="ml-auto text-[10px] text-cp-text-muted">{port.connectorType}</span>
                       </label>
                     )
                   })}

--- a/src/renderer/components/Library/tabs/GroupsTab.tsx
+++ b/src/renderer/components/Library/tabs/GroupsTab.tsx
@@ -27,12 +27,12 @@ export const GroupsTab = () => {
     <div className="flex flex-1 min-h-0 flex-col">
       <div className="mb-2 flex flex-wrap items-center justify-between gap-y-1 gap-x-2">
         <h2 className="text-cp-base font-semibold">{t('library.tabs.groups.title', 'Gerätegruppen')}</h2>
-        <span className="text-[10px] text-slate-400">
+        <span className="text-[10px] text-cp-text-muted">
           {t('library.tabs.groups.subtitle', 'Mehrere Geräte + Kabel als Vorlage')}
         </span>
       </div>
       {groupPresets.length === 0 ? (
-        <div className="flex-1 flex flex-col items-center justify-center gap-2 text-cp-xs text-slate-500 text-center p-4">
+        <div className="flex-1 flex flex-col items-center justify-center gap-2 text-cp-xs text-cp-text-faint text-center p-4">
           <span className="text-2xl">⧉</span>
           <span>{t('library.tabs.groups.empty', 'Noch keine Gruppen gespeichert.')}</span>
           <span>
@@ -78,8 +78,8 @@ export const GroupsTab = () => {
                     >
                       <div className="flex items-start justify-between gap-2">
                         <div className="min-w-0 flex-1">
-                          <div className="truncate font-medium text-slate-100">{preset.name}</div>
-                          <div className="mt-0.5 text-[10px] text-slate-400">
+                          <div className="truncate font-medium text-cp-text">{preset.name}</div>
+                          <div className="mt-0.5 text-[10px] text-cp-text-muted">
                             {format(t('library.tabs.groups.counts', '{items} Geräte · {cables} Kabel'), {
                               items: preset.items.length,
                               cables: preset.cables.length,
@@ -90,7 +90,7 @@ export const GroupsTab = () => {
                                 })
                               : ''}
                           </div>
-                          <div className="mt-0.5 truncate text-[10px] text-slate-400">
+                          <div className="mt-0.5 truncate text-[10px] text-cp-text-muted">
                             {preset.items.map((i) => i.name).join(', ')}
                           </div>
                         </div>
@@ -129,7 +129,7 @@ export const GroupsTab = () => {
                               }
                               renameGroupPreset(preset.id, trimmed)
                             }}
-                            className="rounded bg-slate-700 px-1 text-[11px] text-slate-300 hover:bg-slate-600"
+                            className="rounded bg-cp-surface-4 px-1 text-[11px] text-cp-text-secondary hover:bg-cp-surface-5"
                             title={t('library.tabs.groups.renameTitle', 'Vorlage umbenennen')}
                             aria-label={t('library.tabs.groups.renameAria', 'Umbenennen')}
                           >
@@ -141,7 +141,7 @@ export const GroupsTab = () => {
                               event.stopPropagation()
                               exportPresetToFile(preset)
                             }}
-                            className="rounded bg-slate-700 px-1 text-[11px] text-slate-300 hover:bg-slate-600"
+                            className="rounded bg-cp-surface-4 px-1 text-[11px] text-cp-text-secondary hover:bg-cp-surface-5"
                             title={t(
                               'library.tabs.groups.exportTitle',
                               'Als Datei exportieren (Kopie in den Downloads-Ordner)',

--- a/src/renderer/components/Library/tabs/LocalEquipmentTab.tsx
+++ b/src/renderer/components/Library/tabs/LocalEquipmentTab.tsx
@@ -116,7 +116,7 @@ export const LocalEquipmentTab = ({
             fill="none"
             stroke="currentColor"
             strokeWidth="1.5"
-            className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-slate-500"
+            className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-cp-text-faint"
           >
             <circle cx="7" cy="7" r="4.5" />
             <line x1="10.3" y1="10.3" x2="13" y2="13" strokeLinecap="round" />
@@ -131,7 +131,7 @@ export const LocalEquipmentTab = ({
             }}
             placeholder={t('library.search.placeholder', 'Suchen…')}
             aria-label={t('library.search.placeholder', 'Suchen…')}
-            className="w-full rounded border border-slate-700 bg-slate-900 py-1 pl-7 pr-12 text-cp-xs text-slate-100 placeholder-slate-500"
+            className="w-full rounded border border-cp-border bg-cp-surface-1 py-1 pl-7 pr-12 text-cp-xs text-cp-text placeholder-slate-500"
           />
           {librarySearch ? (
             <button
@@ -139,12 +139,12 @@ export const LocalEquipmentTab = ({
               onClick={() => setLibrarySearch('')}
               title={t('library.search.clear', 'Suche löschen')}
               aria-label={t('library.search.clear', 'Suche löschen')}
-              className="absolute right-1 top-1/2 -translate-y-1/2 rounded px-1 py-0.5 text-cp-xs text-slate-500 hover:bg-slate-700 hover:text-slate-200"
+              className="absolute right-1 top-1/2 -translate-y-1/2 rounded px-1 py-0.5 text-cp-xs text-cp-text-faint hover:bg-cp-surface-4 hover:text-cp-text-bright"
             >
               <Icon icon={X} size="sm" />
             </button>
           ) : (
-            <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[11px] uppercase tracking-wider text-slate-400">
+            <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[11px] uppercase tracking-wider text-cp-text-muted">
               {t('library.search.shortcut', 'Strg+F')}
             </span>
           )}
@@ -211,7 +211,7 @@ export const LocalEquipmentTab = ({
             value={newGroupName}
             onChange={(e) => setNewGroupName(e.target.value)}
             placeholder={t('library.newCategoryPlaceholder', 'Kategoriename…')}
-            className="flex-1 rounded border border-slate-600 bg-slate-900 p-1.5 text-cp-xs"
+            className="flex-1 rounded border border-cp-surface-5 bg-cp-surface-1 p-1.5 text-cp-xs"
           />
           <button
             type="submit"
@@ -222,7 +222,7 @@ export const LocalEquipmentTab = ({
           <button
             type="button"
             onClick={() => setShowNewGroup(false)}
-            className="rounded bg-slate-700 px-2 text-cp-xs hover:bg-slate-600"
+            className="rounded bg-cp-surface-4 px-2 text-cp-xs hover:bg-cp-surface-5"
             aria-label={t('common.close', 'Schließen')}
           >
             <Icon icon={X} size="sm" />
@@ -257,11 +257,11 @@ export const LocalEquipmentTab = ({
             )
             if (!anyMatch) {
               return (
-                <div className="mt-4 rounded border border-slate-800 bg-slate-950/60 p-4 text-center text-cp-xs text-slate-400">
-                  <div className="mb-2 font-semibold text-slate-300">
+                <div className="mt-4 rounded border border-cp-border-muted bg-cp-surface-3/60 p-4 text-center text-cp-xs text-cp-text-muted">
+                  <div className="mb-2 font-semibold text-cp-text-secondary">
                     {t('library.empty.title', 'Keine Geräte gefunden')}
                   </div>
-                  <div className="mb-3 text-[11px] text-slate-400">
+                  <div className="mb-3 text-[11px] text-cp-text-muted">
                     {format(
                       t(
                         'library.empty.body',
@@ -273,7 +273,7 @@ export const LocalEquipmentTab = ({
                   <button
                     type="button"
                     onClick={() => setLibrarySearch('')}
-                    className="rounded bg-slate-700 px-3 py-1 text-[11px] text-slate-100 hover:bg-slate-600"
+                    className="rounded bg-cp-surface-4 px-3 py-1 text-[11px] text-cp-text hover:bg-cp-surface-5"
                   >
                     {t('library.empty.clearSearch', 'Suche zurücksetzen')}
                   </button>
@@ -317,7 +317,7 @@ export const LocalEquipmentTab = ({
                   } catch { /* ignore */ }
                 }}
               >
-                <div className="group/cat flex items-center gap-1.5 rounded-t bg-slate-900/60 px-2 py-1.5 text-left text-[11px] font-semibold uppercase tracking-wide text-slate-300 hover:bg-slate-800/80 hover:text-slate-100">
+                <div className="group/cat flex items-center gap-1.5 rounded-t bg-cp-surface-1/60 px-2 py-1.5 text-left text-[11px] font-semibold uppercase tracking-wide text-cp-text-secondary hover:bg-cp-surface-2/80 hover:text-cp-text">
                   <button
                     type="button"
                     onClick={() =>
@@ -330,7 +330,7 @@ export const LocalEquipmentTab = ({
                     }
                     className="flex flex-1 min-w-0 items-center gap-1.5 text-left"
                   >
-                    <span className="inline-block w-3 text-center text-slate-500">
+                    <span className="inline-block w-3 text-center text-cp-text-faint">
                       <Icon icon={collapsed ? ChevronRight : ChevronDown} size="xs" />
                     </span>
                     <span className="flex-1 truncate normal-case tracking-normal">
@@ -358,13 +358,13 @@ export const LocalEquipmentTab = ({
                         setCategoryTranslation(cat, { de: result.de, en: result.en })
                       }
                     }}
-                    className="hidden rounded bg-slate-700/80 px-1.5 py-0.5 text-[10px] font-normal normal-case text-slate-200 hover:bg-slate-600 group-hover/cat:block"
+                    className="hidden rounded bg-cp-surface-4/80 px-1.5 py-0.5 text-[10px] font-normal normal-case text-cp-text-bright hover:bg-cp-surface-5 group-hover/cat:block"
                     title={t('library.renameCategory', 'Kategorie umbenennen')}
                     aria-label={t('library.renameCategory', 'Kategorie umbenennen')}
                   >
                     <Icon icon={Pencil} size="xs" />
                   </button>
-                  <span className="rounded bg-slate-800 px-1.5 py-0.5 text-[10px] font-normal text-slate-400">
+                  <span className="rounded bg-cp-surface-2 px-1.5 py-0.5 text-[10px] font-normal text-cp-text-muted">
                     {items.length}
                   </span>
                 </div>
@@ -373,7 +373,7 @@ export const LocalEquipmentTab = ({
                 {!collapsed && (
                   <div className="space-y-1 px-1 pb-1">
                     {visibleItems.length === 0 ? (
-                      <div className="px-1 py-1 text-[11px] italic text-slate-400">
+                      <div className="px-1 py-1 text-[11px] italic text-cp-text-muted">
                         {searchQuery
                           ? format(t('library.empty.search', 'Keine Treffer für "{query}"'), { query: librarySearch })
                           : t('library.empty.dragHere', 'Gerät hierher ziehen zum Verschieben')}
@@ -401,7 +401,7 @@ export const LocalEquipmentTab = ({
                           <button
                             type="button"
                             onClick={() => setSelectedTemplateName(item.name)}
-                            className="absolute right-7 top-1 hidden rounded bg-slate-600 px-1 py-0.5 text-[10px] hover:bg-slate-500 group-hover/item:block"
+                            className="absolute right-7 top-1 hidden rounded bg-cp-surface-5 px-1 py-0.5 text-[10px] hover:bg-slate-500 group-hover/item:block"
                             title={t('library.template.editTitle', 'Vorlage bearbeiten (Name, Kategorie)')}
                             aria-label={t('library.template.editTitle', 'Vorlage bearbeiten (Name, Kategorie)')}
                           >

--- a/src/renderer/components/Library/tabs/RacksTab.tsx
+++ b/src/renderer/components/Library/tabs/RacksTab.tsx
@@ -32,7 +32,7 @@ export const RacksTab = ({ onCreateRack, onEditRack }: RacksTabProps) => {
       <div className="mb-2 flex flex-wrap items-center justify-between gap-y-1 gap-x-2">
         <div className="min-w-0">
           <h2 className="text-cp-base font-semibold">{t('library.tabs.racks.title', '2D Rack Builder')}</h2>
-          <div className="text-[10px] text-slate-400">
+          <div className="text-[10px] text-cp-text-muted">
             {t('library.tabs.racks.subtitle', 'Rack-Slots in HE, als platzierbare Gruppe gespeichert')}
           </div>
         </div>
@@ -46,7 +46,7 @@ export const RacksTab = ({ onCreateRack, onEditRack }: RacksTabProps) => {
       </div>
 
       {groupPresets.filter((preset) => !!preset.rack).length === 0 ? (
-        <div className="flex-1 flex flex-col items-center justify-center gap-2 text-cp-xs text-slate-500 text-center p-4">
+        <div className="flex-1 flex flex-col items-center justify-center gap-2 text-cp-xs text-cp-text-faint text-center p-4">
           <span className="text-2xl">▥</span>
           <span>{t('library.tabs.racks.empty', 'Noch kein Rack-Layout gespeichert.')}</span>
         </div>
@@ -86,15 +86,15 @@ export const RacksTab = ({ onCreateRack, onEditRack }: RacksTabProps) => {
                     >
                       <div className="flex items-start justify-between gap-2">
                         <div className="min-w-0 flex-1">
-                          <div className="truncate font-medium text-slate-100">{preset.name}</div>
-                          <div className="mt-0.5 text-[10px] text-slate-400">
+                          <div className="truncate font-medium text-cp-text">{preset.name}</div>
+                          <div className="mt-0.5 text-[10px] text-cp-text-muted">
                             {format(t('library.tabs.racks.counts', '{items} Geräte · {units} HE · {cables} Kabel'), {
                               items: preset.items.length,
                               units: totalUnits,
                               cables: preset.cables.length,
                             })}
                           </div>
-                          <div className="mt-0.5 truncate text-[10px] text-slate-400">
+                          <div className="mt-0.5 truncate text-[10px] text-cp-text-muted">
                             {preset.items.map((i) => i.name).join(', ')}
                           </div>
                         </div>
@@ -109,7 +109,7 @@ export const RacksTab = ({ onCreateRack, onEditRack }: RacksTabProps) => {
                               event.stopPropagation()
                               onEditRack(preset.id)
                             }}
-                            className="rounded bg-slate-700 px-1 py-0.5 text-[11px] hover:bg-slate-600"
+                            className="rounded bg-cp-surface-4 px-1 py-0.5 text-[11px] hover:bg-cp-surface-5"
                             title={t('library.tabs.racks.editTitle', 'Im 2D-Rack-Builder bearbeiten')}
                             aria-label={t('library.tabs.racks.editAria', 'Bearbeiten')}
                           >
@@ -121,7 +121,7 @@ export const RacksTab = ({ onCreateRack, onEditRack }: RacksTabProps) => {
                               event.stopPropagation()
                               exportPresetToFile(preset)
                             }}
-                            className="rounded bg-slate-700 px-1 py-0.5 text-[11px] text-slate-300 hover:bg-slate-600"
+                            className="rounded bg-cp-surface-4 px-1 py-0.5 text-[11px] text-cp-text-secondary hover:bg-cp-surface-5"
                             title={t(
                               'library.tabs.racks.exportTitle',
                               'Als Datei exportieren (Kopie in den Downloads-Ordner)',

--- a/src/renderer/components/Library/tabs/RentmanTab.tsx
+++ b/src/renderer/components/Library/tabs/RentmanTab.tsx
@@ -274,7 +274,7 @@ export const RentmanTab = () => {
           })()}
         </div>
       ) : (
-        <div className="rounded border border-slate-700 bg-slate-900/50 p-2 text-cp-xs text-slate-400">
+        <div className="rounded border border-cp-border bg-cp-surface-1/50 p-2 text-cp-xs text-cp-text-muted">
           <div className="mb-2">{t('library.rentman.noProjectLinked', 'Kein Rentman-Projekt verknüpft.')}</div>
           <button
             type="button"
@@ -287,7 +287,7 @@ export const RentmanTab = () => {
         </div>
       )}
 
-      <div className="grid grid-cols-3 rounded border border-slate-800 bg-slate-900 p-0.5 text-[11px]">
+      <div className="grid grid-cols-3 rounded border border-cp-border-muted bg-cp-surface-1 p-0.5 text-[11px]">
         {([
           ['imported', t('library.rentman.view.imported', 'Importiert')],
           ['catalog', t('library.rentman.view.catalog', 'Katalog')],
@@ -300,7 +300,7 @@ export const RentmanTab = () => {
             className={`rounded px-2 py-1 font-medium ${
               rentmanView === id
                 ? 'bg-orange-700 text-white'
-                : 'text-slate-400 hover:bg-slate-800 hover:text-slate-200'
+                : 'text-cp-text-muted hover:bg-cp-surface-2 hover:text-cp-text-bright'
             }`}
           >
             {label}
@@ -312,7 +312,7 @@ export const RentmanTab = () => {
         <div>
           <div className="mb-2 flex flex-wrap items-center justify-between gap-1">
             <h2 className="text-cp-base font-semibold">{t('library.rentman.imported', 'Importierte Rentman-Geräte')}</h2>
-            <div className="flex items-center gap-2 text-[10px] text-slate-400">
+            <div className="flex items-center gap-2 text-[10px] text-cp-text-muted">
               {(() => {
                 const projectIds = new Set(projectGroups.map((group) => group.id))
                 const categoryKeys = new Set<string>()
@@ -335,7 +335,7 @@ export const RentmanTab = () => {
                         setCollapsedRentmanCats(categoryKeys)
                       }
                     }}
-                    className="underline hover:text-slate-300"
+                    className="underline hover:text-cp-text-secondary"
                   >
                     {allCollapsed
                       ? t('library.rentman.expandAll', 'Alle ausklappen')
@@ -356,7 +356,7 @@ export const RentmanTab = () => {
                 fill="none"
                 stroke="currentColor"
                 strokeWidth="1.5"
-                className="pointer-events-none absolute left-1.5 top-1/2 -translate-y-1/2 text-slate-500"
+                className="pointer-events-none absolute left-1.5 top-1/2 -translate-y-1/2 text-cp-text-faint"
               >
                 <circle cx="7" cy="7" r="4" />
                 <line x1="10.3" y1="10.3" x2="13" y2="13" strokeLinecap="round" />
@@ -370,14 +370,14 @@ export const RentmanTab = () => {
                 }}
                 placeholder={t('library.rentmanSearchPlaceholder', 'In Rentman-Geraeten suchen…')}
                 aria-label={t('library.rentmanSearchPlaceholder', 'In Rentman-Geraeten suchen…')}
-                className="w-full rounded border border-slate-700 bg-slate-900 py-1 pl-7 pr-7 text-cp-xs text-slate-100 placeholder-slate-500"
+                className="w-full rounded border border-cp-border bg-cp-surface-1 py-1 pl-7 pr-7 text-cp-xs text-cp-text placeholder-slate-500"
               />
               {rentmanSearch && (
                 <button
                   type="button"
                   onClick={() => setRentmanSearch('')}
                   title={t('library.search.clear', 'Suche löschen')}
-                  className="absolute right-1 top-1/2 -translate-y-1/2 rounded px-1 py-0.5 text-cp-xs text-slate-500 hover:bg-slate-700 hover:text-slate-200"
+                  className="absolute right-1 top-1/2 -translate-y-1/2 rounded px-1 py-0.5 text-cp-xs text-cp-text-faint hover:bg-cp-surface-4 hover:text-cp-text-bright"
                 >
                   ✕
                 </button>
@@ -401,7 +401,7 @@ export const RentmanTab = () => {
                     .filter((g) => g.items.length > 0)
             if (projectGroups.length === 0) {
               return (
-                <div className="flex flex-col items-center gap-2 p-3 text-center text-cp-xs text-slate-500">
+                <div className="flex flex-col items-center gap-2 p-3 text-center text-cp-xs text-cp-text-faint">
                   <span className="text-2xl">📦</span>
                   <span>{t('library.rentman.noneImported', 'Noch keine Rentman-Geräte importiert.')}</span>
                 </div>
@@ -409,7 +409,7 @@ export const RentmanTab = () => {
             }
             if (visibleProjectGroups.length === 0) {
               return (
-                <div className="flex flex-col items-center gap-2 p-3 text-center text-cp-xs text-slate-500">
+                <div className="flex flex-col items-center gap-2 p-3 text-center text-cp-xs text-cp-text-faint">
                   <span className="text-2xl">🔍</span>
                   <span>{format(t('library.rentman.noMatches', 'Keine Treffer für "{query}".'), { query: rentmanSearch })}</span>
                 </div>
@@ -429,7 +429,7 @@ export const RentmanTab = () => {
                       className={`rounded border ${
                         isLinked
                           ? 'border-orange-600/60 bg-orange-900/10'
-                          : 'border-slate-700 bg-slate-900/40'
+                          : 'border-cp-border bg-cp-surface-1/40'
                       }`}
                     >
                       <button
@@ -438,7 +438,7 @@ export const RentmanTab = () => {
                         className={`flex w-full items-center justify-between gap-2 px-2 py-1.5 text-left ${
                           isLinked
                             ? 'text-orange-200 hover:bg-orange-900/20'
-                            : 'text-slate-300 hover:bg-slate-800/40'
+                            : 'text-cp-text-secondary hover:bg-cp-surface-2/40'
                         }`}
                       >
                         <span className="flex min-w-0 items-center gap-1.5">
@@ -448,23 +448,23 @@ export const RentmanTab = () => {
                           )}
                           <span className="truncate text-cp-xs font-semibold">{group.name}</span>
                         </span>
-                        <span className="text-[10px] text-slate-400">{group.items.length} Geräte</span>
+                        <span className="text-[10px] text-cp-text-muted">{group.items.length} Geräte</span>
                       </button>
                       {!projectCollapsed && (
-                        <div className="space-y-1 border-t border-slate-800 px-1 py-1">
+                        <div className="space-y-1 border-t border-cp-border-muted px-1 py-1">
                           {categories.length === 0 ? (
-                            <div className="px-2 py-1 text-[11px] italic text-slate-400">{t('library.rentman.noneInCategory', 'Keine Geräte importiert.')}</div>
+                            <div className="px-2 py-1 text-[11px] italic text-cp-text-muted">{t('library.rentman.noneInCategory', 'Keine Geräte importiert.')}</div>
                           ) : (
                             categories.map((category) => {
                               const categoryKey = `${group.id}::${category}`
                               const categoryCollapsed = collapsedRentmanCats.has(categoryKey)
                               const categoryItems = group.items.filter((template) => (template.category || 'Sonstiges') === category)
                               return (
-                                <div key={categoryKey} className="rounded border border-slate-800/80">
+                                <div key={categoryKey} className="rounded border border-cp-border-muted/80">
                                   <button
                                     type="button"
                                     onClick={() => toggleRentmanCat(categoryKey)}
-                                    className="flex w-full items-center justify-between gap-1 px-2 py-1 text-left text-[11px] font-semibold uppercase tracking-wide text-slate-400 hover:text-slate-200"
+                                    className="flex w-full items-center justify-between gap-1 px-2 py-1 text-left text-[11px] font-semibold uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright"
                                   >
                                     <span className="flex items-center gap-1">
                                       <span>{categoryCollapsed ? '▶' : '▼'}</span>
@@ -545,13 +545,13 @@ export const RentmanTab = () => {
             <button
               type="button"
               onClick={() => setRentmanCatalogCollapsed((value) => !value)}
-              className="flex flex-1 items-center gap-1 text-left text-cp-base font-semibold text-slate-200 hover:text-white"
+              className="flex flex-1 items-center gap-1 text-left text-cp-base font-semibold text-cp-text-bright hover:text-white"
               title={t('library.rentman.accountTitle', 'Alle in deinem Rentman-Account angelegten Equipments (Account-Katalog), gegliedert nach der Rentman-Ordnerstruktur')}
             >
               <span className="text-cp-xs">{rentmanCatalogCollapsed ? '▶' : '▼'}</span>
               <span>{t('library.rentman.accountAll', 'Alle Rentman-Equipments (Account-Katalog)')}</span>
               {rentmanCatalogLoaded && (
-                <span className="ml-1 rounded-full bg-slate-800 px-1.5 text-[10px] text-slate-400">{rentmanCatalog.length}</span>
+                <span className="ml-1 rounded-full bg-cp-surface-2 px-1.5 text-[10px] text-cp-text-muted">{rentmanCatalog.length}</span>
               )}
             </button>
             <button
@@ -574,7 +574,7 @@ export const RentmanTab = () => {
                 <div className="mb-2 rounded border border-red-700/60 bg-red-900/30 px-2 py-1 text-[11px] text-red-200">{rentmanCatalogError}</div>
               )}
               {!rentmanCatalogLoaded && !rentmanCatalogLoading && !rentmanCatalogError && (
-                <div className="rounded border border-slate-700/60 bg-slate-900/40 p-2 text-center text-[11px] text-slate-400">
+                <div className="rounded border border-cp-border/60 bg-cp-surface-1/40 p-2 text-center text-[11px] text-cp-text-muted">
                   {t(
                     'library.rentman.catalogNotLoaded',
                     'Noch nicht geladen. Klick „Katalog laden", um den gesamten Rentman-Katalog deines Accounts anzuzeigen.',
@@ -589,7 +589,7 @@ export const RentmanTab = () => {
                     onChange={(event) => setRentmanCatalogQuery(event.target.value)}
                     placeholder={t('common.search', 'Suchen…')}
                     aria-label={t('common.search', 'Suchen…')}
-                    className="mb-2 w-full rounded border border-slate-700 bg-slate-900 px-2 py-1 text-cp-xs text-slate-100 placeholder-slate-500"
+                    className="mb-2 w-full rounded border border-cp-border bg-cp-surface-1 px-2 py-1 text-cp-xs text-cp-text placeholder-slate-500"
                   />
                   {(() => {
                     const importedIds = new Set(
@@ -629,11 +629,11 @@ export const RentmanTab = () => {
                           key={item.id}
                           draggable
                           onDragStart={handleDragStart}
-                          className="flex cursor-grab items-center justify-between gap-2 rounded border border-slate-800 bg-slate-900/40 px-2 py-1.5 text-cp-xs"
+                          className="flex cursor-grab items-center justify-between gap-2 rounded border border-cp-border-muted bg-cp-surface-1/40 px-2 py-1.5 text-cp-xs"
                         >
                           <div className="min-w-0 flex-1">
-                            <div className="truncate font-medium text-slate-200">{item.name}</div>
-                            <div className="truncate text-[10px] text-slate-400">{format(t('library.rentman.idLine', 'Rentman-ID {id}'), { id: item.id })}</div>
+                            <div className="truncate font-medium text-cp-text-bright">{item.name}</div>
+                            <div className="truncate text-[10px] text-cp-text-muted">{format(t('library.rentman.idLine', 'Rentman-ID {id}'), { id: item.id })}</div>
                           </div>
                           {linkedRentmanProjectId && (
                             <button
@@ -707,11 +707,11 @@ export const RentmanTab = () => {
                         .sort((a, b) => a.name.localeCompare(b.name))
                       const childIds = childMap.get(folderId) ?? []
                       return (
-                        <div key={folderId} className="rounded border border-slate-800/80">
+                        <div key={folderId} className="rounded border border-cp-border-muted/80">
                           <button
                             type="button"
                             onClick={() => toggleFolder(folderId)}
-                            className="flex w-full items-center justify-between gap-1 px-2 py-1 text-left text-[11px] font-semibold uppercase tracking-wide text-slate-300 hover:text-slate-100"
+                            className="flex w-full items-center justify-between gap-1 px-2 py-1 text-left text-[11px] font-semibold uppercase tracking-wide text-cp-text-secondary hover:text-cp-text"
                             style={{ paddingLeft: `${0.5 + depth * 0.75}rem` }}
                           >
                             <span className="flex items-center gap-1">
@@ -719,7 +719,7 @@ export const RentmanTab = () => {
                               <span>📁</span>
                               <span>{folder.name}</span>
                             </span>
-                            <span className="font-normal text-slate-500">({total})</span>
+                            <span className="font-normal text-cp-text-faint">({total})</span>
                           </button>
                           {!collapsed && (
                             <div className="space-y-1 px-1 pb-1">
@@ -744,8 +744,8 @@ export const RentmanTab = () => {
                       <div className="space-y-2">
                         {rootFolderIds.map((id) => renderFolder(id, 0))}
                         {orphans.length > 0 && (
-                          <div className="rounded border border-slate-800/80">
-                            <div className="px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+                          <div className="rounded border border-cp-border-muted/80">
+                            <div className="px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-cp-text-muted">
                               Ohne Ordner <span className="font-normal text-slate-600">({orphans.length})</span>
                             </div>
                             <div className="space-y-1 px-2 pb-1">{orphans.map(renderItem)}</div>
@@ -765,7 +765,7 @@ export const RentmanTab = () => {
         <div>
           <div className="mb-2 flex items-center justify-between">
             <h2 className="text-cp-base font-semibold text-amber-300">{t('library.rentman.reconcile', 'Abgleich Canvas ↔ Rentman')}</h2>
-            <span className="text-[10px] text-slate-400">{untracked.length} nicht erfasst</span>
+            <span className="text-[10px] text-cp-text-muted">{untracked.length} nicht erfasst</span>
           </div>
           {/* v7.9.128 — Auch im Sync-View ein prominenter Fetch-Knopf. */}
           {linkedRentmanProjectId && (
@@ -784,8 +784,8 @@ export const RentmanTab = () => {
               {removed.map((equipment) => (
                 <div key={equipment.id} className="flex items-center justify-between rounded border border-red-700/50 bg-red-900/20 px-2 py-1 text-cp-xs">
                   <div>
-                    <span className="font-medium text-slate-100">{equipment.name}</span>
-                    <span className="ml-1 text-[10px] text-slate-400">{equipment.category}</span>
+                    <span className="font-medium text-cp-text">{equipment.name}</span>
+                    <span className="ml-1 text-[10px] text-cp-text-muted">{equipment.category}</span>
                   </div>
                   <span className="text-[10px] text-red-400">entfernt</span>
                 </div>
@@ -801,8 +801,8 @@ export const RentmanTab = () => {
               {untracked.map((equipment) => (
                 <div key={equipment.id} className="flex items-center justify-between rounded border border-amber-700/30 bg-amber-900/10 px-2 py-1 text-cp-xs">
                   <div>
-                    <span className="font-medium text-slate-100">{equipment.name}</span>
-                    <span className="ml-1 text-[10px] text-slate-400">{equipment.category}</span>
+                    <span className="font-medium text-cp-text">{equipment.name}</span>
+                    <span className="ml-1 text-[10px] text-cp-text-muted">{equipment.category}</span>
                   </div>
                   <span className="text-[10px] text-amber-500">kein Rentman-ID</span>
                 </div>

--- a/src/renderer/components/MobileShare/MobileShareDialog.tsx
+++ b/src/renderer/components/MobileShare/MobileShareDialog.tsx
@@ -142,12 +142,12 @@ export const MobileShareDialog = () => {
           {!hasDesktopBridge && (
             <div className="rounded border border-amber-700 bg-amber-950/40 p-3 text-cp-xs text-amber-200">
               {t('mobile.dialog.desktopOnly1', 'Diese Funktion benötigt die Desktop-App (Electron). Im Web-Browser ist der Mobile-Viewer als statisches HTML im')}{' '}
-              <code className="rounded bg-slate-800 px-1">dist/renderer/mobile.html</code>{' '}
+              <code className="rounded bg-cp-surface-2 px-1">dist/renderer/mobile.html</code>{' '}
               {t('mobile.dialog.desktopOnly2', 'erreichbar.')}
             </div>
           )}
 
-          <p className="text-cp-xs text-slate-400">
+          <p className="text-cp-xs text-cp-text-muted">
             {t('mobile.dialog.description', 'Startet einen kleinen Web-Server im lokalen Netzwerk. Scanne den QR-Code mit dem Handy → der Mobile-Viewer öffnet sich im Browser und lädt das aktuelle Projekt. Der Server stoppt automatisch beim Schließen der App oder über den Stop-Button.')}
           </p>
 
@@ -157,7 +157,7 @@ export const MobileShareDialog = () => {
                 {qrDataUrl ? (
                   <img src={qrDataUrl} alt={t('mobile.dialog.qrAlt', 'QR-Code')} className="rounded bg-white p-2" />
                 ) : (
-                  <div className="h-[240px] w-[240px] animate-pulse rounded bg-slate-800" />
+                  <div className="h-[240px] w-[240px] animate-pulse rounded bg-cp-surface-2" />
                 )}
                 <div className="w-full">
                   <div className="text-[10px] uppercase tracking-wide text-emerald-300">
@@ -167,13 +167,13 @@ export const MobileShareDialog = () => {
                     <input
                       readOnly
                       value={selectedUrl}
-                      className="flex-1 rounded border border-slate-700 bg-slate-950 px-2 py-1 font-mono text-[11px] text-slate-100"
+                      className="flex-1 rounded border border-cp-border bg-cp-surface-3 px-2 py-1 font-mono text-[11px] text-cp-text"
                       onFocus={(e) => e.target.select()}
                     />
                     <button
                       type="button"
                       onClick={() => void copyUrl()}
-                      className="rounded bg-slate-700 px-2 py-1 text-[10px] hover:bg-slate-600"
+                      className="rounded bg-cp-surface-4 px-2 py-1 text-[10px] hover:bg-cp-surface-5"
                       title={t('mobile.dialog.copyToClipboard', 'In die Zwischenablage kopieren')}
                     >
                       <Icon icon={copied ? Check : Clipboard} size="xs" />
@@ -183,7 +183,7 @@ export const MobileShareDialog = () => {
               </div>
               {status.urls.length > 1 && (
                 <div>
-                  <div className="mb-1 text-[10px] uppercase tracking-wide text-slate-400">
+                  <div className="mb-1 text-[10px] uppercase tracking-wide text-cp-text-muted">
                     {t('mobile.dialog.altUrls', 'Alternative LAN-Adressen (falls eine nicht erreichbar ist)')}
                   </div>
                   <div className="flex flex-wrap gap-1">
@@ -195,7 +195,7 @@ export const MobileShareDialog = () => {
                         className={`rounded border px-2 py-0.5 text-[10px] font-mono ${
                           u === selectedUrl
                             ? 'border-sky-500 bg-sky-900 text-white'
-                            : 'border-slate-700 bg-slate-900 text-slate-300 hover:border-sky-700'
+                            : 'border-cp-border bg-cp-surface-1 text-cp-text-secondary hover:border-sky-700'
                         }`}
                       >
                         {u.replace(/^http:\/\//, '').replace('/mobile.html', '')}
@@ -205,7 +205,7 @@ export const MobileShareDialog = () => {
                 </div>
               )}
               <div className="flex items-center justify-between">
-                <span className="text-[11px] text-slate-400">
+                <span className="text-[11px] text-cp-text-muted">
                   {t('mobile.dialog.portLabel', 'Port')} {status.port} ·{' '}
                   {status.hasProject ? (
                     <span className="text-emerald-300">{t('mobile.dialog.projectSynced', 'Projekt synchronisiert')}</span>
@@ -224,9 +224,9 @@ export const MobileShareDialog = () => {
               </div>
             </div>
           ) : (
-            <div className="flex flex-col items-center gap-3 rounded border border-slate-700 bg-slate-950/40 p-6 text-center">
-              <Icon icon={Radio} size={28} className="text-slate-500" />
-              <p className="text-cp-xs text-slate-400">
+            <div className="flex flex-col items-center gap-3 rounded border border-cp-border bg-cp-surface-3/40 p-6 text-center">
+              <Icon icon={Radio} size={28} className="text-cp-text-faint" />
+              <p className="text-cp-xs text-cp-text-muted">
                 {t('mobile.dialog.stopped', 'Server ist gestoppt. Klicke unten, um den LAN-Server zu starten.')}
               </p>
               <button
@@ -240,8 +240,8 @@ export const MobileShareDialog = () => {
             </div>
           )}
 
-          <details className="text-[11px] text-slate-400">
-            <summary className="cursor-pointer hover:text-slate-300">{t('mobile.dialog.securityHeading', 'Hinweise zur Sicherheit')}</summary>
+          <details className="text-[11px] text-cp-text-muted">
+            <summary className="cursor-pointer hover:text-cp-text-secondary">{t('mobile.dialog.securityHeading', 'Hinweise zur Sicherheit')}</summary>
             <ul className="mt-1 list-inside list-disc space-y-1">
               <li>{t('mobile.dialog.security.readOnly', 'Read-only: das Handy kann nur lesen, nichts schreiben.')}</li>
               <li>{t('mobile.dialog.security.bind', 'Der Server bindet auf das lokale Netzwerk (0.0.0.0). Wenn unklar ist, wer im Netz hängt, lieber stoppen.')}</li>

--- a/src/renderer/components/Onboarding/OnboardingTour.tsx
+++ b/src/renderer/components/Onboarding/OnboardingTour.tsx
@@ -107,7 +107,7 @@ export const OnboardingTour = ({ open, onClose }: OnboardingTourProps) => {
       open={open}
       onClose={finish}
       title={
-        <span className="text-[11px] uppercase tracking-wider text-slate-400">
+        <span className="text-[11px] uppercase tracking-wider text-cp-text-muted">
           {format(t('onboarding.header', 'Erste-Schritte-Tour · Schritt {step} / {total}'), {
             step: step + 1,
             total: STEPS.length,
@@ -120,7 +120,7 @@ export const OnboardingTour = ({ open, onClose }: OnboardingTourProps) => {
           <button
             type="button"
             onClick={finish}
-            className="text-cp-xs text-slate-500 hover:text-slate-300"
+            className="text-cp-xs text-cp-text-faint hover:text-cp-text-secondary"
           >
             {t('onboarding.end', 'Tour beenden')}
           </button>
@@ -134,7 +134,7 @@ export const OnboardingTour = ({ open, onClose }: OnboardingTourProps) => {
                       ? 'bg-orange-500'
                       : index < step
                         ? 'bg-orange-700/60'
-                        : 'bg-slate-700'
+                        : 'bg-cp-surface-4'
                   }`}
                 />
               ))}
@@ -143,7 +143,7 @@ export const OnboardingTour = ({ open, onClose }: OnboardingTourProps) => {
               type="button"
               onClick={() => setStep((index) => Math.max(0, index - 1))}
               disabled={step === 0}
-              className="rounded bg-slate-700 px-3 py-1 text-cp-xs hover:bg-slate-600 disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded bg-cp-surface-4 px-3 py-1 text-cp-xs hover:bg-cp-surface-5 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {t('onboarding.back', 'Zurück')}
             </button>
@@ -169,10 +169,10 @@ export const OnboardingTour = ({ open, onClose }: OnboardingTourProps) => {
       }
     >
       <div className="space-y-3">
-        <h2 className="text-cp-xl font-semibold text-slate-100">{current.title}</h2>
-        <p className="text-cp-base leading-relaxed text-slate-300">{current.body}</p>
+        <h2 className="text-cp-xl font-semibold text-cp-text">{current.title}</h2>
+        <p className="text-cp-base leading-relaxed text-cp-text-secondary">{current.body}</p>
         {current.hint && (
-          <div className="rounded border border-slate-800 bg-slate-950/40 px-2 py-1 text-[11px] text-slate-400">
+          <div className="rounded border border-cp-border-muted bg-cp-surface-3/40 px-2 py-1 text-[11px] text-cp-text-muted">
             {t('onboarding.tip', 'Tipp:')} {current.hint}
           </div>
         )}

--- a/src/renderer/components/Patch/PatchListDialog.tsx
+++ b/src/renderer/components/Patch/PatchListDialog.tsx
@@ -478,7 +478,7 @@ export const PatchListDialog = () => {
       scrollBody={false}
       footer={
         <div className="flex items-center justify-between">
-          <p className="text-[10px] text-slate-400">
+          <p className="text-[10px] text-cp-text-muted">
             {t(
               'patchList.footerHint',
               'Jedes Kabel als eigene Zeile, sortiert für die Patch-Reihenfolge auf dem Set. CSV-Export für Excel/Druck enthält die aktuell gefilterten Zeilen.',
@@ -517,7 +517,7 @@ export const PatchListDialog = () => {
               value={labelCsvFormat}
               onChange={(e) => setLabelCsvFormat(e.target.value as LabelCsvFormat)}
               title={t('patchList.labelCsvFormat', 'Etiketten-Drucker-Format')}
-              className="rounded border border-slate-700 bg-slate-950 px-1 py-1 text-cp-xs"
+              className="rounded border border-cp-border bg-cp-surface-3 px-1 py-1 text-cp-xs"
             >
               <option value="generic">{t('patchList.labelCsv.generic', 'Generisch (CSV)')}</option>
               <option value="brother">{t('patchList.labelCsv.brother', 'Brother P-touch (TXT)')}</option>
@@ -546,20 +546,20 @@ export const PatchListDialog = () => {
       }
     >
       <div className="flex h-full flex-col">
-        <div className="flex items-center gap-2 border-b border-slate-800 py-2">
+        <div className="flex items-center gap-2 border-b border-cp-border-muted py-2">
           <input
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
             placeholder={t('patchList.searchPlaceholder', 'Suchen (Gerät, Port, Typ, Farbe, Notiz …)')}
             aria-label={t('patchList.searchPlaceholder', 'Suchen (Gerät, Port, Typ, Farbe, Notiz …)')}
-            className="flex-1 rounded border border-slate-700 bg-slate-950 px-2 py-1 text-cp-xs"
+            className="flex-1 rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-xs"
           />
           {layers.length > 0 && (
             <select
               value={layerFilter}
               onChange={(e) => setLayerFilter(e.target.value)}
               title={t('patchList.layerFilter', 'Nach Layer/Gewerk filtern')}
-              className="rounded border border-slate-700 bg-slate-950 px-2 py-1 text-cp-xs"
+              className="rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-xs"
             >
               <option value="">{t('patchList.allLayers', 'Alle Layer')}</option>
               {layers.map((l) => (
@@ -569,13 +569,13 @@ export const PatchListDialog = () => {
               ))}
             </select>
           )}
-          <span className="text-[11px] text-slate-400">
+          <span className="text-[11px] text-cp-text-muted">
             {filtered.length} / {rows.length}
           </span>
         </div>
         <div className="flex-1 overflow-auto">
           <table className="w-full text-cp-xs">
-            <thead className="sticky top-0 bg-slate-950 text-slate-400">
+            <thead className="sticky top-0 bg-cp-surface-3 text-cp-text-muted">
               <tr>
                 {[
                   { k: 'number' as const, label: t('patchList.col.number', 'Nr.') },
@@ -589,7 +589,7 @@ export const PatchListDialog = () => {
                 ].map((col, i) => (
                   <th
                     key={`${col.k}-${i}`}
-                    className="cursor-pointer px-2 py-1 text-left hover:text-slate-200"
+                    className="cursor-pointer px-2 py-1 text-left hover:text-cp-text-bright"
                     onClick={() => setSortKey(col.k)}
                   >
                     {col.label}
@@ -600,24 +600,24 @@ export const PatchListDialog = () => {
             </thead>
             <tbody>
               {filtered.map((r) => (
-                <tr key={r.cableId} className="border-t border-slate-800 hover:bg-slate-900">
+                <tr key={r.cableId} className="border-t border-cp-border-muted hover:bg-cp-surface-1">
                   <td className="px-2 py-1 font-mono text-[11px] text-sky-300">{r.cableNumber}</td>
-                  <td className="px-2 py-1 font-medium text-slate-100">{r.fromDevice}</td>
-                  <td className="px-2 py-1 text-slate-300">
+                  <td className="px-2 py-1 font-medium text-cp-text">{r.fromDevice}</td>
+                  <td className="px-2 py-1 text-cp-text-secondary">
                     {r.fromPort}
                     {r.fromPortSub && (
-                      <div className="text-[10px] text-slate-400">{r.fromPortSub}</div>
+                      <div className="text-[10px] text-cp-text-muted">{r.fromPortSub}</div>
                     )}
                   </td>
-                  <td className="px-2 py-1 font-medium text-slate-100">{r.toDevice}</td>
-                  <td className="px-2 py-1 text-slate-300">
+                  <td className="px-2 py-1 font-medium text-cp-text">{r.toDevice}</td>
+                  <td className="px-2 py-1 text-cp-text-secondary">
                     {r.toPort}
                     {r.toPortSub && (
-                      <div className="text-[10px] text-slate-400">{r.toPortSub}</div>
+                      <div className="text-[10px] text-cp-text-muted">{r.toPortSub}</div>
                     )}
                   </td>
-                  <td className="px-2 py-1 text-slate-300">{r.type}</td>
-                  <td className="px-2 py-1 text-right text-slate-300">{r.length}</td>
+                  <td className="px-2 py-1 text-cp-text-secondary">{r.type}</td>
+                  <td className="px-2 py-1 text-right text-cp-text-secondary">{r.length}</td>
                   <td className="px-2 py-1">
                     <span
                       className="inline-block h-3 w-8 rounded"

--- a/src/renderer/components/Print/PrintDialog.tsx
+++ b/src/renderer/components/Print/PrintDialog.tsx
@@ -117,7 +117,7 @@ export const PrintDialog = ({ open, onClose }: PrintDialogProps) => {
       draggableKey="cable-planner:modal-pos:print"
       footer={
         <div className="flex items-center justify-between gap-2">
-          <div className="text-[11px] text-slate-400">
+          <div className="text-[11px] text-cp-text-muted">
             {selectionCount === 0
               ? t('print.noneSelected', 'Kein Gerät ausgewählt')
               : formatStr(t('print.selectionCount', '{count} Geräte ausgewählt'), { count: selectionCount })}
@@ -126,7 +126,7 @@ export const PrintDialog = ({ open, onClose }: PrintDialogProps) => {
             <button
               type="button"
               onClick={onClose}
-              className="rounded border border-slate-700 bg-slate-800 px-3 py-1.5 text-cp-xs text-slate-100 hover:bg-slate-700"
+              className="rounded border border-cp-border bg-cp-surface-2 px-3 py-1.5 text-cp-xs text-cp-text hover:bg-cp-surface-4"
             >
               {t('common.close', 'Schließen')}
             </button>
@@ -157,11 +157,11 @@ export const PrintDialog = ({ open, onClose }: PrintDialogProps) => {
               below generates the PDF in memory and pushes it into a
               hidden iframe whose `contentWindow.print()` opens the
               native dialog — matches what you'd get from any browser. */}
-          <fieldset className="mb-4 rounded border border-slate-700 p-3">
-            <legend className="px-1 text-[11px] uppercase tracking-wide text-slate-400">
+          <fieldset className="mb-4 rounded border border-cp-border p-3">
+            <legend className="px-1 text-[11px] uppercase tracking-wide text-cp-text-muted">
               {t('print.osHint.title', 'Drucker-Hinweis')}
             </legend>
-            <p className="text-[11px] text-slate-400">
+            <p className="text-[11px] text-cp-text-muted">
               {t(
                 'print.osHint.body',
                 'Beim Drucken öffnet sich der Drucker-Dialog deines Betriebssystems — dort kannst du Drucker, Papierformat (A4 / A3 / Letter), Ausrichtung und Kopienzahl einstellen.',
@@ -172,11 +172,11 @@ export const PrintDialog = ({ open, onClose }: PrintDialogProps) => {
           </fieldset>
 
           {/* Per-device section */}
-          <fieldset className="rounded border border-slate-700 p-3">
-            <legend className="px-1 text-[11px] uppercase tracking-wide text-slate-400">
+          <fieldset className="rounded border border-cp-border p-3">
+            <legend className="px-1 text-[11px] uppercase tracking-wide text-cp-text-muted">
               {t('print.devices.title', 'Einzelgeräte (Patch-Sheet)')}
             </legend>
-            <p className="mb-2 text-[11px] text-slate-400">
+            <p className="mb-2 text-[11px] text-cp-text-muted">
               {t(
                 'print.devices.body',
                 'Wählt einzelne Geräte aus und erzeugt eine A4/A3-Patch-Liste mit allen Ports + verbundenen Kabeln — zum Aufkleben am Gerät.',
@@ -190,7 +190,7 @@ export const PrintDialog = ({ open, onClose }: PrintDialogProps) => {
                 onChange={(e) => setFilter(e.target.value)}
                 placeholder={t('print.devices.searchPlaceholder', 'Suchen (Name, Kategorie, Untertitel)…')}
                 aria-label={t('print.devices.searchPlaceholder', 'Suchen (Name, Kategorie, Untertitel)…')}
-                className="flex-1 rounded border border-slate-700 bg-slate-950 px-2 py-1 text-cp-xs text-slate-100 placeholder:text-slate-500"
+                className="flex-1 rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-xs text-cp-text placeholder:text-cp-text-faint"
               />
               {(() => {
                 // v7.6.0 — one toggle button instead of two competing buttons.
@@ -204,7 +204,7 @@ export const PrintDialog = ({ open, onClose }: PrintDialogProps) => {
                     type="button"
                     onClick={() => (allChecked ? selectNone() : selectAll())}
                     disabled={filteredEquipment.length === 0}
-                    className="rounded border border-slate-700 bg-slate-800 px-2 py-1 text-[11px] text-slate-200 hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+                    className="rounded border border-cp-border bg-cp-surface-2 px-2 py-1 text-[11px] text-cp-text-bright hover:bg-cp-surface-4 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {allChecked
                       ? t('print.devices.deselectAll', 'Alle abwählen')
@@ -215,13 +215,13 @@ export const PrintDialog = ({ open, onClose }: PrintDialogProps) => {
             </div>
 
             {/* Device checklist */}
-            <div className="mb-3 max-h-[42vh] overflow-y-auto rounded border border-slate-800 bg-slate-950/40 p-1">
+            <div className="mb-3 max-h-[42vh] overflow-y-auto rounded border border-cp-border-muted bg-cp-surface-3/40 p-1">
               {sortedEquipment.length === 0 ? (
-                <div className="px-3 py-6 text-center text-[11px] text-slate-400">
+                <div className="px-3 py-6 text-center text-[11px] text-cp-text-muted">
                   {t('print.devices.noneInProject', 'Keine Geräte im Projekt.')}
                 </div>
               ) : filteredEquipment.length === 0 ? (
-                <div className="px-3 py-6 text-center text-[11px] text-slate-400">
+                <div className="px-3 py-6 text-center text-[11px] text-cp-text-muted">
                   {formatStr(t('print.devices.noMatch', 'Kein Gerät passt zum Suchbegriff „{q}".'), { q: filter })}
                 </div>
               ) : (
@@ -233,7 +233,7 @@ export const PrintDialog = ({ open, onClose }: PrintDialogProps) => {
                     ).length
                     return (
                       <li key={eq.id}>
-                        <label className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-cp-xs text-slate-200 hover:bg-slate-800/60">
+                        <label className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-cp-xs text-cp-text-bright hover:bg-cp-surface-2/60">
                           <input
                             type="checkbox"
                             checked={selectedIds.has(eq.id)}
@@ -241,12 +241,12 @@ export const PrintDialog = ({ open, onClose }: PrintDialogProps) => {
                             className="h-3.5 w-3.5"
                           />
                           <div className="min-w-0 flex-1">
-                            <div className="truncate font-medium text-slate-100">{eq.name}</div>
-                            <div className="truncate text-[10px] text-slate-400">
+                            <div className="truncate font-medium text-cp-text">{eq.name}</div>
+                            <div className="truncate text-[10px] text-cp-text-muted">
                               {[eq.category, eq.subtitle].filter(Boolean).join(' · ') || '—'}
                             </div>
                           </div>
-                          <span className="shrink-0 text-[10px] text-slate-400">
+                          <span className="shrink-0 text-[10px] text-cp-text-muted">
                             {portCount} Ports · {cableCount} Kabel
                           </span>
                         </label>
@@ -259,11 +259,11 @@ export const PrintDialog = ({ open, onClose }: PrintDialogProps) => {
 
             {/* Action toggle — print via OS dialog vs. download a PDF */}
             <div className="mb-3 grid grid-cols-2 gap-3">
-              <div className="rounded border border-slate-700 p-2">
-                <div className="mb-1 text-[10px] uppercase tracking-wide text-slate-400">
+              <div className="rounded border border-cp-border p-2">
+                <div className="mb-1 text-[10px] uppercase tracking-wide text-cp-text-muted">
                   Aktion
                 </div>
-                <label className="flex cursor-pointer items-center gap-2 text-cp-xs text-slate-200">
+                <label className="flex cursor-pointer items-center gap-2 text-cp-xs text-cp-text-bright">
                   <input
                     type="radio"
                     name="print-action"
@@ -273,7 +273,7 @@ export const PrintDialog = ({ open, onClose }: PrintDialogProps) => {
                   <Icon icon={Printer} size="xs" className="mr-1 inline-block align-text-bottom" />
                   Auf Drucker drucken (Systemdialog)
                 </label>
-                <label className="flex cursor-pointer items-center gap-2 text-cp-xs text-slate-200">
+                <label className="flex cursor-pointer items-center gap-2 text-cp-xs text-cp-text-bright">
                   <input
                     type="radio"
                     name="print-action"
@@ -283,8 +283,8 @@ export const PrintDialog = ({ open, onClose }: PrintDialogProps) => {
                   Als PDF herunterladen
                 </label>
               </div>
-              <div className="rounded border border-slate-700 p-2 text-[10px] text-slate-400">
-                <div className="mb-1 uppercase tracking-wide text-slate-400">
+              <div className="rounded border border-cp-border p-2 text-[10px] text-cp-text-muted">
+                <div className="mb-1 uppercase tracking-wide text-cp-text-muted">
                   {t('print.dialogHint.tag', 'Hinweis')}
                 </div>
                 {t(
@@ -296,11 +296,11 @@ export const PrintDialog = ({ open, onClose }: PrintDialogProps) => {
 
             {/* Options: paper format + output mode */}
             <div className="grid grid-cols-2 gap-3">
-              <div className="rounded border border-slate-700 p-2">
-                <div className="mb-1 text-[10px] uppercase tracking-wide text-slate-400">
+              <div className="rounded border border-cp-border p-2">
+                <div className="mb-1 text-[10px] uppercase tracking-wide text-cp-text-muted">
                   {t('print.format.label', 'Format')}
                 </div>
-                <label className="flex cursor-pointer items-center gap-2 text-cp-xs text-slate-200">
+                <label className="flex cursor-pointer items-center gap-2 text-cp-xs text-cp-text-bright">
                   <input
                     type="radio"
                     name="print-format"
@@ -309,7 +309,7 @@ export const PrintDialog = ({ open, onClose }: PrintDialogProps) => {
                   />
                   {t('print.format.a4', 'A4 (Standard)')}
                 </label>
-                <label className="flex cursor-pointer items-center gap-2 text-cp-xs text-slate-200">
+                <label className="flex cursor-pointer items-center gap-2 text-cp-xs text-cp-text-bright">
                   <input
                     type="radio"
                     name="print-format"
@@ -319,11 +319,11 @@ export const PrintDialog = ({ open, onClose }: PrintDialogProps) => {
                   {t('print.format.a3', 'A3 (mehr Ports / Seite)')}
                 </label>
               </div>
-              <div className="rounded border border-slate-700 p-2">
-                <div className="mb-1 text-[10px] uppercase tracking-wide text-slate-400">
+              <div className="rounded border border-cp-border p-2">
+                <div className="mb-1 text-[10px] uppercase tracking-wide text-cp-text-muted">
                   {t('print.output.label', 'Ausgabe')}
                 </div>
-                <label className="flex cursor-pointer items-center gap-2 text-cp-xs text-slate-200">
+                <label className="flex cursor-pointer items-center gap-2 text-cp-xs text-cp-text-bright">
                   <input
                     type="radio"
                     name="print-mode"
@@ -332,7 +332,7 @@ export const PrintDialog = ({ open, onClose }: PrintDialogProps) => {
                   />
                   {t('print.output.combined', 'Eine Sammel-PDF')}
                 </label>
-                <label className="flex cursor-pointer items-center gap-2 text-cp-xs text-slate-200">
+                <label className="flex cursor-pointer items-center gap-2 text-cp-xs text-cp-text-bright">
                   <input
                     type="radio"
                     name="print-mode"

--- a/src/renderer/components/Project/AiPlanGenDialog.tsx
+++ b/src/renderer/components/Project/AiPlanGenDialog.tsx
@@ -70,7 +70,7 @@ export const AiPlanGenDialog = () => {
           </div>
         )}
         <label className="block">
-          <span className="mb-1 block text-cp-xs text-slate-400">
+          <span className="mb-1 block text-cp-xs text-cp-text-muted">
             {t('aiPlan.promptLabel', 'System in Klartext beschreiben')}
           </span>
           <textarea
@@ -81,11 +81,11 @@ export const AiPlanGenDialog = () => {
               'aiPlan.promptPlaceholder',
               'z. B. "2 Kameras über SDI in einen Switcher, PGM-Out auf einen Recorder und einen Multiviewer-Monitor"',
             )}
-            className="w-full rounded border border-slate-700 bg-slate-950 p-2 text-cp-xs"
+            className="w-full rounded border border-cp-border bg-cp-surface-3 p-2 text-cp-xs"
           />
         </label>
         <div className="flex items-center justify-between gap-2">
-          <span className="text-[10px] text-slate-400">
+          <span className="text-[10px] text-cp-text-muted">
             {t('aiPlan.reviewHint', 'Vorschau wird angezeigt — nichts wird ohne Bestätigung eingefügt.')}
           </span>
           <button
@@ -107,17 +107,17 @@ export const AiPlanGenDialog = () => {
         )}
 
         {plan && (
-          <div className="rounded border border-slate-700 bg-slate-900/40 p-2">
-            <div className="mb-1 text-cp-xs font-semibold text-slate-200">
+          <div className="rounded border border-cp-border bg-cp-surface-1/40 p-2">
+            <div className="mb-1 text-cp-xs font-semibold text-cp-text-bright">
               {format(t('aiPlan.preview', 'Vorschau: {d} Geräte, {c} Kabel'), {
                 d: plan.equipment.length,
                 c: plan.cables.length,
               })}
             </div>
-            <ul className="max-h-40 overflow-auto text-[11px] text-slate-300">
+            <ul className="max-h-40 overflow-auto text-[11px] text-cp-text-secondary">
               {plan.equipment.map((e) => (
                 <li key={e.id}>
-                  • {e.name} <span className="text-slate-500">[{e.category}]</span>
+                  • {e.name} <span className="text-cp-text-faint">[{e.category}]</span>
                 </li>
               ))}
             </ul>

--- a/src/renderer/components/Project/CableBomDialog.tsx
+++ b/src/renderer/components/Project/CableBomDialog.tsx
@@ -306,7 +306,7 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
       scrollBody={false}
       footer={
         <div className="flex items-center justify-between text-[11px]">
-          <span className="text-slate-400">
+          <span className="text-cp-text-muted">
             {draftPlan
               ? t('bom.cable.draftPending', 'Nicht gespeicherte Änderungen an der Rentman-Planung.')
               : t('bom.cable.draftSaved', 'Rentman-Planung wird im Projekt gespeichert.')}
@@ -316,7 +316,7 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
               <button
                 type="button"
                 onClick={discardPlan}
-                className="rounded bg-slate-700 px-3 py-1 text-cp-xs hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-3 py-1 text-cp-xs hover:bg-cp-surface-5"
               >
                 {t('bom.cable.discard', 'Verwerfen')}
               </button>
@@ -350,10 +350,10 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
       }
     >
       <div className="flex h-full min-h-0 flex-col -mx-4 -my-3">
-        <div className="flex items-center gap-2 border-b border-slate-800 px-4 py-2 text-[11px] text-slate-400">
+        <div className="flex items-center gap-2 border-b border-cp-border-muted px-4 py-2 text-[11px] text-cp-text-muted">
           <span>{t('bom.cable.groupedNote', 'Gruppiert nach Typ & Länge.')}</span>
           <span>
-            {t('bom.cable.builtCables', 'Verbaute Kabel:')} <b className="text-slate-200">{project.cables.length}</b>
+            {t('bom.cable.builtCables', 'Verbaute Kabel:')} <b className="text-cp-text-bright">{project.cables.length}</b>
           </span>
           {rows.some((r) => r.diff < 0) && (
             <span className="ml-2 inline-flex items-center gap-1 rounded bg-red-900/50 px-2 py-0.5 font-semibold text-red-300">
@@ -371,7 +371,7 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
             <button
               type="button"
               onClick={exportCsv}
-              className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
             >
               {t('bom.cable.csv', 'CSV')}
             </button>
@@ -387,7 +387,7 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
 
         <div className="min-h-0 flex-1 overflow-auto px-4">
           <table className="w-full text-cp-xs">
-            <thead className="sticky top-0 bg-slate-950 text-slate-300">
+            <thead className="sticky top-0 bg-cp-surface-3 text-cp-text-secondary">
               <tr>
                 <th className="px-3 py-2 text-left">{t('bom.cable.col.type', 'Typ')}</th>
                 <th className="px-3 py-2 text-right">{t('bom.cable.col.length', 'Länge (m)')}</th>
@@ -402,18 +402,18 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
             <tbody>
               {rows.length === 0 && (
                 <tr>
-                  <td className="px-3 py-4 text-center text-slate-500" colSpan={7}>
+                  <td className="px-3 py-4 text-center text-cp-text-faint" colSpan={7}>
                     {t('bom.cable.noCables', 'Keine Kabel im Projekt.')}
                   </td>
                 </tr>
               )}
               {rows.map((r) => (
-                <tr key={r.key} className={`border-t border-slate-800 ${r.diff < 0 ? 'bg-red-950/30' : ''}`}>
+                <tr key={r.key} className={`border-t border-cp-border-muted ${r.diff < 0 ? 'bg-red-950/30' : ''}`}>
                   <td className="px-3 py-1 align-top">
-                    <div className="font-medium text-slate-100">
+                    <div className="font-medium text-cp-text">
                       {r.type}
                       {r.sample && (
-                        <span className="ml-1 text-[10px] text-slate-400">
+                        <span className="ml-1 text-[10px] text-cp-text-muted">
                           ({r.sample.name})
                         </span>
                       )}
@@ -434,7 +434,7 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
                     )}
                     {!r.rentmanName && r.rentmanId && (
                       <div
-                        className="mt-0.5 text-[10px] text-slate-400"
+                        className="mt-0.5 text-[10px] text-cp-text-muted"
                         title={t('bom.cable.rentmanMissingTitle', 'Verknuepft, aber Rentman-Template lokal nicht gefunden')}
                       >
                         R #{r.rentmanId}
@@ -445,7 +445,7 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
                   <td className="px-3 py-1 text-right align-top font-mono">{r.built}</td>
                   {/* Gesamtlänge dieses Bucket = Stückzahl × Einzellänge — fürs
                       Bestellen nach Meter. */}
-                  <td className="px-3 py-1 text-right align-top font-mono text-slate-300">
+                  <td className="px-3 py-1 text-right align-top font-mono text-cp-text-secondary">
                     {Number((r.built * r.length).toFixed(1))}
                   </td>
                   <td className="px-3 py-1 text-right align-top">
@@ -454,7 +454,7 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
                       min={0}
                       value={r.planned}
                       onChange={(e) => setPlanned(r.key, Number(e.target.value))}
-                      className="w-16 rounded border border-slate-700 bg-slate-950 px-1 py-0.5 text-right font-mono"
+                      className="w-16 rounded border border-cp-border bg-cp-surface-3 px-1 py-0.5 text-right font-mono"
                     />
                   </td>
                   <td
@@ -477,7 +477,7 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
                   </td>
                   {/* #292 — Wege-Spalte: max 3 Pfade sichtbar, alle weiteren
                       als Tooltip ("+N weitere"). */}
-                  <td className="px-3 py-1 align-top text-[11px] text-slate-300">
+                  <td className="px-3 py-1 align-top text-[11px] text-cp-text-secondary">
                     {r.paths.length === 0 ? (
                       <span className="text-slate-600">—</span>
                     ) : (
@@ -489,7 +489,7 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
                         ))}
                         {r.paths.length > 3 && (
                           <div
-                            className="cursor-help text-[10px] text-slate-400"
+                            className="cursor-help text-[10px] text-cp-text-muted"
                             title={r.paths.slice(3).join('\n')}
                           >
                             {format(t('bom.cable.morePaths', '+{count} weitere'), { count: r.paths.length - 3 })}
@@ -502,8 +502,8 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
               ))}
             </tbody>
             {rows.length > 0 && (
-              <tfoot className="sticky bottom-0 bg-slate-950">
-                <tr className="border-t-2 border-slate-700 font-semibold text-slate-200">
+              <tfoot className="sticky bottom-0 bg-cp-surface-3">
+                <tr className="border-t-2 border-cp-border font-semibold text-cp-text-bright">
                   <td className="px-3 py-2 text-left" colSpan={2}>
                     {t('bom.cable.total', 'Gesamt')}
                   </td>

--- a/src/renderer/components/Project/LocationBomDialog.tsx
+++ b/src/renderer/components/Project/LocationBomDialog.tsx
@@ -330,32 +330,32 @@ export const LocationBomDialog = () => {
       draggableKey="cable-planner:modal-pos:location-bom"
     >
         <div className="text-cp-xs">
-          <div className="mb-3 flex flex-wrap items-center gap-2 text-[11px] text-slate-400">
+          <div className="mb-3 flex flex-wrap items-center gap-2 text-[11px] text-cp-text-muted">
             <span>
-              {t('locbom.devices', 'Geräte')}: <b className="text-slate-200">{devices.length}</b>
+              {t('locbom.devices', 'Geräte')}: <b className="text-cp-text-bright">{devices.length}</b>
             </span>
             <span>
-              {t('locbom.internalCables', 'Interne Kabel')}: <b className="text-slate-200">{internalCables.length}</b>
+              {t('locbom.internalCables', 'Interne Kabel')}: <b className="text-cp-text-bright">{internalCables.length}</b>
             </span>
             {externalCables.length > 0 && (
               <span>
-                {t('locbom.externalConnections', 'Externe Verbindungen')}: <b className="text-slate-200">{externalCables.length}</b>
+                {t('locbom.externalConnections', 'Externe Verbindungen')}: <b className="text-cp-text-bright">{externalCables.length}</b>
               </span>
             )}
             {/* #351 — Logistik: Gewicht + Strombedarf + Wärmelast je Location. */}
             {logistics.weightKg > 0 && (
               <span title={t('locbom.weightTitle', '{n} von {total} Geräten haben ein Gewicht hinterlegt').replace('{n}', String(logistics.weighed)).replace('{total}', String(devices.length))}>
-                {t('locbom.weight', 'Gewicht')}: <b className="text-slate-200">{logistics.weightKg.toFixed(1)} kg</b>
+                {t('locbom.weight', 'Gewicht')}: <b className="text-cp-text-bright">{logistics.weightKg.toFixed(1)} kg</b>
               </span>
             )}
             {logistics.watts > 0 && (
               <span>
-                {t('locbom.power', 'Leistung')}: <b className="text-slate-200">{logistics.watts.toFixed(0)} W</b>
-                <span className="text-slate-500"> · {logistics.btu} BTU/h</span>
+                {t('locbom.power', 'Leistung')}: <b className="text-cp-text-bright">{logistics.watts.toFixed(0)} W</b>
+                <span className="text-cp-text-faint"> · {logistics.btu} BTU/h</span>
               </span>
             )}
             <label
-              className="ml-auto flex items-center gap-1.5 text-[11px] text-slate-300"
+              className="ml-auto flex items-center gap-1.5 text-[11px] text-cp-text-secondary"
               title={t('locbom.groupTitle', 'Gruppiert gleiche Kabel (selber Typ + Länge) in einer Zeile mit Stückzahl — Standard für Stückliste.')}
             >
               <input
@@ -366,7 +366,7 @@ export const LocationBomDialog = () => {
               {t('locbom.groupCables', 'Kabel zusammenfassen')}
             </label>
             <label
-              className="flex items-center gap-1.5 text-[11px] text-slate-300"
+              className="flex items-center gap-1.5 text-[11px] text-cp-text-secondary"
               title={t('locbom.includePlanTitle', 'Hängt einen Plan-Ausschnitt der Location als JPEG vor die Geräteliste — die Empfänger bekommen Stückliste + Plan in einem Dokument.')}
             >
               <input
@@ -386,10 +386,10 @@ export const LocationBomDialog = () => {
             </button>
           </div>
 
-          <h3 className="mb-1 text-cp-base font-semibold text-slate-200">{t('locbom.section.devices', 'Geräte')}</h3>
+          <h3 className="mb-1 text-cp-base font-semibold text-cp-text-bright">{t('locbom.section.devices', 'Geräte')}</h3>
           <table className="mb-4 w-full text-cp-xs">
-            <thead className="text-slate-400">
-              <tr className="border-b border-slate-700">
+            <thead className="text-cp-text-muted">
+              <tr className="border-b border-cp-border">
                 <th className="px-2 py-1 text-center w-10">{t('locbom.col.packed', 'Pack')}</th>
                 <th className="px-2 py-1 text-left">{t('locbom.col.name', 'Name')}</th>
                 <th className="px-2 py-1 text-left">{t('locbom.col.category', 'Kategorie')}</th>
@@ -400,17 +400,17 @@ export const LocationBomDialog = () => {
             </thead>
             <tbody>
               {devices.map((d) => (
-                <tr key={d.id} className="border-b border-slate-800">
+                <tr key={d.id} className="border-b border-cp-border-muted">
                   <td className="px-2 py-1 text-center">{d.packed ? '☑' : '☐'}</td>
-                  <td className="px-2 py-1 text-slate-100">{d.name}</td>
-                  <td className="px-2 py-1 text-slate-400">{d.category}</td>
-                  <td className="px-2 py-1 font-mono text-slate-400">
+                  <td className="px-2 py-1 text-cp-text">{d.name}</td>
+                  <td className="px-2 py-1 text-cp-text-muted">{d.category}</td>
+                  <td className="px-2 py-1 font-mono text-cp-text-muted">
                     {d.serialNumber ?? '—'}
                   </td>
-                  <td className="px-2 py-1 font-mono text-slate-400">
+                  <td className="px-2 py-1 font-mono text-cp-text-muted">
                     {d.ipAddress ?? '—'}
                   </td>
-                  <td className="px-2 py-1 text-slate-400">
+                  <td className="px-2 py-1 text-cp-text-muted">
                     {formatCategoryProps(d.category, d.categoryProps, lang) || '—'}
                   </td>
                 </tr>
@@ -418,13 +418,13 @@ export const LocationBomDialog = () => {
             </tbody>
           </table>
 
-          <h3 className="mb-1 text-cp-base font-semibold text-slate-200">{t('locbom.section.internalCables', 'Interne Kabel')}</h3>
+          <h3 className="mb-1 text-cp-base font-semibold text-cp-text-bright">{t('locbom.section.internalCables', 'Interne Kabel')}</h3>
           {internalCables.length === 0 ? (
-            <div className="mb-3 text-slate-500">{t('locbom.noInternalCables', 'Keine internen Kabel.')}</div>
+            <div className="mb-3 text-cp-text-faint">{t('locbom.noInternalCables', 'Keine internen Kabel.')}</div>
           ) : grouped ? (
             <table className="mb-4 w-full text-cp-xs">
-              <thead className="text-slate-400">
-                <tr className="border-b border-slate-700">
+              <thead className="text-cp-text-muted">
+                <tr className="border-b border-cp-border">
                   <th className="px-2 py-1 text-right w-12">{t('locbom.col.qty', 'Stk.')}</th>
                   <th className="px-2 py-1 text-left">{t('locbom.col.type', 'Typ')}</th>
                   <th className="px-2 py-1 text-right">{t('locbom.col.lengthM', 'Länge (m)')}</th>
@@ -434,14 +434,14 @@ export const LocationBomDialog = () => {
                 {internalGroups.map((g) => (
                   <tr
                     key={g.key}
-                    className="border-b border-slate-800"
+                    className="border-b border-cp-border-muted"
                     title={g.examples.length > 0 ? `${t('locbom.examples', 'Beispiele:')} ${g.examples.join(', ')}` : undefined}
                   >
                     <td className="px-2 py-1 text-right font-mono font-semibold text-emerald-300">
                       {g.count}×
                     </td>
-                    <td className="px-2 py-1 text-slate-200">{g.type}</td>
-                    <td className="px-2 py-1 text-right font-mono text-slate-400">
+                    <td className="px-2 py-1 text-cp-text-bright">{g.type}</td>
+                    <td className="px-2 py-1 text-right font-mono text-cp-text-muted">
                       {g.length}
                     </td>
                   </tr>
@@ -450,8 +450,8 @@ export const LocationBomDialog = () => {
             </table>
           ) : (
             <table className="mb-4 w-full text-cp-xs">
-              <thead className="text-slate-400">
-                <tr className="border-b border-slate-700">
+              <thead className="text-cp-text-muted">
+                <tr className="border-b border-cp-border">
                   <th className="px-2 py-1 text-left">{t('locbom.col.name', 'Name')}</th>
                   <th className="px-2 py-1 text-left">{t('locbom.col.type', 'Typ')}</th>
                   <th className="px-2 py-1 text-left">{t('locbom.col.connection', 'Verbindung')}</th>
@@ -460,11 +460,11 @@ export const LocationBomDialog = () => {
               </thead>
               <tbody>
                 {internalCables.map((c) => (
-                  <tr key={c.id} className="border-b border-slate-800">
+                  <tr key={c.id} className="border-b border-cp-border-muted">
                     <td className="px-2 py-1">{c.name ?? '—'}</td>
-                    <td className="px-2 py-1 text-slate-400">{c.type ?? '—'}</td>
-                    <td className="px-2 py-1 text-slate-300">{connectionDesc(c)}</td>
-                    <td className="px-2 py-1 text-right font-mono text-slate-400">
+                    <td className="px-2 py-1 text-cp-text-muted">{c.type ?? '—'}</td>
+                    <td className="px-2 py-1 text-cp-text-secondary">{connectionDesc(c)}</td>
+                    <td className="px-2 py-1 text-right font-mono text-cp-text-muted">
                       {c.length ?? '—'}
                     </td>
                   </tr>
@@ -480,8 +480,8 @@ export const LocationBomDialog = () => {
               </h3>
               {grouped ? (
                 <table className="w-full text-cp-xs">
-                  <thead className="text-slate-400">
-                    <tr className="border-b border-slate-700">
+                  <thead className="text-cp-text-muted">
+                    <tr className="border-b border-cp-border">
                       <th className="px-2 py-1 text-right w-12">{t('locbom.col.qty', 'Stk.')}</th>
                       <th className="px-2 py-1 text-left">{t('locbom.col.type', 'Typ')}</th>
                       <th className="px-2 py-1 text-right">{t('locbom.col.lengthM', 'Länge (m)')}</th>
@@ -491,14 +491,14 @@ export const LocationBomDialog = () => {
                     {externalGroups.map((g) => (
                       <tr
                         key={g.key}
-                        className="border-b border-slate-800"
+                        className="border-b border-cp-border-muted"
                         title={g.examples.length > 0 ? `${t('locbom.examples', 'Beispiele:')} ${g.examples.join(', ')}` : undefined}
                       >
                         <td className="px-2 py-1 text-right font-mono font-semibold text-amber-300">
                           {g.count}×
                         </td>
-                        <td className="px-2 py-1 text-slate-200">{g.type}</td>
-                        <td className="px-2 py-1 text-right font-mono text-slate-400">
+                        <td className="px-2 py-1 text-cp-text-bright">{g.type}</td>
+                        <td className="px-2 py-1 text-right font-mono text-cp-text-muted">
                           {g.length}
                         </td>
                       </tr>
@@ -507,8 +507,8 @@ export const LocationBomDialog = () => {
                 </table>
               ) : (
                 <table className="w-full text-cp-xs">
-                  <thead className="text-slate-400">
-                    <tr className="border-b border-slate-700">
+                  <thead className="text-cp-text-muted">
+                    <tr className="border-b border-cp-border">
                       <th className="px-2 py-1 text-left">{t('locbom.col.name', 'Name')}</th>
                       <th className="px-2 py-1 text-left">{t('locbom.col.type', 'Typ')}</th>
                       <th className="px-2 py-1 text-left">{t('locbom.col.connection', 'Verbindung')}</th>
@@ -517,11 +517,11 @@ export const LocationBomDialog = () => {
                   </thead>
                   <tbody>
                     {externalCables.map((c) => (
-                      <tr key={c.id} className="border-b border-slate-800">
+                      <tr key={c.id} className="border-b border-cp-border-muted">
                         <td className="px-2 py-1">{c.name ?? '—'}</td>
-                        <td className="px-2 py-1 text-slate-400">{c.type ?? '—'}</td>
-                        <td className="px-2 py-1 text-slate-300">{connectionDesc(c)}</td>
-                        <td className="px-2 py-1 text-right font-mono text-slate-400">
+                        <td className="px-2 py-1 text-cp-text-muted">{c.type ?? '—'}</td>
+                        <td className="px-2 py-1 text-cp-text-secondary">{connectionDesc(c)}</td>
+                        <td className="px-2 py-1 text-right font-mono text-cp-text-muted">
                           {/* v7.9.93 — Wireless zeigt maxRange statt length (#182). */}
                           {c.wireless
                             ? c.maxRange

--- a/src/renderer/components/Project/ProjectMetaDialog.tsx
+++ b/src/renderer/components/Project/ProjectMetaDialog.tsx
@@ -89,7 +89,7 @@ export const ProjectMetaDialog = ({
           <button
             type="button"
             onClick={onCancel}
-            className="rounded bg-slate-700 px-3 py-1 text-cp-xs hover:bg-slate-600"
+            className="rounded bg-cp-surface-4 px-3 py-1 text-cp-xs hover:bg-cp-surface-5"
           >
             {t('common.cancel', 'Abbrechen')}
           </button>
@@ -114,7 +114,7 @@ export const ProjectMetaDialog = ({
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder={t('project.meta.namePh', 'z.B. ProSieben Studio Umbau')}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+              className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
             />
           </label>
 
@@ -125,7 +125,7 @@ export const ProjectMetaDialog = ({
                 value={contractor}
                 onChange={(e) => setContractor(e.target.value)}
                 placeholder={t('project.meta.contractorPh', 'Deine Firma GmbH')}
-                className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+                className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
               />
             </label>
             <label className="block">
@@ -134,7 +134,7 @@ export const ProjectMetaDialog = ({
                 value={client}
                 onChange={(e) => setClient(e.target.value)}
                 placeholder={t('project.meta.clientPh', 'Endkunde')}
-                className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+                className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
               />
             </label>
             <label className="block">
@@ -143,7 +143,7 @@ export const ProjectMetaDialog = ({
                 value={author}
                 onChange={(e) => setAuthor(e.target.value)}
                 placeholder={t('project.meta.authorPh', 'Vorname Nachname')}
-                className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+                className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
               />
             </label>
             <label className="block">
@@ -152,7 +152,7 @@ export const ProjectMetaDialog = ({
                 value={projectNumber}
                 onChange={(e) => setProjectNumber(e.target.value)}
                 placeholder={t('project.meta.projectNumberPh', 'z.B. 2026-042')}
-                className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+                className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
               />
             </label>
           </div>
@@ -163,13 +163,13 @@ export const ProjectMetaDialog = ({
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               rows={2}
-              className="mt-1 w-full resize-y rounded border border-slate-700 bg-slate-950 p-1.5"
+              className="mt-1 w-full resize-y rounded border border-cp-border bg-cp-surface-3 p-1.5"
             />
           </label>
 
           <div className="grid grid-cols-2 gap-2">
             <div>
-              <div className="mb-1 text-[11px] text-slate-400">
+              <div className="mb-1 text-[11px] text-cp-text-muted">
                 {t('project.meta.companyLogo', 'Firmenlogo')}
               </div>
               {companyLogo ? (
@@ -177,7 +177,7 @@ export const ProjectMetaDialog = ({
                   <img
                     src={companyLogo}
                     alt={t('project.meta.companyLogo', 'Firmenlogo')}
-                    className="h-12 w-auto rounded border border-slate-700 bg-white p-1"
+                    className="h-12 w-auto rounded border border-cp-border bg-white p-1"
                   />
                   <button
                     type="button"
@@ -203,13 +203,13 @@ export const ProjectMetaDialog = ({
               <button
                 type="button"
                 onClick={() => companyInputRef.current?.click()}
-                className="mt-1 rounded bg-slate-700 px-2 py-1 text-[11px] hover:bg-slate-600"
+                className="mt-1 rounded bg-cp-surface-4 px-2 py-1 text-[11px] hover:bg-cp-surface-5"
               >
                 {t('project.meta.chooseLogo', 'Logo auswählen…')}
               </button>
             </div>
             <div>
-              <div className="mb-1 text-[11px] text-slate-400">
+              <div className="mb-1 text-[11px] text-cp-text-muted">
                 {t('project.meta.clientLogo', 'Kundenlogo')}
               </div>
               {clientLogo ? (
@@ -217,7 +217,7 @@ export const ProjectMetaDialog = ({
                   <img
                     src={clientLogo}
                     alt={t('project.meta.clientLogo', 'Kundenlogo')}
-                    className="h-12 w-auto rounded border border-slate-700 bg-white p-1"
+                    className="h-12 w-auto rounded border border-cp-border bg-white p-1"
                   />
                   <button
                     type="button"
@@ -243,14 +243,14 @@ export const ProjectMetaDialog = ({
               <button
                 type="button"
                 onClick={() => clientInputRef.current?.click()}
-                className="mt-1 rounded bg-slate-700 px-2 py-1 text-[11px] hover:bg-slate-600"
+                className="mt-1 rounded bg-cp-surface-4 px-2 py-1 text-[11px] hover:bg-cp-surface-5"
               >
                 {t('project.meta.chooseLogo', 'Logo auswählen…')}
               </button>
             </div>
           </div>
 
-          <p className="text-[10px] italic text-slate-400">
+          <p className="text-[10px] italic text-cp-text-muted">
             {t(
               'project.meta.footnote',
               'Diese Daten erscheinen im Planköpfchen unten rechts beim PDF-Export. Jeder Speichervorgang aktualisiert das „zuletzt geändert"-Datum automatisch.',

--- a/src/renderer/components/Project/RevisionsDialog.tsx
+++ b/src/renderer/components/Project/RevisionsDialog.tsx
@@ -90,8 +90,8 @@ export const RevisionsDialog = () => {
     >
       <div className="flex flex-col gap-3">
         {/* Festschreiben */}
-        <div className="rounded border border-slate-700 bg-slate-900/40 p-2">
-          <div className="mb-1.5 text-cp-xs font-semibold text-slate-300">
+        <div className="rounded border border-cp-border bg-cp-surface-1/40 p-2">
+          <div className="mb-1.5 text-cp-xs font-semibold text-cp-text-secondary">
             {t('revisions.commitTitle', 'Aktuellen Stand festschreiben')}
           </div>
           <div className="flex flex-wrap items-center gap-2">
@@ -99,15 +99,15 @@ export const RevisionsDialog = () => {
               value={label}
               onChange={(e) => setLabel(e.target.value)}
               placeholder={t('revisions.labelPlaceholder', 'Label (z.B. "A", "Rev 2")')}
-              className="w-32 rounded border border-slate-700 bg-slate-950 px-2 py-1 text-cp-xs"
+              className="w-32 rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-xs"
             />
             <input
               value={note}
               onChange={(e) => setNote(e.target.value)}
               placeholder={t('revisions.notePlaceholder', 'Notiz: was hat sich geändert?')}
-              className="flex-1 rounded border border-slate-700 bg-slate-950 px-2 py-1 text-cp-xs"
+              className="flex-1 rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-xs"
             />
-            <label className="flex items-center gap-1 text-cp-xs text-slate-300">
+            <label className="flex items-center gap-1 text-cp-xs text-cp-text-secondary">
               <input
                 type="checkbox"
                 checked={asBuilt}
@@ -128,23 +128,23 @@ export const RevisionsDialog = () => {
 
         {/* Liste */}
         {sorted.length === 0 ? (
-          <p className="py-6 text-center text-cp-xs text-slate-500">
+          <p className="py-6 text-center text-cp-xs text-cp-text-faint">
             {t('revisions.empty', 'Noch keine Revisionen festgeschrieben.')}
           </p>
         ) : (
-          <ul className="divide-y divide-slate-800/60">
+          <ul className="divide-y divide-cp-surface-2/60">
             {sorted.map((rev) => (
               <li key={rev.id} className="flex items-center gap-2 py-1.5 text-cp-xs">
                 <span
                   className={`rounded px-1.5 py-0.5 font-bold ${
-                    rev.asBuilt ? 'bg-amber-600 text-amber-50' : 'bg-slate-700 text-slate-200'
+                    rev.asBuilt ? 'bg-amber-600 text-amber-50' : 'bg-cp-surface-4 text-cp-text-bright'
                   }`}
                 >
                   {rev.label}
                 </span>
                 <span className="min-w-0 flex-1">
-                  <span className="text-slate-300">{rev.note || '—'}</span>
-                  <span className="ml-2 text-slate-500">{fmtDate(rev.createdAt)}</span>
+                  <span className="text-cp-text-secondary">{rev.note || '—'}</span>
+                  <span className="ml-2 text-cp-text-faint">{fmtDate(rev.createdAt)}</span>
                   {rev.asBuilt && (
                     <span className="ml-1 text-amber-400">· {t('revisions.asBuiltTag', 'As-Built')}</span>
                   )}
@@ -169,7 +169,7 @@ export const RevisionsDialog = () => {
             ))}
           </ul>
         )}
-        <p className="text-[10px] text-slate-400">
+        <p className="text-[10px] text-cp-text-muted">
           {t(
             'revisions.footerHint',
             'Eine Revision speichert einen vollständigen Snapshot des Plans. Beim Wiederherstellen bleibt die Historie erhalten.',

--- a/src/renderer/components/Project/WelcomeDialog.tsx
+++ b/src/renderer/components/Project/WelcomeDialog.tsx
@@ -52,7 +52,7 @@ export const WelcomeDialog = ({ open, onNew, onOpen, onClose }: WelcomeDialogPro
           <button
             type="button"
             onClick={onClose}
-            className="rounded bg-cp-surface-2 px-3 py-1 text-cp-xs text-cp-text-muted hover:bg-slate-700 hover:text-slate-200"
+            className="rounded bg-cp-surface-2 px-3 py-1 text-cp-xs text-cp-text-muted hover:bg-cp-surface-4 hover:text-cp-text-bright"
             title={t(
               'project.welcome.laterTitle',
               'Ohne Auswahl fortfahren — bitte denke daran, manuell zu speichern.',
@@ -77,7 +77,7 @@ export const WelcomeDialog = ({ open, onNew, onOpen, onClose }: WelcomeDialogPro
             onNew()
             onClose()
           }}
-          className="flex w-full items-start gap-3 rounded border border-cp-border bg-cp-surface-2 px-3 py-2.5 text-left hover:border-emerald-500 hover:bg-slate-700"
+          className="flex w-full items-start gap-3 rounded border border-cp-border bg-cp-surface-2 px-3 py-2.5 text-left hover:border-emerald-500 hover:bg-cp-surface-4"
         >
           <Icon icon={FileText} size="lg" className="mt-0.5 text-emerald-400" />
           <span className="flex-1">
@@ -96,7 +96,7 @@ export const WelcomeDialog = ({ open, onNew, onOpen, onClose }: WelcomeDialogPro
             onOpen()
             onClose()
           }}
-          className="flex w-full items-start gap-3 rounded border border-cp-border bg-cp-surface-2 px-3 py-2.5 text-left hover:border-sky-500 hover:bg-slate-700"
+          className="flex w-full items-start gap-3 rounded border border-cp-border bg-cp-surface-2 px-3 py-2.5 text-left hover:border-sky-500 hover:bg-cp-surface-4"
         >
           <Icon icon={FolderOpen} size="lg" className="mt-0.5 text-sky-400" />
           <span className="flex-1">

--- a/src/renderer/components/Properties/CableProperties.tsx
+++ b/src/renderer/components/Properties/CableProperties.tsx
@@ -26,7 +26,7 @@ export const CableProperties = () => {
 
   if (!cable) {
     return (
-      <div className="text-cp-xs text-slate-400">
+      <div className="text-cp-xs text-cp-text-muted">
         {t('cable.click.placeholder', 'Kabel anklicken um Eigenschaften zu sehen.')}
       </div>
     )
@@ -78,21 +78,21 @@ export const CableProperties = () => {
     <div className="space-y-2 text-cp-xs">
       {/* Spec info bar */}
       {spec && (
-        <div className="flex items-center gap-1.5 rounded border border-slate-700 bg-slate-900 px-2 py-1.5">
+        <div className="flex items-center gap-1.5 rounded border border-cp-border bg-cp-surface-1 px-2 py-1.5">
           <span
             className="inline-block h-3 w-3 shrink-0 rounded-full"
             style={{ backgroundColor: spec.color }}
           />
           <div className="min-w-0 flex-1">
-            <div className="font-medium text-slate-200 truncate">{spec.name}</div>
+            <div className="font-medium text-cp-text-bright truncate">{spec.name}</div>
             {cable.standard && (
-              <div className="text-[10px] text-slate-400">{cable.standard}</div>
+              <div className="text-[10px] text-cp-text-muted">{cable.standard}</div>
             )}
           </div>
           <button
             type="button"
             onClick={() => openCableEdit(cable.id)}
-            className="shrink-0 rounded bg-slate-700 px-1.5 py-0.5 text-[10px] hover:bg-slate-600"
+            className="shrink-0 rounded bg-cp-surface-4 px-1.5 py-0.5 text-[10px] hover:bg-cp-surface-5"
             title={t('cable.edit.typeStandard', 'Kabeltyp / Standard bearbeiten')}
             aria-label={t('cable.edit.typeStandard', 'Kabeltyp / Standard bearbeiten')}
           >
@@ -104,7 +104,7 @@ export const CableProperties = () => {
         <button
           type="button"
           onClick={() => openCableEdit(cable.id)}
-          className="inline-flex w-full items-center justify-center gap-1.5 rounded border border-dashed border-slate-600 px-2 py-1 text-slate-400 hover:border-slate-400 hover:text-slate-200"
+          className="inline-flex w-full items-center justify-center gap-1.5 rounded border border-dashed border-cp-surface-5 px-2 py-1 text-cp-text-muted hover:border-slate-400 hover:text-cp-text-bright"
         >
           <Icon icon={Pencil} size="xs" /> Kabeltyp / Standard festlegen
         </button>
@@ -136,18 +136,18 @@ export const CableProperties = () => {
         )
       })()}
       <label className="block">
-        <span className="mb-1 block text-slate-300">{t('cable.field.name', 'Name')}</span>
+        <span className="mb-1 block text-cp-text-secondary">{t('cable.field.name', 'Name')}</span>
         <input
           value={cable.name}
           onChange={(event) => updateCable(cable.id, { name: event.target.value })}
-          className="w-full rounded border border-slate-700 bg-slate-900 p-2"
+          className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
         />
       </label>
       {/* v7.9.68 / #182 — Bei Wireless-Links macht "Länge" keinen Sinn;
           stattdessen "Max. Reichweite" eintragen. */}
       {cable.wireless ? (
         <label className="block">
-          <span className="mb-1 block text-slate-300">{t('cable.field.maxReach', 'Max. Reichweite (m)')}</span>
+          <span className="mb-1 block text-cp-text-secondary">{t('cable.field.maxReach', 'Max. Reichweite (m)')}</span>
           <input
             type="number"
             min={0}
@@ -157,18 +157,18 @@ export const CableProperties = () => {
               const v = event.target.value
               updateCable(cable.id, { maxRange: v === '' ? undefined : Number(v) })
             }}
-            className="w-full rounded border border-slate-700 bg-slate-900 p-2"
+            className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
           />
         </label>
       ) : (
         <label className="block">
-          <span className="mb-1 block text-slate-300">{t('cable.field.length', 'Länge (m)')}</span>
+          <span className="mb-1 block text-cp-text-secondary">{t('cable.field.length', 'Länge (m)')}</span>
           <input
             type="number"
             min={0}
             value={cable.length}
             onChange={(event) => updateCable(cable.id, { length: Number(event.target.value) })}
-            className="w-full rounded border border-slate-700 bg-slate-900 p-2"
+            className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
           />
         </label>
       )}
@@ -183,13 +183,13 @@ export const CableProperties = () => {
           kein leerer "ungrouped"-Eintrag mehr. Wenn das Feld doch leer ist
           (legacy), behandelt isCableVisibleByLayer es wie 'other'. */}
       <label className="block">
-        <span className="mb-1 block text-slate-300">{t('cable.field.layer', 'Ebene (Layer)')}</span>
+        <span className="mb-1 block text-cp-text-secondary">{t('cable.field.layer', 'Ebene (Layer)')}</span>
         <select
           value={cable.layer ?? 'other'}
           onChange={(event) =>
             updateCable(cable.id, { layer: event.target.value || undefined })
           }
-          className="w-full rounded border border-slate-700 bg-slate-900 p-2"
+          className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
           title={t('cable.field.layerTitle', 'Wirkt mit dem Layer-Filter in der Toolbar (Ebenen-Chips)')}
         >
           {STANDARD_LAYERS.map((l) => (
@@ -212,9 +212,9 @@ export const CableProperties = () => {
       {/* #363 — Multicore/Snake-Zuordnung: Kabel mit gleichem Namen bilden
           ein Bündel. Datalist schlägt bereits vergebene Namen vor. */}
       <label className="block">
-        <span className="mb-1 block text-slate-300">
+        <span className="mb-1 block text-cp-text-secondary">
           {t('cable.field.multicore', 'Multicore / Snake')}{' '}
-          <span className="text-slate-500">({t('common.optional', 'optional')})</span>
+          <span className="text-cp-text-faint">({t('common.optional', 'optional')})</span>
         </span>
         <input
           list="cp-multicore-names"
@@ -223,7 +223,7 @@ export const CableProperties = () => {
           onChange={(event) =>
             updateCable(cable.id, { multicoreName: event.target.value.trim() || undefined })
           }
-          className="w-full rounded border border-slate-700 bg-slate-900 p-2"
+          className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
           title={t(
             'cable.field.multicoreTitle',
             'Kabel mit gleichem Namen bilden ein physisches Bündel — die BOM zählt es als 1 Stück.',
@@ -239,7 +239,7 @@ export const CableProperties = () => {
       </label>
 
       {/* #368 — Tie-Line / Festverbindung (permanente Haus-/Dauerleitung). */}
-      <label className="flex items-center gap-2 text-[12px] text-slate-300">
+      <label className="flex items-center gap-2 text-[12px] text-cp-text-secondary">
         <input
           type="checkbox"
           checked={!!cable.isTieLine}
@@ -251,8 +251,8 @@ export const CableProperties = () => {
       {/* #221 — Off-Page-/Pfeil-Connector. Statt einer Linie quer über den
           Plan wird an jedem Ende ein benanntes Connector-Symbol gezeichnet.
           Segmente mit gleichem Netznamen bilden ein gemeinsames Netz. */}
-      <div className="rounded border border-slate-700 bg-slate-950/50 p-2 space-y-2">
-        <label className="flex items-center gap-2 text-[11px] text-slate-300 cursor-pointer">
+      <div className="rounded border border-cp-border bg-cp-surface-3/50 p-2 space-y-2">
+        <label className="flex items-center gap-2 text-[11px] text-cp-text-secondary cursor-pointer">
           <input
             type="checkbox"
             checked={!!cable.offPage}
@@ -271,7 +271,7 @@ export const CableProperties = () => {
         {cable.offPage && (
           <div className="pl-5 space-y-1">
             <label className="block">
-              <span className="mb-0.5 block text-[10px] text-slate-400">
+              <span className="mb-0.5 block text-[10px] text-cp-text-muted">
                 {t('cable.field.netName', 'Netzname / Signalname')}
               </span>
               <input
@@ -281,7 +281,7 @@ export const CableProperties = () => {
                 onChange={(event) =>
                   updateCable(cable.id, { netName: event.target.value.trim() || undefined })
                 }
-                className="w-full rounded border border-slate-700 bg-slate-900 p-1.5 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-1 p-1.5 text-cp-xs"
               />
               <datalist id="cp-offpage-nets">
                 {[
@@ -300,7 +300,7 @@ export const CableProperties = () => {
               const peers = netPeerCount(cables, cable)
               const key = netKeyOf(cable)
               return (
-                <p className={`text-[10px] ${peers > 0 ? 'text-amber-300' : 'text-slate-400'}`}>
+                <p className={`text-[10px] ${peers > 0 ? 'text-amber-300' : 'text-cp-text-muted'}`}>
                   {peers > 0
                     ? format(
                         t(
@@ -322,26 +322,26 @@ export const CableProperties = () => {
 
       {/* Endpoint editor — inline accordion (open by default) so users can
           re-route a cable from the properties panel without opening a dialog. */}
-      <details open className="rounded border border-slate-700 bg-slate-950/50">
-        <summary className="cursor-pointer select-none px-2 py-1.5 text-[11px] text-slate-300 hover:bg-slate-800/40">
-          <span className="font-semibold uppercase tracking-wide text-slate-400">
+      <details open className="rounded border border-cp-border bg-cp-surface-3/50">
+        <summary className="cursor-pointer select-none px-2 py-1.5 text-[11px] text-cp-text-secondary hover:bg-cp-surface-2/40">
+          <span className="font-semibold uppercase tracking-wide text-cp-text-muted">
             {t('cable.field.connection', 'Verbindung')}
           </span>
-          <span className="ml-2 text-slate-300">
+          <span className="ml-2 text-cp-text-secondary">
             {fromDev?.name ?? '?'} · {fromPort?.name ?? cable.fromPortId}
-            <span className="mx-1 text-slate-500">→</span>
+            <span className="mx-1 text-cp-text-faint">→</span>
             {toDev?.name ?? '?'} · {toPort?.name ?? cable.toPortId}
           </span>
         </summary>
-        <div className="border-t border-slate-700 p-2">
+        <div className="border-t border-cp-border p-2">
           <div className="grid grid-cols-2 gap-2">
             <div>
-              <div className="mb-0.5 text-[10px] text-slate-400">{t('cable.fromDeviceShort', 'Von Gerät')}</div>
+              <div className="mb-0.5 text-[10px] text-cp-text-muted">{t('cable.fromDeviceShort', 'Von Gerät')}</div>
               <select
                 aria-label={t('cable.aria.fromDevice', 'Quell-Gerät')}
                 value={cable.fromEquipmentId}
                 onChange={(e) => onSelectFromEquipment(e.target.value)}
-                className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
               >
                 {sortedEquipment.map((eq) => (
                   <option key={eq.id} value={eq.id}>
@@ -349,12 +349,12 @@ export const CableProperties = () => {
                   </option>
                 ))}
               </select>
-              <div className="mt-1 text-[10px] text-slate-400">{t('cable.portShort', 'Port')}</div>
+              <div className="mt-1 text-[10px] text-cp-text-muted">{t('cable.portShort', 'Port')}</div>
               <select
                 aria-label={t('cable.aria.fromPort', 'Quell-Port')}
                 value={cable.fromPortId}
                 onChange={(e) => updateCable(cable.id, { fromPortId: e.target.value })}
-                className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
               >
                 {portsOf(fromDev).map((p) => {
                   const inUse = !!portConflict(cable.fromEquipmentId, p.id)
@@ -368,12 +368,12 @@ export const CableProperties = () => {
               </select>
             </div>
             <div>
-              <div className="mb-0.5 text-[10px] text-slate-400">{t('cable.toDeviceShort', 'Nach Gerät')}</div>
+              <div className="mb-0.5 text-[10px] text-cp-text-muted">{t('cable.toDeviceShort', 'Nach Gerät')}</div>
               <select
                 aria-label={t('cable.aria.toDevice', 'Ziel-Gerät')}
                 value={cable.toEquipmentId}
                 onChange={(e) => onSelectToEquipment(e.target.value)}
-                className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
               >
                 {sortedEquipment.map((eq) => (
                   <option key={eq.id} value={eq.id}>
@@ -381,12 +381,12 @@ export const CableProperties = () => {
                   </option>
                 ))}
               </select>
-              <div className="mt-1 text-[10px] text-slate-400">{t('cable.portShort', 'Port')}</div>
+              <div className="mt-1 text-[10px] text-cp-text-muted">{t('cable.portShort', 'Port')}</div>
               <select
                 aria-label={t('cable.aria.toPort', 'Ziel-Port')}
                 value={cable.toPortId}
                 onChange={(e) => updateCable(cable.id, { toPortId: e.target.value })}
-                className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
               >
                 {portsOf(toDev).map((p) => {
                   const inUse = !!portConflict(cable.toEquipmentId, p.id)
@@ -425,7 +425,7 @@ export const CableProperties = () => {
       </details>
 
       <div>
-        <span className="mb-1 block text-slate-300">{t('cable.field.routing', 'Routing')}</span>
+        <span className="mb-1 block text-cp-text-secondary">{t('cable.field.routing', 'Routing')}</span>
         <RoutingToggle
           value={routing}
           onChange={(value) =>
@@ -435,7 +435,7 @@ export const CableProperties = () => {
       </div>
 
       <label className="block">
-        <span className="mb-1 block text-slate-300">{format(t('cable.field.strokeWidth', 'Stroke width ({width}px)'), { width: cable.strokeWidth ?? 2.5 })}</span>
+        <span className="mb-1 block text-cp-text-secondary">{format(t('cable.field.strokeWidth', 'Stroke width ({width}px)'), { width: cable.strokeWidth ?? 2.5 })}</span>
         <input
           type="range"
           min={1}
@@ -453,7 +453,7 @@ export const CableProperties = () => {
             blendet das Label aus, kein 'ausblenden'-Toggle mehr noetig.
             Globaler Hide-Toggle gibt's zusaetzlich in der Toolbar. */}
         <div className="mb-1 flex items-center justify-between">
-          <span className="text-slate-300">{t('cable.field.labelPosition', 'Label Position')}</span>
+          <span className="text-cp-text-secondary">{t('cable.field.labelPosition', 'Label Position')}</span>
         </div>
         {(() => {
           // Issue #234 — kein extra "Aus"-Button mehr. Wenn keine
@@ -494,7 +494,7 @@ export const CableProperties = () => {
                       className={`flex-1 rounded border px-2 py-1 text-cp-xs ${
                         isActive
                           ? 'border-sky-500 bg-sky-800 text-white'
-                          : 'border-slate-700 bg-slate-900 text-slate-300 hover:bg-slate-800'
+                          : 'border-cp-border bg-cp-surface-1 text-cp-text-secondary hover:bg-cp-surface-2'
                       }`}
                     >
                       {p.label}
@@ -503,13 +503,13 @@ export const CableProperties = () => {
                 })}
               </div>
               {isHidden && (
-                <p className="mt-1 text-[10px] text-slate-400">
+                <p className="mt-1 text-[10px] text-cp-text-muted">
                   Label ausgeblendet — Klick auf eine der drei Positionen
                   zeigt es wieder an.
                 </p>
               )}
               <div className={`mt-2 flex items-center gap-2 text-[11px] ${isHidden ? 'opacity-40' : ''}`}>
-                <span className="text-slate-500">{t('cable.field.labelSlider', 'Slider:')}</span>
+                <span className="text-cp-text-faint">{t('cable.field.labelSlider', 'Slider:')}</span>
                 <input
                   type="range"
                   min={0}
@@ -531,7 +531,7 @@ export const CableProperties = () => {
                   className="flex-1 accent-sky-500"
                   title={t('cable.field.labelSliderTitle', 'Feinjustierung des Labels entlang des Kabels (0=Start, 1=Ende)')}
                 />
-                <span className="w-10 text-right font-mono text-slate-400">
+                <span className="w-10 text-right font-mono text-cp-text-muted">
                   {Math.round(
                     (typeof cable.labelT === 'number'
                       ? cable.labelT
@@ -547,7 +547,7 @@ export const CableProperties = () => {
                   <button
                     type="button"
                     onClick={() => updateCable(cable.id, { labelT: undefined })}
-                    className="rounded bg-slate-800 px-1 py-0.5 text-[10px] text-slate-400 hover:bg-slate-700"
+                    className="rounded bg-cp-surface-2 px-1 py-0.5 text-[10px] text-cp-text-muted hover:bg-cp-surface-4"
                     title={t('cable.field.labelSliderReset', 'Slider zurücksetzen — Preset wieder aktiv')}
                   >
                     reset
@@ -562,9 +562,9 @@ export const CableProperties = () => {
       {/* v7.9.127 — Per-Kabel Override fuer Endpoint-Labels (Pfeile
           ans andere Kabel-Ende). Default 'Auto' folgt dem Global-
           Toggle in Settings -> Editing. */}
-      <div className="rounded border border-slate-800 bg-slate-950/40 p-1.5">
+      <div className="rounded border border-cp-border-muted bg-cp-surface-3/40 p-1.5">
         <div className="mb-1 flex items-center justify-between">
-          <span className="text-slate-300">{t('cable.field.endpointLabels', 'Endpoint-Labels (→ zum anderen Ende)')}</span>
+          <span className="text-cp-text-secondary">{t('cable.field.endpointLabels', 'Endpoint-Labels (→ zum anderen Ende)')}</span>
         </div>
         <div className="flex gap-1">
           {[
@@ -582,7 +582,7 @@ export const CableProperties = () => {
                 className={`flex-1 rounded px-1.5 py-1 text-[11px] ${
                   active
                     ? 'bg-emerald-700/40 text-emerald-100 ring-1 ring-emerald-500'
-                    : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+                    : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
                 }`}
               >
                 {opt.label}
@@ -630,8 +630,8 @@ export const CableProperties = () => {
         </label>
       </div>
 
-      <div className="rounded border border-slate-700 bg-slate-950/50 p-2 space-y-2">
-        <label className="flex items-center gap-2 text-[11px] text-slate-300 cursor-pointer">
+      <div className="rounded border border-cp-border bg-cp-surface-3/50 p-2 space-y-2">
+        <label className="flex items-center gap-2 text-[11px] text-cp-text-secondary cursor-pointer">
           <input
             type="checkbox"
             checked={cable.wireless ?? false}
@@ -642,21 +642,21 @@ export const CableProperties = () => {
         {cable.wireless && (
           <div className="grid grid-cols-2 gap-2 pl-5">
             <label className="block">
-              <span className="mb-0.5 block text-[10px] text-slate-400">{t('cable.field.frequencyLabel', 'Frequenz (z.B. 5.8 GHz)')}</span>
+              <span className="mb-0.5 block text-[10px] text-cp-text-muted">{t('cable.field.frequencyLabel', 'Frequenz (z.B. 5.8 GHz)')}</span>
               <input
                 value={cable.frequency ?? ''}
                 onChange={(event) => updateCable(cable.id, { frequency: event.target.value || undefined })}
                 placeholder={t('cable.field.frequencyPlaceholder', 'z.B. 5.8 GHz, 600 MHz')}
-                className="w-full rounded border border-slate-700 bg-slate-900 p-1.5 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-1 p-1.5 text-cp-xs"
               />
             </label>
             <label className="block">
-              <span className="mb-0.5 block text-[10px] text-slate-400">{t('cable.field.channelLabel', 'Kanal / Channel')}</span>
+              <span className="mb-0.5 block text-[10px] text-cp-text-muted">{t('cable.field.channelLabel', 'Kanal / Channel')}</span>
               <input
                 value={cable.wifiChannel ?? ''}
                 onChange={(event) => updateCable(cable.id, { wifiChannel: event.target.value || undefined })}
                 placeholder={t('cable.field.channelPlaceholder', 'z.B. 36, 6, 149')}
-                className="w-full rounded border border-slate-700 bg-slate-900 p-1.5 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-1 p-1.5 text-cp-xs"
               />
             </label>
           </div>
@@ -664,12 +664,12 @@ export const CableProperties = () => {
       </div>
 
       <label className="block">
-        <span className="mb-1 block text-slate-300">{t('cable.field.notes', 'Notes')}</span>
+        <span className="mb-1 block text-cp-text-secondary">{t('cable.field.notes', 'Notes')}</span>
         <textarea
           value={cable.notes}
           onChange={(event) => updateCable(cable.id, { notes: event.target.value })}
           rows={2}
-          className="w-full rounded border border-slate-700 bg-slate-900 p-2"
+          className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
         />
       </label>
 

--- a/src/renderer/components/Properties/EquipmentProperties.tsx
+++ b/src/renderer/components/Properties/EquipmentProperties.tsx
@@ -90,7 +90,7 @@ export const EquipmentProperties = () => {
   const projectMode = useProjectStore((s) => s.project.mode ?? 'editing')
 
   if (!equipment) {
-    return <div className="text-cp-xs text-slate-400">{t('inspector.selectEquipment', 'Wähle ein Gerät auf dem Canvas.')}</div>
+    return <div className="text-cp-xs text-cp-text-muted">{t('inspector.selectEquipment', 'Wähle ein Gerät auf dem Canvas.')}</div>
   }
 
   const handleSectionDragEnd = (event: DragEndEvent) => {
@@ -129,7 +129,7 @@ export const EquipmentProperties = () => {
 
       <RentmanSyncBadge equipment={equipment} />
       <label className="block">
-        <span className="mb-1 block text-slate-300">{t('eq.field.category', 'Kategorie')}</span>
+        <span className="mb-1 block text-cp-text-secondary">{t('eq.field.category', 'Kategorie')}</span>
         <CategorySelect
           value={equipment.category}
           onChange={(category) => updateEquipment(equipment.id, { category })}

--- a/src/renderer/components/Properties/LocationProperties.tsx
+++ b/src/renderer/components/Properties/LocationProperties.tsx
@@ -24,7 +24,7 @@ export const LocationProperties = () => {
   return (
     <div className="space-y-3 text-cp-xs">
       <div>
-        <div className="mb-1 text-[11px] uppercase tracking-wide text-slate-400">
+        <div className="mb-1 text-[11px] uppercase tracking-wide text-cp-text-muted">
           {t('location.title', 'Location')}
         </div>
         <label className="block">
@@ -32,7 +32,7 @@ export const LocationProperties = () => {
           <input
             value={location.name}
             onChange={(e) => updateLocation(location.id, { name: e.target.value })}
-            className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+            className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
           />
         </label>
       </div>
@@ -46,7 +46,7 @@ export const LocationProperties = () => {
             onChange={(e) =>
               updateLocation(location.id, { width: Math.max(40, Number(e.target.value) || 0) })
             }
-            className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+            className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
           />
         </label>
         <label className="block">
@@ -57,7 +57,7 @@ export const LocationProperties = () => {
             onChange={(e) =>
               updateLocation(location.id, { height: Math.max(40, Number(e.target.value) || 0) })
             }
-            className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+            className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
           />
         </label>
       </div>
@@ -69,7 +69,7 @@ export const LocationProperties = () => {
             value={location.floor ?? ''}
             placeholder={t('location.field.floorPlaceholder', 'z.B. EG, 1.OG')}
             onChange={(e) => updateLocation(location.id, { floor: e.target.value })}
-            className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+            className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
           />
         </label>
         <ColorField
@@ -86,7 +86,7 @@ export const LocationProperties = () => {
             value={location.notes ?? ''}
             onChange={(e) => updateLocation(location.id, { notes: e.target.value })}
             rows={2}
-            className="mt-1 w-full resize-y rounded border border-slate-700 bg-slate-950 p-1.5"
+            className="mt-1 w-full resize-y rounded border border-cp-border bg-cp-surface-3 p-1.5"
           />
         </label>
       </div>
@@ -129,7 +129,7 @@ export const LocationProperties = () => {
               deleteLocation(location.id)
             }
           }}
-          className="w-full rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+          className="w-full rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
           title={t(
             'location.action.deleteFrameTitle',
             'Entfernt nur den Rahmen — Geräte darin bleiben auf dem Canvas.',
@@ -165,7 +165,7 @@ export const LocationProperties = () => {
         </button>
       </div>
 
-      <p className="text-[10px] italic text-slate-400">
+      <p className="text-[10px] italic text-cp-text-muted">
         {t(
           'location.tip',
           'Tipp: Der Rahmen bewegt sich standardmäßig unabhängig. Aktiviere „Geräte mitnehmen", wenn alle enthaltenen Geräte beim Verschieben des Rahmens mitwandern sollen.',

--- a/src/renderer/components/Properties/ModeEditorDialog.tsx
+++ b/src/renderer/components/Properties/ModeEditorDialog.tsx
@@ -151,7 +151,7 @@ export const ModeEditorDialog = ({
           <button
             type="button"
             onClick={onCancel}
-            className="rounded bg-slate-700 px-3 py-1 text-cp-xs hover:bg-slate-600"
+            className="rounded bg-cp-surface-4 px-3 py-1 text-cp-xs hover:bg-cp-surface-5"
           >
             {t('common.cancel', 'Abbrechen')}
           </button>
@@ -170,14 +170,14 @@ export const ModeEditorDialog = ({
         {/* Name & description */}
         <div className="space-y-2">
           <label className="block">
-            <span className="text-slate-400">{t('common.name', 'Name')}</span>
+            <span className="text-cp-text-muted">{t('common.name', 'Name')}</span>
               <input
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder={t('modeEditor.namePlaceholder', 'z.B. "12G Single-Link", "4K-Modus", "Workshop-Layout"')}
                 autoFocus
-                className="mt-0.5 w-full rounded border border-slate-700 bg-slate-950 px-2 py-1 text-slate-100"
+                className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-text"
               />
               {nameConflict && (
                 <span className="mt-0.5 flex items-center gap-1 text-[10px] text-amber-400">
@@ -187,19 +187,19 @@ export const ModeEditorDialog = ({
               )}
             </label>
             <label className="block">
-              <span className="text-slate-400">{t('modeEditor.descLabel', 'Beschreibung (optional)')}</span>
+              <span className="text-cp-text-muted">{t('modeEditor.descLabel', 'Beschreibung (optional)')}</span>
               <textarea
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 rows={2}
                 placeholder={t('modeEditor.descPlaceholder', 'z.B. Begrenzt Outputs auf 2 für 4K-Modus (weniger Ressourcen)')}
-                className="mt-0.5 w-full rounded border border-slate-700 bg-slate-950 px-2 py-1 text-slate-100"
+                className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-text"
               />
             </label>
           </div>
 
           <div className="mt-4 flex items-center justify-between">
-            <div className="text-[10px] text-slate-400">
+            <div className="text-[10px] text-cp-text-muted">
               {format(
                 t('modeEditor.portCount', '{count} Port(s) in diesem Modus'),
                 { count: totalPortCount },
@@ -208,7 +208,7 @@ export const ModeEditorDialog = ({
             <button
               type="button"
               onClick={seedFromCurrent}
-              className="rounded bg-slate-700 px-2 py-1 text-[11px] hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-2 py-1 text-[11px] hover:bg-cp-surface-5"
               title={t('modeEditor.seedTitle', 'Übernimmt das AKTUELLE Port-Layout des Geräts als Startpunkt.')}
             >
               <Icon icon={Download} size="xs" className="mr-1 inline-block align-text-bottom" />{t('modeEditor.seedBtn', 'Aus aktuellem Geräte-Layout übernehmen')}
@@ -225,7 +225,7 @@ export const ModeEditorDialog = ({
             ).map(({ side, label, list, accent }) => (
               <div
                 key={side}
-                className="rounded border border-slate-800 bg-slate-950/40 p-2"
+                className="rounded border border-cp-border-muted bg-cp-surface-3/40 p-2"
               >
                 <div className="mb-2 flex items-center justify-between">
                   <span className={`text-[11px] font-semibold ${
@@ -236,13 +236,13 @@ export const ModeEditorDialog = ({
                   <button
                     type="button"
                     onClick={() => addPort(side)}
-                    className="rounded bg-slate-800 px-2 py-0.5 text-[10px] text-slate-300 hover:bg-slate-700"
+                    className="rounded bg-cp-surface-2 px-2 py-0.5 text-[10px] text-cp-text-secondary hover:bg-cp-surface-4"
                   >
                     + Port
                   </button>
                 </div>
                 {list.length === 0 ? (
-                  <div className="rounded border border-dashed border-slate-700 p-3 text-center text-[10px] text-slate-400">
+                  <div className="rounded border border-dashed border-cp-border p-3 text-center text-[10px] text-cp-text-muted">
                     {format(t('modeEditor.emptySide', 'Keine {kind} in diesem Modus.'), { kind: label.toLowerCase() })}
                   </div>
                 ) : (
@@ -250,14 +250,14 @@ export const ModeEditorDialog = ({
                     {list.map((p) => (
                       <li
                         key={p.id}
-                        className="flex items-center gap-1 rounded border border-slate-800 bg-slate-900/60 p-1"
+                        className="flex items-center gap-1 rounded border border-cp-border-muted bg-cp-surface-1/60 p-1"
                       >
                         <input
                           type="text"
                           value={p.name}
                           onChange={(e) => updatePort(side, p.id, { name: e.target.value })}
                           placeholder={t('ports.namePlaceholder', 'Port-Name')}
-                          className="flex-1 rounded border border-slate-700 bg-slate-950 px-1.5 py-0.5 text-[11px]"
+                          className="flex-1 rounded border border-cp-border bg-cp-surface-3 px-1.5 py-0.5 text-[11px]"
                         />
                         <select
                           value={p.connectorType}
@@ -266,7 +266,7 @@ export const ModeEditorDialog = ({
                               connectorType: e.target.value as ConnectorType,
                             })
                           }
-                          className="w-28 rounded border border-slate-700 bg-slate-950 px-1 py-0.5 text-[10px]"
+                          className="w-28 rounded border border-cp-border bg-cp-surface-3 px-1 py-0.5 text-[10px]"
                         >
                           {ALL_CONNECTOR_TYPES.map((c) => (
                             <option key={c} value={c}>

--- a/src/renderer/components/Properties/PortList.tsx
+++ b/src/renderer/components/Properties/PortList.tsx
@@ -85,12 +85,12 @@ const SortablePortItem = ({ port, children }: SortablePortItemProps) => {
         transform: CSS.Transform.toString(transform),
         transition,
       }}
-      className={`rounded border border-slate-800 bg-slate-900 p-2 ${isDragging ? 'opacity-60 shadow-lg shadow-slate-950/50' : ''}`}
+      className={`rounded border border-cp-border-muted bg-cp-surface-1 p-2 ${isDragging ? 'opacity-60 shadow-lg shadow-slate-950/50' : ''}`}
     >
       <div className="flex items-start gap-2">
         <button
           type="button"
-          className="mt-1 cursor-grab rounded border border-slate-700 bg-slate-950 px-1.5 py-1 text-[11px] text-slate-400 hover:bg-slate-900 active:cursor-grabbing"
+          className="mt-1 cursor-grab rounded border border-cp-border bg-cp-surface-3 px-1.5 py-1 text-[11px] text-cp-text-muted hover:bg-cp-surface-1 active:cursor-grabbing"
           title={t('ports.dragHandle', 'Port-Reihenfolge ändern')}
           aria-label={`Reorder ${port.name}`}
           {...attributes}
@@ -481,22 +481,22 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
   void effectivePortNumber
 
   return (
-    <div className="rounded border border-slate-700 p-2">
+    <div className="rounded border border-cp-border p-2">
       <div className="mb-2 flex items-center justify-between">
         {/* v7.9.63 / #185 — Wrapper-Details liefert eigene Headline mit
             Count; PortList-Title hier ausgeblendet damit's nicht doppelt
             steht. Bei direkter Verwendung (ohne Wrapper) bleibt der
             Titel sichtbar. */}
-        <span className="text-cp-xs font-semibold uppercase tracking-wide text-slate-300">{hideTitle ? '' : title}</span>
+        <span className="text-cp-xs font-semibold uppercase tracking-wide text-cp-text-secondary">{hideTitle ? '' : title}</span>
         <button
           type="button"
           onClick={addPort}
-          className="rounded bg-slate-700 px-2 py-0.5 text-[11px] hover:bg-slate-600"
+          className="rounded bg-cp-surface-4 px-2 py-0.5 text-[11px] hover:bg-cp-surface-5"
         >
           {t('ports.add', '+ Hinzufügen')}
         </button>
       </div>
-      {ports.length === 0 && <div className="text-[11px] text-slate-400">{t('ports.none', 'Keine')}</div>}
+      {ports.length === 0 && <div className="text-[11px] text-cp-text-muted">{t('ports.none', 'Keine')}</div>}
       {duplicatePortNumbers.length > 0 && (
         <div className="mb-2 rounded border border-amber-700 bg-amber-950/40 px-2 py-1 text-[11px] text-amber-200">
           {format(t('ports.duplicateNumbers', 'Doppelte Port-Nummern: {nums} — für Beschriftung/Patchliste mehrdeutig.'), {
@@ -523,13 +523,13 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                 }}
                 placeholder={String(portIdx + 1)}
                 title={`Anzeige-Nummer (Default ${portIdx + 1}). Leer = automatisch.`}
-                className="w-12 shrink-0 rounded border border-slate-700 bg-slate-950 p-1 text-center text-cp-xs tabular-nums"
+                className="w-12 shrink-0 rounded border border-cp-border bg-cp-surface-3 p-1 text-center text-cp-xs tabular-nums"
               />
               <input
                 value={port.name}
                 onChange={(event) => updatePort(port.id, { name: event.target.value })}
                 placeholder={t('ports.namePlaceholder', 'Port-Name')}
-                className="flex-1 rounded border border-slate-700 bg-slate-950 p-1 text-cp-xs"
+                className="flex-1 rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
               />
               <Tooltip label={t('ports.remove', 'Port entfernen')}>
                 <button
@@ -562,7 +562,7 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                       type: v,
                     })
                   }}
-                  className="flex-1 rounded border border-slate-700 bg-slate-950 p-1 text-cp-xs"
+                  className="flex-1 rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
                 >
                   {allConnectorTypeOptions.map((type) => (
                     <option key={type} value={type}>
@@ -591,7 +591,7 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                       standard: v ? (v as SignalStandard) : undefined,
                     })
                   }}
-                  className="flex-1 rounded border border-slate-700 bg-slate-950 p-1 text-cp-xs"
+                  className="flex-1 rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
                 >
                   <option value="">-</option>
                   {allSignalStandardOptions.map((std) => (
@@ -618,7 +618,7 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                   updatePort(port.id, { contentLabel: v ? v : undefined })
                 }}
                 placeholder={t('ports.contentLabelPlaceholder', 'Inhalt / Funktion (z.B. PGM, PVW, MV1, Cam1) — optional')}
-                className="w-full rounded border border-slate-700 bg-slate-950 p-1 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
                 title={t('ports.contentLabelTitle', "Was geht durch diesen Port? Trennt 'Inhalt' (PGM/PVW) vom Hardware-Standard (SDI 3G/12G).")}
               />
             </div>
@@ -633,7 +633,7 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                       : undefined,
                   })
                 }
-                className="w-full rounded border border-slate-700 bg-slate-950 p-1 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
                 title={t('ports.directionTitle', 'Richtung - bidirektional ist z.B. für Netzwerk-/RJ45-Ports sinnvoll')}
               >
                 <option value="">{t('ports.direction.auto', 'Richtung (auto)')}</option>
@@ -649,7 +649,7 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                     side: event.target.value ? (event.target.value as 'left' | 'right') : undefined,
                   })
                 }
-                className="w-full rounded border border-slate-700 bg-slate-950 p-1 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
                 title={t('ports.sideTitle', 'Port-Seite am Gerät: Auto nutzt Input/Output + globale Spiegelung')}
               >
                 <option value="">{t('ports.side.auto', 'Seite (auto)')}</option>
@@ -669,7 +669,7 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                       : undefined,
                   })
                 }
-                className="w-full rounded border border-slate-700 bg-slate-950 p-1 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
                 title={t('ports.genderTitle', 'Steckverbinder-Geschlecht (für die Kabel-Konfektion)')}
               >
                 <option value="">{t('ports.gender.none', 'Geschlecht (–)')}</option>
@@ -695,9 +695,9 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                   }}
                   placeholder={t('ports.atemSourceIdPlaceholder', 'z.B. 8001 für AUX 1')}
                   title={t('ports.atemSourceIdTitle', 'Source-ID die im MV-Config-Dialog adressiert wird. AUX = 8001+, PGM = 10010, PVW = 10011, ME 2 PGM = 10020 …. Bei Inputs leer lassen für idx+1-Default.')}
-                  className="w-32 rounded border border-slate-700 bg-slate-950 p-1 text-cp-xs"
+                  className="w-32 rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
                 />
-                <span className="text-[10px] text-slate-400">
+                <span className="text-[10px] text-cp-text-muted">
                   AUX 8001+ · PGM 10010 · PVW 10011
                 </span>
               </div>
@@ -710,35 +710,35 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                     value={port.sfpType ?? ''}
                     onChange={(event) => updatePort(port.id, { sfpType: event.target.value || undefined })}
                     placeholder={t('ports.sfp.typePlaceholder', 'Formfaktor (SFP+)')}
-                    className="rounded border border-slate-700 bg-slate-950 p-1 text-cp-xs"
+                    className="rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
                     title={t('ports.sfp.typeTitle', 'SFP-Formfaktor: SFP, SFP+, SFP28, QSFP+')}
                   />
                   <input
                     value={port.sfpStandard ?? ''}
                     onChange={(event) => updatePort(port.id, { sfpStandard: event.target.value || undefined })}
                     placeholder={t('ports.sfp.standardPlaceholder', 'Standard (10G-LR)')}
-                    className="rounded border border-slate-700 bg-slate-950 p-1 text-cp-xs"
+                    className="rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
                     title={t('ports.sfp.standardTitle', 'Transceiver-Standard: 1G-SX, 1G-LX, 10G-SR, 10G-LR, 25G-SR …')}
                   />
                   <input
                     value={port.sfpWavelength ?? ''}
                     onChange={(event) => updatePort(port.id, { sfpWavelength: event.target.value || undefined })}
                     placeholder={t('ports.sfp.wavelengthPlaceholder', 'Wellenlänge nm (1310)')}
-                    className="rounded border border-slate-700 bg-slate-950 p-1 text-cp-xs"
+                    className="rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
                     title={t('ports.sfp.wavelengthTitle', 'Wellenlänge in nm: 850, 1310, 1550')}
                   />
                   <input
                     value={port.sfpVendor ?? ''}
                     onChange={(event) => updatePort(port.id, { sfpVendor: event.target.value || undefined })}
                     placeholder={t('ports.sfp.vendorPlaceholder', 'Hersteller (Cisco)')}
-                    className="rounded border border-slate-700 bg-slate-950 p-1 text-cp-xs"
+                    className="rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
                     title={t('ports.sfp.vendorTitle', 'Modulhersteller: Cisco, Aruba, Ubiquiti, FS.com …')}
                   />
                   {/* #362 — Optischer Steckverbinder + Faserklasse (LWL-Detail). */}
                   <select
                     value={port.fiberConnector ?? ''}
                     onChange={(event) => updatePort(port.id, { fiberConnector: event.target.value || undefined })}
-                    className="rounded border border-slate-700 bg-slate-950 p-1 text-cp-xs"
+                    className="rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
                     title={t('ports.fiber.connectorTitle', 'Optischer Steckverbinder')}
                   >
                     <option value="">{t('ports.fiber.connectorPlaceholder', 'Stecker (LC/SC/…)')}</option>
@@ -749,7 +749,7 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                   <select
                     value={port.fiberClass ?? ''}
                     onChange={(event) => updatePort(port.id, { fiberClass: event.target.value || undefined })}
-                    className="rounded border border-slate-700 bg-slate-950 p-1 text-cp-xs"
+                    className="rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
                     title={t('ports.fiber.classTitle', 'Faserklasse: OM1–OM5 (Multimode), OS1/OS2 (Singlemode)')}
                   >
                     <option value="">{t('ports.fiber.classPlaceholder', 'Faserklasse (OM/OS)')}</option>
@@ -781,7 +781,7 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                       Level-Optionen bedeutungslos und nur visueller Lärm. */}
                   {port.sdiCaps?.maxSingleLink === 'SDI-3G' && (
                     <>
-                      <label className="flex items-center gap-1 text-slate-300">
+                      <label className="flex items-center gap-1 text-cp-text-secondary">
                         <input
                           type="checkbox"
                           checked={!!port.sdiCaps?.levelA}
@@ -796,7 +796,7 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                         />
                         3G Level A
                       </label>
-                      <label className="flex items-center gap-1 text-slate-300">
+                      <label className="flex items-center gap-1 text-cp-text-secondary">
                         <input
                           type="checkbox"
                           checked={!!port.sdiCaps?.levelB}
@@ -814,7 +814,7 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                     </>
                   )}
                   <label className="col-span-2 block">
-                    <span className="text-slate-400">{t('ports.sdi.maxSingleLink', 'Max Single-Link')}</span>
+                    <span className="text-cp-text-muted">{t('ports.sdi.maxSingleLink', 'Max Single-Link')}</span>
                     <select
                       value={port.sdiCaps?.maxSingleLink ?? ''}
                       onChange={(e) =>
@@ -827,7 +827,7 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                           },
                         })
                       }
-                      className="mt-0.5 w-full rounded border border-slate-700 bg-slate-950 p-1 text-cp-xs"
+                      className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
                     >
                       <option value="">({t('ports.sdi.deviceDefault', 'Geräte-Default')})</option>
                       <option value="SDI-HD">SDI-HD (1.5G)</option>
@@ -837,7 +837,7 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                     </select>
                   </label>
                 </div>
-                <div className="mt-1 text-[11px] text-slate-400">
+                <div className="mt-1 text-[11px] text-cp-text-muted">
                   {t(
                     'ports.sdi.overrideHint',
                     'Überschreibt die Geräte-SDI-Fähigkeiten für diesen Port. Leer = Default vom Gerät.',
@@ -849,11 +849,11 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                   const ok = count === 4
                   return (
                     <div className="mt-1.5 flex items-center gap-1 text-[10px]">
-                      <span className="text-slate-400">{t('ports.sdi.quadSet', 'Quad-Link Set:')}</span>
+                      <span className="text-cp-text-muted">{t('ports.sdi.quadSet', 'Quad-Link Set:')}</span>
                       <select
                         value={g ?? ''}
                         onChange={(e) => void assignQuadGroup(port.id, e.target.value)}
-                        className="rounded border border-slate-700 bg-slate-950 px-1 py-0.5 text-[10px]"
+                        className="rounded border border-cp-border bg-cp-surface-3 px-1 py-0.5 text-[10px]"
                       >
                         <option value="">— Kein —</option>
                         {existingQuadGroups.map((gid) => (
@@ -896,11 +896,11 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                   const ok = count === 2
                   return (
                     <div className="mt-1 flex items-center gap-1 text-[10px]">
-                      <span className="text-slate-400">{t('ports.sdi.dualSet', 'Dual-Link Set:')}</span>
+                      <span className="text-cp-text-muted">{t('ports.sdi.dualSet', 'Dual-Link Set:')}</span>
                       <select
                         value={g ?? ''}
                         onChange={(e) => void assignDualGroup(port.id, e.target.value)}
-                        className="rounded border border-slate-700 bg-slate-950 px-1 py-0.5 text-[10px]"
+                        className="rounded border border-cp-border bg-cp-surface-3 px-1 py-0.5 text-[10px]"
                       >
                         <option value="">— Kein —</option>
                         {existingDualGroups.map((gid) => (

--- a/src/renderer/components/Properties/PropertiesPanel.tsx
+++ b/src/renderer/components/Properties/PropertiesPanel.tsx
@@ -66,9 +66,9 @@ export const PropertiesPanel = () => {
         {selectedLocationId && <LocationProperties />}
         {selectedTemplateName && <TemplateProperties />}
         {!selectedEquipmentId && !selectedCableId && !selectedLocationId && !selectedTemplateName && (
-          <div className="space-y-3 text-cp-xs text-slate-400">
-            <div className="rounded border border-slate-800 bg-slate-900/50 p-3">
-              <div className="mb-1 font-semibold text-slate-200">
+          <div className="space-y-3 text-cp-xs text-cp-text-muted">
+            <div className="rounded border border-cp-border-muted bg-cp-surface-1/50 p-3">
+              <div className="mb-1 font-semibold text-cp-text-bright">
                 {t('inspector.nothingSelected', 'Nichts ausgewählt')}
               </div>
               <div>
@@ -78,8 +78,8 @@ export const PropertiesPanel = () => {
                 )}
               </div>
             </div>
-            <div className="rounded border border-slate-800 bg-slate-900/40 p-3">
-              <div className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+            <div className="rounded border border-cp-border-muted bg-cp-surface-1/40 p-3">
+              <div className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-cp-text-muted">
                 {t('inspector.hints.title', 'Schnelle Orientierung')}
               </div>
               <div className="space-y-1">
@@ -126,8 +126,8 @@ export const PropertiesPanel = () => {
       <FloatingPanelShell
         title={
           <span className="flex flex-col">
-            <span className="text-cp-base font-semibold text-slate-100">{title}</span>
-            <span className="text-[10px] uppercase tracking-wide text-slate-400">
+            <span className="text-cp-base font-semibold text-cp-text">{title}</span>
+            <span className="text-[10px] uppercase tracking-wide text-cp-text-muted">
               {t('inspector.subtitle', 'Eigenschaften')}
             </span>
           </span>
@@ -150,13 +150,13 @@ export const PropertiesPanel = () => {
 
   if (collapsed) {
     return (
-      <aside className="group flex h-full w-8 flex-col items-center border-l border-slate-700 bg-slate-950 transition-colors hover:bg-slate-900">
+      <aside className="group flex h-full w-8 flex-col items-center border-l border-cp-border bg-cp-surface-3 transition-colors hover:bg-cp-surface-1">
         <button
           type="button"
           onClick={toggle}
           title={t('inspector.collapse.show', 'Eigenschaften einblenden')}
           aria-label={t('inspector.collapse.show', 'Eigenschaften einblenden')}
-          className="mt-2 flex h-7 w-7 items-center justify-center rounded-full border border-slate-700 bg-slate-900 text-slate-300 shadow-sm transition-all hover:border-sky-500 hover:bg-slate-800 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+          className="mt-2 flex h-7 w-7 items-center justify-center rounded-full border border-cp-border bg-cp-surface-1 text-cp-text-secondary shadow-sm transition-all hover:border-sky-500 hover:bg-cp-surface-2 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
         >
           <span className="text-cp-lg leading-none">‹</span>
         </button>
@@ -164,7 +164,7 @@ export const PropertiesPanel = () => {
           type="button"
           onClick={toggle}
           aria-label={t('inspector.collapse.show', 'Eigenschaften einblenden')}
-          className="mt-3 flex-1 self-stretch text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400 transition-colors hover:text-slate-300 focus-visible:outline-none focus-visible:text-sky-300"
+          className="mt-3 flex-1 self-stretch text-[10px] font-semibold uppercase tracking-[0.18em] text-cp-text-muted transition-colors hover:text-cp-text-secondary focus-visible:outline-none focus-visible:text-sky-300"
           style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}
         >
           {t('inspector.subtitle', 'Eigenschaften')}
@@ -174,11 +174,11 @@ export const PropertiesPanel = () => {
   }
 
   return (
-    <aside className="flex h-full min-h-0 flex-col border-l border-slate-700 bg-slate-950 text-slate-100">
-      <div className="flex items-start justify-between gap-2 border-b border-slate-800 px-3 py-2.5">
+    <aside className="flex h-full min-h-0 flex-col border-l border-cp-border bg-cp-surface-3 text-cp-text">
+      <div className="flex items-start justify-between gap-2 border-b border-cp-border-muted px-3 py-2.5">
         <div className="min-w-0">
           <h2 className="truncate text-cp-base font-semibold">{title}</h2>
-          <div className="mt-0.5 text-[10px] uppercase tracking-wide text-slate-400">
+          <div className="mt-0.5 text-[10px] uppercase tracking-wide text-cp-text-muted">
             {t('inspector.subtitle', 'Eigenschaften')}
           </div>
         </div>
@@ -196,7 +196,7 @@ export const PropertiesPanel = () => {
             }}
             title={t('inspector.float.title', 'Eigenschaften abdocken (klicken oder herausziehen)')}
             aria-label={t('inspector.float.aria', 'Eigenschaften abdocken')}
-            className="flex h-7 w-7 items-center justify-center rounded-full border border-slate-700 bg-slate-900 text-slate-300 transition-all hover:border-sky-500 hover:bg-slate-800 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+            className="flex h-7 w-7 items-center justify-center rounded-full border border-cp-border bg-cp-surface-1 text-cp-text-secondary transition-all hover:border-sky-500 hover:bg-cp-surface-2 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
             style={{ touchAction: 'none' }}
           >
             <span className="pointer-events-none text-[11px] leading-none">⤢</span>
@@ -206,7 +206,7 @@ export const PropertiesPanel = () => {
             onClick={() => openPanelPopout('properties')}
             title={t('panel.popoutTitle', 'In separates Fenster auslagern (weiterer Monitor)')}
             aria-label={t('panel.popout', 'Auslagern')}
-            className="flex h-7 w-7 items-center justify-center rounded-full border border-slate-700 bg-slate-900 text-slate-300 transition-all hover:border-sky-500 hover:bg-slate-800 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+            className="flex h-7 w-7 items-center justify-center rounded-full border border-cp-border bg-cp-surface-1 text-cp-text-secondary transition-all hover:border-sky-500 hover:bg-cp-surface-2 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
           >
             <Icon icon={ExternalLink} size="xs" />
           </button>
@@ -215,7 +215,7 @@ export const PropertiesPanel = () => {
             onClick={toggle}
             title={t('inspector.collapse.hide', 'Eigenschaften ausblenden')}
             aria-label={t('inspector.collapse.hide', 'Eigenschaften ausblenden')}
-            className="flex h-7 w-7 items-center justify-center rounded-full border border-slate-700 bg-slate-900 text-slate-300 transition-all hover:border-sky-500 hover:bg-slate-800 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+            className="flex h-7 w-7 items-center justify-center rounded-full border border-cp-border bg-cp-surface-1 text-cp-text-secondary transition-all hover:border-sky-500 hover:bg-cp-surface-2 hover:text-sky-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
           >
             <span className="text-cp-lg leading-none">›</span>
           </button>

--- a/src/renderer/components/Properties/SortableSection.tsx
+++ b/src/renderer/components/Properties/SortableSection.tsx
@@ -29,7 +29,7 @@ export const SortableSection = ({
     <details
       ref={setNodeRef}
       open={defaultOpen}
-      className={`rounded border border-slate-700 bg-slate-900/40 [&_summary]:cursor-pointer ${
+      className={`rounded border border-cp-border bg-cp-surface-1/40 [&_summary]:cursor-pointer ${
         isDragging ? 'opacity-60 shadow-xl shadow-slate-950/50' : ''
       }`}
       style={{
@@ -38,7 +38,7 @@ export const SortableSection = ({
         transition,
       }}
     >
-      <summary className="flex items-center gap-2 px-2 py-1.5 text-[11px] uppercase tracking-wide text-slate-400 hover:text-slate-200">
+      <summary className="flex items-center gap-2 px-2 py-1.5 text-[11px] uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright">
         {/* #421 — Drag-Handle deutlicher: groesseres ⠿-Glyph, hellere Farbe,
             breitere Klickflaeche; sichtbar auf jeder Sektion damit klar ist,
             dass die Reihenfolge per Drag&Drop am Handle aenderbar ist. */}
@@ -46,7 +46,7 @@ export const SortableSection = ({
           {...attributes}
           {...listeners}
           title={t('props.section.dragTitle', 'Sektion ziehen, um Reihenfolge zu ändern (geräteübergreifend persistiert).')}
-          className="-my-1 inline-flex h-5 w-5 cursor-grab items-center justify-center rounded text-cp-lg leading-none text-slate-400 hover:bg-slate-700/40 hover:text-slate-200 active:cursor-grabbing"
+          className="-my-1 inline-flex h-5 w-5 cursor-grab items-center justify-center rounded text-cp-lg leading-none text-cp-text-muted hover:bg-cp-surface-4/40 hover:text-cp-text-bright active:cursor-grabbing"
           aria-label={t('props.section.dragAria', 'Sektion verschieben')}
           role="button"
           onClick={(e) => e.preventDefault()}
@@ -55,10 +55,10 @@ export const SortableSection = ({
         </span>
         <span className="flex-1">{title}</span>
         {subtitle && (
-          <span className="normal-case text-[10px] text-slate-400">{subtitle}</span>
+          <span className="normal-case text-[10px] text-cp-text-muted">{subtitle}</span>
         )}
       </summary>
-      <div className="border-t border-slate-800 p-2">{children}</div>
+      <div className="border-t border-cp-border-muted p-2">{children}</div>
     </details>
   )
 }

--- a/src/renderer/components/Properties/TemplateProperties.tsx
+++ b/src/renderer/components/Properties/TemplateProperties.tsx
@@ -23,7 +23,7 @@ export const TemplateProperties = () => {
 
   if (!template) {
     return (
-      <div className="text-cp-xs text-slate-400">
+      <div className="text-cp-xs text-cp-text-muted">
         {t('template.noneSelected', 'Keine Vorlage ausgewählt.')}
       </div>
     )
@@ -67,7 +67,7 @@ export const TemplateProperties = () => {
   return (
     <div className="space-y-3 text-cp-xs">
       <div className="flex items-center justify-between">
-        <span className="text-slate-400 text-[10px] uppercase tracking-wide">
+        <span className="text-cp-text-muted text-[10px] uppercase tracking-wide">
           {t('template.title', 'Vorlage')}
         </span>
         {template.rentmanSource && (
@@ -81,34 +81,34 @@ export const TemplateProperties = () => {
       </div>
 
       <label className="block">
-        <span className="mb-1 block text-slate-300">{t('template.field.name', 'Name')}</span>
+        <span className="mb-1 block text-cp-text-secondary">{t('template.field.name', 'Name')}</span>
         <input
           value={name}
           onChange={(e) => setName(e.target.value)}
-          className="w-full rounded border border-slate-700 bg-slate-900 p-2"
+          className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
         />
       </label>
 
       <label className="block">
-        <span className="mb-1 block text-slate-300">
+        <span className="mb-1 block text-cp-text-secondary">
           {t('template.field.category', 'Kategorie')}
         </span>
         <CategorySelect value={category} onChange={setCategory} />
       </label>
 
-      <div className="rounded bg-slate-900 p-2 space-y-1">
+      <div className="rounded bg-cp-surface-1 p-2 space-y-1">
         <div className="flex justify-between">
-          <span className="text-slate-400">{t('template.field.inputs', 'Eingänge')}</span>
-          <span className="text-slate-200">{template.inputs.length}</span>
+          <span className="text-cp-text-muted">{t('template.field.inputs', 'Eingänge')}</span>
+          <span className="text-cp-text-bright">{template.inputs.length}</span>
         </div>
         <div className="flex justify-between">
-          <span className="text-slate-400">{t('template.field.outputs', 'Ausgänge')}</span>
-          <span className="text-slate-200">{template.outputs.length}</span>
+          <span className="text-cp-text-muted">{t('template.field.outputs', 'Ausgänge')}</span>
+          <span className="text-cp-text-bright">{template.outputs.length}</span>
         </div>
         {template.rentmanId && (
           <div className="flex justify-between">
-            <span className="text-slate-400">{t('template.rentmanIdLabel', 'Rentman-ID')}</span>
-            <span className="text-slate-400 truncate max-w-[120px]" title={template.rentmanId}>
+            <span className="text-cp-text-muted">{t('template.rentmanIdLabel', 'Rentman-ID')}</span>
+            <span className="text-cp-text-muted truncate max-w-[120px]" title={template.rentmanId}>
               {template.rentmanId}
             </span>
           </div>

--- a/src/renderer/components/Properties/sections/CategoryPropsSection.tsx
+++ b/src/renderer/components/Properties/sections/CategoryPropsSection.tsx
@@ -6,7 +6,7 @@ import type { EquipmentItem } from '../../../types/equipment'
 import { schemaForCategory, type CategoryFieldDef } from '../../../lib/categorySchemas'
 import type { Lang } from '../../../lib/categoryTranslations'
 
-const inputCls = 'w-full rounded border border-slate-700 bg-slate-900 p-2'
+const inputCls = 'w-full rounded border border-cp-border bg-cp-surface-1 p-2'
 
 const Field = ({
   field,
@@ -29,15 +29,15 @@ const Field = ({
           checked={value === true}
           onChange={(e) => onChange(e.target.checked ? true : undefined)}
         />
-        <span className="text-slate-300">{label}</span>
+        <span className="text-cp-text-secondary">{label}</span>
       </label>
     )
   }
 
   const labelEl = (
-    <span className="mb-1 block text-slate-300">
+    <span className="mb-1 block text-cp-text-secondary">
       {label}
-      {field.unit ? <span className="text-slate-500"> ({field.unit})</span> : null}
+      {field.unit ? <span className="text-cp-text-faint"> ({field.unit})</span> : null}
     </span>
   )
 
@@ -126,10 +126,10 @@ export const CategoryPropsSection = ({ equipment }: { equipment: EquipmentItem }
     <details
       open={open}
       onToggle={(e) => setOpen(e.currentTarget.open)}
-      className="rounded border border-slate-700 [&_summary]:cursor-pointer"
+      className="rounded border border-cp-border [&_summary]:cursor-pointer"
     >
-      <summary className="flex items-center gap-1 px-2 py-1.5 text-[11px] uppercase tracking-wide text-slate-400 hover:text-slate-200 [&::-webkit-details-marker]:hidden">
-        <span className="text-slate-500">{open ? '▾' : '▸'}</span>
+      <summary className="flex items-center gap-1 px-2 py-1.5 text-[11px] uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright [&::-webkit-details-marker]:hidden">
+        <span className="text-cp-text-faint">{open ? '▾' : '▸'}</span>
         <span className="flex-1">
           {t('catprops.title', 'Fachdaten')} — {equipment.category}
         </span>

--- a/src/renderer/components/Properties/sections/DeviceConfigsBlock.tsx
+++ b/src/renderer/components/Properties/sections/DeviceConfigsBlock.tsx
@@ -23,34 +23,34 @@ export const DeviceConfigsBlock = ({ equipmentId }: { equipmentId: string }) => 
     <details
       open={open}
       onToggle={(e) => setOpen(e.currentTarget.open)}
-      className="rounded border border-slate-700 bg-slate-900/40 [&_summary]:cursor-pointer"
+      className="rounded border border-cp-border bg-cp-surface-1/40 [&_summary]:cursor-pointer"
     >
-      <summary className="flex items-center gap-1 px-2 py-1.5 text-[10px] uppercase tracking-wide text-slate-400 hover:text-slate-200 [&::-webkit-details-marker]:hidden">
-        <span className="text-slate-500">{open ? '▾' : '▸'}</span>
+      <summary className="flex items-center gap-1 px-2 py-1.5 text-[10px] uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright [&::-webkit-details-marker]:hidden">
+        <span className="text-cp-text-faint">{open ? '▾' : '▸'}</span>
         <span className="flex-1">{t('props.deviceConfigs.title', 'Konfigurationen')}</span>
         {!open && assigned.length > 0 && (
-          <span className="rounded bg-slate-700/60 px-1 text-[11px] normal-case text-slate-200">
+          <span className="rounded bg-cp-surface-4/60 px-1 text-[11px] normal-case text-cp-text-bright">
             {assigned.length}
           </span>
         )}
       </summary>
       <div className="px-2 pb-2">
       {assigned.length === 0 ? (
-        <div className="text-[11px] text-slate-400">
+        <div className="text-[11px] text-cp-text-muted">
           {t('props.deviceConfigs.none', 'Keine Konfiguration zugeordnet.')}
         </div>
       ) : (
         <ul className="mb-2 space-y-1">
           {assigned.map((e) => (
-            <li key={e.id} className="flex items-center gap-2 rounded bg-slate-950 px-2 py-1 text-[11px]">
+            <li key={e.id} className="flex items-center gap-2 rounded bg-cp-surface-3 px-2 py-1 text-[11px]">
               <span className="flex-1 truncate" title={`${e.fileName} (${e.kind})`}>
                 {e.name}
               </span>
-              <span className="shrink-0 text-[10px] text-slate-400">{e.kind}</span>
+              <span className="shrink-0 text-[10px] text-cp-text-muted">{e.kind}</span>
               <button
                 type="button"
                 onClick={() => updateDeviceConfig(e.id, { equipmentId: undefined })}
-                className="rounded bg-slate-800 px-1.5 py-0.5 text-[10px] text-slate-300 hover:bg-red-700 hover:text-white"
+                className="rounded bg-cp-surface-2 px-1.5 py-0.5 text-[10px] text-cp-text-secondary hover:bg-red-700 hover:text-white"
                 title={t('props.deviceConfigs.unassignTitle', 'Zuordnung lösen (Datei bleibt in der Bibliothek)')}
               >
                 {t('props.deviceConfigs.unassign', 'Lösen')}
@@ -65,7 +65,7 @@ export const DeviceConfigsBlock = ({ equipmentId }: { equipmentId: string }) => 
           onChange={(e) => {
             if (e.target.value) updateDeviceConfig(e.target.value, { equipmentId })
           }}
-          className="w-full rounded border border-slate-700 bg-slate-950 p-1 text-[11px]"
+          className="w-full rounded border border-cp-border bg-cp-surface-3 p-1 text-[11px]"
         >
           <option value="">
             {t('props.deviceConfigs.assignExisting', '+ Vorhandene Konfiguration zuordnen…')}
@@ -77,7 +77,7 @@ export const DeviceConfigsBlock = ({ equipmentId }: { equipmentId: string }) => 
           ))}
         </select>
       )}
-      <div className="mt-1 text-[10px] text-slate-400">
+      <div className="mt-1 text-[10px] text-cp-text-muted">
         {t(
           'props.deviceConfigs.hint',
           'Neue Konfigurationen über Einstellungen → Konfigurationen hochladen.',

--- a/src/renderer/components/Properties/sections/DeviceKindCards.tsx
+++ b/src/renderer/components/Properties/sections/DeviceKindCards.tsx
@@ -118,7 +118,7 @@ export const DeviceKindCards = ({ equipment }: { equipment: EquipmentItem }) => 
         <button
           type="button"
           disabled
-          className="w-full cursor-not-allowed rounded bg-slate-700 px-2 py-1 text-cp-xs opacity-60"
+          className="w-full cursor-not-allowed rounded bg-cp-surface-4 px-2 py-1 text-cp-xs opacity-60"
           title={t('props.deviceKind.mvExportTitle', 'Multiviewer-Layout Export kommt in v0.4.0')}
         >
           {t('props.deviceKind.mvExport', 'Multiviewer Layout Export (v0.4.0)')}

--- a/src/renderer/components/Properties/sections/DisplayPropertiesBlock.tsx
+++ b/src/renderer/components/Properties/sections/DisplayPropertiesBlock.tsx
@@ -43,16 +43,16 @@ export const DisplayPropertiesBlock = ({ equipment }: { equipment: EquipmentItem
     <details
       open={open}
       onToggle={(e) => setOpen(e.currentTarget.open)}
-      className="rounded border border-slate-700 [&_summary]:cursor-pointer"
+      className="rounded border border-cp-border [&_summary]:cursor-pointer"
     >
-      <summary className="flex items-center gap-1 px-2 py-1.5 text-[11px] uppercase tracking-wide text-slate-400 hover:text-slate-200 [&::-webkit-details-marker]:hidden">
-        <span className="text-slate-500">{open ? '▾' : '▸'}</span>
+      <summary className="flex items-center gap-1 px-2 py-1.5 text-[11px] uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright [&::-webkit-details-marker]:hidden">
+        <span className="text-cp-text-faint">{open ? '▾' : '▸'}</span>
         <span className="flex-1">{t('display.title', 'Display')}</span>
       </summary>
       <div className="px-2 pb-2">
       <div className="grid grid-cols-2 gap-2">
         <label className="block">
-          <span className="mb-1 block text-slate-300">{t('display.resolution', 'Auflösung')}</span>
+          <span className="mb-1 block text-cp-text-secondary">{t('display.resolution', 'Auflösung')}</span>
           <input
             list="display-resolution-options"
             value={equipment.resolution ?? ''}
@@ -60,7 +60,7 @@ export const DisplayPropertiesBlock = ({ equipment }: { equipment: EquipmentItem
               updateEquipment(equipment.id, { resolution: event.target.value || undefined })
             }
             placeholder="1920x1080"
-            className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono"
+            className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
           />
           <datalist id="display-resolution-options">
             {RESOLUTION_PRESETS.map((r) => (
@@ -69,7 +69,7 @@ export const DisplayPropertiesBlock = ({ equipment }: { equipment: EquipmentItem
           </datalist>
         </label>
         <label className="block">
-          <span className="mb-1 block text-slate-300">{t('display.diagonal', 'Diagonale (Zoll)')}</span>
+          <span className="mb-1 block text-cp-text-secondary">{t('display.diagonal', 'Diagonale (Zoll)')}</span>
           <input
             type="number"
             min={1}
@@ -82,7 +82,7 @@ export const DisplayPropertiesBlock = ({ equipment }: { equipment: EquipmentItem
               })
             }}
             placeholder="27"
-            className="w-full rounded border border-slate-700 bg-slate-900 p-2"
+            className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
           />
         </label>
       </div>

--- a/src/renderer/components/Properties/sections/IdentityBlock.tsx
+++ b/src/renderer/components/Properties/sections/IdentityBlock.tsx
@@ -17,11 +17,11 @@ export const IdentityBlock = ({ equipment }: { equipment: EquipmentItem }) => {
   return (
     <>
       <label className="block">
-        <span className="mb-1 block text-slate-300">{t('eq.field.name', 'Name')}</span>
+        <span className="mb-1 block text-cp-text-secondary">{t('eq.field.name', 'Name')}</span>
         <input
           value={equipment.name}
           onChange={(event) => updateEquipment(equipment.id, { name: event.target.value })}
-          className="w-full rounded border border-slate-700 bg-slate-900 p-2"
+          className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
         />
       </label>
 
@@ -30,9 +30,9 @@ export const IdentityBlock = ({ equipment }: { equipment: EquipmentItem }) => {
           auto-generiert aus name (Placeholder zeigt den Vorschlag).
           Refresh-Button setzt den Override auf den Auto-Vorschlag. */}
       <label className="block">
-        <span className="mb-1 block text-slate-300">
+        <span className="mb-1 block text-cp-text-secondary">
           {t('eq.field.shortName', 'Short-Name')}{' '}
-          <span className="text-slate-500">
+          <span className="text-cp-text-faint">
             ({t('common.optional', 'optional')},{' '}
             {t(
               'eq.field.shortNameHint',
@@ -50,7 +50,7 @@ export const IdentityBlock = ({ equipment }: { equipment: EquipmentItem }) => {
                 shortName: event.target.value || undefined,
               })
             }
-            className="flex-1 rounded border border-slate-700 bg-slate-900 p-2"
+            className="flex-1 rounded border border-cp-border bg-cp-surface-1 p-2"
           />
           <button
             type="button"
@@ -63,23 +63,23 @@ export const IdentityBlock = ({ equipment }: { equipment: EquipmentItem }) => {
                 ? `${t('eq.field.shortNameAuto', 'Aus Namen neu generieren')} (${autoSuggestion})`
                 : t('eq.field.shortNameAutoEmpty', 'Kein Vorschlag — Name pflegen.')
             }
-            className="shrink-0 rounded border border-slate-700 bg-slate-800 px-2 text-cp-xs text-slate-200 hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+            className="shrink-0 rounded border border-cp-border bg-cp-surface-2 px-2 text-cp-xs text-cp-text-bright hover:bg-cp-surface-4 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {t('eq.field.shortNameAutoBtn', '↻ auto')}
           </button>
         </div>
         {!equipment.shortName?.trim() && autoSuggestion && (
-          <p className="mt-1 text-[10px] text-slate-400">
+          <p className="mt-1 text-[10px] text-cp-text-muted">
             {t('eq.field.shortNameAutoUsed', 'Verwendet automatisch:')}{' '}
-            <span className="font-mono text-slate-400">{autoSuggestion}</span>
+            <span className="font-mono text-cp-text-muted">{autoSuggestion}</span>
           </p>
         )}
       </label>
 
       <label className="block">
-        <span className="mb-1 block text-slate-300">
+        <span className="mb-1 block text-cp-text-secondary">
           {t('eq.field.subtitle', 'Untertitel')}{' '}
-          <span className="text-slate-500">
+          <span className="text-cp-text-faint">
             ({t('common.optional', 'optional')}, {t('eq.field.subtitleHint', 'z.B. "PGM Monitor"')})
           </span>
         </span>
@@ -87,7 +87,7 @@ export const IdentityBlock = ({ equipment }: { equipment: EquipmentItem }) => {
           value={equipment.subtitle ?? ''}
           placeholder={t('eq.field.subtitlePlaceholder', 'Untertitel…')}
           onChange={(event) => updateEquipment(equipment.id, { subtitle: event.target.value || undefined })}
-          className="w-full rounded border border-slate-700 bg-slate-900 p-2"
+          className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
         />
       </label>
     </>

--- a/src/renderer/components/Properties/sections/NetworkAccessSection.tsx
+++ b/src/renderer/components/Properties/sections/NetworkAccessSection.tsx
@@ -108,7 +108,7 @@ export const NetworkAccessSection = ({ equipment }: { equipment: EquipmentItem }
                   ? t('eq.field.passwordHide', 'Passwort verbergen')
                   : t('eq.field.passwordShow', 'Passwort anzeigen')
               }
-              className="absolute inset-y-0 right-0 flex items-center px-2 text-cp-text-muted hover:text-slate-200"
+              className="absolute inset-y-0 right-0 flex items-center px-2 text-cp-text-muted hover:text-cp-text-bright"
             >
               <Icon icon={showPassword ? EyeOff : Eye} size="sm" />
             </button>

--- a/src/renderer/components/Properties/sections/NetworkConfig.tsx
+++ b/src/renderer/components/Properties/sections/NetworkConfig.tsx
@@ -63,7 +63,7 @@ export const NetworkConfig = ({ equipmentId, item, allPorts, kind }: NetworkConf
         </legend>
         <div className="grid grid-cols-2 gap-2">
           <label className="block">
-            <span className="mb-1 block text-slate-300">{t('net.mgmtVlan', 'Management VLAN')}</span>
+            <span className="mb-1 block text-cp-text-secondary">{t('net.mgmtVlan', 'Management VLAN')}</span>
             <input
               type="number"
               value={item.managementVlanId ?? ''}
@@ -73,46 +73,46 @@ export const NetworkConfig = ({ equipmentId, item, allPorts, kind }: NetworkConf
                 })
               }
               placeholder="1"
-              className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono"
+              className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
             />
           </label>
           <label className="block">
-            <span className="mb-1 block text-slate-300">{t('net.gateway', 'Gateway')}</span>
+            <span className="mb-1 block text-cp-text-secondary">{t('net.gateway', 'Gateway')}</span>
             <input
               value={item.gateway ?? ''}
               onChange={(event) => updateEquipment(equipmentId, { gateway: event.target.value })}
               placeholder="192.168.1.1"
-              className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono"
+              className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
             />
           </label>
           <label className="block">
-            <span className="mb-1 block text-slate-300">DNS</span>
+            <span className="mb-1 block text-cp-text-secondary">DNS</span>
             <input
               value={item.dnsServers ?? ''}
               onChange={(event) =>
                 updateEquipment(equipmentId, { dnsServers: event.target.value })
               }
               placeholder="1.1.1.1, 8.8.8.8"
-              className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono"
+              className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
             />
           </label>
           <label className="block">
-            <span className="mb-1 block text-slate-300">{t('net.firmware', 'Firmware')}</span>
+            <span className="mb-1 block text-cp-text-secondary">{t('net.firmware', 'Firmware')}</span>
             <input
               value={item.firmware ?? ''}
               onChange={(event) => updateEquipment(equipmentId, { firmware: event.target.value })}
               placeholder="v2.8.4"
-              className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono"
+              className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
             />
           </label>
         </div>
         <label className="mt-2 block">
-          <span className="mb-1 block text-slate-300">{t('net.mgmtUrl', 'Management URL')}</span>
+          <span className="mb-1 block text-cp-text-secondary">{t('net.mgmtUrl', 'Management URL')}</span>
           <input
             value={item.mgmtUrl ?? ''}
             onChange={(event) => updateEquipment(equipmentId, { mgmtUrl: event.target.value })}
             placeholder="https://192.168.1.1/"
-            className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono"
+            className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
           />
         </label>
       </fieldset>
@@ -129,7 +129,7 @@ export const NetworkConfig = ({ equipmentId, item, allPorts, kind }: NetworkConf
           </button>
         </div>
         {vlans.length === 0 && (
-          <div className="text-[11px] text-slate-400">{t('net.noVlans', 'Keine VLANs definiert.')}</div>
+          <div className="text-[11px] text-cp-text-muted">{t('net.noVlans', 'Keine VLANs definiert.')}</div>
         )}
         <ul className="space-y-1">
           {vlans.map((v, i) => (
@@ -138,19 +138,19 @@ export const NetworkConfig = ({ equipmentId, item, allPorts, kind }: NetworkConf
                 type="number"
                 value={v.id}
                 onChange={(event) => updateVlan(i, { id: Number(event.target.value) })}
-                className="w-16 rounded border border-slate-700 bg-slate-950 p-1 text-cp-xs font-mono"
+                className="w-16 rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs font-mono"
                 placeholder="ID"
               />
               <input
                 value={v.name}
                 onChange={(event) => updateVlan(i, { name: event.target.value })}
-                className="flex-1 rounded border border-slate-700 bg-slate-950 p-1 text-cp-xs"
+                className="flex-1 rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
                 placeholder={t('net.vlanNamePlaceholder', 'Name (z.B. Production)')}
               />
               <input
                 value={v.notes ?? ''}
                 onChange={(event) => updateVlan(i, { notes: event.target.value })}
-                className="flex-1 rounded border border-slate-700 bg-slate-950 p-1 text-cp-xs"
+                className="flex-1 rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
                 placeholder={t('net.vlanNotePlaceholder', 'Notiz')}
               />
               <button
@@ -170,7 +170,7 @@ export const NetworkConfig = ({ equipmentId, item, allPorts, kind }: NetworkConf
           <legend className="px-1 text-[11px] uppercase tracking-wide text-cyan-300">
             {t('net.portToVlan', 'Port → VLAN')}
           </legend>
-          <div className="mb-1 grid grid-cols-[1fr_70px_120px] gap-1 text-[10px] text-slate-400">
+          <div className="mb-1 grid grid-cols-[1fr_70px_120px] gap-1 text-[10px] text-cp-text-muted">
             <span>{t('net.col.port', 'Port')}</span>
             <span>{t('net.col.untagged', 'Untagged')}</span>
             <span>{t('net.col.tagged', 'Tagged')}</span>
@@ -180,7 +180,7 @@ export const NetworkConfig = ({ equipmentId, item, allPorts, kind }: NetworkConf
               const assign = portVlans[p.id] ?? {}
               return (
                 <li key={p.id} className="grid grid-cols-[1fr_70px_120px] items-center gap-1">
-                  <span className="truncate text-[11px] text-slate-300" title={p.name}>
+                  <span className="truncate text-[11px] text-cp-text-secondary" title={p.name}>
                     {p.name}
                   </span>
                   <input
@@ -191,13 +191,13 @@ export const NetworkConfig = ({ equipmentId, item, allPorts, kind }: NetworkConf
                         untagged: event.target.value ? Number(event.target.value) : undefined,
                       })
                     }
-                    className="rounded border border-slate-700 bg-slate-950 p-1 text-cp-xs font-mono"
+                    className="rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs font-mono"
                     placeholder="—"
                   />
                   <input
                     value={assign.tagged ?? ''}
                     onChange={(event) => setPortVlan(p.id, { tagged: event.target.value })}
-                    className="rounded border border-slate-700 bg-slate-950 p-1 text-cp-xs font-mono"
+                    className="rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs font-mono"
                     placeholder="10,20,30"
                   />
                 </li>

--- a/src/renderer/components/Properties/sections/OptionalFieldsSection.tsx
+++ b/src/renderer/components/Properties/sections/OptionalFieldsSection.tsx
@@ -22,7 +22,7 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
             befuellt; manuell ueberschreibbar. */}
         <div className="grid grid-cols-[1fr_70px] gap-2">
           <label className="block">
-            <span className="mb-1 block text-slate-300">
+            <span className="mb-1 block text-cp-text-secondary">
               {t('eq.field.rentPrice', 'Mietpreis / Tag')}
               {equipment.rentmanId && (
                 <span className="ml-1 rounded bg-emerald-900/60 px-1 text-[10px] text-emerald-200">
@@ -42,11 +42,11 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
                   rentPricePerDay: v === '' ? undefined : Math.max(0, Number(v) || 0),
                 })
               }}
-              className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono"
+              className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
             />
           </label>
           <label className="block">
-            <span className="mb-1 block text-slate-300">{t('eq.field.rentCurrency', 'Wäh.')}</span>
+            <span className="mb-1 block text-cp-text-secondary">{t('eq.field.rentCurrency', 'Wäh.')}</span>
             <input
               type="text"
               maxLength={6}
@@ -56,15 +56,15 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
                 const v = event.target.value.trim().toUpperCase().slice(0, 6)
                 updateEquipment(equipment.id, { rentCurrency: v || undefined })
               }}
-              className="w-full rounded border border-slate-700 bg-slate-900 p-2 text-center font-mono uppercase"
+              className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 text-center font-mono uppercase"
             />
           </label>
         </div>
 
         <label className="block">
-          <span className="mb-1 block text-slate-300">
+          <span className="mb-1 block text-cp-text-secondary">
             {t('eq.field.manufacturerUrl', 'Hersteller-Link')}{' '}
-            <span className="text-slate-500">
+            <span className="text-cp-text-faint">
               ({t('common.optional', 'optional')}, {t('eq.field.manufacturerUrlHint', 'für Datenblatt-Aufruf')})
             </span>
           </span>
@@ -76,7 +76,7 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
               onChange={(event) =>
                 updateEquipment(equipment.id, { manufacturerUrl: event.target.value || undefined })
               }
-              className="flex-1 rounded border border-slate-700 bg-slate-900 p-2"
+              className="flex-1 rounded border border-cp-border bg-cp-surface-1 p-2"
             />
             {equipment.manufacturerUrl && (
               <a
@@ -93,9 +93,9 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
         </label>
 
         <label className="block">
-          <span className="mb-1 block text-slate-300">
+          <span className="mb-1 block text-cp-text-secondary">
             {t('eq.field.priceEUR', 'Preis / Miete (€)')}{' '}
-            <span className="text-slate-500">
+            <span className="text-cp-text-faint">
               ({t('common.optional', 'optional')}, {t('eq.field.priceEURHint', 'für Angebots-Export')})
             </span>
           </span>
@@ -110,14 +110,14 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
                 priceEUR: event.target.value ? Math.max(0, Number(event.target.value)) : undefined,
               })
             }
-            className="w-full rounded border border-slate-700 bg-slate-900 p-2 font-mono"
+            className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
           />
         </label>
 
         <label className="block">
-          <span className="mb-1 block text-slate-300">
+          <span className="mb-1 block text-cp-text-secondary">
             {t('eq.field.refImage', 'Referenzbild')}{' '}
-            <span className="text-slate-500">({t('eq.field.refImageHint', 'z. B. Port-Belegung')})</span>
+            <span className="text-cp-text-faint">({t('eq.field.refImageHint', 'z. B. Port-Belegung')})</span>
           </span>
           <div className="flex items-start gap-2">
             {equipment.imageUrl ? (
@@ -125,13 +125,13 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
                 href={equipment.imageUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="block max-h-24 max-w-[120px] overflow-hidden rounded border border-slate-700"
+                className="block max-h-24 max-w-[120px] overflow-hidden rounded border border-cp-border"
                 title={t('eq.field.refImageFullsize', 'In voller Größe öffnen')}
               >
                 <img src={equipment.imageUrl} alt="" className="max-h-24 max-w-[120px] object-contain" />
               </a>
             ) : (
-              <div className="flex h-24 w-[120px] items-center justify-center rounded border border-dashed border-slate-700 text-[10px] text-slate-400">
+              <div className="flex h-24 w-[120px] items-center justify-center rounded border border-dashed border-cp-border text-[10px] text-cp-text-muted">
                 {t('eq.field.refImageNone', 'Kein Bild')}
               </div>
             )}
@@ -142,7 +142,7 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
                   const dataUri = await pickImageAsDataUri()
                   if (dataUri) updateEquipment(equipment.id, { imageUrl: dataUri })
                 }}
-                className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
               >
                 {equipment.imageUrl
                   ? t('eq.field.refImageReplace', 'Ersetzen…')
@@ -152,7 +152,7 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
                 <button
                   type="button"
                   onClick={() => updateEquipment(equipment.id, { imageUrl: undefined })}
-                  className="rounded bg-slate-800 px-2 py-1 text-cp-xs text-slate-400 hover:bg-red-700 hover:text-white"
+                  className="rounded bg-cp-surface-2 px-2 py-1 text-cp-xs text-cp-text-muted hover:bg-red-700 hover:text-white"
                 >
                   {t('common.remove', 'Entfernen')}
                 </button>
@@ -162,9 +162,9 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
         </label>
 
         <label className="block">
-          <span className="mb-1 block text-slate-300">
+          <span className="mb-1 block text-cp-text-secondary">
             {t('opt.iconLabel', 'Icon')}{' '}
-            <span className="text-slate-500">
+            <span className="text-cp-text-faint">
               ({t('opt.iconHint', 'Glyph oder Emoji, max 2 Zeichen — leer = automatisch')})
             </span>
           </span>
@@ -176,7 +176,7 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
                 const v = event.target.value
                 updateEquipment(equipment.id, { icon: v.length === 0 ? undefined : v.slice(0, 2) })
               }}
-              className="w-20 rounded border border-slate-700 bg-slate-900 p-2 text-center text-cp-lg"
+              className="w-20 rounded border border-cp-border bg-cp-surface-1 p-2 text-center text-cp-lg"
               maxLength={2}
             />
             {ICON_GLYPHS.map((g) => (
@@ -187,7 +187,7 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
                 className={`rounded border px-1.5 py-1 text-cp-lg ${
                   equipment.icon === g
                     ? 'border-sky-500 bg-sky-700/30'
-                    : 'border-slate-700 bg-slate-900 hover:bg-slate-800'
+                    : 'border-cp-border bg-cp-surface-1 hover:bg-cp-surface-2'
                 }`}
                 title={`Icon ${g}`}
               >
@@ -198,7 +198,7 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
               <button
                 type="button"
                 onClick={() => updateEquipment(equipment.id, { icon: undefined })}
-                className="rounded bg-slate-700 px-1.5 py-1 text-[10px] hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-1.5 py-1 text-[10px] hover:bg-cp-surface-5"
                 title={t('opt.iconAutoTitle', 'Auf automatisch zurücksetzen')}
               >
                 auto

--- a/src/renderer/components/Properties/sections/PortAiSuggestButton.tsx
+++ b/src/renderer/components/Properties/sections/PortAiSuggestButton.tsx
@@ -138,7 +138,7 @@ export const PortAiSuggestButton = ({
             <button
               type="button"
               onClick={() => setHints(null)}
-              className="rounded bg-slate-700 px-2 py-0.5 text-[10px] text-slate-200 hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-2 py-0.5 text-[10px] text-cp-text-bright hover:bg-cp-surface-5"
             >
               {t('props.aiPorts.discard', 'Verwerfen')}
             </button>

--- a/src/renderer/components/Properties/sections/RackFacePreview.tsx
+++ b/src/renderer/components/Properties/sections/RackFacePreview.tsx
@@ -19,22 +19,22 @@ export const RackFacePreview = ({
   const panelWidth = Math.round(unitHeight * 10.86)
 
   return (
-    <fieldset className="rounded border border-slate-700 p-2">
-      <legend className="px-1 text-[11px] uppercase tracking-wide text-slate-400">
+    <fieldset className="rounded border border-cp-border p-2">
+      <legend className="px-1 text-[11px] uppercase tracking-wide text-cp-text-muted">
         2D Rack-Vorschau
       </legend>
-      <div className="mb-2 text-[11px] text-slate-400">19" Rack · {equipment.rackUnits} HE · Front/Rear mit Port-Marker</div>
-      <div className="rounded border border-slate-700 bg-slate-950 p-3">
+      <div className="mb-2 text-[11px] text-cp-text-muted">19" Rack · {equipment.rackUnits} HE · Front/Rear mit Port-Marker</div>
+      <div className="rounded border border-cp-border bg-cp-surface-3 p-3">
         <div className={`mx-auto grid w-full max-w-[760px] gap-2 ${viewMode === 'both' ? 'grid-cols-2' : 'grid-cols-1'}`}>
           {(viewMode === 'both' ? ['front', 'rear'] : [viewMode]).map((side) => {
             const imageUrl = side === 'front' ? equipment.frontPanelImageUrl : equipment.rearPanelImageUrl
             return (
-              <div key={side} className="rounded border border-slate-600 bg-gradient-to-b from-slate-800 to-slate-900 px-4 py-3 shadow-inner">
-                <div className="mb-3 flex items-center justify-between text-[10px] uppercase tracking-[0.2em] text-slate-400">
+              <div key={side} className="rounded border border-cp-surface-5 bg-gradient-to-b from-cp-surface-2 to-cp-surface-1 px-4 py-3 shadow-inner">
+                <div className="mb-3 flex items-center justify-between text-[10px] uppercase tracking-[0.2em] text-cp-text-muted">
                   <span>{side === 'front' ? 'Front' : 'Rear'}</span>
                   <span>{equipment.rackUnits} HE</span>
                 </div>
-                <div className="relative mb-3 rounded border border-slate-700 bg-slate-950/70 px-3 py-2 text-center">
+                <div className="relative mb-3 rounded border border-cp-border bg-cp-surface-3/70 px-3 py-2 text-center">
                   {imageUrl ? (
                     <img
                       src={imageUrl}
@@ -44,8 +44,8 @@ export const RackFacePreview = ({
                     />
                   ) : (
                     <>
-                      <div className="truncate text-cp-base font-semibold text-slate-100">{equipment.name}</div>
-                      <div className="truncate text-[11px] text-slate-400">{equipment.category}</div>
+                      <div className="truncate text-cp-base font-semibold text-cp-text">{equipment.name}</div>
+                      <div className="truncate text-[11px] text-cp-text-muted">{equipment.category}</div>
                     </>
                   )}
                 </div>
@@ -55,11 +55,11 @@ export const RackFacePreview = ({
                     const output = equipment.outputs[index]
                     return (
                       <div key={`${equipment.id}-${side}-rack-row-${index}`} className="grid grid-cols-[1fr_auto_1fr] items-center gap-3 text-[11px]">
-                        <div className="min-w-0 rounded border border-slate-700 bg-slate-900/70 px-2 py-1 text-right text-slate-200">
+                        <div className="min-w-0 rounded border border-cp-border bg-cp-surface-1/70 px-2 py-1 text-right text-cp-text-bright">
                           {input ? (
                             <span className="block truncate">
                               {input.name}
-                              <span className="text-slate-500"> · {input.connectorType}</span>
+                              <span className="text-cp-text-faint"> · {input.connectorType}</span>
                             </span>
                           ) : (
                             <span className="text-slate-600">—</span>
@@ -67,15 +67,15 @@ export const RackFacePreview = ({
                         </div>
                         <div className="flex items-center gap-2">
                           <span className="h-2.5 w-2.5 rounded-full bg-sky-400" />
-                          <span className="h-px w-8 bg-slate-700" />
-                          <span className="h-px w-8 bg-slate-700" />
+                          <span className="h-px w-8 bg-cp-surface-4" />
+                          <span className="h-px w-8 bg-cp-surface-4" />
                           <span className="h-2.5 w-2.5 rounded-full bg-emerald-400" />
                         </div>
-                        <div className="min-w-0 rounded border border-slate-700 bg-slate-900/70 px-2 py-1 text-slate-200">
+                        <div className="min-w-0 rounded border border-cp-border bg-cp-surface-1/70 px-2 py-1 text-cp-text-bright">
                           {output ? (
                             <span className="block truncate">
                               {output.name}
-                              <span className="text-slate-500"> · {output.connectorType}</span>
+                              <span className="text-cp-text-faint"> · {output.connectorType}</span>
                             </span>
                           ) : (
                             <span className="text-slate-600">—</span>

--- a/src/renderer/components/Properties/sections/RackInstanceCard.tsx
+++ b/src/renderer/components/Properties/sections/RackInstanceCard.tsx
@@ -20,7 +20,7 @@ export const RackInstanceCard = ({ equipment }: { equipment: EquipmentItem }) =>
       <div className="mb-1 text-[10px] uppercase tracking-wide text-cyan-300">
         {t('rackInstance.label', 'Rack-Instanz')} · {equipment.rackInstanceLabel ?? t('rackInstance.fallback', 'Rack')}
       </div>
-      <p className="mb-2 text-[10px] text-slate-400">
+      <p className="mb-2 text-[10px] text-cp-text-muted">
         {t(
           'rackInstance.intro',
           'Dieses Gerät gehört zu einer Rack-Instanz. Der Rack-Editor zeigt eine gefilterte Sub-Canvas mit nur diesem Rack — Änderungen an der Position werden beim Loslassen auf ganze HU gerundet.',
@@ -34,7 +34,7 @@ export const RackInstanceCard = ({ equipment }: { equipment: EquipmentItem }) =>
         <Icon icon={Server} size="xs" /> {t('rackInstance.openEditor', 'Rack-Editor öffnen')}
       </button>
       {typeof equipment.rackInstanceStartUnit === 'number' && (
-        <div className="mt-1 text-[10px] text-slate-400">
+        <div className="mt-1 text-[10px] text-cp-text-muted">
           {format(t('rackInstance.position', 'Position: ab HU {start}'), {
             start: equipment.rackInstanceStartUnit + 1,
           })}

--- a/src/renderer/components/Properties/sections/RackSection.tsx
+++ b/src/renderer/components/Properties/sections/RackSection.tsx
@@ -53,7 +53,7 @@ export const RackSection = ({ equipment }: { equipment: EquipmentItem }) => {
           </label>
 
           {!equipment.isRackDevice && (
-            <div className="rounded border border-slate-800 bg-slate-900/50 p-2 text-[11px] text-slate-400">
+            <div className="rounded border border-cp-border-muted bg-cp-surface-1/50 p-2 text-[11px] text-cp-text-muted">
               {t(
                 'props.rack.disabledHint',
                 'Rack-Felder erscheinen nur, wenn das Gerät als 19" Rack-Gerät markiert ist.',
@@ -65,7 +65,7 @@ export const RackSection = ({ equipment }: { equipment: EquipmentItem }) => {
             <>
               <div className="grid grid-cols-2 gap-2">
                 <label className="block">
-                  <span className="mb-1 block text-slate-300">{t('props.rack.height', 'Hohe (HE)')}</span>
+                  <span className="mb-1 block text-cp-text-secondary">{t('props.rack.height', 'Hohe (HE)')}</span>
                   <input
                     type="number"
                     min={1}
@@ -76,15 +76,15 @@ export const RackSection = ({ equipment }: { equipment: EquipmentItem }) => {
                         rackUnits: Math.max(1, Number(event.target.value) || 1),
                       })
                     }
-                    className="w-full rounded border border-slate-700 bg-slate-900 p-2"
+                    className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
                   />
                 </label>
                 <label className="block">
-                  <span className="mb-1 block text-slate-300">{t('props.rack.view', 'Ansicht')}</span>
+                  <span className="mb-1 block text-cp-text-secondary">{t('props.rack.view', 'Ansicht')}</span>
                   <select
                     value={rackViewMode}
                     onChange={(event) => setRackViewMode(event.target.value as 'front' | 'rear' | 'both')}
-                    className="w-full rounded border border-slate-700 bg-slate-900 p-2"
+                    className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
                   >
                     <option value="front">{t('props.rack.frontOnly', 'Nur vorne')}</option>
                     <option value="rear">{t('props.rack.rearOnly', 'Nur hinten')}</option>
@@ -131,7 +131,7 @@ export const RackSection = ({ equipment }: { equipment: EquipmentItem }) => {
                       rearPanelCrop: equipment.frontPanelCrop,
                     })
                   }
-                  className="mt-2 w-full rounded border border-slate-600 bg-slate-800 px-2 py-1 text-cp-xs text-slate-200 hover:bg-slate-700"
+                  className="mt-2 w-full rounded border border-cp-surface-5 bg-cp-surface-2 px-2 py-1 text-cp-xs text-cp-text-bright hover:bg-cp-surface-4"
                   title={t('props.rack.swapTitle', 'Front- und Rear-Foto vertauschen (samt Crop-Meta)')}
                 >
                   {t('props.rack.swap', '↔ Front-/Rear-Foto vertauschen')}
@@ -139,7 +139,7 @@ export const RackSection = ({ equipment }: { equipment: EquipmentItem }) => {
               )}
 
               {equipment.netboxPath && (
-                <div className="mt-2 text-[10px] text-slate-400">
+                <div className="mt-2 text-[10px] text-cp-text-muted">
                   {format(t('props.rack.netboxSource', 'Quelle: NetBox device-type-library · {path}'), {
                     path: equipment.netboxPath,
                   })}

--- a/src/renderer/components/Properties/sections/ReplaceDeviceSection.tsx
+++ b/src/renderer/components/Properties/sections/ReplaceDeviceSection.tsx
@@ -165,12 +165,12 @@ export const ReplaceDeviceSection = ({ equipment }: { equipment: EquipmentItem }
               onChange={(e) => setFilter(e.target.value)}
               placeholder={t('replaceDevice.searchPlaceholder', 'Suchen (Name, Kategorie, Hersteller)…')}
               aria-label={t('replaceDevice.searchPlaceholder', 'Suchen (Name, Kategorie, Hersteller)…')}
-              className="flex-1 rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+              className="flex-1 rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
             />
             <button
               type="button"
               onClick={() => setOpen(false)}
-              className="rounded bg-slate-700 px-2 py-1 text-[11px] hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-2 py-1 text-[11px] hover:bg-cp-surface-5"
             >
               ✕
             </button>
@@ -178,7 +178,7 @@ export const ReplaceDeviceSection = ({ equipment }: { equipment: EquipmentItem }
           <select
             value={categoryFilter}
             onChange={(e) => setCategoryFilter(e.target.value)}
-            className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+            className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
           >
             <option value="">{t('replaceDevice.allCategories', '— Alle Kategorien —')}</option>
             {categories.map((c) => (
@@ -187,9 +187,9 @@ export const ReplaceDeviceSection = ({ equipment }: { equipment: EquipmentItem }
               </option>
             ))}
           </select>
-          <div className="max-h-56 overflow-auto rounded border border-slate-800">
+          <div className="max-h-56 overflow-auto rounded border border-cp-border-muted">
             {filtered.length === 0 ? (
-              <div className="px-2 py-3 text-center text-[11px] text-slate-400">
+              <div className="px-2 py-3 text-center text-[11px] text-cp-text-muted">
                 {t('replaceDevice.noMatches', 'Keine Treffer.')}
               </div>
             ) : (
@@ -203,13 +203,13 @@ export const ReplaceDeviceSection = ({ equipment }: { equipment: EquipmentItem }
                       <button
                         type="button"
                         onClick={() => void handlePick(tpl)}
-                        className="flex w-full items-start justify-between gap-2 border-b border-slate-800 px-2 py-1.5 text-left hover:bg-slate-800/60"
+                        className="flex w-full items-start justify-between gap-2 border-b border-cp-border-muted px-2 py-1.5 text-left hover:bg-cp-surface-2/60"
                       >
                         <span>
-                          <span className="block text-cp-xs font-medium text-slate-100">
+                          <span className="block text-cp-xs font-medium text-cp-text">
                             {tpl.name}
                           </span>
-                          <span className="block text-[10px] text-slate-400">
+                          <span className="block text-[10px] text-cp-text-muted">
                             {categoryDisplay(tpl.category ?? '', lang, categoryTranslations)} · {tpl.inputs.length} in / {tpl.outputs.length} out
                           </span>
                         </span>

--- a/src/renderer/components/Rentman/EquipmentChecklist.tsx
+++ b/src/renderer/components/Rentman/EquipmentChecklist.tsx
@@ -122,36 +122,36 @@ export const EquipmentChecklist = ({
           max={999}
           value={item.qty}
           onChange={(event) => onQtyChange(item.id, Number(event.target.value))}
-          className="w-14 rounded border border-slate-700 bg-slate-900 px-1 py-0.5 text-right text-cp-xs"
+          className="w-14 rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-right text-cp-xs"
           aria-label={tBadge('rentman.checklist.qtyAria', 'Quantity')}
           title={tBadge('rentman.checklist.qtyTitle', 'How many to add')}
         />
       )
     }
     return (
-      <span className="rounded bg-slate-700/60 px-1.5 py-0.5 text-[10px] text-slate-400" title={tBadge('rentman.checklist.qtyInProject', 'Stückzahl im Rentman-Projekt')}>
+      <span className="rounded bg-cp-surface-4/60 px-1.5 py-0.5 text-[10px] text-cp-text-muted" title={tBadge('rentman.checklist.qtyInProject', 'Stückzahl im Rentman-Projekt')}>
         ×{item.qty}
       </span>
     )
   }
 
   return (
-    <div className="max-h-72 space-y-3 overflow-auto rounded border border-slate-700 p-2 text-cp-base">
+    <div className="max-h-72 space-y-3 overflow-auto rounded border border-cp-border p-2 text-cp-base">
       {(onSetAll || hasAnySets) && (
-        <div className="flex flex-wrap gap-2 border-b border-slate-700 pb-2 text-cp-xs">
+        <div className="flex flex-wrap gap-2 border-b border-cp-border pb-2 text-cp-xs">
           {onSetAll && (
             <>
               <button
                 type="button"
                 onClick={() => onSetAll(true)}
-                className="rounded bg-slate-700 px-2 py-1 hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-2 py-1 hover:bg-cp-surface-5"
               >
                 {t('rentman.checklist.selectAll', 'Alle auswählen')}
               </button>
               <button
                 type="button"
                 onClick={() => onSetAll(false)}
-                className="rounded bg-slate-700 px-2 py-1 hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-2 py-1 hover:bg-cp-surface-5"
               >
                 {t('rentman.checklist.deselectAll', 'Alle abwählen')}
               </button>
@@ -162,14 +162,14 @@ export const EquipmentChecklist = ({
               <button
                 type="button"
                 onClick={expandAll}
-                className="rounded bg-slate-700 px-2 py-1 hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-2 py-1 hover:bg-cp-surface-5"
               >
                 {t('rentman.checklist.expandAll', 'Alle Sets ausklappen')}
               </button>
               <button
                 type="button"
                 onClick={collapseAll}
-                className="rounded bg-slate-700 px-2 py-1 hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-2 py-1 hover:bg-cp-surface-5"
               >
                 {t('rentman.checklist.collapseAll', 'Alle Sets einklappen')}
               </button>
@@ -185,7 +185,7 @@ export const EquipmentChecklist = ({
         .sort((a, b) => a[0].localeCompare(b[0]))
         .map(([category, categoryItems]) => (
         <div key={category}>
-          <div className="mb-1 text-cp-xs font-semibold uppercase tracking-wide text-slate-300">{category}</div>
+          <div className="mb-1 text-cp-xs font-semibold uppercase tracking-wide text-cp-text-secondary">{category}</div>
           <div className="space-y-1">
             {categoryItems.map((item) => {
               const children = childrenByParent[item.id]
@@ -196,12 +196,12 @@ export const EquipmentChecklist = ({
               // importierbar (kein Häkchen), nur als Notiz anzeigen.
               if (item.kind === 'comment') {
                 return (
-                  <div key={item.id} className="flex items-center gap-2 rounded bg-slate-900/30 px-2 py-1 text-cp-xs">
+                  <div key={item.id} className="flex items-center gap-2 rounded bg-cp-surface-1/30 px-2 py-1 text-cp-xs">
                     <span className="w-5" />
-                    <span className="shrink-0 rounded bg-slate-800 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-slate-400">
+                    <span className="shrink-0 rounded bg-cp-surface-2 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-cp-text-muted">
                       {t('rentman.checklist.kind.comment', 'Kommentar')}
                     </span>
-                    <span className="flex-1 italic text-slate-400">{item.name}</span>
+                    <span className="flex-1 italic text-cp-text-muted">{item.name}</span>
                   </div>
                 )
               }
@@ -212,7 +212,7 @@ export const EquipmentChecklist = ({
                       <button
                         type="button"
                         onClick={() => toggleExpand(item.id)}
-                        className="w-5 rounded bg-slate-800 text-[10px] leading-none hover:bg-slate-700"
+                        className="w-5 rounded bg-cp-surface-2 text-[10px] leading-none hover:bg-cp-surface-4"
                         aria-label={isOpen ? t('rentman.checklist.setCollapse', 'Set einklappen') : t('rentman.checklist.setExpand', 'Set ausklappen')}
                         title={isOpen ? t('rentman.checklist.setCollapse', 'Set einklappen') : t('rentman.checklist.setExpand', 'Set ausklappen')}
                       >
@@ -244,7 +244,7 @@ export const EquipmentChecklist = ({
                               </span>
                             )
                           return (
-                            <span className="ml-2 rounded bg-slate-700/60 px-1.5 py-0.5 text-[10px] text-slate-300">
+                            <span className="ml-2 rounded bg-cp-surface-4/60 px-1.5 py-0.5 text-[10px] text-cp-text-secondary">
                               {format(t('rentman.checklist.kind.set', 'Set · {n}'), { n })}
                             </span>
                           )
@@ -274,7 +274,7 @@ export const EquipmentChecklist = ({
                             className={`ml-2 rounded px-1.5 py-0.5 text-[10px] font-medium ${
                               rackSetIds?.has(item.id)
                                 ? 'bg-sky-700/70 text-sky-100'
-                                : 'bg-slate-700/60 text-slate-300 hover:bg-slate-600/60'
+                                : 'bg-cp-surface-4/60 text-cp-text-secondary hover:bg-cp-surface-5/60'
                             }`}
                             title={t(
                               'rentman.checklist.asRackTitle',
@@ -322,7 +322,7 @@ export const EquipmentChecklist = ({
                           if (kind === 'catalog') {
                             return (
                               <span
-                                className="ml-2 rounded bg-slate-700/60 px-1.5 py-0.5 text-[10px] font-medium text-slate-200"
+                                className="ml-2 rounded bg-cp-surface-4/60 px-1.5 py-0.5 text-[10px] font-medium text-cp-text-bright"
                                 title={format(t('rentman.checklist.badge.catalogTitle', 'Match aus eingebautem Katalog ("{name}"). Wird beim Import automatisch als Template uebernommen.'), { name: item.templateMatch })}
                               >
                                 {t('rentman.checklist.badge.catalog', '⊕ Katalog')}
@@ -364,7 +364,7 @@ export const EquipmentChecklist = ({
                             onChange={(e) => {
                               if (e.target.value) onLinkExisting(item.id, e.target.value)
                             }}
-                            className="rounded border border-slate-700 bg-slate-900 px-1 py-0.5 text-[10px] text-slate-300"
+                            className="rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-[10px] text-cp-text-secondary"
                             title={t('rentman.checklist.linkSelectTitle', 'Mit existierendem Gerät verknüpfen')}
                           >
                             <option value="">{t('rentman.checklist.linkPlaceholder', 'Verknüpfen…')}</option>
@@ -379,7 +379,7 @@ export const EquipmentChecklist = ({
                       <button
                         type="button"
                         onClick={() => onSetAllChildren(item.id, !allChildrenChecked)}
-                        className="rounded bg-slate-700 px-1.5 py-0.5 text-[10px] hover:bg-slate-600"
+                        className="rounded bg-cp-surface-4 px-1.5 py-0.5 text-[10px] hover:bg-cp-surface-5"
                         title={allChildrenChecked ? t('rentman.checklist.deselectChildren', 'Alle Kinder abwählen') : t('rentman.checklist.selectChildren', 'Alle Kinder auswählen')}
                       >
                         <span className="inline-flex items-center gap-1"><Icon icon={allChildrenChecked ? Square : SquareCheck} size="xs" />{allChildrenChecked ? t('rentman.checklist.childrenAllOff', 'alle') : t('rentman.checklist.childrenAllOn', 'alle')}</span>
@@ -387,9 +387,9 @@ export const EquipmentChecklist = ({
                     )}
                   </div>
                   {isSet && isOpen && (
-                    <div className="ml-6 mt-1 space-y-1 border-l border-slate-800 pl-2">
+                    <div className="ml-6 mt-1 space-y-1 border-l border-cp-border-muted pl-2">
                       {children!.map((child) => (
-                        <label key={child.id} className="flex items-center gap-2 text-slate-300">
+                        <label key={child.id} className="flex items-center gap-2 text-cp-text-secondary">
                           <input
                             type="checkbox"
                             checked={child.checked}

--- a/src/renderer/components/Rentman/NewRentmanDeviceWizard.tsx
+++ b/src/renderer/components/Rentman/NewRentmanDeviceWizard.tsx
@@ -181,22 +181,22 @@ export const NewRentmanDeviceWizard = ({
 
   return (
     <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/70 p-6">
-      <div className="max-h-[90vh] w-full max-w-3xl overflow-auto rounded border border-slate-700 bg-slate-900 p-4 text-slate-100">
+      <div className="max-h-[90vh] w-full max-w-3xl overflow-auto rounded border border-cp-border bg-cp-surface-1 p-4 text-cp-text">
         <div className="mb-3 flex items-center justify-between">
           <div>
             <h3 className="text-cp-xl font-semibold">
               {format(t('rentman.wizard.title', 'Neues Rentman-Gerät ({progress})'), { progress })}
             </h3>
-            <p className="mt-1 text-cp-xs text-slate-400">
+            <p className="mt-1 text-cp-xs text-cp-text-muted">
               {t('rentman.wizard.introPre', 'Zum ersten Mal gesehen:')}{' '}
-              <span className="text-slate-200">{current.name}</span>
+              <span className="text-cp-text-bright">{current.name}</span>
               {t('rentman.wizard.introPost', ' — Ein-/Ausgänge bestätigen, sie werden in deiner Bibliothek gespeichert.')}
             </p>
           </div>
           <button
             type="button"
             onClick={onCancel}
-            className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+            className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
           >
             {t('rentman.wizard.cancelImport', 'Import abbrechen')}
           </button>
@@ -208,7 +208,7 @@ export const NewRentmanDeviceWizard = ({
             <input
               value={name}
               onChange={(event) => setName(event.target.value)}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+              className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
             />
           </label>
           <label className="block">
@@ -217,7 +217,7 @@ export const NewRentmanDeviceWizard = ({
               <CategorySelect
                 value={category}
                 onChange={setCategory}
-                className="w-full rounded border border-slate-700 bg-slate-950 p-2"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 p-2"
               />
               <button
                 type="button"
@@ -226,7 +226,7 @@ export const NewRentmanDeviceWizard = ({
                   if (cat) addKnownCategories([cat])
                 }}
                 title={t('rentman.wizard.saveAsCategoryTitle', 'Als neue Kategorie speichern')}
-                className="rounded bg-slate-700 px-2 text-cp-xs hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-2 text-cp-xs hover:bg-cp-surface-5"
               >
                 {t('rentman.wizard.addCategory', '+ Neu')}
               </button>
@@ -258,7 +258,7 @@ export const NewRentmanDeviceWizard = ({
             <button
               type="button"
               onClick={handleOpenAiSettings}
-              className="rounded bg-slate-700 px-2 py-1 hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-2 py-1 hover:bg-cp-surface-5"
               title={t('rentman.wizard.aiSettingsTitle', 'Gemini API-Key konfigurieren')}
             >
               {t('rentman.wizard.aiSettings', 'KI-Einstellungen')}
@@ -289,9 +289,9 @@ export const NewRentmanDeviceWizard = ({
         {aiSettingsOpen && (
           <div className="mb-3 rounded border border-purple-700 bg-purple-950/40 p-3">
             <div className="mb-2 text-cp-xs font-semibold text-purple-200">{t('rentman.wizard.geminiKeyHeading', 'Gemini API-Key')}</div>
-            <p className="mb-2 text-[11px] text-slate-300">
+            <p className="mb-2 text-[11px] text-cp-text-secondary">
               {t('rentman.wizard.geminiKeyHintPre', 'Kostenlos unter')}{' '}
-              <span className="font-mono text-slate-200">aistudio.google.com/apikey</span>{' '}
+              <span className="font-mono text-cp-text-bright">aistudio.google.com/apikey</span>{' '}
               {t('rentman.wizard.geminiKeyHintPost', '(15 Anfragen/Min). Wird lokal im Browser-Storage gespeichert.')}
             </p>
             <input
@@ -299,14 +299,14 @@ export const NewRentmanDeviceWizard = ({
               value={apiKeyDraft}
               onChange={(event) => setApiKeyDraft(event.target.value)}
               placeholder={t('rentman.wizard.aiKeyPlaceholder', 'AIzaSy...')}
-              className="w-full rounded border border-slate-700 bg-slate-950 p-2 text-cp-xs"
+              className="w-full rounded border border-cp-border bg-cp-surface-3 p-2 text-cp-xs"
               autoFocus
             />
             <div className="mt-2 flex justify-end gap-2">
               <button
                 type="button"
                 onClick={() => setAiSettingsOpen(false)}
-                className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
               >
                 {t('common.cancel', 'Abbrechen')}
               </button>
@@ -336,13 +336,13 @@ export const NewRentmanDeviceWizard = ({
           {groups.map((group) => (
             <div
               key={group.id}
-              className="grid grid-cols-[80px_70px_1fr_1fr_40px] items-center gap-2 rounded border border-slate-700 bg-slate-950 p-2 text-cp-xs"
+              className="grid grid-cols-[80px_70px_1fr_1fr_40px] items-center gap-2 rounded border border-cp-border bg-cp-surface-3 p-2 text-cp-xs"
             >
               <select
                 aria-label={t('rentman.wizard.directionAria', 'Richtung')}
                 value={group.direction}
                 onChange={(event) => updateGroup(group.id, { direction: event.target.value as 'in' | 'out' })}
-                className="rounded border border-slate-700 bg-slate-900 p-1"
+                className="rounded border border-cp-border bg-cp-surface-1 p-1"
               >
                 <option value="in">{t('rentman.wizard.directionIn', 'Eingang')}</option>
                 <option value="out">{t('rentman.wizard.directionOut', 'Ausgang')}</option>
@@ -353,13 +353,13 @@ export const NewRentmanDeviceWizard = ({
                 min={1}
                 value={group.count}
                 onChange={(event) => updateGroup(group.id, { count: Number(event.target.value) })}
-                className="rounded border border-slate-700 bg-slate-900 p-1"
+                className="rounded border border-cp-border bg-cp-surface-1 p-1"
               />
               <select
                 aria-label={t('rentman.wizard.connectorTypeAria', 'Steckertyp')}
                 value={group.connectorType}
                 onChange={(event) => updateGroup(group.id, { connectorType: event.target.value as ConnectorType })}
-                className="rounded border border-slate-700 bg-slate-900 p-1"
+                className="rounded border border-cp-border bg-cp-surface-1 p-1"
               >
                 {connectorOptions.map((item) => (
                   <option key={item} value={item}>
@@ -371,7 +371,7 @@ export const NewRentmanDeviceWizard = ({
                 value={group.label}
                 onChange={(event) => updateGroup(group.id, { label: event.target.value })}
                 placeholder={t('rentman.wizard.labelPrefixPlaceholder', 'Label-Präfix')}
-                className="rounded border border-slate-700 bg-slate-900 p-1"
+                className="rounded border border-cp-border bg-cp-surface-1 p-1"
               />
               <button
                 type="button"
@@ -384,7 +384,7 @@ export const NewRentmanDeviceWizard = ({
             </div>
           ))}
           {groups.length === 0 && (
-            <div className="text-cp-xs text-slate-400">{t('rentman.wizard.noGroups', 'Keine Port-Gruppen. Oben hinzufügen oder Gerät überspringen.')}</div>
+            <div className="text-cp-xs text-cp-text-muted">{t('rentman.wizard.noGroups', 'Keine Port-Gruppen. Oben hinzufügen oder Gerät überspringen.')}</div>
           )}
         </div>
 
@@ -400,7 +400,7 @@ export const NewRentmanDeviceWizard = ({
           <button
             type="button"
             onClick={handleSkip}
-            className="rounded bg-slate-700 px-3 py-1 hover:bg-slate-600"
+            className="rounded bg-cp-surface-4 px-3 py-1 hover:bg-cp-surface-5"
             title={t('rentman.wizard.skipTitle', 'Importieren ohne Bibliothekseintrag (1 generischer Ein-/Ausgang)')}
           >
             {t('rentman.wizard.skip', 'Überspringen (generisch)')}

--- a/src/renderer/components/Rentman/ProjectSelector.tsx
+++ b/src/renderer/components/Rentman/ProjectSelector.tsx
@@ -44,7 +44,7 @@ export const ProjectSelector = ({ projects, selectedProjectId, onSelect }: Proje
     <div
       role="listbox"
       aria-label={t('rentman.projectSelector.aria', 'Rentman project')}
-      className="max-h-64 overflow-auto rounded border border-slate-700 bg-slate-900"
+      className="max-h-64 overflow-auto rounded border border-cp-border bg-cp-surface-1"
     >
       {projects.map((project) => {
         const active = project.id === selectedProjectId
@@ -56,24 +56,24 @@ export const ProjectSelector = ({ projects, selectedProjectId, onSelect }: Proje
             aria-selected={active}
             onClick={() => onSelect(project.id)}
             title={formatLabel(project)}
-            className={`flex w-full items-center justify-between gap-2 border-b border-slate-800 px-2.5 py-1.5 text-left text-cp-xs last:border-b-0 ${
-              active ? 'bg-sky-600 text-white' : 'text-slate-200 hover:bg-slate-800'
+            className={`flex w-full items-center justify-between gap-2 border-b border-cp-border-muted px-2.5 py-1.5 text-left text-cp-xs last:border-b-0 ${
+              active ? 'bg-sky-600 text-white' : 'text-cp-text-bright hover:bg-cp-surface-2'
             }`}
           >
             <span className="min-w-0 flex-1 truncate">
               {project.number !== undefined && project.number !== '' && (
-                <span className={active ? 'text-sky-100' : 'text-slate-400'}>#{project.number} </span>
+                <span className={active ? 'text-sky-100' : 'text-cp-text-muted'}>#{project.number} </span>
               )}
               {project.name}
               {(() => {
                 const from = formatDate(project.periodStart)
                 const to = formatDate(project.periodEnd)
                 const span = from && to ? `${from} → ${to}` : from
-                return span ? <span className={`ml-1 ${active ? 'text-sky-100' : 'text-slate-500'}`}>· {span}</span> : null
+                return span ? <span className={`ml-1 ${active ? 'text-sky-100' : 'text-cp-text-faint'}`}>· {span}</span> : null
               })()}
             </span>
             {project.status && (
-              <span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] ${active ? 'bg-sky-700 text-sky-50' : 'bg-slate-800 text-slate-400'}`}>
+              <span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] ${active ? 'bg-sky-700 text-sky-50' : 'bg-cp-surface-2 text-cp-text-muted'}`}>
                 {project.status}
               </span>
             )}

--- a/src/renderer/components/Rentman/RentmanCableExportDialog.tsx
+++ b/src/renderer/components/Rentman/RentmanCableExportDialog.tsx
@@ -277,12 +277,12 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
       scrollBody={false}
     >
       <div className="flex h-full min-h-0 flex-col -mx-4 -my-3">
-        <div className="border-b border-slate-800 px-4 py-1.5 text-[10px] text-slate-400">
+        <div className="border-b border-cp-border-muted px-4 py-1.5 text-[10px] text-cp-text-muted">
           {linkedProjectName
             ? format(t('rentman.cableExport.target', 'Ziel: {name}'), { name: linkedProjectName })
             : t('rentman.cableExport.noLink', 'Kein Rentman-Projekt verknüpft.')}
         </div>
-        <div className="flex flex-wrap items-center gap-2 border-b border-slate-800 px-4 py-2 text-[11px] text-slate-400">
+        <div className="flex flex-wrap items-center gap-2 border-b border-cp-border-muted px-4 py-2 text-[11px] text-cp-text-muted">
           {(() => {
             const totalBuilt = buckets.reduce((sum, b) => sum + b.built, 0)
             const totalSynced = buckets.reduce((sum, b) => sum + b.syncedQty, 0)
@@ -294,8 +294,8 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
             return (
               <>
                 <span>
-                  <span className="font-mono text-slate-200">{totalBuilt}</span> {t('rentman.cableExport.cablesBuilt', 'Kabel verbaut')} ·{' '}
-                  <span className="font-mono text-slate-200">{totalSynced}</span> {t('rentman.cableExport.alreadySent', 'bereits gesendet')}
+                  <span className="font-mono text-cp-text-bright">{totalBuilt}</span> {t('rentman.cableExport.cablesBuilt', 'Kabel verbaut')} ·{' '}
+                  <span className="font-mono text-cp-text-bright">{totalSynced}</span> {t('rentman.cableExport.alreadySent', 'bereits gesendet')}
                 </span>
                 {sendableCount > 0 && (
                   <span className="text-amber-300">
@@ -347,7 +347,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
 
         <div className="min-h-0 flex-1 overflow-auto px-4">
           <table className="w-full text-cp-xs">
-            <thead className="sticky top-0 bg-slate-950 text-slate-300">
+            <thead className="sticky top-0 bg-cp-surface-3 text-cp-text-secondary">
               <tr>
                 <th className="px-3 py-2 text-left">{t('rentman.cableExport.col.typeLength', 'Typ / Länge')}</th>
                 <th className="px-3 py-2 text-right">{t('rentman.cableExport.col.built', 'Verbaut')}</th>
@@ -361,7 +361,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
             <tbody>
               {buckets.length === 0 && (
                 <tr>
-                  <td className="px-3 py-4 text-center text-slate-500" colSpan={7}>
+                  <td className="px-3 py-4 text-center text-cp-text-faint" colSpan={7}>
                     {t('rentman.cableExport.noCables', 'Keine Kabel im Projekt.')}
                   </td>
                 </tr>
@@ -374,10 +374,10 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
                   bucket.delta > 0 &&
                   busyKey !== bucket.key
                 return (
-                  <tr key={bucket.key} className="border-t border-slate-800 align-top">
+                  <tr key={bucket.key} className="border-t border-cp-border-muted align-top">
                     <td className="px-3 py-1.5">
-                      <div className="font-medium text-slate-100">{bucket.type}</div>
-                      <div className="text-[10px] text-slate-400">
+                      <div className="font-medium text-cp-text">{bucket.type}</div>
+                      <div className="text-[10px] text-cp-text-muted">
                         {bucket.length} m
                         {bucket.sample ? ` · ${bucket.sample.name}` : ''}
                       </div>
@@ -407,17 +407,17 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
                       {bucket.mappedId ? (
                         <div className="flex items-center gap-2">
                           <div className="min-w-0 flex-1">
-                            <div className="truncate text-slate-200">
+                            <div className="truncate text-cp-text-bright">
                               {bucket.mappedName ?? format(t('rentman.cableExport.rentmanId', 'Rentman-ID {id}'), { id: bucket.mappedId })}
                             </div>
-                            <div className="text-[10px] text-slate-400">
+                            <div className="text-[10px] text-cp-text-muted">
                               ID {bucket.mappedId}
                             </div>
                           </div>
                           <button
                             type="button"
                             onClick={() => clearMapping(bucket.key)}
-                            className="rounded bg-slate-700 px-1.5 py-0.5 text-[10px] hover:bg-slate-600"
+                            className="rounded bg-cp-surface-4 px-1.5 py-0.5 text-[10px] hover:bg-cp-surface-5"
                             title={t('rentman.cableExport.removeMapping', 'Zuordnung entfernen')}
                             aria-label={t('rentman.cableExport.removeMapping', 'Zuordnung entfernen')}
                           >
@@ -432,29 +432,29 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
                             setPickerKey(bucket.key)
                             setPickerQuery(`${bucket.type}`)
                           }}
-                          className="rounded bg-slate-700 px-2 py-0.5 text-[10px] hover:bg-slate-600"
+                          className="rounded bg-cp-surface-4 px-2 py-0.5 text-[10px] hover:bg-cp-surface-5"
                         >
                           {t('rentman.cableExport.pickEquipment', 'Rentman-Equipment wählen…')}
                         </button>
                       )}
                       {pickerKey === bucket.key && (
-                        <div className="mt-1 rounded border border-slate-700 bg-slate-950 p-1.5">
+                        <div className="mt-1 rounded border border-cp-border bg-cp-surface-3 p-1.5">
                           <input
                             type="text"
                             value={pickerQuery}
                             onChange={(event) => setPickerQuery(event.target.value)}
                             placeholder={t('rentman.cableExport.searchPlaceholder', 'Suchen…')}
                             aria-label={t('rentman.cableExport.searchPlaceholder', 'Suchen…')}
-                            className="mb-1 w-full rounded border border-slate-700 bg-slate-900 px-2 py-0.5 text-[11px]"
+                            className="mb-1 w-full rounded border border-cp-border bg-cp-surface-1 px-2 py-0.5 text-[11px]"
                           />
                           <div className="max-h-40 space-y-0.5 overflow-auto">
                             {!catalogLoaded && !catalogLoading && (
-                              <div className="px-1 py-0.5 text-[10px] italic text-slate-400">
+                              <div className="px-1 py-0.5 text-[10px] italic text-cp-text-muted">
                                 {t('rentman.cableExport.loadCatalogFirst', 'Bitte zuerst Katalog laden.')}
                               </div>
                             )}
                             {catalogLoading && (
-                              <div className="px-1 py-0.5 text-[10px] italic text-slate-400">
+                              <div className="px-1 py-0.5 text-[10px] italic text-cp-text-muted">
                                 {t('rentman.cableExport.loading', 'Lädt…')}
                               </div>
                             )}
@@ -466,12 +466,12 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
                                   setMapping(bucket.key, item.id, { resetSync: true })
                                   setPickerKey(null)
                                 }}
-                                className="flex w-full items-start justify-between gap-2 rounded px-1 py-0.5 text-left text-[11px] hover:bg-slate-800"
+                                className="flex w-full items-start justify-between gap-2 rounded px-1 py-0.5 text-left text-[11px] hover:bg-cp-surface-2"
                               >
-                                <span className="min-w-0 flex-1 truncate text-slate-200">
+                                <span className="min-w-0 flex-1 truncate text-cp-text-bright">
                                   {item.name}
                                 </span>
-                                <span className="shrink-0 text-[10px] text-slate-400">
+                                <span className="shrink-0 text-[10px] text-cp-text-muted">
                                   {item.category}
                                 </span>
                               </button>
@@ -481,7 +481,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
                             <button
                               type="button"
                               onClick={() => setPickerKey(null)}
-                              className="rounded bg-slate-700 px-2 py-0.5 text-[10px] hover:bg-slate-600"
+                              className="rounded bg-cp-surface-4 px-2 py-0.5 text-[10px] hover:bg-cp-surface-5"
                             >
                               {t('common.cancel', 'Abbrechen')}
                             </button>
@@ -491,7 +491,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
                       {status && (
                         <div
                           className={`mt-1 text-[10px] ${
-                            status.startsWith('Fehler') ? 'text-red-400' : 'text-slate-400'
+                            status.startsWith('Fehler') ? 'text-red-400' : 'text-cp-text-muted'
                           }`}
                         >
                           {status}

--- a/src/renderer/components/Rentman/RentmanImportDialog.tsx
+++ b/src/renderer/components/Rentman/RentmanImportDialog.tsx
@@ -1318,24 +1318,24 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-6">
       {/* ── Confirmation: switch linked Rentman project ── */}
       {pendingProjectSwitch && (
-        <div className="w-full max-w-md rounded border border-amber-600 bg-slate-900 p-5 text-slate-100 shadow-xl">
+        <div className="w-full max-w-md rounded border border-amber-600 bg-cp-surface-1 p-5 text-cp-text shadow-xl">
           <h3 className="mb-2 text-cp-xl font-semibold text-amber-400">{t('rentman.import.switch.title', 'Rentman-Projekt wechseln?')}</h3>
-          <p className="mb-1 text-cp-base text-slate-300">
+          <p className="mb-1 text-cp-base text-cp-text-secondary">
             {t('rentman.import.switch.alreadyLinkedPre', 'Dieses Projekt ist bereits mit dem Rentman-Projekt')}
             {linkedProjectName ? (
               <> <span className="font-medium text-white">„{linkedProjectName}"</span></>
             ) : (
-              <> <span className="font-mono text-cp-xs text-slate-400">{linkedProjectId}</span></>
+              <> <span className="font-mono text-cp-xs text-cp-text-muted">{linkedProjectId}</span></>
             )} {t('rentman.import.switch.alreadyLinkedPost', 'verknüpft.')}
           </p>
-          <p className="mb-4 text-cp-base text-slate-300">
+          <p className="mb-4 text-cp-base text-cp-text-secondary">
             {t('rentman.import.switch.askLoadInsteadPre', 'Soll stattdessen')} <span className="font-medium text-white">„{pendingProjectSwitch.name}"</span> {t('rentman.import.switch.askLoadInsteadPost', 'geladen werden? Bereits importierte Geräte auf der Canvas behalten ihre Verknüpfung.')}
           </p>
           <div className="flex justify-end gap-2">
             <button
               type="button"
               onClick={() => setPendingProjectSwitch(null)}
-              className="rounded bg-slate-700 px-3 py-1.5 text-cp-base hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-3 py-1.5 text-cp-base hover:bg-cp-surface-5"
             >
               {t('common.cancel', 'Abbrechen')}
             </button>
@@ -1355,18 +1355,18 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
       )}
 
       {!pendingProjectSwitch && conflictItems && (
-        <div className="w-full max-w-2xl rounded border border-amber-600 bg-slate-900 p-5 text-slate-100 shadow-xl">
+        <div className="w-full max-w-2xl rounded border border-amber-600 bg-cp-surface-1 p-5 text-cp-text shadow-xl">
           <h3 className="mb-2 text-cp-xl font-semibold text-amber-400">
             {conflictItems.length === 1
               ? t('rentman.import.conflict.titleOne', 'Gerät bereits in lokaler Bibliothek')
               : format(t('rentman.import.conflict.titleMany', '{count} Geräte bereits in lokaler Bibliothek'), { count: conflictItems.length })}
           </h3>
-          <p className="mb-3 text-cp-base text-slate-300">
+          <p className="mb-3 text-cp-base text-cp-text-secondary">
             {t('rentman.import.conflict.intro', 'Folgende aus Rentman ausgewählte Geräte gibt es schon in deiner lokalen Bibliothek. Standardmäßig wird die lokale Definition beibehalten – damit gehen deine eigenen Port-Konfigurationen nicht verloren. Du kannst pro Gerät entscheiden:')}
           </p>
-          <div className="mb-3 max-h-[55vh] overflow-auto rounded border border-slate-800">
+          <div className="mb-3 max-h-[55vh] overflow-auto rounded border border-cp-border-muted">
             <table className="w-full text-cp-xs">
-              <thead className="sticky top-0 bg-slate-950 text-left text-[11px] uppercase tracking-wide text-slate-400">
+              <thead className="sticky top-0 bg-cp-surface-3 text-left text-[11px] uppercase tracking-wide text-cp-text-muted">
                 <tr>
                   <th className="px-2 py-1">{t('rentman.import.col.device', 'Gerät')}</th>
                   <th className="px-2 py-1">{t('rentman.import.col.action', 'Aktion')}</th>
@@ -1374,10 +1374,10 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
               </thead>
               <tbody>
                 {conflictItems.map((c, idx) => (
-                  <tr key={c.name} className="border-t border-slate-800 align-top">
+                  <tr key={c.name} className="border-t border-cp-border-muted align-top">
                     <td className="px-2 py-1.5">
                       <div className="font-medium">{c.name}</div>
-                      <div className="text-[11px] text-slate-400">{c.category}</div>
+                      <div className="text-[11px] text-cp-text-muted">{c.category}</div>
                     </td>
                     <td className="px-2 py-1.5">
                       <div className="flex flex-col gap-0.5">
@@ -1423,7 +1423,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                                       [c.name]: e.target.value,
                                     }))
                                   }}
-                                  className="rounded bg-slate-800 px-2 py-1 text-cp-xs text-slate-100"
+                                  className="rounded bg-cp-surface-2 px-2 py-1 text-cp-xs text-cp-text"
                                 >
                                   <option value="">{t('rentman.import.link.placeholder', '-- Gerät wählen --')}</option>
                                   {customLibrary
@@ -1445,7 +1445,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
               </tbody>
             </table>
           </div>
-          <div className="mb-3 flex items-center gap-2 text-[11px] text-slate-400">
+          <div className="mb-3 flex items-center gap-2 text-[11px] text-cp-text-muted">
             <span>{t('rentman.import.setAll', 'Alle setzen:')}</span>
             {(
               [
@@ -1462,7 +1462,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                     prev ? prev.map((item) => ({ ...item, decision: value })) : prev,
                   )
                 }
-                className="rounded bg-slate-700 px-2 py-0.5 hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-2 py-0.5 hover:bg-cp-surface-5"
               >
                 {label}
               </button>
@@ -1472,7 +1472,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
             <button
               type="button"
               onClick={() => setConflictItems(null)}
-              className="rounded bg-slate-700 px-3 py-1.5 text-cp-base hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-3 py-1.5 text-cp-base hover:bg-cp-surface-5"
             >
               {t('common.cancel', 'Abbrechen')}
             </button>
@@ -1531,17 +1531,17 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
       )}
 
       {!pendingProjectSwitch && !conflictItems && categoryAssignments && (
-        <div className="w-full max-w-2xl rounded border border-cyan-700 bg-slate-900 p-5 text-slate-100 shadow-xl">
+        <div className="w-full max-w-2xl rounded border border-cyan-700 bg-cp-surface-1 p-5 text-cp-text shadow-xl">
           <h3 className="mb-2 text-cp-xl font-semibold text-cyan-300">{t('rentman.import.catMap.title', 'Kategorie-Zuordnung vor Import')}</h3>
-          <p className="mb-3 text-cp-base text-slate-300">
+          <p className="mb-3 text-cp-base text-cp-text-secondary">
             {t(
               'rentman.import.catMap.intro',
               'Jedes Gerät einer lokalen Kategorie zuordnen. Passende werden automatisch erkannt und gemerkt — fehlende kannst du mit „+ Neu“ direkt anlegen. „Zurück“ behält deine Auswahl.',
             )}
           </p>
-          <div className="mb-3 max-h-[55vh] overflow-auto rounded border border-slate-800">
+          <div className="mb-3 max-h-[55vh] overflow-auto rounded border border-cp-border-muted">
             <table className="w-full text-cp-xs">
-              <thead className="sticky top-0 bg-slate-950 text-left text-[11px] uppercase tracking-wide text-slate-400">
+              <thead className="sticky top-0 bg-cp-surface-3 text-left text-[11px] uppercase tracking-wide text-cp-text-muted">
                 <tr>
                   <th className="px-2 py-1">{t('rentman.import.col.device', 'Gerät')}</th>
                   <th className="px-2 py-1">{t('rentman.import.col.rentman', 'Rentman')}</th>
@@ -1550,9 +1550,9 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
               </thead>
               <tbody>
                 {categoryAssignments.map((row, index) => (
-                  <tr key={`${row.name}-${index}`} className="border-t border-slate-800">
-                    <td className="px-2 py-1.5 font-medium text-slate-100">{row.name}</td>
-                    <td className="px-2 py-1.5 text-slate-500">{row.sourceCategory}</td>
+                  <tr key={`${row.name}-${index}`} className="border-t border-cp-border-muted">
+                    <td className="px-2 py-1.5 font-medium text-cp-text">{row.name}</td>
+                    <td className="px-2 py-1.5 text-cp-text-faint">{row.sourceCategory}</td>
                     <td className="px-2 py-1.5">
                       <div className="flex items-center gap-1.5">
                         <select
@@ -1566,7 +1566,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                                 : prev,
                             )
                           }
-                          className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1"
+                          className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1"
                         >
                           <option value="">{t('rentman.import.catMap.pickPlaceholder', 'Bitte auswählen...')}</option>
                           {importCategoryOptions.map((cat) => (
@@ -1600,7 +1600,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                 persistAssignments(categoryAssignments)
                 setCategoryAssignments(null)
               }}
-              className="rounded bg-slate-700 px-3 py-1.5 text-cp-base hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-3 py-1.5 text-cp-base hover:bg-cp-surface-5"
             >
               {t('rentman.import.catMap.back', 'Zurück')}
             </button>
@@ -1634,12 +1634,12 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
 
       {!pendingProjectSwitch && !conflictItems && !categoryAssignments && (
         <>
-      <div className="w-full max-w-3xl rounded border border-slate-700 bg-slate-900 p-4 text-slate-100">
+      <div className="w-full max-w-3xl rounded border border-cp-border bg-cp-surface-1 p-4 text-cp-text">
         <div className="mb-3 flex items-center justify-between">
           <h3 className="text-cp-xl font-semibold">
             {t('rentman.import.title', 'Aus Rentman importieren')}
           </h3>
-          <button type="button" onClick={onClose} className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600">
+          <button type="button" onClick={onClose} className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5">
             {t('common.close', 'Schließen')}
           </button>
         </div>
@@ -1654,9 +1654,9 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
               ].filter(Boolean).join(' · ')
             : selectedProjectId
           return (
-            <div className="mb-3 flex flex-wrap items-center gap-2 rounded border border-slate-800 bg-slate-950/40 px-2 py-1.5 text-cp-xs">
-              <span className="text-slate-400">{t('rentman.import.projectLabel', 'Projekt:')}</span>
-              <span className="font-medium text-slate-100">{label}</span>
+            <div className="mb-3 flex flex-wrap items-center gap-2 rounded border border-cp-border-muted bg-cp-surface-3/40 px-2 py-1.5 text-cp-xs">
+              <span className="text-cp-text-muted">{t('rentman.import.projectLabel', 'Projekt:')}</span>
+              <span className="font-medium text-cp-text">{label}</span>
               {selectedProjectId === linkedProjectId && (
                 <span className="inline-flex items-center gap-1 font-medium text-emerald-400">
                   <Icon icon={Check} size="xs" /> {t('rentman.import.linkedShort', 'verknüpft')}
@@ -1667,14 +1667,14 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                   type="button"
                   onClick={() => void fetchEquipment(selectedProjectId)}
                   disabled={loading}
-                  className="rounded px-2 py-0.5 text-slate-300 hover:bg-slate-800 disabled:opacity-50"
+                  className="rounded px-2 py-0.5 text-cp-text-secondary hover:bg-cp-surface-2 disabled:opacity-50"
                 >
                   {loading ? t('rentman.import.loadingShort', 'Lädt…') : t('rentman.import.reloadSync', '↻ Neu laden & Abgleichen')}
                 </button>
                 <button
                   type="button"
                   onClick={() => setPickerOpen(true)}
-                  className="rounded px-2 py-0.5 font-medium text-sky-300 hover:bg-slate-800"
+                  className="rounded px-2 py-0.5 font-medium text-sky-300 hover:bg-cp-surface-2"
                 >
                   {t('rentman.import.changeProject', 'ändern')}
                 </button>
@@ -1683,7 +1683,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
           )
         })()}
         {(!selectedProjectId || items.length === 0 || pickerOpen) && (
-        <div className="mb-3 space-y-2 rounded border border-slate-800 bg-slate-950/40 p-2">
+        <div className="mb-3 space-y-2 rounded border border-cp-border-muted bg-cp-surface-3/40 p-2">
           <div className="flex flex-wrap items-center gap-2">
             <button
               type="button"
@@ -1703,13 +1703,13 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                 {t('rentman.import.refresh', '↺ Rentman aktualisieren')}
               </button>
             )}
-            <span className="text-cp-xs text-slate-500">
+            <span className="text-cp-xs text-cp-text-faint">
               {projects.length > 0
                 ? format(t('rentman.import.projectsCount', '{visible} / {total} Projekte'), { visible: sortedProjects.length, total: projects.length })
                 : t('rentman.import.noneLoaded', 'Noch keine Projekte geladen')}
             </span>
             <div className="ml-auto flex items-center gap-1 text-cp-xs">
-              <span className="text-slate-400">{t('rentman.import.sort', 'Sortierung:')}</span>
+              <span className="text-cp-text-muted">{t('rentman.import.sort', 'Sortierung:')}</span>
               {(
                 [
                   ['number-desc', '# ↓'],
@@ -1725,7 +1725,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                   className={`rounded px-2 py-0.5 ${
                     projectSort === value
                       ? 'bg-sky-600 text-white'
-                      : 'bg-slate-700 hover:bg-slate-600'
+                      : 'bg-cp-surface-4 hover:bg-cp-surface-5'
                   }`}
                 >
                   {label}
@@ -1740,13 +1740,13 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
               onChange={(e) => setProjectQuery(e.target.value)}
               placeholder={t('rentman.import.searchPlaceholder', 'Suche nach Name, Nummer oder Status…')}
               aria-label={t('rentman.import.searchPlaceholder', 'Suche nach Name, Nummer oder Status…')}
-              className="flex-1 rounded border border-slate-700 bg-slate-900 px-2 py-1 text-cp-base"
+              className="flex-1 rounded border border-cp-border bg-cp-surface-1 px-2 py-1 text-cp-base"
             />
             {projectQuery && (
               <button
                 type="button"
                 onClick={() => setProjectQuery('')}
-                className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
               >
                 {t('rentman.import.clearSearch', 'Leeren')}
               </button>
@@ -1770,7 +1770,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
               type="button"
               onClick={() => void fetchEquipment(selectedProjectId)}
               disabled={loading}
-              className="mt-1 w-full rounded bg-slate-700 px-2 py-1 text-cp-xs text-slate-200 hover:bg-slate-600 disabled:opacity-50"
+              className="mt-1 w-full rounded bg-cp-surface-4 px-2 py-1 text-cp-xs text-cp-text-bright hover:bg-cp-surface-5 disabled:opacity-50"
             >
               {loading ? t('rentman.import.loadingShort', 'Lädt…') : t('rentman.import.reloadSync', '↻ Neu laden & Abgleichen')}
             </button>
@@ -1778,7 +1778,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
         </div>
         )}
 
-        {loading && <div className="mb-2 text-cp-base text-slate-300">{t('rentman.import.loading', 'Loading…')}</div>}
+        {loading && <div className="mb-2 text-cp-base text-cp-text-secondary">{t('rentman.import.loading', 'Loading…')}</div>}
         {error && <div className="mb-2 rounded bg-red-900/50 p-2 text-cp-base text-red-100">{error}</div>}
         {warning && <div className="mb-2 rounded bg-amber-900/40 p-2 text-cp-base text-amber-100">{warning}</div>}
 
@@ -1786,14 +1786,14 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
           <>
             {allCategories.length > 1 && (
               <div className="mb-2 flex flex-wrap items-center gap-1 text-cp-xs">
-                <span className="mr-1 text-slate-400">{t('rentman.import.categories', 'Categories:')}</span>
+                <span className="mr-1 text-cp-text-muted">{t('rentman.import.categories', 'Categories:')}</span>
                 <button
                   type="button"
                   onClick={() => setSelectedCategories(new Set())}
                   className={`rounded px-2 py-0.5 ${
                     selectedCategories.size === 0
                       ? 'bg-sky-600 text-white'
-                      : 'bg-slate-700 hover:bg-slate-600'
+                      : 'bg-cp-surface-4 hover:bg-cp-surface-5'
                   }`}
                 >
                   {t('rentman.import.categoriesAll', 'Alle')}
@@ -1806,7 +1806,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                       type="button"
                       onClick={() => toggleCategory(cat)}
                       className={`rounded px-2 py-0.5 ${
-                        active ? 'bg-sky-600 text-white' : 'bg-slate-700 hover:bg-slate-600'
+                        active ? 'bg-sky-600 text-white' : 'bg-cp-surface-4 hover:bg-cp-surface-5'
                       }`}
                     >
                       {cat}
@@ -1815,7 +1815,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                 })}
               </div>
             )}
-            <div className="mb-2 flex items-center justify-between text-cp-xs text-slate-400">
+            <div className="mb-2 flex items-center justify-between text-cp-xs text-cp-text-muted">
               <span>
                 {format(t('rentman.import.shown', '{visible} of {total} shown'), { visible: visibleItems.length, total: items.length })}
                 {setChildCount > 0 && ` ${format(t('rentman.import.inSets', '· {count} in sets (expand to view)'), { count: setChildCount })}`}
@@ -1873,7 +1873,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                   )}
                   {fresh > 0 && (
                     <span
-                      className="rounded bg-slate-800/60 px-1.5 py-0.5 text-slate-400"
+                      className="rounded bg-cp-surface-2/60 px-1.5 py-0.5 text-cp-text-muted"
                       title={t('rentman.import.status.freshTitle', 'Items ohne Match in der lokalen Library — werden frisch als Template importiert.')}
                     >
                       {format(t('rentman.import.status.fresh', '+ {count} neu'), { count: fresh })}
@@ -1996,7 +1996,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                             if (allSelected) setCablePlanSelected(new Set())
                             else setCablePlanSelected(new Set(cableBuckets.map((b) => b.key)))
                           }}
-                          className="rounded bg-slate-700 px-2 py-0.5 hover:bg-slate-600"
+                          className="rounded bg-cp-surface-4 px-2 py-0.5 hover:bg-cp-surface-5"
                         >
                           {allSelected ? t('rentman.import.cablePlan.deselectAll', 'Alle abwählen') : t('rentman.import.cablePlan.selectAll', 'Alle auswählen')}
                         </button>
@@ -2004,24 +2004,24 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                     })()}
                   </div>
                 </div>
-                <div className="max-h-48 space-y-0.5 overflow-auto rounded border border-orange-900/40 bg-slate-950/40 p-1">
+                <div className="max-h-48 space-y-0.5 overflow-auto rounded border border-orange-900/40 bg-cp-surface-3/40 p-1">
                   {cableBuckets.map((bucket) => {
                     const checked = cablePlanSelected.has(bucket.key)
                     const qty = cablePlanQty[bucket.key] ?? bucket.totalQty
                     return (
                       <label
                         key={bucket.key}
-                        className="flex items-center gap-2 rounded px-1.5 py-0.5 text-cp-xs hover:bg-slate-900"
+                        className="flex items-center gap-2 rounded px-1.5 py-0.5 text-cp-xs hover:bg-cp-surface-1"
                       >
                         <input
                           type="checkbox"
                           checked={checked}
                           onChange={() => toggleCableBucket(bucket.key)}
                         />
-                        <span className="w-32 truncate font-medium text-slate-100">
+                        <span className="w-32 truncate font-medium text-cp-text">
                           {bucket.type}
                         </span>
-                        <span className="w-16 text-slate-300">{bucket.length} m</span>
+                        <span className="w-16 text-cp-text-secondary">{bucket.length} m</span>
                         <input
                           type="number"
                           min={0}
@@ -2029,9 +2029,9 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                           onChange={(event) =>
                             setCableBucketQty(bucket.key, Number(event.target.value))
                           }
-                          className="w-16 rounded border border-slate-700 bg-slate-900 px-1 py-0.5 text-right"
+                          className="w-16 rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-right"
                         />
-                        <span className="text-[10px] text-slate-400">
+                        <span className="text-[10px] text-cp-text-muted">
                           {bucket.rows.length === 1
                             ? bucket.rows[0].name
                             : format(t('rentman.import.cablePlan.entryCount', '{count} Einträge'), { count: bucket.rows.length })}
@@ -2047,7 +2047,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                         ? 'text-emerald-400'
                         : cablePlanResult
                           ? 'text-amber-300'
-                          : 'text-slate-500'
+                          : 'text-cp-text-faint'
                     }`}
                   >
                     {cablePlanResult && (
@@ -2074,7 +2074,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                   {format(importResult === 1 ? t('rentman.import.resultOne', '✓ {count} Gerät zur Library hinzugefügt') : t('rentman.import.resultMany', '✓ {count} Geräte zur Library hinzugefügt'), { count: importResult })}
                 </span>
               ) : (
-                <span className="text-cp-xs text-slate-400">
+                <span className="text-cp-xs text-cp-text-muted">
                   {t('rentman.import.resultHint', 'Geräte werden zur Equipment Library hinzugefügt, nicht direkt auf die Canvas platziert.')}
                 </span>
               )}

--- a/src/renderer/components/Sync/SharedSyncPanel.tsx
+++ b/src/renderer/components/Sync/SharedSyncPanel.tsx
@@ -169,7 +169,7 @@ export function SharedSyncPanel() {
       ? 'text-emerald-400'
       : status.kind === 'error' || status.kind === 'locked'
         ? 'text-red-400'
-        : 'text-slate-500'
+        : 'text-cp-text-faint'
 
   return (
     <div className="flex items-center gap-1">
@@ -188,7 +188,7 @@ export function SharedSyncPanel() {
         title={format(t('sync.pullTitle', 'Pull von: {path}'), { path: syncPath })}
         disabled={busy}
         onClick={() => { void handlePull() }}
-        className="flex items-center gap-1 rounded bg-slate-700 px-2 py-1 text-cp-xs text-white hover:bg-slate-600 disabled:opacity-50"
+        className="flex items-center gap-1 rounded bg-cp-surface-4 px-2 py-1 text-cp-xs text-white hover:bg-cp-surface-5 disabled:opacity-50"
       >
         <Icon icon={Download} size="xs" />
         <span>{t('sync.pull', 'Pull')}</span>

--- a/src/renderer/components/shared/CategorySelect.tsx
+++ b/src/renderer/components/shared/CategorySelect.tsx
@@ -41,7 +41,7 @@ export const CategorySelect = ({
   value,
   onChange,
   extraOptions,
-  className = 'w-full rounded border border-slate-700 bg-slate-900 p-2',
+  className = 'w-full rounded border border-cp-border bg-cp-surface-1 p-2',
   noCreate = false,
   promptTitle,
 }: CategorySelectProps) => {

--- a/src/renderer/components/shared/ColorField.tsx
+++ b/src/renderer/components/shared/ColorField.tsx
@@ -39,13 +39,13 @@ export const ColorField = ({
   if (layout === 'inline') {
     return (
       <label className="flex items-center justify-between gap-2">
-        <span className="text-slate-300">{label}</span>
+        <span className="text-cp-text-secondary">{label}</span>
         <div className="flex items-center gap-2">
           <input
             type="color"
             value={value}
             onChange={(event) => onChange(event.target.value)}
-            className="h-7 w-12 cursor-pointer rounded border border-slate-700 bg-slate-900 p-0.5"
+            className="h-7 w-12 cursor-pointer rounded border border-cp-border bg-cp-surface-1 p-0.5"
             title={title}
             aria-label={label}
           />
@@ -53,7 +53,7 @@ export const ColorField = ({
             <button
               type="button"
               onClick={onReset}
-              className="rounded bg-slate-700 px-1.5 py-0.5 text-[10px] hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-1.5 py-0.5 text-[10px] hover:bg-cp-surface-5"
               title={t('colorField.resetTitle', 'Farbe zurücksetzen')}
             >
               {t('colorField.resetBtn', '✕ Reset')}
@@ -65,12 +65,12 @@ export const ColorField = ({
   }
   return (
     <label className="block">
-      <span className="mb-1 block text-slate-300">{label}</span>
+      <span className="mb-1 block text-cp-text-secondary">{label}</span>
       <input
         type="color"
         value={value}
         onChange={(event) => onChange(event.target.value)}
-        className="h-9 w-full cursor-pointer rounded border border-slate-700 bg-slate-900 p-1"
+        className="h-9 w-full cursor-pointer rounded border border-cp-border bg-cp-surface-1 p-1"
         title={title}
         aria-label={label}
       />

--- a/src/renderer/components/shared/ConnectorPicker.tsx
+++ b/src/renderer/components/shared/ConnectorPicker.tsx
@@ -139,7 +139,7 @@ export const ConnectorPicker = ({
         aria-haspopup="dialog"
         aria-expanded={open}
         aria-label={ariaLabel}
-        className={`flex w-full items-center gap-2 rounded border border-slate-700 bg-slate-950 text-left text-slate-200 hover:border-slate-500 ${
+        className={`flex w-full items-center gap-2 rounded border border-cp-border bg-cp-surface-3 text-left text-cp-text-bright hover:border-slate-500 ${
           size === 'sm' ? 'px-1.5 py-1' : 'px-2 py-1.5'
         }`}
       >
@@ -156,7 +156,7 @@ export const ConnectorPicker = ({
         <span className={`flex-1 truncate ${size === 'sm' ? 'text-[11px]' : 'text-cp-base'}`}>
           {connectorLabel(value)}
         </span>
-        <ChevronDown size={14} className="shrink-0 text-slate-500" />
+        <ChevronDown size={14} className="shrink-0 text-cp-text-faint" />
       </button>
 
       {open &&
@@ -165,23 +165,23 @@ export const ConnectorPicker = ({
           <div
             ref={popRef}
             role="dialog"
-            className="fixed z-[300] flex max-h-[360px] flex-col overflow-hidden rounded-cp-card border border-slate-700 bg-slate-900 shadow-2xl"
+            className="fixed z-[300] flex max-h-[360px] flex-col overflow-hidden rounded-cp-card border border-cp-border bg-cp-surface-1 shadow-2xl"
             style={{ left: pos.left, top: pos.top, width: pos.width }}
           >
-            <div className="flex items-center gap-2 border-b border-slate-800 px-2 py-1.5">
-              <Search size={14} className="shrink-0 text-slate-500" />
+            <div className="flex items-center gap-2 border-b border-cp-border-muted px-2 py-1.5">
+              <Search size={14} className="shrink-0 text-cp-text-faint" />
               <input
                 autoFocus
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
                 placeholder={t('connector.picker.search', 'Stecker suchen…')}
                 aria-label={t('connector.picker.search', 'Stecker suchen…')}
-                className="w-full bg-transparent text-cp-base text-slate-200 outline-none placeholder:text-slate-600"
+                className="w-full bg-transparent text-cp-base text-cp-text-bright outline-none placeholder:text-slate-600"
               />
             </div>
             <div className="flex-1 overflow-y-auto p-2">
               {filteredGroups.length === 0 && (
-                <div className="px-2 py-6 text-center text-cp-xs text-slate-500">
+                <div className="px-2 py-6 text-center text-cp-xs text-cp-text-faint">
                   {t('connector.picker.noResults', 'Kein Stecker gefunden')}
                 </div>
               )}
@@ -209,11 +209,11 @@ export const ConnectorPicker = ({
                           className={`flex flex-col items-center gap-1 rounded border px-1 py-1.5 text-center transition ${
                             active
                               ? 'border-sky-500 bg-sky-500/10'
-                              : 'border-slate-800 bg-slate-950/40 hover:border-slate-600 hover:bg-slate-800/60'
+                              : 'border-cp-border-muted bg-cp-surface-3/40 hover:border-cp-surface-5 hover:bg-cp-surface-2/60'
                           }`}
                         >
                           <span style={{ color: connectorColor(e) }}>{tileSymbolFor(e)}</span>
-                          <span className="w-full truncate text-[11px] leading-tight text-slate-300">
+                          <span className="w-full truncate text-[11px] leading-tight text-cp-text-secondary">
                             {e.label}
                           </span>
                         </button>

--- a/src/renderer/components/shared/Icon.tsx
+++ b/src/renderer/components/shared/Icon.tsx
@@ -5,7 +5,7 @@
 // einheitlichen Größen-, Stroke- und Farb-Defaults.
 //
 // Farbe kommt per `currentColor` aus der umgebenden Text-Klasse
-// (z. B. text-slate-400) — dadurch sind Icons automatisch theme-aware,
+// (z. B. text-cp-text-muted) — dadurch sind Icons automatisch theme-aware,
 // ohne dass eine eigene Farb-Prop nötig ist.
 
 import type { LucideIcon, LucideProps } from 'lucide-react'


### PR DESCRIPTION
## Zweck
Großflächige `slate-*`→cp-Token-Migration aller **CSS-gethemeten Dialoge und Panels** (73 Dateien) — der Hauptteil von #449, jetzt möglich da #532 die gesamte slate-Rampe token-abgedeckt hat.

## Umfang
Export, Properties (inkl. sections), Library (+ tabs), Rentman, Calculators, Import, Print, Project, Patch, Cable, Atem, Annotations, Layout (MenuBar/StatusBar), shared, Onboarding u. a. — mechanische Regex-Migration, die Opacity- (`/40`) und State-Prefixes (`hover:`/`focus:`/`group-hover:`) erhält.

**Bewusst ausgelassen** (separat / by design):
- `Canvas/` + `Rack/` + `App.tsx` → eigener Batch mit Canvas-Verifikation.
- isLight-Komponenten (EquipmentNode, RackLivePreview, …) → themen per Prop, behalten rohes slate (CLAUDE.md).
- Nicht-token-fähige Shades (`text-slate-600/700`, `border-slate-400/500`, Matrix-Daten-`bg-slate-300/400/500`) → bleiben roh, vom 340-Zeilen-Remap abgedeckt.

## Verifikation
- Jeder ersetzte slate↔cp-Paar ist in #525/#532 als **pixelgleich (dark+light)** bewiesen → **appearance-neutral by construction**.
- **build 0 · tsc 0 · eslint 0 NEUE Errors** (3 Baseline unverändert: `CalculatorsDialog:395`, `Tooltip:111/116` — Logik-Findings, nicht className-bezogen).
- **Library-Panel + App-Shell** headless in **light + dark** gescreenshottet: theme-korrekt, **0 Console-Errors**.

Refs #449

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_