### PR TITLE
ci(release): Tag-Version nach Release zurück nach main schreiben (Option A, #569)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,3 +145,49 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Option A (#569): nach dem Release die Tag-Version zurück nach main schreiben,
+  # damit package.json.version nicht hinter den Tags zurückbleibt. Genau diese
+  # Drift (package.json 8.0.10 während v8.2.0 schon released) war die Ursache der
+  # Doku-Sync-Korrekturen in #568. Der Build-Job synct die Version nur im Runner
+  # (für den Installer-Dateinamen) — hier wird sie persistiert.
+  #
+  # Läuft einmalig (kein Matrix), nur bei Tag-Pushes, nach erfolgreichem Release.
+  # Hinweis: Pushes mit GITHUB_TOKEN lösen bewusst KEINE weiteren Workflows aus
+  # (kein Loop). Setzt voraus, dass main direkte Bot-Pushes erlaubt (Branch-
+  # Protection ggf. eine Ausnahme für github-actions[bot] geben).
+  sync-version-to-main:
+    needs: release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+
+      - name: package.json auf Tag-Version setzen und nach main committen
+        shell: bash
+        run: |
+          set -eu
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "Tag-Version: $TAG_VERSION"
+          npm version "$TAG_VERSION" --no-git-tag-version --allow-same-version
+          if git diff --quiet -- package.json package-lock.json; then
+            echo "package.json ist bereits auf $TAG_VERSION — nichts zu committen."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "chore(release): package.json auf v$TAG_VERSION (Tag-Sync)"
+          git pull --rebase origin main
+          git push origin HEAD:main


### PR DESCRIPTION
Setzt **Option A** aus #569 um — verhindert, dass `package.json.version` künftig hinter die Release-Tags driftet.

## Problem

Der Build-Job synct die Version per `npm version --no-git-tag-version` **nur im CI-Runner** (damit der Installer-Dateiname zum Tag passt) und schreibt sie **nie nach `main` zurück**. Tags marschierten so auf v8.2.0, während `main`s `package.json` auf `8.0.10` einfror — die Ursache der Doku-Drift in #568.

## Lösung

Neuer Job **`sync-version-to-main`** in `release.yml`:
- `needs: release` + `if: startsWith(github.ref, 'refs/tags/v')` → läuft **einmalig** (kein Matrix), **nur bei Tag-Pushes**, **nach** dem erfolgreichen Release.
- Checkt `main` aus, setzt `package.json` + `package-lock.json` per `npm version` auf die Tag-Version, committet (`chore(release): package.json auf vX.Y.Z (Tag-Sync)`) und pusht nach `main`.
- **Idempotent**: committet nur bei echter Änderung (`git diff --quiet`-Guard) — wenn `package.json` schon stimmt, no-op.
- Push via `GITHUB_TOKEN` löst bewusst **keine** weiteren Workflows aus (kein Loop).

## Voraussetzung / Hinweis

- `main` muss **direkte Pushes von `github-actions[bot]`** erlauben. Falls Branch-Protection aktiv ist: dem Bot eine Bypass-Ausnahme geben, sonst schlägt nur dieser letzte Job fehl — **das Release selbst bleibt unberührt** (der Job läuft als letztes und unabhängig).
- **Nicht live testbar ohne echtes Tag-Release** — verifiziert per YAML-Parse (3 Jobs, Gating korrekt) + Logik-Review. Erster echter Lauf ist der nächste `v*`-Tag.

## Damit ist die Versions-Logik rund
#569 hat den Vergleichs-Bug (SemVer) + den aktuellen Stand (8.2.0) gefixt; dieser PR schließt die Lücke im Prozess, damit es nicht wiederkommt.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yRm9zra43drSbArEXwN6)_