### PR TITLE
rentman: Template-Cache wird nicht mehr von der ärmsten Rekonstruktion überschrieben (ADR-005)

### DIFF
--- a/src/renderer/lib/rentmanTemplateCache.ts
+++ b/src/renderer/lib/rentmanTemplateCache.ts
@@ -80,7 +80,26 @@ export const upsertCachedRentmanTemplate = (template: EquipmentTemplate) => {
   const id = template.rentmanId?.trim()
   if (!id) return
   const cache = readCache()
+  // ADR-005 — Fortschreiben statt Ersetzen.
+  //
+  // Drei Funktionen bauen in dieser Codebase ein Template aus einem
+  // EquipmentItem, und sie sind sich nicht einig, was dazugehoert:
+  // `toTemplateFromEquipment` hier nennt 37 Felder, `templateFromEquipment`
+  // im templateSlice 23, der Synthese-Zweig in `healRentmanLibraryFromProject`
+  // 15. Die Feldmengen der beiden kleineren sind echte Teilmengen dieser hier
+  // — keine von ihnen weiss etwas, das diese nicht auch weiss.
+  //
+  // Ein Ersetzen liess deshalb immer die aermste Rekonstruktion gewinnen, die
+  // zuletzt vorbeikam: Rentman-Import schreibt Rack-Hoehe, Leistung, Gewicht
+  // und Tiefe in den Eintrag, der Nutzer klickt auf einem so importierten
+  // Geraet "Als Template speichern", und der 23-Feld-Nachbau ueberschrieb
+  // alle vier — in einem Cache, der ausdruecklich projektuebergreifend ist.
+  //
+  // Ein Feld, ueber das die neue Fassung nichts sagt, ist keine Anweisung, den
+  // alten Wert zu loeschen. Wer wirklich leeren will, schreibt den Schluessel
+  // mit `undefined` — das ueberschreibt weiterhin, weil der Spread ihn traegt.
   cache[id] = {
+    ...cache[id],
     ...template,
     rentmanId: id,
   }

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -817,6 +817,30 @@ const healRentmanLibraryFromProject = (
         rearPanelCrop: eq.rearPanelCrop,
         netboxPath: eq.netboxPath,
         notes: eq.notes,
+        // ADR-005 — Bis hierhin nannte dieser Zweig 15 Felder. Der
+        // Rentman-Template-Cache baut dasselbe aus 37, und diese 15 sind eine
+        // echte Teilmenge davon: der Synthese-Zweig weiss nichts, was der
+        // Cache nicht auch weiss. Er ist also nicht anders gemeint, sondern
+        // aermer — und wer danach eine zweite Kopie aus der Library zieht,
+        // bekommt ein Geraet ohne Leistungsaufnahme, ohne Tiefe und ohne
+        // Katalog-Identitaet.
+        //
+        // Ergaenzt werden hier die Modell-Eigenschaften: was ein Geraet WIEGT,
+        // WIE TIEF es ist und WAS es kann, haengt am Typ, nicht am Exemplar.
+        deviceTypeId: eq.deviceTypeId,
+        powerWatts: eq.powerWatts,
+        weightKg: eq.weightKg,
+        depthMm: eq.depthMm,
+        resolution: eq.resolution,
+        displaySizeInch: eq.displaySizeInch,
+        sdiCaps: eq.sdiCaps,
+        atemMvConfig: eq.atemMvConfig,
+        // Bewusst NICHT uebernommen: ipAddress, macAddress, username,
+        // password, gateway, vlans und die uebrige Netz-Identitaet. Die beiden
+        // anderen Rekonstruktionen tragen sie, aber eine Library-Vorlage mit
+        // fest eingebauter IP erzeugt beim zweiten Herausziehen einen
+        // Adresskonflikt. Ob das dort richtig ist, ist eine eigene Frage —
+        // sie hier nebenbei mitzuentscheiden waere falsch.
         rentmanId: rid,
         rentmanSource: projectRentmanId,
         rentmanProjectName: projectRentmanName,

--- a/tests/rentmanTemplateCache.test.ts
+++ b/tests/rentmanTemplateCache.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  getCachedRentmanTemplate,
+  upsertCachedRentmanTemplate,
+} from '../src/renderer/lib/rentmanTemplateCache'
+import type { EquipmentTemplate } from '../src/renderer/types/equipment'
+
+// ADR-005 (Verlustfrei oder laut), Inkrement 3.
+//
+// Drei Funktionen bauen hier ein Template aus einem EquipmentItem, und ihre
+// Feldmengen sind ineinander geschachtelt: der Cache nennt 37, das
+// templateSlice 23, der Heal-Zweig 15 — ohne dass eine der kleineren etwas
+// wuesste, das die groesste nicht auch weiss.
+//
+// Solange `upsertCachedRentmanTemplate` den Eintrag ERSETZTE, gewann damit
+// immer die aermste Rekonstruktion, die zuletzt vorbeikam. Der Cache ist
+// projektuebergreifend; was hier faellt, faellt fuer alle Projekte.
+
+const tpl = (over: Partial<EquipmentTemplate>): EquipmentTemplate =>
+  ({ name: 'ATEM 4 M/E', category: 'Video', ...over }) as EquipmentTemplate
+
+describe('rentmanTemplateCache — Fortschreiben statt Ersetzen', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('haelt Felder, ueber die die neue Fassung nichts sagt', () => {
+    // Der Weg, den ein Nutzer wirklich geht: Rentman-Import schreibt die
+    // Engineering-Daten, danach "Als Template speichern" auf demselben Geraet.
+    upsertCachedRentmanTemplate(
+      tpl({ rentmanId: 'r1', rackUnits: 4, isRackDevice: true, powerWatts: 350, depthMm: 480 }),
+    )
+    upsertCachedRentmanTemplate(tpl({ rentmanId: 'r1', notes: 'Ton links' }))
+
+    const cached = getCachedRentmanTemplate('r1')
+    expect(cached?.notes).toBe('Ton links')
+    expect(cached?.rackUnits).toBe(4)
+    expect(cached?.powerWatts).toBe(350)
+    expect(cached?.depthMm).toBe(480)
+    expect(cached?.isRackDevice).toBe(true)
+  })
+
+  it('laesst die neue Fassung gewinnen, wo sie etwas sagt', () => {
+    // Fortschreiben heisst nicht Festhalten: ein wirklich geaenderter Wert
+    // muss durchkommen, sonst waere der Cache nicht mehr aktualisierbar.
+    upsertCachedRentmanTemplate(tpl({ rentmanId: 'r1', rackUnits: 4, powerWatts: 350 }))
+    upsertCachedRentmanTemplate(tpl({ rentmanId: 'r1', powerWatts: 400 }))
+    expect(getCachedRentmanTemplate('r1')?.powerWatts).toBe(400)
+    expect(getCachedRentmanTemplate('r1')?.rackUnits).toBe(4)
+  })
+
+  it('loescht ein Feld, wenn die neue Fassung es ausdruecklich leert', () => {
+    // Der Unterschied zwischen "sagt nichts" und "sagt: nichts". Ein
+    // explizites undefined traegt der Spread, also ueberschreibt es.
+    upsertCachedRentmanTemplate(tpl({ rentmanId: 'r1', powerWatts: 350 }))
+    upsertCachedRentmanTemplate(tpl({ rentmanId: 'r1', powerWatts: undefined }))
+    expect(getCachedRentmanTemplate('r1')?.powerWatts).toBeUndefined()
+  })
+
+  it('haelt Eintraege verschiedener Rentman-Ids auseinander', () => {
+    upsertCachedRentmanTemplate(tpl({ rentmanId: 'r1', rackUnits: 4 }))
+    upsertCachedRentmanTemplate(tpl({ rentmanId: 'r2', notes: 'x' }))
+    expect(getCachedRentmanTemplate('r2')?.rackUnits).toBeUndefined()
+    expect(getCachedRentmanTemplate('r1')?.rackUnits).toBe(4)
+  })
+
+  it('schreibt nichts ohne Rentman-Id', () => {
+    upsertCachedRentmanTemplate(tpl({ rackUnits: 4 }))
+    expect(getCachedRentmanTemplate('')).toBeUndefined()
+  })
+})

