### PR TITLE
ci(pages): enablement zurücknehmen — Pages einmalig manuell aktivieren

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,11 +48,12 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev
       - run: npm ci
       - run: npm run build:renderer
+      # Auto-Aktivierung via `enablement: true` ist hier NICHT möglich: der
+      # GITHUB_TOKEN darf keine Pages-Site anlegen ("Resource not accessible by
+      # integration"). Daher EINMALIG manuell aktivieren:
+      #   Settings → Pages → Build and deployment → Source = "GitHub Actions".
+      # Danach deployt dieser Workflow bei jedem Push auf main automatisch.
       - uses: actions/configure-pages@v5
-        with:
-          # Pages automatisch aktivieren, falls noch nicht geschehen — spart
-          # den manuellen Settings-Schritt. Braucht pages:write (oben gesetzt).
-          enablement: true
       - uses: actions/upload-pages-artifact@v3
         with:
           path: dist/renderer


### PR DESCRIPTION
## Warum

Run #2 mit `enablement: true` scheiterte an:
> `Create Pages site failed. Error: Resource not accessible by integration`

Der Standard-`GITHUB_TOKEN` **darf keine Pages-Site anlegen** — Auto-Aktivierung aus dem Workflow ist also nicht möglich (GitHub-Limitierung). Pages muss **einmalig manuell** aktiviert werden.

## Änderung

- `enablement` entfernt (zurück auf Default `false`). Dann liefert `configure-pages` die **korrekte** Anleitung *„enable Pages and configure to build using GitHub Actions"* statt des irreführenden „Resource not accessible".
- Kommentar dokumentiert den nötigen Handgriff.

## Was du einmalig tun musst (danach läuft alles automatisch)

**Repo → Settings → Pages → „Build and deployment" → Source = „GitHub Actions"**

Danach: nächster Push auf `main` (oder „Run workflow") → die Seite ist live unter `https://larszu.github.io/cable-planner/` (+ `/viewer.html`, `/mobile.html`).

✅ Der **Build** ist zweimal nachweislich grün (`npm ci` + `build:renderer` + Artefakt) — es fehlt ausschließlich dieser eine Setting-Schalter, den die CI nicht selbst umlegen darf.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_