### PR TITLE
identity: Zeichenbudgets + Signalquellen-Rollen + PR-CI (ADR-001, Inkremente 1 und 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+# Der Merge-Gate. Die Standing Directive erlaubt Selbst-Merge nur bei gruenem
+# CI — bis hierher gab es auf Pull Requests aber gar keinen Lauf, der gruen
+# oder rot werden konnte. Dieser Workflow prueft genau das, was in CLAUDE.md
+# als Pflicht vor jedem Push steht:
+#
+#   npx tsc -p tsconfig.app.json --noEmit   MUSS 0 Errors zeigen
+#   npm run lint                            0 Errors (Warnungen sind geduldet)
+#   npm test                                vitest
+#   npm run build                           main + preload + renderer
+#
+# Bewusst NICHT hier: electron-builder (`npm run dist`) — das gehoert zu
+# release.yml und braucht Signatur-Material, und die gezielten Node-Checks
+# (test:crdt, test:signaling, ui:smoke, test:drag), die einen laufenden
+# Renderer bzw. Netzwerk erwarten.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Ein zweiter Push auf denselben Branch bricht den vorigen Lauf ab.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: 'npm'
+      # keytar (native) braucht beim Kompilieren libsecret; Prebuilds decken
+      # nicht jede Node-ABI ab. Gleiche Absicherung wie in pages.yml.
+      - run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev
+      - run: npm ci
+      - name: Type-Check (Renderer)
+        run: npx tsc -p tsconfig.app.json --noEmit
+      - name: Lint
+        run: npm run lint
+      - name: Tests
+        run: npm test
+      - name: Build
+        run: npm run build

--- a/src/renderer/components/Analysis/PlanCheckPanel.tsx
+++ b/src/renderer/components/Analysis/PlanCheckPanel.tsx
@@ -31,11 +31,12 @@ export const PlanCheckPanel = () => {
   const equipment = useProjectStore((s) => s.project.equipment)
   const cables = useProjectStore((s) => s.project.cables)
   const drumKit = useProjectStore((s) => s.project.drumKit)
+  const sourceIdentities = useProjectStore((s) => s.project.sourceIdentities)
   const setSelection = useProjectStore((s) => s.setSelection)
 
   const result = useMemo(
-    () => runDrawingChecks({ equipment, cables, drumKit }),
-    [equipment, cables, drumKit],
+    () => runDrawingChecks({ equipment, cables, drumKit, sourceIdentities }),
+    [equipment, cables, drumKit, sourceIdentities],
   )
 
   if (!open) return null

--- a/src/renderer/components/Export/VideohubExportDialog.tsx
+++ b/src/renderer/components/Export/VideohubExportDialog.tsx
@@ -450,9 +450,6 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
   //   outputConn[i] → was haengt am Output i (Destination-Device + Port)
   // Wird in den Matrix-Labels angezeigt damit der User sieht 'aha
   // Output 12 versorgt Monitor Buhne' beim Routing setzen.
-  // Korrekte, aber vom React-Compiler nicht statisch preservierbare
-  // Memoisierung (komplexer Body, abgeleitete `device`-Dependency).
-  /* eslint-disable react-hooks/preserve-manual-memoization */
   const connections = useMemo(() => {
     const inputConn = new Map<number, { sourceName: string; portName: string }>()
     const outputConn = new Map<number, { destName: string; portName: string }>()
@@ -488,7 +485,6 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
     }
     return { inputConn, outputConn }
   }, [device, cables, equipment])
-  /* eslint-enable react-hooks/preserve-manual-memoization */
 
   /** v7.9.119 / Issue #237 — Erzeugt einen Routing-Vorschlag basierend
    *  auf den Canvas-Verbindungen. Heuristik:
@@ -571,7 +567,6 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
     setRouting(next)
   }
 
-  /* eslint-disable react-hooks/preserve-manual-memoization */
   const preview = useMemo(() => {
     if (!device) return ''
     if (format === 'labels') {
@@ -588,7 +583,6 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
       routing,
     })
   }, [device, format, preset, friendlyName, routing])
