### PR TITLE
sourcemap: Provenienz, die der Plan nicht halten kann, wird gemeldet (ADR-005)

### DIFF
--- a/src/renderer/lib/sourceMap.ts
+++ b/src/renderer/lib/sourceMap.ts
@@ -361,6 +361,18 @@ export const mergeSourceMap = (
     if (entry.extra) {
       for (const key of Object.keys(entry.extra)) unrepresented.push(`${entry.name}.${key}`)
     }
+    // ADR-005 — Blindstelle des extra-Fachs: `provenance` ist ein BEKANNTER
+    // Schluessel, also hebt `collectExtra` ihn nicht auf, und der Plan hat kein
+    // Feld dafuer (SourceIdentity ist bewusst minimal, siehe ADR-001). Ein von
+    // einer Runtime als `confirmed` gemeldeter Wert kommt damit als `planned`
+    // wieder heraus. Ein Schluessel, dessen Namen wir kennen und den wir
+    // trotzdem nicht halten koennen, ist schlimmer als ein unbekannter — der
+    // Mechanismus geht ueber ihn hinweg, statt ihn aufzufangen. Also melden.
+    for (const [field, prov] of Object.entries(entry.provenance ?? {})) {
+      if (prov && prov !== 'planned') {
+        unrepresented.push(`${entry.name}.provenance.${field} (${prov})`)
+      }
+    }
     const mine = byId.get(entry.id)
     if (!mine) {
       const next: SourceIdentity = { id: entry.id, name: entry.name }

--- a/tests/sourceMap.test.ts
+++ b/tests/sourceMap.test.ts
@@ -233,3 +233,53 @@ describe('Rundreise', () => {
     expect(merged.unrepresented).toEqual([])
   })
 })
+
+describe('mergeSourceMap — Provenienz, die der Plan nicht halten kann (ADR-005)', () => {
+  // Die Blindstelle des extra-Fachs: `provenance` ist ein BEKANNTER Schluessel,
+  // also hebt collectExtra ihn nicht auf — und `SourceIdentity` hat kein Feld
+  // dafuer (bewusst minimal, ADR-001). Ein von einer Runtime als `confirmed`
+  // gemeldeter Wert kommt deshalb als `planned` wieder heraus. Bis der Plan
+  // Provenienz halten kann, muss der Import es wenigstens sagen.
+  const mapWith = (provenance: Record<string, string>) =>
+    ({
+      kind: 'av-source-map',
+      formatVersion: 1,
+      app: 'tally-pi',
+      appVersion: '1.0.0',
+      exportedAt: 't',
+      sources: [
+        {
+          id: 's1',
+          name: 'Kamera 1',
+          umdAddress: 4,
+          provenance,
+          bindings: [],
+          labels: {},
+        },
+      ],
+      unresolved: [],
+    }) as never
+
+  it('meldet einen bestaetigten Wert als nicht darstellbar', () => {
+    const r = mergeSourceMap([], mapWith({ name: 'planned', umdAddress: 'confirmed' }))
+    expect(r.unrepresented).toContain('Kamera 1.provenance.umdAddress (confirmed)')
+  })
+
+  it('meldet auch `commanded` — alles ausser planned ist Wissen, das verloren geht', () => {
+    const r = mergeSourceMap([], mapWith({ umdAddress: 'commanded' }))
+    expect(r.unrepresented).toContain('Kamera 1.provenance.umdAddress (commanded)')
+  })
+
+  it('meldet `planned` NICHT — das ist genau das, was der Plan ohnehin ausdrueckt', () => {
+    const r = mergeSourceMap([], mapWith({ name: 'planned', umdAddress: 'planned' }))
+    expect(r.unrepresented.filter((u) => u.includes('provenance'))).toEqual([])
+  })
+
+  it('uebernimmt den Wert trotzdem — Melden heisst nicht Verweigern', () => {
+    // ADR-005 unterscheidet: bewahren, verweigern, melden. Hier ist melden
+    // richtig — eine Adresse abzulehnen, nur weil ihre Herkunft nicht mitkann,
+    // waere eigener Schaden.
+    const r = mergeSourceMap([], mapWith({ umdAddress: 'confirmed' }))
+    expect(r.identities[0].umdAddress).toBe(4)
+  })
+})


### PR DESCRIPTION
ADR-005 Inkrement 3, siebter nachgelesener Hinweis — und er legt eine **Blindstelle im eigenen `extra`-Mechanismus** frei.

## Der Fehler

`.avsourcemap` ist beidseitig (Export, Import, Merge), also nach der Triage-Regel ein Kandidat für echten Verlust. Und der liegt hier:

1. `buildSourceMap` stempelt beim Export **jeden** Wert unbedingt als `'planned'`.
2. `mergeSourceMap` liest `entry.provenance` **nie** — `SourceIdentity` hat kein Feld dafür (bewusst minimal, ADR-001: „Rolle, nicht Gerät").
3. Ein von einer Runtime als `confirmed` gemeldeter Wert kommt damit als `planned` wieder heraus.

Und der Grund, warum die vorhandene Schutzmaschinerie nicht greift, ist der eigentliche Fund:

> `provenance` ist ein **bekannter** Schlüssel. `collectExtra` hebt deshalb nur *unbekannte* Schlüssel ins `extra`-Fach — und geht über diesen hinweg.

**Ein Schlüssel, dessen Namen wir kennen und den wir trotzdem nicht halten können, ist schlimmer als ein unbekannter.** Der Mechanismus fängt genau das Falsche auf: er rettet, was er nicht versteht, und lässt fallen, was er benennen kann.

## Was dieser PR macht

Alles ausser `planned` landet in `unrepresented`, mit Feld und Herkunft:

```
Kamera 1.provenance.umdAddress (confirmed)
```

**Der Wert selbst wird weiter übernommen.** ADR-005 unterscheidet bewahren / verweigern / melden — eine TSL-Adresse abzulehnen, nur weil ihre Herkunft nicht mitkann, wäre eigener Schaden. Ein Test hält genau das fest.

`planned` wird **nicht** gemeldet: das ist die Herkunft, die der Plan ohnehin ausdrückt, und eine Meldung darüber wäre Rauschen.

## Was dieser PR nicht macht

Dass der Plan Provenienz überhaupt halten können sollte, ist **ADR-003 Inkrement 2** — dort bewusst zurückgestellt: *„Erst wenn zwei Stellen sie brauchen, lohnt die Verallgemeinerung."* Dieser Fund ist die zweite Stelle, und damit rückt das Inkrement in Reichweite. Aber es ist eine Erweiterung des Plan-Modells und gehört als solche entschieden, nicht als Nebenwirkung eines Verlust-Audits.

## Prüfung

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npx vitest run` 470/470 (4 neu) · `npm run lint` 0 Errors · `npm run build` grün.

Der Branch musste neu aufgesetzt werden, weil `origin/main` zwischenzeitlich einen automatischen Doku-Kennzahlen-Commit bekommen hat; auf dem neuen Stand ist alles erneut geprüft.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_