### PR TITLE
feat(plancheck): Klick auf einen Fund zentriert die Canvas auf das Element

### DIFF
--- a/src/renderer/components/Analysis/PlanCheckPanel.tsx
+++ b/src/renderer/components/Analysis/PlanCheckPanel.tsx
@@ -13,6 +13,7 @@ import { ModalShell } from '../shared/ModalShell'
 import { Icon } from '../shared/Icon'
 import { useTranslation, format } from '../../lib/i18n'
 import { runDrawingChecks, type CheckFinding, type CheckSeverity } from '../../lib/drawingChecks'
+import { triggerCanvasCenterOn } from '../../lib/canvasViewport'
 
 const SEVERITY_META: Record<
   CheckSeverity,
@@ -38,9 +39,32 @@ export const PlanCheckPanel = () => {
 
   if (!open) return null
 
+  // Fund anklicken → betroffenes Element selektieren UND die Canvas darauf
+  // zentrieren (centerOn-Bridge), damit man es auch sieht wenn es außerhalb des
+  // Viewports liegt. Bei Kabeln auf die Mitte zwischen den beiden Geräten.
+  const centerOnEquipment = (id: string | undefined) => {
+    const e = id ? equipment.find((x) => x.id === id) : undefined
+    if (e) triggerCanvasCenterOn(e.x + e.width / 2, e.y + e.height / 2)
+    return e
+  }
   const focusFinding = (f: CheckFinding) => {
-    if (f.cableId) setSelection(undefined, f.cableId, undefined)
-    else if (f.equipmentId) setSelection(f.equipmentId, undefined, undefined)
+    if (f.cableId) {
+      setSelection(undefined, f.cableId, undefined)
+      const c = cables.find((x) => x.id === f.cableId)
+      const a = c ? equipment.find((e) => e.id === c.fromEquipmentId) : undefined
+      const b = c ? equipment.find((e) => e.id === c.toEquipmentId) : undefined
+      if (a && b) {
+        triggerCanvasCenterOn(
+          (a.x + a.width / 2 + b.x + b.width / 2) / 2,
+          (a.y + a.height / 2 + b.y + b.height / 2) / 2,
+        )
+      } else {
+        centerOnEquipment(a?.id ?? b?.id)
+      }
+    } else if (f.equipmentId) {
+      setSelection(f.equipmentId, undefined, undefined)
+      centerOnEquipment(f.equipmentId)
+    }
   }
 
   const { findings, errorCount, warningCount, infoCount } = result


### PR DESCRIPTION
## Kontext

Du hattest ein „Warnungen-Panel" gewünscht — das gibt es bereits als **Plan-Check** (`PlanCheckPanel`, #411): es listet alle Findings aus `runDrawingChecks` (offene Ports, Connector-/Impedanz-/Faser-Mismatch, doppelte Kabelnummern/IPs, fehlende Längen …) und ist über das **Tools-Menü** und die **Status-Leiste** erreichbar. Es fehlte nur das Wichtigste: beim Klick wurde das Element zwar *selektiert*, die Canvas sprang aber **nicht** dorthin.

## Änderung

`focusFinding` zentriert die Canvas jetzt zusätzlich auf das betroffene Element — über die `triggerCanvasCenterOn`-Bridge, die ich für die Geräte-Suche (#563) gebaut habe:
- **Gerät-Fund** → Sprung + Zoom auf das Gerät.
- **Kabel-Fund** → Sprung auf die Mitte zwischen From- und To-Gerät.

Damit ist die „Klick auf Problem → hin zum Problem"-UX komplett (nur 1 Datei, +~20 Zeilen).

## Verifikation (live, headless)

Demo-Plan geladen → per Suche auf **Kamera 1** zentriert (`translate(201.8px, 243.4px)`) → Plan-Check geöffnet → Fund „Offene Ports: Bildmischer" geklickt → Viewport springt auf den Mischer (`translate(-306.4px, 85px)`, `changed: true`), Inspector zeigt „Device: Bildmischer". Screenshot bestätigt.

`tsc` 0 · `eslint` 0 · `npm test` grün · `npm run build` grün.

→ Damit ist „Warnungen-Panel" abgehakt. Als Nächstes aus deiner Auswahl: Patch-/Verkabelungsliste, Befehlspalette (Strg+K), Tastaturkürzel-Hilfe.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_