### PR TITLE
inventory: Bedarfs-Resolver mit drei Ausgängen + Seed über den Typ (ADR-002, Inkremente 2 und 3)

### DIFF
--- a/src/renderer/lib/inventoryCoverage.ts
+++ b/src/renderer/lib/inventoryCoverage.ts
@@ -1,0 +1,208 @@
+// ───────────────────────────────────────────────────────────────────────────
+// ADR-002, Inkrement 2 — der Bedarfs-Resolver.
+//
+// Beantwortet aus Plan und Lager allein: welche Lager-Position deckt diesen
+// Bedarf? Reine Funktionen ueber Daten — kein Store, kein React, kein IO.
+//
+// DREI AUSGAENGE, NIE ZWEI. Das ist die tragende Regel dieses Moduls:
+//
+//   matched-by-type   Tatsache. Beide Seiten tragen dieselbe Katalog-GUID.
+//   proposed-by-name  VORSCHLAG. Die Namen passen, die Identitaet fehlt.
+//                     Wartet auf eine menschliche Bestaetigung und darf
+//                     nirgends wie eine Deckung aussehen.
+//   unmatched         Im Lager nicht gefunden.
+//
+// Ein Fuzzy-Match ueber Modellnamen waere schnell gebaut und meistens
+// richtig. Genau das ist das Problem: Eine Kommissionier-Liste, die in neun
+// von zehn Faellen stimmt, ist im Lager schlimmer als gar keine — sie wird
+// nicht mehr gelesen, sondern geglaubt, und der zehnte Fall kommt als
+// fehlendes Geraet am Aufbautag heraus. Deshalb wird ein Namenstreffer nie
+// zur Deckung befoerdert, sondern bleibt Vorschlag mit Begruendung.
+//
+// WAS DER BEDARF IST. Nicht „Kamera 1" — das ist der Instanzname eines
+// Geraets. Der Bedarf ist der TYP, gezaehlt: dreimal „Blackmagic URSA
+// Broadcast G2". Wo der Plan eine `deviceTypeId` traegt, kommt der
+// Modellname aus dem Katalog; wo nicht, bleibt nur der Geraetename, und
+// dann ist `unmatched` meist die ehrliche Antwort. Der Ausweg ist, dem
+// Geraet einen Katalog-Typ zu geben — nicht, den Namen besser zu raten.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { EquipmentItem } from '../types/equipment'
+import type { InventoryItem } from '../types/inventory'
+import { resolveDeviceType } from './deviceTypeRegistry'
+import { isWithinDistance } from './levenshtein'
+
+export type CoverageOutcome = 'matched-by-type' | 'proposed-by-name' | 'unmatched'
+
+export interface DemandLine {
+  /** Stabiler Schluessel der Zeile — Typ-Id, sonst der normalisierte Name. */
+  key: string
+  /** Katalog-GUID, wenn der Plan sie kennt. */
+  deviceTypeId?: string
+  /** Modellname aus dem Katalog, sonst der Geraetename. */
+  label: string
+  category?: string
+  quantity: number
+  /** Die Plan-Geraete, die diese Zeile ausmachen. */
+  equipmentIds: string[]
+  /** true, wenn `label` nur der Instanzname ist — dann ist er als
+   *  Modellbezeichnung wenig wert, und die UI soll das zeigen koennen. */
+  labelIsDeviceName: boolean
+}
+
+export interface CoverageLine {
+  demand: DemandLine
+  outcome: CoverageOutcome
+  /** Deckende bzw. VORGESCHLAGENE Lager-Position. */
+  itemId?: string
+  itemModel?: string
+  /** Bestand dieser Position. */
+  available?: number
+  /** Fehlmenge, wenn der Bestand nicht reicht. Nur bei matched aussagekraeftig:
+   *  bei einem Vorschlag ist noch gar nicht sicher, dass es die Position ist. */
+  short?: number
+  /** Warum der Vorschlag zustande kam — damit ein Mensch ihn pruefen kann. */
+  reason?: string
+}
+
+export interface CoverageResult {
+  lines: CoverageLine[]
+  matched: number
+  proposed: number
+  unmatched: number
+}
+
+/** Vergleichsform fuer Namen: Kleinschreibung, Whitespace zusammengefasst. */
+export const normaliseName = (raw: string): string =>
+  raw.trim().toLowerCase().replace(/\s+/g, ' ')
+
+/**
+ * Ab welcher Laenge ein Namensvergleich ueberhaupt etwas aussagt, und wie
+ * viele Zeichen Abstand noch als „derselbe Artikel, anders getippt" durchgehen.
+ * Bewusst streng: ein Vorschlag, der oft danebenliegt, macht die Liste
+ * unbrauchbarer als gar keine Vorschlaege.
+ */
+const MIN_NAME_LENGTH = 4
+const MAX_EDIT_DISTANCE = 2
+
+/**
+ * Zaehlt den Plan zu Bedarfszeilen zusammen.
+ *
+ * Gruppiert wird ueber die `deviceTypeId`, wo sie da ist — genau das behebt
+ * den Fehler, den `seedFromEquipment` heute macht: „Kamera 1" und „Kamera 2"
+ * sind dort zwei Schluessel und werden zu zwei Positionen a 1 Stueck, obwohl
+ * es ein Modell mit Menge 2 ist.
+ */
+export const deriveDemand = (equipment: EquipmentItem[]): DemandLine[] => {
+  const byKey = new Map<string, DemandLine>()
+  for (const eq of equipment) {
+    const type = resolveDeviceType(eq.deviceTypeId)
+    const label = type?.template.name?.trim() || eq.name.trim()
+    if (!label) continue
+    const key = eq.deviceTypeId ?? `name:${normaliseName(label)}|${normaliseName(eq.category ?? '')}`
+    const existing = byKey.get(key)
+    if (existing) {
+      existing.quantity += 1
+      existing.equipmentIds.push(eq.id)
+      continue
+    }
+    byKey.set(key, {
+      key,
+      ...(eq.deviceTypeId ? { deviceTypeId: eq.deviceTypeId } : {}),
+      label,
+      ...(eq.category ? { category: eq.category } : {}),
+      quantity: 1,
+      equipmentIds: [eq.id],
+      labelIsDeviceName: !type,
+    })
+  }
+  return [...byKey.values()].sort((a, b) => a.label.localeCompare(b.label, 'de'))
+}
+
+/**
+ * Deckt jede Bedarfszeile gegen den Lagerbestand ab.
+ *
+ * Reihenfolge der Versuche — und die Reihenfolge ist die Aussage:
+ *   1. gleiche Katalog-GUID   -> Tatsache
+ *   2. gleicher Modellname    -> Vorschlag
+ *   3. Modellname fast gleich -> Vorschlag, mit dem Abstand als Begruendung
+ *   4. sonst                  -> unmatched
+ *
+ * Schritt 2 und 3 laufen nur gegen Positionen OHNE eigene Typ-Identitaet:
+ * Traegt eine Position bereits eine andere GUID, ist sie ein anderer Typ, und
+ * ein Namenstreffer waere dann keine Information, sondern ein Widerspruch.
+ */
+export const resolveCoverage = (
+  equipment: EquipmentItem[],
+  items: InventoryItem[],
+): CoverageResult => {
+  const demands = deriveDemand(equipment)
+  const byType = new Map<string, InventoryItem>()
+  for (const item of items) {
+    if (item.deviceTypeId && !byType.has(item.deviceTypeId)) byType.set(item.deviceTypeId, item)
+  }
+  const untyped = items.filter((i) => !i.deviceTypeId)
+  const byModel = new Map<string, InventoryItem>()
+  for (const item of untyped) {
+    const key = normaliseName(item.model)
+    if (key && !byModel.has(key)) byModel.set(key, item)
+  }
+
+  const lines: CoverageLine[] = demands.map((demand) => {
+    const exactType = demand.deviceTypeId ? byType.get(demand.deviceTypeId) : undefined
+    if (exactType) {
+      const short = Math.max(0, demand.quantity - exactType.quantity)
+      return {
+        demand,
+        outcome: 'matched-by-type',
+        itemId: exactType.id,
+        itemModel: exactType.model,
+        available: exactType.quantity,
+        ...(short > 0 ? { short } : {}),
+      }
+    }
+
+    const wanted = normaliseName(demand.label)
+    const exactName = wanted ? byModel.get(wanted) : undefined
+    if (exactName) {
+      return {
+        demand,
+        outcome: 'proposed-by-name',
+        itemId: exactName.id,
+        itemModel: exactName.model,
+        available: exactName.quantity,
+        reason: `Modellname stimmt ueberein ("${exactName.model}"), aber die Lager-Position traegt keine Typ-Identitaet.`,
+      }
+    }
+
+    if (wanted.length >= MIN_NAME_LENGTH) {
+      const near = untyped.find((item) => {
+        const model = normaliseName(item.model)
+        return (
+          model.length >= MIN_NAME_LENGTH &&
+          model !== wanted &&
+          isWithinDistance(model, wanted, MAX_EDIT_DISTANCE)
+        )
+      })
+      if (near) {
+        return {
+          demand,
+          outcome: 'proposed-by-name',
+          itemId: near.id,
+          itemModel: near.model,
+          available: near.quantity,
+          reason: `Modellname weicht um hoechstens ${MAX_EDIT_DISTANCE} Zeichen ab ("${near.model}") — bitte pruefen.`,
+        }
+      }
+    }
+
+    return { demand, outcome: 'unmatched' }
+  })
+
+  return {
+    lines,
+    matched: lines.filter((l) => l.outcome === 'matched-by-type').length,
+    proposed: lines.filter((l) => l.outcome === 'proposed-by-name').length,
+    unmatched: lines.filter((l) => l.outcome === 'unmatched').length,
+  }
+}

