### PR TITLE
feat(rack): Off-Grid-/Zwischen-HE-Positionierung, record-compare-bewiesen (#521 b)

### DIFF
--- a/src/renderer/components/Rack/RackBuilderDialog.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialog.tsx
@@ -1228,10 +1228,15 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                       if (!dragState || dragState.pointerId !== event.pointerId) return
                       const host = event.currentTarget.getBoundingClientRect()
                       const y = clamp(event.clientY - host.top, 0, host.height)
-                      const unitAtPointer = Math.max(1, Math.min(draft.totalUnits, Math.floor(y / rowHeight) + 1))
+                      // #521(b) — Alt gedrückt = freie (Off-Grid-)Höhe; sonst rastet
+                      // die HE-Position ganzzahlig ein (Backward-Compat, unverändert).
+                      const unitAtPointer = event.altKey
+                        ? Math.max(1, Math.min(draft.totalUnits, y / rowHeight + 1))
+                        : Math.max(1, Math.min(draft.totalUnits, Math.floor(y / rowHeight) + 1))
                       const placement = draft.placements.find((p) => p.id === dragState.placementId)
                       if (!placement) return
-                      const nextStart = Math.max(1, Math.min(draft.totalUnits - placement.rackUnits + 1, unitAtPointer - dragState.offsetUnits))
+                      const rawStart = Math.max(1, Math.min(draft.totalUnits - placement.rackUnits + 1, unitAtPointer - dragState.offsetUnits))
+                      const nextStart = event.altKey ? Math.round(rawStart * 100) / 100 : rawStart
                       updatePlacement(placement.id, { startUnit: nextStart })
                     }}
                     onPointerUp={() => setDragState(null)}
@@ -1326,10 +1331,14 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                             const host = event.currentTarget.parentElement?.getBoundingClientRect()
                             if (!host) return
                             const y = clamp(event.clientY - host.top, 0, host.height)
-                            const unitAtPointer = Math.max(1, Math.min(draft.totalUnits, Math.floor(y / rowHeight) + 1))
+                            // #521(b) — Alt = freie (Off-Grid-)Höhe; sonst ganzzahlig (unverändert).
+                            const unitAtPointer = event.altKey
+                              ? Math.max(1, Math.min(draft.totalUnits, y / rowHeight + 1))
+                              : Math.max(1, Math.min(draft.totalUnits, Math.floor(y / rowHeight) + 1))
                             const placement = draft.placements.find((p) => p.id === dragState.placementId)
                             if (!placement) return
-                            const nextStart = Math.max(1, Math.min(draft.totalUnits - placement.rackUnits + 1, unitAtPointer - dragState.offsetUnits))
+                            const rawStart = Math.max(1, Math.min(draft.totalUnits - placement.rackUnits + 1, unitAtPointer - dragState.offsetUnits))
+                            const nextStart = event.altKey ? Math.round(rawStart * 100) / 100 : rawStart
                             const patch: Partial<RackPlacementDraft> = { startUnit: nextStart }
                             // #506 — Vertikales Stapeln-Snap: an die Ober-/Unter-
                             // kante anderer Geräte andocken (Tops bündig, direkt

--- a/src/renderer/components/Rack/rackBuilderHelpers.ts
+++ b/src/renderer/components/Rack/rackBuilderHelpers.ts
@@ -75,7 +75,12 @@ export const toPlacement = (template: EquipmentTemplate, startUnit: number): Rac
 export const normalizeDraft = (draft: RackDraft): RackDraft => {
   const normalizedPlacements = draft.placements.map((p) => ({
     ...p,
-    startUnit: Math.max(1, Math.round(p.startUnit) || 1),
+    // #521(b) — startUnit darf fraktional sein (Off-Grid-/Zwischen-HE-Position).
+    // Kein Math.round mehr: nur NaN/≤0-Guard + Untergrenze 1. Ganzzahlige Werte
+    // bleiben damit unverändert (Round war für sie ein No-op → Backward-Compat).
+    // Die Höhe (rackUnits) bleibt ganzzahlig; 2D- und 3D-Rendering nutzen bereits
+    // lineare (startUnit-1)·rowHeight- bzw. ·HE_HEIGHT_MM-Mathe → fraktional ok.
+    startUnit: Math.max(1, Number.isFinite(p.startUnit) && p.startUnit > 0 ? p.startUnit : 1),
     rackUnits: Math.max(1, Math.round(p.rackUnits) || 1),
   }))
   // Drop internal cables that point at placements that no longer exist


### PR DESCRIPTION
## Zweck
Behebt #521 **Teil (b)** — „Off-Grid-Höhe: Geräte lassen sich nur auf dem 1-HE-Raster platzieren; Frei-/Zwischenpositionen sind im Datenmodell nicht abbildbar."

## Änderung
- **`normalizeDraft`**: `startUnit` bleibt **fraktional** (nur NaN/≤0-Guard + Untergrenze 1, kein `Math.round` mehr). `rackUnits` (Höhe) bleibt ganzzahlig.
- **`RackBuilderDialog`** (beide Drag-Handler): **Alt gedrückt = freie Off-Grid-Höhe**; ohne Alt rastet es weiterhin ganzzahlig ein → **Default-Verhalten unverändert**.
- 2D- (`top=(startUnit-1)·rowHeight`) und 3D-Rendering (`(totalUnits-startUnit-rackUnits+1)·HE_HEIGHT_MM`) sind bereits **linear** → fraktionale Werte rendern korrekt, kein Render-Umbau nötig.

## Beweis — record → change → compare (headless)
Genau die geforderte Methode: kritisches Verhalten vorher aufgenommen, nachher gegenübergestellt.

| Gerät | startUnit | Golden (vorher) | Nachher |
|---|---|---|---|
| DevA | 1 | top **0px** | top **0px** ✓ unverändert |
| DevB | 3 | top **107.83px** | top **107.83px** ✓ unverändert |
| DevC | 1.5 | top 53.92px (auf 2 **gerundet**) | top **26.96px** = (1.5-1)·rowHeight ✓ neu korrekt |

- **Backward-Compat bewiesen**: einziger Diff in der Positions-Signatur ist DevC (das fraktionale). Ganzzahlige Racks byte-identisch (Round war für sie ein No-op).
- **Persistenz bewiesen (E2E)**: `groupPresets` auf `[]` geleert → Save geklickt → Preset mit `startUnit: 1.5` zurückgeschrieben (nicht gerundet).
- **3D**: identische lineare Formel wie 2D (code-bestätigt) → die in 2D bewiesene Korrektheit überträgt sich.
- tsc 0 · eslint 0 · build 0.

## Offen in #521
(c2) Z-Achse (Tiefe, `shelfOffsetZ`) ist ein separater Folgeschritt (eigene 3D-Charakterisierung). (c)+(d) sind bereits erledigt. Refs #521

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_