### PR TITLE
fix(rack): Überdeckungs-Konflikt tiefenbewusst — Front/Rear entschärfen (#521 d)

### DIFF
--- a/src/renderer/components/Rack/RackBuilderDialog.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialog.tsx
@@ -239,6 +239,18 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
   const isOverlapping = (aStart: number, aEnd: number, bStart: number, bEnd: number): boolean =>
     aStart <= bEnd && bStart <= aEnd
 
+  // #521(d) — Zwei Geräte auf überlappenden HE-Bereichen kollidieren nur dann
+  // TATSÄCHLICH, wenn sie sich auch in der TIEFE überschneiden. Ein 'front'-
+  // und ein 'rear'-Gerät auf derselben HE sind benachbart (verschiedene Rail-
+  // Tiefen, #170), KEINE Überdeckung. Default 'full' belegt beide Tiefen und
+  // überlappt daher mit allem. Entschärft den Konflikt-Fehlalarm bei gültiger
+  // Front/Rear-Doppelbelegung (z. B. Patchblende hinter einem Frontgerät).
+  const mountsOverlapInDepth = (a: RackPlacementDraft, b: RackPlacementDraft): boolean => {
+    const ma = a.mountSide ?? 'full'
+    const mb = b.mountSide ?? 'full'
+    return !((ma === 'front' && mb === 'rear') || (ma === 'rear' && mb === 'front'))
+  }
+
   const conflicts = useMemo(() => {
     const issues: string[] = []
     for (const placement of draft.placements) {
@@ -276,7 +288,8 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
             a.startUnit + a.rackUnits - 1,
             b.startUnit,
             b.startUnit + b.rackUnits - 1,
-          )
+          ) &&
+          mountsOverlapInDepth(a, b)
         ) {
           issues.push(
             format(t('rack.conflict.overlaps', '{a} überlappt mit {b}.'), { a: a.name, b: b.name }),


### PR DESCRIPTION
## Zweck
Behebt #521 **Teil (d)** — „Konflikt-Anzeige entschärfen: warnen nur bei *tatsächlicher* Überdeckung, nicht bei benachbarter Platzierung".

## Root Cause
Der „Überdeckung"-Konflikt im Rack-Builder (`RackBuilderDialog`) prüfte nur die **HE-Höhe** (`isOverlapping` auf startUnit-Bereiche) — **ohne die Tiefe**. Ein `front`- und ein `rear`-Gerät auf derselben HE (z. B. Patchblende hinter einem Frontgerät, die `mountSide`-Funktion aus #170) belegen aber **verschiedene Rail-Tiefen** und sind keine echte Überdeckung — wurden trotzdem als Konflikt gemeldet.

## Fix
Der Overlap-Check ist jetzt **tiefenbewusst** (`mountsOverlapInDepth`): ein Konflikt entsteht nur, wenn sich HE-Bereiche **und** Tiefen überschneiden. `front`+`rear` auf gleicher HE ist konfliktfrei; Default `full` belegt beide Tiefen → Verhalten für klassische Geräte unverändert. Nutzt vorhandene Daten (`mountSide`), kein Schema-Umbau.

## Verifikation
- **Logik-Test 7/7** (exakt die Konflikt-Regel): `front+rear@HE` → kein Konflikt; `full+full` / `front+full` / echt überlappend → Konflikt; benachbarte HE → kein Konflikt; `default=full` → Konflikt.
- `mountSide` wird von `draftFromPreset` durchgereicht (verifiziert, `rackBuilderHelpers.ts:142`).
- tsc 0 · eslint 0 · build 0.

Adressiert (d). Die Teile (b)/(c)/(c2) (fraktionale HE + persistente X/Z-Positionen) bleiben der größere Datenmodell-Umbau und sind weiter in #521 offen. Refs #521

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_