### PR TITLE
rentman: gesendete Menge nicht aus der Planmenge vorbelegen (ADR-003)

### DIFF
--- a/src/renderer/components/Rentman/RentmanCableExportDialog.tsx
+++ b/src/renderer/components/Rentman/RentmanCableExportDialog.tsx
@@ -22,8 +22,9 @@ interface CableBucket {
   /** Rentman equipment id this bucket is mapped to (if any). */
   mappedId?: string
   mappedName?: string
-  /** Quantity that has already been pushed to Rentman (lastSyncedQty). */
-  syncedQty: number
+  /** Quantity that has already been pushed to Rentman (lastSentQty).
+   *  ADR-003: gesendet, nicht von Rentman bestaetigt. */
+  sentQty: number
   delta: number
   /** Sample cable name for display. */
   sample?: Cable
@@ -42,7 +43,7 @@ const keyOf = (c: Pick<Cable, 'type' | 'length'>): string => `${c.type}|${c.leng
  *
  * For every (cable-type, length) bucket the user maps the bucket to a Rentman
  * master-catalogue equipment id once. The dialog then computes the delta
- * between the current built quantity and the last synced quantity, and POSTs
+ * between the current built quantity and the last sent quantity, and POSTs
  * `addProjectEquipment(projectId, equipmentId, delta)` to extend the Rentman
  * project plan. Negative deltas are surfaced as warnings rather than silently
  * removing equipment, because the Rentman REST API has no project-equipment
@@ -143,7 +144,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
       const mappedName = mappedId
         ? catalog.find((item) => item.id === mappedId)?.name
         : undefined
-      const synced = map?.lastSyncedQty ?? 0
+      const sent = map?.lastSentQty ?? 0
       list.push({
         key,
         type,
@@ -152,8 +153,8 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
         planned: plannedCount,
         mappedId,
         mappedName,
-        syncedQty: synced,
-        delta: builtCount - synced,
+        sentQty: sent,
+        delta: builtCount - sent,
         sample: built.get(key)?.sample,
       })
     }
@@ -173,9 +174,9 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
       ...current,
       [key]: {
         rentmanEquipmentId,
-        lastSyncedQty: options.resetSync
+        lastSentQty: options.resetSync
           ? 0
-          : current[key]?.lastSyncedQty ?? 0,
+          : current[key]?.lastSentQty ?? 0,
       },
     }
     updateMeta({ rentmanCableMap: next })
@@ -215,7 +216,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
           ...current,
           [bucket.key]: {
             rentmanEquipmentId: bucket.mappedId,
-            lastSyncedQty: bucket.built,
+            lastSentQty: bucket.built,
           },
         },
       })
@@ -250,7 +251,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
     for (const bucket of sendable) {
       // sendBucket guards on busyKey === bucket.key inside its own state,
       // and updates project metadata after each push so the next iteration
-      // sees the fresh syncedQty value.
+      // sees the fresh sentQty value.
       await sendBucket(bucket)
     }
   }
@@ -285,7 +286,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
         <div className="flex flex-wrap items-center gap-2 border-b border-cp-border-muted px-4 py-2 text-[11px] text-cp-text-muted">
           {(() => {
             const totalBuilt = buckets.reduce((sum, b) => sum + b.built, 0)
-            const totalSynced = buckets.reduce((sum, b) => sum + b.syncedQty, 0)
+            const totalSent = buckets.reduce((sum, b) => sum + b.sentQty, 0)
             const positiveDeltas = buckets.filter((b) => b.delta > 0)
             const sendableCount = positiveDeltas
               .filter((b) => b.mappedId)
@@ -295,7 +296,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
               <>
                 <span>
                   <span className="font-mono text-cp-text-bright">{totalBuilt}</span> {t('rentman.cableExport.cablesBuilt', 'Kabel verbaut')} ·{' '}
-                  <span className="font-mono text-cp-text-bright">{totalSynced}</span> {t('rentman.cableExport.alreadySent', 'bereits gesendet')}
+                  <span className="font-mono text-cp-text-bright">{totalSent}</span> {t('rentman.cableExport.alreadySent', 'bereits gesendet')}
                 </span>
                 {sendableCount > 0 && (
                   <span className="text-amber-300">
@@ -384,7 +385,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
                     </td>
                     <td className="px-3 py-1.5 text-right font-mono">{bucket.built}</td>
                     <td className="px-3 py-1.5 text-right font-mono">{bucket.planned}</td>
-                    <td className="px-3 py-1.5 text-right font-mono">{bucket.syncedQty}</td>
+                    <td className="px-3 py-1.5 text-right font-mono">{bucket.sentQty}</td>
                     <td
                       className={`px-3 py-1.5 text-right font-mono ${
                         bucket.delta > 0

--- a/src/renderer/components/Rentman/RentmanImportDialog.tsx
+++ b/src/renderer/components/Rentman/RentmanImportDialog.tsx
@@ -504,10 +504,14 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
       // lets them re-pick if needed.
       const firstRow = bucket.rows[0]
       const existingMap = mapPatch[bucket.key]
+      // ADR-003 — Startwert ist bucket.totalQty (was Rentman fuehrt), nicht
+      // qty (die im Dialog editierbare Planmenge). Sonst zaehlt der Export
+      // eine geplante Korrektur als bereits gesendet und jede folgende
+      // Differenz ist um genau diesen Betrag zu klein.
       mapPatch[bucket.key] = {
         rentmanEquipmentId:
           existingMap?.rentmanEquipmentId ?? firstRow.rentmanEquipmentId,
-        lastSyncedQty: existingMap?.lastSyncedQty ?? qty,
+        lastSentQty: existingMap?.lastSentQty ?? bucket.totalQty,
       }
     }
     const projectName =

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -668,7 +668,42 @@ const healProjectPositions = (project: CablePlannerProject): CablePlannerProject
     changelog: project.changelog ?? [],
     // ADR-001 — Rollen sind optional; alte Projekte heilen zu [].
     sourceIdentities,
+    // ADR-003 — Rentman-Zaehler: gesendet ist nicht bestaetigt.
+    metadata: healRentmanCableMap(project.metadata),
   }
