### PR TITLE
feat(rack): freie Z-/Tiefen-Position für klassische Geräte — 3D-verifiziert (#521 c2)

### DIFF
--- a/src/renderer/components/Rack/Rack3DView.tsx
+++ b/src/renderer/components/Rack/Rack3DView.tsx
@@ -320,9 +320,19 @@ const DeviceBox = ({
   const xLeftBase = isShelfDevice
     ? railInnerOffset + effectiveShelfX
     : (RACK_OUTER_WIDTH_MM - widthMm) / 2
+  // #521(c2) — Tiefen-Positionierung (shelfOffsetZ) auch für KLASSISCHE Rack-
+  // Geräte respektieren, nicht nur Shelf-Devices. Vorher war ein klassisches
+  // Gerät in Z auf Front (z=0) bzw. Rückwand (mountSide='rear') festgenagelt —
+  // freie Zwischen-Tiefen waren nicht möglich ("Z nur auf der 1-RU-Ebene").
+  // Ohne gesetzten Offset bleibt das Default-Verhalten exakt erhalten.
+  const hasZOffset = shelfDragOverride?.z != null || placement.shelfOffsetZ != null
   const zStart = isShelfDevice
     ? effectiveShelfZ
-    : (mountSide === 'rear' ? rackDepthMm - depthMm : 0)
+    : hasZOffset
+      ? Math.max(0, Math.min(effectiveShelfZ, rackDepthMm - depthMm))
+      : mountSide === 'rear'
+        ? rackDepthMm - depthMm
+        : 0
   const xCenter = xLeftBase + widthMm / 2
   const yCenter = yBottom + heightMm / 2
   const zCenter = zStart + depthMm / 2

--- a/src/renderer/components/Rack/RackPlacementProperties.tsx
+++ b/src/renderer/components/Rack/RackPlacementProperties.tsx
@@ -272,11 +272,38 @@ export const RackPlacementProperties = ({
         </div>
         {(() => {
           const tpl = templates.find((tt) => tt.name === selectedPlacement.templateName)
-          if (!tpl?.widthMm || !tpl?.heightMm) return null
-          const maxX = Math.max(0, RACK_MOUNT_WIDTH_MM - tpl.widthMm)
           const rackDepthRender = rackDepthMm ?? 800
-          const devDepth = tpl.depthMm ?? 400
+          const devDepth = tpl?.depthMm ?? selectedPlacement.depthMm ?? 400
           const maxZ = Math.max(0, rackDepthRender - devDepth)
+          // #521(c2) — Tiefen-(Z-)Position für ALLE Rack-Geräte editierbar.
+          // Klassische Geräte (ohne Shelf-Maße) bekamen vorher 'return null' →
+          // keine Z-Editierung, Gerät klebte an Front/Rückwand. Jetzt eigenes
+          // Tiefen-Feld; Shelf-Devices behalten ihr X+Z-Panel unverändert.
+          if (!(tpl?.widthMm && tpl?.heightMm)) {
+            return (
+              <details className="rounded border border-cp-border-muted bg-cp-surface-1/40 p-2" open>
+                <summary className="cursor-pointer text-[11px] font-semibold text-cp-text-secondary">Tiefen-Position (Z)</summary>
+                <label className="mt-2 block text-[10px]">
+                  <span className="mb-0.5 block text-cp-text-muted">Tiefe (mm von vorne)</span>
+                  <input
+                    type="number"
+                    min={0}
+                    max={maxZ}
+                    step={10}
+                    value={Math.round(selectedPlacement.shelfOffsetZ ?? 0)}
+                    onChange={(e) =>
+                      onUpdate(selectedPlacement.id, {
+                        shelfOffsetZ: Math.max(0, Math.min(maxZ, Number(e.target.value) || 0)),
+                      })
+                    }
+                    className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1"
+                  />
+                  <span className="text-[11px] text-cp-text-muted">max {Math.round(maxZ)} mm · 0 = Front</span>
+                </label>
+              </details>
+            )
+          }
+          const maxX = Math.max(0, RACK_MOUNT_WIDTH_MM - tpl.widthMm)
           return (
             <details className="rounded border border-emerald-800 bg-emerald-900/20 p-2" open>
               <summary className="cursor-pointer text-[11px] font-semibold text-emerald-200">


### PR DESCRIPTION
## Zweck
Behebt #521 **Teil (c2)** — „Z-Achse: Positionierung nur auf der 1-RU-Ebene möglich" — der **letzte** offene Punkt von #521.

## Root Cause (am 3D-View headless verifiziert)
In `Rack3DView` wurde `shelfOffsetZ` nur für **Shelf-Devices** ausgewertet. Klassische Rack-Geräte bekamen `zStart = mountSide==='rear' ? Rückwand : 0` — also **front oder hinten festgenagelt**, keine freie Zwischen-Tiefe. Zusätzlich bot `RackPlacementProperties` das Tiefen-Feld nur Shelf-Devices an (`return null` für klassische).

## Fix
- **`Rack3DView`**: `zStart` respektiert `shelfOffsetZ` auch für klassische Geräte (geclamped `[0, rackDepth−deviceDepth]`). **Ohne** Offset exakt das alte Verhalten (Front bzw. Rückwand bei `mountSide='rear'`).
- **`RackPlacementProperties`**: klassische Geräte bekommen ein eigenes „Tiefen-Position (Z)"-Feld; Shelf-Panel (X+Z) unverändert.

## Beweis — 3D-View **headless gerendert** (SwiftShader-WebGL)
Genau wie gewünscht: den 3D-View tatsächlich gestartet, Zustand vorher/nachher gegenübergestellt.
- **Formel**: klassisches Gerät `full` + `shelfOffsetZ=300` → zCenter **100 (vorher, Offset ignoriert) → 400 (nachher = 300+depth/2)**. `full`/`rear` **ohne** Offset unverändert (100/500) → Backward-Compat.
- **3D-Screenshots vorher/nachher**: das Gerät mit Offset 300 rückt sichtbar in die Tiefe, das Gerät ohne Offset bleibt vorne.
- tsc 0 · eslint 0 · build 0.

Mit (c2) sind **alle** Punkte von #521 erledigt (a/b/c/c2/d). Closes #521

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_