### PR TITLE
lager: Geräte-Inventarfelder (Eigentum/Lagerort) + Projekt-Zeitraum (Phase 0+1)

### DIFF
--- a/docs/inventory-rental-readiness.md
+++ b/docs/inventory-rental-readiness.md
@@ -82,13 +82,14 @@ Optional später: NetBox-/Rentman-Sync als Quelle des Bestands.
 
 ## 4. Vorgeschlagene Phasen (inkrementell, je eigener PR)
 
-**Phase 0 — Datenmodell-Felder am Gerät (klein, sofort nützlich).**
-Felder ergänzen, die schon innerhalb *eines* Plans Wert haben:
+**Phase 0 — Datenmodell-Felder am Gerät (klein, sofort nützlich). ✅ umgesetzt.**
+Felder ergänzt, die schon innerhalb *eines* Plans Wert haben:
 `ownership` (`owned`/`rented`/`subhire`), `stockLocation`, `purchaseDate`,
-`supplier`. Reines Additiv, kein neuer Store. Speist Asset-Register + BOM.
+`supplier`. Reines Additiv, kein neuer Store. Editierbar in der Geräte-
+Lebenszyklus-Section; im Asset-Register-CSV als Spalten.
 
-**Phase 1 — Projekt-Zeitraum.**
-`metadata.eventStart/eventEnd` + UI im Metadaten-Dialog. Voraussetzung für
+**Phase 1 — Projekt-Zeitraum. ✅ umgesetzt.**
+`metadata.eventStart/eventEnd` + UI im Projektdaten-Dialog. Voraussetzung für
 jede Verfügbarkeits-Rechnung. Trivial, aber Türöffner.
 
 **Phase 2 — Zentraler Bestand (Lager-Modul, MVP).**