+}
+
+/**
+ * ADR-003 / Inkrement 1 — `lastSyncedQty` hiess nach dem, was es nicht ist.
+ *
+ * Der Wert kommt aus dem, was der Export-Dialog gesendet hat; von Rentman
+ * zurueckgelesen wird er nie. Der Name behauptete eine Bestaetigung, die es
+ * nicht gibt — deshalb `lastSentQty`. Alte Projektfiles tragen den alten
+ * Schluessel; hier wird er uebernommen und entsorgt. Steht schon ein neuer
+ * Wert da, gewinnt der (ein Projekt, das beide traegt, wurde bereits mit der
+ * neuen Version geschrieben).
+ */
+const healRentmanCableMap = (
+  metadata: CablePlannerProject['metadata'],
+): CablePlannerProject['metadata'] => {
+  const map = metadata.rentmanCableMap
+  if (!map) return metadata
+  let changed = false
+  const healed: NonNullable<CablePlannerProject['metadata']['rentmanCableMap']> = {}
+  for (const [key, entry] of Object.entries(map)) {
+    if (!entry || typeof entry !== 'object') {
+      changed = true
+      continue
+    }
+    const legacy = entry as { lastSentQty?: number; lastSyncedQty?: number }
+    const sent = typeof legacy.lastSentQty === 'number' ? legacy.lastSentQty : legacy.lastSyncedQty
+    if ('lastSyncedQty' in legacy) changed = true
+    healed[key] = {
+      rentmanEquipmentId: entry.rentmanEquipmentId,
+      ...(typeof sent === 'number' && Number.isFinite(sent) ? { lastSentQty: sent } : {}),
+    }
+  }
+  return changed ? { ...metadata, rentmanCableMap: healed } : metadata
 }
 
 /**

--- a/src/renderer/types/project.ts
+++ b/src/renderer/types/project.ts
@@ -71,8 +71,12 @@ export interface ProjectMetadata {
    * and manually when a bucket is mapped via the Rentman cable export dialog.
    * Also remembers the last quantity that was pushed to Rentman so the export
    * can compute deltas.
+   *
+   * ADR-003 — `lastSentQty` heisst so, weil es genau das ist: die Menge, die
+   * abgeschickt wurde. Rentman bestaetigt sie nicht zurueck. Wer hier einen
+   * geplanten Wert hineinschreibt, verrechnet jede folgende Differenz.
    */