--- a/src/renderer/store/inventoryStore.ts
+++ b/src/renderer/store/inventoryStore.ts
@@ -15,6 +15,7 @@ import type {
   InventoryMaterialKind,
 } from '../types/inventory'
 import { wouldCreateCycle } from '../lib/storageTree'
+import { deriveDemand } from '../lib/inventoryCoverage'
 import type { EquipmentItem } from '../types/equipment'
 
 /**
@@ -402,43 +403,90 @@ export const useInventoryStore = create<InventoryState>((set, get) => ({
       return { items, sets, units }
     }),
   seedFromEquipment: (equipment) => {
-    // Gruppieren nach Modell+Kategorie → gezählte Menge.
-    const counts = new Map<string, { model: string; category?: string; qty: number; sample: EquipmentItem }>()
-    for (const eq of equipment) {
-      const model = (eq.name ?? '').trim()
-      if (!model) continue
-      const key = dedupeKey(model, eq.category)
-      const existing = counts.get(key)
-      if (existing) existing.qty += 1
-      else counts.set(key, { model, category: eq.category, qty: 1, sample: eq })
-    }
+    // ADR-002, Inkrement 3 — der Bedarf kommt jetzt aus `deriveDemand`, nicht
+    // mehr aus dem Geraetenamen.
+    //
+    // Vorher gruppierte diese Funktion ueber `dedupeKey(eq.name, category)`.
+    // Der Geraetename ist aber der INSTANZname: „Kamera 1" und „Kamera 2"
+    // waren zwei Schluessel, also entstanden zwei Lagerpositionen a 1 Stueck
+    // fuer ein Modell mit Menge 2 — und der Name landete im `model`-Feld,
+    // wo eine Modellbezeichnung hingehoert.
+    //
+    // Jetzt gilt: Wo der Plan eine Katalog-Identitaet kennt, wird ueber sie
+    // gruppiert, der Modellname kommt aus dem Katalog, und die Identitaet
+    // wandert mit in die Lagerposition. Wo sie fehlt, bleibt es beim Namen —
+    // besser weiss es dann niemand.
+    const demands = deriveDemand(equipment)
+    const sampleById = new Map(equipment.map((e) => [e.id, e]))
 
     let created = 0
     const now = new Date().toISOString()
     const current = get().items
-    const byKey = new Map(current.map((it) => [dedupeKey(it.model, it.category), it] as const))
     const next = [...current]
+    const byType = new Map<string, InventoryItem>()
+    for (const it of current) if (it.deviceTypeId) byType.set(it.deviceTypeId, it)
+    const byName = new Map(current.map((it) => [dedupeKey(it.model, it.category), it] as const))
+    // Fuer TYPISIERTE Bedarfe reicht der Modellname allein: Der Katalogname
+    // identifiziert das Modell, und Lagerpositionen tragen oft gar keine
+    // Kategorie. Nur wenn er EINDEUTIG ist — bei zwei gleichnamigen
+    // Positionen waere jede Wahl geraten, und dann lieber keine.
+    const byModelOnly = new Map<string, InventoryItem | null>()
+    for (const it of current) {
+      const key = it.model.trim().toLowerCase()
+      if (!key) continue
+      byModelOnly.set(key, byModelOnly.has(key) ? null : it)
+    }
 
-    for (const { model, category, qty, sample } of counts.values()) {
-      const key = dedupeKey(model, category)
-      const hit = byKey.get(key)
+    for (const demand of demands) {
+      // Erst ueber die Identitaet, dann ueber den Modellnamen. Der
+      // Namens-Fallback gilt AUCH fuer typisierte Bedarfe: Traegt eine
+      // vorhandene Position denselben Modellnamen, aber noch keine
+      // Identitaet, waere ein zweiter Artikel gleichen Namens schlimmer als
+      // die Verknuepfung — und die Identitaet wird unten nachgetragen, sodass
+      // sie nie wieder ueber den Namen gefunden werden muss.
+      //
+      // Das ist kein Widerspruch zur Regel „Namenstreffer sind nur
+      // Vorschlaege": Die gilt fuer die Deckungs-ANZEIGE, die der Nutzer
+      // liest. Hier hat er gerade selbst „aus dem Plan uebernehmen" geklickt,
+      // und das Ergebnis ist sichtbar und wieder loesbar.
+      const named = byModelOnly.get(demand.label.trim().toLowerCase())
+      const hit = demand.deviceTypeId
+        ? (byType.get(demand.deviceTypeId) ??
+          // Ein Namenstreffer, der bereits eine ANDERE Identitaet traegt, ist
+          // kein Treffer, sondern ein Widerspruch: gleicher Name, anderer Typ.
+          // Ihn als Treffer zu nehmen wuerde den Bedarf verschlucken — die
+          // Position bliebe unveraendert und es entstuende auch keine neue.
+          (named && !named.deviceTypeId ? named : undefined))
+        : byName.get(dedupeKey(demand.label, demand.category))
       if (hit) {
-        // Vorhandenen Artikel nicht duplizieren — nur Menge ggf. anheben.
-        if (qty > hit.quantity) {
-          const idx = next.findIndex((it) => it.id === hit.id)
-          if (idx >= 0) next[idx] = { ...hit, quantity: qty, updatedAt: now }
+        // Vorhandenen Artikel nicht duplizieren — nur Menge ggf. anheben und,
+        // wenn er noch keine trug, die Typ-Identitaet nachtragen.
+        const idx = next.findIndex((it) => it.id === hit.id)
+        if (idx >= 0) {
+          const raise = demand.quantity > hit.quantity
+          const addType = demand.deviceTypeId != null && hit.deviceTypeId == null
+          if (raise || addType) {
+            next[idx] = {
+              ...hit,
+              ...(raise ? { quantity: demand.quantity } : {}),
+              ...(addType ? { deviceTypeId: demand.deviceTypeId } : {}),
+              updatedAt: now,
+            }
+          }
         }
         continue
       }
+      const sample = sampleById.get(demand.equipmentIds[0])
       next.push({
         id: uuidv4(),
-        model,
-        category,
-        quantity: qty,
-        rentPricePerDay: sample.rentPricePerDay,
-        stockLocation: sample.stockLocation,
-        supplier: sample.supplier,
-        ownership: sample.ownership,
+        model: demand.label,
+        category: demand.category,
+        ...(demand.deviceTypeId ? { deviceTypeId: demand.deviceTypeId } : {}),
+        quantity: demand.quantity,
+        rentPricePerDay: sample?.rentPricePerDay,
+        stockLocation: sample?.stockLocation,
+        supplier: sample?.supplier,
+        ownership: sample?.ownership,
         createdAt: now,
         updatedAt: now,
       })

--- a/tests/inventoryCoverage.test.ts
+++ b/tests/inventoryCoverage.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest'
+import {
+  deriveDemand,
+  normaliseName,
+  resolveCoverage,
+} from '../src/renderer/lib/inventoryCoverage'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+import type { InventoryItem } from '../src/renderer/types/inventory'
+
+/** Echter Katalog-Eintrag, damit der Modellname aus der Registry kommt. */
+const F55_ID = 'eb02ca7e-856c-40ab-9a73-d1e98110f003'
+const F55_MODEL = 'Sony PMW-F55'
+
+const eq = (over: Partial<EquipmentItem>): EquipmentItem => ({
+  id: 'e1',
+  name: 'Gerät',
+  category: 'Kameras',
+  inputs: [],
+  outputs: [],
+  x: 0,
+  y: 0,
+  width: 200,
+  height: 160,
+  ...over,
+})
+
+const item = (over: Partial<InventoryItem>): InventoryItem => ({
+  id: 'i1',
+  model: 'Modell',
+  quantity: 1,
+  createdAt: 't',
+  updatedAt: 't',
+  ...over,
+})
+
+describe('deriveDemand', () => {
+  it('zählt zwei Geräte desselben Typs zu EINER Zeile mit Menge 2', () => {
+    // Genau der Fehler, den seedFromEquipment heute macht: "Kamera 1" und
+    // "Kamera 2" werden dort zu zwei Positionen à 1 Stück.
+    const demand = deriveDemand([
+      eq({ id: 'a', name: 'Kamera 1', deviceTypeId: F55_ID }),
+      eq({ id: 'b', name: 'Kamera 2', deviceTypeId: F55_ID }),
+    ])
+    expect(demand).toHaveLength(1)
+    expect(demand[0]).toMatchObject({ quantity: 2, label: F55_MODEL, labelIsDeviceName: false })
+    expect(demand[0].equipmentIds).toEqual(['a', 'b'])
+  })
+
+  it('nimmt den Modellnamen aus dem Katalog, nicht den Instanznamen', () => {
+    const demand = deriveDemand([eq({ name: 'Kamera 1', deviceTypeId: F55_ID })])
+    expect(demand[0].label).toBe(F55_MODEL)
+  })
+
+  it('markiert eine Zeile, deren Label nur der Gerätename ist', () => {
+    const demand = deriveDemand([eq({ name: 'Kamera 1' })])
+    expect(demand[0]).toMatchObject({ label: 'Kamera 1', labelIsDeviceName: true })
+    expect(demand[0].deviceTypeId).toBeUndefined()
+  })
+
+  it('trennt gleichnamige Geräte verschiedener Kategorien', () => {
+    const demand = deriveDemand([
+      eq({ id: 'a', name: 'MS-1', category: 'Kameras' }),
+      eq({ id: 'b', name: 'MS-1', category: 'Audio' }),
+    ])
+    expect(demand).toHaveLength(2)
+  })
+
+  it('überspringt Geräte ohne jeden Namen', () => {
+    expect(deriveDemand([eq({ name: '   ' })])).toEqual([])
+  })
+})
+
+describe('resolveCoverage — matched-by-type', () => {
+  it('deckt über die Katalog-GUID, nicht über den Namen', () => {
+    const res = resolveCoverage(
+      [eq({ name: 'Kamera 1', deviceTypeId: F55_ID })],
+      [item({ id: 'inv1', model: 'Ganz anders benannt', quantity: 3, deviceTypeId: F55_ID })],
+    )
+    expect(res.lines[0]).toMatchObject({
+      outcome: 'matched-by-type',
+      itemId: 'inv1',
+      available: 3,
+    })
+    expect(res.matched).toBe(1)
+  })
+
+  it('meldet die Fehlmenge, wenn der Bestand nicht reicht', () => {
+    const res = resolveCoverage(
+      [
+        eq({ id: 'a', name: 'Kamera 1', deviceTypeId: F55_ID }),
+        eq({ id: 'b', name: 'Kamera 2', deviceTypeId: F55_ID }),
+        eq({ id: 'c', name: 'Kamera 3', deviceTypeId: F55_ID }),
+      ],
+      [item({ id: 'inv1', model: F55_MODEL, quantity: 2, deviceTypeId: F55_ID })],
+    )
+    expect(res.lines[0]).toMatchObject({ outcome: 'matched-by-type', short: 1 })
+  })
+
+  it('lässt short weg, wenn genug da ist', () => {
+    const res = resolveCoverage(
+      [eq({ deviceTypeId: F55_ID })],
+      [item({ quantity: 5, deviceTypeId: F55_ID })],
+    )
+    expect(res.lines[0].short).toBeUndefined()
+  })
+})
+
+describe('resolveCoverage — proposed-by-name', () => {
+  it('schlägt eine Position ohne Typ-Identität bei gleichem Modellnamen vor', () => {
+    const res = resolveCoverage(
+      [eq({ name: 'Kamera 1', deviceTypeId: F55_ID })],
+      [item({ id: 'inv1', model: F55_MODEL, quantity: 4 })],
+    )
+    expect(res.lines[0]).toMatchObject({ outcome: 'proposed-by-name', itemId: 'inv1' })
+    expect(res.lines[0].reason).toContain('keine Typ-Identitaet')
+    expect(res.proposed).toBe(1)
+  })
+
+  it('schlägt auch bei kleiner Abweichung vor — mit Begründung', () => {
+    const res = resolveCoverage(
+      [eq({ deviceTypeId: F55_ID })],
+      [item({ id: 'inv1', model: 'Sony PMW-F56', quantity: 1 })],
+    )
+    expect(res.lines[0].outcome).toBe('proposed-by-name')
+    expect(res.lines[0].reason).toContain('weicht um')
+  })
+
+  it('befördert einen Vorschlag NIE zur Deckung', () => {
+    // Der Kern der Regel: ein Namenstreffer bleibt ein Vorschlag, egal wie
+    // gut er aussieht. Sonst wird die Liste geglaubt statt gelesen.
+    const res = resolveCoverage(
+      [eq({ deviceTypeId: F55_ID })],
+      [item({ model: F55_MODEL, quantity: 99 })],
+    )
+    expect(res.matched).toBe(0)
+    expect(res.lines[0].outcome).toBe('proposed-by-name')
+  })
+
+  it('schlägt keine Position vor, die bereits eine ANDERE Typ-Identität trägt', () => {
+    // Gleicher Name, andere GUID ist kein Treffer, sondern ein Widerspruch.
+    const res = resolveCoverage(
+      [eq({ deviceTypeId: F55_ID })],
+      [item({ model: F55_MODEL, quantity: 9, deviceTypeId: 'dt-fremd' })],
+    )
+    expect(res.lines[0].outcome).toBe('unmatched')
+  })
+
+  it('vergleicht Namen unabhängig von Schreibweise und Leerraum', () => {
+    const res = resolveCoverage(
+      [eq({ deviceTypeId: F55_ID })],
+      [item({ model: '  sony   pmw-f55 ', quantity: 1 })],
+    )
+    expect(res.lines[0].outcome).toBe('proposed-by-name')
+  })
+
+  it('rät nicht bei sehr kurzen Namen', () => {
+    const res = resolveCoverage([eq({ name: 'Mic' })], [item({ model: 'Mix', quantity: 1 })])
+    expect(res.lines[0].outcome).toBe('unmatched')
+  })
+})
+
+describe('resolveCoverage — unmatched', () => {
+  it('meldet ehrlich, was im Lager fehlt', () => {
+    const res = resolveCoverage([eq({ name: 'Blackmagic URSA' })], [])
+    expect(res.lines[0]).toMatchObject({ outcome: 'unmatched' })
+    expect(res.lines[0].itemId).toBeUndefined()
+    expect(res.unmatched).toBe(1)
+  })
+
+  it('bleibt bei leerem Plan leer, statt etwas zu erfinden', () => {
+    expect(resolveCoverage([], [item({})])).toMatchObject({
+      lines: [],
+      matched: 0,
+      proposed: 0,
+      unmatched: 0,
+    })
+  })
+})
+
+describe('normaliseName', () => {
+  it('macht Schreibweise und Leerraum vergleichbar', () => {
+    expect(normaliseName('  Sony   PMW-F55 ')).toBe('sony pmw-f55')
+  })
+})

