### PR TITLE
feat(avplan): read-only Ansicht der verknüpften Venue-Planung

### DIFF
--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -27,6 +27,7 @@ import { exportStagePlotSvg } from '../../lib/exportStagePlot'
 import { downloadBlob } from '../../lib/downloadBlob'
 import { parseCameraList, cameraListToEquipment } from '../../lib/multicamCameraImport'
 import { cableToAvPlan, parseAvPlan } from '../../lib/avplan'
+import { summarizeForeign, hasForeign } from '../../lib/foreignView'
 import type { CablePlannerProject } from '../../types/project'
 import { buildExportFilename } from '../../lib/exportFilename'
 import { hasDesktopBridge, cablePlannerApi } from '../../lib/bridge'
@@ -150,6 +151,40 @@ export const MenuBar = ({
       }
     }
     if (avplanImportRef.current) avplanImportRef.current.value = ''
+  }
+  const avForeign = useProjectStore((s) => s.project.avForeign)
+  const handleViewForeign = async () => {
+    const sum = summarizeForeign(avForeign)
+    await infoDialog(t('app.menu.file.viewForeignTitle', 'Verknüpfte Venue-Planung (nur Ansicht)'), {
+      bodyNode: (
+        <div className="flex flex-col gap-2 text-cp-xs text-cp-text-secondary">
+          <div>
+            {t('app.menu.file.viewForeignRoom', 'Raum')}:{' '}
+            <b className="text-cp-text">{sum.venueName || '—'}</b> · {sum.counts.walls} Wände ·{' '}
+            {sum.counts.persons} Personen · {sum.counts.stage} Bühne
+          </div>
+          <div>
+            <div className="font-semibold text-cp-text">Kameras ({sum.cameras.length})</div>
+            {sum.cameras.length ? (
+              <ul className="list-disc pl-4">{sum.cameras.map((c) => <li key={c.id}>{c.label}</li>)}</ul>
+            ) : <div>—</div>}
+          </div>
+          <div>
+            <div className="font-semibold text-cp-text">Lampen ({sum.fixtures.length})</div>
+            {sum.fixtures.length ? (
+              <ul className="list-disc pl-4">{sum.fixtures.map((f) => (
+                <li key={f.id}>
+                  {f.name || 'Fixture'}
+                  {f.purpose ? ` · ${f.purpose}` : ''}
+                  {f.colorTemp ? ` · ${f.colorTemp}K` : ''}
+                  {f.dimming != null ? ` · ${Math.round(f.dimming * 100)}%` : ''}
+                </li>
+              ))}</ul>
+            ) : <div>—</div>}
+          </div>
+        </div>
+      ),
+    })
   }
 
   // #pre-sale — Manueller "Auf Updates prüfen…"-Flow (Auto-Update beim Quit
