### PR TITLE
canvas: Zoom-to-fit nach Import auf echte Canvas-Größe zentrieren

### DIFF
--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -49,6 +49,7 @@ import { colorByLength } from '../../lib/cableColors'
 import { promptDialog } from '../../lib/promptDialog'
 import {
   setViewportCenterGetter,
+  setCanvasSizeGetter,
   setCanvasSelectionClearer,
   setCanvasInteractionLockHandlers,
   setCanvasFitViewHandler,
@@ -204,6 +205,23 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
     })
     return () => setViewportCenterGetter(null)
   }, [screenToFlowPosition])
+
+  // Gemessene Canvas-Groesse fuer Zoom-to-fit nach Importen bereitstellen.
+  // Lazy Getter statt ResizeObserver: der Wert wird nur beim Import gebraucht
+  // und ist so garantiert frisch (inkl. aktueller Panel-Breiten), ohne bei
+  // jedem Resize State zu schreiben.
+  // Nur die Haupt-Canvas registriert sich — das Rack-Overlay rendert dieselbe
+  // Komponente und wuerde die Messung sonst verdraengen (vgl. #515).
+  useEffect(() => {
+    if (mode !== 'main') return
+    setCanvasSizeGetter(() => {
+      const el = wrapperRef.current
+      if (!el) return null
+      const r = el.getBoundingClientRect()
+      return { width: r.width, height: r.height }
+    })
+    return () => setCanvasSizeGetter(null)
+  }, [mode])
 
   useEffect(() => {
     setCanvasInteractionLockHandlers({

--- a/src/renderer/lib/canvasViewport.ts
+++ b/src/renderer/lib/canvasViewport.ts
@@ -5,8 +5,10 @@
 // CanvasArea registers callbacks on mount.
 
 type Point = { x: number; y: number }
+type Size = { width: number; height: number }
 
 let viewportGetter: (() => Point | null) | null = null
+let canvasSizeGetter: (() => Size | null) | null = null
 let selectionClearer: (() => void) | null = null
 let interactionLockRequester: ((durationMs?: number) => void) | null = null
 let interactionUnlocker: (() => void) | null = null
@@ -18,6 +20,33 @@ export const setViewportCenterGetter = (fn: (() => Point | null) | null) => {
 export const getViewportCenter = (): Point | null => {
   try {
     return viewportGetter ? viewportGetter() : null
+  } catch {
+    return null
+  }
+}
+
+// Gemessene Groesse der sichtbaren Canvas-Flaeche in CSS-Pixeln. Nur die
+// HAUPT-Canvas registriert sich (mode='main') — das Rack-Overlay rendert
+// dieselbe Komponente ein zweites Mal und wuerde die Messung sonst
+// ueberschreiben (siehe #515 weiter unten).
+//
+// Zweck: Zoom-to-fit nach einem Import muss auf die TATSAECHLICHE
+// Canvas-Breite/-Hoehe zentrieren. Vorher lief das gegen einen festen
+// Fallback (1200x700), sodass ein Import auf breiten Screens in der linken
+// Bildschirmhaelfte landete statt mittig.
+export const setCanvasSizeGetter = (fn: (() => Size | null) | null) => {
+  canvasSizeGetter = fn
+}
+
+/** Gemessene Canvas-Groesse oder null, wenn (noch) keine Canvas gemountet
+ *  ist — dann muss der Aufrufer seinen eigenen Fallback nutzen. Null-Werte
+ *  (0-Breite waehrend des ersten Renders) werden ebenfalls als null
+ *  gemeldet, damit niemand durch 0 teilt. */
+export const getCanvasSize = (): Size | null => {
+  try {
+    const s = canvasSizeGetter ? canvasSizeGetter() : null
+    if (!s || s.width <= 0 || s.height <= 0) return null
+    return s
   } catch {
     return null
   }

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -57,6 +57,7 @@ type CableDraft = Pick<Cable, 'name' | 'type' | 'length' | 'color' | 'notes'> &
 
 import { STORAGE_KEYS } from '../lib/storageKeys'
 import { VIEWPORT_DEFAULTS } from '../lib/layoutConstants'
+import { getCanvasSize } from '../lib/canvasViewport'
 import { seedLibrarySyncCache } from '../lib/librarySync'
 
 const CUSTOM_LIB_KEY = STORAGE_KEYS.customLibrary
@@ -940,15 +941,16 @@ const buildProjectStore = (
         if (d.x + w > maxX) maxX = d.x + w
         if (d.y + h > maxY) maxY = d.y + h
       }
-      // Approximate the visible canvas area. The real value depends on
-      // the user's library / properties panel widths, but the constants
-      // below produce a sensible default for both default and collapsed
-      // layouts.
-      // v7.9.23 — vorher hardcoded 1200x700; jetzt aus VIEWPORT_DEFAULTS.
-      // TODO: an die tatsächliche Canvas-Größe binden (ResizeObserver auf
-      // dem CanvasArea-Wrapper) — derzeit ist es ein Fallback.
-      const VIEWPORT_W = VIEWPORT_DEFAULTS.FALLBACK_WIDTH
-      const VIEWPORT_H = VIEWPORT_DEFAULTS.FALLBACK_HEIGHT
+      // Sichtbare Canvas-Flaeche. v7.9.23 war das hardcoded 1200x700, danach
+      // VIEWPORT_DEFAULTS — beides nur geraten. Jetzt wird die Canvas real
+      // gemessen (CanvasArea registriert den Getter), inkl. der aktuellen
+      // Library-/Properties-Panel-Breiten. Auf breiten Screens landete der
+      // Import sonst in der linken Bildschirmhaelfte statt mittig, weil auf
+      // 1200/2 = 600 px zentriert wurde. Fallback bleibt fuer den Fall, dass
+      // noch keine Canvas gemountet ist (Import direkt beim Start).
+      const measured = getCanvasSize()
+      const VIEWPORT_W = measured?.width ?? VIEWPORT_DEFAULTS.FALLBACK_WIDTH
+      const VIEWPORT_H = measured?.height ?? VIEWPORT_DEFAULTS.FALLBACK_HEIGHT
       let canvasState = state.project.canvasState
       if (Number.isFinite(minX)) {
         const bboxW = Math.max(1, maxX - minX)

--- a/tests/canvasSize.test.ts
+++ b/tests/canvasSize.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { getCanvasSize, setCanvasSizeGetter } from '../src/renderer/lib/canvasViewport'
+
+// Canvas-Groessen-Bridge: CanvasArea meldet die real gemessene Canvas-Flaeche,
+// damit Zoom-to-fit nach einem Import auf die TATSAECHLICHE Mitte zentriert
+// statt auf den geratenen 1200x700-Fallback. Wichtig ist, dass ein fehlender
+// oder unbrauchbarer Messwert sauber als `null` durchkommt — der Aufrufer
+// (projectStore) faellt dann auf VIEWPORT_DEFAULTS zurueck, statt durch 0 zu
+// teilen oder auf NaN zu zentrieren.
+describe('getCanvasSize', () => {
+  afterEach(() => setCanvasSizeGetter(null))
+
+  it('liefert null, solange keine Canvas registriert ist', () => {
+    expect(getCanvasSize()).toBeNull()
+  })
+
+  it('liefert die gemessene Groesse der registrierten Canvas', () => {
+    setCanvasSizeGetter(() => ({ width: 2560, height: 1400 }))
+    expect(getCanvasSize()).toEqual({ width: 2560, height: 1400 })
+  })
+
+  it('meldet eine noch nicht gelayoutete Canvas (0 px) als null', () => {
+    // Erster Render: der Wrapper hat noch keine Breite. Ohne diese Wache
+    // wuerde fitZoom durch 0 geteilt bzw. auf 0/0 zentriert.
+    setCanvasSizeGetter(() => ({ width: 0, height: 0 }))
+    expect(getCanvasSize()).toBeNull()
+
+    setCanvasSizeGetter(() => ({ width: 800, height: 0 }))
+    expect(getCanvasSize()).toBeNull()
+  })
+
+  it('meldet negative Werte als null', () => {
+    setCanvasSizeGetter(() => ({ width: -10, height: 700 }))
+    expect(getCanvasSize()).toBeNull()
+  })
+
+  it('schluckt einen werfenden Getter (unmountete Canvas) statt zu crashen', () => {
+    setCanvasSizeGetter(() => {
+      throw new Error('wrapper weg')
+    })
+    expect(getCanvasSize()).toBeNull()
+  })
+
+  it('gibt nach dem Abmelden wieder null zurueck', () => {
+    setCanvasSizeGetter(() => ({ width: 1920, height: 1080 }))
+    expect(getCanvasSize()).not.toBeNull()
+    setCanvasSizeGetter(null)
+    expect(getCanvasSize()).toBeNull()
+  })
+})


### PR DESCRIPTION
## Worum es geht

Nach einem GraphML-/yEd-Import zentriert `projectStore` den eingefügten
Ausschnitt per Zoom-to-fit. Die dafür nötige Canvas-Größe war aber **geraten**:

```ts
const VIEWPORT_W = VIEWPORT_DEFAULTS.FALLBACK_WIDTH   // 1200
const VIEWPORT_H = VIEWPORT_DEFAULTS.FALLBACK_HEIGHT  // 700
```

Auf breiten Screens wurde dadurch auf `1200 / 2 = 600 px` zentriert statt auf die
echte Mitte — der Import landete sichtbar in der **linken Bildschirmhälfte**.
Das dazugehörige `TODO` („an die tatsächliche Canvas-Größe binden") stand seit
v7.9.23 im Code und wird hiermit aufgelöst.

## Änderung

- **`lib/canvasViewport.ts`**: neue `setCanvasSizeGetter` / `getCanvasSize` —
  dieselbe Bridge-Mechanik, die dort schon für Viewport-Center, fitView, Zoom
  und Center-On existiert. `getCanvasSize()` liefert `null` bei fehlender,
  noch nicht gelayouteter (0 px), negativer oder werfender Messung, damit der
  Aufrufer sauber auf den Fallback zurückfällt statt durch 0 zu teilen.
- **`Canvas/CanvasArea.tsx`**: registriert die Messung des vorhandenen
  `wrapperRef` (`getBoundingClientRect`). Bewusst ein **lazy Getter statt
  ResizeObserver** — der Wert wird nur beim Import gebraucht und ist so
  garantiert frisch inkl. der aktuellen Library-/Properties-Panel-Breiten,
  ohne bei jedem Resize State zu schreiben. Nur `mode === 'main'` registriert
  sich, damit das Rack-Overlay (rendert dieselbe Komponente ein zweites Mal)
  die Messung nicht verdrängt — vgl. die #515-Analyse in derselben Datei.
- **`store/projectStore.ts`**: nutzt die Messung, `VIEWPORT_DEFAULTS` bleibt
  Fallback für den Fall, dass noch keine Canvas gemountet ist.

## Test

- Neu: `tests/canvasSize.test.ts` (6 Tests) — null ohne Registrierung, echte
  Größe nach Registrierung, null bei 0 px / negativ / werfendem Getter, null
  nach Abmelden.
- `npx tsc -p tsconfig.app.json --noEmit` → **0 Errors** (Baseline clean)
- `npm test` → 25 Dateien / **183 Tests** grün (vorher 177)
- `npm run lint` → 0 Errors (10 vorbestehende Warnings, unverändert)
- `npm run build` → grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKdmNsZoHwmERs9FX8CVAb

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKdmNsZoHwmERs9FX8CVAb)_