### PR TITLE
camera-list eingefroren — und der Drift-Guard prüft jetzt wirklich

### DIFF
--- a/tests/cameraListContract.test.ts
+++ b/tests/cameraListContract.test.ts
@@ -1,0 +1,127 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Drift-Guard fuer das Kamera-Listen-Format `camera-list` v1.
+//
+// Das Format ist in ZWEI Apps dupliziert: multicam-planner schreibt
+// (src/utils/cameraExport.ts), cable-planner liest (src/renderer/lib/
+// multicamCameraImport.ts). Beide Modulkoepfe behaupten einander:
+// „Schema-identisch zum Cable-Planner" bzw. „Gegenstueck: multicam-planner".
+//
+// Diese Behauptung stand bis ADR-005 Inkrement 4 unter KEINEM Test. Beide
+// Seiten testeten nur sich selbst gegen selbstgeschriebene Fixtures — eine
+// Aenderung auf einer Seite waere auf beiden Seiten gruen durchgelaufen.
+// Die Schemata waren dabei tatsaechlich identisch; es hielt sie nur nichts.
+//
+// Gleiches Muster wie tests/inventoryContract.test.ts: der eingefrorene
+// CONTRACT unten steht WORTGLEICH in multicam-planner
+// src/__tests__/cameraListContract.test.ts. Aendert jemand das Schema in
+// EINEM Repo, schlaegt dessen Guard fehl. Kein Test in einem Repo kann den
+// Code des anderen ausfuehren — aber Auseinanderlaufen wird laut, statt still.
+//
+// !!! Wenn dieser Contract bewusst geaendert wird:
+//   1. CAMERA_LIST_VERSION erhoehen (Abwaertskompatibilitaet beachten),
+//   2. die identische Aenderung im multicam-planner nachziehen,
+//   3. die eingefrorenen Key-Listen in BEIDEN Guards anpassen.
+// ───────────────────────────────────────────────────────────────────────────
+import { describe, it, expect } from 'vitest'
+import { interfaceKeys } from './support/interfaceKeys'
+import {
+  CAMERA_LIST_KIND,
+  CAMERA_LIST_VERSION,
+  parseCameraList,
+  cameraListToEquipment,
+  type CameraListEntry,
+  type CameraListExchange,
+} from '../src/renderer/lib/multicamCameraImport'
+
+const SRC = 'src/renderer/lib/multicamCameraImport.ts'
+
+// Eingefrorener Contract — MUSS in beiden Repos identisch sein.
+const CONTRACT = {
+  kind: 'camera-list',
+  version: 1,
+  envelopeKeys: ['app', 'appVersion', 'cameras', 'exportedAt', 'formatVersion', 'kind'],
+  entryKeys: ['deviceTypeId', 'id', 'label', 'manufacturer', 'model', 'x', 'y'],
+} as const
+
+// Voll besetzter Muster-Eintrag (jedes Feld gesetzt). Er haelt die Laufzeit-
+// Form fest — NICHT die Typ-Vollstaendigkeit: ein neues optionales Feld
+// laesst ihn unveraendert. Dafuer ist der interfaceKeys-Test weiter unten da.
+const entry: CameraListEntry = {
+  id: 'vc1',
+  label: 'Kamera 1',
+  manufacturer: 'Blackmagic Design',
+  model: 'URSA Broadcast G2',
+  deviceTypeId: 'dt-cam-0001',
+  x: 3.5,
+  y: 7.25,
+}
+const exchange: CameraListExchange = {
+  kind: CAMERA_LIST_KIND,
+  formatVersion: CAMERA_LIST_VERSION,
+  app: 'multicam-planner',
+  appVersion: '1.2.3',
+  exportedAt: '2026-01-01T00:00:00.000Z',
+  cameras: [entry],
+}
+
+const sortedKeys = (o: object) => Object.keys(o).sort()
+
+describe('camera-list Wire-Contract (Drift-Guard)', () => {
+  it('Format-Marker + Version sind eingefroren', () => {
+    expect(CAMERA_LIST_KIND).toBe(CONTRACT.kind)
+    expect(CAMERA_LIST_VERSION).toBe(CONTRACT.version)
+  })
+
+  it('Envelope-Shape ist eingefroren', () => {
+    expect(sortedKeys(exchange)).toEqual(CONTRACT.envelopeKeys)
+  })
+
+  it('Feld-Namen des Kamera-Eintrags sind eingefroren', () => {
+    expect(sortedKeys(entry)).toEqual(CONTRACT.entryKeys)
+  })
+
+  it('faengt auch ein neu hinzugefuegtes OPTIONALES Feld', () => {
+    // Die Muster-Literale oben allein wuerden das nicht tun: ein optionales
+    // Feld laesst sie unveraendert kompilieren. Deshalb hier gegen den
+    // Interface-Rumpf im Quelltext — die einzige Pruefung, die unter
+    // `npm test` tatsaechlich laeuft (tests/ liegt ausserhalb der tsconfigs).
+    expect(interfaceKeys(SRC, 'CameraListEntry')).toEqual(CONTRACT.entryKeys)
+    expect(interfaceKeys(SRC, 'CameraListExchange')).toEqual(CONTRACT.envelopeKeys)
+  })
+
+  it('parse akzeptiert den eingefrorenen Envelope', () => {
+    const back = parseCameraList(JSON.stringify(exchange))
+    expect(back).toEqual(exchange)
+  })
+
+  it('parse lehnt fremdes Format und fremde Version ab', () => {
+    expect(() => parseCameraList(JSON.stringify({ ...exchange, kind: 'something-else' }))).toThrow()
+    expect(() =>
+      parseCameraList(JSON.stringify({ ...exchange, formatVersion: CONTRACT.version + 1 })),
+    ).toThrow()
+    expect(() => parseCameraList(JSON.stringify({ ...exchange, cameras: undefined }))).toThrow()
+    expect(() => parseCameraList('not json')).toThrow()
+  })
+
+  it('verbraucht JEDES Feld des Eintrags — kein Feld faellt still hinten runter', () => {
+    // Der Gegenbeweis zur Frage „was liest der Importer nicht, obwohl es
+    // geschrieben wird?". Alle sieben Felder muessen sich im Ergebnis
+    // wiederfinden, sonst traegt das Format Daten, die nirgends ankommen.
+    const [eq] = cameraListToEquipment(exchange)
+    expect(eq.id).toBe(entry.id) // id
+    expect(eq.name).toBe(entry.label) // label
+    expect(eq.deviceTypeId).toBe(entry.deviceTypeId) // deviceTypeId
+    expect(eq.x).toBe(Math.round(entry.x! * 120)) // x (Meter -> Pixel)
+    expect(eq.y).toBe(Math.round(entry.y! * 120)) // y
+
+    // manufacturer + model gehen in den Datenblatt-Match ein: ein Eintrag,
+    // dessen Name auf kein Katalog-Geraet passt, bleibt ohne Ports stehen —
+    // waeren die Felder ungenutzt, saehe das Ergebnis identisch aus.
+    const unknown = cameraListToEquipment({
+      ...exchange,
+      cameras: [{ id: 'x', label: 'X', manufacturer: 'Nicht', model: 'Existent' }],
+    })[0]
+    expect(unknown.portsUnknown).toBe(true)
+    expect(unknown.outputs).toEqual([])
+  })
+})

