### PR TITLE
chore(licence): proprietäre Lizenz statt MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,104 @@
-MIT License
+PROPRIETARY SOFTWARE LICENCE / PROPRIETÄRE SOFTWARE-LIZENZ
 
-Copyright (c) 2026 cable-planner contributors
+Copyright (c) 2026 Lars Zumpe. Alle Rechte vorbehalten. All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+--------------------------------------------------------------------------
+DEUTSCH
+--------------------------------------------------------------------------
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1. EIGENTUM
+   Diese Software, ihr Quellcode, ihre Dokumentation und alle zugehörigen
+   Materialien sind urheberrechtlich geschütztes Eigentum von Lars Zumpe.
+   Die Veröffentlichung des Quellcodes begründet keine Übertragung von
+   Rechten und macht die Software nicht zu Open Source.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+2. NUTZUNGSRECHT FÜR ENDANWENDER
+   Lars Zumpe gewährt jeder natürlichen oder juristischen Person das
+   nicht-ausschliessliche, nicht übertragbare, jederzeit widerrufliche
+   Recht, die offiziell veröffentlichten Programmfassungen (Installer und
+   Binärdateien) unentgeltlich zu eigenen Zwecken zu installieren und zu
+   nutzen — auch geschäftlich, etwa zur Planung eigener Produktionen.
+
+3. NICHT GESTATTET
+   Ohne vorherige schriftliche Zustimmung von Lars Zumpe ist untersagt:
+   a) Weiterverbreitung, Weiterverkauf, Vermietung, Unterlizenzierung oder
+      öffentliches Zugänglichmachen der Software oder von Teilen davon;
+   b) Bearbeitung, Übersetzung, Portierung oder Erstellung abgeleiteter
+      Werke, einschliesslich der Verwendung des Quellcodes oder von Teilen
+      davon in anderen Projekten;
+   c) Entfernen oder Verändern von Urheberrechts- und Lizenzhinweisen;
+   d) Anbieten der Software oder ihrer Funktionen als Dienstleistung
+      gegenüber Dritten.
+
+4. QUELLCODE-EINSICHT
+   Der Quellcode wird zur Einsicht, zur Prüfung und zur Fehlermeldung
+   veröffentlicht. Punkt 3 bleibt davon unberührt.
+
+5. BEITRÄGE
+   Wer Änderungsvorschläge einreicht, überträgt Lars Zumpe damit ein
+   unbefristetes, weltweites, unentgeltliches und unterlizenzierbares Recht
+   zur uneingeschränkten Nutzung des Beitrags.
+
+6. DRITTANBIETER-KOMPONENTEN
+   Die Software nutzt Bibliotheken Dritter, die weiterhin ihren eigenen
+   Lizenzen unterliegen. Diese Lizenz gilt ausschliesslich für die von
+   Lars Zumpe verfassten Bestandteile.
+
+7. KEINE GEWÄHRLEISTUNG
+   DIE SOFTWARE WIRD OHNE JEDE GEWÄHRLEISTUNG BEREITGESTELLT, WEDER
+   AUSDRÜCKLICH NOCH STILLSCHWEIGEND, EINSCHLIESSLICH DER GEWÄHRLEISTUNG
+   DER MARKTGÄNGIGKEIT ODER DER EIGNUNG FÜR EINEN BESTIMMTEN ZWECK.
+
+8. HAFTUNGSBESCHRÄNKUNG
+   Lars Zumpe haftet nicht für Schäden, die aus der Nutzung oder der
+   Unmöglichkeit der Nutzung der Software entstehen, soweit gesetzlich
+   zulässig. Die Haftung für Vorsatz und grobe Fahrlässigkeit sowie nach
+   dem Produkthaftungsgesetz bleibt unberührt.
+
+9. ANWENDBARES RECHT
+   Es gilt das Recht der Bundesrepublik Deutschland.
+
+--------------------------------------------------------------------------
+ENGLISH (convenience translation; the German text prevails)
+--------------------------------------------------------------------------
+
+1. OWNERSHIP. This software, its source code, documentation and all related
+   materials are the copyrighted property of Lars Zumpe. Publication of the
+   source code transfers no rights and does not make the software open
+   source.
+
+2. END-USER RIGHT. Lars Zumpe grants any person or entity a non-exclusive,
+   non-transferable, revocable right to install and use the officially
+   released builds (installers and binaries) free of charge for their own
+   purposes, including commercial use such as planning their own
+   productions.
+
+3. NOT PERMITTED without prior written consent: (a) redistribution, resale,
+   rental, sublicensing or making available to the public; (b) modification,
+   translation, porting or creation of derivative works, including reuse of
+   the source code or parts of it in other projects; (c) removal or
+   alteration of copyright and licence notices; (d) offering the software or
+   its functionality as a service to third parties.
+
+4. SOURCE AVAILABILITY. The source is published for inspection, review and
+   bug reporting. Section 3 remains unaffected.
+
+5. CONTRIBUTIONS. Anyone submitting a change grants Lars Zumpe a perpetual,
+   worldwide, royalty-free, sublicensable right to use it without
+   restriction.
+
+6. THIRD-PARTY COMPONENTS remain under their own licences. This licence
+   covers only the parts authored by Lars Zumpe.
+
+7. NO WARRANTY. THE SOFTWARE IS PROVIDED WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+   PURPOSE.
+
+8. LIMITATION OF LIABILITY to the extent permitted by law. Liability for
+   intent, gross negligence and under the German Product Liability Act
+   remains unaffected.
+
+9. GOVERNING LAW is the law of the Federal Republic of Germany.
+
+--------------------------------------------------------------------------
+Kontakt / Contact: Lars Zumpe — lars@zumpe.dev

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows-blue" />
   <img src="https://img.shields.io/badge/offline-ready-success" />
   <img src="https://img.shields.io/badge/status-active%20development-orange" />
