### PR TITLE
refactor(library): Port-Gruppen-Helfer aus LibraryPanel auslagern (#468)

### DIFF
--- a/src/renderer/components/Library/LibraryPanel.tsx
+++ b/src/renderer/components/Library/LibraryPanel.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../lib/aiSuggestions'
 import { suggestFromWeb } from '../../lib/webPortSuggestions'
 import { ALL_CONNECTOR_TYPES } from '../../types/equipment'
-import type { ConnectorType, EquipmentTemplate, Port } from '../../types/equipment'
+import type { ConnectorType, EquipmentTemplate } from '../../types/equipment'
 import { nextPlacementPosition } from '../../lib/library'
 import {
   clearNetBoxIndexCache,
@@ -42,33 +42,8 @@ import { CableLibraryPanel } from './CableLibraryPanel'
 
 const connectorOptions = ALL_CONNECTOR_TYPES
 
-interface PortGroupDraft {
-  id: string
-  direction: 'in' | 'out'
-  count: number
-  connectorType: ConnectorType
-  label: string
-}
-
-const defaultGroup = (direction: 'in' | 'out'): PortGroupDraft => ({
-  id: uuidv4(),
-  direction,
-  count: 1,
-  connectorType: 'Custom',
-  label: direction === 'in' ? 'Input' : 'Output',
-})
-
-const buildPorts = (groups: PortGroupDraft[], direction: 'in' | 'out'): Port[] => {
-  const filtered = groups.filter((group) => group.direction === direction)
-  return filtered.flatMap((group) =>
-    Array.from({ length: Math.max(0, group.count) }, (_item, index) => ({
-      id: uuidv4(),
-      name: `${group.label} ${index + 1}`,
-      type: group.connectorType,
-      connectorType: group.connectorType,
-    })),
-  )
-}
+import { defaultGroup, buildPorts } from './libraryPanelHelpers'
+import type { PortGroupDraft } from './libraryPanelHelpers'
 
 
 
@@ -1452,3 +1427,4 @@ export const LibraryPanel = () => {
   }
   return inner
 }
+

--- a/src/renderer/components/Library/libraryPanelHelpers.ts
+++ b/src/renderer/components/Library/libraryPanelHelpers.ts
@@ -1,0 +1,31 @@
+// #468 — Port-Gruppen-Helfer aus LibraryPanel ausgelagert (rein, kein React).
+import { v4 as uuidv4 } from 'uuid'
+import type { ConnectorType, Port } from '../../types/equipment'
+
+export interface PortGroupDraft {
+  id: string
+  direction: 'in' | 'out'
+  count: number
+  connectorType: ConnectorType
+  label: string
+}
+
+export const defaultGroup = (direction: 'in' | 'out'): PortGroupDraft => ({
+  id: uuidv4(),
+  direction,
+  count: 1,
+  connectorType: 'Custom',
+  label: direction === 'in' ? 'Input' : 'Output',
+})
+
+export const buildPorts = (groups: PortGroupDraft[], direction: 'in' | 'out'): Port[] => {
+  const filtered = groups.filter((group) => group.direction === direction)
+  return filtered.flatMap((group) =>
+    Array.from({ length: Math.max(0, group.count) }, (_item, index) => ({
+      id: uuidv4(),
+      name: `${group.label} ${index + 1}`,
+      type: group.connectorType,
+      connectorType: group.connectorType,
+    })),
+  )
+}


### PR DESCRIPTION
## Zweck
Weiterer #468-Schritt: reine Port-Gruppen-Helfer aus `LibraryPanel` auslagern.

## Änderung
`LibraryPanel.tsx` **1454 → 1430**. `PortGroupDraft`-Typ + `defaultGroup` + `buildPorts` (rein, kein React/JSX) → neue `libraryPanelHelpers.ts`. Verhaltensneutraler Code-Move.

## Verifikation
tsc 0 · eslint 0 · build 0 (tsc beweist Referenz-Auflösung). Headless-Boot: Library-Panel rendert, react-flow mountet, **0 Console-Errors**.

Refs #468

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_