### PR TITLE
fix(canvas): Zoom-Anzeige folgt jetzt Menü-/Toolbar-Zoom

### DIFF
--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -8,6 +8,7 @@ import ReactFlow, {
   applyNodeChanges,
   updateEdge,
   useReactFlow,
+  useViewport,
   useUpdateNodeInternals,
   ConnectionMode,
   SelectionMode,
@@ -60,6 +61,32 @@ const nodeTypes = { equipment: EquipmentNode, location: LocationFrameNode }
 const edgeTypes = { cable: CableEdge }
 
 type CanvasMode = 'main' | 'rack'
+
+/**
+ * #zoomfix — Spiegelt JEDE Viewport-Änderung (inkl. PROGRAMMATISCHEM Zoom über
+ * das Ansicht-Menü / die Toolbar-Buttons) in den Store, damit die StatusBar-
+ * Zoom-Anzeige stimmt. ReactFlows `onMoveEnd` feuert nur bei Maus-/Wheel-Gesten,
+ * NICHT bei `zoomIn/zoomOut/zoomTo({duration})` — daher zeigte die Anzeige nach
+ * Menü-Zoom weiter „100 %", obwohl die Canvas tatsächlich zoomte. `useViewport()`
+ * reflektiert dagegen den echten Viewport. Debounced geschrieben; setCanvasState
+ * ist #382-history-gefiltert, erzeugt also keine Undo-Schritte.
+ */
+const ViewportStateSync = ({
+  onChange,
+}: {
+  onChange: (x: number, y: number, zoom: number) => void
+}) => {
+  const { x, y, zoom } = useViewport()
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    if (timer.current) clearTimeout(timer.current)
+    timer.current = setTimeout(() => onChange(x, y, zoom), 150)
+    return () => {
+      if (timer.current) clearTimeout(timer.current)
+    }
+  }, [x, y, zoom, onChange])
+  return null
+}
 
 const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
   const t = useTranslation()
@@ -1702,8 +1729,10 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
         // port handles. The store value is read by both components.
         onEdgeMouseEnter={(_event, edge) => setHoveredCableId(edge.id)}
         onEdgeMouseLeave={() => setHoveredCableId(null)}
-        onMoveEnd={(_event, viewport) => setCanvasState(viewport.x, viewport.y, viewport.zoom)}
       >
+        {/* #zoomfix — Viewport→Store-Sync (auch bei Menü-/Toolbar-Zoom), ersetzt
+            das frühere onMoveEnd, das programmatischen Zoom nicht erfasste. */}
+        <ViewportStateSync onChange={setCanvasState} />
         <MiniMap pannable zoomable
           className={effectiveCanvasTheme === 'light' ? '!bg-slate-100' : '!bg-cp-surface-2'}
           maskColor={effectiveCanvasTheme === 'light' ? 'rgba(226,232,240,0.7)' : 'rgba(15,23,42,0.7)'}


### PR DESCRIPTION
## Bug

Nach **Ansicht → Vergrößern / Verkleinern / Zoom 100 %** blieb die StatusBar-Anzeige auf **„100 %"** stehen. Die Canvas zoomte tatsächlich korrekt (ReactFlow-Transform änderte sich), aber die **Anzeige war eingefroren** — auf leerer Canvas wirkte Zoom dadurch komplett tot.

## Ursache

`project.canvasState.zoom` (Quelle der StatusBar-Anzeige) wurde nur über ReactFlows **`onMoveEnd`** gesetzt. Das feuert ausschließlich bei **Maus-/Wheel-Gesten** — der **programmatische** `zoomIn/zoomOut/zoomTo({duration})` aus dem Ansicht-Menü und den Toolbar-Buttons löst `onMoveEnd` nicht aus. Also blieb der Store-Wert (und damit die Anzeige) hängen.

## Fix

Neue Mini-Komponente `ViewportStateSync` (`useViewport()`, 150 ms debounced) spiegelt **jeden** Viewport-Change in den Store und ersetzt `onMoveEnd` — deckt Menü, Toolbar-Buttons **und** Gesten gleichermaßen ab. `useViewport()` reflektiert auch programmatischen Zoom, `onMoveEnd` nicht. Re-Renders sind auf die winzige Null-Komponente isoliert. `setCanvasState` ist bereits #382-history-gefiltert → keine Undo-Schritte.

## Verifikation (headless, echte Electron-App)

Per Chrome-DevTools-Protocol gegen die unter `xvfb` laufende App getestet:

| | Anzeige | Transform |
|---|---|---|
| vorher | `100` | `scale(1)` |
| nach 3× Menü-Zoom | **`173`** ✅ | `scale(1.728)` ✅ |

Plus: `tsc` (main+renderer) 0 Fehler · `eslint` 0 Fehler · `npm test` 31/31 · `npm run build` grün.

⚠️ Wie immer bei Canvas-/Main-Prozess-Änderungen: die finale Bestätigung kommt aus einem echten paketierten Build — headless deckt das Renderer-Verhalten ab, das ist hier der relevante Teil.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_