### PR TITLE
ci: Doku-Kennzahlen bei jedem Merge automatisch aktuell halten

### DIFF
--- a/.github/workflows/docs-stats.yml
+++ b/.github/workflows/docs-stats.yml
@@ -1,0 +1,55 @@
+name: Doku-Kennzahlen aktualisieren
+
+# Hält die maschinell zählbaren Doku-Kennzahlen bei JEDEM Merge auf main
+# automatisch aktuell: Version, Modul-Anzahl, LOC, Store-Slices,
+# Komponenten-Subdomänen und src/-Größe in CLAUDE.md, docs/architecture.md,
+# docs/app-structure.html und docs/comparison.html.
+#
+# Deterministisch (reines Node-Skript, kein API-Key) und committet das
+# Ergebnis direkt zurück. Pushes mit GITHUB_TOKEN lösen KEINEN weiteren
+# Workflow-Lauf aus → keine Endlosschleife.
+#
+# Für die *inhaltliche* Doku-Prüfung (Prosa, Feature-Listen, Links) gibt es
+# zusätzlich den wöchentlichen KI-Auditor in docs-sync.yml.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'package.json'
+      - 'scripts/update-doc-stats.mjs'
+      - '.github/workflows/docs-stats.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# Nicht zwei Läufe gleichzeitig; laufenden NICHT abbrechen (sonst halber Commit).
+concurrency:
+  group: docs-stats
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+
+      - name: Kennzahlen berechnen und Doku aktualisieren
+        run: node scripts/update-doc-stats.mjs
+
+      - name: Änderungen committen (falls vorhanden)
+        run: |
+          if git diff --quiet -- CLAUDE.md docs/architecture.md docs/app-structure.html docs/comparison.html; then
+            echo "Doku-Kennzahlen bereits aktuell — nichts zu committen."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CLAUDE.md docs/architecture.md docs/app-structure.html docs/comparison.html
+          git commit -m "docs: Kennzahlen automatisch aktualisieren"
+          git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,15 @@ npm run test:crdt                        # CRDT-Konvergenz (scripts/crdt-converg
 npm run test:signaling                   # Signaling-Relay (baut main vorher)
 npm run ui:smoke                         # UI-Smoke (scripts/ui-smoke.mjs)
 npm run test:drag                        # Headless Drag-/Interaktions-Test (scripts/drag-test.mjs, braucht laufenden dev:renderer)