--- a/tests/templateIdentity.test.ts
+++ b/tests/templateIdentity.test.ts
@@ -52,3 +52,62 @@ describe('Rentman-Template-Cache — Katalog-Identitaet ueberlebt (ADR-005)', ()
     expect(getCachedRentmanTemplate('rm-42')).toBeUndefined()
   })
 })
+
+// ---------------------------------------------------------------------------
+// ADR-005, Inkrement 3 — neunter nachgelesener Hinweis.
+//
+// `healRentmanLibraryFromProject` synthetisiert eine Library-Vorlage, wenn ein
+// Canvas-Geraet einen `rentmanId` hat, aber kein Template dazu existiert (der
+// Fall aus #171: fremder Rechner, geleerte Library). Der Zweig nannte 15
+// Felder — eine echte Teilmenge der 37 des Caches. Wer danach eine zweite
+// Kopie aus der Library zieht, bekam ein Geraet ohne Leistungsaufnahme, ohne
+// Tiefe und ohne Katalog-Identitaet.
+
+describe('healRentmanLibraryFromProject — Synthese verliert die Modelldaten nicht', () => {
+  const project = (item: Partial<EquipmentItem>) =>
+    ({
+      metadata: {
+        name: 'T',
+        description: '',
+        createdAt: '',
+        updatedAt: '',
+        rentmanProjectId: 'p1',
+        rentmanProjectName: 'Show',
+      },
+      equipment: [eq(item)],
+      cables: [],
+      canvasState: { x: 0, y: 0, zoom: 1 },
+    }) as never
+
+  const synthesize = async (item: Partial<EquipmentItem>) => {
+    const { useProjectStore } = await import('../src/renderer/store/projectStore')
+    useProjectStore.setState({ customLibrary: [] })
+    useProjectStore.getState().loadProject(project(item))
+    return useProjectStore
+      .getState()
+      .customLibrary.find((t) => t.rentmanId === 'rm-42')
+  }
+
+  it('traegt die Engineering-Daten in die synthetisierte Vorlage', async () => {
+    const t = await synthesize({ powerWatts: 350, weightKg: 12.4, depthMm: 480 })
+    expect(t).toBeDefined()
+    expect(t?.powerWatts).toBe(350)
+    expect(t?.weightKg).toBe(12.4)
+    expect(t?.depthMm).toBe(480)
+  })
+
+  it('traegt die Katalog-Identitaet mit', async () => {
+    // Ohne sie faellt der naechste Rentman-Import auf Namens-Heuristiken
+    // zurueck — derselbe Schaden wie oben, nur an einer zweiten Stelle.
+    expect((await synthesize({}))?.deviceTypeId).toBe('dt-0815')
+  })
+
+  it('nimmt die Netz-Identitaet ausdruecklich NICHT mit', async () => {
+    // Eine Library-Vorlage mit fest eingebauter IP erzeugt beim zweiten
+    // Herausziehen einen Adresskonflikt. Die beiden anderen Rekonstruktionen
+    // tragen sie; ob das dort richtig ist, ist eine eigene Frage.
+    const t = await synthesize({ ipAddress: '10.0.0.5', macAddress: 'aa:bb' })
+    expect(t?.ipAddress).toBeUndefined()
+    expect(t?.macAddress).toBeUndefined()
+  })
+})


