### PR TITLE
inventory: deviceTypeId als gemeinsamer Schlüssel Plan ↔ Lager, Contract v2 (ADR-002)

### DIFF
--- a/src/renderer/lib/inventoryPortable.ts
+++ b/src/renderer/lib/inventoryPortable.ts
@@ -10,7 +10,12 @@
 import type { InventoryItem, StorageNode, InventorySet, InventoryUnit } from '../types/inventory'
 
 export const INVENTORY_FORMAT = 'avplan-inventory'
-export const INVENTORY_FORMAT_VERSION = 1
+// Version 2 (ADR-002): `InventoryItem.deviceTypeId`. Die Erhoehung ist kein
+// Formalismus — `inventoryStore.healItem` baut jeden Artikel Feld fuer Feld
+// neu auf, ein Stand ohne dieses Feld wuerde es beim Re-Export also STILL
+// verlieren. Mit der Version weigert er sich stattdessen (siehe unten:
+// `f.version > INVENTORY_FORMAT_VERSION`). Aeltere Dateien lesen wir weiter.
+export const INVENTORY_FORMAT_VERSION = 2
 
 export interface InventorySnapshot {
   items: InventoryItem[]

--- a/src/renderer/store/inventoryStore.ts
+++ b/src/renderer/store/inventoryStore.ts
@@ -77,6 +77,10 @@ const healItem = (raw: unknown): InventoryItem | null => {
     model: r.model,
     manufacturer: typeof r.manufacturer === 'string' ? r.manufacturer : undefined,
     category: typeof r.category === 'string' ? r.category : undefined,
+    // ADR-002 — die Typ-Identitaet muss die Heilung ueberleben; genau hier
+    // ginge sie sonst still verloren.
+    deviceTypeId:
+      typeof r.deviceTypeId === 'string' && r.deviceTypeId.trim() ? r.deviceTypeId : undefined,
     quantity: typeof r.quantity === 'number' && r.quantity >= 0 ? Math.round(r.quantity) : 0,
     rentPricePerDay:
       typeof r.rentPricePerDay === 'number' && r.rentPricePerDay >= 0 ? r.rentPricePerDay : undefined,

--- a/src/renderer/types/inventory.ts
+++ b/src/renderer/types/inventory.ts
@@ -42,6 +42,18 @@ export interface InventoryItem {
   manufacturer?: string
   /** Kategorie (gleiche Taxonomie wie `EquipmentItem.category`). */
   category?: string
+  /**
+   * ADR-002 — stabile Geraetetyp-Identitaet, dieselbe GUID wie
+   * `EquipmentItem.deviceTypeId` (Katalog-Register). Ist sie gesetzt, ist die
+   * Zuordnung Plan-Geraet -> Lager-Position eine Tatsache statt eines
+   * Namensvergleichs.
+   *
+   * Optional, weil ein Lager mehr enthaelt als der Katalog kennt. Fehlt sie,
+   * darf der Bedarfs-Resolver einen Vorschlag machen — aber nur als
+   * Vorschlag, den ein Mensch bestaetigt; die Bestaetigung wird dann hier
+   * festgeschrieben und muss nie wieder geraten werden.
+   */
+  deviceTypeId?: string
   /** Gesamtmenge im Bestand. */
   quantity: number
   /** Mietpreis pro Tag (Kalkulation, Phase 5). */

--- a/tests/inventoryContract.test.ts
+++ b/tests/inventoryContract.test.ts
@@ -26,9 +26,9 @@ import type { InventoryItem, StorageNode, InventorySet, InventoryUnit } from '..
 // Eingefrorener Contract — MUSS in allen drei Repos identisch sein.
 const CONTRACT = {
   format: 'avplan-inventory',
-  version: 1,
+  version: 2,
   envelopeKeys: ['app', 'exportedAt', 'format', 'items', 'nodes', 'sets', 'units', 'version'],
-  itemKeys: ['category', 'code', 'codeType', 'createdAt', 'dimensions', 'id', 'locationId', 'manufacturer', 'materialKinds', 'model', 'notes', 'ownership', 'quantity', 'rentPricePerDay', 'stockLocation', 'supplier', 'updatedAt'],
+  itemKeys: ['category', 'code', 'codeType', 'createdAt', 'deviceTypeId', 'dimensions', 'id', 'locationId', 'manufacturer', 'materialKinds', 'model', 'notes', 'ownership', 'quantity', 'rentPricePerDay', 'stockLocation', 'supplier', 'updatedAt'],
   nodeKeys: ['code', 'codeType', 'createdAt', 'dimensions', 'id', 'kind', 'name', 'notes', 'parentId', 'updatedAt'],
   setKeys: ['components', 'createdAt', 'id', 'name', 'notes', 'updatedAt'],
   unitKeys: ['code', 'codeType', 'condition', 'createdAt', 'history', 'id', 'itemId', 'locationId', 'notes', 'serial', 'updatedAt'],
@@ -39,7 +39,7 @@ const CONTRACT = {
 const item: InventoryItem = {
   id: 'i1', model: 'ULXD2', manufacturer: 'Shure', category: 'wireless', quantity: 4,
   rentPricePerDay: 25, stockLocation: 'Regal A3', supplier: 'AV GmbH', ownership: 'owned',
-  code: 'ITM-1', codeType: 'qr', locationId: 'n1',
+  code: 'ITM-1', codeType: 'qr', locationId: 'n1', deviceTypeId: 'dt-0001',
   dimensions: { widthMm: 50, heightMm: 20, depthMm: 200, weightKg: 0.3 },
   materialKinds: ['rental'], notes: 'x', createdAt: 't', updatedAt: 't',
 }

--- a/tests/inventoryPortable.test.ts
+++ b/tests/inventoryPortable.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, beforeEach } from 'vitest'
-import { serializeInventory, parseInventory, INVENTORY_FORMAT } from '../src/renderer/lib/inventoryPortable'
+import {
+  serializeInventory,
+  parseInventory,
+  INVENTORY_FORMAT,
+  INVENTORY_FORMAT_VERSION,
+} from '../src/renderer/lib/inventoryPortable'
 import { useInventoryStore } from '../src/renderer/store/inventoryStore'
 
 const reset = () => {
@@ -73,5 +78,56 @@ describe('inventoryStore — Import/Export', () => {
     const st = useInventoryStore.getState()
     const n = st.importSnapshot({ items: [{ id: 'x', quantity: 1 } as unknown] }, 'replace')
     expect(n).toBe(0) // model fehlt → geheilt-verworfen
+  })
+})
+
+describe('avplan-inventory — Versionsverhalten (ADR-002)', () => {
+  const file = (version: number, extra: Record<string, unknown> = {}) =>
+    JSON.stringify({
+      format: 'avplan-inventory',
+      version,
+      app: 'cable-planner',
+      exportedAt: 't',
+      items: [{ id: 'i1', model: 'ULXD2', quantity: 1, ...extra }],
+      nodes: [],
+      sets: [],
+      units: [],
+    })
+
+  it('liest ältere Dateien unverändert weiter', () => {
+    const snap = parseInventory(file(1))
+    expect(snap?.items).toHaveLength(1)
+    expect(snap?.items[0].model).toBe('ULXD2')
+  })
+
+  it('weigert sich bei einer neueren Version, statt Felder zu verlieren', () => {
+    // Der Kern der Versionserhöhung: ein Stand, der deviceTypeId nicht kennt,
+    // würde es beim Re-Export still wegwerfen (healItem baut Feld für Feld
+    // neu auf). Eine Weigerung ist der ehrlichere Fehler.
+    expect(parseInventory(file(INVENTORY_FORMAT_VERSION + 1))).toBeNull()
+  })
+
+  it('trägt deviceTypeId durch den Roundtrip', () => {
+    const snap = parseInventory(
+      serializeInventory(
+        {
+          items: [
+            {
+              id: 'i1',
+              model: 'ULXD2',
+              quantity: 1,
+              deviceTypeId: 'dt-0001',
+              createdAt: 't',
+              updatedAt: 't',
+            },
+          ],
+          nodes: [],
+          sets: [],
+          units: [],
+        },
+        'cable-planner',
+      ),
+    )
+    expect(snap?.items[0].deviceTypeId).toBe('dt-0001')
   })
 })

--- a/tests/inventoryStore.test.ts
+++ b/tests/inventoryStore.test.ts
@@ -73,3 +73,27 @@ describe('inventoryStore — LPN-Baum', () => {
     expect(raw.items.find((i: { id: string }) => i.id === itemId).locationId).toBe(caseId)
   })
 })
+
+describe('inventoryStore — Typ-Identität (ADR-002)', () => {
+  beforeEach(reset)
+
+  it('trägt deviceTypeId durch die Heilung', () => {
+    // Genau hier ginge das Feld sonst verloren: healItem baut den Artikel
+    // Feld für Feld neu auf, unbekannte Schlüssel fallen weg.
+    const st = useInventoryStore.getState()
+    st.importSnapshot(
+      { items: [{ id: 'i1', model: 'ULXD2', quantity: 2, deviceTypeId: 'dt-0001' } as never] },
+      'replace',
+    )
+    expect(useInventoryStore.getState().items[0].deviceTypeId).toBe('dt-0001')
+  })
+
+  it('verwirft eine leere Typ-Identität, statt sie als Schlüssel zu führen', () => {
+    const st = useInventoryStore.getState()
+    st.importSnapshot(
+      { items: [{ id: 'i1', model: 'ULXD2', quantity: 1, deviceTypeId: '  ' } as never] },
+      'replace',
+    )
+    expect(useInventoryStore.getState().items[0].deviceTypeId).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Inkrement 1 aus [ADR-002](https://github.com/larszu/av-planner-suite/pull/20). Roadmap-Initiative 3 verlangt, dass der technische Plan die Stückliste und die Kommissionier-Liste **erzeugt** — die Recherche nennt das „the single largest unclaimed piece of value adjacent to the segment", und jedes Rental-ERP der Feature-Matrix steht dort auf `no`.

## Warum das nötig ist

Dafür braucht es genau eine Verbindung: welche Lager-Position deckt dieses Plan-Gerät? Die gibt es nicht — und die einzige vorhandene Brücke macht es aktiv falsch. `inventoryStore.seedFromEquipment` verbindet über `dedupeKey(model, category)`, wobei `model` der **Instanzname** des Geräts ist:

```ts
const model = (eq.name ?? '').trim()
const key = dedupeKey(model, eq.category)
```

„Kamera 1" und „Kamera 2" sind zwei Schlüssel, also entstehen **zwei Lager-Positionen à 1 Stück** für ein Modell mit Menge 2. Zurückverlinkt wird nichts, also kann später niemand feststellen, welche Position welches Gerät gedeckt hat.

Dass der Fehler entsteht, ist strukturell: `EquipmentItem` hat gar kein `model`-Feld. Was für ein Modell dahintersteht, sagt allein die optionale `deviceTypeId` — die stabile Datenblatt-GUID aus dem Katalog-Register mit 444 Einträgen. `InventoryItem` trug sie nicht.

## Was sich ändert

`InventoryItem` trägt jetzt dieselbe GUID. Optional, weil ein Lager mehr enthält, als der Katalog kennt — fehlt sie, darf der Bedarfs-Resolver (Inkrement 2) einen Vorschlag machen, aber nur als Vorschlag, den ein Mensch bestätigt.

`healItem` trägt das Feld durch. Das ist kein Detail: Die Funktion baut jeden Artikel **Feld für Feld** neu auf, hier wäre der Schlüssel sonst still verschwunden. Ein Test hält genau das fest, ein zweiter, dass eine leere Identität verworfen statt als Schlüssel geführt wird.

## Warum die Formatversion steigt

Nicht aus Konvention — der Contract-Test verlangt es zwar, aber mit dem Zusatz „Abwärtskompatibilität beachten", also ist es eine Entscheidung.

Naheliegend wäre, sie **wegzulassen**: Das Feld ist additiv und optional, und `parseInventory` reicht unbekannte Schlüssel durch. Ein Blick in `healItem` zeigt, warum das falsch wäre. Ein Stand, der `deviceTypeId` nicht kennt, würde eine Datei damit anstandslos importieren und beim nächsten Export **still ohne das Feld** zurückschreiben. Mit der Versionserhöhung greift `f.version > INVENTORY_FORMAT_VERSION` und der alte Stand **weigert sich** — dieselbe Regel wie überall in dieser Arbeit: ein Import, der ein Feld nicht erhalten kann, muss sich weigern, statt es zu verlieren.

In der Richtung, auf die es ankommt, ändert sich nichts: Ein neuer Stand liest v1-Dateien unverändert weiter. Beide Richtungen sind jetzt als Test festgehalten.

## Die Schwester-PRs

Der Contract ist in allen drei Planern byte-identisch dupliziert, damit ein Lager app-übergreifend importierbar bleibt. Die Änderung läuft überall gleich:

- [larszu/multicam-planner#77](https://github.com/larszu/multicam-planner/pull/77)
- [larszu/light-planner#43](https://github.com/larszu/light-planner/pull/43)
- [larszu/av-planner-suite#20](https://github.com/larszu/av-planner-suite/pull/20) — `@avplan/inventory-core` plus die vendorten Kopien

## Prüfung

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 353 Tests, 35 Dateien, alle grün (+5 neue)
- `npm run lint` — 0 Fehler (10 vorbestehende Warnungen)
- `npm run build` — grün

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_