### PR TITLE
feat(camera-link): MultiCam-Kameras als Equipment importieren

### DIFF
--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
+import { useEffect, useRef, useState, useSyncExternalStore, type ChangeEvent } from 'react'
 import {
   FileText, Clapperboard, FolderOpen, Save, SaveAll, Ruler, Upload, FileDown,
   Image as ImageIcon, Calculator, Eye, MessageSquare, Paperclip, Plug, Cable,
@@ -25,6 +25,7 @@ import { useProjectStore } from '../../store/projectStore'
 import { useModule } from '../../store/settingsStore'
 import { exportStagePlotSvg } from '../../lib/exportStagePlot'
 import { downloadBlob } from '../../lib/downloadBlob'
+import { parseCameraList, cameraListToEquipment } from '../../lib/multicamCameraImport'
 import { buildExportFilename } from '../../lib/exportFilename'
 import { hasDesktopBridge, cablePlannerApi } from '../../lib/bridge'
 import { infoDialog } from '../../lib/infoDialog'
@@ -97,6 +98,27 @@ export const MenuBar = ({
   projectName,
 }: MenuBarProps) => {
   const t = useTranslation()
+
+  // MultiCam-Planner-Kameras (.cameras.json) als Equipment-Nodes importieren.
+  const cameraImportRef = useRef<HTMLInputElement | null>(null)
+  const handleImportCameras = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) {
+      try {
+        const items = cameraListToEquipment(parseCameraList(await file.text()))
+        useProjectStore.getState().importEquipment(items)
+        await infoDialog(
+          `${items.length} ${t('app.menu.file.importCamerasDone', 'MultiCam-Kamera(s) als Equipment importiert.')}`,
+        )
+      } catch {
+        await infoDialog(
+          t('app.menu.file.importCamerasError', 'Kamera-Import fehlgeschlagen — keine gültige MultiCam-Kameraliste.'),
+          { tone: 'error' },
+        )
+      }
+    }
+    if (cameraImportRef.current) cameraImportRef.current.value = ''
+  }
 
   // #pre-sale — Manueller "Auf Updates prüfen…"-Flow (Auto-Update beim Quit
   // läuft separat). Zeigt Resultat als Dialog; bei verfügbarem Update bietet
