### PR TITLE
mobile: abgelehnte Handy-Kabel verschwinden nicht mehr still

### DIFF
--- a/src/mobile/MobileApp.tsx
+++ b/src/mobile/MobileApp.tsx
@@ -1742,7 +1742,18 @@ const AddCableModal = ({
         <div className="space-y-3 p-3 text-xs">
           {done ? (
             <div className="rounded border border-emerald-700 bg-emerald-900/30 p-3 text-center text-emerald-200">
-              ✓ Kabel gesendet — wird am Desktop mit 📱-Marker eingefügt
+              {/* ADR-005, Regel 4 — hier stand „wird am Desktop mit
+                  📱-Marker eingefügt". Das konnte diese Seite nicht wissen:
+                  der Server bestätigt den Empfang des JSON, der Desktop
+                  entscheidet erst danach und lehnt in vier Fällen ab
+                  (Plan gesperrt, Gerät oder Port weg, Dublette). Ein
+                  Versprechen im Futur von der Seite, die es nicht einlösen
+                  kann. Jetzt steht hier nur, was tatsächlich passiert ist. */}
+              ✓ An den Desktop gesendet
+              <div className="mt-1 text-[10px] font-normal text-emerald-300/80">
+                Ob es im Plan landet, entscheidet der Desktop — dort steht es
+                dann mit 📱-Marker.
+              </div>
             </div>
           ) : (
             <>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,4 +1,5 @@
 import { hasDrops } from './types/loadReport'
+import { hasMobileDrops } from './types/mobileReport'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useIsNarrow } from './hooks/useBreakpoint'
 import { CanvasArea } from './components/Canvas/CanvasArea'
@@ -115,6 +116,8 @@ export default function App() {
   // ADR-005 — Bericht ueber den letzten Ladevorgang (was nicht mitkam).
   const lastLoadReport = useProjectStore((s) => s.lastLoadReport)
   const dismissLoadReport = useProjectStore((s) => s.dismissLoadReport)
+  const lastMobileDrop = useProjectStore((s) => s.lastMobileDrop)
+  const dismissMobileDrop = useProjectStore((s) => s.dismissMobileDrop)
   const inventoryOpen = useUiStore((state) => state.inventory.open)
   const canvasTheme = useUiStore((state) => state.canvasTheme)
   const followSystemTheme = useUiStore((state) => state.followSystemTheme)
@@ -1330,6 +1333,55 @@ export default function App() {
             {t(
               'app.loadReport.hint',
               'Geräte, die auf diese Rollen zeigten, haben ihre Zuordnung verloren — darunter die TSL-Adresse für Tally. Speichern überschreibt die Datei mit diesem Stand.',
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* ADR-005, Regel 3 — Handy-Kabel, die der Desktop abgelehnt hat. Das
+          Handy hat dem Techniker vorher nur „gesendet" gemeldet und kann von
+          der Ablehnung nichts wissen: der Server bestätigt den JSON-Empfang,
+          bevor hier entschieden wird. Wer den Plan besitzt, sieht es hier. */}
+      {hasMobileDrops(lastMobileDrop) && lastMobileDrop && (
+        <div
+          role="status"
+          className="fixed bottom-4 left-1/2 z-[210] w-[560px] max-w-[92vw] -translate-x-1/2 rounded-cp-card border border-cp-warn/60 bg-cp-surface-1 p-4 shadow-2xl"
+        >
+          <div className="mb-1 flex items-start justify-between gap-3">
+            <div className="text-cp-sm font-semibold text-cp-warn">
+              {t(
+                'app.mobileDrop.title',
+                'Vom Handy gesendete Kabel wurden nicht übernommen',
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={dismissMobileDrop}
+              className="rounded bg-cp-surface-4 px-2 py-0.5 text-cp-xs hover:bg-cp-surface-5"
+            >
+              {t('common.ok', 'OK')}
+            </button>
+          </div>
+          <ul className="max-h-40 space-y-0.5 overflow-y-auto text-[11px] text-cp-text-secondary">
+            {lastMobileDrop.drops.slice(0, 20).map((d, i) => (
+              <li key={`${d.reason}-${d.label}-${i}`}>
+                {t('app.mobileDrop.cable', 'Kabel')}
+                {d.label ? ` „${d.label}"` : ''}
+                {' — '}
+                {d.reason === 'plan-locked'
+                  ? t('app.mobileDrop.planLocked', 'Plan ist gesperrt oder finalisiert')
+                  : d.reason === 'equipment-gone'
+                    ? t('app.mobileDrop.equipmentGone', 'Gerät gibt es im Plan nicht mehr')
+                    : d.reason === 'port-gone'
+                      ? t('app.mobileDrop.portGone', 'Port gibt es an diesem Gerät nicht mehr')
+                      : t('app.mobileDrop.duplicate', 'diese Verbindung steht schon im Plan')}
+              </li>
+            ))}
+          </ul>
+          <div className="mt-2 text-[11px] text-cp-text-muted">
+            {t(
+              'app.mobileDrop.hint',
+              'Das Handy hat dem Techniker nur „gesendet" gemeldet — von der Ablehnung weiss es nichts. Wer draussen steht, wartet also womöglich auf ein Kabel, das nie im Plan ankommt.',
             )}
           </div>
         </div>

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3087,6 +3087,13 @@ export const en: Dict = {
   'app.loadReport.duplicateId': 'duplicate id, the first entry wins',
   'app.loadReport.missingRequired': 'required field missing (name)',
   'app.loadReport.hint': 'Devices that pointed at these roles lost their assignment — including the TSL address used for tally. Saving overwrites the file with this state.',
+  'app.mobileDrop.title': 'Cables sent from a phone were not taken over',
+  'app.mobileDrop.cable': 'Cable',
+  'app.mobileDrop.planLocked': 'the plan is locked or finalized',
+  'app.mobileDrop.equipmentGone': 'that device is no longer in the plan',
+  'app.mobileDrop.portGone': 'that port no longer exists on this device',
+  'app.mobileDrop.duplicate': 'this connection is already in the plan',
+  'app.mobileDrop.hint': 'The phone only reported "sent" to the technician — it cannot know about the rejection. Someone out on site may be waiting for a cable that never reaches the plan.',
   'app.pdfProgress.title': 'PDF is being created…',
   'app.pdfProgress.hint':
     'Large plans may take a few seconds. Please do not cancel.',

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -1,4 +1,5 @@
 import type { LoadDrop, LoadReport } from '../types/loadReport'
+import type { MobileDropReport } from '../types/mobileReport'
 import { v4 as uuidv4 } from 'uuid'
 import { create, type StateCreator } from 'zustand'
 import type { Connection } from 'reactflow'
@@ -168,6 +169,14 @@ export interface ProjectState {
   lastLoadReport: LoadReport | null
   /** Bericht weggeraeumt — der Nutzer hat ihn gesehen. */
   dismissLoadReport: () => void
+  /**
+   * ADR-005 — Was der Desktop von einem Handy nicht uebernommen hat. `null`,
+   * wenn nichts abgelehnt wurde. Gehoert wie der Ladebericht NICHT ins
+   * Projektfile: es ist eine Aussage ueber einen Vorgang, nicht ueber den Plan.
+   */
+  lastMobileDrop: MobileDropReport | null
+  /** Bericht weggeraeumt — der Nutzer hat ihn gesehen. */
+  dismissMobileDrop: () => void
   selectedEquipmentId?: string
   selectedCableId?: string
   selectedLocationId?: string
@@ -922,6 +931,8 @@ const buildProjectStore = (
   projectVersion: 0,
   lastLoadReport: initialDrops.length > 0 ? { drops: initialDrops } : null,
   dismissLoadReport: () => set({ lastLoadReport: null }),
+  lastMobileDrop: null,
+  dismissMobileDrop: () => set({ lastMobileDrop: null }),
   showCableDialog: false,
   recentProjects: [],
   customLibrary: loadCustomLibrary(),

--- a/src/renderer/store/slices/mobileSyncSlice.ts
+++ b/src/renderer/store/slices/mobileSyncSlice.ts
@@ -7,6 +7,7 @@ import { detectLayerForConnector } from '../../lib/cableLayers'
 import { inheritedCableType } from '../../lib/cableInheritance'
 import { connectionExists } from '../../lib/portOccupancy'
 import { isProjectLocked, touchProject } from '../projectStoreHelpers'
+import { addMobileDrop, type MobileDropReason } from '../../types/mobileReport'
 import { scheduleProjectAutosave } from '../projectAutosave'
 import type { ProjectState } from '../projectStore'
 
@@ -17,7 +18,8 @@ import type { ProjectState } from '../projectStore'
  *    User-Request "Haken im Canvas auch wieder loeschen koennen"
  *  - addCableFromMobile: vom Mobile-Viewer ergaenztes Kabel (mit
  *    cableSpec-Lookup + Type-Inheritance-Fallback + addedFromMobile-
- *    Badge fuer Canvas-Anzeige)
+ *    Badge fuer Canvas-Anzeige). Lehnt es ab, meldet es das ueber
+ *    `lastMobileDrop` statt still zu verwerfen — siehe types/mobileReport.ts.
  *
  * isProjectLocked-Guard nur bei addCableFromMobile (Defense-in-Depth
  * gegen finalized/viewer Bypass) — checks duerfen auch im viewer-Modus
@@ -87,18 +89,29 @@ export const createMobileSyncSlice: StateCreator<ProjectState, [], [], MobileSyn
       // Kabel mehr einspielen. Der Mobile-Viewer sollte das eigentlich
       // bereits clientseitig unterbinden (read-only beim finalized Plan),
       // aber wir validieren server-side als Defense-in-Depth.
-      if (isProjectLocked(state)) return {}
+      // ADR-005, Regel 3 — die vier Ablehnungen unten waren bis v8.3.x nackte
+      // `return {}`; der Kommentar nannte das selbst „silently skip". Fuer den
+      // Menschen auf der Leiter sah das aus wie Erfolg, weil das Handy schon
+      // „wird am Desktop eingefuegt" gemeldet hatte. Der Rueckweg zum Handy
+      // waere eine Formataenderung (die 200 kommt, bevor wir hier entscheiden);
+      // was ohne sie geht, ist es dem zu sagen, der den Plan besitzt.
+      const drop = (reason: MobileDropReason) => ({
+        lastMobileDrop: addMobileDrop(state.lastMobileDrop, {
+          reason,
+          label: input.name?.trim() || '',
+        }),
+      })
+      if (isProjectLocked(state)) return drop('plan-locked')
       // v7.9.54 — Kabel-Add vom Mobile-Viewer. Validiert dass beide
-      // Endpoints (Equipment+Port-Pair) im aktuellen Projekt existieren;
-      // sonst silently skip (Mobile zeigt eh nur das was im Projekt war).
+      // Endpoints (Equipment+Port-Pair) im aktuellen Projekt existieren.
       const fromEq = state.project.equipment.find((e) => e.id === input.fromEquipmentId)
       const toEq = state.project.equipment.find((e) => e.id === input.toEquipmentId)
-      if (!fromEq || !toEq) return {}
+      if (!fromEq || !toEq) return drop('equipment-gone')
       const fromPort =
         [...fromEq.inputs, ...fromEq.outputs].find((p) => p.id === input.fromPortId) ?? null
       const toPort =
         [...toEq.inputs, ...toEq.outputs].find((p) => p.id === input.toPortId) ?? null
-      if (!fromPort || !toPort) return {}
+      if (!fromPort || !toPort) return drop('port-gone')
       // Doppelte verhindern: dieselbe Verbindung schon vorhanden? skip.
       // #595 — verglichen wird Geraet UND Port. Der reine Port-ID-Vergleich
       // hielt ein Kabel zum zweiten Geraet derselben Vorlage faelschlich fuer
@@ -108,7 +121,7 @@ export const createMobileSyncSlice: StateCreator<ProjectState, [], [], MobileSyn
         { equipmentId: input.fromEquipmentId, portId: input.fromPortId },
         { equipmentId: input.toEquipmentId, portId: input.toPortId },
       )
-      if (dupe) return {}
+      if (dupe) return drop('duplicate')
       // v7.9.88 / #210 — Cable-Type-String → cableSpecId Lookup. Vorher
       // wurde nur `type` als Connector-String gesetzt; cableSpecId blieb
       // undefined → das Properties-Panel in der Hauptapp zeigte das

--- a/src/renderer/types/mobileReport.ts
+++ b/src/renderer/types/mobileReport.ts
@@ -1,0 +1,67 @@
+/**
+ * Was der Desktop von einem Handy NICHT übernommen hat.
+ *
+ * ADR-005, Regel 3: „Wer nicht bewahren kann, sagt es an der Stelle, an der es
+ * passiert." Auf dem Mobile-Pfad war das bisher strukturell unmöglich, und
+ * zwar in beide Richtungen:
+ *
+ * Der Server antwortet auf `POST /cables` mit `200 {"ok":true}`, **bevor** der
+ * Renderer entschieden hat — `onCableAdded` ist ein Fire-and-forget-Aufruf ins
+ * Fenster. Die 200 heisst also „dein JSON ist angekommen", nicht „das Kabel
+ * steht im Plan". Der Renderer lehnt danach in vier Fällen ab und schrieb es
+ * bis v8.3.x mit einem nackten `return {}` nirgendwohin; der Code nannte das
+ * selbst „silently skip".
+ *
+ * Für den Menschen auf der Leiter sah das aus wie Erfolg: das Handy meldete
+ * „✓ Kabel gesendet — wird am Desktop mit 📱-Marker eingefügt". Ein Versprechen
+ * im Futur, abgegeben von der Seite, die es nicht einlösen kann. Er hakt ab
+ * und geht weiter, das Kabel fehlt im Plan.
+ *
+ * Der Rückweg zum Handy bliebe eine Änderung des Draht-Formats (die 200 müsste
+ * auf die Entscheidung des Renderers warten) — das ist eine offene
+ * Design-Frage. Was ohne Formatänderung geht und Regel 3 verlangt: die
+ * Ablehnung wenigstens dort zeigen, wo sie stattfindet, nämlich am Desktop.
+ * Wer den Plan besitzt, kann handeln; das Handy kann es ohnehin nicht.
+ *
+ * Der Grund ist als **Code** hinterlegt, nicht als Satz: der Store soll keine
+ * Sprache kennen, die Oberfläche übersetzt ihn.
+ */
+
+/** Warum ein vom Handy gesendetes Kabel nicht übernommen wurde. */
+export type MobileDropReason =
+  /** Plan ist finalisiert oder im Viewer-Modus — es darf nichts mehr rein. */
+  | 'plan-locked'
+  /** Ein Endpunkt-Gerät gibt es im Projekt nicht (mehr). */
+  | 'equipment-gone'
+  /** Der benannte Port existiert an diesem Gerät nicht (mehr). */
+  | 'port-gone'
+  /** Dieselbe Verbindung steht schon im Plan. */
+  | 'duplicate'
+
+export interface MobileDrop {
+  reason: MobileDropReason
+  /**
+   * Bester menschenlesbarer Griff auf das verworfene Kabel, damit jemand
+   * nachvollziehen kann, worum es ging. Leer, wenn die Meldung keinen hergab —
+   * dann sagt der Bericht wenigstens, dass es sie gab.
+   */
+  label: string
+}
+
+export interface MobileDropReport {
+  drops: MobileDrop[]
+}
+
+/** Ein Bericht ohne Inhalt ist kein Bericht — dann gibt es nichts zu melden. */
+export const hasMobileDrops = (report: MobileDropReport | null | undefined): boolean =>
+  !!report && report.drops.length > 0
+
+/**
+ * Neue Ablehnung anhängen. Der Bericht sammelt, weil ein Handy mehrere Kabel
+ * hintereinander schicken kann und der Desktop-Nutzer sonst nur die letzte
+ * Ablehnung saehe — die vorigen waeren wieder still verschwunden.
+ */
+export const addMobileDrop = (
+  report: MobileDropReport | null | undefined,
+  drop: MobileDrop,
+): MobileDropReport => ({ drops: [...(report?.drops ?? []), drop] })

--- a/tests/mobileCableDrop.test.ts
+++ b/tests/mobileCableDrop.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { useProjectStore } from '../src/renderer/store/projectStore'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+
+// ADR-005, Inkrement 4, Regel 3 — die vier Ablehnungen des Mobile-Kabelwegs.
+//
+// `addCableFromMobile` verwarf in vier Faellen mit einem nackten `return {}`;
+// der Kommentar nannte das selbst „silently skip". Fuer den Techniker sah das
+// aus wie Erfolg, weil das Handy vorher „wird am Desktop eingefuegt" gemeldet
+// hatte — ein Versprechen im Futur von der Seite, die es nicht einloesen kann:
+// der Server antwortet 200, sobald das JSON da ist, der Renderer entscheidet
+// erst danach, und diese Entscheidung hat keinen Rueckweg.
+//
+// Dieser Test nagelt beide Haelften fest: dass jede Ablehnung im Bericht
+// landet, und dass das Handy nicht mehr verspricht, was es nicht weiss.
+
+const eq = (id: string, portId: string): EquipmentItem =>
+  ({
+    id,
+    name: id,
+    category: 'Sonstiges',
+    inputs: [{ id: `${portId}-in`, name: 'IN 1', type: 'port', connectorType: 'BNC' }],
+    outputs: [{ id: portId, name: 'OUT 1', type: 'port', connectorType: 'BNC' }],
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 160,
+  }) as unknown as EquipmentItem
+
+const cable = (over: Record<string, unknown> = {}) => ({
+  fromEquipmentId: 'a',
+  fromPortId: 'a-out',
+  toEquipmentId: 'b',
+  toPortId: 'b-out-in',
+  name: 'Kamera 1 → Regie',
+  ...over,
+})
+
+const reasons = () => useProjectStore.getState().lastMobileDrop?.drops.map((d) => d.reason) ?? []
+
+describe('addCableFromMobile meldet, was es ablehnt', () => {
+  beforeEach(() => {
+    const s = useProjectStore.getState()
+    s.dismissMobileDrop()
+    useProjectStore.setState({
+      project: {
+        ...s.project,
+        equipment: [eq('a', 'a-out'), eq('b', 'b-out')],
+        cables: [],
+        mode: undefined,
+      },
+    })
+  })
+
+  it('gesperrter Plan: gemeldet statt still verworfen', () => {
+    const s = useProjectStore.getState()
+    useProjectStore.setState({ project: { ...s.project, mode: 'finalized' } })
+    useProjectStore.getState().addCableFromMobile(cable())
+    expect(useProjectStore.getState().project.cables).toHaveLength(0)
+    expect(reasons()).toEqual(['plan-locked'])
+  })
+
+  it('fehlendes Geraet: gemeldet statt still verworfen', () => {
+    useProjectStore.getState().addCableFromMobile(cable({ toEquipmentId: 'gibt-es-nicht' }))
+    expect(useProjectStore.getState().project.cables).toHaveLength(0)
+    expect(reasons()).toEqual(['equipment-gone'])
+  })
+
+  it('fehlender Port: gemeldet statt still verworfen', () => {
+    useProjectStore.getState().addCableFromMobile(cable({ toPortId: 'gibt-es-nicht' }))
+    expect(useProjectStore.getState().project.cables).toHaveLength(0)
+    expect(reasons()).toEqual(['port-gone'])
+  })
+
+  it('Dublette: gemeldet statt still verworfen', () => {
+    useProjectStore.getState().addCableFromMobile(cable())
+    expect(useProjectStore.getState().project.cables).toHaveLength(1)
+    expect(reasons()).toEqual([])
+
+    useProjectStore.getState().addCableFromMobile(cable())
+    expect(useProjectStore.getState().project.cables).toHaveLength(1)
+    expect(reasons()).toEqual(['duplicate'])
+  })
+
+  it('sammelt mehrere Ablehnungen — sonst verschwinden die frueheren wieder', () => {
+    useProjectStore.getState().addCableFromMobile(cable({ toEquipmentId: 'weg' }))
+    useProjectStore.getState().addCableFromMobile(cable({ toPortId: 'weg' }))
+    expect(reasons()).toEqual(['equipment-gone', 'port-gone'])
+  })
+
+  it('traegt den Kabelnamen mit, damit der Bericht greifbar ist', () => {
+    useProjectStore.getState().addCableFromMobile(cable({ toEquipmentId: 'weg', name: '  Havarie  ' }))
+    expect(useProjectStore.getState().lastMobileDrop?.drops[0].label).toBe('Havarie')
+  })
+
+  it('der gute Fall meldet nichts', () => {
+    useProjectStore.getState().addCableFromMobile(cable())
+    expect(useProjectStore.getState().project.cables).toHaveLength(1)
+    expect(useProjectStore.getState().lastMobileDrop).toBeNull()
+  })
+})
+
+describe('das Handy verspricht nicht mehr, was es nicht wissen kann', () => {
+  const mobile = readFileSync(resolve(__dirname, '..', 'src/mobile/MobileApp.tsx'), 'utf8')
+
+  it('sagt nicht mehr, das Kabel werde am Desktop eingefuegt', () => {
+    // Der Satz stand als Erfolgsmeldung im Dialog; der Server bestaetigt aber
+    // nur den Empfang. Als Kommentar (mit Begruendung) darf er bleiben —
+    // gesucht wird die Zeichenkette ausserhalb von Kommentarzeilen.
+    const code = mobile
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('//') && !l.trim().startsWith('*') && !l.includes('/*'))
+      .join('\n')
+    expect(code).not.toContain('wird am Desktop mit')
+  })
+
+  it('sagt stattdessen, was tatsaechlich passiert ist', () => {
+    expect(mobile).toContain('An den Desktop gesendet')
+  })
+})


### PR DESCRIPTION
Dritter Fund aus **ADR-005 Inkrement 4**, aus derselben Fläche wie #622 — aber ein anderer Fehler.

## Der Fund

`addCableFromMobile` verwarf in **vier** Fällen mit einem nackten `return {}`. Der Kommentar nannte es selbst „silently skip":

| Fall | Bedingung |
| --- | --- |
| Plan gesperrt | `isProjectLocked(state)` — finalisiert oder Viewer |
| Gerät weg | Endpunkt-Gerät nicht (mehr) im Projekt |
| Port weg | Port existiert an dem Gerät nicht (mehr) |
| Dublette | Verbindung steht schon im Plan |

Für den Techniker auf der Leiter sah jeder dieser Fälle aus wie Erfolg. Das Handy hatte vorher gemeldet:

> ✓ Kabel gesendet — **wird am Desktop mit 📱-Marker eingefügt**

## Warum das Versprechen strukturell unhaltbar war

Der Server ruft `state.onCableAdded?.(cable)` — fire-and-forget ins Fenster — und antwortet unmittelbar danach `200 {"ok":true}`. Die 200 heisst also **„dein JSON ist angekommen"**, nicht „das Kabel steht im Plan". Der Renderer entscheidet erst danach, und diese Entscheidung hat keinen Rückweg.

Ein Versprechen im Futur, abgegeben von der Seite, die es nicht einlösen kann. Er hakt ab und geht weiter; das Kabel fehlt im Plan, und niemand erfährt es.

## Was dieser PR macht — und was bewusst nicht

**Nicht:** den Rückweg zum Handy öffnen. Das hiesse, die 200 auf die Entscheidung des Renderers warten zu lassen — eine Änderung des Draht-Formats, und damit eine Design-Frage, die dir gehört.

**Sondern** was Regel 3 ohne Formatänderung verlangt: es dort zeigen, wo es passiert. Wer den Plan besitzt, kann handeln; das Handy kann es ohnehin nicht.

- Neuer Kanal `lastMobileDrop` / `dismissMobileDrop` mit Desktop-Banner, nach dem Muster des Ladeberichts aus #617. Er **sammelt** — ein Handy kann mehrere Kabel hintereinander schicken, sonst verdrängt die letzte Ablehnung die vorigen.
- Der Kabelname wird mitgetragen, damit der Bericht greifbar ist.
- Das Handy sagt jetzt **„An den Desktop gesendet"** und dass der Desktop entscheidet — nur noch das, was diese Seite wissen kann.

## Anmerkung zu einem verwandten Fund, der hier nicht drin ist

Der Pfad-Durchgang meldete auch, dass `POST /checks` den kompletten `checkState` ersetzt (Handy B überschreibt die Haken von Handy A). Der Mechanismus stimmt — `setCheckState` ist ein dokumentierter Vollersatz, das Handy sät seinen Stand einmal beim Mounten und schickt danach immer die ganze Map.

**Ich habe es trotzdem nicht angefasst**, weil sich aus dem Payload nicht unterscheiden lässt, ob jemand einen fremden Haken überschreibt oder absichtlich enthakt — beides sieht identisch aus. Ein Merge statt Vollersatz würde das Enthaken vom Handy unmöglich machen. Die Wurzel ist, dass Schnappschüsse statt Deltas geschickt werden; das sauber zu drehen ist dieselbe Formatfrage wie oben. Gehört zu den geparkten Design-Fragen.

## Gegenprobe

Am alten Stand fallen **8 von 9** Tests. Der eine, der beidseitig grün ist, ist der gute Fall — der darf sich nicht ändern.

## Prüfung

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npm test` **49 Dateien, 508 Tests grün** · `npm run lint` 0 Errors (10 vorbestehende Warnungen, keine in den geänderten Dateien).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_