-  rentmanCableMap?: Record<string, { rentmanEquipmentId: string; lastSyncedQty?: number }>
+  rentmanCableMap?: Record<string, { rentmanEquipmentId: string; lastSentQty?: number }>
   /** Rentman project ID currently linked to this cable planner project. */
   rentmanProjectId?: string
   /** Human-readable name of the linked Rentman project. */

--- a/tests/rentmanCableMap.test.ts
+++ b/tests/rentmanCableMap.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import type { CablePlannerProject } from '../src/renderer/types/project'
+
+// ADR-003 (Bestaetigter Zustand statt gesendeter Befehl), Inkrement 1.
+//
+// Der Zaehler hinter der Spalte "Bereits gesendet" hiess `lastSyncedQty` und
+// wurde beim Import mit der im Dialog editierbaren *Planmenge* vorbelegt. Beides
+// zusammen behauptete eine Abstimmung mit Rentman, die nie stattgefunden hat.
+// Getestet wird deshalb genau das, was ein Projektfile ueberlebt: dass der alte
+// Schluessel uebernommen und entsorgt wird und der Wert dabei nicht kippt.
+
+const project = (
+  map: Record<string, unknown> | undefined,
+): CablePlannerProject =>
+  ({
+    metadata: {
+      name: 'T',
+      description: '',
+      createdAt: '',
+      updatedAt: '',
+      ...(map ? { rentmanCableMap: map } : {}),
+    },
+    equipment: [],
+    cables: [],
+    canvasState: { x: 0, y: 0, zoom: 1 },
+  }) as unknown as CablePlannerProject
+
+const loadAndRead = async (map: Record<string, unknown> | undefined) => {
+  const { useProjectStore } = await import('../src/renderer/store/projectStore')
+  useProjectStore.getState().loadProject(project(map))
+  return useProjectStore.getState().project.metadata.rentmanCableMap
+}
+
+describe('rentmanCableMap — Migration lastSyncedQty -> lastSentQty (ADR-003)', () => {
+  it('uebernimmt den alten Schluessel und entsorgt ihn', async () => {
+    const healed = await loadAndRead({
+      'BNC|10': { rentmanEquipmentId: 'r1', lastSyncedQty: 12 },
+    })
+    expect(healed?.['BNC|10']).toEqual({ rentmanEquipmentId: 'r1', lastSentQty: 12 })
+    expect('lastSyncedQty' in (healed?.['BNC|10'] ?? {})).toBe(false)
+  })
+
+  it('laesst einen bereits neuen Eintrag unveraendert', async () => {
+    const healed = await loadAndRead({
+      'BNC|10': { rentmanEquipmentId: 'r1', lastSentQty: 7 },
+    })
+    expect(healed?.['BNC|10']).toEqual({ rentmanEquipmentId: 'r1', lastSentQty: 7 })
+  })
+
+  it('behaelt den neuen Wert, wenn ein Projekt beide traegt', async () => {
+    // Kann nur entstehen, wenn eine neuere Version geschrieben und eine
+    // aeltere danach nichts mehr angefasst hat — der neue Wert ist der
+    // juengere.
+    const healed = await loadAndRead({
+      'BNC|10': { rentmanEquipmentId: 'r1', lastSentQty: 7, lastSyncedQty: 12 },
+    })
+    expect(healed?.['BNC|10']).toEqual({ rentmanEquipmentId: 'r1', lastSentQty: 7 })
+  })
+
+  it('haelt eine Zuordnung ohne Menge mengenlos statt sie auf 0 zu setzen', async () => {
+    // 0 hiesse "nichts gesendet" und wuerde die naechste Differenz auf die
+    // volle Menge stellen. Kein Wert heisst "unbekannt" — der Export-Dialog
+    // faellt selbst auf 0 zurueck, aber das Projektfile behauptet es nicht.
+    const healed = await loadAndRead({ 'BNC|10': { rentmanEquipmentId: 'r1' } })
+    expect(healed?.['BNC|10']).toEqual({ rentmanEquipmentId: 'r1' })
+  })
+
+  it('wirft kaputte Eintraege weg, statt am Load zu scheitern', async () => {
+    const healed = await loadAndRead({
+      'BNC|10': null,
+      'BNC|20': { rentmanEquipmentId: 'r2', lastSyncedQty: Number.NaN },
+    })
+    expect(healed?.['BNC|10']).toBeUndefined()
+    expect(healed?.['BNC|20']).toEqual({ rentmanEquipmentId: 'r2' })
+  })
+
+  it('laesst ein Projekt ohne Zuordnung in Ruhe', async () => {
+    expect(await loadAndRead(undefined)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Inkrement 1 aus ADR-003 (Bestätigter Zustand statt gesendeter Befehl, Roadmap-Initiative 10).

## Der Fehler

`RentmanImportDialog` schrieb beim „Kabelplan übernehmen" den Zähler hinter der Spalte **Bereits gesendet** aus `cablePlanQty[key] ?? bucket.totalQty` — also aus der im Dialog **editierbaren Planmenge**, nicht aus der Menge, die Rentman tatsächlich führt.

Der Dialog lädt ausdrücklich dazu ein, die Zahl anzufassen (Zahlenfeld pro Bucket). Wer das tut, schreibt eine *geplante* Menge in das Feld, das der Export-Dialog als *gesendet* liest. Die nächste Differenz (`built - sent`) ist dann um genau diese Korrektur zu klein — still und kumulativ, ohne dass irgendwo eine Fehlermeldung erscheint.

## Was sich ändert

- **Startwert** ist jetzt `bucket.totalQty` — die Menge, die Rentman führt. Das ist der einzige Wert an dieser Stelle, den die Gegenstelle bestätigt hat.
- **`lastSyncedQty` → `lastSentQty`.** Der Wert wird nach dem Senden nie von Rentman zurückgelesen; der Name behauptete eine Abstimmung, die nicht stattfindet. Die Oberfläche sagte übrigens schon die Wahrheit („Bereits gesendet" / „Already sent") — nur das persistierte Feld nicht.
- **Migration** in `healProjectPositions`: alte Projektfiles behalten ihren Wert, der alte Schlüssel wird entsorgt. Trägt ein File beide, gewinnt der neue. Kaputte Einträge fliegen raus, statt den Load zu kippen.
- Eine Zuordnung ohne Menge bleibt mengenlos, statt auf `0` geheilt zu werden — `0` hieße „nichts gesendet" und stellte die nächste Differenz auf die volle Menge.

## Prüfung

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npx vitest run` 405/405 (6 neu in `tests/rentmanCableMap.test.ts`) · `npm run lint` 0 Errors · `npm run build` grün.

Die Tests sind nicht leerlaufend: die erste Erwartung (`lastSentQty: 12` aus einem File mit `lastSyncedQty: 12`) ist ohne die Migration nicht erfüllbar.

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_