### PR DESCRIPTION
ADR-005 Inkrement 3, zehnter und elfter nachgelesener Hinweis.

## Die Zahl, die der Audit genannt hat, trägt nicht — die Struktur dahinter schon

Der Hinweis lautete: *„rebuilds from 23 named keys, silently stripping ~50 others"*. Die Zahl ist wieder unbrauchbar (wie schon bei `#615`), aber diesmal liegt darunter etwas Härteres. Drei Funktionen in dieser Codebase bauen ein Template aus einem `EquipmentItem`:

| Funktion | Felder |
| --- | --- |
| `toTemplateFromEquipment` (`rentmanTemplateCache.ts`) | **37** |
| `templateFromEquipment` (`templateSlice.ts`) | 23 |
| Synthese-Zweig in `healRentmanLibraryFromProject` | 15 |

Nachgezählt statt geschätzt, und der Befund ist eindeutig: **die beiden kleineren Mengen sind echte Teilmengen der größten.** Keine der beiden weiss ein einziges Feld, das der Cache nicht auch kennt.

Das ist entscheidend, weil es die naheliegende Ausrede ausschliesst. Die drei Fassungen sind nicht *unterschiedlich gemeint* — sie sind **ärmer**. Es gibt hier keine Abwägung zwischen konkurrierenden Auffassungen davon, was ein Template ist; es gibt eine vollständige Fassung und zwei unvollständige.

