### PR TITLE
tally: Tally-Karte aus dem Plan ableiten und prüfen (Roadmap-Initiative 2)

### DIFF
--- a/src/renderer/components/Export/ExportDialog.tsx
+++ b/src/renderer/components/Export/ExportDialog.tsx
@@ -17,7 +17,7 @@ import { useDialogA11y } from '../../hooks/useDialogA11y'
 import jsPDF from 'jspdf'
 import { useUiStore } from '../../store/uiStore'
 import { useProjectStore } from '../../store/projectStore'
-import { AlertTriangle, Check } from 'lucide-react'
+import { AlertTriangle, Check, Lightbulb } from 'lucide-react'
 import { useTranslation, format } from '../../lib/i18n'
 import { detectLayerForConnector, type StandardLayer } from '../../lib/cableLayers'
 
@@ -40,13 +40,14 @@ import {
 import { printPdfBlob } from '../../lib/printPdfBlob'
 import { sanitizeForPdf } from '../../lib/sanitizeForPdf'
 import { downloadBlob } from '../../lib/downloadBlob'
+import { buildTallyMap, tallyMapCsv, toTallyPiDevices } from '../../lib/tallyMap'
 import { exportGroupAsPatchPdf, buildGroupPatchPdfBlob } from '../../lib/exportGroupPdf'
 import { buildExportFilenameWithSuffix } from '../../lib/exportFilename'
 import { LayerVisibilityChips } from '../Canvas/LayerVisibilityChips'
 import type { Cable } from '../../types/cable'
 
 export type ExportFormat = 'pdf' | 'png' | 'jpeg' | 'svg' | 'dxf'
-type Section = 'plan' | 'patch' | 'bom' | 'rack'
+type Section = 'plan' | 'patch' | 'bom' | 'rack' | 'tally'
 
 /** v7.9.103 — Page-Size-Optionen fuer den Vektor-PDF-Pfad. */
 export type PdfPageSizeOpt =
@@ -81,6 +82,7 @@ const SECTION_LABEL: Record<Section, string> = {
   patch: 'Patch-Sheets',
   bom: 'Kabel-Stückliste',
   rack: 'Racks & Gruppen',
+  tally: 'Tally-Karte',
 }
 
 const SECTION_ICON: Record<Section, LucideIcon> = {
@@ -88,6 +90,7 @@ const SECTION_ICON: Record<Section, LucideIcon> = {
   patch: CableIcon,
   bom: Calculator,
   rack: Server,
+  tally: Lightbulb,
 }
 
 const SECTION_DESC: Record<Section, string> = {
@@ -95,6 +98,7 @@ const SECTION_DESC: Record<Section, string> = {
   patch: 'Pro Gerät eine Port-Belegungs-Liste — ideal zum Aufkleben am Gerät. Auswahl an Geräten, dann Einzel-PDF, Sammel-PDF oder direkt drucken. Papier-Format wird nach Klick abgefragt. Alternativ: kompakte Patchliste (eine Zeile pro Kabel, sortiert nach Quell-Gerät) für den Techniker im Feld.',
   bom: 'Stückliste aller Kabel im Projekt (Typ + Länge zusammengefasst). Editierbare Rentman-Planung daneben. Export als CSV oder PDF.',
   rack: 'Gespeicherte Racks und Gruppen einzeln als PDF exportieren oder drucken — eine Patch-Seite pro enthaltenem Gerät mit interner Verkabelung.',
+  tally: 'Die Kette Rolle → Gerät → Mischer-Eingang → UMD-Adresse, aus dem Plan abgeleitet und geprüft. Als CSV zum Gegenlesen, als JSON für die tally-pi-Konfiguration. Die Lampe selbst — welcher GPIO-Pin welcher Box — gehört der Hardware und steht bewusst nicht drin.',
 }
 
 export const ExportDialog = ({
@@ -178,6 +182,7 @@ export const ExportDialog = ({
               {section === 'patch' && <PatchSheetSection onClose={onClose} />}
               {section === 'bom' && <BomSection />}
               {section === 'rack' && <RackGroupSection onClose={onClose} />}
+              {section === 'tally' && <TallySection />}
             </div>
           </div>
         </main>
@@ -1238,6 +1243,139 @@ const BomSection = () => {
           title={t('export.bom.osPrint', 'Kabel-Stückliste im OS-Druckdialog öffnen')}
         >
           <span className="inline-flex items-center gap-1"><Icon icon={Printer} size="xs" /> {t('export.printBtn', 'Drucken')}</span>
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// --------------------------------------------------------------------
+// Tally section (Roadmap-Initiative 2)
+//
+// Der Markt plant Tally nicht, er faehrt es nur — die Adress-Zuordnung ist
+// ueberall Handarbeit. Hier steht sie als abgeleitete, pruefbare Tabelle:
+// Rolle → Geraet → Mischer-Eingang → UMD-Adresse. Drei der vier Glieder
+// beantwortet der Plan; das vierte, die Lampe, gehoert der Hardware und wird
+// ausdruecklich NICHT erfunden.
+
+const TallySection = () => {
+  const t = useTranslation()
+  const project = useProjectStore((s) => s.project)
+  const map = useMemo(
+    () =>
+      buildTallyMap({
+        equipment: project.equipment,
+        cables: project.cables,
+        sourceIdentities: project.sourceIdentities,
+      }),
+    [project.equipment, project.cables, project.sourceIdentities],
+  )
+
+  const errors = map.issues.filter((i) => i.severity === 'error')
+  const warnings = map.issues.filter((i) => i.severity === 'warning')
+
+  const downloadCsv = () => {
+    downloadBlob(
+      buildExportFilenameWithSuffix(project.metadata?.name, 'tally', 'csv'),
+      tallyMapCsv(map),
+      'text/csv;charset=utf-8',
+    )
+  }
+  const downloadTallyPi = () => {
+    downloadBlob(
+      buildExportFilenameWithSuffix(project.metadata?.name, 'tally-devices', 'json'),
+      JSON.stringify({ devices: toTallyPiDevices(map) }, null, 2),
+      'application/json',
+    )
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-3">
+      {map.rows.length === 0 ? (
+        <p className="rounded border border-cp-border bg-cp-surface-2 p-3 text-cp-xs text-cp-text-secondary">
+          {t(
+            'export.tally.empty',
+            'Noch keine Signalquellen-Rollen im Plan. Eine Rolle wird am Gerät in den Eigenschaften unter „Signalquelle (Rolle)" vergeben — sie trägt Name, Nummer und UMD-Adresse und überlebt den Gerätetausch.',
+          )}
+        </p>
+      ) : (
+        <div className="min-h-0 flex-1 overflow-auto rounded border border-cp-border">
+          <table className="w-full border-collapse text-cp-xs">
+            <thead className="sticky top-0 bg-cp-surface-3">
+              <tr className="text-left text-cp-text-secondary">
+                <th className="px-2 py-1.5">{t('export.tally.col.no', 'Nr.')}</th>
+                <th className="px-2 py-1.5">{t('export.tally.col.role', 'Rolle')}</th>
+                <th className="px-2 py-1.5">{t('export.tally.col.devices', 'Gerät(e)')}</th>
+                <th className="px-2 py-1.5">{t('export.tally.col.switcher', 'Mischer')}</th>
+                <th className="px-2 py-1.5">{t('export.tally.col.input', 'Eingang')}</th>
+                <th className="px-2 py-1.5">{t('export.tally.col.umd', 'UMD')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {map.rows.map((row) => (
+                <tr key={row.identityId} className="border-t border-cp-border-muted">
+                  <td className="px-2 py-1 font-mono">{row.number ?? ''}</td>
+                  <td className="px-2 py-1">{row.name}</td>
+                  <td className="px-2 py-1 text-cp-text-secondary">
+                    {row.devices.map((d) => d.name).join(' + ') || '—'}
+                  </td>
+                  <td className="px-2 py-1 text-cp-text-secondary">{row.switcher?.name ?? '—'}</td>
+                  <td className="px-2 py-1 font-mono">{row.switcher?.input ?? '—'}</td>
+                  <td
+                    className={`px-2 py-1 font-mono ${
+                      row.umdAddress === undefined ? 'text-cp-warn' : ''
+                    }`}
+                  >
+                    {row.umdAddress ?? '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {map.issues.length > 0 && (
+        <div className="max-h-40 shrink-0 overflow-auto rounded border border-cp-border bg-cp-surface-2 p-2">
+          <p className="mb-1 text-cp-xs font-semibold text-cp-text-secondary">
+            {format(
+              t('export.tally.issues', 'Prüfung: {errors} Fehler, {warnings} Hinweise'),
+              { errors: errors.length, warnings: warnings.length },
+            )}
+          </p>
+          <ul className="flex flex-col gap-0.5 text-cp-xs">
+            {[...errors, ...warnings].map((issue, idx) => (
+              <li
+                key={`${issue.kind}:${issue.subject}:${idx}`}
+                className={issue.severity === 'error' ? 'text-cp-danger' : 'text-cp-warn'}
+              >
+                {issue.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="flex shrink-0 flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={downloadCsv}
+          disabled={map.rows.length === 0}
+          className="rounded bg-sky-700 px-3 py-1.5 text-cp-xs text-white hover:bg-sky-600 disabled:opacity-40"
+        >
+          {t('export.tally.csv', 'Tally-Karte als CSV')}
+        </button>
+        <button
+          type="button"
+          onClick={downloadTallyPi}
+          disabled={map.rows.length === 0}
+          className="rounded border border-cp-border px-3 py-1.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-3 disabled:opacity-40"
+          title={t(
+            'export.tally.piTitle',
+            'Der Teil der tally.json, den der Plan besitzt: id, name, input. ATEM-IP und GPIO-Pins bleiben an der Box.',
+          )}
+        >
+          {t('export.tally.pi', 'tally-pi-Geräte (JSON)')}
         </button>
       </div>
     </div>

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -2148,6 +2148,24 @@ export const en: Dict = {
   'cable.aria.toDevice': 'Target device',
   'cable.aria.toPort': 'Target port',
 
+  // Roadmap-Initiative 2 — Tally-Karte (Export-Hub)
+  'export.section.tally': 'Tally map',
+  'export.desc.tally':
+    'The chain role → device → switcher input → UMD address, derived from the plan and validated. CSV to read over, JSON for the tally-pi configuration. The lamp itself — which GPIO pin on which box — belongs to the hardware and is deliberately not in there.',
+  'export.tally.empty':
+    'No signal-source roles in the plan yet. A role is assigned on the device under "Signal source (role)" in the properties — it carries name, number and UMD address, and outlives the device swap.',
+  'export.tally.col.no': 'No.',
+  'export.tally.col.role': 'Role',
+  'export.tally.col.devices': 'Device(s)',
+  'export.tally.col.switcher': 'Switcher',
+  'export.tally.col.input': 'Input',
+  'export.tally.col.umd': 'UMD',
+  'export.tally.issues': 'Validation: {errors} errors, {warnings} notes',
+  'export.tally.csv': 'Tally map as CSV',
+  'export.tally.pi': 'tally-pi devices (JSON)',
+  'export.tally.piTitle':
+    'The part of tally.json the plan owns: id, name, input. ATEM IP and GPIO pins stay with the box.',
+
   // ADR-001 — Identitaets-Karte (.avsourcemap)
   'app.menu.file.exportSourceMap': 'Export identity map (.avsourcemap)…',
   'app.menu.file.importSourceMap': 'Import identity map (.avsourcemap)…',

--- a/src/renderer/lib/tallyMap.ts
+++ b/src/renderer/lib/tallyMap.ts
@@ -1,0 +1,216 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Roadmap-Initiative 2 — die Tally-Karte aus dem Plan.
+//
+// Der Befund des Tally-Dossiers ist knapp: „Nobody plans tally — they only
+// run it." Adress-Zuordnung ist ueberall Handarbeit, und die woertliche
+// Forderung aus dem Segment lautet: *one authoritative, validated, exportable
+// camera-to-input-to-tally-address-to-lamp map*.
+//
+// Drei der vier Glieder dieser Kette hat der Plan seit ADR-001:
+//   Kamera  → die Rolle (`SourceIdentity`)
+//   Input   → abgeleitet aus dem Kabelgraph (`labelDerivation`)
+//   Adresse → der persistierte Anker (`umdAddress`)
+// Das vierte, die LAMPE, hat er nicht: welcher GPIO-Pin welcher Tally-Box
+// diese Quelle anzeigt, ist eine Verdrahtungs-Entscheidung an der Hardware.
+// Dieses Modul erfindet sie nicht, es nennt sie beim Namen.
+//
+// Deshalb liefert `toTallyPiDevices` genau die Felder, die der Plan besitzt
+// (`id`, `name`, `input`) und laesst `out_gpio`, `out_trigger` und `me` weg,
+// statt Vorgaben zu erfinden: `gpio_watcher.py` setzt fuer `me` selbst die 1
+// ein, und eine erfundene Pin-Nummer waere schlimmer als ein fehlendes Feld —
+// sie sieht aus wie eine Zusage und schaltet die falsche Lampe.
+//
+// Reine Funktionen ueber Plandaten: kein Store, kein React, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { CablePlannerProject } from '../types/project'
+import type { SourceIdentity } from '../types/sourceIdentity'
+import { deriveLabels } from './labelDerivation'
+import { umdAddressClashes } from './sourceIdentity'
+import { toCsv } from './csv'
+
+export interface TallyMapDevice {
+  id: string
+  name: string
+}
+
+export interface TallyMapSwitcher {
+  equipmentId: string
+  name: string
+  /** 1-basierte Eingangsnummer — darueber adressiert der Mischer das Tally. */
+  input: number
+}
+
+export interface TallyMapRow {
+  identityId: string
+  name: string
+  number?: number
+  umdAddress?: number
+  /** Geraete, die die Rolle realisieren (Haupt-/Backup-Paar sind zwei). */
+  devices: TallyMapDevice[]
+  /** Wo die Rolle am Mischer ankommt. Fehlt, wenn nichts verkabelt ist. */
+  switcher?: TallyMapSwitcher
+}
+
+export type TallyIssueKind =
+  | 'no-device'
+  | 'no-switcher-input'
+  | 'no-umd-address'
+  | 'duplicate-address'
+  | 'source-without-role'
+
+export interface TallyIssue {
+  kind: TallyIssueKind
+  severity: 'error' | 'warning'
+  /** Rolle oder Geraet, um das es geht — als Klick-/Sortierschluessel. */
+  subject: string
+  message: string
+}
+
+export interface TallyMap {
+  rows: TallyMapRow[]
+  issues: TallyIssue[]
+}
+
+type TallyProject = Pick<
+  CablePlannerProject,
+  'equipment' | 'cables' | 'sourceIdentities'
+>
+
+/**
+ * Baut die Karte und prueft sie in einem Durchgang.
+ *
+ * Die Befunde bleiben BEWUSST hier und wandern nicht in `runDrawingChecks`:
+ * „Rolle ohne UMD-Adresse" ist nur dann ein Mangel, wenn die Produktion
+ * ueberhaupt Tally faehrt. Im globalen Plan-Check waere es Laerm fuer jeden,
+ * der es nicht tut — und ein Check, der bei jedem Plan meckert, wird
+ * weggeklickt statt gelesen.
+ */
+export const buildTallyMap = (project: TallyProject): TallyMap => {
+  const identities: SourceIdentity[] = project.sourceIdentities ?? []
+  const { sources } = deriveLabels({
+    equipment: project.equipment,
+    cables: project.cables,
+    sourceIdentities: identities,
+  })
+  const eqById = new Map(project.equipment.map((e) => [e.id, e]))
+  const rows: TallyMapRow[] = []
+  const issues: TallyIssue[] = []
+
+  for (const identity of identities) {
+    const devices = project.equipment.filter((e) => e.sourceIdentityId === identity.id)
+    // Der erste Treffer gewinnt: bei einem Haupt-/Backup-Paar haengen beide
+    // Geraete an derselben Rolle, und das Tally folgt dem, was am Mischer
+    // ankommt — nicht dem Blech.
+    const link = sources.find((s) => devices.some((d) => d.id === s.sourceEquipmentId))
+    const sink = link ? eqById.get(link.sinkEquipmentId) : undefined
+
+    const row: TallyMapRow = {
+      identityId: identity.id,
+      name: identity.name,
+      devices: devices.map((d) => ({ id: d.id, name: d.name })),
+    }
+    if (identity.number !== undefined) row.number = identity.number
+    if (identity.umdAddress !== undefined) row.umdAddress = identity.umdAddress
+    if (link && sink) {
+      row.switcher = { equipmentId: sink.id, name: sink.name, input: link.inputIndex }
+    }
+    rows.push(row)
+
+    if (devices.length === 0) {
+      issues.push({
+        kind: 'no-device',
+        severity: 'warning',
+        subject: identity.id,
+        message: `Rolle "${identity.name}" ist an kein Geraet gebunden — es gibt nichts, dessen Tally geschaltet wuerde.`,
+      })
+    } else if (!row.switcher) {
+      issues.push({
+        kind: 'no-switcher-input',
+        severity: 'warning',
+        subject: identity.id,
+        message: `Rolle "${identity.name}" erreicht keinen Mischer-Eingang — ohne Eingang gibt es kein Tally-Signal.`,
+      })
+    }
+    if (identity.umdAddress === undefined) {
+      issues.push({
+        kind: 'no-umd-address',
+        severity: 'warning',
+        subject: identity.id,
+        message: `Rolle "${identity.name}" hat keine UMD-Adresse — das Display bleibt leer.`,
+      })
+    }
+  }
+
+  for (const clash of umdAddressClashes(identities)) {
+    issues.push({
+      kind: 'duplicate-address',
+      severity: 'error',
+      subject: String(clash.address),
+      message: `UMD-Adresse ${clash.address} ist doppelt vergeben: ${clash.identities
+        .map((i) => `"${i.name}"`)
+        .join(', ')}. Beide Displays zeigen denselben Text.`,
+    })
+  }
+
+  // Quellen, die am Mischer ankommen, aber keine Rolle tragen: fuer die kann
+  // die Karte nichts sagen, und das ist der eigentliche Arbeitsvorrat.
+  const boundEquipment = new Set(
+    project.equipment.filter((e) => e.sourceIdentityId).map((e) => e.id),
+  )
+  const reported = new Set<string>()
+  for (const link of sources) {
+    if (boundEquipment.has(link.sourceEquipmentId) || reported.has(link.sourceEquipmentId)) continue
+    reported.add(link.sourceEquipmentId)
+    const source = eqById.get(link.sourceEquipmentId)
+    const sink = eqById.get(link.sinkEquipmentId)
+    if (!source || !sink) continue
+    issues.push({
+      kind: 'source-without-role',
+      severity: 'warning',
+      subject: source.id,
+      message: `"${source.name}" speist ${sink.name} auf Eingang ${link.inputIndex}, traegt aber keine Rolle — ohne Rolle kein Tally-Eintrag.`,
+    })
+  }
+
+  rows.sort((a, b) => {
+    const an = a.number ?? Number.MAX_SAFE_INTEGER
+    const bn = b.number ?? Number.MAX_SAFE_INTEGER
+    return an - bn || a.name.localeCompare(b.name, 'de')
+  })
+  return { rows, issues }
+}
+
+/** Die Karte als reviewbare Tabelle — was auf Papier oder in Excel landet. */
+export const tallyMapCsv = (map: TallyMap): string =>
+  toCsv(
+    ['Nr.', 'Rolle', 'Geraet(e)', 'Mischer', 'Eingang', 'UMD-Adresse'],
+    map.rows.map((r) => [
+      r.number ?? '',
+      r.name,
+      r.devices.map((d) => d.name).join(' + '),
+      r.switcher?.name ?? '',
+      r.switcher?.input ?? '',
+      r.umdAddress ?? '',
+    ]),
+  )
+
+export interface TallyPiDevice {
+  id: string
+  name: string
+  input: number
+}
+
+/**
+ * Der Teil der `tally.json` von `tally-pi`, den der Plan besitzt.
+ *
+ * Zeilen ohne Mischer-Eingang fallen raus — ein Tally-Eintrag ohne Eingang
+ * hat nichts, worauf er hoeren koennte. `id` ist die Rollen-Id und damit
+ * stabil ueber Geraetetausch hinweg: Wer die Datei spaeter neu erzeugt,
+ * trifft dieselben Eintraege wieder und verliert die Hardware-Verdrahtung
+ * nicht, die an dieser Id haengt.
+ */
+export const toTallyPiDevices = (map: TallyMap): TallyPiDevice[] =>
+  map.rows
+    .filter((r) => r.switcher !== undefined)
+    .map((r) => ({ id: r.identityId, name: r.name, input: r.switcher!.input }))

--- a/tests/tallyMap.test.ts
+++ b/tests/tallyMap.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest'
+import { buildTallyMap, tallyMapCsv, toTallyPiDevices } from '../src/renderer/lib/tallyMap'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem, Port } from '../src/renderer/types/equipment'
+
+const port = (id: string, name: string, over: Partial<Port> = {}): Port => ({
+  id,
+  name,
+  type: 'BNC',
+  connectorType: 'BNC',
+  ...over,
+})
+
+const eq = (over: Partial<EquipmentItem>): EquipmentItem => ({
+  id: 'e1',
+  name: 'Gerät',
+  category: 'Video',
+  inputs: [],
+  outputs: [],
+  x: 0,
+  y: 0,
+  width: 200,
+  height: 160,
+  ...over,
+})
+
+const cable = (from: [string, string], to: [string, string]): Cable => ({
+  id: `${from[1]}->${to[1]}`,
+  name: `${from[1]}->${to[1]}`,
+  type: 'BNC',
+  length: 10,
+  color: '#fff',
+  fromEquipmentId: from[0],
+  fromPortId: from[1],
+  toEquipmentId: to[0],
+  toPortId: to[1],
+  notes: '',
+})
+
+const cam = (id: string, name: string, over: Partial<EquipmentItem> = {}) =>
+  eq({ id, name, category: 'Kameras', outputs: [port(`${id}-out`, 'SDI Out')], ...over })
+
+/** Zwei Kameras mit Rollen an einem ATEM. */
+const scene = () => ({
+  equipment: [
+    eq({
+      id: 'atem',
+      name: 'ATEM Mini Extreme',
+      inputs: [port('in1', 'In 1'), port('in2', 'In 2')],
+    }),
+    cam('cam1', 'URSA A', { sourceIdentityId: 'r1' }),
+    cam('cam2', 'URSA B', { sourceIdentityId: 'r2' }),
+  ],
+  cables: [
+    cable(['cam1', 'cam1-out'], ['atem', 'in1']),
+    cable(['cam2', 'cam2-out'], ['atem', 'in2']),
+  ],
+  sourceIdentities: [
+    { id: 'r1', name: 'Kamera 1', number: 1, umdAddress: 1 },
+    { id: 'r2', name: 'Kamera 2', number: 2, umdAddress: 2 },
+  ],
+})
+
+describe('buildTallyMap', () => {
+  it('schliesst die Kette Rolle → Gerät → Eingang → Adresse', () => {
+    const { rows, issues } = buildTallyMap(scene())
+    expect(issues).toEqual([])
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toMatchObject({
+      identityId: 'r1',
+      name: 'Kamera 1',
+      number: 1,
+      umdAddress: 1,
+      switcher: { equipmentId: 'atem', name: 'ATEM Mini Extreme', input: 1 },
+    })
+    expect(rows[0].devices).toEqual([{ id: 'cam1', name: 'URSA A' }])
+  })
+
+  it('sortiert nach redaktioneller Nummer, nicht nach Anlege-Reihenfolge', () => {
+    const s = scene()
+    s.sourceIdentities = [
+      { id: 'r2', name: 'Kamera 2', number: 2, umdAddress: 2 },
+      { id: 'r1', name: 'Kamera 1', number: 1, umdAddress: 1 },
+    ]
+    expect(buildTallyMap(s).rows.map((r) => r.name)).toEqual(['Kamera 1', 'Kamera 2'])
+  })
+
+  it('führt ein Haupt-/Backup-Paar als EINE Zeile mit zwei Geräten', () => {
+    const s = scene()
+    s.equipment.push(cam('cam1b', 'URSA A (Havarie)', { sourceIdentityId: 'r1' }))
+    const row = buildTallyMap(s).rows.find((r) => r.identityId === 'r1')
+    expect(row?.devices.map((d) => d.name)).toEqual(['URSA A', 'URSA A (Havarie)'])
+    // Das Tally folgt dem, was am Mischer ankommt — die Zeile bleibt eine.
+    expect(row?.switcher?.input).toBe(1)
+  })
+
+  it('meldet eine Rolle ohne Gerät', () => {
+    const s = scene()
+    s.sourceIdentities.push({ id: 'r3', name: 'Kamera 3' })
+    const kinds = buildTallyMap(s).issues.filter((i) => i.subject === 'r3').map((i) => i.kind)
+    expect(kinds).toContain('no-device')
+    expect(kinds).toContain('no-umd-address')
+  })
+
+  it('meldet eine Rolle, die keinen Mischer-Eingang erreicht', () => {
+    const s = scene()
+    s.cables = [s.cables[0]]
+    const issue = buildTallyMap(s).issues.find((i) => i.kind === 'no-switcher-input')
+    expect(issue?.subject).toBe('r2')
+    expect(issue?.severity).toBe('warning')
+  })
+
+  it('meldet eine doppelte UMD-Adresse als Fehler', () => {
+    const s = scene()
+    s.sourceIdentities[1].umdAddress = 1
+    const issue = buildTallyMap(s).issues.find((i) => i.kind === 'duplicate-address')
+    expect(issue?.severity).toBe('error')
+    expect(issue?.message).toContain('"Kamera 1"')
+    expect(issue?.message).toContain('"Kamera 2"')
+  })
+
+  it('meldet eine Quelle am Mischer, die keine Rolle trägt', () => {
+    const s = scene()
+    s.equipment[2].sourceIdentityId = undefined
+    s.sourceIdentities = [s.sourceIdentities[0]]
+    const issue = buildTallyMap(s).issues.find((i) => i.kind === 'source-without-role')
+    expect(issue?.subject).toBe('cam2')
+    expect(issue?.message).toContain('Eingang 2')
+  })
+
+  it('meldet dieselbe rollenlose Quelle nur einmal, auch bei Doppelspeisung', () => {
+    const s = scene()
+    s.equipment[2].sourceIdentityId = undefined
+    s.sourceIdentities = [s.sourceIdentities[0]]
+    s.equipment[1].outputs.push(port('cam1-out2', 'SDI Out 2'))
+    const found = buildTallyMap(s).issues.filter((i) => i.kind === 'source-without-role')
+    expect(found).toHaveLength(1)
+  })
+
+  it('bleibt bei einem Plan ohne Rollen leer statt zu raten', () => {
+    const map = buildTallyMap({ equipment: [], cables: [], sourceIdentities: [] })
+    expect(map.rows).toEqual([])
+    expect(map.issues).toEqual([])
+  })
+})
+
+describe('toTallyPiDevices', () => {
+  it('liefert genau die Felder, die der Plan besitzt', () => {
+    const devices = toTallyPiDevices(buildTallyMap(scene()))
+    expect(devices).toEqual([
+      { id: 'r1', name: 'Kamera 1', input: 1 },
+      { id: 'r2', name: 'Kamera 2', input: 2 },
+    ])
+  })
+
+  it('erfindet weder GPIO-Pin noch ME — die gehören der Hardware', () => {
+    const [first] = toTallyPiDevices(buildTallyMap(scene()))
+    expect(Object.keys(first).sort()).toEqual(['id', 'input', 'name'])
+  })
+
+  it('lässt Zeilen ohne Eingang weg — die hätten nichts zu hören', () => {
+    const s = scene()
+    s.cables = []
+    expect(toTallyPiDevices(buildTallyMap(s))).toEqual([])
+  })
+
+  it('nutzt die Rollen-Id, damit die Hardware-Verdrahtung Gerätetausch überlebt', () => {
+    const s = scene()
+    s.equipment[1] = cam('cam1-neu', 'URSA C', { sourceIdentityId: 'r1' })
+    s.cables[0] = cable(['cam1-neu', 'cam1-neu-out'], ['atem', 'in1'])
+    const devices = toTallyPiDevices(buildTallyMap(s))
+    expect(devices.find((d) => d.id === 'r1')).toMatchObject({ name: 'Kamera 1', input: 1 })
+  })
+})
+
+describe('tallyMapCsv', () => {
+  it('schreibt eine Kopfzeile und eine Zeile je Rolle', () => {
+    const csv = tallyMapCsv(buildTallyMap(scene()))
+    const lines = csv.split('\r\n')
+    expect(lines[0]).toContain('UMD-Adresse')
+    expect(lines).toHaveLength(3)
+    expect(lines[1]).toContain('Kamera 1')
+    expect(lines[1]).toContain('ATEM Mini Extreme')
+  })
+
+  it('lässt fehlende Werte leer, statt sie zu erfinden', () => {
+    const s = scene()
+    s.sourceIdentities = [{ id: 'r1', name: 'Kamera 1' }]
+    s.equipment[2].sourceIdentityId = undefined
+    const cells = tallyMapCsv(buildTallyMap(s)).split('\r\n')[1].split(';')
+    expect(cells[0]).toBe('') // keine Nummer
+    expect(cells[5]).toBe('') // keine UMD-Adresse
+    expect(cells[4]).toBe('1') // der Eingang steht sehr wohl da
+  })
+})


### PR DESCRIPTION
Initiative 2 der Roadmap (Score 24, nach der abgeschlossenen Identitäts-Spine die höchste). Der Befund des Tally-Dossiers ist knapp: **„Nobody plans tally — they only run it"** — Adress-Zuordnung ist überall Handarbeit außer bei NDI. Die wörtliche Forderung aus dem Segment lautet: *one authoritative, validated, exportable camera-to-input-to-tally-address-to-lamp map*.

Drei der vier Glieder dieser Kette hat der Plan seit ADR-001:

| Glied | woher |
| --- | --- |
| Kamera | die Rolle (`SourceIdentity`, Inkrement 2) |
| Input | abgeleitet aus dem Kabelgraph (`labelDerivation`, Inkrement 1) |
| Tally-Adresse | der persistierte Anker `umdAddress` |
| **Lampe** | **hat er nicht** — siehe unten |

## Was neu ist

`lib/tallyMap.ts` setzt die Kette zusammen und prüft sie im selben Durchgang. Reine Funktionen über Plandaten: kein Store, kein React, kein IO — 15 Vitest-Fälle.

Geprüft wird, was die Karte unbrauchbar macht: eine Rolle ohne Gerät, eine Rolle, die keinen Mischer-Eingang erreicht, eine Rolle ohne UMD-Adresse, zwei Rollen auf derselben Adresse (Fehler), und — der eigentliche Arbeitsvorrat — eine Quelle, die am Mischer ankommt, aber keine Rolle trägt.

Im Export-Hub gibt es dafür eine eigene Sektion mit der Tabelle, den Befunden und zwei Exporten: **CSV** zum Gegenlesen auf Papier und **`tally-pi`-Gerätedatei** als JSON.

## Die Lampe wird nicht erfunden

Das ist die tragende Entscheidung. `toTallyPiDevices` liefert genau die Felder, die der Plan besitzt — `id`, `name`, `input` — und lässt `out_gpio`, `out_trigger` und `me` weg. Welcher GPIO-Pin welcher Box diese Quelle anzeigt, ist eine Verdrahtungs-Entscheidung an der Hardware; `gpio_watcher.py` setzt für `me` ohnehin selbst die 1 ein. Eine geratene Pin-Nummer wäre schlimmer als ein fehlendes Feld: Sie sieht aus wie eine Zusage und schaltet die falsche Lampe.

Dieselbe Disziplin wie beim `.avsourcemap`-Import — nur ausgeben, was man wirklich weiß, und den Rest beim Namen nennen.

## Zwei Details, die aus der Domäne kommen

**Ein Haupt-/Backup-Paar bleibt EINE Zeile.** Beide Geräte hängen an derselben Rolle, und das Tally folgt dem, was am Mischer ankommt — nicht dem Blech. Die Zeile listet beide Geräte und einen Eingang.

**Die `tally-pi`-`id` ist die Rollen-Id**, nicht die Geräte-Id. Damit trifft eine später neu erzeugte Datei dieselben Einträge wieder, und die Hardware-Verdrahtung, die an dieser Id hängt, überlebt den Gerätetausch. Ein Test hält genau das fest.

## Warum die Befunde nicht in den globalen Plan-Check wandern

„Rolle ohne UMD-Adresse" ist nur dann ein Mangel, wenn die Produktion überhaupt Tally fährt. Im `PlanCheckPanel` wäre es Lärm für jeden, der es nicht tut — und ein Check, der bei jedem Plan meckert, wird weggeklickt statt gelesen. Die doppelte UMD-Adresse steht weiterhin auch dort, weil sie unabhängig vom Tally-Betrieb falsch ist.

## Prüfung

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 348 Tests, 35 Dateien, alle grün (+15 neue)
- `npm run lint` — 0 Fehler (10 vorbestehende Warnungen)
- `npm run build` — grün

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_