-  /* eslint-enable react-hooks/preserve-manual-memoization */
 
   const handleExport = () => {
     if (!device) return

--- a/src/renderer/components/Layout/StatusBar.tsx
+++ b/src/renderer/components/Layout/StatusBar.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { Check, AlertCircle, AlertTriangle, CheckCircle2 } from 'lucide-react'
 import { APP_VERSION } from '../../lib/appInfo'
 import { useUiStore } from '../../store/uiStore'
@@ -73,7 +74,14 @@ export const StatusBar = ({
   const cables = useProjectStore((s) => s.project.cables)
   const drumKit = useProjectStore((s) => s.project.drumKit)
   const togglePlanCheck = useUiStore((s) => s.togglePlanCheck)
-  const { errorCount, warningCount } = runDrawingChecks({ equipment, cables, drumKit })
+  // Memoisiert, weil die StatusBar bei jeder Viewport-Aenderung rendert, die
+  // Check-Engine aber ueber den ganzen Plan laeuft (seit ADR-001 auch ueber
+  // den Kabelgraph). Abhaengigkeiten sind Store-Referenzen, wechseln also nur
+  // bei echter Projekt-Aenderung.
+  const { errorCount, warningCount } = useMemo(
+    () => runDrawingChecks({ equipment, cables, drumKit }),
+    [equipment, cables, drumKit],
+  )
   const checkTone =
     errorCount > 0
       ? 'bg-red-700 text-red-50'

--- a/src/renderer/components/Layout/StatusBar.tsx
+++ b/src/renderer/components/Layout/StatusBar.tsx
@@ -73,14 +73,15 @@ export const StatusBar = ({
   const equipment = useProjectStore((s) => s.project.equipment)
   const cables = useProjectStore((s) => s.project.cables)
   const drumKit = useProjectStore((s) => s.project.drumKit)
+  const sourceIdentities = useProjectStore((s) => s.project.sourceIdentities)
   const togglePlanCheck = useUiStore((s) => s.togglePlanCheck)
   // Memoisiert, weil die StatusBar bei jeder Viewport-Aenderung rendert, die
   // Check-Engine aber ueber den ganzen Plan laeuft (seit ADR-001 auch ueber
   // den Kabelgraph). Abhaengigkeiten sind Store-Referenzen, wechseln also nur
   // bei echter Projekt-Aenderung.
   const { errorCount, warningCount } = useMemo(
-    () => runDrawingChecks({ equipment, cables, drumKit }),
-    [equipment, cables, drumKit],
+    () => runDrawingChecks({ equipment, cables, drumKit, sourceIdentities }),
+    [equipment, cables, drumKit, sourceIdentities],
   )
   const checkTone =
     errorCount > 0

--- a/src/renderer/components/Properties/EquipmentProperties.tsx
+++ b/src/renderer/components/Properties/EquipmentProperties.tsx
@@ -37,6 +37,7 @@ import { ModesSection } from './sections/ModesSection'
 import { RackInstanceCard } from './sections/RackInstanceCard'
 import { ReplaceDeviceSection } from './sections/ReplaceDeviceSection'
 import { LifecycleSection } from './sections/LifecycleSection'
+import { SourceIdentitySection } from './sections/SourceIdentitySection'
 
 /** Module-level sensor options so re-renders don't churn the sensor
  *  instances. Stable references are critical for DnDContext's
@@ -140,6 +141,8 @@ export const EquipmentProperties = () => {
 
       <DisplayPropertiesBlock equipment={equipment} />
       <CategoryPropsSection equipment={equipment} />
+
+      <SourceIdentitySection equipment={equipment} />
 
       <NetworkAccessSection equipment={equipment} />
 

--- a/src/renderer/components/Properties/sections/SourceIdentitySection.tsx
+++ b/src/renderer/components/Properties/sections/SourceIdentitySection.tsx
@@ -1,0 +1,249 @@
+import { useMemo, useState } from 'react'
+import { useCanvasProjectStore as useProjectStore } from '../../../store/projectStoreContext'
+import { useTranslation, format } from '../../../lib/i18n'
+import { SortableSection } from '../SortableSection'
+import {
+  UMD_ADDRESS_MAX,
+  UMD_ADDRESS_MIN,
+  parseUmdAddress,
+  umdAddressClashes,
+} from '../../../lib/sourceIdentity'
+import type { EquipmentItem } from '../../../types/equipment'
+
+const NEW_ROLE = '__new__'
+
+/**
+ * ADR-001, Inkrement 2 — Signalquellen-Rolle eines Geraets.
+ *
+ * Die Rolle („Kamera 1") traegt die Anker, die keine Runtime besitzt: heute
+ * die TSL-UMD-Adresse. Sie liegt bewusst NEBEN dem Geraet, nicht in ihm — ein
+ * Haupt-/Backup-Paar ist EINE Rolle mit zwei Geraeten, und das Tally gehoert
+ * der Rolle. Deshalb zeigt die Sektion auch, welche anderen Geraete dieselbe
+ * Rolle tragen: Wer hier bindet, soll sehen, dass er nicht der Einzige ist.
+ *
+ * Nicht hier hin gehoert alles, was ein Geraet selbst weiss — ATEM-Source-Id,
+ * Videohub-Slot, MV-Fenster. Das loest `lib/labelDerivation.ts` aus dem
+ * Kabelgraph auf; es zusaetzlich zu speichern waere die zweite Wahrheit.
+ */
+export const SourceIdentitySection = ({ equipment }: { equipment: EquipmentItem }) => {
+  const t = useTranslation()
+  const identities = useProjectStore((s) => s.project.sourceIdentities)
+  const allEquipment = useProjectStore((s) => s.project.equipment)
+  const addSourceIdentity = useProjectStore((s) => s.addSourceIdentity)
+  const updateSourceIdentity = useProjectStore((s) => s.updateSourceIdentity)
+  const removeSourceIdentity = useProjectStore((s) => s.removeSourceIdentity)
+  const bindEquipment = useProjectStore((s) => s.bindEquipmentToSourceIdentity)
+
+  const list = useMemo(() => identities ?? [], [identities])
+  const bound = list.find((s) => s.id === equipment.sourceIdentityId)
+
+  const siblings = useMemo(
+    () =>
+      bound
+        ? allEquipment.filter((e) => e.sourceIdentityId === bound.id && e.id !== equipment.id)
+        : [],
+    [allEquipment, bound, equipment.id],
+  )
+
+  // Kollision NICHT nur fuer diese Rolle berechnen: eine Adresse kollidiert
+  // per Definition mit einer anderen Rolle, und die will man beim Tippen
+  // sofort sehen — nicht erst im Plan-Check.
+  const clashPartners = useMemo(() => {
+    if (!bound || bound.umdAddress === undefined) return []
+    const clash = umdAddressClashes(list).find((c) => c.address === bound.umdAddress)
+    return clash ? clash.identities.filter((i) => i.id !== bound.id) : []
+  }, [bound, list])
+
+  // Der Adress-Entwurf bleibt beim Tippen stehen, auch wenn er (noch) nicht
+  // gueltig ist. Ohne ihn verschluckt das Feld den dritten Anschlag von
+  // „999": der Wert waere unparsebar, der Store bliebe leer, und React
+  // zeichnete das Feld leer neu. Der Entwurf traegt die Rollen-Id mit, damit
+  // er beim Wechsel auf ein anderes Geraet nicht mitwandert.
+  const [umdDraft, setUmdDraft] = useState<{ id: string; text: string } | null>(null)
+  const umdText =
+    bound && umdDraft?.id === bound.id
+      ? umdDraft.text
+      : bound?.umdAddress !== undefined
+        ? String(bound.umdAddress)
+        : ''
+  const umdRejected =
+    umdText.trim() !== '' && parseUmdAddress(umdText.trim()) === undefined
+
+  const onPickRole = (value: string) => {
+    if (value === '') {
+      bindEquipment(equipment.id, undefined)
+      return
+    }
+    if (value === NEW_ROLE) {
+      const id = addSourceIdentity({ name: equipment.name })
+      if (id) bindEquipment(equipment.id, id)
+      return
+    }
+    bindEquipment(equipment.id, value)
+  }
+
+  return (
+    <SortableSection
+      id="source-identity"
+      title={t('sourceIdentity.title', 'Signalquelle (Rolle)')}
+      subtitle={
+        bound
+          ? bound.umdAddress !== undefined
+            ? `${bound.name} · UMD ${bound.umdAddress}`
+            : bound.name
+          : t('sourceIdentity.unbound', 'nicht zugewiesen')
+      }
+    >
+      <div className="flex flex-col gap-2">
+        <p className="text-cp-text-muted">
+          {t(
+            'sourceIdentity.hint',
+            'Die Rolle überlebt den Gerätetausch: „Kamera 1" bleibt „Kamera 1", auch wenn die Havarie-Kamera einspringt. An ihr hängt die Tally-/UMD-Adresse.',
+          )}
+        </p>
+
+        <label className="block">
+          <span className="mb-1 block text-cp-text-secondary">
+            {t('sourceIdentity.role', 'Rolle')}
+          </span>
+          <select
+            value={equipment.sourceIdentityId ?? ''}
+            onChange={(event) => onPickRole(event.target.value)}
+            className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
+          >
+            <option value="">{t('sourceIdentity.none', '— keine —')}</option>
+            {list.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+            <option value={NEW_ROLE}>
+              {t('sourceIdentity.create', 'Neue Rolle aus Gerätename anlegen…')}
+            </option>
+          </select>
+        </label>
+
+        {bound && (
+          <>
+            <div className="grid grid-cols-2 gap-2">
+              <label className="block">
+                <span className="mb-1 block text-cp-text-secondary">
+                  {t('sourceIdentity.name', 'Redaktioneller Name')}
+                </span>
+                <input
+                  value={bound.name}
+                  onChange={(event) =>
+                    updateSourceIdentity(bound.id, { name: event.target.value })
+                  }
+                  placeholder="Kamera 1"
+                  className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
+                />
+              </label>
+              <label className="block">
+                <span className="mb-1 block text-cp-text-secondary">
+                  {t('sourceIdentity.number', 'Nummer')}
+                </span>
+                <input
+                  type="number"
+                  min={0}
+                  value={bound.number ?? ''}
+                  onChange={(event) => {
+                    const raw = event.target.value.trim()
+                    const value = raw === '' ? undefined : Number(raw)
+                    updateSourceIdentity(bound.id, {
+                      number:
+                        value !== undefined && Number.isInteger(value) && value >= 0
+                          ? value
+                          : undefined,
+                    })
+                  }}
+                  className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
+                />
+              </label>
+            </div>
+
+            <label className="block">
+              <span className="mb-1 block text-cp-text-secondary">
+                {format(
+                  t('sourceIdentity.umd', 'TSL-UMD-Adresse ({min}–{max})'),
+                  { min: UMD_ADDRESS_MIN, max: UMD_ADDRESS_MAX },
+                )}
+              </span>
+              <input
+                type="number"
+                min={UMD_ADDRESS_MIN}
+                max={UMD_ADDRESS_MAX}
+                value={umdText}
+                onChange={(event) => {
+                  const raw = event.target.value
+                  setUmdDraft({ id: bound.id, text: raw })
+                  const trimmed = raw.trim()
+                  if (trimmed === '') {
+                    updateSourceIdentity(bound.id, { umdAddress: undefined })
+                    return
+                  }
+                  const parsed = parseUmdAddress(trimmed)
+                  // Ungueltiges NICHT uebernehmen: eine halb gueltige Adresse
+                  // sieht im Plan aus wie eine Zusage und bleibt es nicht.
+                  if (parsed !== undefined) updateSourceIdentity(bound.id, { umdAddress: parsed })
+                }}
+                onBlur={() => setUmdDraft(null)}
+                placeholder={t('sourceIdentity.umdPlaceholder', 'z. B. 1')}
+                className={`w-full rounded border bg-cp-surface-1 p-2 font-mono ${
+                  umdRejected ? 'border-cp-warn' : 'border-cp-border'
+                }`}
+              />
+            </label>
+
+            {umdRejected && (
+              <p className="text-cp-warn">
+                {format(
+                  t(
+                    'sourceIdentity.umdRejected',
+                    'Nicht übernommen: TSL UMD v3.1 kennt nur ganze Adressen von {min} bis {max}.',
+                  ),
+                  { min: UMD_ADDRESS_MIN, max: UMD_ADDRESS_MAX },
+                )}
+              </p>
+            )}
+
+            {clashPartners.length > 0 && (
+              <p className="rounded border border-cp-danger/60 bg-cp-danger/10 px-2 py-1.5 text-cp-danger">
+                {format(
+                  t(
+                    'sourceIdentity.umdClash',
+                    'Adresse {address} ist schon vergeben an {names} — beide Displays zeigen denselben Text.',
+                  ),
+                  {
+                    address: bound.umdAddress ?? '',
+                    names: clashPartners.map((i) => i.name).join(', '),
+                  },
+                )}
+              </p>
+            )}
+
+            {siblings.length > 0 && (
+              <p className="text-cp-text-muted">
+                {format(
+                  t(
+                    'sourceIdentity.siblings',
+                    'Dieselbe Rolle tragen außerdem: {names}. Das ist gewollt bei Haupt-/Backup-Paaren.',
+                  ),
+                  { names: siblings.map((e) => e.name).join(', ') },
+                )}
+              </p>
+            )}
+
+            <button
+              type="button"
+              onClick={() => removeSourceIdentity(bound.id)}
+              className="self-start rounded border border-cp-border px-2 py-1 text-cp-text-secondary hover:bg-cp-surface-3"
+            >
+              {t('sourceIdentity.remove', 'Rolle löschen (löst alle Bindungen)')}
+            </button>
+          </>
+        )}
+      </div>
+    </SortableSection>
+  )
+}

--- a/src/renderer/lib/drawingChecks.ts
+++ b/src/renderer/lib/drawingChecks.ts
@@ -16,6 +16,7 @@ import type { DrumKitPlan } from '../types/drumKit'
 import { checkImpedanceMismatch, checkBalanceMismatch, maxPassiveLengthM } from '../types/cableSpec'
 import { networkAddress } from './subnet'
 import { deriveDrumChannels } from './drumMicing'
+import { labelTargetIssues } from './labelDerivation'
 
 export type CheckSeverity = 'error' | 'warning' | 'info'
 
@@ -639,6 +640,13 @@ export const runDrawingChecks = (
       })
     }
   }
+
+  // — Check 20: Zeichenbudgets externer Systeme (ADR-001) --------------------
+  // Was der Plan an ATEM, Videohub, UMD und Dante abgibt, wird dort auf harte
+  // Feldlaengen zugeschnitten. Zwei Namen, die danach gleich sind, faellt
+  // sonst erst auf dem Multiviewer auf. Die Ableitung liegt in
+  // `labelDerivation.ts` und ist ohne Store/React testbar.
+  findings.push(...labelTargetIssues({ equipment, cables }))
 
   // Sortierung: error → warning → info, innerhalb stabil nach category.
   const rank: Record<CheckSeverity, number> = { error: 0, warning: 1, info: 2 }

--- a/src/renderer/lib/drawingChecks.ts
+++ b/src/renderer/lib/drawingChecks.ts
@@ -77,6 +77,8 @@ export interface DrawingCheckInput {
   cables: Cable[]
   /** Optionaler Drum-Mikrofonierungs-Plan — speist den Phantom/Mic-Input-Check. */
   drumKit?: DrumKitPlan
+  /** ADR-001 — Signalquellen-Rollen; speisen die Label-/UMD-Checks. */
+  sourceIdentities?: import('../types/sourceIdentity').SourceIdentity[]
 }
 
 export interface DrawingCheckResult {
@@ -91,7 +93,7 @@ export interface DrawingCheckResult {
  * (errors zuerst). Pure function — leicht testbar, kein Store-Zugriff.
  */
 export const runDrawingChecks = (
-  { equipment, cables, drumKit }: DrawingCheckInput,
+  { equipment, cables, drumKit, sourceIdentities }: DrawingCheckInput,
 ): DrawingCheckResult => {
   const findings: CheckFinding[] = []
   const eqById = new Map(equipment.map((e) => [e.id, e]))
@@ -646,7 +648,7 @@ export const runDrawingChecks = (
   // Feldlaengen zugeschnitten. Zwei Namen, die danach gleich sind, faellt
   // sonst erst auf dem Multiviewer auf. Die Ableitung liegt in
   // `labelDerivation.ts` und ist ohne Store/React testbar.
-  findings.push(...labelTargetIssues({ equipment, cables }))
+  findings.push(...labelTargetIssues({ equipment, cables, sourceIdentities }))
 
   // Sortierung: error → warning → info, innerhalb stabil nach category.
   const rank: Record<CheckSeverity, number> = { error: 0, warning: 1, info: 2 }

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -2148,6 +2148,26 @@ export const en: Dict = {
   'cable.aria.toDevice': 'Target device',
   'cable.aria.toPort': 'Target port',
 
+  // ADR-001 — Signalquellen-Rolle (SourceIdentitySection)
+  'sourceIdentity.title': 'Signal source (role)',
+  'sourceIdentity.unbound': 'not assigned',
+  'sourceIdentity.hint':
+    'The role outlives the device swap: "Camera 1" stays "Camera 1" even when the spare camera steps in. The tally/UMD address hangs on it.',
+  'sourceIdentity.role': 'Role',
+  'sourceIdentity.none': '— none —',
+  'sourceIdentity.create': 'Create new role from device name…',
+  'sourceIdentity.name': 'Editorial name',
+  'sourceIdentity.number': 'Number',
+  'sourceIdentity.umd': 'TSL UMD address ({min}–{max})',
+  'sourceIdentity.umdPlaceholder': 'e.g. 1',
+  'sourceIdentity.umdRejected':
+    'Not applied: TSL UMD v3.1 only knows whole addresses from {min} to {max}.',
+  'sourceIdentity.umdClash':
+    'Address {address} is already taken by {names} — both displays show the same text.',
+  'sourceIdentity.siblings':
+    'The same role is also carried by: {names}. That is intended for main/backup pairs.',
+  'sourceIdentity.remove': 'Delete role (releases all bindings)',
+
   // Section labels (NetworkAccess, Flags, Optional)
   'netAccess.title': 'Network & access',
   'netAccess.subtitle': 'IP · MAC · S/N · login',

--- a/src/renderer/lib/labelDerivation.ts
+++ b/src/renderer/lib/labelDerivation.ts
@@ -1,0 +1,461 @@
+// ADR-001, Inkrement 1 — die reine Ableitungsschicht.
+//
+// Beantwortet aus Plan-Daten allein die Frage: WELCHEN Text bekommt WELCHES
+// externe System fuer WELCHEN Anschluss? Kein React, kein Store, kein
+// Electron, kein persistiertes Feld — Eingabe sind Geraete und Kabel, Ausgabe
+// sind Kandidaten und die Liste dessen, was der Graph NICHT beantworten kann.
+//
+// TREUE-REGEL: Ein Label-Kandidat behauptet nur, was der zustaendige Exporter
+// HEUTE wirklich sendet — ATEM ueber `portDisplayLabel` + `shortenForAtem`
+// (AtemDialog), Videohub ueber `portDisplayLabel` (exportVideohub). Waere die
+// Ableitung hier schon „besser" als die Exporter, meldete der Plan-Check
+// Kollisionen auf Texten, die nie ein Geraet erreichen. Dass die Exporter
+// diesen Resolver uebernehmen, ist Inkrement 2 — nicht dieser Schritt.
+//
+// Die Rueckwaertssuche im Kabelgraph traegt dafuer das, was noch KEIN Exporter
+// abdeckt: `resolveSignalSource` laeuft vom Mischer-Eingang rueckwaerts durch
+// Durchleiter (Konverter, Verteiler) bis zur echten Quelle. Daraus entstehen
+// die Eingangsnummer je Quelle (die der ATEM auf dem Draht adressiert), der
+// UMD-Displaytext und die Liste der offenen Anker. Jeder Kandidat sagt in
+// `provenance`, woher sein Text stammt.
+//
+// Was die Ableitung NICHT kann, bleibt sichtbar statt geraten zu werden:
+// `UnansweredAnchor` sammelt genau die Felder, die kein Graph liefern kann,
+// weil sie Einsatz-Entscheidungen sind (welches UMD-Display zeigt diese
+// Quelle?). Diese Liste ist die Eingabe fuer Inkrement 2.
+//
+// REGEL: kein Anker ohne Ziel-Spec. Es werden nur Felder als offen gemeldet,
+// fuer die `labelTargets.ts` ein belegtes Ziel kennt — sonst entstuende eine
+// Wunschliste statt eines Arbeitsvorrats.
+
+import type { Cable } from '../types/cable'
+import type { EquipmentItem, Port } from '../types/equipment'
+import type { CheckFinding } from './drawingChecks'
+import { detectDeviceKind } from './deviceKind'
+import { portDisplayLabel, shortenForAtem } from './portLabel'
+import { effectiveShortName } from './shortName'
+import { suggestDanteName } from './danteNaming'
+import {
+  LABEL_TARGETS,
+  collisionsForTarget,
+  fitToTarget,
+  type FittedLabel,
+  type LabelTargetId,
+} from './labelTargets'
+
+/** Woher der Wunschtext eines Kandidaten stammt. */
+export type LabelProvenance =
+  | 'port-content-label'
+  | 'port-name'
+  | 'device-short-name'
+  | 'device-name'
+
+export interface LabelCandidate {
+  targetId: LabelTargetId
+  /** Stabiler Schluessel — als Befund-ID und React-key nutzbar. */
+  key: string
+  /** Geraet, das im Zielsystem konfiguriert wird. */
+  equipmentId: string
+  /** Port am Zielgeraet (nur bei portbezogenen Zielen gesetzt). */
+  portId?: string
+  /** Menschliche Verortung fuer Befunde, z. B. "ATEM 1 · In 3". */
+  where: string
+  /** Wunschtext VOR dem Zuschnitt auf das Zielbudget, aber NACH der
+   *  Aufbereitung des Exporters (bei ATEM z. B. `shortenForAtem`). */
+  raw: string
+  /** Derselbe Eintrag, wie er im Plan steht — die Aufbereitung wirft
+   *  Unterschiede weg, und genau die braucht die Kollisionspruefung. */
+  sourceText: string
+  provenance: LabelProvenance
+}
+
+/** Eine im Graph aufgeloeste Signalquelle an einem Router-/Mischer-Eingang. */
+export interface SignalSourceLink {
+  /** Router/Mischer, dessen Eingang betrachtet wird. */
+  sinkEquipmentId: string
+  sinkPortId: string
+  /** 1-basierte Position des Eingangs im Array — das ist die Nummer, mit der
+   *  ATEM und Videohub den Eingang auf dem Draht adressieren. */
+  inputIndex: number
+  /** Geraet, das dort tatsaechlich ankommt (nach Durchleitern). */
+  sourceEquipmentId: string
+  /** Anzahl durchlaufener Zwischengeraete (0 = direkt verkabelt). */
+  hops: number
+}
+
+export type AnchorField = 'umd-address'
+
+export interface UnansweredAnchor {
+  field: AnchorField
+  /** Geraet, dem der Anker fehlt (die Quelle, nicht der Router). */
+  equipmentId: string
+  where: string
+  /** Warum der Graph das nicht beantworten kann. */
+  reason: string
+}
+
+export interface LabelDerivationInput {
+  equipment: EquipmentItem[]
+  cables: Cable[]
+}
+
+export interface LabelDerivation {
+  candidates: LabelCandidate[]
+  sources: SignalSourceLink[]
+  unanswered: UnansweredAnchor[]
+}
+
+// ── Graph-Hilfen ─────────────────────────────────────────────────────────────
+
+interface PortRef {
+  equipmentId: string
+  portId: string
+}
+
+export interface GraphContext {
+  eqById: Map<string, EquipmentItem>
+  portById: Map<string, Port>
+  /** Je Port die Gegenenden seiner Kabel — ein Kabel kann in beide Richtungen
+   *  gezeichnet sein, deshalb wird jedes zweimal eingetragen. */
+  links: Map<string, PortRef[]>
+}
+
+export const buildGraphContext = (
+  equipment: EquipmentItem[],
+  cables: Cable[],
+): GraphContext => {
+  const eqById = new Map(equipment.map((e) => [e.id, e]))
+  const portById = new Map<string, Port>()
+  for (const e of equipment) {
+    for (const p of [...e.inputs, ...e.outputs]) portById.set(p.id, p)
+  }
+  const links = new Map<string, PortRef[]>()
+  const add = (portId: string, ref: PortRef) => {
+    const list = links.get(portId)
+    if (list) list.push(ref)
+    else links.set(portId, [ref])
+  }
+  for (const c of cables) {
+    add(c.fromPortId, { equipmentId: c.toEquipmentId, portId: c.toPortId })
+    add(c.toPortId, { equipmentId: c.fromEquipmentId, portId: c.fromPortId })
+  }
+  return { eqById, portById, links }
+}
+
+/**
+ * Eingaenge, die kein Programmsignal fuehren: Referenz, Rueckweg, Steuerung.
+ *
+ * Ohne diese Liste laeuft die Rueckwaertssuche durch den Genlock-Eingang einer
+ * Kamera hindurch und beschriftet den ATEM-Eingang am Ende mit dem Namen des
+ * Sync-Generators. Geprueft wird der PORT-Name, nicht der Geraetename — der
+ * ist ungleich verlaesslicher, weil er aus dem Katalog-Datenblatt stammt.
+ */
+const REFERENCE_PORT =
+  /genlock|\bref\b|reference|sync|return|tally|timecode|\bltc\b|talkback|intercom|comms|control|\bctrl\b|\brcp\b|\bgpi\b|prompter/i
+
+const isReferencePort = (port: Port): boolean =>
+  REFERENCE_PORT.test(`${port.name ?? ''} ${port.contentLabel ?? ''}`)
+
+/**
+ * Der eine Eingang, durch den das an `arrival` anliegende Signal plausibel
+ * hereingekommen ist — oder null, wenn das Geraet keine eindeutige
+ * Durchleitung ist.
+ *
+ * Bedingungen, bewusst eng gehalten: das Geraet hat keine eigene Rolle
+ * (Router/Mischer fuehren Laufzeit-Routing, keine feste Quelle), und es gibt
+ * GENAU EINEN Eingang mit demselben Steckverbinder, der kein Referenz-/
+ * Rueckweg-Eingang ist. Alles andere ist mehrdeutig — dann haelt die Suche an
+ * und nennt das Zwischengeraet. Das sagt weniger, stimmt aber.
+ */
+const feedingInput = (device: EquipmentItem, arrival: Port): Port | null => {
+  if (detectDeviceKind(device) !== null) return null
+  const candidates = device.inputs.filter(
+    (p) => p.connectorType === arrival.connectorType && !isReferencePort(p),
+  )
+  return candidates.length === 1 ? candidates[0] : null
+}
+
+const MAX_HOPS = 8
+
+/**
+ * Laeuft von einem Eingangsport rueckwaerts bis zur echten Quelle.
+ *
+ * Stoppt bei: keinem Kabel, einem Geraet ohne eindeutige Durchleitung (das IST
+ * die Quelle — siehe `feedingInput`), einem unverkabelten Weiterweg und
+ * spaetestens nach `MAX_HOPS` Zwischenstationen.
+ */
+export const resolveSignalSource = (
+  sinkPortId: string,
+  ctx: GraphContext,
+): { equipmentId: string; hops: number } | null => {
+  const first = ctx.links.get(sinkPortId)?.[0]
+  if (!first) return null
+
+  let current = first
+  let hops = 0
+  const visited = new Set<string>([sinkPortId, first.portId])
+
+  for (;;) {
+    const device = ctx.eqById.get(current.equipmentId)
+    if (!device) return null
+    const here = { equipmentId: current.equipmentId, hops }
+
+    const arrival = ctx.portById.get(current.portId)
+    if (!arrival) return here
+    if (hops >= MAX_HOPS) return here
+
+    const next = feedingInput(device, arrival)
+    if (!next || visited.has(next.id)) return here
+
+    const upstream = ctx.links.get(next.id)?.find((r) => !visited.has(r.portId))
+    if (!upstream) return here
+
+    visited.add(next.id)
+    visited.add(upstream.portId)
+    current = upstream
+    hops += 1
+  }
+}
+
+// ── Wunschtexte ──────────────────────────────────────────────────────────────
+
+/**
+ * Der Text, den die Exporter fuer einen Port abgeben — `portDisplayLabel`,
+ * plus die Herkunft. Leerer Text heisst: der Exporter sendet fuer diesen Port
+ * nichts, also gibt es auch nichts zu pruefen.
+ */
+const portText = (port: Port): { raw: string; provenance: LabelProvenance } => {
+  const content = port.contentLabel?.trim()
+  if (content) return { raw: content, provenance: 'port-content-label' }
+  return { raw: portDisplayLabel(port).trim(), provenance: 'port-name' }
+}
+
+/**
+ * Netzwerkadressierte Geraete — dieselbe Abgrenzung wie im AnalysisDialog,
+ * damit Naming-Pruefung und Kollisionspruefung denselben Geraetekreis sehen.
+ */
+const isNetworkAddressed = (device: EquipmentItem): boolean =>
+  Boolean(device.ipAddress) ||
+  device.managementVlanId != null ||
+  (device.vlans?.length ?? 0) > 0
+
+/** ATEM-Kurzname: der Emitter entfernt Leerzeichen und schreibt gross. */
+export const atemShortSource = (raw: string): string =>
+  shortenForAtem(raw).replace(/\s+/g, '').toUpperCase()
+
+// ── Ableitung ────────────────────────────────────────────────────────────────
+
+export const deriveLabels = ({
+  equipment,
+  cables,
+}: LabelDerivationInput): LabelDerivation => {
+  const ctx = buildGraphContext(equipment, cables)
+  const { eqById } = ctx
+  const candidates: LabelCandidate[] = []
+  const sources: SignalSourceLink[] = []
+  const unanswered: UnansweredAnchor[] = []
+  const umdSeen = new Set<string>()
+
+  /**
+   * Der Multiviewer und das UMD zeigen den Namen der QUELLE, nicht den des
+   * Mischer-Eingangs. Welche Nummer der Eingang auf dem Draht hat, weiss der
+   * Graph — welches physische Display darauf hoert, ist eine
+   * Einsatz-Entscheidung und damit ein offener Anker.
+   */
+  const emitUmd = (
+    source: EquipmentItem | undefined,
+    sink: EquipmentItem,
+    inputIdx: number,
+  ) => {
+    if (!source || umdSeen.has(source.id)) return
+    if (detectDeviceKind(sink) !== 'atem') return
+    umdSeen.add(source.id)
+    candidates.push({
+      targetId: 'tsl-umd-v31',
+      key: `umd:${source.id}`,
+      equipmentId: source.id,
+      where: source.name,
+      raw: effectiveShortName(source),
+      sourceText: source.name,
+      provenance: 'device-short-name',
+    })
+    unanswered.push({
+      field: 'umd-address',
+      equipmentId: source.id,
+      where: source.name,
+      reason:
+        `speist ${sink.name} auf Eingang ${inputIdx + 1} — die UMD-Adresse ` +
+        'des zugehoerigen Displays steht in keinem Plan-Feld',
+    })
+  }
+
+  for (const device of equipment) {
+    const kind = detectDeviceKind(device)
+    if (kind !== 'atem' && kind !== 'videohub') continue
+
+    device.inputs.forEach((port, idx) => {
+      const resolved = resolveSignalSource(port.id, ctx)
+      const source = resolved ? eqById.get(resolved.equipmentId) : undefined
+      if (resolved && source) {
+        sources.push({
+          sinkEquipmentId: device.id,
+          sinkPortId: port.id,
+          inputIndex: idx + 1,
+          sourceEquipmentId: resolved.equipmentId,
+          hops: resolved.hops,
+        })
+      }
+      const { raw, provenance } = portText(port)
+      if (!raw) {
+        // Kein Label heisst nicht: keine Quelle. Der UMD-Text haengt an der
+        // Quelle, nicht am Portnamen — deshalb erst hier abbrechen.
+        emitUmd(source, device, idx)
+        return
+      }
+      const where = `${device.name} · ${port.name || `In ${idx + 1}`}`
+
+      if (kind === 'atem') {
+        const long = shortenForAtem(raw)
+        candidates.push({
+          targetId: 'atem-input-long',
+          key: `atem-long:${port.id}`,
+          equipmentId: device.id,
+          portId: port.id,
+          where,
+          raw: long,
+          sourceText: raw,
+          provenance,
+        })
+        candidates.push({
+          targetId: 'atem-input-short',
+          key: `atem-short:${port.id}`,
+          equipmentId: device.id,
+          portId: port.id,
+          where,
+          raw: atemShortSource(raw),
+          sourceText: raw,
+          provenance,
+        })
+      } else {
+        candidates.push({
+          targetId: 'videohub-label',
+          key: `videohub-in:${port.id}`,
+          equipmentId: device.id,
+          portId: port.id,
+          where,
+          raw,
+          sourceText: raw,
+          provenance,
+        })
+      }
+
+      emitUmd(source, device, idx)
+    })
+
+    if (kind === 'videohub') {
+      device.outputs.forEach((port, idx) => {
+        const { raw, provenance } = portText(port)
+        if (!raw) return
+        candidates.push({
+          targetId: 'videohub-label',
+          key: `videohub-out:${port.id}`,
+          equipmentId: device.id,
+          portId: port.id,
+          where: `${device.name} · ${port.name || `Out ${idx + 1}`}`,
+          raw,
+          sourceText: raw,
+          provenance,
+        })
+      })
+    }
+  }
+
+  // Dante/AES67 — netzwerkfaehige Geraete. Anders als bei ATEM und Videohub
+  // gibt es hier keinen Exporter, sondern einen Vorschlag: `suggestDanteName`
+  // ist der Name, den der Nutzer laut AnalysisDialog vergeben soll. Geprueft
+  // wird also, was nach dem Befolgen des eigenen Rats im Netz steht — zwei
+  // Geraete, deren Vorschlaege zusammenfallen, waeren dort derselbe Host.
+  for (const device of equipment) {
+    if (!isNetworkAddressed(device)) continue
+    candidates.push({
+      targetId: 'dante-device',
+      key: `dante:${device.id}`,
+      equipmentId: device.id,
+      where: device.name,
+      raw: suggestDanteName(device.name),
+      sourceText: device.name,
+      provenance: 'device-name',
+    })
+  }
+
+  return { candidates, sources, unanswered }
+}
+
+// ── Befunde ──────────────────────────────────────────────────────────────────
+
+/**
+ * Uebersetzt die Abbildung auf die Zielsysteme in Befunde.
+ *
+ * Gemeldet wird, was ueberrascht: zwei verschiedene Namen, die im Zielsystem
+ * gleich heissen (Fehler — auf dem Multiviewer nicht mehr unterscheidbar), und
+ * Zeichen, die das Zielformat nicht transportiert (Warnung). Blosses
+ * Abschneiden ist KEIN Befund: es ist der Normalfall und wuerde die Liste
+ * zumuellen.
+ */
+export const labelTargetIssues = (input: LabelDerivationInput): CheckFinding[] => {
+  const { candidates } = deriveLabels(input)
+  const issues: CheckFinding[] = []
+  const byTarget = new Map<LabelTargetId, LabelCandidate[]>()
+  for (const c of candidates) {
+    const list = byTarget.get(c.targetId)
+    if (list) list.push(c)
+    else byTarget.set(c.targetId, [c])
+  }
+
+  for (const [targetId, group] of byTarget) {
+    const spec = LABEL_TARGETS[targetId]
+    const candidateOf = new Map<FittedLabel, LabelCandidate>()
+    const fitted: FittedLabel[] = []
+    for (const c of group) {
+      const f = fitToTarget(c.raw, spec, c.sourceText)
+      fitted.push(f)
+      candidateOf.set(f, c)
+    }
+
+    for (const collision of collisionsForTarget(fitted, spec)) {
+      const members = collision.members
+        .map((f) => candidateOf.get(f))
+        .filter((c): c is LabelCandidate => c != null)
+      if (members.length < 2) continue
+      const budget = spec.budget
+      issues.push({
+        id: `label-collision:${targetId}:${collision.value}`,
+        severity: 'error',
+        category: `${spec.system}-Namenskollision`,
+        message:
+          `${members.map((m) => `"${m.sourceText}"`).join(' und ')} werden im ` +
+          `${spec.system}-${spec.field} beide zu "${collision.value}"` +
+          (budget !== null ? ` (${budget} ${spec.budgetUnit === 'bytes' ? 'Byte' : 'Zeichen'})` : '') +
+          ` — betroffen: ${members.map((m) => m.where).join(', ')}.`,
+        equipmentId: members[0].equipmentId,
+      })
+    }
+
+    for (const f of fitted) {
+      if (f.invalidChars.length === 0) continue
+      const c = candidateOf.get(f)
+      if (!c) continue
+      issues.push({
+        id: `label-charset:${targetId}:${c.key}`,
+        severity: 'warning',
+        category: `${spec.system}-Zeichensatz`,
+        message:
+          `"${f.raw}" enthaelt ${f.invalidChars.map((ch) => `"${ch}"`).join(', ')} — ` +
+          `im ${spec.system}-${spec.field} nicht darstellbar (${c.where}).`,
+        equipmentId: c.equipmentId,
+      })
+    }
+  }
+
+  return issues
+}

--- a/src/renderer/lib/labelDerivation.ts
+++ b/src/renderer/lib/labelDerivation.ts
@@ -30,11 +30,13 @@
 
 import type { Cable } from '../types/cable'
 import type { EquipmentItem, Port } from '../types/equipment'
+import type { SourceIdentity } from '../types/sourceIdentity'
 import type { CheckFinding } from './drawingChecks'
 import { detectDeviceKind } from './deviceKind'
 import { portDisplayLabel, shortenForAtem } from './portLabel'
 import { effectiveShortName } from './shortName'
 import { suggestDanteName } from './danteNaming'
+import { umdAddressClashes } from './sourceIdentity'
 import {
   LABEL_TARGETS,
   collisionsForTarget,
@@ -49,6 +51,7 @@ export type LabelProvenance =
   | 'port-name'
   | 'device-short-name'
   | 'device-name'
+  | 'source-identity'
 
 export interface LabelCandidate {
   targetId: LabelTargetId
@@ -92,11 +95,17 @@ export interface UnansweredAnchor {
   where: string
   /** Warum der Graph das nicht beantworten kann. */
   reason: string
+  /** Rolle, die den Anker tragen wuerde — fehlt, solange keine gebunden ist. */
+  sourceIdentityId?: string
 }
 
 export interface LabelDerivationInput {
   equipment: EquipmentItem[]
   cables: Cable[]
+  /** ADR-001, Inkrement 2 — die persistierten Rollen. Fehlen sie, verhaelt
+   *  sich die Ableitung wie in Inkrement 1: sie leitet ab, was sie kann, und
+   *  meldet den Rest als offen. */
+  sourceIdentities?: SourceIdentity[]
 }
 
 export interface LabelDerivation {
@@ -248,8 +257,10 @@ export const atemShortSource = (raw: string): string =>
 export const deriveLabels = ({
   equipment,
   cables,
+  sourceIdentities = [],
 }: LabelDerivationInput): LabelDerivation => {
   const ctx = buildGraphContext(equipment, cables)
+  const identityById = new Map(sourceIdentities.map((s) => [s.id, s]))
   const { eqById } = ctx
   const candidates: LabelCandidate[] = []
   const sources: SignalSourceLink[] = []
@@ -270,22 +281,33 @@ export const deriveLabels = ({
     if (!source || umdSeen.has(source.id)) return
     if (detectDeviceKind(sink) !== 'atem') return
     umdSeen.add(source.id)
+
+    // Die Rolle gewinnt gegen den Geraetenamen: „Kamera 1" bleibt „Kamera 1",
+    // auch wenn die Havarie-Kamera einspringt. Genau dafuer gibt es sie.
+    const identity = source.sourceIdentityId
+      ? identityById.get(source.sourceIdentityId)
+      : undefined
     candidates.push({
       targetId: 'tsl-umd-v31',
       key: `umd:${source.id}`,
       equipmentId: source.id,
       where: source.name,
-      raw: effectiveShortName(source),
-      sourceText: source.name,
-      provenance: 'device-short-name',
+      raw: identity ? identity.name : effectiveShortName(source),
+      sourceText: identity ? identity.name : source.name,
+      provenance: identity ? 'source-identity' : 'device-short-name',
     })
+
+    if (identity?.umdAddress !== undefined) return
     unanswered.push({
       field: 'umd-address',
       equipmentId: source.id,
       where: source.name,
-      reason:
-        `speist ${sink.name} auf Eingang ${inputIdx + 1} — die UMD-Adresse ` +
-        'des zugehoerigen Displays steht in keinem Plan-Feld',
+      sourceIdentityId: identity?.id,
+      reason: identity
+        ? `Rolle "${identity.name}" speist ${sink.name} auf Eingang ` +
+          `${inputIdx + 1}, traegt aber keine UMD-Adresse`
+        : `speist ${sink.name} auf Eingang ${inputIdx + 1} — ohne gebundene ` +
+          'Rolle gibt es keinen Ort fuer die UMD-Adresse',
     })
   }
 
@@ -405,6 +427,24 @@ export const deriveLabels = ({
 export const labelTargetIssues = (input: LabelDerivationInput): CheckFinding[] => {
   const { candidates } = deriveLabels(input)
   const issues: CheckFinding[] = []
+
+  // Zwei Rollen auf derselben UMD-Adresse: Beide Displays zeigen denselben
+  // Text, und welches Paket zuletzt ankommt, entscheidet. Das ist kein
+  // Schoenheitsfehler, sondern ein falsches Tally auf Sendung — deshalb
+  // Fehler, nicht Warnung. Geprueft wird der Anker selbst, nicht sein
+  // Zeichenbudget; er kommt aus dem Projekt, nicht aus dem Graph.
+  for (const clash of umdAddressClashes(input.sourceIdentities ?? [])) {
+    issues.push({
+      id: `umd-address-clash:${clash.address}`,
+      severity: 'error',
+      category: 'UMD-Adresse doppelt',
+      message:
+        `${clash.identities.map((i) => `"${i.name}"`).join(' und ')} liegen ` +
+        `beide auf UMD-Adresse ${clash.address} — die Displays zeigen ` +
+        'denselben Text, welcher gewinnt entscheidet die Paketreihenfolge.',
+    })
+  }
+
   const byTarget = new Map<LabelTargetId, LabelCandidate[]>()
   for (const c of candidates) {
     const list = byTarget.get(c.targetId)

--- a/src/renderer/lib/labelTargets.ts
+++ b/src/renderer/lib/labelTargets.ts
@@ -1,0 +1,261 @@
+// ADR-001, Inkrement 1 — Zeichenbudgets externer Systeme an EINER Stelle.
+//
+// Jedes System, an das der Plan Namen abgibt, hat ein eigenes, hartes Limit:
+// der ATEM speichert 20 Byte Langname und 4 Byte Kurzname, TSL-UMD v3.1
+// transportiert genau 16 ASCII-Zeichen pro Display, Dante erlaubt 31 Zeichen
+// aus einem engen Zeichensatz. Bisher lagen diese Zahlen als verstreute
+// `slice(0, n)`-Aufrufe in den Emittern — jeder Aufruf schnitt still ab, und
+// ob zwei Geraete nach dem Abschneiden denselben Text tragen, fiel erst auf
+// dem Multiviewer auf.
+//
+// Diese Tabelle macht daraus einen pruefbaren Fakt. Sie persistiert nichts und
+// kennt keine Domaenen-Typen: rein Text rein, Text raus. Die Zuordnung
+// „welches Geraet spricht mit welchem Ziel" liegt in `labelDerivation.ts`.
+//
+// AUFNAHMEKRITERIUM: Ein Ziel kommt nur mit einem BELEGTEN Budget in die
+// Tabelle (`source` nennt den Beleg). Green-GO-Kanalnamen z. B. fehlen hier
+// bewusst — fuer sie ist kein Limit belegt, und eine geratene Zahl waere
+// schlechter als gar keine, weil sie Befunde erzeugt, die niemand nachpruefen
+// kann.
+
+import { DANTE_MAX_LENGTH } from './danteNaming'
+
+export type LabelTargetId =
+  | 'atem-input-long'
+  | 'atem-input-short'
+  | 'videohub-label'
+  | 'tsl-umd-v31'
+  | 'dante-device'
+
+/** In welcher Einheit das Zielsystem sein Limit zaehlt. */
+export type BudgetUnit = 'chars' | 'bytes'
+
+export interface LabelTargetSpec {
+  id: LabelTargetId
+  /** Zielsystem, wie es im Befund genannt wird ("ATEM", "Videohub"). */
+  system: string
+  /** Feld im Zielsystem ("Langname", "Port-Label"). */
+  field: string
+  /** Hartes Limit. `null` = das Ziel dokumentiert keins. */
+  budget: number | null
+  budgetUnit: BudgetUnit
+  /** true: alles ausserhalb 0x20–0x7E ist im Zielformat nicht darstellbar. */
+  asciiOnly: boolean
+  /** Zeichen, die das Transportformat selbst zerlegen wuerden. */
+  forbidden?: RegExp
+  /** false: das Ziel unterscheidet Gross-/Kleinschreibung NICHT — "CAM1" und
+   *  "cam1" landen dort auf demselben Eintrag. */
+  caseSensitive: boolean
+  /** Woher das Limit stammt. Steht hier fuer die Review, nicht fuer die UI. */
+  source: string
+}
+
+export const LABEL_TARGETS: Record<LabelTargetId, LabelTargetSpec> = {
+  'atem-input-long': {
+    id: 'atem-input-long',
+    system: 'ATEM',
+    field: 'Langname',
+    budget: 20,
+    budgetUnit: 'bytes',
+    asciiOnly: true,
+    caseSensitive: true,
+    source:
+      'ATEM-Protokoll: InCm-Block traegt den Langnamen als 20-Byte-Feld. ' +
+      'Gleiche Zahl bereits im Kommentar von lib/portLabel.ts.',
+  },
+  'atem-input-short': {
+    id: 'atem-input-short',
+    system: 'ATEM',
+    field: 'Kurzname',
+    budget: 4,
+    budgetUnit: 'bytes',
+    asciiOnly: true,
+    caseSensitive: true,
+    source:
+      'ATEM-Protokoll: InCm-Block traegt den Kurznamen als 4-Byte-Feld. ' +
+      'Der Kurzname ist das, was Multiviewer-Fenster beschriftet.',
+  },
+  'videohub-label': {
+    id: 'videohub-label',
+    system: 'Videohub',
+    field: 'Port-Label',
+    // Das Videohub-Ethernet-Protokoll definiert KEINE Maximallaenge fuer
+    // Labels — nur die Front-Panel-Anzeige kuerzt. Wir erfinden hier keine
+    // Zahl, pruefen aber das Transportformat.
+    budget: null,
+    budgetUnit: 'chars',
+    asciiOnly: false,
+    // lib/exportVideohub.ts schreibt "Input, <n>, <label>" zeilenweise —
+    // ein Komma oder Zeilenumbruch im Label zerlegt genau diese Datei.
+    forbidden: /[,\r\n]/,
+    caseSensitive: true,
+    source:
+      'Kein dokumentiertes Laengenlimit im Videohub-Ethernet-Protokoll. ' +
+      'Die Zeichen-Einschraenkung folgt aus dem Labels.txt-Format in ' +
+      'lib/exportVideohub.ts (Komma-getrennt, zeilenbasiert).',
+  },
+  'tsl-umd-v31': {
+    id: 'tsl-umd-v31',
+    system: 'TSL UMD v3.1',
+    field: 'Display-Text',
+    budget: 16,
+    budgetUnit: 'bytes',
+    asciiOnly: true,
+    caseSensitive: true,
+    source:
+      'TSL-UMD-Protokoll v3.1: Nachricht ist 18 Byte — 1 Adress-, 1 Steuer- ' +
+      'und exakt 16 Zeichen Display-Daten (7-Bit-ASCII).',
+  },
+  'dante-device': {
+    id: 'dante-device',
+    system: 'Dante',
+    field: 'Geraetename',
+    budget: DANTE_MAX_LENGTH,
+    budgetUnit: 'chars',
+    asciiOnly: true,
+    // DNS-SD-Regeln: nur a-z, A-Z, 0-9 und Bindestrich (lib/danteNaming.ts).
+    forbidden: /[^a-zA-Z0-9-]/,
+    // mDNS-Namen werden case-insensitiv aufgeloest: "Cam-1" und "cam-1"
+    // sind im selben Netz derselbe Name.
+    caseSensitive: false,
+    source:
+      'Audinate-Namensregeln (1–31 Zeichen, DNS-SD-konform) — dieselbe ' +
+      'Konstante wie lib/danteNaming.ts, nicht dupliziert.',
+  },
+}
+
+export const allLabelTargets = (): LabelTargetSpec[] => Object.values(LABEL_TARGETS)
+
+/** UTF-8-Bytelaenge eines Strings — ein Umlaut kostet 2, ein Emoji 4. */
+export const utf8Length = (text: string): number => {
+  let bytes = 0
+  for (const ch of text) {
+    const cp = ch.codePointAt(0) ?? 0
+    if (cp < 0x80) bytes += 1
+    else if (cp < 0x800) bytes += 2
+    else if (cp < 0x10000) bytes += 3
+    else bytes += 4
+  }
+  return bytes
+}
+
+const measure = (text: string, unit: BudgetUnit): number =>
+  unit === 'bytes' ? utf8Length(text) : [...text].length
+
+/**
+ * Schneidet auf das Budget ab, OHNE ein Mehr-Byte-Zeichen zu zerlegen: es
+ * werden ganze Code-Points genommen, solange sie noch ins Budget passen.
+ */
+const clampToBudget = (text: string, spec: LabelTargetSpec): string => {
+  if (spec.budget === null) return text
+  const chars = [...text]
+  let used = 0
+  let out = ''
+  for (const ch of chars) {
+    const cost = spec.budgetUnit === 'bytes' ? utf8Length(ch) : 1
+    if (used + cost > spec.budget) break
+    used += cost
+    out += ch
+  }
+  return out
+}
+
+export interface FittedLabel {
+  targetId: LabelTargetId
+  /** Text, den der Plan liefern will (nach der Aufbereitung des Exporters). */
+  raw: string
+  /** Text, wie er IM PLAN steht — vor jeder Aufbereitung. Daran wird
+   *  gemessen, ob zwei Eintraege ueberhaupt unterschiedlich gemeint sind:
+   *  "1 SDI 3G" und "2 SDI 3G" sind es, ihre ATEM-Aufbereitung ("3G") nicht
+   *  mehr. Ohne diese Trennung verschluckt die Kollisionspruefung genau die
+   *  Faelle, fuer die es sie gibt. Default: `raw`. */
+  origin: string
+  /** Text, den das Zielsystem tatsaechlich speichert. */
+  value: string
+  /** true wenn `value` kuerzer ist als `raw`. */
+  truncated: boolean
+  /** Zeichen aus `raw`, die das Ziel nicht transportieren kann (dedupliziert,
+   *  in Vorkommensreihenfolge). */
+  invalidChars: string[]
+  /** Verbrauch in der Einheit des Ziels — auch wenn kein Budget existiert. */
+  used: number
+}
+
+/**
+ * Bildet einen Wunschtext auf das ab, was beim Ziel wirklich ankommt.
+ * Reine Funktion, kein Zustand, keine Domaenen-Typen.
+ */
+export const fitToTarget = (
+  raw: string,
+  spec: LabelTargetSpec,
+  origin?: string,
+): FittedLabel => {
+  const text = raw ?? ''
+  const invalid: string[] = []
+  const seen = new Set<string>()
+  for (const ch of text) {
+    const cp = ch.codePointAt(0) ?? 0
+    const badAscii = spec.asciiOnly && (cp < 0x20 || cp > 0x7e)
+    const badFormat = spec.forbidden?.test(ch) ?? false
+    if ((badAscii || badFormat) && !seen.has(ch)) {
+      seen.add(ch)
+      invalid.push(ch)
+    }
+  }
+  const value = clampToBudget(text, spec)
+  return {
+    targetId: spec.id,
+    raw: text,
+    origin: origin ?? text,
+    value,
+    truncated: value !== text,
+    invalidChars: invalid,
+    used: measure(text, spec.budgetUnit),
+  }
+}
+
+/** Vergleichsform fuer die Kollisionspruefung. */
+const foldFor = (value: string, spec: LabelTargetSpec): string =>
+  spec.caseSensitive ? value : value.toLowerCase()
+
+export interface LabelCollision {
+  targetId: LabelTargetId
+  /** Der Wert, auf dem mehrere unterschiedliche Wunschtexte landen. */
+  value: string
+  /** Mindestens zwei Eintraege mit UNTERSCHIEDLICHEM `raw`. */
+  members: FittedLabel[]
+}
+
+/**
+ * Findet Wunschtexte, die im Zielsystem ununterscheidbar werden.
+ *
+ * Gemeldet wird nur, was die ABBILDUNG verursacht hat: zwei verschiedene
+ * Wunschtexte, ein Zielwert. Zwei Geraete, die schon im Plan gleich heissen,
+ * sind ein anderer Befund (doppelter Name) und gehoeren nicht hierher — sonst
+ * meldete jedes Ziel denselben Fehler noch einmal.
+ */
+export const collisionsForTarget = (
+  fitted: FittedLabel[],
+  spec: LabelTargetSpec,
+): LabelCollision[] => {
+  const byValue = new Map<string, FittedLabel[]>()
+  for (const f of fitted) {
+    if (f.value === '') continue
+    const key = foldFor(f.value, spec)
+    const list = byValue.get(key)
+    if (list) list.push(f)
+    else byValue.set(key, [f])
+  }
+  const out: LabelCollision[] = []
+  for (const group of byValue.values()) {
+    if (group.length < 2) continue
+    // Unterschiedlichkeit wird an `origin` gemessen, also wie der PLAN sie
+    // sieht (exakt) — der Zielwert daran, wie das ZIEL ihn sieht (ggf.
+    // gefaltet). Genau dazwischen liegt der Verlust: "Cam-1" und "cam-1" sind
+    // im Plan zwei Geraete und im Dante-Netz ein Name.
+    const distinctOrigin = new Set(group.map((f) => f.origin))
+    if (distinctOrigin.size < 2) continue
+    out.push({ targetId: spec.id, value: group[0].value, members: group })
+  }
+  return out
+}

--- a/src/renderer/lib/portLabel.ts
+++ b/src/renderer/lib/portLabel.ts
@@ -69,10 +69,15 @@ export const shortenForAtem = (raw: string): string => {
   const tokens = out.split(/\s+/)
   if (tokens.length > 1) {
     const stripKeywords = /^(SDI|HDMI|BNC|XLR|RJ45|Fiber|SFP\+?|DIN|USB|USB-C|3G|6G|12G)$/i
-    while (tokens.length > 1 && stripKeywords.test(tokens[0])) {
-      tokens.shift()
+    const stripped = [...tokens]
+    while (stripped.length > 1 && stripKeywords.test(stripped[0])) {
+      stripped.shift()
     }
-    out = tokens.join(' ').trim()
+    // Das Ergebnis nur uebernehmen, wenn danach noch etwas BENENNENDES
+    // uebrig ist. Vorher lief die Schleife bedingungslos und machte aus
+    // "SDI 1" die nackte "1" — genau der Fall, den der Kommentar oben
+    // ausschliesst. Bei "SDI 3G PGM" bleibt "PGM" und wird uebernommen.
+    if (stripped.some((t) => !/^\d+$/.test(t))) out = stripped.join(' ').trim()
   }
   return out || raw.trim()
 }

--- a/src/renderer/lib/sourceIdentity.ts
+++ b/src/renderer/lib/sourceIdentity.ts
@@ -1,0 +1,118 @@
+// ADR-001, Inkrement 2 — reine Helfer fuer die Signalquellen-Rollen.
+//
+// Kein Store, kein React: Normalisierung beim Laden, Validierung der
+// UMD-Adresse und die Kollisionspruefung sind Funktionen ueber Daten und
+// damit vollstaendig testbar. Die Normalisierung ist bewusst streng — eine
+// halb gueltige Adresse ist schlimmer als keine: Sie sieht auf dem Papier
+// aus wie eine Zusage, und das Display bleibt trotzdem leer.
+
+import type { SourceIdentity } from '../types/sourceIdentity'
+
+/**
+ * TSL UMD v3.1 adressiert Displays ueber das erste Byte, 0x80 + Adresse.
+ * 0x80–0xFE sind die Displays 0–126; 0xFF ist reserviert.
+ */
+export const UMD_ADDRESS_MIN = 0
+export const UMD_ADDRESS_MAX = 126
+
+export const isValidUmdAddress = (value: unknown): value is number =>
+  typeof value === 'number' &&
+  Number.isInteger(value) &&
+  value >= UMD_ADDRESS_MIN &&
+  value <= UMD_ADDRESS_MAX
+
+/** Nimmt Zahl oder Ziffern-String; alles andere wird zu undefined. */
+export const parseUmdAddress = (raw: unknown): number | undefined => {
+  const value =
+    typeof raw === 'number'
+      ? raw
+      : typeof raw === 'string' && raw.trim() !== ''
+        ? Number(raw)
+        : NaN
+  return isValidUmdAddress(value) ? value : undefined
+}
+
+/**
+ * Haert einen Datensatz aus einer Projektdatei ab. Liefert null, wenn kein
+ * Name da ist — eine namenlose Rolle kann niemand zuweisen, und sie stumm
+ * mit „Unbenannt" zu fuellen wuerde eine Entscheidung erfinden.
+ */
+export const normaliseSourceIdentity = (
+  raw: unknown,
+  fallbackId: string,
+): SourceIdentity | null => {
+  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return null
+  const r = raw as Record<string, unknown>
+  const name = typeof r.name === 'string' ? r.name.trim() : ''
+  if (!name) return null
+  const id = typeof r.id === 'string' && r.id.trim() !== '' ? r.id : fallbackId
+  const numberRaw =
+    typeof r.number === 'number'
+      ? r.number
+      : typeof r.number === 'string' && r.number.trim() !== ''
+        ? Number(r.number)
+        : NaN
+  const identity: SourceIdentity = { id, name }
+  if (Number.isInteger(numberRaw) && numberRaw >= 0) identity.number = numberRaw
+  const umd = parseUmdAddress(r.umdAddress)
+  if (umd !== undefined) identity.umdAddress = umd
+  return identity
+}
+
+/** Normalisiert die Liste und wirft Duplikat-Ids weg (erste gewinnt). */
+export const normaliseSourceIdentities = (raw: unknown): SourceIdentity[] => {
+  if (!Array.isArray(raw)) return []
+  const out: SourceIdentity[] = []
+  const seen = new Set<string>()
+  raw.forEach((entry, idx) => {
+    const identity = normaliseSourceIdentity(entry, `source-${idx + 1}`)
+    if (!identity || seen.has(identity.id)) return
+    seen.add(identity.id)
+    out.push(identity)
+  })
+  return out
+}
+
+/** Ids der gueltigen Rollen — Eingabe fuer `clearDanglingIdentity`. */
+export const sourceIdentityIdSet = (identities: SourceIdentity[]): ReadonlySet<string> =>
+  new Set(identities.map((s) => s.id))
+
+/**
+ * Entfernt eine Bindung, deren Rolle es nicht (mehr) gibt.
+ *
+ * Ein Fehlzeiger ist schlimmer als gar keine Bindung: Im Plan sieht er aus wie
+ * eine zugewiesene Tally-Adresse, im Betrieb bleibt das Display leer. Der
+ * Datensatz selbst bleibt unangetastet, wenn nichts zu tun ist — so muss der
+ * Aufrufer nicht jedes Objekt neu anlegen.
+ */
+export const clearDanglingIdentity = <T extends { sourceIdentityId?: string }>(
+  item: T,
+  identityIds: ReadonlySet<string>,
+): T =>
+  item.sourceIdentityId !== undefined && !identityIds.has(item.sourceIdentityId)
+    ? { ...item, sourceIdentityId: undefined }
+    : item
+
+export interface UmdAddressClash {
+  address: number
+  identities: SourceIdentity[]
+}
+
+/**
+ * Zwei Rollen auf derselben UMD-Adresse: Beide Displays zeigen denselben
+ * Text, und welcher gewinnt, entscheidet die Reihenfolge der Pakete. Das ist
+ * kein Schoenheitsfehler, sondern ein falsches Tally auf Sendung.
+ */
+export const umdAddressClashes = (identities: SourceIdentity[]): UmdAddressClash[] => {
+  const byAddress = new Map<number, SourceIdentity[]>()
+  for (const identity of identities) {
+    if (identity.umdAddress === undefined) continue
+    const list = byAddress.get(identity.umdAddress)
+    if (list) list.push(identity)
+    else byAddress.set(identity.umdAddress, [identity])
+  }
+  return [...byAddress.entries()]
+    .filter(([, list]) => list.length > 1)
+    .map(([address, list]) => ({ address, identities: list }))
+    .sort((a, b) => a.address - b.address)
+}

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -10,6 +10,7 @@ import { defaultProject, isProjectLocked, sanitizePort, touchProject } from './p
 import { createLocationSlice } from './slices/locationSlice'
 import { createCableSlice } from './slices/cableSlice'
 import { createAnnotationSlice } from './slices/annotationSlice'
+import { createSourceIdentitySlice } from './slices/sourceIdentitySlice'
 import { createRevisionSlice } from './slices/revisionSlice'
 import { createMobileSyncSlice } from './slices/mobileSyncSlice'
 import { createTemplateSlice } from './slices/templateSlice'
@@ -61,6 +62,11 @@ import { VIEWPORT_DEFAULTS } from '../lib/layoutConstants'
 import { getCanvasSize } from '../lib/canvasViewport'
 import { seedLibrarySyncCache } from '../lib/librarySync'
 import { normaliseVideohubRouting } from '../lib/videohubRouting'
+import {
+  clearDanglingIdentity,
+  normaliseSourceIdentities,
+  sourceIdentityIdSet,
+} from '../lib/sourceIdentity'
 
 const CUSTOM_LIB_KEY = STORAGE_KEYS.customLibrary
 const PROJECT_AUTOSAVE_KEY = STORAGE_KEYS.projectAutosave
@@ -438,6 +444,18 @@ export interface ProjectState {
   addAnnotation: (annotation: import('../types/project').ProjectAnnotation) => void
   updateAnnotation: (id: string, patch: Partial<import('../types/project').ProjectAnnotation>) => void
   removeAnnotation: (id: string) => void
+  /** ADR-001 — Signalquellen-Rolle anlegen; liefert die (ggf. erzeugte) Id,
+   *  oder undefined wenn nichts angelegt wurde (leerer Name). */
+  addSourceIdentity: (
+    identity: Omit<import('../types/sourceIdentity').SourceIdentity, 'id'> & { id?: string },
+  ) => string | undefined
+  updateSourceIdentity: (
+    id: string,
+    patch: Partial<Omit<import('../types/sourceIdentity').SourceIdentity, 'id'>>,
+  ) => void
+  removeSourceIdentity: (id: string) => void
+  /** Geraet an eine Rolle binden; `undefined` loest die Bindung. */
+  bindEquipmentToSourceIdentity: (equipmentId: string, identityId: string | undefined) => void
   /** #143 — Annotationen aus einer zurückgelesenen Viewer-Datei mergen
    *  (by id: neue hinzufügen, geänderte aktualisieren, vorhandene behalten).
    *  Gibt die Anzahl hinzugefügter/aktualisierter Annotationen zurück. */
@@ -534,9 +552,17 @@ const healProjectPositions = (project: CablePlannerProject): CablePlannerProject
     return Math.round(v)
   }
   const r = (v: unknown): number => snapVal(v, 0)
+  // ADR-001 / Inkrement 2 — Signalquellen-Rollen zuerst normalisieren: die
+  // Geraete-Schleife braucht die gueltigen Ids, um Fehlzeiger zu entsorgen.
+  // Eine Bindung auf eine geloeschte Rolle ist schlimmer als keine — sie
+  // sieht im Plan aus wie eine zugewiesene Tally-Adresse.
+  const sourceIdentities = normaliseSourceIdentities(project.sourceIdentities)
+  const identityIds = sourceIdentityIdSet(sourceIdentities)
   return {
     ...project,
     equipment: project.equipment.map((item) => {
+      item = clearDanglingIdentity(item, identityIds)
+
       // ADR-001 / Inkrement 0 — Videohub-Routing-Migration: der Kreuzpunkt-
       // Zustand lag frueher nur im Komponenten-State des Export-Dialogs.
       // Vorhandene Bloecke werden normalisiert (String-Keys aus JSON,
@@ -640,6 +666,8 @@ const healProjectPositions = (project: CablePlannerProject): CablePlannerProject
     // Festinstallation — Änderungsprotokoll ist optional; alte Projekte
     // heilen zu [].
     changelog: project.changelog ?? [],
+    // ADR-001 — Rollen sind optional; alte Projekte heilen zu [].
+    sourceIdentities,
   }
 }
 
@@ -777,6 +805,7 @@ const buildProjectStore = (
   ...createLocationSlice(set, get, store),
   ...createCableSlice(set, get, store),
   ...createAnnotationSlice(set, get, store),
+  ...createSourceIdentitySlice(set, get, store),
   ...createRevisionSlice(set, get, store),
   ...createMobileSyncSlice(set, get, store),
   ...createTemplateSlice(set, get, store),
@@ -1047,6 +1076,11 @@ const buildProjectStore = (
         portVlans: undefined,
         favorite: undefined,
         hidden: undefined,
+        // ADR-001 — die Rolle wandert NICHT mit. Eine eingefuegte Kopie ist
+        // ein neues Geraet; die Rolle stillschweigend zu erben hiesse, ein
+        // Haupt-/Backup-Paar zu behaupten, das niemand erklaert hat — und
+        // zwei Geraete auf dieselbe Tally-Adresse zu setzen.
+        sourceIdentityId: undefined,
       }
     })
     const newCables: Cable[] = []

--- a/src/renderer/store/slices/sourceIdentitySlice.ts
+++ b/src/renderer/store/slices/sourceIdentitySlice.ts
@@ -1,0 +1,99 @@
+import type { StateCreator } from 'zustand'
+import { v4 as uuidv4 } from 'uuid'
+import { scheduleProjectAutosave } from '../projectAutosave'
+import type { ProjectState } from '../projectStore'
+import type { SourceIdentity } from '../../types/sourceIdentity'
+
+/**
+ * ADR-001, Inkrement 2 — Signalquellen-Rollen.
+ *
+ * Eine Rolle („Kamera 1") ueberlebt den Geraetetausch; deshalb liegt sie
+ * neben den Geraeten und nicht in ihnen. Mehrere Geraete duerfen dieselbe
+ * Rolle tragen (Haupt-/Backup-Paar), ein Geraet traegt hoechstens eine.
+ *
+ * Beim Loeschen einer Rolle werden alle Bindungen mitgeloescht — ein
+ * Fehlzeiger sieht im Plan aus wie eine zugewiesene Tally-Adresse und ist
+ * damit schlimmer als gar keine Bindung. `healProjectPositions` raeumt
+ * dieselben Zeiger beim Laden auf, falls eine Datei sie doch mitbringt.
+ */
+export type SourceIdentitySlice = Pick<
+  ProjectState,
+  | 'addSourceIdentity'
+  | 'updateSourceIdentity'
+  | 'removeSourceIdentity'
+  | 'bindEquipmentToSourceIdentity'
+>
+
+export const createSourceIdentitySlice: StateCreator<
+  ProjectState,
+  [],
+  [],
+  SourceIdentitySlice
+> = (set) => ({
+  addSourceIdentity: (identity) => {
+    // Liefert undefined, wenn nichts angelegt wurde. Sonst bekaeme der
+    // Aufrufer eine Id zurueck, hinter der keine Rolle steht, und wuerde ein
+    // Geraet an ein Phantom binden.
+    const name = identity.name.trim()
+    if (!name) return undefined
+    const id = identity.id?.trim() || uuidv4()
+    let created = false
+    set((state) => {
+      const existing = state.project.sourceIdentities ?? []
+      if (existing.some((s) => s.id === id)) {
+        // Explizit vorgegebene Id existiert schon — der Aufrufer meint diese
+        // Rolle, also gilt sie als "da" und die Id ist gueltig.
+        created = true
+        return {}
+      }
+      const next: SourceIdentity = { ...identity, id, name }
+      const updated = { ...state.project, sourceIdentities: [...existing, next] }
+      scheduleProjectAutosave(updated)
+      created = true
+      return { project: updated }
+    })
+    return created ? id : undefined
+  },
+  updateSourceIdentity: (id, patch) =>
+    set((state) => {
+      const existing = state.project.sourceIdentities ?? []
+      if (!existing.some((s) => s.id === id)) return {}
+      const next = existing.map((s) => {
+        if (s.id !== id) return s
+        const merged = { ...s, ...patch, id: s.id }
+        // Ein leerer Name macht die Rolle unzuweisbar — der alte bleibt.
+        if (typeof merged.name === 'string' && merged.name.trim() === '') merged.name = s.name
+        return merged
+      })
+      const updated = { ...state.project, sourceIdentities: next }
+      scheduleProjectAutosave(updated)
+      return { project: updated }
+    }),
+  removeSourceIdentity: (id) =>
+    set((state) => {
+      const existing = state.project.sourceIdentities ?? []
+      if (!existing.some((s) => s.id === id)) return {}
+      const updated = {
+        ...state.project,
+        sourceIdentities: existing.filter((s) => s.id !== id),
+        equipment: state.project.equipment.map((e) =>
+          e.sourceIdentityId === id ? { ...e, sourceIdentityId: undefined } : e,
+        ),
+      }
+      scheduleProjectAutosave(updated)
+      return { project: updated }
+    }),
+  bindEquipmentToSourceIdentity: (equipmentId, identityId) =>
+    set((state) => {
+      const existing = state.project.sourceIdentities ?? []
+      if (identityId !== undefined && !existing.some((s) => s.id === identityId)) return {}
+      const updated = {
+        ...state.project,
+        equipment: state.project.equipment.map((e) =>
+          e.id === equipmentId ? { ...e, sourceIdentityId: identityId } : e,
+        ),
+      }
+      scheduleProjectAutosave(updated)
+      return { project: updated }
+    }),
+})

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -379,6 +379,7 @@ const defaults: PersistedUiState = {
   canvasBgImageFit: 'cover',
   portLabelFontSize: 11,
   equipmentSectionOrder: [
+    'source-identity',
     'modes',
     'ports',
     'network',

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -454,6 +454,10 @@ export interface EquipmentItem {
   atemAudioConfig?: AtemAudioConfig
   /** Geplantes Videohub-Routing (ADR-001). Nur bei Videohub-Geraeten gesetzt. */
   videohubRouting?: VideohubRouting
+  /** ADR-001 — Rolle, die dieses Geraet realisiert („Kamera 1"). Zeigt auf
+   *  `CablePlannerProject.sourceIdentities`. Mehrere Geraete duerfen dieselbe
+   *  Rolle tragen: das Haupt-/Backup-Paar ist EINE Rolle, nicht zwei. */
+  sourceIdentityId?: string
   /** Mark equipment as favorite in the library (sorted to the top). */
   favorite?: boolean
   /** Hide from the library unless "Ausgeblendete zeigen" is active. */

--- a/src/renderer/types/project.ts
+++ b/src/renderer/types/project.ts
@@ -185,6 +185,11 @@ export interface CablePlannerProject {
   /** Wireless-Rig — Funkstrecken-Kanalplan (Body + Kapsel/Headset + Frequenz).
    *  Optional → alte Projekte laden sauber. Verlustfrei in der .avplan. */
   wirelessRig?: import('./wirelessRig').WirelessRigPlan
+  /** ADR-001 — Signalquellen als Rollen („Kamera 1"), an denen die Anker
+   *  haengen, die keine Runtime besitzt (heute: die TSL-UMD-Adresse). Geraete
+   *  verweisen ueber `EquipmentItem.sourceIdentityId` darauf. Optional → alte
+   *  Projekte heilen zu []. */
+  sourceIdentities?: import('./sourceIdentity').SourceIdentity[]
 }
 
 /** #412 — Ein festgeschriebener Projekt-Stand. */

--- a/src/renderer/types/sourceIdentity.ts
+++ b/src/renderer/types/sourceIdentity.ts
@@ -1,0 +1,29 @@
+// ADR-001, Inkrement 2 — die persistierten Anker.
+//
+// Eine `SourceIdentity` ist eine ROLLE, kein Geraet: „Kamera 1" bleibt
+// „Kamera 1", auch wenn die Havarie-Kamera einspringt. Deshalb haengt der
+// Anker nicht an `EquipmentItem.id` — ein Haupt-/Backup-Paar ist eine Rolle
+// mit zwei Geraeten, und eine Tally-Adresse gehoert der Rolle, nicht dem
+// Blech. Genau daran war die Alternative „Identitaet an die Geraete-Id
+// binden" in ADR-001 gescheitert.
+//
+// EIGENTUMSREGEL (ADR-001): Hier steht ausschliesslich, was KEINE Runtime
+// besitzt. Die ATEM-Source-Id, der Videohub-Slot und das MV-Fenster gehoeren
+// dem jeweiligen Geraet und werden ueber den Kabelgraph aufgeloest
+// (`lib/labelDerivation.ts`), niemals gespeichert — sonst entstuende genau die
+// zweite Wahrheit, die wir dem Markt vorwerfen.
+//
+// Das Schema bleibt bewusst klein: Inkrement 1 hat genau EIN Feld als
+// unbeantwortbar nachgewiesen (die UMD-Adresse), und nur dafuer gibt es
+// `labelTargets.ts` ein belegtes Zielsystem. ISO-Praefix und Comms-Kanal
+// kommen mit ihrem Ziel, nicht davor.
+
+export interface SourceIdentity {
+  id: string
+  /** Redaktioneller Name — was in der Regie gesagt wird („Kamera 1"). */
+  name: string
+  /** Redaktionelle Nummer, wo die Produktion mit Nummern arbeitet. */
+  number?: number
+  /** TSL-UMD-Adresse (v3.1), auf die ein Display hoert. 0–126. */
+  umdAddress?: number
+}

--- a/tests/labelDerivation.test.ts
+++ b/tests/labelDerivation.test.ts
@@ -351,6 +351,90 @@ describe('labelTargetIssues — Dante', () => {
   })
 })
 
+describe('Signalquellen-Rollen (Inkrement 2)', () => {
+  const scene = (over: Partial<EquipmentItem> = {}) => {
+    const equipment = [
+      atem([port('in1', 'In 1')]),
+      camera('cam1', 'Kamera 1 (Blech)', over),
+    ]
+    const cables = [cable(['cam1', 'cam1-out'], ['atem', 'in1'])]
+    return { equipment, cables }
+  }
+
+  it('laesst die Rolle gegen den Geraetenamen gewinnen', () => {
+    // Genau dafuer gibt es die Rolle: "Kamera 1" bleibt "Kamera 1", auch
+    // wenn das Geraet dahinter die Havarie-Kamera ist.
+    const { equipment, cables } = scene({ sourceIdentityId: 'r1' })
+    const { candidates } = deriveLabels({
+      equipment,
+      cables,
+      sourceIdentities: [{ id: 'r1', name: 'Kamera 1', umdAddress: 1 }],
+    })
+    const umd = candidates.find((c) => c.targetId === 'tsl-umd-v31')
+    expect(umd).toMatchObject({ raw: 'Kamera 1', provenance: 'source-identity' })
+  })
+
+  it('meldet nichts mehr als offen, sobald die Adresse steht', () => {
+    const { equipment, cables } = scene({ sourceIdentityId: 'r1' })
+    const { unanswered } = deriveLabels({
+      equipment,
+      cables,
+      sourceIdentities: [{ id: 'r1', name: 'Kamera 1', umdAddress: 1 }],
+    })
+    expect(unanswered).toEqual([])
+  })
+
+  it('unterscheidet "keine Rolle" von "Rolle ohne Adresse"', () => {
+    const ohneRolle = deriveLabels(scene()).unanswered
+    expect(ohneRolle[0].sourceIdentityId).toBeUndefined()
+    expect(ohneRolle[0].reason).toContain('ohne gebundene Rolle')
+
+    const { equipment, cables } = scene({ sourceIdentityId: 'r1' })
+    const ohneAdresse = deriveLabels({
+      equipment,
+      cables,
+      sourceIdentities: [{ id: 'r1', name: 'Kamera 1' }],
+    }).unanswered
+    expect(ohneAdresse[0]).toMatchObject({ sourceIdentityId: 'r1' })
+    expect(ohneAdresse[0].reason).toContain('keine UMD-Adresse')
+  })
+
+  it('ignoriert eine Bindung auf eine Rolle, die es nicht gibt', () => {
+    const { candidates } = deriveLabels({ ...scene({ sourceIdentityId: 'weg' }) })
+    const umd = candidates.find((c) => c.targetId === 'tsl-umd-v31')
+    expect(umd?.provenance).toBe('device-short-name')
+  })
+
+  it('meldet zwei Rollen auf derselben UMD-Adresse als Fehler', () => {
+    const issues = labelTargetIssues({
+      equipment: [],
+      cables: [],
+      sourceIdentities: [
+        { id: 'a', name: 'Kamera 1', umdAddress: 3 },
+        { id: 'b', name: 'Kamera 2', umdAddress: 3 },
+      ],
+    })
+    const clash = issues.find((i) => i.category === 'UMD-Adresse doppelt')
+    expect(clash?.severity).toBe('error')
+    expect(clash?.message).toContain('"Kamera 1"')
+    expect(clash?.message).toContain('"Kamera 2"')
+  })
+
+  it('meldet Rollen-Kollisionen auch ohne jedes Geraet im Plan', () => {
+    // Die Rolle ist ein Projekt-Objekt, kein Geraete-Feld. Eine doppelte
+    // Adresse ist auch dann falsch, wenn noch nichts verkabelt ist.
+    const { errorCount } = runDrawingChecks({
+      equipment: [],
+      cables: [],
+      sourceIdentities: [
+        { id: 'a', name: 'Kamera 1', umdAddress: 3 },
+        { id: 'b', name: 'Kamera 2', umdAddress: 3 },
+      ],
+    })
+    expect(errorCount).toBe(1)
+  })
+})
+
 describe('runDrawingChecks — Verdrahtung', () => {
   it('traegt die Label-Befunde in die Plan-Check-Liste', () => {
     const equipment = [

--- a/tests/labelDerivation.test.ts
+++ b/tests/labelDerivation.test.ts
@@ -1,0 +1,382 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildGraphContext,
+  deriveLabels,
+  labelTargetIssues,
+  resolveSignalSource,
+} from '../src/renderer/lib/labelDerivation'
+import { runDrawingChecks } from '../src/renderer/lib/drawingChecks'
+import { createDemoProject } from '../src/renderer/lib/demoProject'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem, Port } from '../src/renderer/types/equipment'
+
+const port = (id: string, name: string, over: Partial<Port> = {}): Port => ({
+  id,
+  name,
+  type: 'BNC',
+  connectorType: 'BNC',
+  ...over,
+})
+
+const eq = (over: Partial<EquipmentItem>): EquipmentItem => ({
+  id: 'e1',
+  name: 'Gerät',
+  category: 'Video',
+  inputs: [],
+  outputs: [],
+  x: 0,
+  y: 0,
+  width: 200,
+  height: 160,
+  ...over,
+})
+
+const cable = (from: [string, string], to: [string, string], id = `${from[1]}->${to[1]}`): Cable => ({
+  id,
+  name: id,
+  type: 'BNC',
+  length: 10,
+  color: '#fff',
+  fromEquipmentId: from[0],
+  fromPortId: from[1],
+  toEquipmentId: to[0],
+  toPortId: to[1],
+  notes: '',
+})
+
+const atem = (inputs: Port[]) =>
+  eq({ id: 'atem', name: 'ATEM Mini Extreme', category: 'Video', inputs })
+
+const camera = (id: string, name: string, extra: Partial<EquipmentItem> = {}) =>
+  eq({
+    id,
+    name,
+    category: 'Kameras',
+    outputs: [port(`${id}-out`, 'SDI Out')],
+    ...extra,
+  })
+
+describe('resolveSignalSource', () => {
+  it('findet die direkt verkabelte Quelle', () => {
+    const equipment = [atem([port('in1', '1 SDI 3G')]), camera('cam1', 'Kamera 1')]
+    const cables = [cable(['cam1', 'cam1-out'], ['atem', 'in1'])]
+    const ctx = buildGraphContext(equipment, cables)
+    expect(resolveSignalSource('in1', ctx)).toEqual({ equipmentId: 'cam1', hops: 0 })
+  })
+
+  it('laeuft durch einen Konverter hindurch bis zur Kamera', () => {
+    const conv = eq({
+      id: 'conv',
+      name: 'SDI-Konverter',
+      inputs: [port('conv-in', 'SDI In')],
+      outputs: [port('conv-out', 'SDI Out')],
+    })
+    const equipment = [atem([port('in1', '1 SDI 3G')]), camera('cam1', 'Kamera 1'), conv]
+    const cables = [
+      cable(['cam1', 'cam1-out'], ['conv', 'conv-in']),
+      cable(['conv', 'conv-out'], ['atem', 'in1']),
+    ]
+    const ctx = buildGraphContext(equipment, cables)
+    expect(resolveSignalSource('in1', ctx)).toEqual({ equipmentId: 'cam1', hops: 1 })
+  })
+
+  it('laeuft NICHT durch den Genlock-Eingang einer Kamera hindurch', () => {
+    // Der Trugschluss, den diese Regel verhindert: eine Kamera mit genau einem
+    // verkabelten Eingang sieht strukturell aus wie ein Konverter. Ohne die
+    // Referenz-Port-Regel traegt der ATEM-Eingang am Ende den Namen des
+    // Sync-Generators statt den der Kamera.
+    const cam = camera('cam1', 'Kamera 1', { inputs: [port('cam1-ref', 'Genlock In')] })
+    const sync = eq({ id: 'sync', name: 'Sync-Generator', outputs: [port('sync-out', 'Ref Out')] })
+    const equipment = [atem([port('in1', '1 SDI 3G')]), cam, sync]
+    const cables = [
+      cable(['sync', 'sync-out'], ['cam1', 'cam1-ref']),
+      cable(['cam1', 'cam1-out'], ['atem', 'in1']),
+    ]
+    const ctx = buildGraphContext(equipment, cables)
+    expect(resolveSignalSource('in1', ctx)).toEqual({ equipmentId: 'cam1', hops: 0 })
+  })
+
+  it('haelt bei mehrdeutiger Speisung am Zwischengeraet an', () => {
+    const mixer = eq({
+      id: 'mix',
+      name: 'Umschalter',
+      inputs: [port('mix-a', 'In A'), port('mix-b', 'In B')],
+      outputs: [port('mix-out', 'Out')],
+    })
+    const equipment = [
+      atem([port('in1', '1 SDI 3G')]),
+      camera('cam1', 'Kamera 1'),
+      camera('cam2', 'Kamera 2'),
+      mixer,
+    ]
+    const cables = [
+      cable(['cam1', 'cam1-out'], ['mix', 'mix-a']),
+      cable(['cam2', 'cam2-out'], ['mix', 'mix-b']),
+      cable(['mix', 'mix-out'], ['atem', 'in1']),
+    ]
+    const ctx = buildGraphContext(equipment, cables)
+    expect(resolveSignalSource('in1', ctx)).toEqual({ equipmentId: 'mix', hops: 0 })
+  })
+
+  it('liefert null fuer einen unverkabelten Eingang', () => {
+    const equipment = [atem([port('in1', '1 SDI 3G')])]
+    expect(resolveSignalSource('in1', buildGraphContext(equipment, []))).toBeNull()
+  })
+
+  it('laeuft sich in einer Schleife nicht fest', () => {
+    const a = eq({
+      id: 'a',
+      name: 'Konverter A',
+      inputs: [port('a-in', 'In')],
+      outputs: [port('a-out', 'Out')],
+    })
+    const b = eq({
+      id: 'b',
+      name: 'Konverter B',
+      inputs: [port('b-in', 'In')],
+      outputs: [port('b-out', 'Out')],
+    })
+    const equipment = [atem([port('in1', 'In 1')]), a, b]
+    const cables = [
+      cable(['a', 'a-out'], ['b', 'b-in']),
+      cable(['b', 'b-out'], ['a', 'a-in']),
+      cable(['a', 'a-out'], ['atem', 'in1'], 'a-to-atem'),
+    ]
+    const ctx = buildGraphContext(equipment, cables)
+    const resolved = resolveSignalSource('in1', ctx)
+    expect(resolved).not.toBeNull()
+    expect(resolved!.hops).toBeLessThanOrEqual(8)
+  })
+})
+
+describe('deriveLabels', () => {
+  const scene = () => {
+    const equipment = [
+      atem([port('in1', '1 SDI 3G'), port('in2', '2 SDI 3G')]),
+      camera('cam1', 'Kamera 1'),
+      camera('cam2', 'Kamera 10'),
+    ]
+    const cables = [
+      cable(['cam1', 'cam1-out'], ['atem', 'in1']),
+      cable(['cam2', 'cam2-out'], ['atem', 'in2']),
+    ]
+    return { equipment, cables }
+  }
+
+  it('behauptet nur, was der ATEM-Export wirklich sendet', () => {
+    // Treue-Regel: der Kandidat ist `shortenForAtem(portDisplayLabel(port))` —
+    // exakt die Kette aus AtemDialog. Die aufgeloeste Quelle waere ein
+    // schoenerer Text, aber kein Geraet bekaeme ihn je zu sehen.
+    const { candidates } = deriveLabels(scene())
+    const long = candidates.find((c) => c.key === 'atem-long:in1')
+    expect(long).toMatchObject({ raw: '3G', provenance: 'port-name' })
+  })
+
+  it('loest die Quelle trotzdem auf — sie traegt UMD-Text und Anker', () => {
+    const { candidates, sources } = deriveLabels(scene())
+    expect(sources.map((s) => s.sourceEquipmentId)).toEqual(['cam1', 'cam2'])
+    const umd = candidates.filter((c) => c.targetId === 'tsl-umd-v31')
+    expect(umd.map((c) => c.raw)).toEqual(['K1', 'K10'])
+  })
+
+  it('liefert den UMD-Text auch fuer einen Eingang ganz ohne Label', () => {
+    const equipment = [
+      eq({ id: 'atem', name: 'ATEM Mini Extreme', inputs: [port('in1', '')] }),
+      camera('cam1', 'Kamera 1'),
+    ]
+    const cables = [cable(['cam1', 'cam1-out'], ['atem', 'in1'])]
+    const { candidates } = deriveLabels({ equipment, cables })
+    expect(candidates.map((c) => c.targetId)).toEqual(['tsl-umd-v31'])
+  })
+
+  it('laesst ein gesetztes contentLabel gewinnen — das ist eine Aussage', () => {
+    const { equipment, cables } = scene()
+    equipment[0].inputs[0] = port('in1', '1 SDI 3G', { contentLabel: 'PGM' })
+    const { candidates } = deriveLabels({ equipment, cables })
+    const long = candidates.find((c) => c.key === 'atem-long:in1')
+    expect(long).toMatchObject({ raw: 'PGM', provenance: 'port-content-label' })
+  })
+
+  it('nutzt den Portnamen, wenn kein contentLabel gesetzt ist', () => {
+    const equipment = [atem([port('in1', 'SDI 1')])]
+    const { candidates } = deriveLabels({ equipment, cables: [] })
+    expect(candidates.find((c) => c.key === 'atem-long:in1')).toMatchObject({
+      raw: 'SDI 1',
+      provenance: 'port-name',
+    })
+  })
+
+  it('merkt sich die Eingangsnummer — die adressiert der ATEM auf dem Draht', () => {
+    const { sources } = deriveLabels(scene())
+    expect(sources).toEqual([
+      { sinkEquipmentId: 'atem', sinkPortId: 'in1', inputIndex: 1, sourceEquipmentId: 'cam1', hops: 0 },
+      { sinkEquipmentId: 'atem', sinkPortId: 'in2', inputIndex: 2, sourceEquipmentId: 'cam2', hops: 0 },
+    ])
+  })
+
+  it('meldet die UMD-Adresse als offen — die kann kein Graph beantworten', () => {
+    const { unanswered } = deriveLabels(scene())
+    expect(unanswered.map((u) => u.equipmentId)).toEqual(['cam1', 'cam2'])
+    expect(unanswered[0]).toMatchObject({ field: 'umd-address' })
+    expect(unanswered[0].reason).toContain('Eingang 1')
+  })
+
+  it('vergibt je Quelle genau einen UMD-Kandidaten, auch bei Mehrfachspeisung', () => {
+    // Eine Kamera auf zwei Mischer-Eingaengen (z. B. Haupt- und Reserveweg)
+    // ist EIN Display-Text, nicht zwei.
+    const equipment = [
+      atem([port('in1', 'In 1'), port('in2', 'In 2')]),
+      camera('cam1', 'Kamera 1', {
+        outputs: [port('cam1-out', 'SDI Out 1'), port('cam1-out2', 'SDI Out 2')],
+      }),
+    ]
+    const cables = [
+      cable(['cam1', 'cam1-out'], ['atem', 'in1']),
+      cable(['cam1', 'cam1-out2'], ['atem', 'in2']),
+    ]
+    const { candidates } = deriveLabels({ equipment, cables })
+    const umd = candidates.filter((c) => c.targetId === 'tsl-umd-v31')
+    expect(umd.map((c) => c.equipmentId)).toEqual(['cam1'])
+  })
+
+  it('erzeugt fuer einen Videohub Labels aus Ein- UND Ausgaengen, aber kein UMD', () => {
+    const vh = eq({
+      id: 'vh',
+      name: 'Smart Videohub 12x12',
+      inputs: [port('vh-in1', 'In 1', { contentLabel: 'Kamera 1' })],
+      outputs: [port('vh-out1', 'Out 1', { contentLabel: 'Regie' })],
+    })
+    const { candidates } = deriveLabels({ equipment: [vh], cables: [] })
+    expect(candidates.map((c) => c.targetId)).toEqual(['videohub-label', 'videohub-label'])
+    expect(candidates.map((c) => c.raw)).toEqual(['Kamera 1', 'Regie'])
+  })
+
+  it('erzeugt nichts fuer Geraete ohne Zielsystem', () => {
+    const { candidates } = deriveLabels({ equipment: [camera('cam1', 'Kamera 1')], cables: [] })
+    expect(candidates).toEqual([])
+  })
+})
+
+describe('labelTargetIssues', () => {
+  it('meldet zwei Eingaenge, die im ATEM-Kurznamen ununterscheidbar werden', () => {
+    const equipment = [
+      atem([
+        port('in1', '1 SDI 3G', { contentLabel: 'Kamera 1' }),
+        port('in2', '2 SDI 3G', { contentLabel: 'Kamera 10' }),
+      ]),
+    ]
+    const issues = labelTargetIssues({ equipment, cables: [] })
+    const collision = issues.find((i) => i.category === 'ATEM-Namenskollision')
+    expect(collision?.severity).toBe('error')
+    expect(collision?.message).toContain('"Kamera 1"')
+    expect(collision?.message).toContain('"Kamera 10"')
+    expect(collision?.message).toContain('"KAME"')
+  })
+
+  it('meldet auch die stille Variante: zwei Ports, die gleich heissen wollen', () => {
+    // Ohne contentLabel bleibt vom technischen Portnamen im ATEM-Langnamen
+    // "3G" uebrig — auf beiden Eingaengen. Das faellt sonst erst auf dem
+    // Multiviewer auf.
+    const equipment = [atem([port('in1', '1 SDI 3G'), port('in2', '2 SDI 3G')])]
+    const issues = labelTargetIssues({ equipment, cables: [] })
+    expect(issues.some((i) => i.category === 'ATEM-Namenskollision')).toBe(true)
+  })
+
+  it('meldet Abschneiden allein NICHT — das ist der Normalfall', () => {
+    const equipment = [
+      atem([port('in1', 'In 1', { contentLabel: 'Weitwinkel Buehne' })]),
+    ]
+    const issues = labelTargetIssues({ equipment, cables: [] })
+    expect(issues.some((i) => i.category === 'ATEM-Namenskollision')).toBe(false)
+  })
+
+  it('warnt vor einem Komma im Videohub-Label — es zerlegt die Labels.txt', () => {
+    const vh = eq({
+      id: 'vh',
+      name: 'Smart Videohub 12x12',
+      inputs: [port('vh-in1', 'In 1', { contentLabel: 'Kamera 1, links' })],
+    })
+    const issues = labelTargetIssues({ equipment: [vh], cables: [] })
+    const charset = issues.find((i) => i.category === 'Videohub-Zeichensatz')
+    expect(charset?.severity).toBe('warning')
+    expect(charset?.message).toContain('","')
+  })
+
+  it('bleibt bei einem sauberen Plan still', () => {
+    const equipment = [
+      atem([
+        port('in1', 'In 1', { contentLabel: 'CAM1' }),
+        port('in2', 'In 2', { contentLabel: 'CAM2' }),
+      ]),
+      camera('cam1', 'Kamera 1', { shortName: 'CAM1' }),
+      camera('cam2', 'Kamera 2', { shortName: 'CAM2' }),
+    ]
+    const cables = [
+      cable(['cam1', 'cam1-out'], ['atem', 'in1']),
+      cable(['cam2', 'cam2-out'], ['atem', 'in2']),
+    ]
+    expect(labelTargetIssues({ equipment, cables })).toEqual([])
+  })
+})
+
+describe('labelTargetIssues — Dante', () => {
+  it('meldet zwei Geraete, deren Dante-konforme Namen zusammenfallen', () => {
+    // "Pult Regie" und "Pult-Regie" sind im Plan zwei Geraete; DNS-SD-konform
+    // gemacht sind beide "Pult-Regie", und mDNS loest ohne Ruecksicht auf
+    // Gross-/Kleinschreibung auf.
+    const equipment = [
+      eq({ id: 'a', name: 'Pult Regie', ipAddress: '10.0.0.10' }),
+      eq({ id: 'b', name: 'pult-regie', ipAddress: '10.0.0.11' }),
+    ]
+    const issues = labelTargetIssues({ equipment, cables: [] })
+    const collision = issues.find((i) => i.category === 'Dante-Namenskollision')
+    expect(collision?.severity).toBe('error')
+    expect(collision?.message).toContain('"Pult Regie"')
+  })
+
+  it('laesst Geraete ohne Netzwerkadresse aus', () => {
+    const equipment = [
+      eq({ id: 'a', name: 'Pult Regie' }),
+      eq({ id: 'b', name: 'pult-regie' }),
+    ]
+    expect(labelTargetIssues({ equipment, cables: [] })).toEqual([])
+  })
+
+  it('meldet keinen Zeichensatz-Verstoss am Vorschlag selbst', () => {
+    // Der Vorschlag ist per Konstruktion konform — eine Warnung darueber
+    // waere eine Warnung ueber den eigenen Rat.
+    const equipment = [eq({ id: 'a', name: 'Pult Bühne 1', ipAddress: '10.0.0.10' })]
+    const issues = labelTargetIssues({ equipment, cables: [] })
+    expect(issues.some((i) => i.category === 'Dante-Zeichensatz')).toBe(false)
+  })
+})
+
+describe('runDrawingChecks — Verdrahtung', () => {
+  it('traegt die Label-Befunde in die Plan-Check-Liste', () => {
+    const equipment = [
+      atem([
+        port('in1', 'In 1', { contentLabel: 'Kamera 1' }),
+        port('in2', 'In 2', { contentLabel: 'Kamera 10' }),
+      ]),
+    ]
+    const { findings, errorCount } = runDrawingChecks({ equipment, cables: [] })
+    expect(findings.some((f) => f.category === 'ATEM-Namenskollision')).toBe(true)
+    expect(errorCount).toBeGreaterThan(0)
+  })
+})
+
+describe('Demo-Projekt', () => {
+  it('bleibt still, weil dort gar kein Zielsystem steckt', () => {
+    // Das Demo enthaelt einen generischen "Bildmischer" (4 BNC in), keinen
+    // ATEM, keinen Videohub und kein adressiertes Netzwerkgeraet — die
+    // Ableitung hat dort nichts zu sagen, und genau das steht hier.
+    //
+    // Der Test ist trotzdem ein Waechter: sobald `detectDeviceKind` weiter
+    // greift oder ein Ziel dazukommt, faellt er auf und die Wirkung auf das
+    // Erste, was ein neuer Nutzer sieht, wird eine bewusste Entscheidung.
+    const demo = createDemoProject()
+    const input = { equipment: demo.equipment, cables: demo.cables }
+    expect(deriveLabels(input).candidates).toEqual([])
+    expect(labelTargetIssues(input)).toEqual([])
+  })
+})

--- a/tests/labelTargets.test.ts
+++ b/tests/labelTargets.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+import {
+  LABEL_TARGETS,
+  allLabelTargets,
+  collisionsForTarget,
+  fitToTarget,
+  utf8Length,
+} from '../src/renderer/lib/labelTargets'
+import { DANTE_MAX_LENGTH } from '../src/renderer/lib/danteNaming'
+
+describe('utf8Length', () => {
+  it('zaehlt Bytes, nicht Zeichen — ein Umlaut kostet zwei', () => {
+    expect(utf8Length('Cam')).toBe(3)
+    expect(utf8Length('Bühne')).toBe(6)
+    expect(utf8Length('€')).toBe(3)
+  })
+})
+
+describe('fitToTarget — ATEM-Kurzname (4 Byte)', () => {
+  const spec = LABEL_TARGETS['atem-input-short']
+
+  it('schneidet auf das Budget ab', () => {
+    const f = fitToTarget('CAM10', spec)
+    expect(f.value).toBe('CAM1')
+    expect(f.truncated).toBe(true)
+  })
+
+  it('laesst Passendes unangetastet', () => {
+    const f = fitToTarget('PGM', spec)
+    expect(f).toMatchObject({ value: 'PGM', truncated: false, invalidChars: [] })
+  })
+
+  it('zerlegt kein Mehr-Byte-Zeichen — lieber ein Zeichen weniger', () => {
+    // "BÜH" ist 4 Byte; "BÜHN" waere 5 und passt nicht mehr.
+    const f = fitToTarget('BÜHNE', spec)
+    expect(f.value).toBe('BÜH')
+    expect(utf8Length(f.value)).toBeLessThanOrEqual(4)
+  })
+
+  it('meldet Zeichen, die das Ziel gar nicht darstellt', () => {
+    expect(fitToTarget('BÜHNE', spec).invalidChars).toEqual(['Ü'])
+  })
+
+  it('meldet jedes ungueltige Zeichen nur einmal', () => {
+    expect(fitToTarget('ÄÄÖ', spec).invalidChars).toEqual(['Ä', 'Ö'])
+  })
+})
+
+describe('fitToTarget — Videohub (kein Laengenlimit, aber ein Dateiformat)', () => {
+  const spec = LABEL_TARGETS['videohub-label']
+
+  it('kuerzt nicht, weil kein Budget belegt ist', () => {
+    const long = 'Ein sehr langer Port-Name der nirgends abgeschnitten wird'
+    expect(fitToTarget(long, spec)).toMatchObject({ value: long, truncated: false })
+  })
+
+  it('meldet Komma und Zeilenumbruch — die zerlegen die Labels.txt', () => {
+    expect(fitToTarget('Kamera 1, links', spec).invalidChars).toEqual([','])
+    expect(fitToTarget('Zeile\nZwei', spec).invalidChars).toEqual(['\n'])
+  })
+
+  it('laesst Umlaute durch — das Format transportiert sie', () => {
+    expect(fitToTarget('Bühne links', spec).invalidChars).toEqual([])
+  })
+})
+
+describe('fitToTarget — Dante', () => {
+  const spec = LABEL_TARGETS['dante-device']
+
+  it('uebernimmt die Laenge aus danteNaming, statt sie zu duplizieren', () => {
+    expect(spec.budget).toBe(DANTE_MAX_LENGTH)
+  })
+
+  it('meldet alles ausserhalb des DNS-SD-Zeichensatzes', () => {
+    expect(fitToTarget('Pult Regie', spec).invalidChars).toEqual([' '])
+    expect(fitToTarget('Pult-Regie-1', spec).invalidChars).toEqual([])
+  })
+})
+
+describe('collisionsForTarget', () => {
+  const spec = LABEL_TARGETS['atem-input-short']
+  const fit = (raw: string) => fitToTarget(raw, spec)
+
+  it('meldet zwei verschiedene Namen, die auf denselben Wert fallen', () => {
+    const cols = collisionsForTarget([fit('CAM1'), fit('CAM10')], spec)
+    expect(cols).toHaveLength(1)
+    expect(cols[0].value).toBe('CAM1')
+    expect(cols[0].members.map((m) => m.raw)).toEqual(['CAM1', 'CAM10'])
+  })
+
+  it('meldet NICHT, wenn schon die Wunschtexte gleich waren', () => {
+    // Doppelte Namen sind ein eigener Befund — nicht jedes Ziel soll ihn
+    // noch einmal melden.
+    expect(collisionsForTarget([fit('PGM'), fit('PGM')], spec)).toEqual([])
+  })
+
+  it('misst Unterschiedlichkeit am Plantext, nicht am aufbereiteten Text', () => {
+    // "1 SDI 3G" und "2 SDI 3G" sind im Plan zwei Eingaenge; die
+    // ATEM-Aufbereitung macht aus beiden "3G". Ohne den Plantext als
+    // Massstab verschluckt die Pruefung genau diesen Fall.
+    const cols = collisionsForTarget(
+      [fitToTarget('3G', spec, '1 SDI 3G'), fitToTarget('3G', spec, '2 SDI 3G')],
+      spec,
+    )
+    expect(cols).toHaveLength(1)
+    expect(cols[0].members.map((m) => m.origin)).toEqual(['1 SDI 3G', '2 SDI 3G'])
+  })
+
+  it('setzt origin auf den Rohtext, wenn keiner angegeben ist', () => {
+    expect(fit('PGM').origin).toBe('PGM')
+  })
+
+  it('ignoriert leere Werte', () => {
+    expect(collisionsForTarget([fit(''), fit('')], spec)).toEqual([])
+  })
+
+  it('faltet Gross-/Kleinschreibung nur, wo das Ziel es tut', () => {
+    const dante = LABEL_TARGETS['dante-device']
+    const cased = collisionsForTarget(
+      [fitToTarget('Cam-1', dante), fitToTarget('cam-1', dante)],
+      dante,
+    )
+    expect(cased).toHaveLength(1)
+
+    const videohub = LABEL_TARGETS['videohub-label']
+    const kept = collisionsForTarget(
+      [fitToTarget('Cam 1', videohub), fitToTarget('cam 1', videohub)],
+      videohub,
+    )
+    expect(kept).toEqual([])
+  })
+})
+
+describe('LABEL_TARGETS — Tabellen-Disziplin', () => {
+  it('jedes Ziel belegt, woher sein Limit stammt', () => {
+    for (const spec of allLabelTargets()) {
+      expect(spec.source.length).toBeGreaterThan(20)
+    }
+  })
+
+  it('jedes Budget ist positiv oder ausdruecklich nicht vorhanden', () => {
+    for (const spec of allLabelTargets()) {
+      expect(spec.budget === null || spec.budget > 0).toBe(true)
+    }
+  })
+
+  it('die id im Datensatz stimmt mit dem Schluessel ueberein', () => {
+    for (const [key, spec] of Object.entries(LABEL_TARGETS)) {
+      expect(spec.id).toBe(key)
+    }
+  })
+})

--- a/tests/portLabel.test.ts
+++ b/tests/portLabel.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { portDisplayLabel, portLabelPair, shortenForAtem } from '../src/renderer/lib/portLabel'
+
+describe('shortenForAtem', () => {
+  it('macht aus dem technischen Portnamen die inhaltliche Kurzform', () => {
+    expect(shortenForAtem('1 SDI 3G PGM (1080p50/60)')).toBe('PGM')
+  })
+
+  it('entfernt fuehrende Portnummern und Format-Suffixe', () => {
+    expect(shortenForAtem('2 Kamera Buehne (1080p50)')).toBe('Kamera Buehne')
+  })
+
+  it('verstuemmelt "SDI 1" NICHT zur nackten "1"', () => {
+    // Der Kommentar der Funktion schliesst genau das aus; die Schleife tat es
+    // trotzdem, weil sie das Ergebnis bedingungslos uebernahm.
+    expect(shortenForAtem('SDI 1')).toBe('SDI 1')
+    expect(shortenForAtem('HDMI 2')).toBe('HDMI 2')
+  })
+
+  it('laesst einen Namen ohne Stecker-Token unangetastet', () => {
+    expect(shortenForAtem('Kamera 1')).toBe('Kamera 1')
+  })
+
+  it('faellt auf den Rohtext zurueck, statt leer zu liefern', () => {
+    expect(shortenForAtem('SDI')).toBe('SDI')
+  })
+})
+
+describe('portDisplayLabel', () => {
+  it('bevorzugt das inhaltliche Label vor dem Portnamen', () => {
+    expect(portDisplayLabel({ name: '1 SDI 3G', contentLabel: 'PGM' })).toBe('PGM')
+    expect(portDisplayLabel({ name: '1 SDI 3G', contentLabel: '  ' })).toBe('1 SDI 3G')
+  })
+})
+
+describe('portLabelPair', () => {
+  it('liefert beide Zeilen nur, wenn sie sich unterscheiden', () => {
+    expect(portLabelPair({ name: '1 SDI 3G', contentLabel: 'PGM' })).toEqual({
+      main: 'PGM',
+      subline: '1 SDI 3G',
+    })
+    expect(portLabelPair({ name: 'PGM', contentLabel: 'PGM' })).toEqual({ main: 'PGM' })
+  })
+})

--- a/tests/sourceIdentity.test.ts
+++ b/tests/sourceIdentity.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+import {
+  UMD_ADDRESS_MAX,
+  isValidUmdAddress,
+  normaliseSourceIdentities,
+  normaliseSourceIdentity,
+  parseUmdAddress,
+  umdAddressClashes,
+  clearDanglingIdentity,
+  sourceIdentityIdSet,
+} from '../src/renderer/lib/sourceIdentity'
+
+describe('parseUmdAddress', () => {
+  it('nimmt Zahl und Ziffern-String', () => {
+    expect(parseUmdAddress(0)).toBe(0)
+    expect(parseUmdAddress('12')).toBe(12)
+    expect(parseUmdAddress(UMD_ADDRESS_MAX)).toBe(UMD_ADDRESS_MAX)
+  })
+
+  it('verwirft alles ausserhalb des Protokoll-Bereichs', () => {
+    // Eine halb gueltige Adresse ist schlimmer als keine: sie sieht im Plan
+    // aus wie eine Zusage, und das Display bleibt trotzdem leer.
+    for (const bad of [-1, 127, 1.5, '', '  ', 'x', null, undefined, {}, []]) {
+      expect(parseUmdAddress(bad)).toBeUndefined()
+    }
+  })
+
+  it('macht aus dem leeren String kein 0', () => {
+    // Number('') === 0 — der klassische Fallstrick. Ein geloeschtes Feld darf
+    // nicht als Adresse 0 durchgehen.
+    expect(parseUmdAddress('')).toBeUndefined()
+    expect(isValidUmdAddress(Number(''))).toBe(true)
+  })
+})
+
+describe('normaliseSourceIdentity', () => {
+  it('behaelt Name, Nummer und Adresse', () => {
+    expect(
+      normaliseSourceIdentity({ id: 'r1', name: ' Kamera 1 ', number: 1, umdAddress: 3 }, 'fb'),
+    ).toEqual({ id: 'r1', name: 'Kamera 1', number: 1, umdAddress: 3 })
+  })
+
+  it('verwirft eine Rolle ohne Namen — die kann niemand zuweisen', () => {
+    expect(normaliseSourceIdentity({ id: 'r1', name: '   ' }, 'fb')).toBeNull()
+    expect(normaliseSourceIdentity({ id: 'r1' }, 'fb')).toBeNull()
+  })
+
+  it('vergibt eine Ersatz-Id, wenn keine da ist', () => {
+    expect(normaliseSourceIdentity({ name: 'Kamera 1' }, 'fallback-7')?.id).toBe('fallback-7')
+  })
+
+  it('laesst eine ungueltige Adresse weg, statt die Rolle zu verwerfen', () => {
+    const r = normaliseSourceIdentity({ name: 'Kamera 1', umdAddress: 999 }, 'fb')
+    expect(r).toEqual({ id: 'fb', name: 'Kamera 1' })
+  })
+
+  it('behandelt Unsinn als leer statt zu werfen', () => {
+    for (const bad of [null, undefined, 42, 'nope', [1, 2]]) {
+      expect(normaliseSourceIdentity(bad, 'fb')).toBeNull()
+    }
+  })
+})
+
+describe('normaliseSourceIdentities', () => {
+  it('wirft Duplikat-Ids weg — die erste gewinnt', () => {
+    const out = normaliseSourceIdentities([
+      { id: 'r1', name: 'Kamera 1' },
+      { id: 'r1', name: 'Kamera 2' },
+    ])
+    expect(out).toEqual([{ id: 'r1', name: 'Kamera 1' }])
+  })
+
+  it('macht aus fehlender Liste eine leere', () => {
+    expect(normaliseSourceIdentities(undefined)).toEqual([])
+    expect(normaliseSourceIdentities('nope')).toEqual([])
+  })
+})
+
+describe('umdAddressClashes', () => {
+  it('meldet zwei Rollen auf derselben Adresse', () => {
+    const clashes = umdAddressClashes([
+      { id: 'a', name: 'Kamera 1', umdAddress: 3 },
+      { id: 'b', name: 'Kamera 2', umdAddress: 3 },
+      { id: 'c', name: 'Kamera 3', umdAddress: 4 },
+    ])
+    expect(clashes).toHaveLength(1)
+    expect(clashes[0].address).toBe(3)
+    expect(clashes[0].identities.map((i) => i.id)).toEqual(['a', 'b'])
+  })
+
+  it('ignoriert Rollen ohne Adresse — die kollidieren mit nichts', () => {
+    expect(
+      umdAddressClashes([
+        { id: 'a', name: 'Kamera 1' },
+        { id: 'b', name: 'Kamera 2' },
+      ]),
+    ).toEqual([])
+  })
+
+  it('behandelt Adresse 0 wie jede andere', () => {
+    const clashes = umdAddressClashes([
+      { id: 'a', name: 'Kamera 1', umdAddress: 0 },
+      { id: 'b', name: 'Kamera 2', umdAddress: 0 },
+    ])
+    expect(clashes.map((c) => c.address)).toEqual([0])
+  })
+})
+
+describe('clearDanglingIdentity', () => {
+  const ids = sourceIdentityIdSet([{ id: 'r1', name: 'Kamera 1' }])
+
+  it('entfernt eine Bindung auf eine geloeschte Rolle', () => {
+    expect(clearDanglingIdentity({ id: 'e1', sourceIdentityId: 'weg' }, ids)).toEqual({
+      id: 'e1',
+      sourceIdentityId: undefined,
+    })
+  })
+
+  it('laesst eine gueltige Bindung in Ruhe — und zwar dasselbe Objekt', () => {
+    const item = { id: 'e1', sourceIdentityId: 'r1' }
+    expect(clearDanglingIdentity(item, ids)).toBe(item)
+  })
+
+  it('laesst ein Geraet ohne Bindung unangetastet', () => {
+    const item = { id: 'e1' }
+    expect(clearDanglingIdentity(item, ids)).toBe(item)
+  })
+})


### PR DESCRIPTION
Die Inkremente 1 und 2 der Identitäts-Spine (ADR-001), plus ein PR-Gate, das es in diesem Repo noch gar nicht gab. Drei getrennte Commits, jeder für sich les- und rückgängig zu machen.

---

# Inkrement 1 — die Ableitung (`aa6159b`)

Persistiert **nichts**. Eine reine Funktion über Geräte und Kabel, ohne React, Store oder Electron — damit wird jede Aussage des Produkts über Identität zu einer Vitest-Assertion, bevor irgendein Schema festgelegt ist.

**`lib/labelTargets.ts` — die Tabelle der Zeichenbudgets.** Die verstreuten `slice(0, 20)`/`slice(0, 4)`-Aufrufe werden ein Datensatz je Zielsystem: ATEM-Langname (20 Byte), ATEM-Kurzname (4 Byte), TSL-UMD v3.1 (16 Byte), Dante-Gerätename (31 Zeichen, Konstante aus `danteNaming.ts` wiederverwendet statt dupliziert), Videohub-Label (kein dokumentiertes Limit — aber ein Komma zerlegt die `Labels.txt`).

Jede Zahl trägt ihren Beleg im Feld `source`. **Aufnahmekriterium: kein Ziel ohne belegtes Limit.** Green-GO-Kanalnamen fehlen deshalb bewusst — eine geratene Zahl wäre schlechter als gar keine, weil sie Befunde erzeugt, die niemand nachprüfen kann. Gezählt wird in der Einheit des Ziels: ATEM- und UMD-Felder sind Byte-Felder, ein „ü" kostet dort zwei.

**`lib/labelDerivation.ts` — die Ableitung.** `resolveSignalSource` läuft vom Mischer-Eingang rückwärts durch den Kabelgraph bis zur echten Quelle. Daraus entstehen die Eingangsnummer je Quelle, der UMD-Displaytext und `unanswered` — die Liste dessen, was kein Graph beantworten kann.

**Der Befund im vorhandenen `PlanCheckPanel`.** Die Verdrahtung ist ein Einzeiler in `runDrawingChecks`, weil `PlanCheckPanel` und die StatusBar-Badge beide dort hängen. Gemeldet wird, was überrascht: zwei verschiedene Namen, die im Zielsystem gleich heißen (Fehler), und Zeichen, die das Zielformat nicht transportiert (Warnung). Bloßes Abschneiden ist **kein** Befund.

## Zwei Entscheidungen, die den Rest tragen

**Treue-Regel: ein Kandidat behauptet nur, was der Exporter heute wirklich sendet.** Der erste Entwurf setzte stattdessen den aufgelösten Quellnamen ein — schönerer Text, aber kein Gerät hätte ihn je gesehen, und der Plan-Check hätte Kollisionen auf Fiktionen gemeldet.

Der Nebeneffekt ist der eigentliche Gewinn: zwei Eingänge mit den Portnamen „1 SDI 3G" und „2 SDI 3G" bekommen im ATEM **beide** den Langnamen „3G". Das ist heute so, in ausgelieferten Plänen.

**Unterschiedlichkeit wird am Plantext gemessen, nicht am aufbereiteten Text.** Genau daran wäre der Check gescheitert: die Aufbereitung macht aus beiden Portnamen oben „3G", und ein Vergleich danach sieht zwei identische Einträge — also keine Kollision. Deshalb trägt jeder Wert seinen `origin` mit.

## Zwei Fehler, die die Tests gefunden haben

**`shortenForAtem` verstümmelte „SDI 1" zur nackten „1"** — genau das, was sein eigener Kommentar seit jeher ausschließt. Die Strip-Schleife übernahm ihr Ergebnis bedingungslos. `tests/portLabel.test.ts` hält den Vertrag jetzt fest.

**Die Rückwärtssuche wäre durch den Genlock-Eingang einer Kamera gelaufen** und hätte den ATEM-Eingang mit dem Namen des Sync-Generators beschriftet. Eine Kamera mit verkabeltem Referenz-Eingang sieht strukturell aus wie ein Konverter. Jetzt entscheidet der Signalbereich: durchlaufen wird nur ein Eingang mit demselben Steckverbinder, der kein Referenz-/Rückweg-/Steuer-Port ist. Bei allem Mehrdeutigen hält die Suche an und nennt das Zwischengerät — das sagt weniger, stimmt aber.

---

# Inkrement 2 — die persistierten Anker (`9b5252f`)

Inkrement 1 hat genau **ein** Feld als unbeantwortbar nachgewiesen: die UMD-Adresse. Genau dafür — und für nichts darüber hinaus — gibt es jetzt ein Schema.

**`SourceIdentity` liegt NEBEN den Geräten, nicht in ihnen.** Ein Haupt-/Backup-Paar ist EINE Rolle mit zwei Geräten, und die Tally-Adresse gehört der Rolle, nicht dem Blech. Genau daran war die Alternative „Identität an die Geräte-Id binden" in ADR-001 gescheitert. Geräte verweisen über `sourceIdentityId`; mehrere dürfen dieselbe Rolle tragen, und die Properties-Sektion zeigt, wer sonst noch dranhängt.

**Eigentumsregel, Feld für Feld.** Gespeichert wird nur, was keine Runtime besitzt: redaktioneller Name, Nummer, UMD-Adresse. ATEM-Source-Id, Videohub-Slot und MV-Fenster bleiben abgeleitet — sie zusätzlich zu speichern wäre genau die zweite Wahrheit, die wir dem Markt vorwerfen.

**Was dazukommt:**
- Schema-Migration in `healProjectPositions` — Rollen werden normalisiert, **bevor** die Geräte gemappt werden, damit Fehlzeiger entsorgt werden können. Ein Fehlzeiger ist schlimmer als keine Bindung: im Plan sieht er aus wie eine zugewiesene Tally-Adresse.
- Die Rolle gewinnt im UMD-Text gegen den Gerätenamen. „Kamera 1" bleibt „Kamera 1", auch wenn die Havarie-Kamera einspringt.
- `unanswered` unterscheidet jetzt zwei Fälle: *keine Rolle gebunden* und *Rolle ohne Adresse*. Das ist der Arbeitsvorrat, nicht mehr nur eine Feststellung.
- Zwei Rollen auf derselben UMD-Adresse sind ein **Fehler** im Plan-Check, kein Schönheitsfehler: beide Displays zeigen denselben Text, und welcher gewinnt entscheidet die Paketreihenfolge. Die Sektion warnt zusätzlich schon beim Tippen.
- Eingefügte Kopien erben die Rolle **nicht**. Sonst behauptet der Plan ein Backup-Paar, das niemand erklärt hat — und setzt zwei Geräte auf dieselbe Tally-Adresse.
- Ungültige Adressen werden nicht übernommen (TSL v3.1 kennt 0–126), das Feld hält aber den Tastendruck fest und sagt warum. Ohne den Entwurfs-State verschluckt ein `type="number"`-Feld den dritten Anschlag von „999".

`.avplan` braucht keine Anpassung: `cableToAvPlan` reicht das gesamte Projekt minus `avForeign` als `domains.cabling` durch, Revisionen snapshotten per Spread. Beides trägt das neue Feld verlustfrei.

**Was bewusst NICHT drin ist:** ISO-Präfix und Comms-Kanal, die anderen beiden Anker aus ADR-001. Es gilt *kein Anker ohne Ziel-Spec*, und für beide fehlt bislang ein belegtes Zielsystem in `labelTargets.ts`. Sie kommen mit ihrem Ziel, nicht davor — sonst entstünde eine Wunschliste statt eines Arbeitsvorrats.

---

# Dazu: ein PR-Gate, das es noch gar nicht gab (`5902364`)

In diesem Repo lief **kein einziger Workflow auf `pull_request`** — `release` und `mac-build` hängen an Tags, `pages` und `docs-stats` an `main`. Die Standing Directive erlaubt Selbst-Merge nur bei grünem CI; es gab aber nichts, das grün oder rot werden konnte.

`ci.yml` schließt das: Typecheck, Lint, Tests, Build — genau die vier Pflicht-Schritte aus `CLAUDE.md`. `electron-builder` bleibt draußen (gehört zu `release.yml`), ebenso die laufzeitabhängigen Node-Checks (`ui:smoke`, `test:drag`, `test:signaling`), die einen laufenden Renderer bzw. Netzwerk erwarten. `libsecret-1-dev` wird wie in `pages.yml` vorinstalliert, damit `npm ci` nicht an keytar scheitert.

Der erste Lauf ist grün durchgelaufen.

---

## Prüfung

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 315 Tests, 33 Dateien, alle grün (+62 neue)
- `npm run lint` — 0 Fehler (10 vorbestehende Warnungen; zwei unnötig gewordene `eslint-disable`-Direktiven aus dem vorigen Inkrement entfernt)
- `npm run build` — grün

Dasselbe läuft ab diesem PR auch auf GitHub.

Die StatusBar lief `runDrawingChecks` bei **jedem** Render unmemoisiert. Da die Engine jetzt auch über den Kabelgraph geht, ist der Aufruf in `useMemo` — sonst hätte dieser PR einen heißen Pfad teurer gemacht.