### PR TITLE
inventory: Import meldet, was er abgewiesen hat (ADR-005)

### DIFF
--- a/src/renderer/components/Inventory/InventoryDialog.tsx
+++ b/src/renderer/components/Inventory/InventoryDialog.tsx
@@ -103,6 +103,15 @@ const formatDims = (d: PhysicalDimensions | undefined): string => {
   return parts.length ? parts.join(' · ') : '—'
 }
 
+
+/** ADR-005 — Sorte einer abgewiesenen Zeile, lesbar fuer den Import-Bericht. */
+const REJECT_KIND_LABEL: Record<'item' | 'node' | 'set' | 'unit', string> = {
+  item: 'Position',
+  node: 'Lagerort',
+  set: 'Set',
+  unit: 'Einheit',
+}
+
 export const InventoryDialog = ({ open, onClose }: InventoryDialogProps) => {
   const t = useTranslation()
   const items = useInventoryStore((s) => s.items)
@@ -252,10 +261,36 @@ export const InventoryDialog = ({ open, onClose }: InventoryDialogProps) => {
       okLabel: t('inventory.importReplace', 'Ersetzen'),
       cancelLabel: t('inventory.importMerge', 'Zusammenführen'),
     })
-    const n = importSnapshot(snap, replace ? 'replace' : 'merge')
+    const report = importSnapshot(snap, replace ? 'replace' : 'merge')
+    // ADR-005 — was nicht bewahrt werden konnte, wird gesagt. Ein gruener
+    // Erfolg ueber einer Datei, deren Haelfte abgewiesen wurde, waere die
+    // falsche Gewissheit, gegen die diese Regel geschrieben ist.
+    const lines = [
+      format(t('inventory.importDone', '{n} Objekte importiert.'), { n: report.imported }),
+    ]
+    if (report.rejected.length > 0) {
+      lines.push(
+        '',
+        format(
+          t(
+            'inventory.importRejected',
+            '{n} Eintrag/Einträge wurden abgewiesen, weil Pflichtfelder fehlen:',
+          ),
+          { n: report.rejected.length },
+        ),
+        ...report.rejected.slice(0, 12).map((r) => `- ${REJECT_KIND_LABEL[r.kind]}: ${r.label}`),
+      )
+      if (report.rejected.length > 12) {
+        lines.push(
+          format(t('inventory.importRejectedMore', '… und {n} weitere.'), {
+            n: report.rejected.length - 12,
+          }),
+        )
+      }
+    }
     await infoDialog(t('inventory.importDoneTitle', 'Import abgeschlossen'), {
-      tone: 'success',
-      body: format(t('inventory.importDone', '{n} Objekte importiert.'), { n }),
+      tone: report.rejected.length > 0 ? 'warning' : 'success',
+      body: lines.join('\n'),
     })
   }
 

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3680,6 +3680,8 @@ export const en: Dict = {
   'inventory.importErr': 'Not a valid inventory file (avplan-inventory).',
   'inventory.importDoneTitle': 'Import complete',
   'inventory.importDone': '{n} objects imported.',
+  'inventory.importRejected': '{n} entry/entries were rejected because required fields are missing:',
+  'inventory.importRejectedMore': '… and {n} more.',
   // #414 AI plan generation
   'aiPlan.title': 'AI plan generation',
   'aiPlan.noKey': 'No AI API key set. Add a provider key under Settings → AI.',

--- a/src/renderer/store/inventoryStore.ts
+++ b/src/renderer/store/inventoryStore.ts
@@ -68,6 +68,35 @@ const healMaterialKinds = (v: unknown): InventoryMaterialKind[] | undefined => {
 }
 
 /** Heilt ein geladenes Item: erzwingt Pflichtfelder, kappt Unsinn. */
+/**
+ * ADR-005 — Was ein Import nicht bewahren konnte.
+ *
+ * Die Heilung weist Eintraege ohne Pflichtfelder ab; das ist richtig, denn ein
+ * Lagerort ohne Namen ist kein Lagerort. Falsch war nur, es zu verschweigen.
+ * `label` ist der beste menschenlesbare Griff, den der Rohsatz noch hergibt —
+ * damit jemand die Zeile in seiner Quelldatei wiederfindet.
+ */
+export interface ImportRejection {
+  kind: 'item' | 'node' | 'set' | 'unit'
+  label: string
+}
+
+export interface ImportReport {
+  imported: number
+  rejected: ImportRejection[]
+}
+
+/** Bester Griff auf einen Rohsatz, der die Heilung nicht bestanden hat. */
+const rawLabel = (raw: unknown): string => {
+  if (!raw || typeof raw !== 'object') return 'ohne Inhalt'
+  const r = raw as Record<string, unknown>
+  for (const key of ['model', 'name', 'id', 'itemId', 'code']) {
+    const v = r[key]
+    if (typeof v === 'string' && v.trim()) return v.trim()
+  }
+  return 'ohne Kennung'
+}
+
 const healItem = (raw: unknown): InventoryItem | null => {
   if (!raw || typeof raw !== 'object') return null
   const r = raw as Partial<InventoryItem>
@@ -354,13 +383,18 @@ interface InventoryState {
   /**
    * Importiert einen Snapshot. `replace` ersetzt den gesamten Bestand,
    * `merge` fügt per id zusammen (Import gewinnt bei Kollision). Alle Felder
-   * werden geheilt (gleiche Regeln wie beim Laden). Liefert die Anzahl
-   * importierter Objekte.
+   * werden geheilt (gleiche Regeln wie beim Laden).
+   *
+   * ADR-005 — liefert einen Bericht, keine blosse Zahl. Vorher wurden
+   * Eintraege, die die Heilung nicht ueberstehen, still weggefiltert und nur
+   * die Ueberlebenden gezaehlt: eine Datei, deren Haelfte abgewiesen wurde,
+   * meldete einen gruenen Erfolg mit kleinerer Zahl. Wer nicht bewahren kann,
+   * sagt es an der Stelle, an der es passiert.
    */
   importSnapshot: (
     snap: { items?: unknown[]; nodes?: unknown[]; sets?: unknown[]; units?: unknown[] },
     mode: 'replace' | 'merge',
-  ) => number
+  ) => ImportReport
 }
 
 const initial = load()
@@ -658,10 +692,27 @@ export const useInventoryStore = create<InventoryState>((set, get) => ({
     return { items: s.items, nodes: s.nodes, sets: s.sets, units: s.units }
   },
   importSnapshot: (snap, mode) => {
-    const inItems = (snap.items ?? []).map(healItem).filter((x): x is InventoryItem => x !== null)
-    const inNodes = (snap.nodes ?? []).map(healNode).filter((x): x is StorageNode => x !== null)
-    const inSets = (snap.sets ?? []).map(healSet).filter((x): x is InventorySet => x !== null)
-    const inUnits = (snap.units ?? []).map(healUnit).filter((x): x is InventoryUnit => x !== null)
+    // ADR-005 — die Abweisungen werden mitgeschrieben, statt weggefiltert zu
+    // werden. Der Grund kommt aus derselben Heilung, die abweist; es gibt also
+    // keine zweite Bedingungsliste, die auseinanderlaufen koennte.
+    const rejected: ImportRejection[] = []
+    const keep = <T>(
+      kind: ImportRejection['kind'],
+      raws: unknown[],
+      heal: (raw: unknown) => T | null,
+    ): T[] => {
+      const out: T[] = []
+      for (const raw of raws) {
+        const healed = heal(raw)
+        if (healed === null) rejected.push({ kind, label: rawLabel(raw) })
+        else out.push(healed)
+      }
+      return out
+    }
+    const inItems = keep('item', snap.items ?? [], healItem)
+    const inNodes = keep('node', snap.nodes ?? [], healNode)
+    const inSets = keep('set', snap.sets ?? [], healSet)
+    const inUnits = keep('unit', snap.units ?? [], healUnit)
     const total = inItems.length + inNodes.length + inSets.length + inUnits.length
     set((state) => {
       const mergeById = <T extends { id: string }>(base: T[], add: T[]): T[] => {
@@ -676,6 +727,6 @@ export const useInventoryStore = create<InventoryState>((set, get) => ({
       persist(items, nodes, sets, units)
       return { items, nodes, sets, units }
     })
-    return total
+    return { imported: total, rejected }
   },
 }))

--- a/tests/inventoryPortable.test.ts
+++ b/tests/inventoryPortable.test.ts
@@ -54,7 +54,8 @@ describe('inventoryStore — Import/Export', () => {
       { items: [{ id: 'imp1', model: 'Importiert', quantity: 5, createdAt: 'x', updatedAt: 'x' }] },
       'replace',
     )
-    expect(n).toBe(1)
+    expect(n.imported).toBe(1)
+    expect(n.rejected).toEqual([])
     let items = useInventoryStore.getState().items
     expect(items).toHaveLength(1)
     expect(items[0].model).toBe('Importiert')
@@ -74,10 +75,37 @@ describe('inventoryStore — Import/Export', () => {
     expect(items.find((i) => i.id === 'imp1')?.model).toBe('Importiert v2')
   })
 
-  it('Import heilt kaputte Einträge (Pflichtfelder fehlen → verworfen)', () => {
+  it('Import weist kaputte Einträge ab UND meldet sie (ADR-005)', () => {
+    // Vorher stand hier nur `expect(n).toBe(0)` — der Test schrieb damit genau
+    // das Schweigen fest, das ADR-005 als Verstoß führt: die Zeile verschwand,
+    // und der Nutzer sah einen grünen Erfolg mit kleinerer Zahl.
     const st = useInventoryStore.getState()
-    const n = st.importSnapshot({ items: [{ id: 'x', quantity: 1 } as unknown] }, 'replace')
-    expect(n).toBe(0) // model fehlt → geheilt-verworfen
+    const report = st.importSnapshot({ items: [{ id: 'x', quantity: 1 } as unknown] }, 'replace')
+    expect(report.imported).toBe(0) // model fehlt → geheilt-verworfen
+    expect(report.rejected).toHaveLength(1)
+    expect(report.rejected[0].kind).toBe('item')
+    expect(report.rejected[0].label).toBe('x') // wiederauffindbar in der Quelldatei
+  })
+
+  it('meldet je Sorte, was abgewiesen wurde', () => {
+    const st = useInventoryStore.getState()
+    const report = st.importSnapshot(
+      {
+        items: [{ model: 'Gut', quantity: 1 } as unknown, { model: '  ' } as unknown],
+        nodes: [{ name: 'Ohne Sorte' } as unknown],
+        units: [{ id: 'u1' } as unknown],
+      },
+      'replace',
+    )
+    expect(report.imported).toBe(1)
+    expect(report.rejected.map((r) => r.kind).sort()).toEqual(['item', 'node', 'unit'])
+  })
+
+  it('meldet nichts, wenn nichts abzuweisen war', () => {
+    const st = useInventoryStore.getState()
+    const report = st.importSnapshot({ items: [{ model: 'Gut', quantity: 2 } as unknown] }, 'replace')
+    expect(report.imported).toBe(1)
+    expect(report.rejected).toEqual([])
   })
 })
 


### PR DESCRIPTION
ADR-005 Inkrement 3 — der erste von Hand nachgelesene Hinweis aus dem abgebrochenen Audit.

## Der Fehler

`importSnapshot` schickt jede Entität durch `heal*` und filtert alles weg, was `null` zurückgibt. Gezählt werden nur die Überlebenden, und diese Zahl geht als Erfolg an die Oberfläche:

```ts
const n = importSnapshot(snap, …)
await infoDialog(…, { tone: 'success', body: `${n} Objekte importiert.` })
```

Eine Datei mit 100 Positionen, von denen 30 die Pflichtfeldprüfung nicht bestehen, erzeugt damit einen **grünen Erfolgsdialog mit „70 Objekte importiert"** — und kein Wort über die 30. Der Nutzer erfährt nie, dass etwas fehlt, und weiß erst recht nicht, welche Zeilen er in seiner Quelldatei reparieren müsste.

Das ist Design-Regel 2 in ihrer direktesten Form: ein Import, der etwas nicht bewahren kann, verwirft es und meldet Erfolg.

**Und der bestehende Test schrieb das fest.** `expect(n).toBe(0)` mit dem Kommentar „model fehlt → geheilt-verworfen" hielt genau das Schweigen als Sollverhalten. Das Abweisen ist richtig — ein Lagerort ohne Namen ist kein Lagerort. Falsch war nur, es zu verschweigen.

## Der Fix

`importSnapshot` liefert einen `ImportReport` statt einer Zahl:

```ts
interface ImportReport { imported: number; rejected: ImportRejection[] }
interface ImportRejection { kind: 'item'|'node'|'set'|'unit'; label: string }
```

- **Keine zweite Bedingungsliste.** Der Bericht entsteht in derselben Schleife, die heilt — es gibt nichts, was von den Heilungsregeln auseinanderlaufen könnte.
- **Jede abgewiesene Zeile trägt einen Griff** (`model` → `name` → `id` → `itemId` → `code`, sonst „ohne Kennung"), damit sie in der Quelldatei wiederauffindbar ist. Eine Meldung „30 abgewiesen" ohne Angabe welche wäre nur die halbe Ehrlichkeit.
- **Der Dialog wechselt auf Warnton** und listet bis zu zwölf Zeilen, danach „… und n weitere".

## Prüfung

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npx vitest run` 453/453 · `npm run lint` 0 Errors · `npm run build` grün.

Der umgeschriebene Test prüft jetzt, dass die Abweisung *gemeldet* wird, samt Griff; zwei weitere decken die Meldung je Sorte und den Fall ohne Abweisungen ab.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_