### PR TITLE
fix(videohub): Status-Read überschreibt den Plan nicht mehr (Initiative 10)

### DIFF
--- a/src/renderer/components/Export/VideohubExportDialog.tsx
+++ b/src/renderer/components/Export/VideohubExportDialog.tsx
@@ -6,9 +6,10 @@ import {
   emptyVideohubRouting,
   legacySalvoKey,
   mergeLegacySalvos,
+  routingDifferences,
 } from '../../lib/videohubRouting'
 import type { VideohubSalvo } from '../../types/equipment'
-import { useTranslation } from '../../lib/i18n'
+import { useTranslation, format as fmt } from '../../lib/i18n'
 import { videohubPresetForDevice } from '../../lib/deviceKind'
 import { downloadBlob } from '../../lib/downloadBlob'
 import { buildExportFilenameWithSuffix } from '../../lib/exportFilename'
@@ -393,10 +394,16 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
       })
       if (result.ok && result.state) {
         setHubState(result.state)
-        // Aktuelles Routing vom Hub uebernehmen
-        if (Object.keys(result.state.routing).length > 0) {
-          setRouting({ ...result.state.routing })
-        }
+        // Initiative 10 — der Status-Read ueberschreibt den Plan NICHT mehr.
+        //
+        // Vorher stand hier `setRouting({ ...result.state.routing })`. Da das
+        // geplante Routing seit ADR-001 ins Projekt persistiert wird, hat ein
+        // Klick auf "Status lesen" die geplante Kreuzschiene still durch das
+        // ersetzt, was der Hub im Moment gerade tut — und mitgespeichert. Was
+        // der Hub tut, ist eine Beobachtung; was im Plan steht, eine Absicht.
+        // Beide in dieselbe Variable zu schreiben macht die Absicht
+        // unauffindbar. Die Differenz steht jetzt im Hub-Status und wird auf
+        // Wunsch uebernommen.
         const labels = Object.keys(result.state.inputLabels).length
         const locks = Object.values(result.state.outputLocks).filter(
           (v) => v !== 'unlocked',
@@ -1327,6 +1334,44 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                     <Icon icon={Lock} size="xs" className="mr-1 inline-block align-text-bottom" />{lockedCount} Output{lockedCount !== 1 ? 's' : ''} {t('export.locked', 'gesperrt')}
                   </span>
                 ) : null
+              })()}
+              {/* Plan gegen Geraet: die Differenz sichtbar machen, statt sie
+                  still aufzuloesen. Uebernehmen ist eine Entscheidung. */}
+              {(() => {
+                const diff = routingDifferences(routing, hubState.routing)
+                if (diff.length === 0) {
+                  return (
+                    <span className="ml-2 text-emerald-300">
+                      {t('videohub.routingMatches', 'Routing stimmt mit dem Plan überein.')}
+                    </span>
+                  )
+                }
+                return (
+                  <span className="ml-2">
+                    <span className="rounded bg-amber-900/40 px-1 py-0.5 text-amber-200">
+                      {fmt(
+                        t('videohub.routingDiffers', '{n} Kreuzpunkt(e) weichen vom Plan ab'),
+                        { n: diff.length },
+                      )}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setRouting({ ...hubState.routing })
+                        logEvent(
+                          `Hub-Routing in den Plan uebernommen (${diff.length} Kreuzpunkte geaendert).`,
+                        )
+                      }}
+                      className="ml-1.5 rounded border border-sky-600/60 px-1.5 py-0.5 text-sky-100 hover:bg-sky-900/40"
+                      title={t(
+                        'videohub.adoptTitle',
+                        'Ersetzt das geplante Routing durch den gelesenen Hub-Zustand. Bis dahin bleibt der Plan unverändert — ein Status-Read ist eine Beobachtung, keine Planänderung.',
+                      )}
+                    >
+                      {t('videohub.adopt', 'in den Plan übernehmen')}
+                    </button>
+                  </span>
+                )
               })()}
             </div>
           )}

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -2148,6 +2148,13 @@ export const en: Dict = {
   'cable.aria.toDevice': 'Target device',
   'cable.aria.toPort': 'Target port',
 
+  // Initiative 10 — Plan gegen Geraet (Videohub-Status-Read)
+  'videohub.routingMatches': 'Routing matches the plan.',
+  'videohub.routingDiffers': '{n} crosspoint(s) differ from the plan',
+  'videohub.adopt': 'adopt into the plan',
+  'videohub.adoptTitle':
+    'Replaces the planned routing with the hub state that was read. Until then the plan stays unchanged — a status read is an observation, not a plan change.',
+
   // ADR-002 — Katalog-Typ am Geraet (IdentityBlock)
   'eq.field.deviceType': 'Catalogue type',
   'eq.field.deviceTypeClear': 'clear',

--- a/src/renderer/lib/videohubRouting.ts
+++ b/src/renderer/lib/videohubRouting.ts
@@ -114,3 +114,46 @@ export const danglingCrosspoints = (
     .map(([o, i]) => ({ output: Number(o), input: i }))
     .filter(({ output, input }) => output >= outputCount || input >= inputCount)
     .sort((a, b) => a.output - b.output)
+
+export interface CrosspointDifference {
+  /** 0-basierter Ausgang. */
+  output: number
+  /** Geplanter Eingang, oder undefined wenn der Plan dazu nichts sagt. */
+  planned?: number
+  /** Eingang laut Geraet, oder undefined wenn das Geraet ihn nicht meldet. */
+  live?: number
+}
+
+/**
+ * Initiative 10 — Unterschied zwischen Plan und Geraet, Kreuzpunkt fuer
+ * Kreuzpunkt.
+ *
+ * Ein Status-Read darf den Plan NICHT ueberschreiben: Was der Hub gerade tut,
+ * ist eine Beobachtung, was im Plan steht, eine Absicht. Beides in dieselbe
+ * Variable zu schreiben macht die Absicht unauffindbar — und wenn die Variable
+ * persistiert wird, ist sie weg. Diese Funktion macht aus dem stillen
+ * Ueberschreiben eine sichtbare Differenz, ueber die ein Mensch entscheidet.
+ *
+ * Beruecksichtigt Ausgaenge, die nur eine der beiden Seiten kennt: Fehlen ist
+ * ein Unterschied, kein Gleichstand.
+ */
+export const routingDifferences = (
+  planned: VideohubCrosspoints,
+  live: VideohubCrosspoints,
+): CrosspointDifference[] => {
+  const outputs = new Set<number>()
+  for (const key of Object.keys(planned)) outputs.add(Number(key))
+  for (const key of Object.keys(live)) outputs.add(Number(key))
+  const out: CrosspointDifference[] = []
+  for (const output of [...outputs].filter((o) => Number.isInteger(o)).sort((a, b) => a - b)) {
+    const p = planned[output]
+    const l = live[output]
+    if (p === l) continue
+    out.push({
+      output,
+      ...(p !== undefined ? { planned: p } : {}),
+      ...(l !== undefined ? { live: l } : {}),
+    })
+  }
+  return out
+}

--- a/tests/videohubRouting.test.ts
+++ b/tests/videohubRouting.test.ts
@@ -7,6 +7,7 @@ import {
   mergeLegacySalvos,
   legacySalvoKey,
   danglingCrosspoints,
+  routingDifferences,
 } from '../src/renderer/lib/videohubRouting'
 
 describe('normaliseCrosspoints', () => {
@@ -102,5 +103,29 @@ describe('danglingCrosspoints', () => {
 
   it('meldet nichts bei sauberem Routing', () => {
     expect(danglingCrosspoints({ 0: 1, 1: 0 }, 2, 2)).toEqual([])
+  })
+})
+
+describe('routingDifferences (Initiative 10)', () => {
+  it('meldet nur die Kreuzpunkte, die sich unterscheiden', () => {
+    expect(routingDifferences({ 0: 1, 1: 2, 2: 3 }, { 0: 1, 1: 9, 2: 3 })).toEqual([
+      { output: 1, planned: 2, live: 9 },
+    ])
+  })
+
+  it('wertet Fehlen als Unterschied, nicht als Gleichstand', () => {
+    // Ein Ausgang, zu dem der Plan nichts sagt, ist nicht 'wie das Gerät'.
+    expect(routingDifferences({ 0: 1 }, { 0: 1, 5: 7 })).toEqual([{ output: 5, live: 7 }])
+    expect(routingDifferences({ 3: 4 }, {})).toEqual([{ output: 3, planned: 4 }])
+  })
+
+  it('ist leer, wenn Plan und Gerät übereinstimmen', () => {
+    expect(routingDifferences({ 0: 1, 1: 2 }, { 1: 2, 0: 1 })).toEqual([])
+    expect(routingDifferences({}, {})).toEqual([])
+  })
+
+  it('sortiert nach Ausgang, damit die Liste lesbar bleibt', () => {
+    const diff = routingDifferences({ 5: 1, 0: 1, 2: 1 }, { 5: 2, 0: 2, 2: 2 })
+    expect(diff.map((d) => d.output)).toEqual([0, 2, 5])
   })
 })


### PR DESCRIPTION
Beim Sichten des Codes für Roadmap-Initiative 10 (Confirmed-State-Disziplin) gefunden — und es ist eine Regression, die ich selbst eingebaut habe.

## Der Fehler

`handleReadState` im Videohub-Export machte nach einem erfolgreichen Status-Read:

```ts
setRouting({ ...result.state.routing })
```

Das war harmlos, solange `routing` nur Dialog-State war. Seit ADR-001 Inkrement 0 wird es aber ins Projekt persistiert (`equipment.videohubRouting.planned`) — und ein Effekt schreibt jede Änderung durch. Damit hat **ein Klick auf „Status lesen" die geplante Kreuzschiene still durch das ersetzt, was der Hub in diesem Moment gerade tut**, und das Ergebnis mitgespeichert. Die Planungsabsicht war danach nicht mehr auffindbar: Es gibt keine zweite Kopie, aus der sie sich rekonstruieren ließe.

Das ist wörtlich der Befund, den Initiative 10 aus fünf Marktsegmenten zitiert — *den echten Gerätezustand lesen, statt den zuletzt gesendeten Befehl anzuzeigen* — nur in der anderen Richtung und mit schlimmerer Folge: Hier frisst die Beobachtung die Absicht.

## Der Fix

Was der Hub tut, ist eine Beobachtung. Was im Plan steht, ist eine Absicht. Beide in dieselbe Variable zu schreiben löscht die zweite.

- `routingDifferences(planned, live)` vergleicht kreuzpunktweise. **Fehlen zählt als Unterschied, nicht als Gleichstand** — ein Ausgang, zu dem der Plan nichts sagt, ist nicht „wie das Gerät".
- Der Hub-Status zeigt die Abweichung, statt sie aufzulösen: entweder „Routing stimmt mit dem Plan überein" oder „*n* Kreuzpunkte weichen ab" mit einem ausdrücklichen **„in den Plan übernehmen"**.
- Der Status-Read selbst ändert am Plan nichts mehr.

Damit ist Initiative 10 an genau der Stelle umgesetzt, an der wir die Regel selbst verletzt haben — was mir lieber ist als ein ADR über die Regel, während der Verstoß im Code steht.

## Was ich dabei sonst geprüft habe

Nicht jede Integration hat das Problem, und das ist wichtig für den ADR, der noch kommt: Der **ATEM-Dialog liest nach jedem Push den Gerätezustand neu** (`bulkSetInputNames` → `getState` → `setState`) und zeigt danach das Gerät, nicht den Befehl. Er erfüllt die Regel bereits. Ein pauschales „unsere Integrationen sind alle open-loop" wäre falsch gewesen.

## Prüfung

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 399 Tests, 37 Dateien, alle grün (+4 neue für `routingDifferences`)
- `npm run lint` — 0 Fehler (10 vorbestehende Warnungen)
- `npm run build` — grün

Nebenbei: Der Typecheck hat einen Namenskonflikt gefunden, den der Build nicht bemerkt hätte — `format` aus `lib/i18n` kollidiert mit dem lokalen Export-Format-State. `npm run build` lief trotzdem grün durch, weil Vite nicht typprüft. Ein Grund mehr, dass beide Schritte im CI stehen.

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_