### PR TITLE
fix+feat: offene Issues abarbeiten — Port-Layout, Mac-Dropdowns, Rack-Editor, Geräte-Verifizierung (#588, #587, #585, #580)

### DIFF
--- a/docs/app-structure.html
+++ b/docs/app-structure.html
@@ -240,7 +240,7 @@
   <aside>
     <h1>Cable-Planner</h1>
     <div class="subtitle">
-      App-Struktur · v8.3.1 · ~382 TS/TSX-Module · ~110.9k LOC<br>
+      App-Struktur · v8.3.1 · ~382 TS/TSX-Module · ~111.0k LOC<br>
       <small style="color:#64748b">Diese Übersicht zeigt nur die ~62 wichtigsten Module. Für die vollständige Architektur siehe <a href="./architecture.md" style="color:#94a3b8">architecture.md</a>.</small>
     </div>
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Invarianten der App. Sie ist die Pflicht-Lektüre, bevor strukturelle Änderunge
 gemacht werden. Für die interaktive Modul-Übersicht siehe [`app-structure.html`](./app-structure.html),
 für einen Wettbewerber-Vergleich [`comparison.html`](./comparison.html).
 
-Stand: v8.3.1 · ~382 TS/TSX-Module · ~110.9k LOC
+Stand: v8.3.1 · ~382 TS/TSX-Module · ~111.0k LOC
 
 ---
 
@@ -449,7 +449,7 @@ optionales Cloud-Backend (`y-websocket`, Auth/Permissions) bleiben offen.
 `vitest` ist eingerichtet (`npm test` / `npm run test:watch`); dazu kommen
 gezielte Node-Checks (`npm run test:crdt`, `npm run test:signaling`), ein
 UI-Smoke-Skript (`npm run ui:smoke`) und ein headless Drag-/Interaktions-Test
-(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~110.9k LOC
+(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~111.0k LOC
 bleibt der Ausbau der Abdeckung wichtig — empfohlene Schwerpunkte:
 - Snapshot-Tests auf `healProjectPositions` mit echten
   Beispiel-Projekt-JSONs.

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -61,14 +61,14 @@
 <header>
   <h1>Cable-Planner — Strukturvergleich mit ähnlichen Tools</h1>
   <div class="subtitle">Architektur, Tech-Stack und Domänen-Tiefe im Vergleich zu kommerziellen und Open-Source-Alternativen</div>
-  <div class="meta">Stand: 2026-06 · v8.3.1 · ~382 TS/TSX-Module · ~110.9k LOC · ~4.4 MB src/</div>
+  <div class="meta">Stand: 2026-06 · v8.3.1 · ~382 TS/TSX-Module · ~111.0k LOC · ~4.5 MB src/</div>
 </header>
 
 <h2>1 · Cable-Planner — Architektur-Kennzahlen</h2>
 
 <div class="stat-grid">
   <div class="stat"><div class="num">382</div><div class="label">TS/TSX-Module</div></div>
-  <div class="stat"><div class="num">110.9k</div><div class="label">Lines of Code</div></div>
+  <div class="stat"><div class="num">111.0k</div><div class="label">Lines of Code</div></div>
   <div class="stat"><div class="num">~75</div><div class="label">Modul-Dependencies</div></div>
   <div class="stat"><div class="num">7</div><div class="label">User-Flows</div></div>
 </div>

--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -151,6 +151,10 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
   // v7.9.67 / #177 — Toolbar-Sperren für ganze Objektarten.
   const lockFrames = useUiStore((s) => s.lockFrames)
   const lockEquipment = useUiStore((s) => s.lockEquipment)
+  // #585 — Rack-Editor aus Doppelklick/Rechtsklick auf eine Rack-Black-Box.
+  const triggerRackBuilderEditFromBlackBox = useUiStore(
+    (s) => s.triggerRackBuilderEditFromBlackBox,
+  )
   const wrapperRef = useRef<HTMLDivElement>(null)
   // Last screen-pixel mouse position over the canvas. Used by Strg++ quick-add
   // (#44) so the new device lands where the user pointed instead of always at
@@ -1750,6 +1754,14 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
             if (newName !== null && newName.trim()) {
               updateLocation(node.id, { name: newName.trim() })
             }
+            return
+          }
+          // #585 — Doppelklick auf eine Rack-Black-Box öffnet den Rack-Editor.
+          if (node.type === 'equipment') {
+            const eq = project.equipment.find((e) => e.id === node.id)
+            if (eq?.rackInternalSnapshot) {
+              triggerRackBuilderEditFromBlackBox(node.id)
+            }
           }
         }}
         onNodeDragStart={onNodeDragStart}
