### PR TITLE
test: Vitest-Unit-Suite für reine Logik (31 Tests, pre-sale)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.5.0",
+        "happy-dom": "^20.10.3",
         "png-to-ico": "^3.0.1",
         "postcss": "^8.5.6",
         "sharp": "^0.34.5",
@@ -62,6 +63,7 @@
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.2",
         "vite": "^8.0.9",
+        "vitest": "^4.1.9",
         "wait-on": "^9.0.1"
       }
     },
@@ -2837,6 +2839,17 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
@@ -3100,6 +3113,13 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/draco3d": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
@@ -3294,6 +3314,23 @@
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -3591,6 +3628,119 @@
         "babel-plugin-react-compiler": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -3907,6 +4057,16 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -4218,6 +4378,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/builder-util": {
       "version": "26.8.1",
       "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.8.1.tgz",
@@ -4421,6 +4594,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -5400,6 +5583,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -5434,6 +5630,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -5664,6 +5867,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5708,6 +5921,16 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -6337,6 +6560,25 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.10.3",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.3.tgz",
+      "integrity": "sha512-Hjdiy8RziuCcn5z04QI/rlsNuQoG8P0xxjgvsSMpi89cvIXIOcucQtiHS1yHSShxoBcSCeYqAskINmTiy/mlfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -7693,6 +7935,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -7865,6 +8121,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pe-library": {
       "version": "0.4.1",
@@ -8874,6 +9137,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -9090,6 +9360,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackblur-canvas": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
@@ -9134,6 +9411,13 @@
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
       "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string_decoder": {
@@ -9440,6 +9724,23 @@
       "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -9455,6 +9756,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -9905,6 +10216,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/wait-on": {
       "version": "9.0.10",
       "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.0.10.tgz",
@@ -9955,6 +10356,16 @@
       "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
       "license": "MIT"
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9975,6 +10386,23 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "license": "ISC"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/wmf": {
       "version": "1.0.2",
@@ -10031,8 +10459,8 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "build:renderer": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:crdt": "node scripts/crdt-convergence-check.mjs",
     "test:signaling": "npm run build:main && node scripts/signaling-relay-check.mjs",
     "dist": "npm run build && electron-builder",
@@ -102,6 +104,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.5.0",
+    "happy-dom": "^20.10.3",
     "png-to-ico": "^3.0.1",
     "postcss": "^8.5.6",
     "sharp": "^0.34.5",
@@ -109,6 +112,7 @@
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.2",
     "vite": "^8.0.9",
+    "vitest": "^4.1.9",
     "wait-on": "^9.0.1"
   }
 }

--- a/tests/cableInheritance.test.ts
+++ b/tests/cableInheritance.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import {
+  cableTypePatchFromPorts,
+  connectorToCableType,
+  inheritedCableType,
+  isBidirectionalCableType,
+} from '../src/renderer/lib/cableInheritance'
+import type { Cable } from '../src/renderer/types/cable'
+import type { ConnectorType, EquipmentItem } from '../src/renderer/types/equipment'
+
+// v7.9.125 — Cable-Typ folgt dem Port-Connector. Reine Ableitungslogik.
+// (Importiert transitiv den Zustand-Store → verifiziert nebenbei, dass die
+//  Renderer-Module unter happy-dom sauber laden.)
+
+// Minimal-Fixtures: cableInheritance liest nur id/inputs/outputs/connectorType.
+const eq = (id: string, ports: Array<{ id: string; connectorType: ConnectorType; out?: boolean }>): EquipmentItem => {
+  const mk = (p: { id: string; connectorType: ConnectorType }) => ({
+    id: p.id,
+    name: p.id,
+    type: 'port',
+    connectorType: p.connectorType,
+  })
+  return {
+    id,
+    name: id,
+    inputs: ports.filter((p) => !p.out).map(mk),
+    outputs: ports.filter((p) => p.out).map(mk),
+  } as unknown as EquipmentItem
+}
+
+const cable = (over: Partial<Cable>): Cable =>
+  ({
+    id: 'c1',
+    name: 'c1',
+    type: 'Custom',
+    length: 1,
+    color: '#fff',
+    fromEquipmentId: 'A',
+    fromPortId: 'a-out',
+    toEquipmentId: 'B',
+    toPortId: 'b-in',
+    notes: '',
+    ...over,
+  }) as Cable
+
+describe('connectorToCableType', () => {
+  it('reicht direkte Connector→Cable-Typen durch', () => {
+    expect(connectorToCableType('BNC')).toBe('BNC')
+    expect(connectorToCableType('XLR')).toBe('XLR')
+  })
+
+  it('kollabiert Nicht-Kabel-Connectoren + undefined auf Custom', () => {
+    expect(connectorToCableType('DIN')).toBe('Custom')
+    expect(connectorToCableType('DisplayPort')).toBe('Custom')
+    expect(connectorToCableType('USB')).toBe('Custom')
+    expect(connectorToCableType(undefined)).toBe('Custom')
+  })
+})
+
+describe('isBidirectionalCableType', () => {
+  it('markiert physisch bidirektionale Typen', () => {
+    expect(isBidirectionalCableType('Fiber')).toBe(true)
+    expect(isBidirectionalCableType('Ethernet/RJ45')).toBe(true)
+  })
+  it('ist false für unidirektionale Typen', () => {
+    expect(isBidirectionalCableType('BNC')).toBe(false)
+    expect(isBidirectionalCableType('XLR')).toBe(false)
+  })
+})
+
+describe('inheritedCableType', () => {
+  const equipment = [
+    eq('A', [{ id: 'a-out', connectorType: 'BNC', out: true }]),
+    eq('B', [{ id: 'b-in', connectorType: 'BNC' }]),
+    eq('C', [{ id: 'c-in', connectorType: 'XLR' }]),
+  ]
+
+  it('leitet aus übereinstimmenden Ports ab', () => {
+    expect(inheritedCableType(cable({}), equipment)).toBe('BNC')
+  })
+
+  it('bevorzugt den Quell-Port wenn die Ports uneinig sind', () => {
+    const c = cable({ toEquipmentId: 'C', toPortId: 'c-in' }) // out=BNC, in=XLR
+    expect(inheritedCableType(c, equipment)).toBe('BNC')
+  })
+
+  it('liefert undefined für ein verwaistes Kabel (keine Ports auflösbar)', () => {
+    const c = cable({ fromEquipmentId: 'Z', fromPortId: 'z', toEquipmentId: 'Y', toPortId: 'y' })
+    expect(inheritedCableType(c, equipment)).toBeUndefined()
+  })
+})
+
+describe('cableTypePatchFromPorts', () => {
+  const equipment = [
+    eq('A', [{ id: 'a-out', connectorType: 'Fiber', out: true }]),
+    eq('B', [{ id: 'b-in', connectorType: 'Fiber' }]),
+  ]
+
+  it('liefert ein Patch inkl. bidirectional wenn sich der Typ ändert', () => {
+    const patch = cableTypePatchFromPorts(cable({ type: 'BNC' }), equipment)
+    expect(patch).toEqual({ type: 'Fiber', bidirectional: true })
+  })
+
+  it('liefert null wenn der Typ schon passt', () => {
+    expect(cableTypePatchFromPorts(cable({ type: 'Fiber' }), equipment)).toBeNull()
+  })
+
+  it('lässt needsConverter-Kabel unangetastet (null)', () => {
+    expect(cableTypePatchFromPorts(cable({ type: 'BNC', needsConverter: true }), equipment)).toBeNull()
+  })
+})

--- a/tests/exportFilename.test.ts
+++ b/tests/exportFilename.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  buildExportFilename,
+  buildExportFilenameWithSuffix,
+} from '../src/renderer/lib/exportFilename'
+
+// v7.9.116 — Einheitlicher Export-Dateiname YYYYMMDD_<Name>_NNN.<ext>.
+// localStorage (Tages-Counter) wird von happy-dom bereitgestellt.
+
+const DATE = /^\d{8}_/ // führendes YYYYMMDD_
+
+describe('buildExportFilename', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('baut das Format YYYYMMDD_<Name>_NNN.<ext>', () => {
+    const name = buildExportFilename('Demo-Show', 'pdf')
+    expect(name).toMatch(/^\d{8}_Demo-Show_001\.pdf$/)
+  })
+
+  it('zählt den Tages-Counter hoch (001 → 002 → 003)', () => {
+    expect(buildExportFilename('X', 'pdf')).toMatch(/_001\.pdf$/)
+    expect(buildExportFilename('X', 'pdf')).toMatch(/_002\.pdf$/)
+    expect(buildExportFilename('X', 'pdf')).toMatch(/_003\.pdf$/)
+  })
+
+  it('sanitisiert dateisystem-unsichere Zeichen, behält Umlaute', () => {
+    const name = buildExportFilename('A/B:C*?"<>|D', 'csv')
+    expect(name).toMatch(DATE)
+    expect(name.endsWith('.csv')).toBe(true)
+    expect(name).not.toMatch(/[/:*?"<>|]/) // Slash etc. ersetzt
+    expect(buildExportFilename('Tonü Ärör', 'pdf')).toContain('Tonü Ärör')
+  })
+
+  it('normalisiert die Endung (führende Punkte weg, lowercase) + Fallback', () => {
+    expect(buildExportFilename('X', '.PDF')).toMatch(/\.pdf$/)
+    expect(buildExportFilename('X', '')).toMatch(/\.bin$/) // leere Endung → bin
+  })
+
+  it('fällt bei leerem Namen auf "cable-planner" zurück', () => {
+    expect(buildExportFilename('   ', 'pdf')).toMatch(/^\d{8}_cable-planner_\d{3}\.pdf$/)
+  })
+})
+
+describe('buildExportFilenameWithSuffix', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('hängt das Suffix mit Bindestrich vor der Endung an', () => {
+    const name = buildExportFilenameWithSuffix('Demo', 'kabel bom', 'pdf')
+    expect(name).toMatch(/^\d{8}_Demo_001_kabel-bom\.pdf$/) // Leerzeichen → Bindestrich
+  })
+})

