### PR TITLE
print: Rückweg vom Blatt — Dokument-Code und Standvergleich (Initiative 4)

### DIFF
--- a/src/mobile/MobileApp.tsx
+++ b/src/mobile/MobileApp.tsx
@@ -26,7 +26,13 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { AlertTriangle, X, QrCode, Search } from 'lucide-react'
 import { Icon } from '../renderer/components/shared/Icon'
 import { styleForLayer } from '../renderer/lib/cableLayers'
-import { parseQrPayload, lookupQrRef } from '../renderer/lib/qrPayload'
+import {
+  parseQrPayload,
+  lookupQrRef,
+  parseDocQrPayload,
+  docStandStatus,
+} from '../renderer/lib/qrPayload'
+import { currentStand, findByStand, DOCUMENT_LABELS } from '../renderer/lib/documentRegistry'
 import { cableLabelId } from '../renderer/lib/docIds'
 import type { CablePlannerProject } from '../renderer/types/project'
 
@@ -1055,6 +1061,40 @@ const ProjectView = ({
 
   const handleLookup = (raw: string) => {
     setFindOpen(false)
+
+    // ADR-004 — Rueckweg vom Papier. Ein Dokument-Code (oder die acht Zeichen
+    // aus der Fussnote, abgetippt) beantwortet eine andere Frage als ein
+    // Etikett: nicht "welcher Datensatz", sondern "ist dieses Blatt noch
+    // aktuell". Deshalb vor dem Datensatz-Lookup und nicht darin.
+    const doc = parseDocQrPayload(raw)
+    if (doc) {
+      const now = currentStand(doc.docId, project)
+      const label = DOCUMENT_LABELS[doc.docId] ?? doc.docId
+      const status = docStandStatus(doc, now)
+      setFocus(null)
+      setLookupMsg(
+        status === 'current'
+          ? { ok: true, text: `${label}: aktueller Stand` }
+          : status === 'stale'
+            ? { ok: false, text: `${label}: VERALTET — aktueller Stand #${now}` }
+            : { ok: false, text: `${label}: Stand nicht pruefbar` },
+      )
+      return
+    }
+    const typed = findByStand(raw, project)
+    if (typed) {
+      setFocus(null)
+      setLookupMsg({ ok: true, text: `${typed.label}: aktueller Stand` })
+      return
+    }
+    if (/^#?[0-9a-f]{8}$/i.test(raw.trim())) {
+      // Acht Hex-Zeichen, aber kein Dokument passt: das Blatt ist veraltet.
+      // Das ist eine Aussage und kein "nicht gefunden" — deshalb eigener Fall.
+      setFocus(null)
+      setLookupMsg({ ok: false, text: `Stand ${raw.trim()} gehoert zu keinem aktuellen Blatt` })
+      return
+    }
+
     const ref = parseQrPayload(raw)
     const match = ref ? lookupQrRef(ref, project.cables, project.equipment) : null
     if (!match) {

--- a/src/renderer/lib/documentRegistry.ts
+++ b/src/renderer/lib/documentRegistry.ts
@@ -1,0 +1,90 @@
+/**
+ * Welche Dokumente einen Stand haben — und wie er berechnet wird.
+ *
+ * ADR-004, Inkrement 2. Der Stempel auf einem Blatt ist nur die halbe Antwort;
+ * die andere Hälfte ist, denselben Stand *heute* ausrechnen zu können. Diese
+ * Datei hält beide Enden zusammen: der Schlüssel ist derselbe Bezeichner, der im
+ * Dateinamen steht (`pull-liste`, `kabel-schedule` …), und der Wert ist genau
+ * die Ableitung, aus der das Dokument gebaut wurde.
+ *
+ * Getrennt von `documentStamp`, weil die Ableitungen ihrerseits den Stempel
+ * importieren — hier laufen sie zusammen, dort nicht.
+ */
+import type { CablePlannerProject } from '../types/project'
+import { documentFingerprint, planFingerprint } from './documentStamp'
+import {
+  pullListTable,
+  terminationListTable,
+  cableScheduleTable,
+} from './installerLists'
+import { assetRegisterTable } from './assetRegister'
+import { handoverTable } from './handoverPackage'
+import type { CsvTable } from './csv'
+
+const ofTable =
+  (derive: (project: CablePlannerProject) => CsvTable) =>
+  (project: CablePlannerProject): string => {
+    const table = derive(project)
+    return documentFingerprint(table.headers, table.rows)
+  }
+
+/**
+ * Dokument-Bezeichner → aktueller Stand.
+ *
+ * **`kabel-bom` fehlt hier bewusst.** Sein Inhalt hängt vom Reserve-Aufschlag ab,
+ * den der Nutzer beim Export einstellt, und dieser Prozentsatz steht nicht im
+ * Stempel. Ohne ihn liesse sich der Stand nicht reproduzieren — und ein
+ * Vergleich gegen einen anders gerechneten Wert würde jedes Blatt als veraltet
+ * ausweisen. Ein `unknown` ist die ehrlichere Antwort; siehe `docStandStatus`.
+ */
+export const DOCUMENT_STANDS: Record<string, (project: CablePlannerProject) => string> = {
+  plan: planFingerprint,
+  'pull-liste': ofTable(pullListTable),
+  'termination-liste': ofTable(terminationListTable),
+  'kabel-schedule': ofTable(cableScheduleTable),
+  'asset-register': ofTable(assetRegisterTable),
+  uebergabe: ofTable(handoverTable),
+}
+
+/** Lesbarer Name eines Dokument-Bezeichners für Meldungen. */
+export const DOCUMENT_LABELS: Record<string, string> = {
+  plan: 'Plan',
+  'pull-liste': 'Pull-Liste',
+  'termination-liste': 'Termination-Liste',
+  'kabel-schedule': 'Kabel-Schedule',
+  'asset-register': 'Asset-Register',
+  uebergabe: 'Übergabe-Dokument',
+}
+
+/**
+ * Der Stand, den `docId` heute hätte — oder `undefined`, wenn dieses Dokument
+ * nicht reproduzierbar ist. `undefined` ist kein Fehler, sondern die Aussage
+ * „das kann ich nicht ausrechnen"; der Aufrufer macht daraus ein `unknown`
+ * statt einer Behauptung.
+ */
+export const currentStand = (
+  docId: string,
+  project: CablePlannerProject,
+): string | undefined => DOCUMENT_STANDS[docId]?.(project)
+
+/**
+ * Sucht einen blossen Fingerabdruck in allen bekannten Dokumenten.
+ *
+ * Das ist der Rückweg ohne Kamera: auf dem Ausdruck steht `#a1b2c3d4` in der
+ * Fussnote, jemand tippt die acht Zeichen ein, und die Antwort lautet „das ist
+ * die Pull-Liste, und sie ist noch aktuell". Genau dafür sind es acht Zeichen
+ * und kein SHA-256.
+ */
+export const findByStand = (
+  stand: string,
+  project: CablePlannerProject,
+): { docId: string; label: string } | null => {
+  const needle = stand.trim().replace(/^#/, '').toLowerCase()
+  if (!/^[0-9a-f]{8}$/.test(needle)) return null
+  for (const [docId, derive] of Object.entries(DOCUMENT_STANDS)) {
+    if (derive(project).toLowerCase() === needle) {
+      return { docId, label: DOCUMENT_LABELS[docId] ?? docId }
+    }
+  }
+  return null
+}

--- a/src/renderer/lib/exportPdf.ts
+++ b/src/renderer/lib/exportPdf.ts
@@ -2,6 +2,8 @@ import { toJpeg, toPng } from 'html-to-image'
 import jsPDF from 'jspdf'
 import type { ProjectMetadata } from '../types/project'
 import type { DocumentStamp } from './documentStamp'
+import QRCode from 'qrcode'
+import { buildDocQrPayload } from './qrPayload'
 import { composeExportBackground, type ExportBgVariant } from './exportBackground'
 import { pdfText } from './pdfHelpers'
 import { hexToRgb, drawVectorBackground } from './pdfBackground'
@@ -67,6 +69,7 @@ const drawTitleBlock = (
   pageHeight: number,
   margin: number,
   stamp?: DocumentStamp,
+  standQr?: string,
 ): number => {
   const boxW = 300
   const rowH = 14
@@ -92,13 +95,26 @@ const drawTitleBlock = (
   const visibleRows = rows.filter(([, v]) => !!v || true) // keep all rows, show "—" when missing
   const logoH = 36
   const hasLogos = !!(meta.companyLogo || meta.clientLogo)
-  const boxH = visibleRows.length * rowH + 8 + (hasLogos ? logoH + 6 : 0)
+  // ADR-004 — der Stand-Code sitzt im Titelblock, weil er zum Blatt gehoert
+  // und nicht zur Zeichnung. Quadratisch, so hoch wie die Zeilen daneben.
+  const qrSize = standQr ? 54 : 0
+  const boxH =
+    Math.max(visibleRows.length * rowH, qrSize) + 8 + (hasLogos ? logoH + 6 : 0)
   const x = pageWidth - margin - boxW
   const y = pageHeight - margin - boxH
 
   pdf.setDrawColor(40)
   pdf.setLineWidth(0.6)
   pdf.rect(x, y, boxW, boxH)
+
+  if (standQr) {
+    try {
+      pdf.addImage(standQr, 'PNG', x + boxW - qrSize - 4, y + boxH - qrSize - 4, qrSize, qrSize)
+    } catch {
+      // Ein fehlgeschlagener QR darf den Plan-Export nicht kosten; die
+      // Stand-Zeile im Block traegt dieselbe Information als Text.
+    }
+  }
 
   // Logos row at the top of the box.
   let rowY = y + 4
@@ -137,7 +153,7 @@ const drawTitleBlock = (
     pdf.setTextColor(100)
     pdfText(pdf, label, x + 4, rowY + 10)
     pdf.setTextColor(15)
-    pdfText(pdf, value ?? '-', x + 85, rowY + 10, { maxWidth: boxW - 90 })
+    pdfText(pdf, value ?? '-', x + 85, rowY + 10, { maxWidth: boxW - 90 - qrSize })
     pdf.line(x, rowY + rowH, x + boxW, rowY + rowH)
     rowY += rowH
   }
@@ -540,8 +556,24 @@ const buildCanvasPdf = async (
   onProgress('serialize', `PDF-Stream serialisieren…`)
   await yieldToBrowser()
 
+  // ADR-004, Inkrement 2 — Stand-Code fuer den Rueckweg vom Blatt. Der Stand
+  // steht im Code selbst, nicht in einer Datenbank: das Blatt muss ohne Netz
+  // aussagefaehig sein, sonst nimmt man ihm die Eigenschaft, wegen der es
+  // gedruckt wurde.
+  let standQr: string | undefined
+  if (options?.stamp) {
+    try {
+      standQr = await QRCode.toDataURL(
+        buildDocQrPayload('plan', options.stamp.fingerprint, options.stamp.revision),
+        { margin: 0, width: 128 },
+      )
+    } catch {
+      // Kein QR ist besser als kein PDF; die Stand-Zeile bleibt als Text.
+    }
+  }
+
   if (metadata) {
-    drawTitleBlock(pdf, metadata, pageWidth, pageHeight, margin, options?.stamp)
+    drawTitleBlock(pdf, metadata, pageWidth, pageHeight, margin, options?.stamp, standQr)
   }
 
   return pdf

--- a/src/renderer/lib/qrPayload.ts
+++ b/src/renderer/lib/qrPayload.ts
@@ -58,9 +58,18 @@ export const parseQrPayload = (raw: string): QrRef | null => {
     return { kind: KIND_FROM_PREFIX[prefix[1].toUpperCase()], id: text }
   }
 
+  // ADR-004 — Eine Dokument-URI ist kein Datensatz. Ohne diesen Riegel fiele
+  // sie in Fall (4) und der Lookup suchte nach der URI als Kabelnummer: er
+  // faende nichts und sagte "unbekannter Code" statt "das ist ein
+  // Dokument-Code". `parseDocQrPayload` ist dafuer zustaendig.
+  if (DOC_URI.test(text)) return null
+
   // (4) — irgendein Klartext (z.B. eine vergebene Kabelnummer): als ID ohne Sorte.
   return { id: text }
 }
+
+/** Erkennt eine Dokument-URI, in voller oder Deep-Link-Form. */
+const DOC_URI = /(?:cableplanner:\/\/|[#?](?:lookup=)?)doc\//i
 
 const safeDecode = (s: string): string => {
   try {
@@ -118,4 +127,68 @@ export const lookupQrRef = (
     if (e) return { kind: 'equipment', item: e }
   }
   return null
+}
+
+// ─── Dokument-Codes (ADR-004) ──────────────────────────────────────────────
+//
+// Ein Etikett zeigt auf einen Datensatz; ein Dokument-Code zeigt auf ein Blatt
+// und seinen Stand. Beide leben hier, weil diese Datei die eine Quelle fuer das
+// URI-Format ist — die *Aufloesung* ist eine andere: ein Datensatz wird gesucht,
+// ein Dokument wird verglichen.
+
+/** Was auf einem Blatt steht: welches Dokument, welcher Stand. */
+export interface DocRef {
+  /** Dokument-Art, wie im Dateinamen: `pull-liste`, `kabel-bom`, `plan` … */
+  docId: string
+  /** Fingerabdruck des Inhalts zum Druckzeitpunkt (8 Hex-Zeichen). */
+  stand: string
+  /** Revisions-Label zum Druckzeitpunkt, falls eines festgeschrieben war. */
+  revision?: string
+}
+
+/**
+ * Baut den Dokument-Code: `cableplanner://doc/<docId>?s=<stand>[&r=<revision>]`.
+ *
+ * Der Stand steht im Code selbst und nicht in einer Datenbank: das Blatt muss
+ * ohne Netz aussagefaehig sein, sonst nimmt man ihm genau die Eigenschaft, wegen
+ * der es gedruckt wurde.
+ */
+export const buildDocQrPayload = (docId: string, stand: string, revision?: string): string =>
+  `cableplanner://doc/${encodeURIComponent(docId)}?s=${encodeURIComponent(stand)}` +
+  (revision ? `&r=${encodeURIComponent(revision)}` : '')
+
+/**
+ * Parst einen Dokument-Code. Tolerant wie `parseQrPayload`: volle URI, Hash-
+ * oder `?lookup=`-Deep-Link. Ohne `s=` gibt es keinen Stand und damit nichts zu
+ * vergleichen — dann `null`, statt einen leeren Stand zu behaupten.
+ */
+export const parseDocQrPayload = (raw: string): DocRef | null => {
+  const text = raw?.trim()
+  if (!text) return null
+  const m = text.match(/(?:cableplanner:\/\/|[#?](?:lookup=)?|^)doc\/([^?&#\s]+)/i)
+  if (!m) return null
+  const stand = text.match(/[?&]s=([^&#\s]+)/)
+  if (!stand) return null
+  const revision = text.match(/[?&]r=([^&#\s]+)/)
+  return {
+    docId: safeDecode(m[1]),
+    stand: safeDecode(stand[1]),
+    ...(revision ? { revision: safeDecode(revision[1]) } : {}),
+  }
+}
+
+/** Ergebnis des Standvergleichs. */
+export type DocStandStatus = 'current' | 'stale' | 'unknown'
+
+/**
+ * Vergleicht den Stand auf dem Blatt mit dem Stand, den dasselbe Dokument
+ * heute haette.
+ *
+ * `unknown` ist kein Fehlerfall, sondern die ehrliche dritte Antwort: wer den
+ * aktuellen Stand nicht berechnen kann (fremdes Projekt, anderes Dokument),
+ * darf ein Blatt weder fuer aktuell noch fuer veraltet erklaeren.
+ */
+export const docStandStatus = (ref: DocRef, currentStand: string | undefined): DocStandStatus => {
+  if (!currentStand) return 'unknown'
+  return ref.stand.toLowerCase() === currentStand.toLowerCase() ? 'current' : 'stale'
 }

--- a/tests/docQrPayload.test.ts
+++ b/tests/docQrPayload.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildDocQrPayload,
+  parseDocQrPayload,
+  parseQrPayload,
+  docStandStatus,
+} from '../src/renderer/lib/qrPayload'
+
+// ADR-004, Inkrement 2 — der Rueckweg vom Blatt. Ein Etikett zeigt auf einen
+// Datensatz, ein Dokument-Code auf ein Blatt und seinen Stand.
+
+describe('buildDocQrPayload', () => {
+  it('traegt Dokument, Stand und Revision', () => {
+    expect(buildDocQrPayload('pull-liste', 'a1b2c3d4', 'Rev 2')).toBe(
+      'cableplanner://doc/pull-liste?s=a1b2c3d4&r=Rev%202',
+    )
+  })
+
+  it('laesst die Revision weg, wenn keine festgeschrieben ist', () => {
+    expect(buildDocQrPayload('kabel-bom', 'deadbeef')).toBe(
+      'cableplanner://doc/kabel-bom?s=deadbeef',
+    )
+  })
+
+  it('kodiert Dokument-Ids mit Sonderzeichen', () => {
+    const uri = buildDocQrPayload('a/b c', 'deadbeef')
+    expect(uri).toContain('doc/a%2Fb%20c')
+    expect(parseDocQrPayload(uri)?.docId).toBe('a/b c')
+  })
+})
+
+describe('parseDocQrPayload', () => {
+  it('liest den Round-Trip zurueck', () => {
+    const ref = parseDocQrPayload(buildDocQrPayload('pull-liste', 'a1b2c3d4', 'Rev 2'))
+    expect(ref).toEqual({ docId: 'pull-liste', stand: 'a1b2c3d4', revision: 'Rev 2' })
+  })
+
+  it('nimmt Deep-Link-Formen wie parseQrPayload', () => {
+    expect(parseDocQrPayload('#doc/pull-liste?s=a1b2c3d4')?.stand).toBe('a1b2c3d4')
+    expect(parseDocQrPayload('?lookup=doc/pull-liste&s=a1b2c3d4')?.docId).toBe('pull-liste')
+  })
+
+  it('verweigert einen Code ohne Stand, statt einen leeren zu behaupten', () => {
+    // Ohne Stand gibt es nichts zu vergleichen. Ein DocRef mit stand:'' wuerde
+    // gegen jeden echten Stand als "veraltet" ausgehen — eine erfundene Aussage.
+    expect(parseDocQrPayload('cableplanner://doc/pull-liste')).toBeNull()
+  })
+
+  it('ist fuer Datensatz-Codes und Unsinn nicht zustaendig', () => {
+    expect(parseDocQrPayload('cableplanner://cable/C-0001?l=x')).toBeNull()
+    expect(parseDocQrPayload('C-0001')).toBeNull()
+    expect(parseDocQrPayload('')).toBeNull()
+  })
+})
+
+describe('parseQrPayload gegenueber Dokument-Codes', () => {
+  it('reicht eine Dokument-URI nicht als Datensatz-ID durch', () => {
+    // Ohne den Riegel fiele sie in den Klartext-Fall und der Lookup suchte die
+    // ganze URI als Kabelnummer: "unbekannter Code" statt "Dokument-Code".
+    expect(parseQrPayload('cableplanner://doc/pull-liste?s=a1b2c3d4')).toBeNull()
+    expect(parseQrPayload('#doc/kabel-bom?s=deadbeef')).toBeNull()
+  })
+
+  it('laesst Datensatz-Codes unveraendert', () => {
+    expect(parseQrPayload('cableplanner://cable/C-0001?l=Kamera')).toEqual({
+      kind: 'cable',
+      id: 'C-0001',
+      label: 'Kamera',
+    })
+    expect(parseQrPayload('A-0042')).toEqual({ kind: 'equipment', id: 'A-0042' })
+  })
+})
+
+describe('docStandStatus', () => {
+  const ref = { docId: 'pull-liste', stand: 'a1b2c3d4' }
+
+  it('erkennt das aktuelle Blatt', () => {
+    expect(docStandStatus(ref, 'a1b2c3d4')).toBe('current')
+    expect(docStandStatus(ref, 'A1B2C3D4')).toBe('current')
+  })
+
+  it('erkennt das veraltete Blatt', () => {
+    expect(docStandStatus(ref, 'ffffffff')).toBe('stale')
+  })
+
+  it('sagt „unbekannt", wenn der aktuelle Stand nicht berechenbar ist', () => {
+    // Die ehrliche dritte Antwort: wer nicht rechnen kann, darf ein Blatt weder
+    // fuer aktuell noch fuer veraltet erklaeren.
+    expect(docStandStatus(ref, undefined)).toBe('unknown')
+    expect(docStandStatus(ref, '')).toBe('unknown')
+  })
+})

--- a/tests/documentRegistry.test.ts
+++ b/tests/documentRegistry.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DOCUMENT_STANDS,
+  DOCUMENT_LABELS,
+  currentStand,
+  findByStand,
+} from '../src/renderer/lib/documentRegistry'
+import { docStandStatus, parseDocQrPayload, buildDocQrPayload } from '../src/renderer/lib/qrPayload'
+import type { CablePlannerProject } from '../src/renderer/types/project'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+
+// ADR-004, Inkrement 2 — die andere Haelfte des Stempels: denselben Stand heute
+// ausrechnen koennen. Ohne sie ist der Code auf dem Blatt ein Bild.
+
+const eq = (id: string, name: string, over: Partial<EquipmentItem> = {}): EquipmentItem =>
+  ({
+    id,
+    name,
+    category: 'Sonstiges',
+    inputs: [{ id: `${id}-in`, name: 'IN 1', type: 'port', connectorType: 'BNC' }],
+    outputs: [{ id: `${id}-out`, name: 'OUT 1', type: 'port', connectorType: 'BNC' }],
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 100,
+    ...over,
+  }) as unknown as EquipmentItem
+
+const cable = (id: string, over: Partial<Cable> = {}): Cable =>
+  ({
+    id,
+    name: `Kabel ${id}`,
+    type: 'SDI',
+    length: 10,
+    color: '#fff',
+    fromEquipmentId: 'A',
+    fromPortId: 'A-out',
+    toEquipmentId: 'B',
+    toPortId: 'B-in',
+    notes: '',
+    ...over,
+  }) as Cable
+
+const project = (over: Partial<CablePlannerProject> = {}): CablePlannerProject =>
+  ({
+    metadata: { name: 'Testanlage', description: '', createdAt: '', updatedAt: '' },
+    equipment: [eq('A', 'Kamera 1'), eq('B', 'Switcher')],
+    cables: [cable('c1')],
+    canvasState: { x: 0, y: 0, zoom: 1 },
+    ...over,
+  }) as CablePlannerProject
+
+describe('DOCUMENT_STANDS', () => {
+  it('deckt jeden Bezeichner mit einem lesbaren Namen ab', () => {
+    for (const id of Object.keys(DOCUMENT_STANDS)) {
+      expect(DOCUMENT_LABELS[id], `Label fehlt fuer ${id}`).toBeTruthy()
+    }
+  })
+
+  it('liefert je Dokument acht Hex-Zeichen', () => {
+    const p = project()
+    for (const id of Object.keys(DOCUMENT_STANDS)) {
+      expect(currentStand(id, p)).toMatch(/^[0-9a-f]{8}$/)
+    }
+  })
+
+  it('fuehrt kabel-bom bewusst NICHT', () => {
+    // Der Inhalt haengt vom Reserve-Aufschlag ab, den der Stempel nicht traegt.
+    // Ein Vergleich gegen einen anders gerechneten Wert wuerde jedes Blatt als
+    // veraltet ausweisen — „nicht pruefbar" ist die ehrlichere Antwort.
+    expect(currentStand('kabel-bom', project())).toBeUndefined()
+    expect(docStandStatus({ docId: 'kabel-bom', stand: 'aaaaaaaa' }, undefined)).toBe('unknown')
+  })
+
+  it('kennt ein unbekanntes Dokument nicht, statt zu raten', () => {
+    expect(currentStand('gibt-es-nicht', project())).toBeUndefined()
+  })
+})
+
+describe('Der ganze Weg: drucken, scannen, vergleichen', () => {
+  it('erkennt das eigene Blatt als aktuell', () => {
+    const p = project()
+    const uri = buildDocQrPayload('pull-liste', currentStand('pull-liste', p)!)
+    const ref = parseDocQrPayload(uri)!
+    expect(docStandStatus(ref, currentStand('pull-liste', p))).toBe('current')
+  })
+
+  it('erkennt das Blatt nach einer Aenderung als veraltet', () => {
+    const before = project()
+    const uri = buildDocQrPayload('pull-liste', currentStand('pull-liste', before)!)
+    const after = project({ cables: [cable('c1', { length: 25 })] })
+    expect(docStandStatus(parseDocQrPayload(uri)!, currentStand('pull-liste', after))).toBe('stale')
+  })
+
+  it('haelt das Blatt aktuell, wenn sich nur etwas ausserhalb des Dokuments aenderte', () => {
+    const before = project()
+    const uri = buildDocQrPayload('pull-liste', currentStand('pull-liste', before)!)
+    const moved = project({ equipment: [eq('A', 'Kamera 1', { x: 700 }), eq('B', 'Switcher')] })
+    expect(currentStand('plan', moved)).not.toBe(currentStand('plan', before))
+    expect(docStandStatus(parseDocQrPayload(uri)!, currentStand('pull-liste', moved))).toBe(
+      'current',
+    )
+  })
+})
+
+describe('findByStand — der Rueckweg ohne Kamera', () => {
+  it('findet das Dokument zu acht abgetippten Zeichen', () => {
+    const p = project()
+    const stand = currentStand('asset-register', p)!
+    expect(findByStand(stand, p)?.docId).toBe('asset-register')
+    expect(findByStand(`#${stand.toUpperCase()}`, p)?.label).toBe('Asset-Register')
+  })
+
+  it('findet nichts, wenn der Stand zu keinem aktuellen Blatt gehoert', () => {
+    expect(findByStand('00000000', project())).toBeNull()
+  })
+
+  it('nimmt nur echte Fingerabdruecke, nicht jeden Text', () => {
+    // Sonst wuerde eine Kabelnummer wie "C-0001" hier landen statt im
+    // Datensatz-Lookup.
+    expect(findByStand('C-0001', project())).toBeNull()
+    expect(findByStand('', project())).toBeNull()
+    expect(findByStand('zzzzzzzz', project())).toBeNull()
+  })
+})


### PR DESCRIPTION
Roadmap-Initiative 4, Inkrement 2 (ADR-004). Baut auf #612 auf.

Der Stempel auf dem Papier ist die halbe Antwort. Die andere Hälfte ist, **denselben Stand heute ausrechnen zu können** — sonst ist der Code auf dem Blatt ein Bild.

## Was dazukommt

**`cableplanner://doc/<id>?s=<stand>[&r=<revision>]`** in `qrPayload.ts`, wo das URI-Format ohnehin zu Hause ist. Der Stand steht **im Code selbst**, nicht in einer Datenbank: das Blatt muss ohne Netz aussagefähig sein, sonst nimmt man ihm genau die Eigenschaft, wegen der es gedruckt wurde.

Drei Ausgänge beim Vergleich, nicht zwei: `current` / `stale` / **`unknown`**. `unknown` ist kein Fehlerfall, sondern die ehrliche dritte Antwort — wer den aktuellen Stand nicht berechnen kann, darf ein Blatt weder für aktuell noch für veraltet erklären. Das ist ADR-003 an dieser Stelle.

**`documentRegistry.ts`** — Bezeichner (derselbe wie im Dateinamen) auf die Ableitung, aus der das Dokument gebaut wurde. `kabel-bom` fehlt dort **bewusst**: sein Inhalt hängt vom Reserve-Aufschlag ab, den der Nutzer beim Export einstellt, und dieser Prozentsatz steht nicht im Stempel. Ein Vergleich gegen einen anders gerechneten Wert würde *jedes* BOM-Blatt als veraltet ausweisen. Ein Test hält diese Auslassung fest, damit sie nicht später als Lücke „repariert" wird.

**Ein Riegel in `parseQrPayload`:** eine Dokument-URI fiel bisher in den Klartext-Fall und wurde als Kabelnummer gesucht — Ergebnis „unbekannter Code" statt „das ist ein Dokument-Code". Jetzt `null`, und `parseDocQrPayload` ist zuständig.

## Die Verbraucher

- **Plan-PDF:** der Code sitzt im Titelblock, weil er zum Blatt gehört und nicht zur Zeichnung. Schlägt die QR-Erzeugung fehl, bleibt die `Stand: #…`-Zeile als Text — kein QR ist besser als kein PDF.
- **Mobile-Viewer:** ein gescannter Dokument-Code beantwortet „ist dieses Blatt noch aktuell", vor dem Datensatz-Lookup, weil es eine andere Frage ist.
- **Ohne Kamera:** die acht Zeichen aus der CSV-Fußnote (`#a1b2c3d4`) abgetippt finden das Dokument und melden den Stand. Genau dafür sind es acht Zeichen und kein SHA-256 — der Weg funktioniert am Telefon, auf der Baustelle, ohne App. Passt der Stand zu keinem Blatt, ist das eine **Aussage** („gehört zu keinem aktuellen Blatt") und kein „nicht gefunden".

## Prüfung

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npx vitest run` 451/451 (22 neu) · `npm run lint` 0 Errors · `npm run build` grün.

Ein Test geht den ganzen Weg: drucken → scannen → vergleichen, einmal unverändert (`current`), einmal nach einer Längenänderung (`stale`), einmal nach einer reinen Canvas-Verschiebung (`current` — der Plan-Fingerabdruck ändert sich, die Pull-Liste nicht).

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_