-  <img src="https://img.shields.io/badge/license-MIT-lightgrey" />
+  <img src="https://img.shields.io/badge/license-proprietär-critical" />
 </p>
 
 <p align="center">
@@ -26,7 +26,7 @@
  
   </a>
   <br />
-  <sub>Free &amp; MIT-licensed · <code>.dmg</code> (Apple Silicon + Intel) and <code>.exe</code> installers attached to every release</sub>
+  <sub>Kostenlos nutzbar, proprietär lizenziert · <code>.dmg</code> (Apple Silicon + Intel) and <code>.exe</code> installers attached to every release</sub>
 </p>
 
 <!-- HERO IMAGE — see docs/screenshots/README.md for capture + redaction guide -->
@@ -194,7 +194,7 @@ replacement for AV/broadcast wiring, or something more domain-specific than
 
 | | **CablePlanner** | WireCAD | D-Tools SI | Visio / draw.io |
 | --- | --- | --- | --- | --- |
-| Price | **Free · MIT** | ~$1,500–4,500 | $1,000s / yr | Subscription / free |
+| Price | **Kostenlos · proprietär** | ~$1,500–4,500 | $1,000s / yr | Subscription / free |
 | Platforms | **macOS + Windows** | Windows only | Windows + SQL Server | Windows / web |
 | File format | **Open JSON (git-diffable)** | Proprietary | Proprietary | VSDX / XML |
 | Broadcast-smart defaults | **Yes** (connector→layer, BOM, patch sheets) | Yes | Partial | No |
@@ -270,10 +270,10 @@ If CablePlanner saves you time on your next show, consider buying me a coffee:
   </a>
 </p>
 
-Donations are completely optional — the app stays MIT-licensed and free either way. 🙌
+Donations are completely optional — the app stays free to use. It is proprietary software, not open source. 🙌
 
 ---
 
 ## 📄 License
 
-MIT
+Proprietär — © 2026 Lars Zumpe, alle Rechte vorbehalten. Nutzung der veröffentlichten Builds ist kostenlos; Weiterverbreitung und abgeleitete Werke sind es nicht. Siehe [LICENSE](LICENSE).

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -1,6 +1,7 @@
 # Third-Party Licenses
 
-Cable Planner (eigener Code: MIT) bündelt die folgenden Open-Source-Pakete.
+Cable Planner (eigener Code: proprietär, © Lars Zumpe — siehe LICENSE) bündelt die folgenden Open-Source-Pakete.
+Die unten gelisteten Lizenzen gelten für die Fremdpakete und bleiben davon unberührt.
 Diese Datei reproduziert deren Lizenz-/Copyright-Notices wie von den
 jeweiligen Lizenzen gefordert. Automatisch generiert via
 `scripts/generate-notices.mjs` aus dem Produktions-Dependency-Baum.

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <title>CablePlanner — Visual cable planning for broadcast workflows</title>
-<meta name="description" content="CablePlanner is a desktop app for designing, visualizing, and managing broadcast signal infrastructure. Node-based canvas, ATEM multiview, Videohub routing, Rentman import, PDF export. Free & MIT-licensed for macOS and Windows." />
+<meta name="description" content="CablePlanner is a desktop app for designing, visualizing, and managing broadcast signal infrastructure. Node-based canvas, ATEM multiview, Videohub routing, Rentman import, PDF export. Free & proprietary (free to use) for macOS and Windows." />
 <meta property="og:title" content="CablePlanner — Visual cable planning for broadcast workflows" />
 <meta property="og:description" content="Drag-and-drop node canvas for studios, OB vans and live events. ATEM, Videohub, Rentman. macOS & Windows." />
 <meta property="og:type" content="website" />
@@ -14,7 +14,7 @@
 <meta property="og:image:alt" content="CablePlanner — node-based broadcast cabling canvas for SDI signal flow, ATEM and Videohub" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="CablePlanner — Visual cable planning for broadcast workflows" />