--- a/tests/fileOpenService.test.ts
+++ b/tests/fileOpenService.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  findProjectPathInArgv,
+  isProjectFile,
+  setPendingLaunchPath,
+  takePendingLaunchPath,
+} from '../src/main/services/fileOpenService'
+
+// #pre-sale — OS-Dateiverknüpfung (PR #547). Reine argv-/Puffer-Helfer, die
+// das Doppelklick-Öffnen tragen. Bewusst ohne Electron, daher headless testbar.
+
+describe('isProjectFile', () => {
+  it('akzeptiert die drei Projekt-Endungen, case-insensitiv', () => {
+    expect(isProjectFile('/x/A.cableplan')).toBe(true)
+    expect(isProjectFile('/x/A.CABLEPLAN')).toBe(true)
+    expect(isProjectFile('/x/old.json')).toBe(true)
+    expect(isProjectFile('/x/v.cpviewer')).toBe(true)
+  })
+
+  it('lehnt fremde Endungen ab', () => {
+    expect(isProjectFile('/x/notes.txt')).toBe(false)
+    expect(isProjectFile('/x/image.png')).toBe(false)
+    expect(isProjectFile('/x/no-ext')).toBe(false)
+  })
+})
+
+describe('findProjectPathInArgv', () => {
+  it('findet die Projektdatei nach der Executable (Windows-Kaltstart-argv)', () => {
+    expect(findProjectPathInArgv(['C:/app.exe', 'C:/Users/x/My Plan.cableplan'])).toBe(
+      'C:/Users/x/My Plan.cableplan',
+    )
+    expect(findProjectPathInArgv(['/app', '/tmp/old.json'])).toBe('/tmp/old.json')
+    expect(findProjectPathInArgv(['/app', '/tmp/v.cpviewer'])).toBe('/tmp/v.cpviewer')
+  })
+
+  it('überspringt argv[0] (Executable) und Flags', () => {
+    expect(findProjectPathInArgv(['/x/app.cableplan'])).toBeNull() // nur Executable
+    expect(findProjectPathInArgv(['/app', '--inspect', '--foo=bar.json'])).toBeNull()
+  })
+
+  it('liefert null wenn keine Projektdatei dabei ist', () => {
+    expect(findProjectPathInArgv(['/app'])).toBeNull()
+    expect(findProjectPathInArgv(['/app', '/tmp/notes.txt'])).toBeNull()
+  })
+
+  it('nimmt die erste passende Datei bei mehreren Argumenten', () => {
+    expect(findProjectPathInArgv(['/app', '/tmp/a.cableplan', '/tmp/b.json'])).toBe('/tmp/a.cableplan')
+  })
+})
+
+describe('pending launch path buffer', () => {
+  beforeEach(() => {
+    // Puffer leeren, da das Modul zwischen Tests im selben File geteilt wird.
+    takePendingLaunchPath()
+  })
+
+  it('puffert einen gültigen Pfad und gibt ihn genau einmal heraus', () => {
+    setPendingLaunchPath('/p/one.cableplan')
+    expect(takePendingLaunchPath()).toBe('/p/one.cableplan')
+    expect(takePendingLaunchPath()).toBeNull() // take leert den Puffer
+  })
+
+  it('überschreibt einen gepufferten Pfad NICHT mit null/leer (macOS open-file vs argv)', () => {
+    setPendingLaunchPath('/p/one.cableplan')
+    setPendingLaunchPath(null)
+    expect(takePendingLaunchPath()).toBe('/p/one.cableplan')
+  })
+
+  it('ignoriert Nicht-Projekt-Pfade', () => {
+    setPendingLaunchPath('/x/bad.txt')
+    expect(takePendingLaunchPath()).toBeNull()
+  })
+})

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,19 @@
+// happy-dom implementiert window.matchMedia nicht; Theme-/Store-Code beim
+// Modul-Import greift teils darauf zu. Minimaler No-op-Stub als Sicherheitsnetz,
+// damit der Import der Renderer-Module nicht an einer fehlenden Browser-API
+// scheitert.
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  })
+}

