### PR TITLE
Festinstallation: mitwachsende Doku, Listen, Übergabe + F501.01-Labels, QR-Scan-Lookup & Feld-Rückkanal

### DIFF
--- a/docs/festinstallation-readiness.md
+++ b/docs/festinstallation-readiness.md
@@ -1,0 +1,449 @@
+# Cable-Planner für Festinstallationen — Bedarfsanalyse & Roadmap
+
+> Strategie-Dokument. Es beantwortet die Frage: *Was muss Cable-Planner
+> können, damit es nicht nur Show-/Event-Verkabelung plant, sondern
+> dauerhafte Festinstallationen dokumentiert, die nach der Erstinstallation
+> durch einen Dienstleister weiter verändert werden und dynamisch wachsen?*
+>
+> Adressaten der Features: **Betreiber/Endkunden**, **Elektro-/AV-Installateure**,
+> **Architekten/Planer** und der **wartende Dienstleister**.
+>
+> Stand: 2026-06 · Basis: Codebase v8.1.0 + Branchen-/Standard-Recherche
+> (Quellen am Ende).
+
+---
+
+## 0 · Kernthese in drei Sätzen
+
+Cable-Planner ist heute ein exzellentes Werkzeug für den **Projekt-Lebenszyklus
+einer Show**: aufbauen, dokumentieren, abbauen — der Plan ist eine Momentaufnahme.
+Eine Festinstallation hat einen **Betriebs-Lebenszyklus über Jahre**: der Plan
+ist ein *lebendes Dokument*, das jede Move/Add/Change überlebt, von wechselnden
+Personen gepflegt wird und am Ende einem fremden Dienstleister übergeben werden
+können muss. Die App hat das technische Fundament dafür überraschend weit
+(Revisionen, Annotations, Plan-Checks, Tie-Lines, Mobile-Sync), aber alle
+Konzepte sind auf den Show-Lebenszyklus zugeschnitten — der Schritt zur
+Festinstallation ist primär ein **Konzept- und Daten-Schritt, kein Rewrite**.
+
+---
+
+## 1 · Der fundamentale Unterschied: Projekt vs. Anlage
+
+| Dimension | Event/Show (heute) | Festinstallation (Ziel) |
+|---|---|---|
+| Lebensdauer des Plans | Tage bis Wochen | Jahre bis Jahrzehnte |
+| Wahrheitsbegriff | "wie geplant" (as-designed) | "wie gebaut", laufend aktuell (as-built / living) |
+| Wer pflegt | dieselbe Person, die geplant hat | wechselnde Techniker, oft fremde Firma |
+| Änderungsmodell | neuer Plan pro Job | inkrementelle MACs auf bestehender Anlage |
+| Wichtigster Wert | schneller, korrekter Aufbau | *Auffindbarkeit* Jahre später ("Was ist dieses Kabel?") |
+| Ortsbezug | Bühne/Locations frei platziert | echte Räume/Etagen, oft auf Gebäude-Grundriss |
+| Abschluss | Abbau | **Abnahme + Übergabe-Paket** |
+| Stückliste | Mietliste (Rentman) | Kaufteile + Reserve + Wartungsteile |
+
+Daraus folgen vier Bedürfnis-Cluster, die den Rest des Dokuments strukturieren:
+**(A)** mitwachsende Doku, **(B)** Installateur-Listen, **(C)** Architekten-Tauglichkeit,
+**(D)** Betreiber-/Kunden-Übergabe.
+
+---
+
+## 2 · Relevante Branchen-Standards (das Vokabular der Zielbranche)
+
+Festinstallation heißt: man bewegt sich in einem Feld mit etablierten Normen.
+Wer hier mitspielen will, sollte deren Begriffe sprechen — das ist gleichzeitig
+die beste Feature-Checkliste.
+
+**AV-Dokumentation & Symbole**
+- **ANSI/AVIXA D401.01:2023** — *Documentation Requirements for Audiovisual
+  Systems* (vormals INFOCOMM 2M-2010). Definiert das **Minimum an Doku** für
+  ein AV-Projekt: Deckblatt, Zeichnungsindex, Symbol-Legende, Abkürzungen,
+  Projekt-Notizen, Geräte-Detailblätter (Pinbelegung, Plattenlayouts),
+  Kabel-/Pfad-Informationen zwischen den Komponenten. → *Das ist die Norm, die
+  ein Architekt/Betreiber zitieren kann, um ein vollständiges Doku-Paket zu
+  verlangen.*
+- **ANSI J-STD-710 (CEA/CEDIA-2039, 2015)** — der **AV-Symbol-Standard**: 84
+  standardisierte Symbole für Grundriss- und Deckenspiegel-Zeichnungen
+  (Audio/Video/Control). *(Korrektur zu einem verbreiteten Irrtum: nicht
+  „F501“ — F501 ist Labeling.)*
+- **ANSI/AVIXA F501.01:2015** — *Cable Labeling for Audiovisual Systems*:
+  Label **an beiden Enden**, ≤ 2 Zoll vom Stecker, **gedrucktes
+  selbstlaminierendes** Etikett, hierarchisch **Quelle → Ziel** (Beispiel aus
+  der Norm: `VDA2 Out 3 to PROJ Input A`). Lebensdauer des Labels ≥ Lebensdauer
+  des Kabels. Handschrift/Isoband ausdrücklich unzulässig.
+
+**Strukturierte Verkabelung / Administration**
+- **ANSI/TIA-606-D (2021)** — Administrationsstandard: vergibt **Identifier**
+  für Räume, Racks (Grid-Koordinaten z. B. `AD02`), Patchpanels, **Ports**,
+  Kabel, Pfade, Anschlussdosen, Erdung, Brandschotts; definiert **Records**
+  (Felddefinitionen je Identifier), **Relationen** und **Reports**.
+  Vier **Klassen** (1 = ein Raum … 4 = Multi-Campus/WAN). Empfohlenes
+  **Farb-Code-Schema** (orange = Demarc, blau = Horizontal, grau/weiß =
+  Backbone, …).
+
+**Elektro / Pfad-Dimensionierung**
+- **NEC Chapter 9, Tables 1/4/5/8** — Conduit-Füllgrad (1 Leiter 53 %, 2 = 31 %,
+  ≥ 3 = 40 %); **NEC 392.22** — Kabeltrassen-Füllung (50 % Leiter, 40 %
+  Vollboden). (US; EU-Pendant DIN VDE / Trassen-Belegung sinngemäß.)
+
+**Test & Abnahme**
+- **ANSI/TIA-568 + TIA-1152** (Kupfer, Permanent-Link/Channel: Wiremap, Länge,
+  Insertion Loss, NEXT/PSNEXT, Return Loss, je mit Marge) und
+  **TIA-568.3 / ISO/IEC 14763-3** (Glas: Tier 1 OLTS pflicht, Tier 2 OTDR
+  optional). Test-Reports sind **Garantie-Voraussetzung** beim Hersteller.
+- **ANSI/AVIXA 10:2013 → D402.02** — *AV Systems Performance Verification*:
+  **160 Prüf-Items** in **13 Kategorien**; besonders relevant: **CABL**
+  (Labeling/Termination), **DOC** (Doku-Vollständigkeit als prüfbares Item),
+  **SERV** (Wartbarkeit).
+
+**Lebenszyklus**
+- **MAC / IMACD** (Moves, Adds, Changes [, Disposal]) — die Branchen-Sprache
+  für „Anlage verändert sich"; jede MAC ist die dokumentierte Änderungs-Einheit.
+- **Revisions-Disziplin**: Revisionsblock (Nr./Datum/Beschreibung/Autor),
+  Issue-Status (P/T-Sets → „Issued for Construction" Rev 0 → As-Built),
+  Schemata wie **R0 As-Designed / R2 As-Built / R3 As-Installed**.
+  Normen: ASME Y14.35, ISO 7200 (Titelblock-Felder), ISO 19650 (Living BIM).
+
+---
+
+## 3 · Was Cable-Planner heute schon hat (das Fundament — nicht wegwerfen)
+
+Wichtig für die Aufwandsschätzung: vieles ist da, nur anders gerahmt.
+
+| Vorhandenes Feature | Datei/Typ | Wiederverwendbar für … |
+|---|---|---|
+| **Revisionen mit `asBuilt`-Flag** (#412) | `ProjectRevision`, `revisionSlice.ts` | Versionierung/Change-Log einer Anlage |
+| **Annotations** mit Status `open/built/resolved` + Autor | `ProjectAnnotation`, `annotationSlice.ts` | Service-/Mängel-Tickets, Punch-List |
+| **Plan-Checks** (~20 Regeln) (#411) | `lib/drawingChecks.ts` | Commissioning-Checkliste (10:2013) |
+| **Tie-Line-Flag** (permanent vs. Show-Kabel) | `Cable.isTieLine` | Fest-Verkabelung vs. Patch unterscheiden |
+| **LocationFrame mit `floor`** | `LocationFrame`, `locationSlice.ts` | Raum/Etagen-Bezug (TIA-606) |
+| **Auto-Kabel-Nummerierung** | `lib/cableNumbering.ts`, `metadata.cableNumbering` | Label-IDs nach Schema |
+| **BOM-Aggregation via `cableSpecId`** | `cableSpec.ts`, `LocationBomDialog` | Material-/Stückliste je Raum |
+| **Längen-Schätzung** (geometrisch) | `metadata.lengthEstimation` | Pull-Listen mit Längen |
+| **Patch-Sheets + Patch-Liste** | `Print/`, `Patch/` | Installateur-Arbeitsblätter |
+| **DXF-Export (Layer-codiert)** | `lib/exportDxf.ts` | Übergabe an CAD |
+| **Mobile-Share + Bauteam-Häkchen** | `mobileShareServer.ts`, `checkState` | Vor-Ort-Erfassung |
+| **Read-only Viewer + Annotations-Merge** | `.cpviewer`, `project:import-annotations` | Übergabe an Kunde/Fremdfirma |
+| **NetBox-Import** (DCIM) | `library.netbox.*` | Brücke in die Facility-/IT-Welt |
+| **CRDT-Fundament** (Yjs, Konvergenz bewiesen) | `lib/crdt/projectCrdt.ts` | Mehr-Personen-Pflege |
+| **Geräte-Metadaten** (Serien-Nr., IP/VLAN, Firmware, Power, Bilder, Notes, `categoryProps`) | `EquipmentItem` | Asset-Register |
+| **`importSource` + stabile `graphmlId`** | `EquipmentItem` | Re-Import/Sync ohne Datenverlust |
+
+**Lücke auf einen Blick:** kein Gebäude-Grundriss-Underlay, keine echte
+Change-History „wer/was/wann" pro Edit, kein Übergabe-/Abnahme-Paket, kein
+QR-Label-Lookup, keine standardisierten Symbole/Layer, keine Asset-
+/Wartungs-Historie, keine Mehr-Personen-Live-Pflege im Produktivbetrieb.
+
+---
+
+## 4 · Bedarf nach Zielgruppe (Gap-Analyse + konkrete Features)
+
+### 4.A · Mitwachsende Doku — das Herzstück (Betreiber + wartender Dienstleister)
+
+Die Forderung aus dem Auftrag: *Die Vor-Ort-Doku darf nicht nur ein gedrucktes
+DIN-A0-Schema vom Installationszeitpunkt sein; Anpassungen müssen leicht
+nachtragbar sein, auch ohne den ganzen Plan in technischer Tiefe zu verstehen.*
+
+Das braucht es:
+
+1. **Echte Change-History pro Anlage** (nicht nur Snapshots).
+   - Jede Änderung als Eintrag: *wer, wann, was, warum* (Branchen-Begriff: **MAC/IMACD**).
+   - Diff-Ansicht zwischen zwei Revisionen („zwischen Rev 4 und Rev 7 wurden
+     diese 3 Kabel ergänzt, 1 Gerät getauscht").
+   - Aufbauen auf `ProjectRevision` (#412) → von „manueller Snapshot" zu
+     automatischem, attribuiertem Change-Log. Voraussetzung: persistente
+     Autor-Identität (heute fehlt sie — siehe 4.A-Punkt 5).
+
+2. **„Quick-Edit"-Modus für Nicht-Planer.**
+   - Ein vereinfachter Erfassungs-Fluss: „Ich habe vor Ort ein Kabel von Dose
+     12 zu Switch-Port 8 gezogen" — ohne Canvas-Layout-Verständnis.
+   - Realistisch der **Ausbau der Mobile-Ansicht vom Read/Check-only zum
+     Light-Editor** (Architektur-Doku §6.6 nennt genau das als nächsten Schritt;
+     braucht eine echte API-Schicht statt File-Push).
+   - Erfassbar mit minimalem Wissen: Endpunkt A / Endpunkt B (per Label-Scan
+     wählbar), Kabeltyp, Foto, Notiz. Der Eintrag landet als „pending change"
+     im Haupt-Plan, der Planer bestätigt/platziert ihn später.
+
+3. **Status-Lebenszyklus pro Kabel/Gerät** über den Show-Zustand hinaus.
+   - Heute: `checkState` (gebaut/nicht). Für Festinstallation:
+     `geplant → installiert → getestet → in Betrieb → außer Betrieb → entfernt`.
+   - Damit bleibt Historie sichtbar statt Daten zu löschen (Heal-Invariante:
+     Userdaten nie still löschen → „retired"-Status statt Delete).
+
+4. **Foto-/Dokument-Anhänge an Geräten, Kabeln, Räumen.**
+   - „Was ist das?" beantwortet ein Foto besser als jede Zeichnung.
+   - Heute sind Bilder Data-URIs im Projekt-File (Größen-Problem bei Festanlagen
+     mit hunderten Fotos). → **Asset-Ordner neben der Projektdatei** + Referenz
+     statt Inline-Base64 (analog Library-Ordner). Wartungs-Handbücher (PDF),
+     Mess-Protokolle, Garantiescheine als Anhang.
+
+5. **Persistente Bearbeiter-Identität + Mehr-Personen-Pflege.**
+   - Heute alle Edits anonym; nur Annotations haben Autor. Für ein lebendes
+     Dokument unverzichtbar: jede Änderung einem Bearbeiter zuordnen.
+   - Skalierungspfad steht in Architektur-Doku §9.4: CRDT-Fundament (#413)
+     existiert; nächste Stufe Transport + Store-Bindung. Für reine
+     *Nachvollziehbarkeit* reicht aber schon ein Bearbeiter-Name in den
+     Revisions-/Change-Einträgen — das ist die günstige erste Stufe.
+
+### 4.B · Elektro-/AV-Installateure — die Arbeitslisten
+
+Installateure setzen *Teile* des Plans um und arbeiten **nicht am Canvas**,
+sondern aus **Excel/CSV (editierbar, sortierbar, Status-trackbar) und PDF**
+(ausgegeben/abgenommen). Cable-Planner kann diese Listen generieren — heute
+fehlt der Großteil als strukturierter Export.
+
+1. **Pull-Liste / Pull-Schedule** (die wichtigste fehlende Liste).
+   Spalten (Branchen-Standard): `Kabel-ID/Label` · `Von → Nach`
+   (Rack-Panel-Port ↔ Raum-Dose-Port) · `Kabeltyp` · `Länge` (as-built, nicht
+   Luftlinie) · `Pfad/Trasse` · `Mantel/Brandklasse` (CM/CMR/CMP/LSZH) ·
+   `Termination` (T568A/B, LC/SC/MPO) · `Trommel/Reel` ·
+   `Status` (geplant/gezogen/aufgelegt/getestet) · `Testergebnis` · `Notiz`.
+   → Datenbasis größtenteils vorhanden (`Cable.from/to`, `length`, `type`,
+   `cableNumber`); fehlen Pfad/Trasse, Mantel-/Brandklasse, Reel, Status.
+
+2. **Kabel-Schedule** (Design-Register) und **Termination-Liste**
+   (welcher Leiter auf welche Klemme/Port, beide Enden) — TIA-606-Mapping
+   Panel-Port ↔ Dose-Port.
+
+3. **Anschlag-/Conduit-Fill-Hinweis pro Trasse** — Conduit-Größe/-Typ,
+   Leiterzahl, Füllgrad-Check (NEC Ch. 9 / 392.22 bzw. DIN VDE). Passt
+   konzeptionell zu den bestehenden Plan-Checks (`lib/drawingChecks.ts`).
+
+4. **Cut-Liste / BOM mit Längen + Reserve** — heute BOM via `cableSpecId`
+   vorhanden; ergänzen um Schnittlängen, ~10 % Reserve, Patchpanel-Ports in
+   12er-Schritten, 90-m-Permanent-Link-Grenze als Check.
+
+5. **Test-/Zertifikats-Erfassung** — pro Kabel Pass/Fail + Marge + Referenz
+   auf die Fluke-/OLTS-Report-Datei (Garantie-Nachweis). Mindestens als
+   Status-Feld + Datei-Anhang.
+
+> Querschnitt: **Excel/CSV-Export mit Status-Spalten** ist für Installateure
+> Pflicht (xlsx ist bereits Dependency: `xlsx-js-style`). Der PDF-Pfad existiert
+> schon; CSV/Excel-Listen sind der größte Quick-Win für diese Gruppe.
+
+### 4.C · Architekten / Planer — Tauglichkeit für den Bau-Kontext
+
+Kernforderung: AV-/Kabel-Doku muss aussehen, benannt, skaliert, layered, nummeriert
+und revisioniert sein **wie der Rest des Architektur-/MEP-Plansatzes** — sonst ist
+sie im Bau-Workflow nicht koordinierbar.
+
+1. **Grundriss-Underlay (DWG/PDF) als maßstäblicher Hintergrund.**
+   Der mit Abstand größte Hebel und die größte Lücke. Geräte/Dosen/Trassen
+   werden *auf den Gebäudeplan* gezeichnet, nicht ins Leere. Braucht:
+   PDF/DWG-Import als nicht-editierbares Underlay, Kalibrierung auf bekannte
+   Maße, maßstäbliche Platzierung (1:50/1:100). Erst damit werden
+   Kabel-Längen vom Plan und Geräte-Positionen vertrauenswürdig.
+
+2. **Standardisierte Symbole (J-STD-710) + Legende-Blatt.**
+   84 Norm-Symbole statt Haus-Stil; automatische Legende. Heute hat die App
+   `ConnectorSymbol` u. ä. — aber keine plan-view J-STD-710-Symbolbibliothek.
+
+3. **AIA/NCS-Layer & Sheet-Nummerierung.** AV/Kabel gehört auf **T-Layer**
+   (Telecom), Strom auf **E-**, Architektur auf **A-**; Blätter als
+   `T-101` etc. im Zeichnungsindex. Der DXF-Export ist schon Layer-codiert —
+   auf Norm-Layer-Namen mappen.
+
+4. **Maßstäbliche, normgerechte Plansätze** mit Titelblock (ISO 7200-Felder:
+   Eigentümer, Status, Revision, Datum, Freigabe) — Titelblock existiert im
+   Export rudimentär, fehlende Felder ergänzen.
+
+5. **Revisions-Disziplin auf Zeichnungen**: Revisionswolken + Delta-Dreiecke +
+   Revisionstabelle, Issue-Status (Tender/Construction/As-Built). Knüpft an
+   Revisionen (#412) und Annotations an.
+
+6. **Riser-Diagramm & Deckenspiegel (RCP)** — vertikale Steig-Schemata
+   zwischen Etagen (Bezug zu `LocationFrame.floor`); RCP für Decken-Geräte
+   (Beamer, Lautsprecher, Kameras).
+
+7. **Koordination mit anderen Gewerken** — pragmatisch: sauberer **IFC-/DWG-
+   Austausch** und Pfad-/Trassen-Objekte mit Geometrie, damit AV-Pfade in die
+   Navisworks/ACC-Clash-Welt einspeisbar sind. (Voll-BIM ist out of scope; das
+   Ziel ist *interoperabel*, nicht *Revit-Ersatz*.)
+
+### 4.D · Endkunden / Betreiber — Übergabe & Langzeit-Betrieb
+
+1. **Übergabe-/Closeout-Paket als Ein-Klick-Export.** Die Branche hat dafür
+   eine fertige Inhaltsliste — das ist eine konkrete Export-Spezifikation:
+   As-built-Zeichnungen · O&M-Handbuch · Asset-Register · Commissioning-/
+   Test-Zertifikate · Garantien · Ersatzteil-/Reserve-Liste · Schulungsnachweis.
+   Vieles davon kann Cable-Planner aus vorhandenen Daten erzeugen.
+
+2. **QR-Label → digitaler Datensatz** („Was ist dieses Kabel? Wo geht es hin?").
+   Mainstream-Praxis aus der CMMS-Welt. Jedes Kabel/Gerät bekommt eine kurze
+   stabile ID + QR; Scan öffnet den Datensatz (Endpunkte, Typ, Foto, Historie)
+   im Read-only-Viewer/Mobile. Konventionen: kurze stabile ID, ≥ 1,6 cm,
+   langlebiges Material. → Baut direkt auf `cableNumber` + Viewer/Mobile auf.
+
+3. **Verständliche, nicht-technische As-built-Sicht.** Eine Betreiber-Ansicht,
+   die „wo ist was / wo geht das hin" beantwortet, ohne Signalfluss-Tiefe.
+   Read-only-Viewer ist die Basis; braucht einen „Laien-Modus".
+
+4. **Asset-/Wartungs-Register.** Pro Gerät: Serien-Nr. (vorhanden), Standort,
+   Garantie/Ablauf, Wartungsintervall, Service-Historie. Optional Export/Sync
+   in ein CMMS. Felder größtenteils via `EquipmentItem` + `categoryProps`
+   schon modellierbar; Wartungs-Historie ist neu.
+
+5. **Kein Vendor-Lock-in.** Offenes, vollständiges Übergabe-Paket = jeder
+   Folge-Dienstleister kann übernehmen. Das ist sogar ein Verkaufsargument
+   *für* das Tool (der Erst-Installateur liefert saubere Doku als Differenzierung).
+
+---
+
+## 5 · Konkrete Datenmodell-Änderungen (gemappt auf die Architektur)
+
+Alle neuen optionalen Felder gehören in `src/renderer/types/` + Default-Setzung
+in `healProjectPositions` (Architektur-Invariante §5.2). Stichpunkte:
+
+- **`Cable`**: `installStatus` (geplant…entfernt), `pathwayId`/`trasse`,
+  `jacketRating` (CM/CMR/CMP/LSZH), `reel`, `terminationA/B`,
+  `testResult` {pass, marginDb, reportRef}, `labelId` (TIA-606/F501-konform),
+  `qrId`.
+- **`EquipmentItem`**: `assetTag`/`qrId`, `warrantyUntil`, `maintenanceIntervalDays`,
+  `serviceHistory[]`, `attachments[]` (Datei-Referenzen statt Inline),
+  `installStatus`, `roomRef` (TIA-606 Raum-/Grid-ID).
+- **Neuer Typ `ChangeLogEntry`** (`types/changelog.ts`): {id, ts, author, kind
+  (move/add/change/dispose), targetRef, summary, revisionId}. Eigener
+  **`changelogSlice.ts`**; speist Diff-Ansicht.
+- **Neuer Typ `Pathway`/`Trasse`** (Conduit/Tray) mit Geometrie + Füllgrad —
+  Canvas-Objekt analog `LocationFrame`.
+- **`ProjectMetadata`**: `floorplanUnderlay` {fileRef, scale, calibration},
+  Titelblock-Felder (ISO 7200), Standard-Doku-Profil (D401.01).
+- **Asset-Storage**: Ordner neben `.cableplan` (analog `userData/library/`),
+  atomic writes; Fotos/PDFs als Referenz. Vermeidet Projekt-File-Bloat.
+- **Neuer IPC-Domain** `assets:*` (Datei-Anhänge) bzw. Ausbau `mobileShare:*`
+  zum Light-Editor mit echter API (Architektur-Doku §6.6).
+- **Export**: neue Generatoren in `components/Export/` — Pull-Liste (CSV/xlsx),
+  Termination-Liste, Übergabe-Paket (ZIP/PDF-Bundle), Commissioning-Checkliste
+  (10:2013-Stil aus `drawingChecks` ableitbar).
+
+> Heal als Migrationsschicht trägt das: bestehende `.cableplan`-Dateien laden
+> weiter, neue Felder bekommen Defaults, nichts wird gelöscht.
+
+---
+
+## 6 · Wettbewerb & Positionierung
+
+Die Recherche bestätigt die Markt-These (schlechte Doku-Tools, hohe Preise) und
+— wichtiger — zeigt eine **konkrete, unbesetzte Lücke**.
+
+**Die nächsten Analoga zu Cable-Planner (direkteste Wettbewerber):**
+- **WireCAD** — das am ehesten vergleichbare Tool: Punkt-zu-Punkt, Auto-Kabel-
+  Nummerierung, Block-Diagramme aus DB, Rack-Layouts, Labels/BOM/Schedules.
+  Aber: gealterter Windows-Desktop mit **SQL-Server-Pflicht** für Mehrbenutzer,
+  **2D-only**, intransparente Preise, praktisch keine Community/Reviews. Stark
+  bei Kabel-Daten, **schwach bei Grundriss-Integration und Übergabe**.
+- **NetBox (DCIM, Open Source)** — bestes *maschinenlesbares* Kabel-Pfad-Tracing,
+  API-first, gratis. Aber: **keine AV-Medien/Steckertypen** (HDMI/SDI/XLR-
+  Erweiterung als „not planned" abgelehnt, Issue #11019), **kein 1-zu-N-Signal**
+  (DA/Matrix/Splitter strukturell unmöglich, Disc. #21772), keine Zeichnungen,
+  data-entry-lastig. → *Genau die zwei NetBox-Schwächen (AV-Signaltypen,
+  1-zu-N-Verteilung) kann Cable-Planner heute schon* — relevant nur als
+  Schnittstelle/Datenmodell-Vorbild, nicht als Wettbewerber.
+
+**AV-Design-Plattformen (Cluster mit Doku-Anspruch):**
+- **D-Tools SI** — Branchen-Schwergewicht; tiefste Engineering-Zeichnungen, aber
+  **nur über externes Visio/AutoCAD** (Zusatzlizenz), steile Lernkurve,
+  ~150 $/User/Monat + ~200 $/h Setup, Support-Klagen. **D-Tools Cloud** ist
+  bewusst schwach bei Zeichnungen (nur Markup/„Visual Quoting").
+- **XTEN-AV** — Cloud/AI-nativ, schnelle Auto-Schematics, riesige Library; aber
+  **keine eindeutigen Geräte-Namen → manuelle Label-Nacharbeit**, keine echten
+  Maße/Linien, Save/Reopen-Bugs, per-Seat teuer. Benennt selbst die Schmerzen:
+  fehlende BOM-Verknüpfung, **Spreadsheet-Schedules brechen zusammen**, siloierte
+  Tools, Daten fließen nicht über den Lebenszyklus.
+- **Stardraw / Visio+Stencils / AutoCAD** — von „AV-nativ aber Legacy" (Stardraw,
+  140k Symbole, J-STD-710) über „billig aber dumme Zeichnungen, alles manuell"
+  (Visio) bis „Pflicht-Format DWG, aber keine AV-Intelligenz" (AutoCAD).
+
+**Übergreifende Branchen-Klagen (mehrfach unabhängig belegt):**
+1. As-builts veralten / Feldänderungen werden nie erfasst → Techniker
+   „reverse-engineeren" die Anlage beim Service-Call.
+2. Doku-Tools enden bei Design/Verkauf, **nichts überlebt in die
+   Wartungs-/Betriebsphase**.
+3. Kein brauchbares Übergabe-Paket für den Betreiber (NIST GCR 04-867:
+   **~10,6 Mrd. $/Jahr** Betreiber-Last durch verlorene Projektdaten, größter
+   Anteil in O&M).
+4. Manuelles Labeling fehleranfällig; **Label ↔ Datensatz driften auseinander**.
+5. Schematic ↔ Grundriss ↔ BOM driften (kein Single Source of Truth).
+6. Tools zu teuer/komplex für kleine Integratoren; **Abo-Zwang-Frust**
+   (Bluebeam, Vectorworks, AutoCAD).
+
+**Lücke = Positionierung für Cable-Planner:** Kein einziges Tool vereint heute
+*strukturierte Kabel-/Signal-Daten* **+** *gezeichnete Pläne* **+** *lebende,
+mitwachsende As-built* **+** *übergebbares Betreiber-Paket*. WireCAD/NetBox haben
+die Daten, aber keine Übergabe; D-Tools/XTEN-AV haben Design, aber Lebenszyklus-
+Lücken und Lock-in. Cable-Planner ist als **bezahlbares, offline-fähiges,
+Desktop-first Tool** positioniert, das die *Lücke zwischen Show-Tool und schwerem
+CAD/CMMS* füllt — mit dem Killer-Feature, das alle vermissen: **durchgängige,
+lebende, übergebbare Doku vom Plan bis zum Service-Call** (Label/QR → Datensatz →
+Historie), standard-konform (D401.01, F501.01, J-STD-710, TIA-606), ohne
+Abo-Falle. Die schon vorhandene **AV-Signal-Intelligenz + 1-zu-N-Verteilung +
+3D-Rack** ist dabei genau das, woran NetBox scheitert und was WireCAD/Visio nicht
+sauber können.
+
+---
+
+## 7 · Roadmap / Priorisierung
+
+**Stufe 1 — „Festinstallation MVP" (höchster Wert, baut auf Vorhandenem)**
+1. Bearbeiter-Identität + echtes Change-Log (`ChangeLogEntry`, attribuierte
+   Revisionen, Diff-Ansicht). → 4.A
+2. Installateur-Listen als CSV/xlsx: **Pull-Liste**, Termination-Liste, BOM mit
+   Reserve. → 4.B
+3. `installStatus` + Datei-Anhänge (Asset-Ordner statt Inline-Base64). → 4.A/D
+4. **Übergabe-Paket-Export** (Bundle aus vorhandenen Daten). → 4.D
+
+**Stufe 2 — „Plan auf dem Gebäude"**
+5. Grundriss-Underlay (PDF/DWG) + Kalibrierung + Maßstab. → 4.C
+6. QR-Label-Generierung + Scan-Lookup im Mobile/Viewer. → 4.D
+7. J-STD-710-Symbole + Norm-Layer/Titelblock im Export. → 4.C
+
+**Stufe 3 — „Lebende, gepflegte Anlage"**
+8. Mobile Light-Editor (Read/Check → erfassen) mit echter API. → 4.A
+9. Trassen/Conduit-Objekte + Füllgrad-Checks. → 4.B/C
+10. Mehr-Personen-Pflege (CRDT-Transport, #413 weiterführen). → 4.A
+11. Commissioning-Checkliste (10:2013) + Test-Erfassung. → 4.B/D
+12. CMMS-/Asset-Register-Export. → 4.D
+
+Reihenfolge folgt der Standing Directive „Patch-Versionen bevorzugt" — jede
+Nummer ist als eigener, kleiner PR schneidbar; keine großen Sprünge.
+
+---
+
+## 8 · Quellen
+
+**AV-Doku & Symbole**
+- ANSI/AVIXA D401.01:2023 — https://www.avixa.org/resources/standards/documentation-requirements-for-audiovisual-systems
+- ANSI J-STD-710 (Symbole, 84) — https://www.avixa.org/standards/audio-video-and-control-architectural-drawing-symbols · https://www.sdmmag.com/articles/91402
+- ANSI/AVIXA F501.01:2015 (Labeling) — https://www.avixa.org/standards/cable-labeling-for-audiovisual-systems · https://standards.globalspec.com/std/10030464/F501.01
+- AVIXA 10:2013 / D402.02 (Verification, 160 Items / 13 Kategorien) — https://www.avixa.org/standards/audiovisual-systems-performance-verification · https://www.ravepubs.com/infocomms-audiovisual-systems-performance-verification-guide/
+
+**Strukturierte Verkabelung**
+- TIA-606-C/D (Administration, Klassen, Identifier, Farbcode) — https://www.cablinginstall.com/cable/article/14035166 · https://www.tiafotc.org/tia-standards-update/tia-606-d/ · https://navepoint.com/blog/cable-color-codes-ansitiaeia606/
+
+**Installateur-Dokumente**
+- Pull-Schedule (TIA-568) — https://capitalbuildcon.com/cable-pull-schedule-tia-568-a-practical-template-based-guide/
+- Kabel-/Termination-Schedule — https://automationforum.co/instrument-cable-schedule/ · https://docs.hexagonppm.com/r/en-US/CADWorx-Electrical-and-Instrumentation-Design-Suite/1367574
+- NEC Ch. 9 Conduit Fill / 392.22 Tray — https://expertce.com/learn-articles/nec-chapter-9-table-1-conduit-fill/ · https://fasttraxsystem.com/nec-392-22b1c-explained-cable-tray-sizing-for-mixed-single-conductors/
+- Test/Zertifizierung (TIA-1152 Kupfer / OLTS-OTDR Glas) — https://www.belden.com/blog/ansi-tia-1152-and-cat-6a-testing · https://www.belden.com/blog/olts-or-otdr-which-test-is-acceptable-for-fiber-certification
+
+**Architekten / Planer**
+- US National CAD Standard / AIA Layer Guidelines (Layer, Sheet-Nr.) — https://www.nationalcadstandard.org/ncs6/content.php · https://www.archtoolbox.com/construction-document-sheet-numbers/
+- Maßstäbe — https://www.archdaily.com/904882/understanding-and-using-architectural-scales
+- PDF/DWG-Underlay — https://novedge.com/blogs/design-news/autocad-tip-pdf-underlay-best-practices-for-autocad
+- MEP-Koordination / Clash — https://bim-services.us/mep-coordination-guide/
+- Revisions-Delta-Prozess — https://vdci.edu/learn/autocad/understanding-the-delta-ing-process-in-architectural-design-development
+
+**Betreiber / Handover / Lifecycle**
+- As-built / Record / O&M / Closeout — https://www.designingbuildings.co.uk/wiki/O&M%20Manuals · https://mclinestudios.com/understanding-as-built-drawings-in-architectural-documentation/ · https://www.documentcrunch.com/blog/construction-project-closeout
+- QR / Asset-Tagging / CMMS — https://blog.invgate.com/qr-codes-for-asset-management · https://www.getmaintainx.com/blog/optimizing-maintenance-with-qr-codes-and-a-cmms · https://upkeep.com/blog/what-is-cmms/
+- MAC / IMACD — https://www.techtarget.com/searchdatacenter/definition/moves-adds-and-changes-MAC
+- Revisions-Standards (ASME Y14.35 / ISO 7200) — https://ndia.dtic.mil/wp-content/uploads/2008/technical/GastonEngineeringDrawingsY14_35.pdf
+- Acceptance/SAT/Punch-List — https://flowdit.com/glossary/site-acceptance-test/ · https://en.wikipedia.org/wiki/Punch_list
+
+**Wettbewerb**
+- Vectorworks/ConnectCAD — https://www.vectorworks.net/en-US/connectcad/capabilities · https://xtenav.com/vectorworks-connectcad-pricing/
+- Bluebeam Revu — https://www.bluebeam.com/product/ · https://www.bluebeam.com/pricing/
+- Branchen-Doku-Lücken — https://xtenav.com/av-rack-cable-management-mistakes-that-delay-projects/ · https://vocal.media/fyi/top-5-av-design-software-tools-for-professionals-in-2025
+
+> Methoden-Hinweis: Die zitierten Norm-Nummern wurden je gegen ≥ 2 Quellen
+> geprüft. Einige Norm-Volltexte (AVIXA/ANSI/TIA) sind kostenpflichtig; die
+> Detail-Feldlisten stammen aus den offiziellen Beschreibungen plus
+> Sekundärquellen, nicht aus dem Norm-Volltext.

--- a/docs/festinstallation-readiness.md
+++ b/docs/festinstallation-readiness.md
@@ -447,3 +447,113 @@ Nummer ist als eigener, kleiner PR schneidbar; keine großen Sprünge.
 > geprüft. Einige Norm-Volltexte (AVIXA/ANSI/TIA) sind kostenpflichtig; die
 > Detail-Feldlisten stammen aus den offiziellen Beschreibungen plus
 > Sekundärquellen, nicht aus dem Norm-Volltext.
+
+---
+
+## 9 · Markt-Validierung — gelobte Features & unbesetzte Lücken
+
+Ergänzende Recherche (Review-Portale, Vendor-Feature-Request-Boards, Fachpresse,
+Foren): *Was loben Nutzer an anderer Software, und welche Wünsche erfüllt kaum
+jemand?* Methoden-Hinweis: Capterra/G2/TrustRadius und die Canny-Boards
+blockieren automatisches Abrufen (403); Zitate stammen aus Such-Index-Snippets
+derselben Seiten plus Hersteller-/Help-Dokus. NetBox-GitHub-Issues sind direkt
+verifiziert. **Reddit war hart blockiert** — verifizierte Reddit-Zitate fehlen.
+
+### 9.1 · Top-5 Features, die Nutzer loben
+
+1. **„Die Zeichnung ist die Datenbank"** — Schedule/Etiketten/BOM/Rack aus dem
+   Plan generiert + auto-Kabelnummerierung mit Fehlerprüfung (WireCAD,
+   ConnectCAD, XTEN-AV „~80 % Block-Diagramme automatisch", D-Tools).
+   *CP heute: teilweise (Nummerierung, Patch-Liste, BOM, Installateur-Listen).*
+2. **Riesige Hersteller-Bibliothek** mit echten Port-Daten/Preisen (Stardraw
+   140k, D-Tools 2 Mio., XTEN-AV 1,5 Mio., SketchUp 3D-Warehouse).
+   *CP heute: ~500 Templates + NetBox-Import.*
+3. **Echtzeit-Multi-User-Kollaboration** (Lucidchart, Bluebeam Studio Sessions,
+   Jetbuilt). *CP heute: nur CRDT-Fundament (#413).*
+4. **Reaktiver Support + mitwachsende Bibliothek + niedrige Lernkurve**
+   (XTEN-AV „Parts in 48 h", SketchUp, Jetbuilt-Onboarding, Q-SYS).
+5. **Vor dem Bau validieren** (Q-SYS Emulate Mode; ConnectCAD/WireCAD
+   Error-Checking; XTEN AI Connection Checker). *CP heute: stark —
+   `drawingChecks.ts` (#411) mit ~20 Regeln.*
+
+Sekundär oft gelobt: daten-verknüpfte Diagramme (Visio/Lucid), Maß-/Takeoff +
+Dokument-Vergleich (Bluebeam), 3D-Client-Visualisierung (SketchUp),
+Back-Office/QuickBooks + Mobile-Install mit Barcode (D-Tools), Auto-Kabellänge
+aus skaliertem Grundriss (D-Tools Wirepath / ConnectCAD), Source-of-Truth +
+Audit-Log + API (NetBox).
+
+### 9.2 · Wünsche, die kaum/niemand erfüllt (Rang nach „wie offen")
+
+| # | Wunsch | Verdikt | Bestes Tool heute |
+|---|---|---|---|
+| ① | Daten-Eigentum/Kontrolle, kein Vendor-Lock-in/still ablaufende Lizenzen | **offen** (im AV-Doku-Bereich) | — (alle Cloud-Abo) |
+| ② | Bestehende „chaotische" Doku importieren (PDF/Scans/Alt-Bestand) | **offen** | Cable Pilot (nur CSV) |
+| ③ | Lebendes As-built mit **Feld-Rückkanal** (Vor-Ort → kanonischer Datensatz) | **teilweise** (Design-Time ja, Feld-Loop nein) | WireCAD |
+| ④ | Kabel-natives QR-Lookup (Scan → Kabel-Datensatz im selben Modell) | **teilweise** (generisch ja, kabel-nativ nein) | GoCodes u. a. (generisch) |
+| ⑤ | Foto vom Rack → editierbare Doku (KI) | **offen** | RackScan (Startup, Android-only) |
+| – | Auto-Kabellänge aus skaliertem Grundriss | **gelöst** (nicht Lücke) | D-Tools Wirepath, ConnectCAD |
+| – | Doku **für Betreiber** statt Ingenieure (Laien-Sicht) | **offen** | — |
+| – | Konfig-/Intent- & Steuerungs-Code-Übergabe („BOM ≠ working room") | **offen** | — |
+
+**Wichtige Korrektur:** „Offline / kein Abo" ist als *Wunsch* schwächer belegt,
+als zunächst angenommen. Der einzige unabhängige Artikel (Commercial Integrator,
+„How AV Integrators Are Misreading Subscription Sales") rahmt den Widerstand als
+**Kontrolle/Risiko, nicht Abo-Hass**; D-Tools hat den Offline-Mobile-Wunsch
+inzwischen *bedient*. Daher ① als **Daten-Eigentum/Kontrolle** positionieren,
+nicht als „kein Abo".
+
+### 9.3 · Board-verifizierte, konkrete Wünsche (mit Quelle)
+
+- **Auto-Kabel-ID = Quelle→Ziel nach AVIXA F501.01** — D-Tools-Request
+  „Cable ID Format to include source and destination" („ohne jedes Kabel manuell
+  zu labeln"). → *CP-Quick-Win: Geräte-/Port-Namen + `cableLabelId` sind da.*
+  <https://d-tools.canny.io/feature-requests/p/cable-id-format-to-include-source-and-destination>
+- **Living/Lifecycle-As-built nach Übergabe** — D-Tools „Client Sites" (Items
+  „become assets, drawings continuously updated over the life of the system")
+  + „end user portal". → *deckt sich mit unserem Lebenszyklus-/Asset-Pfad.*
+  <https://d-tools.canny.io/feature-requests/p/client-sites>
+- **Auto-Revisions-/Versionshistorie auf der Zeichnung** — D-Tools „Drawings
+  Version/Revision History". → *deckt sich mit Revisionen (#412) + changelog.*
+  <https://d-tools.canny.io/feature-requests/p/drawings-version-revision-history-visio>
+- **„Drawing-Package"-Lücke** (Schedule + Floor-plan-Markup + Line-Drawings als
+  *ein* Paket) — mehrfach von Tool-Wechslern gevotet.
+  <https://dt.canny.io/drawings/p/cable-schedule>
+- **BOM ↔ Items ↔ Label live in Sync** — XTEN-AV-Reviewer: „wish the initial BOM
+  and Areas & Items were linked and updated simultaneously"; „no way to assign
+  unique device names → extra time for cable labels".
+  <https://www.softwareadvice.com/project-management/xten-av-profile/>
+- **NetBox (voll verifiziert):** `cable_id`-Feld (#2271), Serien-Nr./Länge/Typ
+  (#619), „cable groups" für strukturierte Verkabelung (#7976) — bestätigt die
+  Kabel-Metadaten, die wir ergänzt haben (`qrId`, `jacketRating`, Termination …).
+  <https://github.com/netbox-community/netbox/issues/7976>
+
+### 9.4 · Schlussfolgerung
+
+Die Schnittmenge ist günstig: **drei der größten offenen Lücken (①, ③, ④) liegen
+dort, wo Cable-Planner bereits ein Fundament hat** — lokales Datei-/Daten-Modell
+(①), Lebenszyklus/Änderungsprotokoll (③), QR-IDs (④). Empfohlene Reihenfolge:
+
+1. **Positionierung „eigene Daten / kein Lock-in"** aktiv ausspielen (①, kostet
+   fast nichts).
+2. **Feld-Rückkanal** (Mobile-Light-Editor → pending changes ins
+   Änderungsprotokoll) — schließt ③.
+3. **QR-Scan-Lookup** im Viewer/Mobile (④, baut auf den neuen qrIds auf).
+4. **Auto-Kabel-ID Quelle→Ziel (F501.01)** — kleiner, board-gevoteter Quick-Win.
+5. **KI-Import von Alt-Doku (PDF/CSV)** (②) — größter „das-hat-keiner"-Effekt,
+   höherer Aufwand.
+
+Von den **gelobten** Features am ehesten ausbauen: „Auto-Doku/Etiketten aus einer
+Quelle" (9.1-1) und die schon starke Plan-Validierung (9.1-5) sichtbarer machen.
+
+### 9.5 · Zusätzliche Quellen (Markt-Validierung)
+
+- D-Tools Canny (Boards) — <https://d-tools.canny.io/feature-requests> · <https://dt.canny.io/drawings>
+- XTEN-AV Reviews — <https://www.capterra.com/p/10008832/XTEN-AV/reviews/> · <https://www.softwareadvice.com/project-management/xten-av-profile/>
+- NetBox Issues — #2271, #619, #7976, #11019 (<https://github.com/netbox-community/netbox/issues>)
+- As-built-Drift / Handover — <https://www.cablinginstall.com/design-install/article/16467178/turning-cabling-documentation-into-a-strategic-asset> · <https://www.avixa.org/explore/articles/multi-vendor-av-stack-ownership> · <https://integrio.app/seamless-handovers-creating-professional-av-project-documentation-that-wows-clients-and-saves-you-time/>
+- Betreiber-Sicht / Commissioning — <https://www.avixa.org/pro-av-trends/articles/what-do-facility-managers-wish-av-specialists-knew> · <https://www.appa.org/facilities-manager/finishing-av-projects-ten-commissioning-tips-for-facilities-managers/>
+- BOM ≠ Working Room / Code-Ownership — <https://www.ravepubs.com/the-av-bill-of-materials-bom/> · <https://www.ravepubs.com/who-owns-the-code/>
+- Subscription-Nuance — <https://www.commercialintegrator.com/insights/how-av-integrators-are-misreading-subscription-sales/146404/>
+- Foto→Doku (Startup) — <https://rackscan.app/>
+- Lob-Quellen — <https://www.g2.com/products/lucid-software-inc-lucid-visual-collaboration-suite/reviews> · <https://www.trustradius.com/products/bluebeam-revu/reviews> · <https://help.qsys.com/Content/Q-SYS_Designer/003_Emulate_Mode.htm> · <https://www.capterra.com/p/149371/Jetbuilt/reviews/>
+

--- a/docs/inventory-rental-readiness.md
+++ b/docs/inventory-rental-readiness.md
@@ -1,0 +1,130 @@
+# Lager- & Inventar-Verwaltung — Readiness & Plan
+
+Analyse: Was fehlt, um in Cable-Planner ein **Lagerstand-/Inventar-System**
+für **Festinstallation** *und* **Rental** (Vermietung) zu integrieren —
+inkl. der bei Rental üblichen Module *Lager* und *Material*.
+
+Stand: 2026-06-15. Ergänzt `docs/architecture.md` und
+`docs/festinstallation-readiness.md`.
+
+---
+
+## 1. Was heute existiert (solides Fundament)
+
+Cable-Planner ist **projekt-zentrisch**: eine Datei = ein Plan (ein Event
+bzw. eine Anlage). Auf dieser Basis ist bereits viel da:
+
+| Baustein | Datei | Zweck |
+|---|---|---|
+| Asset-Register (CSV) | `lib/assetRegister.ts` | Übergabe an Betreiber |
+| Seriennr./Asset-Tag/QR-ID | `types/equipment.ts` | Identität je Gerät |
+| Garantie + Wartungsintervall + Service-Historie | `types/equipment.ts`, `lib/*` | Lebenszyklus |
+| Betriebs-Status (`installStatus`) | `types/lifecycle.ts` | geplant…außer Betrieb |
+| Änderungsprotokoll (MAC/IMACD) | `slices/lifecycleSlice.ts` | wer/was/wann |
+| **Feld-Rückkanal** (pending changes) | `slices/pendingChangesSlice.ts` | Korrekturen aus dem Feld |
+| **QR-Scan-Lookup** | `lib/qrPayload.ts`, Mobile | Etikett → Datensatz |
+| Installateur-Listen + BOM | `lib/installerLists.ts` | Pull/Termination/Schedule |
+| Rentman-Kopplung | `components/Rentman/*`, `lib/rentmanRack.ts` | Import/Export Katalog+Kabelmengen |
+| Mietpreis je Gerät (`rentPricePerDay`) | `types/equipment.ts` | Kalkulationsfeld |
+| Geräte-Kataloge/Templates | `lib/*Catalog.ts`, `lib/library.ts` | Geräte auf den Canvas ziehen |
+
+**Wichtig:** Die Rentman-Integration ist **Daten-Import/-Export** (Katalog +
+Kabelmengen-Abgleich), *kein* Inventar-Management. Bestände, Verfügbarkeit
+und Buchungen leben in Rentman, nicht in Cable-Planner.
+
+---
+
+## 2. Was komplett fehlt (die eigentliche Lücke)
+
+Ein Lager-/Rental-System ist **bestands-zentrisch** statt projekt-zentrisch.
+Genau diese Achse fehlt:
+
+1. **Zentraler, projektübergreifender Bestand.** Es gibt keine `projects[]`
+   und keinen gemeinsamen Pool. „Wir haben 5 ATEM, 3 sind in Projekt A —
+   wie viele sind frei?" ist heute nicht beantwortbar.
+2. **Trennung Template ↔ Instanz ↔ Bestand.** Ein `EquipmentItem` ist eine
+   *Plan-Instanz auf dem Canvas*. Es gibt kein „Lager-Artikel mit Menge N"
+   und keine „physische Einheit mit Seriennr." als eigene Entität.
+3. **Menge / Verfügbarkeit / Lager-Status.** Kein `quantity`, kein
+   `available/reserved/in-repair`, kein Lagerort („Regal A3").
+4. **Zeitraum-Buchungen.** Kein `projectStart/End`, keine Reservierung
+   „Gerät X 10.–15.6. Projekt A". Damit kein Überbuchungs-/Konflikt-Check.
+5. **Lager-Bewegungen / Inventur.** Kein Ein-/Ausgang, Versand, Kalibrier-
+   Workflow, Cycle-Count.
+6. **Verfügbarkeits-/Auslastungs-Reporting.** Kein „was ist wann frei",
+   keine Mehr-Projekt-Kalkulation.
+
+---
+
+## 3. Architektur-Konsequenz
+
+Das ist **keine Slice-Ergänzung**, sondern eine neue Top-Level-Achse. Es
+braucht eine vom einzelnen Plan **unabhängige, persistente Bestands-DB**:
+
+```
+Inventory (neu, projektübergreifend, eigener Store + Persistenz)
+ ├─ items[]        Lager-Artikel (Modell) — Hersteller/Modell/Kategorie/Menge/Mietpreis
+ ├─ units[]        physische Einheiten (Seriennr., Lagerort, Zustand) — optional je Artikel
+ ├─ allocations[]  Buchung: artikel/unit × projektId × von–bis × Menge
+ └─ movements[]    Bewegungen: Eingang/Ausgang/Reparatur/Inventur
+```
+
+Jeder Plan (`CablePlannerProject`) bekommt einen optionalen Zeitraum
+(`metadata.eventStart/eventEnd`) und referenziert Bestand über
+`equipment[].inventoryItemId`. Verfügbarkeit = Bestandsmenge − Summe der
+überlappenden Allocations.
+
+Persistenz: eigener Store (`inventoryStore`) + IPC-Domäne `inventory:*`
+(lokale JSON-DB im userData-Verzeichnis), unabhängig vom geöffneten Plan.
+Optional später: NetBox-/Rentman-Sync als Quelle des Bestands.
+
+---
+
+## 4. Vorgeschlagene Phasen (inkrementell, je eigener PR)
+
+**Phase 0 — Datenmodell-Felder am Gerät (klein, sofort nützlich).**
+Felder ergänzen, die schon innerhalb *eines* Plans Wert haben:
+`ownership` (`owned`/`rented`/`subhire`), `stockLocation`, `purchaseDate`,
+`supplier`. Reines Additiv, kein neuer Store. Speist Asset-Register + BOM.
+
+**Phase 1 — Projekt-Zeitraum.**
+`metadata.eventStart/eventEnd` + UI im Metadaten-Dialog. Voraussetzung für
+jede Verfügbarkeits-Rechnung. Trivial, aber Türöffner.
+
+**Phase 2 — Zentraler Bestand (Lager-Modul, MVP).**
+Neuer `inventoryStore` + `inventory:*` IPC + lokale JSON-DB. CRUD für
+`items[]` (Modell + Menge + Mietpreis + Lagerort). Eigene „Lager"-Ansicht,
+unabhängig vom Plan. Import-Seed aus Rentman-Katalog wiederverwendbar.
+
+**Phase 3 — Verknüpfung Plan ↔ Bestand + Verfügbarkeit.**
+`equipment[].inventoryItemId`; beim Platzieren aus dem Lager wählen.
+Verfügbarkeits-Badge im Plan („5 angefordert, 3 frei im Zeitraum"). Erzeugt
+`allocations[]` aus den Plänen.
+
+**Phase 4 — Material-Modul (Pick-/Packliste & Bewegungen).**
+Pack-/Rückgabeliste je Projekt (baut auf BOM + Allocation), `movements[]`
+für Ein-/Ausgang, Scan-Erfassung (nutzt bereits gebautes `lib/qrPayload.ts`
++ Mobile-Scanner!). Inventur/Cycle-Count.
+
+**Phase 5 — Reporting.**
+Verfügbarkeits-Kalender, Auslastungsmatrix, Überbuchungs-Warnung,
+Mehr-Projekt-Mietkalkulation (Menge × Tage × `rentPricePerDay`).
+
+---
+
+## 5. Strategische Empfehlung
+
+Drei gangbare Wege:
+
+1. **Rentman bleibt Lager-Quelle** (kurzfristig): Integration vertiefen,
+   Verfügbarkeit aus Rentman lesen statt eigener DB. Wenig Aufwand, aber
+   Bestandshoheit bleibt extern und nur für Rentman-Nutzer.
+2. **Eigenes Inventar-Modul** (mittelfristig, empfohlen): Phasen 0–4 oben.
+   Macht Cable-Planner eigenständig lager-/rental-fähig, baut maximal auf
+   Vorhandenem auf (QR-Scan, BOM, Service-Historie, Mietpreis).
+3. **Voll-Split Planung/Lager** (langfristig): zwei Modi/Workspaces. Nur
+   wenn das Lager zum Hauptprodukt wird.
+
+**Pragmatischer Start:** Phase 0 + 1 sind klein, additiv und sofort
+nützlich (auch ohne den großen Umbau). Sie sind die risikoarme Brücke zu
+Phase 2.

--- a/src/main/ipc/mobileShareIpc.ts
+++ b/src/main/ipc/mobileShareIpc.ts
@@ -7,6 +7,7 @@ import {
   setMobileShareProject,
   setMobileShareChecksHandler,
   setMobileShareCableAddedHandler,
+  setMobileSharePendingChangeHandler,
   startMobileShareServer,
   stopMobileShareServer,
 } from '../services/mobileShareServer.js'
@@ -70,6 +71,15 @@ export const registerMobileShareIpc = () => {
     for (const win of BrowserWindow.getAllWindows()) {
       if (win.isDestroyed()) continue
       win.webContents.send('mobileShare:cableAdded', cable)
+    }
+  })
+
+  // Feld-Rückkanal — Mobile-User hat eine Korrektur/ein Problem gemeldet.
+  // Broadcast an alle Renderer; ProjectStore legt sie in die Review-Queue.
+  setMobileSharePendingChangeHandler((change) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (win.isDestroyed()) continue
+      win.webContents.send('mobileShare:pendingChange', change)
     }
   })
 

--- a/src/main/preload.cts
+++ b/src/main/preload.cts
@@ -334,5 +334,29 @@ contextBridge.exposeInMainWorld('cablePlanner', {
       ipcRenderer.on('mobileShare:cableAdded', listener)
       return () => ipcRenderer.removeListener('mobileShare:cableAdded', listener)
     },
+    // Feld-Rückkanal — Mobile-User hat eine Korrektur/ein Problem gemeldet.
+    // Renderer legt sie in die Review-Queue (project.pendingChanges).
+    onPendingChange: (
+      cb: (change: {
+        author?: string
+        kind: string
+        target?: { type: 'cable' | 'equipment'; id?: string; name?: string }
+        summary: string
+        patch?: Record<string, unknown>
+      }) => void,
+    ) => {
+      const listener = (
+        _event: unknown,
+        change: {
+          author?: string
+          kind: string
+          target?: { type: 'cable' | 'equipment'; id?: string; name?: string }
+          summary: string
+          patch?: Record<string, unknown>
+        },
+      ) => cb(change)
+      ipcRenderer.on('mobileShare:pendingChange', listener)
+      return () => ipcRenderer.removeListener('mobileShare:pendingChange', listener)
+    },
   },
 })

--- a/src/main/services/mobileShareServer.ts
+++ b/src/main/services/mobileShareServer.ts
@@ -107,6 +107,19 @@ interface MobileShareState {
         notes?: string
       }) => void)
     | null
+  /** Feld-Rückkanal: vom Mobile-Companion gemeldete, noch nicht angewandte
+   *  Änderung (Längen-Korrektur, Problem-Meldung …). Renderer legt sie in
+   *  die Review-Queue (project.pendingChanges); der Planer übernimmt/verwirft
+   *  sie am Desktop. */
+  onPendingChange:
+    | ((change: {
+        author?: string
+        kind: string
+        target?: { type: 'cable' | 'equipment'; id?: string; name?: string }
+        summary: string
+        patch?: Record<string, unknown>
+      }) => void)
+    | null
 }
 
 const state: MobileShareState = {
@@ -119,6 +132,7 @@ const state: MobileShareState = {
   devProxyUrl: undefined,
   onChecksUpdate: null,
   onCableAdded: null,
+  onPendingChange: null,
 }
 
 /** Loopback or RFC-1918 / link-local / unique-local address? Used to
@@ -396,6 +410,74 @@ const handleRequest = (req: IncomingMessage, res: ServerResponse) => {
     return
   }
 
+  // Feld-Rückkanal — POST /pending-changes: der Mobile-Companion meldet eine
+  // Korrektur/ein Problem. Minimal validiert (summary + kind), Rest reicht der
+  // Renderer-Callback in die Review-Queue.
+  if (pathname === '/pending-changes' && req.method === 'POST') {
+    if (!authed(req, url)) return denyUnauthorized(req, res)
+    let body = ''
+    let aborted = false
+    req.on('data', (chunk) => {
+      if (aborted) return
+      body += chunk
+      if (body.length > 200_000) {
+        aborted = true
+        res.statusCode = 413
+        res.end('Payload too large')
+        req.destroy()
+      }
+    })
+    req.on('end', () => {
+      if (aborted) return
+      try {
+        const parsed = JSON.parse(body) as Record<string, unknown>
+        const summary = String(parsed.summary ?? '').trim()
+        const kind = String(parsed.kind ?? '').trim()
+        if (!summary || !kind) {
+          res.statusCode = 400
+          applyCors(req, res)
+          res.end('{"error":"missing summary or kind"}')
+          return
+        }
+        const rawTarget = parsed.target as Record<string, unknown> | undefined
+        const target =
+          rawTarget && (rawTarget.type === 'cable' || rawTarget.type === 'equipment')
+            ? {
+                type: rawTarget.type as 'cable' | 'equipment',
+                id: typeof rawTarget.id === 'string' ? rawTarget.id : undefined,
+                name: typeof rawTarget.name === 'string' ? rawTarget.name : undefined,
+              }
+            : undefined
+        state.onPendingChange?.({
+          author: typeof parsed.author === 'string' ? parsed.author : undefined,
+          kind,
+          summary,
+          target,
+          patch:
+            parsed.patch && typeof parsed.patch === 'object'
+              ? (parsed.patch as Record<string, unknown>)
+              : undefined,
+        })
+        res.statusCode = 200
+        applyCors(req, res)
+        res.end('{"ok":true}')
+      } catch {
+        res.statusCode = 400
+        applyCors(req, res)
+        res.end('{"error":"invalid json"}')
+      }
+    })
+    return
+  }
+  if (pathname === '/pending-changes' && req.method === 'OPTIONS') {
+    res.statusCode = 204
+    applyCors(req, res)
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-CP-Token')
+    res.end()
+    return
+  }
+
   // Health/info endpoint — useful for the renderer to verify
   // the server is alive without round-tripping the whole project.
   if (pathname === '/share-info.json') {
@@ -568,6 +650,21 @@ export const setMobileShareCableAddedHandler = (
     | null,
 ): void => {
   state.onCableAdded = handler
+}
+
+/** Feld-Rückkanal — Registrierung des Callbacks für POST /pending-changes. */
+export const setMobileSharePendingChangeHandler = (
+  handler:
+    | ((change: {
+        author?: string
+        kind: string
+        target?: { type: 'cable' | 'equipment'; id?: string; name?: string }
+        summary: string
+        patch?: Record<string, unknown>
+      }) => void)
+    | null,
+): void => {
+  state.onPendingChange = handler
 }
 
 export const getMobileShareStatus = (): MobileShareInfo & { running: boolean } => ({

--- a/src/mobile/MobileApp.tsx
+++ b/src/mobile/MobileApp.tsx
@@ -986,6 +986,7 @@ const ProjectView = ({
   // Port, mit Nonce damit erneutes Scannen desselben Geräts neu „blitzt") und
   // eine kurze Status-Meldung.
   const [findOpen, setFindOpen] = useState(false)
+  const [showReport, setShowReport] = useState(false)
   const [focus, setFocus] = useState<{ deviceId: string; portId?: string; nonce: number } | null>(
     null,
   )
@@ -1159,6 +1160,14 @@ const ProjectView = ({
           </button>
           <button
             type="button"
+            onClick={() => setShowReport(true)}
+            className="rounded bg-slate-800 px-2 py-1 text-[11px] text-amber-300 hover:bg-slate-700"
+            title="Korrektur/Problem melden (Feld-Rückkanal)"
+          >
+            Meldung
+          </button>
+          <button
+            type="button"
             onClick={() => setShowAddCable(true)}
             className="rounded bg-sky-700 px-2 py-1 text-[11px] text-white hover:bg-sky-600"
             title="Kabel vor Ort hinzufügen (Dropdowns)"
@@ -1202,6 +1211,9 @@ const ProjectView = ({
       )}
       {findOpen && (
         <QrFindOverlay onSubmit={handleLookup} onClose={() => setFindOpen(false)} />
+      )}
+      {showReport && (
+        <MobileReportModal project={project} onClose={() => setShowReport(false)} />
       )}
       {viewMode === 'list' ? (
         <div className="space-y-2 pb-8">
@@ -1718,6 +1730,270 @@ const AddCableModal = ({
                   className="rounded bg-sky-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-sky-500 disabled:cursor-not-allowed disabled:opacity-40"
                 >
                   {busy ? 'Sende…' : '📤 An Desktop senden'}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Feld-Rückkanal — Light-Editor für Korrekturen/Problem-Meldungen.
+//
+// Use-Case: Techniker bemerkt vor Ort eine Abweichung (z.B. Kabel ist
+// kürzer/länger als geplant) oder einen Defekt. Statt direkt den Plan zu
+// ändern (das darf nur der Planer), meldet er es: POST /pending-changes →
+// Review-Queue am Desktop. Beim Übernehmen mergt der Planer den Patch und
+// es wird ins Änderungsprotokoll geschrieben.
+type ReportKind = 'cable-edit' | 'issue' | 'note'
+const REPORTER_KEY = 'cable-planner-mobile:reporter'
+
+const MobileReportModal = ({
+  project,
+  onClose,
+}: {
+  project: CablePlannerProject
+  onClose: () => void
+}) => {
+  const [kind, setKind] = useState<ReportKind>('cable-edit')
+  const [deviceId, setDeviceId] = useState('')
+  const [cableId, setCableId] = useState('')
+  const [lengthVal, setLengthVal] = useState('')
+  const [note, setNote] = useState('')
+  const [reporter, setReporter] = useState(() => {
+    try {
+      return localStorage.getItem(REPORTER_KEY) ?? ''
+    } catch {
+      return ''
+    }
+  })
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const [done, setDone] = useState(false)
+
+  const cablesForDevice = useMemo(
+    () =>
+      deviceId
+        ? project.cables.filter(
+            (c) => c.fromEquipmentId === deviceId || c.toEquipmentId === deviceId,
+          )
+        : project.cables,
+    [project.cables, deviceId],
+  )
+  const selCable = project.cables.find((c) => c.id === cableId)
+
+  const canSubmit =
+    !busy &&
+    (kind === 'cable-edit' ? !!cableId && (!!lengthVal || !!note.trim()) : !!note.trim())
+
+  const submit = async () => {
+    if (!canSubmit) return
+    setBusy(true)
+    setErr(null)
+    try {
+      let target: { type: 'cable' | 'equipment'; id?: string; name?: string } | undefined
+      let patch: Record<string, unknown> | undefined
+      let summary = note.trim()
+
+      if (kind === 'cable-edit' && selCable) {
+        target = { type: 'cable', id: selCable.id, name: cableLabelId(selCable) }
+        const parts: string[] = []
+        if (lengthVal) {
+          patch = { length: Number(lengthVal) }
+          parts.push(`Länge → ${Number(lengthVal)} m`)
+        }
+        if (note.trim()) parts.push(note.trim())
+        summary = parts.join(' · ') || 'Kabel-Korrektur'
+      } else {
+        const dev = project.equipment.find((e) => e.id === deviceId)
+        if (dev) target = { type: 'equipment', id: dev.id, name: dev.name }
+      }
+
+      const res = await apiFetch('/pending-changes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          author: reporter.trim() || undefined,
+          kind,
+          summary,
+          target,
+          patch,
+        }),
+      })
+      if (!res.ok) throw new Error(`Server ${res.status}`)
+      try {
+        if (reporter.trim()) localStorage.setItem(REPORTER_KEY, reporter.trim())
+      } catch {
+        /* localStorage evtl. gesperrt — egal */
+      }
+      setDone(true)
+      window.setTimeout(onClose, 1300)
+    } catch (e) {
+      setErr(
+        e instanceof Error
+          ? `Konnte Meldung nicht senden: ${e.message}. Verbindung zum Desktop prüfen.`
+          : 'Konnte Meldung nicht senden.',
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-20 flex items-end justify-center bg-black/60 p-2"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div className="w-full max-w-md rounded-t-lg border border-slate-700 bg-slate-900 text-slate-100 shadow-2xl">
+        <header className="flex items-center justify-between border-b border-slate-700 px-3 py-2">
+          <h2 className="text-sm font-semibold">⚠ Meldung an Planer</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded px-2 py-0.5 text-xs text-slate-400 hover:bg-slate-800"
+          >
+            <Icon icon={X} size="sm" />
+          </button>
+        </header>
+        <div className="space-y-3 p-3 text-xs">
+          {done ? (
+            <div className="rounded border border-emerald-700 bg-emerald-900/30 p-3 text-center text-emerald-200">
+              ✓ Meldung gesendet — erscheint am Desktop unter „Feld-Rückmeldungen"
+            </div>
+          ) : (
+            <>
+              <p className="text-[10px] italic text-slate-400">
+                Wird NICHT direkt geändert — der Planer übernimmt oder verwirft deine
+                Meldung am Desktop (landet dann im Änderungsprotokoll).
+              </p>
+
+              <div className="grid grid-cols-3 gap-1 rounded bg-slate-950 p-0.5">
+                {(
+                  [
+                    ['cable-edit', 'Kabel-Korrektur'],
+                    ['issue', 'Problem'],
+                    ['note', 'Notiz'],
+                  ] as const
+                ).map(([k, label]) => (
+                  <button
+                    key={k}
+                    type="button"
+                    onClick={() => setKind(k)}
+                    className={`rounded px-2 py-1 text-[11px] font-medium ${
+                      kind === k ? 'bg-sky-700 text-white' : 'text-slate-300 hover:bg-slate-800'
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+
+              <label className="block">
+                <span className="mb-1 block text-slate-300">Gerät (Kontext)</span>
+                <select
+                  value={deviceId}
+                  onChange={(e) => {
+                    setDeviceId(e.target.value)
+                    setCableId('')
+                  }}
+                  className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-2 text-slate-100"
+                >
+                  <option value="">— wählen —</option>
+                  {project.equipment.map((d) => (
+                    <option key={d.id} value={d.id}>
+                      {d.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              {kind === 'cable-edit' && (
+                <>
+                  <label className="block">
+                    <span className="mb-1 block text-slate-300">Kabel</span>
+                    <select
+                      value={cableId}
+                      onChange={(e) => setCableId(e.target.value)}
+                      className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-2 text-slate-100"
+                    >
+                      <option value="">— wählen —</option>
+                      {cablesForDevice.map((c) => (
+                        <option key={c.id} value={c.id}>
+                          {cableLabelId(c)} · {c.name || c.type}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="block">
+                    <span className="mb-1 block text-slate-300">
+                      Korrigierte Länge (m){selCable ? ` · aktuell ${selCable.length} m` : ''}
+                    </span>
+                    <input
+                      type="number"
+                      inputMode="decimal"
+                      value={lengthVal}
+                      onChange={(e) => setLengthVal(e.target.value)}
+                      placeholder="z.B. 7.5"
+                      className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-2 text-slate-100"
+                    />
+                  </label>
+                </>
+              )}
+
+              <label className="block">
+                <span className="mb-1 block text-slate-300">
+                  {kind === 'cable-edit' ? 'Bemerkung (optional)' : 'Beschreibung'}
+                </span>
+                <textarea
+                  value={note}
+                  onChange={(e) => setNote(e.target.value)}
+                  rows={3}
+                  placeholder={
+                    kind === 'issue'
+                      ? 'Was ist das Problem?'
+                      : kind === 'note'
+                        ? 'Notiz für den Planer…'
+                        : 'optional…'
+                  }
+                  className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-2 text-slate-100"
+                />
+              </label>
+
+              <label className="block">
+                <span className="mb-1 block text-slate-300">Dein Name (optional)</span>
+                <input
+                  value={reporter}
+                  onChange={(e) => setReporter(e.target.value)}
+                  placeholder="für die Protokoll-Zuordnung"
+                  className="w-full rounded border border-slate-700 bg-slate-950 px-2 py-2 text-slate-100"
+                />
+              </label>
+
+              {err && (
+                <div className="rounded border border-rose-700 bg-rose-900/30 p-2 text-rose-200">
+                  {err}
+                </div>
+              )}
+
+              <div className="flex justify-end gap-2 pt-1">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="rounded bg-slate-700 px-3 py-1.5 text-xs text-slate-200 hover:bg-slate-600"
+                >
+                  Abbrechen
+                </button>
+                <button
+                  type="button"
+                  onClick={submit}
+                  disabled={!canSubmit}
+                  className="rounded bg-amber-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  {busy ? 'Sende…' : '📤 Meldung senden'}
                 </button>
               </div>
             </>

--- a/src/mobile/MobileApp.tsx
+++ b/src/mobile/MobileApp.tsx
@@ -23,10 +23,22 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { AlertTriangle, X } from 'lucide-react'
+import { AlertTriangle, X, QrCode, Search } from 'lucide-react'
 import { Icon } from '../renderer/components/shared/Icon'
 import { styleForLayer } from '../renderer/lib/cableLayers'
+import { parseQrPayload, lookupQrRef } from '../renderer/lib/qrPayload'
+import { cableLabelId } from '../renderer/lib/docIds'
 import type { CablePlannerProject } from '../renderer/types/project'
+
+/** Deep-Link beim Laden: `?lookup=cable/C-0001` oder `#cable/C-0001` /
+ *  `#C-0001`. Wird einmalig nach dem Projekt-Load aufgelöst und springt
+ *  zum Element. Leerstring = kein Deep-Link. */
+const INITIAL_LOOKUP =
+  typeof window !== 'undefined'
+    ? window.location.hash.replace(/^#/, '') ||
+      new URLSearchParams(window.location.search).get('lookup') ||
+      ''
+    : ''
 
 // The desktop share server gates every data/write route behind a
 // per-session token handed to the phone via the QR/URL (`?t=…`). Read it
@@ -273,12 +285,15 @@ const DevicePortDetail = ({
   checks,
   onTogglePort,
   allEquipment,
+  highlightPortId,
 }: {
   device: CablePlannerProject['equipment'][number]
   cables: CablePlannerProject['cables']
   checks: CheckState
   onTogglePort: (deviceId: string, portId: string) => void
   allEquipment: CablePlannerProject['equipment']
+  /** QR-Lookup: hervorzuhebender Port (Treffer eines Kabel-Scans). */
+  highlightPortId?: string
 }) => {
   const inputCables = useMemo(
     () => cables.filter((c) => c.toEquipmentId === device.id),
@@ -299,6 +314,7 @@ const DevicePortDetail = ({
         checks={checks}
         onTogglePort={onTogglePort}
         allEquipment={allEquipment}
+        highlightPortId={highlightPortId}
       />
       <PortList
         label="Outputs"
@@ -309,6 +325,7 @@ const DevicePortDetail = ({
         checks={checks}
         onTogglePort={onTogglePort}
         allEquipment={allEquipment}
+        highlightPortId={highlightPortId}
       />
     </div>
   )
@@ -321,6 +338,8 @@ const DeviceCard = ({
   onTogglePort,
   onOpenChange,
   allEquipment,
+  autoOpenKey,
+  highlightPortId,
 }: {
   device: CablePlannerProject['equipment'][number]
   cables: CablePlannerProject['cables']
@@ -331,15 +350,37 @@ const DeviceCard = ({
    *  Open-Aktion via diesem Callback. */
   onOpenChange?: (deviceId: string, open: boolean) => void
   allEquipment: CablePlannerProject['equipment']
+  /** QR-Lookup: wenn gesetzt (Nonce), Karte aufklappen, hinscrollen und
+   *  kurz hervorheben. Nonce-Wechsel triggert das erneut. */
+  autoOpenKey?: number
+  /** QR-Lookup: Port, der beim Treffer hervorgehoben werden soll. */
+  highlightPortId?: string
 }) => {
   const totalPorts = (device.inputs?.length ?? 0) + (device.outputs?.length ?? 0)
   const checkedPorts = [...(device.inputs ?? []), ...(device.outputs ?? [])].filter(
     (p) => checks.ports[portKey(device.id, p.id)],
   ).length
 
+  const detailsRef = useRef<HTMLDetailsElement>(null)
+  const [flash, setFlash] = useState(false)
+  useEffect(() => {
+    if (autoOpenKey == null) return
+    const el = detailsRef.current
+    if (el) {
+      el.open = true
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }
+    setFlash(true)
+    const t = setTimeout(() => setFlash(false), 2400)
+    return () => clearTimeout(t)
+  }, [autoOpenKey])
+
   return (
     <details
-      className="rounded border border-slate-800 bg-slate-900 open:bg-slate-900/80"
+      ref={detailsRef}
+      className={`rounded border bg-slate-900 open:bg-slate-900/80 ${
+        flash ? 'border-sky-400 ring-2 ring-sky-400/70' : 'border-slate-800'
+      }`}
       onToggle={(e) => onOpenChange?.(device.id, (e.target as HTMLDetailsElement).open)}
     >
       <summary className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm">
@@ -364,6 +405,7 @@ const DeviceCard = ({
           checks={checks}
           onTogglePort={onTogglePort}
           allEquipment={allEquipment}
+          highlightPortId={highlightPortId}
         />
       </div>
     </details>
@@ -586,6 +628,7 @@ const PortList = ({
   checks,
   onTogglePort,
   allEquipment,
+  highlightPortId,
 }: {
   label: string
   deviceId: string
@@ -595,6 +638,8 @@ const PortList = ({
   checks: CheckState
   onTogglePort: (deviceId: string, portId: string) => void
   allEquipment: CablePlannerProject['equipment']
+  /** QR-Lookup: dieser Port wird mit einem Ring hervorgehoben. */
+  highlightPortId?: string
 }) => {
   if (ports.length === 0) return null
   return (
@@ -649,6 +694,7 @@ const PortList = ({
             }
           }
           const checked = !!checks.ports[portKey(deviceId, p.id)]
+          const highlighted = highlightPortId === p.id
           return (
             <li key={p.id}>
               <button
@@ -658,7 +704,7 @@ const PortList = ({
                   checked
                     ? 'border-emerald-700 bg-emerald-900/30 text-emerald-100'
                     : 'border-slate-800 bg-slate-950 text-slate-200 hover:border-slate-700'
-                }`}
+                } ${highlighted ? 'ring-2 ring-sky-400' : ''}`}
               >
                 <span
                   className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded ${
@@ -720,6 +766,147 @@ const PortList = ({
           )
         })}
       </ul>
+    </div>
+  )
+}
+
+// QR-Scan-Lookup — die Companion läuft im Studio-LAN typisch über http://,
+// wo Browser getUserMedia (Kamera) sperren (kein Secure-Context). Wir bieten
+// daher IMMER eine Texteingabe (gescannten Code einfügen / ID tippen) und
+// blenden den Live-Kamera-Scan nur ein, wenn der Context ihn erlaubt
+// (HTTPS/localhost/file:// + BarcodeDetector vorhanden).
+type BarcodeDetectorLike = {
+  detect: (src: CanvasImageSource) => Promise<Array<{ rawValue: string }>>
+}
+type BarcodeDetectorCtor = new (opts?: { formats?: string[] }) => BarcodeDetectorLike
+const getBarcodeDetector = (): BarcodeDetectorCtor | undefined =>
+  (window as unknown as { BarcodeDetector?: BarcodeDetectorCtor }).BarcodeDetector
+
+const cameraScanSupported = (): boolean =>
+  typeof window !== 'undefined' &&
+  window.isSecureContext === true &&
+  !!navigator.mediaDevices?.getUserMedia &&
+  !!getBarcodeDetector()
+
+/** Vollbild-Overlay: Live-Kamera-Scan (wo möglich) + manuelle Eingabe. */
+const QrFindOverlay = ({
+  onSubmit,
+  onClose,
+}: {
+  onSubmit: (raw: string) => void
+  onClose: () => void
+}) => {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const [text, setText] = useState('')
+  const [camError, setCamError] = useState<string | null>(null)
+  const canScan = cameraScanSupported()
+
+  useEffect(() => {
+    if (!canScan) return
+    let stream: MediaStream | null = null
+    let raf = 0
+    let cancelled = false
+    const Detector = getBarcodeDetector()
+    if (!Detector) return
+    const detector = new Detector({ formats: ['qr_code'] })
+    const tick = async () => {
+      if (cancelled || !videoRef.current) return
+      try {
+        const codes = await detector.detect(videoRef.current)
+        const hit = codes.find((c) => c.rawValue)?.rawValue
+        if (hit) {
+          onSubmit(hit)
+          return
+        }
+      } catch {
+        /* transienter Decode-Fehler — weiter pollen */
+      }
+      raf = requestAnimationFrame(() => void tick())
+    }
+    const start = async () => {
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: 'environment' },
+        })
+        if (cancelled) return
+        const v = videoRef.current
+        if (!v) return
+        v.srcObject = stream
+        await v.play()
+        raf = requestAnimationFrame(() => void tick())
+      } catch (e) {
+        setCamError((e as Error).message || 'Kamera nicht verfügbar')
+      }
+    }
+    void start()
+    return () => {
+      cancelled = true
+      cancelAnimationFrame(raf)
+      stream?.getTracks().forEach((t) => t.stop())
+    }
+    // onSubmit ist stabil (Parent-Closure pro Render); bewusst nur canScan.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canScan])
+
+  const submitText = () => {
+    const v = text.trim()
+    if (v) onSubmit(v)
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col bg-slate-950/95 p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="flex items-center gap-2 text-sm font-semibold text-slate-100">
+          <Icon icon={QrCode} size="sm" /> QR / ID finden
+        </h2>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded bg-slate-800 p-1.5 text-slate-300 hover:bg-slate-700"
+          aria-label="Schließen"
+        >
+          <Icon icon={X} size="sm" />
+        </button>
+      </div>
+
+      {canScan ? (
+        <div className="relative mb-3 overflow-hidden rounded-lg border border-slate-700 bg-black">
+          <video ref={videoRef} className="h-56 w-full object-cover" muted playsInline />
+          <div className="pointer-events-none absolute inset-0 m-auto h-40 w-40 rounded-lg border-2 border-sky-400/80" />
+          {camError && (
+            <div className="absolute inset-x-0 bottom-0 bg-amber-900/80 px-2 py-1 text-[11px] text-amber-100">
+              {camError}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="mb-3 rounded border border-slate-700 bg-slate-900 px-3 py-2 text-[11px] text-slate-400">
+          Kamera-Scan hier nicht verfügbar (kein HTTPS/Secure-Context). Scanne das
+          Etikett mit der Kamera-App deines Geräts und füge den Code unten ein —
+          oder tippe die Kabel-/Asset-ID.
+        </div>
+      )}
+
+      <label className="mb-1 block text-[11px] text-slate-400">Code / ID</label>
+      <div className="flex items-center gap-2">
+        <input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') submitText()
+          }}
+          autoFocus={!canScan}
+          placeholder="z.B. C-0001, A-0007 oder cableplanner://…"
+          className="flex-1 rounded border border-slate-700 bg-slate-900 px-2 py-2 text-sm text-slate-100"
+        />
+        <button
+          type="button"
+          onClick={submitText}
+          className="flex items-center gap-1 rounded bg-sky-700 px-3 py-2 text-xs text-white hover:bg-sky-600"
+        >
+          <Icon icon={Search} size="sm" /> Finden
+        </button>
+      </div>
     </div>
   )
 }
@@ -794,6 +981,52 @@ const ProjectView = ({
   // Karte (Last-Open-Wins) — beim Toggle einer Karte wird die ID hier
   // gesetzt (oder geloescht wenn die selbe wieder geschlossen wird).
   const [lastOpenedDeviceId, setLastOpenedDeviceId] = useState<string | null>(null)
+
+  // QR-Scan-Lookup — Overlay-Sichtbarkeit, Treffer-Fokus (Gerät + optional
+  // Port, mit Nonce damit erneutes Scannen desselben Geräts neu „blitzt") und
+  // eine kurze Status-Meldung.
+  const [findOpen, setFindOpen] = useState(false)
+  const [focus, setFocus] = useState<{ deviceId: string; portId?: string; nonce: number } | null>(
+    null,
+  )
+  const [lookupMsg, setLookupMsg] = useState<{ ok: boolean; text: string } | null>(null)
+
+  const handleLookup = (raw: string) => {
+    setFindOpen(false)
+    const ref = parseQrPayload(raw)
+    const match = ref ? lookupQrRef(ref, project.cables, project.equipment) : null
+    if (!match) {
+      setFocus(null)
+      setLookupMsg({ ok: false, text: `Kein Treffer für „${raw.slice(0, 40)}"` })
+      return
+    }
+    setViewMode('list')
+    setFilter('')
+    if (match.kind === 'equipment') {
+      setFocus({ deviceId: match.item.id, nonce: Date.now() })
+      setLookupMsg({ ok: true, text: `Gerät: ${match.item.name}` })
+    } else {
+      const c = match.item
+      setFocus({ deviceId: c.fromEquipmentId, portId: c.fromPortId, nonce: Date.now() })
+      setLookupMsg({ ok: true, text: `Kabel ${cableLabelId(c)}: ${c.name || c.type}` })
+    }
+  }
+
+  // Deep-Link beim ersten Render auflösen (einmalig).
+  const initialRan = useRef(false)
+  useEffect(() => {
+    if (initialRan.current || !INITIAL_LOOKUP) return
+    initialRan.current = true
+    handleLookup(INITIAL_LOOKUP)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Treffer-Meldung nach ein paar Sekunden ausblenden.
+  useEffect(() => {
+    if (!lookupMsg) return
+    const t = setTimeout(() => setLookupMsg(null), 4000)
+    return () => clearTimeout(t)
+  }, [lookupMsg])
 
   // v7.7.3 — Toggling a port toggles BOTH endpoints of the cable that's
   // plugged into it (and the cable itself), because physically plugging
@@ -918,6 +1151,14 @@ const ProjectView = ({
           </label>
           <button
             type="button"
+            onClick={() => setFindOpen(true)}
+            className="flex items-center rounded bg-slate-800 px-2 py-1 text-[11px] text-slate-200 hover:bg-slate-700"
+            title="Per QR-Scan oder ID zu Kabel/Gerät springen"
+          >
+            <Icon icon={QrCode} size="xs" />
+          </button>
+          <button
+            type="button"
             onClick={() => setShowAddCable(true)}
             className="rounded bg-sky-700 px-2 py-1 text-[11px] text-white hover:bg-sky-600"
             title="Kabel vor Ort hinzufügen (Dropdowns)"
@@ -925,6 +1166,18 @@ const ProjectView = ({
             + Kabel
           </button>
         </div>
+        )}
+        {lookupMsg && (
+          <div
+            className={`mt-2 rounded px-2 py-1 text-[11px] ${
+              lookupMsg.ok
+                ? 'border border-sky-700/60 bg-sky-900/30 text-sky-200'
+                : 'border border-amber-700/60 bg-amber-900/30 text-amber-200'
+            }`}
+          >
+            {lookupMsg.ok ? '📍 ' : ''}
+            {lookupMsg.text}
+          </div>
         )}
         {/* v7.9.54 — Offline-Banner. Erscheint sobald der Poll fehlschlägt
             oder der initiale Load aus dem Cache kam. Klar erkennbar in
@@ -947,6 +1200,9 @@ const ProjectView = ({
           onClose={() => setShowAddCable(false)}
         />
       )}
+      {findOpen && (
+        <QrFindOverlay onSubmit={handleLookup} onClose={() => setFindOpen(false)} />
+      )}
       {viewMode === 'list' ? (
         <div className="space-y-2 pb-8">
           {filteredDevices.length === 0 ? (
@@ -961,6 +1217,8 @@ const ProjectView = ({
                 cables={project.cables}
                 checks={checks}
                 onTogglePort={togglePort}
+                autoOpenKey={focus?.deviceId === d.id ? focus.nonce : undefined}
+                highlightPortId={focus?.deviceId === d.id ? focus.portId : undefined}
                 onOpenChange={(deviceId, open) => {
                   setLastOpenedDeviceId((prev) => {
                     if (open) return deviceId

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -555,6 +555,24 @@ export default function App() {
     })
   }, [addCableFromMobile])
 
+  // Feld-Rückkanal — Mobile-User hat eine Korrektur/ein Problem gemeldet.
+  // ProjectStore legt es in die Review-Queue (project.pendingChanges); der
+  // Planer übernimmt/verwirft es im Festinstallations-Doku-Dialog.
+  const addPendingChange = useProjectStore((s) => s.addPendingChange)
+  useEffect(() => {
+    if (!hasDesktopBridge) return
+    return cablePlannerApi.mobileShare.onPendingChange((change) => {
+      addPendingChange({
+        author: change.author,
+        source: 'mobile',
+        kind: change.kind as import('./types/lifecycle').PendingChangeKind,
+        summary: change.summary,
+        target: change.target,
+        patch: change.patch,
+      })
+    })
+  }, [addPendingChange])
+
   // Issue #69: dispatch user-customizable hotkeys defined in
   // Settings → Hotkeys. The undo/redo entries below intentionally
   // overlap with useUndoRedoShortcuts() — only the first matching

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -38,6 +38,7 @@ const AnnotationsPanelHost = () => {
 import { MobileShareDialog } from './components/MobileShare/MobileShareDialog'
 import { AboutDialog } from './components/About/AboutDialog'
 import { PatchListDialog } from './components/Patch/PatchListDialog'
+import { InstallationDocsDialog } from './components/Export/InstallationDocsDialog'
 import { BandwidthCalculatorDialog, PowerCalculatorDialog } from './components/Calculators/CalculatorsDialog'
 import { RecordingStorageCalculatorDialog } from './components/Calculators/RecordingStorageCalculatorDialog'
 import { ProjectionCalculatorDialog } from './components/Calculators/ProjectionCalculatorDialog'
@@ -1092,6 +1093,7 @@ export default function App() {
       <MobileShareDialog />
       <AboutDialog />
       <PatchListDialog />
+      <InstallationDocsDialog />
       <BandwidthCalculatorDialog />
       <PowerCalculatorDialog />
       <RecordingStorageCalculatorDialog />

--- a/src/renderer/components/Export/InstallationDocsDialog.tsx
+++ b/src/renderer/components/Export/InstallationDocsDialog.tsx
@@ -1,0 +1,332 @@
+/**
+ * Festinstallation — Doku-/Übergabe-Dialog.
+ *
+ * Ein Ort für alle Lebenszyklus-Deliverables einer Festinstallation:
+ *  - Installateur-Listen (Pull-/Termination-/Schedule-/BOM-CSV)
+ *  - Betreiber-Asset-Register (CSV)
+ *  - QR-/Asset-IDs vergeben + QR-Etiketten-PDF
+ *  - Übergabe-Paket (Markdown-Manifest)
+ *  - Änderungsprotokoll (wer/was/wann) ansehen/leeren
+ *  - Bearbeiter-Identität setzen (Autor der Protokoll-/Service-Einträge)
+ */
+import { useMemo, useState } from 'react'
+import jsPDF from 'jspdf'
+import QRCode from 'qrcode'
+import {
+  Download,
+  ClipboardList,
+  QrCode,
+  PackageCheck,
+  History,
+  Trash2,
+  Tag,
+} from 'lucide-react'
+import { useUiStore } from '../../store/uiStore'
+import { useProjectStore } from '../../store/projectStore'
+import { useSettingsStore } from '../../store/settingsStore'
+import { ModalShell } from '../shared/ModalShell'
+import { Icon } from '../shared/Icon'
+import { useTranslation } from '../../lib/i18n'
+import { downloadBlob } from '../../lib/downloadBlob'
+import { buildExportFilenameWithSuffix } from '../../lib/exportFilename'
+import {
+  pullListCsv,
+  terminationListCsv,
+  cableScheduleCsv,
+  cableBomCsv,
+} from '../../lib/installerLists'
+import { assetRegisterCsv } from '../../lib/assetRegister'
+import { buildHandoverManifest } from '../../lib/handoverPackage'
+import { cableLabelId, equipmentAssetTag, qrPayload } from '../../lib/docIds'
+
+type ExportRow = {
+  key: string
+  label: string
+  hint: string
+  build: () => { content: string; suffix: string; ext: string; mime: string }
+}
+
+export const InstallationDocsDialog = () => {
+  const t = useTranslation()
+  const open = useUiStore((s) => s.installDocs.open)
+  const close = useUiStore((s) => s.closeInstallDocs)
+  const project = useProjectStore((s) => s.project)
+  const assignDocIds = useProjectStore((s) => s.assignDocIds)
+  const clearChangelog = useProjectStore((s) => s.clearChangelog)
+  const editorName = useSettingsStore((s) => s.editorName)
+  const setEditorName = useSettingsStore((s) => s.setEditorName)
+
+  const [reserve, setReserve] = useState(10)
+  const [busy, setBusy] = useState(false)
+  const [info, setInfo] = useState('')
+
+  const baseName = project.metadata.name || 'anlage'
+
+  const save = (content: string, suffix: string, ext: string, mime: string) => {
+    downloadBlob(buildExportFilenameWithSuffix(baseName, suffix, ext), content, mime)
+  }
+
+  const exports: ExportRow[] = useMemo(
+    () => [
+      {
+        key: 'pull',
+        label: t('docs.pullList', 'Pull-/Verlege-Liste'),
+        hint: t('docs.pullList.hint', 'Je Kabel: Von→Nach, Länge, Trasse, Status (CSV)'),
+        build: () => ({ content: pullListCsv(project), suffix: 'pull-liste', ext: 'csv', mime: 'text/csv' }),
+      },
+      {
+        key: 'term',
+        label: t('docs.terminationList', 'Termination-Liste'),
+        hint: t('docs.terminationList.hint', 'Je Kabelende: Gerät, Port, Steckverbinder (CSV)'),
+        build: () => ({ content: terminationListCsv(project), suffix: 'termination-liste', ext: 'csv', mime: 'text/csv' }),
+      },
+      {
+        key: 'sched',
+        label: t('docs.cableSchedule', 'Kabel-Schedule (Register)'),
+        hint: t('docs.cableSchedule.hint', 'Master-Register aller Kabel (CSV)'),
+        build: () => ({ content: cableScheduleCsv(project), suffix: 'kabel-schedule', ext: 'csv', mime: 'text/csv' }),
+      },
+      {
+        key: 'bom',
+        label: t('docs.cableBom', 'Kabel-Stückliste + Reserve'),
+        hint: t('docs.cableBom.hint', 'Aggregiert nach Typ/Länge inkl. Reserve-Aufschlag (CSV)'),
+        build: () => ({ content: cableBomCsv(project, reserve), suffix: 'kabel-bom', ext: 'csv', mime: 'text/csv' }),
+      },
+      {
+        key: 'asset',
+        label: t('docs.assetRegister', 'Asset-Register'),
+        hint: t('docs.assetRegister.hint', 'Geräte: Asset-Tag, Standort, Serie, Garantie, Service (CSV)'),
+        build: () => ({ content: assetRegisterCsv(project), suffix: 'asset-register', ext: 'csv', mime: 'text/csv' }),
+      },
+      {
+        key: 'handover',
+        label: t('docs.handover', 'Übergabe-Dokument'),
+        hint: t('docs.handover.hint', 'Betreiber-Übersicht: Umfang, Status, BOM, Assets (Markdown)'),
+        build: () => ({ content: buildHandoverManifest(project), suffix: 'uebergabe', ext: 'md', mime: 'text/markdown' }),
+      },
+    ],
+    [project, reserve, t],
+  )
+
+  const onAssignIds = () => {
+    const res = assignDocIds()
+    setInfo(
+      res.cables + res.equipment === 0
+        ? t('docs.ids.none', 'Alle Elemente haben bereits eine ID.')
+        : `${res.cables} Kabel-IDs, ${res.equipment} Geräte-IDs vergeben.`,
+    )
+  }
+
+  const onQrLabelsPdf = async () => {
+    setBusy(true)
+    setInfo('')
+    try {
+      const doc = new jsPDF({ unit: 'mm', format: 'a4' })
+      const pageW = 210
+      const pageH = 297
+      const margin = 12
+      const cellW = 63
+      const cellH = 30
+      const cols = 3
+      const gapX = (pageW - 2 * margin - cols * cellW) / (cols - 1)
+      let x = margin
+      let y = margin
+      const items: { id: string; label: string; sub: string; kind: 'cable' | 'equipment' }[] = []
+      for (const c of project.cables) {
+        const id = c.qrId || cableLabelId(c)
+        items.push({ id, label: id, sub: c.name || c.type, kind: 'cable' })
+      }
+      for (const e of project.equipment) {
+        const id = e.qrId || equipmentAssetTag(e)
+        items.push({ id, label: id, sub: e.name, kind: 'equipment' })
+      }
+      if (items.length === 0) {
+        setInfo(t('docs.qr.empty', 'Keine Elemente vorhanden.'))
+        setBusy(false)
+        return
+      }
+      let col = 0
+      for (const it of items) {
+        const dataUrl = await QRCode.toDataURL(qrPayload(it.kind, it.id, it.label), {
+          margin: 0,
+          width: 256,
+        })
+        doc.addImage(dataUrl, 'PNG', x, y, cellH - 8, cellH - 8)
+        doc.setFontSize(9)
+        doc.text(it.label, x + cellH - 4, y + 6)
+        doc.setFontSize(7)
+        doc.text(doc.splitTextToSize(it.sub, cellW - cellH).slice(0, 3), x + cellH - 4, y + 11)
+        col += 1
+        if (col >= cols) {
+          col = 0
+          x = margin
+          y += cellH
+          if (y + cellH > pageH - margin) {
+            doc.addPage()
+            y = margin
+          }
+        } else {
+          x += cellW + gapX
+        }
+      }
+      // jsPDF liefert einen binären Blob — direkt herunterladen (kein .text()).
+      const blob = doc.output('blob')
+      downloadBlob(
+        buildExportFilenameWithSuffix(baseName, 'qr-etiketten', 'pdf'),
+        blob,
+        'application/pdf',
+      )
+      setInfo(`${items.length} Etiketten erzeugt.`)
+    } catch (err) {
+      setInfo(`Fehler: ${err instanceof Error ? err.message : String(err)}`)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const changelog = useMemo(
+    () => [...(project.changelog ?? [])].reverse().slice(0, 30),
+    [project.changelog],
+  )
+
+  return (
+    <ModalShell
+      open={open}
+      onClose={close}
+      title={t('docs.title', 'Festinstallation — Doku & Übergabe')}
+      titleIcon={<Icon icon={PackageCheck} size="md" />}
+      maxWidth="3xl"
+      draggableKey="cable-planner:modal-pos:install-docs"
+    >
+      <div className="space-y-4 text-cp-sm">
+        {/* Bearbeiter-Identität */}
+        <section className="rounded border border-cp-border bg-cp-surface-2/40 p-3">
+          <label className="block">
+            <span className="mb-1 block text-cp-text-secondary">
+              {t('docs.editor', 'Bearbeiter (Autor für Änderungsprotokoll & Service)')}
+            </span>
+            <input
+              value={editorName}
+              onChange={(e) => setEditorName(e.target.value)}
+              placeholder={t('docs.editor.placeholder', 'z. B. Lars Z. / Firma XY')}
+              className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
+            />
+          </label>
+        </section>
+
+        {/* Listen / Exporte */}
+        <section>
+          <h3 className="mb-2 flex items-center gap-1.5 font-semibold text-cp-text-bright">
+            <Icon icon={ClipboardList} size="sm" />
+            {t('docs.exports', 'Listen & Übergabe-Dokumente')}
+          </h3>
+          <label className="mb-2 flex items-center gap-2 text-cp-xs text-cp-text-secondary">
+            {t('docs.reserve', 'Reserve-Aufschlag für Stückliste (%)')}
+            <input
+              type="number"
+              min={0}
+              max={100}
+              value={reserve}
+              onChange={(e) => setReserve(Math.max(0, Math.min(100, Number(e.target.value) || 0)))}
+              className="w-16 rounded border border-cp-border bg-cp-surface-1 p-1 text-right"
+            />
+          </label>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {exports.map((row) => (
+              <button
+                key={row.key}
+                type="button"
+                onClick={() => {
+                  const r = row.build()
+                  save(r.content, r.suffix, r.ext, r.mime)
+                }}
+                className="flex items-start gap-2 rounded border border-cp-border bg-cp-surface-1 p-2 text-left hover:bg-cp-surface-2"
+              >
+                <Icon icon={Download} size="sm" className="mt-0.5 shrink-0 text-cp-accent" />
+                <span className="min-w-0">
+                  <span className="block font-medium text-cp-text-bright">{row.label}</span>
+                  <span className="block text-cp-xs text-cp-text-muted">{row.hint}</span>
+                </span>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        {/* QR / Etiketten */}
+        <section className="rounded border border-cp-border bg-cp-surface-2/40 p-3">
+          <h3 className="mb-2 flex items-center gap-1.5 font-semibold text-cp-text-bright">
+            <Icon icon={QrCode} size="sm" />
+            {t('docs.qr', 'QR-/Asset-IDs & Etiketten')}
+          </h3>
+          <p className="mb-2 text-cp-xs text-cp-text-muted">
+            {t(
+              'docs.qr.hint',
+              'Vergibt kurzen, stabilen IDs an Kabel/Geräte ohne ID und druckt QR-Etiketten, die das physische Label mit dem Datensatz verknüpfen.',
+            )}
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={onAssignIds}
+              className="inline-flex items-center gap-1.5 rounded bg-cp-surface-4 px-3 py-1.5 hover:bg-cp-surface-5"
+            >
+              <Icon icon={Tag} size="sm" /> {t('docs.qr.assign', 'QR-/Asset-IDs vergeben')}
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={onQrLabelsPdf}
+              className="inline-flex items-center gap-1.5 rounded bg-cp-surface-4 px-3 py-1.5 hover:bg-cp-surface-5 disabled:opacity-50"
+            >
+              <Icon icon={QrCode} size="sm" /> {t('docs.qr.pdf', 'QR-Etiketten (PDF)')}
+            </button>
+          </div>
+        </section>
+
+        {info && (
+          <p className="rounded bg-cp-surface-2 px-2 py-1 text-cp-xs text-cp-text-secondary">{info}</p>
+        )}
+
+        {/* Änderungsprotokoll */}
+        <section>
+          <div className="mb-2 flex items-center justify-between">
+            <h3 className="flex items-center gap-1.5 font-semibold text-cp-text-bright">
+              <Icon icon={History} size="sm" />
+              {t('docs.changelog', 'Änderungsprotokoll')}{' '}
+              <span className="text-cp-text-muted">({(project.changelog ?? []).length})</span>
+            </h3>
+            {(project.changelog ?? []).length > 0 && (
+              <button
+                type="button"
+                onClick={() => clearChangelog()}
+                className="inline-flex items-center gap-1 rounded px-2 py-1 text-cp-xs text-cp-danger hover:bg-cp-surface-2"
+              >
+                <Icon icon={Trash2} size="xs" /> {t('docs.changelog.clear', 'Leeren')}
+              </button>
+            )}
+          </div>
+          {changelog.length === 0 ? (
+            <p className="text-cp-xs text-cp-text-muted">
+              {t('docs.changelog.empty', 'Noch keine Einträge. Status-/Service-Änderungen werden hier protokolliert.')}
+            </p>
+          ) : (
+            <ul className="max-h-48 space-y-1 overflow-y-auto text-cp-xs">
+              {changelog.map((e) => (
+                <li key={e.id} className="flex gap-2 rounded bg-cp-surface-1 px-2 py-1">
+                  <span className="shrink-0 font-mono text-cp-text-faint">
+                    {new Date(e.ts).toLocaleString('de-DE', {
+                      dateStyle: 'short',
+                      timeStyle: 'short',
+                    })}
+                  </span>
+                  <span className="min-w-0 flex-1">{e.summary}</span>
+                  <span className="shrink-0 text-cp-text-muted">{e.author}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </ModalShell>
+  )
+}

--- a/src/renderer/components/Export/InstallationDocsDialog.tsx
+++ b/src/renderer/components/Export/InstallationDocsDialog.tsx
@@ -20,6 +20,9 @@ import {
   History,
   Trash2,
   Tag,
+  Inbox,
+  Check,
+  X,
 } from 'lucide-react'
 import { useUiStore } from '../../store/uiStore'
 import { useProjectStore } from '../../store/projectStore'
@@ -54,6 +57,8 @@ export const InstallationDocsDialog = () => {
   const assignDocIds = useProjectStore((s) => s.assignDocIds)
   const applySourceDestLabels = useProjectStore((s) => s.applySourceDestLabels)
   const clearChangelog = useProjectStore((s) => s.clearChangelog)
+  const applyPendingChange = useProjectStore((s) => s.applyPendingChange)
+  const rejectPendingChange = useProjectStore((s) => s.rejectPendingChange)
   const editorName = useSettingsStore((s) => s.editorName)
   const setEditorName = useSettingsStore((s) => s.setEditorName)
 
@@ -190,6 +195,10 @@ export const InstallationDocsDialog = () => {
     () => [...(project.changelog ?? [])].reverse().slice(0, 30),
     [project.changelog],
   )
+  const pending = useMemo(
+    () => [...(project.pendingChanges ?? [])].reverse(),
+    [project.pendingChanges],
+  )
 
   return (
     <ModalShell
@@ -313,6 +322,71 @@ export const InstallationDocsDialog = () => {
         {info && (
           <p className="rounded bg-cp-surface-2 px-2 py-1 text-cp-xs text-cp-text-secondary">{info}</p>
         )}
+
+        {/* Feld-Rückkanal — vom Mobile-Companion gemeldete, noch offene Änderungen */}
+        <section className="rounded border border-cp-border bg-cp-surface-2/40 p-3">
+          <div className="mb-2 flex items-center justify-between">
+            <h3 className="flex items-center gap-1.5 font-semibold text-cp-text-bright">
+              <Icon icon={Inbox} size="sm" />
+              {t('docs.pending', 'Feld-Rückmeldungen')}{' '}
+              <span className={pending.length > 0 ? 'text-cp-accent' : 'text-cp-text-muted'}>
+                ({pending.length})
+              </span>
+            </h3>
+          </div>
+          {pending.length === 0 ? (
+            <p className="text-cp-xs text-cp-text-muted">
+              {t(
+                'docs.pending.empty',
+                'Keine offenen Meldungen. Korrekturen/Probleme aus dem Mobile-Companion landen hier zum Übernehmen.',
+              )}
+            </p>
+          ) : (
+            <ul className="max-h-56 space-y-1.5 overflow-y-auto text-cp-xs">
+              {pending.map((p) => (
+                <li
+                  key={p.id}
+                  className="flex items-start gap-2 rounded border border-cp-border-muted bg-cp-surface-1 px-2 py-1.5"
+                >
+                  <span className="mt-0.5 shrink-0 rounded bg-cp-surface-3 px-1.5 py-0.5 text-[10px] uppercase text-cp-text-secondary">
+                    {p.target?.type === 'cable'
+                      ? t('docs.pending.cable', 'Kabel')
+                      : p.target?.type === 'equipment'
+                        ? t('docs.pending.equipment', 'Gerät')
+                        : t('docs.pending.note', 'Notiz')}
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block break-words text-cp-text">{p.summary}</span>
+                    <span className="text-cp-text-faint">
+                      {p.target?.name ? `${p.target.name} · ` : ''}
+                      {p.author} ·{' '}
+                      {new Date(p.ts).toLocaleString('de-DE', {
+                        dateStyle: 'short',
+                        timeStyle: 'short',
+                      })}
+                    </span>
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => applyPendingChange(p.id)}
+                    title={t('docs.pending.apply', 'Übernehmen (mergt + protokolliert)')}
+                    className="shrink-0 rounded p-1 text-cp-accent hover:bg-cp-surface-2"
+                  >
+                    <Icon icon={Check} size="xs" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => rejectPendingChange(p.id)}
+                    title={t('docs.pending.reject', 'Verwerfen')}
+                    className="shrink-0 rounded p-1 text-cp-danger hover:bg-cp-surface-2"
+                  >
+                    <Icon icon={X} size="xs" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
 
         {/* Änderungsprotokoll */}
         <section>

--- a/src/renderer/components/Export/InstallationDocsDialog.tsx
+++ b/src/renderer/components/Export/InstallationDocsDialog.tsx
@@ -52,6 +52,7 @@ export const InstallationDocsDialog = () => {
   const close = useUiStore((s) => s.closeInstallDocs)
   const project = useProjectStore((s) => s.project)
   const assignDocIds = useProjectStore((s) => s.assignDocIds)
+  const applySourceDestLabels = useProjectStore((s) => s.applySourceDestLabels)
   const clearChangelog = useProjectStore((s) => s.clearChangelog)
   const editorName = useSettingsStore((s) => s.editorName)
   const setEditorName = useSettingsStore((s) => s.setEditorName)
@@ -59,6 +60,7 @@ export const InstallationDocsDialog = () => {
   const [reserve, setReserve] = useState(10)
   const [busy, setBusy] = useState(false)
   const [info, setInfo] = useState('')
+  const [overwriteLabels, setOverwriteLabels] = useState(false)
 
   const baseName = project.metadata.name || 'anlage'
 
@@ -280,6 +282,31 @@ export const InstallationDocsDialog = () => {
             >
               <Icon icon={QrCode} size="sm" /> {t('docs.qr.pdf', 'QR-Etiketten (PDF)')}
             </button>
+          </div>
+          <div className="mt-2 flex flex-wrap items-center gap-2 border-t border-cp-border pt-2">
+            <button
+              type="button"
+              onClick={() => {
+                const n = applySourceDestLabels({ overwrite: overwriteLabels })
+                setInfo(
+                  n === 0
+                    ? t('docs.label.none', 'Keine Labels geändert (alle benannt — ggf. „überschreiben" aktivieren).')
+                    : `${n} Kabel-Labels aus Quelle→Ziel erzeugt.`,
+                )
+              }}
+              className="inline-flex items-center gap-1.5 rounded bg-cp-surface-4 px-3 py-1.5 hover:bg-cp-surface-5"
+            >
+              <Icon icon={Tag} size="sm" />{' '}
+              {t('docs.label.sourceDest', 'Kabel-Labels „Quelle → Ziel" (AVIXA F501.01)')}
+            </button>
+            <label className="flex items-center gap-1.5 text-cp-xs text-cp-text-secondary">
+              <input
+                type="checkbox"
+                checked={overwriteLabels}
+                onChange={(e) => setOverwriteLabels(e.target.checked)}
+              />
+              {t('docs.label.overwrite', 'vorhandene Namen überschreiben')}
+            </label>
           </div>
         </section>
 

--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -5,7 +5,7 @@ import {
   Undo2, Redo2, Radio, Zap, BarChart3, Server, Monitor, MonitorPlay, SlidersHorizontal, Tag,
   Shuffle, Headphones, Import as ImportIcon, Users, Lightbulb, Info, Check,
   Pencil, Smartphone, Settings, HardDrive, Copy, ClipboardCheck, History, Sparkles,
-  Maximize, Maximize2, ZoomIn, ZoomOut, Scan, BoxSelect, RefreshCw,
+  Maximize, Maximize2, ZoomIn, ZoomOut, Scan, BoxSelect, RefreshCw, PackageCheck,
 } from 'lucide-react'
 import { Icon } from '../shared/Icon'
 import {
@@ -429,6 +429,9 @@ export const MenuBar = ({
           <MenuSectionHeader>{t('app.menu.tools.group.io', 'Import & Export')}</MenuSectionHeader>
           <MenuItem onClick={() => useUiStore.getState().openPatchList()} icon={<Icon icon={Cable} size="sm" />}>
             {t('app.menu.tools.patchList', 'Patch-Liste…')}
+          </MenuItem>
+          <MenuItem onClick={() => useUiStore.getState().openInstallDocs()} icon={<Icon icon={PackageCheck} size="sm" />}>
+            {t('app.menu.tools.installDocs', 'Festinstallation: Doku & Übergabe…')}
           </MenuItem>
           <MenuItem
             onClick={() => {

--- a/src/renderer/components/Properties/CableProperties.tsx
+++ b/src/renderer/components/Properties/CableProperties.tsx
@@ -12,6 +12,7 @@ import { RoutingToggle } from '../shared/RoutingToggle'
 import { format, useTranslation } from '../../lib/i18n'
 import { STANDARD_LAYERS, LAYER_STYLES } from '../../lib/cableLayers'
 import { netKeyOf, netPeerCount } from '../../lib/offPageNet'
+import { sourceDestLabel } from '../../lib/cableLabel'
 import {
   INSTALL_STATUSES,
   INSTALL_STATUS_LABEL,
@@ -150,6 +151,18 @@ export const CableProperties = () => {
           onChange={(event) => updateCable(cable.id, { name: event.target.value })}
           className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
         />
+        <button
+          type="button"
+          onClick={() =>
+            updateCable(cable.id, {
+              name: sourceDestLabel(cable, new Map(equipment.map((e) => [e.id, e]))),
+            })
+          }
+          className="mt-1 text-[10px] text-cp-accent hover:underline"
+          title={t('cable.field.sourceDestTitle', 'Name aus Quelle → Ziel erzeugen (AVIXA F501.01)')}
+        >
+          ↳ {t('cable.field.sourceDest', 'aus Quelle → Ziel')}
+        </button>
       </label>
       {/* v7.9.68 / #182 — Bei Wireless-Links macht "Länge" keinen Sinn;
           stattdessen "Max. Reichweite" eintragen. */}

--- a/src/renderer/components/Properties/CableProperties.tsx
+++ b/src/renderer/components/Properties/CableProperties.tsx
@@ -12,6 +12,12 @@ import { RoutingToggle } from '../shared/RoutingToggle'
 import { format, useTranslation } from '../../lib/i18n'
 import { STANDARD_LAYERS, LAYER_STYLES } from '../../lib/cableLayers'
 import { netKeyOf, netPeerCount } from '../../lib/offPageNet'
+import {
+  INSTALL_STATUSES,
+  INSTALL_STATUS_LABEL,
+  type InstallStatus,
+  type CableTestResult,
+} from '../../types/lifecycle'
 
 export const CableProperties = () => {
   const t = useTranslation()
@@ -21,6 +27,8 @@ export const CableProperties = () => {
   const cables = useProjectStore((state) => state.project.cables)
   const updateCable = useProjectStore((state) => state.updateCable)
   const deleteCable = useProjectStore((state) => state.deleteCable)
+  const setCableInstallStatus = useProjectStore((state) => state.setCableInstallStatus)
+  const setCableTestResult = useProjectStore((state) => state.setCableTestResult)
   const openCableEdit = useUiStore((state) => state.openCableEdit)
   const cableLayersFromStore = useUiStore((state) => state.customLayers)
 
@@ -208,6 +216,152 @@ export const CableProperties = () => {
           )}
         </select>
       </label>
+
+      {/* Festinstallation — Lebenszyklus: Status, Trasse, Mantel,
+          Terminierung und Mess-/Test-Ergebnis. */}
+      <details className="rounded border border-cp-border bg-cp-surface-3/40">
+        <summary className="cursor-pointer select-none px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-cp-text-muted hover:bg-cp-surface-2/40">
+          {t('lifecycle.cableSection', 'Festinstallation / Lebenszyklus')}
+        </summary>
+        <div className="space-y-2 border-t border-cp-border p-2">
+          <label className="block">
+            <span className="mb-1 block text-cp-text-secondary">{t('lifecycle.status', 'Status')}</span>
+            <select
+              value={cable.installStatus ?? ''}
+              onChange={(e) =>
+                setCableInstallStatus(
+                  cable.id,
+                  (e.target.value || undefined) as InstallStatus | undefined,
+                )
+              }
+              className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
+            >
+              <option value="">{t('lifecycle.statusNone', '— kein Status —')}</option>
+              {INSTALL_STATUSES.map((s) => (
+                <option key={s} value={s}>
+                  {INSTALL_STATUS_LABEL[s]}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="grid grid-cols-2 gap-2">
+            <label className="block">
+              <span className="mb-1 block text-cp-text-secondary">{t('lifecycle.pathway', 'Trasse / Pfad')}</span>
+              <input
+                value={cable.pathway ?? ''}
+                onChange={(e) => updateCable(cable.id, { pathway: e.target.value || undefined })}
+                className="w-full rounded border border-cp-border bg-cp-surface-1 p-1.5"
+              />
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-cp-text-secondary">{t('lifecycle.jacket', 'Mantel/Brandklasse')}</span>
+              <input
+                value={cable.jacketRating ?? ''}
+                placeholder="CM / CMR / CMP / LSZH"
+                onChange={(e) => updateCable(cable.id, { jacketRating: e.target.value || undefined })}
+                className="w-full rounded border border-cp-border bg-cp-surface-1 p-1.5"
+              />
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-cp-text-secondary">{t('lifecycle.termFrom', 'Term. A')}</span>
+              <input
+                value={cable.terminationFrom ?? ''}
+                placeholder="T568B / LC / …"
+                onChange={(e) => updateCable(cable.id, { terminationFrom: e.target.value || undefined })}
+                className="w-full rounded border border-cp-border bg-cp-surface-1 p-1.5"
+              />
+            </label>
+            <label className="block">
+              <span className="mb-1 block text-cp-text-secondary">{t('lifecycle.termTo', 'Term. B')}</span>
+              <input
+                value={cable.terminationTo ?? ''}
+                placeholder="T568B / LC / …"
+                onChange={(e) => updateCable(cable.id, { terminationTo: e.target.value || undefined })}
+                className="w-full rounded border border-cp-border bg-cp-surface-1 p-1.5"
+              />
+            </label>
+          </div>
+          {/* Mess-/Test-Ergebnis */}
+          <div className="rounded border border-cp-border-muted bg-cp-surface-1/40 p-1.5">
+            <div className="mb-1 flex items-center justify-between">
+              <span className="text-[11px] text-cp-text-secondary">{t('lifecycle.test', 'Mess-/Test-Ergebnis')}</span>
+              {cable.testResult && (
+                <button
+                  type="button"
+                  onClick={() => setCableTestResult(cable.id, undefined)}
+                  className="rounded px-1 py-0.5 text-[10px] text-cp-text-muted hover:bg-cp-surface-3"
+                >
+                  {t('common.clear', 'Löschen')}
+                </button>
+              )}
+            </div>
+            <div className="grid grid-cols-2 gap-1.5">
+              <select
+                value={cable.testResult?.result ?? ''}
+                onChange={(e) => {
+                  const v = e.target.value
+                  if (!v) {
+                    setCableTestResult(cable.id, undefined)
+                    return
+                  }
+                  const next: CableTestResult = {
+                    ...(cable.testResult ?? {}),
+                    result: v as 'pass' | 'fail',
+                    testedAt: cable.testResult?.testedAt ?? new Date().toISOString(),
+                  }
+                  setCableTestResult(cable.id, next)
+                }}
+                className="rounded border border-cp-border bg-cp-surface-1 p-1.5 text-[11px]"
+              >
+                <option value="">{t('lifecycle.testNone', '— nicht getestet —')}</option>
+                <option value="pass">PASS</option>
+                <option value="fail">FAIL</option>
+              </select>
+              <input
+                type="number"
+                step="0.1"
+                value={cable.testResult?.marginDb ?? ''}
+                placeholder={t('lifecycle.margin', 'Marge dB')}
+                disabled={!cable.testResult}
+                onChange={(e) =>
+                  cable.testResult &&
+                  setCableTestResult(cable.id, {
+                    ...cable.testResult,
+                    marginDb: e.target.value === '' ? undefined : Number(e.target.value),
+                  })
+                }
+                className="rounded border border-cp-border bg-cp-surface-1 p-1.5 text-[11px] disabled:opacity-40"
+              />
+              <input
+                value={cable.testResult?.standard ?? ''}
+                placeholder={t('lifecycle.testStd', 'Standard/Limit')}
+                disabled={!cable.testResult}
+                onChange={(e) =>
+                  cable.testResult &&
+                  setCableTestResult(cable.id, {
+                    ...cable.testResult,
+                    standard: e.target.value || undefined,
+                  })
+                }
+                className="rounded border border-cp-border bg-cp-surface-1 p-1.5 text-[11px] disabled:opacity-40"
+              />
+              <input
+                value={cable.testResult?.reportRef ?? ''}
+                placeholder={t('lifecycle.reportRef', 'Report-Datei')}
+                disabled={!cable.testResult}
+                onChange={(e) =>
+                  cable.testResult &&
+                  setCableTestResult(cable.id, {
+                    ...cable.testResult,
+                    reportRef: e.target.value || undefined,
+                  })
+                }
+                className="rounded border border-cp-border bg-cp-surface-1 p-1.5 text-[11px] disabled:opacity-40"
+              />
+            </div>
+          </div>
+        </div>
+      </details>
 
       {/* #363 — Multicore/Snake-Zuordnung: Kabel mit gleichem Namen bilden
           ein Bündel. Datalist schlägt bereits vergebene Namen vor. */}

--- a/src/renderer/components/Properties/EquipmentProperties.tsx
+++ b/src/renderer/components/Properties/EquipmentProperties.tsx
@@ -36,6 +36,7 @@ import { NetworkConfigSection } from './sections/NetworkConfigSection'
 import { ModesSection } from './sections/ModesSection'
 import { RackInstanceCard } from './sections/RackInstanceCard'
 import { ReplaceDeviceSection } from './sections/ReplaceDeviceSection'
+import { LifecycleSection } from './sections/LifecycleSection'
 
 /** Module-level sensor options so re-renders don't churn the sensor
  *  instances. Stable references are critical for DnDContext's
@@ -141,6 +142,8 @@ export const EquipmentProperties = () => {
       <CategoryPropsSection equipment={equipment} />
 
       <NetworkAccessSection equipment={equipment} />
+
+      <LifecycleSection equipment={equipment} />
 
       <PowerConsumptionSection equipment={equipment} />
 

--- a/src/renderer/components/Properties/sections/LifecycleSection.tsx
+++ b/src/renderer/components/Properties/sections/LifecycleSection.tsx
@@ -1,0 +1,188 @@
+/**
+ * Festinstallation — Geräte-Lebenszyklus-Section.
+ *
+ * Betriebs-Status, Asset-Tag, Garantie, Wartungsintervall und die
+ * zeitgestempelte Service-Historie eines Geräts. Bewusst ein einfaches
+ * <details> (nicht draggable), damit kein Eintrag in der sortierbaren
+ * Section-Order nötig ist.
+ */
+import { useState } from 'react'
+import { Wrench, Trash2, Plus } from 'lucide-react'
+import { useCanvasProjectStore as useProjectStore } from '../../../store/projectStoreContext'
+import { useSettingsStore } from '../../../store/settingsStore'
+import { useTranslation } from '../../../lib/i18n'
+import { Icon } from '../../shared/Icon'
+import {
+  INSTALL_STATUSES,
+  INSTALL_STATUS_LABEL,
+  type InstallStatus,
+  type ServiceRecord,
+} from '../../../types/lifecycle'
+import type { EquipmentItem } from '../../../types/equipment'
+
+const SERVICE_KINDS: ServiceRecord['kind'][] = [
+  'install',
+  'inspection',
+  'repair',
+  'replacement',
+  'note',
+]
+const SERVICE_KIND_LABEL: Record<ServiceRecord['kind'], string> = {
+  install: 'Installation',
+  inspection: 'Inspektion',
+  repair: 'Reparatur',
+  replacement: 'Austausch',
+  note: 'Notiz',
+}
+
+export const LifecycleSection = ({ equipment }: { equipment: EquipmentItem }) => {
+  const t = useTranslation()
+  const updateEquipment = useProjectStore((s) => s.updateEquipment)
+  const setStatus = useProjectStore((s) => s.setEquipmentInstallStatus)
+  const addServiceRecord = useProjectStore((s) => s.addServiceRecord)
+  const removeServiceRecord = useProjectStore((s) => s.removeServiceRecord)
+  const editorName = useSettingsStore((s) => s.editorName)
+
+  const [kind, setKind] = useState<ServiceRecord['kind']>('inspection')
+  const [summary, setSummary] = useState('')
+
+  const history = equipment.serviceHistory ?? []
+
+  const onAdd = () => {
+    const text = summary.trim()
+    if (!text) return
+    addServiceRecord(equipment.id, {
+      date: new Date().toISOString(),
+      author: editorName.trim() || 'Unbekannt',
+      kind,
+      summary: text,
+    })
+    setSummary('')
+  }
+
+  return (
+    <details className="rounded border border-cp-border bg-cp-surface-3/40">
+      <summary className="flex cursor-pointer select-none items-center gap-1.5 px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-cp-text-muted hover:bg-cp-surface-2/40">
+        <Icon icon={Wrench} size="xs" />
+        {t('lifecycle.section', 'Lebenszyklus / Wartung')}
+      </summary>
+      <div className="space-y-2 border-t border-cp-border p-2">
+        <label className="block">
+          <span className="mb-1 block text-cp-text-secondary">{t('lifecycle.status', 'Status')}</span>
+          <select
+            value={equipment.installStatus ?? ''}
+            onChange={(e) =>
+              setStatus(equipment.id, (e.target.value || undefined) as InstallStatus | undefined)
+            }
+            className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
+          >
+            <option value="">{t('lifecycle.statusNone', '— kein Status —')}</option>
+            {INSTALL_STATUSES.map((s) => (
+              <option key={s} value={s}>
+                {INSTALL_STATUS_LABEL[s]}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="grid grid-cols-2 gap-2">
+          <label className="block">
+            <span className="mb-1 block text-cp-text-secondary">{t('lifecycle.assetTag', 'Asset-Tag')}</span>
+            <input
+              value={equipment.assetTag ?? ''}
+              onChange={(e) => updateEquipment(equipment.id, { assetTag: e.target.value || undefined })}
+              className="w-full rounded border border-cp-border bg-cp-surface-1 p-1.5"
+            />
+          </label>
+          <label className="block">
+            <span className="mb-1 block text-cp-text-secondary">{t('lifecycle.warranty', 'Garantie bis')}</span>
+            <input
+              type="date"
+              value={(equipment.warrantyUntil ?? '').slice(0, 10)}
+              onChange={(e) => updateEquipment(equipment.id, { warrantyUntil: e.target.value || undefined })}
+              className="w-full rounded border border-cp-border bg-cp-surface-1 p-1.5"
+            />
+          </label>
+        </div>
+
+        <label className="block">
+          <span className="mb-1 block text-cp-text-secondary">
+            {t('lifecycle.maintInterval', 'Wartungsintervall (Tage)')}
+          </span>
+          <input
+            type="number"
+            min={0}
+            value={equipment.maintenanceIntervalDays ?? ''}
+            onChange={(e) =>
+              updateEquipment(equipment.id, {
+                maintenanceIntervalDays: e.target.value === '' ? undefined : Number(e.target.value),
+              })
+            }
+            className="w-full rounded border border-cp-border bg-cp-surface-1 p-1.5"
+          />
+        </label>
+
+        {/* Service-Historie */}
+        <div>
+          <div className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-cp-text-muted">
+            {t('lifecycle.history', 'Service-Historie')} ({history.length})
+          </div>
+          {history.length > 0 && (
+            <ul className="mb-2 space-y-1">
+              {[...history]
+                .sort((a, b) => b.date.localeCompare(a.date))
+                .map((r) => (
+                  <li key={r.id} className="flex items-start gap-1.5 rounded bg-cp-surface-1 px-2 py-1 text-[11px]">
+                    <span className="shrink-0 font-mono text-cp-text-faint">
+                      {new Date(r.date).toLocaleDateString('de-DE')}
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="text-cp-text-muted">[{SERVICE_KIND_LABEL[r.kind]}]</span> {r.summary}
+                      {r.author ? <span className="text-cp-text-faint"> — {r.author}</span> : null}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => removeServiceRecord(equipment.id, r.id)}
+                      className="shrink-0 rounded p-0.5 text-cp-danger hover:bg-cp-surface-3"
+                      aria-label={t('lifecycle.history.delete', 'Eintrag löschen')}
+                    >
+                      <Icon icon={Trash2} size="xs" />
+                    </button>
+                  </li>
+                ))}
+            </ul>
+          )}
+          <div className="flex gap-1">
+            <select
+              value={kind}
+              onChange={(e) => setKind(e.target.value as ServiceRecord['kind'])}
+              className="rounded border border-cp-border bg-cp-surface-1 p-1.5 text-[11px]"
+            >
+              {SERVICE_KINDS.map((k) => (
+                <option key={k} value={k}>
+                  {SERVICE_KIND_LABEL[k]}
+                </option>
+              ))}
+            </select>
+            <input
+              value={summary}
+              onChange={(e) => setSummary(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') onAdd()
+              }}
+              placeholder={t('lifecycle.history.placeholder', 'Was wurde gemacht?')}
+              className="min-w-0 flex-1 rounded border border-cp-border bg-cp-surface-1 p-1.5 text-[11px]"
+            />
+            <button
+              type="button"
+              onClick={onAdd}
+              className="inline-flex shrink-0 items-center gap-1 rounded bg-cp-surface-4 px-2 py-1.5 text-[11px] hover:bg-cp-surface-5"
+            >
+              <Icon icon={Plus} size="xs" /> {t('common.add', 'Hinzufügen')}
+            </button>
+          </div>
+        </div>
+      </div>
+    </details>
+  )
+}

--- a/src/renderer/lib/assetRegister.ts
+++ b/src/renderer/lib/assetRegister.ts
@@ -1,0 +1,96 @@
+/**
+ * Festinstallation — Asset-Register für den Betreiber.
+ *
+ * Pro Gerät: Asset-Tag, Standort, Serien-Nr., Status, Garantie, Wartungs-
+ * intervall, letzter Service. Die Grundlage für die Langzeit-Wartung und für
+ * einen späteren CMMS-Import (Branchen-Praxis: Etikett/QR → Asset-Datensatz).
+ */
+import type { CablePlannerProject } from '../types/project'
+import type { EquipmentItem } from '../types/equipment'
+import { INSTALL_STATUS_LABEL } from '../types/lifecycle'
+import { equipmentAssetTag } from './docIds'
+import { toCsv, type CsvCell } from './csv'
+
+export interface AssetRow {
+  assetTag: string
+  name: string
+  category: string
+  location: string
+  serial: string
+  ip: string
+  firmware: string
+  status: string
+  warrantyUntil: string
+  maintenanceIntervalDays: string
+  lastService: string
+  serviceCount: number
+}
+
+/** Standort aus der umschließenden Location (Raum + Etage), wenn vorhanden. */
+const locationOf = (project: CablePlannerProject, eq: EquipmentItem): string => {
+  const loc = (project.locations ?? []).find(
+    (l) =>
+      eq.x >= l.x &&
+      eq.y >= l.y &&
+      eq.x <= l.x + l.width &&
+      eq.y <= l.y + l.height,
+  )
+  if (!loc) return ''
+  return loc.floor ? `${loc.name} (${loc.floor})` : loc.name
+}
+
+export const buildAssetRows = (project: CablePlannerProject): AssetRow[] =>
+  project.equipment.map((e) => {
+    const history = e.serviceHistory ?? []
+    const last = history.reduce<string>((acc, r) => (r.date > acc ? r.date : acc), '')
+    return {
+      assetTag: equipmentAssetTag(e),
+      name: e.name,
+      category: e.category ?? '',
+      location: locationOf(project, e),
+      serial: e.serialNumber ?? '',
+      ip: e.ipAddress ?? '',
+      firmware: e.firmware ?? '',
+      status: e.installStatus ? INSTALL_STATUS_LABEL[e.installStatus] : '',
+      warrantyUntil: e.warrantyUntil ?? '',
+      maintenanceIntervalDays:
+        typeof e.maintenanceIntervalDays === 'number'
+          ? String(e.maintenanceIntervalDays)
+          : '',
+      lastService: last,
+      serviceCount: history.length,
+    }
+  })
+
+export const assetRegisterCsv = (project: CablePlannerProject): string => {
+  const rows = buildAssetRows(project)
+  const headers = [
+    'Asset-Tag',
+    'Gerät',
+    'Kategorie',
+    'Standort',
+    'Serien-Nr.',
+    'IP',
+    'Firmware',
+    'Status',
+    'Garantie bis',
+    'Wartungsintervall (Tage)',
+    'Letzter Service',
+    'Service-Einträge',
+  ]
+  const body: CsvCell[][] = rows.map((r) => [
+    r.assetTag,
+    r.name,
+    r.category,
+    r.location,
+    r.serial,
+    r.ip,
+    r.firmware,
+    r.status,
+    r.warrantyUntil,
+    r.maintenanceIntervalDays,
+    r.lastService,
+    r.serviceCount,
+  ])
+  return toCsv(headers, body)
+}

--- a/src/renderer/lib/bridge.ts
+++ b/src/renderer/lib/bridge.ts
@@ -314,6 +314,16 @@ type CablePlannerApi = {
         notes?: string
       }) => void,
     ) => () => void
+    /** Feld-Rückkanal — Listener für Mobile-Pending-Change-Meldungen. */
+    onPendingChange: (
+      cb: (change: {
+        author?: string
+        kind: string
+        target?: { type: 'cable' | 'equipment'; id?: string; name?: string }
+        summary: string
+        patch?: Record<string, unknown>
+      }) => void,
+    ) => () => void
   }
 }
 
@@ -765,6 +775,7 @@ const webFallbackApi: CablePlannerApi = {
     setProject: async () => ({ ok: true }),
     onChecksUpdate: () => () => {},
     onCableAdded: () => () => {},
+    onPendingChange: () => () => {},
   },
 }
 

--- a/src/renderer/lib/cableLabel.ts
+++ b/src/renderer/lib/cableLabel.ts
@@ -1,0 +1,40 @@
+/**
+ * Festinstallation — Kabel-Label im AVIXA-F501.01-Stil (Quelle → Ziel).
+ *
+ * F501.01 verlangt am Kabel ein druckbares Label, das hierarchisch sagt, WO das
+ * Kabel angeschlossen ist (Beispiel der Norm: "VDA2 Out 3 to PROJ Input A").
+ * Diese reine Funktion baut genau diesen String aus den beiden Endpunkten des
+ * Kabels — Gerät (Kurzname) + Port (Content-Label/Name) je Ende.
+ */
+import type { Cable } from '../types/cable'
+import type { EquipmentItem } from '../types/equipment'
+import { generateShortName } from './shortName'
+import { portDisplayLabel } from './portLabel'
+
+const deviceShort = (eq?: EquipmentItem): string => {
+  if (!eq) return '?'
+  return eq.shortName?.trim() || generateShortName(eq.name) || eq.name || '?'
+}
+
+const portText = (eq: EquipmentItem | undefined, portId: string): string => {
+  if (!eq) return ''
+  const p = eq.outputs.find((x) => x.id === portId) ?? eq.inputs.find((x) => x.id === portId)
+  return p ? portDisplayLabel(p) : ''
+}
+
+/**
+ * Baut das Quelle→Ziel-Label. `separator` ist per Default ein Pfeil (kompakt für
+ * Etiketten); für norm-näheres Wording kann " to " übergeben werden.
+ */
+export const sourceDestLabel = (
+  cable: Cable,
+  eqById: Map<string, EquipmentItem>,
+  opts: { separator?: string } = {},
+): string => {
+  const sep = opts.separator ?? '→'
+  const from = eqById.get(cable.fromEquipmentId)
+  const to = eqById.get(cable.toEquipmentId)
+  const src = [deviceShort(from), portText(from, cable.fromPortId)].filter(Boolean).join(' ')
+  const dst = [deviceShort(to), portText(to, cable.toPortId)].filter(Boolean).join(' ')
+  return `${src} ${sep} ${dst}`.trim()
+}

--- a/src/renderer/lib/csv.ts
+++ b/src/renderer/lib/csv.ts
@@ -1,0 +1,35 @@
+/**
+ * Minimaler, robuster CSV-Builder für die Festinstallations-Exporte
+ * (Pull-Liste, Termination-Liste, Asset-Register …). Installateure
+ * erwarten editierbares, sortierbares CSV/Excel.
+ *
+ * - RFC-4180-Quoting (Feld mit Delimiter/Quote/Zeilenumbruch → in "…",
+ *   innere " verdoppelt).
+ * - CRLF-Zeilenenden + UTF-8-BOM, damit Excel Umlaute korrekt erkennt.
+ * - Default-Delimiter ist `;` (deutsches Excel) — überschreibbar.
+ */
+
+export type CsvCell = string | number | null | undefined
+
+const escapeCell = (value: CsvCell, delimiter: string): string => {
+  const s = value === null || value === undefined ? '' : String(value)
+  const needsQuote =
+    s.includes(delimiter) ||
+    s.includes('"') ||
+    s.includes('\n') ||
+    s.includes('\r')
+  return needsQuote ? `"${s.replace(/"/g, '""')}"` : s
+}
+
+export const toCsv = (
+  headers: string[],
+  rows: CsvCell[][],
+  opts: { delimiter?: string; bom?: boolean } = {},
+): string => {
+  const delimiter = opts.delimiter ?? ';'
+  const bom = opts.bom ?? true
+  const lines = [headers, ...rows].map((row) =>
+    row.map((cell) => escapeCell(cell, delimiter)).join(delimiter),
+  )
+  return (bom ? '﻿' : '') + lines.join('\r\n')
+}

--- a/src/renderer/lib/docIds.ts
+++ b/src/renderer/lib/docIds.ts
@@ -7,6 +7,7 @@
  */
 import type { Cable } from '../types/cable'
 import type { EquipmentItem } from '../types/equipment'
+import { buildQrPayload } from './qrPayload'
 
 /** Baut eine Doc-ID `PREFIX-NNNN` (nullgepolstert). */
 export const makeDocId = (prefix: string, n: number, pad = 4): string =>
@@ -26,8 +27,4 @@ export const equipmentAssetTag = (e: EquipmentItem): string =>
  * `cableplanner:`-URI, die ein Scan-Lookup (Mobile/Viewer) auf den
  * Datensatz auflösen kann — plus Klartext-Fallback für jede QR-App.
  */
-export const qrPayload = (
-  kind: 'cable' | 'equipment',
-  id: string,
-  label: string,
-): string => `cableplanner://${kind}/${encodeURIComponent(id)}?l=${encodeURIComponent(label)}`
+export const qrPayload = buildQrPayload

--- a/src/renderer/lib/docIds.ts
+++ b/src/renderer/lib/docIds.ts
@@ -1,0 +1,33 @@
+/**
+ * Festinstallation — stabile, druckbare Dokumentations-IDs.
+ *
+ * Verknüpft das physische Etikett (Kabel-Label, Asset-Tag, QR-Code) mit dem
+ * digitalen Datensatz. Konvention an TIA-606/AVIXA F501.01 angelehnt: kurze,
+ * eindeutige, stabile IDs; das volle Quelle→Ziel-Mapping lebt im Plan.
+ */
+import type { Cable } from '../types/cable'
+import type { EquipmentItem } from '../types/equipment'
+
+/** Baut eine Doc-ID `PREFIX-NNNN` (nullgepolstert). */
+export const makeDocId = (prefix: string, n: number, pad = 4): string =>
+  `${prefix}-${String(n).padStart(pad, '0')}`
+
+/** Effektives Kabel-Label für Listen/Etiketten: vergebene Kabelnummer →
+ *  QR-ID → Kurzform der internen UUID als letzter Fallback. */
+export const cableLabelId = (c: Cable): string =>
+  c.cableNumber?.trim() || c.qrId?.trim() || `C-${c.id.slice(0, 8)}`
+
+/** Effektiver Asset-Tag eines Geräts: Asset-Nummer → QR-ID → UUID-Kurzform. */
+export const equipmentAssetTag = (e: EquipmentItem): string =>
+  e.assetTag?.trim() || e.qrId?.trim() || `A-${e.id.slice(0, 8)}`
+
+/**
+ * Inhalt eines QR-Codes auf einem Etikett. Bewusst eine kompakte
+ * `cableplanner:`-URI, die ein Scan-Lookup (Mobile/Viewer) auf den
+ * Datensatz auflösen kann — plus Klartext-Fallback für jede QR-App.
+ */
+export const qrPayload = (
+  kind: 'cable' | 'equipment',
+  id: string,
+  label: string,
+): string => `cableplanner://${kind}/${encodeURIComponent(id)}?l=${encodeURIComponent(label)}`

--- a/src/renderer/lib/handoverPackage.ts
+++ b/src/renderer/lib/handoverPackage.ts
@@ -1,0 +1,117 @@
+/**
+ * Festinstallation — Übergabe-/Closeout-Paket für den Betreiber.
+ *
+ * Die Branche hat eine feste Inhaltsliste für das Handover (As-built, O&M,
+ * Asset-Register, Commissioning, Garantien, Reserve-/Ersatzteile). Diese
+ * Funktion baut daraus ein menschenlesbares Übergabe-Dokument (Markdown) +
+ * eine Datei-Liste, die der Dialog einzeln als Download anbietet.
+ */
+import type { CablePlannerProject } from '../types/project'
+import { buildAssetRows } from './assetRegister'
+import { buildCableBomRows } from './installerLists'
+import { INSTALL_STATUS_LABEL, type InstallStatus } from './../types/lifecycle'
+
+const fmtDate = (iso?: string): string => {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleDateString('de-DE')
+}
+
+/** Zählt Kabel je Status für die Commissioning-Übersicht. */
+const cableStatusCounts = (project: CablePlannerProject): Record<string, number> => {
+  const counts: Record<string, number> = {}
+  for (const c of project.cables) {
+    const key = c.installStatus ?? 'unset'
+    counts[key] = (counts[key] ?? 0) + 1
+  }
+  return counts
+}
+
+export const buildHandoverManifest = (project: CablePlannerProject): string => {
+  const m = project.metadata
+  const assets = buildAssetRows(project)
+  const bom = buildCableBomRows(project)
+  const statusCounts = cableStatusCounts(project)
+  const tested = project.cables.filter((c) => c.testResult).length
+  const passed = project.cables.filter((c) => c.testResult?.result === 'pass').length
+  const totalLength = project.cables.reduce((s, c) => s + (c.length ?? 0), 0)
+  const asBuilt = (project.revisions ?? []).filter((r) => r.asBuilt)
+
+  const lines: string[] = []
+  lines.push(`# Übergabe-Dokumentation — ${m.name || 'Anlage'}`)
+  lines.push('')
+  lines.push(`Erstellt: ${fmtDate(new Date().toISOString())}`)
+  lines.push('')
+  lines.push('## 1 · Projekt / Anlage')
+  lines.push('')
+  lines.push(`- **Anlage:** ${m.name || '—'}`)
+  lines.push(`- **Standort:** ${m.siteAddress || '—'}`)
+  lines.push(`- **Kunde:** ${m.client || '—'}`)
+  lines.push(`- **Errichter:** ${m.contractor || m.author || '—'}`)
+  lines.push(`- **Projekt-Nr.:** ${m.projectNumber || '—'}`)
+  lines.push(`- **Übergabe-Datum:** ${fmtDate(m.handoverDate)}`)
+  lines.push(`- **Wartender Dienstleister:** ${m.serviceProvider || '—'}`)
+  lines.push(`- **Notfall-/Servicekontakt:** ${m.emergencyContact || '—'}`)
+  lines.push(`- **Aktuelle Revision:** ${m.revision || '—'}`)
+  lines.push('')
+  lines.push('## 2 · Umfang (Überblick)')
+  lines.push('')
+  lines.push(`- Geräte: **${project.equipment.length}**`)
+  lines.push(`- Kabel/Verbindungen: **${project.cables.length}**`)
+  lines.push(`- Gesamt-Kabellänge: **${totalLength.toFixed(1)} m**`)
+  lines.push(`- Räume/Bereiche: **${(project.locations ?? []).length}**`)
+  lines.push('')
+  lines.push('## 3 · Commissioning / Status')
+  lines.push('')
+  for (const key of Object.keys(statusCounts)) {
+    const label =
+      key === 'unset' ? 'ohne Status' : INSTALL_STATUS_LABEL[key as InstallStatus] ?? key
+    lines.push(`- ${label}: ${statusCounts[key]}`)
+  }
+  lines.push(`- Kabel getestet: **${tested}** (davon PASS: **${passed}**)`)
+  if (asBuilt.length > 0) {
+    lines.push('')
+    lines.push('### As-Built-Revisionen')
+    for (const r of asBuilt) {
+      lines.push(`- ${r.label} — ${fmtDate(r.createdAt)}${r.note ? ` — ${r.note}` : ''}`)
+    }
+  }
+  lines.push('')
+  lines.push('## 4 · Kabel-Stückliste (mit 10% Reserve)')
+  lines.push('')
+  lines.push('| Typ | Länge (m) | Menge | inkl. Reserve |')
+  lines.push('|---|---|---|---|')
+  for (const r of bom) {
+    lines.push(`| ${r.type} | ${r.lengthM} | ${r.qty} | ${r.qtyWithReserve} |`)
+  }
+  lines.push('')
+  lines.push('## 5 · Asset-Register (Auszug)')
+  lines.push('')
+  lines.push('| Asset-Tag | Gerät | Standort | Serien-Nr. | Garantie bis |')
+  lines.push('|---|---|---|---|---|')
+  for (const a of assets) {
+    lines.push(`| ${a.assetTag} | ${a.name} | ${a.location || '—'} | ${a.serial || '—'} | ${a.warrantyUntil || '—'} |`)
+  }
+  lines.push('')
+  lines.push('## 6 · Enthaltene Dateien')
+  lines.push('')
+  lines.push('- `pull-liste.csv` — Pull-/Verlege-Liste je Kabel')
+  lines.push('- `termination-liste.csv` — Terminierung je Kabelende')
+  lines.push('- `kabel-schedule.csv` — Kabel-Register')
+  lines.push('- `kabel-bom.csv` — Stückliste inkl. Reserve')
+  lines.push('- `asset-register.csv` — Geräte-/Asset-Register')
+  lines.push('- Plan-PDF / As-built-Schema (separat aus dem Export-Dialog)')
+  lines.push('')
+  lines.push('---')
+  lines.push('')
+  lines.push('_Erzeugt mit Cable-Planner. Diese Doku ist vendor-neutral —')
+  lines.push('jeder qualifizierte Dienstleister kann die Anlage übernehmen._')
+  return lines.join('\n')
+}
+
+/** Einzelne Datei-Bausteine des Übergabe-Pakets (der Dialog lädt sie herunter). */
+export interface HandoverFile {
+  name: string
+  content: string
+  mime: string
+}

--- a/src/renderer/lib/installerLists.ts
+++ b/src/renderer/lib/installerLists.ts
@@ -1,0 +1,319 @@
+/**
+ * Festinstallation — Listen für Elektro-/AV-Installateure.
+ *
+ * Installateure arbeiten nicht am Canvas, sondern aus editierbaren Listen
+ * (Excel/CSV). Diese reinen Funktionen leiten aus dem Plan die branchen-
+ * üblichen Dokumente ab:
+ *   - Pull-Liste / Pull-Schedule (die Feld-To-do-Liste pro Kabel)
+ *   - Termination-Liste (welcher Leiter/Stecker je Ende)
+ *   - Kabel-Schedule (Design-Register aller Kabel)
+ *   - Kabel-BOM mit Reserve-Aufschlag
+ *
+ * Spaltennamen orientieren sich an TIA-568-Pull-Schedule / Cable-Schedule.
+ * Alles ist seiteneffektfrei und damit headless testbar.
+ */
+import type { CablePlannerProject } from '../types/project'
+import type { Cable } from '../types/cable'
+import type { EquipmentItem, Port } from '../types/equipment'
+import { INSTALL_STATUS_LABEL } from '../types/lifecycle'
+import { cableLabelId } from './docIds'
+import { toCsv, type CsvCell } from './csv'
+
+const portName = (eq: EquipmentItem | undefined, portId: string): string => {
+  if (!eq) return ''
+  const p =
+    eq.outputs.find((x) => x.id === portId) ??
+    eq.inputs.find((x) => x.id === portId)
+  if (!p) return portId
+  return p.contentLabel?.trim() || p.name || portId
+}
+
+const portObj = (eq: EquipmentItem | undefined, portId: string): Port | undefined =>
+  eq?.outputs.find((x) => x.id === portId) ?? eq?.inputs.find((x) => x.id === portId)
+
+const statusLabel = (c: Cable): string =>
+  c.installStatus ? INSTALL_STATUS_LABEL[c.installStatus] : ''
+
+const testLabel = (c: Cable): string => {
+  if (!c.testResult) return ''
+  const r = c.testResult.result === 'pass' ? 'PASS' : 'FAIL'
+  const m =
+    typeof c.testResult.marginDb === 'number' ? ` (${c.testResult.marginDb} dB)` : ''
+  return `${r}${m}`
+}
+
+/** Index Equipment-ID → Item für schnelle Endpunkt-Auflösung. */
+const indexEquipment = (project: CablePlannerProject) =>
+  new Map(project.equipment.map((e) => [e.id, e]))
+
+// --- Pull-Liste -----------------------------------------------------------
+
+export interface PullListRow {
+  labelId: string
+  cableNumber: string
+  name: string
+  fromDevice: string
+  fromPort: string
+  toDevice: string
+  toPort: string
+  type: string
+  lengthM: number
+  layer: string
+  pathway: string
+  jacket: string
+  terminationFrom: string
+  terminationTo: string
+  status: string
+  test: string
+  notes: string
+}
+
+export const buildPullListRows = (project: CablePlannerProject): PullListRow[] => {
+  const byId = indexEquipment(project)
+  return project.cables.map((c) => {
+    const from = byId.get(c.fromEquipmentId)
+    const to = byId.get(c.toEquipmentId)
+    return {
+      labelId: cableLabelId(c),
+      cableNumber: c.cableNumber ?? '',
+      name: c.name ?? '',
+      fromDevice: from?.name ?? '—',
+      fromPort: portName(from, c.fromPortId),
+      toDevice: to?.name ?? '—',
+      toPort: portName(to, c.toPortId),
+      type: c.type,
+      lengthM: c.length ?? 0,
+      layer: c.layer ?? '',
+      pathway: c.pathway ?? '',
+      jacket: c.jacketRating ?? '',
+      terminationFrom: c.terminationFrom ?? '',
+      terminationTo: c.terminationTo ?? '',
+      status: statusLabel(c),
+      test: testLabel(c),
+      notes: c.notes ?? '',
+    }
+  })
+}
+
+export const pullListCsv = (project: CablePlannerProject): string => {
+  const rows = buildPullListRows(project)
+  const headers = [
+    'Label-ID',
+    'Kabel-Nr.',
+    'Name',
+    'Von Gerät',
+    'Von Port',
+    'Nach Gerät',
+    'Nach Port',
+    'Typ',
+    'Länge (m)',
+    'Ebene',
+    'Trasse/Pfad',
+    'Mantel/Brandklasse',
+    'Term. A',
+    'Term. B',
+    'Status',
+    'Test',
+    'Notizen',
+  ]
+  const body: CsvCell[][] = rows.map((r) => [
+    r.labelId,
+    r.cableNumber,
+    r.name,
+    r.fromDevice,
+    r.fromPort,
+    r.toDevice,
+    r.toPort,
+    r.type,
+    r.lengthM,
+    r.layer,
+    r.pathway,
+    r.jacket,
+    r.terminationFrom,
+    r.terminationTo,
+    r.status,
+    r.test,
+    r.notes,
+  ])
+  return toCsv(headers, body)
+}
+
+// --- Termination-Liste ----------------------------------------------------
+
+export interface TerminationRow {
+  labelId: string
+  end: 'A' | 'B'
+  device: string
+  port: string
+  connector: string
+  gender: string
+  termination: string
+}
+
+export const buildTerminationRows = (
+  project: CablePlannerProject,
+): TerminationRow[] => {
+  const byId = indexEquipment(project)
+  const rows: TerminationRow[] = []
+  const gender = (p?: Port) => (p?.gender === 'male' ? 'm' : p?.gender === 'female' ? 'w' : '')
+  for (const c of project.cables) {
+    const from = byId.get(c.fromEquipmentId)
+    const to = byId.get(c.toEquipmentId)
+    const fromPort = portObj(from, c.fromPortId)
+    const toPort = portObj(to, c.toPortId)
+    rows.push({
+      labelId: cableLabelId(c),
+      end: 'A',
+      device: from?.name ?? '—',
+      port: portName(from, c.fromPortId),
+      connector: fromPort?.connectorType ?? c.type,
+      gender: gender(fromPort),
+      termination: c.terminationFrom ?? '',
+    })
+    rows.push({
+      labelId: cableLabelId(c),
+      end: 'B',
+      device: to?.name ?? '—',
+      port: portName(to, c.toPortId),
+      connector: toPort?.connectorType ?? c.type,
+      gender: gender(toPort),
+      termination: c.terminationTo ?? '',
+    })
+  }
+  return rows
+}
+
+export const terminationListCsv = (project: CablePlannerProject): string => {
+  const rows = buildTerminationRows(project)
+  const headers = ['Label-ID', 'Ende', 'Gerät', 'Port', 'Steckverbinder', 'Geschlecht', 'Terminierung']
+  const body: CsvCell[][] = rows.map((r) => [
+    r.labelId,
+    r.end,
+    r.device,
+    r.port,
+    r.connector,
+    r.gender,
+    r.termination,
+  ])
+  return toCsv(headers, body)
+}
+
+// --- Kabel-Schedule (Design-Register) -------------------------------------
+
+export const cableScheduleCsv = (project: CablePlannerProject): string => {
+  const byId = indexEquipment(project)
+  const headers = [
+    'Label-ID',
+    'Kabel-Nr.',
+    'Name',
+    'Typ',
+    'Standard',
+    'Länge (m)',
+    'Von Gerät',
+    'Von Port',
+    'Nach Gerät',
+    'Nach Port',
+    'Ebene',
+    'Tie-Line',
+    'Status',
+  ]
+  const body: CsvCell[][] = project.cables.map((c) => {
+    const from = byId.get(c.fromEquipmentId)
+    const to = byId.get(c.toEquipmentId)
+    return [
+      cableLabelId(c),
+      c.cableNumber ?? '',
+      c.name ?? '',
+      c.type,
+      c.standard ?? '',
+      c.length ?? 0,
+      from?.name ?? '—',
+      portName(from, c.fromPortId),
+      to?.name ?? '—',
+      portName(to, c.toPortId),
+      c.layer ?? '',
+      c.isTieLine ? 'ja' : '',
+      statusLabel(c),
+    ]
+  })
+  return toCsv(headers, body)
+}
+
+// --- Kabel-BOM mit Reserve ------------------------------------------------
+
+export interface CableBomRow {
+  type: string
+  lengthM: number
+  qty: number
+  qtyWithReserve: number
+  totalLengthM: number
+  tieLine: boolean
+}
+
+/**
+ * Aggregiert Kabel nach (Typ, Länge) und schlägt einen Reserve-Prozentsatz
+ * auf (typisch ~10 %). Multicore-Adern mit gleichem `multicoreName` werden zu
+ * einem physischen Strang gezählt. Tie-Lines (Festverbindungen) werden
+ * separat ausgewiesen.
+ */
+export const buildCableBomRows = (
+  project: CablePlannerProject,
+  reservePercent = 10,
+): CableBomRow[] => {
+  const factor = 1 + Math.max(0, reservePercent) / 100
+  const buckets = new Map<string, CableBomRow>()
+  const countedBundles = new Set<string>()
+  for (const c of project.cables) {
+    if (c.wireless) continue
+    // Multicore: pro Bündel nur einmal zählen.
+    if (c.multicoreName) {
+      const bundleKey = `${c.multicoreName}`
+      if (countedBundles.has(bundleKey)) continue
+      countedBundles.add(bundleKey)
+    }
+    const len = c.length ?? 0
+    const key = `${c.type}|${len}|${c.isTieLine ? 'tie' : 'show'}`
+    const existing = buckets.get(key)
+    if (existing) {
+      existing.qty += 1
+      existing.qtyWithReserve = Math.ceil(existing.qty * factor)
+      existing.totalLengthM = +(existing.qty * len).toFixed(2)
+    } else {
+      buckets.set(key, {
+        type: c.type,
+        lengthM: len,
+        qty: 1,
+        qtyWithReserve: Math.ceil(1 * factor),
+        totalLengthM: len,
+        tieLine: !!c.isTieLine,
+      })
+    }
+  }
+  return Array.from(buckets.values()).sort(
+    (a, b) => a.type.localeCompare(b.type) || a.lengthM - b.lengthM,
+  )
+}
+
+export const cableBomCsv = (
+  project: CablePlannerProject,
+  reservePercent = 10,
+): string => {
+  const rows = buildCableBomRows(project, reservePercent)
+  const headers = [
+    'Typ',
+    'Länge (m)',
+    'Menge',
+    `Menge inkl. ${reservePercent}% Reserve`,
+    'Gesamtlänge (m)',
+    'Festverbindung',
+  ]
+  const body: CsvCell[][] = rows.map((r) => [
+    r.type,
+    r.lengthM,
+    r.qty,
+    r.qtyWithReserve,
+    r.totalLengthM,
+    r.tieLine ? 'ja' : '',
+  ])
+  return toCsv(headers, body)
+}

--- a/src/renderer/lib/qrPayload.ts
+++ b/src/renderer/lib/qrPayload.ts
@@ -1,0 +1,121 @@
+/**
+ * QR-/Etiketten-Payload — Bauen, Parsen und Auflösen.
+ *
+ * Ein Etikett trägt eine kompakte `cableplanner://`-URI (siehe `docIds.qrPayload`),
+ * die ein Scan-/Such-Lookup im Mobile-Viewer oder Web-Viewer wieder auf den
+ * konkreten Datensatz (Kabel/Gerät) abbildet. Diese Datei ist die *eine* Quelle
+ * für Format + Auflösung, damit Drucken (Erzeugen) und Scannen (Parsen) nie
+ * auseinanderlaufen. Bewusst Framework-frei: Mobile, Viewer und Renderer teilen
+ * sie sich.
+ */
+import type { Cable } from '../types/cable'
+import type { EquipmentItem } from '../types/equipment'
+
+export type QrKind = 'cable' | 'equipment'
+
+/** Referenz auf einen Datensatz, wie sie aus einem QR-Inhalt geparst wird.
+ *  `kind` ist optional: bei nacktem Klartext kann die Sorte unbekannt sein. */
+export interface QrRef {
+  kind?: QrKind
+  id: string
+  label?: string
+}
+
+/**
+ * Baut den QR-Inhalt: `cableplanner://<kind>/<id>?l=<label>`. Identisch zu
+ * `docIds.qrPayload` (das hierher delegiert) — kompakte URI plus lesbares Label.
+ */
+export const buildQrPayload = (kind: QrKind, id: string, label: string): string =>
+  `cableplanner://${kind}/${encodeURIComponent(id)}?l=${encodeURIComponent(label)}`
+
+const KIND_FROM_PREFIX: Record<string, QrKind> = { C: 'cable', A: 'equipment' }
+
+/**
+ * Parst einen gescannten/eingegebenen QR-Inhalt zu einer `QrRef`. Tolerant:
+ *  1. volle `cableplanner://cable/C-0001?l=…`-URI
+ *  2. `#cable/C-0001` / `?lookup=cable/C-0001` aus einem Deep-Link
+ *  3. nackte ID wie `C-0001` / `A-0042` → Sorte aus dem Präfix abgeleitet
+ *  4. beliebiger Freitext → als ID ohne Sorte (Lookup sucht dann in beidem)
+ * Liefert `null` nur bei leerer Eingabe.
+ */
+export const parseQrPayload = (raw: string): QrRef | null => {
+  const text = raw?.trim()
+  if (!text) return null
+
+  // (1)/(2) — strukturierte Deep-Links. Wir ziehen "<kind>/<id>" aus dem
+  // ersten Vorkommen heraus, egal ob als URI-Pfad, Hash oder ?lookup=.
+  const m = text.match(/(?:cableplanner:\/\/|[#?](?:lookup=)?|^)(cable|equipment)\/([^?&#\s]+)/i)
+  if (m) {
+    const kind = m[1].toLowerCase() as QrKind
+    const id = safeDecode(m[2])
+    const label = extractLabel(text)
+    return { kind, id, ...(label ? { label } : {}) }
+  }
+
+  // (3) — nackte Doc-ID mit bekanntem Präfix (C-0001 / A-0001).
+  const prefix = text.match(/^([CA])-/i)
+  if (prefix) {
+    return { kind: KIND_FROM_PREFIX[prefix[1].toUpperCase()], id: text }
+  }
+
+  // (4) — irgendein Klartext (z.B. eine vergebene Kabelnummer): als ID ohne Sorte.
+  return { id: text }
+}
+
+const safeDecode = (s: string): string => {
+  try {
+    return decodeURIComponent(s)
+  } catch {
+    return s
+  }
+}
+
+const extractLabel = (text: string): string | undefined => {
+  const lm = text.match(/[?&]l=([^&#\s]+)/)
+  return lm ? safeDecode(lm[1]) : undefined
+}
+
+const norm = (s: string | undefined): string => (s ?? '').trim().toLowerCase()
+
+/** Treffer eines Lookups: der gefundene Datensatz plus seine Sorte. */
+export type QrMatch =
+  | { kind: 'cable'; item: Cable }
+  | { kind: 'equipment'; item: EquipmentItem }
+
+/**
+ * Löst eine `QrRef` gegen Kabel + Geräte auf. Matcht großzügig gegen alle
+ * sichtbaren Kennungen (qrId / cableNumber / assetTag / interne UUID), damit
+ * sowohl die stabile Etiketten-ID als auch ein abgekürzter UUID-Fallback
+ * gescannt werden können. Liefert den ersten Treffer oder `null`.
+ */
+export const lookupQrRef = (
+  ref: QrRef,
+  cables: Cable[],
+  equipment: EquipmentItem[],
+): QrMatch | null => {
+  const needle = norm(ref.id)
+  if (!needle) return null
+
+  const cableHit = (c: Cable): boolean =>
+    norm(c.qrId) === needle ||
+    norm(c.cableNumber) === needle ||
+    norm(c.id) === needle ||
+    norm(c.id).startsWith(needle.replace(/^c-/, '')) // C-<uuid8>-Fallback
+
+  const eqHit = (e: EquipmentItem): boolean =>
+    norm(e.qrId) === needle ||
+    norm(e.assetTag) === needle ||
+    norm(e.id) === needle ||
+    norm(e.id).startsWith(needle.replace(/^a-/, ''))
+
+  // Bei bekannter Sorte zuerst dort suchen; sonst beide Sammlungen.
+  if (ref.kind !== 'equipment') {
+    const c = cables.find(cableHit)
+    if (c) return { kind: 'cable', item: c }
+  }
+  if (ref.kind !== 'cable') {
+    const e = equipment.find(eqHit)
+    if (e) return { kind: 'equipment', item: e }
+  }
+  return null
+}

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -450,6 +450,10 @@ export interface ProjectState {
   /** Vergibt allen Kabeln/Geräten ohne QR-/Asset-ID eine stabile ID.
    *  Liefert die Anzahl neu vergebener IDs je Sorte. */
   assignDocIds: () => { cables: number; equipment: number }
+  /** Setzt den Kabel-Namen auf das AVIXA-F501.01-Label „Quelle → Ziel".
+   *  Ohne `overwrite` werden nur leere Namen gefüllt. Liefert die Anzahl
+   *  geänderter Kabel. */
+  applySourceDestLabels: (opts?: { overwrite?: boolean }) => number
 }
 
 

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -20,6 +20,7 @@ import { createEquipmentSlice } from './slices/equipmentSlice'
 import { createGroupPresetSpawnSlice } from './slices/groupPresetSpawnSlice'
 import { createSelectionLifecycleSlice } from './slices/selectionLifecycleSlice'
 import { createLifecycleSlice } from './slices/lifecycleSlice'
+import { createPendingChangesSlice } from './slices/pendingChangesSlice'
 import {
   loadCustomLibrary,
   persistCustomLibrary,
@@ -454,6 +455,18 @@ export interface ProjectState {
    *  Ohne `overwrite` werden nur leere Namen gefüllt. Liefert die Anzahl
    *  geänderter Kabel. */
   applySourceDestLabels: (opts?: { overwrite?: boolean }) => number
+  /** Feld-Rückkanal — eine vom Mobile-Companion/Viewer gemeldete, noch nicht
+   *  angewandte Änderung in die Review-Queue legen. */
+  addPendingChange: (
+    input: Omit<import('../types/lifecycle').PendingChange, 'id' | 'ts' | 'author'> &
+      Partial<Pick<import('../types/lifecycle').PendingChange, 'id' | 'ts' | 'author'>>,
+  ) => void
+  /** Übernimmt eine Feld-Meldung: mergt den (whitelisteten) Patch aufs Ziel,
+   *  schreibt einen Änderungsprotokoll-Eintrag und entfernt die Meldung.
+   *  Liefert true bei Erfolg. */
+  applyPendingChange: (id: string) => boolean
+  /** Verwirft eine Feld-Meldung (mit Protokoll-Eintrag) und entfernt sie. */
+  rejectPendingChange: (id: string) => void
 }
 
 
@@ -731,6 +744,7 @@ const buildProjectStore = (
   ...createGroupPresetSpawnSlice(set, get, store),
   ...createSelectionLifecycleSlice(set, get, store),
   ...createLifecycleSlice(set, get, store),
+  ...createPendingChangesSlice(set, get, store),
   project:
     opts.initialProject ??
     (() => {

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -19,6 +19,7 @@ import { createCategorySlice } from './slices/categorySlice'
 import { createEquipmentSlice } from './slices/equipmentSlice'
 import { createGroupPresetSpawnSlice } from './slices/groupPresetSpawnSlice'
 import { createSelectionLifecycleSlice } from './slices/selectionLifecycleSlice'
+import { createLifecycleSlice } from './slices/lifecycleSlice'
 import {
   loadCustomLibrary,
   persistCustomLibrary,
@@ -421,6 +422,34 @@ export interface ProjectState {
    *  schreibt sie in `cable.length`. Liefert die Anzahl aktualisierter
    *  Kabel. */
   estimateCableLengths: () => number
+  /** Festinstallation — mitwachsende Doku / Lebenszyklus (siehe
+   *  lifecycleSlice). */
+  addChangeLogEntry: (
+    kind: import('../types/lifecycle').ChangeLogKind,
+    summary: string,
+    target?: import('../types/lifecycle').ChangeLogEntry['target'],
+  ) => void
+  clearChangelog: () => void
+  setCableInstallStatus: (
+    id: string,
+    status: import('../types/lifecycle').InstallStatus | undefined,
+  ) => void
+  setEquipmentInstallStatus: (
+    id: string,
+    status: import('../types/lifecycle').InstallStatus | undefined,
+  ) => void
+  setCableTestResult: (
+    id: string,
+    result: import('../types/lifecycle').CableTestResult | undefined,
+  ) => void
+  addServiceRecord: (
+    equipmentId: string,
+    record: Omit<import('../types/lifecycle').ServiceRecord, 'id'>,
+  ) => void
+  removeServiceRecord: (equipmentId: string, recordId: string) => void
+  /** Vergibt allen Kabeln/Geräten ohne QR-/Asset-ID eine stabile ID.
+   *  Liefert die Anzahl neu vergebener IDs je Sorte. */
+  assignDocIds: () => { cables: number; equipment: number }
 }
 
 
@@ -548,6 +577,9 @@ const healProjectPositions = (project: CablePlannerProject): CablePlannerProject
     })),
     // #412 — Revisionen sind optional; alte Projekte heilen zu [].
     revisions: project.revisions ?? [],
+    // Festinstallation — Änderungsprotokoll ist optional; alte Projekte
+    // heilen zu [].
+    changelog: project.changelog ?? [],
   }
 }
 
@@ -694,6 +726,7 @@ const buildProjectStore = (
   ...createEquipmentSlice(set, get, store),
   ...createGroupPresetSpawnSlice(set, get, store),
   ...createSelectionLifecycleSlice(set, get, store),
+  ...createLifecycleSlice(set, get, store),
   project:
     opts.initialProject ??
     (() => {

--- a/src/renderer/store/settingsStore.ts
+++ b/src/renderer/store/settingsStore.ts
@@ -8,12 +8,17 @@ interface PersistedSettings {
   autosaveIntervalMs: number
   sharedSyncPath: string
   sharedSyncUser: string
+  /** Festinstallation — Name des aktuellen Bearbeiters. Wird Änderungs-
+   *  protokoll- und Service-Einträgen als Autor zugeordnet. App-weit
+   *  (pro Maschine) persistiert, nicht pro Projekt. */
+  editorName: string
 }
 
 const defaults: PersistedSettings = {
   autosaveIntervalMs: 400,
   sharedSyncPath: '',
   sharedSyncUser: '',
+  editorName: '',
 }
 
 const load = (): PersistedSettings => {
@@ -28,6 +33,7 @@ const load = (): PersistedSettings => {
           : defaults.autosaveIntervalMs,
       sharedSyncPath: typeof parsed.sharedSyncPath === 'string' ? parsed.sharedSyncPath : defaults.sharedSyncPath,
       sharedSyncUser: typeof parsed.sharedSyncUser === 'string' ? parsed.sharedSyncUser : defaults.sharedSyncUser,
+      editorName: typeof parsed.editorName === 'string' ? parsed.editorName : defaults.editorName,
     }
   } catch {
     return defaults
@@ -50,11 +56,13 @@ interface SettingsState {
   autosaveIntervalMs: number
   sharedSyncPath: string
   sharedSyncUser: string
+  editorName: string
   setHasToken: (value: boolean) => void
   setTokenStatus: (value: string) => void
   setAutosaveIntervalMs: (value: number) => void
   setSyncPath: (value: string) => void
   setSyncUser: (value: string) => void
+  setEditorName: (value: string) => void
 }
 
 const initial = load()
@@ -65,22 +73,28 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   autosaveIntervalMs: initial.autosaveIntervalMs,
   sharedSyncPath: initial.sharedSyncPath,
   sharedSyncUser: initial.sharedSyncUser,
+  editorName: initial.editorName,
   setHasToken: (value) => set({ hasToken: value }),
   setTokenStatus: (value) => set({ tokenStatus: value }),
   setAutosaveIntervalMs: (value) =>
     set((state) => {
       const next = Math.max(LIMITS.AUTOSAVE_INTERVAL.MIN_MS, Math.min(LIMITS.AUTOSAVE_INTERVAL.MAX_MS, Math.round(value || defaults.autosaveIntervalMs)))
-      persist({ autosaveIntervalMs: next, sharedSyncPath: state.sharedSyncPath, sharedSyncUser: state.sharedSyncUser })
+      persist({ autosaveIntervalMs: next, sharedSyncPath: state.sharedSyncPath, sharedSyncUser: state.sharedSyncUser, editorName: state.editorName })
       return { autosaveIntervalMs: next }
     }),
   setSyncPath: (value) =>
     set((state) => {
-      persist({ autosaveIntervalMs: state.autosaveIntervalMs, sharedSyncPath: value, sharedSyncUser: state.sharedSyncUser })
+      persist({ autosaveIntervalMs: state.autosaveIntervalMs, sharedSyncPath: value, sharedSyncUser: state.sharedSyncUser, editorName: state.editorName })
       return { sharedSyncPath: value }
     }),
   setSyncUser: (value) =>
     set((state) => {
-      persist({ autosaveIntervalMs: state.autosaveIntervalMs, sharedSyncPath: state.sharedSyncPath, sharedSyncUser: value })
+      persist({ autosaveIntervalMs: state.autosaveIntervalMs, sharedSyncPath: state.sharedSyncPath, sharedSyncUser: value, editorName: state.editorName })
       return { sharedSyncUser: value }
+    }),
+  setEditorName: (value) =>
+    set((state) => {
+      persist({ autosaveIntervalMs: state.autosaveIntervalMs, sharedSyncPath: state.sharedSyncPath, sharedSyncUser: state.sharedSyncUser, editorName: value })
+      return { editorName: value }
     }),
 }))

--- a/src/renderer/store/slices/lifecycleSlice.ts
+++ b/src/renderer/store/slices/lifecycleSlice.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../types/lifecycle'
 import { INSTALL_STATUS_LABEL } from '../../types/lifecycle'
 import { cableLabelId, makeDocId } from '../../lib/docIds'
+import { sourceDestLabel } from '../../lib/cableLabel'
 import { touchProject } from '../projectStoreHelpers'
 import { useSettingsStore } from '../settingsStore'
 import type { ProjectState } from '../projectStore'
@@ -39,6 +40,7 @@ export type LifecycleSlice = Pick<
   | 'addServiceRecord'
   | 'removeServiceRecord'
   | 'assignDocIds'
+  | 'applySourceDestLabels'
 >
 
 const currentAuthor = (): string =>
@@ -238,6 +240,36 @@ export const createLifecycleSlice: StateCreator<ProjectState, [], [], LifecycleS
       }
     })
     return { cables: cableCount, equipment: equipmentCount }
+  },
+
+  applySourceDestLabels: (opts) => {
+    const overwrite = opts?.overwrite ?? false
+    let count = 0
+    set((state) => {
+      const eqById = new Map(state.project.equipment.map((e) => [e.id, e]))
+      const cables = state.project.cables.map((c) => {
+        // Ohne Overwrite nur leere Namen füllen — vorhandene (oft vom User
+        // vergebene) Namen werden nicht überschrieben.
+        if (!overwrite && c.name?.trim()) return c
+        const label = sourceDestLabel(c, eqById)
+        if (!label || label === c.name) return c
+        count += 1
+        return { ...c, name: label }
+      })
+      if (count === 0) return state
+      const next = { ...state.project, cables }
+      return {
+        project: touchProject(
+          appendLog(
+            next,
+            'change',
+            `Kabel-Labels aus Quelle→Ziel erzeugt (${count}${overwrite ? ', überschrieben' : ''})`,
+            { type: 'project' },
+          ),
+        ),
+      }
+    })
+    return count
   },
 })
 

--- a/src/renderer/store/slices/lifecycleSlice.ts
+++ b/src/renderer/store/slices/lifecycleSlice.ts
@@ -1,0 +1,245 @@
+import type { StateCreator } from 'zustand'
+import { v4 as uuidv4 } from 'uuid'
+import type { CablePlannerProject } from '../../types/project'
+import type {
+  ChangeLogEntry,
+  ChangeLogKind,
+  CableTestResult,
+  InstallStatus,
+  ServiceRecord,
+} from '../../types/lifecycle'
+import { INSTALL_STATUS_LABEL } from '../../types/lifecycle'
+import { cableLabelId, makeDocId } from '../../lib/docIds'
+import { touchProject } from '../projectStoreHelpers'
+import { useSettingsStore } from '../settingsStore'
+import type { ProjectState } from '../projectStore'
+
+/**
+ * Festinstallation — Lebenszyklus-Slice (mitwachsende Doku).
+ *
+ * Trägt die Setter, die aus dem Plan ein lebendes Dokument machen:
+ *  - Betriebs-Status je Kabel/Gerät (geplant…außer Betrieb)
+ *  - Mess-/Test-Ergebnis je Kabel
+ *  - Service-/Wartungs-Historie je Gerät
+ *  - attribuiertes Änderungsprotokoll (MAC/IMACD) — wer/was/wann
+ *  - Vergabe stabiler QR-/Asset-IDs für Etiketten ↔ Datensatz
+ *
+ * Bewusst KEIN Lock-Check: Lebenszyklus-Pflege ist der Post-Install-Use-Case
+ * — sie muss auch auf einem als „finalized"/As-built markierten Plan möglich
+ * sein (analog metaSlice, das im Viewer-Modus Metadaten erlaubt).
+ */
+
+export type LifecycleSlice = Pick<
+  ProjectState,
+  | 'addChangeLogEntry'
+  | 'clearChangelog'
+  | 'setCableInstallStatus'
+  | 'setEquipmentInstallStatus'
+  | 'setCableTestResult'
+  | 'addServiceRecord'
+  | 'removeServiceRecord'
+  | 'assignDocIds'
+>
+
+const currentAuthor = (): string =>
+  useSettingsStore.getState().editorName?.trim() || 'Unbekannt'
+
+/** Hängt einen Änderungs-Eintrag an (capped auf die letzten 500). */
+const appendLog = (
+  project: CablePlannerProject,
+  kind: ChangeLogKind,
+  summary: string,
+  target?: ChangeLogEntry['target'],
+): CablePlannerProject => {
+  const entry: ChangeLogEntry = {
+    id: uuidv4(),
+    ts: new Date().toISOString(),
+    author: currentAuthor(),
+    kind,
+    summary,
+    target,
+  }
+  return {
+    ...project,
+    changelog: [...(project.changelog ?? []), entry].slice(-500),
+  }
+}
+
+export const createLifecycleSlice: StateCreator<ProjectState, [], [], LifecycleSlice> = (
+  set,
+) => ({
+  addChangeLogEntry: (kind, summary, target) =>
+    set((state) => ({
+      project: touchProject(appendLog(state.project, kind, summary, target)),
+    })),
+
+  clearChangelog: () =>
+    set((state) => ({
+      project: touchProject({ ...state.project, changelog: [] }),
+    })),
+
+  setCableInstallStatus: (id, status) =>
+    set((state) => {
+      const cable = state.project.cables.find((c) => c.id === id)
+      if (!cable) return state
+      const next = {
+        ...state.project,
+        cables: state.project.cables.map((c) =>
+          c.id === id ? { ...c, installStatus: status } : c,
+        ),
+      }
+      const label = status ? INSTALL_STATUS_LABEL[status] : 'kein Status'
+      return {
+        project: touchProject(
+          appendLog(next, 'status', `Kabel „${cableLabelId(cable)}" → ${label}`, {
+            type: 'cable',
+            id,
+            name: cable.name,
+          }),
+        ),
+      }
+    }),
+
+  setEquipmentInstallStatus: (id, status) =>
+    set((state) => {
+      const eq = state.project.equipment.find((e) => e.id === id)
+      if (!eq) return state
+      const next = {
+        ...state.project,
+        equipment: state.project.equipment.map((e) =>
+          e.id === id ? { ...e, installStatus: status } : e,
+        ),
+      }
+      const label = status ? INSTALL_STATUS_LABEL[status] : 'kein Status'
+      return {
+        project: touchProject(
+          appendLog(next, 'status', `Gerät „${eq.name}" → ${label}`, {
+            type: 'equipment',
+            id,
+            name: eq.name,
+          }),
+        ),
+      }
+    }),
+
+  setCableTestResult: (id, result) =>
+    set((state) => {
+      const cable = state.project.cables.find((c) => c.id === id)
+      if (!cable) return state
+      const next = {
+        ...state.project,
+        cables: state.project.cables.map((c) =>
+          c.id === id ? { ...c, testResult: result } : c,
+        ),
+      }
+      const summary = result
+        ? `Test „${cableLabelId(cable)}": ${result.result === 'pass' ? 'PASS' : 'FAIL'}`
+        : `Test „${cableLabelId(cable)}" gelöscht`
+      return {
+        project: touchProject(
+          appendLog(next, 'commission', summary, { type: 'cable', id, name: cable.name }),
+        ),
+      }
+    }),
+
+  addServiceRecord: (equipmentId, record) =>
+    set((state) => {
+      const eq = state.project.equipment.find((e) => e.id === equipmentId)
+      if (!eq) return state
+      const full: ServiceRecord = { ...record, id: uuidv4() }
+      const next = {
+        ...state.project,
+        equipment: state.project.equipment.map((e) =>
+          e.id === equipmentId
+            ? { ...e, serviceHistory: [...(e.serviceHistory ?? []), full] }
+            : e,
+        ),
+      }
+      return {
+        project: touchProject(
+          appendLog(next, 'service', `Service „${eq.name}": ${record.summary}`, {
+            type: 'equipment',
+            id: equipmentId,
+            name: eq.name,
+          }),
+        ),
+      }
+    }),
+
+  removeServiceRecord: (equipmentId, recordId) =>
+    set((state) => {
+      const eq = state.project.equipment.find((e) => e.id === equipmentId)
+      if (!eq) return state
+      return {
+        project: touchProject({
+          ...state.project,
+          equipment: state.project.equipment.map((e) =>
+            e.id === equipmentId
+              ? {
+                  ...e,
+                  serviceHistory: (e.serviceHistory ?? []).filter(
+                    (r) => r.id !== recordId,
+                  ),
+                }
+              : e,
+          ),
+        }),
+      }
+    }),
+
+  assignDocIds: () => {
+    let cableCount = 0
+    let equipmentCount = 0
+    set((state) => {
+      // Bereits vergebene IDs sammeln, damit wir keine Kollision erzeugen.
+      const used = new Set<string>()
+      for (const c of state.project.cables) if (c.qrId) used.add(c.qrId)
+      for (const e of state.project.equipment) if (e.qrId) used.add(e.qrId)
+
+      let cn = 0
+      const cables = state.project.cables.map((c) => {
+        if (c.qrId) return c
+        cn += 1
+        let id = makeDocId('C', cn)
+        while (used.has(id)) {
+          cn += 1
+          id = makeDocId('C', cn)
+        }
+        used.add(id)
+        cableCount += 1
+        return { ...c, qrId: id }
+      })
+
+      let en = 0
+      const equipment = state.project.equipment.map((e) => {
+        if (e.qrId) return e
+        en += 1
+        let id = makeDocId('A', en)
+        while (used.has(id)) {
+          en += 1
+          id = makeDocId('A', en)
+        }
+        used.add(id)
+        equipmentCount += 1
+        return { ...e, qrId: id }
+      })
+
+      if (cableCount === 0 && equipmentCount === 0) return state
+      const next = { ...state.project, cables, equipment }
+      return {
+        project: touchProject(
+          appendLog(
+            next,
+            'change',
+            `QR-/Asset-IDs vergeben (${cableCount} Kabel, ${equipmentCount} Geräte)`,
+            { type: 'project' },
+          ),
+        ),
+      }
+    })
+    return { cables: cableCount, equipment: equipmentCount }
+  },
+})
+
+// Re-export für Konsumenten, die nur die Typen brauchen.
+export type { CableTestResult, InstallStatus, ServiceRecord }

--- a/src/renderer/store/slices/pendingChangesSlice.ts
+++ b/src/renderer/store/slices/pendingChangesSlice.ts
@@ -1,0 +1,173 @@
+import type { StateCreator } from 'zustand'
+import { v4 as uuidv4 } from 'uuid'
+import type { CablePlannerProject } from '../../types/project'
+import type { ChangeLogEntry, ChangeLogKind, PendingChange } from '../../types/lifecycle'
+import { touchProject } from '../projectStoreHelpers'
+import { scheduleProjectAutosave } from '../projectAutosave'
+import { useSettingsStore } from '../settingsStore'
+import type { ProjectState } from '../projectStore'
+
+/**
+ * Feld-Rückkanal — Review-Queue für vom Mobile-Companion/Viewer gemeldete
+ * Änderungen.
+ *
+ * Der Techniker vor Ort korrigiert z.B. eine Kabellänge oder meldet ein
+ * Problem; das landet als `PendingChange` im Plan (nicht direkt angewandt).
+ * Der Planer am Desktop übernimmt (`applyPendingChange`) — dann wird der
+ * whitelistete Patch auf das Ziel gemerged und ein `ChangeLogEntry`
+ * geschrieben — oder verwirft (`rejectPendingChange`). So fließt Feldwissen
+ * kontrolliert und nachvollziehbar ins lebende Dokument.
+ *
+ * Bewusst KEIN Lock-Check (analog lifecycleSlice): Post-Install-Pflege muss
+ * auch auf einem „finalized"/As-built-Plan möglich sein.
+ */
+
+export type PendingChangesSlice = Pick<
+  ProjectState,
+  'addPendingChange' | 'applyPendingChange' | 'rejectPendingChange'
+>
+
+const currentAuthor = (): string => useSettingsStore.getState().editorName?.trim() || 'Unbekannt'
+
+/** Hängt einen Änderungs-Eintrag an (capped auf die letzten 500) — gespiegelt
+ *  aus lifecycleSlice, damit Übernehmen/Verwerfen denselben Verlauf füttern. */
+const appendLog = (
+  project: CablePlannerProject,
+  kind: ChangeLogKind,
+  summary: string,
+  target?: ChangeLogEntry['target'],
+): CablePlannerProject => {
+  const entry: ChangeLogEntry = {
+    id: uuidv4(),
+    ts: new Date().toISOString(),
+    author: currentAuthor(),
+    kind,
+    summary,
+    target,
+  }
+  return { ...project, changelog: [...(project.changelog ?? []), entry].slice(-500) }
+}
+
+/** Felder, die eine Feld-Meldung tatsächlich auf ein Kabel schreiben darf. */
+const CABLE_PATCH_KEYS = new Set([
+  'name',
+  'length',
+  'notes',
+  'color',
+  'type',
+  'installStatus',
+  'jacketRating',
+  'terminationFrom',
+  'terminationTo',
+  'pathway',
+])
+/** Felder, die eine Feld-Meldung tatsächlich auf ein Gerät schreiben darf. */
+const EQUIP_PATCH_KEYS = new Set([
+  'name',
+  'notes',
+  'serialNumber',
+  'assetTag',
+  'firmware',
+  'ipAddress',
+  'installStatus',
+])
+
+const pickWhitelisted = (
+  patch: Record<string, unknown>,
+  allowed: Set<string>,
+): Record<string, unknown> => {
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(patch)) {
+    if (allowed.has(k) && v !== undefined) out[k] = v
+  }
+  return out
+}
+
+export const createPendingChangesSlice: StateCreator<
+  ProjectState,
+  [],
+  [],
+  PendingChangesSlice
+> = (set) => ({
+  addPendingChange: (input) =>
+    set((state) => {
+      const entry: PendingChange = {
+        id: input.id ?? uuidv4(),
+        ts: input.ts ?? new Date().toISOString(),
+        author: input.author?.trim() || 'Feld',
+        source: input.source,
+        kind: input.kind,
+        summary: input.summary,
+        ...(input.target ? { target: input.target } : {}),
+        ...(input.patch ? { patch: input.patch } : {}),
+      }
+      const updated = touchProject({
+        ...state.project,
+        pendingChanges: [...(state.project.pendingChanges ?? []), entry].slice(-200),
+      })
+      scheduleProjectAutosave(updated)
+      return { project: updated }
+    }),
+
+  applyPendingChange: (id) => {
+    let ok = false
+    set((state) => {
+      const list = state.project.pendingChanges ?? []
+      const pc = list.find((p) => p.id === id)
+      if (!pc) return state
+      let project = state.project
+
+      // (1) Patch auf das Ziel mergen (nur whitelistete Felder).
+      if (pc.target?.id && pc.patch) {
+        if (pc.target.type === 'cable') {
+          const patch = pickWhitelisted(pc.patch, CABLE_PATCH_KEYS)
+          if (Object.keys(patch).length > 0) {
+            project = {
+              ...project,
+              cables: project.cables.map((c) =>
+                c.id === pc.target!.id ? { ...c, ...patch } : c,
+              ),
+            }
+          }
+        } else if (pc.target.type === 'equipment') {
+          const patch = pickWhitelisted(pc.patch, EQUIP_PATCH_KEYS)
+          if (Object.keys(patch).length > 0) {
+            project = {
+              ...project,
+              equipment: project.equipment.map((e) =>
+                e.id === pc.target!.id ? { ...e, ...patch } : e,
+              ),
+            }
+          }
+        }
+      }
+
+      // (2) Ins Änderungsprotokoll + (3) aus der Queue entfernen.
+      project = appendLog(project, 'change', `Feld-Meldung übernommen: ${pc.summary}`, pc.target)
+      project = { ...project, pendingChanges: list.filter((p) => p.id !== id) }
+
+      ok = true
+      const updated = touchProject(project)
+      scheduleProjectAutosave(updated)
+      return { project: updated, projectVersion: state.projectVersion + 1 }
+    })
+    return ok
+  },
+
+  rejectPendingChange: (id) =>
+    set((state) => {
+      const list = state.project.pendingChanges ?? []
+      const pc = list.find((p) => p.id === id)
+      if (!pc) return state
+      let project = appendLog(
+        state.project,
+        'change',
+        `Feld-Meldung verworfen: ${pc.summary}`,
+        pc.target,
+      )
+      project = { ...project, pendingChanges: list.filter((p) => p.id !== id) }
+      const updated = touchProject(project)
+      scheduleProjectAutosave(updated)
+      return { project: updated }
+    }),
+})

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -825,6 +825,11 @@ interface UiState extends PersistedUiState {
   patchList: { open: boolean }
   openPatchList: () => void
   closePatchList: () => void
+  /** Festinstallation — Doku-/Übergabe-Dialog (Installateur-Listen,
+   *  Asset-Register, QR-IDs, Übergabe-Paket, Änderungsprotokoll). */
+  installDocs: { open: boolean }
+  openInstallDocs: () => void
+  closeInstallDocs: () => void
   calculators: { open: boolean; tab?: 'bandwidth' | 'power' }
   openCalculators: (tab?: 'bandwidth' | 'power') => void
   closeCalculators: () => void
@@ -1275,6 +1280,9 @@ export const useUiStore = create<UiState>((set) => ({
   patchList: { open: false },
   openPatchList: () => set({ patchList: { open: true } }),
   closePatchList: () => set({ patchList: { open: false } }),
+  installDocs: { open: false },
+  openInstallDocs: () => set({ installDocs: { open: true } }),
+  closeInstallDocs: () => set({ installDocs: { open: false } }),
   calculators: { open: false },
   openCalculators: (tab) => set({ calculators: { open: true, tab } }),
   closeCalculators: () => set({ calculators: { open: false } }),

--- a/src/renderer/types/cable.ts
+++ b/src/renderer/types/cable.ts
@@ -1,5 +1,6 @@
 import type { ConnectorType } from './equipment'
 import type { SignalStandard } from './cableSpec'
+import type { InstallStatus, CableTestResult } from './lifecycle'
 
 export type CableType = Exclude<ConnectorType, 'DIN' | 'DisplayPort' | 'USB'> | 'Custom'
 
@@ -135,4 +136,23 @@ export interface Cable {
    *  löschen). Undefined/leer = gerade Linie Port → Symbol. */
   offPageFromWaypoints?: { x: number; y: number }[]
   offPageToWaypoints?: { x: number; y: number }[]
+  /** Festinstallation — Betriebs-Status der Verbindung (geplant…außer Betrieb).
+   *  Geht über den binären Mobile-`checkState` hinaus und überlebt im
+   *  As-built als lebender Status. Undefined = nicht gesetzt. */
+  installStatus?: InstallStatus
+  /** Festinstallation — Mantel-/Brandklasse für Pull-/Schedule-Listen
+   *  (CM/CMR/CMP/LSZH). Frei editierbar. */
+  jacketRating?: string
+  /** Festinstallation — Trassen-/Pfad-Bezeichnung (Conduit-/Tray-ID), in der
+   *  das Kabel verläuft. Erscheint in der Pull-Liste. */
+  pathway?: string
+  /** Festinstallation — Terminierung je Ende (T568A/B, LC/SC/MPO …). */
+  terminationFrom?: string
+  terminationTo?: string
+  /** Festinstallation — Mess-/Zertifikats-Ergebnis (TIA-568/1152, OLTS/OTDR). */
+  testResult?: CableTestResult
+  /** Festinstallation — kurze stabile QR-/Lookup-ID (druckbar, ≥ 1,6 cm).
+   *  Verknüpft das physische Etikett mit dem digitalen Datensatz
+   *  ("Was ist dieses Kabel? Wo geht es hin?"). */
+  qrId?: string
 }

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -70,6 +70,7 @@ export const ALL_CONNECTOR_TYPES: ConnectorType[] = [
 
 import type { SignalStandard } from './cableSpec'
 import type { SdiCapabilities } from './videoFormat'
+import type { InstallStatus, ServiceRecord } from './lifecycle'
 
 export interface Port {
   id: string
@@ -526,6 +527,19 @@ export interface EquipmentItem {
    * (verteilt dann faktisch nichts).
    */
   isDistributionAmp?: boolean
+  /** Festinstallation — Betriebs-Status des Geräts (geplant…außer Betrieb). */
+  installStatus?: InstallStatus
+  /** Festinstallation — Inventar-/Asset-Nummer für das Asset-Register. */
+  assetTag?: string
+  /** Festinstallation — kurze stabile QR-/Lookup-ID (Etikett → Datensatz). */
+  qrId?: string
+  /** Festinstallation — Garantie-Ablauf (ISO-Datum) für die Betreiber-Doku. */
+  warrantyUntil?: string
+  /** Festinstallation — Wartungsintervall in Tagen (preventive maintenance). */
+  maintenanceIntervalDays?: number
+  /** Festinstallation — zeitgestempelte Service-/Wartungs-Historie. Macht aus
+   *  der Doku ein CMMS-artiges Asset-Register. Undefined/[] = keine Einträge. */
+  serviceHistory?: ServiceRecord[]
 }
 
 /**

--- a/src/renderer/types/lifecycle.ts
+++ b/src/renderer/types/lifecycle.ts
@@ -96,3 +96,36 @@ export interface ChangeLogEntry {
   /** Kurze, menschenlesbare Zusammenfassung. */
   summary: string
 }
+
+/** Art einer Feld-Rückmeldung (vom Mobile-/Viewer-Light-Editor). */
+export type PendingChangeKind = 'cable-edit' | 'equipment-edit' | 'issue' | 'note'
+
+/**
+ * Feld-Rückkanal: eine vom Mobile-Companion (oder Viewer) gemeldete, noch
+ * NICHT angewandte Änderung. Der Techniker vor Ort korrigiert z.B. eine
+ * Kabellänge oder meldet ein Problem; das landet als „pending" im Plan und
+ * der Planer am Desktop übernimmt oder verwirft es. Beim Übernehmen wird der
+ * `patch` auf das Ziel gemerged und ein `ChangeLogEntry` geschrieben — so
+ * fließt Feldwissen kontrolliert ins lebende Dokument.
+ */
+export interface PendingChange {
+  id: string
+  /** ISO-Zeitstempel der Meldung. */
+  ts: string
+  /** Name des Melders (vor Ort), Fallback „Feld". */
+  author: string
+  /** Woher die Meldung kam. */
+  source: 'mobile' | 'viewer' | 'desktop'
+  kind: PendingChangeKind
+  /** Worauf sich die Meldung bezieht (zum Anwenden + Navigieren). */
+  target?: {
+    type: 'cable' | 'equipment'
+    id?: string
+    name?: string
+  }
+  /** Menschenlesbare Zusammenfassung (wird im Review angezeigt). */
+  summary: string
+  /** Optionaler Feld-Patch, der beim Übernehmen auf das Ziel gemerged wird
+   *  (nur whitelistete Felder werden tatsächlich angewandt). */
+  patch?: Record<string, unknown>
+}

--- a/src/renderer/types/lifecycle.ts
+++ b/src/renderer/types/lifecycle.ts
@@ -1,0 +1,98 @@
+/**
+ * Festinstallation / mitwachsende Doku — Lebenszyklus-Typen.
+ *
+ * Cable-Planner war ursprünglich auf den Show-Lebenszyklus zugeschnitten
+ * (planen → aufbauen → abbauen). Für dauerhafte Festinstallationen ist der
+ * Plan ein *lebendes Dokument*, das jede Move/Add/Change (MAC) überlebt.
+ * Diese Typen tragen den Betriebs-Status, Mess-/Service-Historie und ein
+ * attribuiertes Änderungsprotokoll. Alle Felder sind optional bzw. werden
+ * beim Laden geheilt — alte Projekte bleiben gültig.
+ */
+
+/** Betriebs-Status eines Kabels/Geräts über den reinen "gebaut?"-Status hinaus. */
+export type InstallStatus =
+  | 'planned'
+  | 'installed'
+  | 'tested'
+  | 'operational'
+  | 'fault'
+  | 'retired'
+
+/** Anzeige-Reihenfolge der Status. */
+export const INSTALL_STATUSES: InstallStatus[] = [
+  'planned',
+  'installed',
+  'tested',
+  'operational',
+  'fault',
+  'retired',
+]
+
+/** Deutsche Default-Labels (UI heilt EN über i18n nach). */
+export const INSTALL_STATUS_LABEL: Record<InstallStatus, string> = {
+  planned: 'Geplant',
+  installed: 'Installiert',
+  tested: 'Getestet',
+  operational: 'In Betrieb',
+  fault: 'Störung',
+  retired: 'Außer Betrieb',
+}
+
+/**
+ * Mess-/Zertifikats-Ergebnis einer Kabelstrecke (TIA-568/1152 Kupfer,
+ * OLTS/OTDR Glas). Reicht als Garantie-/Abnahme-Nachweis (CABL/DOC in
+ * AVIXA 10:2013).
+ */
+export interface CableTestResult {
+  result: 'pass' | 'fail'
+  /** Test-Standard / Limit, z.B. "TIA Cat 6A Perm. Link", "OLTS OM4". */
+  standard?: string
+  /** Worst-Case-Marge in dB. */
+  marginDb?: number
+  /** ISO-Datum des Tests. */
+  testedAt?: string
+  /** Prüfer. */
+  testedBy?: string
+  /** Referenz auf die Zertifikats-Datei (Fluke/LinkWare-Report etc.). */
+  reportRef?: string
+}
+
+/** Einzelner Service-/Wartungs-Eintrag an einem Gerät. */
+export interface ServiceRecord {
+  id: string
+  /** ISO-Datum. */
+  date: string
+  author: string
+  kind: 'install' | 'inspection' | 'repair' | 'replacement' | 'note'
+  summary: string
+}
+
+/** Art einer Änderung im Projekt-Änderungsprotokoll. */
+export type ChangeLogKind =
+  | 'add'
+  | 'change'
+  | 'move'
+  | 'remove'
+  | 'service'
+  | 'status'
+  | 'commission'
+
+/**
+ * Ein attribuierter Änderungs-Eintrag (MAC/IMACD). Macht aus dem Plan ein
+ * nachvollziehbares lebendes Dokument: wer hat was wann geändert.
+ */
+export interface ChangeLogEntry {
+  id: string
+  /** ISO-Zeitstempel. */
+  ts: string
+  author: string
+  kind: ChangeLogKind
+  /** Worauf sich die Änderung bezieht (zur Navigation/Filterung). */
+  target?: {
+    type: 'cable' | 'equipment' | 'location' | 'project'
+    id?: string
+    name?: string
+  }
+  /** Kurze, menschenlesbare Zusammenfassung. */
+  summary: string
+}

--- a/src/renderer/types/project.ts
+++ b/src/renderer/types/project.ts
@@ -4,7 +4,7 @@ import type { GreenGoConfig } from './greengo'
 import type { LocationFrame } from './location'
 import type { VideoFormatId } from './videoFormat'
 import type { PowerStandardId } from './powerStandard'
-import type { ChangeLogEntry } from './lifecycle'
+import type { ChangeLogEntry, PendingChange } from './lifecycle'
 
 /**
  * Auto-Kabelnummerierung — Schema fuer automatisch vergebene Kabel-IDs.
@@ -155,6 +155,11 @@ export interface CablePlannerProject {
    *  Plan ein nachvollziehbares lebendes Dokument bleibt. Optional → alte
    *  Projekte heilen zu []. */
   changelog?: ChangeLogEntry[]
+  /** Feld-Rückkanal — vom Mobile-Companion/Viewer gemeldete, noch nicht
+   *  übernommene Änderungen (Längen-Korrektur, Problem-Meldung …). Der
+   *  Planer übernimmt/verwirft sie am Desktop; beim Übernehmen wandert die
+   *  Änderung ins `changelog`. Optional → alte Projekte heilen zu []. */
+  pendingChanges?: PendingChange[]
 }
 
 /** #412 — Ein festgeschriebener Projekt-Stand. */

--- a/src/renderer/types/project.ts
+++ b/src/renderer/types/project.ts
@@ -4,6 +4,7 @@ import type { GreenGoConfig } from './greengo'
 import type { LocationFrame } from './location'
 import type { VideoFormatId } from './videoFormat'
 import type { PowerStandardId } from './powerStandard'
+import type { ChangeLogEntry } from './lifecycle'
 
 /**
  * Auto-Kabelnummerierung — Schema fuer automatisch vergebene Kabel-IDs.
@@ -84,6 +85,14 @@ export interface ProjectMetadata {
   revision?: string
   /** #350 — Längen-Schätzung aus Canvas-Geometrie. */
   lengthEstimation?: LengthEstimationScheme
+  /** Festinstallation — Standort/Adresse der Anlage (Übergabe-Doku). */
+  siteAddress?: string
+  /** Festinstallation — Übergabe-/Abnahme-Datum (ISO). */
+  handoverDate?: string
+  /** Festinstallation — wartender Dienstleister / Servicekontakt. */
+  serviceProvider?: string
+  /** Festinstallation — Notfall-/Servicekontakt (Telefon/E-Mail). */
+  emergencyContact?: string
 }
 
 /** #350 — Konfiguration für die geometrische Kabellängen-Schätzung. */
@@ -141,6 +150,11 @@ export interface CablePlannerProject {
    *  hält einen vollständigen Snapshot des Plans, sodass ein früherer Stand
    *  wiederhergestellt werden kann. Optional → alte Projekte laden sauber. */
   revisions?: ProjectRevision[]
+  /** Festinstallation — attribuiertes Änderungsprotokoll (MAC/IMACD). Jede
+   *  Move/Add/Change/Service-Aktion landet hier mit wer/was/wann, sodass der
+   *  Plan ein nachvollziehbares lebendes Dokument bleibt. Optional → alte
+   *  Projekte heilen zu []. */
+  changelog?: ChangeLogEntry[]
 }
 
 /** #412 — Ein festgeschriebener Projekt-Stand. */

--- a/tests/lifecycleDocs.test.ts
+++ b/tests/lifecycleDocs.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../src/renderer/lib/installerLists'
 import { buildAssetRows } from '../src/renderer/lib/assetRegister'
 import { buildHandoverManifest } from '../src/renderer/lib/handoverPackage'
+import { sourceDestLabel } from '../src/renderer/lib/cableLabel'
 import type { CablePlannerProject } from '../src/renderer/types/project'
 import type { Cable } from '../src/renderer/types/cable'
 import type { EquipmentItem } from '../src/renderer/types/equipment'
@@ -173,6 +174,22 @@ describe('buildAssetRows', () => {
   })
 })
 
+describe('sourceDestLabel (F501.01)', () => {
+  it('baut „Quelle Port → Ziel Port" aus den Endpunkten', () => {
+    const p = project()
+    const eqById = new Map(p.equipment.map((e) => [e.id, e]))
+    const label = sourceDestLabel(p.cables[0], eqById)
+    expect(label).toContain('OUT 1')
+    expect(label).toContain('IN 1')
+    expect(label).toContain('→')
+  })
+  it('respektiert einen eigenen Separator', () => {
+    const p = project()
+    const eqById = new Map(p.equipment.map((e) => [e.id, e]))
+    expect(sourceDestLabel(p.cables[0], eqById, { separator: 'to' })).toContain(' to ')
+  })
+})
+
 describe('buildHandoverManifest', () => {
   it('enthält die Pflicht-Abschnitte des Übergabe-Dokuments', () => {
     const md = buildHandoverManifest(project())
@@ -222,6 +239,22 @@ describe('lifecycleSlice (store)', () => {
     // Idempotent: zweiter Lauf vergibt nichts mehr.
     const again = useProjectStore.getState().assignDocIds()
     expect(again.cables + again.equipment).toBe(0)
+  })
+
+  it('erzeugt Quelle→Ziel-Labels (nur leere Namen ohne overwrite)', async () => {
+    const { useProjectStore } = await import('../src/renderer/store/projectStore')
+    const cid = useProjectStore.getState().project.cables[0].id
+    // Leerer Name → Default-Lauf füllt ihn.
+    useProjectStore.getState().updateCable(cid, { name: '' })
+    expect(useProjectStore.getState().applySourceDestLabels()).toBe(1)
+    expect(useProjectStore.getState().project.cables[0].name).toContain('→')
+    // Identischer Lauf ist idempotent (Label unverändert).
+    expect(useProjectStore.getState().applySourceDestLabels({ overwrite: true })).toBe(0)
+    // Eigener Name bleibt ohne overwrite stehen, mit overwrite wird er ersetzt.
+    useProjectStore.getState().updateCable(cid, { name: 'Mein Kabel' })
+    expect(useProjectStore.getState().applySourceDestLabels()).toBe(0)
+    expect(useProjectStore.getState().applySourceDestLabels({ overwrite: true })).toBe(1)
+    expect(useProjectStore.getState().project.cables[0].name).toContain('→')
   })
 
   it('fügt Service-Records hinzu und entfernt sie wieder', async () => {

--- a/tests/lifecycleDocs.test.ts
+++ b/tests/lifecycleDocs.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { toCsv } from '../src/renderer/lib/csv'
+import { cableLabelId, equipmentAssetTag, makeDocId } from '../src/renderer/lib/docIds'
+import {
+  buildPullListRows,
+  buildTerminationRows,
+  buildCableBomRows,
+} from '../src/renderer/lib/installerLists'
+import { buildAssetRows } from '../src/renderer/lib/assetRegister'
+import { buildHandoverManifest } from '../src/renderer/lib/handoverPackage'
+import type { CablePlannerProject } from '../src/renderer/types/project'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+
+// Festinstallation — reine Logik der mitwachsenden Doku + Installateur-Listen.
+
+const eq = (id: string, name: string, over: Partial<EquipmentItem> = {}): EquipmentItem =>
+  ({
+    id,
+    name,
+    category: 'Sonstiges',
+    inputs: [{ id: `${id}-in`, name: 'IN 1', type: 'port', connectorType: 'BNC' }],
+    outputs: [{ id: `${id}-out`, name: 'OUT 1', type: 'port', connectorType: 'BNC' }],
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 100,
+    ...over,
+  }) as unknown as EquipmentItem
+
+const cable = (id: string, over: Partial<Cable> = {}): Cable =>
+  ({
+    id,
+    name: `Cable ${id}`,
+    type: 'BNC',
+    length: 5,
+    color: '#fff',
+    fromEquipmentId: 'A',
+    fromPortId: 'A-out',
+    toEquipmentId: 'B',
+    toPortId: 'B-in',
+    notes: '',
+    ...over,
+  }) as Cable
+
+const project = (over: Partial<CablePlannerProject> = {}): CablePlannerProject =>
+  ({
+    metadata: { name: 'Testanlage', description: '', createdAt: '', updatedAt: '' },
+    equipment: [eq('A', 'Kamera 1'), eq('B', 'Switcher')],
+    cables: [cable('c1')],
+    canvasState: { x: 0, y: 0, zoom: 1 },
+    ...over,
+  }) as CablePlannerProject
+
+describe('toCsv', () => {
+  it('quotet Felder mit Delimiter/Quote/Newline und setzt ein BOM', () => {
+    const csv = toCsv(['a', 'b'], [['x;y', 'he"llo'], ['plain', 'li\nne']])
+    expect(csv.startsWith('﻿')).toBe(true)
+    expect(csv).toContain('"x;y"')
+    expect(csv).toContain('"he""llo"')
+    expect(csv).toContain('"li\nne"')
+    // CRLF-Zeilenenden
+    expect(csv).toContain('\r\n')
+  })
+})
+
+describe('docIds', () => {
+  it('makeDocId pollt null', () => {
+    expect(makeDocId('C', 7)).toBe('C-0007')
+    expect(makeDocId('A', 123, 2)).toBe('A-123')
+  })
+  it('cableLabelId folgt cableNumber → qrId → UUID-Kurzform', () => {
+    expect(cableLabelId(cable('x', { cableNumber: 'V-001' }))).toBe('V-001')
+    expect(cableLabelId(cable('x', { qrId: 'C-0009' }))).toBe('C-0009')
+    expect(cableLabelId(cable('abcd1234efgh'))).toBe('C-abcd1234')
+  })
+  it('equipmentAssetTag folgt assetTag → qrId → UUID-Kurzform', () => {
+    expect(equipmentAssetTag(eq('zz', 'X', { assetTag: 'INV-1' }))).toBe('INV-1')
+    expect(equipmentAssetTag(eq('abcdef0012', 'X'))).toBe('A-abcdef00')
+  })
+})
+
+describe('buildPullListRows', () => {
+  it('löst Geräte-/Port-Namen auf und reicht Festinstall-Felder durch', () => {
+    const p = project({
+      cables: [
+        cable('c1', {
+          pathway: 'Trasse-3',
+          jacketRating: 'CMP',
+          installStatus: 'installed',
+        }),
+      ],
+    })
+    const rows = buildPullListRows(p)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].fromDevice).toBe('Kamera 1')
+    expect(rows[0].fromPort).toBe('OUT 1')
+    expect(rows[0].toDevice).toBe('Switcher')
+    expect(rows[0].toPort).toBe('IN 1')
+    expect(rows[0].pathway).toBe('Trasse-3')
+    expect(rows[0].jacket).toBe('CMP')
+    expect(rows[0].status).toBe('Installiert')
+  })
+})
+
+describe('buildTerminationRows', () => {
+  it('liefert zwei Zeilen (A/B) je Kabel mit Connector + Terminierung', () => {
+    const rows = buildTerminationRows(
+      project({ cables: [cable('c1', { terminationFrom: 'T568B', terminationTo: 'LC' })] }),
+    )
+    expect(rows).toHaveLength(2)
+    expect(rows[0].end).toBe('A')
+    expect(rows[0].connector).toBe('BNC')
+    expect(rows[0].termination).toBe('T568B')
+    expect(rows[1].end).toBe('B')
+    expect(rows[1].termination).toBe('LC')
+  })
+})
+
+describe('buildCableBomRows', () => {
+  it('aggregiert nach Typ/Länge und schlägt Reserve auf (aufgerundet)', () => {
+    const p = project({
+      cables: [cable('1'), cable('2'), cable('3'), cable('4'), cable('5')],
+    })
+    const rows = buildCableBomRows(p, 10)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].qty).toBe(5)
+    // 5 * 1.1 = 5.5 → ceil 6
+    expect(rows[0].qtyWithReserve).toBe(6)
+    expect(rows[0].totalLengthM).toBe(25)
+  })
+
+  it('zählt Multicore-Bündel nur einmal und überspringt Wireless', () => {
+    const p = project({
+      cables: [
+        cable('1', { multicoreName: 'Snake-1' }),
+        cable('2', { multicoreName: 'Snake-1' }),
+        cable('3', { wireless: true }),
+      ],
+    })
+    const rows = buildCableBomRows(p, 0)
+    const total = rows.reduce((s, r) => s + r.qty, 0)
+    expect(total).toBe(1)
+  })
+
+  it('weist Tie-Lines separat aus', () => {
+    const p = project({
+      cables: [cable('1'), cable('2', { isTieLine: true })],
+    })
+    const rows = buildCableBomRows(p, 0)
+    expect(rows).toHaveLength(2)
+    expect(rows.some((r) => r.tieLine)).toBe(true)
+  })
+})
+
+describe('buildAssetRows', () => {
+  it('mappt Status-Label, Serie und Service-Anzahl', () => {
+    const p = project({
+      equipment: [
+        eq('A', 'Kamera 1', {
+          serialNumber: 'SN-42',
+          installStatus: 'operational',
+          serviceHistory: [
+            { id: 's1', date: '2026-01-01', author: 'x', kind: 'inspection', summary: 'ok' },
+          ],
+        }),
+      ],
+    })
+    const rows = buildAssetRows(p)
+    expect(rows[0].serial).toBe('SN-42')
+    expect(rows[0].status).toBe('In Betrieb')
+    expect(rows[0].serviceCount).toBe(1)
+  })
+})
+
+describe('buildHandoverManifest', () => {
+  it('enthält die Pflicht-Abschnitte des Übergabe-Dokuments', () => {
+    const md = buildHandoverManifest(project())
+    expect(md).toContain('# Übergabe-Dokumentation')
+    expect(md).toContain('Commissioning')
+    expect(md).toContain('Kabel-Stückliste')
+    expect(md).toContain('Asset-Register')
+    expect(md).toContain('Testanlage')
+  })
+})
+
+// Store-Slice (importiert transitiv den Zustand-Store; verifiziert unter
+// happy-dom, dass die Setter Status/Service/Changelog korrekt mutieren).
+describe('lifecycleSlice (store)', () => {
+  beforeEach(async () => {
+    const { useProjectStore } = await import('../src/renderer/store/projectStore')
+    useProjectStore.getState().loadProject(project())
+  })
+
+  it('setzt Kabel-Status und protokolliert die Änderung mit Autor', async () => {
+    const { useProjectStore } = await import('../src/renderer/store/projectStore')
+    const { useSettingsStore } = await import('../src/renderer/store/settingsStore')
+    useSettingsStore.getState().setEditorName('Tester')
+    const cableId = useProjectStore.getState().project.cables[0].id
+    useProjectStore.getState().setCableInstallStatus(cableId, 'tested')
+    const st = useProjectStore.getState().project
+    expect(st.cables[0].installStatus).toBe('tested')
+    const log = st.changelog ?? []
+    expect(log.length).toBeGreaterThan(0)
+    const last = log[log.length - 1]
+    expect(last.kind).toBe('status')
+    expect(last.author).toBe('Tester')
+  })
+
+  it('vergibt eindeutige QR-/Asset-IDs nur dort wo keine existiert', async () => {
+    const { useProjectStore } = await import('../src/renderer/store/projectStore')
+    const res = useProjectStore.getState().assignDocIds()
+    expect(res.cables).toBe(1)
+    expect(res.equipment).toBe(2)
+    const st = useProjectStore.getState().project
+    const ids = [
+      ...st.cables.map((c) => c.qrId),
+      ...st.equipment.map((e) => e.qrId),
+    ]
+    expect(ids.every(Boolean)).toBe(true)
+    expect(new Set(ids).size).toBe(ids.length)
+    // Idempotent: zweiter Lauf vergibt nichts mehr.
+    const again = useProjectStore.getState().assignDocIds()
+    expect(again.cables + again.equipment).toBe(0)
+  })
+
+  it('fügt Service-Records hinzu und entfernt sie wieder', async () => {
+    const { useProjectStore } = await import('../src/renderer/store/projectStore')
+    const eqId = useProjectStore.getState().project.equipment[0].id
+    useProjectStore.getState().addServiceRecord(eqId, {
+      date: new Date().toISOString(),
+      author: 'Tester',
+      kind: 'repair',
+      summary: 'Lüfter getauscht',
+    })
+    let item = useProjectStore.getState().project.equipment.find((e) => e.id === eqId)!
+    expect(item.serviceHistory).toHaveLength(1)
+    const recId = item.serviceHistory![0].id
+    useProjectStore.getState().removeServiceRecord(eqId, recId)
+    item = useProjectStore.getState().project.equipment.find((e) => e.id === eqId)!
+    expect(item.serviceHistory).toHaveLength(0)
+  })
+})

--- a/tests/lifecycleDocs.test.ts
+++ b/tests/lifecycleDocs.test.ts
@@ -273,4 +273,48 @@ describe('lifecycleSlice (store)', () => {
     item = useProjectStore.getState().project.equipment.find((e) => e.id === eqId)!
     expect(item.serviceHistory).toHaveLength(0)
   })
+
+  it('Feld-Rückkanal: pending change übernehmen mergt Patch + protokolliert', async () => {
+    const { useProjectStore } = await import('../src/renderer/store/projectStore')
+    const cid = useProjectStore.getState().project.cables[0].id
+    const logBefore = useProjectStore.getState().project.changelog?.length ?? 0
+    useProjectStore.getState().addPendingChange({
+      author: 'Field-Tech',
+      source: 'mobile',
+      kind: 'cable-edit',
+      target: { type: 'cable', id: cid, name: 'Cable c1' },
+      summary: 'Länge korrigiert auf 7 m',
+      patch: { length: 7, evilField: 'nope' },
+    })
+    expect(useProjectStore.getState().project.pendingChanges).toHaveLength(1)
+    const pcId = useProjectStore.getState().project.pendingChanges![0].id
+
+    expect(useProjectStore.getState().applyPendingChange(pcId)).toBe(true)
+    const st = useProjectStore.getState().project
+    // Patch angewandt (whitelisted), Müll-Feld ignoriert.
+    const c = st.cables.find((x) => x.id === cid)!
+    expect(c.length).toBe(7)
+    expect((c as unknown as Record<string, unknown>).evilField).toBeUndefined()
+    // Queue geleert + Änderungsprotokoll-Eintrag geschrieben.
+    expect(st.pendingChanges).toHaveLength(0)
+    expect((st.changelog?.length ?? 0)).toBe(logBefore + 1)
+  })
+
+  it('Feld-Rückkanal: pending change verwerfen entfernt + protokolliert', async () => {
+    const { useProjectStore } = await import('../src/renderer/store/projectStore')
+    useProjectStore.getState().addPendingChange({
+      source: 'mobile',
+      kind: 'issue',
+      target: { type: 'equipment', id: 'A' },
+      summary: 'Gerät defekt?',
+    })
+    const pcId = useProjectStore
+      .getState()
+      .project.pendingChanges!.find((p) => p.summary === 'Gerät defekt?')!.id
+    const logBefore = useProjectStore.getState().project.changelog?.length ?? 0
+    useProjectStore.getState().rejectPendingChange(pcId)
+    const st = useProjectStore.getState().project
+    expect(st.pendingChanges!.some((p) => p.id === pcId)).toBe(false)
+    expect((st.changelog?.length ?? 0)).toBe(logBefore + 1)
+  })
 })

--- a/tests/qrPayload.test.ts
+++ b/tests/qrPayload.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildQrPayload,
+  parseQrPayload,
+  lookupQrRef,
+} from '../src/renderer/lib/qrPayload'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+
+const cable = (over: Partial<Cable> = {}): Cable =>
+  ({
+    id: 'cab-uuid-1',
+    name: 'Kabel',
+    type: 'BNC' as Cable['type'],
+    length: 1,
+    color: '#000',
+    fromEquipmentId: 'e1',
+    fromPortId: 'p1',
+    toEquipmentId: 'e2',
+    toPortId: 'p2',
+    qrId: 'C-0001',
+    cableNumber: 'CBL-7',
+    ...over,
+  }) as Cable
+
+const equip = (over: Partial<EquipmentItem> = {}): EquipmentItem =>
+  ({
+    id: 'eq-uuid-1',
+    name: 'ATEM',
+    category: 'mixer',
+    inputs: [],
+    outputs: [],
+    x: 0,
+    y: 0,
+    qrId: 'A-0001',
+    assetTag: 'INV-42',
+    ...over,
+  }) as EquipmentItem
+
+describe('buildQrPayload / parseQrPayload roundtrip', () => {
+  it('baut eine cableplanner-URI und parst sie zurück', () => {
+    const payload = buildQrPayload('cable', 'C-0001', 'ATEM OUT 1 → PROJ IN 1')
+    expect(payload).toBe('cableplanner://cable/C-0001?l=ATEM%20OUT%201%20%E2%86%92%20PROJ%20IN%201')
+    const ref = parseQrPayload(payload)
+    expect(ref).toEqual({ kind: 'cable', id: 'C-0001', label: 'ATEM OUT 1 → PROJ IN 1' })
+  })
+
+  it('parst Equipment-URIs', () => {
+    expect(parseQrPayload('cableplanner://equipment/A-0007?l=Rack')).toEqual({
+      kind: 'equipment',
+      id: 'A-0007',
+      label: 'Rack',
+    })
+  })
+
+  it('parst Deep-Links aus Hash und ?lookup=', () => {
+    expect(parseQrPayload('https://host/mobile.html#cable/C-0009')).toMatchObject({
+      kind: 'cable',
+      id: 'C-0009',
+    })
+    expect(parseQrPayload('http://x/?lookup=equipment/A-0003')).toMatchObject({
+      kind: 'equipment',
+      id: 'A-0003',
+    })
+  })
+
+  it('parst die nackte kind/id-Form (Deep-Link ohne Präfix)', () => {
+    expect(parseQrPayload('cable/C-0001')).toMatchObject({ kind: 'cable', id: 'C-0001' })
+    expect(parseQrPayload('equipment/A-9')).toMatchObject({ kind: 'equipment', id: 'A-9' })
+  })
+
+  it('leitet die Sorte aus nackten Doc-IDs ab', () => {
+    expect(parseQrPayload('C-0001')).toEqual({ kind: 'cable', id: 'C-0001' })
+    expect(parseQrPayload('a-0002')).toEqual({ kind: 'equipment', id: 'a-0002' })
+  })
+
+  it('behandelt Freitext als ID ohne Sorte', () => {
+    expect(parseQrPayload('CBL-7')).toEqual({ id: 'CBL-7' })
+    expect(parseQrPayload('   ')).toBeNull()
+  })
+})
+
+describe('lookupQrRef', () => {
+  const cables = [cable(), cable({ id: 'cab-2', qrId: 'C-0002', cableNumber: 'CBL-9' })]
+  const equipment = [equip(), equip({ id: 'eq-2', qrId: 'A-0002', assetTag: 'INV-99' })]
+
+  it('findet Kabel über qrId', () => {
+    const m = lookupQrRef({ kind: 'cable', id: 'C-0002' }, cables, equipment)
+    expect(m).toMatchObject({ kind: 'cable', item: { id: 'cab-2' } })
+  })
+
+  it('findet Kabel über cableNumber (Freitext-Scan)', () => {
+    const m = lookupQrRef(parseQrPayload('CBL-9')!, cables, equipment)
+    expect(m).toMatchObject({ kind: 'cable', item: { id: 'cab-2' } })
+  })
+
+  it('findet Gerät über assetTag', () => {
+    const m = lookupQrRef({ id: 'INV-99' }, cables, equipment)
+    expect(m).toMatchObject({ kind: 'equipment', item: { id: 'eq-2' } })
+  })
+
+  it('respektiert die Sorte (equipment-Ref findet kein Kabel)', () => {
+    expect(lookupQrRef({ kind: 'equipment', id: 'C-0001' }, cables, equipment)).toBeNull()
+  })
+
+  it('liefert null bei keinem Treffer', () => {
+    expect(lookupQrRef({ id: 'nope' }, cables, equipment)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Worum es geht

Macht Cable-Planner für **dauerhafte Festinstallationen** tauglich, die nach der
Erstinstallation weiter verändert werden und wachsen — statt nur temporärer
Show-Verkabelung. Inzwischen über die ursprüngliche Doku/Übergabe-Stufe hinaus
gewachsen (Labels, Scan-Workflow, Feld-Rückkanal) plus eine Analyse zur
Lager-/Inventar-Tauglichkeit.

## Implementiert

**1. Festinstallation: mitwachsende Doku, Listen & Übergabe** (Ausgangs-Scope)
- Datenmodell `types/lifecycle.ts`: `InstallStatus`, `ServiceRecord`,
  `CableTestResult`, `ChangeLogEntry` + Kabel-/Geräte-/Projekt-Felder
- `lifecycleSlice`: Status, Test-Ergebnis, Service-Historie, attribuiertes
  Änderungsprotokoll (MAC/IMACD), `assignDocIds()` (stabile QR-/Asset-IDs)
- Installateur-Listen (Pull/Termination/Schedule/BOM), Asset-Register,
  Übergabe-Manifest — reine, headless-getestete Logik + CSV
- UI: `InstallationDocsDialog`, `CableProperties`, `EquipmentProperties`

**2. Kabel-Label „Quelle → Ziel" (AVIXA F501.01)**
- `lib/cableLabel.ts` `sourceDestLabel()` — `ATEM OUT 1 → PROJ IN 1`
- Store `applySourceDestLabels({overwrite})` (füllt leere Namen; protokolliert)
- Button im Doku-Dialog + Per-Kabel-Button in CableProperties

**3. QR-Scan-Lookup (Mobile-Companion)**
- `lib/qrPayload.ts` — eine Quelle für QR-Format (`buildQrPayload`), Parsen
  (`parseQrPayload`: URI / Deep-Link / nackte Doc-ID / Freitext) und Auflösen
  (`lookupQrRef` gegen qrId/cableNumber/assetTag/UUID); `docIds.qrPayload`
  delegiert dorthin
- Mobile: QR-Finden-Overlay (Live-Kamera via `BarcodeDetector` wo
  Secure-Context erlaubt, sonst manuelle Eingabe), Treffer klappt Gerätekarte
  auf, scrollt hin, hebt Karte + Ziel-Port hervor; Deep-Link beim Laden
- Schließt die bisherige Lücke: das `cableplanner://`-Schema der Etiketten
  wurde nirgends aufgelöst

**4. Feld-Rückkanal (pending changes)**
- `PendingChange`-Modell + `pendingChangesSlice` (add / apply mergt
  whitelisteten Patch aufs Ziel + schreibt ChangeLogEntry / reject)
- Electron-Pfad gespiegelt an `/cables`: `POST /pending-changes` (Server, IPC,
  preload, bridge, App.tsx)
- Mobile: `MobileReportModal` (Kabel-Längenkorrektur / Problem / Notiz)
- Desktop: Review-Sektion „Feld-Rückmeldungen" im Doku-Dialog

**5. Analyse: Lager-/Inventar-Readiness**
- `docs/inventory-rental-readiness.md` — was existiert, was fehlt (zentraler
  Bestand, Mengen, Verfügbarkeit, Zeitraum-Buchungen), Architektur-Konsequenz
  und 6-Phasen-Plan (Lager-/Material-Modul für Festinstallation + Rental)

## Verifikation (headless)
- `tsc` für app/main/preload/node → **0 Errors**
- `npx vitest run` → **61 Tests grün** (`lifecycleDocs`, `qrPayload`, …)
- ESLint der geänderten Renderer-Dateien → 0 Errors

## Kompatibilität
Alle neuen Felder optional (`changelog`, `pendingChanges` heilen zu `[]`). Alte
`.cableplan`-Dateien laden unverändert.

Draft: Review zu Scope/Priorisierung willkommen.