+npm run docs:stats                       # Doku-Kennzahlen (Version/Module/LOC/Slices/Subdomänen) neu berechnen + in Doku schreiben
 ```
+
+**Doku-Kennzahlen-Automatik:** `scripts/update-doc-stats.mjs` hält die
+maschinell zählbaren Zahlen in `CLAUDE.md`, `docs/architecture.md`,
+`docs/app-structure.html`, `docs/comparison.html` aktuell. Der Workflow
+`.github/workflows/docs-stats.yml` führt es bei **jedem Merge auf main** aus und
+committet Differenzen zurück. Prosa/Feature-Drift prüft zusätzlich der
+wöchentliche KI-Auditor `docs-sync.yml`.
 
 Es gibt **fünf tsconfigs** — pro Prozess eine: `tsconfig.main.json` (main, ESM
 node16), `tsconfig.preload.json` (preload, **CommonJS**), `tsconfig.app.json`

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -61,14 +61,14 @@
 <header>
   <h1>Cable-Planner — Strukturvergleich mit ähnlichen Tools</h1>
   <div class="subtitle">Architektur, Tech-Stack und Domänen-Tiefe im Vergleich zu kommerziellen und Open-Source-Alternativen</div>
-  <div class="meta">Stand: 2026-06 · v8.2.1 · ~346 TS/TSX-Module · ~99.7k LOC · ~4.9 MB src/</div>
+  <div class="meta">Stand: 2026-06 · v8.2.1 · ~346 TS/TSX-Module · ~99.7k LOC · ~4.0 MB src/</div>
 </header>
 
 <h2>1 · Cable-Planner — Architektur-Kennzahlen</h2>
 
 <div class="stat-grid">
-  <div class="stat"><div class="num">166</div><div class="label">TS/TSX-Module</div></div>
-  <div class="stat"><div class="num">61.5k</div><div class="label">Lines of Code</div></div>
+  <div class="stat"><div class="num">346</div><div class="label">TS/TSX-Module</div></div>
+  <div class="stat"><div class="num">99.7k</div><div class="label">Lines of Code</div></div>
   <div class="stat"><div class="num">~75</div><div class="label">Modul-Dependencies</div></div>
   <div class="stat"><div class="num">7</div><div class="label">User-Flows</div></div>
 </div>

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "test:watch": "vitest",
     "ui:smoke": "node scripts/ui-smoke.mjs",
     "test:drag": "node scripts/drag-test.mjs",
+    "docs:stats": "node scripts/update-doc-stats.mjs",
     "test:crdt": "node scripts/crdt-convergence-check.mjs",
     "test:signaling": "npm run build:main && node scripts/signaling-relay-check.mjs",
     "dist": "npm run build && electron-builder",

--- a/scripts/update-doc-stats.mjs
+++ b/scripts/update-doc-stats.mjs
@@ -1,0 +1,132 @@
+// Hält die maschinell zählbaren Doku-Kennzahlen automatisch aktuell.
+//
+// Aktualisiert in CLAUDE.md, docs/architecture.md, docs/app-structure.html und
+// docs/comparison.html die abgeleiteten Zahlen:
+//   - Version (aus package.json)
+//   - Anzahl TS/TSX-Module in src/
+//   - Gesamt-LOC (~Nk)
+//   - Anzahl Store-Slices (src/renderer/store/slices/)
+//   - Anzahl Komponenten-Subdomänen (src/renderer/components/)
+//   - src/-Größe in MB (nur comparison.html)
+//
+// Lauf:  node scripts/update-doc-stats.mjs          (schreibt Änderungen)
+//        node scripts/update-doc-stats.mjs --check   (Exit 1 wenn veraltet)
+//
+// Wird von .github/workflows/docs-stats.yml bei jedem Merge auf main
+// ausgeführt; bei Differenzen committet der Workflow das Ergebnis zurück.
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ROOT = process.cwd()
+const CHECK = process.argv.includes('--check')
+
+// ---- Kennzahlen aus dem Code berechnen ------------------------------------
+const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8'))
+const version = pkg.version
+
+const walk = (dir, exts) => {
+  let files = []
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, e.name)
+    if (e.isDirectory()) files = files.concat(walk(p, exts))
+    else if (exts.some((x) => e.name.endsWith(x))) files.push(p)
+  }
+  return files
+}
+
+const srcFiles = walk(join(ROOT, 'src'), ['.ts', '.tsx'])
+const moduleCount = srcFiles.length
+let loc = 0
+let bytes = 0
+for (const f of srcFiles) {
+  const txt = readFileSync(f, 'utf-8')
+  // wie `wc -l`: Anzahl Zeilenumbrüche (idempotent, env-unabhängig)
+  loc += txt.split('\n').length - 1
+  bytes += Buffer.byteLength(txt, 'utf-8')
+}
+// LOC inkl. aller src-Dateien (nicht nur ts/tsx) für die MB-Angabe konsistent:
+const allSrc = walk(join(ROOT, 'src'), [''])
+let srcBytes = 0
+for (const f of allSrc) {
+  try {
+    srcBytes += statSync(f).size
+  } catch {
+    /* ignore */
+  }
+}
+
+const sliceCount = readdirSync(join(ROOT, 'src/renderer/store/slices')).filter((f) =>
+  f.endsWith('.ts'),
+).length
+const componentDirCount = readdirSync(join(ROOT, 'src/renderer/components'), {
+  withFileTypes: true,
+}).filter((e) => e.isDirectory()).length
+
+const locK = `${(loc / 1000).toFixed(1)}k`
+const srcMB = `${(srcBytes / (1024 * 1024)).toFixed(1)} MB`
+
+const stats = { version, moduleCount, locK, sliceCount, componentDirCount, srcMB }
+
+// ---- Doku-Dateien aktualisieren -------------------------------------------
+// Jede Regel ersetzt eine stabil formatierte Phrase. Bewusst eng gefasst,
+// damit nur die Kennzahlen angefasst werden, nicht beliebiger Fließtext.
+const rules = [
+  // Version direkt vor "· ~N TS/TSX-Module" (nur die Stat-Zeilen, keine Issue-Refs)
+  [/v\d+\.\d+\.\d+(?=[^\n]*TS\/TSX-Module)/g, `v${version}`],
+  // Modul-Anzahl
+  [/~\d+ TS\/TSX-Module/g, `~${moduleCount} TS/TSX-Module`],
+  // Gesamt-LOC (~Nk)
+  [/~[\d.]+k LOC/g, `~${locK} LOC`],
+  // Store-Slices
+  [/\b\d+ Slices\b/g, `${sliceCount} Slices`],
+  // Komponenten-Subdomänen
+  [/\b\d+ Subdomänen\b/g, `${componentDirCount} Subdomänen`],
+  // src/-Größe (nur comparison.html-Format)
+  [/~[\d.]+ MB src\//g, `~${srcMB} src/`],
+  // comparison.html Stat-Grid-Karten (eigenes <div class="num">…</div>-Format)
+  [
+    /(<div class="num">)\d+(<\/div><div class="label">TS\/TSX-Module<\/div>)/g,
+    `$1${moduleCount}$2`,
+  ],
+  [
+    /(<div class="num">)[\d.]+k(<\/div><div class="label">Lines of Code<\/div>)/g,
+    `$1${locK}$2`,
+  ],
+]
+
+const targets = [
+  'CLAUDE.md',
+  'docs/architecture.md',
+  'docs/app-structure.html',
+  'docs/comparison.html',
+]
+
+let changedFiles = []
+for (const rel of targets) {
+  const path = join(ROOT, rel)
+  let txt
+  try {
+    txt = readFileSync(path, 'utf-8')
+  } catch {
+    continue
+  }
+  let next = txt
+  for (const [re, repl] of rules) next = next.replace(re, repl)
+  if (next !== txt) {
+    changedFiles.push(rel)
+    if (!CHECK) writeFileSync(path, next)
+  }
+}
+
+console.log('Doku-Kennzahlen:', JSON.stringify(stats))
+if (changedFiles.length === 0) {
+  console.log('Doku ist aktuell — keine Änderungen.')
+  process.exit(0)
+}
+if (CHECK) {
+  console.error('Veraltete Doku-Kennzahlen in:', changedFiles.join(', '))
+  console.error('→ `node scripts/update-doc-stats.mjs` ausführen und committen.')
+  process.exit(1)
+}
+console.log('Aktualisiert:', changedFiles.join(', '))


### PR DESCRIPTION
## Übersicht

Hält die maschinell zählbaren Doku-Kennzahlen bei **jedem Merge auf `main`** automatisch aktuell — genau die Werte, die zuletzt manuell korrigiert werden mussten.

### Wie es funktioniert
- **`scripts/update-doc-stats.mjs`** (reines Node, keine Deps): berechnet aus dem Code
  - Version (package.json), Anzahl TS/TSX-Module, Gesamt-LOC (`~Nk`, wie `wc -l`), Store-Slices, Komponenten-Subdomänen, `src/`-Größe (MB)
  - und schreibt sie in **CLAUDE.md, docs/architecture.md, docs/app-structure.html, docs/comparison.html** (inkl. Stat-Grid-Karten).
  - Idempotent; `--check`-Modus (Exit 1 bei veralteten Zahlen) für optionale CI-Gates.
  - Auch via `npm run docs:stats`.
- **`.github/workflows/docs-stats.yml`**: läuft bei `push` auf `main` (Pfade `src/**`, `package.json`, das Skript selbst), aktualisiert die Doku und committet Differenzen via `GITHUB_TOKEN` zurück. Pushes mit `GITHUB_TOKEN` lösen **keinen** weiteren Lauf aus → keine Endlosschleife.

### Abgrenzung
Ergänzt den bereits vorhandenen wöchentlichen KI-Auditor `docs-sync.yml`, der *inhaltliche* Drift (Prosa, Feature-Listen, Links) per PR prüft. Der neue Workflow ist der schnelle, deterministische Teil für die reinen Zahlen — passend für „bei jedem Merge".

### Validierung
- Skript idempotent (`--check` Exit 0 bei aktuellem Stand), Stat-Grid in comparison.html korrigiert (166→346, 61.5k→99.7k)
- Workflow-YAML geparst, `package.json` valide, `eslint` 0 Fehler

> Hinweis: Der Workflow braucht keine Secrets. Damit der Bot-Commit auf `main` durchgeht, muss „Allow GitHub Actions to create and approve …"/Branch-Protection ggf. Bot-Pushes erlauben — bei Standard-Repos ist der `contents: write`-Token ausreichend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvdNHBUVagyR4fhekcp6rv)_