### PR TITLE
feat(videohub): Routing-Zustand ins Projekt (ADR-001, Inkrement 0)

### DIFF
--- a/src/renderer/lib/videohubRouting.ts
+++ b/src/renderer/lib/videohubRouting.ts
@@ -1,0 +1,116 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Videohub-Routing: reine Logik (ADR-001, Inkrement 0).
+//
+// Kein React, kein Store, kein Electron — damit headless testbar, so wie es
+// ADR-001 fuer die Ableitungsschicht verlangt: erst beweisen, dann verdrahten.
+// ───────────────────────────────────────────────────────────────────────────
+import type { VideohubCrosspoints, VideohubRouting, VideohubSalvo } from '../types/equipment'
+
+/** Leerer, gueltiger Routing-Block. */
+export const emptyVideohubRouting = (): VideohubRouting => ({ planned: {}, salvos: [] })
+
+/**
+ * Normalisiert unbekannte Daten zu einem gueltigen Kreuzpunkt-Satz.
+ *
+ * Robust gegen das, was in gewachsenen Projektfiles und altem localStorage
+ * wirklich steht: String-Keys, Fliesskomma, negative Werte, null. Alles, was
+ * kein Paar aus zwei nicht-negativen Ganzzahlen ergibt, faellt raus — still
+ * zu raten waere schlimmer als die Route zu verlieren, weil ein falscher
+ * Kreuzpunkt live auf Sendung geht.
+ */
+export const normaliseCrosspoints = (raw: unknown): VideohubCrosspoints => {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {}
+  const out: VideohubCrosspoints = {}
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    const out_i = Number(k)
+    // Number(null) und Number('') sind 0 — beides waere ein gueltig aussehender
+    // Kreuzpunkt auf Eingang 0, obwohl der Wert in Wahrheit fehlt. Nur echte
+    // Zahlen und Zahl-Strings zaehlen.
+    const in_i =
+      typeof v === 'number' ? v : typeof v === 'string' && v.trim() !== '' ? Number(v) : NaN
+    if (!Number.isInteger(out_i) || out_i < 0) continue
+    if (!Number.isInteger(in_i) || in_i < 0) continue
+    out[out_i] = in_i
+  }
+  return out
+}
+
+/** Normalisiert einen Salvo; gibt null zurueck, wenn er unbrauchbar ist. */
+export const normaliseSalvo = (raw: unknown, fallbackId: string): VideohubSalvo | null => {
+  if (!raw || typeof raw !== 'object') return null
+  const r = raw as Record<string, unknown>
+  const name = typeof r.name === 'string' ? r.name.trim() : ''
+  if (!name) return null
+  const createdAt =
+    typeof r.createdAt === 'string'
+      ? r.createdAt
+      : typeof r.createdAt === 'number' && Number.isFinite(r.createdAt)
+        ? new Date(r.createdAt).toISOString()
+        : new Date(0).toISOString()
+  return {
+    id: typeof r.id === 'string' && r.id ? r.id : fallbackId,
+    name,
+    routing: normaliseCrosspoints(r.routing),
+    createdAt,
+  }
+}
+
+/** Normalisiert einen ganzen Routing-Block aus einem geladenen Projekt. */
+export const normaliseVideohubRouting = (raw: unknown): VideohubRouting => {
+  if (!raw || typeof raw !== 'object') return emptyVideohubRouting()
+  const r = raw as Record<string, unknown>
+  const salvos = Array.isArray(r.salvos)
+    ? r.salvos
+        .map((s, i) => normaliseSalvo(s, `salvo-${i}`))
+        .filter((s): s is VideohubSalvo => s !== null)
+    : []
+  return { planned: normaliseCrosspoints(r.planned), salvos }
+}
+
+/**
+ * Uebernimmt Salvos aus dem alten localStorage-Schluessel in das Projekt.
+ *
+ * Bewusst nicht destruktiv und bewusst nicht stillschweigend: bestehende
+ * Projekt-Salvos gewinnen bei Namensgleichheit, und der Aufrufer erfaehrt ueber
+ * `imported`, wie viele uebernommen wurden. Die Recherche nennt stillen
+ * Datenverlust beim Import den schaedlichsten Integrationsfehler ueberhaupt
+ * (COMPETITOR-PAIN-SYNTHESIS.md, Cluster E) — deshalb wird hier gemeldet
+ * statt geschluckt.
+ */
+export const mergeLegacySalvos = (
+  current: VideohubRouting,
+  legacyRaw: unknown,
+): { routing: VideohubRouting; imported: number } => {
+  if (!Array.isArray(legacyRaw)) return { routing: current, imported: 0 }
+  const have = new Set(current.salvos.map((s) => s.name))
+  const add: VideohubSalvo[] = []
+  legacyRaw.forEach((s, i) => {
+    const n = normaliseSalvo(s, `legacy-${i}`)
+    if (n && !have.has(n.name)) {
+      have.add(n.name)
+      add.push(n)
+    }
+  })
+  if (!add.length) return { routing: current, imported: 0 }
+  return { routing: { ...current, salvos: [...current.salvos, ...add] }, imported: add.length }
+}
+
+/** localStorage-Schluessel, unter dem Salvos vor ADR-001 lagen. */
+export const legacySalvoKey = (deviceId: string): string =>
+  `cable-planner.videohub.salvos.${deviceId || '_'}`
+
+/**
+ * Kreuzpunkte, die auf einen Ein- oder Ausgang ausserhalb des Geraets zeigen.
+ *
+ * Entsteht real, wenn ein Videohub im Plan verkleinert wird, nachdem geroutet
+ * wurde. Wird als Befund gemeldet statt still korrigiert.
+ */
+export const danglingCrosspoints = (
+  routing: VideohubCrosspoints,
+  inputCount: number,
+  outputCount: number,
+): { output: number; input: number }[] =>
+  Object.entries(routing)
+    .map(([o, i]) => ({ output: Number(o), input: i }))
+    .filter(({ output, input }) => output >= outputCount || input >= inputCount)
+    .sort((a, b) => a.output - b.output)

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -60,6 +60,7 @@ import { STORAGE_KEYS } from '../lib/storageKeys'
 import { VIEWPORT_DEFAULTS } from '../lib/layoutConstants'
 import { getCanvasSize } from '../lib/canvasViewport'
 import { seedLibrarySyncCache } from '../lib/librarySync'