--- a/tests/inventoryStore.test.ts
+++ b/tests/inventoryStore.test.ts
@@ -97,3 +97,125 @@ describe('inventoryStore — Typ-Identität (ADR-002)', () => {
     expect(useInventoryStore.getState().items[0].deviceTypeId).toBeUndefined()
   })
 })
+
+describe('inventoryStore — seedFromEquipment (ADR-002, Inkrement 3)', () => {
+  beforeEach(reset)
+
+  const F55_ID = 'eb02ca7e-856c-40ab-9a73-d1e98110f003'
+  const F55_MODEL = 'Sony PMW-F55'
+  const dev = (over: Record<string, unknown>) =>
+    ({
+      id: 'e1',
+      name: 'Gerät',
+      category: 'Kameras',
+      inputs: [],
+      outputs: [],
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 160,
+      ...over,
+    }) as never
+
+  it('macht aus zwei Geräten EINES Typs eine Position mit Menge 2', () => {
+    // Der Fehler, den diese Funktion vorher hatte: Sie gruppierte über den
+    // Instanznamen, also wurden "Kamera 1" und "Kamera 2" zu zwei
+    // Positionen à 1 Stück — und der Instanzname landete im model-Feld.
+    const st = useInventoryStore.getState()
+    const created = st.seedFromEquipment([
+      dev({ id: 'a', name: 'Kamera 1', deviceTypeId: F55_ID }),
+      dev({ id: 'b', name: 'Kamera 2', deviceTypeId: F55_ID }),
+    ])
+    expect(created).toBe(1)
+    const items = useInventoryStore.getState().items
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({
+      model: F55_MODEL,
+      quantity: 2,
+      deviceTypeId: F55_ID,
+    })
+  })
+
+  it('nimmt für Geräte ohne Katalog-Typ weiter den Namen', () => {
+    const st = useInventoryStore.getState()
+    st.seedFromEquipment([dev({ id: 'a', name: 'Sonderbau XY' })])
+    const items = useInventoryStore.getState().items
+    expect(items[0]).toMatchObject({ model: 'Sonderbau XY', quantity: 1 })
+    expect(items[0].deviceTypeId).toBeUndefined()
+  })
+
+  it('legt eine vorhandene Position nicht doppelt an, sondern hebt die Menge', () => {
+    const st = useInventoryStore.getState()
+    st.addItem({ model: F55_MODEL, quantity: 1, deviceTypeId: F55_ID })
+    st.seedFromEquipment([
+      dev({ id: 'a', deviceTypeId: F55_ID }),
+      dev({ id: 'b', deviceTypeId: F55_ID }),
+    ])
+    const items = useInventoryStore.getState().items
+    expect(items).toHaveLength(1)
+    expect(items[0].quantity).toBe(2)
+  })
+
+  it('trägt die Typ-Identität an einer namensgleichen Position nach', () => {
+    // Ein zweiter Artikel gleichen Namens wäre schlimmer als die
+    // Verknüpfung — und danach muss sie nie wieder über den Namen gefunden
+    // werden.
+    const st = useInventoryStore.getState()
+    st.addItem({ model: F55_MODEL, quantity: 5 })
+    st.seedFromEquipment([dev({ id: 'a', deviceTypeId: F55_ID })])
+    const items = useInventoryStore.getState().items
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({ deviceTypeId: F55_ID, quantity: 5 })
+  })
+
+  it('senkt eine vorhandene Menge nicht ab', () => {
+    const st = useInventoryStore.getState()
+    st.addItem({ model: F55_MODEL, quantity: 9, deviceTypeId: F55_ID })
+    st.seedFromEquipment([dev({ id: 'a', deviceTypeId: F55_ID })])
+    expect(useInventoryStore.getState().items[0].quantity).toBe(9)
+  })
+})
+
+describe('inventoryStore — seedFromEquipment, Grenzfälle des Namens-Fallbacks', () => {
+  beforeEach(reset)
+
+  const F55_ID = 'eb02ca7e-856c-40ab-9a73-d1e98110f003'
+  const F55_MODEL = 'Sony PMW-F55'
+  const dev = (over: Record<string, unknown>) =>
+    ({
+      id: 'e1',
+      name: 'Gerät',
+      category: 'Kameras',
+      inputs: [],
+      outputs: [],
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 160,
+      ...over,
+    }) as never
+
+  it('verknüpft NICHT, wenn der Modellname mehrdeutig ist', () => {
+    // Zwei gleichnamige Positionen: jede Wahl wäre geraten, also lieber keine.
+    const st = useInventoryStore.getState()
+    st.addItem({ model: F55_MODEL, quantity: 2, category: 'Kameras' })
+    st.addItem({ model: F55_MODEL, quantity: 3, category: 'Miete' })
+    st.seedFromEquipment([dev({ id: 'a', deviceTypeId: F55_ID })])
+    const items = useInventoryStore.getState().items
+    expect(items).toHaveLength(3)
+    expect(items.filter((i) => i.deviceTypeId === F55_ID)).toHaveLength(1)
+  })
+
+  it('verschluckt den Bedarf nicht an einer fremd-typisierten Namensgleichheit', () => {
+    // Gleicher Name, andere Identität ist ein Widerspruch, kein Treffer.
+    // Würde er als Treffer zählen, bliebe die fremde Position unverändert
+    // UND es entstünde keine neue — der Bedarf wäre spurlos verschwunden.
+    const st = useInventoryStore.getState()
+    st.addItem({ model: F55_MODEL, quantity: 4, deviceTypeId: 'dt-fremd' })
+    const created = st.seedFromEquipment([dev({ id: 'a', deviceTypeId: F55_ID })])
+    expect(created).toBe(1)
+    const items = useInventoryStore.getState().items
+    expect(items.find((i) => i.deviceTypeId === 'dt-fremd')?.quantity).toBe(4)
+    expect(items.find((i) => i.deviceTypeId === F55_ID)?.quantity).toBe(1)
+  })
+})


