### PR TITLE
canvas: Geräte-Suche verschiebbar machen + headless Drag-Harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "ui:smoke": "node scripts/ui-smoke.mjs",
+    "test:drag": "node scripts/drag-test.mjs",
     "test:crdt": "node scripts/crdt-convergence-check.mjs",
     "test:signaling": "npm run build:main && node scripts/signaling-relay-check.mjs",
     "dist": "npm run build && electron-builder",

--- a/scripts/drag-test.mjs
+++ b/scripts/drag-test.mjs
@@ -1,0 +1,201 @@
+/**
+ * Headless Drag-/Interaktions-Test im BROWSER-Modus (Renderer via Vite).
+ * Desktop-/IPC-Features sind inert, aber das Canvas-/ReactFlow-Drag-
+ * Verhalten ist reine Renderer-Logik — ideal um Verschiebbarkeit zu prüfen.
+ *
+ * Prüft, dass Geräte-Knoten, Location-Rahmen und die Inline-Auswahl-Toolbar
+ * (#118) sich verhalten wie erwartet, und meldet Renderer-Konsolenfehler.
+ *
+ * Voraussetzung: `npm run dev:renderer` läuft auf :5173.
+ * Lauf:          npm run test:drag   (oder: node scripts/drag-test.mjs)
+ *   Browser-Pfad ggf. via CP_CHROME=… überschreiben (Sandbox), Screenshots
+ *   landen in CP_UI_SHOTS (Default /tmp/cp-drag-shots).
+ */
+import { chromium } from 'playwright-core'
+import { mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const URL = process.env.CP_URL || 'http://localhost:5173/'
+const OUT = process.env.CP_UI_SHOTS || '/tmp/cp-drag-shots'
+mkdirSync(OUT, { recursive: true })
+
+// Auf einem normalen Dev-Rechner findet Playwright sein eigenes Chromium
+// (nach `npx playwright install`). In einer Sandbox mit vorinstalliertem
+// Browser kann der Pfad über CP_CHROME gesetzt werden.
+const browser = await chromium.launch({
+  args: ['--no-sandbox'],
+  ...(process.env.CP_CHROME ? { executablePath: process.env.CP_CHROME } : {}),
+})
+const ctx = await browser.newContext({ viewport: { width: 1600, height: 1000 } })
+const page = await ctx.newPage()
+
+// Onboarding/Tour vorab als gesehen markieren (frischer Browser hat leeren
+// localStorage → sonst blockiert der Welcome-Dialog den Canvas).
+await page.addInitScript(() => {
+  try {
+    localStorage.setItem('cable-planner.tour.seen.v1', '1')
+    localStorage.setItem('cable-planner:settings', JSON.stringify({ onboardingDone: true }))
+  } catch {
+    /* noop */
+  }
+})
+
+const consoleErrors = []
+page.on('console', (m) => {
+  if (m.type() === 'error') consoleErrors.push(m.text())
+})
+page.on('pageerror', (e) => consoleErrors.push('pageerror: ' + e.message))
+
+const log = (...a) => console.log(...a)
+const shot = async (name) => {
+  await page.screenshot({ path: join(OUT, `${name}.png`) })
+  log('  · screenshot', name)
+}
+
+await page.goto(URL, { waitUntil: 'domcontentloaded' })
+await page.waitForTimeout(3000)
+
+for (const rx of [/Decide later|Später/i, /Skip|Überspringen|End tour|Beenden|Fertig|Los geht/i]) {
+  const b = page.getByRole('button', { name: rx })
+  if (await b.count()) await b.first().click({ timeout: 1500 }).catch(() => {})
+}
+await page.keyboard.press('Escape').catch(() => {})
+await page.waitForTimeout(400)
+await shot('01-start')
+
+// Beispielprojekt laden.
+let loaded = false
+const demoBtn = page.getByText(/Beispielprojekt laden|Load demo|example project/i)
+if (await demoBtn.count()) {
+  await demoBtn.first().click().catch(() => {})
+  loaded = true
+}
+if (!loaded) {
+  await page.keyboard.press('Control+k').catch(() => {})
+  await page.waitForTimeout(300)
+  const cmd = page.getByText(/Beispielprojekt laden|Load demo/i)
+  if (await cmd.count()) await cmd.first().click().catch(() => {})
+  await page.keyboard.press('Escape').catch(() => {})
+}
+await page.waitForTimeout(1500)
+await shot('02-demo-loaded')
+
+const nodeInfo = async (sel) =>
+  page.$$eval(sel, (els) =>
+    els.map((el) => {
+      const r = el.getBoundingClientRect()
+      return {
+        id: el.getAttribute('data-id'),
+        transform: el.style.transform,
+        rect: { x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width), h: Math.round(r.height) },
+      }
+    }),
+  )
+
+const equip = await nodeInfo('.react-flow__node-equipment')
+log(`\nGeräte-Knoten gefunden: ${equip.length}`)
+if (equip.length === 0) {
+  log('!! Keine Geräte — Demo nicht geladen. Konsolenfehler:', consoleErrors.slice(0, 10))
+  await browser.close()
+  process.exit(2)
+}
+
+const dragNode = async (selector, id, dx, dy, label, grabYOffset = 10) => {
+  const before = (await nodeInfo(selector)).find((n) => n.id === id)
+  if (!before) return { ok: false }
+  const sx = before.rect.x + Math.min(before.rect.w / 2, 40)
+  const sy = before.rect.y + grabYOffset
+  await page.mouse.move(sx, sy)
+  await page.mouse.down()
+  for (let i = 1; i <= 12; i++) {
+    await page.mouse.move(sx + (dx * i) / 12, sy + (dy * i) / 12)
+    await page.waitForTimeout(14)
+  }
+  await page.mouse.up()
+  await page.waitForTimeout(350)
+  const after = (await nodeInfo(selector)).find((n) => n.id === id)
+  const moved =
+    !!after &&
+    after.transform !== before.transform &&
+    (Math.abs(after.rect.x - before.rect.x) > 4 || Math.abs(after.rect.y - before.rect.y) > 4)
+  log(
+    `\n[${label}] id=${id}\n  vorher : ${before.transform} @ (${before.rect.x},${before.rect.y})\n  nachher: ${after?.transform} @ (${after?.rect.x},${after?.rect.y})\n  → ${moved ? 'VERSCHOBEN ✓' : 'NICHT verschoben ✗'}`,
+  )
+  return { ok: moved, before, after }
+}
+
+// Test 1: Gerät anklicken (Auswahl) + Screenshot
+await page.mouse.click(equip[0].rect.x + 30, equip[0].rect.y + 8)
+await page.waitForTimeout(300)
+await shot('03-device-selected')
+// Kleiner Versatz in freie Fläche darunter (Overlap-Schutz #183 revertiert
+// Drops auf belegte Flächen — daher bewusst in den freien Bereich ziehen).
+const r1 = await dragNode('.react-flow__node-equipment', equip[0].id, 0, 44, 'Gerät 1', 6)
+await shot('04-device-after-drag')
+
+// Test 2: zweites Gerät, ebenfalls in freie Fläche
+let r2 = { ok: true, skipped: true }
+if (equip.length > 1) {
+  await page.keyboard.press('Escape')
+  await page.waitForTimeout(200)
+  const fresh = await nodeInfo('.react-flow__node-equipment')
+  r2 = await dragNode('.react-flow__node-equipment', fresh[1].id, 0, 44, 'Gerät 2', 6)
+  await shot('05-device2-after-drag')
+}
+
+// Test 3: Inline-Toolbar bei Auswahl
+await page.keyboard.press('Escape')
+await page.waitForTimeout(150)
+const freshAll = await nodeInfo('.react-flow__node-equipment')
+await page.mouse.click(freshAll[0].rect.x + 30, freshAll[0].rect.y + 10)
+await page.waitForTimeout(300)
+const inlineCount = await page.locator('div[role="toolbar"][aria-label]').count()
+log(`\nInline-Toolbar sichtbar bei Einzel-Auswahl: ${inlineCount > 0 ? 'JA' : 'NEIN'} (${inlineCount})`)
+await shot('06-inline-toolbar')
+
+// Test 4: Multi-Select + Inline-Toolbar (Ausrichten sichtbar?)
+await page.keyboard.press('Escape')
+await page.waitForTimeout(150)
+const all = await nodeInfo('.react-flow__node-equipment')
+if (all.length > 1) {
+  await page.mouse.click(all[0].rect.x + 30, all[0].rect.y + 10)
+  await page.keyboard.down('Shift')
+  await page.mouse.click(all[1].rect.x + 30, all[1].rect.y + 10)
+  await page.keyboard.up('Shift')
+  await page.waitForTimeout(300)
+  const toolbarButtons = await page.locator('div[role="toolbar"][aria-label] button').count()
+  log(`Inline-Toolbar Buttons bei Mehrfach-Auswahl: ${toolbarButtons}`)
+  await shot('07-inline-toolbar-multi')
+}
+
+// Test 5: Location-Rahmen — via Inline-Toolbar "Rahmen um Auswahl"
+let frameResult = { ok: null }
+const frameBtn = page.getByRole('button', { name: /Rahmen um Auswahl|Frame around/i })
+if (await frameBtn.count()) {
+  await frameBtn.first().click().catch(() => {})
+  await page.waitForTimeout(500)
+}
+await shot('08-after-frame-create')
+const frames = await nodeInfo('.react-flow__node-location')
+log(`\nLocation-Rahmen gefunden: ${frames.length}`)
+if (frames.length > 0) {
+  await page.keyboard.press('Escape')
+  await page.waitForTimeout(200)
+  frameResult = await dragNode('.react-flow__node-location', frames[0].id, 130, 60, 'Location-Rahmen', 6)
+  await shot('09-frame-after-drag')
+}
+
+log('\n--- Renderer-Konsolenfehler ---')
+if (consoleErrors.length === 0) log('  (keine)')
+else consoleErrors.slice(0, 20).forEach((e) => log('  ✗', e))
+
+await browser.close()
+
+log('\n================ ERGEBNIS ================')
+log(`Gerät 1 verschiebbar     : ${r1.ok ? 'JA' : 'NEIN'}`)
+log(`Gerät 2 verschiebbar     : ${r2.skipped ? 'n/a' : r2.ok ? 'JA' : 'NEIN'}`)
+log(`Inline-Toolbar (1 Gerät) : ${inlineCount > 0 ? 'JA' : 'NEIN'}`)
+log(`Location-Rahmen verschiebbar: ${frameResult.ok === null ? 'n/a' : frameResult.ok ? 'JA' : 'NEIN'}`)
+log(`Konsolenfehler: ${consoleErrors.length}`)
+log(`Screenshots → ${OUT}`)
+process.exit(!r1.ok ? 1 : 0)

