### PR TITLE
ci(pages): Web-App (Editor + Viewer + Mobile) auf GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,59 @@
+name: Deploy Web (GitHub Pages)
+
+# Veröffentlicht den Renderer-Build als statische Web-App auf GitHub Pages:
+#   index.html  = voller Editor (Web-Variante)
+#   viewer.html = Zero-Install-Reviewer für .cpviewer-Dateien
+#   mobile.html = Build-Day-Mobile-Viewer
+# Damit gibt es eine echte URL für externe Reviewer + funktionierende
+# Kollaborations-Einladungslinks. Desktop-only Features (Datei-IPC, ATEM/LAN,
+# Auto-Update, Keychain) fallen im Browser sauber auf den Web-Fallback
+# (src/renderer/lib/bridge.ts) zurück.
+#
+# EINMALIG manuell nötig: Repo → Settings → Pages → "Build and deployment"
+# → Source = "GitHub Actions". Ohne diese Einstellung schlägt nur der
+# Deploy-Step fehl — es wird nichts überschrieben.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Immer nur ein Deploy gleichzeitig; laufende abbrechen wenn ein neuer kommt.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: 'npm'
+      # keytar (native) braucht beim Kompilieren libsecret; Prebuilds decken
+      # nicht jede Node-ABI ab. Insurance, damit `npm ci` nicht an keytar
+      # scheitert — der Renderer-Build selbst nutzt keytar nicht.
+      - run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev
+      - run: npm ci
+      - run: npm run build:renderer
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/renderer
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Worum geht's

Du hast „komplette App auf GitHub Pages" gewählt. Dieser Workflow veröffentlicht den **Renderer-Build** als statische Web-App unter `https://larszu.github.io/cable-planner/`:

- **`index.html`** — voller Editor (Web-Variante)
- **`viewer.html`** — Zero-Install-Reviewer für `.cpviewer` → **schließt die Hosting-Lücke**: externe Gutachter brauchen keine Desktop-App mehr
- **`mobile.html`** — Build-Day-Mobile-Viewer

Desktop-only Features (Datei-IPC, ATEM/LAN, Auto-Update, Keychain) fallen im Browser sauber auf den **Web-Fallback** (`src/renderer/lib/bridge.ts`) zurück. `base: './'` passt bereits zum `/cable-planner/`-Subpfad; Kollab-Einladungslinks (`#join=`) funktionieren dann auch.

## ⚠️ Einmalige manuelle Einstellung (sonst kein Effekt)

**Repo → Settings → Pages → „Build and deployment" → Source = „GitHub Actions"**.
Ohne das schlägt nur der `deploy`-Step fehl — **es wird nichts überschrieben** (es gibt aktuell kein `gh-pages`/CNAME).

## Sicherheits-/Verifikations-Hinweise

- Trigger: Push auf `main` + manuell (`workflow_dispatch`).
- `libsecret-1-dev` wird installiert, damit `npm ci` nicht an keytar (nativ) scheitert — der Renderer-Build selbst nutzt keytar nicht.
- YAML validiert; `npm run build:renderer` erzeugt lokal verlässlich `dist/renderer/{index,viewer,mobile}.html`.
- **Caveat:** Der echte Pages-Lauf passiert erst nach Merge auf `main` (+ aktivierter Pages-Source). Ich kann den Deploy aus der Sandbox nicht selbst auslösen.

Hinweis: Eine öffentlich gehostete Editor-Variante macht die App für jeden im Browser nutzbar (MIT/gratis ohnehin). Falls du den Editor doch *nicht* öffentlich willst, sag Bescheid — dann hoste ich nur `viewer.html` + `mobile.html`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_