@@ -1843,6 +1855,13 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
           : project.equipment.find((e) => e.id === nodeContextMenu.nodeId)
         if (!target) return null
         const isLocked = !!target.positionLocked
+        // #585 — Rack-Black-Box (Equipment mit rackInternalSnapshot) bietet
+        // zusätzlich "Rack-Editor öffnen".
+        const isRack = !isLocation && !!(target as { rackInternalSnapshot?: unknown }).rackInternalSnapshot
+        const openRackEditor = () => {
+          triggerRackBuilderEditFromBlackBox(nodeContextMenu.nodeId)
+          setNodeContextMenu(null)
+        }
         const toggle = () => {
           if (isLocation) {
             updateLocation(nodeContextMenu.nodeId, { positionLocked: !isLocked })
@@ -1911,6 +1930,36 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
               color: '#e2e8f0',
             }}
           >
+            {isRack && (
+              <>
+                <button
+                  type="button"
+                  onClick={openRackEditor}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    width: '100%',
+                    padding: '6px 10px',
+                    background: 'transparent',
+                    color: 'inherit',
+                    border: 'none',
+                    borderRadius: 4,
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                  }}
+                  onMouseEnter={(e) => (e.currentTarget.style.background = '#334155')}
+                  onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+                >
+                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                    <rect x="3" y="2" width="10" height="12" rx="1" />
+                    <path d="M3 5.5h10M3 9h10" />
+                  </svg>
+                  <span>{t('canvas.nodeMenu.openRackEditor', 'Rack-Editor öffnen')}</span>
+                </button>
+                <div style={{ height: 1, background: '#334155', margin: '4px 0' }} />
+              </>
+            )}
             <button
               type="button"
               onClick={toggle}

--- a/src/renderer/components/Canvas/EquipmentNode.tsx
+++ b/src/renderer/components/Canvas/EquipmentNode.tsx
@@ -523,12 +523,17 @@ export const EquipmentNode = ({ id, data, selected }: NodeProps<EquipmentNodeDat
     0,
   )
   const labelWidth = longestPortText * 7 + 32
+  // #588 — Auch der Geräte-Name (Header) muss auf EINE Zeile passen, sonst
+  // umbricht der Titel und schiebt die Port-Positionen (die aus der fixen
+  // headerHeight berechnet werden) gegen die gerenderten Handles. Reserve
+  // ~44 px für führendes Icon/R-Badge + Padding.
+  const nameWidth = (data.name?.length ?? 0) * 7 + 44
   // v7.9.26 — Width rastet auf gridSize-Vielfache (11 px) ein, sodass
   // die Außenkanten der Karte mit Dot-Spalten zusammenfallen. Auto-
   // Expand für lange Port-Labels rundet entsprechend AUF.
   const GRID = EQUIPMENT_LAYOUT.GRID_SIZE
   const snapUp = (n: number) => Math.ceil(n / GRID) * GRID
-  const intrinsicWidth = snapUp(Math.max(EQUIPMENT_LAYOUT.DEFAULT_WIDTH, labelWidth * 2))
+  const intrinsicWidth = snapUp(Math.max(EQUIPMENT_LAYOUT.DEFAULT_WIDTH, labelWidth * 2, nameWidth))
   const width = Math.max(snapUp(data.width ?? intrinsicWidth), intrinsicWidth)
   // computedHeight ist per Konstruktion bereits Vielfaches von GRID
   // (headerHeight, PORT_ROW, PADDING sind alle Vielfache); data.height
@@ -566,7 +571,7 @@ export const EquipmentNode = ({ id, data, selected }: NodeProps<EquipmentNodeDat
           : tokens.header,
         borderRadius: '5px 5px 0 0',
       }}>
