### PR TITLE
UI: restliche Module hinter useModule verdrahten + Rentman voll ins Modul-System migriert

### DIFF
--- a/docs/modular-ui-concept.md
+++ b/docs/modular-ui-concept.md
@@ -74,12 +74,19 @@ leeren Stellen — kein Dauer-Nag.)
 |---|---|---|---|
 | `festinstallation` | Festinstallation | Lebenszyklus/Service, Asset-Register/QR, Übergabe-Doku, Feld-Rückkanal | an |
 | `mobile` | Mobile-Companion | Handy-Patchliste, Check-off, QR-Scan, Feld-Meldungen | an |
-| `rentman` | Rentman | Import/Export-Kopplung | an |
+| `rentman` | Rentman | Import/Export-Kopplung | aus¹ |
 | `rental` | Rental / Lager | Bestand, Eigentum/Verfügbarkeit, Mietkalkulation (Phase 2+) | aus |
 
 Defaults sind so gewählt, dass **bestehende Installationen nichts verlieren**
 (alles bisher Sichtbare bleibt an; nur das neue `rental` startet aus und wird
 über Onboarding/Settings angeboten).
+
+¹ `rentman` war schon vorher opt-in über ein eigenes uiStore-Flag
+(`rentmanEnabled`, Default aus). Dieses Flag wurde **vollständig ins
+Modul-System migriert** (`useModule('rentman')`); der frühere Wert wird beim
+ersten Laden einmalig aus dem uiStore übernommen, sodass niemand seine
+Rentman-Einstellung verliert. Der Integrations-Tab schreibt jetzt dasselbe
+Modul-Flag.
 
 ## Umsetzung in der Architektur
 

--- a/src/renderer/components/Canvas/EquipmentNode.tsx
+++ b/src/renderer/components/Canvas/EquipmentNode.tsx
@@ -3,6 +3,7 @@ import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 import { Headphones, Lock, Check } from 'lucide-react'
 import type { EquipmentItem } from '../../types/equipment'
 import { useUiStore } from '../../store/uiStore'
+import { useModule } from '../../store/settingsStore'
 import { useCanvasProjectStore as useProjectStore } from '../../store/projectStoreContext'
 import { AlertTriangle } from 'lucide-react'
 import { useTranslation } from '../../lib/i18n'
@@ -68,7 +69,7 @@ export const EquipmentNode = ({ id, data, selected }: NodeProps<EquipmentNodeDat
   // Per-Geraet-`nodeColor` gewinnt weiter — der User kann immer einzeln
   // ueberschreiben.
   const categoryColors = useUiStore((s) => s.categoryColors)
-  const rentmanEnabled = useUiStore((s) => s.rentmanEnabled)
+  const rentmanEnabled = useModule('rentman')
   // #291 — User-konfigurierbare Port-Label-Schriftgroesse. Skaliert
   // beide Port-Spalten + die Collapsed-View. Header bleibt fix damit
   // headerHeight nicht recomputet werden muss.

--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -157,9 +157,11 @@ export const MenuBar = ({
       }
     })
   }, [t])
-  const rentmanEnabled = useUiStore((s) => s.rentmanEnabled)
+  const rentmanEnabled = useModule('rentman')
   // Modulares UI — Festinstallations-Doku nur zeigen, wenn das Modul an ist.
   const festinstallationModule = useModule('festinstallation')
+  // Modulares UI — Handy-Zugriff nur zeigen, wenn das Mobile-Modul an ist.
+  const mobileModule = useModule('mobile')
   // #341 — View-Menü spiegelt Toolbar-Toggles; Status für Häkchen lesen.
   const canvasTheme = useUiStore((s) => s.canvasTheme)
   const followSystemTheme = useUiStore((s) => s.followSystemTheme)
