### PR TITLE
netbox: Site/Rack aus eigener NetBox-Instanz als Kabelplan importieren (#597)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ strukturellen Änderungen.** Hier nur das Nötigste zum schnellen Einstieg:
 
 **IPC:** Alle Channels sind domain-präfixiert (`project:*`, `library:*`,
 `atem:*`, `videohub:*`, `sync:*`, `mobileShare:*`, `credentials:*`, `rentman:*`,
-`graphml:*`, `print:*`, `logs:*`, `signaling:*`, `collabDiscovery:*`). Definition in `src/main/ipc/<domain>Ipc.ts`,
+`netbox:*`, `graphml:*`, `print:*`, `logs:*`, `signaling:*`, `collabDiscovery:*`). Definition in `src/main/ipc/<domain>Ipc.ts`,
 Aufruf via `window.cablePlanner.<domain>.<action>`. Ein Channel = eine Domäne.
 Pfad-Validierung passiert **immer in main**, nie im Renderer.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,6 +54,7 @@ Alle IPC-Channels sind nach Domäne präfixiert. Definitionen in
 | `project:*` | `projectIpc.ts` | `new`, `open`, `save`, `save-as`, `get-recent`, `export-viewer`, `import-annotations` |
 | `library:*` | `libraryIpc.ts` | `get-folder-path`, `reveal-folder`, `scan`, `write`, `delete` |
 | `rentman:*` | `rentmanIpc.ts` | `get-projects`, `get-project-equipment`, `get-equipment`, `add-project-equipment`, `add-project-file` |
+| `netbox:*` | `netboxIpc.ts` | `save-token`, `has-token`, `delete-token`, `normalize-url`, `test-connection`, `get-sites`, `get-racks`, `fetch-snapshot` |
 | `atem:*` | `atemIpc.ts` | `connect`, `disconnect`, `state`, `get-status`, `get-events`, `set-input-name`, `bulk-set-input-names`, `apply-mv-config`, `read-mv-config`, `apply-audio-config`, `discover`, plus `atem:event` (broadcast) |
 | `videohub:*` | `videohubIpc.ts` | `send` (TCP zu Blackmagic Videohub) |
 | `sync:*` | `syncIpc.ts` | `read-file`, `write-file`, `exists`, `acquire-lock`, `release-lock` |
@@ -302,24 +303,67 @@ verbundenen Switcher, `apply-mv-config` schreibt zurück.
 HTTP-API in `services/rentmanApiClient.ts`. Token im OS-Credential-Store.
 **Niemals Token loggen oder ins Projekt-File schreiben.**
 
-### 6.3 · GraphML-Import (yEd)
+### 6.3 · NetBox (DCIM, selbst gehostet, #597)
+
+Lesende REST-Anbindung an eine **eigene** NetBox-Instanz, um eine dort
+geplante Site oder ein Rack als Kabelplan zu übernehmen
+(`services/netboxApiClient.ts`, Referenz unter
+`<instanz>/api/schema/swagger-ui/`).
+
+Anders als bei Rentman gibt es keine feste Cloud-URL. Die Basis-URL lebt
+deshalb in den App-Settings (`settingsStore.netboxUrl`) und wird bei jedem
+IPC-Aufruf mitgegeben; **validiert wird sie immer in main**
+(`normalizeNetboxBaseUrl`: nur http/https, `/api…`-Suffix und Query werden
+abgeschnitten). Der Main-Prozess bleibt damit zustandslos. Das API-Token
+liegt via `keytar` unter dem Account `netbox-api-token` und wird — anders
+als der Rentman-Token — **nie an den Renderer zurückgegeben**; der fragt
+nur `has-token`.
+
+Genutzte Endpoints (alle nur lesend): `/api/status/`, `/api/dcim/sites/`,
+`/api/dcim/racks/`, `/api/dcim/devices/`, die sieben Komponenten-Endpoints
+(`interfaces`, `front-ports`, `rear-ports`, `console-ports`,
+`console-server-ports`, `power-ports`, `power-outlets`) und
+`/api/dcim/cables/`. Paginiert wird über `limit`/`offset` statt über die
+`next`-URL — hinter einem Reverse-Proxy zeigt die auf interne Hostnamen.
+
+**Mapping** (`lib/netboxMapping.ts`, rein und unit-getestet):
+- NetBox-Komponente → Cable-Planner-Port. Richtungslose Interfaces werden
+  als **gespiegeltes In/Out-Paar** angelegt (beide Ports tragen dieselbe
+  `netboxId`), damit jedes Kabel als Ausgang→Eingang zeichenbar bleibt.
+  Strom/Konsole/Patchfeld haben in NetBox eine echte Richtung und bekommen
+  genau einen Port.
+- Default `onlyConnectedPorts: true` — ein 48-Port-Switch brächte sonst 96
+  Handles auf den Knoten, von denen im Rack eine Handvoll gepatcht ist.
+- Layout: eine Spalte je Rack, innerhalb der Spalte nach Höheneinheit
+  absteigend gestapelt, optional ein `LocationFrame` je Rack. Der Block
+  landet rechts vom Bestand, überdeckt also nie einen vorhandenen Plan.
+
+**Der Abgleich ist per Konstruktion additiv.** NetBox ist die Wahrheit über
+die Verkabelung, der Cable Planner über die Darstellung (Positionen,
+Farben, Wegpunkte, Labels, Multicore-Bündel). Ein erneuter Lauf legt nur
+an, was über `netboxId` noch nicht im Plan ist, und ergänzt an bestehenden
+Geräten ausschliesslich neu hinzugekommene Ports. In NetBox gelöschte
+Elemente werden als `staleDeviceIds`/`staleCableIds` **gemeldet, nicht
+entfernt** — das Aufräumen bleibt beim Planer. Angewendet wird der Plan
+atomar über `applyNetboxImport` (`slices/netboxImportSlice.ts`), damit der
+Undo-Stack einen Import als einen Schritt sieht.
+
+Nicht zu verwechseln mit `lib/netboxImport.ts` — das ist der ältere
+Import einzelner Gerätetypen aus der öffentlichen
+`netbox-community/devicetype-library` auf GitHub (statische YAML), ohne
+eigene Instanz.
+
+### 6.4 · GraphML-Import (yEd)
 
 `fast-xml-parser` parst yEd-XML. **Sicher gegen XXE** —
 fast-xml-parser ignoriert DTDs/external entities per default.
 
-### 6.4 · Videohub (Blackmagic Router)
+### 6.5 · Videohub (Blackmagic Router)
 
 `videohubIpc.ts` öffnet eine TCP-Verbindung zum Videohub und sendet
 plain-text Routing-/Label-Blöcke. Smart-Routing erkennt Quellen anhand
 ihrer Namen (Fuzzy-Match mit AI-Provider-Fallback bei niedriger
 Score-Schwelle).
-
-### 6.5 · NetBox / DCIM
-
-`library.netbox.*`-Endpunkte importieren Device-Types aus einer NetBox-
-Instanz (oder dem öffentlichen device-type-library-Repo). Konflikt-
-Resolution bei vorhandenen Library-Einträgen über einen merge/replace/
-keep-local Dialog.
 
 ### 6.6 · Mobile-Share
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url'
 import fs from 'node:fs'
 import { registerCredentialsIpc } from './ipc/credentialsIpc.js'
 import { registerRentmanIpc } from './ipc/rentmanIpc.js'
+import { registerNetboxIpc } from './ipc/netboxIpc.js'
 import { openExternalProject, registerProjectIpc } from './ipc/projectIpc.js'
 import { findProjectPathInArgv, setPendingLaunchPath } from './services/fileOpenService.js'
 import { registerAtemIpc } from './ipc/atemIpc.js'
@@ -352,6 +353,7 @@ app.whenReady().then(async () => {
 
   registerCredentialsIpc()
   registerRentmanIpc()
+  registerNetboxIpc()
   registerProjectIpc()
   registerAtemIpc()
   registerVideohubIpc()

--- a/src/main/ipc/netboxIpc.ts
+++ b/src/main/ipc/netboxIpc.ts
@@ -1,0 +1,95 @@
+import { ipcMain } from 'electron'
+import { netboxCredentialsService } from '../services/credentialsService.js'
+import {
+  createNetboxApiClient,
+  normalizeNetboxBaseUrl,
+  type NetboxRecord,
+  type NetboxSnapshot,
+} from '../services/netboxApiClient.js'
+
+/**
+ * IPC-Domäne `netbox:*` (#597).
+ *
+ * Der Main-Prozess ist zustandslos: die Instanz-URL kommt bei jedem Aufruf
+ * aus den Renderer-Settings mit und wird hier validiert (nie im Renderer —
+ * gleiche Regel wie bei Pfaden). Das Token liegt im OS-Schlüsselbund und
+ * wird nie an den Renderer zurückgegeben.
+ */
+
+const getClient = async (baseUrl: string) => {
+  const token = await netboxCredentialsService.getToken()
+  if (!token) {
+    throw new Error(
+      'Kein NetBox-Token hinterlegt — Einstellungen → Integrationen → NetBox.',
+    )
+  }
+  // Wirft bei ungültiger/nicht-http(s)-URL.
+  return createNetboxApiClient(baseUrl, token)
+}
+
+const asId = (value: unknown, label: string): number => {
+  const n = typeof value === 'number' ? value : Number(value)
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`Ungültige ${label}: ${String(value)}`)
+  }
+  return n
+}
+
+export const registerNetboxIpc = () => {
+  ipcMain.handle('netbox:save-token', async (_event, token: string) =>
+    netboxCredentialsService.saveToken(typeof token === 'string' ? token : ''),
+  )
+
+  ipcMain.handle('netbox:has-token', async () => netboxCredentialsService.hasToken())
+
+  ipcMain.handle('netbox:delete-token', async () => netboxCredentialsService.deleteToken())
+
+  /** URL-Validierung ohne Netzwerk-Zugriff — für Live-Feedback im
+   *  Settings-Feld, bevor der User „Verbindung testen" drückt. */
+  ipcMain.handle('netbox:normalize-url', async (_event, url: string) => {
+    try {
+      return { ok: true as const, url: normalizeNetboxBaseUrl(url) }
+    } catch (error) {
+      return {
+        ok: false as const,
+        message: error instanceof Error ? error.message : String(error),
+      }
+    }
+  })
+
+  ipcMain.handle(
+    'netbox:test-connection',
+    async (_event, baseUrl: string): Promise<{ ok: boolean; message: string; version?: string }> => {
+      try {
+        const client = await getClient(baseUrl)
+        return await client.testConnection()
+      } catch (error) {
+        return { ok: false, message: error instanceof Error ? error.message : String(error) }
+      }
+    },
+  )
+
+  ipcMain.handle('netbox:get-sites', async (_event, baseUrl: string): Promise<NetboxRecord[]> => {
+    const client = await getClient(baseUrl)
+    return client.getSites()
+  })
+
+  ipcMain.handle(
+    'netbox:get-racks',
+    async (_event, baseUrl: string, siteId?: number): Promise<NetboxRecord[]> => {
+      const client = await getClient(baseUrl)
+      return client.getRacks(siteId == null ? undefined : asId(siteId, 'Site-ID'))
+    },
+  )
+
+  ipcMain.handle(
+    'netbox:fetch-snapshot',
+    async (_event, baseUrl: string, scope: 'site' | 'rack', scopeId: number): Promise<NetboxSnapshot> => {
+      if (scope !== 'site' && scope !== 'rack') {
+        throw new Error(`Unbekannter NetBox-Scope: ${String(scope)}`)
+      }
+      const client = await getClient(baseUrl)
+      return client.fetchSnapshot(scope, asId(scopeId, `${scope}-ID`))
+    },
+  )
+}

--- a/src/main/preload.cts
+++ b/src/main/preload.cts
@@ -47,6 +47,30 @@ contextBridge.exposeInMainWorld('cablePlanner', {
         mimeType,
       ) as Promise<unknown>,
   },
