### PR TITLE
docs: Architektur-Doku an aktuellen Code angleichen

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Invarianten der App. Sie ist die Pflicht-Lektüre, bevor strukturelle Änderunge
 gemacht werden. Für die interaktive Modul-Übersicht siehe [`app-structure.html`](./app-structure.html),
 für einen Wettbewerber-Vergleich [`comparison.html`](./comparison.html).
 
-Stand: v8.1.0 · ~235 TS/TSX-Module · ~73.5k LOC
+Stand: v8.2.0 · ~339 TS/TSX-Module · ~97.7k LOC
 
 ---
 
@@ -434,18 +434,22 @@ Erweiterung auf `equipment`/`locations`, Undo-Integration.
 
 ### 9.5 · Tests
 
-Heute: kein Test-Skript in `package.json`. Bei 73k LOC ist das ein
-Regressions-Risiko. Empfohlene Erst-Suite:
-- `vitest` + Snapshot-Tests auf `healProjectPositions` mit echten
+`vitest` ist eingerichtet (`npm test` / `npm run test:watch`); dazu kommen
+gezielte Node-Checks (`npm run test:crdt`, `npm run test:signaling`) und ein
+UI-Smoke-Skript (`npm run ui:smoke`). Bei ~97.7k LOC bleibt der Ausbau der
+Abdeckung wichtig — empfohlene Schwerpunkte:
+- Snapshot-Tests auf `healProjectPositions` mit echten
   Beispiel-Projekt-JSONs.
 - Property-Tests auf `projectHistory` (Undo-Redo-Invarianten).
 - Smoke-Tests auf IPC-Channels (Mock-`fs`).
 
-### 9.6 · Web-Viewer (Issue #143)
+### 9.6 · Web-Viewer (Issue #143) — **umgesetzt** ✓
 
-Read-only Web-Renderer (separate Vite-Entry `viewer.html`) für
-Reviewer ohne Desktop-App. Annotations-only, keine Edits. Phase 1
-geplant ~2-3 Tage.
+Read-only Web-Renderer als eigener Vite-Entry `viewer.html`
+(`src/viewer/ViewerApp.tsx`, in `vite.config.ts` als `viewer`-Input) für
+Reviewer ohne Desktop-App — rendert ein geladenes `.cpviewer`/`.json`
+standalone, keine Edits. Wird über `.github/workflows/pages.yml`
+(`npm run build:renderer` → `dist/renderer`) auf GitHub Pages deployt.
 
 ---
 


### PR DESCRIPTION
## Was

Manueller **Doku-Sync** — genau das, was die CI-Action `docs-sync.yml` (#564) tut, hier von Hand ausgeführt, weil die Action das Secret `ANTHROPIC_API_KEY` braucht (noch nicht gesetzt). Ich habe alle in `docs-sync.yml` gelisteten Docs gegen `src/**`, `package.json` und die Workflows geprüft und **nur belegbare Drift** korrigiert (minimaler Diff, deutsch-first, `*.html`/`CLAUDE.md`/`LICENSE` etc. bewusst nicht angefasst).

Geändert: **`docs/architecture.md`** (eine Datei, drei Stellen):

1. **Stand-Zeile** — Metriken waren `~235 TS/TSX-Module · ~73.5k LOC`, real sind es **339 Dateien · 97.724 LOC** (per `find`/`wc` verifiziert). Version auf **v8.2.0** gesetzt (neuester Release-Tag; die Zeile stand auf v8.1.0).
2. **§9.5 Tests** — „Heute: kein Test-Skript in `package.json`" stimmt nicht mehr: `vitest` ist eingerichtet (`npm test` / `npm run test:watch`) plus `test:crdt`, `test:signaling`, `ui:smoke`. (§9.4 referenzierte `npm run test:crdt` ohnehin schon — war intern widersprüchlich.) LOC-Angabe mitgezogen.
3. **§9.6 Web-Viewer** — von „geplant ~2-3 Tage" auf **„umgesetzt ✓"**: `viewer.html` + `src/viewer/ViewerApp.tsx` existieren (in `vite.config.ts` als `viewer`-Input) und werden über `pages.yml` (`build:renderer` → `dist/renderer`) auf GitHub Pages deployt.

## Bewusst NICHT geändert

- **`docs/comparison.html`** und **`docs/app-structure.html`** tragen dieselbe Versions-/Metrik-Drift (`v7.9.94` bzw. `v8.1.0`), sind aber `*.html` → laut Action-Regel tabu. Falls gewünscht, ziehe ich die in einem separaten PR nach.
- **`package.json`** steht auf `8.0.10`, obwohl `v8.2.0` schon getaggt ist — separate Sache (kein Doku-Thema), hier nicht angefasst. Daher die v8.2.0-Angabe aus dem Release-Tag statt aus package.json.
- README/CONTRIBUTING/TESTING/SECURITY und die übrigen `docs/*.md` waren im Rahmen der Action-Regeln (falsche/veraltete Aussagen korrigieren, keine Neu-Dokumentation) **korrekt** — kein Handlungsbedarf.

Reine Doku-Änderung, kein Code berührt.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_