### PR TITLE
feat(canvas): Empty-State-Hinweis auf leerer Canvas

### DIFF
--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -1518,6 +1518,23 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
         lastMousePosRef.current = { x: event.clientX, y: event.clientY }
       }}
     >
+      {/* #ux — Empty-State: leere Haupt-Canvas erklärte sich bisher nicht
+          (schwarze Fläche). Hinweis weist auf die Bibliothek; pointer-events-
+          none, damit Drag&Drop + Pan/Zoom darunter ungestört funktionieren.
+          Nur Haupt-Canvas (im Rack-Overlay irrelevant). */}
+      {mode === 'main' && project.equipment.length === 0 && (
+        <div className="pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 px-6 text-center">
+          <div className="text-cp-lg font-medium text-cp-text-secondary">
+            {t('canvas.empty.title', 'Noch keine Geräte im Plan')}
+          </div>
+          <div className="max-w-sm text-cp-sm text-cp-text-muted">
+            {t(
+              'canvas.empty.hint',
+              'Zieh ein Gerät aus der Bibliothek (links) auf die Fläche, um zu starten.',
+            )}
+          </div>
+        </div>
+      )}
       {/* v7.9.12 — Toolbar wird auch im Rack-Mode gerendert, allerdings
           mit reduziertem Feature-Set (Frame/Group/Lock/Annotations
           ausgeblendet). Snap/Grid/Routing-Defaults/Align bleiben

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -754,6 +754,8 @@ export const en: Dict = {
   'graphml.dialog.unresolved': '{count} edges could not be resolved and will be dropped.',
 
   // Status bar (right side of canvas footer)
+  'canvas.empty.title': 'No devices yet',
+  'canvas.empty.hint': 'Drag a device from the library on the left onto the canvas to get started.',
   'statusbar.equipment': '{count} devices',
   'statusbar.cables': '{count} cables',
   'statusbar.locations': '{count} frames',


### PR DESCRIPTION
## Problem

Die leere Haupt-Canvas war ein **schwarzes Nichts** ohne jede Anleitung — Neueinsteiger sahen nicht, wie sie anfangen. (Hat auch mit dazu beigetragen, dass Zoom „tot" wirkte: ohne Geräte gibt es nichts sichtbar zu skalieren.)

## Fix

Zentrierter Empty-State-Hinweis auf der leeren Canvas:
> **Noch keine Geräte im Plan**
> Zieh ein Gerät aus der Bibliothek (links) auf die Fläche, um zu starten.

- `pointer-events-none` → Drag&Drop, Pan und Zoom darunter funktionieren ungestört.
- Nur **Haupt-Canvas** (`mode === 'main'` + `equipment.length === 0`), nicht im Rack-Overlay.
- DE-Quelltext + EN-Übersetzung (`canvas.empty.title/hint`).

## Verifikation (live, headless)

Screenshot der leeren Canvas zeigt den Hinweis korrekt zentriert statt schwarzer Fläche. `tsc` 0 · `eslint` 0 · `npm test` 31/31 · `npm run build` grün · `npm run ui:smoke` 5/5 Menüs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_