+  // #597 — NetBox-Instanz (self-hosted). Die Basis-URL kommt aus den
+  // Renderer-Settings und wird bei jedem Aufruf mitgegeben; das Token
+  // liegt im OS-Schlüsselbund und verlässt den Main-Prozess nie.
+  netbox: {
+    saveToken: (token: string) => ipcRenderer.invoke('netbox:save-token', token) as Promise<boolean>,
+    hasToken: () => ipcRenderer.invoke('netbox:has-token') as Promise<boolean>,
+    deleteToken: () => ipcRenderer.invoke('netbox:delete-token') as Promise<boolean>,
+    normalizeUrl: (url: string) =>
+      ipcRenderer.invoke('netbox:normalize-url', url) as Promise<
+        { ok: true; url: string } | { ok: false; message: string }
+      >,
+    testConnection: (baseUrl: string) =>
+      ipcRenderer.invoke('netbox:test-connection', baseUrl) as Promise<{
+        ok: boolean
+        message: string
+        version?: string
+      }>,
+    getSites: (baseUrl: string) =>
+      ipcRenderer.invoke('netbox:get-sites', baseUrl) as Promise<Record<string, unknown>[]>,
+    getRacks: (baseUrl: string, siteId?: number) =>
+      ipcRenderer.invoke('netbox:get-racks', baseUrl, siteId) as Promise<Record<string, unknown>[]>,
+    fetchSnapshot: (baseUrl: string, scope: 'site' | 'rack', scopeId: number) =>
+      ipcRenderer.invoke('netbox:fetch-snapshot', baseUrl, scope, scopeId) as Promise<unknown>,
+  },
   graphml: {
     openFile: () =>
       ipcRenderer.invoke('graphml:open-file') as Promise<{

--- a/src/main/services/credentialsService.ts
+++ b/src/main/services/credentialsService.ts
@@ -2,6 +2,18 @@ import keytar from 'keytar'
 
 const SERVICE_NAME = 'cable-planner'
 const ACCOUNT_NAME = 'rentman-api-token'
+/** #597 — NetBox-Token liegt im gleichen Keychain-Service, aber unter
+ *  eigenem Account. Getrennt von Rentman, damit das Loeschen der einen
+ *  Integration die andere nicht mitnimmt. */
+const NETBOX_ACCOUNT_NAME = 'netbox-api-token'
+
+/** Tokens kommen fast immer aus Copy-Paste (Mail, PDF, Browser) und
+ *  schleppen unsichtbare Zeichen mit: BOM, NBSP, Zero-Width-Spaces,
+ *  Bidi-Marks, Control-Chars. Wir behalten nur printable ASCII
+ *  (0x21–0x7e) — Rentman-JWTs wie NetBox-Hex-Tokens liegen komplett
+ *  darin — und strippen ein versehentlich mitkopiertes Auth-Prefix. */
+const sanitizeToken = (token: string | null | undefined): string =>
+  (token ?? '').replace(/[^!-~]/g, '').replace(/^(Bearer|Token)\s*/i, '')
 
 export const credentialsService = {
   async getToken(): Promise<string | null> {
@@ -13,14 +25,43 @@ export const credentialsService = {
     // (0x21-0x7e). Strippt Zero-Width-Spaces, Bidi-Marks und alles
     // andere was meine v7.9.120-Regex (control chars + NBSP + BOM)
     // noch durchgelassen hat. Tokens sind base64/hex/JWT — alle ASCII.
-    const clean = (token ?? '')
-      .replace(/[^!-~]/g, '')
-      .replace(/^Bearer\s*/i, '')
-    await keytar.setPassword(SERVICE_NAME, ACCOUNT_NAME, clean)
+    await keytar.setPassword(SERVICE_NAME, ACCOUNT_NAME, sanitizeToken(token))
     return true
   },
 
   async deleteToken(): Promise<boolean> {
     return keytar.deletePassword(SERVICE_NAME, ACCOUNT_NAME)
+  },
+}
+
+/**
+ * #597 — NetBox-API-Token im OS-Schlüsselbund.
+ *
+ * Anders als bei Rentman gibt der Renderer das Token nie wieder zurück:
+ * er fragt nur `hasToken()`. Das Token verlässt den Main-Prozess nicht,
+ * es wird ausschliesslich für ausgehende NetBox-Requests genutzt.
+ */
+export const netboxCredentialsService = {
+  async getToken(): Promise<string | null> {
+    return keytar.getPassword(SERVICE_NAME, NETBOX_ACCOUNT_NAME)
+  },
+
+  async hasToken(): Promise<boolean> {
+    const token = await keytar.getPassword(SERVICE_NAME, NETBOX_ACCOUNT_NAME)
+    return Boolean(token)
+  },
+
+  async saveToken(token: string): Promise<boolean> {
+    const clean = sanitizeToken(token)
+    if (!clean) {
+      await keytar.deletePassword(SERVICE_NAME, NETBOX_ACCOUNT_NAME)
+      return false
+    }
+    await keytar.setPassword(SERVICE_NAME, NETBOX_ACCOUNT_NAME, clean)
+    return true
+  },
+
+  async deleteToken(): Promise<boolean> {
+    return keytar.deletePassword(SERVICE_NAME, NETBOX_ACCOUNT_NAME)
   },
 }

--- a/src/main/services/netboxApiClient.ts
+++ b/src/main/services/netboxApiClient.ts
@@ -1,0 +1,331 @@
+import axios, { AxiosError } from 'axios'
+
+/**
+ * NetBox-REST-API-Client (#597).
+ *
+ * Anders als Rentman hat NetBox keine feste Cloud-URL — jede Firma betreibt
+ * ihre eigene Instanz. Die Basis-URL kommt deshalb bei JEDEM Aufruf aus dem
+ * Renderer mit und wird hier (im Main-Prozess) validiert. Der Main-Prozess
+ * bleibt damit zustandslos; persistiert wird nur das Token (keytar) und die
+ * URL (Renderer-Settings).
+ *
+ * API-Referenz: `<instanz>/api/schema/swagger-ui/`. Wir nutzen ausschliesslich
+ * lesende DCIM-Endpoints:
+ *   /api/status/                    — Verbindungstest + Versions-Info
+ *   /api/dcim/sites/                — Standorte
+ *   /api/dcim/racks/                — Racks (optional nach Site gefiltert)
+ *   /api/dcim/devices/              — Geraete
+ *   /api/dcim/interfaces/           — Netzwerk-/Signal-Ports
+ *   /api/dcim/front-ports/          — Patchfeld vorne
+ *   /api/dcim/rear-ports/           — Patchfeld hinten
+ *   /api/dcim/console-ports/        — Konsole (DTE)
+ *   /api/dcim/console-server-ports/ — Konsolen-Server (DCE)
+ *   /api/dcim/power-ports/          — Strom-Eingaenge
+ *   /api/dcim/power-outlets/        — Strom-Ausgaenge (PDU)
+ *   /api/dcim/cables/               — Verkabelung
+ */
+
+/** Roh-Objekt wie es die NetBox-API liefert. Wir typen bewusst schwach und
+ *  reichen die Records unveraendert an den Renderer weiter — das Mapping auf
+ *  Cable-Planner-Typen passiert dort (`lib/netboxMapping.ts`), damit es
+ *  unit-testbar bleibt und der Main-Prozess kein Domaenen-Wissen braucht. */
+export type NetboxRecord = Record<string, unknown>
+
+/** Ein vollstaendiger Lese-Snapshot fuer Site- oder Rack-Import. */
+export interface NetboxSnapshot {
+  scope: 'site' | 'rack'
+  scopeId: number
+  scopeName: string
+  /** Site-Name — bei Rack-Scope die Site, in der das Rack steht. */
+  siteName: string
+  racks: NetboxRecord[]
+  devices: NetboxRecord[]
+  /** Alle Geraete-Komponenten, gebuendelt nach NetBox-Komponententyp. Der
+   *  Key ist der NetBox-`object_type` ohne Prefix (`interface`, `frontport`,
+   *  …), damit `a_terminations[].object_type` direkt darauf zeigt. */
+  components: Record<string, NetboxRecord[]>
+  cables: NetboxRecord[]
+  /** Von der Instanz gemeldete NetBox-Version (aus /api/status/). */
+  netboxVersion: string
+}
+
+/** Component-Endpoints → NetBox-`object_type`-Suffix. Die Reihenfolge
+ *  bestimmt auch die Port-Reihenfolge am importierten Geraet. */
+export const NETBOX_COMPONENT_ENDPOINTS: Array<{ path: string; objectType: string }> = [
+  { path: 'dcim/interfaces', objectType: 'interface' },
+  { path: 'dcim/front-ports', objectType: 'frontport' },
+  { path: 'dcim/rear-ports', objectType: 'rearport' },
+  { path: 'dcim/console-ports', objectType: 'consoleport' },
+  { path: 'dcim/console-server-ports', objectType: 'consoleserverport' },
+  { path: 'dcim/power-ports', objectType: 'powerport' },
+  { path: 'dcim/power-outlets', objectType: 'poweroutlet' },
+]
+
+/**
+ * Normalisiert und validiert die vom User eingetragene Instanz-URL.
+ *
+ * Erlaubt sind ausschliesslich http/https. Ein angehaengtes `/api` (oder
+ * `/api/schema/swagger-ui/`, was User gerne aus der Browser-Adresszeile
+ * kopieren) wird abgeschnitten, ebenso Trailing-Slashes. Wirft bei allem
+ * anderen — die Validierung passiert bewusst hier im Main-Prozess, nicht
+ * im Renderer.
+ */
+export const normalizeNetboxBaseUrl = (raw: string): string => {
+  const trimmed = (raw ?? '').trim()
+  if (!trimmed) {
+    throw new Error('Keine NetBox-URL konfiguriert — Einstellungen → Integrationen → NetBox.')
+  }
+  let parsed: URL
+  try {
+    parsed = new URL(/^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`)
+  } catch {
+    throw new Error(`Ungültige NetBox-URL: "${trimmed}"`)
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`NetBox-URL muss http oder https sein (war "${parsed.protocol}").`)
+  }
+  // Query/Hash sind bei einer Basis-URL immer ein Copy-Paste-Unfall.
+  parsed.search = ''
+  parsed.hash = ''
+  // `/api`, `/api/`, `/api/schema/swagger-ui/` → Instanz-Root.
+  const path = parsed.pathname.replace(/\/+$/, '')
+  parsed.pathname = path.replace(/\/api(\/.*)?$/i, '')
+  return parsed.toString().replace(/\/+$/, '')
+}
+
+/** Uebersetzt Axios-/NetBox-Fehler in eine sprechende deutsche Meldung. */
+const wrapNetboxError = (err: unknown, context: string): Error => {
+  if (axios.isAxiosError(err)) {
+    const ax = err as AxiosError<unknown>
+    const status = ax.response?.status
+    const data = ax.response?.data as Record<string, unknown> | undefined
+    const serverMsg =
+      (typeof data?.detail === 'string' && data.detail) ||
+      (typeof data?.error === 'string' && data.error) ||
+      ax.message
+    const reqUrl = ax.config?.url ?? '?'
+    // Nur Status + Pfad loggen — Response-Bodies koennen Infrastruktur-
+    // Daten der Instanz enthalten und gehoeren nicht ins Log.
+    console.error('[netbox]', ax.config?.method?.toUpperCase() ?? '?', reqUrl, '->', status ?? 'network')
+
+    if (!ax.response) {
+      return new Error(
+        `NetBox nicht erreichbar (${context}): ${ax.message}. URL, VPN/Netzwerk und Zertifikat prüfen.`,
+      )
+    }
+    const hint =
+      status === 401 || status === 403
+        ? 'Token ungültig oder ohne Leserechte — Einstellungen → Integrationen → NetBox prüfen.'
+        : status === 404
+          ? `Endpoint ${reqUrl} existiert auf dieser Instanz nicht. Ist die URL wirklich die NetBox-Basis-URL?`
+          : status && status >= 500
+            ? 'NetBox-Server-Fehler — später erneut versuchen.'
+            : serverMsg
+    return new Error(`NetBox ${status} (${context}): ${hint}`)
+  }
+  if (err instanceof Error) return new Error(`${context}: ${err.message}`)
+  return new Error(`${context}: ${String(err)}`)
+}
+
+/** Wie viele Objekte pro Seite. NetBox deckelt `limit` serverseitig
+ *  (MAX_PAGE_SIZE, Default 1000) — 250 ist ein sicherer Mittelweg. */
+const PAGE_SIZE = 250
+/** Obergrenze gegen Endlos-Paginierung bei einer kaputten Instanz. */
+const MAX_PAGES = 200
+/** Wie viele `device_id=`-Parameter pro Component-Request. Haelt die URL
+ *  unter den ueblichen 8-KB-Limits von nginx/gunicorn. */
+const DEVICE_ID_BATCH = 50
+
+export const createNetboxApiClient = (rawBaseUrl: string, token: string) => {
+  const baseUrl = normalizeNetboxBaseUrl(rawBaseUrl)
+  // Token-Sanitization analog Rentman: Copy-Paste schleppt gerne BOM,
+  // NBSP, Zero-Width-Spaces oder ein 'Token '-Prefix mit ein. NetBox-
+  // Tokens sind 40-stellige Hex-Strings — reines ASCII-printable.
+  const cleanToken = (token ?? '').replace(/[^!-~]/g, '').replace(/^Token\s*/i, '')
+
+  const client = axios.create({
+    baseURL: `${baseUrl}/api/`,
+    headers: {
+      Authorization: `Token ${cleanToken}`,
+      Accept: 'application/json',
+    },
+    timeout: 30000,
+  })
+
+  /** Holt alle Seiten eines paginierten NetBox-Endpoints. NetBox antwortet
+   *  mit `{count, next, previous, results}`; wir paginieren ueber
+   *  limit/offset statt `next` zu folgen, damit eine hinter einem Reverse-
+   *  Proxy falsch gesetzte `next`-URL (interner Hostname!) uns nicht aus
+   *  der konfigurierten Basis-URL herauswirft. */
+  const fetchAll = async (path: string, params: string[] = []): Promise<NetboxRecord[]> => {
+    const all: NetboxRecord[] = []
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const query = [...params, `limit=${PAGE_SIZE}`, `offset=${page * PAGE_SIZE}`].join('&')
+      const response = await client.get(`${path}/?${query}`)
+      const body = response.data as { results?: unknown; count?: number } | unknown[]
+      const results = Array.isArray(body)
+        ? body
+        : Array.isArray((body as { results?: unknown }).results)
+          ? ((body as { results: unknown[] }).results)
+          : []
+      all.push(...(results as NetboxRecord[]))
+      if (results.length < PAGE_SIZE) return all
+    }
+    console.warn(`[netbox] ${path}: Seitenlimit (${MAX_PAGES}) erreicht — Ergebnis evtl. unvollständig.`)
+    return all
+  }
+
+  /** Component-Endpoint fuer eine Geraeteliste, in `device_id`-Baetchen. */
+  const fetchComponentsForDevices = async (
+    path: string,
+    deviceIds: number[],
+  ): Promise<NetboxRecord[]> => {
+    const out: NetboxRecord[] = []
+    for (let i = 0; i < deviceIds.length; i += DEVICE_ID_BATCH) {
+      const batch = deviceIds.slice(i, i + DEVICE_ID_BATCH)
+      const params = batch.map((id) => `device_id=${encodeURIComponent(String(id))}`)
+      out.push(...(await fetchAll(path, params)))
+    }
+    return out
+  }
+
+  const getStatus = async (): Promise<NetboxRecord> => {
+    try {
+      const response = await client.get('status/')
+      return (response.data ?? {}) as NetboxRecord
+    } catch (err) {
+      throw wrapNetboxError(err, 'GET /api/status/')
+    }
+  }
+
+  const numericId = (record: NetboxRecord): number | null => {
+    const id = record.id
+    return typeof id === 'number' ? id : typeof id === 'string' && /^\d+$/.test(id) ? Number(id) : null
+  }
+
+  const textField = (record: NetboxRecord | undefined, key: string): string => {
+    const value = record?.[key]
+    return typeof value === 'string' ? value : ''
+  }
+
+  return {
+    baseUrl,
+
+    /** Verbindungstest: /api/status/ liefert Version + Plugin-Liste und
+     *  verlangt (bei nicht-oeffentlichen Instanzen) ein gueltiges Token. */
+    async testConnection(): Promise<{ ok: boolean; message: string; version?: string }> {
+      const status = await getStatus()
+      const version = textField(status, 'netbox-version') || textField(status, 'netbox_version')
+      // Ein zweiter, token-pflichtiger Read stellt sicher, dass wir nicht nur
+      // eine anonym lesbare Statusseite erwischt haben.
+      try {
+        await client.get('dcim/sites/?limit=1')
+      } catch (err) {
+        throw wrapNetboxError(err, 'GET /api/dcim/sites/')
+      }
+      return {
+        ok: true,
+        message: version
+          ? `Verbindung OK — NetBox ${version} unter ${baseUrl}.`
+          : `Verbindung OK — ${baseUrl}.`,
+        version: version || undefined,
+      }
+    },
+
+    async getSites(): Promise<NetboxRecord[]> {
+      try {
+        return await fetchAll('dcim/sites')
+      } catch (err) {
+        throw wrapNetboxError(err, 'GET /api/dcim/sites/')
+      }
+    },
+
+    async getRacks(siteId?: number): Promise<NetboxRecord[]> {
+      try {
+        const params = typeof siteId === 'number' ? [`site_id=${encodeURIComponent(String(siteId))}`] : []
+        return await fetchAll('dcim/racks', params)
+      } catch (err) {
+        throw wrapNetboxError(err, 'GET /api/dcim/racks/')
+      }
+    },
+
+    /**
+     * Liest alles, was fuer einen Import gebraucht wird, in einem Rutsch:
+     * Racks, Geraete, alle Geraete-Komponenten und die Kabel.
+     *
+     * Kabel werden IMMER ueber die Site geholt (ein Rack gehoert genau zu
+     * einer Site) und erst im Renderer auf die importierten Geraete
+     * eingeschraenkt. Grund: der `rack_id`-Filter auf /dcim/cables/ ist
+     * nicht in allen NetBox-Versionen vorhanden, `site_id` schon.
+     */
+    async fetchSnapshot(scope: 'site' | 'rack', scopeId: number): Promise<NetboxSnapshot> {
+      if (!Number.isInteger(scopeId) || scopeId <= 0) {
+        throw new Error(`Ungültige NetBox-ID: ${String(scopeId)}`)
+      }
+      const status = await getStatus()
+      const netboxVersion =
+        textField(status, 'netbox-version') || textField(status, 'netbox_version')
+
+      let siteId: number
+      let scopeName: string
+      let siteName: string
+      let racks: NetboxRecord[]
+
+      try {
+        if (scope === 'site') {
+          const site = (await client.get(`dcim/sites/${scopeId}/`)).data as NetboxRecord
+          siteId = numericId(site) ?? scopeId
+          scopeName = textField(site, 'name') || `Site ${scopeId}`
+          siteName = scopeName
+          racks = await fetchAll('dcim/racks', [`site_id=${siteId}`])
+        } else {
+          const rack = (await client.get(`dcim/racks/${scopeId}/`)).data as NetboxRecord
+          const site = (rack.site ?? {}) as NetboxRecord
+          const resolvedSiteId = numericId(site)
+          if (resolvedSiteId === null) {
+            throw new Error(`Rack #${scopeId} hat keine Site — Import nicht möglich.`)
+          }
+          siteId = resolvedSiteId
+          scopeName = textField(rack, 'name') || `Rack ${scopeId}`
+          siteName = textField(site, 'name') || `Site ${siteId}`
+          racks = [rack]
+        }
+      } catch (err) {
+        throw wrapNetboxError(err, `GET ${scope} #${scopeId}`)
+      }
+
+      try {
+        const deviceFilter =
+          scope === 'site' ? [`site_id=${siteId}`] : [`rack_id=${scopeId}`]
+        const devices = await fetchAll('dcim/devices', deviceFilter)
+        const deviceIds = devices
+          .map((d) => numericId(d))
+          .filter((id): id is number => id !== null)
+
+        const components: Record<string, NetboxRecord[]> = {}
+        for (const { path, objectType } of NETBOX_COMPONENT_ENDPOINTS) {
+          components[objectType] =
+            deviceIds.length > 0 ? await fetchComponentsForDevices(path, deviceIds) : []
+        }
+
+        const cables = await fetchAll('dcim/cables', [`site_id=${siteId}`])
+
+        return {
+          scope,
+          scopeId,
+          scopeName,
+          siteName,
+          racks,
+          devices,
+          components,
+          cables,
+          netboxVersion,
+        }
+      } catch (err) {
+        throw wrapNetboxError(err, `Snapshot ${scope} #${scopeId}`)
+      }
+    },
+  }
+}
+
+export type NetboxApiClient = ReturnType<typeof createNetboxApiClient>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -9,6 +9,7 @@ import { MenuBar } from './components/Layout/MenuBar'
 import { StatusBar } from './components/Layout/StatusBar'
 import { PropertiesPanel } from './components/Properties/PropertiesPanel'
 import { RentmanImportDialog } from './components/Rentman/RentmanImportDialog'
+import { NetboxImportDialog } from './components/Netbox/NetboxImportDialog'
 import { GraphmlImportDialog } from './components/Import/GraphmlImportDialog'
 import { RentmanCableExportDialog } from './components/Rentman/RentmanCableExportDialog'
 import { OnboardingTour } from './components/Onboarding/OnboardingTour'
@@ -171,6 +172,8 @@ export default function App() {
     open ? useUiStore.getState().openSettings() : useUiStore.getState().closeSettings()
   const rentmanImport = useUiStore((state) => state.rentmanImport)
   const closeRentmanImport = useUiStore((state) => state.closeRentmanImport)
+  const netboxImport = useUiStore((state) => state.netboxImport)
+  const closeNetboxImport = useUiStore((state) => state.closeNetboxImport)
   const rentmanCableExport = useUiStore((state) => state.rentmanCableExport)
   const openRentmanCableExport = useUiStore((state) => state.openRentmanCableExport)
   const closeRentmanCableExport = useUiStore((state) => state.closeRentmanCableExport)
@@ -1086,6 +1089,7 @@ export default function App() {
         initialSection={settingsSection}
       />
       <RentmanImportDialog open={rentmanImport.open} onClose={closeRentmanImport} />
+      <NetboxImportDialog open={netboxImport.open} onClose={closeNetboxImport} />
       <GraphmlImportDialog open={graphmlImportOpen} onClose={() => setGraphmlImportOpen(false)} />
       <RentmanCableExportDialog
         open={rentmanCableExport.open}

--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -248,6 +248,7 @@ export const MenuBar = ({
     })
   }, [t])
   const rentmanEnabled = useModule('rentman')
+  const netboxEnabled = useModule('netbox')
   // Modulares UI — Festinstallations-Doku nur zeigen, wenn das Modul an ist.
   const festinstallationModule = useModule('festinstallation')
   // Modulares UI — Handy-Zugriff nur zeigen, wenn das Mobile-Modul an ist.