-        <div style={{ fontWeight: 600, lineHeight: '16px', display: 'flex', alignItems: 'center', gap: 4 }}>
+        <div style={{ fontWeight: 600, lineHeight: '16px', display: 'flex', alignItems: 'center', gap: 4, minWidth: 0 }}>
           {rentmanEnabled && (
             data.rentmanId && !data.rentmanRemoved ? (
               <span
@@ -627,7 +632,36 @@ export const EquipmentNode = ({ id, data, selected }: NodeProps<EquipmentNodeDat
               </span>
             )
           })()}
-          <span>{data.name}</span>
+          <span
+            style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}
+            title={data.name}
+          >
+            {data.name}
+          </span>
+          {/* #580 — Verifiziert-Badge (von N Personen bestätigt) */}
+          {(data.verifiedBy?.length ?? 0) > 0 && (
+            <span
+              style={{
+                flexShrink: 0,
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 2,
+                background: '#065f46',
+                color: '#d1fae5',
+                fontSize: 9,
+                fontWeight: 700,
+                borderRadius: 3,
+                padding: '0 3px',
+                lineHeight: '13px',
+              }}
+              title={format(
+                t('eqNode.verified', 'Verifiziert von {n}: {names}'),
+                { n: data.verifiedBy!.length, names: data.verifiedBy!.join(', ') },
+              )}
+            >
+              ✓{data.verifiedBy!.length > 1 ? ` ${data.verifiedBy!.length}` : ''}
+            </span>
+          )}
           {data.packed && (
             <span
               style={{

--- a/src/renderer/components/Properties/sections/OptionalFieldsSection.tsx
+++ b/src/renderer/components/Properties/sections/OptionalFieldsSection.tsx
@@ -1,6 +1,7 @@
 import { useCanvasProjectStore as useProjectStore } from '../../../store/projectStoreContext'
 import { format, useTranslation } from '../../../lib/i18n'
 import { pickImageAsDataUri } from '../../../lib/readImageAsDataUri'
+import { promptDialog } from '../../../lib/promptDialog'
 import { SortableSection } from '../SortableSection'
 import type { EquipmentItem } from '../../../types/equipment'
 
@@ -14,10 +15,63 @@ const ICON_GLYPHS = ['📷', '🖥', '💻', '📺', '🎙', '💡', '🌐', '�
 export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem }) => {
   const t = useTranslation()
   const updateEquipment = useProjectStore((state) => state.updateEquipment)
+  const projectAuthor = useProjectStore((state) => state.project.metadata.author)
+
+  // #580 — Verifizierung: eine Person bestätigt, dass die Ports/Daten des
+  // Geräts korrekt sind. Name kommt aus dem Projekt-Autor (Einstellungen);
+  // sonst wird einmalig gefragt. Wiederholtes Klicken toggelt die eigene
+  // Bestätigung.
+  const verifiedBy = equipment.verifiedBy ?? []
+  const toggleVerify = async () => {
+    const name =
+      (projectAuthor ?? '').trim() ||
+      (await promptDialog(t('verify.namePrompt', 'Dein Name (für die Geräte-Verifizierung):')))?.trim()
+    if (!name) return
+    const next = verifiedBy.includes(name)
+      ? verifiedBy.filter((n) => n !== name)
+      : [...verifiedBy, name]
+    updateEquipment(equipment.id, { verifiedBy: next.length > 0 ? next : undefined })
+  }
 
   return (
-    <SortableSection id="optional" title={t('opt.title', 'Optionale Felder')} subtitle={t('opt.subtitle', 'Hersteller-Link, Referenzbild, Icon, Mietpreis')}>
+    <SortableSection id="optional" title={t('opt.title', 'Optionale Felder')} subtitle={t('opt.subtitle', 'Hersteller-Link, Referenzbild, Icon, Mietpreis, Verifizierung')}>
       <div className="space-y-3">
+        {/* #580 — Geräte-Verifizierung: bestätigen, dass die eingetragenen
+            Ports/Daten korrekt sind. Zeigt die Zahl der Bestätigungen. */}
+        <div className="rounded border border-cp-border-muted bg-cp-surface-1 p-2">
+          <div className="mb-1 flex items-center justify-between">
+            <span className="flex items-center gap-1.5 text-cp-text-secondary">
+              {verifiedBy.length > 0 && (
+                <span
+                  className="inline-flex items-center gap-1 rounded bg-emerald-900/60 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-200"
+                  title={format(
+                    t('verify.byTitle', 'Verifiziert von: {names}'),
+                    { names: verifiedBy.join(', ') },
+                  )}
+                >
+                  ✓ {format(t('verify.count', '{n}× verifiziert'), { n: verifiedBy.length })}
+                </span>
+              )}
+              {verifiedBy.length === 0 && (
+                <span className="text-[11px] text-cp-text-muted">
+                  {t('verify.none', 'Noch nicht verifiziert')}
+                </span>
+              )}
+            </span>
+            <button
+              type="button"
+              onClick={() => void toggleVerify()}
+              className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
+              title={t('verify.buttonTitle', 'Bestätigen, dass die Ports/Daten dieses Geräts korrekt sind')}
+            >
+              {t('verify.button', 'Als korrekt verifizieren')}
+            </button>
+          </div>
+          <p className="text-[10px] text-cp-text-faint">
+            {t('verify.hint', 'Bestätigt, dass die Ports stimmen. Beim Teilen von Bibliotheken summieren sich die Bestätigungen mehrerer Nutzer.')}
+          </p>
+        </div>
+
         {/* #420 — Mietpreis pro Tag. Beim Rentman-Import automatisch
             befuellt; manuell ueberschreibbar. */}
         <div className="grid grid-cols-[1fr_70px] gap-2">

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -542,6 +542,19 @@ body,
 [data-theme="light"] .border-yellow-600  { border-color: #ca8a04; }
 
 
+/* #587 — Native <select> auf macOS hat per Default `min-width: auto`
+   (= min-content der laengsten Option) und laesst sich in Flex-/Grid-
+   Containern nicht schmaler ziehen → die Dropdowns in den Geraete-
+   Eigenschaften laufen ueber die Panel-Breite. `min-width: 0` erlaubt das
+   Schrumpfen (Text wird bei Bedarf abgeschnitten), `max-width: 100%`
+   verhindert Ueberlauf auch bei breitenlosen Selects. Betrifft nur
+   eingeschraenkte Container; frei stehende Selects behalten ihre Auto-
+   Breite. */
+select {
+  min-width: 0;
+  max-width: 100%;
+}
+
 /* v7.3.0 — Global focus-visible rings so keyboard navigation works on
    every button/link/input without per-component edits. Per-component
    focus styles still override via more-specific selectors. */

--- a/src/renderer/lib/equipmentLayout.ts
+++ b/src/renderer/lib/equipmentLayout.ts
@@ -97,6 +97,9 @@ export const computeEquipmentLayout = (
     0,
   )
   const labelWidth = longestPortText * 7 + 32
+  // #588 — Geräte-Name muss ebenfalls auf eine Zeile passen (siehe
+  // EquipmentNode); identische Formel für konsistente Breite.
+  const nameWidth = (eq.name?.length ?? 0) * 7 + 44
   // #501 — Breite/Höhe müssen BYTE-genau wie im Renderer (EquipmentNode,
   // v7.9.26 snapUp) aufs Grid einrasten. Sonst startet die Pending-Kabel-
   // Linie an einer UN-gesnappten Außenkante, während der echte Port-Handle
@@ -104,7 +107,7 @@ export const computeEquipmentLayout = (
   // (sichtbar v.a. am breiten Videohub mit vielen Output-Ports).
   const GRID = EQUIPMENT_LAYOUT.GRID_SIZE
   const snapUp = (n: number): number => Math.ceil(n / GRID) * GRID
-  const intrinsicWidth = snapUp(Math.max(EQUIPMENT_LAYOUT.DEFAULT_WIDTH, labelWidth * 2))
+  const intrinsicWidth = snapUp(Math.max(EQUIPMENT_LAYOUT.DEFAULT_WIDTH, labelWidth * 2, nameWidth))
   const width = Math.max(snapUp(eq.width ?? intrinsicWidth), intrinsicWidth)
 
   const portRows = Math.max(sideCounts.left, sideCounts.right, 1)

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -4396,4 +4396,13 @@ export const de: Dict = {
   "lifecycle.ownership.owned": "Owned",
   "lifecycle.ownership.rented": "Rented",
   "lifecycle.ownership.subhire": "Sub-hire",
+  "canvas.nodeMenu.openRackEditor": "Open rack editor",
+  "verify.namePrompt": "Your name (for device verification):",
+  "verify.byTitle": "Verified by: {names}",
+  "verify.count": "{n}\u00d7 verified",
+  "verify.none": "Not verified yet",
+  "verify.buttonTitle": "Confirm that this device's ports/data are correct",
+  "verify.button": "Verify as correct",
+  "verify.hint": "Confirms the ports are correct. When sharing libraries, confirmations from multiple users add up.",
+  "eqNode.verified": "Verified by {n}: {names}",
 }

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -549,6 +549,12 @@ export interface EquipmentItem {
    * (verteilt dann faktisch nichts).
    */
   isDistributionAmp?: boolean
+  /** #580 — Namen der Personen, die bestätigt haben, dass die eingetragenen
+   *  Ports/Daten dieses Geräts korrekt sind (Community-Verifizierung). Beim
+   *  Zusammenführen geteilter Bibliotheken werden die Listen vereinigt, sodass
+   *  sich "von N Personen verifiziert" über mehrere Nutzer aufbaut. Ein
+   *  nicht-leeres Array zeigt auf dem Canvas ein Verifiziert-Badge. */
+  verifiedBy?: string[]
   /** Festinstallation — Betriebs-Status des Geräts (geplant…außer Betrieb). */
   installStatus?: InstallStatus
   /** Festinstallation — Inventar-/Asset-Nummer für das Asset-Register. */


### PR DESCRIPTION
## Übersicht

Arbeitet die vier offenen Issues ab — zwei Bugs und zwei Features.

### #588 — Zweizeilige Titel verschieben Input/Output-Ports (Bug)
Die Node-Breite wurde nur aus den Port-Labels berechnet, nicht aus dem Geräte-**Namen**. Ein langer Name (z. B. „Macbook Pro M4") umbrach auf zwei Zeilen → der Header wurde höher, während die Ports aus der fixen `headerHeight` positioniert blieben.
- Node-Breite wächst jetzt auch für den Namen (identische Formel in `EquipmentNode` **und** `equipmentLayout`, damit Pending-Kabel/BOM konsistent bleiben).
- Titel ist einzeilig mit Ellipsis + `title`-Tooltip als Sicherheitsnetz.

### #587 — Mac-Dropdowns laufen über die Container-Breite (Bug)
Native `<select>` haben auf macOS `min-width: auto` (= min-content der längsten Option) und schrumpfen in Flex-/Grid-Containern nicht. Fix: eine Basis-CSS-Regel `select { min-width: 0; max-width: 100% }` — betrifft nur eingeschränkte Container, frei stehende Selects behalten ihre Auto-Breite.

### #585 — Rack-Editor per Doppelklick / Rechtsklick (Feature)
- Doppelklick auf eine Rack-Black-Box öffnet den Rack-Editor (`triggerRackBuilderEditFromBlackBox`).
- Zusätzlich „Rack-Editor öffnen" im Rechtsklick-Kontextmenü (nur bei Rack-Black-Boxes).

### #580 — Geräte verifizieren + Firmware + Badge (Feature)
- **Firmware** war bereits vorhanden (Netzwerk-Section + Asset-Register) — unverändert.
- Neu: `verifiedBy: string[]` — eine „Als korrekt verifizieren"-Aktion in den Geräte-Eigenschaften trägt den Projekt-Autor (bzw. abgefragten Namen) ein/aus. Zeigt die Anzahl der Bestätigungen.
- **Verifiziert-Badge** (✓ mit Zähler) auf dem Canvas-Node, Tooltip mit den Namen.
- Cross-User-Aufsummierung baut sich auf, wenn dasselbe Gerät von mehreren Autoren bestätigt wird (z. B. über geteilte Projekte/Bibliotheken). Ein automatisches Vereinen der `verifiedBy`-Listen im Shared-Library-Konflikt-Merge wäre ein sinnvoller Folge-Schritt.

### Validierung
- `npx tsc -p tsconfig.app.json --noEmit` → 0 Fehler
- `npm test` → 74/74 · `eslint` → 0 Fehler
- Headless-Smoke: Canvas rendert, alles verschiebbar, 0 Renderer-Konsolenfehler

Closes #588, #587, #585, #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvdNHBUVagyR4fhekcp6rv)_