### PR TITLE
UI: modulares System — ein-/ausschaltbare Module + Erststart-Onboarding (Konzept + Gerüst)

### DIFF
--- a/docs/modular-ui-concept.md
+++ b/docs/modular-ui-concept.md
@@ -1,0 +1,107 @@
+# Modulares UI — Konzept
+
+Cable-Planner wächst (Show/Event, Festinstallation, QR/Mobile, Rentman,
+künftig Rental/Lager). Damit die Oberfläche nicht zur „eierlegenden
+Wollmilchsau" wird, sollen Funktionsbereiche als **ein-/ausschaltbare Module**
+laufen. Dieses Dokument hält das UX-Konzept fest (recherche-gestützt) und die
+Umsetzung in der bestehenden Architektur.
+
+## Ziel
+
+- Schlanke Oberfläche je nach Anwendungsfall, **ohne Funktionen zu löschen**.
+- Beim ersten Start eine **leichte** Abfrage „wofür nutzt du die App?", die ein
+  passendes Modul-Preset setzt — überspringbar, kein Tutorial-Zwang.
+- Module jederzeit unter **Einstellungen → Module** umschaltbar.
+
+## Recherche-Erkenntnisse (Kurzform)
+
+1. **„Module togglen" ist erprobt** — ClickUp *ClickApps* sind die Blaupause:
+   kleine Funktionspakete, per Toggle aktivierbar; Oberfläche bleibt schlank,
+   nichts wird gelöscht.
+2. **Grundprinzip Progressive Disclosure** — Selten-/Fortgeschrittenes erst
+   zeigen, wenn relevant. Modul-Toggles = nutzergesteuerte Progressive
+   Disclosure.
+3. **Intent-Onboarding funktioniert** (HubSpot/Canva): nach **Rolle/Use-Case**
+   fragen, nicht nach Feature-Liste; auf **2–3 Optionen** begrenzen.
+4. **NN/g-Warnung**: Onboarding, das man vor der Nutzung wegklicken muss, wird
+   übersprungen → **kurz, begründet, überspringbar** halten.
+5. **Schattenseite Modularität**: versteckte Funktionen (vgl. VS Code, ~40 %
+   genutzt). Ausgeschaltetes darf nicht unauffindbar werden.
+
+Quellen: NN/g „Onboarding: Skip it When Possible" + „Mobile-App Onboarding";
+ClickUp „Intro to ClickApps"; IxDF/UXPin „Progressive Disclosure"; Chameleon
+„User Onboarding Best Practices".
+
+## Designentscheidungen
+
+### 1. Kein Pflicht-Wizard
+Erststart zeigt **einen** überspringbaren Dialog mit *einer* Intent-Frage
+(Mehrfachauswahl). „Später entscheiden" ist gleichwertig sichtbar. Ohne
+Antwort gilt der Default (Kern an, neue/nische Module aus).
+
+### 2. Presets statt Einzel-Häkchen (im Onboarding)
+| Preset | aktiviert zusätzlich zum Kern |
+|---|---|
+| **Show/Event** | Mobile-Companion, Rentman |
+| **Festinstallation** | Festinstallation (Lebenszyklus/Asset/QR/Übergabe/Feld-Rückkanal) |
+| **Rental/Vermietung** | Rental/Lager, Rentman |
+
+Der **Kern** (Canvas, Geräte/Kabel, Properties, Export/PDF) ist immer an und
+kein Modul.
+
+### 3. Dauerhafter Schaltplatz: Einstellungen → Module
+ClickApps-artige Liste mit Toggle + Ein-Satz-Beschreibung je Modul. Das ist
+die durchsuchbare, sichtbare Heimat (gegen „versteckte Features").
+
+### 4. Discoverability-Sicherung
+Ausgeschaltete Module verschwinden aus Menü/Panels, **aber** das Onboarding
+und der Module-Tab bleiben die offensichtliche Stelle, sie wieder zu
+aktivieren. (Optional später: dezenter „+ Modul aktivieren"-Hinweis an
+leeren Stellen — kein Dauer-Nag.)
+
+### 5. Granularität & Datensicherheit (Invariante)
+- **Modul-An/Aus = pro Installation** (`settingsStore`, localStorage), denn es
+  ist eine Nutzer-Vorliebe, **nicht** Teil der Projektdatei.
+- Module steuern **nur die UI-Sichtbarkeit**. Die `.cableplan`-Daten bleiben
+  immer vollständig — ein Plan öffnet auf jeder Installation, egal welche
+  Module dort an sind. **Kein Datenverlust durch ein ausgeschaltetes Modul.**
+- Der **Projekt-Typ** (Show/Festinstallation/Rental) kann *pro Projekt* das
+  passende Preset **vorschlagen** (späterer Schritt), erzwingt aber nichts.
+
+## Module (Erst-Taxonomie)
+
+| ModuleId | Label | Inhalt | Default |
+|---|---|---|---|
+| `festinstallation` | Festinstallation | Lebenszyklus/Service, Asset-Register/QR, Übergabe-Doku, Feld-Rückkanal | an |
+| `mobile` | Mobile-Companion | Handy-Patchliste, Check-off, QR-Scan, Feld-Meldungen | an |
+| `rentman` | Rentman | Import/Export-Kopplung | an |
+| `rental` | Rental / Lager | Bestand, Eigentum/Verfügbarkeit, Mietkalkulation (Phase 2+) | aus |
+
+Defaults sind so gewählt, dass **bestehende Installationen nichts verlieren**
+(alles bisher Sichtbare bleibt an; nur das neue `rental` startet aus und wird
+über Onboarding/Settings angeboten).
+
+## Umsetzung in der Architektur
+
+- `lib/modules.ts` — Registry: `ModuleId`, `MODULES` (Metadaten),
+  `PRESETS`, `DEFAULT_ENABLED`. Framework-frei, testbar.
+- `settingsStore` — `enabledModules: Record<ModuleId, boolean>` +
+  `onboardingDone: boolean` + Setter (`setModuleEnabled`, `applyModulePreset`,
+  `setOnboardingDone`), persistiert wie die übrigen Settings.
+- `useModule(id)` — Hook für konditionales Rendern von Menüeinträgen,
+  Panels und Dialogen.
+- `ModuleOnboardingDialog` — überspringbarer Erststart-Dialog (Presets).
+- Settings-Tab **„Module"** — Dauer-Schaltplatz.
+
+### Umsetzungs-Reihenfolge
+1. Registry + Store-Flags + `useModule` (+ Tests).
+2. Settings-Tab „Module".
+3. Überspringbarer Erststart-Dialog (Presets).
+4. **Ein** Modul als Referenz konditional verdrahten (Festinstallation:
+   Menüeintrag „Doku & Übergabe").
+5. Restliche Module nach und nach hinter `useModule` hängen.
+
+## Fallstricke (bewusst vermeiden)
+- ❌ Pflicht-Setup-Wizard mit langer Feature-Liste.
+- ❌ Module, die Projektdaten wegblenden/entfernen statt nur UI.
+- ❌ Ausgeschaltetes unauffindbar machen.

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -39,6 +39,7 @@ import { MobileShareDialog } from './components/MobileShare/MobileShareDialog'
 import { AboutDialog } from './components/About/AboutDialog'
 import { PatchListDialog } from './components/Patch/PatchListDialog'
 import { InstallationDocsDialog } from './components/Export/InstallationDocsDialog'
+import { ModuleOnboardingDialog } from './components/Onboarding/ModuleOnboardingDialog'
 import { BandwidthCalculatorDialog, PowerCalculatorDialog } from './components/Calculators/CalculatorsDialog'
 import { RecordingStorageCalculatorDialog } from './components/Calculators/RecordingStorageCalculatorDialog'
 import { ProjectionCalculatorDialog } from './components/Calculators/ProjectionCalculatorDialog'
@@ -1112,6 +1113,7 @@ export default function App() {
       <AboutDialog />
       <PatchListDialog />
       <InstallationDocsDialog />
+      <ModuleOnboardingDialog />
       <BandwidthCalculatorDialog />
       <PowerCalculatorDialog />
       <RecordingStorageCalculatorDialog />

--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -21,6 +21,7 @@ import { useTranslation, format } from '../../lib/i18n'
 import { projectHistory } from '../../store/projectHistory'
 import { useUiStore } from '../../store/uiStore'
 import { useProjectStore } from '../../store/projectStore'
+import { useModule } from '../../store/settingsStore'
 import { exportStagePlotSvg } from '../../lib/exportStagePlot'
 import { downloadBlob } from '../../lib/downloadBlob'
 import { buildExportFilename } from '../../lib/exportFilename'
@@ -157,6 +158,8 @@ export const MenuBar = ({
     })
   }, [t])
   const rentmanEnabled = useUiStore((s) => s.rentmanEnabled)
+  // Modulares UI — Festinstallations-Doku nur zeigen, wenn das Modul an ist.
+  const festinstallationModule = useModule('festinstallation')
   // #341 — View-Menü spiegelt Toolbar-Toggles; Status für Häkchen lesen.
   const canvasTheme = useUiStore((s) => s.canvasTheme)
   const followSystemTheme = useUiStore((s) => s.followSystemTheme)
@@ -430,9 +433,11 @@ export const MenuBar = ({
           <MenuItem onClick={() => useUiStore.getState().openPatchList()} icon={<Icon icon={Cable} size="sm" />}>
             {t('app.menu.tools.patchList', 'Patch-Liste…')}
           </MenuItem>
-          <MenuItem onClick={() => useUiStore.getState().openInstallDocs()} icon={<Icon icon={PackageCheck} size="sm" />}>
-            {t('app.menu.tools.installDocs', 'Festinstallation: Doku & Übergabe…')}
-          </MenuItem>
+          {festinstallationModule && (
+            <MenuItem onClick={() => useUiStore.getState().openInstallDocs()} icon={<Icon icon={PackageCheck} size="sm" />}>
+              {t('app.menu.tools.installDocs', 'Festinstallation: Doku & Übergabe…')}
+            </MenuItem>
+          )}
           <MenuItem
             onClick={() => {
               const p = useProjectStore.getState().project

--- a/src/renderer/components/Onboarding/ModuleOnboardingDialog.tsx
+++ b/src/renderer/components/Onboarding/ModuleOnboardingDialog.tsx
@@ -1,0 +1,107 @@
+/**
+ * Modulares UI — überspringbarer Erststart-Dialog.
+ *
+ * EINE Intent-Frage („wofür nutzt du die App?") mit Mehrfachauswahl von
+ * Use-Case-Presets, die ein Modul-Set setzen. NN/g-konform: kurz, begründet,
+ * jederzeit überspringbar. Ohne Antwort gilt der Default (Kern an, Nische aus).
+ * Siehe `docs/modular-ui-concept.md`.
+ */
+import { useState } from 'react'
+import { Blocks } from 'lucide-react'
+import { useSettingsStore } from '../../store/settingsStore'
+import { useTranslation } from '../../lib/i18n'
+import { PRESETS, type PresetId } from '../../lib/modules'
+import { ModalShell } from '../shared/ModalShell'
+import { Icon } from '../shared/Icon'
+
+export const ModuleOnboardingDialog = () => {
+  const t = useTranslation()
+  const onboardingDone = useSettingsStore((s) => s.onboardingDone)
+  const applyModulePreset = useSettingsStore((s) => s.applyModulePreset)
+  const setOnboardingDone = useSettingsStore((s) => s.setOnboardingDone)
+  const [selected, setSelected] = useState<PresetId[]>([])
+
+  if (onboardingDone) return null
+
+  const toggle = (id: PresetId) =>
+    setSelected((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
+
+  // Überspringen behält die Defaults (Kern + bisher Sichtbares), NICHT das
+  // leere Preset (das würde alles ausschalten).
+  const skip = () => setOnboardingDone(true)
+  const confirm = () => {
+    if (selected.length === 0) return skip()
+    applyModulePreset(selected)
+    setOnboardingDone(true)
+  }
+
+  return (
+    <ModalShell
+      open
+      onClose={skip}
+      maxWidth="lg"
+      titleIcon={<Icon icon={Blocks} size="sm" />}
+      title={t('onboarding.title', 'Willkommen — wofür nutzt du Cable-Planner?')}
+      footer={
+        <div className="flex items-center justify-between gap-2">
+          <button
+            type="button"
+            onClick={skip}
+            className="rounded px-3 py-1 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-2"
+          >
+            {t('onboarding.skip', 'Später entscheiden')}
+          </button>
+          <button
+            type="button"
+            onClick={confirm}
+            disabled={selected.length === 0}
+            className="rounded bg-emerald-700 px-3 py-1 text-cp-xs enabled:hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {t('onboarding.confirm', 'Loslegen')}
+          </button>
+        </div>
+      }
+    >
+      <div className="space-y-3 text-cp-xs">
+        <p className="text-cp-text-secondary">
+          {t(
+            'onboarding.intro',
+            'Wähle einen oder mehrere Anwendungsfälle — passende Funktionsmodule werden aktiviert. Du kannst alles jederzeit unter Einstellungen → Module ändern.',
+          )}
+        </p>
+        <div className="grid gap-2 sm:grid-cols-3">
+          {PRESETS.map((p) => {
+            const on = selected.includes(p.id)
+            return (
+              <button
+                key={p.id}
+                type="button"
+                onClick={() => toggle(p.id)}
+                aria-pressed={on}
+                className={`rounded border p-3 text-left transition ${
+                  on
+                    ? 'border-emerald-500 bg-emerald-900/20'
+                    : 'border-cp-border bg-cp-surface-1 hover:border-cp-border-muted'
+                }`}
+              >
+                <div className="mb-1 flex items-center gap-2 font-semibold text-cp-text-bright">
+                  <span
+                    className={`flex h-4 w-4 items-center justify-center rounded-sm border text-[10px] ${
+                      on ? 'border-emerald-500 bg-emerald-600 text-white' : 'border-cp-border'
+                    }`}
+                  >
+                    {on ? '✓' : ''}
+                  </span>
+                  {t(`onboarding.preset.${p.id}.label`, p.label)}
+                </div>
+                <p className="text-cp-text-muted">
+                  {t(`onboarding.preset.${p.id}.desc`, p.description)}
+                </p>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </ModalShell>
+  )
+}

--- a/src/renderer/components/Settings/SettingsBody.tsx
+++ b/src/renderer/components/Settings/SettingsBody.tsx
@@ -5,10 +5,11 @@
  */
 import { useState, type HTMLAttributes, type ReactNode } from 'react'
 import {
-  ClipboardList, Palette, Pencil, Keyboard, Plug, Database, RefreshCw, Settings, X,
+  ClipboardList, Palette, Pencil, Keyboard, Plug, Database, RefreshCw, Settings, Blocks, X,
   type LucideIcon,
 } from 'lucide-react'
 import { Icon } from '../shared/Icon'
+import { ModulesTab } from './tabs/ModulesTab'
 import { HotkeysTab } from './tabs/HotkeysTab'
 import { SyncTab } from './tabs/SyncTab'
 import { AdvancedTab } from './tabs/AdvancedTab'
@@ -21,6 +22,7 @@ import { useTranslation } from '../../lib/i18n'
 
 export type SettingsSection =
   | 'project'
+  | 'modules'
   | 'appearance'
   | 'editing'
   | 'hotkeys'
@@ -31,6 +33,7 @@ export type SettingsSection =
 
 const TAB_ICONS: Record<SettingsSection, LucideIcon> = {
   project: ClipboardList,
+  modules: Blocks,
   appearance: Palette,
   editing: Pencil,
   hotkeys: Keyboard,
@@ -42,6 +45,7 @@ const TAB_ICONS: Record<SettingsSection, LucideIcon> = {
 
 const TAB_FALLBACK_LABEL: Record<SettingsSection, string> = {
   project: 'Projekt',
+  modules: 'Module',
   appearance: 'Darstellung',
   editing: 'Bearbeiten',
   hotkeys: 'Hotkeys',
@@ -53,6 +57,7 @@ const TAB_FALLBACK_LABEL: Record<SettingsSection, string> = {
 
 const TAB_FALLBACK_TITLE: Record<SettingsSection, string> = {
   project: 'Projekt-Einstellungen',
+  modules: 'Module',
   appearance: 'Darstellung',
   editing: 'Bearbeiten',
   hotkeys: 'Tastenkürzel',
@@ -64,7 +69,7 @@ const TAB_FALLBACK_TITLE: Record<SettingsSection, string> = {
 
 const isSection = (v: unknown): v is SettingsSection =>
   typeof v === 'string' &&
-  ['project', 'appearance', 'editing', 'hotkeys', 'integrations', 'configs', 'sync', 'advanced'].includes(v)
+  ['project', 'modules', 'appearance', 'editing', 'hotkeys', 'integrations', 'configs', 'sync', 'advanced'].includes(v)
 
 interface SettingsBodyProps {
   onClose: () => void
@@ -131,6 +136,7 @@ export const SettingsBody = ({ onClose, initialSection, headerProps, titleId, he
             im langen Erweitert-Tab). */}
         <div className="min-h-0 flex-1 overflow-y-auto p-4">
           {section === 'project' && <ProjectTab onClose={onClose} />}
+          {section === 'modules' && <ModulesTab />}
           {section === 'appearance' && <AppearanceTab />}
           {section === 'editing' && <EditingTab />}
           {section === 'hotkeys' && <HotkeysTab />}

--- a/src/renderer/components/Settings/tabs/ModulesTab.tsx
+++ b/src/renderer/components/Settings/tabs/ModulesTab.tsx
@@ -1,0 +1,44 @@
+/**
+ * Modulares UI — Settings-Tab „Module" (ClickApps-artiger Schaltplatz).
+ *
+ * Dauerhafte, durchsuchbare Heimat zum Ein-/Ausschalten der Funktionsmodule.
+ * Module steuern NUR die UI-Sichtbarkeit; Projektdaten bleiben unberührt.
+ * Siehe `docs/modular-ui-concept.md`.
+ */
+import { useSettingsStore } from '../../../store/settingsStore'
+import { useTranslation } from '../../../lib/i18n'
+import { MODULES } from '../../../lib/modules'
+import { SettingsCard } from '../SettingsCard'
+
+export const ModulesTab = () => {
+  const t = useTranslation()
+  const enabledModules = useSettingsStore((s) => s.enabledModules)
+  const setModuleEnabled = useSettingsStore((s) => s.setModuleEnabled)
+
+  return (
+    <div className="space-y-3">
+      <p className="text-cp-base text-cp-text-secondary">
+        {t(
+          'settings.modules.intro',
+          'Schalte Funktionsbereiche ein oder aus, um die Oberfläche auf deinen Anwendungsfall zuzuschneiden. Das betrifft nur die Sichtbarkeit — gespeicherte Projektdaten bleiben immer vollständig erhalten.',
+        )}
+      </p>
+      {MODULES.map((m) => (
+        <SettingsCard
+          key={m.id}
+          title={t(`settings.modules.${m.id}.label`, m.label)}
+          description={t(`settings.modules.${m.id}.desc`, m.description)}
+        >
+          <label className="flex items-center gap-2 text-cp-base text-cp-text-bright">
+            <input
+              type="checkbox"
+              checked={enabledModules[m.id]}
+              onChange={(e) => setModuleEnabled(m.id, e.target.checked)}
+            />
+            {t('settings.modules.enable', 'Modul aktiviert')}
+          </label>
+        </SettingsCard>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -108,6 +108,7 @@ export const en: Dict = {
   'settings.title': 'Settings',
   'settings.section': 'Settings',
   'settings.tab.project': 'Project',
+  'settings.tab.modules': 'Modules',
   'settings.tab.appearance': 'Appearance',
   'settings.tab.editing': 'Editing',
   'settings.tab.hotkeys': 'Hotkeys',
@@ -116,6 +117,7 @@ export const en: Dict = {
   'settings.tab.sync': 'Network sync',
   'settings.tab.advanced': 'Advanced',
   'settings.tabTitle.project': 'Project settings',
+  'settings.tabTitle.modules': 'Modules',
   'settings.tabTitle.appearance': 'Appearance',
   'settings.tabTitle.editing': 'Editing',
   'settings.tabTitle.hotkeys': 'Keyboard shortcuts',
@@ -123,6 +125,36 @@ export const en: Dict = {
   'settings.tabTitle.configs': 'Device configurations',
   'settings.tabTitle.sync': 'Network sync',
   'settings.tabTitle.advanced': 'Advanced',
+
+  // Settings → Modules (modular UI)
+  'settings.modules.intro':
+    'Turn feature areas on or off to tailor the interface to your use case. This only affects visibility — saved project data is always kept in full.',
+  'settings.modules.enable': 'Module enabled',
+  'settings.modules.festinstallation.label': 'Permanent install',
+  'settings.modules.festinstallation.desc':
+    'Lifecycle/service, asset register & QR labels, handover docs and field feedback.',
+  'settings.modules.mobile.label': 'Mobile companion',
+  'settings.modules.mobile.desc':
+    'Phone patch list, plug-in check-off, QR scan lookup and field reports.',
+  'settings.modules.rentman.label': 'Rentman',
+  'settings.modules.rentman.desc': 'Import/export link to Rentman (catalogue + cable quantities).',
+  'settings.modules.rental.label': 'Rental / inventory',
+  'settings.modules.rental.desc':
+    'Stock, ownership & availability, rental costing (work in progress, phase 2+).',
+
+  // First-run module onboarding
+  'onboarding.title': 'Welcome — what do you use Cable Planner for?',
+  'onboarding.intro':
+    'Pick one or more use cases — matching feature modules get enabled. You can change everything later under Settings → Modules.',
+  'onboarding.skip': 'Decide later',
+  'onboarding.confirm': 'Get started',
+  'onboarding.preset.show.label': 'Show / Event',
+  'onboarding.preset.show.desc': 'Temporary productions — plan fast, check off on site.',
+  'onboarding.preset.festinstallation.label': 'Permanent install',
+  'onboarding.preset.festinstallation.desc':
+    'Permanent systems — living docs, service, handover.',
+  'onboarding.preset.rental.label': 'Rental',
+  'onboarding.preset.rental.desc': 'Stock & availability across projects.',
 
   // Settings → Project
   'settings.project.intro': 'Project metadata — saved with the Cable Planner file.',

--- a/src/renderer/lib/modules.ts
+++ b/src/renderer/lib/modules.ts
@@ -1,0 +1,123 @@
+/**
+ * Modulares UI — Registry der ein-/ausschaltbaren Funktionsmodule.
+ *
+ * Siehe `docs/modular-ui-concept.md`. Module steuern NUR die UI-Sichtbarkeit
+ * (Menüeinträge, Panels, Dialoge) — niemals die Projektdaten. Der „Kern"
+ * (Canvas, Geräte/Kabel, Properties, Export) ist immer an und kein Modul.
+ *
+ * Framework-frei und damit testbar; UI (Settings-Tab, Onboarding) liest hier.
+ */
+
+export type ModuleId = 'festinstallation' | 'mobile' | 'rentman' | 'rental'
+
+export interface ModuleMeta {
+  id: ModuleId
+  /** Deutsche Default-Bezeichnung (UI heilt EN via i18n). */
+  label: string
+  /** Ein-Satz-Beschreibung für den Settings-Tab. */
+  description: string
+}
+
+/** Anzeige-Reihenfolge + Metadaten. */
+export const MODULES: ModuleMeta[] = [
+  {
+    id: 'festinstallation',
+    label: 'Festinstallation',
+    description:
+      'Lebenszyklus/Service, Asset-Register & QR-Etiketten, Übergabe-Doku und Feld-Rückkanal.',
+  },
+  {
+    id: 'mobile',
+    label: 'Mobile-Companion',
+    description: 'Handy-Patchliste, Steck-Check, QR-Scan-Lookup und Feld-Meldungen.',
+  },
+  {
+    id: 'rentman',
+    label: 'Rentman',
+    description: 'Import/Export-Kopplung zu Rentman (Katalog + Kabelmengen).',
+  },
+  {
+    id: 'rental',
+    label: 'Rental / Lager',
+    description:
+      'Lagerbestand, Eigentum & Verfügbarkeit, Mietkalkulation (im Aufbau, Phase 2+).',
+  },
+]
+
+export const MODULE_IDS: ModuleId[] = MODULES.map((m) => m.id)
+
+/**
+ * Default-Aktivierung. Bewusst so, dass bestehende Installationen nichts
+ * verlieren: alles bisher Sichtbare bleibt an; nur das neue `rental` startet
+ * aus und wird über Onboarding/Settings angeboten.
+ */
+export const DEFAULT_ENABLED: Record<ModuleId, boolean> = {
+  festinstallation: true,
+  mobile: true,
+  rentman: true,
+  rental: false,
+}
+
+export type PresetId = 'show' | 'festinstallation' | 'rental'
+
+export interface PresetMeta {
+  id: PresetId
+  label: string
+  description: string
+  /** Module, die dieses Preset zusätzlich zum Kern aktiviert. */
+  modules: ModuleId[]
+}
+
+/** Use-Case-Presets fürs Erststart-Onboarding (Intent statt Feature-Liste). */
+export const PRESETS: PresetMeta[] = [
+  {
+    id: 'show',
+    label: 'Show / Event',
+    description: 'Temporäre Produktionen — schnell planen, vor Ort abhaken.',
+    modules: ['mobile', 'rentman'],
+  },
+  {
+    id: 'festinstallation',
+    label: 'Festinstallation',
+    description: 'Dauerhafte Anlagen — mitwachsende Doku, Service, Übergabe.',
+    modules: ['festinstallation', 'mobile'],
+  },
+  {
+    id: 'rental',
+    label: 'Vermietung / Rental',
+    description: 'Lagerbestand & Verfügbarkeit über Projekte hinweg.',
+    modules: ['rental', 'rentman'],
+  },
+]
+
+/**
+ * Baut die `enabledModules`-Map aus einer Auswahl von Presets. Der Kern ist
+ * immer an (kein Modul); ein Modul ist an, sobald MINDESTENS ein gewähltes
+ * Preset es enthält. Nicht referenzierte Module bleiben aus.
+ */
+export const enabledFromPresets = (presetIds: PresetId[]): Record<ModuleId, boolean> => {
+  const wanted = new Set<ModuleId>()
+  for (const pid of presetIds) {
+    const p = PRESETS.find((x) => x.id === pid)
+    p?.modules.forEach((m) => wanted.add(m))
+  }
+  return MODULE_IDS.reduce(
+    (acc, id) => {
+      acc[id] = wanted.has(id)
+      return acc
+    },
+    {} as Record<ModuleId, boolean>,
+  )
+}
+
+/** Heilt eine (evtl. alte/teildefinierte) Map gegen die aktuelle Modul-Liste. */
+export const healEnabledModules = (
+  raw: Partial<Record<ModuleId, boolean>> | undefined,
+): Record<ModuleId, boolean> =>
+  MODULE_IDS.reduce(
+    (acc, id) => {
+      acc[id] = typeof raw?.[id] === 'boolean' ? (raw[id] as boolean) : DEFAULT_ENABLED[id]
+      return acc
+    },
+    {} as Record<ModuleId, boolean>,
+  )

--- a/src/renderer/store/settingsStore.ts
+++ b/src/renderer/store/settingsStore.ts
@@ -1,6 +1,13 @@
 import { create } from 'zustand'
 import { STORAGE_KEYS } from '../lib/storageKeys'
 import { LIMITS } from '../lib/layoutConstants'
+import {
+  type ModuleId,
+  DEFAULT_ENABLED,
+  healEnabledModules,
+  enabledFromPresets,
+  type PresetId,
+} from '../lib/modules'
 
 const SETTINGS_KEY = STORAGE_KEYS.settings
 
@@ -12,6 +19,11 @@ interface PersistedSettings {
    *  protokoll- und Service-Einträgen als Autor zugeordnet. App-weit
    *  (pro Maschine) persistiert, nicht pro Projekt. */
   editorName: string
+  /** Modulares UI — welche Funktionsmodule sichtbar sind (pro Installation). */
+  enabledModules: Record<ModuleId, boolean>
+  /** Modulares UI — true, sobald der Erststart-Modul-Dialog beantwortet/
+   *  übersprungen wurde (steuert, ob er nochmal erscheint). */
+  onboardingDone: boolean
 }
 
 const defaults: PersistedSettings = {
@@ -19,6 +31,8 @@ const defaults: PersistedSettings = {
   sharedSyncPath: '',
   sharedSyncUser: '',
   editorName: '',
+  enabledModules: { ...DEFAULT_ENABLED },
+  onboardingDone: false,
 }
 
 const load = (): PersistedSettings => {
@@ -34,6 +48,11 @@ const load = (): PersistedSettings => {
       sharedSyncPath: typeof parsed.sharedSyncPath === 'string' ? parsed.sharedSyncPath : defaults.sharedSyncPath,
       sharedSyncUser: typeof parsed.sharedSyncUser === 'string' ? parsed.sharedSyncUser : defaults.sharedSyncUser,
       editorName: typeof parsed.editorName === 'string' ? parsed.editorName : defaults.editorName,
+      enabledModules: healEnabledModules(parsed.enabledModules),
+      // Bestehende Installationen (Settings vorhanden, aber noch ohne dieses
+      // Feld) gelten als „onboarded" → kein nachträglicher Dialog für sie.
+      onboardingDone:
+        typeof parsed.onboardingDone === 'boolean' ? parsed.onboardingDone : true,
     }
   } catch {
     return defaults
@@ -48,6 +67,17 @@ const persist = (state: PersistedSettings) => {
   }
 }
 
+/** Pickt die persistierten Felder aus dem Store-State (gegen Persist-Drift,
+ *  wenn neue Felder dazukommen). */
+const snapshot = (s: PersistedSettings): PersistedSettings => ({
+  autosaveIntervalMs: s.autosaveIntervalMs,
+  sharedSyncPath: s.sharedSyncPath,
+  sharedSyncUser: s.sharedSyncUser,
+  editorName: s.editorName,
+  enabledModules: s.enabledModules,
+  onboardingDone: s.onboardingDone,
+})
+
 interface SettingsState {
   // NOTE: the actual token string is intentionally NOT stored here to avoid
   // leaking it into global React state. Use the IPC credentials API directly.
@@ -57,12 +87,20 @@ interface SettingsState {
   sharedSyncPath: string
   sharedSyncUser: string
   editorName: string
+  enabledModules: Record<ModuleId, boolean>
+  onboardingDone: boolean
   setHasToken: (value: boolean) => void
   setTokenStatus: (value: string) => void
   setAutosaveIntervalMs: (value: number) => void
   setSyncPath: (value: string) => void
   setSyncUser: (value: string) => void
   setEditorName: (value: string) => void
+  /** Ein einzelnes Modul ein-/ausschalten. */
+  setModuleEnabled: (id: ModuleId, value: boolean) => void
+  /** Module aus einer Preset-Auswahl setzen (Erststart-Onboarding). */
+  applyModulePreset: (presetIds: PresetId[]) => void
+  /** Erststart-Modul-Dialog als erledigt markieren. */
+  setOnboardingDone: (value: boolean) => void
 }
 
 const initial = load()
@@ -74,27 +112,50 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   sharedSyncPath: initial.sharedSyncPath,
   sharedSyncUser: initial.sharedSyncUser,
   editorName: initial.editorName,
+  enabledModules: initial.enabledModules,
+  onboardingDone: initial.onboardingDone,
   setHasToken: (value) => set({ hasToken: value }),
   setTokenStatus: (value) => set({ tokenStatus: value }),
   setAutosaveIntervalMs: (value) =>
     set((state) => {
       const next = Math.max(LIMITS.AUTOSAVE_INTERVAL.MIN_MS, Math.min(LIMITS.AUTOSAVE_INTERVAL.MAX_MS, Math.round(value || defaults.autosaveIntervalMs)))
-      persist({ autosaveIntervalMs: next, sharedSyncPath: state.sharedSyncPath, sharedSyncUser: state.sharedSyncUser, editorName: state.editorName })
+      persist(snapshot({ ...state, autosaveIntervalMs: next }))
       return { autosaveIntervalMs: next }
     }),
   setSyncPath: (value) =>
     set((state) => {
-      persist({ autosaveIntervalMs: state.autosaveIntervalMs, sharedSyncPath: value, sharedSyncUser: state.sharedSyncUser, editorName: state.editorName })
+      persist(snapshot({ ...state, sharedSyncPath: value }))
       return { sharedSyncPath: value }
     }),
   setSyncUser: (value) =>
     set((state) => {
-      persist({ autosaveIntervalMs: state.autosaveIntervalMs, sharedSyncPath: state.sharedSyncPath, sharedSyncUser: value, editorName: state.editorName })
+      persist(snapshot({ ...state, sharedSyncUser: value }))
       return { sharedSyncUser: value }
     }),
   setEditorName: (value) =>
     set((state) => {
-      persist({ autosaveIntervalMs: state.autosaveIntervalMs, sharedSyncPath: state.sharedSyncPath, sharedSyncUser: state.sharedSyncUser, editorName: value })
+      persist(snapshot({ ...state, editorName: value }))
       return { editorName: value }
     }),
+  setModuleEnabled: (id, value) =>
+    set((state) => {
+      const enabledModules = { ...state.enabledModules, [id]: value }
+      persist(snapshot({ ...state, enabledModules }))
+      return { enabledModules }
+    }),
+  applyModulePreset: (presetIds) =>
+    set((state) => {
+      const enabledModules = enabledFromPresets(presetIds)
+      persist(snapshot({ ...state, enabledModules }))
+      return { enabledModules }
+    }),
+  setOnboardingDone: (value) =>
+    set((state) => {
+      persist(snapshot({ ...state, onboardingDone: value }))
+      return { onboardingDone: value }
+    }),
 }))
+
+/** Hook für konditionales Rendern: ist dieses Modul aktiv? */
+export const useModule = (id: ModuleId): boolean =>
+  useSettingsStore((s) => s.enabledModules[id])

--- a/tests/modules.test.ts
+++ b/tests/modules.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import {
+  MODULE_IDS,
+  DEFAULT_ENABLED,
+  enabledFromPresets,
+  healEnabledModules,
+} from '../src/renderer/lib/modules'
+
+describe('enabledFromPresets', () => {
+  it('aktiviert die Module der gewählten Presets (Vereinigung)', () => {
+    const e = enabledFromPresets(['festinstallation'])
+    expect(e.festinstallation).toBe(true)
+    expect(e.mobile).toBe(true)
+    expect(e.rental).toBe(false)
+  })
+
+  it('vereinigt mehrere Presets', () => {
+    const e = enabledFromPresets(['show', 'rental'])
+    expect(e.mobile).toBe(true)
+    expect(e.rentman).toBe(true)
+    expect(e.rental).toBe(true)
+    expect(e.festinstallation).toBe(false)
+  })
+
+  it('leere Auswahl → alle aus (nur Kern bleibt, der kein Modul ist)', () => {
+    const e = enabledFromPresets([])
+    expect(Object.values(e).every((v) => v === false)).toBe(true)
+  })
+})
+
+describe('healEnabledModules', () => {
+  it('füllt fehlende Schlüssel mit Defaults', () => {
+    const e = healEnabledModules({ rental: true })
+    expect(e.rental).toBe(true)
+    expect(e.festinstallation).toBe(DEFAULT_ENABLED.festinstallation)
+    expect(Object.keys(e).sort()).toEqual([...MODULE_IDS].sort())
+  })
+
+  it('undefined → komplette Defaults', () => {
+    expect(healEnabledModules(undefined)).toEqual(DEFAULT_ENABLED)
+  })
+
+  it('ignoriert Nicht-Boolean-Werte', () => {
+    const e = healEnabledModules({ mobile: 'yes' as unknown as boolean })
+    expect(e.mobile).toBe(DEFAULT_ENABLED.mobile)
+  })
+})


### PR DESCRIPTION
## Worum es geht

Mit wachsendem Funktionsumfang (Show, Festinstallation, QR/Mobile, Rentman,
künftig Rental/Lager) braucht Cable-Planner ein **modulares UI**: Funktions-
bereiche als **ein-/ausschaltbare Module** + eine leichte Erststart-Abfrage.
Konzept zuerst dokumentiert, dann gebaut.

## Konzept (zuerst festgehalten)
`docs/modular-ui-concept.md` — UX-recherche-gestützt (ClickUp ClickApps,
Progressive Disclosure, NN/g „Onboarding: skip when possible", VS-Code-
Discoverability-Problem). Kernentscheidungen: kein Pflicht-Wizard; Presets
nach Intent; Settings als Dauer-Schaltplatz; Module = nur UI-Sichtbarkeit,
nie Projektdaten.

## Implementierung (Grundgerüst + 1 Referenzmodul)
- **`lib/modules.ts`** — Registry (`ModuleId`, `MODULES`, `PRESETS`,
  `DEFAULT_ENABLED`) + reine Logik (`enabledFromPresets`, `healEnabledModules`)
- **`settingsStore`** — `enabledModules` + `onboardingDone` (persistiert,
  `snapshot`-Refactor gegen Persist-Drift), `setModuleEnabled` /
  `applyModulePreset` / `setOnboardingDone`, `useModule(id)`-Hook
- **Settings → „Module"** — ClickApps-artiger Schaltplatz (Toggle + Beschr.)
- **`ModuleOnboardingDialog`** — überspringbare Erststart-Intent-Frage
- **Referenz-Verdrahtung** — Festinstallations-Menüeintrag hinter `useModule`
- **i18n** — EN-Keys für Module-Tab + Onboarding

## Migration / Kompatibilität
- Bestehende Installationen gelten als „onboarded" → **kein** nachträglicher
  Dialog; Defaults aktivieren alles bisher Sichtbare (nur neues `rental` aus)
  → niemand verliert Funktionen.
- Module steuern **nur die UI-Sichtbarkeit**; `.cableplan`-Daten bleiben
  vollständig, ein Plan öffnet auf jeder Installation.

## Verifikation (headless)
- `tsc` app/main/preload/node → **0 Errors**
- `npx vitest run` → **68 Tests grün** (neu: `tests/modules.test.ts`)
- ESLint der geänderten Dateien → 0 Errors

## Nächste Schritte (Folge-PRs)
Restliche Module hinter `useModule` hängen (Properties-Lifecycle-Sections,
Mobile, Rentman, Rental) — siehe `docs/modular-ui-concept.md` §Reihenfolge.

Draft: Review zum Konzept/Scope willkommen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3N1U9wfo2EosdGLxS5DFi)_