### PR TITLE
refactor(theme): migrate Canvas/Rack/App shell slate-* → cp-tokens (#449)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -964,7 +964,7 @@ export default function App() {
   }, [pendingConnection, project.equipment])
 
   return (
-    <div className="flex h-screen flex-col bg-slate-900 text-slate-100">
+    <div className="flex h-screen flex-col bg-cp-surface-1 text-cp-text">
       <MenuBar
         onNewProject={handleNewProject}
         onOpenProject={() => void openProject()}
@@ -1154,8 +1154,8 @@ export default function App() {
           : undefined
         return (
           <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
-            <div className="w-full max-w-md rounded border border-amber-700 bg-slate-900 text-slate-100 shadow-2xl">
-              <header className="border-b border-slate-700 px-4 py-2">
+            <div className="w-full max-w-md rounded border border-amber-700 bg-cp-surface-1 text-cp-text shadow-2xl">
+              <header className="border-b border-cp-border px-4 py-2">
                 <h2 className="text-cp-base font-semibold text-amber-300">
                   {t('app.portConflict.title', 'Port bereits belegt')}
                 </h2>
@@ -1176,35 +1176,35 @@ export default function App() {
                   </strong>{' '}
                   {t('app.portConflict.connected', 'belegt:')}
                 </p>
-                <ul className="mb-3 max-h-32 space-y-1 overflow-auto rounded border border-slate-700 bg-slate-950 p-2 text-cp-xs">
+                <ul className="mb-3 max-h-32 space-y-1 overflow-auto rounded border border-cp-border bg-cp-surface-3 p-2 text-cp-xs">
                   {conflictingCables.map((c) => {
                     const srcEq = getEquipmentById(project.equipment, c.fromEquipmentId)
                     const srcPort = srcEq
                       ? [...srcEq.inputs, ...srcEq.outputs].find((p) => p.id === c.fromPortId)
                       : undefined
                     return (
-                      <li key={c.id} className="font-mono text-slate-300">
+                      <li key={c.id} className="font-mono text-cp-text-secondary">
                         {srcEq?.name ?? '?'} · {srcPort?.name ?? '?'} →{' '}
                         {targetEq?.name ?? '?'} · {targetPort?.name ?? '?'}
                         {c.name ? (
-                          <span className="ml-1 text-slate-500">({c.name})</span>
+                          <span className="ml-1 text-cp-text-faint">({c.name})</span>
                         ) : null}
                       </li>
                     )
                   })}
                 </ul>
-                <p className="text-[12px] text-slate-400">
+                <p className="text-[12px] text-cp-text-muted">
                   {t(
                     'app.portConflict.hint',
                     '„Ersetzen" entfernt die obige(n) Verbindung(en) und legt das neue Kabel an. „Abbrechen" verwirft den Connect-Versuch.',
                   )}
                 </p>
               </div>
-              <footer className="flex justify-end gap-2 border-t border-slate-700 px-4 py-2">
+              <footer className="flex justify-end gap-2 border-t border-cp-border px-4 py-2">
                 <button
                   type="button"
                   onClick={cancelPortConflict}
-                  className="rounded bg-slate-700 px-3 py-1 text-cp-xs hover:bg-slate-600"
+                  className="rounded bg-cp-surface-4 px-3 py-1 text-cp-xs hover:bg-cp-surface-5"
                 >
                   {t('common.cancel', 'Abbrechen')}
                 </button>
@@ -1222,19 +1222,19 @@ export default function App() {
       })()}
       {pdfProgress.active && (
         <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/60 backdrop-blur-sm">
-          <div className="w-[420px] max-w-[90vw] rounded-cp-card border border-slate-700 bg-slate-900 p-5 text-slate-100 shadow-2xl">
+          <div className="w-[420px] max-w-[90vw] rounded-cp-card border border-cp-border bg-cp-surface-1 p-5 text-cp-text shadow-2xl">
             <div className="mb-3 flex items-center gap-3">
               <div className="h-3 w-3 animate-pulse rounded-full bg-sky-400" />
               <h2 className="text-cp-base font-semibold">{t('app.pdfProgress.title', 'PDF wird erstellt…')}</h2>
             </div>
-            <div className="mb-3 h-1.5 w-full overflow-hidden rounded bg-slate-800">
+            <div className="mb-3 h-1.5 w-full overflow-hidden rounded bg-cp-surface-2">
               <div className="h-full w-full origin-left animate-pulse bg-sky-500" />
             </div>
-            <div className="text-cp-xs text-slate-300">{pdfProgress.phase}</div>
+            <div className="text-cp-xs text-cp-text-secondary">{pdfProgress.phase}</div>
             {pdfProgress.detail && (
-              <div className="mt-1 text-[11px] text-slate-400">{pdfProgress.detail}</div>
+              <div className="mt-1 text-[11px] text-cp-text-muted">{pdfProgress.detail}</div>
             )}
-            <div className="mt-3 text-[10px] text-slate-400">
+            <div className="mt-3 text-[10px] text-cp-text-muted">
               {t('app.pdfProgress.hint', 'Bei großen Plänen können einige Sekunden vergehen. Bitte nicht abbrechen.')}
             </div>
           </div>
@@ -1267,33 +1267,33 @@ const PdfExportDialog = ({
   if (!open) return null
   return (
     <div className="fixed inset-0 z-50 grid place-items-center bg-black/60 p-4">
-      <div className="w-full max-w-md rounded-cp-card border border-slate-700 bg-slate-900 p-4 shadow-2xl">
-        <h2 className="mb-3 text-cp-base font-semibold text-slate-100">{t('pdfExport.title', 'Plan als PDF exportieren')}</h2>
+      <div className="w-full max-w-md rounded-cp-card border border-cp-border bg-cp-surface-1 p-4 shadow-2xl">
+        <h2 className="mb-3 text-cp-base font-semibold text-cp-text">{t('pdfExport.title', 'Plan als PDF exportieren')}</h2>
         <div className="space-y-3">
           {/* Layer-Sichtbarkeit — uebernimmt die Chip-Komponente aus
               der Canvas-Toolbar. Same store, daher synchronisiert sich
               die Auswahl bidirektional mit dem Canvas. Damit kann der
               User z.B. nur die Video-Ebene drucken indem er alle
               anderen Chips deaktiviert. */}
-          <fieldset className="rounded border border-slate-700 p-3">
-            <legend className="px-1 text-[11px] uppercase tracking-wide text-slate-400">
+          <fieldset className="rounded border border-cp-border p-3">
+            <legend className="px-1 text-[11px] uppercase tracking-wide text-cp-text-muted">
               {t('pdfExport.layers.title', 'Ebenen (im PDF enthalten)')}
             </legend>
             <div className="-mx-1 flex flex-wrap gap-1">
               <LayerVisibilityChips />
             </div>
-            <p className="mt-2 text-[10px] text-slate-400">
+            <p className="mt-2 text-[10px] text-cp-text-muted">
               {t(
                 'pdfExport.layers.hint',
                 'Klick auf einen Chip schaltet die Ebene fuer Canvas UND PDF um. Beispiel: nur Video drucken ⇒ alle anderen Chips ausschalten.',
               )}
             </p>
           </fieldset>
-          <fieldset className="rounded border border-slate-700 p-3">
-            <legend className="px-1 text-[11px] uppercase tracking-wide text-slate-400">
+          <fieldset className="rounded border border-cp-border p-3">
+            <legend className="px-1 text-[11px] uppercase tracking-wide text-cp-text-muted">
               {t('pdfExport.bg.title', 'Hintergrund')}
             </legend>
-            <label className="mb-2 flex cursor-pointer items-center gap-2 text-cp-xs text-slate-200">
+            <label className="mb-2 flex cursor-pointer items-center gap-2 text-cp-xs text-cp-text-bright">
               <input
                 type="radio"
                 name="pdf-bg-theme"
@@ -1302,7 +1302,7 @@ const PdfExportDialog = ({
               />
               {t('pdfExport.bg.light', 'Hell')}
             </label>
-            <label className="flex cursor-pointer items-center gap-2 text-cp-xs text-slate-200">
+            <label className="flex cursor-pointer items-center gap-2 text-cp-xs text-cp-text-bright">
               <input
                 type="radio"
                 name="pdf-bg-theme"
@@ -1316,11 +1316,11 @@ const PdfExportDialog = ({
               bestehenden Workflows die bekannte Raster-Pipeline
               nutzen. Wenn an: Text bleibt im PDF als echter Text,
               keine Pixelung beim Zoom. */}
-          <fieldset className="rounded border border-slate-700 p-3">
-            <legend className="px-1 text-[11px] uppercase tracking-wide text-slate-400">
+          <fieldset className="rounded border border-cp-border p-3">
+            <legend className="px-1 text-[11px] uppercase tracking-wide text-cp-text-muted">
               {t('pdfExport.render.title', 'Render-Modus')}
             </legend>
-            <label className="mb-2 flex cursor-pointer items-start gap-2 text-cp-xs text-slate-200">
+            <label className="mb-2 flex cursor-pointer items-start gap-2 text-cp-xs text-cp-text-bright">
               <input
                 type="radio"
                 name="pdf-render-mode"
@@ -1329,7 +1329,7 @@ const PdfExportDialog = ({
               />
               <span>
                 {t('pdfExport.render.raster', 'Raster (klassisch)')}
-                <span className="block text-[10px] text-slate-400">
+                <span className="block text-[10px] text-cp-text-muted">
                   {t(
                     'pdfExport.render.rasterHint',
                     'JPEG-Snapshot des Canvas. Zuverlässig, aber unscharf bei großem Zoom in der PDF.',
@@ -1337,7 +1337,7 @@ const PdfExportDialog = ({
                 </span>
               </span>
             </label>
-            <label className="flex cursor-pointer items-start gap-2 text-cp-xs text-slate-200">
+            <label className="flex cursor-pointer items-start gap-2 text-cp-xs text-cp-text-bright">
               <input
                 type="radio"
                 name="pdf-render-mode"
@@ -1346,7 +1346,7 @@ const PdfExportDialog = ({
               />
               <span>
                 {t('pdfExport.render.vector', 'Vektor')}
-                <span className="block text-[10px] text-slate-400">
+                <span className="block text-[10px] text-cp-text-muted">
                   {t(
                     'pdfExport.render.vectorHint',
                     'Chromium printToPDF. Text bleibt selektierbar & scharf bei jedem Zoom. Kleinere Dateigröße.',
@@ -1360,7 +1360,7 @@ const PdfExportDialog = ({
           <button
             type="button"
             onClick={onClose}
-            className="rounded border border-slate-700 bg-slate-800 px-3 py-1.5 text-cp-xs text-slate-100 hover:bg-slate-700"
+            className="rounded border border-cp-border bg-cp-surface-2 px-3 py-1.5 text-cp-xs text-cp-text hover:bg-cp-surface-4"
           >
             {t('common.cancel', 'Abbrechen')}
           </button>
@@ -1554,7 +1554,7 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-6"
       onMouseDown={(e) => e.target === e.currentTarget && onClose()}
     >
-      <div className="w-full max-w-lg rounded border border-slate-700 bg-slate-900 p-4 text-slate-100">
+      <div className="w-full max-w-lg rounded border border-cp-border bg-cp-surface-1 p-4 text-cp-text">
         <h3 className="mb-2 text-cp-xl font-semibold">Kabel bearbeiten</h3>
 
         <div className="space-y-2 text-cp-base">
@@ -1563,7 +1563,7 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
             <select
               value={specId}
               onChange={(e) => onSelectSpec(e.target.value)}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+              className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
             >
               <option value={CUSTOM_CABLE_SPEC_ID}>★ Custom Cable…</option>
               {fullCableCatalog.map((c) => (
@@ -1575,7 +1575,7 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
           </label>
 
           {specId === CUSTOM_CABLE_SPEC_ID && (
-            <div className="grid grid-cols-2 gap-2 rounded border border-slate-700 bg-slate-950/60 p-2">
+            <div className="grid grid-cols-2 gap-2 rounded border border-cp-border bg-cp-surface-3/60 p-2">
               <label className="block">
                 Connector Type
                 <select
@@ -1592,7 +1592,7 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
                     }
                     setCustomConnectorType(v as ConnectorType)
                   }}
-                  className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+                  className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
                 >
                   {allConnectorOptions.map((type) => (
                     <option key={type} value={type}>
@@ -1622,7 +1622,7 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
                     setCustomStandard(next)
                     setStandard(next)
                   }}
-                  className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+                  className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
                 >
                   {allStandardOptions.map((item) => (
                     <option key={item} value={item}>
@@ -1642,7 +1642,7 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
               <select
                 value={standard ?? ''}
                 onChange={(e) => setStandard(e.target.value as SignalStandard)}
-                className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+                className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
               >
                 {selected.standards.map((s) => (
                   <option key={s} value={s}>
@@ -1658,7 +1658,7 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
             <input
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+              className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
             />
           </label>
 
@@ -1675,7 +1675,7 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
                     const v = e.target.value
                     setMaxRange(v === '' ? undefined : Number(v))
                   }}
-                  className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+                  className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
                 />
               </label>
             ) : (
@@ -1686,7 +1686,7 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
                   min={0}
                   value={length}
                   onChange={(e) => setLength(Number(e.target.value))}
-                  className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+                  className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
                 />
               </label>
             )}
@@ -1696,7 +1696,7 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
                 type="color"
                 value={color}
                 onChange={(e) => setColor(e.target.value)}
-                className="mt-1 h-10 w-full rounded border border-slate-700 bg-slate-950 p-1"
+                className="mt-1 h-10 w-full rounded border border-cp-border bg-cp-surface-3 p-1"
               />
             </label>
           </div>
@@ -1704,24 +1704,24 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
           {/* Endpoint editor as collapsible accordion below color. Compact
               summary always visible (current routing); expand to change
               device/port on either side. */}
-          <details open className="rounded border border-slate-700 bg-slate-950/50">
-            <summary className="cursor-pointer select-none px-2 py-1.5 text-[11px] text-slate-300 hover:bg-slate-800/40">
-              <span className="font-semibold uppercase tracking-wide text-slate-400">Verbindung</span>
-              <span className="ml-2 text-slate-300">
+          <details open className="rounded border border-cp-border bg-cp-surface-3/50">
+            <summary className="cursor-pointer select-none px-2 py-1.5 text-[11px] text-cp-text-secondary hover:bg-cp-surface-2/40">
+              <span className="font-semibold uppercase tracking-wide text-cp-text-muted">Verbindung</span>
+              <span className="ml-2 text-cp-text-secondary">
                 {fromDev?.name ?? '?'} · {fromPort?.name ?? cable.fromPortId}
-                <span className="mx-1 text-slate-500">→</span>
+                <span className="mx-1 text-cp-text-faint">→</span>
                 {toDev?.name ?? '?'} · {toPort?.name ?? cable.toPortId}
               </span>
             </summary>
-            <div className="border-t border-slate-700 p-2">
+            <div className="border-t border-cp-border p-2">
               <div className="grid grid-cols-2 gap-2">
                 <div>
-                  <div className="mb-0.5 text-[10px] text-slate-400">{t('cable.fromDeviceShort', 'Von Gerät')}</div>
+                  <div className="mb-0.5 text-[10px] text-cp-text-muted">{t('cable.fromDeviceShort', 'Von Gerät')}</div>
                   <select
                     aria-label={t('cable.aria.fromDevice', 'Quell-Gerät')}
                     value={fromEquipmentId}
                     onChange={(e) => onSelectFromEquipment(e.target.value)}
-                    className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+                    className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
                   >
                     {sortedEquipment.map((eq) => (
                       <option key={eq.id} value={eq.id}>
@@ -1729,12 +1729,12 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
                       </option>
                     ))}
                   </select>
-                  <div className="mt-1 text-[10px] text-slate-400">Port</div>
+                  <div className="mt-1 text-[10px] text-cp-text-muted">Port</div>
                   <select
                     aria-label={t('cable.aria.fromPort', 'Quell-Port')}
                     value={fromPortId}
                     onChange={(e) => setFromPortId(e.target.value)}
-                    className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+                    className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
                   >
                     {portsOf(fromDev).map((p) => {
                       const inUse = !!portConflict(fromEquipmentId, p.id)
@@ -1748,12 +1748,12 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
                   </select>
                 </div>
                 <div>
-                  <div className="mb-0.5 text-[10px] text-slate-400">{t('cable.toDeviceShort', 'Nach Gerät')}</div>
+                  <div className="mb-0.5 text-[10px] text-cp-text-muted">{t('cable.toDeviceShort', 'Nach Gerät')}</div>
                   <select
                     aria-label={t('cable.aria.toDevice', 'Ziel-Gerät')}
                     value={toEquipmentId}
                     onChange={(e) => onSelectToEquipment(e.target.value)}
-                    className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+                    className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
                   >
                     {sortedEquipment.map((eq) => (
                       <option key={eq.id} value={eq.id}>
@@ -1761,12 +1761,12 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
                       </option>
                     ))}
                   </select>
-                  <div className="mt-1 text-[10px] text-slate-400">Port</div>
+                  <div className="mt-1 text-[10px] text-cp-text-muted">Port</div>
                   <select
                     aria-label={t('cable.aria.toPort', 'Ziel-Port')}
                     value={toPortId}
                     onChange={(e) => setToPortId(e.target.value)}
-                    className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+                    className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
                   >
                     {portsOf(toDev).map((p) => {
                       const inUse = !!portConflict(toEquipmentId, p.id)
@@ -1807,7 +1807,7 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
             <textarea
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-2"
+              className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
               rows={2}
             />
           </label>
@@ -1824,7 +1824,7 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
           <button
             type="button"
             onClick={onClose}
-            className="rounded bg-slate-700 px-3 py-1 hover:bg-slate-600"
+            className="rounded bg-cp-surface-4 px-3 py-1 hover:bg-cp-surface-5"
           >
             Abbrechen
           </button>

--- a/src/renderer/components/Canvas/BulkConnectDialog.tsx
+++ b/src/renderer/components/Canvas/BulkConnectDialog.tsx
@@ -113,7 +113,7 @@ export const BulkConnectDialog = () => {
           <button
             type="button"
             onClick={close}
-            className="rounded bg-slate-700 px-3 py-1 text-cp-xs hover:bg-slate-600"
+            className="rounded bg-cp-surface-4 px-3 py-1 text-cp-xs hover:bg-cp-surface-5"
           >
             {t('common.cancel', 'Abbrechen')}
           </button>
@@ -129,7 +129,7 @@ export const BulkConnectDialog = () => {
       }
     >
       <div className="space-y-3 p-4 text-cp-base">
-        <p className="text-[11px] text-slate-400">
+        <p className="text-[11px] text-cp-text-muted">
           {t(
             'bulk.intro',
             'Erstellt N Kabel auf einmal: Quelle-Port i → Ziel-Port i. Belegte Ziel-Ports werden übersprungen.',
@@ -138,16 +138,16 @@ export const BulkConnectDialog = () => {
 
         <div className="grid grid-cols-2 gap-3">
           {/* Quelle */}
-          <fieldset className="rounded border border-slate-700 p-2">
-            <legend className="px-1 text-[11px] uppercase tracking-wide text-slate-400">
+          <fieldset className="rounded border border-cp-border p-2">
+            <legend className="px-1 text-[11px] uppercase tracking-wide text-cp-text-muted">
               {t('bulk.source', 'Quelle')}
             </legend>
             <label className="block">
-              <span className="mb-1 block text-cp-xs text-slate-400">{t('bulk.device', 'Gerät')}</span>
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('bulk.device', 'Gerät')}</span>
               <select
                 value={fromEqId}
                 onChange={(e) => setFromEqId(e.target.value)}
-                className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
               >
                 <option value="">—</option>
                 {equipment.map((e) => (
@@ -158,18 +158,18 @@ export const BulkConnectDialog = () => {
               </select>
             </label>
             <label className="mt-2 block">
-              <span className="mb-1 block text-cp-xs text-slate-400">{t('bulk.side', 'Seite')}</span>
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('bulk.side', 'Seite')}</span>
               <select
                 value={fromSide}
                 onChange={(e) => setFromSide(e.target.value as 'outputs' | 'inputs')}
-                className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
               >
                 <option value="outputs">{t('bulk.outputs', 'Outputs')}</option>
                 <option value="inputs">{t('bulk.inputs', 'Inputs')}</option>
               </select>
             </label>
             <label className="mt-2 block">
-              <span className="mb-1 block text-cp-xs text-slate-400">
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">
                 {format(
                   t('bulk.startFrom', 'Start-{side} (1..{total})'),
                   { side: fromSide === 'outputs' ? 'Output' : 'Input', total: fromPorts.length },
@@ -181,22 +181,22 @@ export const BulkConnectDialog = () => {
                 max={Math.max(1, fromPorts.length)}
                 value={fromStart}
                 onChange={(e) => setFromStart(Math.max(1, Number(e.target.value) || 1))}
-                className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 font-mono text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 font-mono text-cp-xs"
               />
             </label>
           </fieldset>
 
           {/* Ziel */}
-          <fieldset className="rounded border border-slate-700 p-2">
-            <legend className="px-1 text-[11px] uppercase tracking-wide text-slate-400">
+          <fieldset className="rounded border border-cp-border p-2">
+            <legend className="px-1 text-[11px] uppercase tracking-wide text-cp-text-muted">
               {t('bulk.target', 'Ziel')}
             </legend>
             <label className="block">
-              <span className="mb-1 block text-cp-xs text-slate-400">{t('bulk.device', 'Gerät')}</span>
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('bulk.device', 'Gerät')}</span>
               <select
                 value={toEqId}
                 onChange={(e) => setToEqId(e.target.value)}
-                className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
               >
                 <option value="">—</option>
                 {equipment.map((e) => (
@@ -207,18 +207,18 @@ export const BulkConnectDialog = () => {
               </select>
             </label>
             <label className="mt-2 block">
-              <span className="mb-1 block text-cp-xs text-slate-400">{t('bulk.side', 'Seite')}</span>
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('bulk.side', 'Seite')}</span>
               <select
                 value={toSide}
                 onChange={(e) => setToSide(e.target.value as 'inputs' | 'outputs')}
-                className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
               >
                 <option value="inputs">{t('bulk.inputs', 'Inputs')}</option>
                 <option value="outputs">{t('bulk.outputs', 'Outputs')}</option>
               </select>
             </label>
             <label className="mt-2 block">
-              <span className="mb-1 block text-cp-xs text-slate-400">
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">
                 {format(
                   t('bulk.startTo', 'Start-{side} (1..{total})'),
                   { side: toSide === 'inputs' ? 'Input' : 'Output', total: toPorts.length },
@@ -230,7 +230,7 @@ export const BulkConnectDialog = () => {
                 max={Math.max(1, toPorts.length)}
                 value={toStart}
                 onChange={(e) => setToStart(Math.max(1, Number(e.target.value) || 1))}
-                className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 font-mono text-cp-xs"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 font-mono text-cp-xs"
               />
             </label>
           </fieldset>
@@ -239,22 +239,22 @@ export const BulkConnectDialog = () => {
         {/* Anzahl + Kabel-Spec + Laenge */}
         <div className="grid grid-cols-3 gap-3">
           <label className="block">
-            <span className="mb-1 block text-cp-xs text-slate-400">{t('bulk.count', 'Anzahl Kabel')}</span>
+            <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('bulk.count', 'Anzahl Kabel')}</span>
             <input
               type="number"
               min={1}
               max={256}
               value={count}
               onChange={(e) => setCount(Math.max(1, Math.min(256, Number(e.target.value) || 1)))}
-              className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 font-mono text-cp-xs"
+              className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 font-mono text-cp-xs"
             />
           </label>
           <label className="col-span-2 block">
-            <span className="mb-1 block text-cp-xs text-slate-400">{t('bulk.spec', 'Kabel-Typ')}</span>
+            <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('bulk.spec', 'Kabel-Typ')}</span>
             <select
               value={cableSpecId}
               onChange={(e) => setCableSpecId(e.target.value)}
-              className="w-full rounded border border-slate-700 bg-slate-950 p-1.5 text-cp-xs"
+              className="w-full rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
             >
               {allSpecs.map((s) => (
                 <option key={s.id} value={s.id}>
@@ -266,38 +266,38 @@ export const BulkConnectDialog = () => {
         </div>
 
         <label className="block">
-          <span className="mb-1 block text-cp-xs text-slate-400">{t('bulk.length', 'Länge pro Kabel (m)')}</span>
+          <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('bulk.length', 'Länge pro Kabel (m)')}</span>
           <input
             type="number"
             min={0}
             step="0.5"
             value={lengthMeters}
             onChange={(e) => setLengthMeters(Math.max(0, Number(e.target.value) || 0))}
-            className="w-32 rounded border border-slate-700 bg-slate-950 p-1.5 font-mono text-cp-xs"
+            className="w-32 rounded border border-cp-border bg-cp-surface-3 p-1.5 font-mono text-cp-xs"
           />
         </label>
 
         {/* Preview */}
-        <div className="rounded border border-slate-700 bg-slate-950/40 p-2">
-          <div className="mb-1 text-[10px] uppercase tracking-wide text-slate-400">
+        <div className="rounded border border-cp-border bg-cp-surface-3/40 p-2">
+          <div className="mb-1 text-[10px] uppercase tracking-wide text-cp-text-muted">
             {format(t('bulk.preview', 'Vorschau ({n}/{plan} Kabel)'), {
               n: planned.length,
               plan: count,
             })}
           </div>
           {planned.length === 0 ? (
-            <p className="text-[11px] text-slate-400">
+            <p className="text-[11px] text-cp-text-muted">
               {t('bulk.previewEmpty', 'Wähle Quelle/Ziel und Port-Bereich.')}
             </p>
           ) : (
-            <ul className="max-h-32 space-y-0.5 overflow-auto text-[11px] text-slate-300">
+            <ul className="max-h-32 space-y-0.5 overflow-auto text-[11px] text-cp-text-secondary">
               {planned.slice(0, 12).map((p, i) => (
                 <li key={i} className="font-mono">
                   {p.from} → {p.to}
                 </li>
               ))}
               {planned.length > 12 && (
-                <li className="text-slate-500">… + {planned.length - 12} weitere</li>
+                <li className="text-cp-text-faint">… + {planned.length - 12} weitere</li>
               )}
             </ul>
           )}

--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -1910,7 +1910,7 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
         onMoveEnd={(_event, viewport) => setCanvasState(viewport.x, viewport.y, viewport.zoom)}
       >
         <MiniMap pannable zoomable
-          className={effectiveCanvasTheme === 'light' ? '!bg-slate-100' : '!bg-slate-800'}
+          className={effectiveCanvasTheme === 'light' ? '!bg-slate-100' : '!bg-cp-surface-2'}
           maskColor={effectiveCanvasTheme === 'light' ? 'rgba(226,232,240,0.7)' : 'rgba(15,23,42,0.7)'}
         />
         <Controls />

--- a/src/renderer/components/Canvas/TitleBlock.tsx
+++ b/src/renderer/components/Canvas/TitleBlock.tsx
@@ -45,7 +45,7 @@ export const TitleBlock = () => {
         type="button"
         onClick={() => setCollapsed(false)}
         title={t('canvas.titleBlock.showTitle', 'Bauplan-Signatur einblenden')}
-        className="nodrag nopan absolute bottom-2 right-2 z-10 rounded border border-slate-700 bg-slate-900/90 px-2 py-1 text-[11px] font-semibold text-slate-200 shadow hover:bg-slate-800"
+        className="nodrag nopan absolute bottom-2 right-2 z-10 rounded border border-cp-border bg-cp-surface-1/90 px-2 py-1 text-[11px] font-semibold text-cp-text-bright shadow hover:bg-cp-surface-2"
       >
         {t('canvas.titleBlock.signatureBtn', 'Signatur')}
       </button>
@@ -54,24 +54,24 @@ export const TitleBlock = () => {
 
   return (
     <div
-      className="nodrag nopan absolute bottom-2 right-2 z-10 select-none rounded border border-slate-700 bg-slate-900/95 text-[11px] text-slate-200 shadow-lg"
+      className="nodrag nopan absolute bottom-2 right-2 z-10 select-none rounded border border-cp-border bg-cp-surface-1/95 text-[11px] text-cp-text-bright shadow-lg"
       style={{ width: 280, fontFamily: 'system-ui, sans-serif' }}
     >
-      <div className="flex items-center justify-between border-b border-slate-700 px-2 py-1">
-        <span className="truncate font-semibold text-slate-100" title={projectName}>
+      <div className="flex items-center justify-between border-b border-cp-border px-2 py-1">
+        <span className="truncate font-semibold text-cp-text" title={projectName}>
           {projectName}
         </span>
         <button
           type="button"
           onClick={() => setCollapsed(true)}
           title={t('canvas.titleBlock.collapseTitle', 'Signatur einklappen')}
-          className="ml-2 rounded px-1 text-slate-400 hover:bg-slate-800 hover:text-slate-200"
+          className="ml-2 rounded px-1 text-cp-text-muted hover:bg-cp-surface-2 hover:text-cp-text-bright"
         >
           –
         </button>
       </div>
       {hasLogo && (
-        <div className="flex items-center justify-between gap-2 border-b border-slate-800 bg-slate-950/50 p-1.5">
+        <div className="flex items-center justify-between gap-2 border-b border-cp-border-muted bg-cp-surface-3/50 p-1.5">
           <div className="flex h-10 flex-1 items-center justify-center overflow-hidden rounded bg-white/5">
             {metadata.companyLogo ? (
               <img
@@ -80,7 +80,7 @@ export const TitleBlock = () => {
                 className="max-h-10 max-w-full object-contain"
               />
             ) : (
-              <span className="text-[9px] text-slate-400">
+              <span className="text-[9px] text-cp-text-muted">
                 {t('canvas.titleBlock.noLogo', 'kein Logo')}
               </span>
             )}
@@ -93,7 +93,7 @@ export const TitleBlock = () => {
                 className="max-h-10 max-w-full object-contain"
               />
             ) : (
-              <span className="text-[9px] text-slate-400">
+              <span className="text-[9px] text-cp-text-muted">
                 {t('canvas.titleBlock.noLogo', 'kein Logo')}
               </span>
             )}
@@ -104,11 +104,11 @@ export const TitleBlock = () => {
         <table className="w-full border-collapse">
           <tbody>
             {rows.map(({ label, value }) => (
-              <tr key={label} className="border-b border-slate-800/60 last:border-b-0">
-                <td className="py-0.5 pr-2 align-top text-[10px] font-medium uppercase tracking-wide text-slate-400">
+              <tr key={label} className="border-b border-cp-border-muted/60 last:border-b-0">
+                <td className="py-0.5 pr-2 align-top text-[10px] font-medium uppercase tracking-wide text-cp-text-muted">
                   {label}
                 </td>
-                <td className="py-0.5 text-right align-top text-slate-200">
+                <td className="py-0.5 text-right align-top text-cp-text-bright">
                   {value && value !== '—' ? value : <span className="text-slate-600">—</span>}
                 </td>
               </tr>

--- a/src/renderer/components/Rack/NonRackAddDialog.tsx
+++ b/src/renderer/components/Rack/NonRackAddDialog.tsx
@@ -92,7 +92,7 @@ export const NonRackAddDialog = ({
         </div>
       }
     >
-        <div className="mb-3 text-[11px] text-slate-400">
+        <div className="mb-3 text-[11px] text-cp-text-muted">
           {t('rack.nonRack.intro', 'Das Gerät ist nicht als 19″-Rack-Gerät markiert. Wähle wie es im Rack platziert werden soll:')}
         </div>
 
@@ -103,11 +103,11 @@ export const NonRackAddDialog = ({
             className={`rounded border p-3 text-left transition ${
               mode === 'rack'
                 ? 'border-sky-500 bg-sky-900/40 text-sky-100'
-                : 'border-slate-700 bg-slate-950/50 text-slate-400 hover:bg-slate-900'
+                : 'border-cp-border bg-cp-surface-3/50 text-cp-text-muted hover:bg-cp-surface-1'
             }`}
           >
             <div className="flex items-center gap-1.5 font-semibold"><Icon icon={Ruler} size="xs" /> {t('rack.nonRack.option.rack', 'Als 19″-Gerät')}</div>
-            <div className="mt-0.5 text-[10px] text-slate-400">
+            <div className="mt-0.5 text-[10px] text-cp-text-muted">
               {t('rack.nonRack.option.rackHint', 'Belegt N HE auf den Rack-Schienen')}
             </div>
           </button>
@@ -117,11 +117,11 @@ export const NonRackAddDialog = ({
             className={`rounded border p-3 text-left transition ${
               mode === 'shelf'
                 ? 'border-emerald-500 bg-emerald-900/40 text-emerald-100'
-                : 'border-slate-700 bg-slate-950/50 text-slate-400 hover:bg-slate-900'
+                : 'border-cp-border bg-cp-surface-3/50 text-cp-text-muted hover:bg-cp-surface-1'
             }`}
           >
             <div className="flex items-center gap-1.5 font-semibold"><Icon icon={Armchair} size="xs" /> {t('rack.nonRack.option.shelf', 'Auf Shelf')}</div>
-            <div className="mt-0.5 text-[10px] text-slate-400">
+            <div className="mt-0.5 text-[10px] text-cp-text-muted">
               {t('rack.nonRack.option.shelfHint', 'Eigene Maße in mm, sitzt auf einem Rack-Shelf')}
             </div>
           </button>
@@ -130,14 +130,14 @@ export const NonRackAddDialog = ({
         {mode === 'rack' && (
           <div className="mb-3 space-y-2">
             <label className="block">
-              <span className="mb-1 block text-cp-xs text-slate-400">{t('rack.nonRack.rackUnits', 'HE-Höhe')}</span>
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('rack.nonRack.rackUnits', 'HE-Höhe')}</span>
               <input
                 type="number"
                 min={1}
                 max={20}
                 value={rackUnits}
                 onChange={(e) => setRackUnits(Math.max(1, Math.min(20, Number(e.target.value) || 1)))}
-                className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1.5"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1.5"
                 autoFocus
               />
             </label>
@@ -148,7 +148,7 @@ export const NonRackAddDialog = ({
           <div className="mb-3 space-y-2">
             <div className="grid grid-cols-3 gap-2">
               <label className="block">
-                <span className="mb-1 block text-cp-xs text-slate-400">{t('rack.nonRack.widthMm', 'Breite (mm)')}</span>
+                <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('rack.nonRack.widthMm', 'Breite (mm)')}</span>
                 <input
                   type="number"
                   min={20}
@@ -156,7 +156,7 @@ export const NonRackAddDialog = ({
                   step={5}
                   value={widthMm}
                   onChange={(e) => setWidthMm(Number(e.target.value) || 0)}
-                  className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1.5"
+                  className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1.5"
                   autoFocus
                 />
                 {/* v7.9.87 / #208 — Quick-Presets: 1/3, 1/2, 2/3 der
@@ -165,7 +165,7 @@ export const NonRackAddDialog = ({
                   <button
                     type="button"
                     onClick={() => setWidthMm(150)}
-                    className="flex-1 rounded bg-slate-800 px-1 py-0.5 text-[10px] text-slate-400 hover:bg-slate-700"
+                    className="flex-1 rounded bg-cp-surface-2 px-1 py-0.5 text-[10px] text-cp-text-muted hover:bg-cp-surface-4"
                     title={t('rack.nonRack.widthPreset.third', '1/3 Rack-Mount-Breite ≈ 150 mm')}
                   >
                     1/3
@@ -173,7 +173,7 @@ export const NonRackAddDialog = ({
                   <button
                     type="button"
                     onClick={() => setWidthMm(225)}
-                    className="flex-1 rounded bg-slate-800 px-1 py-0.5 text-[10px] text-slate-400 hover:bg-slate-700"
+                    className="flex-1 rounded bg-cp-surface-2 px-1 py-0.5 text-[10px] text-cp-text-muted hover:bg-cp-surface-4"
                     title={t('rack.nonRack.widthPreset.half', '1/2 Rack-Mount-Breite ≈ 225 mm')}
                   >
                     1/2
@@ -181,7 +181,7 @@ export const NonRackAddDialog = ({
                   <button
                     type="button"
                     onClick={() => setWidthMm(300)}
-                    className="flex-1 rounded bg-slate-800 px-1 py-0.5 text-[10px] text-slate-400 hover:bg-slate-700"
+                    className="flex-1 rounded bg-cp-surface-2 px-1 py-0.5 text-[10px] text-cp-text-muted hover:bg-cp-surface-4"
                     title={t('rack.nonRack.widthPreset.twoThirds', '2/3 Rack-Mount-Breite ≈ 300 mm')}
                   >
                     2/3
@@ -189,7 +189,7 @@ export const NonRackAddDialog = ({
                 </div>
               </label>
               <label className="block">
-                <span className="mb-1 block text-cp-xs text-slate-400">{t('rack.nonRack.heightMm', 'Höhe (mm)')}</span>
+                <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('rack.nonRack.heightMm', 'Höhe (mm)')}</span>
                 <input
                   type="number"
                   min={10}
@@ -197,11 +197,11 @@ export const NonRackAddDialog = ({
                   step={5}
                   value={heightMm}
                   onChange={(e) => setHeightMm(Number(e.target.value) || 0)}
-                  className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1.5"
+                  className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1.5"
                 />
               </label>
               <label className="block">
-                <span className="mb-1 block text-cp-xs text-slate-400">{t('rack.nonRack.depthMm', 'Tiefe (mm)')}</span>
+                <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('rack.nonRack.depthMm', 'Tiefe (mm)')}</span>
                 <input
                   type="number"
                   min={20}
@@ -209,17 +209,17 @@ export const NonRackAddDialog = ({
                   step={5}
                   value={depthMm}
                   onChange={(e) => setDepthMm(Number(e.target.value) || 0)}
-                  className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1.5"
+                  className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1.5"
                 />
               </label>
             </div>
-            <div className="rounded border border-slate-800 bg-slate-950/50 p-2 text-[10px] text-slate-400">
+            <div className="rounded border border-cp-border-muted bg-cp-surface-3/50 p-2 text-[10px] text-cp-text-muted">
               {t('rack.nonRack.shelfTip', 'Lege das Gerät auf ein vorhandenes Rack-Shelf, indem du es auf derselben Start-HE einfügst. Maße werden im 3D-Tab als reale Boxen-Größe visualisiert.')}
             </div>
           </div>
         )}
 
-        <label className="mb-3 flex items-start gap-2 rounded border border-slate-800 bg-slate-950/40 p-2 text-[11px]">
+        <label className="mb-3 flex items-start gap-2 rounded border border-cp-border-muted bg-cp-surface-3/40 p-2 text-[11px]">
           <input
             type="checkbox"
             checked={persistFlag}
@@ -227,8 +227,8 @@ export const NonRackAddDialog = ({
             className="mt-0.5 accent-sky-500"
           />
           <span className="flex-1">
-            <span className="font-medium text-slate-200">{t('rack.nonRack.persist', 'Maße permanent ans Template speichern')}</span>
-            <span className="ml-1 text-slate-500">
+            <span className="font-medium text-cp-text-bright">{t('rack.nonRack.persist', 'Maße permanent ans Template speichern')}</span>
+            <span className="ml-1 text-cp-text-faint">
               {t('rack.nonRack.persistHint', '(beim nächsten Hinzufügen wird nicht mehr gefragt)')}
             </span>
           </span>

--- a/src/renderer/components/Rack/PatchPanelCreateDialog.tsx
+++ b/src/renderer/components/Rack/PatchPanelCreateDialog.tsx
@@ -145,12 +145,12 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
         </div>
       }
     >
-        <div className="mb-3 flex overflow-hidden rounded border border-slate-700 text-cp-xs">
+        <div className="mb-3 flex overflow-hidden rounded border border-cp-border text-cp-xs">
           <button
             type="button"
             onClick={() => setTab('basics')}
             className={`flex-1 px-3 py-1.5 ${
-              tab === 'basics' ? 'bg-sky-700 text-white' : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+              tab === 'basics' ? 'bg-sky-700 text-white' : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
             }`}
           >
             {t('rack.patchPanel.tab.basics', 'Basics')}
@@ -159,7 +159,7 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
             type="button"
             onClick={() => setTab('ports')}
             className={`flex-1 px-3 py-1.5 ${
-              tab === 'ports' ? 'bg-sky-700 text-white' : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+              tab === 'ports' ? 'bg-sky-700 text-white' : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
             }`}
           >
             {format(t('rack.patchPanel.tab.perPort', 'Per-Port-Detail ({count})'), { count: portCount })}
@@ -169,31 +169,31 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
         {tab === 'basics' && (
           <div className="space-y-3">
             <label className="block">
-              <span className="mb-1 block text-cp-xs text-slate-400">{t('rack.patchPanel.name', 'Name')}</span>
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('rack.patchPanel.name', 'Name')}</span>
               <input
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1.5"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1.5"
               />
             </label>
             <div className="grid grid-cols-2 gap-2">
               <label className="block">
-                <span className="mb-1 block text-cp-xs text-slate-400">{t('rack.patchPanel.heightUnits', 'Höhe (HE)')}</span>
+                <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('rack.patchPanel.heightUnits', 'Höhe (HE)')}</span>
                 <input
                   type="number"
                   min={1}
                   max={6}
                   value={heightUnits}
                   onChange={(e) => setHeightUnits(Math.max(1, Math.min(6, Number(e.target.value) || 1)))}
-                  className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1.5"
+                  className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1.5"
                 />
               </label>
               <label className="block">
-                <span className="mb-1 block text-cp-xs text-slate-400">{t('rack.patchPanel.mount', 'Montage')}</span>
+                <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('rack.patchPanel.mount', 'Montage')}</span>
                 <select
                   value={mountSide}
                   onChange={(e) => setMountSide(e.target.value as 'front' | 'rear' | 'full')}
-                  className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1.5"
+                  className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1.5"
                   title={t('rack.patchPanel.mountTitle', 'Patchblenden sind häufig rear-mounted hinter vorderen Geräten.')}
                 >
                   <option value="full">{t('rack.patchPanel.mount.full', 'Full-Depth (vorne)')}</option>
@@ -203,7 +203,7 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
               </label>
             </div>
             <label className="block">
-              <span className="mb-1 block text-cp-xs text-slate-400">{t('rack.patchPanel.portCount', 'Anzahl Ports')}</span>
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('rack.patchPanel.portCount', 'Anzahl Ports')}</span>
               <div className="flex items-center gap-2">
                 <input
                   type="number"
@@ -211,7 +211,7 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
                   max={128}
                   value={portCount}
                   onChange={(e) => setPortCount(Math.max(1, Math.min(128, Number(e.target.value) || 1)))}
-                  className="w-24 rounded border border-slate-700 bg-slate-950 px-2 py-1.5"
+                  className="w-24 rounded border border-cp-border bg-cp-surface-3 px-2 py-1.5"
                 />
                 <div className="flex gap-1">
                   {COMMON_PORT_COUNTS.map((n) => (
@@ -222,7 +222,7 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
                       className={`rounded px-2 py-0.5 text-[10px] ${
                         portCount === n
                           ? 'bg-sky-700 text-white'
-                          : 'bg-slate-800 text-slate-400 hover:bg-slate-700'
+                          : 'bg-cp-surface-2 text-cp-text-muted hover:bg-cp-surface-4'
                       }`}
                     >
                       {n}
@@ -236,7 +236,7 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
                 Selects (Front + Rear). Ohne Adapter-Mode wird der Rear-
                 Connector automatisch dem Front gleichgesetzt — klassische
                 Patchblende. */}
-            <label className="flex items-center gap-2 rounded border border-slate-700 bg-slate-950/40 px-2 py-1.5 text-cp-xs">
+            <label className="flex items-center gap-2 rounded border border-cp-border bg-cp-surface-3/40 px-2 py-1.5 text-cp-xs">
               <input
                 type="checkbox"
                 checked={adapterMode}
@@ -244,15 +244,15 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
                 className="accent-sky-500"
               />
               <span className="flex-1">
-                <span className="font-medium text-slate-200">{t('rack.patchPanel.adapter', 'Adapter-Patchblende')}</span>
-                <span className="ml-1 text-[10px] text-slate-400">
+                <span className="font-medium text-cp-text-bright">{t('rack.patchPanel.adapter', 'Adapter-Patchblende')}</span>
+                <span className="ml-1 text-[10px] text-cp-text-muted">
                   {t('rack.patchPanel.adapterHint', '(Front ≠ Rear Stecker, mit internem Adapterkabel)')}
                 </span>
               </span>
             </label>
             <div className={`grid gap-2 ${adapterMode ? 'grid-cols-2' : 'grid-cols-1'}`}>
               <label className="block">
-                <span className="mb-1 block text-cp-xs text-slate-400">
+                <span className="mb-1 block text-cp-xs text-cp-text-muted">
                   {adapterMode ? t('rack.patchPanel.frontConnector', 'Front-Connector') : t('rack.patchPanel.bothConnector', 'Connector-Typ (beide Seiten)')}
                 </span>
                 <ConnectorPicker
@@ -268,7 +268,7 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
               </label>
               {adapterMode && (
                 <label className="block">
-                  <span className="mb-1 block text-cp-xs text-slate-400">{t('rack.patchPanel.rearConnector', 'Rear-Connector')}</span>
+                  <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('rack.patchPanel.rearConnector', 'Rear-Connector')}</span>
                   <ConnectorPicker
                     value={rearConnector}
                     onChange={(id) => setRearConnector(id as ConnectorType)}
@@ -278,7 +278,7 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
                 </label>
               )}
             </div>
-            <span className="block text-[10px] text-slate-400">
+            <span className="block text-[10px] text-cp-text-muted">
               {format(t('rack.patchPanel.appliesToAllPorts', 'Wirkt auf alle {count} Ports. Einzeln im Tab "Per-Port-Detail" anpassbar.'), { count: portCount })}
               {adapterMode
                 ? ` ${t('rack.patchPanel.adapterCouplingNote', 'Jeder Front-Port koppelt intern via Adapterkabel auf den gleichnamigen Rear-Port.')}`
@@ -289,13 +289,13 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
 
         {tab === 'ports' && (
           <div className="space-y-2">
-            <div className="text-[10px] text-slate-400">
+            <div className="text-[10px] text-cp-text-muted">
               {t('rack.patchPanel.perPortNote', 'Pro Port Label und Connector-Typ überschreibbar. Leerlassen = Default.')}
               {adapterMode && ` ${t('rack.patchPanel.perPortAdapterNote', 'Bei Adapter-Patchblende sind Front- und Rear-Connector unabhängig wählbar.')}`}
             </div>
-            <div className="max-h-[40vh] overflow-y-auto rounded border border-slate-800">
+            <div className="max-h-[40vh] overflow-y-auto rounded border border-cp-border-muted">
               <table className="w-full text-cp-xs">
-                <thead className="sticky top-0 bg-slate-800 text-slate-400">
+                <thead className="sticky top-0 bg-cp-surface-2 text-cp-text-muted">
                   <tr>
                     <th className="px-2 py-1 text-left">#</th>
                     <th className="px-2 py-1 text-left">{t('rack.patchPanel.col.label', 'Label')}</th>
@@ -305,14 +305,14 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
                 </thead>
                 <tbody>
                   {ports.map((p, idx) => (
-                    <tr key={p.id} className="border-t border-slate-800">
-                      <td className="px-2 py-0.5 text-slate-500">{idx + 1}</td>
+                    <tr key={p.id} className="border-t border-cp-border-muted">
+                      <td className="px-2 py-0.5 text-cp-text-faint">{idx + 1}</td>
                       <td className="px-2 py-0.5">
                         <input
                           value={perPortOverrides[idx]?.label ?? ''}
                           placeholder={`P${idx + 1}`}
                           onChange={(e) => setOverride(idx, { label: e.target.value || undefined })}
-                          className="w-full rounded border border-slate-700 bg-slate-950 px-1.5 py-0.5"
+                          className="w-full rounded border border-cp-border bg-cp-surface-3 px-1.5 py-0.5"
                         />
                       </td>
                       <td className="px-2 py-0.5">

--- a/src/renderer/components/Rack/RackAddSplitButton.tsx
+++ b/src/renderer/components/Rack/RackAddSplitButton.tsx
@@ -78,7 +78,7 @@ export const RackAddSplitButton = ({
       {open && (
         <div
           role="menu"
-          className="absolute right-0 z-30 mt-1 w-44 overflow-hidden rounded-cp-control border border-slate-700 bg-slate-900 text-[11px] shadow-2xl"
+          className="absolute right-0 z-30 mt-1 w-44 overflow-hidden rounded-cp-control border border-cp-border bg-cp-surface-1 text-[11px] shadow-2xl"
         >
           <button
             type="button"
@@ -87,7 +87,7 @@ export const RackAddSplitButton = ({
               setOpen(false)
               onAddFront()
             }}
-            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-slate-200 hover:bg-slate-800"
+            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-cp-text-bright hover:bg-cp-surface-2"
           >
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
               <rect x="2" y="3" width="12" height="10" rx="1" stroke="#475569" strokeWidth="1" />
@@ -95,7 +95,7 @@ export const RackAddSplitButton = ({
             </svg>
             <div className="flex flex-col">
               <span className="font-semibold text-emerald-300">{t('rackAdd.frontOnly', 'Nur vorne')}</span>
-              <span className="text-[11px] text-slate-400">{t('rackAdd.frontMount', 'Front-Mount')}</span>
+              <span className="text-[11px] text-cp-text-muted">{t('rackAdd.frontMount', 'Front-Mount')}</span>
             </div>
           </button>
           <button
@@ -105,14 +105,14 @@ export const RackAddSplitButton = ({
               setOpen(false)
               onAddFull()
             }}
-            className="flex w-full items-center gap-2 border-t border-slate-800 bg-slate-800/50 px-3 py-1.5 text-left text-slate-200 hover:bg-slate-800"
+            className="flex w-full items-center gap-2 border-t border-cp-border-muted bg-cp-surface-2/50 px-3 py-1.5 text-left text-cp-text-bright hover:bg-cp-surface-2"
           >
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
               <rect x="2" y="3" width="12" height="10" rx="1" fill="#64748b" />
             </svg>
             <div className="flex flex-col">
-              <span className="font-semibold text-slate-100">{t('rackAdd.fullDepth', 'Full-Depth')}</span>
-              <span className="text-[11px] text-slate-400">{t('rackAdd.fullDepthSub', 'vorne + hinten (Default)')}</span>
+              <span className="font-semibold text-cp-text">{t('rackAdd.fullDepth', 'Full-Depth')}</span>
+              <span className="text-[11px] text-cp-text-muted">{t('rackAdd.fullDepthSub', 'vorne + hinten (Default)')}</span>
             </div>
           </button>
           <button
@@ -122,7 +122,7 @@ export const RackAddSplitButton = ({
               setOpen(false)
               onAddRear()
             }}
-            className="flex w-full items-center gap-2 border-t border-slate-800 px-3 py-1.5 text-left text-slate-200 hover:bg-slate-800"
+            className="flex w-full items-center gap-2 border-t border-cp-border-muted px-3 py-1.5 text-left text-cp-text-bright hover:bg-cp-surface-2"
           >
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
               <rect x="2" y="3" width="12" height="10" rx="1" stroke="#475569" strokeWidth="1" />
@@ -130,7 +130,7 @@ export const RackAddSplitButton = ({
             </svg>
             <div className="flex flex-col">
               <span className="font-semibold text-purple-300">{t('rackAdd.rearOnly', 'Nur hinten')}</span>
-              <span className="text-[11px] text-slate-400">{t('rackAdd.rearMount', 'Rear-Mount (z.B. Patchblende)')}</span>
+              <span className="text-[11px] text-cp-text-muted">{t('rackAdd.rearMount', 'Rear-Mount (z.B. Patchblende)')}</span>
             </div>
           </button>
         </div>

--- a/src/renderer/components/Rack/RackBuilder3DTab.tsx
+++ b/src/renderer/components/Rack/RackBuilder3DTab.tsx
@@ -63,7 +63,7 @@ export const RackBuilder3DTab = ({
   return (
     <>
       <div className="mb-2 flex items-center gap-1 text-[10px]">
-        <span className="text-slate-500">{t('rack.view.label', 'Ansicht:')}</span>
+        <span className="text-cp-text-faint">{t('rack.view.label', 'Ansicht:')}</span>
         {(['all', 'free', 'released'] as const).map((m) => (
           <button
             key={m}
@@ -72,7 +72,7 @@ export const RackBuilder3DTab = ({
             className={`rounded px-2 py-0.5 ${
               renderMode === m
                 ? 'bg-purple-700 text-white'
-                : 'bg-slate-800 text-slate-400 hover:bg-slate-700'
+                : 'bg-cp-surface-2 text-cp-text-muted hover:bg-cp-surface-4'
             }`}
             title={
               m === 'all'
@@ -93,7 +93,7 @@ export const RackBuilder3DTab = ({
       {placements.length > 0 ? (
         <div
           style={{ height: 'min(75vh, 800px)' }}
-          className="rounded border border-slate-800 bg-slate-950"
+          className="rounded border border-cp-border-muted bg-cp-surface-3"
           // v7.9.76 / #170 — Drag&Drop von Library-Cards auf die 3D-Canvas.
           // Da Raycast hier overkill wäre, nutzen wir smart-Placement:
           // Drop fügt das Gerät in den nächsten freien HE-Block ein.
@@ -258,7 +258,7 @@ export const RackBuilder3DTab = ({
           />
         </div>
       ) : (
-        <div className="rounded border border-dashed border-slate-700 bg-slate-950/40 p-8 text-center text-cp-xs text-slate-500">
+        <div className="rounded border border-dashed border-cp-border bg-cp-surface-3/40 p-8 text-center text-cp-xs text-cp-text-faint">
           Erst Geräte ins Rack legen, dann erscheint die 3D-Ansicht.
         </div>
       )}

--- a/src/renderer/components/Rack/RackBuilderDialog.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialog.tsx
@@ -766,7 +766,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
         style={containerStyle}
         // v7.9.2 — responsive: kein fixes 1400px max-width, sondern
         // 100vw mit Padding. Verhindert horizontal-Scroll auf Laptops.
-        className="flex max-h-[96vh] w-[min(1400px,calc(100vw-1rem))] flex-col overflow-hidden rounded border border-slate-700 bg-slate-900 p-3 text-slate-100 shadow-2xl sm:p-4"
+        className="flex max-h-[96vh] w-[min(1400px,calc(100vw-1rem))] flex-col overflow-hidden rounded border border-cp-border bg-cp-surface-1 p-3 text-cp-text shadow-2xl sm:p-4"
       >
         <RackBuilderHeader
           editingId={editingId}
@@ -798,7 +798,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
             + längster Inhalt) bekommt 2 Spalten, Höhe + Ansicht + Zoom je 1.
             Zoom hat jetzt explizite +/- Buttons für Tastatur/Maus-User. */}
         <div className="mb-3 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-[2fr_1fr_1fr_1fr]">
-          <label className="block text-cp-xs font-medium text-slate-300 lg:col-span-2">
+          <label className="block text-cp-xs font-medium text-cp-text-secondary lg:col-span-2">
             {t('rack.field.name', 'Rack-Name')} *
             <input
               ref={rackNameInputRef}
@@ -810,15 +810,15 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
               aria-required="true"
               aria-invalid={!draft.rackName.trim() && !!saveError}
               placeholder={t('rack.field.namePlaceholder', 'z.B. "Power Rack A" oder "Main Video Rack"')}
-              className={`mt-1 w-full rounded border bg-slate-950 px-2.5 py-1.5 text-cp-base font-normal text-slate-100 placeholder-slate-600 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 ${
+              className={`mt-1 w-full rounded border bg-cp-surface-3 px-2.5 py-1.5 text-cp-base font-normal text-cp-text placeholder-slate-600 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 ${
                 !draft.rackName.trim() && saveError
                   ? 'border-red-600 ring-1 ring-red-600/40'
-                  : 'border-slate-700'
+                  : 'border-cp-border'
               }`}
             />
           </label>
-          <label className="block text-cp-xs font-medium text-slate-300">
-            {t('rack.field.height', 'Höhe')} <span className="text-slate-500">(HE)</span>
+          <label className="block text-cp-xs font-medium text-cp-text-secondary">
+            {t('rack.field.height', 'Höhe')} <span className="text-cp-text-faint">(HE)</span>
             <input
               type="number"
               min={1}
@@ -830,13 +830,13 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                   totalUnits: Math.max(1, Math.min(LIMITS.MAX_RACK_HEIGHT_HE, Number(event.target.value) || 1)),
                 }))
               }
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-2.5 py-1.5 text-cp-base font-normal text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+              className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 px-2.5 py-1.5 text-cp-base font-normal text-cp-text focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
             />
           </label>
           {/* v7.9.73 / #170 — Rack-Tiefe in mm. Wird vom 3D-Builder genutzt
               um zu prüfen ob hinten noch Platz für Patchblenden ist. */}
-          <label className="block text-cp-xs font-medium text-slate-300">
-            {t('rack.field.depth', 'Tiefe')} <span className="text-slate-500">(mm)</span>
+          <label className="block text-cp-xs font-medium text-cp-text-secondary">
+            {t('rack.field.depth', 'Tiefe')} <span className="text-cp-text-faint">(mm)</span>
             <input
               type="number"
               min={200}
@@ -849,7 +849,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                   depthMm: Math.max(200, Math.min(1500, Number(event.target.value) || 800)),
                 }))
               }
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-2.5 py-1.5 text-cp-base font-normal text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+              className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 px-2.5 py-1.5 text-cp-base font-normal text-cp-text focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
               title={t('rack.depthTitle', 'Rack-Tiefe in mm. Standard: 800 mm. Gängige Werte: 350/450/600/800/1000/1200.')}
             />
           </label>
@@ -871,14 +871,14 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
           style={{ '--lib-col': `${libraryColWidth}px` } as CSSProperties}
           className="grid grid-cols-1 gap-3 md:grid-cols-[var(--lib-col)_minmax(0,1fr)] lg:grid-cols-[var(--lib-col)_minmax(0,1fr)_300px]"
         >
-          <div className="relative rounded border border-slate-700 bg-slate-950/50 p-2">
+          <div className="relative rounded border border-cp-border bg-cp-surface-3/50 p-2">
             {/* v7.9.11 — Library-Header mit Counter, dann Search-Input
                 mit Magnifier-Icon + Clear-Button für bessere Affordance. */}
             <div className="mb-2 flex items-center justify-between">
-              <div className="text-cp-xs font-semibold uppercase tracking-wide text-slate-400">
+              <div className="text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">
                 {t('library.title', 'Library')}
               </div>
-              <span className="rounded bg-slate-800 px-1.5 py-0.5 text-[10px] text-slate-400">
+              <span className="rounded bg-cp-surface-2 px-1.5 py-0.5 text-[10px] text-cp-text-muted">
                 {filteredTemplates.length} / {templates.length}
               </span>
             </div>
@@ -913,7 +913,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                 fill="none"
                 stroke="currentColor"
                 strokeWidth="1.5"
-                className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-slate-500"
+                className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-cp-text-faint"
               >
                 <circle cx="7" cy="7" r="4" />
                 <path d="M10.5 10.5 L14 14" />
@@ -923,7 +923,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                 onChange={(event) => setQuery(event.target.value)}
                 placeholder={t('rack.searchDevicesPlaceholder', 'Gerät suchen…')}
                 aria-label={t('rack.searchDevicesPlaceholder', 'Gerät suchen…')}
-                className="w-full rounded border border-slate-700 bg-slate-950 pl-7 pr-7 py-1.5 text-cp-xs placeholder-slate-600 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 pl-7 pr-7 py-1.5 text-cp-xs placeholder-slate-600 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
               />
               {query && (
                 <button
@@ -931,14 +931,14 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                   onClick={() => setQuery('')}
                   title={t('library.search.clear', 'Suche löschen')}
                   aria-label={t('library.search.clear', 'Suche löschen')}
-                  className="absolute right-1.5 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-slate-500 hover:bg-slate-800 hover:text-slate-200"
+                  className="absolute right-1.5 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-cp-text-faint hover:bg-cp-surface-2 hover:text-cp-text-bright"
                 >
                   ×
                 </button>
               )}
             </div>
             <label
-              className="mb-2 flex items-center gap-1.5 text-[10px] text-slate-400"
+              className="mb-2 flex items-center gap-1.5 text-[10px] text-cp-text-muted"
               title={t(
                 'rack.showNonRackTitle',
                 'Wenn aktiv, werden auch Templates angezeigt die nicht als 19"-Rack-Gerät markiert sind. Beim Hinzufügen wirst du nach der HE-Höhe gefragt.',
@@ -954,16 +954,16 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
             </label>
             <div className="max-h-[58vh] space-y-1 overflow-auto">
               {filteredTemplates.length === 0 && (
-                <div className="rounded border border-dashed border-slate-700 bg-slate-950/40 p-4 text-center text-[11px] text-slate-400">
+                <div className="rounded border border-dashed border-cp-border bg-cp-surface-3/40 p-4 text-center text-[11px] text-cp-text-muted">
                   {query ? (
                     <>
                       {t('rack.noMatchesPre', 'Keine Treffer für')}{' '}
-                      <strong className="text-slate-300">"{query}"</strong>.
+                      <strong className="text-cp-text-secondary">"{query}"</strong>.
                     </>
                   ) : (
                     <>
                       {t('rack.noRackDevices', 'Keine Rack-Geräte verfügbar.')}{' '}
-                      <span className="text-slate-400">
+                      <span className="text-cp-text-muted">
                         "{t('rack.showNonRack', 'Auch Nicht-Rack-Geräte')}"
                       </span>{' '}
                       {t('rack.activatePrompt', 'aktivieren?')}
@@ -998,7 +998,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                     }}
                     className={`group rounded border p-2 text-cp-xs transition-colors ${
                       isRack
-                        ? 'cursor-grab border-slate-800 bg-slate-900/60 hover:border-slate-600 hover:bg-slate-900 active:cursor-grabbing'
+                        ? 'cursor-grab border-cp-border-muted bg-cp-surface-1/60 hover:border-cp-surface-5 hover:bg-cp-surface-1 active:cursor-grabbing'
                         : 'cursor-grab border-amber-800/40 bg-amber-950/20 hover:border-amber-700/60'
                     }`}
                   >
@@ -1008,7 +1008,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                           {/* #509 — Name bricht in weitere Zeilen um statt mit
                               … abzuschneiden (min-w-0 + break-words lassen den
                               Flex-Text wirklich umbrechen). */}
-                          <span className="min-w-0 break-words font-medium leading-snug text-slate-100">{template.name}</span>
+                          <span className="min-w-0 break-words font-medium leading-snug text-cp-text">{template.name}</span>
                           {placedCount > 0 && (
                             <span
                               className="shrink-0 rounded bg-emerald-800/70 px-1 text-[8px] font-semibold uppercase text-emerald-200"
@@ -1026,7 +1026,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                             </span>
                           )}
                         </div>
-                        <div className="break-words text-[10px] text-slate-400">{template.category}</div>
+                        <div className="break-words text-[10px] text-cp-text-muted">{template.category}</div>
                       </div>
                       {/* v7.9.80 / #170 — Split-Button: Hauptaktion
                           "+ Hinzufügen" (Default = full-depth) + kleines
@@ -1040,7 +1040,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                         primaryLabel={placedCount > 0 ? '+ Weitere' : '+ Ins Rack'}
                       />
                     </div>
-                    <div className="mt-1 text-[10px] text-slate-400">
+                    <div className="mt-1 text-[10px] text-cp-text-muted">
                       {isRack ? `${parseUnits(template)} HE · ` : 'HE ? · '}
                       {template.inputs.length} In · {template.outputs.length} Out
                     </div>
@@ -1055,24 +1055,24 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
             </div>
           </div>
 
-          <div className="min-w-0 rounded border border-slate-700 bg-slate-950/50 p-2">
+          <div className="min-w-0 rounded border border-cp-border bg-cp-surface-3/50 p-2">
             {/* v7.9.11 — Rack-Header mit Live-HE-Belegung + Drag-Hint. */}
             <div className="mb-2 flex items-center justify-between gap-2">
               <div className="flex items-center gap-2">
-                <div className="text-cp-xs font-semibold uppercase tracking-wide text-slate-400">
+                <div className="text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">
                   {t('rack.layout', 'Rack-Layout')}
                 </div>
                 {/* v7.9.73 / #170 — 2D/3D Tab-Toggle. 2D ist der bestehende
                     Front/Rear-Panel-Editor; 3D ist die neue Orbit-Ansicht
                     auf Basis von react-three-fiber. */}
-                <div className="ml-2 inline-flex overflow-hidden rounded-cp-control border border-slate-700 text-[11px] font-medium">
+                <div className="ml-2 inline-flex overflow-hidden rounded-cp-control border border-cp-border text-[11px] font-medium">
                   <button
                     type="button"
                     onClick={() => setViewTab('2d')}
                     className={`inline-flex items-center gap-1 px-2.5 py-1 ${
                       viewTab === '2d'
                         ? 'bg-sky-600 text-white'
-                        : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+                        : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
                     }`}
                     title={t('rack.tab2dTitle', '2D-Editor: Vorderseite/Rückseite als Panel-Ansichten')}
                   >
@@ -1081,10 +1081,10 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                   <button
                     type="button"
                     onClick={() => setViewTab('3d')}
-                    className={`inline-flex items-center gap-1 border-l border-slate-700 px-2.5 py-1 ${
+                    className={`inline-flex items-center gap-1 border-l border-cp-border px-2.5 py-1 ${
                       viewTab === '3d'
                         ? 'bg-purple-600 text-white'
-                        : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+                        : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
                     }`}
                     title={t('rack.tab3dTitle', '3D-Visualisierung mit Front/Rear-Tiefe und Rotation. Nur-Lesen — bearbeitet wird im 2D-Tab.')}
                   >
@@ -1097,11 +1097,11 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                     Stepper (−/Prozent/+/Einpassen) statt Slider. Nur im 2D-Tab,
                     weil 3D per Orbit/Scroll zoomt. Klick aufs Prozent = Auto-Fit. */}
                 {viewTab === '2d' && (
-                  <div className="flex items-center gap-0.5 rounded-cp-control border border-slate-700 bg-slate-900/60 p-0.5 text-slate-300">
+                  <div className="flex items-center gap-0.5 rounded-cp-control border border-cp-border bg-cp-surface-1/60 p-0.5 text-cp-text-secondary">
                     <button
                       type="button"
                       onClick={() => setZoom((z) => Math.max(0.5, +(z - 0.1).toFixed(2)))}
-                      className="flex h-6 w-6 items-center justify-center rounded hover:bg-slate-800"
+                      className="flex h-6 w-6 items-center justify-center rounded hover:bg-cp-surface-2"
                       title={t('rack.zoomOut', 'Verkleinern')}
                       aria-label={t('rack.zoomOut', 'Verkleinern')}
                     >
@@ -1110,7 +1110,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                     <button
                       type="button"
                       onClick={() => setZoom(1)}
-                      className="min-w-[2.75rem] rounded px-1 text-center text-[11px] tabular-nums hover:bg-slate-800"
+                      className="min-w-[2.75rem] rounded px-1 text-center text-[11px] tabular-nums hover:bg-cp-surface-2"
                       title={t('rack.zoomFitTitle', 'Auf 100 % zurück (Auto-Fit)')}
                     >
                       {Math.round(zoom * 100)}%
@@ -1118,7 +1118,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                     <button
                       type="button"
                       onClick={() => setZoom((z) => Math.min(2, +(z + 0.1).toFixed(2)))}
-                      className="flex h-6 w-6 items-center justify-center rounded hover:bg-slate-800"
+                      className="flex h-6 w-6 items-center justify-center rounded hover:bg-cp-surface-2"
                       title={t('rack.zoomIn', 'Vergrößern')}
                       aria-label={t('rack.zoomIn', 'Vergrößern')}
                     >
@@ -1127,7 +1127,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                     <button
                       type="button"
                       onClick={() => setZoom(1)}
-                      className="flex h-6 w-6 items-center justify-center rounded hover:bg-slate-800"
+                      className="flex h-6 w-6 items-center justify-center rounded hover:bg-cp-surface-2"
                       title={t('rack.zoomFit', 'Einpassen (Auto-Fit)')}
                       aria-label={t('rack.zoomFit', 'Einpassen')}
                     >
@@ -1135,7 +1135,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                     </button>
                   </div>
                 )}
-                <div className="hidden items-center gap-1.5 text-[10px] text-slate-400 sm:flex">
+                <div className="hidden items-center gap-1.5 text-[10px] text-cp-text-muted sm:flex">
                   <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                     <path d="M8 2 L8 14 M5 5 L8 2 L11 5 M5 11 L8 14 L11 11" />
                   </svg>
@@ -1144,13 +1144,13 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
               </div>
             </div>
             {draft.placements.length === 0 && (
-              <div className="rounded border border-dashed border-slate-700 bg-slate-950/40 p-8 text-center text-cp-xs text-slate-500">
+              <div className="rounded border border-dashed border-cp-border bg-cp-surface-3/40 p-8 text-center text-cp-xs text-cp-text-faint">
                 <div className="mb-2 text-3xl">▥</div>
-                <div className="mb-1 font-semibold text-slate-300">{t('rack.empty', 'Rack ist leer')}</div>
+                <div className="mb-1 font-semibold text-cp-text-secondary">{t('rack.empty', 'Rack ist leer')}</div>
                 <div>{t('rack.addFromLibraryHint', 'Geräte aus der Library links hinzufügen (Button "+ Rack").')}</div>
                 <div className="mt-2 text-[10px]">
                   {t('rack.tipPrefix', 'Tipp:')}{' '}
-                  <span className="text-slate-400">"{t('rack.showNonRack', 'Auch Nicht-Rack-Geräte')}"</span>{' '}
+                  <span className="text-cp-text-muted">"{t('rack.showNonRack', 'Auch Nicht-Rack-Geräte')}"</span>{' '}
                   {t('rack.tipBody', 'aktivieren wenn das Wunschgerät fehlt.')}
                 </div>
               </div>
@@ -1201,7 +1201,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
             {/* v7.9.80 / #170 — Front/Rear/Both-Toggle ist jetzt Teil der
                 2D-Rack-Spalte (war vorher als Select im Header). */}
             {viewTab === '2d' && (
-              <div className="mb-2 flex overflow-hidden rounded-cp-control border border-slate-700 text-[11px]">
+              <div className="mb-2 flex overflow-hidden rounded-cp-control border border-cp-border text-[11px]">
                 {([
                   ['front', t('rack.viewMode.front', 'Vorne'), RectangleVertical],
                   ['rear', t('rack.viewMode.rear', 'Hinten'), FlipHorizontal2],
@@ -1215,7 +1215,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                     className={`flex flex-1 items-center justify-center gap-1.5 px-2 py-1.5 font-medium transition ${
                       draft.viewMode === mode
                         ? 'bg-sky-600 text-white'
-                        : 'bg-slate-900/50 text-slate-400 hover:bg-slate-800/60'
+                        : 'bg-cp-surface-1/50 text-cp-text-muted hover:bg-cp-surface-2/60'
                     }`}
                     aria-pressed={draft.viewMode === mode}
                     title={label}
@@ -1228,7 +1228,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
             )}
             {/* #472 — Steckverbinder-Symbole im 2D- UND 3D-Rack ein-/ausblenden. */}
             {(viewTab === '2d' || viewTab === '3d') && (
-              <label className="mb-2 flex cursor-pointer items-center gap-1.5 text-[11px] text-slate-300">
+              <label className="mb-2 flex cursor-pointer items-center gap-1.5 text-[11px] text-cp-text-secondary">
                 <input
                   type="checkbox"
                   checked={showConnectorSymbols}
@@ -1251,13 +1251,13 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                   Panel (Tiefenansicht). Front/Rear/Both Modi laufen wie
                   vorher. */}
               {draft.viewMode === 'side' && (
-                <div className="rounded border border-slate-800 bg-slate-950 p-2">
+                <div className="rounded border border-cp-border-muted bg-cp-surface-3 p-2">
                   <div className="mb-2 flex items-center gap-2">
                     <span className="inline-flex items-center gap-1 rounded bg-sky-900/50 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-sky-200">
                       <span className="inline-block h-1.5 w-1.5 rounded-full" style={{ background: '#0ea5e9' }} />
                       Seitenansicht (Tiefe)
                     </span>
-                    <span className="text-[10px] text-slate-400">
+                    <span className="text-[10px] text-cp-text-muted">
                       Vorne ◀ {draft.depthMm ?? 800} mm ▶ Hinten
                     </span>
                   </div>
@@ -1267,7 +1267,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                     const sidePxPerMm = sideWidthPx / depthMm
                     return (
                       <div
-                        className="relative mx-auto overflow-hidden rounded border border-slate-700 bg-slate-900"
+                        className="relative mx-auto overflow-hidden rounded border border-cp-border bg-cp-surface-1"
                         style={{ width: sideWidthPx, height: draft.totalUnits * rowHeight }}
                       >
                         {/* HE-Grid */}
@@ -1276,10 +1276,10 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                           return (
                             <div
                               key={`side-grid-${unit}`}
-                              className="absolute left-0 right-0 border-t border-slate-800/80"
+                              className="absolute left-0 right-0 border-t border-cp-border-muted/80"
                               style={{ top: idx * rowHeight, height: rowHeight }}
                             >
-                              <span className="absolute left-1 top-0.5 text-[9px] text-slate-400">U{unit}</span>
+                              <span className="absolute left-1 top-0.5 text-[9px] text-cp-text-muted">U{unit}</span>
                             </div>
                           )
                         })}
@@ -1304,7 +1304,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                             ? 'border-purple-500 bg-purple-900/40'
                             : mount === 'front'
                               ? 'border-green-500 bg-green-900/40'
-                              : 'border-slate-500 bg-slate-700/40'
+                              : 'border-slate-500 bg-cp-surface-4/40'
                           return (
                             <div
                               key={`side-block-${item.id}`}
@@ -1325,7 +1325,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                 </div>
               )}
               {draft.viewMode !== 'side' && (draft.viewMode === 'both' ? ['front', 'rear'] : [draft.viewMode]).map((side) => (
-                <div key={side} className="rounded border border-slate-800 bg-slate-950 p-2">
+                <div key={side} className="rounded border border-cp-border-muted bg-cp-surface-3 p-2">
                   <div className="mb-2 flex items-center gap-2">
                     <span
                       className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
@@ -1342,7 +1342,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                     </span>
                   </div>
                   <div
-                    className="relative mx-auto overflow-hidden rounded border border-slate-700 bg-slate-900"
+                    className="relative mx-auto overflow-hidden rounded border border-cp-border bg-cp-surface-1"
                     // Lock the panel width to the 19"-rack aspect so the rows
                     // always look correct, even in single-side view where the
                     // grid would otherwise stretch the panel to the full pane
@@ -1404,10 +1404,10 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                       return (
                         <div
                           key={`${side}-grid-${unit}`}
-                          className="absolute left-0 right-0 border-t border-slate-800/80"
+                          className="absolute left-0 right-0 border-t border-cp-border-muted/80"
                           style={{ top: index * rowHeight, height: rowHeight }}
                         >
-                          <span className="absolute left-1 top-0.5 text-[9px] text-slate-400">U{unit}</span>
+                          <span className="absolute left-1 top-0.5 text-[9px] text-cp-text-muted">U{unit}</span>
                         </div>
                       )
                     })}
@@ -1661,8 +1661,8 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
           <div className="space-y-3 md:col-span-2 lg:col-span-1">
           {/* v7.9.9 — Live-Preview-Pane: Black-Box auf Canvas + interne
               Verkabelung — Updates live mit jeder Draft-Änderung. */}
-          <div className="rounded border border-slate-700 bg-slate-950/50 p-2">
-            <div className="mb-2 text-cp-xs font-semibold uppercase tracking-wide text-slate-400">
+          <div className="rounded border border-cp-border bg-cp-surface-3/50 p-2">
+            <div className="mb-2 text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">
               Live-Preview
             </div>
             <RackLivePreview
@@ -1690,7 +1690,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
               (PlacementPropertiesDialog am Ende der Component), das per
               Doppelklick auf ein Gerät im Rack aufgeht. Hier nur ein
               kleiner Hinweis statt der dauerhaft offenen Sidebar. */}
-          <div className="rounded border border-dashed border-slate-700 bg-slate-950/30 px-2 py-3 text-center text-[10px] text-slate-400">
+          <div className="rounded border border-dashed border-cp-border bg-cp-surface-3/30 px-2 py-3 text-center text-[10px] text-cp-text-muted">
             Doppelklick auf ein Gerät im Rack → öffnet Eigenschaften-Popup
             (Höhe, Start-HE, Panel-Bilder, Entfernen).
           </div>

--- a/src/renderer/components/Rack/RackBuilderDialogExportMenu.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialogExportMenu.tsx
@@ -80,7 +80,7 @@ export const RackBuilderDialogExportMenu = ({
         type="button"
         onClick={() => setOpen((v) => !v)}
         title={t('rack.exportTitle', 'Rack exportieren (PNG / STL / .cpgroup)')}
-        className="flex h-8 items-center gap-1 rounded border border-slate-700 bg-slate-800 px-3 text-cp-xs text-slate-300 hover:border-sky-500/50 hover:bg-sky-900/30 hover:text-sky-200"
+        className="flex h-8 items-center gap-1 rounded border border-cp-border bg-cp-surface-2 px-3 text-cp-xs text-cp-text-secondary hover:border-sky-500/50 hover:bg-sky-900/30 hover:text-sky-200"
       >
         <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
           <path d="M8 1 L8 10 M4 7 L8 11 L12 7 M2 13 L14 13" />
@@ -90,7 +90,7 @@ export const RackBuilderDialogExportMenu = ({
       {open && (
         <div
           onMouseLeave={() => setOpen(false)}
-          className="absolute right-0 top-9 z-50 w-64 overflow-hidden rounded border border-slate-700 bg-slate-900 text-cp-xs shadow-2xl"
+          className="absolute right-0 top-9 z-50 w-64 overflow-hidden rounded border border-cp-border bg-cp-surface-1 text-cp-xs shadow-2xl"
         >
           <button
             type="button"
@@ -100,10 +100,10 @@ export const RackBuilderDialogExportMenu = ({
               if (!rackCanvasEl) return
               void exportRack2DAsPng(rackCanvasEl, rackName || 'rack')
             }}
-            className="flex w-full flex-col items-start gap-0.5 border-b border-slate-800 px-3 py-2 text-left text-slate-200 hover:bg-slate-800"
+            className="flex w-full flex-col items-start gap-0.5 border-b border-cp-border-muted px-3 py-2 text-left text-cp-text-bright hover:bg-cp-surface-2"
           >
             <span className="font-semibold"><Icon icon={Camera} size="xs" className="mr-1 inline-block align-text-bottom" />{t('rack.export.png2d', '2D als PNG')}</span>
-            <span className="text-[10px] text-slate-400">
+            <span className="text-[10px] text-cp-text-muted">
               {t('rack.export.png2dDesc', 'Aktuelle Front/Rear/Both-Ansicht als Bild')}
             </span>
           </button>
@@ -123,10 +123,10 @@ export const RackBuilderDialogExportMenu = ({
                 rackDepthMm: depthMm ?? 800,
               })
             }}
-            className="flex w-full flex-col items-start gap-0.5 border-b border-slate-800 px-3 py-2 text-left text-slate-200 hover:bg-slate-800"
+            className="flex w-full flex-col items-start gap-0.5 border-b border-cp-border-muted px-3 py-2 text-left text-cp-text-bright hover:bg-cp-surface-2"
           >
             <span className="font-semibold"><Icon icon={Camera} size="xs" className="mr-1 inline-block align-text-bottom" />{t('rack.export.png3d', '3D aus 4 Perspektiven')}</span>
-            <span className="text-[10px] text-slate-400">
+            <span className="text-[10px] text-cp-text-muted">
               {t('rack.export.png3dDesc', 'PNG: Front · Rear · Iso · Top (1× pro Datei)')}
             </span>
           </button>
@@ -141,10 +141,10 @@ export const RackBuilderDialogExportMenu = ({
               }
               exportRackAsStl(refs.scene, rackName || 'rack')
             }}
-            className="flex w-full flex-col items-start gap-0.5 border-b border-slate-800 px-3 py-2 text-left text-slate-200 hover:bg-slate-800"
+            className="flex w-full flex-col items-start gap-0.5 border-b border-cp-border-muted px-3 py-2 text-left text-cp-text-bright hover:bg-cp-surface-2"
           >
             <span className="font-semibold"><Icon icon={Box} size="xs" className="mr-1 inline-block align-text-bottom" />{t('rack.export.stl', '3D als STL')}</span>
-            <span className="text-[10px] text-slate-400">
+            <span className="text-[10px] text-cp-text-muted">
               {t('rack.export.stlDesc', 'Komplettes Rack als binäres STL (3D-Druck, CAD)')}
             </span>
           </button>
@@ -197,10 +197,10 @@ export const RackBuilderDialogExportMenu = ({
               }
               exportRackAsCpgroup(preset)
             }}
-            className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left text-slate-200 hover:bg-slate-800"
+            className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left text-cp-text-bright hover:bg-cp-surface-2"
           >
             <span className="font-semibold"><Icon icon={Save} size="xs" className="mr-1 inline-block align-text-bottom" />{t('rack.export.cpgroup', '.cpgroup herunterladen')}</span>
-            <span className="text-[10px] text-slate-400">
+            <span className="text-[10px] text-cp-text-muted">
               {t('rack.export.cpgroupDesc', 'Komplettes Rack inkl. STL + Fotos zum Cross-PC-Transfer')}
             </span>
           </button>

--- a/src/renderer/components/Rack/RackBuilderFooter.tsx
+++ b/src/renderer/components/Rack/RackBuilderFooter.tsx
@@ -39,16 +39,16 @@ export const RackBuilderFooter = ({
 }: RackBuilderFooterProps) => {
   const t = useTranslation()
   return (
-    <div className="mt-3 flex flex-wrap items-center justify-between gap-3 border-t border-slate-800 pt-3">
+    <div className="mt-3 flex flex-wrap items-center justify-between gap-3 border-t border-cp-border-muted pt-3">
       <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
-        <span className="inline-flex items-center gap-1 rounded bg-slate-800 px-2 py-0.5 text-slate-300">
-          <span className="text-slate-500">{t('rack.devicesLabel', 'Geräte:')}</span>
-          <strong className="text-slate-100">{devicesCount}</strong>
+        <span className="inline-flex items-center gap-1 rounded bg-cp-surface-2 px-2 py-0.5 text-cp-text-secondary">
+          <span className="text-cp-text-faint">{t('rack.devicesLabel', 'Geräte:')}</span>
+          <strong className="text-cp-text">{devicesCount}</strong>
         </span>
-        <span className="inline-flex items-center gap-1 rounded bg-slate-800 px-2 py-0.5 text-slate-300">
-          <span className="text-slate-500">{t('rack.heOccupied', 'HE belegt:')}</span>
-          <strong className="text-slate-100">{occupiedUnits}</strong>
-          <span className="text-slate-500">/ {totalUnits}</span>
+        <span className="inline-flex items-center gap-1 rounded bg-cp-surface-2 px-2 py-0.5 text-cp-text-secondary">
+          <span className="text-cp-text-faint">{t('rack.heOccupied', 'HE belegt:')}</span>
+          <strong className="text-cp-text">{occupiedUnits}</strong>
+          <span className="text-cp-text-faint">/ {totalUnits}</span>
         </span>
         {internalCablesCount > 0 && (
           <span
@@ -72,7 +72,7 @@ export const RackBuilderFooter = ({
       </div>
 
       <div
-        className="flex items-center gap-1.5 text-[10px] text-slate-400"
+        className="flex items-center gap-1.5 text-[10px] text-cp-text-muted"
         title={
           dirty
             ? t('rack.autosaveActive', 'Autosave läuft alle paar Sekunden')
@@ -103,7 +103,7 @@ export const RackBuilderFooter = ({
         <button
           type="button"
           onClick={onCancel}
-          className="rounded px-3 py-1.5 text-cp-xs text-slate-400 hover:bg-slate-800 hover:text-slate-200"
+          className="rounded px-3 py-1.5 text-cp-xs text-cp-text-muted hover:bg-cp-surface-2 hover:text-cp-text-bright"
         >
           {t('common.cancel', 'Abbrechen')}
         </button>

--- a/src/renderer/components/Rack/RackBuilderHeader.tsx
+++ b/src/renderer/components/Rack/RackBuilderHeader.tsx
@@ -36,7 +36,7 @@ export const RackBuilderHeader = ({
     >
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <h3 className="truncate text-cp-xl font-semibold text-slate-100">
+          <h3 className="truncate text-cp-xl font-semibold text-cp-text">
             {editingId ? rackName || '(unbenanntes Rack)' : 'Neues Rack'}
           </h3>
           <span
@@ -58,13 +58,13 @@ export const RackBuilderHeader = ({
             </span>
           )}
         </div>
-        <p className="mt-0.5 text-[11px] text-slate-400">
+        <p className="mt-0.5 text-[11px] text-cp-text-muted">
           {t(
             'rack.subtitle',
             '2D Rack Builder · Geräte aus Library hinzufügen, HE-Position per Drag, Verkabelung intern',
           )}
           <span className="ml-2 hidden sm:inline">
-            <kbd className="rounded border border-slate-700 bg-slate-800 px-1 text-[10px]">Esc</kbd>{' '}
+            <kbd className="rounded border border-cp-border bg-cp-surface-2 px-1 text-[10px]">Esc</kbd>{' '}
             {t('rack.closeShortcut', 'schließen')}
           </span>
         </p>
@@ -75,7 +75,7 @@ export const RackBuilderHeader = ({
         onClick={onClose}
         aria-label={t('common.close', 'Schließen')}
         title={t('rack.closeTitle', 'Schließen (Esc)')}
-        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-slate-700 bg-slate-800 text-slate-300 transition-colors hover:border-red-500/50 hover:bg-red-900/30 hover:text-red-300"
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-cp-border bg-cp-surface-2 text-cp-text-secondary transition-colors hover:border-red-500/50 hover:bg-red-900/30 hover:text-red-300"
       >
         <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2">
           <path d="M4 4 L12 12 M12 4 L4 12" />

--- a/src/renderer/components/Rack/RackEditorDialog.tsx
+++ b/src/renderer/components/Rack/RackEditorDialog.tsx
@@ -222,15 +222,15 @@ export const RackEditorDialog = () => {
       <div
         ref={containerRef}
         style={containerStyle}
-        className="flex h-[80vh] w-full max-w-5xl flex-col overflow-hidden rounded border border-slate-700 bg-slate-900 text-slate-100 shadow-2xl"
+        className="flex h-[80vh] w-full max-w-5xl flex-col overflow-hidden rounded border border-cp-border bg-cp-surface-1 text-cp-text shadow-2xl"
       >
         <header
           {...headerProps}
-          className="flex items-center justify-between border-b border-slate-700 px-4 py-2 select-none"
+          className="flex items-center justify-between border-b border-cp-border px-4 py-2 select-none"
         >
           <div>
             <h2 className="text-cp-base font-semibold">{t('rackEditor.title', 'Rack-Editor')}</h2>
-            <p className="text-[10px] text-slate-400">
+            <p className="text-[10px] text-cp-text-muted">
               {t(
                 'rackEditor.intro',
                 'Sub-Canvas pro Rack — Geräte sind im Hauptprojekt gespeichert, der Editor zeigt nur diese Rack-Instanz. Vertikal ziehen rastet auf HU-Linien ein.',
@@ -240,17 +240,17 @@ export const RackEditorDialog = () => {
           <button
             type="button"
             onClick={close}
-            className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+            className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
           >
             {t('common.close', 'Schließen')}
           </button>
         </header>
-        <div className="flex-1 min-h-0 bg-slate-950">
+        <div className="flex-1 min-h-0 bg-cp-surface-3">
           <ReactFlowProvider>
             <RackEditorContent rackInstanceId={slot.rackInstanceId} />
           </ReactFlowProvider>
         </div>
-        <footer className="border-t border-slate-700 px-4 py-2 text-[11px] text-slate-400">
+        <footer className="border-t border-cp-border px-4 py-2 text-[11px] text-cp-text-muted">
           {t(
             'rackEditor.footer',
             'Tipp: HU-Position wird beim Loslassen automatisch auf die nächste ganze HU gerundet. Änderungen wirken sofort auf die Haupt-Canvas.',

--- a/src/renderer/components/Rack/RackImageCropDialog.tsx
+++ b/src/renderer/components/Rack/RackImageCropDialog.tsx
@@ -307,7 +307,7 @@ export const RackImageCropDialog = ({
       <div
         ref={containerRef}
         style={containerStyle}
-        className="max-h-[94vh] w-full max-w-5xl overflow-auto rounded border border-slate-700 bg-slate-900 p-4 text-slate-100 shadow-2xl"
+        className="max-h-[94vh] w-full max-w-5xl overflow-auto rounded border border-cp-border bg-cp-surface-1 p-4 text-cp-text shadow-2xl"
       >
         <div
           {...headerProps}
@@ -322,7 +322,7 @@ export const RackImageCropDialog = ({
                 { units: rackUnits },
               )}
             </h3>
-            <p className="mt-0.5 text-cp-xs text-slate-400">
+            <p className="mt-0.5 text-cp-xs text-cp-text-muted">
               {t(
                 'rackCrop.hint',
                 'Mausrad zoomt · Ecken & Kanten ziehen zum Skalieren · Shift = Aspekt halten · Pfeiltasten nudgen · R = Reset',
@@ -332,15 +332,15 @@ export const RackImageCropDialog = ({
           <button
             type="button"
             onClick={onCancel}
-            className="rounded bg-slate-700 px-2 py-1 text-cp-xs hover:bg-slate-600"
+            className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
           >
             {t('rackCrop.close', 'Schliessen')}
           </button>
         </div>
 
         <div className="mb-3 grid grid-cols-1 gap-3 lg:grid-cols-[1fr_280px]">
-          <div className="rounded border border-slate-700 bg-slate-950/40 p-2">
-            <div className="mb-2 flex items-center gap-2 text-cp-xs text-slate-400">
+          <div className="rounded border border-cp-border bg-cp-surface-3/40 p-2">
+            <div className="mb-2 flex items-center gap-2 text-cp-xs text-cp-text-muted">
               <span>{t('rackCrop.zoom', 'Zoom')}</span>
               <input
                 type="range"
@@ -364,7 +364,7 @@ export const RackImageCropDialog = ({
             </div>
             <div
               ref={scrollRef}
-              className="relative max-h-[70vh] overflow-auto rounded border border-slate-700"
+              className="relative max-h-[70vh] overflow-auto rounded border border-cp-border"
               onWheel={onWheelZoom}
             >
               <div
@@ -432,9 +432,9 @@ export const RackImageCropDialog = ({
             </div>
           </div>
 
-          <div className="space-y-2 rounded border border-slate-700 bg-slate-950/40 p-2 text-cp-xs">
+          <div className="space-y-2 rounded border border-cp-border bg-cp-surface-3/40 p-2 text-cp-xs">
             <div className="flex items-center justify-between">
-              <span className="text-[11px] uppercase tracking-wide text-slate-400">
+              <span className="text-[11px] uppercase tracking-wide text-cp-text-muted">
                 {t('rackCrop.presets', 'Schnittvorlagen')}
               </span>
               <button
@@ -443,7 +443,7 @@ export const RackImageCropDialog = ({
                   setCrop(defaultCrop(rackUnits, imgAspect))
                   setZoom(1)
                 }}
-                className="rounded bg-slate-700 px-2 py-0.5 text-[10px] hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-2 py-0.5 text-[10px] hover:bg-cp-surface-5"
                 title={t('rackCrop.resetTitle', 'Crop und Zoom zurücksetzen (R)')}
               >
                 {t('rackCrop.reset', '⟲ Reset')}
@@ -455,7 +455,7 @@ export const RackImageCropDialog = ({
                   key={he}
                   type="button"
                   onClick={() => setCrop(defaultCrop(he, imgAspect))}
-                  className={`rounded px-2 py-1 ${he === rackUnits ? 'bg-cyan-700 hover:bg-cyan-600' : 'bg-slate-700 hover:bg-slate-600'}`}
+                  className={`rounded px-2 py-1 ${he === rackUnits ? 'bg-cyan-700 hover:bg-cyan-600' : 'bg-cp-surface-4 hover:bg-cp-surface-5'}`}
                   title={format(t('rackCrop.presetTitle', 'Vorlage {n} HE Aspekt'), { n: he })}
                 >
                   {he}HE
@@ -463,8 +463,8 @@ export const RackImageCropDialog = ({
               ))}
             </div>
 
-            <div className="mt-3 rounded border border-slate-800 bg-slate-900/60 p-2">
-              <div className="mb-1 text-[10px] uppercase tracking-wide text-slate-400">
+            <div className="mt-3 rounded border border-cp-border-muted bg-cp-surface-1/60 p-2">
+              <div className="mb-1 text-[10px] uppercase tracking-wide text-cp-text-muted">
                 {t('rackCrop.manualValues', 'Manuelle Werte (0–1)')}
               </div>
               <div className="grid grid-cols-2 gap-1.5">
@@ -480,7 +480,7 @@ export const RackImageCropDialog = ({
                       const value = clamp(Number(event.target.value) || 0, 0, 1 - crop.width)
                       setCrop((current) => ({ ...current, x: value }))
                     }}
-                    className="mt-0.5 w-full rounded border border-slate-700 bg-slate-900 p-1 tabular-nums"
+                    className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-1 p-1 tabular-nums"
                   />
                 </label>
                 <label className="block text-[11px]">
@@ -495,7 +495,7 @@ export const RackImageCropDialog = ({
                       const value = clamp(Number(event.target.value) || 0, 0, 1 - crop.height)
                       setCrop((current) => ({ ...current, y: value }))
                     }}
-                    className="mt-0.5 w-full rounded border border-slate-700 bg-slate-900 p-1 tabular-nums"
+                    className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-1 p-1 tabular-nums"
                   />
                 </label>
                 <label className="block text-[11px]">
@@ -510,7 +510,7 @@ export const RackImageCropDialog = ({
                       const width = clamp(Number(event.target.value) || MIN_SIZE, MIN_SIZE, 1)
                       setCrop((current) => ({ ...current, width, x: clamp(current.x, 0, 1 - width) }))
                     }}
-                    className="mt-0.5 w-full rounded border border-slate-700 bg-slate-900 p-1 tabular-nums"
+                    className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-1 p-1 tabular-nums"
                   />
                 </label>
                 <label className="block text-[11px]">
@@ -525,33 +525,33 @@ export const RackImageCropDialog = ({
                       const height = clamp(Number(event.target.value) || MIN_SIZE, MIN_SIZE, 1)
                       setCrop((current) => ({ ...current, height, y: clamp(current.y, 0, 1 - height) }))
                     }}
-                    className="mt-0.5 w-full rounded border border-slate-700 bg-slate-900 p-1 tabular-nums"
+                    className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-1 p-1 tabular-nums"
                   />
                 </label>
               </div>
             </div>
 
-            <div className="rounded border border-slate-800 bg-slate-900/60 p-2 text-[11px] text-slate-400">
+            <div className="rounded border border-cp-border-muted bg-cp-surface-1/60 p-2 text-[11px] text-cp-text-muted">
               <div>
                 {t('rackCrop.targetAspect', 'Ziel-Aspekt:')}{' '}
-                <span className="tabular-nums text-slate-200">{targetAspect.toFixed(2)}:1</span>
+                <span className="tabular-nums text-cp-text-bright">{targetAspect.toFixed(2)}:1</span>
               </div>
               <div>
                 {t('rackCrop.currentAspect', 'Aktueller Crop-Aspekt:')}{' '}
-                <span className="tabular-nums text-slate-200">
+                <span className="tabular-nums text-cp-text-bright">
                   {(crop.width / Math.max(0.001, crop.height)).toFixed(2)}:1
                 </span>
               </div>
               <div>
                 {t('rackCrop.liveHe', 'Live HE:')}{' '}
-                <span className="tabular-nums text-slate-200">{liveHe.toFixed(2)}</span>
+                <span className="tabular-nums text-cp-text-bright">{liveHe.toFixed(2)}</span>
               </div>
             </div>
           </div>
         </div>
 
         <div className="flex justify-end gap-2">
-          <button type="button" onClick={onCancel} className="rounded bg-slate-700 px-3 py-1 text-cp-base hover:bg-slate-600">
+          <button type="button" onClick={onCancel} className="rounded bg-cp-surface-4 px-3 py-1 text-cp-base hover:bg-cp-surface-5">
             {t('common.cancel', 'Abbrechen')}
           </button>
           <button type="button" onClick={finalizeCrop} className="rounded bg-emerald-600 px-3 py-1 text-cp-base hover:bg-emerald-500">

--- a/src/renderer/components/Rack/RackInternalCanvas.tsx
+++ b/src/renderer/components/Rack/RackInternalCanvas.tsx
@@ -461,10 +461,10 @@ const RackSidePropertiesPane = () => {
       ? `Kabel: ${selectedCable.name}`
       : 'Inspector'
   return (
-    <aside className="flex h-full min-h-0 flex-col rounded border border-slate-700 bg-slate-950">
-      <div className="border-b border-slate-800 px-3 py-2">
-        <h3 className="truncate text-cp-xs font-semibold text-slate-100">{title}</h3>
-        <div className="mt-0.5 text-[9px] uppercase tracking-wide text-slate-400">
+    <aside className="flex h-full min-h-0 flex-col rounded border border-cp-border bg-cp-surface-3">
+      <div className="border-b border-cp-border-muted px-3 py-2">
+        <h3 className="truncate text-cp-xs font-semibold text-cp-text">{title}</h3>
+        <div className="mt-0.5 text-[9px] uppercase tracking-wide text-cp-text-muted">
           Eigenschaften (Rack-Scope)
         </div>
       </div>
@@ -472,7 +472,7 @@ const RackSidePropertiesPane = () => {
         {selectedEquipmentId && <EquipmentProperties />}
         {selectedCableId && <CableProperties />}
         {!selectedEquipmentId && !selectedCableId && (
-          <div className="rounded border border-slate-800 bg-slate-900/40 p-3 text-[11px] text-slate-400">
+          <div className="rounded border border-cp-border-muted bg-cp-surface-1/40 p-3 text-[11px] text-cp-text-muted">
             Klick auf ein Rack-Gerät oder eine Verbindung im Canvas → die Eigenschaften erscheinen hier.
           </div>
         )}

--- a/src/renderer/components/Rack/RackInternalWireOverlay.tsx
+++ b/src/renderer/components/Rack/RackInternalWireOverlay.tsx
@@ -63,11 +63,11 @@ export const RackInternalWireOverlay = ({
 
   return (
     <div className="fixed inset-0 z-[80] flex items-center justify-center bg-black/70 p-2 sm:p-6">
-      <div className="flex h-[92vh] w-[min(1500px,calc(100vw-1rem))] flex-col rounded border border-slate-700 bg-slate-900 p-3 text-slate-100 shadow-2xl">
+      <div className="flex h-[92vh] w-[min(1500px,calc(100vw-1rem))] flex-col rounded border border-cp-border bg-cp-surface-1 p-3 text-cp-text shadow-2xl">
         <div className="mb-2 flex items-center justify-between gap-3">
           <div>
             <h3 className="text-cp-xl font-semibold">{t('rack.wire.title', 'Rack-Verkabelung')}: {rackName || t('rack.unnamed', '(unbenannt)')}</h3>
-            <p className="mt-1 text-cp-xs text-slate-400">
+            <p className="mt-1 text-cp-xs text-cp-text-muted">
               {t(
                 'rack.wire.intro',
                 'Ziehe Linien Output → Input. Rechtsklick auf Kabel = Menü, Doppelklick = Eigenschaften, Entf = Löschen. Verwendet jetzt die echte Canvas-Komponente — Toolbar, Routing, Waypoints, A*-Routing alles wie im Hauptcanvas.',
@@ -82,7 +82,7 @@ export const RackInternalWireOverlay = ({
             {t('common.done', 'Fertig')}
           </button>
         </div>
-        <div className="min-h-0 flex-1 overflow-hidden rounded border border-slate-700">
+        <div className="min-h-0 flex-1 overflow-hidden rounded border border-cp-border">
           <RackInternalCanvas
             rackName={rackName}
             placements={placements.map((p) => ({

--- a/src/renderer/components/Rack/RackPlacementProperties.tsx
+++ b/src/renderer/components/Rack/RackPlacementProperties.tsx
@@ -81,7 +81,7 @@ export const RackPlacementProperties = ({
           <button
             type="button"
             onClick={onClose}
-            className="rounded bg-slate-700 px-3 py-1 text-cp-xs hover:bg-slate-600"
+            className="rounded bg-cp-surface-4 px-3 py-1 text-cp-xs hover:bg-cp-surface-5"
           >
             {t('common.close', 'Schließen')}
           </button>
@@ -94,7 +94,7 @@ export const RackPlacementProperties = ({
           <input
             value={selectedPlacement.name}
             onChange={(event) => onUpdate(selectedPlacement.id, { name: event.target.value })}
-            className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+            className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
           />
         </label>
         <label className="block">
@@ -103,7 +103,7 @@ export const RackPlacementProperties = ({
             value={selectedPlacement.category}
             onChange={(category) => onUpdate(selectedPlacement.id, { category })}
             extraOptions={[...categoryOptions, selectedPlacement.category]}
-            className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+            className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
           />
         </label>
         <label className="flex items-center gap-2 opacity-60" title={t('rack.readonlyInBuilder', 'Im Builder schreibgeschützt — wurde beim Hinzufügen gesetzt.')}>
@@ -127,8 +127,8 @@ export const RackPlacementProperties = ({
                 )
                 onUpdate(selectedPlacement.id, { rackUnits: clamped })
               }}
-              className={`mt-1 w-full rounded border bg-slate-950 p-1.5 ${
-                heightInvalid ? 'border-red-600 ring-1 ring-red-600/40' : 'border-slate-700'
+              className={`mt-1 w-full rounded border bg-cp-surface-3 p-1.5 ${
+                heightInvalid ? 'border-red-600 ring-1 ring-red-600/40' : 'border-cp-border'
               }`}
             />
             {heightInvalid && (
@@ -156,11 +156,11 @@ export const RackPlacementProperties = ({
                 const clamped = Math.min(raw, startMax)
                 onUpdate(selectedPlacement.id, { startUnit: clamped })
               }}
-              className={`mt-1 w-full rounded border bg-slate-950 p-1.5 ${
-                heightInvalid ? 'border-red-600 ring-1 ring-red-600/40' : 'border-slate-700'
+              className={`mt-1 w-full rounded border bg-cp-surface-3 p-1.5 ${
+                heightInvalid ? 'border-red-600 ring-1 ring-red-600/40' : 'border-cp-border'
               }`}
             />
-            <span className="mt-0.5 block text-[10px] text-slate-400">
+            <span className="mt-0.5 block text-[10px] text-cp-text-muted">
               {format(
                 t('rack.props.maxHint', 'max {max} (Höhe {he} HE)'),
                 { max: startMax, he: selectedPlacement.rackUnits },
@@ -185,7 +185,7 @@ export const RackPlacementProperties = ({
                   depthMm: v === '' ? undefined : Math.max(20, Math.min(1500, Number(v))),
                 })
               }}
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+              className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
               title={t('rack.deviceDepthTitle', 'Geräte-Tiefe in mm. Leer = 400 mm Standard. Wird vom 3D-Tab visualisiert.')}
             />
           </label>
@@ -198,7 +198,7 @@ export const RackPlacementProperties = ({
                   mountSide: event.target.value as 'front' | 'rear' | 'full',
                 })
               }
-              className="mt-1 w-full rounded border border-slate-700 bg-slate-950 p-1.5"
+              className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
               title={t('rack.mountTitle', 'full = volle Rack-Tiefe. front = nur vorne. rear = nur hinten (z.B. Patchblende).')}
             >
               <option value="full">{t('rack.mount.full', 'Full-Depth')}</option>
@@ -209,10 +209,10 @@ export const RackPlacementProperties = ({
         </div>
         {/* STL-Upload für 3D-Modell. */}
         <div className="block">
-          <div className="mb-1 text-cp-xs text-slate-300">{t('rack.stl.header', '3D-Modell (STL, optional)')}</div>
+          <div className="mb-1 text-cp-xs text-cp-text-secondary">{t('rack.stl.header', '3D-Modell (STL, optional)')}</div>
           <div className="mt-1 flex items-center gap-2">
             <label
-              className="inline-flex cursor-pointer items-center gap-1 rounded border border-slate-600 bg-sky-700 px-3 py-1 text-[11px] font-semibold text-white hover:bg-sky-600"
+              className="inline-flex cursor-pointer items-center gap-1 rounded border border-cp-surface-5 bg-sky-700 px-3 py-1 text-[11px] font-semibold text-white hover:bg-sky-600"
               title={t('rack.stlUploadTitle', 'STL-Datei (.stl, max 5 MB) zum Gerät hochladen')}
             >
               <span>📁</span>
@@ -252,7 +252,7 @@ export const RackPlacementProperties = ({
                   const tpl = templates.find((tt) => tt.name === selectedPlacement.templateName)
                   if (tpl && tpl.stlDataUri) onSyncStlToTemplate(selectedPlacement.templateName, undefined)
                 }}
-                className="rounded border border-slate-600 bg-slate-700 px-2 py-1 text-[11px] text-slate-200 hover:bg-slate-600"
+                className="rounded border border-cp-surface-5 bg-cp-surface-4 px-2 py-1 text-[11px] text-cp-text-bright hover:bg-cp-surface-5"
                 title={t('rack.stlRemoveTitle', 'STL entfernen — Gerät wird wieder als Box gerendert')}
               >
                 ✕ {t('common.remove', 'Entfernen')}
@@ -264,7 +264,7 @@ export const RackPlacementProperties = ({
               <StlPreview stlDataUri={selectedPlacement.stlDataUri} size={120} />
             </div>
           )}
-          <span className="mt-1 block text-[10px] text-slate-400">
+          <span className="mt-1 block text-[10px] text-cp-text-muted">
             {selectedPlacement.stlDataUri
               ? t('rack.stl.loaded', '✓ STL geladen — wird im 3D-Tab gerendert und permanent am Gerät gespeichert (Library + Projekt).')
               : t('rack.stl.noStl', 'Ohne STL wird das Gerät als Box mit Front-/Rear-Foto dargestellt.')}
@@ -299,9 +299,9 @@ export const RackPlacementProperties = ({
                         shelfOffsetX: Math.max(0, Math.min(maxX, Number(e.target.value) || 0)),
                       })
                     }
-                    className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1"
+                    className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1"
                   />
-                  <span className="text-[11px] text-slate-400">max {Math.round(maxX)} mm</span>
+                  <span className="text-[11px] text-cp-text-muted">max {Math.round(maxX)} mm</span>
                 </label>
                 <label className="block text-[10px]">
                   <span className="mb-0.5 block text-emerald-300/80">Tiefe (mm von vorne)</span>
@@ -316,21 +316,21 @@ export const RackPlacementProperties = ({
                         shelfOffsetZ: Math.max(0, Math.min(maxZ, Number(e.target.value) || 0)),
                       })
                     }
-                    className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1"
+                    className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1"
                   />
-                  <span className="text-[11px] text-slate-400">max {Math.round(maxZ)} mm</span>
+                  <span className="text-[11px] text-cp-text-muted">max {Math.round(maxZ)} mm</span>
                 </label>
               </div>
-              <div className="mt-1 text-[10px] text-slate-400">
+              <div className="mt-1 text-[10px] text-cp-text-muted">
                 Tipp: Im 2D-Tab kannst du das Gerät auch horizontal per Maus verschieben. Tiefen-Position nur hier oder im 3D-Tab editierbar.
               </div>
             </details>
           )
         })()}
-        <details className="rounded border border-slate-800 bg-slate-900/40 p-2" open>
-          <summary className="cursor-pointer text-[11px] font-semibold text-slate-300">
+        <details className="rounded border border-cp-border-muted bg-cp-surface-1/40 p-2" open>
+          <summary className="cursor-pointer text-[11px] font-semibold text-cp-text-secondary">
             Port-Seite (Front/Rear)
-            <span className="ml-1 text-slate-500">
+            <span className="ml-1 text-cp-text-faint">
               ({selectedPlacement.inputs.length} Inputs / {selectedPlacement.outputs.length} Outputs)
             </span>
           </summary>
@@ -362,7 +362,7 @@ export const RackPlacementProperties = ({
                   })),
                 })
               }
-              className="rounded bg-slate-700 px-2 py-1 text-slate-100 hover:bg-slate-600"
+              className="rounded bg-cp-surface-4 px-2 py-1 text-cp-text hover:bg-cp-surface-5"
               title={t('rack.portsSwap', 'Front-Ports werden zu Rear-Ports und umgekehrt')}
             >
               ↔ spiegeln
@@ -381,7 +381,7 @@ export const RackPlacementProperties = ({
               ⏫ alle nach vorne
             </button>
           </div>
-          <div className="mt-2 max-h-48 overflow-y-auto rounded border border-slate-800">
+          <div className="mt-2 max-h-48 overflow-y-auto rounded border border-cp-border-muted">
             {[
               ...selectedPlacement.inputs.map((p) => ({ port: p, dir: 'in' as const })),
               ...selectedPlacement.outputs.map((p) => ({ port: p, dir: 'out' as const })),
@@ -390,7 +390,7 @@ export const RackPlacementProperties = ({
               return (
                 <div
                   key={port.id}
-                  className="flex items-center justify-between gap-2 border-t border-slate-800/60 px-2 py-0.5 text-[10px] first:border-t-0"
+                  className="flex items-center justify-between gap-2 border-t border-cp-border-muted/60 px-2 py-0.5 text-[10px] first:border-t-0"
                 >
                   <span className="flex min-w-0 items-center gap-1">
                     <span
@@ -414,9 +414,9 @@ export const RackPlacementProperties = ({
                         })
                       }}
                       title={t('rack.portRename', 'Port-Name bearbeiten')}
-                      className="min-w-0 flex-1 rounded border border-transparent bg-transparent px-1 text-slate-300 hover:border-slate-700 focus:border-sky-600 focus:bg-slate-950 focus:outline-none"
+                      className="min-w-0 flex-1 rounded border border-transparent bg-transparent px-1 text-cp-text-secondary hover:border-cp-border focus:border-sky-600 focus:bg-cp-surface-3 focus:outline-none"
                     />
-                    <span className="shrink-0 text-slate-500">· {port.connectorType}</span>
+                    <span className="shrink-0 text-cp-text-faint">· {port.connectorType}</span>
                   </span>
                   <button
                     type="button"
@@ -457,7 +457,7 @@ export const RackPlacementProperties = ({
         </details>
         <div className="space-y-2">
           <div className="flex items-center justify-between">
-            <div className="text-[11px] font-semibold text-slate-400">{t('rack.panelImages.header', 'Panel-Bilder (Import + Zuschneiden)')}</div>
+            <div className="text-[11px] font-semibold text-cp-text-muted">{t('rack.panelImages.header', 'Panel-Bilder (Import + Zuschneiden)')}</div>
             {(selectedPlacement.frontPanelImageUrl || selectedPlacement.rearPanelImageUrl) && (
               <button
                 type="button"
@@ -469,7 +469,7 @@ export const RackPlacementProperties = ({
                     rearPanelCrop: selectedPlacement.frontPanelCrop,
                   })
                 }
-                className="rounded bg-slate-700 px-2 py-0.5 text-[10px] text-slate-200 hover:bg-slate-600"
+                className="rounded bg-cp-surface-4 px-2 py-0.5 text-[10px] text-cp-text-bright hover:bg-cp-surface-5"
                 title={t('rack.swapPhotos', 'Front- und Rear-Foto vertauschen (falls die Zuordnung falsch ist)')}
               >
                 ↔ Front/Rear tauschen
@@ -496,7 +496,7 @@ export const RackPlacementProperties = ({
                   </button>
                   {currentUrl && (
                     <div className="flex items-center gap-1">
-                      <img src={currentUrl} alt={`${side} panel`} className="h-7 flex-1 rounded border border-slate-700 object-contain" />
+                      <img src={currentUrl} alt={`${side} panel`} className="h-7 flex-1 rounded border border-cp-border object-contain" />
                       <button
                         type="button"
                         onClick={() => onUpdate(selectedPlacement.id, { [urlKey]: undefined, [side === 'front' ? 'frontPanelCrop' : 'rearPanelCrop']: undefined })}

--- a/src/renderer/components/Rack/RackShelfCreateDialog.tsx
+++ b/src/renderer/components/Rack/RackShelfCreateDialog.tsx
@@ -65,27 +65,27 @@ export const RackShelfCreateDialog = ({ open, onClose, onCreated }: Props) => {
     >
         <div className="space-y-3">
           <label className="block">
-            <span className="mb-1 block text-cp-xs text-slate-400">{t('rack.shelf.name', 'Name')}</span>
+            <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('rack.shelf.name', 'Name')}</span>
             <input
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1.5"
+              className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1.5"
             />
           </label>
           <div className="grid grid-cols-2 gap-2">
             <label className="block">
-              <span className="mb-1 block text-cp-xs text-slate-400">{t('rack.shelf.heightUnits', 'Höhe (HE)')}</span>
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('rack.shelf.heightUnits', 'Höhe (HE)')}</span>
               <input
                 type="number"
                 min={1}
                 max={6}
                 value={heightUnits}
                 onChange={(e) => setHeightUnits(Math.max(1, Math.min(6, Number(e.target.value) || 1)))}
-                className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1.5"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1.5"
               />
             </label>
             <label className="block">
-              <span className="mb-1 block text-cp-xs text-slate-400">{t('rack.shelf.depth', 'Tiefe (mm)')}</span>
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('rack.shelf.depth', 'Tiefe (mm)')}</span>
               <input
                 type="number"
                 min={150}
@@ -95,11 +95,11 @@ export const RackShelfCreateDialog = ({ open, onClose, onCreated }: Props) => {
                 onChange={(e) =>
                   setDepthMm(Math.max(150, Math.min(1200, Number(e.target.value) || 450)))
                 }
-                className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-1.5"
+                className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1.5"
               />
             </label>
           </div>
-          <div className="rounded border border-slate-800 bg-slate-950/50 p-2 text-[11px] text-slate-400">
+          <div className="rounded border border-cp-border-muted bg-cp-surface-3/50 p-2 text-[11px] text-cp-text-muted">
             {t('rack.shelf.tip', 'Tipp: Lege das Shelf auf den gewünschten HE-Slot, danach platziere beliebige Non-19"-Items mit demselben Start-HE — sie erscheinen optisch auf dem Shelf.')}
           </div>
         </div>


### PR DESCRIPTION
## Zweck
Schließt die `slate-*`→cp-Migration für die **canvas-nahen, CSS-gethemeten** Komponenten ab (18 Dateien) — der letzte große Block von #449.

## Umfang
`RackBuilderDialog` + alle Rack-Dialoge (Footer/Header/Placement/Shelf/PatchPanel/Crop/Editor/3DTab/InternalCanvas/WireOverlay …), `App.tsx`, `BulkConnectDialog`, `CanvasArea`-Chrome, `TitleBlock` u. a.

**Bewusst roh belassen** — isLight-Komponenten (EquipmentNode, Rack3DView, RackLivePreview, CableContextMenu, LayerVisibilityChips): sie themen per Prop für Canvas-/Print-Render (CLAUDE.md), nicht über CSS-Variablen.

## Verifikation (headless)
Diese Komponenten sind canvas-adjacent → über reine Konstruktionsgarantie hinaus real getestet:
- **Rack-Harness** in **light + dark**: Preset geseedet → Wire-Overlay geöffnet → **Nodes 286px** (kein Sprung, #528 intakt) → **Kabel gezogen 0→1 edge** (#527 intakt) → **0 Console-Errors**.
- **App-Shell light** verifiziert: `data-theme=light`, menubar/app-root computed = `rgb(240,244,248)`/`rgb(234,239,245)` (hell).
- build 0 · tsc 0 · eslint **0 neue** Errors (3 Baseline unverändert).
- Ersetzte Paare pixelgleich (#525/#532) → appearance-neutral by construction.

Damit ist die slate→cp-Migration für alle CSS-gethemeten Komponenten **abgeschlossen**; verbleibendes rohes slate ist by-design (isLight-Canvas/Print + nicht-token-fähige Einzel-Shades). Refs #449

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_