### PR TITLE
fix(version): Update-Vergleich auf SemVer + package.json an Release-Tag angleichen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cable-planner",
-  "version": "8.0.10",
+  "version": "8.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cable-planner",
-      "version": "8.0.10",
+      "version": "8.2.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cable-planner",
   "private": true,
-  "version": "8.0.10",
+  "version": "8.2.0",
   "description": "Electron desktop app for planning and visualizing broadcast equipment cabling",
   "author": {
     "name": "Lars Zumpe",

--- a/src/main/services/updaterService.ts
+++ b/src/main/services/updaterService.ts
@@ -1,5 +1,6 @@
 import electronUpdater from 'electron-updater'
 import { app, ipcMain, type BrowserWindow } from 'electron'
+import { isNewerVersion } from '../util/versionCompare.js'
 
 const { autoUpdater } = electronUpdater
 
@@ -60,8 +61,10 @@ export function registerUpdaterIpc(getWin: () => BrowserWindow | null): void {
       autoUpdater.autoInstallOnAppQuit = true
       const result = await autoUpdater.checkForUpdates()
       const latest = result?.updateInfo?.version
-      // electron-updater meldet nur die neueste Release-Version; gleich ⇒ aktuell.
-      const available = !!latest && latest !== current
+      // electron-updater meldet nur die neueste Release-Version. Update nur, wenn
+      // sie ECHT neuer ist (SemVer) — nicht bei bloßer Abweichung (kein Downgrade,
+      // korrekt bei 8.10 > 8.9). Siehe util/versionCompare.
+      const available = !!latest && isNewerVersion(latest, current)
       return { ok: true, current, latest: latest ?? current, available }
     } catch (err) {
       // Dev/unpackaged (keine app-update.yml), offline, kein Release → sauber melden.

--- a/src/main/util/versionCompare.ts
+++ b/src/main/util/versionCompare.ts
@@ -1,0 +1,26 @@
+// #version — SemVer-Vergleich für die Update-Logik (electron-updater).
+//
+// electron-updater meldet die neueste GitHub-Release-Version. Ein Update-Hinweis
+// soll NUR erscheinen, wenn diese echt neuer ist als die laufende App — nicht bei
+// jeder Abweichung. Der frühere String-Vergleich (`latest !== current`) hätte sonst
+// (a) "8.10.0" als älter denn "8.9.0" einsortiert und (b) eine Dev-/Pre-Release-
+// Version, die VOR dem letzten Release liegt, fälschlich als "Update" angeboten
+// (Downgrade). Reiner Helper ohne Electron-Import → unit-testbar (tests/).
+
+/** Zerlegt "v8.2.0" / "8.2.0-beta.1" in [major, minor, patch] (Suffixe ignoriert). */
+function parseVersion(v: string): [number, number, number] {
+  const core = v.trim().replace(/^v/i, '').split(/[-+]/)[0] // Pre-Release/Build abschneiden
+  const parts = core.split('.')
+  return [parseInt(parts[0], 10) || 0, parseInt(parts[1], 10) || 0, parseInt(parts[2], 10) || 0]
+}
+
+/** true, wenn `latest` echt neuer (höher) als `current` ist — numerisch je Segment. */
+export function isNewerVersion(latest: string, current: string): boolean {
+  if (!latest || !current) return false
+  const a = parseVersion(latest)
+  const b = parseVersion(current)
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] > b[i]
+  }
+  return false
+}

