### PR TITLE
feat(avplan): verlustfreies .avplan-Gesamtformat (Cable-Seite)

### DIFF
--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -26,6 +26,8 @@ import { useModule } from '../../store/settingsStore'
 import { exportStagePlotSvg } from '../../lib/exportStagePlot'
 import { downloadBlob } from '../../lib/downloadBlob'
 import { parseCameraList, cameraListToEquipment } from '../../lib/multicamCameraImport'
+import { cableToAvPlan, parseAvPlan } from '../../lib/avplan'
+import type { CablePlannerProject } from '../../types/project'
 import { buildExportFilename } from '../../lib/exportFilename'
 import { hasDesktopBridge, cablePlannerApi } from '../../lib/bridge'
 import { infoDialog } from '../../lib/infoDialog'
@@ -118,6 +120,36 @@ export const MenuBar = ({
       }
     }
     if (cameraImportRef.current) cameraImportRef.current.value = ''
+  }
+
+  // ── Gesamtprojekt (.avplan): verlustfrei. Cable bearbeitet den cabling-Slot
+  // nativ und bewahrt geteilten Raum + Kamera-/Licht-Domaenen 1:1 (in der
+  // .avplan UND im eigenen Projektfile via project.avForeign).
+  const avplanImportRef = useRef<HTMLInputElement | null>(null)
+  const handleExportAvplan = () => {
+    const project = useProjectStore.getState().project
+    const avplan = cableToAvPlan(project, { appVersion: __APP_VERSION__, exportedAt: new Date().toISOString() })
+    const safe = (project.metadata?.name || 'projekt').replace(/[^a-zA-Z0-9_-]+/g, '_')
+    downloadBlob(`${safe}.avplan`, JSON.stringify(avplan, null, 2), 'application/json')
+  }
+  const handleImportAvplan = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) {
+      try {
+        const avplan = parseAvPlan(await file.text())
+        const base = (avplan.domains.cabling as CablePlannerProject | undefined) ?? useProjectStore.getState().project
+        useProjectStore.getState().loadProject({
+          ...base,
+          avForeign: { venue: avplan.venue, cameras: avplan.domains.cameras, lighting: avplan.domains.lighting },
+        })
+      } catch {
+        await infoDialog(
+          t('app.menu.file.importAvplanError', 'Import fehlgeschlagen — keine gültige .avplan-Datei.'),
+          { tone: 'error' },
+        )
+      }
+    }
+    if (avplanImportRef.current) avplanImportRef.current.value = ''
   }
 
   // #pre-sale — Manueller "Auf Updates prüfen…"-Flow (Auto-Update beim Quit
