### PR TITLE
rentman: zusammengefasste Kabel-Positionen gehen nicht mehr verloren (ADR-005)

### DIFF
--- a/src/renderer/components/Rentman/RentmanCableExportDialog.tsx
+++ b/src/renderer/components/Rentman/RentmanCableExportDialog.tsx
@@ -22,6 +22,11 @@ interface CableBucket {
   /** Rentman equipment id this bucket is mapped to (if any). */
   mappedId?: string
   mappedName?: string
+  /** ADR-005 — Wie viele Rentman-Stammartikel in diesem Eimer zusammenfallen.
+   *  1 (oder undefined) heisst: genau einer, nichts zu sagen. Groesser als 1
+   *  heisst: gebucht wird auf einen davon, und das gehoert hier gesagt, weil
+   *  hier gebucht wird. */
+  mergedCount?: number
   /** Quantity that has already been pushed to Rentman (lastSentQty).
    *  ADR-003: gesendet, nicht von Rentman bestaetigt. */
   sentQty: number
@@ -153,6 +158,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
         planned: plannedCount,
         mappedId,
         mappedName,
+        mergedCount: map?.mergedEquipmentIds?.length,
         sentQty: sent,
         delta: builtCount - sent,
         sample: built.get(key)?.sample,
@@ -173,6 +179,11 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
     const next = {
       ...current,
       [key]: {
+        // ADR-005 — Eintrag fortschreiben, nicht neu bauen. Wer hier die
+        // bekannten Schluessel auflistet, loescht `mergedEquipmentIds` beim
+        // ersten Umzuordnen — also genau dann, wenn der Hinweis auf die
+        // Zusammenfassung am noetigsten ist.
+        ...current[key],
         rentmanEquipmentId,
         lastSentQty: options.resetSync
           ? 0
@@ -215,6 +226,8 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
         rentmanCableMap: {
           ...current,
           [bucket.key]: {
+            // ADR-005 — siehe setMapping: fortschreiben, nicht neu bauen.
+            ...current[bucket.key],
             rentmanEquipmentId: bucket.mappedId,
             lastSentQty: bucket.built,
           },
@@ -414,6 +427,28 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
                             <div className="text-[10px] text-cp-text-muted">
                               ID {bucket.mappedId}
                             </div>
+                            {/* ADR-005 — Der Import hat mehrere Rentman-
+                                Stammartikel in diesen Eimer gelegt; gebucht
+                                wird auf den einen oben. Ohne diesen Satz sieht
+                                der Nutzer hier nur einen Namen und haelt ihn
+                                fuer den ganzen Bestand. */}
+                            {(bucket.mergedCount ?? 0) > 1 && (
+                              <div
+                                className="text-[10px] text-cp-warn"
+                                title={t(
+                                  'rentman.cableExport.mergedTitle',
+                                  'Import und Export fassen Kabel nach Typ und Länge zusammen. Gebucht wird auf den oben zugeordneten Artikel; die Menge auf mehrere Artikel aufzuteilen geht nur in Rentman.',
+                                )}
+                              >
+                                {format(
+                                  t(
+                                    'rentman.cableExport.mergedFrom',
+                                    'aus {count} Rentman-Positionen zusammengefasst',
+                                  ),
+                                  { count: bucket.mergedCount ?? 0 },
+                                )}
+                              </div>
+                            )}
                           </div>
                           <button
                             type="button"

--- a/src/renderer/components/Rentman/RentmanImportDialog.tsx
+++ b/src/renderer/components/Rentman/RentmanImportDialog.tsx
@@ -502,16 +502,31 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
       // bucket. If the user has multiple Rentman line items for the same
       // bucket they'll all be aggregated under one mapping; the export dialog
       // lets them re-pick if needed.
+      //
+      // ADR-005 — Das Re-Picken gab es schon, die Grundlage dafuer nicht:
+      // gebucht wird auf eine Id, und die uebrigen Ids dieses Eimers wurden
+      // hier weggeworfen. Der Export-Dialog baut seine Eimer aus dem
+      // Projektfile, nicht aus einem Rentman-Abruf — er konnte also gar nicht
+      // wissen, dass er auf einen von mehreren Stammartikeln bucht, und der
+      // Nutzer sah dort nur den einen Namen. Der Hinweis "2 Eintraege" steht
+      // im Import-Dialog, also Wochen vor der Buchung. Die uebrigen Ids
+      // werden deshalb aufgehoben.
       const firstRow = bucket.rows[0]
+      const mergedIds = bucket.rows.map((r) => r.rentmanEquipmentId).filter(Boolean)
       const existingMap = mapPatch[bucket.key]
       // ADR-003 — Startwert ist bucket.totalQty (was Rentman fuehrt), nicht
       // qty (die im Dialog editierbare Planmenge). Sonst zaehlt der Export
       // eine geplante Korrektur als bereits gesendet und jede folgende
       // Differenz ist um genau diesen Betrag zu klein.
       mapPatch[bucket.key] = {
+        ...existingMap,
         rentmanEquipmentId:
           existingMap?.rentmanEquipmentId ?? firstRow.rentmanEquipmentId,
         lastSentQty: existingMap?.lastSentQty ?? bucket.totalQty,
+        // Nur schreiben, wenn wirklich mehrere Stammartikel zusammenfallen —
+        // ein einelementiges Feld in jedem Eintrag waere Ballast und wuerde
+        // eine Zusammenlegung behaupten, die es nicht gab.
+        ...(mergedIds.length > 1 ? { mergedEquipmentIds: mergedIds } : {}),
       }
     }
     const projectName =

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -1904,6 +1904,9 @@ export const en: Dict = {
   'rentman.cableExport.deltaZeroTitle': 'Built = already sent to Rentman.',
   'rentman.cableExport.rentmanId': 'Rentman ID {id}',
   'rentman.cableExport.removeMapping': 'Remove mapping',
+  'rentman.cableExport.mergedFrom': 'merged from {count} Rentman items',
+  'rentman.cableExport.mergedTitle':
+    'Import and export group cables by type and length. The quantity is booked onto the item mapped above; splitting it across several items is only possible in Rentman.',
   'rentman.cableExport.pickEquipment': 'Pick Rentman equipment…',
   'rentman.cableExport.searchPlaceholder': 'Search…',
   'rentman.cableExport.loadCatalogFirst': 'Please load the catalog first.',

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -719,7 +719,20 @@ const healRentmanCableMap = (
     const legacy = entry as { lastSentQty?: number; lastSyncedQty?: number }
     const sent = typeof legacy.lastSentQty === 'number' ? legacy.lastSentQty : legacy.lastSyncedQty
     if ('lastSyncedQty' in legacy) changed = true
+    // ADR-005 — Uebernehmen statt neu bauen. Diese Funktion listete frueher
+    // die beiden Schluessel auf, die sie kennt, und verwarf damit jeden
+    // dritten. Das war so lange folgenlos, wie es keinen dritten gab; mit
+    // `mergedEquipmentIds` gibt es einen, und ein alter Schluessel im File
+    // haette ihn beim naechsten Laden mitgenommen. Ein Migrationsschritt, der
+    // nur die Felder ueberleben laesst, die er beim Schreiben kannte, ist
+    // genau die Falle, gegen die dieser ADR geschrieben ist.
+    // Beide Mengen-Schluessel fallen hier raus und werden unten kontrolliert
+    // wieder gesetzt; alles andere bleibt unangetastet.
+    const { lastSyncedQty, lastSentQty, ...rest } = legacy as Record<string, unknown>
+    void lastSyncedQty
+    void lastSentQty
     healed[key] = {
+      ...(rest as (typeof healed)[string]),
       rentmanEquipmentId: entry.rentmanEquipmentId,
       ...(typeof sent === 'number' && Number.isFinite(sent) ? { lastSentQty: sent } : {}),
     }

--- a/src/renderer/types/project.ts
+++ b/src/renderer/types/project.ts
@@ -76,7 +76,26 @@ export interface ProjectMetadata {
    * abgeschickt wurde. Rentman bestaetigt sie nicht zurueck. Wer hier einen
    * geplanten Wert hineinschreibt, verrechnet jede folgende Differenz.
    */
-  rentmanCableMap?: Record<string, { rentmanEquipmentId: string; lastSentQty?: number }>
+  rentmanCableMap?: Record<
+    string,
+    {
+      rentmanEquipmentId: string
+      lastSentQty?: number
+      /**
+       * ADR-005 — Die uebrigen Rentman-Positionen, die in denselben Eimer
+       * gefallen sind. Ein Eimer ist `typ|laenge`; zwei Marken desselben
+       * BNC-10m sind zwei Rentman-Stammartikel, aber ein Eimer. Gebucht wird
+       * auf genau eine Id, und das bleibt so — die Menge auf mehrere Artikel
+       * aufzuteilen ist eine Entscheidung, die der Nutzer treffen muss, nicht
+       * der Import. Bisher wurden die anderen Ids beim Import aber schlicht
+       * weggeworfen: `bucket.rows[0]` gewann, der Rest verschwand. Der
+       * Export-Dialog konnte deshalb gar nicht sagen, dass er auf einen von
+       * mehreren Artikeln bucht — die Information war zu diesem Zeitpunkt
+       * nicht mehr da. Sie wird jetzt aufgehoben.
+       */
+      mergedEquipmentIds?: string[]
+    }
+  >
   /** Rentman project ID currently linked to this cable planner project. */
   rentmanProjectId?: string
   /** Human-readable name of the linked Rentman project. */

--- a/tests/rentmanCableMap.test.ts
+++ b/tests/rentmanCableMap.test.ts
@@ -78,3 +78,60 @@ describe('rentmanCableMap — Migration lastSyncedQty -> lastSentQty (ADR-003)',
     expect(await loadAndRead(undefined)).toBeUndefined()
   })
 })
+
+describe('rentmanCableMap — die Migration verwirft nichts Fremdes (ADR-005)', () => {
+  // Die Migration baute jeden Eintrag aus den zwei Schluesseln neu auf, die sie
+  // kennt. Solange es nur diese zwei gab, war das folgenlos — deshalb stand der
+  // Befund im Audit als "kosmetisch". Mit `mergedEquipmentIds` gibt es einen
+  // dritten, und damit wird aus der Kosmetik ein Datenverlust: es genuegt EIN
+  // altes Projektfile mit `lastSyncedQty`, damit `changed` greift und der
+  // Neuaufbau die Zusammenfassung mitnimmt.
+
+  it('haelt mergedEquipmentIds, waehrend es den alten Mengen-Schluessel migriert', async () => {
+    const healed = await loadAndRead({
+      'BNC|10': {
+        rentmanEquipmentId: 'r1',
+        lastSyncedQty: 12,
+        mergedEquipmentIds: ['r1', 'r2'],
+      },
+    })
+    expect(healed?.['BNC|10']).toEqual({
+      rentmanEquipmentId: 'r1',
+      lastSentQty: 12,
+      mergedEquipmentIds: ['r1', 'r2'],
+    })
+  })
+
+  it('haelt auch einen Schluessel, den diese Version noch gar nicht kennt', async () => {
+    // Der eigentliche Punkt: die Regel gilt nicht nur fuer das Feld, das wir
+    // gerade hinzufuegen. Ein aelterer Build, der eine neuere Datei laedt,
+    // darf sie nicht beschneiden.
+    const healed = await loadAndRead({
+      'BNC|10': { rentmanEquipmentId: 'r1', lastSyncedQty: 3, zukunftsFeld: { tief: [1] } },
+    })
+    expect(healed?.['BNC|10']).toEqual({
+      rentmanEquipmentId: 'r1',
+      lastSentQty: 3,
+      zukunftsFeld: { tief: [1] },
+    })
+  })
+
+  it('entsorgt den alten Mengen-Schluessel trotzdem', async () => {
+    // Bewahren heisst nicht alles behalten: der migrierte Schluessel muss weg,
+    // sonst traegt die Datei zwei Wahrheiten ueber dieselbe Menge.
+    const healed = await loadAndRead({
+      'BNC|10': { rentmanEquipmentId: 'r1', lastSyncedQty: 12, mergedEquipmentIds: ['r1', 'r2'] },
+    })
+    expect('lastSyncedQty' in (healed?.['BNC|10'] ?? {})).toBe(false)
+  })
+
+  it('haelt mergedEquipmentIds auch dann, wenn gar keine Menge da ist', async () => {
+    const healed = await loadAndRead({
+      'BNC|10': { rentmanEquipmentId: 'r1', mergedEquipmentIds: ['r1', 'r2'], lastSyncedQty: 'kaputt' },
+    })
+    expect(healed?.['BNC|10']).toEqual({
+      rentmanEquipmentId: 'r1',
+      mergedEquipmentIds: ['r1', 'r2'],
+    })
+  })
+})


### PR DESCRIPTION
ADR-005 Inkrement 3, achter und neunter nachgelesener Hinweis. Beide hängen zusammen — und das ist der eigentliche Fund.

## Was der Audit behauptet hat, und was davon stimmt

Der Hinweis lautete: *„Cable buckets collapse N Rentman equipment ids into one, then the export pushes the whole bucket quantity onto that single id"* — Schweregrad `loses-foreign-data`, angeblich stiller Schaden an Rentman.

Nachgelesen hält das so **nicht**:

- Rentman nimmt keinen Schaden. Der Export ist POST-only, die Stammartikel bleiben unangetastet.
- Der Import-Dialog **sagt** es sogar: bei mehr als einer Zeile zeigt er `{count} Einträge` statt eines Namens (`RentmanImportDialog.tsx:1724`).
- Das Re-Picken, das der Code-Kommentar an dieser Stelle verspricht, gibt es wirklich — `setMapping` im Export-Dialog.

Der Hinweis traf also den richtigen Ort mit der falschen Begründung. Zum achten Mal in dieser Runde.

## Der Fehler, der wirklich da ist

Der Export-Dialog baut seine Eimer aus dem **Projektfile**, nicht aus einem Rentman-Abruf. Im Projektfile steht genau eine Id — `bucket.rows[0]`, die übrigen wurden beim Import verworfen.

Damit ist die Lage im Moment der Buchung:

| | Import-Dialog | Export-Dialog |
| --- | --- | --- |
| weiss von der Zusammenfassung | ja | **nein, strukturell nicht** |
| bucht | nein | **ja** |

Der Hinweis „2 Einträge" steht dort, wo nichts passiert, und fehlt dort, wo die volle Menge auf einen von mehreren Stammartikeln geht — typischerweise Wochen später. Ein Bestand mit zwei Marken BNC-10m ist dabei nicht der Sonderfall, sondern der Normalfall.

## Und die Kopplung, die es scharf macht

Der zweite Hinweis betraf `healRentmanCableMap`: es baut jeden Eintrag aus den zwei Schlüsseln neu auf, die es kennt. Der Audit stufte das als `cosmetic` ein — *„only with a hypothetical future field"*.

Dieser PR fügt genau dieses Feld hinzu. Damit wird aus der Kosmetik ein Datenverlust: **ein** altes Projektfile mit `lastSyncedQty` lässt `changed` greifen, und der Neuaufbau nimmt die Zusammenfassung beim nächsten Laden mit. Dieselbe Form steckte noch in `setMapping` und `sendBucket` — dort hätte schon das erste Umzuordnen oder Senden gereicht.

Alle drei schreiben den Eintrag jetzt fort, statt ihn neu zu bauen. Der migrierte Alt-Schlüssel fliegt weiter raus — Bewahren heisst nicht alles behalten.

## Was dieser PR nicht macht

**Die Menge auf mehrere Artikel aufteilen.** Gebucht wird weiter auf genau eine Id. Welcher Anteil auf welche Marke geht, ist eine Bestandsentscheidung des Nutzers und gehört nach Rentman, nicht in eine Heuristik des Imports. Der PR sorgt nur dafür, dass die Frage im richtigen Moment sichtbar ist — ADR-005 Regel 3, melden statt still zusammenfassen.

## Prüfung

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npx vitest run` 474/474 (4 neu) · `npm run lint` 0 Errors · `npm run build` grün.

Die neuen Tests wurden gegen den **alten** Stand von `healRentmanCableMap` gegengeprüft: drei der vier schlagen dort fehl, der vierte ist eine Absicherung, die schon hielt.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_