### PR TITLE
feat(i18n): Default-Sprache folgt der OS-Locale (DE statt fix EN)

### DIFF
--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -290,6 +290,21 @@ interface PersistedUiState {
   portLabelFontSize: number
 }
 
+/**
+ * #ux — Default-Sprache anhand der OS-/Browser-Locale wählen statt fix Englisch.
+ * Greift NUR beim ersten Start (kein persistierter Wert in localStorage) — eine
+ * vom User gespeicherte Sprache gewinnt weiter, weil load() sie über die Defaults
+ * merged. Electron setzt navigator.language auf die System-Locale.
+ */
+const detectDefaultLanguage = (): Language => {
+  try {
+    const lang = (typeof navigator !== 'undefined' && navigator.language) || ''
+    return lang.toLowerCase().startsWith('de') ? 'de' : 'en'
+  } catch {
+    return 'en'
+  }
+}
+
 const defaults: PersistedUiState = {
   propertiesCollapsed: false,
   libraryCollapsed: false,
@@ -303,7 +318,7 @@ const defaults: PersistedUiState = {
   canvasTheme: 'dark',
   followSystemTheme: false,
   colorPortsByType: false,
-  language: 'en',
+  language: detectDefaultLanguage(),
   overrideConnectionWarnings: false,
   rentmanEnabled: false,
   libraryViewMode: 'list',


### PR DESCRIPTION
## Problem (verifiziert)

`uiStore.ts` hatte die Default-Sprache **fix auf `'en'`** (Zeile 306) — **keine** OS-Locale-Erkennung. Ein frischer Start zeigte also für **jeden** Englisch, auch auf einem deutschen System. Sichtbar im Headless-Test: Menüs Englisch, Bibliothekskategorien aber Deutsch („Konverter", „Sync/Referenz") → verwirrend für DE-Nutzer.

## Fix

Neuer Helfer `detectDefaultLanguage()` liest `navigator.language` (von Electron = OS-Locale) → **`'de'` bei `de-*`, sonst `'en'`**.

**Sicher / nicht-invasiv:** greift NUR beim Erststart (kein persistierter Wert). Eine vom User in den Einstellungen gewählte Sprache **gewinnt weiterhin**, weil `load()` den gespeicherten Wert über die Defaults merged (`{...defaults, ...parsed}`).

## Verifikation

`tsc` (renderer) 0 Fehler · `eslint` 0 Fehler · `npm test` 31/31 grün.

⚠️ Headless-Container hat `en`-Locale, daher live nur die Logik geprüft (trivial, try/catch-gekapselt) — auf einem deutschen System greift `de`.

Teil der UX-Politur für Laien-Verständlichkeit (kommt im nächsten Release nach v8.2.0).

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_