### PR TITLE
identity: Katalog-Typ am Gerät zuweisbar machen (ADR-002)

### DIFF
--- a/src/renderer/components/Properties/sections/IdentityBlock.tsx
+++ b/src/renderer/components/Properties/sections/IdentityBlock.tsx
@@ -1,6 +1,8 @@
+import { useMemo, useState } from 'react'
 import { useCanvasProjectStore as useProjectStore } from '../../../store/projectStoreContext'
 import { generateShortName } from '../../../lib/shortName'
-import { useTranslation } from '../../../lib/i18n'
+import { useTranslation, format } from '../../../lib/i18n'
+import { listDeviceTypes, resolveDeviceType } from '../../../lib/deviceTypeRegistry'
 import type { EquipmentItem } from '../../../types/equipment'
 
 /**
@@ -8,6 +10,12 @@ import type { EquipmentItem } from '../../../types/equipment'
  * die zusammen die "Identitaet" des Geraets beschreiben. Short-Name
  * (#v7.9.127) wird auto-generiert wenn leer — Placeholder zeigt den
  * Vorschlag, "↻ auto"-Button uebernimmt ihn ins Override-Feld.
+ *
+ * ADR-002 — dazu der KATALOG-TYP. Er ist die vierte und einzige Angabe
+ * hier, die nicht der Mensch formuliert, sondern das Datenblatt: die
+ * stabile GUID, ueber die Plan und Lager sich ohne Namensvergleich finden.
+ * Bis hierher konnte sie nur beim Anlegen aus dem Katalog entstehen; ein
+ * von Hand angelegtes oder importiertes Geraet hatte nie eine.
  */
 export const IdentityBlock = ({ equipment }: { equipment: EquipmentItem }) => {
   const t = useTranslation()
@@ -16,6 +24,8 @@ export const IdentityBlock = ({ equipment }: { equipment: EquipmentItem }) => {
 
   return (
     <>
+      <DeviceTypePicker equipment={equipment} />
+
       <label className="block">
         <span className="mb-1 block text-cp-text-secondary">{t('eq.field.name', 'Name')}</span>
         <input
@@ -91,5 +101,94 @@ export const IdentityBlock = ({ equipment }: { equipment: EquipmentItem }) => {
         />
       </label>
     </>
+  )
+}
+
+/**
+ * Zuweisung des Katalog-Typs.
+ *
+ * BEWUSST NUR DIE IDENTITAET: Ports, Masse und Leistung des Geraets bleiben
+ * unangetastet. Der Nutzer sagt hier „das IST dieses Modell", er tauscht das
+ * Geraet nicht aus — dafuer gibt es die Geraete-Ersetzung weiter unten. Ein
+ * Klick, der stillschweigend die Verkabelungspunkte neu schreibt, waere eine
+ * andere Aktion mit demselben Aussehen.
+ */
+const DeviceTypePicker = ({ equipment }: { equipment: EquipmentItem }) => {
+  const t = useTranslation()
+  const updateEquipment = useProjectStore((state) => state.updateEquipment)
+  const [filter, setFilter] = useState('')
+
+  const current = resolveDeviceType(equipment.deviceTypeId)
+  const all = useMemo(() => listDeviceTypes(), [])
+  const matches = useMemo(() => {
+    const needle = filter.trim().toLowerCase()
+    if (!needle) return all
+    return all.filter(
+      (c) =>
+        c.name.toLowerCase().includes(needle) ||
+        (c.category ?? '').toLowerCase().includes(needle),
+    )
+  }, [all, filter])
+
+  return (
+    <div className="rounded border border-cp-border-muted bg-cp-surface-1/40 p-2">
+      <div className="mb-1 flex items-baseline justify-between gap-2">
+        <span className="text-cp-text-secondary">
+          {t('eq.field.deviceType', 'Katalog-Typ')}
+        </span>
+        {current ? (
+          <button
+            type="button"
+            onClick={() => updateEquipment(equipment.id, { deviceTypeId: undefined })}
+            className="text-cp-xs text-cp-text-muted hover:text-cp-text"
+          >
+            {t('eq.field.deviceTypeClear', 'lösen')}
+          </button>
+        ) : null}
+      </div>
+
+      {current ? (
+        <p className="mb-1 text-cp-text">{current.template.name}</p>
+      ) : (
+        <p className="mb-1 text-cp-text-muted">
+          {t(
+            'eq.field.deviceTypeNone',
+            'Kein Katalog-Typ — Lager-Deckung und Stückliste können dieses Gerät nur über den Namen erraten.',
+          )}
+        </p>
+      )}
+
+      <input
+        value={filter}
+        onChange={(event) => setFilter(event.target.value)}
+        placeholder={t('eq.field.deviceTypeFilter', 'Katalog durchsuchen…')}
+        className="mb-1 w-full rounded border border-cp-border bg-cp-surface-1 p-1.5 text-cp-xs"
+      />
+      <select
+        value={equipment.deviceTypeId ?? ''}
+        onChange={(event) =>
+          updateEquipment(equipment.id, { deviceTypeId: event.target.value || undefined })
+        }
+        className="w-full rounded border border-cp-border bg-cp-surface-1 p-1.5 text-cp-xs"
+      >
+        <option value="">{t('eq.field.deviceTypeUnset', '— keiner —')}</option>
+        {matches.map((c) => (
+          <option key={c.id} value={c.id}>
+            {c.category ? `${c.name} · ${c.category}` : c.name}
+          </option>
+        ))}
+      </select>
+      <p className="mt-1 text-cp-xs text-cp-text-faint">
+        {format(t('eq.field.deviceTypeCount', '{n} von {total} Typen'), {
+          n: matches.length,
+          total: all.length,
+        })}
+        {' — '}
+        {t(
+          'eq.field.deviceTypeScope',
+          'setzt nur die Identität; Ports, Maße und Leistung bleiben unverändert.',
+        )}
+      </p>
+    </div>
   )
 }

--- a/src/renderer/lib/deviceTypeRegistry.ts
+++ b/src/renderer/lib/deviceTypeRegistry.ts
@@ -120,6 +120,33 @@ const buildRegistry = (): Map<string, DeviceTypeInfo> => {
  * Loest eine stabile Geraetetyp-ID autoritativ auf — oder null, wenn die ID
  * (noch) nicht in unseren Katalogen liegt. Kein Raten: null heisst unbekannt.
  */
+export interface DeviceTypeChoice {
+  id: string
+  /** Modellname aus dem Datenblatt-Template. */
+  name: string
+  category?: string
+}
+
+/**
+ * ADR-002 — alle Katalog-Typen zur Auswahl.
+ *
+ * Bis hierher konnte eine `deviceTypeId` NUR ueber ein Katalog-Template in ein
+ * Geraet gelangen: Wer eines von Hand anlegt oder importiert, bekam nie eine
+ * Identitaet — und ohne sie bleibt die Lager-Deckung fuer immer ein
+ * Namensvergleich. Diese Liste ist die Voraussetzung dafuer, sie nachtraeglich
+ * zuzuweisen.
+ */
+export const listDeviceTypes = (): DeviceTypeChoice[] => {
+  registry ??= buildRegistry()
+  return [...registry.entries()]
+    .map(([id, info]) => ({
+      id,
+      name: info.template.name,
+      ...(info.template.category ? { category: info.template.category } : {}),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name, 'de'))
+}
+
 export const resolveDeviceType = (deviceTypeId: string | undefined): DeviceTypeInfo | null => {
   if (!deviceTypeId) return null
   registry ??= buildRegistry()

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -2148,6 +2148,17 @@ export const en: Dict = {
   'cable.aria.toDevice': 'Target device',
   'cable.aria.toPort': 'Target port',
 
+  // ADR-002 — Katalog-Typ am Geraet (IdentityBlock)
+  'eq.field.deviceType': 'Catalogue type',
+  'eq.field.deviceTypeClear': 'clear',
+  'eq.field.deviceTypeNone':
+    'No catalogue type — inventory coverage and the BOM can only guess this device from its name.',
+  'eq.field.deviceTypeFilter': 'Search the catalogue…',
+  'eq.field.deviceTypeUnset': '— none —',
+  'eq.field.deviceTypeCount': '{n} of {total} types',
+  'eq.field.deviceTypeScope':
+    'sets the identity only; ports, dimensions and power stay unchanged.',
+
   // ADR-002, Inkrement 4 — Geraete-Stueckliste + Kommissionier-Liste
   'export.section.devicebom': 'Device BOM',
   'export.desc.devicebom':

--- a/tests/deviceTypeRegistry.test.ts
+++ b/tests/deviceTypeRegistry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolveDeviceType } from '../src/renderer/lib/deviceTypeRegistry'
+import { listDeviceTypes, resolveDeviceType } from '../src/renderer/lib/deviceTypeRegistry'
 import {
   detectDeviceKind,
   detectNetworkDevice,
@@ -214,5 +214,33 @@ describe('videohubPresetForDevice — kein Raten', () => {
   it('ohne ID und ohne BNC-Ports → custom 16/16 (klar editierbare Eigen-Groesse)', () => {
     const r = videohubPresetForDevice(eq({ name: 'Leergeraet' }))
     expect(r).toEqual({ key: 'custom', customInputs: 16, customOutputs: 16 })
+  })
+})
+
+describe('listDeviceTypes (ADR-002)', () => {
+  it('liefert jeden Registry-Eintrag mit Id und Modellnamen', () => {
+    const all = listDeviceTypes()
+    expect(all.length).toBeGreaterThan(100)
+    for (const c of all) {
+      expect(c.id).toBeTruthy()
+      expect(c.name.trim()).not.toBe('')
+    }
+  })
+
+  it('vergibt keine Id doppelt', () => {
+    const all = listDeviceTypes()
+    expect(new Set(all.map((c) => c.id)).size).toBe(all.length)
+  })
+
+  it('ist nach Modellname sortiert', () => {
+    const names = listDeviceTypes().map((c) => c.name)
+    expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b, 'de')))
+  })
+
+  it('jeder gelistete Eintrag ist auch auflösbar', () => {
+    // Sonst böte die Auswahl Typen an, die danach ins Leere zeigen.
+    for (const c of listDeviceTypes()) {
+      expect(resolveDeviceType(c.id)?.template.name).toBe(c.name)
+    }
   })
 })


### PR DESCRIPTION
Die zweite Hälfte des offenen Punkts aus [ADR-002](https://github.com/larszu/av-planner-suite/blob/main/docs/decisions/ADR-002-device-identity-plan-and-stock.md). [#608](https://github.com/larszu/cable-planner/pull/608) hat den Weg geschlossen, einen Vorschlag zur Tatsache zu machen — aber nur, wenn der Plan-Bedarf überhaupt eine Identität hat.

## Der Befund

Nachgeprüft, nicht vermutet: `deviceTypeId` gelangt heute **ausschließlich** über Katalog-Templates in ein Gerät. Eine Suche über den ganzen Renderer findet keine andere Stelle, die das Feld auf einem `EquipmentItem` setzt. Wer ein Gerät von Hand anlegt, aus GraphML oder aus Rentman importiert, bekommt nie eine — und ohne sie bleibt die Lager-Deckung für immer ein Namensvergleich, egal wie oft man ihn bestätigt.

## Was dazukommt

`listDeviceTypes()` öffnet das Register (444 Einträge) zur Auswahl — mit einem Test, dass **jeder angebotene Typ auch auflösbar ist**, sonst böte die Auswahl Einträge an, die ins Leere zeigen.

Der Picker sitzt im `IdentityBlock`, und zwar dort, weil er hingehört: Dessen eigener Kommentar beschreibt „drei Felder, die zusammen die Identität des Geräts beschreiben". Der Katalog-Typ ist das vierte — und das einzige, das nicht der Mensch formuliert, sondern das Datenblatt.

Ohne gesetzten Typ steht dort nicht nur „keiner", sondern die Folge: *„Lager-Deckung und Stückliste können dieses Gerät nur über den Namen erraten."* Das ist die Stelle, an der jemand den Zusammenhang sieht.

## Er setzt nur die Identität

Ports, Maße und Leistung bleiben unangetastet — und das steht auch unter dem Feld. „Das **ist** dieses Modell" ist eine andere Aussage als „tausche das Gerät aus"; für Letzteres gibt es die Geräte-Ersetzung weiter unten in derselben Palette. Ein Klick, der stillschweigend die Verkabelungspunkte neu schreibt, wäre eine andere Aktion mit demselben Aussehen.

## Prüfung

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 395 Tests, 37 Dateien, alle grün (+4 neue)
- `npm run lint` — 0 Fehler (10 vorbestehende Warnungen)
- `npm run build` — grün

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_