-<meta name="twitter:description" content="Free, MIT-licensed broadcast cable planning software. Node-based SDI signal-flow canvas, ATEM multiviewer editor, Videohub routing, PDF export. macOS & Windows." />
+<meta name="twitter:description" content="Free, proprietary (free to use) broadcast cable planning software. Node-based SDI signal-flow canvas, ATEM multiviewer editor, Videohub routing, PDF export. macOS & Windows." />
 <meta name="twitter:image" content="https://larszu.github.io/cable-planner/screenshots/hero.png" />
 <link rel="canonical" href="https://larszu.github.io/cable-planner/" />
 <meta name="author" content="Lars Zumpe" />
@@ -35,7 +35,7 @@
   "description": "Free, open-source broadcast cable planning software with a node-based canvas for SDI signal flow, ATEM multiviewer layouts, Blackmagic Videohub routing, Rentman import and PDF export. Offline-first desktop app for macOS and Windows.",
   "image": "https://larszu.github.io/cable-planner/screenshots/hero.png",
   "screenshot": "https://larszu.github.io/cable-planner/screenshots/hero.png",
-  "license": "https://opensource.org/licenses/MIT",
+  "license": "LICENSE",
   "isAccessibleForFree": true,
   "author": { "@type": "Person", "name": "Lars Zumpe" },
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
@@ -765,7 +765,7 @@
         <div class="stat"><div class="n">15+</div><div class="l">Cable types · extensible</div></div>
         <div class="stat"><div class="n">∞</div><div class="l">Nodes per plan</div></div>
         <div class="stat"><div class="n">100%</div><div class="l">Offline</div></div>
-        <div class="stat"><div class="n">MIT</div><div class="l">Open source</div></div>
+        <div class="stat"><div class="n">0 €</div><div class="l">Free to use</div></div>
       </div>
     </div>
   </div>
@@ -941,7 +941,7 @@
     <div class="section-head reveal">
       <div class="eyebrow">Latest release</div>
       <h2>Download CablePlanner</h2>
-      <p>Free, open source, MIT-licensed. Pick the build for your machine — no account required.</p>
+      <p>Free, open source, proprietary (free to use). Pick the build for your machine — no account required.</p>
     </div>
 
     <div class="card release-card reveal">
@@ -1020,7 +1020,7 @@
       <div class="lks">
         <a href="https://github.com/larszu/cable-planner" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/larszu/cable-planner/releases" target="_blank" rel="noopener">Releases</a>
-        <a href="https://github.com/larszu/cable-planner/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
+        <a href="https://github.com/larszu/cable-planner/blob/main/LICENSE" target="_blank" rel="noopener">Licence</a>
         <a href="https://paypal.me/larszumpe" target="_blank" rel="noopener">Donate</a>
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "name": "Lars Zumpe",
     "email": "lars@zumpe.dev"
   },
-  "license": "MIT",
+  "license": "UNLICENSED",
   "homepage": "https://larszu.github.io/cable-planner/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Die Software ist Eigentum von Lars Zumpe und soll nicht unter MIT stehen.

## Die neue Lizenz

Proprietär, zweisprachig DE/EN, deutsches Recht — so geschnitten, dass sie das Eigentum sichert, ohne das Vertriebsmodell zu zerstören:

| | |
| --- | --- |
| Nutzung der veröffentlichten Installer | kostenlos, auch geschäftlich |
| Quellcode-Einsicht, Prüfung, Fehlermeldung | erlaubt |
| Weiterverbreitung, abgeleitete Werke, Dienstleistung | nur mit schriftlicher Zustimmung |

## Geändert

- `LICENSE` ersetzt — der alte Text nannte als Rechteinhaber „cable-planner contributors", nicht Sie
- `package.json` → `"UNLICENSED"`
- `README.md`: Badge, Download-CTA, Vergleichstabelle (`Free · MIT` → `Kostenlos · proprietär`), Lizenz-Abschnitt
- `docs/index.html`: JSON-LD-Feld zeigte maschinenlesbar auf `opensource.org/licenses/MIT`, dazu Kachel „MIT / Open source" und Link „MIT License"

## Fremdlizenzen bleiben unberührt

In `THIRD-PARTY-LICENSES.md` wurde **nur die Aussage über den eigenen Code** geändert. Die Lizenzzählung der 244 MIT-Pakete und aller anderen Abhängigkeiten bleibt unverändert — sie gilt weiter für die Fremdpakete.

## Hinweis

Bereits veröffentlichte Versionen bleiben MIT: Wer eine ältere Fassung unter MIT erhalten hat, behält diese Rechte daran. Eine Lizenzänderung wirkt nur nach vorn.

Ich bin kein Anwalt — für den kommerziellen Ernstfall gehört der Text juristisch geprüft.

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_