### PR TITLE
bom: Geräte-Stückliste und Kommissionier-Liste aus dem Plan (ADR-002, Inkrement 4)

### DIFF
--- a/src/renderer/components/Export/ExportDialog.tsx
+++ b/src/renderer/components/Export/ExportDialog.tsx
@@ -17,7 +17,7 @@ import { useDialogA11y } from '../../hooks/useDialogA11y'
 import jsPDF from 'jspdf'
 import { useUiStore } from '../../store/uiStore'
 import { useProjectStore } from '../../store/projectStore'
-import { AlertTriangle, Check, Lightbulb } from 'lucide-react'
+import { AlertTriangle, Check, Lightbulb, Package as PackageIcon } from 'lucide-react'
 import { useTranslation, format } from '../../lib/i18n'
 import { detectLayerForConnector, type StandardLayer } from '../../lib/cableLayers'
 
@@ -41,13 +41,15 @@ import { printPdfBlob } from '../../lib/printPdfBlob'
 import { sanitizeForPdf } from '../../lib/sanitizeForPdf'
 import { downloadBlob } from '../../lib/downloadBlob'
 import { buildTallyMap, tallyMapCsv, toTallyPiDevices } from '../../lib/tallyMap'
+import { buildPlanBom, outcomeLabel, pickListCsv, planBomCsv } from '../../lib/planBom'
+import { useInventoryStore } from '../../store/inventoryStore'
 import { exportGroupAsPatchPdf, buildGroupPatchPdfBlob } from '../../lib/exportGroupPdf'
 import { buildExportFilenameWithSuffix } from '../../lib/exportFilename'
 import { LayerVisibilityChips } from '../Canvas/LayerVisibilityChips'
 import type { Cable } from '../../types/cable'
 
 export type ExportFormat = 'pdf' | 'png' | 'jpeg' | 'svg' | 'dxf'
-type Section = 'plan' | 'patch' | 'bom' | 'rack' | 'tally'
+type Section = 'plan' | 'patch' | 'bom' | 'devicebom' | 'rack' | 'tally'
 
 /** v7.9.103 — Page-Size-Optionen fuer den Vektor-PDF-Pfad. */
 export type PdfPageSizeOpt =
@@ -81,6 +83,7 @@ const SECTION_LABEL: Record<Section, string> = {
   plan: 'Plan',
   patch: 'Patch-Sheets',
   bom: 'Kabel-Stückliste',
+  devicebom: 'Geräte-Stückliste',
   rack: 'Racks & Gruppen',
   tally: 'Tally-Karte',
 }
@@ -89,6 +92,7 @@ const SECTION_ICON: Record<Section, LucideIcon> = {
   plan: FileText,
   patch: CableIcon,
   bom: Calculator,
+  devicebom: PackageIcon,
   rack: Server,
   tally: Lightbulb,
 }
@@ -97,6 +101,7 @@ const SECTION_DESC: Record<Section, string> = {
   plan: 'Den Canvas-Plan als PDF herunterladen oder direkt drucken. PDF mit Titelblock — druckfertig. Auch PNG/JPEG für E-Mail/Slack.',
   patch: 'Pro Gerät eine Port-Belegungs-Liste — ideal zum Aufkleben am Gerät. Auswahl an Geräten, dann Einzel-PDF, Sammel-PDF oder direkt drucken. Papier-Format wird nach Klick abgefragt. Alternativ: kompakte Patchliste (eine Zeile pro Kabel, sortiert nach Quell-Gerät) für den Techniker im Feld.',
   bom: 'Stückliste aller Kabel im Projekt (Typ + Länge zusammengefasst). Editierbare Rentman-Planung daneben. Export als CSV oder PDF.',
+  devicebom: 'Was der Plan an Geräten braucht, gezählt nach Modell und gegen das Lager gedeckt. Drei Zustände, die unterscheidbar bleiben: gedeckt (über die Katalog-Identität), VORSCHLAG (Namenstreffer, wartet auf Bestätigung) und nicht im Lager. Dazu die Kommissionier-Liste — nur sicher Gedecktes, nach Lagerort sortiert.',
   rack: 'Gespeicherte Racks und Gruppen einzeln als PDF exportieren oder drucken — eine Patch-Seite pro enthaltenem Gerät mit interner Verkabelung.',
   tally: 'Die Kette Rolle → Gerät → Mischer-Eingang → UMD-Adresse, aus dem Plan abgeleitet und geprüft. Als CSV zum Gegenlesen, als JSON für die tally-pi-Konfiguration. Die Lampe selbst — welcher GPIO-Pin welcher Box — gehört der Hardware und steht bewusst nicht drin.',
 }