### PR DESCRIPTION
Inkremente 2 und 3 aus [ADR-002](https://github.com/larszu/av-planner-suite/blob/main/docs/decisions/ADR-002-device-identity-plan-and-stock.md), aufbauend auf dem gemeinsamen Schlüssel aus [#605](https://github.com/larszu/cable-planner/pull/605).

## Inkrement 2 — `lib/inventoryCoverage.ts`

Reine Funktionen über Plan und Lager, kein Store, kein React, kein IO.

**`deriveDemand`** zählt den Plan zu **Typ-Zeilen** zusammen. Der Bedarf ist nicht „Kamera 1" — das ist der Instanzname eines Geräts —, sondern dreimal „Sony PMW-F55". Wo der Plan eine `deviceTypeId` trägt, kommt der Modellname aus dem Katalog; wo nicht, bleibt nur der Gerätename, und die Zeile ist als solche markiert (`labelIsDeviceName`), damit die UI das zeigen kann.

**`resolveCoverage`** kennt **drei Ausgänge, nie zwei**:

| Ausgang | Bedeutung |
| --- | --- |
| `matched-by-type` | Tatsache. Beide Seiten tragen dieselbe Katalog-GUID. |
| `proposed-by-name` | **Vorschlag** mit Begründung. Wartet auf Bestätigung. |
| `unmatched` | Im Lager nicht gefunden. |

Ein Namenstreffer wird **nie** zur Deckung befördert, egal wie gut er aussieht. Eine Kommissionier-Liste, die in neun von zehn Fällen stimmt, ist im Lager schlimmer als gar keine — sie wird nicht mehr gelesen, sondern geglaubt, und der zehnte Fall kommt als fehlendes Gerät am Aufbautag heraus. Ein Test hält diese Regel ausdrücklich fest.

Vorgeschlagen wird nur gegen Positionen **ohne** eigene Typ-Identität. Trägt eine Position bereits eine andere GUID, ist ein Namenstreffer keine Information, sondern ein Widerspruch.

## Inkrement 3 — `seedFromEquipment` über den Typ

Die Funktion, die den Fehler bisher produziert hat, steht jetzt auf `deriveDemand`:

- „Kamera 1" und „Kamera 2" werden **eine** Position mit Menge 2 statt zwei à 1 Stück
- im `model`-Feld steht der **Modellname**, nicht der Instanzname
- die Typ-Identität wandert mit und wird an einer **eindeutig** namensgleichen Position nachgetragen, statt einen Zwilling anzulegen

Dass hier über den Namen verknüpft wird, ist kein Widerspruch zur Regel oben: Die gilt für die Deckungs-**Anzeige**, die der Nutzer liest. Hier hat er gerade selbst „aus dem Plan übernehmen" geklickt, das Ergebnis ist sichtbar und wieder lösbar.

## Zwei Fälle, die erst die Tests sichtbar gemacht haben

**Der Namens-Fallback traf nicht, weil die Kategorie verglichen wurde.** Für eine typisierte Zeile ist das zu streng: Der Katalogname identifiziert das Modell allein, und Lagerpositionen tragen oft gar keine Kategorie. Typisierte Bedarfe suchen jetzt über den Modellnamen allein — aber nur, wenn er **eindeutig** ist. Bei zwei gleichnamigen Positionen wäre jede Wahl geraten, also wird keine getroffen.

**Ein Namenstreffer mit fremder Identität verschluckte den Bedarf.** Er zählte als Treffer, wurde wegen der fremden GUID aber nicht angefasst — und weil er als Treffer galt, entstand auch keine neue Position. Der Bedarf verschwand spurlos. Der ursprüngliche Test hatte das nicht gemerkt, weil er nur prüfte, dass die fremde Position unverändert bleibt; er prüft jetzt beides.

## Was bewusst noch fehlt

Die Stückliste und die Kommissionier-Liste selbst — das ist Inkrement 4, und es setzt voraus, dass die Deckung belastbar ist. Der Resolver hat deshalb noch keinen UI-Konsumenten; er ist die geprüfte Grundlage dafür, so wie die Ableitungsschicht in ADR-001 es für die Anker war.

## Prüfung

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 377 Tests, 36 Dateien, alle grün (+24 neue)
- `npm run lint` — 0 Fehler (10 vorbestehende Warnungen)
- `npm run build` — grün

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_