### PR TITLE
load: Kanal für Lade-Hinweise (ADR-005, Regel 3)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,3 +1,4 @@
+import { hasDrops } from './types/loadReport'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useIsNarrow } from './hooks/useBreakpoint'
 import { CanvasArea } from './components/Canvas/CanvasArea'
@@ -111,6 +112,9 @@ import { cableTouches } from './lib/portOccupancy'
 export default function App() {
   const t = useTranslation()
   const project = useProjectStore((state) => state.project)
+  // ADR-005 — Bericht ueber den letzten Ladevorgang (was nicht mitkam).
+  const lastLoadReport = useProjectStore((s) => s.lastLoadReport)
+  const dismissLoadReport = useProjectStore((s) => s.dismissLoadReport)
   const inventoryOpen = useUiStore((state) => state.inventory.open)
   const canvasTheme = useUiStore((state) => state.canvasTheme)
   const followSystemTheme = useUiStore((state) => state.followSystemTheme)
@@ -1285,6 +1289,51 @@ export default function App() {
           </div>
         )
       })()}
+      {/* ADR-005, Regel 3 — was die Heilung beim Laden verworfen hat, wird
+          gesagt. Vorher war das strukturell unmoeglich: healProjectPositions
+          ist eine reine Funktion ohne Weg zur Oberflaeche, also verschwand
+          alles Verworfene definitionsgemaess still. Eine verworfene
+          Signalquellen-Rolle nimmt die Tally-Adresse der Kamera mit. */}
+      {hasDrops(lastLoadReport) && lastLoadReport && (
+        <div
+          role="status"
+          className="fixed bottom-4 left-1/2 z-[210] w-[560px] max-w-[92vw] -translate-x-1/2 rounded-cp-card border border-cp-warn/60 bg-cp-surface-1 p-4 shadow-2xl"
+        >
+          <div className="mb-1 flex items-start justify-between gap-3">
+            <div className="text-cp-sm font-semibold text-cp-warn">
+              {t(
+                'app.loadReport.title',
+                'Beim Laden konnten nicht alle Datensätze übernommen werden',
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={dismissLoadReport}
+              className="rounded bg-cp-surface-4 px-2 py-0.5 text-cp-xs hover:bg-cp-surface-5"
+            >
+              {t('common.ok', 'OK')}
+            </button>
+          </div>
+          <ul className="max-h-40 space-y-0.5 overflow-y-auto text-[11px] text-cp-text-secondary">
+            {lastLoadReport.drops.slice(0, 20).map((d, i) => (
+              <li key={`${d.kind}-${d.label}-${i}`}>
+                {t('app.loadReport.sourceIdentity', 'Signalquelle')}
+                {d.label ? ` „${d.label}"` : ''}
+                {' — '}
+                {d.reason === 'duplicate-id'
+                  ? t('app.loadReport.duplicateId', 'doppelte Id, der erste Eintrag gilt')
+                  : t('app.loadReport.missingRequired', 'Pflichtfeld fehlt (Name)')}
+              </li>
+            ))}
+          </ul>
+          <div className="mt-2 text-[11px] text-cp-text-muted">
+            {t(
+              'app.loadReport.hint',
+              'Geräte, die auf diese Rollen zeigten, haben ihre Zuordnung verloren — darunter die TSL-Adresse für Tally. Speichern überschreibt die Datei mit diesem Stand.',
+            )}
+          </div>
+        </div>
+      )}
       {pdfProgress.active && (
         <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/60 backdrop-blur-sm">
           <div className="w-[420px] max-w-[90vw] rounded-cp-card border border-cp-border bg-cp-surface-1 p-5 text-cp-text shadow-2xl">

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3076,6 +3076,11 @@ export const en: Dict = {
   // Cable dialog – save-as-custom prompt
   'cable.dialog.newTypeNamePrompt': 'Name for the new cable type:',
   // App.tsx PDF progress overlay
+  'app.loadReport.title': 'Some records could not be loaded',
+  'app.loadReport.sourceIdentity': 'Source',
+  'app.loadReport.duplicateId': 'duplicate id, the first entry wins',
+  'app.loadReport.missingRequired': 'required field missing (name)',
+  'app.loadReport.hint': 'Devices that pointed at these roles lost their assignment — including the TSL address used for tally. Saving overwrites the file with this state.',
   'app.pdfProgress.title': 'PDF is being created…',
   'app.pdfProgress.hint':
     'Large plans may take a few seconds. Please do not cancel.',

--- a/src/renderer/lib/sourceIdentity.ts
+++ b/src/renderer/lib/sourceIdentity.ts
@@ -6,6 +6,7 @@
 // halb gueltige Adresse ist schlimmer als keine: Sie sieht auf dem Papier
 // aus wie eine Zusage, und das Display bleibt trotzdem leer.
 
+import type { LoadDrop } from '../types/loadReport'
 import type { SourceIdentity } from '../types/sourceIdentity'
 
 /**
@@ -59,18 +60,46 @@ export const normaliseSourceIdentity = (
   return identity
 }
 
-/** Normalisiert die Liste und wirft Duplikat-Ids weg (erste gewinnt). */
-export const normaliseSourceIdentities = (raw: unknown): SourceIdentity[] => {
+/**
+ * Normalisiert die Liste und wirft Duplikat-Ids weg (erste gewinnt).
+ *
+ * ADR-005 — `onDrop` ist der Kanal, den es vorher nicht gab. Eine verworfene
+ * Rolle nimmt ueber `clearDanglingIdentity` die Bindung der Geraete mit; eine
+ * Kamera verliert dann ihre TSL-Adresse. Das darf nicht wortlos passieren.
+ * Der Grund ist ein Code, kein Satz — der Store kennt keine Sprache.
+ */
+export const normaliseSourceIdentities = (
+  raw: unknown,
+  onDrop?: (drop: LoadDrop) => void,
+): SourceIdentity[] => {
   if (!Array.isArray(raw)) return []
   const out: SourceIdentity[] = []
   const seen = new Set<string>()
   raw.forEach((entry, idx) => {
     const identity = normaliseSourceIdentity(entry, `source-${idx + 1}`)
-    if (!identity || seen.has(identity.id)) return
+    if (!identity) {
+      onDrop?.({ kind: 'source-identity', reason: 'missing-required', label: rawLabel(entry) })
+      return
+    }
+    if (seen.has(identity.id)) {
+      onDrop?.({ kind: 'source-identity', reason: 'duplicate-id', label: identity.name })
+      return
+    }
     seen.add(identity.id)
     out.push(identity)
   })
   return out
+}
+
+/** Bester Griff auf einen Rohsatz, der die Normalisierung nicht bestanden hat. */
+const rawLabel = (raw: unknown): string => {
+  if (!raw || typeof raw !== 'object') return ''
+  const r = raw as Record<string, unknown>
+  for (const key of ['name', 'id']) {
+    const v = r[key]
+    if (typeof v === 'string' && v.trim()) return v.trim()
+  }
+  return ''
 }
 
 /** Ids der gueltigen Rollen — Eingabe fuer `clearDanglingIdentity`. */

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -1,3 +1,4 @@
+import type { LoadDrop, LoadReport } from '../types/loadReport'
 import { v4 as uuidv4 } from 'uuid'
 import { create, type StateCreator } from 'zustand'
 import type { Connection } from 'reactflow'
@@ -158,6 +159,15 @@ export interface ProjectState {
   /** Incremented each time loadProject or clear() is called. Canvas uses this
    *  to detect a project-load event and restore the saved viewport. */
   projectVersion: number
+  /**
+   * ADR-005 — Was beim letzten Laden nicht uebernommen werden konnte. `null`,
+   * wenn alles mitkam. Die Oberflaeche zeigt es und raeumt es weg; es gehoert
+   * nicht ins Projektfile, weil es eine Aussage ueber den LADEVORGANG ist und
+   * nicht ueber den Plan.
+   */
+  lastLoadReport: LoadReport | null
+  /** Bericht weggeraeumt — der Nutzer hat ihn gesehen. */
+  dismissLoadReport: () => void
   selectedEquipmentId?: string
   selectedCableId?: string
   selectedLocationId?: string
@@ -533,7 +543,18 @@ export interface ProjectState {
  * rounding is enough to remove the visible drift and is reversible (the
  * shift is in the order of fractions of a pixel, never more).
  */
-const healProjectPositions = (project: CablePlannerProject): CablePlannerProject => {
+/**
+ * ADR-005 — Sammelt, was der Autoload verwirft. Der laeuft beim Aufbau des
+ * Stores, also bevor es einen Store gibt, in den er berichten koennte; das
+ * Array ueberbrueckt genau diese eine Luecke und wird danach nicht mehr
+ * beschrieben.
+ */
+const initialDrops: LoadDrop[] = []
+
+const healProjectPositions = (
+  project: CablePlannerProject,
+  onDrop?: (drop: LoadDrop) => void,
+): CablePlannerProject => {
   // v7.9.100 — Snap-to-Grid-Heal: alle Equipment-/Location-/Waypoint-
   // Koordinaten + Maße auf gridSize-Vielfache runden. Alte Projekte
   // (vor snapToGrid-Default) haben x=137, width=215 usw. → liegen
@@ -556,7 +577,7 @@ const healProjectPositions = (project: CablePlannerProject): CablePlannerProject
   // Geraete-Schleife braucht die gueltigen Ids, um Fehlzeiger zu entsorgen.
   // Eine Bindung auf eine geloeschte Rolle ist schlimmer als keine — sie
   // sieht im Plan aus wie eine zugewiesene Tally-Adresse.
-  const sourceIdentities = normaliseSourceIdentities(project.sourceIdentities)
+  const sourceIdentities = normaliseSourceIdentities(project.sourceIdentities, onDrop)
   const identityIds = sourceIdentityIdSet(sourceIdentities)
   return {
     ...project,
@@ -857,9 +878,13 @@ const buildProjectStore = (
     opts.initialProject ??
     (() => {
       const auto = loadAutosavedProject()
-      return auto ? healProjectPositions(auto) : defaultProject()
+      // ADR-005 — der Autoload laeuft vor dem ersten Render; sein Bericht
+      // landet im Store und wird gezeigt, sobald die Oberflaeche steht.
+      return auto ? healProjectPositions(auto, (d) => initialDrops.push(d)) : defaultProject()
     })(),
   projectVersion: 0,
+  lastLoadReport: initialDrops.length > 0 ? { drops: initialDrops } : null,
+  dismissLoadReport: () => set({ lastLoadReport: null }),
   showCableDialog: false,
   recentProjects: [],
   customLibrary: loadCustomLibrary(),
@@ -901,8 +926,12 @@ const buildProjectStore = (
       // "Importierte Rentman-Geräte"-Liste auf, ohne dass der User alles
       // neu anlegen muss.
       const healedLibrary = healRentmanLibraryFromProject(project, state.customLibrary)
+      // ADR-005 — was die Heilung verwirft, wird gemeldet statt verschwiegen.
+      const drops: LoadDrop[] = []
+      const healed = healProjectPositions(project, (d) => drops.push(d))
       return {
-        project: healProjectPositions(project),
+        project: healed,
+        lastLoadReport: drops.length > 0 ? { drops } : null,
         filePath,
         projectVersion: state.projectVersion + 1,
         selectedEquipmentId: undefined,

--- a/src/renderer/types/loadReport.ts
+++ b/src/renderer/types/loadReport.ts
@@ -1,0 +1,45 @@
+/**
+ * Was beim Laden eines Projekts nicht übernommen werden konnte.
+ *
+ * ADR-005, Regel 3: „Wer nicht bewahren kann, sagt es an der Stelle, an der es
+ * passiert." Auf dem Lade-Pfad war das bisher **strukturell unmöglich**:
+ * `healProjectPositions` ist eine reine Funktion ohne Weg zur Oberfläche, also
+ * verschwand alles, was sie verwarf, definitionsgemäß still.
+ *
+ * Konkret aufgefallen an den Signalquellen-Rollen aus ADR-001: eine Rolle ohne
+ * Namen oder mit doppelter Id wurde wortlos entfernt, und `clearDanglingIdentity`
+ * strich anschließend die Verweise der Geräte darauf. Eine Kamera verlor damit
+ * ihre TSL-Adresse, ohne dass irgendwo etwas stand.
+ *
+ * Der Grund ist als **Code** hinterlegt, nicht als Satz: der Store soll keine
+ * Sprache kennen, die Oberfläche übersetzt ihn.
+ */
+
+/** Warum ein Datensatz beim Laden nicht übernommen wurde. */
+export type LoadDropReason =
+  /** Pflichtfeld fehlte (z. B. eine Rolle ohne Namen). */
+  | 'missing-required'
+  /** Eine Id kam mehrfach vor; der erste Datensatz hat gewonnen. */
+  | 'duplicate-id'
+
+/** Woher der verworfene Datensatz kam. */
+export type LoadDropKind = 'source-identity'
+
+export interface LoadDrop {
+  kind: LoadDropKind
+  reason: LoadDropReason
+  /**
+   * Bester menschenlesbarer Griff auf den verworfenen Datensatz, damit jemand
+   * ihn in seiner Datei wiederfindet. Leer, wenn die Datei keinen hergab —
+   * dann sagt der Bericht wenigstens, dass es ihn gab.
+   */
+  label: string
+}
+
+export interface LoadReport {
+  drops: LoadDrop[]
+}
+
+/** Ein Bericht ohne Inhalt ist kein Bericht — dann gibt es nichts zu melden. */
+export const hasDrops = (report: LoadReport | null | undefined): boolean =>
+  !!report && report.drops.length > 0

--- a/tests/loadReport.test.ts
+++ b/tests/loadReport.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { normaliseSourceIdentities } from '../src/renderer/lib/sourceIdentity'
+import { hasDrops } from '../src/renderer/types/loadReport'
+import type { LoadDrop } from '../src/renderer/types/loadReport'
+
+// ADR-005, Regel 3 — „Wer nicht bewahren kann, sagt es an der Stelle, an der es
+// passiert."
+//
+// Auf dem Lade-Pfad war das strukturell unmoeglich: healProjectPositions ist
+// eine reine Funktion ohne Weg zur Oberflaeche, also verschwand alles, was sie
+// verwarf, definitionsgemaess still. Aufgefallen an den Rollen aus ADR-001:
+// eine Rolle ohne Namen wurde wortlos entfernt, und clearDanglingIdentity
+// strich danach die Verweise der Geraete darauf — eine Kamera verlor ihre
+// TSL-Adresse, ohne dass irgendwo etwas stand.
+
+const collect = (raw: unknown) => {
+  const drops: LoadDrop[] = []
+  const kept = normaliseSourceIdentities(raw, (d) => drops.push(d))
+  return { kept, drops }
+}
+
+describe('normaliseSourceIdentities — meldet, was sie verwirft (ADR-005)', () => {
+  it('meldet eine Rolle ohne Namen mit ihrer Id als Griff', () => {
+    const { kept, drops } = collect([{ id: 'cam-4' }])
+    expect(kept).toEqual([])
+    expect(drops).toEqual([{ kind: 'source-identity', reason: 'missing-required', label: 'cam-4' }])
+  })
+
+  it('meldet eine doppelte Id und behaelt den ersten Eintrag', () => {
+    const { kept, drops } = collect([
+      { id: 'a', name: 'Kamera 1', umdAddress: 4 },
+      { id: 'a', name: 'Kamera 1 (Kopie)', umdAddress: 9 },
+    ])
+    expect(kept).toHaveLength(1)
+    expect(kept[0].umdAddress).toBe(4)
+    expect(drops).toEqual([
+      { kind: 'source-identity', reason: 'duplicate-id', label: 'Kamera 1 (Kopie)' },
+    ])
+  })
+
+  it('meldet nichts, wenn alles mitkommt', () => {
+    const { kept, drops } = collect([
+      { id: 'a', name: 'Kamera 1' },
+      { id: 'b', name: 'Kamera 2' },
+    ])
+    expect(kept).toHaveLength(2)
+    expect(drops).toEqual([])
+  })
+
+  it('kommt ohne Griff aus, statt den Verlust zu verschweigen', () => {
+    // Ein Rohsatz ohne name UND ohne id gibt keinen Griff her. Der Bericht
+    // sagt trotzdem, dass es ihn gab — das ist der Punkt der Regel.
+    const { drops } = collect([{ umdAddress: 7 }])
+    expect(drops).toHaveLength(1)
+    expect(drops[0].label).toBe('')
+  })
+
+  it('bleibt ohne Sammler funktionsgleich', () => {
+    // Der Kanal ist optional; bestehende Aufrufer aendern ihr Verhalten nicht.
+    expect(normaliseSourceIdentities([{ id: 'a', name: 'Kamera 1' }, { id: 'a', name: 'X' }])).toEqual(
+      [{ id: 'a', name: 'Kamera 1' }],
+    )
+  })
+})
+
+describe('hasDrops', () => {
+  it('ist nur wahr, wenn es wirklich etwas zu melden gibt', () => {
+    expect(hasDrops(null)).toBe(false)
+    expect(hasDrops(undefined)).toBe(false)
+    expect(hasDrops({ drops: [] })).toBe(false)
+    expect(hasDrops({ drops: [{ kind: 'source-identity', reason: 'duplicate-id', label: 'x' }] })).toBe(
+      true,
+    )
+  })
+})


### PR DESCRIPTION
Schließt die **strukturelle Lücke**, die ADR-005 als Voraussetzung für alles Weitere auf dem Lade-Pfad benennt.

## Warum das keine Kosmetik ist

Regel 3 verlangt, dass ein Import sagt, was er nicht bewahren konnte. Auf dem Lade-Pfad war das **strukturell unmöglich**: `healProjectPositions` ist eine reine Funktion ohne Weg zur Oberfläche. Alles, was sie verwirft, verschwindet definitionsgemäß still — es gab schlicht keinen Kanal, über den sie hätte reden können.

## Der Fund, an dem es aufgefallen ist — eigener Code

`normaliseSourceIdentities` (aus ADR-001, von mir) verwirft **wortlos**:

- eine Rolle ohne Namen
- eine Rolle mit doppelter Id

Und `clearDanglingIdentity` streicht anschließend die Verweise der Geräte darauf. **Eine Kamera verliert damit ihre TSL-Adresse**, und beim nächsten Speichern ist sie endgültig weg — ohne dass irgendwo etwas gestanden hätte.

ADR-001 hatte den verwandten Fall sogar schon bedacht („Eine Bindung auf eine gelöschte Rolle ist schlimmer als keine"), nur eben nicht den Fall, dass die *Rolle selbst* verschwindet.

## Was gebaut ist

- **`types/loadReport.ts`** — `LoadDrop` / `LoadReport`. Der Grund ist ein **Code**, kein Satz: der Store kennt keine Sprache, die Oberfläche übersetzt ihn.
- **Optionaler Sammler** in `normaliseSourceIdentities` und `healProjectPositions`. Ohne ihn ändert sich kein Verhalten — ein Test hält das fest.
- **`projectStore.lastLoadReport`** plus `dismissLoadReport`. Bewusst **nicht** im Projektfile: es ist eine Aussage über den *Ladevorgang*, nicht über den Plan.
- **Banner in `App.tsx`** mit einem Griff je verworfenem Satz — und dem Satz, auf den es ankommt: *„Speichern überschreibt die Datei mit diesem Stand."*

Ein Sonderfall, der einen eigenen Kommentar bekommen hat: der Autoload läuft beim Aufbau des Stores, also bevor es einen Store gibt, in den er berichten könnte. Ein Modul-Array überbrückt genau diese eine Lücke und wird danach nicht mehr beschrieben.

## Was noch nicht gebaut ist

Der Kanal trägt bisher **eine** Quelle (Signalquellen-Rollen). Er ist die Voraussetzung für jeden weiteren Fund in `healProjectPositions` — die anderen Heilungsschritte anzuschließen ist eigene Arbeit und gehört nicht spekulativ vorweggenommen.

## Prüfung

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npx vitest run` 466/466 (6 neu) · `npm run lint` 0 Errors · `npm run build` grün.

Ein Test prüft ausdrücklich den Fall ohne Griff: ein Rohsatz ohne `name` und ohne `id` gibt keinen her — der Bericht sagt trotzdem, dass es ihn gab. Das ist der Punkt der Regel.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_