@@ -181,6 +186,7 @@ export const ExportDialog = ({
               )}
               {section === 'patch' && <PatchSheetSection onClose={onClose} />}
               {section === 'bom' && <BomSection />}
+              {section === 'devicebom' && <DeviceBomSection />}
               {section === 'rack' && <RackGroupSection onClose={onClose} />}
               {section === 'tally' && <TallySection />}
             </div>
@@ -1376,6 +1382,136 @@ const TallySection = () => {
           )}
         >
           {t('export.tally.pi', 'tally-pi-Geräte (JSON)')}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// --------------------------------------------------------------------
+// Device BOM section (ADR-002, Inkrement 4)
+//
+// Das groesste unbesetzte Feld der Feature-Matrix: der technische Plan
+// erzeugt die kaufmaennische Stueckliste, statt dass sie abgetippt wird —
+// und ihre andere Haelfte, die Kommissionier-Liste fuers Lager.
+//
+// Die Darstellung hat eine Pflicht: Ein VORSCHLAG muss als Vorschlag
+// erkennbar bleiben. Eine Liste, die Vorschlag und Deckung gleich aussehen
+// laesst, wird geglaubt statt gelesen, und der erste Irrtum kommt als
+// fehlendes Geraet am Aufbautag heraus.
+
+const OUTCOME_STYLE: Record<string, string> = {
+  'matched-by-type': 'text-cp-text',
+  'proposed-by-name': 'text-cp-warn font-semibold',
+  unmatched: 'text-cp-danger',
+}
+
+const DeviceBomSection = () => {
+  const t = useTranslation()
+  const equipment = useProjectStore((s) => s.project.equipment)
+  const projectName = useProjectStore((s) => s.project.metadata?.name)
+  const items = useInventoryStore((s) => s.items)
+  const nodes = useInventoryStore((s) => s.nodes)
+
+  const bom = useMemo(
+    () => buildPlanBom(equipment, items, nodes),
+    [equipment, items, nodes],
+  )
+
+  const download = (suffix: string, content: string) =>
+    downloadBlob(
+      buildExportFilenameWithSuffix(projectName, suffix, 'csv'),
+      content,
+      'text/csv;charset=utf-8',
+    )
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-3">
+      {bom.rows.length === 0 ? (
+        <p className="rounded border border-cp-border bg-cp-surface-2 p-3 text-cp-xs text-cp-text-secondary">
+          {t('export.devicebom.empty', 'Noch keine Geräte im Plan.')}
+        </p>
+      ) : (
+        <>
+          <div className="flex shrink-0 flex-wrap gap-3 text-cp-xs">
+            <span className="text-cp-text-secondary">
+              {format(t('export.devicebom.matched', '{n} gedeckt'), { n: bom.matched })}
+            </span>
+            <span className={bom.proposed > 0 ? 'text-cp-warn' : 'text-cp-text-muted'}>
+              {format(t('export.devicebom.proposed', '{n} Vorschläge'), { n: bom.proposed })}
+            </span>
+            <span className={bom.unmatched > 0 ? 'text-cp-danger' : 'text-cp-text-muted'}>
+              {format(t('export.devicebom.unmatched', '{n} nicht im Lager'), { n: bom.unmatched })}
+            </span>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-auto rounded border border-cp-border">
+            <table className="w-full border-collapse text-cp-xs">
+              <thead className="sticky top-0 bg-cp-surface-3">
+                <tr className="text-left text-cp-text-secondary">
+                  <th className="px-2 py-1.5">{t('export.devicebom.col.qty', 'Menge')}</th>
+                  <th className="px-2 py-1.5">{t('export.devicebom.col.model', 'Modell')}</th>
+                  <th className="px-2 py-1.5">{t('export.devicebom.col.state', 'Deckung')}</th>
+                  <th className="px-2 py-1.5">{t('export.devicebom.col.stock', 'Bestand')}</th>
+                  <th className="px-2 py-1.5">{t('export.devicebom.col.location', 'Lagerort')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {bom.rows.map((row, idx) => (
+                  <tr key={`${row.model}:${idx}`} className="border-t border-cp-border-muted">
+                    <td className="px-2 py-1 font-mono">{row.quantity}</td>
+                    <td className="px-2 py-1">
+                      {row.model}
+                      {row.modelIsDeviceName && (
+                        <span
+                          className="ml-1 text-cp-text-muted"
+                          title={t(
+                            'export.devicebom.noTypeTitle',
+                            'Ohne Katalog-Typ — der Modellname ist hier nur der Gerätename. Einen Katalog-Typ zuweisen macht die Deckung zur Tatsache.',
+                          )}
+                        >
+                          {t('export.devicebom.noType', '(ohne Katalog-Typ)')}
+                        </span>
+                      )}
+                    </td>
+                    <td className={`px-2 py-1 ${OUTCOME_STYLE[row.outcome] ?? ''}`} title={row.reason}>
+                      {outcomeLabel(row.outcome)}
+                      {row.short !== undefined && row.short > 0 && (
+                        <span className="ml-1 text-cp-danger">
+                          {format(t('export.devicebom.short', '— {n} fehlen'), { n: row.short })}
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-2 py-1 font-mono">{row.available ?? '—'}</td>
+                    <td className="px-2 py-1 text-cp-text-secondary">{row.location || '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+
+      <div className="flex shrink-0 flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => download('geraete-bom', planBomCsv(bom))}
+          disabled={bom.rows.length === 0}
+          className="rounded bg-sky-700 px-3 py-1.5 text-cp-xs text-white hover:bg-sky-600 disabled:opacity-40"
+        >
+          {t('export.devicebom.csv', 'Stückliste als CSV')}
+        </button>
+        <button
+          type="button"
+          onClick={() => download('kommissionierliste', pickListCsv(bom))}
+          disabled={bom.matched === 0}
+          className="rounded border border-cp-border px-3 py-1.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-3 disabled:opacity-40"
+          title={t(
+            'export.devicebom.pickTitle',
+            'Nur sicher Gedecktes, nach Lagerort sortiert. Vorschläge stehen bewusst nicht drin — wer kommissioniert, soll nicht unterwegs entscheiden müssen.',
+          )}
+        >
+          {t('export.devicebom.pick', 'Kommissionier-Liste (CSV)')}
         </button>
       </div>
     </div>

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -2148,6 +2148,28 @@ export const en: Dict = {
   'cable.aria.toDevice': 'Target device',
   'cable.aria.toPort': 'Target port',
 
+  // ADR-002, Inkrement 4 — Geraete-Stueckliste + Kommissionier-Liste
+  'export.section.devicebom': 'Device BOM',
+  'export.desc.devicebom':
+    'What the plan needs in devices, counted by model and checked against the inventory. Three states that stay distinguishable: covered (via the catalogue identity), PROPOSAL (name match, awaiting confirmation) and not in stock. Plus the pick list — only what is certainly covered, sorted by storage location.',
+  'export.devicebom.empty': 'No devices in the plan yet.',
+  'export.devicebom.matched': '{n} covered',
+  'export.devicebom.proposed': '{n} proposals',
+  'export.devicebom.unmatched': '{n} not in stock',
+  'export.devicebom.col.qty': 'Qty',
+  'export.devicebom.col.model': 'Model',
+  'export.devicebom.col.state': 'Coverage',
+  'export.devicebom.col.stock': 'Stock',
+  'export.devicebom.col.location': 'Location',
+  'export.devicebom.noType': '(no catalogue type)',
+  'export.devicebom.noTypeTitle':
+    'No catalogue type — the model name here is only the device name. Assigning a catalogue type turns the coverage into a fact.',
+  'export.devicebom.short': '— {n} missing',
+  'export.devicebom.csv': 'Device BOM as CSV',
+  'export.devicebom.pick': 'Pick list (CSV)',
+  'export.devicebom.pickTitle':
+    'Only what is certainly covered, sorted by storage location. Proposals are deliberately left out — whoever picks should not have to decide on the way.',
+
   // Roadmap-Initiative 2 — Tally-Karte (Export-Hub)
   'export.section.tally': 'Tally map',
   'export.desc.tally':

--- a/src/renderer/lib/planBom.ts
+++ b/src/renderer/lib/planBom.ts
@@ -1,0 +1,144 @@
+// ───────────────────────────────────────────────────────────────────────────
+// ADR-002, Inkrement 4 — die Stückliste und die Kommissionier-Liste.
+//
+// Roadmap-Initiative 3: „das größte unbesetzte Feld der Feature-Matrix".
+// Jedes Rental-ERP steht dort auf `no`; Produktionsleitung und Lager haben
+// unabhängig voneinander dasselbe verlangt, von beiden Enden aus — „der
+// technische Plan erzeugt die kaufmännische Stückliste, statt dass sie
+// abgetippt wird" und „schließt die Lücke vom technischen Plan zur
+// Kommissionier-Liste".
+//
+// Beides ist hier EINE Projektion über `inventoryCoverage`, keine zweite
+// Wahrheit: Menge, Modell und Deckung kommen aus dem Resolver, der Lagerort
+// aus dem Lager-Baum. Nichts davon wird gespeichert.
+//
+// DIE REGEL DER DARSTELLUNG. Ein Vorschlag muss als Vorschlag erkennbar
+// bleiben — auch auf Papier, auch in der CSV. Deshalb trägt jede Zeile das
+// Ergebnis im Klartext und, wo es einer ist, die Begründung. Eine Liste, die
+// Vorschlag und Deckung gleich aussehen lässt, wird im Lager geglaubt statt
+// gelesen, und der erste Irrtum kommt als fehlendes Gerät am Aufbautag heraus.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { EquipmentItem } from '../types/equipment'
+import type { InventoryItem, StorageNode } from '../types/inventory'
+import { resolveCoverage, type CoverageLine, type CoverageOutcome } from './inventoryCoverage'
+import { nodePathLabel } from './storageTree'
+import { toCsv } from './csv'
+
+export interface PlanBomRow {
+  /** Anzahl im Plan. */
+  quantity: number
+  /** Modellname (Katalog, sonst Gerätename). */
+  model: string
+  category?: string
+  outcome: CoverageOutcome
+  /** Bestand der deckenden bzw. vorgeschlagenen Position. */
+  available?: number
+  /** Fehlmenge — nur bei einer echten Deckung aussagekräftig. */
+  short?: number
+  /** Lagerort-Pfad („Depot › Regal A3 › Case 1"). Leer, wenn unbekannt. */
+  location: string
+  /** Begründung eines Vorschlags. Bei einer Deckung leer. */
+  reason?: string
+  /** true, wenn `model` nur der Instanzname eines Geräts ist. */
+  modelIsDeviceName: boolean
+}
+
+export interface PlanBom {
+  rows: PlanBomRow[]
+  /** Zeilen, die im Lager nicht gedeckt sind — der Einkaufs-/Subhire-Bedarf. */
+  missing: PlanBomRow[]
+  matched: number
+  proposed: number
+  unmatched: number
+}
+
+const OUTCOME_LABEL: Record<CoverageOutcome, string> = {
+  'matched-by-type': 'gedeckt',
+  'proposed-by-name': 'VORSCHLAG',
+  unmatched: 'nicht im Lager',
+}
+
+/** Klartext für Papier und CSV — die drei Zustände bleiben unterscheidbar. */
+export const outcomeLabel = (outcome: CoverageOutcome): string => OUTCOME_LABEL[outcome]
+
+const rowOf = (
+  line: CoverageLine,
+  items: InventoryItem[],
+  nodes: StorageNode[],
+): PlanBomRow => {
+  const item = line.itemId ? items.find((i) => i.id === line.itemId) : undefined
+  return {
+    quantity: line.demand.quantity,
+    model: line.demand.label,
+    ...(line.demand.category ? { category: line.demand.category } : {}),
+    outcome: line.outcome,
+    ...(line.available !== undefined ? { available: line.available } : {}),
+    ...(line.short !== undefined ? { short: line.short } : {}),
+    // Der Lagerort gilt nur für eine echte Deckung: Bei einem Vorschlag ist
+    // noch gar nicht sicher, dass es diese Position ist, und ein Regalplatz
+    // liest sich wie eine Zusage.
+    location:
+      line.outcome === 'matched-by-type' && item?.locationId
+        ? nodePathLabel(nodes, item.locationId)
+        : '',
+    ...(line.reason ? { reason: line.reason } : {}),
+    modelIsDeviceName: line.demand.labelIsDeviceName,
+  }
+}
+
+export const buildPlanBom = (
+  equipment: EquipmentItem[],
+  items: InventoryItem[],
+  nodes: StorageNode[],
+): PlanBom => {
+  const coverage = resolveCoverage(equipment, items)
+  const rows = coverage.lines.map((line) => rowOf(line, items, nodes))
+  return {
+    rows,
+    // Fehlend ist beides: gar nicht im Lager, und zu wenig davon. Ein
+    // Vorschlag zählt NICHT als gedeckt — solange ihn niemand bestätigt hat,
+    // ist die Deckung offen.
+    missing: rows.filter(
+      (r) => r.outcome !== 'matched-by-type' || (r.short !== undefined && r.short > 0),
+    ),
+    matched: coverage.matched,
+    proposed: coverage.proposed,
+    unmatched: coverage.unmatched,
+  }
+}
+
+/** Die kaufmännische Sicht: was der Plan braucht, mit Deckungsstand. */
+export const planBomCsv = (bom: PlanBom): string =>
+  toCsv(
+    ['Menge', 'Modell', 'Kategorie', 'Deckung', 'Bestand', 'Fehlmenge', 'Hinweis'],
+    bom.rows.map((r) => [
+      r.quantity,
+      r.model,
+      r.category ?? '',
+      outcomeLabel(r.outcome),
+      r.available ?? '',
+      r.short ?? '',
+      r.reason ?? (r.modelIsDeviceName ? 'Ohne Katalog-Typ — Modellname ist der Gerätename.' : ''),
+    ]),
+  )
+
+/**
+ * Die Lager-Sicht: nur was sicher gedeckt ist, sortiert nach Lagerort, damit
+ * man den Weg durchs Depot einmal geht statt dreimal.
+ *
+ * Vorschläge stehen bewusst NICHT drin: Wer kommissioniert, soll nicht
+ * unterwegs entscheiden müssen, ob eine Zuordnung stimmt.
+ */
+export const pickListCsv = (bom: PlanBom): string =>
+  toCsv(
+    ['Lagerort', 'Menge', 'Modell', 'Bestand'],
+    bom.rows
+      .filter((r) => r.outcome === 'matched-by-type')
+      .slice()
+      .sort(
+        (a, b) =>
+          a.location.localeCompare(b.location, 'de') || a.model.localeCompare(b.model, 'de'),
+      )
+      .map((r) => [r.location, r.quantity, r.model, r.available ?? '']),
+  )

--- a/tests/planBom.test.ts
+++ b/tests/planBom.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest'
+import { buildPlanBom, outcomeLabel, pickListCsv, planBomCsv } from '../src/renderer/lib/planBom'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+import type { InventoryItem, StorageNode } from '../src/renderer/types/inventory'
+
+const F55_ID = 'eb02ca7e-856c-40ab-9a73-d1e98110f003'
+const F55_MODEL = 'Sony PMW-F55'
+
+const eq = (over: Partial<EquipmentItem>): EquipmentItem => ({
+  id: 'e1',
+  name: 'Gerät',
+  category: 'Kameras',
+  inputs: [],
+  outputs: [],
+  x: 0,
+  y: 0,
+  width: 200,
+  height: 160,
+  ...over,
+})
+
+const item = (over: Partial<InventoryItem>): InventoryItem => ({
+  id: 'i1',
+  model: 'Modell',
+  quantity: 1,
+  createdAt: 't',
+  updatedAt: 't',
+  ...over,
+})
+
+const node = (over: Partial<StorageNode>): StorageNode => ({
+  id: 'n1',
+  name: 'Knoten',
+  kind: 'shelf',
+  createdAt: 't',
+  updatedAt: 't',
+  ...over,
+})
+
+const NODES = [
+  node({ id: 'depot', name: 'Depot', kind: 'depot' }),
+  node({ id: 'regal', name: 'Regal A3', kind: 'shelf', parentId: 'depot' }),
+]
+
+describe('buildPlanBom', () => {
+  it('zeigt Menge, Modell, Deckung und Lagerort für eine echte Deckung', () => {
+    const bom = buildPlanBom(
+      [eq({ id: 'a', deviceTypeId: F55_ID }), eq({ id: 'b', deviceTypeId: F55_ID })],
+      [item({ id: 'i1', model: F55_MODEL, quantity: 4, deviceTypeId: F55_ID, locationId: 'regal' })],
+      NODES,
+    )
+    expect(bom.rows[0]).toMatchObject({
+      quantity: 2,
+      model: F55_MODEL,
+      outcome: 'matched-by-type',
+      available: 4,
+      location: 'Depot › Regal A3',
+    })
+    expect(bom.matched).toBe(1)
+    expect(bom.missing).toEqual([])
+  })
+
+  it('zählt eine Unterdeckung zu den fehlenden, obwohl sie gedeckt ist', () => {
+    const bom = buildPlanBom(
+      [
+        eq({ id: 'a', deviceTypeId: F55_ID }),
+        eq({ id: 'b', deviceTypeId: F55_ID }),
+        eq({ id: 'c', deviceTypeId: F55_ID }),
+      ],
+      [item({ model: F55_MODEL, quantity: 1, deviceTypeId: F55_ID })],
+      NODES,
+    )
+    expect(bom.rows[0].short).toBe(2)
+    expect(bom.missing).toHaveLength(1)
+  })
+
+  it('nennt bei einem Vorschlag KEINEN Lagerort', () => {
+    // Ein Regalplatz liest sich wie eine Zusage; bei einem Vorschlag ist
+    // noch gar nicht sicher, dass es diese Position ist.
+    const bom = buildPlanBom(
+      [eq({ deviceTypeId: F55_ID })],
+      [item({ model: F55_MODEL, quantity: 9, locationId: 'regal' })],
+      NODES,
+    )
+    expect(bom.rows[0].outcome).toBe('proposed-by-name')
+    expect(bom.rows[0].location).toBe('')
+    expect(bom.rows[0].reason).toBeTruthy()
+  })
+
+  it('zählt einen Vorschlag NICHT als gedeckt', () => {
+    const bom = buildPlanBom(
+      [eq({ deviceTypeId: F55_ID })],
+      [item({ model: F55_MODEL, quantity: 9 })],
+      NODES,
+    )
+    expect(bom.matched).toBe(0)
+    expect(bom.proposed).toBe(1)
+    expect(bom.missing).toHaveLength(1)
+  })
+
+  it('markiert eine Zeile, deren Modellname nur der Gerätename ist', () => {
+    const bom = buildPlanBom([eq({ name: 'Sonderbau XY' })], [], NODES)
+    expect(bom.rows[0]).toMatchObject({ modelIsDeviceName: true, outcome: 'unmatched' })
+  })
+
+  it('bleibt bei leerem Plan leer', () => {
+    expect(buildPlanBom([], [item({})], NODES)).toMatchObject({
+      rows: [],
+      missing: [],
+      matched: 0,
+    })
+  })
+})
+
+describe('planBomCsv', () => {
+  it('schreibt den Deckungszustand im Klartext', () => {
+    const bom = buildPlanBom(
+      [eq({ deviceTypeId: F55_ID })],
+      [item({ model: F55_MODEL, quantity: 2, deviceTypeId: F55_ID })],
+      NODES,
+    )
+    const lines = planBomCsv(bom).split('\r\n')
+    expect(lines[0]).toContain('Deckung')
+    expect(lines[1]).toContain('gedeckt')
+  })
+
+  it('macht einen Vorschlag auch auf Papier als solchen kenntlich', () => {
+    const bom = buildPlanBom(
+      [eq({ deviceTypeId: F55_ID })],
+      [item({ model: F55_MODEL, quantity: 2 })],
+      NODES,
+    )
+    const line = planBomCsv(bom).split('\r\n')[1]
+    expect(line).toContain('VORSCHLAG')
+    expect(line).toContain('Typ-Identitaet')
+  })
+
+  it('erklärt eine Zeile ohne Katalog-Typ', () => {
+    const bom = buildPlanBom([eq({ name: 'Sonderbau XY' })], [], NODES)
+    expect(planBomCsv(bom)).toContain('Ohne Katalog-Typ')
+  })
+})
+
+describe('pickListCsv', () => {
+  it('enthält nur sicher gedeckte Zeilen', () => {
+    const bom = buildPlanBom(
+      [eq({ id: 'a', deviceTypeId: F55_ID }), eq({ id: 'b', name: 'Vorschlagsware' })],
+      [
+        item({ id: 'i1', model: F55_MODEL, quantity: 3, deviceTypeId: F55_ID, locationId: 'regal' }),
+        item({ id: 'i2', model: 'Vorschlagsware', quantity: 1 }),
+      ],
+      NODES,
+    )
+    const csv = pickListCsv(bom)
+    expect(csv).toContain(F55_MODEL)
+    expect(csv).not.toContain('Vorschlagsware')
+  })
+
+  it('sortiert nach Lagerort, damit man den Weg einmal geht', () => {
+    const nodes = [
+      ...NODES,
+      node({ id: 'regal-z', name: 'Regal Z9', kind: 'shelf', parentId: 'depot' }),
+    ]
+    const bom = buildPlanBom(
+      [eq({ id: 'a', deviceTypeId: F55_ID }), eq({ id: 'b', name: 'Zweitgerät' })],
+      [
+        item({ id: 'i1', model: F55_MODEL, quantity: 1, deviceTypeId: F55_ID, locationId: 'regal-z' }),
+        item({ id: 'i2', model: 'Zweitgerät', quantity: 1, locationId: 'regal' }),
+      ],
+      nodes,
+    )
+    // Nur die typisierte Zeile ist gedeckt; die zweite ist ein Vorschlag und
+    // gehört nicht auf die Kommissionier-Liste.
+    const rows = pickListCsv(bom).split('\r\n').slice(1)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toContain('Regal Z9')
+  })
+})
+
+describe('outcomeLabel', () => {
+  it('unterscheidet die drei Zustände im Klartext', () => {
+    expect(outcomeLabel('matched-by-type')).toBe('gedeckt')
+    expect(outcomeLabel('proposed-by-name')).toBe('VORSCHLAG')
+    expect(outcomeLabel('unmatched')).toBe('nicht im Lager')
+  })
+})


### PR DESCRIPTION
Das letzte Inkrement aus [ADR-002](https://github.com/larszu/av-planner-suite/blob/main/docs/decisions/ADR-002-device-identity-plan-and-stock.md), und damit Roadmap-Initiative 3.

Die Recherche nennt sie „the single largest unclaimed piece of value adjacent to the segment": Jedes Rental-ERP der Feature-Matrix steht dort auf `no`. Produktionsleitung und Lager haben unabhängig voneinander dasselbe verlangt, von beiden Enden aus — *„der technische Plan erzeugt die kaufmännische Stückliste, statt dass sie abgetippt wird"* und *„schließt die Lücke vom technischen Plan zur Kommissionier-Liste"*.

## Zwei Sichten, eine Projektion

`lib/planBom.ts` projiziert den Resolver aus Inkrement 2 auf zwei Listen. Nichts davon wird gespeichert — Menge, Modell und Deckung kommen aus dem Resolver, der Lagerort aus dem Lager-Baum.

**Die kaufmännische Stückliste**: Menge, Modell, Deckung, Bestand, Fehlmenge, Hinweis. Was fehlt, ist der Einkaufs- bzw. Subhire-Bedarf — und dazu zählt auch eine Unterdeckung, nicht nur „gar nicht da".

**Die Kommissionier-Liste**: nur sicher Gedecktes, nach Lagerort sortiert, damit man den Weg durchs Depot einmal geht statt dreimal.

Beides als CSV in einer eigenen Export-Hub-Sektion neben der Kabel-Stückliste.

## Die Darstellungsregel, dreimal angewandt

Ein **Vorschlag muss als Vorschlag erkennbar bleiben** — sonst wird die Liste geglaubt statt gelesen, und der erste Irrtum kommt als fehlendes Gerät am Aufbautag heraus. Das hat drei konkrete Folgen im Code:

1. **Auf Papier auch.** Die CSV trägt den Zustand im Klartext (`gedeckt` / `VORSCHLAG` / `nicht im Lager`) plus die Begründung des Vorschlags. Ein Test prüft genau das.
2. **Ein Vorschlag bekommt keinen Lagerort.** Ein Regalplatz liest sich wie eine Zusage; ob es diese Position überhaupt ist, steht noch gar nicht fest.
3. **Die Kommissionier-Liste enthält keine Vorschläge.** Wer kommissioniert, soll nicht unterwegs entscheiden müssen, ob eine Zuordnung stimmt.

Dazu markiert die Tabelle Zeilen, deren „Modellname" in Wahrheit nur der Gerätename ist — mit dem Hinweis, dass ein zugewiesener Katalog-Typ die Deckung zur Tatsache macht. Das ist der Weg aus `unmatched` heraus, und er steht dort, wo das Problem sichtbar wird.

## Prüfung

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 389 Tests, 37 Dateien, alle grün (+12 neue)
- `npm run lint` — 0 Fehler (10 vorbestehende Warnungen)
- `npm run build` — grün

Damit sind alle vier Inkremente von ADR-002 gebaut.

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_