--- a/src/renderer/components/Canvas/CanvasSearch.tsx
+++ b/src/renderer/components/Canvas/CanvasSearch.tsx
@@ -1,12 +1,16 @@
 // #ux — Geräte-Suche auf der Canvas.
 //
 // Bei großen Plänen war ein bestimmtes Gerät kaum zu finden. Diese
-// schwebende Suchleiste (oben mittig) filtert die Geräte nach Name /
+// schwebende Suchleiste (Default oben mittig) filtert die Geräte nach Name /
 // Kurzname / Kategorie / Notiz, springt per Klick zum Treffer (Auswahl +
 // Zentrieren) und öffnet sich mit Strg/Cmd+F.
+//
+// Verschiebbar: am Grip-Griff (links) lässt sich die Leiste frei
+// positionieren; die Lage wird im uiStore gemerkt (canvasSearchPos).
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Search, X } from 'lucide-react'
+import { Search, X, GripVertical } from 'lucide-react'
 import { useCanvasProjectStore } from '../../store/projectStoreContext'
+import { useUiStore } from '../../store/uiStore'
 import { triggerCanvasCenterOn } from '../../lib/canvasViewport'
 import { useTranslation } from '../../lib/i18n'
 import { Icon } from '../shared/Icon'
@@ -15,9 +19,12 @@ export const CanvasSearch = () => {
   const t = useTranslation()
   const equipment = useCanvasProjectStore((s) => s.project.equipment)
   const setSelection = useCanvasProjectStore((s) => s.setSelection)
+  const pos = useUiStore((s) => s.canvasSearchPos)
+  const setPos = useUiStore((s) => s.setCanvasSearchPos)
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
 
   // Strg/Cmd+F öffnet + fokussiert die Suche (nicht beim Tippen in Feldern,
   // damit man weiterhin in Eingaben suchen/markieren kann); Esc schließt.
@@ -61,26 +68,87 @@ export const CanvasSearch = () => {
     setQuery('')
   }
 
+  // Verschieben per Grip-Griff. Beim ersten Greifen wird die aktuell
+  // gerenderte Lage (auch die Default-Zentrierung) in px übernommen, danach
+  // dem Cursor gefolgt und auf die Canvas-Fläche geclampt.
+  const startDrag = (e: React.PointerEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    const el = containerRef.current
+    const parent = el?.offsetParent as HTMLElement | null
+    if (!el || !parent) return
+    const rect = el.getBoundingClientRect()
+    const prect = parent.getBoundingClientRect()
+    const startX = rect.left - prect.left
+    const startY = rect.top - prect.top
+    const w = rect.width
+    const h = rect.height
+    const startMouseX = e.clientX
+    const startMouseY = e.clientY
+    const onMove = (ev: PointerEvent) => {
+      const maxX = Math.max(0, prect.width - w)
+      const maxY = Math.max(0, prect.height - h)
+      const nx = Math.min(Math.max(0, startX + (ev.clientX - startMouseX)), maxX)
+      const ny = Math.min(Math.max(0, startY + (ev.clientY - startMouseY)), maxY)
+      setPos({ x: nx, y: ny })
+    }
+    const onUp = () => {
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+    }
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+  }
+
+  // Positionierung: Default oben mittig (pos === null), sonst freie px-Lage.
+  const posClass = pos ? '' : 'top-3 left-1/2 -translate-x-1/2'
+  const posStyle = pos ? { left: pos.x, top: pos.y } : undefined
+
+  const Grip = (
+    <button
+      type="button"
+      onPointerDown={startDrag}
+      onClick={(e) => e.stopPropagation()}
+      className="cursor-grab text-cp-text-faint hover:text-cp-text active:cursor-grabbing"
+      title={t('canvas.search.move', 'Suchleiste verschieben')}
+      aria-label={t('canvas.search.move', 'Suchleiste verschieben')}
+    >
+      <Icon icon={GripVertical} size="sm" />
+    </button>
+  )
+
   if (!open) {
     return (
-      <button
-        type="button"
-        onClick={() => {
-          setOpen(true)
-          requestAnimationFrame(() => inputRef.current?.focus())
-        }}
-        className="pointer-events-auto absolute top-3 left-1/2 z-20 flex -translate-x-1/2 items-center gap-2 rounded-cp-control border border-cp-border bg-cp-surface-1 px-cp-3 py-cp-2 text-cp-xs text-cp-text-muted shadow-lg hover:text-cp-text"
-        title={t('canvas.search.open', 'Gerät suchen (Strg+F)')}
+      <div
+        ref={containerRef}
+        className={`pointer-events-auto absolute z-20 flex items-center gap-1 rounded-cp-control border border-cp-border bg-cp-surface-1 px-cp-2 py-cp-2 shadow-lg ${posClass}`}
+        style={posStyle}
       >
-        <Icon icon={Search} size="sm" />
-        {t('canvas.search.placeholder', 'Gerät suchen…')}
-      </button>
+        {Grip}
+        <button
+          type="button"
+          onClick={() => {
+            setOpen(true)
+            requestAnimationFrame(() => inputRef.current?.focus())
+          }}
+          className="flex items-center gap-2 text-cp-xs text-cp-text-muted hover:text-cp-text"
+          title={t('canvas.search.open', 'Gerät suchen (Strg+F)')}
+        >
+          <Icon icon={Search} size="sm" />
+          {t('canvas.search.placeholder', 'Gerät suchen…')}
+        </button>
+      </div>
     )
   }
 
   return (
-    <div className="pointer-events-auto absolute top-3 left-1/2 z-20 w-80 -translate-x-1/2 rounded-cp-modal border border-cp-border bg-cp-surface-1 shadow-2xl">
+    <div
+      ref={containerRef}
+      className={`pointer-events-auto absolute z-20 w-80 rounded-cp-modal border border-cp-border bg-cp-surface-1 shadow-2xl ${posClass}`}
+      style={posStyle}
+    >
       <div className="flex items-center gap-2 border-b border-cp-border px-cp-3 py-cp-2">
+        {Grip}
         <Icon icon={Search} size="sm" />
         <input
           ref={inputRef}

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -811,6 +811,7 @@ export const en: Dict = {
   'canvas.empty.loadDemo': 'Load example project',
   'canvas.search.open': 'Find device (Ctrl+F)',
   'canvas.search.placeholder': 'Find device…',
+  'canvas.search.move': 'Move search bar',
   'canvas.search.none': 'No matches',
   'statusbar.equipment': '{count} devices',
   'statusbar.cables': '{count} cables',

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -210,6 +210,10 @@ interface PersistedUiState {
   /** #118 — Schwebende Inline-Selektions-Toolbar (Schnellaktionen direkt
    *  neben der Auswahl). Default an; abschaltbar in den Einstellungen. */
   inlineToolbarEnabled: boolean
+  /** Position der schwebenden Canvas-Geräte-Suche (px, relativ zur
+   *  Canvas-Fläche). `null` = Default oben mittig. Wird beim Verschieben
+   *  per Grip gesetzt und merkt sich die Lage. */
+  canvasSearchPos: { x: number; y: number } | null
   /** v7.9.112 / Issue #234 — Global Toggle der ALLE Kabel-Labels
    *  ausblendet, unabhaengig vom per-Kabel labelPosition. Praktisch
    *  fuer aufgeraeumte Plan-Ansicht beim Praesentieren ohne dass jedes
@@ -340,6 +344,7 @@ const defaults: PersistedUiState = {
   deviceConfigLibrary: [],
   cableBumps: false,
   inlineToolbarEnabled: true,
+  canvasSearchPos: null,
   hideAllCableLabels: false,
   offPageShowNames: false,
   showCableEndpointLabels: false,
@@ -422,6 +427,16 @@ const load = (): PersistedUiState => {
     if (!Array.isArray(merged.deviceConfigLibrary)) merged.deviceConfigLibrary = []
     if (typeof merged.cableBumps !== 'boolean') merged.cableBumps = defaults.cableBumps
     if (typeof merged.inlineToolbarEnabled !== 'boolean') merged.inlineToolbarEnabled = defaults.inlineToolbarEnabled
+    if (
+      merged.canvasSearchPos != null &&
+      !(
+        typeof merged.canvasSearchPos === 'object' &&
+        typeof merged.canvasSearchPos.x === 'number' &&
+        typeof merged.canvasSearchPos.y === 'number'
+      )
+    ) {
+      merged.canvasSearchPos = defaults.canvasSearchPos
+    }
     if (merged.libraryViewMode !== 'list' && merged.libraryViewMode !== 'grid')
       merged.libraryViewMode = defaults.libraryViewMode
     if (
@@ -666,6 +681,7 @@ interface UiState extends PersistedUiState {
   replaceDeviceConfigLibrary: (entries: DeviceConfigEntry[]) => void
   setCableBumps: (value: boolean) => void
   setInlineToolbarEnabled: (value: boolean) => void
+  setCanvasSearchPos: (value: { x: number; y: number } | null) => void
   setHideAllCableLabels: (value: boolean) => void
   setOffPageShowNames: (value: boolean) => void
   setShowCableEndpointLabels: (value: boolean) => void
@@ -1134,6 +1150,7 @@ export const useUiStore = create<UiState>((set) => ({
     set((state) => applyPatch({ deviceConfigLibrary: entries })(state)),
   setCableBumps: (value) => set(applyPatch({ cableBumps: value })),
   setInlineToolbarEnabled: (value) => set(applyPatch({ inlineToolbarEnabled: value })),
+  setCanvasSearchPos: (value) => set(applyPatch({ canvasSearchPos: value })),
   setHideAllCableLabels: (value) => set(applyPatch({ hideAllCableLabels: value })),
   setOffPageShowNames: (value) => set(applyPatch({ offPageShowNames: value })),
   setShowCableEndpointLabels: (value) => set(applyPatch({ showCableEndpointLabels: value })),


### PR DESCRIPTION
## Übersicht

Zwei Teile aus dem Drag-Test-Auftrag:

### 1. Fix: Canvas-Geräte-Suche verschiebbar (#user)
Die schwebende Geräte-Suchleiste (oben mittig, öffnet mit Strg/Cmd+F) war hart auf `top-3 left-1/2` gepinnt und ließ sich **nicht verschieben**. Jetzt:
- **Grip-Griff** links an der Leiste → per Pointer frei positionierbar, auf die Canvas-Fläche geclampt.
- Drag (am Griff) und Klick/Tippen (Rest) sind sauber getrennt.
- Position **persistiert** im uiStore (`canvasSearchPos`) und bleibt nach Reload erhalten. Default weiterhin oben mittig.
- Headless verifiziert: Leiste bewegt sich (732,62 → 405,295) und Position bleibt nach Reload.

### 2. Headless Drag-/Interaktions-Harness
`scripts/drag-test.mjs` + `npm run test:drag` — treibt den echten Renderer (Vite + ReactFlow) via Playwright/Chromium, prüft Verschiebbarkeit von Geräten/Location-Rahmen, die Inline-Toolbar (#118) und sammelt Renderer-Konsolenfehler (Screenshots → `CP_UI_SHOTS`).

### Befund zur „Geräte nicht verschiebbar"-Beobachtung
Geräte **sind** verschiebbar; was sich wie „klemmt" anfühlt, ist der **Overlap-Schutz (#183)**, der Drops auf belegte Flächen zurücksetzt. (Details im Chat.)

### Validierung
- `npx tsc -p tsconfig.app.json --noEmit` → 0 Errors
- `npm test` → 74/74 grün · `eslint` sauber
- `npm run test:drag` → alle Checks grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)