--- a/tests/versionCompare.test.ts
+++ b/tests/versionCompare.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { isNewerVersion } from '../src/main/util/versionCompare'
+
+// Update-Logik: zeigt einen Update-Hinweis nur, wenn die neueste Release-Version
+// ECHT neuer ist als die laufende App. Deckt die Fallstricke des alten
+// String-Vergleichs (`latest !== current`) ab.
+describe('isNewerVersion', () => {
+  it('erkennt eine echt neuere Version', () => {
+    expect(isNewerVersion('8.2.0', '8.0.10')).toBe(true)
+    expect(isNewerVersion('8.2.1', '8.2.0')).toBe(true)
+    expect(isNewerVersion('9.0.0', '8.99.99')).toBe(true)
+  })
+
+  it('vergleicht numerisch statt lexikografisch (8.10.0 > 8.9.0)', () => {
+    expect(isNewerVersion('8.10.0', '8.9.0')).toBe(true)
+    expect(isNewerVersion('8.9.0', '8.10.0')).toBe(false)
+  })
+
+  it('ist false bei gleicher Version (führendes „v" egal)', () => {
+    expect(isNewerVersion('8.2.0', '8.2.0')).toBe(false)
+    expect(isNewerVersion('v8.2.0', '8.2.0')).toBe(false)
+  })
+
+  it('bietet KEIN Downgrade an (current neuer als latest)', () => {
+    expect(isNewerVersion('8.0.10', '8.2.0')).toBe(false)
+  })
+
+  it('ignoriert Pre-Release-/Build-Suffixe beim Kern-Vergleich', () => {
+    expect(isNewerVersion('8.2.0', '8.2.0-beta.1')).toBe(false)
+    expect(isNewerVersion('8.3.0-rc.1', '8.2.0')).toBe(true)
+  })
+
+  it('ist robust gegen leere Eingaben', () => {
+    expect(isNewerVersion('', '8.2.0')).toBe(false)
+    expect(isNewerVersion('8.2.0', '')).toBe(false)
+  })
+})


### PR DESCRIPTION
Behebt die beim Doku-Sync (#568) aufgefallene Versions-Logik — zwei Defekte:

## 1 · Update-Vergleich war ein String-Vergleich (echter Bug)

`src/main/services/updaterService.ts` entschied „Update verfügbar" mit:
```ts
const available = !!latest && latest !== current   // ❌
```
Folgen:
- **Downgrade-Hinweis**: ist `current` neuer als die letzte Release-Version (Dev-/Pre-Release-Build), meldet `!==` trotzdem „Update verfügbar".
- **Falsche Ordnung**: `"8.10.0" !== "8.9.0"` ist zwar `true`, aber String-Logik hat keine Größer-Relation — bei jeder anderen Vergleichsart wäre `8.10` < `8.9` gelandet.

Jetzt SemVer-aware:
```ts
const available = !!latest && isNewerVersion(latest, current)  // ✅ nur wenn echt neuer
```
- Neuer **reiner Helper** `src/main/util/versionCompare.ts` (kein Electron-Import → testbar), numerischer Vergleich je Segment, ignoriert führendes `v` und Pre-Release-/Build-Suffixe.
- **6 Unit-Tests** `tests/versionCompare.test.ts` (neuer/gleich/Downgrade/`8.10>8.9`/Suffixe/leer).

## 2 · `package.json` lag hinter dem Release-Tag (Quelle der Drift)

`package.json` stand auf **8.0.10**, obwohl **v8.2.0** längst getaggt/released ist. Ursache: die Release-Action (`release.yml`) synct `package.json.version` per `npm version --no-git-tag-version` **nur im CI-Runner** (damit der Installer-Dateiname zum Tag passt) und **committet sie nie nach `main` zurück**. Dadurch spiegelt `main` den echten Stand nicht — genau das hat in #568 die Doku-Drift verursacht.

→ `package.json` + `package-lock.json` auf **8.2.0** (= neuester Release-Tag) gehoben.

## Verifikation
`tsc` (app+main) 0 · `eslint` 0 · **`vitest` 74/74** (inkl. der 6 neuen) · `build` 0.

## Noch offen (deine Entscheidung — Prozess, nicht in diesem PR)
Damit `package.json` auf `main` künftig **nicht wieder** hinter die Tags driftet, gibt es zwei saubere Wege. Sag, welchen du willst, dann baue ich ihn:
- **(A)** Release-Workflow committet die Versions-Sync nach dem Tag-Build zurück nach `main` (CI push → `main`).
- **(B)** Versions-Bump in `package.json` per PR = Quelle der Wahrheit; ein kleiner Workflow erzeugt daraus den Tag (statt Tags von Hand).

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_