### PR TITLE
print: Dokument-Stempel — ein Ausdruck sagt seinen Stand (Initiative 4)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -64,6 +64,7 @@ import { useProject } from './hooks/useProject'
 import { useRentman } from './hooks/useRentman'
 import { cablePlannerApi, hasDesktopBridge } from './lib/bridge'
 import { exportCanvasToPdf, exportCanvasToPdfBytes } from './lib/exportPdf'
+import { stampForPlan } from './lib/documentStamp'
 import { exportCanvasToPdfVector } from './lib/exportPdfVector'
 import { printPdfBlob } from './lib/printPdfBlob'
 import { exportCanvasToImage } from './lib/exportImage'
@@ -795,6 +796,9 @@ export default function App() {
           gridSize: exportGridSize,
           bgOpacity: exportBgOpacity,
           customPalette: exportCustomPalette,
+          // Initiative 4 — der Titelblock soll sagen koennen, ob dieser
+          // Ausdruck noch der festgeschriebene Stand ist.
+          stamp: stampForPlan(project, new Date()),
           onProgress: (phase, detail) =>
             setPdfProgress({ active: true, phase, detail }),
         })

--- a/src/renderer/components/Export/InstallationDocsDialog.tsx
+++ b/src/renderer/components/Export/InstallationDocsDialog.tsx
@@ -34,12 +34,17 @@ import { downloadBlob } from '../../lib/downloadBlob'
 import { buildExportFilenameWithSuffix } from '../../lib/exportFilename'
 import {
   pullListCsv,
+  pullListTable,
   terminationListCsv,
+  terminationListTable,
   cableScheduleCsv,
+  cableScheduleTable,
   cableBomCsv,
+  cableBomTable,
 } from '../../lib/installerLists'
-import { assetRegisterCsv } from '../../lib/assetRegister'
-import { buildHandoverManifest } from '../../lib/handoverPackage'
+import { assetRegisterCsv, assetRegisterTable } from '../../lib/assetRegister'
+import { stampForRows } from '../../lib/documentStamp'
+import { buildHandoverManifest, handoverTable } from '../../lib/handoverPackage'
 import { cableLabelId, equipmentAssetTag, qrPayload } from '../../lib/docIds'
 
 type ExportRow = {
@@ -79,37 +84,83 @@ export const InstallationDocsDialog = () => {
         key: 'pull',
         label: t('docs.pullList', 'Pull-/Verlege-Liste'),
         hint: t('docs.pullList.hint', 'Je Kabel: Von→Nach, Länge, Trasse, Status (CSV)'),
-        build: () => ({ content: pullListCsv(project), suffix: 'pull-liste', ext: 'csv', mime: 'text/csv' }),
+        build: () => ({
+          content: pullListCsv(project, stampForRows(project, pullListTable, new Date())),
+          suffix: 'pull-liste',
+          ext: 'csv',
+          mime: 'text/csv',
+        }),
       },
       {
         key: 'term',
         label: t('docs.terminationList', 'Termination-Liste'),
         hint: t('docs.terminationList.hint', 'Je Kabelende: Gerät, Port, Steckverbinder (CSV)'),
-        build: () => ({ content: terminationListCsv(project), suffix: 'termination-liste', ext: 'csv', mime: 'text/csv' }),
+        build: () => ({
+          content: terminationListCsv(
+            project,
+            stampForRows(project, terminationListTable, new Date()),
+          ),
+          suffix: 'termination-liste',
+          ext: 'csv',
+          mime: 'text/csv',
+        }),
       },
       {
         key: 'sched',
         label: t('docs.cableSchedule', 'Kabel-Schedule (Register)'),
         hint: t('docs.cableSchedule.hint', 'Master-Register aller Kabel (CSV)'),
-        build: () => ({ content: cableScheduleCsv(project), suffix: 'kabel-schedule', ext: 'csv', mime: 'text/csv' }),
+        build: () => ({
+          content: cableScheduleCsv(
+            project,
+            stampForRows(project, cableScheduleTable, new Date()),
+          ),
+          suffix: 'kabel-schedule',
+          ext: 'csv',
+          mime: 'text/csv',
+        }),
       },
       {
         key: 'bom',
         label: t('docs.cableBom', 'Kabel-Stückliste + Reserve'),
         hint: t('docs.cableBom.hint', 'Aggregiert nach Typ/Länge inkl. Reserve-Aufschlag (CSV)'),
-        build: () => ({ content: cableBomCsv(project, reserve), suffix: 'kabel-bom', ext: 'csv', mime: 'text/csv' }),
+        build: () => ({
+          content: cableBomCsv(
+            project,
+            reserve,
+            stampForRows(project, (src) => cableBomTable(src, reserve), new Date()),
+          ),
+          suffix: 'kabel-bom',
+          ext: 'csv',
+          mime: 'text/csv',
+        }),
       },
       {
         key: 'asset',
         label: t('docs.assetRegister', 'Asset-Register'),
         hint: t('docs.assetRegister.hint', 'Geräte: Asset-Tag, Standort, Serie, Garantie, Service (CSV)'),
-        build: () => ({ content: assetRegisterCsv(project), suffix: 'asset-register', ext: 'csv', mime: 'text/csv' }),
+        build: () => ({
+          content: assetRegisterCsv(
+            project,
+            stampForRows(project, assetRegisterTable, new Date()),
+          ),
+          suffix: 'asset-register',
+          ext: 'csv',
+          mime: 'text/csv',
+        }),
       },
       {
         key: 'handover',
         label: t('docs.handover', 'Übergabe-Dokument'),
         hint: t('docs.handover.hint', 'Betreiber-Übersicht: Umfang, Status, BOM, Assets (Markdown)'),
-        build: () => ({ content: buildHandoverManifest(project), suffix: 'uebergabe', ext: 'md', mime: 'text/markdown' }),
+        build: () => ({
+          content: buildHandoverManifest(
+            project,
+            stampForRows(project, handoverTable, new Date()),
+          ),
+          suffix: 'uebergabe',
+          ext: 'md',
+          mime: 'text/markdown',
+        }),
       },
     ],
     [project, reserve, t],