--- a/src/renderer/components/Project/ProjectMetaDialog.tsx
+++ b/src/renderer/components/Project/ProjectMetaDialog.tsx
@@ -32,6 +32,8 @@ export const ProjectMetaDialog = ({
   const [client, setClient] = useState('')
   const [contractor, setContractor] = useState('')
   const [projectNumber, setProjectNumber] = useState('')
+  const [eventStart, setEventStart] = useState('')
+  const [eventEnd, setEventEnd] = useState('')
   const [companyLogo, setCompanyLogo] = useState<string | undefined>(undefined)
   const [clientLogo, setClientLogo] = useState<string | undefined>(undefined)
   const companyInputRef = useRef<HTMLInputElement>(null)
@@ -54,6 +56,8 @@ export const ProjectMetaDialog = ({
     setClient(src.client ?? '')
     setContractor(src.contractor ?? '')
     setProjectNumber(src.projectNumber ?? '')
+    setEventStart((src.eventStart ?? '').slice(0, 10))
+    setEventEnd((src.eventEnd ?? '').slice(0, 10))
     setCompanyLogo(src.companyLogo)
     setClientLogo(src.clientLogo)
   }, [open, mode])
@@ -69,6 +73,8 @@ export const ProjectMetaDialog = ({
       client: client.trim() || undefined,
       contractor: contractor.trim() || undefined,
       projectNumber: projectNumber.trim() || undefined,
+      eventStart: eventStart || undefined,
+      eventEnd: eventEnd || undefined,
       companyLogo,
       clientLogo,
     })
@@ -152,6 +158,28 @@ export const ProjectMetaDialog = ({
                 value={projectNumber}
                 onChange={(e) => setProjectNumber(e.target.value)}
                 placeholder={t('project.meta.projectNumberPh', 'z.B. 2026-042')}
+                className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
+              />
+            </label>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <label className="block">
+              {t('project.meta.eventStart', 'Einsatz-/Mietbeginn')}
+              <input
+                type="date"
+                value={eventStart}
+                onChange={(e) => setEventStart(e.target.value)}
+                className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
+              />
+            </label>
+            <label className="block">
+              {t('project.meta.eventEnd', 'Einsatz-/Mietende')}
+              <input
+                type="date"
+                value={eventEnd}
+                min={eventStart || undefined}
+                onChange={(e) => setEventEnd(e.target.value)}
                 className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
               />
             </label>

--- a/src/renderer/components/Properties/sections/LifecycleSection.tsx
+++ b/src/renderer/components/Properties/sections/LifecycleSection.tsx
@@ -18,7 +18,12 @@ import {
   type InstallStatus,
   type ServiceRecord,
 } from '../../../types/lifecycle'
-import type { EquipmentItem } from '../../../types/equipment'
+import {
+  EQUIPMENT_OWNERSHIPS,
+  EQUIPMENT_OWNERSHIP_LABEL,
+  type EquipmentItem,
+  type EquipmentOwnership,
+} from '../../../types/equipment'
 
 const SERVICE_KINDS: ServiceRecord['kind'][] = [
   'install',
@@ -121,6 +126,69 @@ export const LifecycleSection = ({ equipment }: { equipment: EquipmentItem }) =>
             className="w-full rounded border border-cp-border bg-cp-surface-1 p-1.5"
           />
         </label>
+
+        {/* Lager (Phase 0) — Eigentum, Lagerort, Lieferant, Anschaffung */}
+        <div className="grid grid-cols-2 gap-2">
+          <label className="block">
+            <span className="mb-1 block text-cp-text-secondary">
+              {t('lifecycle.ownership', 'Eigentum')}
+            </span>
+            <select
+              value={equipment.ownership ?? ''}
+              onChange={(e) =>
+                updateEquipment(equipment.id, {
+                  ownership: (e.target.value || undefined) as EquipmentOwnership | undefined,
+                })
+              }
+              className="w-full rounded border border-cp-border bg-cp-surface-1 p-1.5"
+            >
+              <option value="">{t('lifecycle.ownershipNone', '— k.A. —')}</option>
+              {EQUIPMENT_OWNERSHIPS.map((o) => (
+                <option key={o} value={o}>
+                  {EQUIPMENT_OWNERSHIP_LABEL[o]}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block">
+            <span className="mb-1 block text-cp-text-secondary">
+              {t('lifecycle.purchaseDate', 'Anschaffung')}
+            </span>
+            <input
+              type="date"
+              value={(equipment.purchaseDate ?? '').slice(0, 10)}
+              onChange={(e) =>
+                updateEquipment(equipment.id, { purchaseDate: e.target.value || undefined })
+              }
+              className="w-full rounded border border-cp-border bg-cp-surface-1 p-1.5"
+            />
+          </label>
+          <label className="block">
+            <span className="mb-1 block text-cp-text-secondary">
+              {t('lifecycle.stockLocation', 'Lagerort')}
+            </span>
+            <input
+              value={equipment.stockLocation ?? ''}
+              onChange={(e) =>
+                updateEquipment(equipment.id, { stockLocation: e.target.value || undefined })
+              }
+              placeholder={t('lifecycle.stockLocationPh', 'z.B. Lager A · Regal 3.2')}
+              className="w-full rounded border border-cp-border bg-cp-surface-1 p-1.5"
+            />
+          </label>
+          <label className="block">
+            <span className="mb-1 block text-cp-text-secondary">
+              {t('lifecycle.supplier', 'Lieferant')}
+            </span>
+            <input
+              value={equipment.supplier ?? ''}
+              onChange={(e) =>
+                updateEquipment(equipment.id, { supplier: e.target.value || undefined })
+              }
+              className="w-full rounded border border-cp-border bg-cp-surface-1 p-1.5"
+            />
+          </label>
+        </div>
 
         {/* Service-Historie */}
         <div>

--- a/src/renderer/lib/assetRegister.ts
+++ b/src/renderer/lib/assetRegister.ts
@@ -8,6 +8,7 @@
 import type { CablePlannerProject } from '../types/project'
 import type { EquipmentItem } from '../types/equipment'
 import { INSTALL_STATUS_LABEL } from '../types/lifecycle'
+import { EQUIPMENT_OWNERSHIP_LABEL } from '../types/equipment'
 import { equipmentAssetTag } from './docIds'
 import { toCsv, type CsvCell } from './csv'
 
@@ -20,6 +21,10 @@ export interface AssetRow {
   ip: string
   firmware: string
   status: string
+  ownership: string
+  stockLocation: string
+  supplier: string
+  purchaseDate: string
   warrantyUntil: string
   maintenanceIntervalDays: string
   lastService: string
@@ -52,6 +57,10 @@ export const buildAssetRows = (project: CablePlannerProject): AssetRow[] =>
       ip: e.ipAddress ?? '',
       firmware: e.firmware ?? '',
       status: e.installStatus ? INSTALL_STATUS_LABEL[e.installStatus] : '',
+      ownership: e.ownership ? EQUIPMENT_OWNERSHIP_LABEL[e.ownership] : '',
+      stockLocation: e.stockLocation ?? '',
+      supplier: e.supplier ?? '',
+      purchaseDate: e.purchaseDate ?? '',
       warrantyUntil: e.warrantyUntil ?? '',
       maintenanceIntervalDays:
         typeof e.maintenanceIntervalDays === 'number'
@@ -73,6 +82,10 @@ export const assetRegisterCsv = (project: CablePlannerProject): string => {
     'IP',
     'Firmware',
     'Status',
+    'Eigentum',
+    'Lagerort',
+    'Lieferant',
+    'Anschaffung',
     'Garantie bis',
     'Wartungsintervall (Tage)',
     'Letzter Service',
@@ -87,6 +100,10 @@ export const assetRegisterCsv = (project: CablePlannerProject): string => {
     r.ip,
     r.firmware,
     r.status,
+    r.ownership,
+    r.stockLocation,
+    r.supplier,
+    r.purchaseDate,
     r.warrantyUntil,
     r.maintenanceIntervalDays,
     r.lastService,

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -540,6 +540,27 @@ export interface EquipmentItem {
   /** Festinstallation — zeitgestempelte Service-/Wartungs-Historie. Macht aus
    *  der Doku ein CMMS-artiges Asset-Register. Undefined/[] = keine Einträge. */
   serviceHistory?: ServiceRecord[]
+  /** Lager (Phase 0) — Eigentumsverhältnis: eigenes Gerät, angemietet oder
+   *  Sub-Hire (von Dritten weitervermietet). Steuert später die
+   *  Verfügbarkeits-/Mietkalkulation; schon jetzt für Asset-Register/BOM. */
+  ownership?: 'owned' | 'rented' | 'subhire'
+  /** Lager (Phase 0) — Lagerort/Stellplatz (z.B. „Lager A · Regal 3.2"). */
+  stockLocation?: string
+  /** Lager (Phase 0) — Anschaffungsdatum (ISO) für Inventar/Abschreibung. */
+  purchaseDate?: string
+  /** Lager (Phase 0) — Lieferant/Bezugsquelle (Inventar-Herkunft). */
+  supplier?: string
+}
+
+/** Lager (Phase 0) — Eigentumsverhältnis eines Geräts. */
+export type EquipmentOwnership = 'owned' | 'rented' | 'subhire'
+
+/** Anzeige-Reihenfolge + deutsche Default-Labels (UI heilt EN via i18n). */
+export const EQUIPMENT_OWNERSHIPS: EquipmentOwnership[] = ['owned', 'rented', 'subhire']
+export const EQUIPMENT_OWNERSHIP_LABEL: Record<EquipmentOwnership, string> = {
+  owned: 'Eigenbestand',
+  rented: 'Angemietet',
+  subhire: 'Sub-Hire',
 }
 
 /**

--- a/src/renderer/types/project.ts
+++ b/src/renderer/types/project.ts
@@ -93,6 +93,11 @@ export interface ProjectMetadata {
   serviceProvider?: string
   /** Festinstallation — Notfall-/Servicekontakt (Telefon/E-Mail). */
   emergencyContact?: string
+  /** Lager (Phase 1) — Beginn des Einsatz-/Miet-Zeitraums (ISO-Datum). Basis
+   *  für die spätere projektübergreifende Verfügbarkeits-/Konflikt-Rechnung. */
+  eventStart?: string
+  /** Lager (Phase 1) — Ende des Einsatz-/Miet-Zeitraums (ISO-Datum). */
+  eventEnd?: string
 }
 
 /** #350 — Konfiguration für die geometrische Kabellängen-Schätzung. */

--- a/tests/lifecycleDocs.test.ts
+++ b/tests/lifecycleDocs.test.ts
@@ -172,6 +172,24 @@ describe('buildAssetRows', () => {
     expect(rows[0].status).toBe('In Betrieb')
     expect(rows[0].serviceCount).toBe(1)
   })
+
+  it('mappt die Lager-Felder (Eigentum/Lagerort/Lieferant/Anschaffung)', () => {
+    const p = project({
+      equipment: [
+        eq('A', 'Kamera 1', {
+          ownership: 'rented',
+          stockLocation: 'Lager A · Regal 3.2',
+          supplier: 'Rentcorp',
+          purchaseDate: '2025-11-02',
+        }),
+      ],
+    })
+    const r = buildAssetRows(p)[0]
+    expect(r.ownership).toBe('Angemietet')
+    expect(r.stockLocation).toBe('Lager A · Regal 3.2')
+    expect(r.supplier).toBe('Rentcorp')
+    expect(r.purchaseDate).toBe('2025-11-02')
+  })
 })
 
 describe('sourceDestLabel (F501.01)', () => {


### PR DESCRIPTION
## Worum es geht

Erster, bewusst kleiner Schritt aus `docs/inventory-rental-readiness.md`
(Phase 0 + 1) Richtung Lager-/Inventar-Tauglichkeit. Rein **additiv** — kein
neuer Store, keine Architektur-Änderung. Schon ohne den großen
bestands-zentrischen Umbau sofort nützlich und Türöffner für die
Verfügbarkeitsrechnung.

## Phase 0 — Geräte-Inventarfelder
- `types/equipment.ts`: `ownership` (`owned`/`rented`/`subhire`) +
  `EQUIPMENT_OWNERSHIPS`/`EQUIPMENT_OWNERSHIP_LABEL`, `stockLocation`,
  `purchaseDate`, `supplier`
- `LifecycleSection`: editierbarer Lager-Block (Eigentum / Anschaffung /
  Lagerort / Lieferant)
- `assetRegister`: 4 neue CSV-Spalten (Eigentum, Lagerort, Lieferant,
  Anschaffung)

## Phase 1 — Projekt-Zeitraum
- `types/project.ts`: `metadata.eventStart` / `eventEnd` (ISO) — Basis für die
  spätere projektübergreifende Verfügbarkeits-/Konflikt-Rechnung
- `ProjectMetaDialog`: Datumsfelder „Einsatz-/Mietbeginn" + „-ende"

## Verifikation (headless)
- `tsc -p tsconfig.app.json` → **0 Errors**
- `npx vitest run` → **62 Tests grün** (neu: Lager-Felder im Asset-Register)
- ESLint der geänderten Dateien → 0 Errors

## Kompatibilität
Alle Felder optional → alte `.cableplan`-Dateien laden unverändert.

Draft: Review willkommen. Nächste Stufen (zentraler Bestand, Verknüpfung
Plan↔Bestand, Verfügbarkeit) siehe `docs/inventory-rental-readiness.md`
Phase 2–5.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3N1U9wfo2EosdGLxS5DFi)_