@@ -214,6 +246,7 @@ export const MenuBar = ({
   return (
     <header className="flex shrink-0 items-center justify-between gap-3 border-b border-[var(--cp-border)] bg-[var(--cp-surface-3)] px-3 py-1.5 text-cp-xs shadow-sm">
       <input ref={cameraImportRef} type="file" accept=".cameras.json,.json" className="hidden" onChange={handleImportCameras} />
+      <input ref={avplanImportRef} type="file" accept=".avplan,.json" className="hidden" onChange={handleImportAvplan} />
       <div className="flex shrink-0 items-center gap-2">
         <span className="hidden select-none font-semibold tracking-wide text-cp-text-secondary lg:inline">
           {t('app.title', 'Cable Planner')}
@@ -247,6 +280,13 @@ export const MenuBar = ({
           )}
           <MenuItem onClick={() => cameraImportRef.current?.click()} icon={<Icon icon={ImportIcon} size="sm" />}>
             {t('app.menu.file.importCameras', 'MultiCam-Kameras importieren…')}
+          </MenuItem>
+          <MenuSep />
+          <MenuItem onClick={handleExportAvplan} icon={<Icon icon={Upload} size="sm" />}>
+            {t('app.menu.file.exportAvplan', 'Gesamtprojekt exportieren (.avplan)…')}
+          </MenuItem>
+          <MenuItem onClick={() => avplanImportRef.current?.click()} icon={<Icon icon={ImportIcon} size="sm" />}>
+            {t('app.menu.file.importAvplan', 'Gesamtprojekt importieren (.avplan)…')}
           </MenuItem>
           <MenuSep />
           {/* v7.9.2 — Vereinheitlichter Export-Hub. Statt 5 separater

--- a/src/renderer/lib/avplan.ts
+++ b/src/renderer/lib/avplan.ts
@@ -1,0 +1,86 @@
+// ───────────────────────────────────────────────────────────────────────────
+// .avplan — gemeinsames, VERLUSTFREIES Gesamtprojektformat fuer alle drei Apps
+//
+// Schema-identisch zu light-planner src/core/avplan.ts und multicam-planner
+// src/utils/avplan.ts. Der Cable-Planner bearbeitet den "cabling"-Slot nativ
+// und reicht den geteilten Raum (`venue`) plus "cameras"/"lighting" 1:1 durch —
+// hier zusaetzlich im eigenen Projektfile aufbewahrt (CablePlannerProject.
+// avForeign), damit auch ueber das native .cp-Speichern nichts verloren geht.
+// ───────────────────────────────────────────────────────────────────────────
+
+export const AVPLAN_KIND = 'avplan' as const
+export const AVPLAN_VERSION = 1 as const
+
+/** Geteilter Raum — gleiche Form wie das venue-exchange `.venue` der anderen Apps. */
+export interface AvVenue {
+  name: string
+  widthM?: number
+  heightM?: number
+  persons: unknown[]
+  walls: unknown[]
+  stageObjects: unknown[]
+  floorPlan?: unknown
+}
+
+export interface AvPlan {
+  kind: typeof AVPLAN_KIND
+  formatVersion: typeof AVPLAN_VERSION
+  app: string
+  appVersion: string
+  exportedAt: string
+  venue: AvVenue
+  domains: {
+    cameras?: unknown
+    lighting?: unknown
+    cabling?: unknown
+  }
+}
+
+export function makeAvPlan(args: {
+  app: string
+  appVersion: string
+  exportedAt: string
+  venue: AvVenue
+  domains: AvPlan['domains']
+}): AvPlan {
+  return {
+    kind: AVPLAN_KIND,
+    formatVersion: AVPLAN_VERSION,
+    app: args.app,
+    appVersion: args.appVersion,
+    exportedAt: args.exportedAt,
+    venue: args.venue,
+    domains: { ...args.domains },
+  }
+}
+
+export function parseAvPlan(text: string): AvPlan {
+  const data = JSON.parse(text) as Partial<AvPlan>
+  if (!data || data.kind !== AVPLAN_KIND) {
+    throw new Error('Keine gueltige .avplan-Datei (kind != avplan).')
+  }
+  if (data.formatVersion !== AVPLAN_VERSION) {
+    throw new Error(`Nicht unterstuetzte .avplan-Version: ${data.formatVersion}`)
+  }
+  if (!data.venue || !data.domains) throw new Error('.avplan ohne venue/domains.')
+  return data as AvPlan
+}
+
+const EMPTY_VENUE: AvVenue = { name: 'Venue', persons: [], walls: [], stageObjects: [] }
+
+/** Baut eine .avplan aus dem aktuellen Cable-Projekt. Der cabling-Slot ist das
+ *  Projekt ohne sein avForeign-Feld (das wandert auf die Top-Ebene zurueck),
+ *  geteilter Raum + Kamera-/Licht-Domaenen kommen aus dem bewahrten avForeign. */
+export function cableToAvPlan(
+  project: { avForeign?: { venue?: unknown; cameras?: unknown; lighting?: unknown } },
+  meta: { appVersion: string; exportedAt: string },
+): AvPlan {
+  const { avForeign, ...cabling } = project
+  return makeAvPlan({
+    app: 'cable-planner',
+    appVersion: meta.appVersion,
+    exportedAt: meta.exportedAt,
+    venue: (avForeign?.venue as AvVenue | undefined) ?? EMPTY_VENUE,
+    domains: { cabling, cameras: avForeign?.cameras, lighting: avForeign?.lighting },
+  })
+}

--- a/src/renderer/types/project.ts
+++ b/src/renderer/types/project.ts
@@ -165,6 +165,11 @@ export interface CablePlannerProject {
    *  Planer übernimmt/verwirft sie am Desktop; beim Übernehmen wandert die
    *  Änderung ins `changelog`. Optional → alte Projekte heilen zu []. */
   pendingChanges?: PendingChange[]
+  /** .avplan-Passthrough — fremde Domaenen (geteilter Raum + Kamera- + Licht-
+   *  Planung), die der Cable-Planner nicht bearbeitet, aber verlustfrei sowohl
+   *  in der gemeinsamen .avplan als auch im eigenen Projektfile aufbewahrt,
+   *  damit beim App-uebergreifenden Austausch nichts verloren geht. Optional. */
+  avForeign?: { venue?: unknown; cameras?: unknown; lighting?: unknown }
 }
 
 /** #412 — Ein festgeschriebener Projekt-Stand. */

--- a/tests/avplan.test.ts
+++ b/tests/avplan.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { cableToAvPlan, parseAvPlan, makeAvPlan, AVPLAN_KIND, type AvVenue } from '../src/renderer/lib/avplan'
+
+const venue: AvVenue = { name: 'Halle', widthM: 20, heightM: 12, persons: [], walls: [], stageObjects: [] }
+
+describe('avplan (Cable — Slot "cabling")', () => {
+  it('cableToAvPlan legt das Projekt in cabling, fremde Domaenen aus avForeign auf die Top-Ebene', () => {
+    const project = {
+      metadata: { name: 'Show' },
+      equipment: [{ id: 'e1' }],
+      avForeign: {
+        venue,
+        cameras: { cameras: [{ id: 'c1' }] },
+        lighting: { fixtures: [{ id: 'f1', dimming: 0.8 }] },
+      },
+    }
+    const avplan = cableToAvPlan(project, { appVersion: '8.2.0', exportedAt: 't' })
+    expect(avplan.kind).toBe(AVPLAN_KIND)
+    expect(avplan.app).toBe('cable-planner')
+    // cabling-Slot = Projekt OHNE avForeign.
+    expect((avplan.domains.cabling as { avForeign?: unknown }).avForeign).toBeUndefined()
+    expect((avplan.domains.cabling as { equipment: unknown[] }).equipment).toHaveLength(1)
+    // Fremde Domaenen verlustfrei oben.
+    expect(avplan.venue).toEqual(venue)
+    expect(avplan.domains.lighting).toEqual({ fixtures: [{ id: 'f1', dimming: 0.8 }] })
+  })
+
+  it('Passthrough: Cable bearbeitet cabling, Licht/Kamera kommen unveraendert zurueck', () => {
+    const fromLight = makeAvPlan({
+      app: 'light-planner', appVersion: '1.0.0', exportedAt: 't', venue,
+      domains: { lighting: { fixtures: [{ id: 'f1', gelFilterIds: ['L201'] }] }, cameras: { cameras: [] } },
+    })
+    // Cable importiert -> bewahrt fremde Domaenen in project.avForeign.
+    const loaded = parseAvPlan(JSON.stringify(fromLight))
+    const projectAfterImport = {
+      metadata: { name: 'X' }, equipment: [],
+      avForeign: { venue: loaded.venue, cameras: loaded.domains.cameras, lighting: loaded.domains.lighting },
+    }
+    // ... bearbeitet seine Verkabelung und exportiert wieder.
+    projectAfterImport.equipment.push({ id: 'atem' } as never)
+    const reexported = cableToAvPlan(projectAfterImport, { appVersion: '8.2.0', exportedAt: 't2' })
+    expect(reexported.domains.lighting).toEqual(fromLight.domains.lighting)
+    expect((reexported.domains.cabling as { equipment: unknown[] }).equipment).toHaveLength(1)
+  })
+
+  it('lehnt fremde Dateien ab', () => {
+    expect(() => parseAvPlan('{"kind":"cpviewer"}')).toThrow()
+  })
+})


### PR DESCRIPTION
## Übersicht

Führt das **gemeinsame, verlustfreie `.avplan`-Gesamtprojektformat** ein (Cable-Seite). Cable bearbeitet den `cabling`-Slot nativ und **bewahrt den geteilten Raum + Kamera-/Licht-Domänen 1:1** — sowohl in der gemeinsamen `.avplan` als auch im eigenen Projektfile.

## Änderungen
- **`src/renderer/lib/avplan.ts`** — `.avplan` v1 (schema-identisch zu Light/MultiCam) + `cableToAvPlan`.
- **`src/renderer/types/project.ts`** — `CablePlannerProject.avForeign?` (Blaupause `greengoConfig?`): fremde Domänen werden verlustfrei im eigenen `.cp` **und** in der `.avplan` aufbewahrt. `healProjectPositions` reicht das Feld via `...project`-Spread automatisch durch.
- **`src/renderer/components/Layout/MenuBar.tsx`** — Datei-Menü „Gesamtprojekt exportieren/importieren (.avplan)". Nutzt die bestehende `loadProject`-Action.
- **`tests/avplan.test.ts`** — `cableToAvPlan` + Passthrough.

## Validierung
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm run build`, `npm test` (81/81), `npm run lint` (0 Errors) — alle grün.
- Vollständiger 3-App-Round-Trip (light→multicam→cable→light) verlustfrei verifiziert.

Gegenstücke: light `src/core/avplan.ts`, multicam `src/utils/avplan.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018Db9MeqzyxDR6oCJxwUhxA)_