### PR TITLE
bom: Vorschlag bestätigen — der Ausweg aus dem Namensraten (ADR-002)

### DIFF
--- a/src/renderer/components/Export/ExportDialog.tsx
+++ b/src/renderer/components/Export/ExportDialog.tsx
@@ -1412,6 +1412,7 @@ const DeviceBomSection = () => {
   const projectName = useProjectStore((s) => s.project.metadata?.name)
   const items = useInventoryStore((s) => s.items)
   const nodes = useInventoryStore((s) => s.nodes)
+  const updateItem = useInventoryStore((s) => s.updateItem)
 
   const bom = useMemo(
     () => buildPlanBom(equipment, items, nodes),
@@ -1480,6 +1481,25 @@ const DeviceBomSection = () => {
                         <span className="ml-1 text-cp-danger">
                           {format(t('export.devicebom.short', '— {n} fehlen'), { n: row.short })}
                         </span>
+                      )}
+                      {/* Der Ausweg aus dem Vorschlag: ein Klick schreibt die
+                          Katalog-Identitaet auf die Lager-Position, und die
+                          Zeile ist ab dann eine Tatsache — dauerhaft, nicht
+                          nur in dieser Ansicht. */}
+                      {row.outcome === 'proposed-by-name' && row.itemId && row.deviceTypeId && (
+                        <button
+                          type="button"
+                          onClick={() =>
+                            updateItem(row.itemId!, { deviceTypeId: row.deviceTypeId })
+                          }
+                          className="ml-2 rounded border border-cp-border px-1.5 py-0.5 text-[10px] font-normal text-cp-text-secondary hover:bg-cp-surface-3"
+                          title={t(
+                            'export.devicebom.confirmTitle',
+                            'Schreibt die Katalog-Identität dauerhaft auf diese Lager-Position. Danach ist die Deckung eine Tatsache und muss nie wieder über den Namen geraten werden.',
+                          )}
+                        >
+                          {t('export.devicebom.confirm', 'Bestätigen')}
+                        </button>
                       )}
                     </td>
                     <td className="px-2 py-1 font-mono">{row.available ?? '—'}</td>

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -2165,6 +2165,9 @@ export const en: Dict = {
   'export.devicebom.noTypeTitle':
     'No catalogue type — the model name here is only the device name. Assigning a catalogue type turns the coverage into a fact.',
   'export.devicebom.short': '— {n} missing',
+  'export.devicebom.confirm': 'Confirm',
+  'export.devicebom.confirmTitle':
+    'Writes the catalogue identity permanently onto this inventory position. The coverage is then a fact and never has to be guessed from the name again.',
   'export.devicebom.csv': 'Device BOM as CSV',
   'export.devicebom.pick': 'Pick list (CSV)',
   'export.devicebom.pickTitle':

--- a/src/renderer/lib/planBom.ts
+++ b/src/renderer/lib/planBom.ts
@@ -42,6 +42,11 @@ export interface PlanBomRow {
   reason?: string
   /** true, wenn `model` nur der Instanzname eines Geräts ist. */
   modelIsDeviceName: boolean
+  /** Lager-Position, die deckt bzw. vorgeschlagen ist — Ziel der Bestätigung. */
+  itemId?: string
+  /** Katalog-Identität des Bedarfs. Zusammen mit `itemId` ist das alles, was
+   *  eine Bestätigung braucht: die Identität auf die Position schreiben. */
+  deviceTypeId?: string
 }
 
 export interface PlanBom {
@@ -84,6 +89,8 @@ const rowOf = (
         : '',
     ...(line.reason ? { reason: line.reason } : {}),
     modelIsDeviceName: line.demand.labelIsDeviceName,
+    ...(line.itemId ? { itemId: line.itemId } : {}),
+    ...(line.demand.deviceTypeId ? { deviceTypeId: line.demand.deviceTypeId } : {}),
   }
 }
 

--- a/src/renderer/store/inventoryStore.ts
+++ b/src/renderer/store/inventoryStore.ts
@@ -301,11 +301,15 @@ interface InventoryState {
   /** Entfernt einen Artikel (und aus allen Set-Komponenten). */
   removeItem: (id: string) => void
   /**
-   * Seed aus dem aktuellen Plan: gruppiert Equipment nach Name (+ Kategorie)
-   * und legt je Gruppe einen Artikel mit Menge = Anzahl der Instanzen an.
-   * Bereits vorhandene Artikel (gleiches Modell+Kategorie, case-insensitive)
-   * werden NICHT dupliziert — ihre Menge wird auf max(bestehend, gezählt)
-   * angehoben. Liefert die Anzahl neu angelegter Artikel.
+   * Seed aus dem aktuellen Plan (ADR-002): gruppiert Equipment ueber die
+   * Katalog-Identitaet `deviceTypeId`, sonst ueber Name + Kategorie, und legt
+   * je Gruppe einen Artikel mit Menge = Anzahl der Instanzen an. Der
+   * Modellname kommt bei typisierten Geraeten aus dem Katalog, nicht vom
+   * Geraet.
+   *
+   * Vorhandene Artikel werden NICHT dupliziert: Ihre Menge wird auf
+   * max(bestehend, gezaehlt) angehoben, und eine fehlende Typ-Identitaet wird
+   * nachgetragen. Liefert die Anzahl neu angelegter Artikel.
    */
   seedFromEquipment: (equipment: EquipmentItem[]) => number
   /** Legt einen Lager-Knoten (Lagerplatz oder Container) an, liefert die id. */

--- a/tests/planBom.test.ts
+++ b/tests/planBom.test.ts
@@ -184,3 +184,31 @@ describe('outcomeLabel', () => {
     expect(outcomeLabel('unmatched')).toBe('nicht im Lager')
   })
 })
+
+describe('PlanBomRow — was eine Bestätigung braucht', () => {
+  it('trägt bei einem Vorschlag Position UND Katalog-Identität mit', () => {
+    // Beides zusammen ist alles, was die Bestätigung braucht: die Identität
+    // auf die Position schreiben, dann ist die Deckung eine Tatsache.
+    const bom = buildPlanBom(
+      [eq({ deviceTypeId: F55_ID })],
+      [item({ id: 'i1', model: F55_MODEL, quantity: 2 })],
+      NODES,
+    )
+    expect(bom.rows[0]).toMatchObject({
+      outcome: 'proposed-by-name',
+      itemId: 'i1',
+      deviceTypeId: F55_ID,
+    })
+  })
+
+  it('lässt die Identität weg, wo der Bedarf keine hat', () => {
+    // Ohne Katalog-Typ im Plan gibt es nichts zu bestätigen — die Zeile darf
+    // dann auch keinen Knopf anbieten.
+    const bom = buildPlanBom(
+      [eq({ name: 'Sonderbau XY' })],
+      [item({ id: 'i1', model: 'Sonderbau XY', quantity: 1 })],
+      NODES,
+    )
+    expect(bom.rows[0].deviceTypeId).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Der Nachsatz von [ADR-002](https://github.com/larszu/av-planner-suite/blob/main/docs/decisions/ADR-002-device-identity-plan-and-stock.md): *„Der Namensabgleich bleibt erlaubt — aber nur als Vorschlag, den ein Mensch einmal bestätigt, und die Bestätigung wird als `deviceTypeId` festgeschrieben. Danach ist sie eine Tatsache und muss nie wieder geraten werden."*

Die erste Hälfte davon stand seit Inkrement 4: Die Stückliste zeigt einen Vorschlag und begründet ihn. Die zweite fehlte — es gab **keinen Weg**, ihn zur Tatsache zu machen. Damit blieb jede Zeile für immer ein Vorschlag, und die Begründung erschien bei jedem Öffnen neu.

Jetzt trägt eine Vorschlagszeile einen Knopf. Ein Klick schreibt die Katalog-Identität dauerhaft auf die Lager-Position; die Zeile ist beim nächsten Rendern `matched-by-type`, bekommt ihren Lagerort und steht auf der Kommissionier-Liste.

**Der Knopf erscheint nur, wo es wirklich etwas zu bestätigen gibt.** Trägt der Plan-Bedarf selbst keinen Katalog-Typ — etwa bei einem handangelegten „Sonderbau XY" —, gäbe es nichts zu schreiben, und die Zeile bietet folgerichtig nichts an. Ein Test hält beide Fälle fest.

Nebenbei: Der Interface-Kommentar an `seedFromEquipment` beschrieb noch die Gruppierung über den Namen, die derselbe Zweig gerade ersetzt hat. Korrigiert.

## Prüfung

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 391 Tests, 37 Dateien, alle grün (+2 neue)
- `npm run lint` — 0 Fehler (10 vorbestehende Warnungen)
- `npm run build` — grün

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_