### PR TITLE
videohub: der Routing-Dump erfindet keinen Sperrzustand mehr (ADR-005)

### DIFF
--- a/src/renderer/lib/exportVideohub.ts
+++ b/src/renderer/lib/exportVideohub.ts
@@ -90,10 +90,31 @@ export const buildVideohubLabelTxt = (
  * Build a full Videohub protocol dump matching Blackmagic's telnet protocol 2.5.
  * This format is accepted by most Videohub control software via "Import routing".
  * Consists of sections: PROTOCOL PREAMBLE, VIDEOHUB DEVICE, INPUT LABELS,
- * OUTPUT LABELS, VIDEO OUTPUT LOCKS, VIDEO OUTPUT ROUTING.
+ * OUTPUT LABELS, VIDEO OUTPUT ROUTING.
  *
- * All outputs default to input 0 (slot 1) because the canvas has no routing
- * data yet; the user adjusts routes inside the hub after import.
+ * Outputs ohne Eintrag in `opts.routing` fallen auf Input 0 (Slot 1) zurueck.
+ *
+ * ADR-005 — Warum hier KEIN "VIDEO OUTPUT LOCKS"-Block mehr steht.
+ *
+ * Bis v7.9 schrieb dieser Dump `<n> U` fuer jeden Output, unbedingt. Das ist
+ * kein neutraler Platzhalter: `U` ist im Protokoll die Anweisung ZU ENTSPERREN.
+ * Der Dump landet per Zwischenablage in Fremdsoftware oder einer
+ * Telnet-Sitzung — ein Lock schuetzt aber typischerweise einen Live-Ausgang.
+ *
+ * Der naheliegende Fix waere gewesen, den echten Sperrzustand einzusetzen: der
+ * Hub-Status-Read liest ihn (`videohubIpc`, `outputLocks`), der Export-Dialog
+ * haelt ihn in `hubState` und zeigt sogar dessen Anzahl an. Genau das waere
+ * aber falsch. Das Routing in diesem Dokument ist der PLAN — Initiative 10 hat
+ * den Status-Read ausdruecklich davon getrennt: „Was der Hub tut, ist eine
+ * Beobachtung; was im Plan steht, eine Absicht." Beobachtete Sperren neben
+ * geplantes Routing zu schreiben ergaebe ein Dokument mit zwei Herkuenften in
+ * einem Atemzug — der Verstoss, den ADR-003 Regel 1 benennt.
+ *
+ * Der Plan modelliert keine Sperr-Absicht. Also sagt er dazu nichts. Bloecke
+ * sind im Protokoll unabhaengig und einzeln optional — der Parser dieses
+ * Repos ueberliest fehlende wie unbekannte Bloecke (`videohubIpc`).
+ *
+ * Sollte der Plan eines Tages eine Sperr-Absicht kennen, gehoert sie hierher.
  */
 export const buildVideohubRoutingDump = (
   device: Pick<EquipmentItem, 'name' | 'inputs' | 'outputs'>,
@@ -151,9 +172,6 @@ export const buildVideohubRoutingDump = (
     const label = display ? `${i + 1} ${display}`.trim() : `${i + 1}`
     out.push(`${i} ${label}`)
   }
-  out.push('')
-  out.push('VIDEO OUTPUT LOCKS:')
-  for (let i = 0; i < totalOut; i++) out.push(`${i} U`)
   out.push('')
   out.push('VIDEO OUTPUT ROUTING:')
   for (let i = 0; i < totalOut; i++) out.push(`${i} ${opts.routing?.[i] ?? 0}`)

--- a/tests/exportVideohubLocks.test.ts
+++ b/tests/exportVideohubLocks.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { buildVideohubRoutingDump } from '../src/renderer/lib/exportVideohub'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+
+// ADR-005 (Verlustfrei oder laut), Inkrement 3.
+//
+// Der Dump schrieb `<n> U` fuer jeden Output. `U` ist im Videohub-Protokoll
+// nicht "keine Angabe", sondern die Anweisung ZU ENTSPERREN — und der Dump ist
+// ausdruecklich dafuer gedacht, in Fremdsoftware oder eine Telnet-Sitzung
+// kopiert zu werden. Der Plan kennt aber gar keine Sperr-Absicht: er hat sich
+// eine ausgedacht, und zwar die gefaehrliche Richtung.
+
+const device = {
+  name: 'Videohub 40x40',
+  inputs: [],
+  outputs: [],
+} as unknown as Pick<EquipmentItem, 'name' | 'inputs' | 'outputs'>
+
+const dump = (routing?: Record<number, number>) =>
+  buildVideohubRoutingDump(device, {
+    modelName: 'Smart Videohub 40x40',
+    totalInputs: 4,
+    totalOutputs: 4,
+    routing,
+  })
+
+describe('Videohub-Dump — behauptet keinen Sperrzustand', () => {
+  it('schreibt keinen VIDEO OUTPUT LOCKS-Block', () => {
+    expect(dump()).not.toContain('VIDEO OUTPUT LOCKS')
+  })
+
+  it('schreibt insbesondere kein Entsperren-Kommando', () => {
+    // Der eigentliche Schaden: nicht die fehlende Information, sondern die
+    // erfundene. Ein `0 U` in einer Telnet-Sitzung hebt eine Sperre auf, die
+    // einen Live-Ausgang schuetzt.
+    const lines = dump().split('\r\n')
+    expect(lines.filter((l) => /^\d+ U$/.test(l))).toEqual([])
+  })
+
+  it('schreibt das geplante Routing weiterhin vollstaendig', () => {
+    // Weglassen heisst nicht Ausduennen: was der Plan WEISS, steht drin.
+    const text = dump({ 0: 3, 1: 2 })
+    const body = text.slice(text.indexOf('VIDEO OUTPUT ROUTING:'))
+    expect(body).toContain('0 3')
+    expect(body).toContain('1 2')
+    expect(body).toContain('2 0')
+    expect(body).toContain('3 0')
+  })
+
+  it('haelt die uebrigen Bloecke unveraendert', () => {
+    const text = dump()
+    expect(text).toContain('VIDEOHUB DEVICE:')
+    expect(text).toContain('INPUT LABELS:')
+    expect(text).toContain('OUTPUT LABELS:')
+    expect(text).toContain('VIDEO OUTPUT ROUTING:')
+  })
+})


### PR DESCRIPTION
ADR-005 Inkrement 3, zwölfter nachgelesener Hinweis — und der erste dieser Runde, bei dem der Schaden nicht *fehlende*, sondern **erfundene** Information ist.

## Der Fund

`buildVideohubRoutingDump` schrieb für jeden Output `<n> U`, unbedingt.

Im Videohub-Protokoll ist `U` keine Leerstelle. Es ist die Anweisung **zu entsperren**. Und der Dump ist ausdrücklich dafür gemacht, weiterverwendet zu werden — der Modulkopf sagt „accepted by most Videohub control software via *Import routing*", der Dialog legt ihn zusätzlich in die Zwischenablage. Eine Sperre auf einem Videohub-Ausgang schützt typischerweise einen Live-Weg.

Der Plan modelliert überhaupt keine Sperr-Absicht. Er hat sich also eine ausgedacht — und zwar die gefährliche Richtung.

Das ist eine andere Sorte Fehler als die elf davor. Bisher ging Information verloren. Hier wird welche **hergestellt**, und ein Dokument, das etwas Falsches behauptet, ist schlimmer als eines, das schweigt.

## Warum der naheliegende Fix falsch gewesen wäre

Der echte Sperrzustand ist verfügbar: `videohubIpc` parst `outputLocks` aus dem Hub-Status, der Export-Dialog hält ihn in `hubState` und zeigt sogar dessen Anzahl in der Statuszeile an. Ihn einzusetzen sieht nach der offensichtlichen Lösung aus.

Sie wäre falsch. Das Routing in diesem Dokument ist der **Plan**. Initiative 10 hat den Status-Read ausdrücklich davon getrennt, mit einem Kommentar, der genau hierher gehört:

> Was der Hub tut, ist eine Beobachtung; was im Plan steht, eine Absicht. Beide in dieselbe Variable zu schreiben macht die Absicht unauffindbar.

Beobachtete Sperren neben geplantes Routing zu schreiben ergäbe ein Dokument mit zwei Herkünften in einem Atemzug — genau der Verstoss, den **ADR-003 Regel 1** benennt. Der Fix für einen Verlust-Befund darf keinen Provenienz-Befund erzeugen.

## Was dieser PR macht

Der Block entfällt. Der Plan kennt keine Sperr-Absicht, also sagt er dazu nichts.

Dass das zulässig ist, belegt der Code dieses Repos selbst: `videohubIpc` iteriert die Blöcke einzeln und überliest fehlende wie unbekannte („Unknown blocks … ignored"). Blöcke sind im Protokoll unabhängig und einzeln optional; ein Dump ohne `VIDEO OUTPUT LOCKS` ist kein kaputter Dump, sondern einer ohne Meinung dazu.

Nebenbei richtiggestellt: der Doc-Kommentar behauptete „All outputs default to input 0 because the canvas has no routing data yet". Das stimmt seit Längerem nicht — der Dialog reicht das geplante Routing durch, der Dump ist also eine Momentaufnahme des Plans und kein leeres Template. Genau deshalb fiel der erfundene Locks-Block überhaupt ins Gewicht: er stand in einem ansonsten wahren Dokument.

Sollte der Plan eines Tages eine Sperr-Absicht modellieren, gehört sie an diese Stelle; der Kommentar sagt das.

## Prüfung

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npx vitest run` 486/486 (4 neu) · `npm run lint` 0 Errors · `npm run build` grün.

Kein Test im Repo hat den Locks-Block erwartet — geprüft, bevor er entfernt wurde.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_