### PR TITLE
identity: .avsourcemap als Austauschformat (ADR-001, Inkrement 3)

### DIFF
--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -27,6 +27,7 @@ import { exportStagePlotSvg } from '../../lib/exportStagePlot'
 import { downloadBlob } from '../../lib/downloadBlob'
 import { parseCameraList, cameraListToEquipment } from '../../lib/multicamCameraImport'
 import { cableToAvPlan, parseAvPlan } from '../../lib/avplan'
+import { buildSourceMap, mergeSourceMap, parseSourceMap } from '../../lib/sourceMap'
 import { summarizeForeign, hasForeign } from '../../lib/foreignView'
 import type { CablePlannerProject } from '../../types/project'
 import { buildExportFilename } from '../../lib/exportFilename'
@@ -152,6 +153,86 @@ export const MenuBar = ({
     }
     if (avplanImportRef.current) avplanImportRef.current.value = ''
   }
+  // ── Identitaets-Karte (.avsourcemap): das kleine Format fuer Runtimes.
+  // Eine Tally-Maschine soll nicht ein ganzes Kabelprojekt parsen muessen, um
+  // zu erfahren, dass "Kamera 1" auf ATEM-Eingang 3 liegt.
+  const sourceMapImportRef = useRef<HTMLInputElement | null>(null)
+  const handleExportSourceMap = () => {
+    const project = useProjectStore.getState().project
+    const map = buildSourceMap(project, {
+      appVersion: __APP_VERSION__,
+      exportedAt: new Date().toISOString(),
+    })
+    const safe = (project.metadata?.name || 'projekt').replace(/[^a-zA-Z0-9_-]+/g, '_')
+    downloadBlob(`${safe}.avsourcemap`, JSON.stringify(map, null, 2), 'application/json')
+  }
+  const handleImportSourceMap = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) {
+      try {
+        const map = parseSourceMap(await file.text())
+        const store = useProjectStore.getState()
+        const result = mergeSourceMap(store.project.sourceIdentities ?? [], map)
+        store.loadProject({ ...store.project, sourceIdentities: result.identities })
+        // Der Bericht ist der eigentliche Ertrag: der Import fuellt nur
+        // Luecken, und alles andere muss der Mensch sehen statt es zu ahnen.
+        const lines: string[] = []
+        if (result.added.length > 0) {
+          lines.push(format(t('sourceMap.report.added', 'Neu angelegt: {names}'), { names: result.added.join(', ') }))
+        }
+        if (result.filled.length > 0) {
+          lines.push(format(t('sourceMap.report.filled', 'Ergänzt: {fields}'), { fields: result.filled.join(', ') }))
+        }
+        for (const c of result.conflicts) {
+          lines.push(
+            format(
+              t('sourceMap.report.conflict', 'Nicht übernommen — {name} · {field}: hier „{mine}“, in der Datei „{theirs}“.'),
+              { name: c.name, field: c.field, mine: c.mine, theirs: c.theirs },
+            ),
+          )
+        }
+        for (const r of result.rejected) {
+          lines.push(
+            format(t('sourceMap.report.rejected', 'Verworfen — {name} · {field} = {value}: {reason}.'), {
+              name: r.name,
+              field: r.field,
+              value: r.value,
+              reason: r.reason,
+            }),
+          )
+        }
+        if (result.unrepresented.length > 0) {
+          lines.push(
+            format(
+              t('sourceMap.report.unrepresented', 'Kein Feld dafür in dieser App — bleibt nur in der Datei: {fields}'),
+              { fields: result.unrepresented.join(', ') },
+            ),
+          )
+        }
+        if (lines.length === 0) {
+          lines.push(t('sourceMap.report.nothing', 'Nichts zu tun — die Karte sagt dasselbe wie der Plan.'))
+        }
+        await infoDialog(t('sourceMap.report.title', 'Identitäts-Karte importiert'), {
+          bodyNode: (
+            <ul className="flex list-disc flex-col gap-1 pl-4 text-cp-xs text-cp-text-secondary">
+              {lines.map((line, idx) => (
+                <li key={idx}>{line}</li>
+              ))}
+            </ul>
+          ),
+        })
+      } catch (err) {
+        await infoDialog(
+          format(t('sourceMap.importError', 'Import fehlgeschlagen: {message}'), {
+            message: err instanceof Error ? err.message : String(err),
+          }),
+          { tone: 'error' },
+        )
+      }
+    }
+    if (sourceMapImportRef.current) sourceMapImportRef.current.value = ''
+  }
+
   const avForeign = useProjectStore((s) => s.project.avForeign)
   const handleViewForeign = async () => {
     const sum = summarizeForeign(avForeign)
@@ -283,6 +364,7 @@ export const MenuBar = ({
     <header className="flex shrink-0 items-center justify-between gap-3 border-b border-[var(--cp-border)] bg-[var(--cp-surface-3)] px-3 py-1.5 text-cp-xs shadow-sm">
       <input ref={cameraImportRef} type="file" accept=".cameras.json,.json" className="hidden" onChange={handleImportCameras} />
       <input ref={avplanImportRef} type="file" accept=".avplan,.json" className="hidden" onChange={handleImportAvplan} />
+      <input ref={sourceMapImportRef} type="file" accept=".avsourcemap,.json" className="hidden" onChange={handleImportSourceMap} />
       <div className="flex shrink-0 items-center gap-2">
         <span className="hidden select-none font-semibold tracking-wide text-cp-text-secondary lg:inline">
           {t('app.title', 'Cable Planner')}
@@ -323,6 +405,12 @@ export const MenuBar = ({
           </MenuItem>
           <MenuItem onClick={() => avplanImportRef.current?.click()} icon={<Icon icon={ImportIcon} size="sm" />}>
             {t('app.menu.file.importAvplan', 'Gesamtprojekt importieren (.avplan)…')}
+          </MenuItem>
+          <MenuItem onClick={handleExportSourceMap} icon={<Icon icon={Upload} size="sm" />}>
+            {t('app.menu.file.exportSourceMap', 'Identitäts-Karte exportieren (.avsourcemap)…')}
+          </MenuItem>
+          <MenuItem onClick={() => sourceMapImportRef.current?.click()} icon={<Icon icon={ImportIcon} size="sm" />}>
+            {t('app.menu.file.importSourceMap', 'Identitäts-Karte importieren (.avsourcemap)…')}
           </MenuItem>
           {hasForeign(avForeign) && (
             <MenuItem onClick={handleViewForeign} icon={<Icon icon={Eye} size="sm" />}>

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -2148,6 +2148,20 @@ export const en: Dict = {
   'cable.aria.toDevice': 'Target device',
   'cable.aria.toPort': 'Target port',
 
+  // ADR-001 — Identitaets-Karte (.avsourcemap)
+  'app.menu.file.exportSourceMap': 'Export identity map (.avsourcemap)…',
+  'app.menu.file.importSourceMap': 'Import identity map (.avsourcemap)…',
+  'sourceMap.report.title': 'Identity map imported',
+  'sourceMap.report.added': 'Newly created: {names}',
+  'sourceMap.report.filled': 'Filled in: {fields}',
+  'sourceMap.report.conflict':
+    'Not applied — {name} · {field}: here "{mine}", in the file "{theirs}".',
+  'sourceMap.report.rejected': 'Discarded — {name} · {field} = {value}: {reason}.',
+  'sourceMap.report.unrepresented':
+    'No field for this in this app — stays in the file only: {fields}',
+  'sourceMap.report.nothing': 'Nothing to do — the map says what the plan already says.',
+  'sourceMap.importError': 'Import failed: {message}',
+
   // ADR-001 — Signalquellen-Rolle (SourceIdentitySection)
   'sourceIdentity.title': 'Signal source (role)',
   'sourceIdentity.unbound': 'not assigned',

--- a/src/renderer/lib/sourceMap.ts
+++ b/src/renderer/lib/sourceMap.ts
@@ -1,0 +1,410 @@
+// ───────────────────────────────────────────────────────────────────────────
+// ADR-001, Inkrement 3 — `.avsourcemap`, das Austauschformat der Identitaet.
+//
+// WOFUER. Der `.avplan` traegt das ganze Projekt und ist fuer die Planungs-
+// Apps gedacht. Der Konsument der Identitaet ist aber eine RUNTIME — ein
+// Tally-Rechner, ein UMD-Sender, ein Aufnahme-Controller —, und die soll
+// nicht ein komplettes Kabelprojekt parsen muessen, um zu erfahren, dass
+// „Kamera 1" auf ATEM-Eingang 3 liegt und ihr Display die UMD-Adresse 3 hat.
+// Deshalb ein eigenes, flaches, kleines Format.
+//
+// WAS DRINSTEHT. Die Rollen (`SourceIdentity`) mit ihren Ankern, dazu je
+// Rolle die ABGELEITETE Bindung: welches Geraet sie realisiert, welchen
+// Mischer es auf welchem Eingang speist, und was die Zielsysteme nach ihren
+// Zeichenbudgets tatsaechlich anzeigen. Die Ableitung wird mitgeschrieben,
+// nicht die Quelle der Ableitung: Der Empfaenger soll nicht den Kabelgraph
+// nachbauen muessen.
+//
+// ZWEI REGELN AUS DER STRATEGIE, hier woertlich umgesetzt:
+//
+// 1. PROVENIENZ PRO WERT. Jeder Anker sagt, woher er kommt: `planned` (aus
+//    der Planung), `commanded` (an ein Geraet geschickt), `confirmed` (vom
+//    Geraet zurueckgemeldet). Der Cable-Planner schreibt ausschliesslich
+//    `planned` — er plant, er misst nicht. Eine Runtime, die zurueckschreibt,
+//    setzt `confirmed`. Damit kann keine Oberflaeche einen unbestaetigten
+//    Wert als Tatsache zeigen.
+//
+// 2. VERWEIGERUNG STATT STILLEN VERLUSTS. Was der Plan nicht beantwortet,
+//    steht in `unresolved` — es wird nicht weggelassen. Und was eine fremde
+//    Datei mitbringt und wir nicht kennen, bleibt beim Lesen als `extra`
+//    erhalten, statt beim naechsten Schreiben zu verschwinden.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { CablePlannerProject } from '../types/project'
+import type { SourceIdentity } from '../types/sourceIdentity'
+import { deriveLabels, type UnansweredAnchor } from './labelDerivation'
+import type { LabelTargetId } from './labelTargets'
+import { LABEL_TARGETS, fitToTarget } from './labelTargets'
+import { UMD_ADDRESS_MAX, UMD_ADDRESS_MIN, isValidUmdAddress } from './sourceIdentity'
+
+export const SOURCE_MAP_KIND = 'av-source-map' as const
+export const SOURCE_MAP_VERSION = 1 as const
+
+/** Woher ein Wert stammt — nie raten, nie als Tatsache zeigen, was geplant ist. */
+export type ValueProvenance = 'planned' | 'commanded' | 'confirmed'
+
+export interface SourceMapBinding {
+  /** Geraet, das die Rolle realisiert. */
+  equipmentId: string
+  equipmentName: string
+  /** Mischer/Router, den es speist — fehlt, wenn nichts verkabelt ist. */
+  sinkEquipmentId?: string
+  sinkName?: string
+  /** 1-basierte Eingangsnummer: damit adressiert der Mischer auf dem Draht. */
+  input?: number
+  /** Zwischengeraete auf dem Weg (0 = direkt verkabelt). */
+  hops?: number
+}
+
+export interface SourceMapEntry {
+  id: string
+  name: string
+  number?: number
+  umdAddress?: number
+  /** Provenienz je Feldname. Fehlt ein Eintrag, gilt der Wert als ungeprueft. */
+  provenance: Partial<Record<'name' | 'number' | 'umdAddress', ValueProvenance>>
+  bindings: SourceMapBinding[]
+  /** Was das jeweilige Zielsystem nach seinem Zeichenbudget wirklich zeigt. */
+  labels: Partial<Record<LabelTargetId, string>>
+  /** Felder einer fremden Datei, die wir nicht kennen — bleiben erhalten. */
+  extra?: Record<string, unknown>
+}
+
+export interface SourceMapUnresolved {
+  field: string
+  equipmentId: string
+  where: string
+  reason: string
+}
+
+export interface SourceMap {
+  kind: typeof SOURCE_MAP_KIND
+  formatVersion: typeof SOURCE_MAP_VERSION
+  app: string
+  appVersion: string
+  exportedAt: string
+  sources: SourceMapEntry[]
+  /** Was der Plan nicht beantwortet. Steht ausdruecklich drin. */
+  unresolved: SourceMapUnresolved[]
+  extra?: Record<string, unknown>
+}
+
+const KNOWN_ENTRY_KEYS = new Set([
+  'id',
+  'name',
+  'number',
+  'umdAddress',
+  'provenance',
+  'bindings',
+  'labels',
+  'extra',
+])
+
+const KNOWN_ROOT_KEYS = new Set([
+  'kind',
+  'formatVersion',
+  'app',
+  'appVersion',
+  'exportedAt',
+  'sources',
+  'unresolved',
+  'extra',
+])
+
+const collectExtra = (
+  raw: Record<string, unknown>,
+  known: ReadonlySet<string>,
+): Record<string, unknown> | undefined => {
+  const extra: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(raw)) {
+    if (!known.has(key)) extra[key] = value
+  }
+  return Object.keys(extra).length > 0 ? extra : undefined
+}
+
+/**
+ * Baut die Karte aus dem Projekt.
+ *
+ * `sources` sind die ROLLEN, nicht die Geraete. Ein Plan ohne Rollen liefert
+ * eine leere Liste — und das ist die richtige Antwort, nicht ein Fehler: Das
+ * Format transportiert Identitaet, und ohne Rolle gibt es keine. Was dabei
+ * offen bleibt, steht dann umso deutlicher in `unresolved`.
+ */
+export const buildSourceMap = (
+  project: Pick<CablePlannerProject, 'equipment' | 'cables' | 'sourceIdentities'>,
+  meta: { app?: string; appVersion: string; exportedAt: string },
+): SourceMap => {
+  const identities: SourceIdentity[] = project.sourceIdentities ?? []
+  const { candidates, sources, unanswered } = deriveLabels({
+    equipment: project.equipment,
+    cables: project.cables,
+    sourceIdentities: identities,
+  })
+  const eqById = new Map(project.equipment.map((e) => [e.id, e]))
+  const candidateByKey = new Map(candidates.map((c) => [c.key, c]))
+
+  /** Was beim Ziel wirklich ankommt — inklusive Zuschnitt aufs Budget. */
+  const fitted = (key: string, target: LabelTargetId): string | undefined => {
+    const candidate = candidateByKey.get(key)
+    if (!candidate) return undefined
+    const value = fitToTarget(candidate.raw, LABEL_TARGETS[target]).value
+    return value || undefined
+  }
+
+  const entries: SourceMapEntry[] = identities.map((identity) => {
+    const devices = project.equipment.filter((e) => e.sourceIdentityId === identity.id)
+    const labels: Partial<Record<LabelTargetId, string>> = {}
+    const bindings: SourceMapBinding[] = devices.map((device) => {
+      const link = sources.find((s) => s.sourceEquipmentId === device.id)
+      if (link) {
+        const long = fitted(`atem-long:${link.sinkPortId}`, 'atem-input-long')
+        const short = fitted(`atem-short:${link.sinkPortId}`, 'atem-input-short')
+        if (long) labels['atem-input-long'] = long
+        if (short) labels['atem-input-short'] = short
+      }
+      const umd = fitted(`umd:${device.id}`, 'tsl-umd-v31')
+      if (umd) labels['tsl-umd-v31'] = umd
+      const sink = link ? eqById.get(link.sinkEquipmentId) : undefined
+      return {
+        equipmentId: device.id,
+        equipmentName: device.name,
+        ...(sink ? { sinkEquipmentId: sink.id, sinkName: sink.name } : {}),
+        ...(link ? { input: link.inputIndex, hops: link.hops } : {}),
+      }
+    })
+
+    const provenance: SourceMapEntry['provenance'] = { name: 'planned' }
+    if (identity.number !== undefined) provenance.number = 'planned'
+    if (identity.umdAddress !== undefined) provenance.umdAddress = 'planned'
+
+    return {
+      id: identity.id,
+      name: identity.name,
+      ...(identity.number !== undefined ? { number: identity.number } : {}),
+      ...(identity.umdAddress !== undefined ? { umdAddress: identity.umdAddress } : {}),
+      provenance,
+      bindings,
+      labels,
+    }
+  })
+
+  return {
+    kind: SOURCE_MAP_KIND,
+    formatVersion: SOURCE_MAP_VERSION,
+    app: meta.app ?? 'cable-planner',
+    appVersion: meta.appVersion,
+    exportedAt: meta.exportedAt,
+    sources: entries,
+    unresolved: unanswered.map((u: UnansweredAnchor) => ({
+      field: u.field,
+      equipmentId: u.equipmentId,
+      where: u.where,
+      reason: u.reason,
+    })),
+  }
+}
+
+// ── Lesen ────────────────────────────────────────────────────────────────────
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  value != null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined
+
+const asProvenance = (value: unknown): ValueProvenance | undefined =>
+  value === 'planned' || value === 'commanded' || value === 'confirmed' ? value : undefined
+
+/**
+ * Liest eine `.avsourcemap`. Wirft nur, wenn die Datei gar keine ist — ein
+ * einzelner kaputter Eintrag laesst den Rest stehen, weil ein halber Import
+ * immer noch besser ist als gar keiner, solange klar bleibt, was fehlt.
+ *
+ * Unbekannte Felder werden NICHT weggeworfen, sondern in `extra` gehoben.
+ * Wer die Datei weiterreicht, verliert nichts; wer sie importiert, bekommt
+ * ueber `mergeSourceMap` gesagt, was hier keinen Platz hat.
+ */
+export const parseSourceMap = (text: string): SourceMap => {
+  const data = asRecord(JSON.parse(text))
+  if (!data || data.kind !== SOURCE_MAP_KIND) {
+    throw new Error('Keine gueltige .avsourcemap-Datei (kind != av-source-map).')
+  }
+  const version = data.formatVersion
+  if (typeof version !== 'number' || version > SOURCE_MAP_VERSION) {
+    throw new Error(
+      `.avsourcemap-Version ${String(version)} ist neuer als unterstuetzt (${SOURCE_MAP_VERSION}).`,
+    )
+  }
+
+  const rawSources = Array.isArray(data.sources) ? data.sources : []
+  const sources: SourceMapEntry[] = []
+  rawSources.forEach((raw, idx) => {
+    const r = asRecord(raw)
+    if (!r) return
+    const name = asString(r.name)
+    if (!name) return
+    const rawProv = asRecord(r.provenance) ?? {}
+    const provenance: SourceMapEntry['provenance'] = {}
+    for (const field of ['name', 'number', 'umdAddress'] as const) {
+      const p = asProvenance(rawProv[field])
+      if (p) provenance[field] = p
+    }
+    const entry: SourceMapEntry = {
+      id: asString(r.id) ?? `source-${idx + 1}`,
+      name,
+      provenance,
+      bindings: Array.isArray(r.bindings) ? (r.bindings as SourceMapBinding[]) : [],
+      labels: (asRecord(r.labels) ?? {}) as SourceMapEntry['labels'],
+    }
+    if (typeof r.number === 'number' && Number.isInteger(r.number) && r.number >= 0) {
+      entry.number = r.number
+    }
+    if (typeof r.umdAddress === 'number') entry.umdAddress = r.umdAddress
+    const extra = collectExtra(r, KNOWN_ENTRY_KEYS)
+    if (extra) entry.extra = extra
+    sources.push(entry)
+  })
+
+  const map: SourceMap = {
+    kind: SOURCE_MAP_KIND,
+    formatVersion: SOURCE_MAP_VERSION,
+    app: asString(data.app) ?? 'unbekannt',
+    appVersion: asString(data.appVersion) ?? '',
+    exportedAt: asString(data.exportedAt) ?? '',
+    sources,
+    unresolved: Array.isArray(data.unresolved)
+      ? (data.unresolved as SourceMapUnresolved[])
+      : [],
+  }
+  const rootExtra = collectExtra(data, KNOWN_ROOT_KEYS)
+  if (rootExtra) map.extra = rootExtra
+  return map
+}
+
+// ── Zusammenfuehren ──────────────────────────────────────────────────────────
+
+export interface SourceMapConflict {
+  name: string
+  field: string
+  mine: string
+  theirs: string
+}
+
+export interface SourceMapRejection {
+  name: string
+  field: string
+  value: string
+  reason: string
+}
+
+export interface SourceMapMergeResult {
+  identities: SourceIdentity[]
+  /** Rollen, die es hier noch nicht gab. */
+  added: string[]
+  /** Felder, die eine Luecke geschlossen haben — „Rolle · Feld". */
+  filled: string[]
+  /** Wo beide Seiten etwas ANDERES sagen. Wird NICHT ueberschrieben. */
+  conflicts: SourceMapConflict[]
+  /** Werte, die das Protokoll gar nicht kennt — nicht uebernommen, aber
+   *  benannt. Eine Adresse ausserhalb 0–126 laesst das Display leer. */
+  rejected: SourceMapRejection[]
+  /** Felder der Datei, fuer die es hier kein Feld gibt — beim Namen genannt,
+   *  statt still verschluckt. */
+  unrepresented: string[]
+}
+
+/**
+ * Fuehrt eine gelesene Karte mit den vorhandenen Rollen zusammen.
+ *
+ * REGEL: Der Import FUELLT nur Luecken. Wo hier schon ein anderer Wert steht,
+ * wird nichts ueberschrieben — er landet in `conflicts` und der Mensch
+ * entscheidet. Ein Import, der stillschweigend die Tally-Adresse aendert, ist
+ * genau die Sorte Automatik, die im Betrieb niemand zurueckverfolgen kann.
+ *
+ * Was die Datei mitbringt und wofuer es hier kein Feld gibt, steht in
+ * `unrepresented`. Gespeichert werden kann es nicht — aber verschwiegen wird
+ * es auch nicht.
+ */
+export const mergeSourceMap = (
+  existing: SourceIdentity[],
+  map: SourceMap,
+): SourceMapMergeResult => {
+  const byId = new Map(existing.map((s) => [s.id, s]))
+  const identities = existing.map((s) => ({ ...s }))
+  const indexById = new Map(identities.map((s, i) => [s.id, i]))
+  const added: string[] = []
+  const filled: string[] = []
+  const conflicts: SourceMapConflict[] = []
+  const rejected: SourceMapRejection[] = []
+  const unrepresented: string[] = []
+
+  /** Uebernommen wird nur, was das Zielprotokoll auch senden kann. */
+  const acceptedUmd = (entry: SourceMapEntry): number | undefined => {
+    if (entry.umdAddress === undefined) return undefined
+    if (isValidUmdAddress(entry.umdAddress)) return entry.umdAddress
+    rejected.push({
+      name: entry.name,
+      field: 'umdAddress',
+      value: String(entry.umdAddress),
+      reason: `TSL UMD v3.1 kennt nur ganze Adressen ${UMD_ADDRESS_MIN}–${UMD_ADDRESS_MAX}`,
+    })
+    return undefined
+  }
+
+  if (map.extra) {
+    for (const key of Object.keys(map.extra)) unrepresented.push(key)
+  }
+
+  for (const entry of map.sources) {
+    if (entry.extra) {
+      for (const key of Object.keys(entry.extra)) unrepresented.push(`${entry.name}.${key}`)
+    }
+    const mine = byId.get(entry.id)
+    if (!mine) {
+      const next: SourceIdentity = { id: entry.id, name: entry.name }
+      if (entry.number !== undefined) next.number = entry.number
+      const umd = acceptedUmd(entry)
+      if (umd !== undefined) next.umdAddress = umd
+      identities.push(next)
+      indexById.set(next.id, identities.length - 1)
+      byId.set(next.id, next)
+      added.push(entry.name)
+      continue
+    }
+
+    const idx = indexById.get(entry.id)
+    if (idx === undefined) continue
+    const target = identities[idx]
+
+    const reconcile = (
+      field: 'name' | 'number' | 'umdAddress',
+      theirs: string | number | undefined,
+    ) => {
+      if (theirs === undefined) return
+      const current = target[field]
+      if (current === undefined) {
+        // Zuweisung ueber den Feldnamen, damit die drei Faelle nicht
+        // dreimal denselben Rumpf brauchen.
+        ;(target as Record<string, unknown>)[field] = theirs
+        filled.push(`${entry.name} · ${field}`)
+        return
+      }
+      if (current !== theirs) {
+        conflicts.push({
+          name: entry.name,
+          field,
+          mine: String(current),
+          theirs: String(theirs),
+        })
+      }
+    }
+
+    reconcile('name', entry.name)
+    reconcile('number', entry.number)
+    reconcile('umdAddress', acceptedUmd(entry))
+  }
+
+  return { identities, added, filled, conflicts, rejected, unrepresented }
+}

--- a/tests/sourceMap.test.ts
+++ b/tests/sourceMap.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SOURCE_MAP_KIND,
+  SOURCE_MAP_VERSION,
+  buildSourceMap,
+  mergeSourceMap,
+  parseSourceMap,
+} from '../src/renderer/lib/sourceMap'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem, Port } from '../src/renderer/types/equipment'
+
+const port = (id: string, name: string, over: Partial<Port> = {}): Port => ({
+  id,
+  name,
+  type: 'BNC',
+  connectorType: 'BNC',
+  ...over,
+})
+
+const eq = (over: Partial<EquipmentItem>): EquipmentItem => ({
+  id: 'e1',
+  name: 'Gerät',
+  category: 'Video',
+  inputs: [],
+  outputs: [],
+  x: 0,
+  y: 0,
+  width: 200,
+  height: 160,
+  ...over,
+})
+
+const cable = (from: [string, string], to: [string, string]): Cable => ({
+  id: `${from[1]}->${to[1]}`,
+  name: `${from[1]}->${to[1]}`,
+  type: 'BNC',
+  length: 10,
+  color: '#fff',
+  fromEquipmentId: from[0],
+  fromPortId: from[1],
+  toEquipmentId: to[0],
+  toPortId: to[1],
+  notes: '',
+})
+
+const META = { appVersion: '1.2.3', exportedAt: '2026-01-01T00:00:00.000Z' }
+
+const scene = () => ({
+  equipment: [
+    eq({
+      id: 'atem',
+      name: 'ATEM Mini Extreme',
+      inputs: [port('in1', 'In 1', { contentLabel: 'Kamera 1' })],
+    }),
+    eq({
+      id: 'cam1',
+      name: 'Blackmagic URSA',
+      category: 'Kameras',
+      outputs: [port('cam1-out', 'SDI Out')],
+      sourceIdentityId: 'r1',
+    }),
+  ],
+  cables: [cable(['cam1', 'cam1-out'], ['atem', 'in1'])],
+  sourceIdentities: [{ id: 'r1', name: 'Kamera 1', number: 1, umdAddress: 3 }],
+})
+
+describe('buildSourceMap', () => {
+  it('schreibt die Rolle mit Anker, Bindung und Eingangsnummer', () => {
+    const map = buildSourceMap(scene(), META)
+    expect(map).toMatchObject({ kind: SOURCE_MAP_KIND, formatVersion: SOURCE_MAP_VERSION })
+    expect(map.sources).toHaveLength(1)
+    expect(map.sources[0]).toMatchObject({
+      id: 'r1',
+      name: 'Kamera 1',
+      number: 1,
+      umdAddress: 3,
+    })
+    expect(map.sources[0].bindings[0]).toMatchObject({
+      equipmentId: 'cam1',
+      equipmentName: 'Blackmagic URSA',
+      sinkEquipmentId: 'atem',
+      input: 1,
+      hops: 0,
+    })
+  })
+
+  it('markiert jeden Wert als geplant — der Planer misst nicht', () => {
+    const map = buildSourceMap(scene(), META)
+    expect(map.sources[0].provenance).toEqual({
+      name: 'planned',
+      number: 'planned',
+      umdAddress: 'planned',
+    })
+  })
+
+  it('schreibt die Labels so, wie das Zielsystem sie wirklich zeigt', () => {
+    const map = buildSourceMap(scene(), META)
+    // ATEM-Kurzname ist 4 Byte: aus "Kamera 1" wird "KAME".
+    expect(map.sources[0].labels['atem-input-short']).toBe('KAME')
+    expect(map.sources[0].labels['atem-input-long']).toBe('Kamera 1')
+    expect(map.sources[0].labels['tsl-umd-v31']).toBe('Kamera 1')
+  })
+
+  it('nennt, was der Plan nicht beantwortet, statt es wegzulassen', () => {
+    const s = scene()
+    s.equipment[1].sourceIdentityId = undefined
+    s.sourceIdentities = []
+    const map = buildSourceMap(s, META)
+    expect(map.sources).toEqual([])
+    expect(map.unresolved).toHaveLength(1)
+    expect(map.unresolved[0]).toMatchObject({ field: 'umd-address', equipmentId: 'cam1' })
+  })
+
+  it('liefert eine leere Rollenliste, wenn es keine Rollen gibt', () => {
+    // Das ist die richtige Antwort, kein Fehler: das Format transportiert
+    // Identität, und ohne Rolle gibt es keine.
+    const map = buildSourceMap({ equipment: [], cables: [], sourceIdentities: [] }, META)
+    expect(map.sources).toEqual([])
+    expect(map.unresolved).toEqual([])
+  })
+
+  it('kommt mit einer Rolle ohne verkabeltes Gerät klar', () => {
+    const map = buildSourceMap(
+      { equipment: [], cables: [], sourceIdentities: [{ id: 'r1', name: 'Kamera 1' }] },
+      META,
+    )
+    expect(map.sources[0].bindings).toEqual([])
+    expect(map.sources[0].provenance).toEqual({ name: 'planned' })
+  })
+})
+
+describe('parseSourceMap', () => {
+  it('liest, was buildSourceMap geschrieben hat', () => {
+    const map = buildSourceMap(scene(), META)
+    const back = parseSourceMap(JSON.stringify(map))
+    expect(back.sources[0]).toMatchObject({ id: 'r1', name: 'Kamera 1', umdAddress: 3 })
+  })
+
+  it('weist an, was gar keine Karte ist', () => {
+    expect(() => parseSourceMap('{"kind":"avplan"}')).toThrow(/av-source-map/)
+    expect(() => parseSourceMap('nope')).toThrow()
+  })
+
+  it('weist eine neuere Formatversion ab, statt sie halb zu lesen', () => {
+    const text = JSON.stringify({ kind: SOURCE_MAP_KIND, formatVersion: 99, sources: [] })
+    expect(() => parseSourceMap(text)).toThrow(/neuer als unterstuetzt/)
+  })
+
+  it('hebt unbekannte Felder nach extra, statt sie zu verlieren', () => {
+    const text = JSON.stringify({
+      kind: SOURCE_MAP_KIND,
+      formatVersion: 1,
+      zukunft: { irgendwas: true },
+      sources: [{ id: 'r1', name: 'Kamera 1', isoPrefix: 'CAM1_' }],
+    })
+    const map = parseSourceMap(text)
+    expect(map.extra).toEqual({ zukunft: { irgendwas: true } })
+    expect(map.sources[0].extra).toEqual({ isoPrefix: 'CAM1_' })
+  })
+
+  it('überspringt einen namenlosen Eintrag, statt den ganzen Import zu kippen', () => {
+    const text = JSON.stringify({
+      kind: SOURCE_MAP_KIND,
+      formatVersion: 1,
+      sources: [{ id: 'r1' }, { id: 'r2', name: 'Kamera 2' }],
+    })
+    expect(parseSourceMap(text).sources.map((s) => s.id)).toEqual(['r2'])
+  })
+})
+
+describe('mergeSourceMap', () => {
+  const mapWith = (entry: Record<string, unknown>) =>
+    parseSourceMap(
+      JSON.stringify({ kind: SOURCE_MAP_KIND, formatVersion: 1, sources: [entry] }),
+    )
+
+  it('legt eine unbekannte Rolle an', () => {
+    const out = mergeSourceMap([], mapWith({ id: 'r1', name: 'Kamera 1', umdAddress: 3 }))
+    expect(out.added).toEqual(['Kamera 1'])
+    expect(out.identities).toEqual([{ id: 'r1', name: 'Kamera 1', umdAddress: 3 }])
+  })
+
+  it('füllt eine Lücke, überschreibt aber nichts', () => {
+    const out = mergeSourceMap(
+      [{ id: 'r1', name: 'Kamera 1' }],
+      mapWith({ id: 'r1', name: 'Kamera 1', umdAddress: 3 }),
+    )
+    expect(out.filled).toEqual(['Kamera 1 · umdAddress'])
+    expect(out.identities[0].umdAddress).toBe(3)
+    expect(out.conflicts).toEqual([])
+  })
+
+  it('meldet einen abweichenden Wert als Konflikt, statt ihn zu übernehmen', () => {
+    // Ein Import, der stillschweigend die Tally-Adresse ändert, ist im
+    // Betrieb nicht zurückzuverfolgen.
+    const out = mergeSourceMap(
+      [{ id: 'r1', name: 'Kamera 1', umdAddress: 3 }],
+      mapWith({ id: 'r1', name: 'Kamera 1', umdAddress: 7 }),
+    )
+    expect(out.identities[0].umdAddress).toBe(3)
+    expect(out.conflicts).toEqual([
+      { name: 'Kamera 1', field: 'umdAddress', mine: '3', theirs: '7' },
+    ])
+  })
+
+  it('übernimmt keine Adresse, die das Protokoll nicht kennt', () => {
+    const out = mergeSourceMap([], mapWith({ id: 'r1', name: 'Kamera 1', umdAddress: 999 }))
+    expect(out.identities[0].umdAddress).toBeUndefined()
+    expect(out.rejected[0]).toMatchObject({ name: 'Kamera 1', field: 'umdAddress', value: '999' })
+  })
+
+  it('nennt Felder beim Namen, für die es hier keinen Platz gibt', () => {
+    const out = mergeSourceMap([], mapWith({ id: 'r1', name: 'Kamera 1', isoPrefix: 'CAM1_' }))
+    expect(out.unrepresented).toEqual(['Kamera 1.isoPrefix'])
+  })
+
+  it('lässt die vorhandene Liste unangetastet', () => {
+    const existing = [{ id: 'r1', name: 'Kamera 1' }]
+    mergeSourceMap(existing, mapWith({ id: 'r1', name: 'Kamera 1', umdAddress: 3 }))
+    expect(existing[0].umdAddress).toBeUndefined()
+  })
+})
+
+describe('Rundreise', () => {
+  it('überlebt build → parse → merge ohne Verlust', () => {
+    const s = scene()
+    const map = buildSourceMap(s, META)
+    const back = parseSourceMap(JSON.stringify(map))
+    const merged = mergeSourceMap([], back)
+    expect(merged.identities).toEqual(s.sourceIdentities)
+    expect(merged.conflicts).toEqual([])
+    expect(merged.rejected).toEqual([])
+    expect(merged.unrepresented).toEqual([])
+  })
+})


### PR DESCRIPTION
Das letzte Inkrement von ADR-001. Die Reihenfolge dort lautet: *„Austauschformat — erst wenn klar ist, was drinsteht."* Nach den Inkrementen 1 und 2 ([#602](https://github.com/larszu/cable-planner/pull/602), gemergt) steht es fest, also gibt es jetzt eins.

## Warum ein eigenes Format neben `.avplan`

Der `.avplan` trägt das ganze Projekt und richtet sich an die Planungs-Apps. Der Konsument der *Identität* ist aber eine **Runtime** — ein Tally-Rechner, ein UMD-Sender, ein Aufnahme-Controller. Die soll nicht ein komplettes Kabelprojekt parsen müssen, um zu erfahren, dass „Kamera 1" auf ATEM-Eingang 3 liegt und ihr Display die UMD-Adresse 3 hat.

Deshalb `.avsourcemap`: flach, klein, selbstbeschreibend. Pro Rolle stehen darin die Anker (Name, Nummer, UMD-Adresse), die **abgeleitete** Bindung (welches Gerät sie realisiert, welchen Mischer es auf welchem Eingang speist, wie viele Zwischengeräte dazwischen liegen) und die Labels so, wie die Zielsysteme sie nach ihren Zeichenbudgets tatsächlich anzeigen. Geschrieben wird das *Ergebnis* der Ableitung, nicht ihre Grundlage — der Empfänger soll den Kabelgraph nicht nachbauen müssen.

## Die zwei Strategie-Regeln, hier wörtlich umgesetzt

**Provenienz pro Wert.** Jeder Anker sagt, woher er kommt: `planned`, `commanded`, `confirmed`. Der Cable-Planner schreibt ausschließlich `planned` — er plant, er misst nicht. Eine Runtime, die zurückschreibt, setzt `confirmed`. Damit kann keine Oberfläche einen unbestätigten Wert als Tatsache zeigen.

**Verweigerung statt stillen Verlusts.** Was der Plan nicht beantwortet, steht in `unresolved` statt wegzufallen. Was eine fremde Datei mitbringt und wir nicht kennen, überlebt beim Lesen als `extra`. Und was wir hier gar nicht speichern können, wird beim Namen genannt, statt still verschluckt zu werden.

## Der Import füllt nur Lücken

Das ist die wichtigste Entscheidung in diesem PR. Ein Import, der stillschweigend die Tally-Adresse ändert, ist im Betrieb nicht zurückzuverfolgen — deshalb überschreibt `mergeSourceMap` **nichts**:

- **Lücke** → wird gefüllt, und der Bericht sagt welche.
- **Abweichender Wert** → landet in `conflicts`, beide Seiten werden benannt, der Mensch entscheidet.
- **Wert außerhalb des Protokolls** (UMD ≠ 0–126) → `rejected`, mit Grund. Eine halb gültige Adresse sieht im Plan aus wie eine Zusage und lässt das Display trotzdem leer.
- **Feld ohne Platz in dieser App** (z. B. ein `isoPrefix` aus einer künftigen Version) → `unrepresented`, beim Namen genannt. Speichern können wir es nicht, verschweigen aber auch nicht.

Der Bericht ist der eigentliche Ertrag des Imports und wird nach jedem Lauf als Dialog gezeigt — auch wenn nichts zu tun war.

## Ein Plan ohne Rollen exportiert eine leere Liste

Und das ist die richtige Antwort, kein Fehler: Das Format transportiert Identität, und ohne Rolle gibt es keine. Was dabei offen bleibt, steht dann umso deutlicher in `unresolved` — das ist der Arbeitsvorrat, mit dem man die Karte füllt.

## Prüfung

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 333 Tests, 34 Dateien, alle grün (+18 neue, inkl. Rundreise `build → parse → merge` ohne Verlust)
- `npm run lint` — 0 Fehler (10 vorbestehende Warnungen)
- `npm run build` — grün

Läuft ab hier auch im PR-CI, das mit #602 dazugekommen ist.

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_