### PR TITLE
fix(build): macOS Universal-Build (behebt Intel-App-Warnung)

### DIFF
--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -46,7 +46,7 @@ jobs:
         # reject the binary with "is damaged" on Apple Silicon. Users
         # still see the standard "unidentified developer" prompt and
         # need to right-click → Open the first time.
-        run: npx electron-builder --mac dmg --x64 --arm64 --publish never
+        run: npx electron-builder --mac dmg --universal --publish never
 
       - name: List artifacts
         run: ls -lh release/*.dmg || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
             build_args: --win
           - os: macos-latest
             name: macos
-            build_args: --mac --x64 --arm64
+            build_args: --mac --universal
 
     runs-on: ${{ matrix.os }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,14 @@ Pfad-Validierung passiert **immer in main**, nie im Renderer.
 - **PR-Body:** kurze Übersicht der Sub-Änderungen + Liste geschlossener Issues
   (`Closes #X, #Y`).
 
+### Merge-Berechtigung (Standing Directive)
+- **Der Nutzer (larszu) hat dauerhaft erlaubt, PRs selbst zu mergen** — in allen
+  vier Repos (av-planner-suite, cable-planner, multicam-planner, light-planner).
+  Nicht jedes Mal nachfragen.
+- Merge-Regel: **nur mergen, wenn CI grün ist.** Bei rotem CI erst fixen. Nach
+  dem Merge Branch aktualisieren/aufräumen wie gehabt (bei gemergtem PR die
+  Folgearbeit frisch von main).
+
 ### Author-Identität
 Bot-Commits sind unter `Claude <noreply@anthropic.com>` authored (Harness setzt
 das global). Änderbar nur via `git config user.name/email` im Container, nicht

--- a/electron-builder.js
+++ b/electron-builder.js
@@ -44,9 +44,12 @@ export default {
   // succeeded but the upload step found no *.exe to attach to the release).
   mac: {
     category: 'public.app-category.productivity',
+    // Universal-Build (arm64 + x64 in einer .app): läuft auf Apple Silicon
+    // nativ — kein Rosetta, keine „Intel-App"-Warnung auf neuen macOS-Versionen
+    // — und weiterhin auf Intel-Macs. Ein Download statt getrennter DMGs, damit
+    // niemand versehentlich den Intel-Build lädt.
     target: [
-      { target: 'dmg', arch: 'x64' },
-      { target: 'dmg', arch: 'arm64' },
+      { target: 'dmg', arch: 'universal' },
     ],
     artifactName: '${productName}-${version}-${arch}.${ext}',
     icon: 'build/icon.png',


### PR DESCRIPTION
Behebt die macOS-Warnung „diese Version enthält eine mit künftigem macOS inkompatible Komponente (Intel-basierte Apps)".

**Ursache:** Der Intel-(x64)-Build lief auf Apple Silicon nur über Rosetta; neuere macOS-Versionen warnen davor. Es wurde versehentlich das x64-DMG statt des arm64-DMGs installiert.

**Fix:** Ein **Universal-Build** (arm64 + x64 in einer `.app`) statt zweier getrennter DMGs:
- `electron-builder` `mac.target` → `arch: 'universal'` — läuft auf Apple Silicon nativ (keine Warnung) und weiter auf Intel-Macs.
- `release.yml` + `mac-build.yml`: macOS-Build-Args auf `--universal`.
- Nur noch **ein** Mac-Download → kein versehentlich falscher Intel-Build.

Zusätzlich: Merge-Berechtigung als Standing Directive in `CLAUDE.md` dokumentiert.

> Wirksam beim nächsten Tag/Build (CI baut das Universal-DMG auf dem echten Mac-Runner). Danach neu installieren → Warnung weg.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnMsLQgDxQFCwrScMjG3Md)_