### PR TITLE
fix(debug): React-19-Tooltip-Ref-Bug + setState-in-Effect (eslint 3→0)

### DIFF
--- a/src/renderer/components/Calculators/CalculatorsDialog.tsx
+++ b/src/renderer/components/Calculators/CalculatorsDialog.tsx
@@ -8,7 +8,7 @@
  * with three more menu items.
  */
 
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useUiStore } from '../../store/uiStore'
 import { useProjectStore } from '../../store/projectStore'
 import { ModalShell } from '../shared/ModalShell'
@@ -390,11 +390,12 @@ const PowerTab = () => {
   const std = powerStandardById(powerStandardId)
   const mainsVoltage = std?.voltage ?? 230
   const supplies = POWER_SUPPLY_PRESETS[std?.region ?? 'eu']
-  // Beim Regionswechsel auf ein gültiges Preset zurückfallen.
-  useEffect(() => {
-    if (!supplies.some((s) => s.id === supplyId)) setSupplyId(supplies[0].id)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [supplies])
+  // Beim Regionswechsel auf ein gültiges Preset zurückfallen — OHNE setState-
+  // im-Effect (vermeidet kaskadierende Re-Renders, react-hooks/set-state-in-
+  // effect). rawSupply löst per Fallback immer ein gültiges Preset auf; das
+  // <select> ist an rawSupply.id gebunden, zeigt also nach Regionswechsel
+  // automatisch das erste gültige Preset. supplyId-State wird nur durch
+  // User-Auswahl gesetzt; ein stale Wert ist hier folgenlos.
   const rawSupply = supplies.find((s) => s.id === supplyId) ?? supplies[0]
   const supply = { ...rawSupply, voltage: mainsVoltage }
 
@@ -602,7 +603,7 @@ const PowerTab = () => {
         <label className="block">
           <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('calc.connectionType', 'Anschluss-Typ')}</span>
           <select
-            value={supplyId}
+            value={rawSupply.id}
             onChange={(e) => setSupplyId(e.target.value as SupplyPresetId)}
             className="w-full rounded border border-cp-border bg-cp-surface-3 p-2"
           >

--- a/src/renderer/components/shared/Tooltip.tsx
+++ b/src/renderer/components/shared/Tooltip.tsx
@@ -108,11 +108,23 @@ export const Tooltip = ({ label, children, side = 'top', delay = 400 }: TooltipP
   const childProps = children.props as Record<string, unknown>
   const describedBy = [childProps['aria-describedby'], open ? id : null].filter(Boolean).join(' ') || undefined
 
+  // Ref-Merge für das umschlossene Kind: unser triggerRef (für Positionierung)
+  // UND der evtl. vom Aufrufer am Kind gesetzte Original-Ref. Der Callback läuft
+  // im COMMIT (nicht im Render); das Ziel-Ref-Objekt gehört dem Aufrufer und ist
+  // genau dafür da, mutiert zu werden. Die react-hooks/refs- bzw. /immutability-
+  // Regeln können diesen Forwarding-Fall nicht von echtem Render-Ref-Zugriff
+  // unterscheiden → hier bewusst lokal unterdrückt.
+  // eslint-disable-next-line react-hooks/refs
   const trigger = cloneElement(children, {
     ref: (node: HTMLElement | null) => {
       triggerRef.current = node
-      const r = (children as unknown as { ref?: unknown }).ref
+      // React 19: ref ist ein normales Prop → vom Kind über props.ref lesen
+      // (children.ref ist entfernt/deprecated und lieferte hier nichts mehr,
+      // wodurch der Original-Ref des Kindes still NICHT mehr weitergereicht
+      // wurde). Forward an Funktions- wie Objekt-Refs.
+      const r = (children.props as { ref?: unknown }).ref
       if (typeof r === 'function') (r as (n: HTMLElement | null) => void)(node)
+      // eslint-disable-next-line react-hooks/immutability
       else if (r && typeof r === 'object') (r as { current: HTMLElement | null }).current = node
     },
     'aria-describedby': describedBy,


### PR DESCRIPTION
## Debug-Durchlauf über die gesamte Codebase

**Gate-Bestandsaufnahme:** `tsc` (app/main/preload) **0**, full build **0**, `test:crdt` + `test:signaling` **grün**. eslint hatte **3 Errors** (React-Compiler-Regeln) — alle behoben → Baseline wieder **0 Errors** (CLAUDE.md-Invariante).

## Behobene Findings

**1. Echter Bug — Tooltip-Ref unter React 19 (`shared/Tooltip.tsx`)**
React 19 macht `ref` zu einem normalen Prop; der Ref-Merge las noch `children.ref` (in 19 entfernt) → der **Original-Ref des Kindes wurde still nicht mehr weitergereicht**. Fix: `children.props.ref`. Die `react-hooks/refs`- und `react-hooks/immutability`-Errors betreffen den **legitimen** Ref-Forwarding-Callback (läuft im **Commit**, nicht im Render; das Ziel-Ref-Objekt gehört dem Aufrufer und ist genau zum Mutieren da) → lokal mit Begründung unterdrückt.

**2. Code-Qualität — setState-im-Effect (`CalculatorsDialog.tsx`)**
`react-hooks/set-state-in-effect`: ein Effect resettete `supplyId` bei Regionswechsel. Entfernt — das `<select>` ist jetzt an `rawSupply.id` (per Fallback immer gültig) gebunden → kein kaskadierender Re-Render. **Verhaltensgleich** (nur `rawSupply`/Select lesen `supplyId`).

## Verifikation (headless)
- **Tooltip** erscheint bei echtem Hover („Add new location frame").
- **Calculators** öffnet, Supply-Select valide (`cee32`, 8 Optionen).
- **0 Console-Errors.** tsc 0 · eslint **0 Errors** (8 benigne `exhaustive-deps`-Warnings bleiben — stabile `t`/konditionale Deps, intentional) · build 0.

## Nicht reproduzierbar
Ein sporadischer Boot-Pageerror (`reading 'document'`) trat **einmalig** unter Headless-Timing auf, in mehreren gezielten Reproduktionen nicht mehr — kein konsistenter Bug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_