@@ -580,6 +581,12 @@ export const MenuBar = ({
           {rentmanEnabled && (
             <MenuItem onClick={() => useUiStore.getState().openRentmanImport()} icon={<Icon icon={Users} size="sm" />}>
               {t('app.menu.tools.rentmanImport', 'Rentman-Import…')}
+            </MenuItem>
+          )}
+          {/* #597 — NetBox-Import, ebenfalls nur bei aktivem Modul. */}
+          {netboxEnabled && (
+            <MenuItem onClick={() => useUiStore.getState().openNetboxImport()} icon={<Icon icon={Server} size="sm" />}>
+              {t('app.menu.tools.netboxImport', 'NetBox-Import…')}
             </MenuItem>
           )}
         </Menu>

--- a/src/renderer/components/Netbox/NetboxImportDialog.tsx
+++ b/src/renderer/components/Netbox/NetboxImportDialog.tsx
@@ -1,0 +1,487 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Server, RefreshCw, Download, AlertTriangle } from 'lucide-react'
+import { ModalShell } from '../shared/ModalShell'
+import { Icon } from '../shared/Icon'
+import { cablePlannerApi } from '../../lib/bridge'
+import { useProjectStore } from '../../store/projectStore'
+import { useSettingsStore } from '../../store/settingsStore'
+import { useTranslation, format } from '../../lib/i18n'
+import { buildNetboxImportPlan, type NetboxImportPlan } from '../../lib/netboxMapping'
+import type { NetboxRack, NetboxSite, NetboxSnapshot } from '../../types/netbox'
+
+/**
+ * #597 — NetBox-Import.
+ *
+ * Zweistufig: erst Site (und optional Rack) aus der konfigurierten Instanz
+ * wählen, dann eine Vorschau des Deltas bestätigen. Der Abgleich ist immer
+ * additiv, deshalb ist der zweite Lauf („Aktualisieren") derselbe Weg —
+ * er zeigt dann nur noch, was seit dem letzten Import dazugekommen ist.
+ */
+
+type Phase = 'choose' | 'preview'
+
+const numberOr = (value: unknown, fallback: number): number =>
+  typeof value === 'number' && Number.isFinite(value) ? value : fallback
+
+export const NetboxImportDialog = ({ open, onClose }: { open: boolean; onClose: () => void }) => {
+  const t = useTranslation()
+  const netboxUrl = useSettingsStore((s) => s.netboxUrl)
+  const applyNetboxImport = useProjectStore((s) => s.applyNetboxImport)
+  const metadata = useProjectStore((s) => s.project.metadata)
+
+  const [phase, setPhase] = useState<Phase>('choose')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [sites, setSites] = useState<NetboxSite[]>([])
+  const [racks, setRacks] = useState<NetboxRack[]>([])
+  const [siteId, setSiteId] = useState<number | null>(null)
+  const [rackId, setRackId] = useState<number | null>(null)
+
+  const [onlyConnectedPorts, setOnlyConnectedPorts] = useState(true)
+  const [includeCables, setIncludeCables] = useState(true)
+  const [createRackFrames, setCreateRackFrames] = useState(true)
+
+  const [snapshot, setSnapshot] = useState<NetboxSnapshot | null>(null)
+  const [plan, setPlan] = useState<NetboxImportPlan | null>(null)
+
+  const configured = netboxUrl.trim().length > 0
+  /** Das Projekt hängt bereits an einer NetBox-Quelle → „Aktualisieren". */
+  const linked =
+    metadata.netboxSourceUrl === netboxUrl.trim() &&
+    typeof metadata.netboxScopeId === 'number' &&
+    (metadata.netboxScope === 'site' || metadata.netboxScope === 'rack')
+
+  /** Dialog beim Öffnen in den Ausgangszustand bringen; wenn das Projekt
+   *  schon verknüpft ist, direkt die gespeicherte Auswahl vorbelegen. */
+  useEffect(() => {
+    if (!open) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Dialog beim Öffnen zurücksetzen + gespeicherte Quelle seeden (keyed sync)
+    setPhase('choose')
+    setError(null)
+    setSnapshot(null)
+    setPlan(null)
+    if (linked && metadata.netboxScope === 'rack') {
+      setRackId(metadata.netboxScopeId ?? null)
+    } else if (linked && metadata.netboxScope === 'site') {
+      setSiteId(metadata.netboxScopeId ?? null)
+      setRackId(null)
+    }
+  }, [open, linked, metadata.netboxScope, metadata.netboxScopeId])
+
+  const loadSites = useCallback(async () => {
+    if (!configured) return
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await cablePlannerApi.netbox.getSites(netboxUrl)
+      setSites(result)
+      if (result.length > 0 && siteId === null) {
+        setSiteId(numberOr(result[0].id, 0) || null)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
+  }, [configured, netboxUrl, siteId])
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Site-Liste beim Öffnen aus der Instanz nachladen (externes System)
+    if (open && configured && sites.length === 0) void loadSites()
+    // Absichtlich nur `open`/`configured` als Deps: `loadSites` haengt an
+    // `siteId`, ein Re-Run bei jeder Auswahl waere ein unnoetiger Refetch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, configured])
+
+  // Racks nachladen, sobald eine Site gewählt ist.
+  useEffect(() => {
+    if (!open || !configured || siteId === null) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const result = await cablePlannerApi.netbox.getRacks(netboxUrl, siteId)
+        if (!cancelled) setRacks(result)
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err))
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [open, configured, netboxUrl, siteId])
+
+  const scope: 'site' | 'rack' = rackId === null ? 'site' : 'rack'
+  const scopeId = rackId ?? siteId
+
+  const buildPreview = async () => {
+    if (scopeId === null) return
+    setBusy(true)
+    setError(null)
+    try {
+      const fetched = await cablePlannerApi.netbox.fetchSnapshot(netboxUrl, scope, scopeId)
+      const { equipment, cables } = useProjectStore.getState().project
+      const next = buildNetboxImportPlan(fetched, equipment, cables, {
+        baseUrl: netboxUrl.trim(),
+        onlyConnectedPorts,
+        includeCables,
+        createRackFrames,
+      })
+      setSnapshot(fetched)
+      setPlan(next)
+      setPhase('preview')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const confirmImport = () => {
+    if (!plan || !snapshot) return
+    applyNetboxImport({
+      newEquipment: plan.newEquipment,
+      newCables: plan.newCables,
+      portAdditions: plan.portAdditions,
+      newLocations: plan.newLocations,
+      source: {
+        baseUrl: netboxUrl.trim(),
+        scope: snapshot.scope,
+        scopeId: snapshot.scopeId,
+        scopeName: snapshot.scopeName,
+      },
+    })
+    onClose()
+  }
+
+  const addedPortCount = useMemo(
+    () => (plan ? plan.portAdditions.reduce((n, p) => n + p.inputs.length + p.outputs.length, 0) : 0),
+    [plan],
+  )
+
+  const nothingToDo =
+    plan !== null &&
+    plan.newEquipment.length === 0 &&
+    plan.newCables.length === 0 &&
+    addedPortCount === 0
+
+  return (
+    <ModalShell
+      open={open}
+      onClose={onClose}
+      title={t('netbox.import.title', 'NetBox-Import')}
+      titleIcon={<Icon icon={Server} size="md" />}
+      maxWidth="2xl"
+      draggableKey="cable-planner:modal-pos:netbox-import"
+      footer={
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <span className="text-cp-xs text-cp-text-muted">
+            {configured ? netboxUrl : t('netbox.notConfigured', 'Keine NetBox-URL konfiguriert')}
+          </span>
+          <div className="flex gap-2">
+            {phase === 'preview' && (
+              <button
+                type="button"
+                onClick={() => setPhase('choose')}
+                className="rounded bg-cp-surface-2 px-3 py-1 text-cp-base hover:bg-cp-surface-3"
+              >
+                {t('common.back', 'Zurück')}
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded bg-cp-surface-2 px-3 py-1 text-cp-base hover:bg-cp-surface-3"
+            >
+              {t('common.cancel', 'Abbrechen')}
+            </button>
+            {phase === 'choose' ? (
+              <button
+                type="button"
+                disabled={busy || !configured || scopeId === null}
+                onClick={() => void buildPreview()}
+                className="rounded bg-sky-600 px-3 py-1 text-cp-base font-semibold text-white hover:bg-sky-500 disabled:opacity-50"
+              >
+                {busy
+                  ? t('netbox.import.loading', 'Lade aus NetBox…')
+                  : t('netbox.import.preview', 'Vorschau erstellen')}
+              </button>
+            ) : (
+              <button
+                type="button"
+                disabled={busy || nothingToDo}
+                onClick={confirmImport}
+                className="rounded bg-emerald-600 px-3 py-1 text-cp-base font-semibold text-white hover:bg-emerald-500 disabled:opacity-50"
+              >
+                <Icon icon={Download} size="sm" />{' '}
+                {t('netbox.import.apply', 'In Projekt übernehmen')}
+              </button>
+            )}
+          </div>
+        </div>
+      }
+    >
+      {!configured ? (
+        <div className="rounded border border-amber-700/50 bg-amber-900/20 p-3 text-cp-base text-amber-200">
+          {t(
+            'netbox.import.needsConfig',
+            'Bitte zuerst unter Einstellungen → Integrationen → NetBox die Instanz-URL und ein API-Token hinterlegen.',
+          )}
+        </div>
+      ) : phase === 'choose' ? (
+        <div className="space-y-3">
+          <p className="text-cp-base text-cp-text-secondary">
+            {t(
+              'netbox.import.intro',
+              'Wähle eine Site oder ein einzelnes Rack. Geräte, Ports und Verbindungen werden gelesen und als Kabelplan angelegt. Der Abgleich fügt immer nur hinzu — bereits vorhandene Geräte und Kabel bleiben mit allen Anpassungen erhalten.',
+            )}
+          </p>
+
+          <label className="block text-cp-base">
+            {t('netbox.import.site', 'Site')}
+            <div className="mt-1 flex gap-2">
+              <select
+                value={siteId ?? ''}
+                onChange={(e) => {
+                  setSiteId(e.target.value ? Number(e.target.value) : null)
+                  setRackId(null)
+                }}
+                className="flex-1 rounded border border-cp-border bg-cp-surface-3 p-2 text-cp-base"
+              >
+                <option value="">{t('netbox.import.sitePlaceholder', '— Site wählen —')}</option>
+                {sites.map((site) => (
+                  <option key={site.id} value={site.id}>
+                    {site.name ?? site.display ?? `Site ${site.id}`}
+                    {typeof site.device_count === 'number' ? ` (${site.device_count})` : ''}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void loadSites()}
+                className="rounded bg-cp-surface-2 px-2 py-1 text-cp-text-muted hover:bg-cp-surface-4 disabled:opacity-50"
+                title={t('netbox.import.reload', 'Neu laden')}
+                aria-label={t('netbox.import.reload', 'Neu laden')}
+              >
+                <Icon icon={RefreshCw} size="sm" />
+              </button>
+            </div>
+          </label>
+
+          <label className="block text-cp-base">
+            {t('netbox.import.rack', 'Rack (optional)')}
+            <select
+              value={rackId ?? ''}
+              disabled={siteId === null}
+              onChange={(e) => setRackId(e.target.value ? Number(e.target.value) : null)}
+              className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2 text-cp-base disabled:opacity-50"
+            >
+              <option value="">
+                {t('netbox.import.wholeSite', '— ganze Site importieren —')}
+              </option>
+              {racks.map((rack) => (
+                <option key={rack.id} value={rack.id}>
+                  {rack.name ?? rack.display ?? `Rack ${rack.id}`}
+                  {typeof rack.device_count === 'number' ? ` (${rack.device_count})` : ''}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <fieldset className="space-y-2 rounded border border-cp-border bg-cp-surface-3/40 p-3">
+            <legend className="px-1 text-cp-xs text-cp-text-muted">
+              {t('netbox.import.options', 'Optionen')}
+            </legend>
+            <label className="flex items-start gap-2 text-cp-base">
+              <input
+                type="checkbox"
+                checked={onlyConnectedPorts}
+                onChange={(e) => setOnlyConnectedPorts(e.target.checked)}
+                className="mt-1 accent-sky-500"
+              />
+              <span>
+                {t('netbox.import.onlyConnected', 'Nur verkabelte Ports importieren')}
+                <span className="block text-cp-xs text-cp-text-muted">
+                  {t(
+                    'netbox.import.onlyConnectedHint',
+                    'Empfohlen: ein 48-Port-Switch bringt sonst 48 unbenutzte Ports mit auf den Plan.',
+                  )}
+                </span>
+              </span>
+            </label>
+            <label className="flex items-center gap-2 text-cp-base">
+              <input
+                type="checkbox"
+                checked={includeCables}
+                onChange={(e) => setIncludeCables(e.target.checked)}
+                className="accent-sky-500"
+              />
+              {t('netbox.import.includeCables', 'Verbindungen importieren')}
+            </label>
+            <label className="flex items-center gap-2 text-cp-base">
+              <input
+                type="checkbox"
+                checked={createRackFrames}
+                onChange={(e) => setCreateRackFrames(e.target.checked)}
+                className="accent-sky-500"
+              />
+              {t('netbox.import.rackFrames', 'Rahmen je Rack anlegen')}
+            </label>
+          </fieldset>
+
+          {linked && (
+            <div className="rounded border border-sky-700/50 bg-sky-900/20 p-2 text-cp-xs text-sky-200">
+              {format(
+                t(
+                  'netbox.import.linked',
+                  'Dieses Projekt ist mit {scope} „{name}" verknüpft. Letzter Abgleich: {when}.',
+                ),
+                {
+                  scope: metadata.netboxScope === 'rack' ? 'Rack' : 'Site',
+                  name: metadata.netboxScopeName ?? '—',
+                  when: metadata.netboxLastSyncAt
+                    ? new Date(metadata.netboxLastSyncAt).toLocaleString()
+                    : '—',
+                },
+              )}
+            </div>
+          )}
+        </div>
+      ) : plan && snapshot ? (
+        <div className="space-y-3">
+          <div className="text-cp-base">
+            <span className="font-semibold">
+              {snapshot.scope === 'rack' ? 'Rack' : 'Site'} „{snapshot.scopeName}"
+            </span>
+            <span className="ml-2 text-cp-xs text-cp-text-muted">
+              {snapshot.siteName}
+              {snapshot.netboxVersion ? ` · NetBox ${snapshot.netboxVersion}` : ''}
+            </span>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+            <PreviewStat
+              label={t('netbox.preview.newDevices', 'Neue Geräte')}
+              value={plan.newEquipment.length}
+              accent
+            />
+            <PreviewStat
+              label={t('netbox.preview.newCables', 'Neue Verbindungen')}
+              value={plan.newCables.length}
+              accent
+            />
+            <PreviewStat
+              label={t('netbox.preview.newPorts', 'Neue Ports an Bestand')}
+              value={addedPortCount}
+              accent={addedPortCount > 0}
+            />
+            <PreviewStat
+              label={t('netbox.preview.unchanged', 'Unverändert')}
+              value={plan.unchangedDeviceIds.length + plan.unchangedCableIds.length}
+            />
+          </div>
+
+          <div className="rounded border border-cp-border bg-cp-surface-3/40 p-2 text-cp-xs text-cp-text-muted">
+            {format(
+              t(
+                'netbox.preview.source',
+                'In NetBox: {devices} Geräte, {cables} Verbindungen, {ports} Ports — davon {imported} übernommen.',
+              ),
+              {
+                devices: plan.stats.devicesInNetbox,
+                cables: plan.stats.cablesInNetbox,
+                ports: plan.stats.componentsInNetbox,
+                imported: plan.stats.componentsImported,
+              },
+            )}
+          </div>
+
+          {nothingToDo && (
+            <div className="rounded border border-emerald-700/50 bg-emerald-900/20 p-2 text-cp-base text-emerald-200">
+              {t(
+                'netbox.preview.upToDate',
+                'Der Plan ist bereits auf dem Stand von NetBox — es gibt nichts hinzuzufügen.',
+              )}
+            </div>
+          )}
+
+          {(plan.staleDeviceIds.length > 0 || plan.staleCableIds.length > 0) && (
+            <div className="rounded border border-amber-700/50 bg-amber-900/20 p-2 text-cp-xs text-amber-200">
+              <Icon icon={AlertTriangle} size="sm" />{' '}
+              {format(
+                t(
+                  'netbox.preview.stale',
+                  '{devices} Geräte und {cables} Verbindungen im Plan gibt es in NetBox nicht mehr. Sie bleiben unangetastet — bitte manuell prüfen.',
+                ),
+                { devices: plan.staleDeviceIds.length, cables: plan.staleCableIds.length },
+              )}
+            </div>
+          )}
+
+          {plan.skipped.length > 0 && (
+            <details className="rounded border border-cp-border bg-cp-surface-3/40 p-2">
+              <summary className="cursor-pointer text-cp-xs text-cp-text-secondary">
+                {format(t('netbox.preview.skipped', '{count} übersprungene Objekte'), {
+                  count: plan.skipped.length,
+                })}
+              </summary>
+              <ul className="mt-2 max-h-48 space-y-1 overflow-y-auto text-cp-xs text-cp-text-muted">
+                {plan.skipped.slice(0, 100).map((skip) => (
+                  <li key={`${skip.kind}-${skip.netboxId}-${skip.reason}`}>
+                    <span className="font-mono">#{skip.netboxId}</span> {skip.label} — {skip.reason}
+                  </li>
+                ))}
+              </ul>
+            </details>
+          )}
+
+          {plan.newEquipment.length > 0 && (
+            <details className="rounded border border-cp-border bg-cp-surface-3/40 p-2" open>
+              <summary className="cursor-pointer text-cp-xs text-cp-text-secondary">
+                {t('netbox.preview.deviceList', 'Geräte, die angelegt werden')}
+              </summary>
+              <ul className="mt-2 max-h-48 space-y-1 overflow-y-auto text-cp-xs">
+                {plan.newEquipment.map((item) => (
+                  <li key={item.id} className="flex justify-between gap-2">
+                    <span className="truncate text-cp-text">{item.name}</span>
+                    <span className="shrink-0 text-cp-text-muted">
+                      {item.category} · {item.inputs.length + item.outputs.length} Ports
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </details>
+          )}
+        </div>
+      ) : null}
+
+      {error && (
+        <div className="mt-3 rounded border border-red-700/50 bg-red-900/20 p-2 text-cp-xs text-red-200">
+          {error}
+        </div>
+      )}
+    </ModalShell>
+  )
+}
+
+const PreviewStat = ({
+  label,
+  value,
+  accent,
+}: {
+  label: string
+  value: number
+  accent?: boolean
+}) => (
+  <div
+    className={`rounded border p-2 text-center ${
+      accent && value > 0
+        ? 'border-emerald-700/50 bg-emerald-900/20 text-emerald-200'
+        : 'border-cp-border bg-cp-surface-3/40 text-cp-text-muted'
+    }`}
+  >
+    <div className="text-cp-xl font-semibold">{value}</div>
+    <div className="text-[10px] leading-tight">{label}</div>
+  </div>
+)

--- a/src/renderer/components/Netbox/NetboxImportDialog.tsx
+++ b/src/renderer/components/Netbox/NetboxImportDialog.tsx
@@ -76,21 +76,24 @@ export const NetboxImportDialog = ({ open, onClose }: { open: boolean; onClose: 
     try {
       const result = await cablePlannerApi.netbox.getSites(netboxUrl)
       setSites(result)
-      if (result.length > 0 && siteId === null) {
-        setSiteId(numberOr(result[0].id, 0) || null)
-      }
+      // Funktionales Update statt `siteId`-Closure: der Reset-Effect kann
+      // im selben Commit eine gespeicherte Site vorbelegt haben, die diese
+      // Closure noch als null sieht — die dürfen wir nicht überschreiben.
+      setSiteId((current) =>
+        current === null && result.length > 0 ? numberOr(result[0].id, 0) || null : current,
+      )
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
       setBusy(false)
     }
-  }, [configured, netboxUrl, siteId])
+  }, [configured, netboxUrl])
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- Site-Liste beim Öffnen aus der Instanz nachladen (externes System)
     if (open && configured && sites.length === 0) void loadSites()
-    // Absichtlich nur `open`/`configured` als Deps: `loadSites` haengt an
-    // `siteId`, ein Re-Run bei jeder Auswahl waere ein unnoetiger Refetch.
+    // Absichtlich nur `open`/`configured` als Deps: `sites.length` mit
+    // aufzunehmen wuerde den Effect direkt nach dem Laden erneut ausloesen.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, configured])
 

--- a/src/renderer/components/Settings/tabs/IntegrationsTab.tsx
+++ b/src/renderer/components/Settings/tabs/IntegrationsTab.tsx
@@ -287,6 +287,236 @@ const GreenGoPresetsCard = () => {
   )
 }
 
+/**
+ * #597 — NetBox-Instanz konfigurieren.
+ *
+ * Zwei Dinge gehören hierher: die Basis-URL der (selbst gehosteten)
+ * Instanz — die lebt in den App-Settings, weil dieselbe Instanz alle
+ * Projekte bedient — und das API-Token, das wie der Rentman-Token im
+ * OS-Schlüsselbund landet. Anders als bei Rentman holt der Renderer das
+ * Token nie zurück: er fragt nur, ob eines hinterlegt ist.
+ */
+const NetboxCard = ({ onClose }: { onClose: () => void }) => {
+  const t = useTranslation()
+  const netboxEnabled = useModule('netbox')
+  const setModuleEnabled = useSettingsStore((s) => s.setModuleEnabled)
+  const netboxUrl = useSettingsStore((s) => s.netboxUrl)
+  const setNetboxUrl = useSettingsStore((s) => s.setNetboxUrl)
+  const openNetboxImport = useUiStore((s) => s.openNetboxImport)
+
+  const [url, setUrl] = useState(netboxUrl)
+  const [token, setToken] = useState('')
+  const [hasToken, setHasToken] = useState(false)
+  const [status, setStatus] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    if (!netboxEnabled) return
+    void cablePlannerApi.netbox.hasToken().then(setHasToken)
+  }, [netboxEnabled])
+
+  const saveUrl = async () => {
+    setBusy(true)
+    try {
+      // Normalisierung passiert im Main-Prozess (dort liegt die
+      // Validierung) — ein getipptes "netbox.firma.de/api/" wird so
+      // automatisch zur brauchbaren Basis-URL.
+      const result = await cablePlannerApi.netbox.normalizeUrl(url)
+      if (!result.ok) {
+        setStatus(result.message)
+        return
+      }
+      setUrl(result.url)
+      setNetboxUrl(result.url)
+      setStatus(t('settings.integrations.netbox.urlSaved', 'URL gespeichert.'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const saveToken = async () => {
+    setBusy(true)
+    try {
+      const stored = await cablePlannerApi.netbox.saveToken(token)
+      setHasToken(stored)
+      setToken('')
+      setStatus(
+        stored
+          ? t('settings.integrations.netbox.tokenSaved', 'Token sicher im Schlüsselbund gespeichert.')
+          : t('settings.integrations.netbox.tokenCleared', 'Token gelöscht.'),
+      )
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : String(error))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const removeToken = async () => {
+    setBusy(true)
+    try {
+      await cablePlannerApi.netbox.deleteToken()
+      setHasToken(false)
+      setToken('')
+      setStatus(t('settings.integrations.netbox.tokenCleared', 'Token gelöscht.'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const testConnection = async () => {
+    setBusy(true)
+    try {
+      const result = await cablePlannerApi.netbox.testConnection(netboxUrl || url)
+      setStatus(result.message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <>
+      <SettingsCard
+        title={t('settings.integrations.netboxToggle.title', 'NetBox-Integration')}
+        description={t(
+          'settings.integrations.netboxToggle.desc',
+          'Wenn aktiv: Menüeintrag und Import-Dialog für die eigene NetBox-Instanz erscheinen. Aus NetBox geplante Sites und Racks lassen sich damit als Kabelplan übernehmen.',
+        )}
+      >
+        <label className="flex items-center gap-2 text-cp-base">
+          <input
+            type="checkbox"
+            checked={netboxEnabled}
+            onChange={(e) => setModuleEnabled('netbox', e.target.checked)}
+            className="h-4 w-4 accent-sky-500"
+          />
+          <span>
+            {t('settings.integrations.netboxToggle.label', 'NetBox-Integration aktivieren')}{' '}
+            <span className="text-[10px] text-cp-text-muted">
+              ({netboxEnabled ? t('common.on', 'ein') : t('common.off', 'aus')})
+            </span>
+          </span>
+        </label>
+      </SettingsCard>
+
+      {netboxEnabled && (
+        <SettingsCard
+          title={t('settings.integrations.netbox', 'NetBox API')}
+          description={t(
+            'settings.integrations.netboxDesc',
+            'Basis-URL deiner NetBox-Instanz plus ein API-Token mit Leserechten. Das Token wird im Betriebssystem-Schlüsselbund verschlüsselt gespeichert (nie im Projektfile) und verlässt den Hauptprozess nicht.',
+          )}
+        >
+          <label className="block text-cp-base">
+            {t('settings.integrations.netbox.url', 'Instanz-URL')}
+            <div className="mt-1 flex gap-2">
+              <input
+                type="url"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                className="flex-1 rounded border border-cp-border bg-cp-surface-3 p-2 font-mono text-cp-xs"
+                placeholder="https://netbox.firma.de"
+                autoComplete="off"
+                spellCheck={false}
+              />
+              <button
+                type="button"
+                disabled={busy || !url.trim()}
+                onClick={() => void saveUrl()}
+                className="rounded bg-sky-600 px-3 py-1 text-cp-base hover:bg-sky-500 disabled:opacity-50"
+              >
+                {t('common.save', 'Speichern')}
+              </button>
+            </div>
+          </label>
+
+          <label className="mt-2 block text-cp-base">
+            {t('settings.integrations.netbox.token', 'API-Token')}
+            <input
+              type="password"
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-2 font-mono text-cp-xs"
+              placeholder={
+                hasToken
+                  ? t('settings.integrations.netbox.tokenStoredPlaceholder', 'Token hinterlegt — zum Ersetzen neues einfügen')
+                  : t('settings.integrations.netbox.tokenPlaceholder', 'API-Token einfügen')
+              }
+              autoComplete="off"
+            />
+          </label>
+
+          <div
+            className={`mt-2 rounded border p-2 text-cp-xs ${
+              hasToken
+                ? 'border-emerald-700/50 bg-emerald-900/20 text-emerald-300'
+                : 'border-cp-border bg-cp-surface-3/40 text-cp-text-muted'
+            }`}
+          >
+            <div>
+              <span className="font-semibold">
+                {t('settings.integrations.netbox.status', 'Status:')}
+              </span>{' '}
+              {status || t('settings.integrations.netbox.statusIdle', 'Noch nicht getestet.')}
+            </div>
+            <div className="text-cp-text-faint">
+              {t('settings.integrations.netbox.tokenStored', 'Token gespeichert:')}{' '}
+              {hasToken ? t('common.yes', 'Ja') : t('common.no', 'Nein')}
+            </div>
+          </div>
+
+          <div className="mt-2 flex flex-wrap gap-2">
+            <button
+              type="button"
+              disabled={busy || !token}
+              onClick={() => void saveToken()}
+              className="rounded bg-sky-600 px-3 py-1 text-cp-base hover:bg-sky-500 disabled:opacity-50"
+            >
+              {t('settings.integrations.netbox.saveToken', 'Token speichern')}
+            </button>
+            <button
+              type="button"
+              disabled={busy || !hasToken || !(netboxUrl || url).trim()}
+              onClick={() => void testConnection()}
+              className="rounded bg-emerald-600 px-3 py-1 text-cp-base hover:bg-emerald-500 disabled:opacity-50"
+            >
+              {t('settings.integrations.netbox.test', 'Verbindung testen')}
+            </button>
+            <button
+              type="button"
+              disabled={busy || !hasToken}
+              onClick={() => void removeToken()}
+              className="rounded bg-red-600 px-3 py-1 text-cp-base hover:bg-red-500 disabled:opacity-50"
+            >
+              {t('settings.integrations.netbox.deleteToken', 'Token löschen')}
+            </button>
+            <button
+              type="button"
+              disabled={!hasToken || !netboxUrl}
+              onClick={() => {
+                openNetboxImport()
+                onClose()
+              }}
+              className="rounded bg-orange-700 px-3 py-1 text-cp-base font-semibold text-white hover:bg-orange-600 disabled:opacity-50"
+            >
+              {t('settings.integrations.netbox.import', 'Site/Rack importieren…')}
+            </button>
+          </div>
+
+          <div className="mt-2 text-[11px] text-cp-text-muted">
+            {t('settings.integrations.netbox.apiHint', 'Genutzte API:')}{' '}
+            <code>/api/dcim/…</code>{' '}
+            {t(
+              'settings.integrations.netbox.apiHint2',
+              '— nur lesend. Die Endpunkt-Referenz deiner Instanz liegt unter /api/schema/swagger-ui/.',
+            )}
+          </div>
+        </SettingsCard>
+      )}
+    </>
+  )
+}
+
 export const IntegrationsTab = ({ onClose }: { onClose: () => void }) => {
   const [token, setToken] = useState('')
   const hasToken = useSettingsStore((s) => s.hasToken)
@@ -512,6 +742,9 @@ export const IntegrationsTab = ({ onClose }: { onClose: () => void }) => {
       </SettingsCard>
       </>
       )}
+
+      {/* #597 — NetBox-Instanz (Toggle + URL + Token). */}
+      <NetboxCard onClose={onClose} />
 
       {/* v7.9.86 / #197 — Multi-AI-Provider Card (Gemini / Claude / OpenAI). */}
       <AiProvidersCard />

--- a/src/renderer/lib/bridge.ts
+++ b/src/renderer/lib/bridge.ts
@@ -1,4 +1,5 @@
 import type { CablePlannerProject } from '../types/project'
+import type { NetboxRack, NetboxSite, NetboxSnapshot } from '../types/netbox'
 import { downloadBlob } from './downloadBlob'
 
 type OpenProjectResponse = {
@@ -132,6 +133,23 @@ type CablePlannerApi = {
     getLaunchFile: () => Promise<OpenProjectResponse | null>
     /** #pre-sale — bei laufender App geöffnete Datei (second-instance/open-file). */
     onOpenExternal: (cb: (payload: OpenProjectResponse) => void) => () => void
+  }
+  /** #597 — self-hosted NetBox-Instanz. baseUrl kommt aus den Settings und
+   *  wird im Main-Prozess validiert; das Token bleibt im Schlüsselbund und
+   *  wird nie an den Renderer zurückgegeben (daher nur `hasToken`). */
+  netbox: {
+    saveToken: (token: string) => Promise<boolean>
+    hasToken: () => Promise<boolean>
+    deleteToken: () => Promise<boolean>
+    normalizeUrl: (url: string) => Promise<{ ok: true; url: string } | { ok: false; message: string }>
+    testConnection: (baseUrl: string) => Promise<{ ok: boolean; message: string; version?: string }>
+    getSites: (baseUrl: string) => Promise<NetboxSite[]>
+    getRacks: (baseUrl: string, siteId?: number) => Promise<NetboxRack[]>
+    fetchSnapshot: (
+      baseUrl: string,
+      scope: 'site' | 'rack',
+      scopeId: number,
+    ) => Promise<NetboxSnapshot>
   }
   graphml: {
     openFile: () => Promise<{ filePath: string; fileName: string; xml: string } | null>
@@ -657,6 +675,34 @@ const webFallbackApi: CablePlannerApi = {
     // keine OS-Übergabe → kein Launch-File, kein External-Open.
     getLaunchFile: async () => null,
     onOpenExternal: () => () => {},
+  },
+  netbox: {
+    // Web-Fallback: eine NetBox-Instanz steht praktisch immer im internen
+    // Netz und schickt keine CORS-Header für unseren Origin — ein Fetch aus
+    // dem Browser scheitert unabhängig vom Token. Der Import braucht daher
+    // den Main-Prozess.
+    saveToken: async () => {
+      throw new Error('NetBox-Integration erfordert die Desktop-App.')
+    },
+    hasToken: async () => false,
+    deleteToken: async () => false,
+    normalizeUrl: async () => ({
+      ok: false as const,
+      message: 'NetBox-Integration erfordert die Desktop-App.',
+    }),
+    testConnection: async () => ({
+      ok: false,
+      message: 'NetBox-Integration erfordert die Desktop-App.',
+    }),
+    getSites: async () => {
+      throw new Error('NetBox-Integration erfordert die Desktop-App.')
+    },
+    getRacks: async () => {
+      throw new Error('NetBox-Integration erfordert die Desktop-App.')
+    },
+    fetchSnapshot: async () => {
+      throw new Error('NetBox-Integration erfordert die Desktop-App.')
+    },
   },
   graphml: {
     // Browser fallback for dev / non-Electron contexts: use a hidden

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -74,6 +74,7 @@ export const en: Dict = {
   'common.rename': 'Rename',
   'common.search': 'Search…',
   'common.yes': 'Yes',
+  'common.back': 'Back',
   'common.no': 'No',
   'common.optional': 'optional',
   'common.loading': 'Loading…',
@@ -259,6 +260,72 @@ export const en: Dict = {
   'settings.integrations.rentman.test': 'Test connection',
   'settings.integrations.rentman.delete': 'Delete token',
   'settings.integrations.rentman.endpoint': 'Endpoint:',
+
+  // #597 — Settings → Integrations → NetBox
+  'settings.integrations.netboxToggle.title': 'NetBox integration',
+  'settings.integrations.netboxToggle.desc':
+    'When enabled: menu entry and import dialog for your own NetBox instance appear. Sites and racks planned in NetBox can then be pulled in as a cable plan.',
+  'settings.integrations.netboxToggle.label': 'Enable NetBox integration',
+  'settings.integrations.netbox': 'NetBox API',
+  'settings.integrations.netboxDesc':
+    'Base URL of your NetBox instance plus an API token with read access. The token is stored encrypted in the OS keychain (never in the project file) and never leaves the main process.',
+  'settings.integrations.netbox.url': 'Instance URL',
+  'settings.integrations.netbox.token': 'API token',
+  'settings.integrations.netbox.tokenPlaceholder': 'Paste API token',
+  'settings.integrations.netbox.tokenStoredPlaceholder': 'Token stored — paste a new one to replace it',
+  'settings.integrations.netbox.status': 'Status:',
+  'settings.integrations.netbox.statusIdle': 'Not tested yet.',
+  'settings.integrations.netbox.tokenStored': 'Token stored:',
+  'settings.integrations.netbox.urlSaved': 'URL saved.',
+  'settings.integrations.netbox.tokenSaved': 'Token stored securely in the keychain.',
+  'settings.integrations.netbox.tokenCleared': 'Token deleted.',
+  'settings.integrations.netbox.saveToken': 'Save token',
+  'settings.integrations.netbox.test': 'Test connection',
+  'settings.integrations.netbox.deleteToken': 'Delete token',
+  'settings.integrations.netbox.import': 'Import site/rack…',
+  'settings.integrations.netbox.apiHint': 'API used:',
+  'settings.integrations.netbox.apiHint2':
+    '— read only. The endpoint reference for your instance lives at /api/schema/swagger-ui/.',
+
+  // #597 — NetBox import dialog
+  'app.menu.tools.netboxImport': 'NetBox import…',
+  'netbox.import.title': 'NetBox import',
+  'netbox.notConfigured': 'No NetBox URL configured',
+  'netbox.import.needsConfig':
+    'Please configure the instance URL and an API token first under Settings → Integrations → NetBox.',
+  'netbox.import.intro':
+    'Pick a site or a single rack. Devices, ports and connections are read and laid out as a cable plan. The sync only ever adds — devices and cables already in the plan keep all their edits.',
+  'netbox.import.site': 'Site',
+  'netbox.import.sitePlaceholder': '— pick a site —',
+  'netbox.import.rack': 'Rack (optional)',
+  'netbox.import.wholeSite': '— import the whole site —',
+  'netbox.import.reload': 'Reload',
+  'netbox.import.options': 'Options',
+  'netbox.import.onlyConnected': 'Only import cabled ports',
+  'netbox.import.onlyConnectedHint':
+    'Recommended: otherwise a 48-port switch drags 48 unused ports onto the plan.',
+  'netbox.import.includeCables': 'Import connections',
+  'netbox.import.rackFrames': 'Create a frame per rack',
+  'netbox.import.linked': 'This project is linked to {scope} "{name}". Last sync: {when}.',
+  'netbox.import.loading': 'Loading from NetBox…',
+  'netbox.import.preview': 'Build preview',
+  'netbox.import.apply': 'Add to project',
+  'netbox.preview.newDevices': 'New devices',
+  'netbox.preview.newCables': 'New connections',
+  'netbox.preview.newPorts': 'New ports on existing devices',
+  'netbox.preview.unchanged': 'Unchanged',
+  'netbox.preview.source':
+    'In NetBox: {devices} devices, {cables} connections, {ports} ports — {imported} of them imported.',
+  'netbox.preview.upToDate': 'The plan already matches NetBox — there is nothing to add.',
+  'netbox.preview.stale':
+    '{devices} devices and {cables} connections in the plan no longer exist in NetBox. They are left untouched — please review manually.',
+  'netbox.preview.skipped': '{count} skipped objects',
+  'netbox.preview.deviceList': 'Devices that will be created',
+
+  // #597 — Modules tab entry
+  'settings.modules.netbox.label': 'NetBox',
+  'settings.modules.netbox.desc':
+    'Import a site or rack from a NetBox instance as a cable plan, and later top it up with new devices/connections only.',
   'settings.integrations.linkedRentman': 'Linked Rentman project',
   'settings.integrations.linkedRentman.current': 'Currently linked to ',
   'settings.integrations.linkedRentman.choose': 'Choose another Rentman project…',

--- a/src/renderer/lib/modules.ts
+++ b/src/renderer/lib/modules.ts
@@ -8,7 +8,7 @@
  * Framework-frei und damit testbar; UI (Settings-Tab, Onboarding) liest hier.
  */
 
-export type ModuleId = 'festinstallation' | 'mobile' | 'rentman' | 'rental'
+export type ModuleId = 'festinstallation' | 'mobile' | 'rentman' | 'rental' | 'netbox'
 
 export interface ModuleMeta {
   id: ModuleId
@@ -42,6 +42,12 @@ export const MODULES: ModuleMeta[] = [
     description:
       'Lagerbestand, Eigentum & Verfügbarkeit, Mietkalkulation (im Aufbau, Phase 2+).',
   },
+  {
+    id: 'netbox',
+    label: 'NetBox',
+    description:
+      'Site oder Rack aus einer NetBox-Instanz als Kabelplan importieren und später nur um neue Geräte/Verbindungen ergänzen.',
+  },
 ]
 
 export const MODULE_IDS: ModuleId[] = MODULES.map((m) => m.id)
@@ -57,6 +63,9 @@ export const DEFAULT_ENABLED: Record<ModuleId, boolean> = {
   mobile: true,
   rentman: false,
   rental: false,
+  // #597 — wie rentman opt-in: ohne eigene NetBox-Instanz ist das Modul
+  // wertlos und würde nur Menüeinträge zustellen.
+  netbox: false,
 }
 
 export type PresetId = 'show' | 'festinstallation' | 'rental'
@@ -81,7 +90,8 @@ export const PRESETS: PresetMeta[] = [
     id: 'festinstallation',
     label: 'Festinstallation',
     description: 'Dauerhafte Anlagen — mitwachsende Doku, Service, Übergabe.',
-    modules: ['festinstallation', 'mobile'],
+    // NetBox ist die typische Dokumentationsquelle für Festinstallationen.
+    modules: ['festinstallation', 'mobile', 'netbox'],
   },
   {
     id: 'rental',

--- a/src/renderer/lib/netboxMapping.ts
+++ b/src/renderer/lib/netboxMapping.ts
@@ -1,0 +1,875 @@
+import { v4 as uuidv4 } from 'uuid'
+import type { Cable, CableType } from '../types/cable'
+import type { ConnectorType, EquipmentItem, Port } from '../types/equipment'
+import type { LocationFrame } from '../types/location'
+import type {
+  NetboxCable,
+  NetboxComponent,
+  NetboxDevice,
+  NetboxRack,
+  NetboxRef,
+  NetboxSnapshot,
+  NetboxTermination,
+} from '../types/netbox'
+
+/**
+ * NetBox-Instanz → Cable-Planner-Plan (#597).
+ *
+ * Reines Daten-Modul ohne React/Store-Bezug, damit es unit-testbar bleibt
+ * (`tests/netboxMapping.test.ts`). Der Import-Dialog ruft ausschliesslich
+ * `buildNetboxImportPlan` und reicht das Ergebnis an den projectStore.
+ *
+ * ## Warum „nur hinzufügen"
+ * NetBox ist die Wahrheit über die *Verkabelung*, der Cable Planner die
+ * Wahrheit über die *Darstellung*: Positionen, Farben, Wegpunkte, Labels,
+ * Multicore-Bündel. Ein Re-Import darf diese Arbeit nie überschreiben.
+ * Deshalb ist der Abgleich additiv — bereits importierte Geräte, Ports und
+ * Kabel (erkannt an ihrer NetBox-ID) bleiben unverändert; nur in NetBox
+ * neu hinzugekommene Elemente landen im Plan. In NetBox gelöschte Elemente
+ * werden gemeldet, aber nicht automatisch entfernt.
+ */
+
+// ---------------------------------------------------------------------------
+// Konstanten
+// ---------------------------------------------------------------------------
+
+/** Node-Geometrie — gleiche Werte wie beim device-type-library-Import. */
+const NODE_WIDTH = 260
+const NODE_BASE_HEIGHT = 80
+const NODE_PORT_ROW_HEIGHT = 22
+/** Horizontaler Abstand zwischen zwei Rack-Spalten. */
+const COLUMN_GAP = 140
+/** Vertikaler Abstand zwischen zwei Geräten derselben Spalte. */
+const ROW_GAP = 40
+/** Innenabstand des Rack-Rahmens um seine Geräte. */
+const FRAME_PADDING = 32
+/** Kopfbereich des Rack-Rahmens (Titelzeile). */
+const FRAME_HEADER = 44
+
+/** Fallback-Kabelfarbe, wenn NetBox keine hinterlegt hat. */
+const DEFAULT_CABLE_COLOR = '#94a3b8'
+
+/** Rahmenfarben für die Rack-Frames (rotierend). */
+const FRAME_COLORS = ['#0ea5e9', '#22c55e', '#f59e0b', '#a855f7', '#ef4444', '#14b8a6']
+
+/**
+ * NetBox-Komponententyp → Signalrichtung im Cable Planner.
+ *
+ * NetBox modelliert Interfaces als richtungslos (ein RJ45 ist Ein- und
+ * Ausgang zugleich); Cable Planner trennt `inputs`/`outputs`, weil daraus
+ * Canvas-Seite und Kabelrichtung folgen. Richtungslose Komponenten werden
+ * deshalb als gespiegeltes In/Out-Paar angelegt — beide Ports tragen
+ * dieselbe `netboxId`, und die Kabelauflösung greift sich je Kabelende die
+ * passende Hälfte. Alles, was in NetBox eine echte Richtung hat (Strom,
+ * Konsole, Patchfeld), bekommt genau einen Port.
+ */
+const DIRECTION_BY_OBJECT_TYPE: Record<string, 'in' | 'out' | 'bidirectional'> = {
+  interface: 'bidirectional',
+  // Patchfeld: vorne zum Raum (Eingang), hinten zur Festverkabelung (Ausgang).
+  frontport: 'in',
+  rearport: 'out',
+  // Konsole: der Geräte-Port ist DTE (Eingang), der Konsolenserver DCE.
+  consoleport: 'in',
+  consoleserverport: 'out',
+  // Strom: das Gerät zieht (Eingang), die PDU speist (Ausgang).
+  powerport: 'in',
+  poweroutlet: 'out',
+}
+
+/** Anzeige-Reihenfolge der Ports am importierten Gerät. */
+const OBJECT_TYPE_ORDER = [
+  'interface',
+  'frontport',
+  'rearport',
+  'consoleport',
+  'consoleserverport',
+  'powerport',
+  'poweroutlet',
+]
+
+/** NetBox-Rollen-Slug (Substring) → Cable-Planner-Kategorie. Erster
+ *  Treffer gewinnt, daher stehen spezifische Muster oben. */
+const ROLE_CATEGORY_RULES: Array<{ match: RegExp; category: string }> = [
+  { match: /camera|kamera/, category: 'Kameras' },
+  { match: /monitor|display|screen|beamer|projector/, category: 'Monitore' },
+  { match: /switch|router|firewall|access-?point|wlan|wifi|patch|network|netzwerk/, category: 'Netzwerk' },
+  { match: /pdu|ups|power|strom|usv/, category: 'Strom' },
+  { match: /mic|mikro/, category: 'Mikrofone' },
+  { match: /mixer|mischpult|console|desk/, category: 'Mischpult' },
+  { match: /audio|dante|intercom/, category: 'Audio' },
+  { match: /light|licht|dmx|fixture/, category: 'Licht' },
+  { match: /server|storage|nas|workstation|pc|compute/, category: 'PC' },
+  { match: /video|sdi|encoder|decoder|matrix|scaler|converter/, category: 'Video' },
+]
+
+const FALLBACK_CATEGORY = 'Sonstiges'
+
+// ---------------------------------------------------------------------------
+// Öffentliche Typen
+// ---------------------------------------------------------------------------
+
+export interface NetboxMappingOptions {
+  /** Basis-URL der Instanz — landet auf jedem Gerät, damit gleiche IDs aus
+   *  verschiedenen Instanzen (Test/Produktion) unterscheidbar bleiben. */
+  baseUrl: string
+  /**
+   * Nur Komponenten importieren, an denen in NetBox ein Kabel hängt.
+   *
+   * Default `true`, und zwar bewusst: ein 48-Port-Switch erzeugt sonst
+   * (gespiegelt) 96 Handles am Knoten, von denen im typischen Rack sechs
+   * verkabelt sind. Für einen lesbaren Kabelplan sind die belegten Ports
+   * das Interessante. Wer die Reserve-Kapazität sehen will, schaltet es ab.
+   */
+  onlyConnectedPorts?: boolean
+  /** Auch Kabel importieren (aus). Wenn false, kommen nur die Geräte. */
+  includeCables?: boolean
+  /** Einen Rahmen je Rack anlegen. Default true. */
+  createRackFrames?: boolean
+  /** Linke obere Ecke des Import-Blocks auf dem Canvas. */
+  origin?: { x: number; y: number }
+}
+
+/** Warum ein NetBox-Objekt nicht in den Plan gewandert ist. */
+export interface NetboxSkip {
+  kind: 'device' | 'cable' | 'port'
+  /** NetBox-ID des übersprungenen Objekts. */
+  netboxId: number
+  label: string
+  reason: string
+}
+
+export interface NetboxImportPlan {
+  /** Neu anzulegende Geräte (mit fertigen uuids, direkt einfügbar). */
+  newEquipment: EquipmentItem[]
+  /** Neu anzulegende Kabel — referenzieren neue UND bestehende Geräte. */
+  newCables: Cable[]
+  /** Ports, die an bereits vorhandenen Geräten ergänzt werden müssen
+   *  (NetBox-Interface nachträglich angelegt). Patch je Gerät. */
+  portAdditions: Array<{
+    equipmentId: string
+    deviceName: string
+    inputs: Port[]
+    outputs: Port[]
+  }>
+  /** Rack-Rahmen, die es im Plan noch nicht gibt. */
+  newLocations: LocationFrame[]
+  /** Bereits vorhandene, unverändert gelassene Geräte (NetBox-ID). */
+  unchangedDeviceIds: number[]
+  /** Bereits vorhandene, unverändert gelassene Kabel (NetBox-ID). */
+  unchangedCableIds: number[]
+  /** Im Plan vorhandene NetBox-Geräte, die die Instanz nicht mehr kennt.
+   *  Werden NICHT gelöscht — nur gemeldet, damit der Planer entscheidet. */
+  staleDeviceIds: number[]
+  staleCableIds: number[]
+  skipped: NetboxSkip[]
+  /** Zähler für die Vorschau im Dialog. */
+  stats: {
+    devicesInNetbox: number
+    cablesInNetbox: number
+    componentsInNetbox: number
+    componentsImported: number
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Kleine Helfer
+// ---------------------------------------------------------------------------
+
+const asNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && /^-?\d+(\.\d+)?$/.test(value)) return Number(value)
+  return null
+}
+
+/** Zieht den Anzeigenamen aus einem NetBox-Brief-Objekt. */
+const refName = (ref: NetboxRef | undefined | null): string =>
+  (ref?.name ?? ref?.display ?? ref?.slug ?? '').trim()
+
+/** NetBox liefert `type` mal als `{value,label}`, mal als blanken String. */
+const typeSlug = (value: NetboxComponent['type']): string => {
+  if (typeof value === 'string') return value
+  if (value && typeof value === 'object') return String(value.value ?? value.label ?? '')
+  return ''
+}
+
+/** Hängt an einer Komponente ein Kabel? `cable` ist je nach NetBox-Version
+ *  ein Brief-Objekt, eine blanke ID oder null. */
+const componentCableId = (component: NetboxComponent): number | null => {
+  const cable = component.cable
+  if (cable == null) return null
+  if (typeof cable === 'number') return cable
+  if (typeof cable === 'object') return asNumber(cable.id)
+  return null
+}
+
+/**
+ * NetBox-Port-/Interface-Typ → Cable-Planner-Steckertyp.
+ *
+ * Bewertet wird der NetBox-`type`-Slug zuerst (der ist maschinell gepflegt
+ * und eindeutig), erst danach der freie Name. So gewinnt `1000base-t`
+ * gegen ein Interface, das jemand „SDI-Uplink" genannt hat.
+ */
+export const netboxConnectorType = (
+  objectType: string,
+  name: string,
+  rawType: NetboxComponent['type'],
+): ConnectorType => {
+  const slug = typeSlug(rawType).toLowerCase()
+  const haystack = `${slug} ${name}`.toLowerCase()
+
+  // --- Strom: der Slug ist hier besonders aussagekräftig. -------------------
+  if (objectType === 'powerport' || objectType === 'poweroutlet') {
+    if (/powercon|nac3/.test(haystack)) return 'PowerCON'
+    if (/cee-?7-?7|cee-?7-?4|schuko/.test(haystack)) return 'Schuko 230V'
+    if (/c5|cloverleaf|kleeblatt/.test(haystack)) return 'Kleeblatt'
+    if (/c7|figure-?8|euro/.test(haystack)) return 'C7 Eurostecker'
+    if (/iec|c13|c14|c15|c19|c20|nema/.test(haystack)) return 'IEC 230V'
+    if (/cee.*16|iec-?60309.*16|16a/.test(haystack)) return 'CEE16'
+    if (/cee.*32|32a/.test(haystack)) return 'CEE32'
+    if (/cee.*63|63a/.test(haystack)) return 'CEE63'
+    if (/powerlock/.test(haystack)) return 'Powerlock'
+    return 'IEC 230V'
+  }
+
+  // --- Konsole ------------------------------------------------------------
+  if (objectType === 'consoleport' || objectType === 'consoleserverport') {
+    if (/usb-?c/.test(haystack)) return 'USB-C'
+    if (/usb/.test(haystack)) return 'USB'
+    if (/de-?9|db-?9|rs-?232/.test(haystack)) return 'DB9'
+    return 'Ethernet/RJ45'
+  }
+
+  // --- Optik / Kupfer / Video ---------------------------------------------
+  if (/qsfp|sfp28|sfp56|sfp\+|sfpp|xfp/.test(haystack)) return 'SFP+'
+  if (/\bsfp\b/.test(haystack)) return 'SFP'
+  if (/\blc\b|\bsc\b|\bst\b|\bmpo\b|\bmtp\b|fiber|fibre|lwl|base-?[lsex]\b/.test(haystack)) {
+    return 'Fiber'
+  }
+  if (/hd-?bnc/.test(haystack)) return 'HD-BNC'
+  if (/mini-?bnc/.test(haystack)) return 'Mini-BNC'
+  if (/\bbnc\b|\bsdi\b|coax/.test(haystack)) return 'BNC'
+  if (/mini-?hdmi/.test(haystack)) return 'Mini-HDMI'
+  if (/hdmi/.test(haystack)) return 'HDMI'
+  if (/displayport|\bdp\b/.test(haystack)) return 'DisplayPort'
+  if (/\bdvi\b/.test(haystack)) return 'DVI'
+  if (/\bvga\b/.test(haystack)) return 'VGA'
+  if (/xlr/.test(haystack)) return 'XLR'
+  if (/\bdmx\b/.test(haystack)) return 'DMX 5-pol (XLR)'
+  if (/usb-?c/.test(haystack)) return 'USB-C'
+  if (/\busb\b/.test(haystack)) return 'USB'
+  if (/\bf-?connector\b|\bcatv\b/.test(haystack)) return 'F-Connector'
+  if (/8p8c|base-?t\b|rj-?45|ethernet|1000base|10gbase|2\.5gbase|5gbase/.test(haystack)) {
+    return 'Ethernet/RJ45'
+  }
+  // `virtual`, `lag`, `ieee802.11…` haben keinen physischen Stecker.
+  if (/virtual|\blag\b|bridge|ieee802\.11|wireless|\bwlan\b/.test(haystack)) return 'Wireless/RF'
+  return 'Custom'
+}
+
+/** Steckertyp → Kabeltyp. `CableType` schliesst drei Steckerformen aus,
+ *  die es als Kabelsorte im Planer nicht gibt. */
+export const connectorToCableType = (connector: ConnectorType): CableType => {
+  if (connector === 'DIN' || connector === 'DisplayPort' || connector === 'USB') return 'Custom'
+  return connector
+}
+
+/** NetBox-Rolle → Cable-Planner-Kategorie. */
+export const netboxCategoryForRole = (device: NetboxDevice): string => {
+  const role = device.role ?? device.device_role
+  const haystack = `${role?.slug ?? ''} ${role?.name ?? ''}`.toLowerCase()
+  if (!haystack.trim()) return FALLBACK_CATEGORY
+  for (const rule of ROLE_CATEGORY_RULES) {
+    if (rule.match.test(haystack)) return rule.category
+  }
+  return FALLBACK_CATEGORY
+}
+
+/** NetBox-Farbe (`"f44336"`, ohne Raute) → CSS-Hex. */
+const netboxColor = (raw: string | undefined): string | null => {
+  const value = (raw ?? '').trim().replace(/^#/, '')
+  return /^[0-9a-f]{6}$/i.test(value) ? `#${value}` : null
+}
+
+/** Kabellänge in Metern. NetBox speichert Wert + Einheit getrennt. */
+export const netboxCableLength = (cable: NetboxCable): number => {
+  const raw = asNumber(cable.length)
+  if (raw === null || raw <= 0) return 0
+  const unit = typeof cable.length_unit === 'string'
+    ? cable.length_unit
+    : String(cable.length_unit?.value ?? '')
+  switch (unit.toLowerCase()) {
+    case 'km':
+      return raw * 1000
+    case 'cm':
+      return raw / 100
+    case 'mm':
+      return raw / 1000
+    case 'ft':
+      return raw * 0.3048
+    case 'in':
+      return raw * 0.0254
+    case 'mi':
+      return raw * 1609.344
+    default:
+      // 'm' und alles Unbekannte: als Meter lesen.
+      return raw
+  }
+}
+
+/**
+ * Normalisiert die Kabelenden über NetBox-Versionen hinweg.
+ *
+ * Ab NetBox 3.3 liegen sie als `a_terminations`/`b_terminations`-Arrays vor
+ * (Mehrfach-Terminierung), davor als einzelne `termination_a_*`-Felder. Wir
+ * werten je Seite genau die erste Terminierung aus: der Cable Planner kennt
+ * pro Kabelende genau einen Port, und Mehrfach-Terminierungen sind in der
+ * AV-Praxis die Ausnahme (sie werden unten als Hinweis gemeldet).
+ */
+export const netboxTerminations = (
+  cable: NetboxCable,
+  side: 'a' | 'b',
+): NetboxTermination[] => {
+  const modern = side === 'a' ? cable.a_terminations : cable.b_terminations
+  if (Array.isArray(modern) && modern.length > 0) return modern
+  const legacyType = side === 'a' ? cable.termination_a_type : cable.termination_b_type
+  const legacyId = side === 'a' ? cable.termination_a_id : cable.termination_b_id
+  const legacyObj = side === 'a' ? cable.termination_a : cable.termination_b
+  if (legacyType && legacyId != null) {
+    return [{ object_type: legacyType, object_id: legacyId, object: legacyObj }]
+  }
+  return []
+}
+
+/** `"dcim.interface"` → `"interface"`. */
+const terminationObjectType = (termination: NetboxTermination): string =>
+  String(termination.object_type ?? '').split('.').pop()?.toLowerCase() ?? ''
+
+// ---------------------------------------------------------------------------
+// Port-Aufbau
+// ---------------------------------------------------------------------------
+
+/** Interner Marker, mit dem wir den object_type an der Komponente führen,
+ *  ohne den Snapshot-Typ aufzublähen. */
+type TaggedComponent = NetboxComponent & { __objectType?: string }
+
+const makePort = (
+  component: NetboxComponent,
+  objectType: string,
+  direction: 'in' | 'out' | 'bidirectional',
+  connectorType: ConnectorType,
+): Port => {
+  const label = (component.label ?? '').trim()
+  const name = (component.name ?? '').trim() || label || `Port ${component.id ?? ''}`.trim()
+  return {
+    id: uuidv4(),
+    name,
+    originalName: name,
+    type: connectorType,
+    connectorType,
+    direction,
+    netboxId: asNumber(component.id) ?? undefined,
+    netboxObjectType: objectType,
+    ...(label && label !== name ? { contentLabel: label } : {}),
+  }
+}
+
+/**
+ * Baut die Ports eines Geräts aus seinen NetBox-Komponenten.
+ *
+ * Richtungslose Komponenten (Interfaces) erzeugen ein gespiegeltes Paar:
+ * je einen Eintrag in `inputs` und `outputs` mit gleicher `netboxId`. Damit
+ * kann jedes Kabel als Ausgang→Eingang gezeichnet werden, was der Canvas
+ * für die Kantendarstellung braucht.
+ */
+const buildPortsForDevice = (
+  components: TaggedComponent[],
+  onlyConnected: boolean,
+): { inputs: Port[]; outputs: Port[]; imported: number; skippedUnconnected: number } => {
+  const inputs: Port[] = []
+  const outputs: Port[] = []
+  let imported = 0
+  let skippedUnconnected = 0
+
+  const ordered = [...components].sort((a, b) => {
+    const typeA = OBJECT_TYPE_ORDER.indexOf(a.__objectType ?? '')
+    const typeB = OBJECT_TYPE_ORDER.indexOf(b.__objectType ?? '')
+    if (typeA !== typeB) return typeA - typeB
+    return String(a.name ?? '').localeCompare(String(b.name ?? ''), undefined, { numeric: true })
+  })
+
+  for (const component of ordered) {
+    const objectType = String(component.__objectType ?? '')
+    if (onlyConnected && componentCableId(component) === null) {
+      skippedUnconnected++
+      continue
+    }
+    const direction = DIRECTION_BY_OBJECT_TYPE[objectType] ?? 'bidirectional'
+    const connectorType = netboxConnectorType(objectType, String(component.name ?? ''), component.type)
+    if (direction === 'in') {
+      inputs.push(makePort(component, objectType, 'in', connectorType))
+    } else if (direction === 'out') {
+      outputs.push(makePort(component, objectType, 'out', connectorType))
+    } else {
+      inputs.push(makePort(component, objectType, 'bidirectional', connectorType))
+      outputs.push(makePort(component, objectType, 'bidirectional', connectorType))
+    }
+    imported++
+  }
+
+  return { inputs, outputs, imported, skippedUnconnected }
+}
+
+const nodeHeight =(inputs: Port[], outputs: Port[]): number =>
+  NODE_BASE_HEIGHT + Math.max(inputs.length, outputs.length, 3) * NODE_PORT_ROW_HEIGHT
+
+// ---------------------------------------------------------------------------
+// Haupt-Einstieg
+// ---------------------------------------------------------------------------
+
+/**
+ * Baut aus einem NetBox-Snapshot den additiven Import-/Abgleich-Plan.
+ *
+ * `existingEquipment`/`existingCables` sind der aktuelle Projektstand. Beim
+ * Erstimport sind sie leer, beim „Aktualisieren" enthalten sie die bereits
+ * importierten Elemente — der Plan enthält dann nur noch das Delta.
+ */
+export const buildNetboxImportPlan = (
+  snapshot: NetboxSnapshot,
+  existingEquipment: EquipmentItem[],
+  existingCables: Cable[],
+  options: NetboxMappingOptions,
+): NetboxImportPlan => {
+  const {
+    baseUrl,
+    onlyConnectedPorts = true,
+    includeCables = true,
+    createRackFrames = true,
+    origin = { x: 0, y: 0 },
+  } = options
+
+  const skipped: NetboxSkip[] = []
+
+  // --- 1. Komponenten je Gerät bündeln -------------------------------------
+  const componentsByDevice = new Map<number, TaggedComponent[]>()
+  let componentsInNetbox = 0
+  for (const [objectType, list] of Object.entries(snapshot.components ?? {})) {
+    for (const component of list ?? []) {
+      const deviceId = asNumber(component.device?.id)
+      if (deviceId === null) continue
+      componentsInNetbox++
+      const bucket = componentsByDevice.get(deviceId) ?? []
+      bucket.push({ ...component, __objectType: objectType })
+      componentsByDevice.set(deviceId, bucket)
+    }
+  }
+
+  // --- 2. Bestand indizieren ------------------------------------------------
+  // Nur Geräte derselben Instanz zählen als „schon importiert". Ältere
+  // Importe ohne gespeicherte URL werden mitgenommen (Rückwärtskompat).
+  const sameInstance = (item: EquipmentItem): boolean =>
+    !item.netboxSourceUrl || item.netboxSourceUrl === baseUrl
+
+  const existingByNetboxId = new Map<number, EquipmentItem>()
+  for (const item of existingEquipment) {
+    if (typeof item.netboxId === 'number' && sameInstance(item)) {
+      existingByNetboxId.set(item.netboxId, item)
+    }
+  }
+  const existingCableIds = new Set<number>()
+  for (const cable of existingCables) {
+    if (typeof cable.netboxId === 'number') existingCableIds.add(cable.netboxId)
+  }
+
+  // --- 3. Geräte abarbeiten -------------------------------------------------
+  const newEquipment: EquipmentItem[] = []
+  const portAdditions: NetboxImportPlan['portAdditions'] = []
+  const unchangedDeviceIds: number[] = []
+  let componentsImported = 0
+
+  /** NetBox-Device-ID → { equipmentId, Port-Index }. Deckt neue UND
+   *  bestehende Geräte ab, damit Kabel zwischen beiden auflösbar sind. */
+  interface PortLookup {
+    equipmentId: string
+    /** `${netboxId}` → Ports dieser Komponente, getrennt nach Seite. */
+    byComponent: Map<number, { input?: Port; output?: Port }>
+  }
+  const lookup = new Map<number, PortLookup>()
+
+  const indexPorts = (equipmentId: string, inputs: Port[], outputs: Port[]): PortLookup => {
+    const byComponent = new Map<number, { input?: Port; output?: Port }>()
+    for (const port of inputs) {
+      if (typeof port.netboxId !== 'number') continue
+      const entry = byComponent.get(port.netboxId) ?? {}
+      entry.input = port
+      byComponent.set(port.netboxId, entry)
+    }
+    for (const port of outputs) {
+      if (typeof port.netboxId !== 'number') continue
+      const entry = byComponent.get(port.netboxId) ?? {}
+      entry.output = port
+      byComponent.set(port.netboxId, entry)
+    }
+    return { equipmentId, byComponent }
+  }
+
+  for (const device of snapshot.devices ?? []) {
+    const netboxId = asNumber(device.id)
+    if (netboxId === null) continue
+    const deviceName =
+      (device.name ?? '').trim() ||
+      refName(device.device_type) ||
+      device.device_type?.model ||
+      `NetBox-Gerät ${netboxId}`
+    const components = componentsByDevice.get(netboxId) ?? []
+    const built = buildPortsForDevice(components, onlyConnectedPorts)
+    componentsImported += built.imported
+
+    const existing = existingByNetboxId.get(netboxId)
+    if (existing) {
+      // Bereits im Plan: Gerät bleibt wie es ist, nur in NetBox neu
+      // hinzugekommene Ports werden ergänzt.
+      unchangedDeviceIds.push(netboxId)
+      const knownComponentIds = new Set(
+        [...existing.inputs, ...existing.outputs]
+          .map((p) => p.netboxId)
+          .filter((id): id is number => typeof id === 'number'),
+      )
+      const addInputs = built.inputs.filter(
+        (p) => typeof p.netboxId === 'number' && !knownComponentIds.has(p.netboxId),
+      )
+      const addOutputs = built.outputs.filter(
+        (p) => typeof p.netboxId === 'number' && !knownComponentIds.has(p.netboxId),
+      )
+      if (addInputs.length > 0 || addOutputs.length > 0) {
+        portAdditions.push({
+          equipmentId: existing.id,
+          deviceName: existing.name,
+          inputs: addInputs,
+          outputs: addOutputs,
+        })
+      }
+      // Für die Kabelauflösung zählen bestehende UND neue Ports.
+      lookup.set(
+        netboxId,
+        indexPorts(
+          existing.id,
+          [...existing.inputs, ...addInputs],
+          [...existing.outputs, ...addOutputs],
+        ),
+      )
+      continue
+    }
+
+    const manufacturer = refName(device.device_type?.manufacturer)
+    const model = device.device_type?.model ?? refName(device.device_type)
+    const uHeight = asNumber(device.device_type?.u_height) ?? 0
+    const primaryIp = device.primary_ip?.address ?? device.primary_ip4?.address ?? ''
+    const noteParts = [
+      `Importiert aus NetBox (${baseUrl}), Gerät #${netboxId}.`,
+      manufacturer || model ? `Typ: ${[manufacturer, model].filter(Boolean).join(' ')}` : '',
+      device.serial ? `Seriennummer: ${device.serial}` : '',
+      device.asset_tag ? `Asset-Tag: ${device.asset_tag}` : '',
+      (device.description ?? '').trim(),
+    ].filter(Boolean)
+
+    const item: EquipmentItem = {
+      id: uuidv4(),
+      name: deviceName,
+      ...(model && model !== deviceName ? { subtitle: model } : {}),
+      category: netboxCategoryForRole(device),
+      inputs: built.inputs,
+      outputs: built.outputs,
+      // Position wird in Schritt 4 gesetzt (Rack-Layout).
+      x: origin.x,
+      y: origin.y,
+      width: NODE_WIDTH,
+      height: nodeHeight(built.inputs, built.outputs),
+      ...(uHeight > 0 ? { isRackDevice: true, rackUnits: Math.max(1, Math.round(uHeight)) } : {}),
+      ...(primaryIp ? { ipAddress: primaryIp.split('/')[0] } : {}),
+      importSource: 'netbox',
+      netboxId,
+      netboxSourceUrl: baseUrl,
+      notes: noteParts.join('\n'),
+      // Ein Gerät ohne jede Komponente hätte sonst still eine leere
+      // Port-Liste — der Plan-Check soll das Datenblatt einfordern.
+      ...(built.inputs.length === 0 && built.outputs.length === 0 ? { portsUnknown: true } : {}),
+    }
+    newEquipment.push(item)
+    lookup.set(netboxId, indexPorts(item.id, item.inputs, item.outputs))
+  }
+
+  // --- 4. Layout: eine Spalte je Rack, Reihenfolge wie in der Elevation ----
+  const rackById = new Map<number, NetboxRack>()
+  for (const rack of snapshot.racks ?? []) {
+    const id = asNumber(rack.id)
+    if (id !== null) rackById.set(id, rack)
+  }
+
+  const newLocations = layoutNewEquipment(
+    newEquipment,
+    snapshot,
+    rackById,
+    origin,
+    createRackFrames,
+    existingEquipment,
+  )
+
+  // --- 5. Kabel -------------------------------------------------------------
+  const newCables: Cable[] = []
+  const unchangedCableIds: number[] = []
+  const seenCableIds = new Set<number>()
+
+  if (includeCables) {
+    for (const cable of snapshot.cables ?? []) {
+      const netboxId = asNumber(cable.id)
+      if (netboxId === null) continue
+      seenCableIds.add(netboxId)
+      const label = (cable.label ?? '').trim() || `Kabel #${netboxId}`
+
+      if (existingCableIds.has(netboxId)) {
+        unchangedCableIds.push(netboxId)
+        continue
+      }
+
+      const aTerms = netboxTerminations(cable, 'a')
+      const bTerms = netboxTerminations(cable, 'b')
+      if (aTerms.length === 0 || bTerms.length === 0) {
+        skipped.push({
+          kind: 'cable',
+          netboxId,
+          label,
+          reason: 'Kabel hat in NetBox nur ein belegtes Ende.',
+        })
+        continue
+      }
+      if (aTerms.length > 1 || bTerms.length > 1) {
+        skipped.push({
+          kind: 'cable',
+          netboxId,
+          label,
+          reason:
+            'Mehrfach-Terminierung: nur das jeweils erste Ende wurde übernommen.',
+        })
+      }
+
+      const endA = resolveEnd(aTerms[0], lookup)
+      const endB = resolveEnd(bTerms[0], lookup)
+      if (!endA || !endB) {
+        skipped.push({
+          kind: 'cable',
+          netboxId,
+          label,
+          reason: 'Mindestens ein Kabelende liegt außerhalb des importierten Bereichs.',
+        })
+        continue
+      }
+
+      // Ausgang → Eingang. Passt die natürliche A→B-Richtung nicht (z. B.
+      // weil NetBox die PDU als B-Seite führt), drehen wir das Kabel um.
+      let from = endA
+      let to = endB
+      if (!(endA.ports.output && endB.ports.input)) {
+        if (endB.ports.output && endA.ports.input) {
+          from = endB
+          to = endA
+        } else {
+          skipped.push({
+            kind: 'cable',
+            netboxId,
+            label,
+            reason:
+              'Keine gültige Ausgang→Eingang-Richtung: beide Enden sind gleichgerichtet (z. B. zwei Strom-Eingänge).',
+          })
+          continue
+        }
+      }
+      const fromPort = from.ports.output
+      const toPort = to.ports.input
+      if (!fromPort || !toPort) continue
+
+      const connector = fromPort.connectorType
+      newCables.push({
+        id: uuidv4(),
+        name: label,
+        type: connectorToCableType(connector),
+        length: netboxCableLength(cable),
+        color: netboxColor(cable.color) ?? DEFAULT_CABLE_COLOR,
+        fromEquipmentId: from.equipmentId,
+        fromPortId: fromPort.id,
+        toEquipmentId: to.equipmentId,
+        toPortId: toPort.id,
+        notes: `NetBox-Kabel #${netboxId}${cable.description ? ` — ${cable.description}` : ''}`,
+        netboxId,
+        bidirectional: fromPort.direction === 'bidirectional',
+      })
+    }
+  }
+
+  // --- 6. Verwaiste Elemente melden (nicht löschen) -------------------------
+  const snapshotDeviceIds = new Set(
+    (snapshot.devices ?? []).map((d) => asNumber(d.id)).filter((id): id is number => id !== null),
+  )
+  const staleDeviceIds = [...existingByNetboxId.keys()].filter((id) => !snapshotDeviceIds.has(id))
+  const staleCableIds = includeCables
+    ? [...existingCableIds].filter((id) => !seenCableIds.has(id))
+    : []
+
+  return {
+    newEquipment,
+    newCables,
+    portAdditions,
+    newLocations,
+    unchangedDeviceIds,
+    unchangedCableIds,
+    staleDeviceIds,
+    staleCableIds,
+    skipped,
+    stats: {
+      devicesInNetbox: (snapshot.devices ?? []).length,
+      cablesInNetbox: (snapshot.cables ?? []).length,
+      componentsInNetbox,
+      componentsImported,
+    },
+  }
+}
+
+/** Löst ein NetBox-Kabelende auf einen Cable-Planner-Port auf. */
+const resolveEnd = (
+  termination: NetboxTermination | undefined,
+  lookup: Map<number, { equipmentId: string; byComponent: Map<number, { input?: Port; output?: Port }> }>,
+): { equipmentId: string; ports: { input?: Port; output?: Port } } | null => {
+  if (!termination) return null
+  const objectType = terminationObjectType(termination)
+  // Circuit-/Powerfeed-Terminierungen hängen an keinem Gerät und haben im
+  // Kabelplan kein Gegenstück.
+  if (!DIRECTION_BY_OBJECT_TYPE[objectType]) return null
+  const componentId = asNumber(termination.object_id) ?? asNumber(termination.object?.id)
+  if (componentId === null) return null
+  const deviceId = asNumber(termination.object?.device?.id)
+
+  // Direkter Weg: das Kabelende nennt sein Gerät.
+  if (deviceId !== null) {
+    const entry = lookup.get(deviceId)
+    const ports = entry?.byComponent.get(componentId)
+    if (entry && ports) return { equipmentId: entry.equipmentId, ports }
+    if (entry) return null
+  }
+  // Fallback für schlanke Terminierungs-Objekte ohne `device`: die
+  // Komponenten-ID ist NetBox-weit eindeutig, also über alle Geräte suchen.
+  for (const entry of lookup.values()) {
+    const ports = entry.byComponent.get(componentId)
+    if (ports) return { equipmentId: entry.equipmentId, ports }
+  }
+  return null
+}
+
+/**
+ * Positioniert die neu importierten Geräte: eine Spalte je Rack, innerhalb
+ * der Spalte von oben nach unten in Rack-Reihenfolge (höchste HE zuerst).
+ *
+ * Bewusst gestapelt statt HE-proportional: die Knotenhöhe hängt an der
+ * Port-Anzahl, eine maßstäbliche Elevation würde deshalb überlappen. Die
+ * Reihenfolge bleibt die des Racks, was für die Montage das Relevante ist.
+ *
+ * Der Block wird rechts neben bereits vorhandene Geräte gesetzt, damit ein
+ * Import einen bestehenden Plan nie überdeckt.
+ */
+const layoutNewEquipment = (
+  newEquipment: EquipmentItem[],
+  snapshot: NetboxSnapshot,
+  rackById: Map<number, NetboxRack>,
+  origin: { x: number; y: number },
+  createRackFrames: boolean,
+  existingEquipment: EquipmentItem[],
+): LocationFrame[] => {
+  if (newEquipment.length === 0) return []
+
+  const deviceById = new Map<number, NetboxDevice>()
+  for (const device of snapshot.devices ?? []) {
+    const id = asNumber(device.id)
+    if (id !== null) deviceById.set(id, device)
+  }
+
+  /** Rack-ID (oder null für „ohne Rack") → Geräte. */
+  const columns = new Map<number | null, EquipmentItem[]>()
+  for (const item of newEquipment) {
+    const device = item.netboxId != null ? deviceById.get(item.netboxId) : undefined
+    const rackId = asNumber(device?.rack?.id)
+    const key = rackId ?? null
+    const bucket = columns.get(key) ?? []
+    bucket.push(item)
+    columns.set(key, bucket)
+  }
+
+  // Innerhalb einer Spalte: höchste Höheneinheit zuerst (Rack-Ansicht von
+  // oben), Geräte ohne Position hinten, dann alphabetisch.
+  for (const bucket of columns.values()) {
+    bucket.sort((a, b) => {
+      const posA = asNumber(deviceById.get(a.netboxId ?? -1)?.position)
+      const posB = asNumber(deviceById.get(b.netboxId ?? -1)?.position)
+      if (posA !== null && posB !== null && posA !== posB) return posB - posA
+      if (posA === null && posB !== null) return 1
+      if (posA !== null && posB === null) return -1
+      return a.name.localeCompare(b.name, undefined, { numeric: true })
+    })
+  }
+
+  // Spalten-Reihenfolge: Racks nach Namen, „ohne Rack" ganz rechts.
+  const orderedKeys = [...columns.keys()].sort((a, b) => {
+    if (a === null) return 1
+    if (b === null) return -1
+    return refName(rackById.get(a)).localeCompare(refName(rackById.get(b)), undefined, {
+      numeric: true,
+    })
+  })
+
+  // Startpunkt rechts neben dem Bestand, damit nichts überdeckt wird.
+  const existingRight = existingEquipment.reduce(
+    (max, item) => Math.max(max, item.x + (item.width || NODE_WIDTH)),
+    Number.NEGATIVE_INFINITY,
+  )
+  const startX = Number.isFinite(existingRight)
+    ? Math.max(origin.x, existingRight + COLUMN_GAP * 2)
+    : origin.x
+  const startY = origin.y
+
+  const frames: LocationFrame[] = []
+  let cursorX = startX
+  let frameIndex = 0
+
+  for (const key of orderedKeys) {
+    const bucket = columns.get(key) ?? []
+    if (bucket.length === 0) continue
+    const columnX = cursorX + (createRackFrames ? FRAME_PADDING : 0)
+    let cursorY = startY + (createRackFrames ? FRAME_HEADER : 0)
+    for (const item of bucket) {
+      item.x = columnX
+      item.y = cursorY
+      cursorY += item.height + ROW_GAP
+    }
+    const columnHeight = cursorY - ROW_GAP - startY
+
+    if (createRackFrames) {
+      const rack = key === null ? undefined : rackById.get(key)
+      frames.push({
+        id: uuidv4(),
+        name: rack ? refName(rack) || `Rack ${key}` : 'Ohne Rack',
+        x: cursorX,
+        y: startY,
+        width: NODE_WIDTH + FRAME_PADDING * 2,
+        height: columnHeight + FRAME_PADDING,
+        color: FRAME_COLORS[frameIndex % FRAME_COLORS.length],
+        notes: rack
+          ? `NetBox-Rack #${key}${rack.u_height ? ` (${rack.u_height} HE)` : ''} — ${snapshot.siteName}`
+          : `Geräte ohne Rack-Zuordnung — ${snapshot.siteName}`,
+        moveContents: true,
+      })
+      cursorX += NODE_WIDTH + FRAME_PADDING * 2 + COLUMN_GAP
+    } else {
+      cursorX += NODE_WIDTH + COLUMN_GAP
+    }
+    frameIndex++
+  }
+
+  return frames
+}

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -21,6 +21,7 @@ import { createGroupPresetSpawnSlice } from './slices/groupPresetSpawnSlice'
 import { createSelectionLifecycleSlice } from './slices/selectionLifecycleSlice'
 import { createLifecycleSlice } from './slices/lifecycleSlice'
 import { createPendingChangesSlice } from './slices/pendingChangesSlice'
+import { createNetboxImportSlice } from './slices/netboxImportSlice'
 import {
   loadCustomLibrary,
   persistCustomLibrary,
@@ -194,6 +195,23 @@ export interface ProjectState {
   /** #414 — Fügt KI-generierte Geräte + Kabel atomar ein, ohne IDs neu zu
    *  vergeben (die Kabel referenzieren die mitgelieferten IDs). */
   insertGeneratedPlan: (equipment: EquipmentItem[], cables: import('../types/cable').Cable[]) => void
+  /**
+   * #597 — Ergebnis eines NetBox-Abgleichs anwenden (Erstimport wie
+   * „Aktualisieren"). Rein additiv: neue Geräte/Kabel/Rack-Rahmen kommen
+   * dazu, an bestehenden Geräten werden nur neu hinzugekommene Ports
+   * ergänzt. Nichts wird ersetzt oder gelöscht — der Plan gibt in
+   * `staleDeviceIds`/`staleCableIds` nur Hinweise auf in NetBox
+   * verschwundene Elemente, das Aufräumen bleibt beim Planer.
+   *
+   * Der Plan kommt aus `lib/netboxMapping.ts#buildNetboxImportPlan`.
+   */
+  applyNetboxImport: (payload: {
+    newEquipment: EquipmentItem[]
+    newCables: Cable[]
+    portAdditions: Array<{ equipmentId: string; deviceName: string; inputs: Port[]; outputs: Port[] }>
+    newLocations: LocationFrame[]
+    source: { baseUrl: string; scope: 'site' | 'rack'; scopeId: number; scopeName: string }
+  }) => void
   /**
    * Insert devices and cables coming from a yEd / GraphML import. Each
    * device carries an optional `graphmlId` so a re-import (`mode:
@@ -758,6 +776,7 @@ const buildProjectStore = (
   ...createSelectionLifecycleSlice(set, get, store),
   ...createLifecycleSlice(set, get, store),
   ...createPendingChangesSlice(set, get, store),
+  ...createNetboxImportSlice(set, get, store),
   project:
     opts.initialProject ??
     (() => {

--- a/src/renderer/store/settingsStore.ts
+++ b/src/renderer/store/settingsStore.ts
@@ -81,6 +81,11 @@ interface PersistedSettings {
   /** Feld-Builder — user-definierte Fachfelder je Kategorie (kanonischer
    *  lowercase-Key). Overlay über die Built-in-`CATEGORY_SCHEMAS`. */
   userSchema: UserSchemaMap
+  /** #597 — Basis-URL der NetBox-Instanz (z. B. https://netbox.firma.de).
+   *  Pro Installation, nicht pro Projekt: dieselbe Instanz bedient alle
+   *  Projekte. Das zugehörige Token liegt im OS-Schlüsselbund, niemals
+   *  hier. Leerer String = NetBox nicht konfiguriert. */
+  netboxUrl: string
 }
 
 const defaults: PersistedSettings = {
@@ -91,6 +96,7 @@ const defaults: PersistedSettings = {
   enabledModules: { ...DEFAULT_ENABLED },
   onboardingDone: false,
   userSchema: {},
+  netboxUrl: '',
 }
 
 const load = (): PersistedSettings => {
@@ -120,6 +126,7 @@ const load = (): PersistedSettings => {
       onboardingDone:
         typeof parsed.onboardingDone === 'boolean' ? parsed.onboardingDone : true,
       userSchema: sanitizeUserSchema(parsed.userSchema),
+      netboxUrl: typeof parsed.netboxUrl === 'string' ? parsed.netboxUrl : defaults.netboxUrl,
     }
   } catch {
     return defaults
@@ -144,6 +151,7 @@ const snapshot = (s: PersistedSettings): PersistedSettings => ({
   enabledModules: s.enabledModules,
   onboardingDone: s.onboardingDone,
   userSchema: s.userSchema,
+  netboxUrl: s.netboxUrl,
 })
 
 interface SettingsState {
@@ -158,6 +166,7 @@ interface SettingsState {
   enabledModules: Record<ModuleId, boolean>
   onboardingDone: boolean
   userSchema: UserSchemaMap
+  netboxUrl: string
   setHasToken: (value: boolean) => void
   setTokenStatus: (value: string) => void
   setAutosaveIntervalMs: (value: number) => void
@@ -172,6 +181,8 @@ interface SettingsState {
   setOnboardingDone: (value: boolean) => void
   /** Feld-Builder — die komplette User-Schema-Map ersetzen. */
   setUserSchema: (map: UserSchemaMap) => void
+  /** #597 — Basis-URL der NetBox-Instanz setzen (leer = nicht konfiguriert). */
+  setNetboxUrl: (value: string) => void
 }
 
 const initial = load()
@@ -189,6 +200,7 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   enabledModules: initial.enabledModules,
   onboardingDone: initial.onboardingDone,
   userSchema: initial.userSchema,
+  netboxUrl: initial.netboxUrl,
   setHasToken: (value) => set({ hasToken: value }),
   setTokenStatus: (value) => set({ tokenStatus: value }),
   setAutosaveIntervalMs: (value) =>
@@ -235,6 +247,12 @@ export const useSettingsStore = create<SettingsState>((set) => ({
       persist(snapshot({ ...state, userSchema }))
       setUserSchemaOverlay(userSchema) // Overlay live nachziehen.
       return { userSchema }
+    }),
+  setNetboxUrl: (value) =>
+    set((state) => {
+      const netboxUrl = value.trim()
+      persist(snapshot({ ...state, netboxUrl }))
+      return { netboxUrl }
     }),
 }))
 

--- a/src/renderer/store/slices/netboxImportSlice.ts
+++ b/src/renderer/store/slices/netboxImportSlice.ts
@@ -1,0 +1,71 @@
+import type { StateCreator } from 'zustand'
+import { isProjectLocked, sanitizePort, touchProject } from '../projectStoreHelpers'
+import type { ProjectState } from '../projectStore'
+
+/**
+ * #597 — NetBox-Import-Slice.
+ *
+ * Eigenständige Slice, weil ein NetBox-Abgleich als EINE Mutation über
+ * vier Bereiche des Projekts geht (Equipment, Kabel, Locations, Metadata)
+ * und dabei atomar bleiben muss: der Undo-Stack soll einen Import als
+ * einen Schritt sehen, nicht als vier. Die eigentliche Diff-Logik liegt
+ * bewusst ausserhalb des Stores in `lib/netboxMapping.ts` (rein, testbar) —
+ * hier wird nur noch angewendet.
+ *
+ * Additiv per Konstruktion: es wird nur angehängt und ergänzt, nie ersetzt
+ * oder gelöscht. Bereits vorhandene Geräte/Kabel bleiben inklusive aller
+ * manuellen Nacharbeit (Position, Farbe, Wegpunkte, Labels) unangetastet.
+ */
+export type NetboxImportSlice = Pick<ProjectState, 'applyNetboxImport'>
+
+export const createNetboxImportSlice: StateCreator<ProjectState, [], [], NetboxImportSlice> = (
+  set,
+) => ({
+  applyNetboxImport: (payload) =>
+    set((state) => {
+      if (isProjectLocked(state)) return state
+
+      // Ports an bereits vorhandenen Geräten ergänzen (in NetBox neu
+      // angelegte Interfaces). Die Ports tragen fertige uuids aus dem
+      // Mapping — `sanitizePort` heilt trotzdem, falls eines fehlt.
+      const additionsById = new Map(payload.portAdditions.map((p) => [p.equipmentId, p]))
+      const equipment = state.project.equipment.map((item) => {
+        const addition = additionsById.get(item.id)
+        if (!addition) return item
+        return {
+          ...item,
+          inputs: [
+            ...item.inputs,
+            ...addition.inputs.map((p) => sanitizePort(p, p.name ?? 'Input')),
+          ],
+          outputs: [
+            ...item.outputs,
+            ...addition.outputs.map((p) => sanitizePort(p, p.name ?? 'Output')),
+          ],
+          // Sobald echte Ports da sind, ist die Belegung nicht mehr unbekannt.
+          ...(addition.inputs.length + addition.outputs.length > 0
+            ? { portsUnknown: undefined }
+            : {}),
+        }
+      })
+
+      return {
+        project: touchProject({
+          ...state.project,
+          // Neue Geräte behalten ihre im Mapping vergebenen IDs — die neuen
+          // Kabel referenzieren genau diese Equipment-/Port-IDs.
+          equipment: [...equipment, ...payload.newEquipment],
+          cables: [...state.project.cables, ...payload.newCables],
+          locations: [...(state.project.locations ?? []), ...payload.newLocations],
+          metadata: {
+            ...state.project.metadata,
+            netboxSourceUrl: payload.source.baseUrl,
+            netboxScope: payload.source.scope,
+            netboxScopeId: payload.source.scopeId,
+            netboxScopeName: payload.source.scopeName,
+            netboxLastSyncAt: new Date().toISOString(),
+          },
+        }),
+      }
+    }),
+})

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -920,6 +920,10 @@ interface UiState extends PersistedUiState {
   rentmanImport: { open: boolean }
   openRentmanImport: () => void
   closeRentmanImport: () => void
+  /** #597 — NetBox-Import-Dialog (Site/Rack aus der eigenen Instanz). */
+  netboxImport: { open: boolean }
+  openNetboxImport: () => void
+  closeNetboxImport: () => void
   /** Rentman cable export dialog (push canvas cable BOM to Rentman). */
   rentmanCableExport: { open: boolean }
   openRentmanCableExport: () => void
@@ -1360,6 +1364,9 @@ export const useUiStore = create<UiState>((set) => ({
   rentmanImport: { open: false },
   openRentmanImport: () => set({ rentmanImport: { open: true } }),
   closeRentmanImport: () => set({ rentmanImport: { open: false } }),
+  netboxImport: { open: false },
+  openNetboxImport: () => set({ netboxImport: { open: true } }),
+  closeNetboxImport: () => set({ netboxImport: { open: false } }),
   rentmanCableExport: { open: false },
   openRentmanCableExport: () => set({ rentmanCableExport: { open: true } }),
   closeRentmanCableExport: () => set({ rentmanCableExport: { open: false } }),

--- a/src/renderer/types/cable.ts
+++ b/src/renderer/types/cable.ts
@@ -72,6 +72,11 @@ export interface Cable {
    *  re-import correlate the same cable across runs. Set by the GraphML
    *  import flow only. */
   graphmlEdgeId?: string
+  /** #597 — `dcim.cable`-ID aus der importierten NetBox-Instanz. Der
+   *  Aktualisieren-Lauf legt nur Kabel an, deren ID noch nicht im Plan
+   *  ist — bestehende Kabel (inkl. manueller Nacharbeit an Farbe, Route
+   *  oder Länge) bleiben unangetastet. */
+  netboxId?: number
   /** v7.9.127 — per-cable Override fuer den globalen Endpoint-Labels-
    *  Toggle (Settings -> Editing -> "Endpoint-Labels einblenden").
    *  undefined = global folgen, 'show' = immer zeigen,

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -155,6 +155,17 @@ export interface Port {
    */
   direction?: 'in' | 'out' | 'bidirectional'
   /**
+   * #597 — ID der NetBox-Komponente (Interface, FrontPort, PowerPort, …),
+   * aus der dieser Port importiert wurde, zusammen mit ihrem NetBox-
+   * `object_type` (`interface`, `frontport`, …). Beides zusammen ist der
+   * stabile Schlüssel, über den der Aktualisieren-Lauf bereits importierte
+   * Ports wiederfindet und Kabel-Endpunkte auflöst. Bidirektionale
+   * NetBox-Komponenten erzeugen ein gespiegeltes In/Out-Paar — beide Ports
+   * tragen dieselbe `netboxId`.
+   */
+  netboxId?: number
+  netboxObjectType?: string
+  /**
    * #410 — Steckverbinder-Geschlecht (male/female). Optional; alte Projekte
    * heilen zu undefined. Wird als ♂/♀ am Port-Handle gezeigt und in
    * Patchliste/Etiketten durchgereicht — relevant fuer die Kabel-Konfektion
@@ -333,6 +344,13 @@ export interface EquipmentItem {
   rentmanId?: string
   /** Set to true when a Rentman re-fetch no longer finds this item in the project. */
   rentmanRemoved?: boolean
+  /** #597 — `dcim.device`-ID aus der importierten NetBox-Instanz. Stabile
+   *  Identität über Import-Läufe hinweg: der Aktualisieren-Lauf erkennt
+   *  daran, welche Geräte bereits im Plan sind, und fügt nur Neues hinzu. */
+  netboxId?: number
+  /** #597 — Basis-URL der NetBox-Instanz, aus der das Gerät stammt. Trennt
+   *  Geräte gleicher ID aus verschiedenen Instanzen (Test vs. Produktion). */
+  netboxSourceUrl?: string
   /** Stable origin id from an imported yEd / GraphML node. Lets a
    *  re-import correlate the same device across runs even when names or
    *  positions change. Set by the GraphML import flow only. */

--- a/src/renderer/types/netbox.ts
+++ b/src/renderer/types/netbox.ts
@@ -1,0 +1,138 @@
+/**
+ * NetBox-Roh-Typen (#597).
+ *
+ * Spiegelt die Teilmenge der NetBox-DCIM-API, die der Import braucht. Die
+ * Felder sind bewusst alle optional: NetBox-Instanzen laufen in freier
+ * Wildbahn zwischen v3.2 und v4.x, und einzelne Felder wurden zwischen
+ * diesen Versionen umbenannt (`device_role` → `role`, `termination_a_*` →
+ * `a_terminations[]`). Das Mapping (`lib/netboxMapping.ts`) kennt beide
+ * Formen; hier stehen sie deshalb nebeneinander.
+ *
+ * Die Typen leben im Renderer, weil `tsconfig.main.json` ein eigenes
+ * `rootDir` (src/main) hat und der Main-Prozess nicht aus dem Renderer
+ * importieren kann. Main gibt den Snapshot als reines JSON durch.
+ */
+
+/** Verkürztes Referenz-Objekt, wie NetBox es in verschachtelten Feldern
+ *  liefert (`{id, url, display, name, slug}`). */
+export interface NetboxRef {
+  id?: number
+  name?: string
+  display?: string
+  slug?: string
+  url?: string
+}
+
+export interface NetboxSite extends NetboxRef {
+  description?: string
+  status?: { value?: string; label?: string }
+  device_count?: number
+  rack_count?: number
+}
+
+export interface NetboxRack extends NetboxRef {
+  site?: NetboxRef
+  location?: NetboxRef
+  u_height?: number
+  /** Ab NetBox 4.1: `starting_unit`. Davor beginnt jedes Rack bei 1. */
+  starting_unit?: number
+  /** true = HE 1 oben statt unten. */
+  desc_units?: boolean
+  device_count?: number
+  status?: { value?: string; label?: string }
+}
+
+export interface NetboxDeviceType extends NetboxRef {
+  model?: string
+  manufacturer?: NetboxRef
+  u_height?: number
+}
+
+export interface NetboxDevice extends NetboxRef {
+  device_type?: NetboxDeviceType
+  /** NetBox ≥ 3.6. */
+  role?: NetboxRef
+  /** NetBox ≤ 3.5 (deprecated, aber noch im Feld anzutreffen). */
+  device_role?: NetboxRef
+  site?: NetboxRef
+  rack?: NetboxRef
+  /** Unterste belegte Höheneinheit (float ab NetBox 3.4 wegen halber HE). */
+  position?: number | null
+  face?: { value?: string; label?: string } | null
+  status?: { value?: string; label?: string }
+  serial?: string
+  asset_tag?: string | null
+  primary_ip?: { address?: string } | null
+  primary_ip4?: { address?: string } | null
+  description?: string
+  comments?: string
+}
+
+/** Gemeinsame Form aller Geräte-Komponenten (Interface, FrontPort, …). */
+export interface NetboxComponent extends NetboxRef {
+  device?: NetboxRef
+  label?: string
+  type?: { value?: string; label?: string } | string | null
+  /** Kabel-Referenz: ab NetBox 3.3 ein Brief-Objekt, davor eine blanke ID. */
+  cable?: NetboxRef | number | null
+  description?: string
+  /** Nur Interfaces. */
+  mgmt_only?: boolean
+  enabled?: boolean
+  mac_address?: string | null
+  /** Nur FrontPorts: der zugehörige RearPort. */
+  rear_port?: NetboxRef
+}
+
+/** Ein Kabelende. NetBox ≥ 3.3 liefert `a_terminations`/`b_terminations`
+ *  als Arrays (Mehrfach-Terminierung möglich). */
+export interface NetboxTermination {
+  object_type?: string
+  object_id?: number
+  object?: NetboxRef & { device?: NetboxRef }
+}
+
+export interface NetboxCable extends NetboxRef {
+  label?: string
+  color?: string
+  type?: string | null
+  status?: { value?: string; label?: string } | string
+  length?: number | null
+  length_unit?: { value?: string; label?: string } | string | null
+  description?: string
+  /** NetBox ≥ 3.3. */
+  a_terminations?: NetboxTermination[]
+  b_terminations?: NetboxTermination[]
+  /** NetBox ≤ 3.2 — Einzel-Terminierung. */
+  termination_a_type?: string
+  termination_a_id?: number
+  termination_a?: NetboxRef & { device?: NetboxRef }
+  termination_b_type?: string
+  termination_b_id?: number
+  termination_b?: NetboxRef & { device?: NetboxRef }
+}
+
+/**
+ * Lese-Snapshot, den `netbox:fetch-snapshot` liefert. `components` ist nach
+ * NetBox-`object_type`-Suffix gebündelt (`interface`, `frontport`,
+ * `rearport`, `consoleport`, `consoleserverport`, `powerport`,
+ * `poweroutlet`), damit `termination.object_type` direkt darauf zeigt.
+ */
+export interface NetboxSnapshot {
+  scope: 'site' | 'rack'
+  scopeId: number
+  scopeName: string
+  siteName: string
+  racks: NetboxRack[]
+  devices: NetboxDevice[]
+  components: Record<string, NetboxComponent[]>
+  cables: NetboxCable[]
+  netboxVersion: string
+}
+
+/** Wahl von Site oder Rack im Import-Dialog. */
+export interface NetboxScopeChoice {
+  scope: 'site' | 'rack'
+  id: number
+  name: string
+}

--- a/src/renderer/types/project.ts
+++ b/src/renderer/types/project.ts
@@ -77,6 +77,15 @@ export interface ProjectMetadata {
   rentmanProjectId?: string
   /** Human-readable name of the linked Rentman project. */
   rentmanProjectName?: string
+  /** #597 — Verknüpfte NetBox-Quelle. Wird beim Import gesetzt und vom
+   *  „Aktualisieren"-Button wiederverwendet, damit der Nutzer Instanz und
+   *  Site/Rack nicht erneut auswählen muss. */
+  netboxSourceUrl?: string
+  netboxScope?: 'site' | 'rack'
+  netboxScopeId?: number
+  netboxScopeName?: string
+  /** ISO-Zeitpunkt des letzten NetBox-Imports/Abgleichs. */
+  netboxLastSyncAt?: string
   /** Auto-Kabelnummerierungs-Schema. Undefined = noch nie konfiguriert
    *  (Defaults siehe `DEFAULT_CABLE_NUMBERING` in `lib/cableNumbering`). */
   cableNumbering?: CableNumberingScheme

--- a/tests/netboxMapping.test.ts
+++ b/tests/netboxMapping.test.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildNetboxImportPlan,
+  connectorToCableType,
+  netboxCableLength,
+  netboxCategoryForRole,
+  netboxConnectorType,
+  netboxTerminations,
+} from '../src/renderer/lib/netboxMapping'
+import type { NetboxSnapshot } from '../src/renderer/types/netbox'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+
+const BASE_URL = 'https://netbox.example.test'
+
+/** Baut einen minimalen, aber realistischen Snapshot:
+ *  Rack "R1" mit Switch (2 Interfaces) und PDU (1 Outlet, 1 Port am Switch),
+ *  verbunden durch zwei Kabel. */
+const makeSnapshot = (overrides: Partial<NetboxSnapshot> = {}): NetboxSnapshot => ({
+  scope: 'rack',
+  scopeId: 10,
+  scopeName: 'R1',
+  siteName: 'Studio A',
+  netboxVersion: '4.1.0',
+  racks: [{ id: 10, name: 'R1', u_height: 42, site: { id: 1, name: 'Studio A' } }],
+  devices: [
+    {
+      id: 100,
+      name: 'sw-core',
+      device_type: { id: 5, model: 'EX2300', manufacturer: { id: 2, name: 'Juniper' }, u_height: 1 },
+      role: { id: 3, name: 'Access Switch', slug: 'access-switch' },
+      rack: { id: 10, name: 'R1' },
+      position: 40,
+      primary_ip: { address: '10.0.0.2/24' },
+    },
+    {
+      id: 200,
+      name: 'pdu-1',
+      device_type: { id: 6, model: 'PDU-16', manufacturer: { id: 3, name: 'APC' }, u_height: 1 },
+      role: { id: 4, name: 'PDU', slug: 'pdu' },
+      rack: { id: 10, name: 'R1' },
+      position: 1,
+    },
+  ],
+  components: {
+    interface: [
+      { id: 1001, device: { id: 100 }, name: 'ge-0/0/0', type: { value: '1000base-t' }, cable: { id: 900 } },
+      { id: 1002, device: { id: 100 }, name: 'ge-0/0/1', type: { value: '1000base-t' }, cable: null },
+    ],
+    powerport: [{ id: 1100, device: { id: 100 }, name: 'PSU0', type: { value: 'iec-60320-c14' }, cable: { id: 901 } }],
+    poweroutlet: [{ id: 1200, device: { id: 200 }, name: 'Out-1', type: { value: 'iec-60320-c13' }, cable: { id: 901 } }],
+  },
+  cables: [
+    {
+      id: 900,
+      label: 'Uplink',
+      color: 'f44336',
+      length: 3,
+      length_unit: { value: 'm' },
+      a_terminations: [{ object_type: 'dcim.interface', object_id: 1001, object: { id: 1001, device: { id: 100 } } }],
+      // Gegenstelle liegt ausserhalb des Racks → muss übersprungen werden.
+      b_terminations: [{ object_type: 'dcim.interface', object_id: 5001, object: { id: 5001, device: { id: 999 } } }],
+    },
+    {
+      id: 901,
+      label: 'Power PSU0',
+      // A = Verbraucher-Eingang, B = PDU-Ausgang → Kabel muss gedreht werden.
+      a_terminations: [{ object_type: 'dcim.powerport', object_id: 1100, object: { id: 1100, device: { id: 100 } } }],
+      b_terminations: [{ object_type: 'dcim.poweroutlet', object_id: 1200, object: { id: 1200, device: { id: 200 } } }],
+    },
+  ],
+  ...overrides,
+})
+
+describe('netboxConnectorType', () => {
+  it('erkennt Kupfer-Ethernet am NetBox-Slug', () => {
+    expect(netboxConnectorType('interface', 'ge-0/0/0', { value: '1000base-t' })).toBe('Ethernet/RJ45')
+  })
+
+  it('erkennt SFP+/QSFP als SFP+', () => {
+    expect(netboxConnectorType('interface', 'xe-0/0/0', { value: '10gbase-x-sfpp' })).toBe('SFP+')
+    expect(netboxConnectorType('interface', 'et-0/0/0', { value: '100gbase-x-qsfp28' })).toBe('SFP+')
+  })
+
+  it('mappt Strom-Slugs auf die passende Steckerform', () => {
+    expect(netboxConnectorType('powerport', 'PSU0', { value: 'iec-60320-c14' })).toBe('IEC 230V')
+    expect(netboxConnectorType('poweroutlet', 'Out-1', { value: 'cee-7-7' })).toBe('Schuko 230V')
+    expect(netboxConnectorType('poweroutlet', 'Stage', { value: 'neutrik-powercon-32' })).toBe('PowerCON')
+  })
+
+  it('erkennt BNC/SDI und Glasfaser', () => {
+    expect(netboxConnectorType('frontport', 'SDI 1', { value: 'bnc' })).toBe('BNC')
+    expect(netboxConnectorType('rearport', 'Trunk', { value: 'lc' })).toBe('Fiber')
+  })
+
+  it('führt virtuelle Interfaces nicht als physischen Stecker', () => {
+    expect(netboxConnectorType('interface', 'ae0', { value: 'lag' })).toBe('Wireless/RF')
+  })
+})
+
+describe('connectorToCableType', () => {
+  it('bildet nicht-kabelfähige Steckertypen auf Custom ab', () => {
+    expect(connectorToCableType('DisplayPort')).toBe('Custom')
+    expect(connectorToCableType('USB')).toBe('Custom')
+    expect(connectorToCableType('BNC')).toBe('BNC')
+  })
+})
+
+describe('netboxCableLength', () => {
+  it('rechnet die NetBox-Einheit in Meter um', () => {
+    expect(netboxCableLength({ length: 3, length_unit: { value: 'm' } })).toBe(3)
+    expect(netboxCableLength({ length: 250, length_unit: { value: 'cm' } })).toBe(2.5)
+    expect(netboxCableLength({ length: 10, length_unit: 'ft' })).toBeCloseTo(3.048, 3)
+    expect(netboxCableLength({ length: null })).toBe(0)
+  })
+})
+
+describe('netboxTerminations', () => {
+  it('liest das moderne a_terminations-Array', () => {
+    const terms = netboxTerminations(
+      { a_terminations: [{ object_type: 'dcim.interface', object_id: 7 }] },
+      'a',
+    )
+    expect(terms).toHaveLength(1)
+    expect(terms[0].object_id).toBe(7)
+  })
+
+  it('fällt auf die alten termination_a_*-Felder zurück (NetBox ≤ 3.2)', () => {
+    const terms = netboxTerminations({ termination_a_type: 'dcim.interface', termination_a_id: 9 }, 'a')
+    expect(terms[0].object_id).toBe(9)
+    expect(terms[0].object_type).toBe('dcim.interface')
+  })
+})
+
+describe('netboxCategoryForRole', () => {
+  it('mappt bekannte Rollen auf Cable-Planner-Kategorien', () => {
+    expect(netboxCategoryForRole({ role: { slug: 'access-switch' } })).toBe('Netzwerk')
+    expect(netboxCategoryForRole({ role: { slug: 'pdu' } })).toBe('Strom')
+    expect(netboxCategoryForRole({ device_role: { slug: 'broadcast-camera' } })).toBe('Kameras')
+  })
+
+  it('fällt ohne Rolle auf Sonstiges zurück', () => {
+    expect(netboxCategoryForRole({})).toBe('Sonstiges')
+  })
+})
+
+describe('buildNetboxImportPlan — Erstimport', () => {
+  const plan = buildNetboxImportPlan(makeSnapshot(), [], [], { baseUrl: BASE_URL })
+
+  it('legt je NetBox-Gerät genau ein Equipment an', () => {
+    expect(plan.newEquipment).toHaveLength(2)
+    expect(plan.newEquipment.map((e) => e.netboxId).sort()).toEqual([100, 200])
+    expect(plan.newEquipment.every((e) => e.importSource === 'netbox')).toBe(true)
+    expect(plan.newEquipment.every((e) => e.netboxSourceUrl === BASE_URL)).toBe(true)
+  })
+
+  it('importiert per Default nur verkabelte Ports', () => {
+    const sw = plan.newEquipment.find((e) => e.netboxId === 100)!
+    const portIds = [...sw.inputs, ...sw.outputs].map((p) => p.netboxId)
+    // ge-0/0/1 (1002) hat kein Kabel und darf nicht auftauchen.
+    expect(portIds).not.toContain(1002)
+    expect(portIds).toContain(1001)
+  })
+
+  it('spiegelt richtungslose Interfaces als In/Out-Paar, Strom-Ports nicht', () => {
+    const sw = plan.newEquipment.find((e) => e.netboxId === 100)!
+    // Interface 1001 einmal als Input und einmal als Output.
+    expect(sw.inputs.filter((p) => p.netboxId === 1001)).toHaveLength(1)
+    expect(sw.outputs.filter((p) => p.netboxId === 1001)).toHaveLength(1)
+    // Der Power-Port ist nur Eingang.
+    expect(sw.inputs.some((p) => p.netboxId === 1100)).toBe(true)
+    expect(sw.outputs.some((p) => p.netboxId === 1100)).toBe(false)
+  })
+
+  it('dreht das Strom-Kabel auf Ausgang→Eingang', () => {
+    const power = plan.newCables.find((c) => c.netboxId === 901)
+    expect(power).toBeDefined()
+    const pdu = plan.newEquipment.find((e) => e.netboxId === 200)!
+    const sw = plan.newEquipment.find((e) => e.netboxId === 100)!
+    // Quelle muss die PDU (Outlet) sein, Ziel der Switch (Power-Eingang).
+    expect(power!.fromEquipmentId).toBe(pdu.id)
+    expect(power!.toEquipmentId).toBe(sw.id)
+  })
+
+  it('überspringt Kabel, deren Gegenstelle ausserhalb des Bereichs liegt', () => {
+    expect(plan.newCables.some((c) => c.netboxId === 900)).toBe(false)
+    expect(plan.skipped.some((s) => s.netboxId === 900 && s.kind === 'cable')).toBe(true)
+  })
+
+  it('legt einen Rahmen je Rack an und stapelt Geräte nach Höheneinheit', () => {
+    expect(plan.newLocations).toHaveLength(1)
+    expect(plan.newLocations[0].name).toBe('R1')
+    const sw = plan.newEquipment.find((e) => e.netboxId === 100)!
+    const pdu = plan.newEquipment.find((e) => e.netboxId === 200)!
+    // Switch steht auf HE 40, PDU auf HE 1 → Switch gehört nach oben.
+    expect(sw.y).toBeLessThan(pdu.y)
+    expect(sw.x).toBe(pdu.x)
+  })
+
+  it('übernimmt Farbe, Länge und IP aus NetBox', () => {
+    const sw = plan.newEquipment.find((e) => e.netboxId === 100)!
+    expect(sw.ipAddress).toBe('10.0.0.2')
+    expect(sw.rackUnits).toBe(1)
+    expect(sw.isRackDevice).toBe(true)
+  })
+})
+
+describe('buildNetboxImportPlan — Aktualisieren (nur hinzufügen)', () => {
+  it('legt bereits importierte Geräte und Kabel nicht erneut an', () => {
+    const first = buildNetboxImportPlan(makeSnapshot(), [], [], { baseUrl: BASE_URL })
+    const existingEquipment = first.newEquipment as EquipmentItem[]
+    const existingCables = first.newCables as Cable[]
+
+    const second = buildNetboxImportPlan(makeSnapshot(), existingEquipment, existingCables, {
+      baseUrl: BASE_URL,
+    })
+
+    expect(second.newEquipment).toHaveLength(0)
+    expect(second.newCables).toHaveLength(0)
+    expect(second.portAdditions).toHaveLength(0)
+    expect(second.unchangedDeviceIds.sort()).toEqual([100, 200])
+    expect(second.unchangedCableIds).toEqual([901])
+  })
+
+  it('ergänzt an bestehenden Geräten nur die in NetBox neu hinzugekommenen Ports', () => {
+    const first = buildNetboxImportPlan(makeSnapshot(), [], [], { baseUrl: BASE_URL })
+
+    // In NetBox kommt ein weiteres, verkabeltes Interface am Switch dazu.
+    const grown = makeSnapshot()
+    grown.components.interface = [
+      ...grown.components.interface,
+      { id: 1003, device: { id: 100 }, name: 'ge-0/0/2', type: { value: '1000base-t' }, cable: { id: 902 } },
+    ]
+
+    const second = buildNetboxImportPlan(
+      grown,
+      first.newEquipment as EquipmentItem[],
+      first.newCables as Cable[],
+      { baseUrl: BASE_URL },
+    )
+
+    expect(second.newEquipment).toHaveLength(0)
+    expect(second.portAdditions).toHaveLength(1)
+    const addition = second.portAdditions[0]
+    expect(addition.equipmentId).toBe(first.newEquipment.find((e) => e.netboxId === 100)!.id)
+    // Gespiegeltes Paar für das neue Interface.
+    expect(addition.inputs.map((p) => p.netboxId)).toEqual([1003])
+    expect(addition.outputs.map((p) => p.netboxId)).toEqual([1003])
+  })
+
+  it('legt ein neues Gerät samt Kabel zum Bestand an', () => {
+    const first = buildNetboxImportPlan(makeSnapshot(), [], [], { baseUrl: BASE_URL })
+
+    const grown = makeSnapshot()
+    grown.devices = [
+      ...grown.devices,
+      {
+        id: 300,
+        name: 'sw-edge',
+        device_type: { id: 5, model: 'EX2300', u_height: 1 },
+        role: { slug: 'access-switch' },
+        rack: { id: 10, name: 'R1' },
+        position: 20,
+      },
+    ]
+    grown.components.interface = [
+      ...grown.components.interface,
+      { id: 3001, device: { id: 300 }, name: 'ge-0/0/0', type: { value: '1000base-t' }, cable: { id: 903 } },
+    ]
+    // Neues Kabel zwischen dem bestehenden Switch-Port 1002 und dem neuen Gerät.
+    grown.components.interface = grown.components.interface.map((i) =>
+      i.id === 1002 ? { ...i, cable: { id: 903 } } : i,
+    )
+    grown.cables = [
+      ...grown.cables,
+      {
+        id: 903,
+        label: 'Core→Edge',
+        a_terminations: [{ object_type: 'dcim.interface', object_id: 1002, object: { id: 1002, device: { id: 100 } } }],
+        b_terminations: [{ object_type: 'dcim.interface', object_id: 3001, object: { id: 3001, device: { id: 300 } } }],
+      },
+    ]
+
+    const second = buildNetboxImportPlan(
+      grown,
+      first.newEquipment as EquipmentItem[],
+      first.newCables as Cable[],
+      { baseUrl: BASE_URL },
+    )
+
+    expect(second.newEquipment.map((e) => e.netboxId)).toEqual([300])
+    const newCable = second.newCables.find((c) => c.netboxId === 903)
+    expect(newCable).toBeDefined()
+    // Quelle ist der bestehende Switch (dessen Port 1002 jetzt ergänzt wird).
+    expect(newCable!.fromEquipmentId).toBe(first.newEquipment.find((e) => e.netboxId === 100)!.id)
+    expect(newCable!.toEquipmentId).toBe(second.newEquipment[0].id)
+  })
+
+  it('meldet in NetBox verschwundene Elemente, entfernt sie aber nicht', () => {
+    const first = buildNetboxImportPlan(makeSnapshot(), [], [], { baseUrl: BASE_URL })
+
+    const shrunk = makeSnapshot()
+    shrunk.devices = shrunk.devices.filter((d) => d.id !== 200)
+    shrunk.cables = []
+
+    const second = buildNetboxImportPlan(
+      shrunk,
+      first.newEquipment as EquipmentItem[],
+      first.newCables as Cable[],
+      { baseUrl: BASE_URL },
+    )
+
+    expect(second.staleDeviceIds).toEqual([200])
+    expect(second.staleCableIds).toEqual([901])
+    expect(second.newEquipment).toHaveLength(0)
+  })
+
+  it('behandelt eine andere Instanz mit gleichen IDs als fremd', () => {
+    const first = buildNetboxImportPlan(makeSnapshot(), [], [], { baseUrl: BASE_URL })
+
+    const second = buildNetboxImportPlan(makeSnapshot(), first.newEquipment as EquipmentItem[], [], {
+      baseUrl: 'https://netbox-test.example.test',
+    })
+
+    // Gleiche NetBox-IDs, andere Instanz → wird neu angelegt, nicht gemerged.
+    expect(second.newEquipment).toHaveLength(2)
+  })
+})
+
+describe('buildNetboxImportPlan — Optionen', () => {
+  it('importiert auf Wunsch auch unverkabelte Ports', () => {
+    const plan = buildNetboxImportPlan(makeSnapshot(), [], [], {
+      baseUrl: BASE_URL,
+      onlyConnectedPorts: false,
+    })
+    const sw = plan.newEquipment.find((e) => e.netboxId === 100)!
+    expect([...sw.inputs, ...sw.outputs].map((p) => p.netboxId)).toContain(1002)
+  })
+
+  it('lässt Kabel und Rahmen auf Wunsch weg', () => {
+    const plan = buildNetboxImportPlan(makeSnapshot(), [], [], {
+      baseUrl: BASE_URL,
+      includeCables: false,
+      createRackFrames: false,
+    })
+    expect(plan.newCables).toHaveLength(0)
+    expect(plan.newLocations).toHaveLength(0)
+  })
+
+  it('setzt den Import-Block rechts neben bestehende Geräte', () => {
+    const existing: EquipmentItem[] = [
+      {
+        id: 'manual-1',
+        name: 'Bestand',
+        category: 'Video',
+        inputs: [],
+        outputs: [],
+        x: 0,
+        y: 0,
+        width: 300,
+        height: 100,
+      },
+    ]
+    const plan = buildNetboxImportPlan(makeSnapshot(), existing, [], { baseUrl: BASE_URL })
+    expect(plan.newEquipment.every((e) => e.x > 300)).toBe(true)
+  })
+})


### PR DESCRIPTION
Konfigurierbare Anbindung an eine **eigene** NetBox-Instanz, um eine dort geplante Site oder ein Rack als Kabelplan zu übernehmen — plus einen Aktualisieren-Weg, der den bestehenden Plan unangetastet lässt und nur Neues ergänzt.

Nicht zu verwechseln mit dem bestehenden `lib/netboxImport.ts`: das importiert einzelne Gerätetypen aus dem öffentlichen `devicetype-library`-Repo auf GitHub. Hier geht es um die REST-API der eigenen Instanz (`<instanz>/api/schema/swagger-ui/`).

## Änderungen

**Main-Prozess**
- `services/netboxApiClient.ts` — lesende DCIM-API (`status`, `sites`, `racks`, `devices`, die sieben Komponenten-Endpoints, `cables`). Paginierung über `limit`/`offset` statt über die `next`-URL, weil die hinter einem Reverse-Proxy auf interne Hostnamen zeigt. Komponenten werden in `device_id`-Batches à 50 geholt, damit die URL unter den üblichen 8-KB-Limits bleibt.
- `ipc/netboxIpc.ts` — Domäne `netbox:*`. Bewusst zustandslos: die Basis-URL kommt bei jedem Aufruf aus den Settings mit und wird **in main** validiert (`normalizeNetboxBaseUrl`: nur http/https, abgeschnittenes `/api…`-Suffix und Query — ein aus der Adresszeile kopiertes `…/api/schema/swagger-ui/` funktioniert damit direkt).
- Token via `keytar` unter eigenem Account `netbox-api-token`, getrennt vom Rentman-Token. Anders als dort wird es **nie an den Renderer zurückgegeben** — der fragt nur `has-token`.

**Mapping** (`lib/netboxMapping.ts`, rein und unit-getestet)
- NetBox-Komponente → Port. Richtungslose Interfaces werden als gespiegeltes In/Out-Paar angelegt (gleiche `netboxId`), damit jedes Kabel als Ausgang→Eingang zeichenbar bleibt; Strom/Konsole/Patchfeld haben eine echte Richtung und bekommen genau einen Port. Kabel werden gedreht, wenn NetBox die Richtung andersherum führt (PDU als B-Seite).
- Steckertyp-Erkennung primär über den NetBox-`type`-Slug, erst danach über den freien Namen.
- Layout: eine Spalte je Rack, nach Höheneinheit absteigend gestapelt, optional ein `LocationFrame` je Rack. Der Block landet rechts vom Bestand und überdeckt nie einen vorhandenen Plan.
- Default `onlyConnectedPorts: true` — ein 48-Port-Switch brächte sonst 96 Handles auf den Knoten, von denen im Rack eine Handvoll gepatcht ist. Abschaltbar im Dialog.

**Additiver Abgleich (das „Nice to have" aus dem Issue)**
NetBox ist die Wahrheit über die Verkabelung, der Cable Planner über die Darstellung. Ein erneuter Lauf legt deshalb nur an, was über `netboxId` noch nicht im Plan ist, und ergänzt an bestehenden Geräten ausschliesslich neu hinzugekommene Ports — Positionen, Farben, Wegpunkte, Labels und Multicore-Bündel bleiben erhalten. In NetBox gelöschte Elemente werden als `staleDeviceIds`/`staleCableIds` **gemeldet, nicht entfernt**; das Aufräumen bleibt beim Planer. Angewendet wird der Plan atomar über `applyNetboxImport` (eigene Slice), damit der Undo-Stack einen Import als einen Schritt sieht.

**UI**
- `Netbox/NetboxImportDialog.tsx` — Site/Rack-Wahl, Optionen, Delta-Vorschau mit Zählern, Liste der übersprungenen Objekte und Begründung.
- Modul `netbox` (opt-in wie Rentman, im Preset „Festinstallation" enthalten) + Settings-Karte für URL und Token unter Einstellungen → Integrationen. Menüeintrag unter Werkzeuge, nur bei aktivem Modul.
- Web-Fallback wirft bewusst: eine NetBox-Instanz steht im internen Netz und schickt keine CORS-Header — der Import braucht den Main-Prozess.

## Prüfung

- `npm test` — 226 Tests grün, davon 26 neu in `tests/netboxMapping.test.ts` (Steckertyp-Erkennung, Längeneinheiten, alte `termination_a_*`- und neue `a_terminations`-Form, Erstimport, Kabel-Drehung, Ports-nur-hinzufügen, Stale-Meldung, andere Instanz mit gleichen IDs).
- `npx tsc --noEmit` auf allen drei Prozess-tsconfigs sauber.
- `npm run lint` — 0 Errors; die 10 verbleibenden Warnings sind identisch mit dem Stand auf `main` (gegengeprüft), also keine neuen.
- `npm run build` läuft durch.

Ungetestet ist der Live-Zugriff gegen eine echte Instanz — dafür fehlt hier eine NetBox. Die Versions-Unterschiede zwischen NetBox 3.2 und 4.x (`device_role` → `role`, `termination_a_*` → `a_terminations[]`, `cable` als ID vs. Brief-Objekt) sind im Mapping beidseitig abgedeckt und durch Tests belegt.

Closes #597


---
_Generated by [Claude Code](https://claude.ai/code/session_01SaqDtnGwaLZs4zTobFjRdJ)_