### PR TITLE
template: Katalog-Identität überlebt die Rekonstruktion (ADR-005)

### DIFF
--- a/src/renderer/lib/rentmanTemplateCache.ts
+++ b/src/renderer/lib/rentmanTemplateCache.ts
@@ -28,6 +28,11 @@ const writeCache = (cache: RentmanTemplateCache) => {
 const toTemplateFromEquipment = (item: EquipmentItem): EquipmentTemplate => ({
   name: item.name,
   category: item.category || 'Sonstiges',
+  // ADR-002/ADR-005 — die Katalog-Identitaet muss die Rekonstruktion ueberleben.
+  // Ohne sie kommt ein Geraet aus dem Cache ohne deviceTypeId zurueck, und der
+  // Rentman-Import faellt auf die Namens-Heuristiken darunter zurueck: aus einer
+  // Datenblatt-Tatsache wird wieder ein Regex-Treffer.
+  deviceTypeId: item.deviceTypeId,
   inputs: item.inputs,
   outputs: item.outputs,
   isRackDevice: item.isRackDevice,

--- a/src/renderer/store/slices/templateSlice.ts
+++ b/src/renderer/store/slices/templateSlice.ts
@@ -45,6 +45,10 @@ const templateFromEquipment = (
 ): EquipmentTemplate => ({
   name: override.name ?? item.name,
   category: (override.category || item.category || 'Sonstiges').trim() || 'Sonstiges',
+  // ADR-002/ADR-005 — ein Template IST ein Geraetetyp; die stabile
+  // Typ-Identitaet gehoert also zwingend mit. Sie hier fallenzulassen machte
+  // aus einem Katalog-Geraet ein namentlich geratenes.
+  deviceTypeId: item.deviceTypeId,
   inputs: item.inputs,
   outputs: item.outputs,
   width: item.width,

--- a/tests/templateIdentity.test.ts
+++ b/tests/templateIdentity.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import {
+  upsertCachedRentmanTemplateFromEquipment,
+  getCachedRentmanTemplate,
+} from '../src/renderer/lib/rentmanTemplateCache'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+
+// ADR-005, Inkrement 3 — zweiter von Hand nachgelesener Hinweis.
+//
+// `deviceTypeId` ist die stabile Katalog-Identitaet aus ADR-002. Der Kommentar
+// in `healItem` sagt dazu: „die Typ-Identitaet muss die Heilung ueberleben;
+// genau hier ginge sie sonst still verloren." Genau das passierte eine Datei
+// weiter: der Rentman-Template-Cache und `saveEquipmentAsTemplate` bauen ihr
+// Template aus einer festen Feldliste neu, und `deviceTypeId` stand auf keiner
+// von beiden. Ein Geraet kam aus dem Cache ohne Katalog-Identitaet zurueck und
+// der Import fiel auf die Namens-Heuristiken zurueck — aus einer
+// Datenblatt-Tatsache wurde wieder ein Regex-Treffer.
+
+const eq = (over: Partial<EquipmentItem> = {}): EquipmentItem =>
+  ({
+    id: 'e1',
+    name: 'ATEM Mini Extreme',
+    category: 'Videomischer',
+    inputs: [],
+    outputs: [],
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 100,
+    rentmanId: 'rm-42',
+    deviceTypeId: 'dt-0815',
+    ...over,
+  }) as unknown as EquipmentItem
+
+describe('Rentman-Template-Cache — Katalog-Identitaet ueberlebt (ADR-005)', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('traegt deviceTypeId in den Cache und wieder heraus', () => {
+    upsertCachedRentmanTemplateFromEquipment(eq())
+    expect(getCachedRentmanTemplate('rm-42')?.deviceTypeId).toBe('dt-0815')
+  })
+
+  it('erfindet keine Identitaet, wo das Geraet keine hat', () => {
+    // Ein manuell angelegtes Geraet hat keine Katalog-Zeile. Es bekommt hier
+    // auch keine — sonst waere die ID eine Behauptung statt einer Tatsache.
+    upsertCachedRentmanTemplateFromEquipment(eq({ deviceTypeId: undefined }))
+    expect(getCachedRentmanTemplate('rm-42')?.deviceTypeId).toBeUndefined()
+  })
+
+  it('schreibt nichts ohne rentmanId', () => {
+    upsertCachedRentmanTemplateFromEquipment(eq({ rentmanId: undefined }))
+    expect(getCachedRentmanTemplate('rm-42')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
ADR-005 Inkrement 3, zweiter von Hand nachgelesener Hinweis.

## Der Fehler

`deviceTypeId` ist die stabile Katalog-Identität aus ADR-002. Der Kommentar in `healItem` sagt dazu ausdrücklich:

> die Typ-Identitaet muss die Heilung ueberleben; **genau hier ginge sie sonst still verloren**

Eine Datei weiter fiel sie trotzdem. Zwei Stellen bauen ihr Template aus einer festen Feldliste neu:

| Stelle | kopiert | von |
|---|---|---|
| `rentmanTemplateCache.toTemplateFromEquipment` | 36 Felder | 97 auf `EquipmentItem` |
| `templateSlice.templateFromEquipment` | 24 Felder | dieselben 97 |

`deviceTypeId` stand auf **keiner von beiden**.

Die Folge ist ein geschlossener Kreis: `equipmentSlice` schreibt ein bearbeitetes Gerät via `upsertCachedRentmanTemplateFromEquipment` in den Cache, der Rentman-Import liest es als `base` zurück — und findet keine `deviceTypeId`. Direkt darunter steht die Fallback-Kette `matchBlackmagicTemplate` / `matchUbiquitiTemplate` / `matchCameraTemplate` / … Aus einer **Datenblatt-Tatsache wird wieder ein Regex-Treffer**, also genau die Umkehrung dessen, was ADR-002 beseitigt hatte.

## Was dieser PR *nicht* entscheidet

Von den 58 nicht kopierten Feldern ist `deviceTypeId` das eindeutige: ein Template **ist** ein Gerätetyp, die Typ-Identität gehört zwingend mit. Die übrigen zerfallen in zwei Klassen, und die Grenze ist eine Design-Entscheidung, keine mechanische:

- **Instanz-Felder, die in einem Template nichts zu suchen haben** — `assetTag`, `serialNumber`, `qrId`, `installStatus`, `packed`, `rackInstanceId`, `sourceIdentityId`, `videohubRouting`, `serviceHistory` … Sie zu kopieren wäre der umgekehrte Fehler.
- **Modell-Felder, die vermutlich mitgehören** — `rentPricePerDay`, `rentCurrency`, `priceEUR`, `powerConsumptionWatts`, `currentAmps`, `voltage`, `heightMm`/`widthMm`, `modes`, `shortName`, `manufacturerUrl`, `isConverter`/`isPatchPanel`/`isRackShelf`.

Die zweite Gruppe betrifft **kommerzielle Daten, die in Stücklisten weiterlaufen**. Eine falsche Zuordnung dort propagiert still falsche Preise. Das gehört entschieden und nicht im Vorbeigehen mitgenommen — deshalb steht es hier als benannte offene Frage statt als stiller Teil dieses Diffs.

## Prüfung

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npx vitest run` 456/456 (3 neu) · `npm run lint` 0 Errors · `npm run build` grün.

Die Tests enthalten die Gegenprobe: ein manuell angelegtes Gerät ohne Katalog-Zeile bekommt **keine** Identität angedichtet — sonst wäre die ID eine Behauptung statt einer Tatsache.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_