--- a/tests/cameraListContract.test.ts
+++ b/tests/cameraListContract.test.ts
@@ -24,6 +24,7 @@
 // ───────────────────────────────────────────────────────────────────────────
 import { describe, it, expect } from 'vitest'
 import { interfaceKeys } from './support/interfaceKeys'
+import importerSrc from '../src/renderer/lib/multicamCameraImport.ts?raw'
 import {
   CAMERA_LIST_KIND,
   CAMERA_LIST_VERSION,
@@ -32,8 +33,6 @@ import {
   type CameraListEntry,
   type CameraListExchange,
 } from '../src/renderer/lib/multicamCameraImport'
-
-const SRC = 'src/renderer/lib/multicamCameraImport.ts'
 
 // Eingefrorener Contract — MUSS in beiden Repos identisch sein.
 const CONTRACT = {
@@ -85,8 +84,8 @@ describe('camera-list Wire-Contract (Drift-Guard)', () => {
     // Feld laesst sie unveraendert kompilieren. Deshalb hier gegen den
     // Interface-Rumpf im Quelltext — die einzige Pruefung, die unter
     // `npm test` tatsaechlich laeuft (tests/ liegt ausserhalb der tsconfigs).
-    expect(interfaceKeys(SRC, 'CameraListEntry')).toEqual(CONTRACT.entryKeys)
-    expect(interfaceKeys(SRC, 'CameraListExchange')).toEqual(CONTRACT.envelopeKeys)
+    expect(interfaceKeys(importerSrc, 'CameraListEntry')).toEqual(CONTRACT.entryKeys)
+    expect(interfaceKeys(importerSrc, 'CameraListExchange')).toEqual(CONTRACT.envelopeKeys)
   })
 
   it('parse akzeptiert den eingefrorenen Envelope', () => {

--- a/tests/inventoryContract.test.ts
+++ b/tests/inventoryContract.test.ts
@@ -14,6 +14,7 @@
 //   3. die eingefrorenen Key-Listen unten anpassen.
 // ───────────────────────────────────────────────────────────────────────────
 import { describe, it, expect } from 'vitest'
+import { interfaceKeys } from './support/interfaceKeys'
 import {
   INVENTORY_FORMAT,
   INVENTORY_FORMAT_VERSION,
@@ -34,8 +35,15 @@ const CONTRACT = {
   unitKeys: ['code', 'codeType', 'condition', 'createdAt', 'history', 'id', 'itemId', 'locationId', 'notes', 'serial', 'updatedAt'],
 } as const
 
-// Voll besetzte Muster-Entitaeten (jedes Feld gesetzt) — TS erzwingt, dass sie
-// zum Typ passen; die Key-Assertions unten erzwingen, dass kein Feld fehlt.
+// Voll besetzte Muster-Entitaeten (jedes Feld gesetzt). Sie halten die
+// Laufzeit-Form fest — NICHT die Typ-Vollstaendigkeit. Hier stand frueher
+// „TS erzwingt, dass sie zum Typ passen"; das stimmt in diesem Repo nicht:
+// tests/ liegt bewusst ausserhalb aller Emit-tsconfigs (vitest.config.ts:
+// kein Test-File in dist/), `npx tsc -p tsconfig.app.json` sieht diese Datei
+// also nie, und vitest streift Typen ueber esbuild ohne sie zu pruefen.
+// Nachgemessen: ein testweise hinzugefuegtes optionales Feld blieb auf beiden
+// Wegen gruen. Ein neues OPTIONALES Feld faengt daher erst der
+// interfaceKeys-Test unten, der den Interface-Rumpf aus dem Quelltext liest.
 const item: InventoryItem = {
   id: 'i1', model: 'ULXD2', manufacturer: 'Shure', category: 'wireless', quantity: 4,
   rentPricePerDay: 25, stockLocation: 'Regal A3', supplier: 'AV GmbH', ownership: 'owned',
@@ -79,6 +87,15 @@ describe('avplan-inventory Wire-Contract (Drift-Guard)', () => {
     expect(sortedKeys(node)).toEqual(CONTRACT.nodeKeys)
     expect(sortedKeys(set)).toEqual(CONTRACT.setKeys)
     expect(sortedKeys(unit)).toEqual(CONTRACT.unitKeys)
+  })
+
+  it('faengt auch ein neu hinzugefuegtes OPTIONALES Feld', () => {
+    // Die Muster-Entitaeten oben wuerden das nicht tun (siehe Kommentar dort).
+    const T = 'src/renderer/types/inventory.ts'
+    expect(interfaceKeys(T, 'InventoryItem')).toEqual(CONTRACT.itemKeys)
+    expect(interfaceKeys(T, 'StorageNode')).toEqual(CONTRACT.nodeKeys)
+    expect(interfaceKeys(T, 'InventorySet')).toEqual(CONTRACT.setKeys)
+    expect(interfaceKeys(T, 'InventoryUnit')).toEqual(CONTRACT.unitKeys)
   })
 
   it('Round-Trip serialize -> parse ist verlustfrei', () => {

--- a/tests/inventoryContract.test.ts
+++ b/tests/inventoryContract.test.ts
@@ -15,6 +15,7 @@
 // ───────────────────────────────────────────────────────────────────────────
 import { describe, it, expect } from 'vitest'
 import { interfaceKeys } from './support/interfaceKeys'
+import inventoryTypesSrc from '../src/renderer/types/inventory.ts?raw'
 import {
   INVENTORY_FORMAT,
   INVENTORY_FORMAT_VERSION,
@@ -91,11 +92,10 @@ describe('avplan-inventory Wire-Contract (Drift-Guard)', () => {
 
   it('faengt auch ein neu hinzugefuegtes OPTIONALES Feld', () => {
     // Die Muster-Entitaeten oben wuerden das nicht tun (siehe Kommentar dort).
-    const T = 'src/renderer/types/inventory.ts'
-    expect(interfaceKeys(T, 'InventoryItem')).toEqual(CONTRACT.itemKeys)
-    expect(interfaceKeys(T, 'StorageNode')).toEqual(CONTRACT.nodeKeys)
-    expect(interfaceKeys(T, 'InventorySet')).toEqual(CONTRACT.setKeys)
-    expect(interfaceKeys(T, 'InventoryUnit')).toEqual(CONTRACT.unitKeys)
+    expect(interfaceKeys(inventoryTypesSrc, 'InventoryItem')).toEqual(CONTRACT.itemKeys)
+    expect(interfaceKeys(inventoryTypesSrc, 'StorageNode')).toEqual(CONTRACT.nodeKeys)
+    expect(interfaceKeys(inventoryTypesSrc, 'InventorySet')).toEqual(CONTRACT.setKeys)
+    expect(interfaceKeys(inventoryTypesSrc, 'InventoryUnit')).toEqual(CONTRACT.unitKeys)
   })
 
   it('Round-Trip serialize -> parse ist verlustfrei', () => {

--- a/tests/support/interfaceKeys.ts
+++ b/tests/support/interfaceKeys.ts
@@ -1,34 +1,38 @@
 // ───────────────────────────────────────────────────────────────────────────
-// Feld-Namen eines TS-Interface zur LAUFZEIT aus der Quelle lesen.
+// Feld-Namen eines TS-Interface zur LAUFZEIT aus dem Quelltext lesen.
 //
-// WARUM NICHT AUF TYP-EBENE. Der naheliegende Weg waere
+// Zeichengleich zu multicam-planner src/__tests__/support/interfaceKeys.ts
+// (bis auf die Semikolon-Konvention), damit die Contract-Guards beider Repos
+// dieselbe Pruefung machen und „wortgleich“ nachpruefbar bleibt. Der Aufrufer
+// laedt die Quelle per `?raw`-Import — die Funktion selbst fasst kein
+// Dateisystem an und braucht darum weder @types/node noch eine gemeinsame
+// Pfad-Konvention.
+//
+// WARUM ZUR LAUFZEIT. Der naheliegende Weg waere
 // `const _x: Record<keyof T, true> = { ... }` — ein tsc-Fehler, sobald jemand
-// ein Feld hinzufuegt. Der greift hier aber nicht: `tests/` liegt bewusst
-// ausserhalb aller Emit-tsconfigs (siehe vitest.config.ts: kein Test-File in
-// dist/), `npx tsc -p tsconfig.app.json` sieht die Testdateien also nie, und
-// vitest streift Typen ueber esbuild ohne sie zu pruefen. Nachgemessen an
-// einem eingebauten Zusatzfeld: beide Wege blieben gruen.
+// ein Feld hinzufuegt. HIER greift das nicht: tests/ liegt bewusst ausserhalb
+// aller Emit-tsconfigs (siehe vitest.config.ts: kein Test-File in dist/),
+// `npx tsc -p tsconfig.app.json` sieht die Testdateien also nie, und vitest
+// streift Typen ueber esbuild ohne sie zu pruefen. Nachgemessen an einem
+// eingebauten Zusatzfeld: beide Wege blieben gruen.
 //
-// Ein Contract-Guard, der eine nie ausgefuehrte Pruefung enthaelt, ist
-// schlimmer als keiner — er behauptet Sicherheit, die es nicht gibt. Also
-// wird der Interface-Rumpf aus dem Quelltext gelesen. Das laeuft unter
-// `npm test` und damit in CI.
+// Im multicam-planner WUERDE der Typ-Weg greifen (tsconfig `include: ["src"]`,
+// Tests unter src/__tests__). Eine Pruefung, die nur auf EINER Seite eines
+// zweiseitigen Vertrags laeuft, taugt aber nicht — deshalb dort wie hier
+// derselbe Laufzeit-Weg.
 //
 // GRENZEN, ausdruecklich: bewusst simpel gehalten — ein Interface ohne
 // Vererbung (`extends`) und ohne verschachtelte Objekt-Literale im Rumpf.
-// Genau so sind die Austauschformat-Interfaces geschnitten. Trifft das
-// nicht mehr zu, faellt `interfaceKeys` mit einer klaren Meldung, statt
-// still eine falsche Menge zu liefern.
+// Genau so sind die Austauschformat-Interfaces geschnitten. Trifft das nicht
+// mehr zu, faellt `interfaceKeys` mit einer klaren Meldung, statt still eine
+// falsche Menge zu liefern.
 // ───────────────────────────────────────────────────────────────────────────
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 
-/** Feld-Namen des Interface `name` aus der Datei `relPath` (repo-relativ). */
-export const interfaceKeys = (relPath: string, name: string): string[] => {
-  const src = readFileSync(resolve(__dirname, '..', '..', relPath), 'utf8')
+/** Feld-Namen des Interface `name` im Quelltext `src` (via `?raw` geladen). */
+export const interfaceKeys = (src: string, name: string): string[] => {
   const head = new RegExp(`\\binterface\\s+${name}\\b([^{]*)\\{`)
   const m = head.exec(src)
-  if (!m) throw new Error(`Interface ${name} nicht in ${relPath} gefunden`)
+  if (!m) throw new Error(`Interface ${name} nicht im Quelltext gefunden`)
   if (m[1].includes('extends')) {
     throw new Error(`${name} benutzt extends — interfaceKeys kann das nicht aufloesen`)
   }
@@ -41,20 +45,15 @@ export const interfaceKeys = (relPath: string, name: string): string[] => {
     if (src[i] === '{') depth++
     else if (src[i] === '}') depth--
   }
-  if (depth !== 0) throw new Error(`Rumpf von ${name} in ${relPath} nicht geschlossen`)
+  if (depth !== 0) throw new Error(`Rumpf von ${name} nicht geschlossen`)
   const body = src.slice(start, i - 1)
 
-  if (/\{/.test(body.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, ''))) {
+  const stripped = body.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
+  if (/\{/.test(stripped)) {
     throw new Error(`${name} hat verschachtelte Objekt-Literale — interfaceKeys ist dafuer zu simpel`)
   }
 
-  return [
-    ...body
-      // Kommentare raus, sonst zaehlen Doku-Zeilen als Felder.
-      .replace(/\/\*[\s\S]*?\*\//g, '')
-      .replace(/\/\/.*$/gm, '')
-      .matchAll(/^\s*(?:readonly\s+)?([A-Za-z_$][\w$]*)\??\s*:/gm),
-  ]
+  return [...stripped.matchAll(/^\s*(?:readonly\s+)?([A-Za-z_$][\w$]*)\??\s*:/gm)]
     .map((k) => k[1])
     .sort()
 }

--- a/tests/support/interfaceKeys.ts
+++ b/tests/support/interfaceKeys.ts
@@ -1,0 +1,60 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Feld-Namen eines TS-Interface zur LAUFZEIT aus der Quelle lesen.
+//
+// WARUM NICHT AUF TYP-EBENE. Der naheliegende Weg waere
+// `const _x: Record<keyof T, true> = { ... }` — ein tsc-Fehler, sobald jemand
+// ein Feld hinzufuegt. Der greift hier aber nicht: `tests/` liegt bewusst
+// ausserhalb aller Emit-tsconfigs (siehe vitest.config.ts: kein Test-File in
+// dist/), `npx tsc -p tsconfig.app.json` sieht die Testdateien also nie, und
+// vitest streift Typen ueber esbuild ohne sie zu pruefen. Nachgemessen an
+// einem eingebauten Zusatzfeld: beide Wege blieben gruen.
+//
+// Ein Contract-Guard, der eine nie ausgefuehrte Pruefung enthaelt, ist
+// schlimmer als keiner — er behauptet Sicherheit, die es nicht gibt. Also
+// wird der Interface-Rumpf aus dem Quelltext gelesen. Das laeuft unter
+// `npm test` und damit in CI.
+//
+// GRENZEN, ausdruecklich: bewusst simpel gehalten — ein Interface ohne
+// Vererbung (`extends`) und ohne verschachtelte Objekt-Literale im Rumpf.
+// Genau so sind die Austauschformat-Interfaces geschnitten. Trifft das
+// nicht mehr zu, faellt `interfaceKeys` mit einer klaren Meldung, statt
+// still eine falsche Menge zu liefern.
+// ───────────────────────────────────────────────────────────────────────────
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+/** Feld-Namen des Interface `name` aus der Datei `relPath` (repo-relativ). */
+export const interfaceKeys = (relPath: string, name: string): string[] => {
+  const src = readFileSync(resolve(__dirname, '..', '..', relPath), 'utf8')
+  const head = new RegExp(`\\binterface\\s+${name}\\b([^{]*)\\{`)
+  const m = head.exec(src)
+  if (!m) throw new Error(`Interface ${name} nicht in ${relPath} gefunden`)
+  if (m[1].includes('extends')) {
+    throw new Error(`${name} benutzt extends — interfaceKeys kann das nicht aufloesen`)
+  }
+
+  // Rumpf bis zur passenden schliessenden Klammer.
+  const start = m.index + m[0].length
+  let depth = 1
+  let i = start
+  for (; i < src.length && depth > 0; i++) {
+    if (src[i] === '{') depth++
+    else if (src[i] === '}') depth--
+  }
+  if (depth !== 0) throw new Error(`Rumpf von ${name} in ${relPath} nicht geschlossen`)
+  const body = src.slice(start, i - 1)
+
+  if (/\{/.test(body.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, ''))) {
+    throw new Error(`${name} hat verschachtelte Objekt-Literale — interfaceKeys ist dafuer zu simpel`)
+  }
+
+  return [
+    ...body
+      // Kommentare raus, sonst zaehlen Doku-Zeilen als Felder.
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '')
+      .matchAll(/^\s*(?:readonly\s+)?([A-Za-z_$][\w$]*)\??\s*:/gm),
+  ]
+    .map((k) => k[1])
+    .sort()
+}


### PR DESCRIPTION
Zweiter Fund aus **ADR-005 Inkrement 4**. Gegenstück: [larszu/multicam-planner#84](https://github.com/larszu/multicam-planner/pull/84).

## Der Fund

`multicamCameraImport.ts` und multicams `cameraExport.ts` behaupten einander im Modulkopf „Schema-identisch" bzw. „Gegenstück". **Geprüft hat das nichts** — beide Seiten testeten nur sich selbst gegen selbstgeschriebene Fixtures.

Präzisierung: die Schemata sind heute tatsächlich identisch. Kein Drift-Schaden, sondern eine Zusage ohne Sicherung.

Der Guard friert `camera-list` v1 nach dem Hausmuster (`inventoryContract.test.ts`) ein und prüft zusätzlich, dass der Importer **jedes** der sieben Felder verbraucht — die Gegenprobe zur Frage „was liest er nicht, obwohl es geschrieben wird?". Antwort: nichts fällt hinten runter.

## Der grössere Fund: das Hausmuster hat ein Loch

Beim Nachbauen wollte ich die Vollständigkeit auf Typ-Ebene erzwingen (`Record<keyof T, true>` — tsc-Fehler beim Feld-Hinzufügen). Die Gegenprobe zeigte: **das läuft hier nie.**

- `tests/` liegt bewusst ausserhalb aller Emit-tsconfigs (`vitest.config.ts` nennt den Grund: kein Test-File in `dist/`), also sieht `npx tsc -p tsconfig.app.json` die Testdateien nicht.
- vitest streift Typen über esbuild, ohne sie zu prüfen.

Nachgemessen mit einem testweise hinzugefügten `tiltDeg?`: **beide Wege blieben grün.**

Damit gilt dasselbe für den bestehenden `inventoryContract.test.ts`, dessen Kommentar sagt: *„TS erzwingt, dass sie zum Typ passen."* Das stimmt in diesem Repo nicht. Ein Guard, der eine nie ausgeführte Prüfung enthält, ist schlimmer als keiner — er behauptet Sicherheit, die es nicht gibt. Das ist derselbe Fehler, den Inkrement 4 sucht, nur diesmal im Prüfwerkzeug selbst.

Deshalb hier mit im PR, obwohl es über `camera-list` hinausgeht:

- `tests/support/interfaceKeys.ts` liest die Feldnamen zur Laufzeit aus dem Quelltext (`?raw`-Import, kein `node:fs` — damit derselbe Helfer im multicam-planner läuft, der `types: []` fährt).
- **Beide** Guards nutzen ihn, beide gegengeprüft mit eingebauter Drift.
- Der falsche Kommentar korrigiert; er sagt jetzt, was tatsächlich hält.

Der eingefrorene `CONTRACT` und der Funktions-Rumpf des Helfers sind zwischen beiden Repos nachweislich identisch (`diff` sauber bis auf die Semikolon-Konvention) — die „wortgleich"-Zusage des Guards ist damit selbst prüfbar.

## Was der Guard nicht kann

Kein Test in einem Repo führt den Code des anderen aus. Der Guard verhindert keine Divergenz — er macht sie **laut statt still**: wer eine Seite ändert, dessen eigener Guard fällt.

## Gegenprobe

`tiltDeg?` in `CameraListEntry` eingebaut → Guard fällt. `serialPolicy?` in `InventoryItem` eingebaut → Guard fällt. Beide zurückgesetzt → grün.

## Prüfung

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npm test` **48 Dateien, 499 Tests grün** · `npm run lint` 0 Errors (10 vorbestehende Warnungen, keine in den geänderten Dateien).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_