@@ -191,6 +213,7 @@ export const MenuBar = ({
   )
   return (
     <header className="flex shrink-0 items-center justify-between gap-3 border-b border-[var(--cp-border)] bg-[var(--cp-surface-3)] px-3 py-1.5 text-cp-xs shadow-sm">
+      <input ref={cameraImportRef} type="file" accept=".cameras.json,.json" className="hidden" onChange={handleImportCameras} />
       <div className="flex shrink-0 items-center gap-2">
         <span className="hidden select-none font-semibold tracking-wide text-cp-text-secondary lg:inline">
           {t('app.title', 'Cable Planner')}
@@ -222,6 +245,9 @@ export const MenuBar = ({
               </MenuItem>
             </>
           )}
+          <MenuItem onClick={() => cameraImportRef.current?.click()} icon={<Icon icon={ImportIcon} size="sm" />}>
+            {t('app.menu.file.importCameras', 'MultiCam-Kameras importieren…')}
+          </MenuItem>
           <MenuSep />
           {/* v7.9.2 — Vereinheitlichter Export-Hub. Statt 5 separater
               Menü-Einträge (Plan PDF/PNG/JPEG, Kabel-BOM, Drucken)

--- a/src/renderer/lib/multicamCameraImport.ts
+++ b/src/renderer/lib/multicamCameraImport.ts
@@ -1,0 +1,79 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Import von MultiCam-Planner-Kameras als Equipment (`camera-list` v1)
+//
+// Der MultiCam-Planner exportiert seine platzierten Kameras als neutrale
+// Kamera-Liste (Modell, Hersteller, Venue-Position). Hier werden sie zu
+// EquipmentItems der Kategorie "Kameras": passt ein Modell zum CAMERA_CATALOG,
+// erbt es dessen echte Port-Belegung (SDI/HDMI/XLR…), sonst bekommt es einen
+// generischen SDI-Ausgang. So kann man in MultiCam platzierte Kameras hier
+// direkt verkabeln. Gegenstueck: multicam-planner src/utils/cameraExport.ts.
+// ───────────────────────────────────────────────────────────────────────────
+import type { EquipmentItem, Port } from '../types/equipment'
+import { CAMERA_CATALOG } from './cameraCatalog'
+
+export const CAMERA_LIST_KIND = 'camera-list' as const
+export const CAMERA_LIST_VERSION = 1 as const
+
+export interface CameraListEntry {
+  id: string
+  label: string
+  manufacturer?: string
+  model?: string
+  x?: number // Meter im Venue
+  y?: number
+}
+export interface CameraListExchange {
+  kind: typeof CAMERA_LIST_KIND
+  formatVersion: typeof CAMERA_LIST_VERSION
+  app: string
+  appVersion: string
+  exportedAt: string
+  cameras: CameraListEntry[]
+}
+
+export function parseCameraList(text: string): CameraListExchange {
+  const data = JSON.parse(text) as Partial<CameraListExchange>
+  if (!data || data.kind !== CAMERA_LIST_KIND) {
+    throw new Error('Keine gueltige Kamera-Liste (kind != camera-list).')
+  }
+  if (data.formatVersion !== CAMERA_LIST_VERSION) {
+    throw new Error(`Nicht unterstuetzte Kamera-Listen-Version: ${data.formatVersion}`)
+  }
+  if (!Array.isArray(data.cameras)) throw new Error('Kamera-Liste ohne cameras-Array.')
+  return data as CameraListExchange
+}
+
+// Venue-Meter → Canvas-Pixel (grobe Platzierung; der User ordnet danach an).
+const PX_PER_METER = 120
+
+const clonePort = (p: Port): Port => ({ ...p, id: '' })
+
+function matchTemplate(entry: CameraListEntry) {
+  const hay = `${entry.manufacturer ?? ''} ${entry.model ?? ''}`.toLowerCase().trim()
+  if (!hay) return undefined
+  for (const c of CAMERA_CATALOG) {
+    if (c.match.some((m) => hay.includes(m.toLowerCase()))) return c.template
+  }
+  return undefined
+}
+
+/** Neutrale Kamera-Liste → Equipment-Nodes (Kategorie "Kameras"). */
+export function cameraListToEquipment(ex: CameraListExchange): EquipmentItem[] {
+  const fallbackOut: Port[] = [{ id: '', name: 'SDI Out', type: 'BNC', connectorType: 'BNC' }]
+  return ex.cameras.map((c, i) => {
+    const tmpl = matchTemplate(c)
+    const outputs: Port[] = (tmpl?.outputs ?? fallbackOut).map(clonePort)
+    const inputs: Port[] = (tmpl?.inputs ?? []).map(clonePort)
+    return {
+      id: c.id || '',
+      name: c.label || tmpl?.name || 'Kamera',
+      category: 'Kameras',
+      inputs,
+      outputs,
+      width: tmpl?.width ?? 240,
+      height: tmpl?.height ?? 200,
+      x: Math.round((c.x ?? i * 2) * PX_PER_METER),
+      y: Math.round((c.y ?? 0) * PX_PER_METER),
+    }
+  })
+}

--- a/tests/multicamCameraImport.test.ts
+++ b/tests/multicamCameraImport.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import {
+  cameraListToEquipment,
+  parseCameraList,
+  type CameraListExchange,
+} from '../src/renderer/lib/multicamCameraImport'
+
+const sample: CameraListExchange = {
+  kind: 'camera-list',
+  formatVersion: 1,
+  app: 'multicam-planner',
+  appVersion: '0.4.0',
+  exportedAt: '2026-06-30T00:00:00.000Z',
+  cameras: [
+    { id: 'c1', label: 'CAM 1', manufacturer: 'Sony', model: 'PMW-F55', x: 5, y: 7 },
+    { id: 'c2', label: 'CAM 2', manufacturer: 'NoName', model: 'Mystery 9000', x: 2, y: 3 },
+  ],
+}
+
+describe('multicamCameraImport (Cable ← MultiCam)', () => {
+  it('mappt Kameras auf Equipment der Kategorie "Kameras"', () => {
+    const items = cameraListToEquipment(sample)
+    expect(items).toHaveLength(2)
+    expect(items.every((e) => e.category === 'Kameras')).toBe(true)
+    expect(items[0].name).toBe('CAM 1')
+    // Venue-Meter → Canvas-Pixel.
+    expect(items[0].x).toBe(5 * 120)
+    expect(items[0].y).toBe(7 * 120)
+  })
+
+  it('erbt echte Ports aus dem CAMERA_CATALOG bei bekanntem Modell', () => {
+    const [f55] = cameraListToEquipment(sample)
+    // Sony PMW-F55 hat im Katalog mehrere SDI-/HDMI-Ausgaenge.
+    expect(f55.outputs.length).toBeGreaterThan(1)
+    expect(f55.outputs.some((p) => p.connectorType === 'BNC')).toBe(true)
+  })
+
+  it('gibt unbekannten Modellen einen generischen SDI-Ausgang', () => {
+    const mystery = cameraListToEquipment(sample)[1]
+    expect(mystery.outputs).toHaveLength(1)
+    expect(mystery.outputs[0]).toMatchObject({ name: 'SDI Out', connectorType: 'BNC' })
+  })
+
+  it('parseCameraList lehnt fremde Dateien ab', () => {
+    expect(() => parseCameraList('{"kind":"venue-exchange"}')).toThrow()
+    expect(() => parseCameraList(JSON.stringify(sample))).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Übersicht

Schlägt die Brücke **MultiCam-Planner → Cable-Planner**: in MultiCam platzierte Kameras lassen sich als neutrale `.cameras.json` exportieren und hier als **Equipment-Nodes** importieren — dann kann man sie direkt verkabeln. Das ist die „Wo stehen die Kameras?" ↔ „Wie sind sie verkabelt?"-Verknüpfung (Stufe B aus `docs/MERGE_INTO_CABLE_PLANNER.md` / `multicam:docs/venue-suite-architecture.md`), ohne Repo-Merge.

## Änderungen
- **`src/renderer/lib/multicamCameraImport.ts`** — `camera-list` v1 → `EquipmentItem[]` (Kategorie „Kameras"). Bekanntes Modell **erbt echte Ports** aus dem bestehenden `CAMERA_CATALOG` (SDI/HDMI/XLR…), unbekanntes bekommt einen generischen SDI-Ausgang. Venue-Meter → Canvas-Pixel. Rein, headless-testbar.
- **`src/renderer/components/Layout/MenuBar.tsx`** — Datei-Menü „MultiCam-Kameras importieren…" (versteckter File-Input → `importEquipment`). Nutzt die bestehende `importEquipment`-Slice-Action, keine neue IPC nötig.
- **`tests/multicamCameraImport.test.ts`** — Mapping auf „Kameras", Katalog-Port-Vererbung (Sony PMW-F55), generischer Fallback, Format-Ablehnung.

Gegenstück im MultiCam-Planner: `src/utils/cameraExport.ts` + Header-Button „→ Cable".

## Validierung
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm run build` — grün (main + preload + renderer)
- `npm test` — grün, **78/78** (4 neu)
- `npm run lint` — grün (0 Errors)

## Hinweis
- Neue UI-Strings nutzen `t('app.menu.file.importCameras…', 'Deutscher Fallback')`; EN-Einträge in `lib/i18n.ts` können bei Bedarf nachgezogen werden (fehlende Keys fallen sauber auf Deutsch zurück).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018Db9MeqzyxDR6oCJxwUhxA)_