+import { normaliseVideohubRouting } from '../lib/videohubRouting'
 
 const CUSTOM_LIB_KEY = STORAGE_KEYS.customLibrary
 const PROJECT_AUTOSAVE_KEY = STORAGE_KEYS.projectAutosave
@@ -536,6 +537,17 @@ const healProjectPositions = (project: CablePlannerProject): CablePlannerProject
   return {
     ...project,
     equipment: project.equipment.map((item) => {
+      // ADR-001 / Inkrement 0 — Videohub-Routing-Migration: der Kreuzpunkt-
+      // Zustand lag frueher nur im Komponenten-State des Export-Dialogs.
+      // Vorhandene Bloecke werden normalisiert (String-Keys aus JSON,
+      // Fliesskomma, negative Werte fliegen raus), fehlende bleiben
+      // undefined — nur Videohub-Geraete bekommen das Feld ueberhaupt, und
+      // erst wenn der Nutzer routet. Ein leerer Block auf jedem Geraet waere
+      // Ballast in jedem Projektfile.
+      if (item.videohubRouting !== undefined) {
+        item = { ...item, videohubRouting: normaliseVideohubRouting(item.videohubRouting) }
+      }
+
       // #422 — Legacy-Dimensions-Migration: dimensionHmm/Wmm/Dmm waren das
       // erste Schema (v7.9.131 / #216), wurden aber spaeter durch
       // heightMm/widthMm/depthMm ersetzt. Beide Felder gleichzeitig zu

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -245,6 +245,46 @@ export interface DeviceMode {
   weightKg?: number
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// Videohub-Routing (ADR-001, Inkrement 0)
+//
+// Der Kreuzpunkt-Zustand lag bisher nur im Komponenten-State des Export-
+// Dialogs und ging beim Schliessen verloren; benannte Salvos lagen in
+// localStorage pro Geraet, also ausserhalb des Projektfiles — nicht
+// versioniert, nicht mit dem Projekt teilbar, nicht exportierbar.
+//
+// exportVideohub.ts sagt es im eigenen Kommentar: "the canvas has no routing
+// data yet". Damit ist die Kette Kamera -> Router -> Mischer-Input nicht
+// ableitbar, und genau die verlangt die Recherche (Tally-Segment, woertlich:
+// "camera-to-input-to-tally-address-to-lamp map"). Deshalb wandert der
+// GEPLANTE Routing-Zustand ins Projekt.
+//
+// Eigentumsregel aus ADR-001: der Videohub besitzt seine echten Kreuzpunkte,
+// wir besitzen den PLAN. Deshalb heisst das Feld `planned` und nicht `state` —
+// ein spaeter gelesener Ist-Zustand bekommt ein eigenes Feld mit eigener
+// Provenienz und ueberschreibt den Plan nicht.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Ein Kreuzpunkt-Satz: `routing[outputIndex] = inputIndex`, beide 0-basiert. */
+export type VideohubCrosspoints = Record<number, number>
+
+/** Benannter Routing-Schnappschuss ("Salvo"). */
+export interface VideohubSalvo {
+  id: string
+  name: string
+  routing: VideohubCrosspoints
+  /** ISO-Zeitstempel. */
+  createdAt: string
+}
+
+/** Geplantes Routing eines Videohub-Geraets, Teil des Projekts. */
+export interface VideohubRouting {
+  /** Aktuell geplante Kreuzpunkte. */
+  planned: VideohubCrosspoints
+  /** Benannte Schnappschuesse, z. B. pro Sendungsteil. */
+  salvos: VideohubSalvo[]
+}
+
 export interface EquipmentItem {
   id: string
   name: string
@@ -412,6 +452,8 @@ export interface EquipmentItem {
    * the user can plan audio routing offline (Fairlight-style).
    */
   atemAudioConfig?: AtemAudioConfig
+  /** Geplantes Videohub-Routing (ADR-001). Nur bei Videohub-Geraeten gesetzt. */
+  videohubRouting?: VideohubRouting
   /** Mark equipment as favorite in the library (sorted to the top). */
   favorite?: boolean
   /** Hide from the library unless "Ausgeblendete zeigen" is active. */

--- a/tests/videohubRouting.test.ts
+++ b/tests/videohubRouting.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import {
+  emptyVideohubRouting,
+  normaliseCrosspoints,
+  normaliseSalvo,
+  normaliseVideohubRouting,
+  mergeLegacySalvos,
+  legacySalvoKey,
+  danglingCrosspoints,
+} from '../src/renderer/lib/videohubRouting'
+
+describe('normaliseCrosspoints', () => {
+  it('nimmt String-Keys, wie sie aus JSON kommen', () => {
+    expect(normaliseCrosspoints({ '0': 3, '1': 0 })).toEqual({ 0: 3, 1: 0 })
+  })
+
+  it('wirft alles weg, was kein Paar nicht-negativer Ganzzahlen ist', () => {
+    // Ein falscher Kreuzpunkt geht live auf Sendung — lieber verlieren als raten.
+    expect(normaliseCrosspoints({ 0: 1.5, 1: -2, '-1': 0, x: 4, 2: null, 3: 7 })).toEqual({ 3: 7 })
+  })
+
+  it('behandelt Unsinn als leer statt zu werfen', () => {
+    for (const bad of [null, undefined, 42, 'nope', [1, 2]]) {
+      expect(normaliseCrosspoints(bad)).toEqual({})
+    }
+  })
+})
+
+describe('normaliseSalvo', () => {
+  it('wandelt den alten Zahl-Zeitstempel in ISO', () => {
+    const s = normaliseSalvo({ id: 'a', name: 'Teil 1', routing: { 0: 2 }, createdAt: 0 }, 'fb')
+    expect(s?.createdAt).toBe(new Date(0).toISOString())
+    expect(s?.routing).toEqual({ 0: 2 })
+  })
+
+  it('vergibt eine Ersatz-Id, wenn keine da ist', () => {
+    expect(normaliseSalvo({ name: 'X' }, 'fallback-7')?.id).toBe('fallback-7')
+  })
+
+  it('verwirft Salvos ohne Namen — ein namenloser Snapshot ist nicht aufrufbar', () => {
+    expect(normaliseSalvo({ name: '   ', routing: { 0: 1 } }, 'fb')).toBeNull()
+    expect(normaliseSalvo({ routing: { 0: 1 } }, 'fb')).toBeNull()
+  })
+})
+
+describe('normaliseVideohubRouting', () => {
+  it('liefert fuer fehlende Daten einen gueltigen leeren Block', () => {
+    expect(normaliseVideohubRouting(undefined)).toEqual(emptyVideohubRouting())
+  })
+
+  it('filtert kaputte Salvos heraus, behaelt die guten', () => {
+    const r = normaliseVideohubRouting({
+      planned: { 0: 1 },
+      salvos: [{ name: 'gut', routing: { 1: 2 } }, { name: '' }, null, 5],
+    })
+    expect(r.planned).toEqual({ 0: 1 })
+    expect(r.salvos).toHaveLength(1)
+    expect(r.salvos[0].name).toBe('gut')
+  })
+})
+
+describe('mergeLegacySalvos', () => {
+  it('uebernimmt Salvos aus dem alten localStorage-Format', () => {
+    const { routing, imported } = mergeLegacySalvos(emptyVideohubRouting(), [
+      { id: 'l1', name: 'Vorband', routing: { 0: 1 }, createdAt: 1700000000000 },
+    ])
+    expect(imported).toBe(1)
+    expect(routing.salvos[0].name).toBe('Vorband')
+    expect(routing.salvos[0].createdAt).toBe(new Date(1700000000000).toISOString())
+  })
+
+  it('laesst dem Projekt den Vortritt und meldet, was wirklich kam', () => {
+    const current = { planned: {}, salvos: [{ id: 'p', name: 'Vorband', routing: { 9: 9 }, createdAt: 'x' }] }
+    const { routing, imported } = mergeLegacySalvos(current, [
+      { name: 'Vorband', routing: { 0: 0 } },
+      { name: 'Hauptact', routing: { 0: 1 } },
+    ])
+    expect(imported).toBe(1)
+    expect(routing.salvos.find((s) => s.name === 'Vorband')?.routing).toEqual({ 9: 9 })
+    expect(routing.salvos.map((s) => s.name)).toEqual(['Vorband', 'Hauptact'])
+  })
+
+  it('ist ein no-op ohne Altdaten und meldet das ehrlich', () => {
+    const cur = emptyVideohubRouting()
+    expect(mergeLegacySalvos(cur, null)).toEqual({ routing: cur, imported: 0 })
+    expect(mergeLegacySalvos(cur, []).imported).toBe(0)
+  })
+})
+
+describe('legacySalvoKey', () => {
+  it('trifft den Schluessel, unter dem vor ADR-001 gespeichert wurde', () => {
+    expect(legacySalvoKey('dev-1')).toBe('cable-planner.videohub.salvos.dev-1')
+    expect(legacySalvoKey('')).toBe('cable-planner.videohub.salvos._')
+  })
+})
+
+describe('danglingCrosspoints', () => {
+  it('findet Routen, die ins Leere zeigen, wenn das Geraet schrumpft', () => {
+    const d = danglingCrosspoints({ 0: 1, 5: 0, 1: 9 }, 4, 4)
+    expect(d).toEqual([{ output: 1, input: 9 }, { output: 5, input: 0 }])
+  })
+
+  it('meldet nichts bei sauberem Routing', () => {
+    expect(danglingCrosspoints({ 0: 1, 1: 0 }, 2, 2)).toEqual([])
+  })
+})


### PR DESCRIPTION
Erster Codeschritt der Identitäts-Spine (Roadmap-Initiative 1). Der Entwurf steht in [ADR-001](https://github.com/larszu/av-planner-suite/pull/17).

## Warum das der erste Schritt ist

Vier Architekturentwürfe traten gegeneinander an. Der bestplatzierte — Identität als reine Ableitung ohne persistenten Zustand — führte einen Punkt als Risiko. Die gegnerische Prüfung belegte ihn aus dem Code, und `lib/exportVideohub.ts` sagt es in seinem **eigenen Kommentar**:

> *All outputs default to input 0 (slot 1) because the canvas has no routing data yet.*

Der Kreuzpunkt-Zustand liegt nicht im Projekt. In einer echten Regie läuft die Kamera über den Router zum Mischer — eine reine Ableitung liefert also `ambiguous` für genau die Pläne, auf die es ankommt. Die vom Tally-Segment wörtlich geforderte *„camera-to-input-to-tally-address-to-lamp map"* ist ohne ihn **nicht ableitbar**.

Damit ist das keine Nebenarbeit, sondern die Voraussetzung.

## Was heute verloren geht

| | vorher | jetzt |
| --- | --- | --- |
| Aktives Routing | `useState` im Dialog — beim Schließen weg | im Projekt |
| Benannte Salvos | `localStorage` pro Gerät | im Projekt |
| Mit Projekt teilbar / versioniert / exportierbar | nein | ja |

## Änderungen

- **`types/equipment.ts`**: `VideohubCrosspoints`, `VideohubSalvo`, `VideohubRouting`, optionales `videohubRouting` auf `EquipmentItem`
- **`lib/videohubRouting.ts`**: reine Logik — kein React, kein Store, kein Electron, damit headless testbar. ADR-001 gibt genau diese Reihenfolge vor: erst beweisen, dann verdrahten.
- **`healProjectPositions`**: normalisiert vorhandene Blöcke beim Laden. Fehlende bleiben `undefined` — ein leerer Block auf jedem Gerät wäre Ballast in jedem Projektfile.

## Drei Entscheidungen, die Erklärung verdienen

**Das Feld heißt `planned`, nicht `state`.** Eigentumsregel aus ADR-001: Der Videohub besitzt seine echten Kreuzpunkte, wir besitzen den Plan. Ein später gelesener Ist-Zustand bekommt ein eigenes Feld mit eigener Provenienz und überschreibt den Plan nicht.

**`mergeLegacySalvos` meldet, statt zu schlucken.** Die Übernahme aus `localStorage` ist nicht destruktiv (bestehende Projekt-Salvos gewinnen bei Namensgleichheit) und gibt die Anzahl zurück. Die Recherche nennt stillen Datenverlust beim Import den schädlichsten Integrationsfehler überhaupt.

**`danglingCrosspoints` korrigiert nicht still.** Wird ein Videohub im Plan verkleinert, nachdem geroutet wurde, zeigen Routen ins Leere. Das wird gemeldet — ein stillschweigend „korrigierter" Kreuzpunkt geht live auf Sendung.

## Ein Test hat einen echten Fehler gefunden

`Number(null)` ist `0`. Ein fehlender Wert wäre damit als gültiger Kreuzpunkt **auf Eingang 0** durchgegangen — also genau die Art Fehler, die erst im Multiviewer auffällt. Behoben: nur echte Zahlen und Zahl-Strings zählen.

## Verifikation

`npx tsc -p tsconfig.app.json --noEmit` → **0 Fehler** (Baseline aus CLAUDE.md), **240 Tests grün** (226 + 14 neue), Lint ohne Fehler.

## Noch nicht enthalten

Die Verdrahtung des Export-Dialogs auf den Store. Dieser PR legt Datenmodell, Migration und geprüfte Logik; das UI folgt separat, damit der Review überschaubar bleibt.

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_