--- a/src/renderer/lib/assetRegister.ts
+++ b/src/renderer/lib/assetRegister.ts
@@ -10,7 +10,8 @@ import type { EquipmentItem } from '../types/equipment'
 import { INSTALL_STATUS_LABEL } from '../types/lifecycle'
 import { EQUIPMENT_OWNERSHIP_LABEL } from '../types/equipment'
 import { equipmentAssetTag } from './docIds'
-import { toCsv, type CsvCell } from './csv'
+import type { CsvCell, CsvTable } from './csv'
+import { csvFromTable, type DocumentStamp } from './documentStamp'
 
 export interface AssetRow {
   assetTag: string
@@ -71,7 +72,7 @@ export const buildAssetRows = (project: CablePlannerProject): AssetRow[] =>
     }
   })
 
-export const assetRegisterCsv = (project: CablePlannerProject): string => {
+export const assetRegisterTable = (project: CablePlannerProject): CsvTable => {
   const rows = buildAssetRows(project)
   const headers = [
     'Asset-Tag',
@@ -109,5 +110,10 @@ export const assetRegisterCsv = (project: CablePlannerProject): string => {
     r.lastService,
     r.serviceCount,
   ])
-  return toCsv(headers, body)
+  return { headers, rows: body }
 }
+
+export const assetRegisterCsv = (
+  project: CablePlannerProject,
+  stamp?: DocumentStamp,
+): string => csvFromTable(assetRegisterTable(project), stamp)

--- a/src/renderer/lib/csv.ts
+++ b/src/renderer/lib/csv.ts
@@ -11,6 +11,19 @@
 
 export type CsvCell = string | number | null | undefined
 
+/**
+ * Kopfzeile plus Datenzeilen — ein Dokument, bevor es CSV wird.
+ *
+ * Getrennt vom Serialisieren, damit derselbe Aufbau zweimal laufen kann: einmal
+ * auf dem Plan und einmal auf dem Snapshot der letzten Revision. Nur so ist der
+ * Fingerabdruck in `documentStamp` derselbe Inhalt und nicht eine zweite,
+ * nachgebaute Wahrheit ueber dasselbe Dokument.
+ */
+export interface CsvTable {
+  headers: string[]
+  rows: CsvCell[][]
+}
+
 const escapeCell = (value: CsvCell, delimiter: string): string => {
   const s = value === null || value === undefined ? '' : String(value)
   const needsQuote =

--- a/src/renderer/lib/documentStamp.ts
+++ b/src/renderer/lib/documentStamp.ts
@@ -1,0 +1,233 @@
+/**
+ * Dokument-Stempel — was ein Ausdruck über sich selbst weiß.
+ *
+ * Roadmap-Initiative 4. Die Recherche ist an einer Stelle eindeutig: Papier ist
+ * kein Altlast-Verhalten, das man wegautomatisiert. Kamera-Leute und Lageristen
+ * halten daran fest, *weil* es ohne Akku funktioniert und sich nicht unter der
+ * Hand ändert. Der eigentliche Fehler ist ein anderer: **ein Ausdruck veraltet
+ * unsichtbar.**
+ *
+ * Der Stempel beantwortet deshalb genau eine Frage, und zwar entscheidbar:
+ * *Ist dieses Blatt noch der aktuelle Stand?* Nicht „ungefähr", nicht „das
+ * Projekt wurde seitdem angefasst" — sondern: enthält es dieselben Zeilen, die
+ * es heute enthielte.
+ *
+ * Zwei Regeln, beide aus ADR-003 (bestätigter Zustand):
+ *
+ *  1. **Der Fingerabdruck läuft über den Inhalt des Dokuments, nicht über das
+ *     Projekt.** Ein verschobener Knoten auf dem Canvas ändert keine Zeile der
+ *     Pull-Liste. Würde er sie trotzdem als veraltet markieren, wäre der
+ *     Hinweis nach einer Woche Rauschen — und ein Hinweis, den alle
+ *     wegklicken, ist schlimmer als keiner.
+ *  2. **Ohne festgeschriebene Revision behauptet der Stempel keine Abweichung.**
+ *     `drifted` ist dann `false`, weil es nichts gibt, wovon abgewichen werden
+ *     könnte. Eine erfundene Abweichung ist derselbe Schaden wie ein erfundener
+ *     Zustand.
+ */
+import { toCsv, type CsvCell, type CsvTable } from './csv'
+import type { CablePlannerProject, ProjectRevision, RevisionSnapshot } from '../types/project'
+
+export interface DocumentStamp {
+  /** Projektname, wie er im Plan steht. */
+  project: string
+  /** Label der zuletzt festgeschriebenen Revision, sonst nicht gesetzt. */
+  revision?: string
+  /**
+   * Der Plan weicht von der festgeschriebenen Revision ab — der Ausdruck ist
+   * also nicht „Rev 2", sondern „Rev 2 plus Änderungen". Ohne Revision immer
+   * `false`: keine Behauptung ohne Bezugspunkt.
+   */
+  drifted: boolean
+  /** Zeitpunkt der Erzeugung (ISO). */
+  printedAt: string
+  /** 8 Hex-Zeichen über den Inhalt — der eigentliche Vergleichswert. */
+  fingerprint: string
+}
+
+/**
+ * FNV-1a, 32 Bit, als 8 Hex-Zeichen.
+ *
+ * Bewusst kein Krypto-Hash: der Stempel schützt vor Verwechslung, nicht vor
+ * Fälschung. Acht Zeichen kann ein Mensch am Telefon vorlesen und mit dem
+ * Bildschirm vergleichen — das ist der Rückweg vom Papier, den die Recherche
+ * verlangt, und er braucht kein Gerät.
+ */
+export const fingerprint = (input: string): string => {
+  let h = 0x811c9dc5
+  for (let i = 0; i < input.length; i += 1) {
+    h ^= input.charCodeAt(i)
+    // FNV-Prime 16777619, in 32-Bit-Arithmetik ohne BigInt.
+    h = Math.imul(h, 0x01000193) >>> 0
+  }
+  return h.toString(16).padStart(8, '0')
+}
+
+/**
+ * Zellen zu einem stabilen String.
+ *
+ * Der Trenner ist ein Unit-Separator (U+001F) und kein Semikolon: Zellen
+ * enthalten Semikolons, Kommas und Zeilenumbrüche. Ein Trenner, der im Inhalt
+ * vorkommen kann, macht zwei verschiedene Dokumente gleich — genau das, was ein
+ * Fingerabdruck nicht darf.
+ */
+const SEP = '\u001F'
+const ROW_SEP = '\u001E'
+
+const joinRows = (headers: string[], rows: CsvCell[][]): string =>
+  [headers, ...rows]
+    .map((row) => row.map((c) => (c === null || c === undefined ? '' : String(c))).join(SEP))
+    .join(ROW_SEP)
+
+/** Fingerabdruck über den Inhalt eines Zeilen-Dokuments (CSV-Listen). */
+export const documentFingerprint = (headers: string[], rows: CsvCell[][]): string =>
+  fingerprint(joinRows(headers, rows))
+
+/**
+ * Fingerabdruck über den *Zeichnungs*-Inhalt eines Plans — für Ausdrucke, die
+ * das Bild zeigen (PDF/PNG). Hier zählen Positionen mit: ein verschobenes Gerät
+ * ist auf dem Blatt sichtbar anders. Viewport/Zoom zählen nicht, die stehen
+ * nicht auf dem Papier.
+ */
+export const planFingerprint = (project: CablePlannerProject | RevisionSnapshot): string => {
+  const equipment = (project.equipment ?? [])
+    .map((e) => [e.id, e.name, e.x, e.y, e.width, e.height].join(SEP))
+    .sort()
+  const cables = (project.cables ?? [])
+    .map((c) =>
+      [
+        c.id,
+        c.fromEquipmentId,
+        c.fromPortId,
+        c.toEquipmentId,
+        c.toPortId,
+        c.type ?? '',
+        c.length ?? '',
+        c.name ?? '',
+      ].join(SEP),
+    )
+    .sort()
+  const locations = (project.locations ?? [])
+    .map((l) => [l.id, l.name, l.x, l.y, l.width, l.height].join(SEP))
+    .sort()
+  return fingerprint(
+    [equipment.join(ROW_SEP), cables.join(ROW_SEP), locations.join(ROW_SEP)].join(''),
+  )
+}
+
+/** Die zuletzt festgeschriebene Revision, sonst undefined. */
+export const latestRevision = (project: CablePlannerProject): ProjectRevision | undefined => {
+  const list = project.revisions ?? []
+  return list.length > 0 ? list[list.length - 1] : undefined
+}
+
+/**
+ * Baut den Stempel. `current` ist der Fingerabdruck des Dokuments, wie es jetzt
+ * aussieht; `atRevision` derselbe Fingerabdruck, berechnet auf dem Snapshot der
+ * letzten Revision. Fehlt einer von beiden, gilt `drifted: false` — siehe
+ * Regel 2 im Datei-Kopf.
+ */
+export const buildDocumentStamp = (
+  project: CablePlannerProject,
+  current: string,
+  atRevision: string | undefined,
+  now: Date,
+): DocumentStamp => {
+  const rev = latestRevision(project)
+  return {
+    project: project.metadata.name || '—',
+    ...(rev ? { revision: project.metadata.revision || rev.label } : {}),
+    drifted: !!rev && !!atRevision && atRevision !== current,
+    printedAt: now.toISOString(),
+    fingerprint: current,
+  }
+}
+
+/**
+ * Stempel für ein Zeilen-Dokument: berechnet beide Fingerabdrücke selbst, indem
+ * es dieselbe Ableitung einmal auf den Plan und einmal auf den Revisions-
+ * Snapshot anwendet. Das ist der Grund, warum die Builder in `installerLists`
+ * pur sind und ein Projekt entgegennehmen.
+ */
+export const stampForRows = (
+  project: CablePlannerProject,
+  derive: (source: CablePlannerProject) => CsvTable,
+  now: Date,
+): DocumentStamp => {
+  const current = derive(project)
+  const rev = latestRevision(project)
+  const atRevision = rev
+    ? (() => {
+        const snapshot = { ...rev.snapshot, revisions: [] } as CablePlannerProject
+        const past = derive(snapshot)
+        return documentFingerprint(past.headers, past.rows)
+      })()
+    : undefined
+  return buildDocumentStamp(
+    project,
+    documentFingerprint(current.headers, current.rows),
+    atRevision,
+    now,
+  )
+}
+
+/**
+ * Stempel für einen Plan-Ausdruck (PDF/PNG). Vergleicht den Zeichnungs-Inhalt
+ * gegen den Snapshot der letzten Revision — hier zählen Positionen mit, denn sie
+ * sind auf dem Blatt sichtbar.
+ */
+export const stampForPlan = (project: CablePlannerProject, now: Date): DocumentStamp => {
+  const rev = latestRevision(project)
+  return buildDocumentStamp(
+    project,
+    planFingerprint(project),
+    rev ? planFingerprint(rev.snapshot) : undefined,
+    now,
+  )
+}
+
+/** Datum/Uhrzeit kurz und lesbar (lokal), für die Fußzeile. */
+const fmtStampDate = (iso: string): string => {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  const p = (n: number) => String(n).padStart(2, '0')
+  return `${p(d.getDate())}.${p(d.getMonth() + 1)}.${d.getFullYear()} ${p(d.getHours())}:${p(d.getMinutes())}`
+}
+
+/**
+ * Eine Zeile für Fußzeilen und Titelblöcke.
+ *
+ * Der Revisions-Teil ist der Punkt: steht nur „Rev 2" auf dem Blatt, liest sich
+ * das als *dieser Ausdruck ist Rev 2*. Weicht der Plan ab, sagt der Stempel das
+ * hin — sonst behauptet das Papier einen Stand, den es nicht hat.
+ */
+export const stampLine = (stamp: DocumentStamp): string => {
+  const parts = [stamp.project]
+  if (stamp.revision) parts.push(stamp.drifted ? `${stamp.revision} + Änderungen` : stamp.revision)
+  parts.push(fmtStampDate(stamp.printedAt))
+  parts.push(`#${stamp.fingerprint}`)
+  return parts.join('  ·  ')
+}
+
+/**
+ * Fußzeile für ein CSV: eine Zeile *nach* den Daten, mit `#` beginnend.
+ *
+ * Bewusst nicht davor: eine Zeile vor der Kopfzeile verschiebt jede Auswertung,
+ * die die erste Zeile als Header liest. Hinten steht sie da, wo eine Fußzeile
+ * hingehört — auf dem Ausdruck unten, und in Excel in der letzten Zeile.
+ */
+export const csvStampRow = (stamp: DocumentStamp, columns: number): CsvCell[] => {
+  const row: CsvCell[] = [`# ${stampLine(stamp)}`]
+  while (row.length < Math.max(1, columns)) row.push('')
+  return row
+}
+
+/**
+ * Serialisiert eine Tabelle als CSV und haengt den Stempel als letzte Zeile an.
+ * Ohne Stempel identisch zu `toCsv` — der Aufrufer entscheidet, ob das Dokument
+ * einen tragen soll (ein Zwischenexport in Excel braucht keinen).
+ */
+export const csvFromTable = (table: CsvTable, stamp?: DocumentStamp): string =>
+  toCsv(
+    table.headers,
+    stamp ? [...table.rows, csvStampRow(stamp, table.headers.length)] : table.rows,
+  )

--- a/src/renderer/lib/exportPdf.ts
+++ b/src/renderer/lib/exportPdf.ts
@@ -1,6 +1,7 @@
 import { toJpeg, toPng } from 'html-to-image'
 import jsPDF from 'jspdf'
 import type { ProjectMetadata } from '../types/project'
+import type { DocumentStamp } from './documentStamp'
 import { composeExportBackground, type ExportBgVariant } from './exportBackground'
 import { pdfText } from './pdfHelpers'
 import { hexToRgb, drawVectorBackground } from './pdfBackground'
@@ -36,6 +37,14 @@ export interface ExportPdfOptions {
    *  'tile'|'render'|'done', detail?) gerufen damit das UI Fortschritts-
    *  Indikatoren zeigen kann. */
   onProgress?: (phase: string, detail?: string) => void
+  /**
+   * Initiative 4 — Dokument-Stempel fuer den Titelblock. Ohne ihn zeigt der
+   * Block nur `metadata.revision`, und das ist eine Behauptung: der Stempel
+   * wird beim Festschreiben gesetzt und bleibt stehen, waehrend der Plan
+   * weiterlaeuft. Mit Stempel steht dort, ob der Ausdruck noch dieser Stand
+   * ist.
+   */
+  stamp?: DocumentStamp
 }
 
 const fmtDate = (iso?: string): string => {
@@ -57,6 +66,7 @@ const drawTitleBlock = (
   pageWidth: number,
   pageHeight: number,
   margin: number,
+  stamp?: DocumentStamp,
 ): number => {
   const boxW = 300
   const rowH = 14
@@ -69,7 +79,15 @@ const drawTitleBlock = (
     ['Erstellt', fmtDate(meta.createdAt)],
     ['Geändert', fmtDate(meta.updatedAt)],
     // #412 — Revisions-Stempel (nur wenn eine Revision festgeschrieben ist).
-    ...(meta.revision ? ([['Revision', meta.revision]] as [string, string][]) : []),
+    // Initiative 4 — mit Dokument-Stempel sagt die Zeile dazu, ob der Plan seit
+    // dem Festschreiben weitergelaufen ist. „Rev 2" alleine liest sich auf
+    // Papier als *dieser Ausdruck ist Rev 2*, und das stimmt dann nicht mehr.
+    ...(meta.revision
+      ? ([
+          ['Revision', stamp?.drifted ? `${meta.revision} + Änderungen` : meta.revision],
+        ] as [string, string][])
+      : []),
+    ...(stamp ? ([['Stand', `#${stamp.fingerprint}`]] as [string, string][]) : []),
   ]
   const visibleRows = rows.filter(([, v]) => !!v || true) // keep all rows, show "—" when missing
   const logoH = 36
@@ -523,7 +541,7 @@ const buildCanvasPdf = async (
   await yieldToBrowser()
 
   if (metadata) {
-    drawTitleBlock(pdf, metadata, pageWidth, pageHeight, margin)
+    drawTitleBlock(pdf, metadata, pageWidth, pageHeight, margin, options?.stamp)
   }
 
   return pdf

--- a/src/renderer/lib/handoverPackage.ts
+++ b/src/renderer/lib/handoverPackage.ts
@@ -7,8 +7,10 @@
  * eine Datei-Liste, die der Dialog einzeln als Download anbietet.
  */
 import type { CablePlannerProject } from '../types/project'
-import { buildAssetRows } from './assetRegister'
-import { buildCableBomRows } from './installerLists'
+import type { CsvTable } from './csv'
+import { buildAssetRows, assetRegisterTable } from './assetRegister'
+import { buildCableBomRows, cableBomTable } from './installerLists'
+import { stampLine, type DocumentStamp } from './documentStamp'
 import { INSTALL_STATUS_LABEL, type InstallStatus } from './../types/lifecycle'
 
 const fmtDate = (iso?: string): string => {
@@ -27,7 +29,25 @@ const cableStatusCounts = (project: CablePlannerProject): Record<string, number>
   return counts
 }
 
-export const buildHandoverManifest = (project: CablePlannerProject): string => {
+/**
+ * Der Inhalt, den das Uebergabe-Dokument zeigt — als Tabelle, damit `stampForRows`
+ * denselben Aufbau auf den Revisions-Snapshot anwenden kann. Fingerabdruck ueber
+ * das, was auf dem Blatt steht: Assets und Kabel-Stueckliste. Der Kopf mit
+ * Adressen und Kontakten aendert sich zwischen Revisionen nicht.
+ */
+export const handoverTable = (project: CablePlannerProject): CsvTable => {
+  const assets = assetRegisterTable(project)
+  const bom = cableBomTable(project)
+  return {
+    headers: [...assets.headers, ...bom.headers],
+    rows: [...assets.rows, ...bom.rows],
+  }
+}
+
+export const buildHandoverManifest = (
+  project: CablePlannerProject,
+  stamp?: DocumentStamp,
+): string => {
   const m = project.metadata
   const assets = buildAssetRows(project)
   const bom = buildCableBomRows(project)
@@ -52,7 +72,14 @@ export const buildHandoverManifest = (project: CablePlannerProject): string => {
   lines.push(`- **Übergabe-Datum:** ${fmtDate(m.handoverDate)}`)
   lines.push(`- **Wartender Dienstleister:** ${m.serviceProvider || '—'}`)
   lines.push(`- **Notfall-/Servicekontakt:** ${m.emergencyContact || '—'}`)
-  lines.push(`- **Aktuelle Revision:** ${m.revision || '—'}`)
+  // Initiative 4 — „Rev 2" alleine behauptet, dieses Dokument sei Rev 2. Der
+  // Stempel wird beim Festschreiben gesetzt und bleibt stehen, waehrend der
+  // Plan weiterlaeuft.
+  lines.push(
+    `- **Aktuelle Revision:** ${
+      m.revision ? (stamp?.drifted ? `${m.revision} + Änderungen` : m.revision) : '—'
+    }`,
+  )
   lines.push('')
   lines.push('## 2 · Umfang (Überblick)')
   lines.push('')
@@ -106,6 +133,10 @@ export const buildHandoverManifest = (project: CablePlannerProject): string => {
   lines.push('')
   lines.push('_Erzeugt mit Cable-Planner. Diese Doku ist vendor-neutral —')
   lines.push('jeder qualifizierte Dienstleister kann die Anlage übernehmen._')
+  if (stamp) {
+    lines.push('')
+    lines.push(`_${stampLine(stamp)}_`)
+  }
   return lines.join('\n')
 }
 

--- a/src/renderer/lib/installerLists.ts
+++ b/src/renderer/lib/installerLists.ts
@@ -17,7 +17,8 @@ import type { Cable } from '../types/cable'
 import type { EquipmentItem, Port } from '../types/equipment'
 import { INSTALL_STATUS_LABEL } from '../types/lifecycle'
 import { cableLabelId } from './docIds'
-import { toCsv, type CsvCell } from './csv'
+import type { CsvCell, CsvTable } from './csv'
+import { csvFromTable, type DocumentStamp } from './documentStamp'
 
 const portName = (eq: EquipmentItem | undefined, portId: string): string => {
   if (!eq) return ''
@@ -95,7 +96,7 @@ export const buildPullListRows = (project: CablePlannerProject): PullListRow[] =
   })
 }
 
-export const pullListCsv = (project: CablePlannerProject): string => {
+export const pullListTable = (project: CablePlannerProject): CsvTable => {
   const rows = buildPullListRows(project)
   const headers = [
     'Label-ID',
@@ -135,8 +136,11 @@ export const pullListCsv = (project: CablePlannerProject): string => {
     r.test,
     r.notes,
   ])
-  return toCsv(headers, body)
+  return { headers, rows: body }
 }
+
+export const pullListCsv = (project: CablePlannerProject, stamp?: DocumentStamp): string =>
+  csvFromTable(pullListTable(project), stamp)
 
 // --- Termination-Liste ----------------------------------------------------
 
@@ -183,7 +187,7 @@ export const buildTerminationRows = (
   return rows
 }
 
-export const terminationListCsv = (project: CablePlannerProject): string => {
+export const terminationListTable = (project: CablePlannerProject): CsvTable => {
   const rows = buildTerminationRows(project)
   const headers = ['Label-ID', 'Ende', 'Gerät', 'Port', 'Steckverbinder', 'Geschlecht', 'Terminierung']
   const body: CsvCell[][] = rows.map((r) => [
@@ -195,12 +199,17 @@ export const terminationListCsv = (project: CablePlannerProject): string => {
     r.gender,
     r.termination,
   ])
-  return toCsv(headers, body)
+  return { headers, rows: body }
 }
+
+export const terminationListCsv = (
+  project: CablePlannerProject,
+  stamp?: DocumentStamp,
+): string => csvFromTable(terminationListTable(project), stamp)
 
 // --- Kabel-Schedule (Design-Register) -------------------------------------
 
-export const cableScheduleCsv = (project: CablePlannerProject): string => {
+export const cableScheduleTable = (project: CablePlannerProject): CsvTable => {
   const byId = indexEquipment(project)
   const headers = [
     'Label-ID',
@@ -236,8 +245,13 @@ export const cableScheduleCsv = (project: CablePlannerProject): string => {
       statusLabel(c),
     ]
   })
-  return toCsv(headers, body)
+  return { headers, rows: body }
 }
+
+export const cableScheduleCsv = (
+  project: CablePlannerProject,
+  stamp?: DocumentStamp,
+): string => csvFromTable(cableScheduleTable(project), stamp)
 
 // --- Kabel-BOM mit Reserve ------------------------------------------------
 
@@ -294,10 +308,10 @@ export const buildCableBomRows = (
   )
 }
 
-export const cableBomCsv = (
+export const cableBomTable = (
   project: CablePlannerProject,
   reservePercent = 10,
-): string => {
+): CsvTable => {
   const rows = buildCableBomRows(project, reservePercent)
   const headers = [
     'Typ',
@@ -315,5 +329,11 @@ export const cableBomCsv = (
     r.totalLengthM,
     r.tieLine ? 'ja' : '',
   ])
-  return toCsv(headers, body)
+  return { headers, rows: body }
 }
+
+export const cableBomCsv = (
+  project: CablePlannerProject,
+  reservePercent = 10,
+  stamp?: DocumentStamp,
+): string => csvFromTable(cableBomTable(project, reservePercent), stamp)

--- a/tests/documentStamp.test.ts
+++ b/tests/documentStamp.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildDocumentStamp,
+  csvFromTable,
+  csvStampRow,
+  documentFingerprint,
+  fingerprint,
+  latestRevision,
+  planFingerprint,
+  stampForRows,
+  stampLine,
+} from '../src/renderer/lib/documentStamp'
+import { pullListTable, pullListCsv } from '../src/renderer/lib/installerLists'
+import { buildHandoverManifest, handoverTable } from '../src/renderer/lib/handoverPackage'
+import type { CablePlannerProject, ProjectRevision } from '../src/renderer/types/project'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+
+// Roadmap-Initiative 4 — ein Ausdruck soll sagen koennen, ob er noch der
+// aktuelle Stand ist. Getestet wird genau das und nicht mehr: dass der
+// Fingerabdruck auf Inhalt reagiert und nur auf Inhalt, und dass der Stempel
+// keine Abweichung behauptet, fuer die es keinen Bezugspunkt gibt.
+
+const eq = (id: string, name: string, over: Partial<EquipmentItem> = {}): EquipmentItem =>
+  ({
+    id,
+    name,
+    category: 'Sonstiges',
+    inputs: [{ id: `${id}-in`, name: 'IN 1', type: 'port', connectorType: 'BNC' }],
+    outputs: [{ id: `${id}-out`, name: 'OUT 1', type: 'port', connectorType: 'BNC' }],
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 100,
+    ...over,
+  }) as unknown as EquipmentItem
+
+const cable = (id: string, over: Partial<Cable> = {}): Cable =>
+  ({
+    id,
+    name: `Kabel ${id}`,
+    type: 'SDI',
+    length: 10,
+    color: '#fff',
+    fromEquipmentId: 'A',
+    fromPortId: 'A-out',
+    toEquipmentId: 'B',
+    toPortId: 'B-in',
+    notes: '',
+    ...over,
+  }) as Cable
+
+const project = (over: Partial<CablePlannerProject> = {}): CablePlannerProject =>
+  ({
+    metadata: { name: 'Testanlage', description: '', createdAt: '', updatedAt: '' },
+    equipment: [eq('A', 'Kamera 1'), eq('B', 'Switcher')],
+    cables: [cable('c1')],
+    canvasState: { x: 0, y: 0, zoom: 1 },
+    ...over,
+  }) as CablePlannerProject
+
+/** Eine festgeschriebene Revision aus einem Plan-Stand. */
+const revision = (snapshotOf: CablePlannerProject, label = 'Rev 1'): ProjectRevision => {
+  const { revisions: _ignored, ...snapshot } = snapshotOf
+  void _ignored
+  return {
+    id: 'r1',
+    label,
+    note: '',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    asBuilt: false,
+    snapshot,
+  }
+}
+
+const NOW = new Date('2026-09-01T12:34:00.000Z')
+
+describe('fingerprint', () => {
+  it('ist stabil und laengenfest', () => {
+    expect(fingerprint('abc')).toBe(fingerprint('abc'))
+    expect(fingerprint('abc')).toHaveLength(8)
+    expect(fingerprint('')).toHaveLength(8)
+  })
+
+  it('unterscheidet Inhalte, die sich nur in der Feldgrenze unterscheiden', () => {
+    // Der Grund fuer den Unit-Separator: mit ';' als Trenner waeren
+    // ['a;b'] und ['a','b'] derselbe String — zwei verschiedene Dokumente
+    // mit demselben Fingerabdruck.
+    expect(documentFingerprint(['h'], [['a;b']])).not.toBe(
+      documentFingerprint(['h', 'h2'], [['a', 'b']]),
+    )
+  })
+})
+
+describe('documentFingerprint', () => {
+  it('aendert sich, wenn sich eine Zelle aendert', () => {
+    const a = documentFingerprint(['x'], [['1'], ['2']])
+    const b = documentFingerprint(['x'], [['1'], ['3']])
+    expect(a).not.toBe(b)
+  })
+
+  it('aendert sich, wenn sich die Reihenfolge aendert', () => {
+    // Auf einem Ausdruck ist die Reihenfolge sichtbar; ein Fingerabdruck, der
+    // sie ignoriert, wuerde ein anders sortiertes Blatt als identisch ausgeben.
+    expect(documentFingerprint(['x'], [['1'], ['2']])).not.toBe(
+      documentFingerprint(['x'], [['2'], ['1']]),
+    )
+  })
+
+  it('behandelt null/undefined wie eine leere Zelle', () => {
+    expect(documentFingerprint(['x'], [[null]])).toBe(documentFingerprint(['x'], [['']]))
+  })
+})
+
+describe('planFingerprint', () => {
+  it('reagiert auf eine verschobene Position — die steht auf dem Blatt', () => {
+    const before = planFingerprint(project())
+    const after = planFingerprint(
+      project({ equipment: [eq('A', 'Kamera 1', { x: 40 }), eq('B', 'Switcher')] }),
+    )
+    expect(before).not.toBe(after)
+  })
+
+  it('ignoriert Viewport und Zoom — die stehen nicht auf dem Blatt', () => {
+    expect(planFingerprint(project())).toBe(
+      planFingerprint(project({ canvasState: { x: 900, y: -400, zoom: 4 } })),
+    )
+  })
+
+  it('ist unabhaengig von der Reihenfolge der Collections', () => {
+    const a = project({ equipment: [eq('A', 'Kamera 1'), eq('B', 'Switcher')] })
+    const b = project({ equipment: [eq('B', 'Switcher'), eq('A', 'Kamera 1')] })
+    expect(planFingerprint(a)).toBe(planFingerprint(b))
+  })
+})
+
+describe('buildDocumentStamp', () => {
+  it('behauptet ohne Revision keine Abweichung', () => {
+    const s = buildDocumentStamp(project(), 'aaaaaaaa', 'bbbbbbbb', NOW)
+    expect(s.revision).toBeUndefined()
+    expect(s.drifted).toBe(false)
+  })
+
+  it('nennt die Revision und meldet Gleichstand', () => {
+    const base = project()
+    const p = project({ revisions: [revision(base)] })
+    const s = buildDocumentStamp(p, 'aaaaaaaa', 'aaaaaaaa', NOW)
+    expect(s.revision).toBe('Rev 1')
+    expect(s.drifted).toBe(false)
+  })
+
+  it('meldet Abweichung, wenn der Inhalt vom Revisions-Stand abweicht', () => {
+    const p = project({ revisions: [revision(project())] })
+    expect(buildDocumentStamp(p, 'aaaaaaaa', 'bbbbbbbb', NOW).drifted).toBe(true)
+  })
+
+  it('bevorzugt den Metadaten-Stempel vor dem rohen Label (As-Built-Zusatz)', () => {
+    const base = project()
+    const p = {
+      ...base,
+      revisions: [revision(base)],
+      metadata: { ...base.metadata, revision: 'Rev 1 (As-Built)' },
+    } as CablePlannerProject
+    expect(buildDocumentStamp(p, 'a', 'a', NOW).revision).toBe('Rev 1 (As-Built)')
+  })
+})
+
+describe('stampForRows — der eigentliche Zweck', () => {
+  it('meldet keine Abweichung, solange sich das Dokument nicht geaendert hat', () => {
+    const base = project()
+    const p = { ...base, revisions: [revision(base)] } as CablePlannerProject
+    expect(stampForRows(p, pullListTable, NOW).drifted).toBe(false)
+  })
+
+  it('meldet Abweichung, sobald sich eine Zeile des Dokuments geaendert hat', () => {
+    const base = project()
+    const changed = {
+      ...base,
+      cables: [cable('c1', { length: 25 })],
+      revisions: [revision(base)],
+    } as CablePlannerProject
+    expect(stampForRows(changed, pullListTable, NOW).drifted).toBe(true)
+  })
+
+  it('meldet KEINE Abweichung, wenn sich nur etwas aenderte, das nicht im Dokument steht', () => {
+    // Das ist die Regel, an der sich der Nutzen entscheidet. Eine verschobene
+    // Position aendert keine Zeile der Pull-Liste. Wuerde sie den Ausdruck als
+    // veraltet markieren, waere der Hinweis nach einer Woche Rauschen.
+    const base = project()
+    const moved = {
+      ...base,
+      equipment: [eq('A', 'Kamera 1', { x: 880, y: 640 }), eq('B', 'Switcher')],
+      revisions: [revision(base)],
+    } as CablePlannerProject
+    expect(planFingerprint(moved)).not.toBe(planFingerprint(base))
+    expect(stampForRows(moved, pullListTable, NOW).drifted).toBe(false)
+  })
+})
+
+describe('stampLine', () => {
+  it('sagt „+ Änderungen", statt die Revision alleine zu behaupten', () => {
+    const base = project()
+    const p = { ...base, revisions: [revision(base)] } as CablePlannerProject
+    const drifted = buildDocumentStamp(p, 'aaaaaaaa', 'bbbbbbbb', NOW)
+    expect(stampLine(drifted)).toContain('Rev 1 + Änderungen')
+    const clean = buildDocumentStamp(p, 'aaaaaaaa', 'aaaaaaaa', NOW)
+    expect(stampLine(clean)).toContain('Rev 1')
+    expect(stampLine(clean)).not.toContain('Änderungen')
+  })
+
+  it('traegt Projekt, Zeitpunkt und Fingerabdruck', () => {
+    const line = stampLine(buildDocumentStamp(project(), 'deadbeef', undefined, NOW))
+    expect(line).toContain('Testanlage')
+    expect(line).toContain('#deadbeef')
+    expect(line).toMatch(/\d{2}\.\d{2}\.\d{4}/)
+  })
+})
+
+describe('CSV-Fussnote', () => {
+  it('haengt den Stempel als letzte Zeile an, nicht vor die Kopfzeile', () => {
+    const p = project()
+    const stamp = buildDocumentStamp(p, 'deadbeef', undefined, NOW)
+    const csv = pullListCsv(p, stamp)
+    const lines = csv.replace(/^﻿/, '').split('\r\n')
+    expect(lines[0]).toContain('Label-ID')
+    expect(lines[lines.length - 1]).toContain('#deadbeef')
+  })
+
+  it('laesst das CSV ohne Stempel unveraendert', () => {
+    const p = project()
+    expect(pullListCsv(p)).toBe(csvFromTable(pullListTable(p)))
+  })
+
+  it('fuellt die Stempelzeile auf die Spaltenzahl auf', () => {
+    const stamp = buildDocumentStamp(project(), 'deadbeef', undefined, NOW)
+    expect(csvStampRow(stamp, 5)).toHaveLength(5)
+    expect(csvStampRow(stamp, 0)).toHaveLength(1)
+  })
+})
+
+describe('latestRevision', () => {
+  it('nimmt die zuletzt festgeschriebene, nicht die erste', () => {
+    const base = project()
+    const p = project({ revisions: [revision(base, 'Rev 1'), revision(base, 'Rev 2')] })
+    expect(latestRevision(p)?.label).toBe('Rev 2')
+    expect(latestRevision(project())).toBeUndefined()
+  })
+})
+
+describe('Übergabe-Dokument', () => {
+  it('sagt „+ Änderungen", statt die Revision alleine zu behaupten', () => {
+    const base = project()
+    const p = {
+      ...base,
+      cables: [cable('c1', { length: 25 })],
+      revisions: [revision(base)],
+      metadata: { ...base.metadata, revision: 'Rev 1' },
+    } as CablePlannerProject
+    const md = buildHandoverManifest(p, stampForRows(p, handoverTable, NOW))
+    expect(md).toContain('Aktuelle Revision:** Rev 1 + Änderungen')
+  })
+
+  it('laesst die Revision stehen, solange das Dokument unveraendert ist', () => {
+    const base = project()
+    const p = {
+      ...base,
+      revisions: [revision(base)],
+      metadata: { ...base.metadata, revision: 'Rev 1' },
+    } as CablePlannerProject
+    const md = buildHandoverManifest(p, stampForRows(p, handoverTable, NOW))
+    expect(md).toContain('Aktuelle Revision:** Rev 1')
+    expect(md).not.toContain('Änderungen')
+  })
+
+  it('bleibt ohne Stempel wortgleich wie bisher', () => {
+    // Der Stempel ist optional; ein Aufrufer, der keinen baut, bekommt exakt
+    // das alte Dokument. Sonst waere das eine stille Formatänderung.
+    const p = project()
+    expect(buildHandoverManifest(p)).toBe(buildHandoverManifest(p, undefined))
+    // Kein Stempel-Fussnoten-Block (die '#' der Markdown-Ueberschriften bleiben).
+    expect(buildHandoverManifest(p)).not.toMatch(/_Testanlage {2}·/)
+  })
+})


### PR DESCRIPTION
Roadmap-Initiative 4, Inkrement 1.

## Die Prämisse, die man leicht falsch liest

Papier ist **kein** Altlast-Verhalten, das man wegautomatisiert. Die Recherche ist an dieser Stelle ausdrücklich: Kamera-Leute und Lageristen halten daran fest, *weil* es ohne Akku funktioniert und sich nicht unter der Hand ändert. Der eigentliche Fehler ist ein anderer — **ein Ausdruck veraltet unsichtbar.**

## Der Befund im Code

- Sechs Installateur-Dokumente (Pull-Liste, Termination-Liste, Kabel-Schedule, Kabel-BOM, Asset-Register, Übergabe-Dokument) gehen aufs Papier und tragen **keinerlei** Stand-Angabe.
- Der PDF-Titelblock zeigt `Revision: Rev 2`. Dieser Stempel wird in `commitRevision` gesetzt und **bleibt stehen**, während der Plan weiterläuft. Auf Papier liest sich „Rev 2" als *dieser Ausdruck ist Rev 2* — und das stimmt ab der nächsten Änderung nicht mehr. Dasselbe im Übergabe-Dokument („Aktuelle Revision").
- Der Rückweg vom Papier existiert bereits für einzelne Datensätze (`qrPayload`: `cableplanner://cable/C-0001`), aber nicht für ein ganzes Dokument.

## Was dieser PR baut

`src/renderer/lib/documentStamp.ts` — ein Stempel, der genau eine Frage beantwortet, und zwar *entscheidbar*: **Ist dieses Blatt noch der aktuelle Stand?**

Zwei Regeln, beide aus ADR-003:

1. **Der Fingerabdruck läuft über den Inhalt des Dokuments, nicht über das Projekt.** Ein verschobener Knoten auf dem Canvas ändert keine Zeile der Pull-Liste. Würde er sie trotzdem als veraltet markieren, wäre der Hinweis nach einer Woche Rauschen — und ein Hinweis, den alle wegklicken, ist schlimmer als keiner. Ein Test hält genau das fest.
2. **Ohne festgeschriebene Revision behauptet der Stempel keine Abweichung.** `drifted` ist dann `false`: eine erfundene Abweichung ist derselbe Schaden wie ein erfundener Zustand.

Konkret:

- **CSV-Fußnote** als *letzte* Zeile, nicht vor der Kopfzeile — davor verschöbe sie jede Auswertung, die Zeile 1 als Header liest. Hinten steht sie da, wo eine Fußzeile hingehört.
- **PDF-Titelblock** und **Übergabe-Dokument** sagen jetzt `Rev 2 + Änderungen`, wenn der Plan seit dem Festschreiben weitergelaufen ist, plus eine `Stand: #a1b2c3d4`-Zeile.
- **8 Hex-Zeichen, kein Krypto-Hash** (FNV-1a). Der Stempel schützt vor Verwechslung, nicht vor Fälschung. Acht Zeichen kann jemand am Telefon vorlesen und mit dem Bildschirm vergleichen — das ist der Rückweg vom Papier, und er braucht kein Gerät.
- **Trenner ist U+001F**, nicht `;`: Zellen enthalten Semikolons. Ein Trenner, der im Inhalt vorkommt, macht zwei verschiedene Dokumente gleich.
- Die `*Csv`-Funktionen sind in ein pures `*Table` plus ein dünnes `*Csv` gesplittet, damit derselbe Aufbau einmal auf den Plan und einmal auf den Revisions-Snapshot laufen kann. Ohne das wäre jeder Fingerabdruck eine zweite, nachgebaute Wahrheit über dasselbe Dokument.

Der Stempel ist überall **optional** — ohne ihn erzeugen alle Bauer wortgleich das bisherige Dokument. Ein Test hält das fest, damit die Änderung keine stille Formatänderung ist.

## Prüfung

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npx vitest run` 429/429 (24 neu) · `npm run lint` 0 Errors · `npm run build` grün.

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_