### PR TITLE
feat: .cableplan-Projektendung + OS-Dateiverknüpfung (Doppelklick öffnet Projekte)

### DIFF
--- a/electron-builder.js
+++ b/electron-builder.js
@@ -18,6 +18,25 @@ export default {
     buildResources: 'build',
     output: 'release',
   },
+  // #pre-sale — OS-Dateiverknüpfung: Doppelklick auf eine .cableplan-/.cpviewer-
+  // Datei startet die App (Handling in main: open-file/argv → project:open-external).
+  // Ohne explizites `icon` nutzt electron-builder das App-Icon (build/icon.*) —
+  // wir haben (noch) kein eigenes Dokument-Icon und vermeiden so ein fehlendes
+  // .icns auf macOS, das den Build sonst abbrechen ließe.
+  fileAssociations: [
+    {
+      ext: 'cableplan',
+      name: 'Cable Planner Project',
+      description: 'Cable Planner Projekt',
+      role: 'Editor',
+    },
+    {
+      ext: 'cpviewer',
+      name: 'Cable Planner Viewer',
+      description: 'Cable Planner Viewer (read-only)',
+      role: 'Viewer',
+    },
+  ],
   // npmRebuild defaults to true. We explicitly do NOT set it to false here:
   // skipping the rebuild leaves native modules (keytar, @julusian/freetype2)
   // built against Node's ABI rather than Electron's, which on Windows caused

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,7 +4,8 @@ import { fileURLToPath } from 'node:url'
 import fs from 'node:fs'
 import { registerCredentialsIpc } from './ipc/credentialsIpc.js'
 import { registerRentmanIpc } from './ipc/rentmanIpc.js'
-import { registerProjectIpc } from './ipc/projectIpc.js'
+import { openExternalProject, registerProjectIpc } from './ipc/projectIpc.js'
+import { findProjectPathInArgv, setPendingLaunchPath } from './services/fileOpenService.js'
 import { registerAtemIpc } from './ipc/atemIpc.js'
 import { registerVideohubIpc } from './ipc/videohubIpc.js'
 import { registerLogIpc } from './ipc/logIpc.js'
@@ -22,6 +23,39 @@ const __dirname = path.dirname(__filename)
 
 const isDev = Boolean(process.env.VITE_DEV_SERVER_URL)
 const shouldOpenDevTools = process.env.ELECTRON_OPEN_DEVTOOLS === '1'
+
+const firstReadyWindow = (): BrowserWindow | null =>
+  BrowserWindow.getAllWindows().find((w) => !w.isDestroyed()) ?? null
+
+// #pre-sale — Single-Instance-Lock: ein Doppelklick auf eine .cableplan-Datei
+// während die App schon läuft soll keine zweite Instanz starten, sondern den
+// Pfad an die laufende reichen (second-instance). Ohne Lock öffnet jede Datei
+// ein eigenes App-Fenster mit leerem zweiten Prozess.
+const gotInstanceLock = app.requestSingleInstanceLock()
+if (!gotInstanceLock) {
+  app.quit()
+} else {
+  // macOS reicht das Öffnen über open-file rein — das kann VOR app.whenReady
+  // feuern (OS startet die App mit der Datei). Existiert noch kein Fenster,
+  // puffern wir den Pfad; der Renderer holt ihn beim Mounten ab.
+  app.on('open-file', (event, filePath) => {
+    event.preventDefault()
+    const win = firstReadyWindow()
+    if (win) void openExternalProject(win, filePath)
+    else setPendingLaunchPath(filePath)
+  })
+
+  // Windows/Linux: die zweite Instanz (Doppelklick bei laufender App) bekommt
+  // den Pfad in ihrem argv; an das vorhandene Fenster weiterreichen + fokussieren.
+  app.on('second-instance', (_event, argv) => {
+    const win = firstReadyWindow()
+    if (!win) return
+    if (win.isMinimized()) win.restore()
+    win.focus()
+    const filePath = findProjectPathInArgv(argv)
+    if (filePath) void openExternalProject(win, filePath)
+  })
+}
 
 // Append to a log file with a hard size cap so a crash-loop can't fill
 // the user's disk. When the file passes the cap it is rotated to `.1`.
