### PR TITLE
feat(canvas): "Beispielprojekt laden" im Empty-State (Demo-Plan)

### DIFF
--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -54,7 +54,9 @@ import {
   setCanvasDuplicateHandler,
   setCanvasZoomHandlers,
   setCanvasSelectAllHandler,
+  triggerCanvasFitView,
 } from '../../lib/canvasViewport'
+import { createDemoProject } from '../../lib/demoProject'
 import { format, useTranslation } from '../../lib/i18n'
 
 const nodeTypes = { equipment: EquipmentNode, location: LocationFrameNode }
@@ -101,6 +103,7 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
   const projectVersion = useProjectStore((state) => state.projectVersion)
   const updateEquipment = useProjectStore((state) => state.updateEquipment)
   const addEquipment = useProjectStore((state) => state.addEquipment)
+  const loadProjectIntoStore = useProjectStore((state) => state.loadProject)
   const pasteEquipment = useProjectStore((state) => state.pasteEquipment)
   const deleteEquipment = useProjectStore((state) => state.deleteEquipment)
   const deleteLocation = useProjectStore((state) => state.deleteLocation)
@@ -1533,6 +1536,21 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
               'Zieh ein Gerät aus der Bibliothek (links) auf die Fläche, um zu starten.',
             )}
           </div>