--- a/tests/sharedLibraryMerge.test.ts
+++ b/tests/sharedLibraryMerge.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { diffByName, joinSyncPath, unionByName } from '../src/renderer/lib/sharedLibraryMerge'
+
+// #434 — Reine Merge-Logik der Workgroup-/Shared-Library (explizit ohne
+// Browser-/Store-Abhängigkeiten gebaut, damit unit-testbar).
+
+describe('joinSyncPath', () => {
+  it('verbindet POSIX-Pfade mit /', () => {
+    expect(joinSyncPath('/home/user/sync', 'lib.json')).toBe('/home/user/sync/lib.json')
+    expect(joinSyncPath('/home/user/sync/', 'lib.json')).toBe('/home/user/sync/lib.json')
+  })
+
+  it('verbindet reine Windows-Pfade mit \\', () => {
+    expect(joinSyncPath('C:\\Users\\x\\sync', 'lib.json')).toBe('C:\\Users\\x\\sync\\lib.json')
+    expect(joinSyncPath('C:\\Users\\x\\sync\\', 'lib.json')).toBe('C:\\Users\\x\\sync\\lib.json')
+  })
+})
+
+type Named = { name: string; v?: number }
+
+describe('diffByName', () => {
+  it('listet fehlende Items zum Hinzufügen', () => {
+    const local: Named[] = [{ name: 'A' }]
+    const shared: Named[] = [{ name: 'A' }, { name: 'B' }]
+    const { add, conflicts } = diffByName(local, shared)
+    expect(add.map((x) => x.name)).toEqual(['B'])
+    expect(conflicts).toEqual([])
+  })
+
+  it('erkennt Namensgleiche mit abweichendem Inhalt als Konflikt', () => {
+    const local: Named[] = [{ name: 'A', v: 1 }]
+    const shared: Named[] = [{ name: 'A', v: 2 }]
+    const { add, conflicts } = diffByName(local, shared)
+    expect(add).toEqual([])
+    expect(conflicts).toEqual(['A'])
+  })
+
+  it('ignoriert identische Items (kein add, kein Konflikt)', () => {
+    const local: Named[] = [{ name: 'A', v: 1 }]
+    const shared: Named[] = [{ name: 'A', v: 1 }]
+    const { add, conflicts } = diffByName(local, shared)
+    expect(add).toEqual([])
+    expect(conflicts).toEqual([])
+  })
+})
+
+describe('unionByName', () => {
+  it('vereinigt nach Name; bei Gleichheit gewinnt local', () => {
+    const local: Named[] = [{ name: 'A', v: 1 }]
+    const shared: Named[] = [{ name: 'A', v: 99 }, { name: 'B', v: 2 }]
+    const result = unionByName(local, shared)
+    const byName = new Map(result.map((x) => [x.name, x.v]))
+    expect(byName.get('A')).toBe(1) // local gewinnt
+    expect(byName.get('B')).toBe(2) // shared-only übernommen
+    expect(result).toHaveLength(2)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config'
+
+// Test-Suite-Konfiguration. Bewusst getrennt von der App-/Build-Config:
+// die Tests liegen unter tests/ (außerhalb der Emit-tsconfigs, damit kein
+// Test-File in dist/ landet) und decken die reine Logik ab — keine React-
+// Komponenten, daher kein react-Plugin nötig.
+//
+// environment: 'happy-dom' weil mehrere Renderer-Module beim Import den
+// Zustand-Store nachziehen, der localStorage/window beim Laden anfasst.
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+    include: ['tests/**/*.test.ts'],
+    setupFiles: ['tests/setup.ts'],
+    globals: false,
+    restoreMocks: true,
+  },
+})


### PR DESCRIPTION
## Worum geht's

Erste lauffähige automatisierte Test-Suite — bisher gab es nur ad-hoc `scripts/*.mjs` + die manuelle `TESTING.md`. Jetzt: `npm test`.

## Setup

- **Vitest 4 + happy-dom** als Test-Umgebung. happy-dom ist nötig, weil mehrere Renderer-Module beim Import den Zustand-Store nachziehen, der `localStorage`/`window` anfasst (z. B. `cableInheritance` → `equipmentSelectors` → `projectStore`).
- Tests liegen in **`tests/`** — bewusst außerhalb der Emit-tsconfigs (`tsconfig.main.json` emittiert aus `src/main`), damit kein Test-File in `dist/` landet.
- Eigene `vitest.config.ts`, getrennt von der Build-Config. Reine Logik → kein react-Plugin nötig.
- Neue Scripts: `npm test` (`vitest run`) + `npm run test:watch`.

## Abgedeckt (31 Tests, 4 Files)

| Modul | Was getestet wird |
|---|---|
| `fileOpenService` | argv-Parsing + Launch-Puffer der Dateiverknüpfung (#547) — Endungserkennung, Flag-Skip, „null überschreibt Puffer nicht" |
| `exportFilename` | Format `YYYYMMDD_<Name>_NNN.<ext>`, Tages-Counter-Inkrement, Sanitize (Umlaute bleiben), Endungs-Normalisierung/Fallback |
| `sharedLibraryMerge` | `diffByName` (add/conflicts), `unionByName` (local gewinnt), `joinSyncPath` (Win `\\` vs POSIX `/`) |
| `cableInheritance` | `connectorToCableType`, `isBidirectionalCableType`, `inheritedCableType` (Quell-Port-Präferenz, verwaiste Kabel), `cableTypePatchFromPorts` (needsConverter-Schutz) |

## Verifikation

- `npm test`: **31/31 grün** (~1 s)
- Test-Files typecheck-sauber (one-shot tsc gegen App-Config)
- Build-Gates unverändert grün: `tsc` main + renderer 0 Fehler, `npm run build` grün, `eslint .` 0 Fehler (nur vorbestehende Warnungen), **kein Test-File in `dist/`**
- **Prod-Deps: 0 Vulnerabilities.** vitest/happy-dom sind dev-only; die von `npm audit` gemeldeten Tooling-Vulns (`shell-quote` via `concurrently`, `tmp`) sind vorbestehend und werden nicht ausgeliefert.

Fundament zum Ausbauen — weitere reine Module (z. B. `cableLayers`, `videoFormat`-Helfer, BOM-Aggregation) lassen sich nach demselben Muster ergänzen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_