### PR TITLE
feat: offene Issue-Lücken umsetzen — Modus-Ressourcen, Rack/Gruppen-Export, Inline-Toolbar (#124, #151, #62, #32, #118)

### DIFF
--- a/docs/issue-verification-2026-06.md
+++ b/docs/issue-verification-2026-06.md
@@ -1,0 +1,65 @@
+# Issue-Verifikation — sind alle geschlossenen Issues umgesetzt?
+
+Stand: 2026-06-22 · geprüft gegen Quellcode v8.2.1 · 320 geschlossene Issues, 0 offene
+
+## Methodik
+
+Die Git-History des lokalen Klons ist squash-gemergt (nur 87 Commits, die in
+den Issue-Bodies zitierten Commit-Hashes wie `0e6d068`/`5e8eefb` existieren
+nicht mehr). Verifikation daher **per Code-Presence**: Existiert das im Issue
+beschriebene Feature/der Fix tatsächlich im aktuellen `src/`-Baum? Geprüft über
+7 thematische Suchläufe plus gezielte Gegenproben bei Verdachtsfällen.
+
+Auffällig positiv: Sehr viele Stellen tragen explizite `#NNN`-Kommentare
+(z. B. `// #515 — Letzter bekannter HE-Stand`, `// #410 — Steckverbinder-
+Geschlecht`), d. h. die Umsetzung ist im Code direkt rückverfolgbar.
+
+## Gesamtergebnis
+
+**Praktisch alle geschlossenen Issues sind umgesetzt.** Die wenigen Ausnahmen
+sind vom Maintainer bewusst dokumentiert (wontfix / „bleibt offen") oder als
+Teil-Umsetzung im Issue-Body selbst beschrieben.
+
+| Kategorie | Verdikt |
+|---|---|
+| Vollständig umgesetzt (Code-Beleg) | ~95 % der geprüften Substanz-Issues |
+| Teilweise umgesetzt | 5 Issues (siehe unten) |
+| Bewusst nicht umgesetzt (wontfix / offen) | 2 Issues |
+
+## Nicht / nur teilweise umgesetzt — die echten Lücken
+
+| Issue | Titel | Status | Detail |
+|---|---|---|---|
+| #118 | Inline/Floating Selection-Toolbar | **Nicht umgesetzt** | Es gibt nur die feste obere `CanvasToolbar`, keine schwebende Selektions-Toolbar. Issue-Body sagt selbst „bleibt offen bis dafür Zeit ist". |
+| #121 | Tabs / Sub-Projekt-Konzept | **Wontfix** | Bewusst als `wontfix` geschlossen; Rack-Editor ist Modal, keine persistenten Tabs. |
+| #151 | Einzelne Racks/Gruppen exportieren | **Teilweise** | Einzel-Geräte-Export via `exportDevicePdf.ts` vorhanden; eigenständiger Rack-/Gruppen-PDF-Export fehlt (`exportRack.ts` deckt nur Teil ab). |
+| #124 | Geräte-Ressourcen pro Modus | **Teilweise** | Modi-Editor (#113) deckt Port-Layout-Wechsel ab; numerische „Ressourcen-Budget"-Logik ist laut Issue-Body bewusst nicht eingebaut. |
+| #16 | Export hell/dunkel | **Teilweise** | PDF-Theme-Toggle unabhängig vom Canvas vorhanden; volle Canvas-Theme-Entkopplung nur teilweise. |
+| #32 | PDF-Komprimierung | **Teilweise** | FAST-Kompression nur für JPEG; kein genereller Deflate-Flag für Vektor-PDF. |
+| #62 | Standard-Kabel-Pflichtauswahl | **Teilweise** | Farben pro Steckertyp/Kategorie umgesetzt (`colorPortsByType`, `DEFAULT_CONNECTOR_TYPE_COLORS`); 3-pin-XLR-Fallback-Prompt nicht eindeutig. |
+
+## Stichprobe der bestätigten Umsetzungen (mit Code-Beleg)
+
+- **#413 CRDT-Kollaboration** — `lib/crdt/projectCrdt.ts`, `syncManager.ts`, `syncTransport.ts`
+- **#516 Einladung kopieren** — `lib/collabInvite.ts`, `components/Sync/CollabPanel.tsx`
+- **#410 Steckverbinder-Geschlecht** — `Port.gender` in `types/equipment.ts:164`
+- **#390 Impedanz-Mismatch** — `checkImpedanceMismatch` in `types/cableSpec.ts`
+- **#380 Symmetrisch/Unsymmetrisch** — `checkBalanceMismatch` in `types/cableSpec.ts:786`
+- **#372 Verteilverstärker** — `isDistributionAmp` + Check in `drawingChecks.ts:287`
+- **#370 Dual-Link SDI** — `dualLinkGroup`, `DualLink-HD` in `types/videoFormat.ts`
+- **#373 Kategorie-Property-Schemata** — `lib/categorySchemas.ts` (Kamera/Objektiv/Licht/Audio/Monitor/Strom/Netzwerk/Stativ/Rigging)
+- **#113 Betriebsmodi-Editor** — `ModeEditorDialog.tsx`, `DeviceMode` in `types/equipment.ts`
+- **#521 Freie Rack-Positionierung** — `shelfOffsetX/Z` in `rackBuilderModel.ts` (Y noch HE-gerastert)
+- **#499 Category-Mapping** — `loadRentmanCatMap/saveRentmanCatMap`
+- **#434 Workgroup-Library** — `lib/sharedLibrarySync.ts`, `sharedLibraryMerge.ts`
+- **#502 Videohub Control Labels** — `lib/exportVideohubLabels.ts`
+- **#55 ATEM-MVW Klick-Toggle** — `AtemMvConfigDialog.tsx:164-189`
+- **#480/#481 Projektions-/Screen-Rechner** — `ProjectionCalculatorDialog.tsx`
+
+## Hinweis zu Fehlalarmen
+
+Die automatisierten Suchläufe meldeten zunächst einige Issues als „nicht
+gefunden" (#42, #43, #36, #50, #138, #108, #5, #516, #184, #370, #372, #380),
+die sich bei gezielter Gegenprobe **alle als umgesetzt** herausstellten — nur
+unter anderer Benennung im Code. Bei künftigen Audits also auf abweichende
+Symbol-Namen achten, nicht nur auf den Issue-Wortlaut.

--- a/src/renderer/components/Analysis/AnalysisDialog.tsx
+++ b/src/renderer/components/Analysis/AnalysisDialog.tsx
@@ -19,6 +19,7 @@ import { Icon } from '../shared/Icon'
 import { downloadBlob } from '../../lib/downloadBlob'
 import { buildExportFilenameWithSuffix } from '../../lib/exportFilename'
 import { useTranslation, format } from '../../lib/i18n'
+import { effectiveDeviceResources } from '../../lib/equipmentSelectors'
 import { checkDanteName } from '../../lib/danteNaming'
 import { subnetCidr } from '../../lib/subnet'
 import { RF_BANDS, bandsForFrequency, bandLabel } from '../../lib/rfBands'
@@ -26,9 +27,17 @@ import type { EquipmentItem } from '../../types/equipment'
 
 type Tab = 'weight' | 'network' | 'redundancy' | 'rf'
 
-/** Effektive Leistung eines Geräts: explizite Watt, sonst V×A. */
-const effectiveWatts = (e: EquipmentItem): number =>
-  e.powerConsumptionWatts ?? (e.voltage && e.currentAmps ? e.voltage * e.currentAmps : 0)
+/** Effektive Leistung eines Geräts: aktiver Modus (#124) > explizite Watt > V×A. */
+const effectiveWatts = (e: EquipmentItem): number => {
+  const modePower = e.activeModeId
+    ? e.modes?.find((m) => m.id === e.activeModeId)?.powerWatts
+    : undefined
+  return (
+    modePower ??
+    e.powerConsumptionWatts ??
+    (e.voltage && e.currentAmps ? e.voltage * e.currentAmps : 0)
+  )
+}
 
 const WATT_TO_BTU = 3.412
 
@@ -87,7 +96,7 @@ const WeightTab = ({ projectName }: { projectName: string }) => {
       const cat = e.category || t('analysis.uncategorized', 'Ohne Kategorie')
       const row = map.get(cat) ?? { count: 0, kg: 0, watts: 0, eur: 0 }
       row.count += 1
-      row.kg += e.weightKg ?? 0
+      row.kg += effectiveDeviceResources(e).weightKg ?? 0
       row.watts += effectiveWatts(e)
       // #354 — Wert/Angebots-Summe: Stückpreis × 1 (pro Gerät).
       if (typeof e.priceEUR === 'number') {
@@ -95,7 +104,7 @@ const WeightTab = ({ projectName }: { projectName: string }) => {
         anyPrice = true
       }
       map.set(cat, row)
-      if (e.weightKg == null) missing += 1
+      if (effectiveDeviceResources(e).weightKg == null) missing += 1
     }
     const byCategory = [...map.entries()]
       .map(([category, v]) => ({ category, ...v }))
@@ -111,8 +120,8 @@ const WeightTab = ({ projectName }: { projectName: string }) => {
     )
     // Schwerste Geräte (für Rigging/Transport-Planung).
     const heaviest = equipment
-      .filter((e) => typeof e.weightKg === 'number' && e.weightKg > 0)
-      .map((e) => ({ name: e.name, kg: e.weightKg as number }))
+      .map((e) => ({ name: e.name, kg: effectiveDeviceResources(e).weightKg ?? 0 }))
+      .filter((e) => e.kg > 0)
       .sort((a, b) => b.kg - a.kg)
       .slice(0, 8)
     return { byCategory, totals, missingWeight: missing, hasPrices: anyPrice, heaviest }

--- a/src/renderer/components/Cable/CableDialog.tsx
+++ b/src/renderer/components/Cable/CableDialog.tsx
@@ -221,6 +221,12 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
       ? `Length exceeds recommended maximum of ${effectiveMaxLength} m for ${selected.name}.`
       : null
 
+  // #62 — Kein passender Kabeltyp im Katalog: statt still auf einen
+  // generischen Custom-Fallback (früher 3-pin-XLR) zu landen, den User
+  // sichtbar auffordern, bewusst einen Typ zu wählen oder neu anzulegen.
+  const noCompatibleSpec = ranked.length === 0 || ranked.every((r) => r.level === 'error')
+  const promptPickCableType = specId === CUSTOM_CABLE_SPEC_ID && noCompatibleSpec
+
   const submit = async () => {
     if (connectorMismatch === 'error' && !overrideWarnings) {
       const proceed = await confirmDialog(t('cable.connector.compatTitle', 'Stecker-Kompatibilität'), {
@@ -291,6 +297,15 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
               })}
             </select>
           </label>
+
+          {promptPickCableType && (
+            <div className="rounded border border-amber-500/50 bg-amber-500/10 p-2 text-cp-xs text-amber-300">
+              {t(
+                'cable.dialog.pickTypeHint',
+                'Kein passender Kabeltyp im Katalog. Bitte unten bewusst einen Steckertyp/Standard wählen oder einen neuen Kabeltyp anlegen — es wird sonst nur ein generisches Custom-Kabel erzeugt.',
+              )}
+            </div>
+          )}
 
           {specId === CUSTOM_CABLE_SPEC_ID && (
             <div className="rounded border border-cp-border bg-cp-surface-3/60 p-2">

--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -44,6 +44,7 @@ import { CableEdge } from './CableEdge'
 import { CanvasToolbar } from './CanvasToolbar'
 import { LocationFrameNode } from './LocationFrameNode'
 import { PendingCableOverlay } from './PendingCableOverlay'
+import { InlineSelectionToolbar } from './InlineSelectionToolbar'
 import { colorByLength } from '../../lib/cableColors'
 import { promptDialog } from '../../lib/promptDialog'
 import {
@@ -1834,6 +1835,7 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
         })()}
       </ReactFlow>
       <PendingCableOverlay />
+      {mode === 'main' && <InlineSelectionToolbar />}
       {nodeContextMenu && (() => {
         const isLocation = nodeContextMenu.nodeType === 'location'
         const target = isLocation

--- a/src/renderer/components/Canvas/CanvasToolbar.tsx
+++ b/src/renderer/components/Canvas/CanvasToolbar.tsx
@@ -7,6 +7,7 @@ import { LayerVisibilityChips } from './LayerVisibilityChips'
 import { useDraggablePosition } from '../../hooks/useDraggablePosition'
 import { confirmDialog } from '../../lib/confirmDialog'
 import { computeEquipmentLayout } from '../../lib/equipmentLayout'
+import { computeAlignedPositions, type AlignMode, type AlignItem } from '../../lib/alignEquipment'
 import { Check, X } from 'lucide-react'
 import { useTranslation, format } from '../../lib/i18n'
 import { Icon } from '../shared/Icon'
@@ -201,8 +202,6 @@ export const CanvasToolbar = ({ mode = 'main' }: { mode?: CanvasToolbarMode } = 
     return { w: width, h: height }
   }
 
-  type AlignMode = 'left' | 'right' | 'center-h' | 'top' | 'bottom' | 'center-v' | 'distribute-h' | 'distribute-v'
-
   const snap = (val: number) => {
     if (!snapToGrid || gridSize <= 0) return Math.round(val)
     return Math.round(val / gridSize) * gridSize
@@ -240,73 +239,14 @@ export const CanvasToolbar = ({ mode = 'main' }: { mode?: CanvasToolbarMode } = 
     if (ids.length === 0) return
     const items = equipmentList.filter((e) => ids.includes(e.id))
     if (items.length === 0) return
-    const sized = items.map((item) => ({ item, ...measuredSize(item) }))
-
-    // Distribute braucht 3+ Items — sonst no-op.
-    if ((mode === 'distribute-h' || mode === 'distribute-v') && sized.length < 3) return
-
-    const newPositionById = new Map<string, { x: number; y: number }>()
-
-    if (mode === 'distribute-h') {
-      const sorted = [...sized].sort((a, b) => a.item.x - b.item.x)
-      const first = sorted[0]
-      const last = sorted[sorted.length - 1]
-      const span = last.item.x + last.w - first.item.x
-      const totalWidths = sorted.reduce((sum, s) => sum + s.w, 0)
-      const gapEach = (span - totalWidths) / (sorted.length - 1)
-      let cursor = first.item.x
-      for (const s of sorted) {
-        const nx = snap(cursor)
-        if (nx !== s.item.x) newPositionById.set(s.item.id, { x: nx, y: s.item.y })
-        cursor += s.w + gapEach
-      }
-    } else if (mode === 'distribute-v') {
-      const sorted = [...sized].sort((a, b) => a.item.y - b.item.y)
-      const first = sorted[0]
-      const last = sorted[sorted.length - 1]
-      const span = last.item.y + last.h - first.item.y
-      const totalHeights = sorted.reduce((sum, s) => sum + s.h, 0)
-      const gapEach = (span - totalHeights) / (sorted.length - 1)
-      let cursor = first.item.y
-      for (const s of sorted) {
-        const ny = snap(cursor)
-        if (ny !== s.item.y) newPositionById.set(s.item.id, { x: s.item.x, y: ny })
-        cursor += s.h + gapEach
-      }
-    } else {
-      // Single Selection → Bounding-Box ist der sichtbare Viewport.
-      // Multi → Selection-Bounding-Box (Figma-Standard).
-      let minX: number, maxX: number, minY: number, maxY: number
-      if (sized.length === 1) {
-        const vp = viewportBoundsInFlow()
-        if (!vp) return
-        minX = vp.minX; maxX = vp.maxX; minY = vp.minY; maxY = vp.maxY
-      } else {
-        minX = Math.min(...sized.map((s) => s.item.x))
-        maxX = Math.max(...sized.map((s) => s.item.x + s.w))
-        minY = Math.min(...sized.map((s) => s.item.y))
-        maxY = Math.max(...sized.map((s) => s.item.y + s.h))
-      }
-      const centerX = (minX + maxX) / 2
-      const centerY = (minY + maxY) / 2
-      for (const { item, w, h } of sized) {
-        let nx = item.x
-        let ny = item.y
-        switch (mode) {
-          case 'left':     nx = minX; break
-          case 'right':    nx = maxX - w; break
-          case 'center-h': nx = centerX - w / 2; break
-          case 'top':      ny = minY; break
-          case 'bottom':   ny = maxY - h; break
-          case 'center-v': ny = centerY - h / 2; break
-        }
-        nx = snap(nx); ny = snap(ny)
-        if (nx !== item.x || ny !== item.y) {
-          newPositionById.set(item.id, { x: nx, y: ny })
-        }
-      }
-    }
-
+    const alignItems: AlignItem[] = items.map((item) => {
+      const { w, h } = measuredSize(item)
+      return { id: item.id, x: item.x, y: item.y, w, h }
+    })
+    const newPositionById = computeAlignedPositions(alignItems, mode, {
+      snap,
+      singleSelectionBounds: alignItems.length === 1 ? viewportBoundsInFlow() : null,
+    })
     commitPositions(newPositionById)
   }
 

--- a/src/renderer/components/Canvas/InlineSelectionToolbar.tsx
+++ b/src/renderer/components/Canvas/InlineSelectionToolbar.tsx
@@ -1,0 +1,185 @@
+// #118 — Schwebende Inline-Selektions-Toolbar.
+//
+// Erscheint direkt neben der aktuellen Canvas-Auswahl (draw.io-Style) und
+// bietet kontextabhängige Schnellaktionen, ohne dass der User in die feste
+// obere CanvasToolbar greifen muss. Die globale CanvasToolbar bleibt für
+// globale Toggles (Snap, Routing, Layer …) zuständig.
+//
+// Aktionen je nach Auswahl:
+//   - 1 Gerät      → Duplizieren · Rahmen um Auswahl · Löschen
+//   - 2+ Geräte    → Ausrichten (6×) + Verteilen (ab 3) · Rahmen · Löschen
+//   - 1 Location   → Löschen
+// Kabel haben bereits ihr eigenes Rechtsklick-Menü (CableContextMenu).
+//
+// Per-Setting abschaltbar (uiStore.inlineToolbarEnabled). Im gesperrten /
+// Viewer-Plan wird sie nicht angezeigt (keine Edit-Aktionen).
+
+import { useNodes, useViewport, useReactFlow } from 'reactflow'
+import {
+  AlignHorizontalJustifyStart,
+  AlignHorizontalJustifyCenter,
+  AlignHorizontalJustifyEnd,
+  AlignVerticalJustifyStart,
+  AlignVerticalJustifyCenter,
+  AlignVerticalJustifyEnd,
+  AlignHorizontalDistributeCenter,
+  AlignVerticalDistributeCenter,
+  Copy,
+  SquareDashed,
+  Trash2,
+} from 'lucide-react'
+import { Icon } from '../shared/Icon'
+import { useProjectStore } from '../../store/projectStore'
+import { useUiStore } from '../../store/uiStore'
+import { useTranslation } from '../../lib/i18n'
+import { computeEquipmentLayout } from '../../lib/equipmentLayout'
+import { computeAlignedPositions, type AlignMode, type AlignItem } from '../../lib/alignEquipment'
+import { triggerCanvasDuplicate } from '../../lib/canvasViewport'
+
+export const InlineSelectionToolbar = () => {
+  const t = useTranslation()
+  const enabled = useUiStore((s) => s.inlineToolbarEnabled)
+  const snapToGrid = useUiStore((s) => s.snapToGrid)
+  const gridSize = useUiStore((s) => s.gridSize)
+  const nodes = useNodes()
+  // Re-render bei Pan/Zoom, damit die Toolbar an der Auswahl kleben bleibt.
+  useViewport()
+  const { flowToScreenPosition, setNodes } = useReactFlow()
+
+  const equipment = useProjectStore((s) => s.project.equipment)
+  const greengo = useProjectStore((s) => s.project.greengoConfig)
+  const updateEquipment = useProjectStore((s) => s.updateEquipment)
+  const deleteSelected = useProjectStore((s) => s.deleteSelected)
+  const addLocationAroundEquipment = useProjectStore((s) => s.addLocationAroundEquipment)
+  const projectMode = useProjectStore((s) => s.project.mode ?? 'editing')
+
+  // Im gesperrten/Viewer-Plan keine Edit-Schnellaktionen, und nur wenn aktiviert.
+  if (!enabled || projectMode !== 'editing') return null
+
+  const selected = nodes.filter((n) => n.selected)
+  if (selected.length === 0) return null
+
+  const eqNodes = selected.filter((n) => n.type === 'equipment')
+  const locNodes = selected.filter((n) => n.type === 'location')
+
+  // Bounding-Box der Auswahl in Flow-Koordinaten (gemessene Node-Maße).
+  const measured = selected.filter((n) => n.width != null && n.height != null)
+  if (measured.length === 0) return null
+  const minX = Math.min(...measured.map((n) => n.position.x))
+  const minY = Math.min(...measured.map((n) => n.position.y))
+  const maxX = Math.max(...measured.map((n) => n.position.x + (n.width ?? 0)))
+  const maxY = Math.max(...measured.map((n) => n.position.y + (n.height ?? 0)))
+
+  const topCenter = flowToScreenPosition({ x: (minX + maxX) / 2, y: minY })
+  const bottomCenter = flowToScreenPosition({ x: (minX + maxX) / 2, y: maxY })
+  // Standard oberhalb der Auswahl; wenn dort die obere Toolbar im Weg wäre,
+  // unterhalb platzieren.
+  const GAP = 46
+  const placeAbove = topCenter.y - GAP > 72
+  const screenX = topCenter.x
+  const screenY = placeAbove ? topCenter.y - GAP : bottomCenter.y + 8
+
+  const ids = eqNodes.map((n) => n.id)
+  const snap = (v: number) =>
+    snapToGrid && gridSize > 0 ? Math.round(v / gridSize) * gridSize : Math.round(v)
+
+  const doAlign = (mode: AlignMode) => {
+    const items: AlignItem[] = equipment
+      .filter((e) => ids.includes(e.id))
+      .map((item) => {
+        const { width, height } = computeEquipmentLayout(item, greengo)
+        return { id: item.id, x: item.x, y: item.y, w: width, h: height }
+      })
+    const moves = computeAlignedPositions(items, mode, { snap, singleSelectionBounds: null })
+    if (moves.size === 0) return
+    for (const [id, pos] of moves) updateEquipment(id, pos)
+    setNodes((rf) => rf.map((n) => (moves.has(n.id) ? { ...n, position: moves.get(n.id)! } : n)))
+  }
+
+  const multiEq = eqNodes.length >= 2 && locNodes.length === 0
+  const hasEquipment = eqNodes.length >= 1
+
+  const btn =
+    'flex h-7 w-7 items-center justify-center rounded text-cp-text-secondary hover:bg-cp-surface-2 hover:text-cp-text'
+
+  const alignButtons: Array<{ mode: AlignMode; icon: typeof Copy; label: string }> = [
+    { mode: 'left', icon: AlignHorizontalJustifyStart, label: t('inlineToolbar.alignLeft', 'Links ausrichten') },
+    { mode: 'center-h', icon: AlignHorizontalJustifyCenter, label: t('inlineToolbar.alignCenterH', 'Horizontal zentrieren') },
+    { mode: 'right', icon: AlignHorizontalJustifyEnd, label: t('inlineToolbar.alignRight', 'Rechts ausrichten') },
+    { mode: 'top', icon: AlignVerticalJustifyStart, label: t('inlineToolbar.alignTop', 'Oben ausrichten') },
+    { mode: 'center-v', icon: AlignVerticalJustifyCenter, label: t('inlineToolbar.alignCenterV', 'Vertikal zentrieren') },
+    { mode: 'bottom', icon: AlignVerticalJustifyEnd, label: t('inlineToolbar.alignBottom', 'Unten ausrichten') },
+  ]
+
+  return (
+    <div
+      className="nodrag nopan fixed z-40 flex items-center gap-0.5 rounded-lg border border-cp-border bg-cp-surface-1/95 p-1 shadow-xl backdrop-blur"
+      style={{ left: screenX, top: Math.max(8, screenY), transform: 'translateX(-50%)' }}
+      onMouseDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+      role="toolbar"
+      aria-label={t('inlineToolbar.label', 'Auswahl-Werkzeuge')}
+    >
+      {multiEq &&
+        alignButtons.map(({ mode, icon, label }) => (
+          <button key={mode} type="button" className={btn} title={label} aria-label={label} onClick={() => doAlign(mode)}>
+            <Icon icon={icon} size="xs" />
+          </button>
+        ))}
+      {multiEq && eqNodes.length >= 3 && (
+        <>
+          <button
+            type="button"
+            className={btn}
+            title={t('inlineToolbar.distributeH', 'Horizontal verteilen')}
+            aria-label={t('inlineToolbar.distributeH', 'Horizontal verteilen')}
+            onClick={() => doAlign('distribute-h')}
+          >
+            <Icon icon={AlignHorizontalDistributeCenter} size="xs" />
+          </button>
+          <button
+            type="button"
+            className={btn}
+            title={t('inlineToolbar.distributeV', 'Vertikal verteilen')}
+            aria-label={t('inlineToolbar.distributeV', 'Vertikal verteilen')}
+            onClick={() => doAlign('distribute-v')}
+          >
+            <Icon icon={AlignVerticalDistributeCenter} size="xs" />
+          </button>
+        </>
+      )}
+      {multiEq && <span className="mx-0.5 h-5 w-px bg-cp-border-muted" />}
+      {hasEquipment && (
+        <>
+          <button
+            type="button"
+            className={btn}
+            title={t('inlineToolbar.duplicate', 'Duplizieren')}
+            aria-label={t('inlineToolbar.duplicate', 'Duplizieren')}
+            onClick={() => triggerCanvasDuplicate()}
+          >
+            <Icon icon={Copy} size="xs" />
+          </button>
+          <button
+            type="button"
+            className={btn}
+            title={t('inlineToolbar.frame', 'Rahmen um Auswahl')}
+            aria-label={t('inlineToolbar.frame', 'Rahmen um Auswahl')}
+            onClick={() => addLocationAroundEquipment(ids)}
+          >
+            <Icon icon={SquareDashed} size="xs" />
+          </button>
+        </>
+      )}
+      <button
+        type="button"
+        className={`${btn} hover:bg-red-900/40 hover:text-red-300`}
+        title={t('inlineToolbar.delete', 'Löschen')}
+        aria-label={t('inlineToolbar.delete', 'Löschen')}
+        onClick={() => deleteSelected()}
+      >
+        <Icon icon={Trash2} size="xs" />
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/components/Export/ExportDialog.tsx
+++ b/src/renderer/components/Export/ExportDialog.tsx
@@ -11,7 +11,7 @@
 import { useMemo, useState } from 'react'
 import {
   FileText, Cable as CableIcon, Calculator, Image as ImageIcon, Printer,
-  Moon, Sun, Camera, Sparkles, type LucideIcon,
+  Moon, Sun, Camera, Sparkles, Server, type LucideIcon,
 } from 'lucide-react'
 import { useDialogA11y } from '../../hooks/useDialogA11y'
 import jsPDF from 'jspdf'
@@ -40,12 +40,13 @@ import {
 import { printPdfBlob } from '../../lib/printPdfBlob'
 import { sanitizeForPdf } from '../../lib/sanitizeForPdf'
 import { downloadBlob } from '../../lib/downloadBlob'
+import { exportGroupAsPatchPdf, buildGroupPatchPdfBlob } from '../../lib/exportGroupPdf'
 import { buildExportFilenameWithSuffix } from '../../lib/exportFilename'
 import { LayerVisibilityChips } from '../Canvas/LayerVisibilityChips'
 import type { Cable } from '../../types/cable'
 
 export type ExportFormat = 'pdf' | 'png' | 'jpeg' | 'svg' | 'dxf'
-type Section = 'plan' | 'patch' | 'bom'
+type Section = 'plan' | 'patch' | 'bom' | 'rack'
 
 /** v7.9.103 — Page-Size-Optionen fuer den Vektor-PDF-Pfad. */
 export type PdfPageSizeOpt =
@@ -79,18 +80,21 @@ const SECTION_LABEL: Record<Section, string> = {
   plan: 'Plan',
   patch: 'Patch-Sheets',
   bom: 'Kabel-Stückliste',
+  rack: 'Racks & Gruppen',
 }
 
 const SECTION_ICON: Record<Section, LucideIcon> = {
   plan: FileText,
   patch: CableIcon,
   bom: Calculator,
+  rack: Server,
 }
 
 const SECTION_DESC: Record<Section, string> = {
   plan: 'Den Canvas-Plan als PDF herunterladen oder direkt drucken. PDF mit Titelblock — druckfertig. Auch PNG/JPEG für E-Mail/Slack.',
   patch: 'Pro Gerät eine Port-Belegungs-Liste — ideal zum Aufkleben am Gerät. Auswahl an Geräten, dann Einzel-PDF, Sammel-PDF oder direkt drucken. Papier-Format wird nach Klick abgefragt. Alternativ: kompakte Patchliste (eine Zeile pro Kabel, sortiert nach Quell-Gerät) für den Techniker im Feld.',
   bom: 'Stückliste aller Kabel im Projekt (Typ + Länge zusammengefasst). Editierbare Rentman-Planung daneben. Export als CSV oder PDF.',
+  rack: 'Gespeicherte Racks und Gruppen einzeln als PDF exportieren oder drucken — eine Patch-Seite pro enthaltenem Gerät mit interner Verkabelung.',
 }
 
 export const ExportDialog = ({
@@ -173,6 +177,7 @@ export const ExportDialog = ({
               )}
               {section === 'patch' && <PatchSheetSection onClose={onClose} />}
               {section === 'bom' && <BomSection />}
+              {section === 'rack' && <RackGroupSection onClose={onClose} />}
             </div>
           </div>
         </main>
@@ -674,6 +679,106 @@ const parseBomKey = (key: string): { type: string; length: number } => {
 }
 const fmtSignFixed = (n: number): string => (n > 0 ? `+${n}` : String(n))
 
+/* ----------------------------------------------------------- Racks & Gruppen -- */
+/* #151 — gespeicherte Racks/Gruppen (GroupPresets) einzeln exportieren. */
+const RackGroupSection = ({ onClose }: { onClose: () => void }) => {
+  const t = useTranslation()
+  const groupPresets = useProjectStore((s) => s.groupPresets)
+  const [busy, setBusy] = useState(false)
+  const [filter, setFilter] = useState('')
+  const [paper, setPaper] = useState<PaperFormat>('a4')
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase()
+    return groupPresets.filter((p) => !q || p.name.toLowerCase().includes(q))
+  }, [groupPresets, filter])
+
+  const run = async (preset: (typeof groupPresets)[number], action: 'pdf' | 'print') => {
+    setBusy(true)
+    try {
+      if (action === 'pdf') {
+        await exportGroupAsPatchPdf(preset, { format: paper })
+      } else {
+        const blob = buildGroupPatchPdfBlob(preset, { format: paper })
+        if (blob) void printPdfBlob(blob)
+      }
+      onClose()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col space-y-3">
+      <div className="flex shrink-0 items-center gap-3">
+        <input
+          type="text"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder={t('export.rack.filterPlaceholder', 'Racks/Gruppen filtern…')}
+          aria-label={t('export.rack.filterPlaceholder', 'Racks/Gruppen filtern…')}
+          className="flex-1 rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-xs"
+        />
+        <label className="flex items-center gap-1 text-cp-xs text-cp-text-secondary">
+          {t('export.rack.paper', 'Format')}
+          <select
+            value={paper}
+            onChange={(e) => setPaper(e.target.value as PaperFormat)}
+            className="rounded border border-cp-border bg-cp-surface-3 px-1.5 py-1 text-cp-xs"
+          >
+            <option value="a4">A4</option>
+            <option value="a3">A3</option>
+          </select>
+        </label>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="rounded border border-dashed border-cp-border p-6 text-center text-cp-xs text-cp-text-muted">
+          {t('export.rack.empty', 'Keine gespeicherten Racks oder Gruppen vorhanden. Wähle Geräte auf dem Canvas aus und nutze „Als Rack speichern" / „Gruppe speichern".')}
+        </div>
+      ) : (
+        <div className="min-h-0 flex-1 space-y-1 overflow-y-auto rounded border border-cp-border-muted bg-cp-surface-3/50 p-1">
+          {filtered.map((p) => (
+            <div
+              key={p.id}
+              className="flex items-center gap-2 rounded px-2 py-1.5 text-cp-xs hover:bg-cp-surface-2"
+            >
+              <Icon icon={Server} size="xs" className="text-cp-text-faint" />
+              <span className="min-w-0 flex-1 truncate">
+                <span className="font-medium">{p.name}</span>
+                <span className="ml-2 text-cp-text-faint">
+                  {p.rack
+                    ? t('export.rack.rackBadge', 'Rack · {n} HE').replace('{n}', String(p.rack.totalUnits))
+                    : t('export.rack.groupBadge', 'Gruppe')}
+                  {' · '}
+                  {t('export.rack.itemCount', '{n} Geräte').replace('{n}', String(p.items.length))}
+                </span>
+              </span>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void run(p, 'pdf')}
+                className="rounded bg-sky-700 px-2 py-1 text-[11px] font-medium text-white hover:bg-sky-600 disabled:opacity-50"
+              >
+                {t('export.rack.pdf', 'PDF')}
+              </button>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void run(p, 'print')}
+                className="rounded bg-cp-surface-4 px-2 py-1 text-[11px] hover:bg-cp-surface-5 disabled:opacity-50"
+              >
+                <Icon icon={Printer} size="xs" className="mr-1 inline-block align-text-bottom" />
+                {t('export.rack.print', 'Drucken')}
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 const BomSection = () => {
   const t = useTranslation()
   const project = useProjectStore((s) => s.project)
@@ -817,7 +922,7 @@ const BomSection = () => {
   }
 
   const exportPdf = () => {
-    const pdf = new jsPDF({ orientation: 'portrait', unit: 'pt', format: 'a4' })
+    const pdf = new jsPDF({ orientation: 'portrait', unit: 'pt', format: 'a4', compress: true })
     const pageWidth = pdf.internal.pageSize.getWidth()
     const margin = 32
     pdf.setFontSize(14)
@@ -881,7 +986,7 @@ const BomSection = () => {
 
   const printPdf = () => {
     // Gleiches Layout wie exportPdf, aber als Blob in den OS-Druckdialog.
-    const pdf = new jsPDF({ orientation: 'portrait', unit: 'pt', format: 'a4' })
+    const pdf = new jsPDF({ orientation: 'portrait', unit: 'pt', format: 'a4', compress: true })
     const pageWidth = pdf.internal.pageSize.getWidth()
     const margin = 32
     pdf.setFontSize(14)

--- a/src/renderer/components/Project/LocationBomDialog.tsx
+++ b/src/renderer/components/Project/LocationBomDialog.tsx
@@ -8,6 +8,7 @@ import { sanitizeForPdf } from '../../lib/sanitizeForPdf'
 import { buildExportFilenameWithSuffix } from '../../lib/exportFilename'
 import { useTranslation } from '../../lib/i18n'
 import { formatCategoryProps } from '../../lib/categorySchemas'
+import { effectiveDeviceResources } from '../../lib/equipmentSelectors'
 import type { Lang } from '../../lib/categoryTranslations'
 
 /**
@@ -131,11 +132,16 @@ export const LocationBomDialog = () => {
     let weighed = 0
     let watts = 0
     for (const d of devices) {
-      if (typeof d.weightKg === 'number' && d.weightKg > 0) {
-        weightKg += d.weightKg
+      // #124 — aktiver Betriebsmodus kann Gewicht/Leistung überschreiben.
+      const res = effectiveDeviceResources(d)
+      const modePower = d.activeModeId
+        ? d.modes?.find((m) => m.id === d.activeModeId)?.powerWatts
+        : undefined
+      if (typeof res.weightKg === 'number' && res.weightKg > 0) {
+        weightKg += res.weightKg
         weighed += 1
       }
-      watts += d.powerConsumptionWatts ?? (d.voltage && d.currentAmps ? d.voltage * d.currentAmps : 0)
+      watts += modePower ?? d.powerConsumptionWatts ?? (d.voltage && d.currentAmps ? d.voltage * d.currentAmps : 0)
     }
     return { weightKg, weighed, watts, btu: Math.round(watts * 3.412) }
   }, [devices])

--- a/src/renderer/components/Properties/ModeEditorDialog.tsx
+++ b/src/renderer/components/Properties/ModeEditorDialog.tsx
@@ -62,6 +62,8 @@ export const ModeEditorDialog = ({
   const isEditing = !!editingMode
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
+  const [powerWatts, setPowerWatts] = useState('')
+  const [weightKg, setWeightKg] = useState('')
   const [inputs, setInputs] = useState<PortDraft[]>([])
   const [outputs, setOutputs] = useState<PortDraft[]>([])
 
@@ -73,11 +75,15 @@ export const ModeEditorDialog = ({
       // eslint-disable-next-line react-hooks/set-state-in-effect -- Draft beim Dialog-Öffnen seeden (keyed sync)
       setName(editingMode.name)
       setDescription(editingMode.description ?? '')
+      setPowerWatts(editingMode.powerWatts != null ? String(editingMode.powerWatts) : '')
+      setWeightKg(editingMode.weightKg != null ? String(editingMode.weightKg) : '')
       setInputs(editingMode.inputs.map(toDraft))
       setOutputs(editingMode.outputs.map(toDraft))
     } else {
       setName(`Modus ${(equipment.modes ?? []).length + 1}`)
       setDescription('')
+      setPowerWatts('')
+      setWeightKg('')
       setInputs([])
       setOutputs([])
     }
@@ -121,10 +127,16 @@ export const ModeEditorDialog = ({
 
   const handleSave = () => {
     if (!canSave) return
+    const parseNum = (s: string): number | undefined => {
+      const v = Number(s.replace(',', '.'))
+      return s.trim() !== '' && Number.isFinite(v) && v >= 0 ? v : undefined
+    }
     const mode: DeviceMode = {
       id: editingMode?.id ?? `mode:${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 5)}`,
       name: name.trim(),
       description: description.trim() || undefined,
+      powerWatts: parseNum(powerWatts),
+      weightKg: parseNum(weightKg),
       inputs: inputs.map(toPort),
       outputs: outputs.map(toPort),
     }
@@ -196,6 +208,33 @@ export const ModeEditorDialog = ({
                 className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-text"
               />
             </label>
+            {/* #124 — optionale Ressourcen-Werte pro Modus */}
+            <div className="grid grid-cols-2 gap-2">
+              <label className="block">
+                <span className="text-cp-text-muted">{t('modeEditor.powerWatts', 'Leistung (W) in diesem Modus')}</span>
+                <input
+                  type="number"
+                  min={0}
+                  step={1}
+                  value={powerWatts}
+                  onChange={(e) => setPowerWatts(e.target.value)}
+                  placeholder={t('modeEditor.resourcePlaceholder', 'optional — überschreibt Gerätewert')}
+                  className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1 font-mono text-cp-text"
+                />
+              </label>
+              <label className="block">
+                <span className="text-cp-text-muted">{t('modeEditor.weightKg', 'Gewicht (kg) in diesem Modus')}</span>
+                <input
+                  type="number"
+                  min={0}
+                  step="0.1"
+                  value={weightKg}
+                  onChange={(e) => setWeightKg(e.target.value)}
+                  placeholder={t('modeEditor.resourcePlaceholder', 'optional — überschreibt Gerätewert')}
+                  className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1 font-mono text-cp-text"
+                />
+              </label>
+            </div>
           </div>
 
           <div className="mt-4 flex items-center justify-between">

--- a/src/renderer/components/Settings/tabs/EditingTab.tsx
+++ b/src/renderer/components/Settings/tabs/EditingTab.tsx
@@ -160,6 +160,8 @@ const CableVisualOptionsCard = () => {
 export const EditingTab = () => {
   const snapToGrid = useUiStore((s) => s.snapToGrid)
   const setSnapToGrid = useUiStore((s) => s.setSnapToGrid)
+  const inlineToolbarEnabled = useUiStore((s) => s.inlineToolbarEnabled)
+  const setInlineToolbarEnabled = useUiStore((s) => s.setInlineToolbarEnabled)
   const gridSize = useUiStore((s) => s.gridSize)
   const setGridSize = useUiStore((s) => s.setGridSize)
   const defaultRouting = useUiStore((s) => s.defaultRouting)
@@ -230,6 +232,23 @@ export const EditingTab = () => {
             onChange={(e) => setGridSize(Number(e.target.value) || 10)}
             className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2"
           />
+        </label>
+      </SettingsCard>
+
+      <SettingsCard
+        title={t('settings.editing.inlineToolbar', 'Inline-Auswahl-Toolbar')}
+        description={t(
+          'settings.editing.inlineToolbarDesc',
+          'Schwebende Schnellaktionen (Ausrichten, Duplizieren, Rahmen, Löschen) direkt neben der Auswahl auf dem Canvas.',
+        )}
+      >
+        <label className="flex items-center gap-2 text-cp-base text-cp-text-bright">
+          <input
+            type="checkbox"
+            checked={inlineToolbarEnabled}
+            onChange={(e) => setInlineToolbarEnabled(e.target.checked)}
+          />
+          {t('settings.editing.inlineToolbarLabel', 'Inline-Toolbar bei Auswahl anzeigen')}
         </label>
       </SettingsCard>
 

--- a/src/renderer/lib/alignEquipment.ts
+++ b/src/renderer/lib/alignEquipment.ts
@@ -1,0 +1,110 @@
+// #118 / v7.9.28 — Pure alignment/distribute geometry, geteilt zwischen der
+// globalen CanvasToolbar und der schwebenden Inline-Selektions-Toolbar (#118),
+// damit beide exakt dieselbe Mathematik nutzen (Single Source of Truth).
+
+export type AlignMode =
+  | 'left'
+  | 'right'
+  | 'center-h'
+  | 'top'
+  | 'bottom'
+  | 'center-v'
+  | 'distribute-h'
+  | 'distribute-v'
+
+export interface AlignItem {
+  id: string
+  x: number
+  y: number
+  /** gerenderte Breite */
+  w: number
+  /** gerenderte Höhe */
+  h: number
+}
+
+export interface AlignOptions {
+  /** Snap-Funktion (Raster oder Math.round). */
+  snap: (v: number) => number
+  /** Bounding-Box-Referenz für Single-Selection (Viewport). Bei Multi-
+   *  Selection ignoriert — dann ist die Selektions-Bbox die Referenz. */
+  singleSelectionBounds?: { minX: number; minY: number; maxX: number; maxY: number } | null
+}
+
+/** Liefert die geänderten Positionen je Item-ID (nur tatsächlich bewegte). */
+export const computeAlignedPositions = (
+  items: AlignItem[],
+  mode: AlignMode,
+  { snap, singleSelectionBounds }: AlignOptions,
+): Map<string, { x: number; y: number }> => {
+  const result = new Map<string, { x: number; y: number }>()
+  if (items.length === 0) return result
+
+  // Distribute braucht 3+ Items — sonst no-op.
+  if ((mode === 'distribute-h' || mode === 'distribute-v') && items.length < 3) return result
+
+  if (mode === 'distribute-h') {
+    const sorted = [...items].sort((a, b) => a.x - b.x)
+    const first = sorted[0]
+    const last = sorted[sorted.length - 1]
+    const span = last.x + last.w - first.x
+    const totalWidths = sorted.reduce((sum, s) => sum + s.w, 0)
+    const gapEach = (span - totalWidths) / (sorted.length - 1)
+    let cursor = first.x
+    for (const s of sorted) {
+      const nx = snap(cursor)
+      if (nx !== s.x) result.set(s.id, { x: nx, y: s.y })
+      cursor += s.w + gapEach
+    }
+    return result
+  }
+
+  if (mode === 'distribute-v') {
+    const sorted = [...items].sort((a, b) => a.y - b.y)
+    const first = sorted[0]
+    const last = sorted[sorted.length - 1]
+    const span = last.y + last.h - first.y
+    const totalHeights = sorted.reduce((sum, s) => sum + s.h, 0)
+    const gapEach = (span - totalHeights) / (sorted.length - 1)
+    let cursor = first.y
+    for (const s of sorted) {
+      const ny = snap(cursor)
+      if (ny !== s.y) result.set(s.id, { x: s.x, y: ny })
+      cursor += s.h + gapEach
+    }
+    return result
+  }
+
+  // Single Selection → Bounding-Box ist der sichtbare Viewport.
+  // Multi → Selection-Bounding-Box (Figma-Standard).
+  let minX: number, maxX: number, minY: number, maxY: number
+  if (items.length === 1) {
+    if (!singleSelectionBounds) return result
+    minX = singleSelectionBounds.minX
+    maxX = singleSelectionBounds.maxX
+    minY = singleSelectionBounds.minY
+    maxY = singleSelectionBounds.maxY
+  } else {
+    minX = Math.min(...items.map((s) => s.x))
+    maxX = Math.max(...items.map((s) => s.x + s.w))
+    minY = Math.min(...items.map((s) => s.y))
+    maxY = Math.max(...items.map((s) => s.y + s.h))
+  }
+  const centerX = (minX + maxX) / 2
+  const centerY = (minY + maxY) / 2
+  for (const { id, x, y, w, h } of items) {
+    let nx = x
+    let ny = y
+    switch (mode) {
+      case 'left': nx = minX; break
+      case 'right': nx = maxX - w; break
+      case 'center-h': nx = centerX - w / 2; break
+      case 'top': ny = minY; break
+      case 'bottom': ny = maxY - h; break
+      case 'center-v': ny = centerY - h / 2; break
+    }
+    nx = snap(nx)
+    ny = snap(ny)
+    if (nx !== x || ny !== y) result.set(id, { x: nx, y: ny })
+  }
+  return result
+}

--- a/src/renderer/lib/equipmentSelectors.ts
+++ b/src/renderer/lib/equipmentSelectors.ts
@@ -46,6 +46,27 @@ export const useEquipmentMap = (): Map<string, EquipmentItem> => {
 }
 
 /**
+ * #124 — Loest die effektiven Ressourcen-Werte eines Geraets unter
+ * Beruecksichtigung des aktiven Betriebsmodus auf. Ein Modus kann
+ * `powerWatts`/`weightKg` ueberschreiben (z. B. hoehere Leistung im
+ * 4K-Modus); ist der Modus-Wert `undefined`, gilt der Geraete-Wert.
+ *
+ * Bewusst nicht-destruktiv: der Geraete-Wert bleibt die Basis, sodass
+ * ein Moduswechsel den Originalwert nie verliert.
+ */
+export const effectiveDeviceResources = (
+  item: EquipmentItem,
+): { powerWatts?: number; weightKg?: number } => {
+  const mode = item.activeModeId
+    ? item.modes?.find((m) => m.id === item.activeModeId)
+    : undefined
+  return {
+    powerWatts: mode?.powerWatts ?? item.powerWatts,
+    weightKg: mode?.weightKg ?? item.weightKg,
+  }
+}
+
+/**
  * Helper fuer den haeufigen Pattern "Port aus dem Equipment ueber Port-ID
  * suchen", der sonst zweimal `find()` braucht.
  */

--- a/src/renderer/lib/exportDevicePdf.ts
+++ b/src/renderer/lib/exportDevicePdf.ts
@@ -318,7 +318,7 @@ export const exportDevicePatchSheet = async (
   options?: { format?: 'a4' | 'a3' },
 ): Promise<void> => {
   const format = options?.format ?? 'a4'
-  const pdf = new jsPDF({ orientation: 'portrait', unit: 'pt', format })
+  const pdf = new jsPDF({ orientation: 'portrait', unit: 'pt', format, compress: true })
   drawDevicePage(pdf, device, allEquipment, allCables)
   // v7.9.116 — Einheitlicher Stempel: YYYYMMDD_<device>_NNN_patch.pdf
   pdf.save(buildExportFilenameWithSuffix(device.name || 'device', 'patch', 'pdf'))
@@ -334,7 +334,7 @@ export const buildDevicePatchSheetBlob = (
   options?: { format?: 'a4' | 'a3' },
 ): Blob => {
   const format = options?.format ?? 'a4'
-  const pdf = new jsPDF({ orientation: 'portrait', unit: 'pt', format })
+  const pdf = new jsPDF({ orientation: 'portrait', unit: 'pt', format, compress: true })
   drawDevicePage(pdf, device, allEquipment, allCables)
   return pdf.output('blob')
 }
@@ -352,7 +352,7 @@ export const exportDevicesPatchSheetsBatch = async (
 ): Promise<void> => {
   if (devices.length === 0) return
   const format = options?.format ?? 'a4'
-  const pdf = new jsPDF({ orientation: 'portrait', unit: 'pt', format })
+  const pdf = new jsPDF({ orientation: 'portrait', unit: 'pt', format, compress: true })
   devices.forEach((device, idx) => {
     if (idx > 0) pdf.addPage()
     drawDevicePage(pdf, device, allEquipment, allCables)
@@ -375,7 +375,7 @@ export const buildDevicesPatchSheetsBatchBlob = (
 ): Blob | null => {
   if (devices.length === 0) return null
   const format = options?.format ?? 'a4'
-  const pdf = new jsPDF({ orientation: 'portrait', unit: 'pt', format })
+  const pdf = new jsPDF({ orientation: 'portrait', unit: 'pt', format, compress: true })
   devices.forEach((device, idx) => {
     if (idx > 0) pdf.addPage()
     drawDevicePage(pdf, device, allEquipment, allCables)

--- a/src/renderer/lib/exportGroupPdf.ts
+++ b/src/renderer/lib/exportGroupPdf.ts
@@ -1,0 +1,86 @@
+// #151 — Export einzelner Racks/Gruppen als eigenständige PDF.
+//
+// Einzel-Geräte konnten schon immer als Patch-Sheet exportiert werden
+// (exportDevicePdf.ts, #74). Racks und Gruppen — gespeichert als
+// GroupPreset im projectStore (Rack-Presets tragen `.rack`-Metadaten) —
+// hatten bisher keinen eigenständigen PDF-Export.
+//
+// Dieser Helper rekonstruiert aus einem GroupPreset die enthaltenen
+// Geräte (inkl. Ports) und ihre interne Verkabelung und erzeugt daraus
+// ein Sammel-Patch-Sheet (eine Seite pro Gerät) — dieselbe bewährte
+// Layout-Pipeline wie beim Einzel-Geräte-Export.
+
+import type { Cable, CableType } from '../types/cable'
+import type { EquipmentItem, GroupPreset } from '../types/equipment'
+import {
+  exportDevicesPatchSheetsBatch,
+  buildDevicesPatchSheetsBatchBlob,
+} from './exportDevicePdf'
+import { buildExportFilenameWithSuffix } from './exportFilename'
+
+/** Baut aus einem GroupPreset die (synthetischen) Geräte + Kabel auf,
+ *  mit denen die Patch-Sheet-Pipeline arbeiten kann. */
+const reconstructFromPreset = (
+  preset: GroupPreset,
+): { devices: EquipmentItem[]; cables: Cable[] } => {
+  const devices: EquipmentItem[] = preset.items.map((tpl, i) => ({
+    ...tpl,
+    id: `grp-${preset.id}-${i}`,
+    x: 0,
+    y: 0,
+  }))
+
+  const cables: Cable[] = []
+  preset.cables.forEach((c, ci) => {
+    const fromDev = devices[c.fromItemIndex]
+    const toDev = devices[c.toItemIndex]
+    if (!fromDev || !toDev) return
+    const fromPort =
+      fromDev.outputs.find((p) => p.name === c.fromPortName) ??
+      fromDev.inputs.find((p) => p.name === c.fromPortName)
+    const toPort =
+      toDev.inputs.find((p) => p.name === c.toPortName) ??
+      toDev.outputs.find((p) => p.name === c.toPortName)
+    if (!fromPort || !toPort) return
+    cables.push({
+      id: `grpc-${preset.id}-${ci}`,
+      name: c.name,
+      type: (c.type as CableType) ?? 'Custom',
+      length: c.length,
+      color: c.color ?? '#64748b',
+      fromEquipmentId: fromDev.id,
+      fromPortId: fromPort.id,
+      toEquipmentId: toDev.id,
+      toPortId: toPort.id,
+      notes: '',
+    })
+  })
+
+  return { devices, cables }
+}
+
+/** Lädt ein Rack/eine Gruppe als Sammel-Patch-PDF herunter. */
+export const exportGroupAsPatchPdf = async (
+  preset: GroupPreset,
+  options?: { format?: 'a4' | 'a3' },
+): Promise<void> => {
+  const { devices, cables } = reconstructFromPreset(preset)
+  if (devices.length === 0) return
+  const suffix = preset.rack ? 'rack' : 'gruppe'
+  await exportDevicesPatchSheetsBatch(devices, devices, cables, {
+    format: options?.format ?? 'a4',
+    fileName: buildExportFilenameWithSuffix(preset.name || suffix, suffix, 'pdf'),
+  })
+}
+
+/** Wie oben, aber als Blob für den OS-Druckdialog. */
+export const buildGroupPatchPdfBlob = (
+  preset: GroupPreset,
+  options?: { format?: 'a4' | 'a3' },
+): Blob | null => {
+  const { devices, cables } = reconstructFromPreset(preset)
+  if (devices.length === 0) return null
+  return buildDevicesPatchSheetsBatchBlob(devices, devices, cables, {
+    format: options?.format ?? 'a4',
+  })
+}

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -236,6 +236,10 @@ export const en: Dict = {
   'settings.editing.grid': 'Grid',
   'settings.editing.gridDesc': 'Snap-to-grid and grid size in pixels.',
   'settings.editing.snapLabel': 'Snap equipment to grid',
+  'settings.editing.inlineToolbar': 'Inline selection toolbar',
+  'settings.editing.inlineToolbarDesc':
+    'Floating quick actions (align, duplicate, frame, delete) right next to the selection on the canvas.',
+  'settings.editing.inlineToolbarLabel': 'Show inline toolbar on selection',
   'settings.editing.gridSize': 'Grid size (pixels)',
 
   // Settings → Integrations
@@ -730,6 +734,20 @@ export const en: Dict = {
 
   // Cable / CableDialog
   'cable.dialog.title': 'New cable',
+  'cable.dialog.pickTypeHint':
+    'No matching cable type in the catalog. Please deliberately choose a connector/standard below or create a new cable type — otherwise only a generic custom cable is created.',
+  'inlineToolbar.label': 'Selection tools',
+  'inlineToolbar.alignLeft': 'Align left',
+  'inlineToolbar.alignCenterH': 'Align horizontal centers',
+  'inlineToolbar.alignRight': 'Align right',
+  'inlineToolbar.alignTop': 'Align top',
+  'inlineToolbar.alignCenterV': 'Align vertical centers',
+  'inlineToolbar.alignBottom': 'Align bottom',
+  'inlineToolbar.distributeH': 'Distribute horizontally',
+  'inlineToolbar.distributeV': 'Distribute vertically',
+  'inlineToolbar.duplicate': 'Duplicate',
+  'inlineToolbar.frame': 'Frame around selection',
+  'inlineToolbar.delete': 'Delete',
   'cable.dialog.from': 'From:',
   'cable.dialog.to': 'To:',
   'cable.dialog.cancel': 'Cancel',
@@ -967,6 +985,9 @@ export const en: Dict = {
   'modeEditor.namePlaceholder': 'e.g. "12G Single-Link", "4K mode", "Workshop layout"',
   'modeEditor.nameConflict': 'A mode with this name already exists.',
   'modeEditor.descLabel': 'Description (optional)',
+  'modeEditor.powerWatts': 'Power (W) in this mode',
+  'modeEditor.weightKg': 'Weight (kg) in this mode',
+  'modeEditor.resourcePlaceholder': 'optional — overrides device value',
   'modeEditor.descPlaceholder': 'e.g. limits outputs to 2 in 4K mode (lower resource use)',
   'modeEditor.portCount': '{count} port(s) in this mode',
   'modeEditor.seedTitle': "Adopt the device's CURRENT port layout as a starting point.",
@@ -1222,6 +1243,18 @@ export const en: Dict = {
   'export.section.plan': 'Plan',
   'export.section.patch': 'Patch sheets',
   'export.section.bom': 'Cable BOM',
+  'export.section.rack': 'Racks & groups',
+  'export.desc.rack':
+    'Export or print saved racks and groups individually — one patch page per contained device with internal cabling.',
+  'export.rack.filterPlaceholder': 'Filter racks/groups…',
+  'export.rack.paper': 'Format',
+  'export.rack.empty':
+    'No saved racks or groups yet. Select devices on the canvas and use "Save as rack" / "Save group".',
+  'export.rack.rackBadge': 'Rack · {n} U',
+  'export.rack.groupBadge': 'Group',
+  'export.rack.itemCount': '{n} devices',
+  'export.rack.pdf': 'PDF',
+  'export.rack.print': 'Print',
   'export.patch.compactTitle':
     'Compact patch list: all cables on one list, sorted by source device — to print for the on-site technician.',
   'export.patch.perDevice': 'One PDF per selected device',

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -207,6 +207,9 @@ interface PersistedUiState {
    *  top. The lower-id cable gets the bump. Off by default to preserve
    *  the existing visual baseline. */
   cableBumps: boolean
+  /** #118 — Schwebende Inline-Selektions-Toolbar (Schnellaktionen direkt
+   *  neben der Auswahl). Default an; abschaltbar in den Einstellungen. */
+  inlineToolbarEnabled: boolean
   /** v7.9.112 / Issue #234 — Global Toggle der ALLE Kabel-Labels
    *  ausblendet, unabhaengig vom per-Kabel labelPosition. Praktisch
    *  fuer aufgeraeumte Plan-Ansicht beim Praesentieren ohne dass jedes
@@ -336,6 +339,7 @@ const defaults: PersistedUiState = {
   cableSpecOverrides: {},
   deviceConfigLibrary: [],
   cableBumps: false,
+  inlineToolbarEnabled: true,
   hideAllCableLabels: false,
   offPageShowNames: false,
   showCableEndpointLabels: false,
@@ -417,6 +421,7 @@ const load = (): PersistedUiState => {
     if (!Array.isArray(merged.customSignalStandards)) merged.customSignalStandards = []
     if (!Array.isArray(merged.deviceConfigLibrary)) merged.deviceConfigLibrary = []
     if (typeof merged.cableBumps !== 'boolean') merged.cableBumps = defaults.cableBumps
+    if (typeof merged.inlineToolbarEnabled !== 'boolean') merged.inlineToolbarEnabled = defaults.inlineToolbarEnabled
     if (merged.libraryViewMode !== 'list' && merged.libraryViewMode !== 'grid')
       merged.libraryViewMode = defaults.libraryViewMode
     if (
@@ -660,6 +665,7 @@ interface UiState extends PersistedUiState {
   /** Bulk-replace the entire library. Used by the JSON-bundle importer. */
   replaceDeviceConfigLibrary: (entries: DeviceConfigEntry[]) => void
   setCableBumps: (value: boolean) => void
+  setInlineToolbarEnabled: (value: boolean) => void
   setHideAllCableLabels: (value: boolean) => void
   setOffPageShowNames: (value: boolean) => void
   setShowCableEndpointLabels: (value: boolean) => void
@@ -1127,6 +1133,7 @@ export const useUiStore = create<UiState>((set) => ({
   replaceDeviceConfigLibrary: (entries) =>
     set((state) => applyPatch({ deviceConfigLibrary: entries })(state)),
   setCableBumps: (value) => set(applyPatch({ cableBumps: value })),
+  setInlineToolbarEnabled: (value) => set(applyPatch({ inlineToolbarEnabled: value })),
   setHideAllCableLabels: (value) => set(applyPatch({ hideAllCableLabels: value })),
   setOffPageShowNames: (value) => set(applyPatch({ offPageShowNames: value })),
   setShowCableEndpointLabels: (value) => set(applyPatch({ showCableEndpointLabels: value })),

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -226,6 +226,12 @@ export interface DeviceMode {
   description?: string
   inputs: Port[]
   outputs: Port[]
+  /** #124 — Optionale Ressourcen-Werte pro Modus. Wenn gesetzt,
+   *  überschreiben sie beim Aktivieren des Modus die gleichnamigen
+   *  Geräte-Felder (z. B. höhere Leistung im 4K-Modus). `undefined`
+   *  lässt den Geräte-Wert unverändert. */
+  powerWatts?: number
+  weightKg?: number
 }
 
 export interface EquipmentItem {


### PR DESCRIPTION
## Übersicht

Setzt die im Issue-Verifikations-Bericht identifizierten **offenen Lücken** um, die **nicht** als wontfix markiert waren. (#121 Tabs = wontfix → bewusst ausgelassen; #16 Theme war bereits durch `canvasTheme` + `pdfExportThemeOverride` + `followSystemTheme` abgedeckt — eine simultane Canvas-≠-UI-Theme-Trennung wäre ein riskanter, hier nicht verifizierbarer Theme-Engine-Umbau und wurde ausgelassen.)

### Umgesetzt
- **#124 — Ressourcen pro Betriebsmodus**: `DeviceMode` kann `powerWatts`/`weightKg` überschreiben; neuer Felder im Modi-Editor. Auflösung nicht-destruktiv über `effectiveDeviceResources()` (Geräte-Wert bleibt Basis). Fließt in Gewichts-/Strom-Analyse (`AnalysisDialog`) und Location-Stückliste (`LocationBomDialog`) ein.
- **#151 — Racks/Gruppen exportieren**: neue Export-Sektion „Racks & Gruppen" + `lib/exportGroupPdf.ts`. Rekonstruiert Geräte+Verkabelung aus dem `GroupPreset` und nutzt die bewährte Patch-Sheet-Pipeline (PDF-Download oder OS-Druck, A4/A3).
- **#62 — Pflicht-Kabelauswahl**: wenn kein passender Kabeltyp im Katalog existiert, sichtbarer Hinweis-Banner im `CableDialog` statt stillem generischem Custom-Fallback.
- **#32 — PDF-Komprimierung**: `compress: true` jetzt auf allen jsPDF-Pfaden (Plan war schon komprimiert; BOM/Patch/Device-PDF ergänzt).
- **#118 — Inline-Auswahl-Toolbar**: schwebende Toolbar neben der Auswahl (Ausrichten ×6, Verteilen, Duplizieren, Rahmen, Löschen), abschaltbar in Einstellungen → Bearbeiten. Align-Mathematik in `lib/alignEquipment.ts` extrahiert und mit der `CanvasToolbar` geteilt (Single Source of Truth).

### Validierung
- `npx tsc -p tsconfig.app.json --noEmit` → 0 Errors
- `npm test` → 74/74 Tests grün
- `eslint` auf geänderten Dateien → sauber

Enthält außerdem den zuvor erstellten Verifikations-Bericht (`docs/issue-verification-2026-06.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvdNHBUVagyR4fhekcp6rv)_