@@ -608,7 +610,7 @@ export const MenuBar = ({
           </button>
         </div>
         <SharedSyncPanel />
-        {hasDesktopBridge && (
+        {hasDesktopBridge && mobileModule && (
           <button
             type="button"
             onClick={() => useUiStore.getState().openMobileShare()}

--- a/src/renderer/components/Layout/StatusBar.tsx
+++ b/src/renderer/components/Layout/StatusBar.tsx
@@ -1,6 +1,7 @@
 import { Check, AlertCircle, AlertTriangle, CheckCircle2 } from 'lucide-react'
 import { APP_VERSION } from '../../lib/appInfo'
 import { useUiStore } from '../../store/uiStore'
+import { useModule } from '../../store/settingsStore'
 import { useCollabStore } from '../../store/collabStore'
 import { useProjectStore } from '../../store/projectStore'
 import { useTranslation, format } from '../../lib/i18n'
@@ -130,7 +131,7 @@ export const StatusBar = ({
         {/* v7.9.4 — Rentman-Badge nur sichtbar wenn die Integration
             in den Einstellungen aktiviert ist. */}
         <CollabStatusBadge />
-        {useUiStore((s) => s.rentmanEnabled) && (
+        {useModule('rentman') && (
           <span className={`hidden whitespace-nowrap lg:inline ${rentmanProjectName ? 'text-orange-300' : hasToken ? 'text-[var(--cp-text-muted)]' : 'text-[var(--cp-text-faint)]'}`}>
             {t('statusbar.rentman.label', 'Rentman:')}{' '}
             {rentmanProjectName ??

--- a/src/renderer/components/Library/LibraryPanel.tsx
+++ b/src/renderer/components/Library/LibraryPanel.tsx
@@ -5,6 +5,7 @@ import { Icon } from '../shared/Icon'
 import { Spinner } from '../shared/Spinner'
 import { useProjectStore } from '../../store/projectStore'
 import { useUiStore } from '../../store/uiStore'
+import { useModule } from '../../store/settingsStore'
 import { CategorySelect } from '../shared/CategorySelect'
 import { confirmDialog } from '../../lib/confirmDialog'
 import { infoDialog } from '../../lib/infoDialog'
@@ -61,7 +62,7 @@ export const LibraryPanel = () => {
   const addCustomTemplate = useProjectStore((state) => state.addCustomTemplate)
   const collapsed = useUiStore((state) => state.libraryCollapsed)
   // v7.9.4 — Rentman-Tabs ausblenden wenn die Integration deaktiviert ist.
-  const rentmanEnabled = useUiStore((state) => state.rentmanEnabled)
+  const rentmanEnabled = useModule('rentman')
   const toggleCollapsed = useUiStore((state) => state.toggleLibraryCollapsed)
   // #427 — In separates OS-Fenster ausgelagert (Hauptfenster blendet aus);
   //  inPopout = wir SIND dieses Fenster (dann keine Ab-/Andock-Controls).

--- a/src/renderer/components/Project/ProjectMetaDialog.tsx
+++ b/src/renderer/components/Project/ProjectMetaDialog.tsx
@@ -3,6 +3,7 @@ import type { ProjectMetadata } from '../../types/project'
 import { readImageAsDataUri } from '../../lib/readImageAsDataUri'
 import { ModalShell } from '../shared/ModalShell'
 import { useTranslation } from '../../lib/i18n'
+import { useModule } from '../../store/settingsStore'
 
 /**
  * Dialog used both when starting a new project and when editing metadata
@@ -26,6 +27,8 @@ export const ProjectMetaDialog = ({
   onConfirm,
 }: ProjectMetaDialogProps) => {
   const t = useTranslation()
+  // Modulares UI — Einsatz-/Mietzeitraum nur bei aktivem Rental-/Lager-Modul.
+  const rentalModule = useModule('rental')
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
   const [author, setAuthor] = useState('')
@@ -163,6 +166,7 @@ export const ProjectMetaDialog = ({
             </label>
           </div>
 
+          {rentalModule && (
           <div className="grid grid-cols-2 gap-2">
             <label className="block">
               {t('project.meta.eventStart', 'Einsatz-/Mietbeginn')}
@@ -184,6 +188,7 @@ export const ProjectMetaDialog = ({
               />
             </label>
           </div>
+          )}
 
           <label className="block">
             {t('project.meta.description', 'Beschreibung')}

--- a/src/renderer/components/Properties/CableProperties.tsx
+++ b/src/renderer/components/Properties/CableProperties.tsx
@@ -3,6 +3,7 @@ import { useCanvasProjectStore as useProjectStore } from '../../store/projectSto
 import { Icon } from '../shared/Icon'
 import { cableCatalog } from '../../types/cableSpec'
 import { useUiStore } from '../../store/uiStore'
+import { useModule } from '../../store/settingsStore'
 import { cableTypePatchFromPorts } from '../../lib/cableInheritance'
 import type { Cable } from '../../types/cable'
 import type { EquipmentItem, Port } from '../../types/equipment'
@@ -32,6 +33,8 @@ export const CableProperties = () => {
   const setCableTestResult = useProjectStore((state) => state.setCableTestResult)
   const openCableEdit = useUiStore((state) => state.openCableEdit)
   const cableLayersFromStore = useUiStore((state) => state.customLayers)
+  // Modulares UI — Kabel-Lebenszyklus nur bei aktivem Festinstallations-Modul.
+  const festinstallationModule = useModule('festinstallation')
 
   if (!cable) {
     return (
@@ -231,7 +234,8 @@ export const CableProperties = () => {
       </label>
 
       {/* Festinstallation — Lebenszyklus: Status, Trasse, Mantel,
-          Terminierung und Mess-/Test-Ergebnis. */}
+          Terminierung und Mess-/Test-Ergebnis. Nur bei aktivem Modul. */}
+      {festinstallationModule && (
       <details className="rounded border border-cp-border bg-cp-surface-3/40">
         <summary className="cursor-pointer select-none px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-cp-text-muted hover:bg-cp-surface-2/40">
           {t('lifecycle.cableSection', 'Festinstallation / Lebenszyklus')}
@@ -375,6 +379,7 @@ export const CableProperties = () => {
           </div>
         </div>
       </details>
+      )}
 
       {/* #363 — Multicore/Snake-Zuordnung: Kabel mit gleichem Namen bilden
           ein Bündel. Datalist schlägt bereits vergebene Namen vor. */}

--- a/src/renderer/components/Properties/sections/LifecycleSection.tsx
+++ b/src/renderer/components/Properties/sections/LifecycleSection.tsx
@@ -9,7 +9,7 @@
 import { useState } from 'react'
 import { Wrench, Trash2, Plus } from 'lucide-react'
 import { useCanvasProjectStore as useProjectStore } from '../../../store/projectStoreContext'
-import { useSettingsStore } from '../../../store/settingsStore'
+import { useSettingsStore, useModule } from '../../../store/settingsStore'
 import { useTranslation } from '../../../lib/i18n'
 import { Icon } from '../../shared/Icon'
 import {
@@ -47,11 +47,17 @@ export const LifecycleSection = ({ equipment }: { equipment: EquipmentItem }) =>
   const addServiceRecord = useProjectStore((s) => s.addServiceRecord)
   const removeServiceRecord = useProjectStore((s) => s.removeServiceRecord)
   const editorName = useSettingsStore((s) => s.editorName)
+  // Modulares UI — Festinstallations-Felder bzw. Lager-Felder je nach Modul.
+  const festinstallationModule = useModule('festinstallation')
+  const rentalModule = useModule('rental')
 
   const [kind, setKind] = useState<ServiceRecord['kind']>('inspection')
   const [summary, setSummary] = useState('')
 
   const history = equipment.serviceHistory ?? []
+
+  // Ist kein relevantes Modul aktiv, die ganze Section ausblenden.
+  if (!festinstallationModule && !rentalModule) return null
 
   const onAdd = () => {
     const text = summary.trim()
@@ -72,6 +78,8 @@ export const LifecycleSection = ({ equipment }: { equipment: EquipmentItem }) =>
         {t('lifecycle.section', 'Lebenszyklus / Wartung')}
       </summary>
       <div className="space-y-2 border-t border-cp-border p-2">
+        {festinstallationModule && (
+        <>
         <label className="block">
           <span className="mb-1 block text-cp-text-secondary">{t('lifecycle.status', 'Status')}</span>
           <select
@@ -126,8 +134,12 @@ export const LifecycleSection = ({ equipment }: { equipment: EquipmentItem }) =>
             className="w-full rounded border border-cp-border bg-cp-surface-1 p-1.5"
           />
         </label>
+        </>
+        )}
 
-        {/* Lager (Phase 0) — Eigentum, Lagerort, Lieferant, Anschaffung */}
+        {/* Lager (Phase 0) — Eigentum, Lagerort, Lieferant, Anschaffung. Nur
+            bei aktivem Rental-/Lager-Modul. */}
+        {rentalModule && (
         <div className="grid grid-cols-2 gap-2">
           <label className="block">
             <span className="mb-1 block text-cp-text-secondary">
@@ -189,8 +201,10 @@ export const LifecycleSection = ({ equipment }: { equipment: EquipmentItem }) =>
             />
           </label>
         </div>
+        )}
 
-        {/* Service-Historie */}
+        {/* Service-Historie — nur bei aktivem Festinstallations-Modul. */}
+        {festinstallationModule && (
         <div>
           <div className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-cp-text-muted">
             {t('lifecycle.history', 'Service-Historie')} ({history.length})
@@ -250,6 +264,7 @@ export const LifecycleSection = ({ equipment }: { equipment: EquipmentItem }) =>
             </button>
           </div>
         </div>
+        )}
       </div>
     </details>
   )

--- a/src/renderer/components/Properties/sections/RentmanSyncBadge.tsx
+++ b/src/renderer/components/Properties/sections/RentmanSyncBadge.tsx
@@ -1,5 +1,5 @@
 import { AlertTriangle } from 'lucide-react'
-import { useUiStore } from '../../../store/uiStore'
+import { useModule } from '../../../store/settingsStore'
 import type { EquipmentItem } from '../../../types/equipment'
 import { format, useTranslation } from '../../../lib/i18n'
 import { Icon } from '../../shared/Icon'
@@ -16,7 +16,7 @@ import { Icon } from '../../shared/Icon'
  */
 export const RentmanSyncBadge = ({ equipment }: { equipment: EquipmentItem }) => {
   const t = useTranslation()
-  const rentmanEnabled = useUiStore((state) => state.rentmanEnabled)
+  const rentmanEnabled = useModule('rentman')
   if (!rentmanEnabled) return null
 
   if (equipment.rentmanRemoved) {

--- a/src/renderer/components/Settings/tabs/IntegrationsTab.tsx
+++ b/src/renderer/components/Settings/tabs/IntegrationsTab.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { X, Eye, EyeOff } from 'lucide-react'
 import { Icon } from '../../shared/Icon'
 import { cablePlannerApi } from '../../../lib/bridge'
-import { useSettingsStore } from '../../../store/settingsStore'
+import { useSettingsStore, useModule } from '../../../store/settingsStore'
 import { useProjectStore } from '../../../store/projectStore'
 import { useUiStore } from '../../../store/uiStore'
 import { useTranslation, format } from '../../../lib/i18n'
@@ -295,9 +295,9 @@ export const IntegrationsTab = ({ onClose }: { onClose: () => void }) => {
   const setTokenStatus = useSettingsStore((s) => s.setTokenStatus)
   const metadata = useProjectStore((s) => s.project.metadata)
   const openRentmanImport = useUiStore((s) => s.openRentmanImport)
-  // v7.9.4 — Rentman komplett ein-/ausschaltbar.
-  const rentmanEnabled = useUiStore((s) => s.rentmanEnabled)
-  const setRentmanEnabled = useUiStore((s) => s.setRentmanEnabled)
+  // Modulares UI — Rentman ist jetzt ein Modul (settingsStore).
+  const rentmanEnabled = useModule('rentman')
+  const setModuleEnabled = useSettingsStore((s) => s.setModuleEnabled)
   const [busy, setBusy] = useState(false)
   const t = useTranslation()
 
@@ -368,7 +368,7 @@ export const IntegrationsTab = ({ onClose }: { onClose: () => void }) => {
           <input
             type="checkbox"
             checked={rentmanEnabled}
-            onChange={(e) => setRentmanEnabled(e.target.checked)}
+            onChange={(e) => setModuleEnabled('rentman', e.target.checked)}
             className="h-4 w-4 accent-sky-500"
           />
           <span>

--- a/src/renderer/lib/modules.ts
+++ b/src/renderer/lib/modules.ts
@@ -48,13 +48,14 @@ export const MODULE_IDS: ModuleId[] = MODULES.map((m) => m.id)
 
 /**
  * Default-Aktivierung. Bewusst so, dass bestehende Installationen nichts
- * verlieren: alles bisher Sichtbare bleibt an; nur das neue `rental` startet
- * aus und wird über Onboarding/Settings angeboten.
+ * verlieren: alles bisher Sichtbare bleibt an; `rental` startet aus (neu) und
+ * `rentman` startet aus (war schon immer opt-in — der Alt-Wert wird beim Laden
+ * aus dem uiStore migriert, siehe settingsStore).
  */
 export const DEFAULT_ENABLED: Record<ModuleId, boolean> = {
   festinstallation: true,
   mobile: true,
-  rentman: true,
+  rentman: false,
   rental: false,
 }
 

--- a/src/renderer/store/settingsStore.ts
+++ b/src/renderer/store/settingsStore.ts
@@ -11,6 +11,23 @@ import {
 
 const SETTINGS_KEY = STORAGE_KEYS.settings
 
+/**
+ * Einmalige Rentman-Migration: `rentmanEnabled` lebte früher im uiStore
+ * (`cable-planner:ui`). Beim Übergang aufs Modul-System lesen wir den Alt-Wert
+ * einmal aus, damit bestehende Nutzer ihre Rentman-Einstellung behalten.
+ * Liefert null, wenn kein Alt-Wert existiert.
+ */
+const readLegacyRentmanEnabled = (): boolean | null => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEYS.ui)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as { rentmanEnabled?: unknown }
+    return typeof parsed.rentmanEnabled === 'boolean' ? parsed.rentmanEnabled : null
+  } catch {
+    return null
+  }
+}
+
 interface PersistedSettings {
   autosaveIntervalMs: number
   sharedSyncPath: string
@@ -48,7 +65,15 @@ const load = (): PersistedSettings => {
       sharedSyncPath: typeof parsed.sharedSyncPath === 'string' ? parsed.sharedSyncPath : defaults.sharedSyncPath,
       sharedSyncUser: typeof parsed.sharedSyncUser === 'string' ? parsed.sharedSyncUser : defaults.sharedSyncUser,
       editorName: typeof parsed.editorName === 'string' ? parsed.editorName : defaults.editorName,
-      enabledModules: healEnabledModules(parsed.enabledModules),
+      enabledModules: (() => {
+        const e = healEnabledModules(parsed.enabledModules)
+        // Rentman noch nicht im Modul-System gespeichert → Alt-Wert übernehmen.
+        if (parsed.enabledModules?.rentman === undefined) {
+          const legacy = readLegacyRentmanEnabled()
+          if (legacy !== null) e.rentman = legacy
+        }
+        return e
+      })(),
       // Bestehende Installationen (Settings vorhanden, aber noch ohne dieses
       // Feld) gelten als „onboarded" → kein nachträglicher Dialog für sie.
       onboardingDone:

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -120,13 +120,9 @@ interface PersistedUiState {
    *  The cable is still flagged needsConverter for downstream warnings,
    *  it just doesn't interrupt the user mid-flow. */
   overrideConnectionWarnings: boolean
-  /** v7.9.4 — Rentman-Integration ein-/ausschaltbar. Wenn `false`,
-   *  werden alle Rentman-Funktionen ausgeblendet (Library-Tab,
-   *  Menü-Einträge, Status-Badge, Badges am LibraryItem, BOM-
-   *  Rentman-Spalten). Persistiert. Default `false` — Rentman ist ein
-   *  optionales Feature und wird beim ersten Start im Menü (Werkzeuge →
-   *  Rentman-Integration) bzw. in den Einstellungen aktiviert. */
-  rentmanEnabled: boolean
+  // Modulares UI — Rentman ist jetzt ein Modul (settingsStore.enabledModules
+  // .rentman, via useModule('rentman')). Das frühere uiStore-Flag
+  // `rentmanEnabled` wurde dorthin migriert (siehe settingsStore).
   /** v7.9.5 — Library-Liste vs. Kachel-Ansicht. Kachel zeigt Front-
    *  Panel-Thumbnails wenn vorhanden. */
   libraryViewMode: 'list' | 'grid'
@@ -320,7 +316,6 @@ const defaults: PersistedUiState = {
   colorPortsByType: false,
   language: detectDefaultLanguage(),
   overrideConnectionWarnings: false,
-  rentmanEnabled: false,
   libraryViewMode: 'list',
   librarySortMode: 'manual',
   annotationAuthor: '',
@@ -422,7 +417,6 @@ const load = (): PersistedUiState => {
     if (!Array.isArray(merged.customSignalStandards)) merged.customSignalStandards = []
     if (!Array.isArray(merged.deviceConfigLibrary)) merged.deviceConfigLibrary = []
     if (typeof merged.cableBumps !== 'boolean') merged.cableBumps = defaults.cableBumps
-    if (typeof merged.rentmanEnabled !== 'boolean') merged.rentmanEnabled = defaults.rentmanEnabled
     if (merged.libraryViewMode !== 'list' && merged.libraryViewMode !== 'grid')
       merged.libraryViewMode = defaults.libraryViewMode
     if (
@@ -619,7 +613,6 @@ interface UiState extends PersistedUiState {
   setColorPortsByType: (value: boolean) => void
   setLanguage: (value: Language) => void
   setOverrideConnectionWarnings: (value: boolean) => void
-  setRentmanEnabled: (value: boolean) => void
   setLibraryViewMode: (mode: 'list' | 'grid') => void
   setLibrarySortMode: (mode: 'manual' | 'asc' | 'desc') => void
   setAnnotationAuthor: (name: string) => void
@@ -974,7 +967,6 @@ export const useUiStore = create<UiState>((set) => ({
   setColorPortsByType: (value) => set(applyPatch({ colorPortsByType: value })),
   setLanguage: (value) => set(applyPatch({ language: value })),
   setOverrideConnectionWarnings: (value) => set(applyPatch({ overrideConnectionWarnings: value })),
-  setRentmanEnabled: (value) => set(applyPatch({ rentmanEnabled: value })),
   setLibraryViewMode: (mode) => set(applyPatch({ libraryViewMode: mode })),
   setLibrarySortMode: (mode) => set(applyPatch({ librarySortMode: mode })),
   setAnnotationAuthor: (name) => set(applyPatch({ annotationAuthor: name })),


### PR DESCRIPTION
## Worum es geht

Folge-PR zum modularen UI (#560): die angelegten Module werden jetzt an ihren
UI-Flächen tatsächlich konditional gerendert — und **Rentman** wird (wie von
dir entschieden) **vollständig** ins Modul-System migriert.

## Module verdrahtet (`useModule`)
- **mobile** → Handy-Zugriff-Button (MenuBar)
- **festinstallation** → Kabel-Lebenszyklus-Section (CableProperties) +
  Geräte-Status/Asset/Service-Felder (LifecycleSection)
- **rental** → Lager-Felder in LifecycleSection (Eigentum/Lagerort/Lieferant/
  Anschaffung) + Einsatz-/Mietzeitraum im ProjectMetaDialog

`LifecycleSection` blendet sich komplett aus, wenn weder `festinstallation`
noch `rental` aktiv ist; die festinstallations- bzw. rental-spezifischen
Felder erscheinen jeweils nur bei ihrem Modul.

## Rentman voll migriert
Rentman hatte bereits ein eigenes uiStore-Flag (`rentmanEnabled`). Statt zweier
konkurrierender Schalter ist es jetzt **ein** Modul:
- `uiStore`: `rentmanEnabled` + `setRentmanEnabled` entfernt
- `settingsStore`: **einmalige Migration** — der Alt-Wert wird beim ersten
  Laden aus `cable-planner:ui` übernommen, sodass niemand seine Einstellung
  verliert (`DEFAULT_ENABLED.rentman = false`, war schon immer opt-in)
- alle **7 Consumer** auf `useModule('rentman')` umgestellt (MenuBar,
  StatusBar, IntegrationsTab-Toggle, RentmanSyncBadge, EquipmentNode,
  LibraryPanel); der Integrations-Tab schreibt nun dasselbe Modul-Flag

## Verifikation (headless)
- `tsc` app/main/preload/node → **0 Errors**
- `npx vitest run` → **68 Tests grün**
- ESLint der geänderten Dateien → 0 Errors (nur 1 vorbestehende Warnung)

## Kompatibilität
Reine UI-Sichtbarkeit; Projektdaten unberührt. Bestehende Rentman-Nutzer
behalten ihre Einstellung dank Migration. `docs/modular-ui-concept.md`
aktualisiert.

Draft: Review willkommen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3N1U9wfo2EosdGLxS5DFi)_