## Der Schaden

`upsertCachedRentmanTemplate` **ersetzte** den Eintrag. Damit gewann immer die ärmste Rekonstruktion, die zuletzt vorbeikam:

1. Rentman-Import schreibt Rack-Höhe, Leistung, Gewicht und Tiefe in den Cache-Eintrag.
2. Der Nutzer platziert das Gerät, ändert ein Port-Label, klickt **„Als Template speichern"**.
3. Der 23-Feld-Nachbau überschreibt den Eintrag — `rackUnits`, `powerWatts`, `weightKg`, `depthMm`, beide Panel-Bilder und deren Crops sind weg.

Der Cache ist ausdrücklich **projektübergreifend**. Was hier fällt, fällt für alle Projekte, und nichts warnt davor. „Als Template speichern" ist eine ganz normale, beworbene Aktion.

Der zweite Hinweis trifft denselben Bau an anderer Stelle: der Synthese-Zweig (der Fall aus `#171` — fremder Rechner, geleerte Library) baut die Vorlage aus 15 Feldern. Wer danach eine zweite Kopie herauszieht, bekommt ein Gerät ohne Leistungsaufnahme, ohne Tiefe und ohne Katalog-Identität.

## Der Fix

**Fortschreiben statt Ersetzen** — dieselbe Regel wie in `#619`, dritte Anwendung:

> Ein Feld, über das die neue Fassung nichts sagt, ist keine Anweisung, den alten Wert zu löschen.

Ein *ausdrückliches* `undefined` überschreibt weiterhin — der Unterschied zwischen „sagt nichts" und „sagt: nichts" ist testgesichert, sonst wäre der Cache nicht mehr aktualisierbar.

Der Synthese-Zweig bekommt `deviceTypeId` und die Engineering-Daten.

## Was dieser PR ausdrücklich nicht entscheidet

- **Netz-Identität.** `ipAddress`, `macAddress`, Zugangsdaten und VLANs wandern **nicht** in die synthetisierte Vorlage, obwohl die beiden anderen Rekonstruktionen sie tragen. Eine Library-Vorlage mit fest eingebauter IP erzeugt beim zweiten Herausziehen einen Adresskonflikt. Ob das in den anderen beiden Pfaden richtig ist, ist eine eigene Frage — sie hier nebenbei mitzuentscheiden wäre genau der Fehler, den ADR-005 beschreibt.
- **`rentPricePerDay` / `rentCurrency`** — die parkierte Design-Frage 2. Sie stehen in *keiner* der drei Fassungen, dieser PR fasst sie nicht an.

## Prüfung

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npx vitest run` 482/482 (8 neu) · `npm run lint` 0 Errors · `npm run build` grün.

Gegen den alten Stand gegengeprüft: **vier der acht neuen Tests schlagen dort fehl**, die übrigen vier sind Absicherungen, die schon hielten.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_