@@ -288,6 +323,11 @@ export const MenuBar = ({
           <MenuItem onClick={() => avplanImportRef.current?.click()} icon={<Icon icon={ImportIcon} size="sm" />}>
             {t('app.menu.file.importAvplan', 'Gesamtprojekt importieren (.avplan)…')}
           </MenuItem>
+          {hasForeign(avForeign) && (
+            <MenuItem onClick={handleViewForeign} icon={<Icon icon={Eye} size="sm" />}>
+              {t('app.menu.file.viewForeign', 'Verknüpfte Venue-Planung ansehen…')}
+            </MenuItem>
+          )}
           <MenuSep />
           {/* v7.9.2 — Vereinheitlichter Export-Hub. Statt 5 separater
               Menü-Einträge (Plan PDF/PNG/JPEG, Kabel-BOM, Drucken)

--- a/src/renderer/lib/foreignView.ts
+++ b/src/renderer/lib/foreignView.ts
@@ -1,0 +1,57 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Read-only Ansicht der fremden .avplan-Domaenen im Cable-Planner.
+//
+// Cables Canvas ist ein Signalfluss-Graph (nicht metrisch), daher werden die
+// verlustfrei mitgefuehrten Domaenen (geteilter Raum + Kamera- + Licht-Planung)
+// als kompakte read-only Uebersicht gezeigt — man kann alles EINSEHEN, ohne es
+// hier zu bearbeiten. Die Domaenen sind `unknown` → alles defensiv, wirft nie.
+// ───────────────────────────────────────────────────────────────────────────
+
+export interface ForeignSummary {
+  venueName?: string
+  counts: { walls: number; persons: number; stage: number }
+  cameras: { id: string; label: string }[]
+  fixtures: { id: string; name?: string; purpose?: string; dimming?: number; colorTemp?: number }[]
+}
+
+const arr = (v: unknown): unknown[] => (Array.isArray(v) ? v : [])
+const num = (v: unknown): number | undefined =>
+  typeof v === 'number' && Number.isFinite(v) ? v : undefined
+const str = (v: unknown): string | undefined => (typeof v === 'string' ? v : undefined)
+
+export type AvForeign = { venue?: unknown; cameras?: unknown; lighting?: unknown } | undefined
+
+export function hasForeign(avForeign: AvForeign): boolean {
+  if (!avForeign) return false
+  const camCount = arr((avForeign.cameras as { cameras?: unknown } | undefined)?.cameras).length
+  const fxCount = arr((avForeign.lighting as { fixtures?: unknown } | undefined)?.fixtures).length
+  return camCount > 0 || fxCount > 0 || !!avForeign.venue
+}
+
+export function summarizeForeign(avForeign: AvForeign): ForeignSummary {
+  const venue = avForeign?.venue as
+    | { name?: unknown; walls?: unknown; persons?: unknown; stageObjects?: unknown }
+    | undefined
+  const cameras = arr((avForeign?.cameras as { cameras?: unknown } | undefined)?.cameras)
+    .filter((c): c is Record<string, unknown> => !!c && typeof c === 'object')
+    .map((c) => ({ id: String(c.id ?? ''), label: str(c.label) ?? 'Kamera' }))
+  const fixtures = arr((avForeign?.lighting as { fixtures?: unknown } | undefined)?.fixtures)
+    .filter((f): f is Record<string, unknown> => !!f && typeof f === 'object')
+    .map((f) => ({
+      id: String(f.id ?? ''),
+      name: str((f.fixture as { name?: unknown } | undefined)?.name),
+      purpose: str(f.purpose),
+      dimming: num(f.dimming),
+      colorTemp: num(f.currentColorTemp),
+    }))
+  return {
+    venueName: str(venue?.name),
+    counts: {
+      walls: arr(venue?.walls).length,
+      persons: arr(venue?.persons).length,
+      stage: arr(venue?.stageObjects).length,
+    },
+    cameras,
+    fixtures,
+  }
+}

--- a/tests/foreignView.test.ts
+++ b/tests/foreignView.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { summarizeForeign, hasForeign } from '../src/renderer/lib/foreignView'
+
+describe('foreignView (Cable read-only Uebersicht der fremden .avplan-Domaenen)', () => {
+  it('fasst Raum, Kameras und Lampen zusammen', () => {
+    const avForeign = {
+      venue: { name: 'Halle A', walls: [{}, {}], persons: [{}], stageObjects: [] },
+      cameras: { cameras: [{ id: 'c1', label: 'CAM 1' }, { id: 'c2', label: 'CAM 2' }] },
+      lighting: { fixtures: [{ id: 'f1', fixture: { name: 'ETC S4' }, purpose: 'Key', dimming: 0.8, currentColorTemp: 3200 }] },
+    }
+    const s = summarizeForeign(avForeign)
+    expect(s.venueName).toBe('Halle A')
+    expect(s.counts).toEqual({ walls: 2, persons: 1, stage: 0 })
+    expect(s.cameras.map((c) => c.label)).toEqual(['CAM 1', 'CAM 2'])
+    expect(s.fixtures[0]).toMatchObject({ name: 'ETC S4', purpose: 'Key', dimming: 0.8, colorTemp: 3200 })
+  })
+
+  it('hasForeign / summarize sind robust gegen Muell', () => {
+    expect(hasForeign(undefined)).toBe(false)
+    expect(hasForeign({})).toBe(false)
+    expect(hasForeign({ cameras: { cameras: [{ id: 'c1', label: 'X' }] } })).toBe(true)
+    const empty = summarizeForeign(undefined)
+    expect(empty.cameras).toEqual([])
+    expect(empty.fixtures).toEqual([])
+    expect(summarizeForeign({ lighting: { fixtures: 'nope' } }).fixtures).toEqual([])
+  })
+})


### PR DESCRIPTION
## Übersicht

„Ansicht überall" (Teil 2): Da cables Canvas ein Signalfluss-Graph (nicht metrisch) ist, zeigt der Cable-Planner die via `.avplan` **verlustfrei mitgeführten Domänen** (geteilter Raum + Kameras + Lampen) als kompakte **read-only Übersicht** — alles einsehbar, ohne es hier zu bearbeiten.

## Änderungen
- **`src/renderer/lib/foreignView.ts`** — defensiver Summary aus `project.avForeign` (Raum-Zähler, Kamera-Liste, Lampen mit Purpose/CCT/Dimming). `unknown` → robust.
- **`src/renderer/components/Layout/MenuBar.tsx`** — Datei-Menü „Verknüpfte Venue-Planung ansehen…" (nur wenn vorhanden) → read-only Liste via `infoDialog` (bodyNode).
- **`tests/foreignView.test.ts`** — Summary + Robustheit.

## Validierung
`npx tsc -p tsconfig.app.json --noEmit` (0), `npm run build`, `npm test` (83/83), `npm run lint` (0 Errors) — grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018Db9MeqzyxDR6oCJxwUhxA)_