@@ -284,6 +318,10 @@ const createWindow = async () => {
 }
 
 app.whenReady().then(async () => {
+  // Zweite Instanz hat den Lock nicht bekommen → wir haben oben bereits
+  // app.quit() gerufen; hier nichts mehr aufbauen (kein zweites Fenster).
+  if (!gotInstanceLock) return
+
   Menu.setApplicationMenu(null)
 
   // Content-Security-Policy for the packaged renderer. Skipped in dev
@@ -328,11 +366,17 @@ app.whenReady().then(async () => {
 
   const mainWindow = await createWindow()
 
+  // #pre-sale — Kaltstart per Doppelklick (Windows/Linux): der Datei-Pfad
+  // steht in process.argv. Puffern, damit der Renderer ihn beim Mounten über
+  // project:get-launch-file abholt. macOS liefert ihn stattdessen via open-file
+  // (oben), das null hier nicht überschreibt.
+  setPendingLaunchPath(findProjectPathInArgv(process.argv))
+
   // #pre-sale — Update-IPC IMMER registrieren, damit der Menüpunkt "Auf
   // Updates prüfen…" auch in Dev funktioniert (liefert dort sauber ok:false).
   try {
     const { registerUpdaterIpc, initAutoUpdater } = await import('./services/updaterService.js')
-    registerUpdaterIpc(() => BrowserWindow.getAllWindows().find((w) => !w.isDestroyed()) ?? null)
+    registerUpdaterIpc(firstReadyWindow)
     // Auto-Check beim Start nur im paketierten Build (in Dev gibt es keine
     // app-update.yml → checkForUpdates würde werfen).
     if (!isDev) initAutoUpdater(mainWindow)

--- a/src/main/ipc/projectIpc.ts
+++ b/src/main/ipc/projectIpc.ts
@@ -59,7 +59,9 @@ const defaultSavePath = (project: unknown): string => {
     project && typeof project === 'object' && 'metadata' in project
       ? String(((project as { metadata?: { name?: unknown } }).metadata?.name ?? '')).trim()
       : ''
-  return `${sanitizeFileName(name || 'cable-project')}.json`
+  // #pre-sale — Eigene Projekt-Endung .cableplan (statt generischem .json),
+  // damit Datei-Verknüpfung + eigenes Icon möglich sind. Inhalt bleibt JSON.
+  return `${sanitizeFileName(name || 'cable-project')}.cableplan`
 }
 
 const defaultViewerPath = (project: unknown): string => {
@@ -70,10 +72,15 @@ const defaultViewerPath = (project: unknown): string => {
   return `${sanitizeFileName(name || 'cable-project')}.cpviewer`
 }
 
-const ensureJsonExtension = (filePath: string): string =>
-  filePath.toLowerCase().endsWith('.json') || filePath.toLowerCase().endsWith('.cpviewer')
+// #pre-sale — neue Projekte bekommen .cableplan; bereits als .json/.cpviewer
+// gespeicherte Dateien behalten ihre Endung (Abwärtskompatibilität beim
+// Re-Save eines alten Projekts).
+const ensureProjectExtension = (filePath: string): string => {
+  const lower = filePath.toLowerCase()
+  return lower.endsWith('.cableplan') || lower.endsWith('.json') || lower.endsWith('.cpviewer')
     ? filePath
-    : `${filePath}.json`
+    : `${filePath}.cableplan`
+}
 
 const ensureViewerExtension = (filePath: string): string =>
   filePath.toLowerCase().endsWith('.cpviewer') ? filePath : `${filePath}.cpviewer`
@@ -87,7 +94,7 @@ export const registerProjectIpc = () => {
       filters: [
         // v7.9.3 — .cpviewer ist eine Read-only Variante der normalen
         // JSON-Datei (gleicher Inhalt + project.mode='viewer').
-        { name: 'Cable Planner Project / Viewer', extensions: ['json', 'cpviewer'] },
+        { name: 'Cable Planner Project / Viewer', extensions: ['cableplan', 'json', 'cpviewer'] },
         { name: 'JSON', extensions: ['json'] },
         { name: 'Viewer (read-only)', extensions: ['cpviewer'] },
       ],
@@ -160,16 +167,16 @@ export const registerProjectIpc = () => {
       const { canceled, filePath } = await dialog.showSaveDialog({
         title: 'Save Cable Planner Project',
         defaultPath: defaultSavePath(project),
-        filters: [{ name: 'Cable Planner Project', extensions: ['json'] }],
+        filters: [{ name: 'Cable Planner Project', extensions: ['cableplan', 'json'] }],
       })
 
       if (canceled || !filePath) {
         return null
       }
 
-      targetPath = ensureJsonExtension(filePath)
+      targetPath = ensureProjectExtension(filePath)
     } else {
-      targetPath = ensureJsonExtension(targetPath)
+      targetPath = ensureProjectExtension(targetPath)
     }
 
     await atomicWriteFile(targetPath, JSON.stringify(project, null, 2))
@@ -181,14 +188,14 @@ export const registerProjectIpc = () => {
     const { canceled, filePath } = await dialog.showSaveDialog({
       title: 'Save Cable Planner Project As',
       defaultPath: defaultSavePath(project),
-      filters: [{ name: 'Cable Planner Project', extensions: ['json'] }],
+      filters: [{ name: 'Cable Planner Project', extensions: ['cableplan', 'json'] }],
     })
 
     if (canceled || !filePath) {
       return null
     }
 
-    const target = ensureJsonExtension(filePath)
+    const target = ensureProjectExtension(filePath)
     await atomicWriteFile(target, JSON.stringify(project, null, 2))
     await writeRecent(target)
     return target

--- a/src/main/ipc/projectIpc.ts
+++ b/src/main/ipc/projectIpc.ts
@@ -1,7 +1,8 @@
-import { app, dialog, ipcMain } from 'electron'
+import { app, dialog, ipcMain, type BrowserWindow } from 'electron'
 import { access, mkdir, readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { atomicWriteFile } from '../util/atomicWrite.js'
+import { takePendingLaunchPath } from '../services/fileOpenService.js'
 
 const RECENT_PATH = path.join(app.getPath('userData'), 'recent-projects.json')
 
@@ -84,6 +85,36 @@ const ensureProjectExtension = (filePath: string): string => {
 
 const ensureViewerExtension = (filePath: string): string =>
   filePath.toLowerCase().endsWith('.cpviewer') ? filePath : `${filePath}.cpviewer`
+
+// #pre-sale — Liest eine extern (Doppelklick/Argv) geöffnete Projektdatei und
+// liefert das gleiche { filePath, data }-Format wie project:open zurück, damit
+// der Renderer-Loader (useProject) wiederverwendet werden kann. Aktualisiert
+// die Recent-Liste. Bei Lese-/Parse-Fehler: null (kein Crash).
+const loadExternalPayload = async (
+  filePath: string,
+): Promise<{ filePath: string; data: unknown } | null> => {
+  try {
+    const content = await readFile(filePath, 'utf-8')
+    const data = JSON.parse(content)
+    await writeRecent(filePath)
+    return { filePath, data }
+  } catch (err) {
+    console.error('[project] open-external failed:', (err as Error)?.message ?? err)
+    return null
+  }
+}
+
+// #pre-sale — Schiebt eine extern geöffnete Datei in einen bereits laufenden
+// Renderer (zweite Instanz auf Win/Linux, open-file auf macOS). Cold-Start
+// läuft stattdessen über project:get-launch-file (Renderer holt ab).
+export const openExternalProject = async (
+  win: BrowserWindow | null,
+  filePath: string,
+): Promise<void> => {
+  if (!win || win.isDestroyed()) return
+  const payload = await loadExternalPayload(filePath)
+  if (payload) win.webContents.send('project:open-external', payload)
+}
 
 export const registerProjectIpc = () => {
   ipcMain.handle('project:new', async () => null)
@@ -202,4 +233,13 @@ export const registerProjectIpc = () => {
   })
 
   ipcMain.handle('project:get-recent', () => readRecentValid())
+
+  // #pre-sale — Kaltstart-Öffnen: der Renderer holt beim Mounten die per
+  // OS-Doppelklick übergebene Datei ab (über process.argv / open-file vor
+  // whenReady gepuffert). takePendingLaunchPath leert den Puffer → genau
+  // einmal laden. Null wenn ohne Datei gestartet wurde.
+  ipcMain.handle('project:get-launch-file', async () => {
+    const pending = takePendingLaunchPath()
+    return pending ? loadExternalPayload(pending) : null
+  })
 }

--- a/src/main/preload.cts
+++ b/src/main/preload.cts
@@ -69,6 +69,18 @@ contextBridge.exposeInMainWorld('cablePlanner', {
       ipcRenderer.invoke('project:import-annotations') as Promise<
         { filePath: string; annotations: unknown[] } | null
       >,
+    // #pre-sale — Datei-Verknüpfung: beim Kaltstart per OS-Doppelklick
+    // übergebene Datei abholen (null wenn ohne Datei gestartet).
+    getLaunchFile: () =>
+      ipcRenderer.invoke('project:get-launch-file') as Promise<
+        { filePath: string; data: unknown } | null
+      >,
+    // #pre-sale — bei laufender App geöffnete Datei (second-instance/open-file).
+    onOpenExternal: (cb: (payload: { filePath: string; data: unknown }) => void) => {
+      const listener = (_e: unknown, payload: { filePath: string; data: unknown }) => cb(payload)
+      ipcRenderer.on('project:open-external', listener)
+      return () => ipcRenderer.removeListener('project:open-external', listener)
+    },
   },
   atem: {
     connect: (ip: string) => ipcRenderer.invoke('atem:connect', ip) as Promise<unknown>,

--- a/src/main/services/fileOpenService.ts
+++ b/src/main/services/fileOpenService.ts
@@ -1,0 +1,46 @@
+/**
+ * #pre-sale — Doppelklick-Öffnen von Projektdateien aus dem OS.
+ *
+ * Reine Helfer ohne Electron-Window-Abhängigkeit:
+ *  - findProjectPathInArgv: zieht den Datei-Pfad aus einem process.argv
+ *    (Windows/Linux reichen die Datei als Kommandozeilen-Argument durch).
+ *  - setPendingLaunchPath/takePendingLaunchPath: puffern den beim Kaltstart
+ *    übergebenen Pfad, bis der Renderer bereit ist und ihn per IPC abholt
+ *    (project:get-launch-file). „take" leert den Puffer (genau einmal laden).
+ *
+ * Das eigentliche Lesen/Senden + Recent-Liste liegt in projectIpc.ts
+ * (openExternalProject / project:get-launch-file), damit writeRecent dort
+ * an einer Stelle bleibt und kein Import-Zyklus entsteht.
+ */
+const PROJECT_EXTS = ['.cableplan', '.json', '.cpviewer']
+
+export const isProjectFile = (filePath: string): boolean => {
+  const lower = filePath.toLowerCase()
+  return PROJECT_EXTS.some((ext) => lower.endsWith(ext))
+}
+
+/**
+ * Findet den ersten Projekt-Datei-Pfad in einem argv-Array. argv[0] ist die
+ * Executable und wird übersprungen; Flags (beginnen mit '-') ignoriert.
+ */
+export const findProjectPathInArgv = (argv: readonly string[]): string | null => {
+  for (const arg of argv.slice(1)) {
+    if (!arg || arg.startsWith('-')) continue
+    if (isProjectFile(arg)) return arg
+  }
+  return null
+}
+
+let pendingLaunchPath: string | null = null
+
+/** Puffert einen Pfad fürs spätere Abholen durch den Renderer (Kaltstart). */
+export const setPendingLaunchPath = (filePath: string | null): void => {
+  if (filePath && isProjectFile(filePath)) pendingLaunchPath = filePath
+}
+
+/** Liefert den gepufferten Pfad und leert den Puffer (einmaliges Laden). */
+export const takePendingLaunchPath = (): string | null => {
+  const p = pendingLaunchPath
+  pendingLaunchPath = null
+  return p
+}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -147,7 +147,15 @@ export default function App() {
   const closeAtemDialog = useUiStore((state) => state.closeAtemDialog)
   const atemMvLayout = useUiStore((state) => state.atemMvLayout)
   const closeAtemMvLayout = useUiStore((state) => state.closeAtemMvLayout)
-  const { newProject, openProject, saveProject, saveProjectAs, refreshRecent } = useProject()
+  const {
+    newProject,
+    openProject,
+    openLaunchFile,
+    applyOpenedProject,
+    saveProject,
+    saveProjectAs,
+    refreshRecent,
+  } = useProject()
   const settingsOpen = useUiStore((s) => s.settingsOpen)
   const settingsSection = useUiStore((s) => s.settingsSection)
   const setSettingsOpen = (open: boolean) =>
@@ -454,6 +462,17 @@ export default function App() {
       setHasToken(Boolean(token))
     })
   }, [refreshRecent, setHasToken])
+
+  // #pre-sale — OS-Dateiverknüpfung: beim Kaltstart die per Doppelklick
+  // übergebene Datei abholen (einmalig) und auf später geöffnete Dateien
+  // (zweite Instanz / macOS open-file bei laufender App) hören.
+  useEffect(() => {
+    void openLaunchFile()
+    const off = cablePlannerApi.project.onOpenExternal((payload) => {
+      void applyOpenedProject(payload)
+    })
+    return off
+  }, [openLaunchFile, applyOpenedProject])
 
   useUndoRedoShortcuts()
 

--- a/src/renderer/hooks/useProject.ts
+++ b/src/renderer/hooks/useProject.ts
@@ -16,7 +16,9 @@ interface OpenProjectResponse {
 /** Derive a human-readable project name from a file path (drops extension). */
 const nameFromPath = (filePath: string): string => {
   const base = filePath.split(/[\\/]/).pop() ?? filePath
-  return base.replace(/\.json$/i, '')
+  // #pre-sale — .cableplan ist die neue Projekt-Endung; .json/.cpviewer
+  // bleiben abwärtskompatibel.
+  return base.replace(/\.(cableplan|json|cpviewer)$/i, '')
 }
 
 export const useProject = () => {

--- a/src/renderer/hooks/useProject.ts
+++ b/src/renderer/hooks/useProject.ts
@@ -39,10 +39,12 @@ export const useProject = () => {
     await refreshRecent()
   }, [clear, refreshRecent])
 
-  const openProject = useCallback(async () => {
-    const result = (await cablePlannerApi.project.openProject()) as OpenProjectResponse | null
-    if (result) {
-      console.log('[openProject] from disk', {
+  // Gemeinsamer Loader für alle Öffnen-Pfade (Dialog, OS-Doppelklick beim
+  // Kaltstart, Doppelklick bei laufender App). Synct den Namen, fragt bei
+  // Viewer-Dateien den Reviewer-Namen ab und lädt das Projekt in den Store.
+  const applyOpenedProject = useCallback(
+    async (result: OpenProjectResponse) => {
+      console.log('[openProject] load', {
         filePath: result.filePath,
         equipmentCount: result.data?.equipment?.length,
         firstThreePositions: result.data?.equipment?.slice(0, 3).map((e) => ({
@@ -105,8 +107,20 @@ export const useProject = () => {
       loadProject(incoming, result.filePath)
       projectHistory.reset()
       await refreshRecent()
-    }
-  }, [loadProject, refreshRecent])
+    },
+    [loadProject, refreshRecent],
+  )
+
+  const openProject = useCallback(async () => {
+    const result = (await cablePlannerApi.project.openProject()) as OpenProjectResponse | null
+    if (result) await applyOpenedProject(result)
+  }, [applyOpenedProject])
+
+  // #pre-sale — beim Kaltstart per OS-Doppelklick übergebene Datei laden.
+  const openLaunchFile = useCallback(async () => {
+    const result = await cablePlannerApi.project.getLaunchFile()
+    if (result) await applyOpenedProject(result as OpenProjectResponse)
+  }, [applyOpenedProject])
 
   const saveProject = useCallback(async () => {
     const { project, filePath } = useProjectStore.getState()
@@ -144,6 +158,8 @@ export const useProject = () => {
   return {
     newProject,
     openProject,
+    openLaunchFile,
+    applyOpenedProject,
     saveProject,
     saveProjectAs,
     refreshRecent,

--- a/src/renderer/lib/bridge.ts
+++ b/src/renderer/lib/bridge.ts
@@ -128,6 +128,10 @@ type CablePlannerApi = {
     exportViewer: (project: CablePlannerProject) => Promise<string | null>
     /** v7.9.3 — Annotations aus einer Viewer-Datei zurück-importieren. */
     importAnnotations: () => Promise<{ filePath: string; annotations: unknown[] } | null>
+    /** #pre-sale — beim Kaltstart per OS-Doppelklick übergebene Datei abholen. */
+    getLaunchFile: () => Promise<OpenProjectResponse | null>
+    /** #pre-sale — bei laufender App geöffnete Datei (second-instance/open-file). */
+    onOpenExternal: (cb: (payload: OpenProjectResponse) => void) => () => void
   }
   graphml: {
     openFile: () => Promise<{ filePath: string; fileName: string; xml: string } | null>
@@ -639,6 +643,10 @@ const webFallbackApi: CablePlannerApi = {
       return fileName
     },
     importAnnotations: async () => null,
+    // #pre-sale — Datei-Verknüpfung ist Desktop-only; im Browser gibt es
+    // keine OS-Übergabe → kein Launch-File, kein External-Open.
+    getLaunchFile: async () => null,
+    onOpenExternal: () => () => {},
   },
   graphml: {
     // Browser fallback for dev / non-Electron contexts: use a hidden

--- a/src/renderer/lib/bridge.ts
+++ b/src/renderer/lib/bridge.ts
@@ -596,7 +596,7 @@ const webFallbackApi: CablePlannerApi = {
     openProject: async () => {
       const input = document.createElement('input')
       input.type = 'file'
-      input.accept = '.json,application/json'
+      input.accept = '.cableplan,.json,application/json'
 
       return await new Promise<OpenProjectResponse | null>((resolve) => {
         input.onchange = async () => {
@@ -619,13 +619,13 @@ const webFallbackApi: CablePlannerApi = {
       })
     },
     saveProject: async (project: CablePlannerProject, currentPath?: string) => {
-      const fileName = currentPath || `${project.metadata.name || 'project'}.json`
+      const fileName = currentPath || `${project.metadata.name || 'project'}.cableplan`
       downloadJson(project, fileName)
       pushRecent(fileName)
       return fileName
     },
     saveProjectAs: async (project: CablePlannerProject) => {
-      const fileName = `${project.metadata.name || 'project'}.json`
+      const fileName = `${project.metadata.name || 'project'}.cableplan`
       downloadJson(project, fileName)
       pushRecent(fileName)
       return fileName


### PR DESCRIPTION
## Worum geht's

Pre-Sale-Politur: Projekte bekommen eine **eigene Endung `.cableplan`** statt des generischen `.json`, das OS verknüpft sie mit der App, und ein **Doppelklick öffnet das Projekt** direkt. Inhalt bleibt JSON.

## Änderungen

**1. `.cableplan` als Projekt-Endung (commit 1)**
- Neue Projekte speichern als `.cableplan`; `defaultSavePath` + Save-/Save-As-Dialoge ziehen nach.
- **Abwärtskompatibel:** `.json`/`.cpviewer` öffnen + re-saven weiterhin unter ihrer Endung (`ensureProjectExtension`).
- `nameFromPath` strippt jetzt alle drei Endungen für den Anzeigenamen.
- `electron-builder.js`: `fileAssociations` für `.cableplan` (Editor) + `.cpviewer` (Viewer) → OS verknüpft Doppelklick mit der App (nutzt das App-Icon).
- Web-Fallback (`bridge.ts`) erzeugt/akzeptiert ebenfalls `.cableplan`.

**2. Doppelklick-Routing zur Laufzeit (commit 2)**
- **Single-Instance-Lock:** zweite Instanz reicht den Pfad an die laufende App (`second-instance`, Win/Linux) statt ein leeres Fenster zu öffnen.
- **macOS `open-file`** (kann vor `whenReady` feuern) → puffern bzw. pushen.
- **Kaltstart:** Pfad aus `process.argv` puffern; Renderer holt ihn beim Mounten über `project:get-launch-file` ab (einmaliges Laden).
- **Laufende App:** `project:open-external` pusht das geladene Projekt in den Renderer (`App.tsx` hört via `project.onOpenExternal`).
- `useProject`: gemeinsamer `applyOpenedProject`-Loader (Dialog + Launch + External teilen Namens-Sync, Viewer-Prompt, Recent-Update).
- Neuer reiner Helfer `fileOpenService` (argv-Parse + Launch-Puffer) — isoliert getestet (11 Assertions grün).

## Verifikation

- `tsc` main + renderer: **0 Fehler**
- `eslint` geänderte Dateien: **0 Fehler** (nur 2 vorbestehende Warnungen)
- `npm run build`: grün (inkl. `build:preload`; neue IPC-Channels im Bundle verifiziert)
- Reine Helfer (`findProjectPathInArgv`, Launch-Puffer): 11/11 Assertions grün

⚠️ **Caveat:** `fileAssociations` + Doppelklick-Routing greifen erst im **paketierten Build** (electron-builder). Headless nur tsc-/build-/helfer-getestet — die echte OS-Verknüpfung + Doppelklick braucht einen Win/Mac-Installer zur Laufzeit-Verifikation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_