+          <div className="mt-1 text-cp-xs text-cp-text-faint">
+            {t('canvas.empty.or', '— oder —')}
+          </div>
+          <button
+            type="button"
+            className="pointer-events-auto rounded-cp-control border border-cp-border bg-cp-surface-2 px-cp-4 py-cp-2 text-cp-sm font-medium text-cp-text hover:bg-cp-surface-3"
+            onClick={() => {
+              // Demo nur laden wenn wirklich leer (Empty-State) — kein Überschreiben.
+              loadProjectIntoStore(createDemoProject())
+              // Nach dem Neu-Mount der Nodes auf den Inhalt zoomen.
+              setTimeout(() => triggerCanvasFitView(), 80)
+            }}
+          >
+            {t('canvas.empty.loadDemo', 'Beispielprojekt laden')}
+          </button>
         </div>
       )}
       {/* v7.9.12 — Toolbar wird auch im Rack-Mode gerendert, allerdings

--- a/src/renderer/lib/demoProject.ts
+++ b/src/renderer/lib/demoProject.ts
@@ -1,0 +1,181 @@
+import { v4 as uuidv4 } from 'uuid'
+import type { CablePlannerProject } from '../types/project'
+
+/**
+ * #ux — Beispiel-/Demo-Plan für Neueinsteiger.
+ *
+ * Wird aus dem Empty-State der leeren Canvas geladen ("Beispielprojekt laden").
+ * Zeigt einen kleinen, realistischen Broadcast-Aufbau, damit man sofort sieht,
+ * wie ein fertiger Plan aussieht (Geräte + verbundene Kabel) statt vor einer
+ * leeren Fläche zu stehen.
+ *
+ * Bewusst klein gehalten: 2 Kameras → Bildmischer → Multiviewer & Regie-Monitor.
+ * Jeder Aufruf erzeugt frische UUIDs, damit mehrfaches Laden sauber bleibt und
+ * keine ID-Kollisionen entstehen.
+ */
+export const createDemoProject = (): CablePlannerProject => {
+  const now = new Date().toISOString()
+
+  // Geräte- + Port-IDs vorab, damit die Kabel gültige Endpunkte referenzieren.
+  const cam1 = uuidv4()
+  const cam1Out = uuidv4()
+  const cam2 = uuidv4()
+  const cam2Out = uuidv4()
+  const mix = uuidv4()
+  const mixIn1 = uuidv4()
+  const mixIn2 = uuidv4()
+  const mixIn3 = uuidv4()
+  const mixIn4 = uuidv4()
+  const mixPgm = uuidv4()
+  const mixMv = uuidv4()
+  const mv = uuidv4()
+  const mvIn = uuidv4()
+  const mon = uuidv4()
+  const monIn = uuidv4()
+
+  return {
+    metadata: {
+      name: 'Beispiel: Kleines Studio-Setup',
+      description:
+        'Demo-Plan: 2 Kameras → Bildmischer → Multiviewer & Regie-Monitor. ' +
+        'Zum Ausprobieren — einfach Geräte/Kabel anklicken oder löschen.',
+      createdAt: now,
+      updatedAt: now,
+      defaultVideoFormat: '1080p50',
+      defaultPowerStandard: 'eu-230-1ph',
+      defaultLightingControl: 'dmx512',
+    },
+    equipment: [
+      {
+        id: cam1,
+        name: 'Kamera 1',
+        category: 'Kameras',
+        inputs: [],
+        outputs: [{ id: cam1Out, name: 'SDI Out', type: 'BNC', connectorType: 'BNC', direction: 'out' }],
+        x: 80,
+        y: 80,
+        width: 200,
+        height: 130,
+        nodeColor: '#0f4c81',
+      },
+      {
+        id: cam2,
+        name: 'Kamera 2',
+        category: 'Kameras',
+        inputs: [],
+        outputs: [{ id: cam2Out, name: 'SDI Out', type: 'BNC', connectorType: 'BNC', direction: 'out' }],
+        x: 80,
+        y: 320,
+        width: 200,
+        height: 130,
+        nodeColor: '#0f4c81',
+      },
+      {
+        id: mix,
+        name: 'Bildmischer',
+        category: 'Mischer',
+        inputs: [
+          { id: mixIn1, name: 'In 1', type: 'BNC', connectorType: 'BNC', direction: 'in' },
+          { id: mixIn2, name: 'In 2', type: 'BNC', connectorType: 'BNC', direction: 'in' },
+          { id: mixIn3, name: 'In 3', type: 'BNC', connectorType: 'BNC', direction: 'in' },
+          { id: mixIn4, name: 'In 4', type: 'BNC', connectorType: 'BNC', direction: 'in' },
+        ],
+        outputs: [
+          { id: mixPgm, name: 'PGM Out', type: 'BNC', connectorType: 'BNC', direction: 'out' },
+          { id: mixMv, name: 'Multiview Out', type: 'BNC', connectorType: 'BNC', direction: 'out' },
+        ],
+        x: 460,
+        y: 170,
+        width: 240,
+        height: 210,
+        nodeColor: '#7c3aed',
+      },
+      {
+        id: mv,
+        name: 'Multiviewer',
+        category: 'Monitor',
+        inputs: [{ id: mvIn, name: 'SDI In', type: 'BNC', connectorType: 'BNC', direction: 'in' }],
+        outputs: [],
+        x: 880,
+        y: 80,
+        width: 210,
+        height: 140,
+      },
+      {
+        id: mon,
+        name: 'Regie-Monitor',
+        category: 'Monitor',
+        inputs: [{ id: monIn, name: 'SDI In', type: 'BNC', connectorType: 'BNC', direction: 'in' }],
+        outputs: [],
+        x: 880,
+        y: 320,
+        width: 210,
+        height: 140,
+      },
+    ],
+    cables: [
+      {
+        id: uuidv4(),
+        name: 'CAM 1 → Mischer',
+        type: 'BNC',
+        length: 12,
+        color: '#3b82f6',
+        fromEquipmentId: cam1,
+        fromPortId: cam1Out,
+        toEquipmentId: mix,
+        toPortId: mixIn1,
+        notes: '',
+        routing: 'orthogonal',
+        arrowEnd: true,
+        layer: 'video',
+      },
+      {
+        id: uuidv4(),
+        name: 'CAM 2 → Mischer',
+        type: 'BNC',
+        length: 18,
+        color: '#3b82f6',
+        fromEquipmentId: cam2,
+        fromPortId: cam2Out,
+        toEquipmentId: mix,
+        toPortId: mixIn2,
+        notes: '',
+        routing: 'orthogonal',
+        arrowEnd: true,
+        layer: 'video',
+      },
+      {
+        id: uuidv4(),
+        name: 'PGM → Regie-Monitor',
+        type: 'BNC',
+        length: 6,
+        color: '#ef4444',
+        fromEquipmentId: mix,
+        fromPortId: mixPgm,
+        toEquipmentId: mon,
+        toPortId: monIn,
+        notes: '',
+        routing: 'orthogonal',
+        arrowEnd: true,
+        layer: 'video',
+      },
+      {
+        id: uuidv4(),
+        name: 'Multiview → Multiviewer',
+        type: 'BNC',
+        length: 6,
+        color: '#22c55e',
+        fromEquipmentId: mix,
+        fromPortId: mixMv,
+        toEquipmentId: mv,
+        toPortId: mvIn,
+        notes: '',
+        routing: 'orthogonal',
+        arrowEnd: true,
+        layer: 'video',
+      },
+    ],
+    locations: [],
+    canvasState: { x: 0, y: 0, zoom: 1 },
+  }
+}

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -756,6 +756,8 @@ export const en: Dict = {
   // Status bar (right side of canvas footer)
   'canvas.empty.title': 'No devices yet',
   'canvas.empty.hint': 'Drag a device from the library on the left onto the canvas to get started.',
+  'canvas.empty.or': '— or —',
+  'canvas.empty.loadDemo': 'Load example project',
   'statusbar.equipment': '{count} devices',
   'statusbar.cables': '{count} cables',
   'statusbar.locations': '{count} frames',


### PR DESCRIPTION
## Feature: „Beispielprojekt laden"

Neueinsteiger standen vor der leeren Canvas und wussten nicht, wie ein fertiger Plan aussieht. Der Empty-State (#552) bekommt jetzt einen Button, der einen kleinen, realistischen Broadcast-Aufbau lädt:

> **2 Kameras → Bildmischer → Multiviewer & Regie-Monitor** = 5 Geräte / 4 Kabel

## Umsetzung

- **`src/renderer/lib/demoProject.ts`** — `createDemoProject()` baut einen typ-validen `CablePlannerProject` mit frischen UUIDs pro Aufruf (keine ID-Kollisionen bei Mehrfach-Laden). Kabel referenzieren echte Port-IDs.
- **Empty-State-Button** (CanvasArea): ruft das kanonische `loadProject()` + danach `triggerCanvasFitView()` zum Einrahmen. `pointer-events-auto` nur auf dem Button — Drag&Drop/Pan/Zoom drumherum bleiben aktiv.
- **i18n**: DE-Quelltext + EN (`canvas.empty.or`, `canvas.empty.loadDemo`).

## Verifikation (live, headless)

Klick auf „Load example project": Canvas **0 → 5 Nodes / 0 → 4 Edges**, korrekte Geräte (Kamera 1/2, Bildmischer, Multiviewer, Regie-Monitor), `fitView` zentriert den Plan. Screenshot bestätigt sauberes Rendering.

`tsc` 0 · `eslint` 0 · `npm test` grün · `npm run build` grün.

Teil der Laien-Freundlichkeits-Reihe; kommt im nächsten Release nach v8.2.0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_