### PR TITLE
greengo: Import sagt, welche Abschnitte er nicht liest (ADR-005)

### DIFF
--- a/src/renderer/components/Export/GreenGoExportDialog.tsx
+++ b/src/renderer/components/Export/GreenGoExportDialog.tsx
@@ -775,6 +775,30 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
 
             <div className="flex-1 overflow-y-auto p-4 space-y-4">
 
+              {/* ADR-005 — was die Datei mitbringt und dieser Import nicht liest.
+                  Der Export schreibt diese Sektionen aus Defaults; wer eine echte
+                  Anlagen-Konfiguration hier durchreicht, bekommt sie leer zurueck.
+                  Bis der Round-Trip sie bewahrt, sagt er es wenigstens. */}
+              {importResult.unreadSections.length > 0 && (
+                <div className="rounded border border-cp-warn/50 bg-cp-warn/10 p-3">
+                  <div className="mb-1 text-cp-xs font-semibold text-cp-warn">
+                    {t(
+                      'greengo.importOverlay.unreadTitle',
+                      'Diese Datei enthält Abschnitte, die der Import nicht liest',
+                    )}
+                  </div>
+                  <div className="font-mono text-[11px] text-cp-text-secondary">
+                    {importResult.unreadSections.join(', ')}
+                  </div>
+                  <div className="mt-1.5 text-[11px] text-cp-text-muted">
+                    {t(
+                      'greengo.importOverlay.unreadHint',
+                      'Ein Export aus dem Cable-Planner erzeugt eine neue .gg5 und füllt diese Abschnitte mit Standardwerten. Er ersetzt die Original-Datei nicht — bewahre sie auf.',
+                    )}
+                  </div>
+                </div>
+              )}
+
               {/* Groups summary */}
               {importResult.config.groups.length > 0 && (
                 <div>

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -1410,6 +1410,8 @@ export const en: Dict = {
   'greengo.export.gg5': 'Export as .gg5',
   'greengo.importOverlay.title': 'Import .gg5 — link devices',
   'greengo.importOverlay.system': 'System:',
+  'greengo.importOverlay.unreadTitle': 'This file contains sections the import does not read',
+  'greengo.importOverlay.unreadHint': 'An export from Cable Planner creates a new .gg5 and fills those sections with defaults. It does not replace the original file — keep it.',
   'greengo.importOverlay.importedGroups': 'Imported groups',
   'greengo.importOverlay.linkStations': 'Link stations → canvas devices',
   'greengo.importOverlay.linkHint':

--- a/src/renderer/lib/importGreengo.ts
+++ b/src/renderer/lib/importGreengo.ts
@@ -25,6 +25,17 @@ export interface Gg5ImportResult {
    * Derived from the user's Name in the .gg5 file.
    */
   userTypeHints: Map<number, string>
+  /**
+   * ADR-005 — Sektionen, die in der Datei stehen und die dieses Modul NICHT
+   * liest (Devices, Rooms, Templates …).
+   *
+   * Das ist keine Kosmetik: der Exporter schreibt eine vollstaendige .gg5 und
+   * fuellt genau diese Sektionen aus hartkodierten Defaults. Wer eine echte
+   * Anlagen-Konfiguration importiert, etwas aendert und wieder exportiert,
+   * bekommt sie leer zurueck. Bis der Round-Trip sie bewahrt, muss er wenigstens
+   * sagen, was er nicht gelesen hat — schweigen ist der Schaden.
+   */
+  unreadSections: string[]
 }
 
 export interface Gg5ParseError {
@@ -258,5 +269,21 @@ export const parseGg5File = (jsonText: string): Gg5ParseOutcome => {
       groups,
     },
     userTypeHints,
+    unreadSections: unreadTopLevelSections(raw),
   }
 }
+
+/** Von diesem Modul gelesene Sektionen einer .gg5. Alles andere ist ungelesen. */
+const READ_SECTIONS = new Set(['Settings', 'Users', 'Groups'])
+
+/**
+ * ADR-005 — Welche Sektionen die Datei mitbringt, die hier niemand anfasst.
+ *
+ * Bewusst aus dem Rohdokument abgeleitet und nicht aus einer gepflegten Liste:
+ * eine zweite Liste wuerde von READ_SECTIONS auseinanderlaufen, sobald der
+ * Parser eine Sektion dazubekommt.
+ */
+const unreadTopLevelSections = (raw: Record<string, unknown>): string[] =>
+  Object.keys(raw)
+    .filter((k) => !READ_SECTIONS.has(k))
+    .sort()

--- a/tests/importGreengoUnread.test.ts
+++ b/tests/importGreengoUnread.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { parseGg5File, isParseError } from '../src/renderer/lib/importGreengo'
+
+// ADR-005, Inkrement 3 — vierter von Hand nachgelesener Hinweis, und der
+// schwerste bestaetigte.
+//
+// Der Importer liest genau drei Sektionen (Settings, Users, Groups) — der
+// Modulkopf sagt das sogar selbst und zaehlt „Devices, Rooms, Templates, …"
+// als vorhanden auf. Der EXPORTER schreibt aber eine vollstaendige .gg5 und
+// fuellt Channels, SpecialChannels, ScriptSettings und UserSettings aus
+// hartkodierten Defaults. Wer eine echte Anlagen-Konfiguration importiert,
+// etwas aendert und wieder exportiert, bekommt diese Abschnitte leer zurueck —
+// auf einer Intercom-Anlage sind das die Tastenbelegungen.
+//
+// Bis der Round-Trip sie bewahrt, muss der Import wenigstens sagen, was er
+// nicht gelesen hat. Genau das prueft dieser Test.
+
+const gg5 = (extra: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    Settings: { Name: 'Halle', MulticastAddress: '239.1.160.1', SampleRate: 48000 },
+    Users: {
+      keys: ['u1'],
+      u1: { myId: 1, Name: 'BPX Regie', Settings: {} },
+    },
+    Groups: {
+      keys: ['g1'],
+      g1: { myId: 1, Name: 'Produktion', Settings: {} },
+    },
+    ...extra,
+  })
+
+describe('parseGg5File — meldet ungelesene Abschnitte (ADR-005)', () => {
+  it('nennt jede Sektion, die es nicht liest', () => {
+    const r = parseGg5File(gg5({ Devices: {}, Rooms: {}, Templates: {} }))
+    expect(isParseError(r)).toBe(false)
+    if (isParseError(r)) return
+    expect(r.unreadSections).toEqual(['Devices', 'Rooms', 'Templates'])
+  })
+
+  it('meldet nichts, wenn die Datei nur Bekanntes enthaelt', () => {
+    const r = parseGg5File(gg5())
+    expect(isParseError(r)).toBe(false)
+    if (isParseError(r)) return
+    expect(r.unreadSections).toEqual([])
+  })
+
+  it('leitet die Liste aus der Datei ab, nicht aus einer gepflegten Aufzaehlung', () => {
+    // Der Punkt der Ableitung: eine Sektion, die es 2026 noch gar nicht gibt,
+    // wird trotzdem gemeldet. Eine zweite gepflegte Liste wuerde von den
+    // gelesenen Sektionen auseinanderlaufen, sobald der Parser dazulernt.
+    const r = parseGg5File(gg5({ ZukunftsSektion: { a: 1 } }))
+    expect(isParseError(r)).toBe(false)
+    if (isParseError(r)) return
+    expect(r.unreadSections).toContain('ZukunftsSektion')
+  })
+
+  it('meldet die gelesenen Sektionen NICHT als ungelesen', () => {
+    const r = parseGg5File(gg5({ Devices: {} }))
+    expect(isParseError(r)).toBe(false)
+    if (isParseError(r)) return
+    for (const known of ['Settings', 'Users', 'Groups']) {
+      expect(r.unreadSections).not.toContain(known)
+    }
+  })
+})


### PR DESCRIPTION
ADR-005 Inkrement 3, vierter nachgelesener Hinweis — und der **schwerste bestätigte**.

## Der Fehler

Anders als NetBox und GraphML (beide lesend, deshalb keine Verlust-, sondern Grenzfälle) hat Green-GO **Importer und Exporter**. Damit gibt es einen echten Round-Trip — und der verliert:

| | liest / schreibt |
|---|---|
| `parseGg5File` | **liest** `Settings`, `Users`, `Groups` |
| `exportGreengo` | **schreibt** diese plus `Channels`, `SpecialChannels`, `ScriptSettings`, `UserSettings` — aus **hartkodierten Defaults** (`Channels: {}`, `ScriptSettings: { Id: '--', status: '--' }`) |

Wer eine echte Anlagen-Konfiguration importiert, eine Gruppe ändert und wieder exportiert, bekommt diese Abschnitte **leer** zurück. Auf einer Intercom-Anlage sind das die Tastenbelegungen.

Der Modulkopf des Importers benennt die Lücke sogar selbst:

> A .gg5 file is a JSON document with the following top-level keys:
>   Settings, Users, Groups, **Devices, Rooms, Templates, …**
> This module extracts Users and Groups …

Das Wissen stand also im Kommentar — nur nicht im Produkt.

## Was dieser PR macht

Die **Meldung**, nicht die Bewahrung. ADR-005 Regel 3: wer nicht bewahren kann, sagt es an der Stelle, an der es passiert.

- `Gg5ImportResult` trägt `unreadSections`, **abgeleitet aus dem Rohdokument** statt aus einer zweiten gepflegten Liste — die würde von den gelesenen Sektionen auseinanderlaufen, sobald der Parser dazulernt. Ein Test prüft genau das mit einer erfundenen Zukunfts-Sektion.
- Der Import-Dialog zeigt sie in einem Warnblock und sagt dazu, dass ein Export eine **neue** Datei erzeugt und das Original nicht ersetzt — „bewahre sie auf".

## Was dieser PR bewusst offenlässt

Ob `exportGreengo` ein **Generator** bleibt (erzeugt eine frische Konfiguration aus dem Plan) oder zum **Editor** wird (behält das importierte Rohdokument und merged nur die geänderten Abschnitte hinein), ist eine Design-Entscheidung mit Folgen für den ganzen Green-GO-Weg. Die gehört entschieden und nicht nebenbei getroffen.

Bis dahin ist die Warnung das ehrliche Minimum: sie kostet nichts und verhindert den Fall, in dem jemand die Originaldatei überschreibt, weil er annahm, der Export sei eine bearbeitete Fassung davon.

## Prüfung

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npx vitest run` 460/460 (4 neu) · `npm run lint` 0 Errors · `npm run build` grün.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_