### PR TITLE
rentman: „Alle senden" verwarf die Zähler aller Eimer ausser dem letzten

### DIFF
--- a/src/renderer/components/Rentman/RentmanCableExportDialog.tsx
+++ b/src/renderer/components/Rentman/RentmanCableExportDialog.tsx
@@ -4,6 +4,7 @@ import { Icon } from '../shared/Icon'
 import { ModalShell } from '../shared/ModalShell'
 import { Spinner } from '../shared/Spinner'
 import { useProjectStore } from '../../store/projectStore'
+import { withSentQty, type RentmanCableMap } from '../../lib/rentmanCableMap'
 import { useRentman } from '../../hooks/useRentman'
 import { format, useTranslation } from '../../lib/i18n'
 import type { Cable } from '../../types/cable'
@@ -201,12 +202,28 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
     updateMeta({ rentmanCableMap: next })
   }
 
-  const sendBucket = async (bucket: CableBucket) => {
-    if (!linkedProjectId) return
-    if (!bucket.mappedId) return
-    if (bucket.delta <= 0) return
+  /**
+   * Schickt EINEN Eimer und gibt die fortgeschriebene Karte zurueck.
+   *
+   * `baseMap` ist der Grund fuer den Rueckgabewert: `sendAll` reicht das
+   * Ergebnis der vorigen Runde herein, statt jede Runde `project` aus der
+   * Render-Closure zu lesen — die aendert sich waehrend der Schleife nicht,
+   * und jede Runde loeschte so den Zaehler der vorigen. Ohne `baseMap` (der
+   * Knopf in einer einzelnen Zeile) wird frisch aus dem Store gelesen, nicht
+   * aus der Closure: der Dialog kann zwischen Render und Klick veraltet sein.
+   */
+  const sendBucket = async (
+    bucket: CableBucket,
+    baseMap?: RentmanCableMap,
+  ): Promise<RentmanCableMap | undefined> => {
+    if (!linkedProjectId) return baseMap
+    if (!bucket.mappedId) return baseMap
+    if (bucket.delta <= 0) return baseMap
     setBusyKey(bucket.key)
     setStatusByKey((prev) => ({ ...prev, [bucket.key]: t('rentman.cableExport.sending', 'Sende an Rentman…') }))
+    // Bei Fehler bleibt die Karte, wie sie war — die schon gebuchten Eimer
+    // der vorigen Runden duerfen dabei nicht verlorengehen.
+    let carried: RentmanCableMap | undefined = baseMap
     try {
       // v7.9.110 — Nutzt die neue Batch-Export-Action. Landet in der
       // 'CablePlanner'-EquipmentGroup im Subproject (wird angelegt
@@ -219,20 +236,13 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
       if (result.failed.length > 0) {
         const msg = result.failed[0]?.error ?? t('rentman.cableExport.unknownError', 'Unbekannter Fehler')
         setStatusByKey((prev) => ({ ...prev, [bucket.key]: format(t('rentman.cableExport.errorFormat', 'Fehler: {msg}'), { msg }) }))
-        return
+        return carried
       }
-      const current = project.metadata.rentmanCableMap ?? {}
-      updateMeta({
-        rentmanCableMap: {
-          ...current,
-          [bucket.key]: {
-            // ADR-005 — siehe setMapping: fortschreiben, nicht neu bauen.
-            ...current[bucket.key],
-            rentmanEquipmentId: bucket.mappedId,
-            lastSentQty: bucket.built,
-          },
-        },
-      })
+      const current = baseMap ?? useProjectStore.getState().project.metadata.rentmanCableMap
+      // ADR-005 — siehe setMapping: fortschreiben, nicht neu bauen.
+      const next = withSentQty(current, bucket.key, bucket.mappedId, bucket.built)
+      carried = next
+      updateMeta({ rentmanCableMap: next })
       // v7.9.117 — Drei Faelle (siehe rentmanApiClient).
       const groupNote = result.groupCreated
         ? t('rentman.cableExport.groupCreated', ' (Gruppe angelegt)')
@@ -249,6 +259,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
     } finally {
       setBusyKey(null)
     }
+    return carried
   }
 
   /**
@@ -256,16 +267,25 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
    * still need a Rentman mapping are skipped (and reported in their row).
    * Used by the "Alle senden" header button so the user doesn't have to
    * click `Senden` on each row individually.
+   *
+   * ADR-005 — hier stand: „updates project metadata after each push so the
+   * next iteration sees the fresh sentQty value." Das stimmte fuer den Store,
+   * aber nicht fuer die Quelle, aus der gelesen wurde: `project` kommt aus
+   * der Render-Closure und aendert sich waehrend der Schleife nicht. Jede
+   * Runde schrieb `{ ...alteKarte, [ihrKey]: … }` und loeschte damit den
+   * Zaehler der vorigen. Nach N Eimern stand nur der letzte in der Datei —
+   * die uebrigen behielten ihr Delta und wurden beim naechsten Mal ein
+   * zweites Mal nach Rentman gebucht.
+   *
+   * Jetzt wird die Karte durchgereicht statt neu gelesen.
    */
   const sendAll = async () => {
     if (!linkedProjectId) return
     const sendable = buckets.filter((b) => b.mappedId && b.delta > 0)
     if (sendable.length === 0) return
+    let acc = useProjectStore.getState().project.metadata.rentmanCableMap
     for (const bucket of sendable) {
-      // sendBucket guards on busyKey === bucket.key inside its own state,
-      // and updates project metadata after each push so the next iteration
-      // sees the fresh sentQty value.
-      await sendBucket(bucket)
+      acc = await sendBucket(bucket, acc)
     }
   }
 

--- a/src/renderer/lib/rentmanCableMap.ts
+++ b/src/renderer/lib/rentmanCableMap.ts
@@ -1,0 +1,55 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Fortschreibung der Rentman-Kabel-Zuordnung (`rentmanCableMap`).
+//
+// WARUM ALS EIGENE FUNKTION. Der Export-Dialog schrieb die Karte an drei
+// Stellen selbst zusammen — und „Alle senden" tat es in einer Schleife. Jede
+// Runde las dabei `project.metadata.rentmanCableMap` aus der Render-Closure,
+// die sich waehrend der Schleife nicht aendert. Runde 2 schrieb also
+// `{ ...alteKarte, [key2]: … }` und loeschte damit den Zaehler aus Runde 1
+// wieder. Nach „Alle senden" ueber N Eimer stand nur der LETZTE `lastSentQty`
+// in der Datei.
+//
+// Das ist kein kosmetischer Fehler: die uebrigen Eimer behalten ihren alten
+// Zaehler, ihr Delta bleibt positiv, und der naechste Versand bucht dieselbe
+// Menge ein zweites Mal nach Rentman. Auf einer Produktion sind das reale
+// Kabel auf einem realen Lieferschein.
+//
+// Der Kommentar im Dialog behauptete sogar das Gegenteil — „updates project
+// metadata after each push so the next iteration sees the fresh sentQty
+// value". Das stimmte fuer den Store, aber nicht fuer die Closure, aus der
+// gelesen wurde.
+//
+// Deshalb hier: eine reine Funktion, die eine Karte NIMMT und eine neue
+// zurueckgibt. Der Aufrufer reicht das Ergebnis weiter, statt jede Runde neu
+// aus dem Render zu lesen — damit kann der Fehler strukturell nicht
+// wiederkehren, und die Verschmelzung ist headless testbar.
+// ───────────────────────────────────────────────────────────────────────────
+import type { CablePlannerProject } from '../types/project'
+
+export type RentmanCableMap = NonNullable<CablePlannerProject['metadata']['rentmanCableMap']>
+
+/**
+ * Traegt `lastSentQty` (und die Zuordnung) fuer EINEN Eimer nach und laesst
+ * alles andere unangetastet.
+ *
+ * ADR-005, Regel 1: der Eintrag wird FORTGESCHRIEBEN, nicht neu gebaut. Wer
+ * hier die bekannten Schluessel auflistet, loescht `mergedEquipmentIds` —
+ * also genau den Hinweis darauf, dass mehrere Rentman-Stammartikel in diesen
+ * Eimer gefallen sind.
+ */
+export const withSentQty = (
+  map: RentmanCableMap | undefined,
+  key: string,
+  rentmanEquipmentId: string,
+  lastSentQty: number,
+): RentmanCableMap => {
+  const current = map ?? {}
+  return {
+    ...current,
+    [key]: {
+      ...current[key],
+      rentmanEquipmentId,
+      lastSentQty,
+    },
+  }
+}

--- a/tests/rentmanCableMap.test.ts
+++ b/tests/rentmanCableMap.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { CablePlannerProject } from '../src/renderer/types/project'
+import { withSentQty, type RentmanCableMap } from '../src/renderer/lib/rentmanCableMap'
+import dialogSrc from '../src/renderer/components/Rentman/RentmanCableExportDialog.tsx?raw'
 
 // ADR-003 (Bestaetigter Zustand statt gesendeter Befehl), Inkrement 1.
 //
@@ -133,5 +135,127 @@ describe('rentmanCableMap — die Migration verwirft nichts Fremdes (ADR-005)', 
       rentmanEquipmentId: 'r1',
       mergedEquipmentIds: ['r1', 'r2'],
     })
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// ADR-005, Inkrement 4 — „Alle senden" buchte doppelt.
+//
+// Bis hierher ging es um die Migration des Zaehlers (ADR-003). Ab hier um das
+// Fortschreiben: der Export-Dialog schrieb die Karte in einer Schleife und las
+// jede Runde `project.metadata.rentmanCableMap` aus der Render-Closure. Die
+// aendert sich waehrend der Schleife nicht, also schrieb Runde 2
+// `{ ...alteKarte, [key2]: … }` und loeschte den Zaehler aus Runde 1.
+//
+// Folge: nach „Alle senden" ueber N Eimer stand nur der LETZTE `lastSentQty`
+// in der Datei. Die uebrigen behielten ihren alten Zaehler, ihr Delta blieb
+// positiv, und der naechste Versand buchte dieselbe Menge ein zweites Mal
+// nach Rentman — reale Kabel auf einem realen Lieferschein.
+//
+// Der Kommentar im Dialog behauptete das Gegenteil: „updates project metadata
+// after each push so the next iteration sees the fresh sentQty value."
+// ───────────────────────────────────────────────────────────────────────────
+
+const base: RentmanCableMap = {
+  'BNC|10': { rentmanEquipmentId: 'rm-1', lastSentQty: 4 },
+  'BNC|20': { rentmanEquipmentId: 'rm-2', lastSentQty: 0 },
+  'XLR|5': { rentmanEquipmentId: 'rm-3', lastSentQty: 2 },
+}
+
+describe('withSentQty — Fortschreibung der Rentman-Kabel-Zuordnung', () => {
+  it('haelt ALLE Eimer, wenn nacheinander gesendet wird', () => {
+    // Die Schleife aus sendAll: das Ergebnis der vorigen Runde ist die
+    // Eingabe der naechsten. Genau das tat der Dialog vorher NICHT.
+    let acc: RentmanCableMap | undefined = base
+    acc = withSentQty(acc, 'BNC|10', 'rm-1', 12)
+    acc = withSentQty(acc, 'BNC|20', 'rm-2', 7)
+    acc = withSentQty(acc, 'XLR|5', 'rm-3', 9)
+
+    expect(acc['BNC|10'].lastSentQty).toBe(12)
+    expect(acc['BNC|20'].lastSentQty).toBe(7)
+    expect(acc['XLR|5'].lastSentQty).toBe(9)
+  })
+
+  it('zeigt, was der Fehler war: gegen einen festen Stand ueberlebt nur der letzte', () => {
+    // Kein Test der Funktion, sondern des Missbrauchs — er haelt fest, WARUM
+    // der Rueckgabewert durchgereicht werden muss. Faellt dieser Test, ist
+    // die Fortschreibung nicht mehr abhaengig von der Eingabe, und der erste
+    // Test oben ist wertlos geworden.
+    const a = withSentQty(base, 'BNC|10', 'rm-1', 12)
+    const b = withSentQty(base, 'BNC|20', 'rm-2', 7) // wieder von `base`!
+
+    expect(a['BNC|10'].lastSentQty).toBe(12)
+    expect(b['BNC|20'].lastSentQty).toBe(7)
+    // ... aber b kennt die 12 nicht mehr: der Zaehler aus Runde 1 ist weg,
+    // das Delta bleibt positiv, Rentman bucht doppelt.
+    expect(b['BNC|10'].lastSentQty).toBe(4)
+  })
+
+  it('schreibt den Eintrag fort statt ihn neu zu bauen (Regel 1)', () => {
+    // mergedEquipmentIds ist der Hinweis darauf, dass mehrere
+    // Rentman-Stammartikel in denselben Eimer gefallen sind. Wer den
+    // Eintrag neu baut, loescht ihn — und zwar genau beim Senden, wo er
+    // am ehesten gebraucht wird.
+    const withMerged: RentmanCableMap = {
+      'BNC|10': {
+        rentmanEquipmentId: 'rm-1',
+        lastSentQty: 4,
+        mergedEquipmentIds: ['rm-9', 'rm-8'],
+      },
+    }
+    const out = withSentQty(withMerged, 'BNC|10', 'rm-1', 12)
+    expect(out['BNC|10'].mergedEquipmentIds).toEqual(['rm-9', 'rm-8'])
+    expect(out['BNC|10'].lastSentQty).toBe(12)
+  })
+
+  it('legt einen unbekannten Eimer an, ohne die uebrigen anzufassen', () => {
+    const out = withSentQty(base, 'CAT|30', 'rm-neu', 3)
+    expect(out['CAT|30']).toEqual({ rentmanEquipmentId: 'rm-neu', lastSentQty: 3 })
+    expect(out['BNC|10']).toEqual(base['BNC|10'])
+    expect(Object.keys(out).sort()).toEqual(['BNC|10', 'BNC|20', 'CAT|30', 'XLR|5'])
+  })
+
+  it('kommt mit einer noch leeren Karte klar', () => {
+    expect(withSentQty(undefined, 'BNC|10', 'rm-1', 5)).toEqual({
+      'BNC|10': { rentmanEquipmentId: 'rm-1', lastSentQty: 5 },
+    })
+  })
+
+  it('fasst die Eingabe nicht an', () => {
+    const before = JSON.stringify(base)
+    withSentQty(base, 'BNC|10', 'rm-1', 99)
+    expect(JSON.stringify(base)).toBe(before)
+  })
+})
+
+describe('der Dialog reicht die Karte durch, statt sie neu zu lesen', () => {
+  // OFFEN GESAGT: die Tests oben pruefen den neuen Helfer — der existierte am
+  // alten Stand nicht, sie koennen den Fehler also nicht gefangen haben. Der
+  // Fehler sass im AUFRUFMUSTER des Dialogs, und das ist eine React-Komponente;
+  // diese Suite deckt bewusst nur Logik ab (vitest.config.ts). Bleibt der Weg,
+  // den auch mobileShareWriteBack.test.ts geht: die Form im Quelltext festnageln.
+  //
+  // Das ist schwaecher als ein Verhaltenstest und soll nicht so aussehen. Es
+  // faengt genau eine Sache — dass jemand die Schleife wieder gegen einen
+  // festen Ausgangsstand laufen laesst — und die war der ganze Fehler.
+
+  it('sendAll faedelt das Ergebnis jeder Runde in die naechste', () => {
+    const sendAll = dialogSrc.slice(dialogSrc.indexOf('const sendAll'))
+    const body = sendAll.slice(0, sendAll.indexOf('\n  }'))
+    // Der Rueckgabewert muss zurueck in den Akkumulator, sonst ist die
+    // Schleife wieder zustandslos.
+    expect(body).toMatch(/acc\s*=\s*await\s+sendBucket\(bucket,\s*acc\)/)
+  })
+
+  it('sendBucket liest ohne Akkumulator frisch aus dem Store, nicht aus der Closure', () => {
+    // `project` in der Closure kann zwischen Render und Klick veraltet sein.
+    const send = dialogSrc.slice(dialogSrc.indexOf('const sendBucket'))
+    const body = send.slice(0, send.indexOf('\n  /**'))
+    expect(body).toContain('baseMap ?? useProjectStore.getState().project.metadata.rentmanCableMap')
+    expect(body).not.toContain('project.metadata.rentmanCableMap ?? {}')
+  })
+
+  it('der alte, falsche Kommentar steht nicht mehr da', () => {
+    expect(dialogSrc).not.toContain('sees the fresh sentQty value.\n      await sendBucket(bucket)')
   })
 })


### PR DESCRIPTION
Vierter Fund aus **ADR-005 Inkrement 4** — und der erste mit Folgen ausserhalb der App.

## Der Fehler

`sendAll` ruft `sendBucket` in einer Schleife. Jede Runde las `project.metadata.rentmanCableMap` — aber `project` kommt aus `useProjectStore(...)`, also aus der **Render-Closure**, und die ändert sich während der Schleife nicht.

Runde 2 schrieb damit `{ ...alteKarte, [key2]: … }` und löschte den Zähler aus Runde 1.

Nach „Alle senden" über N Eimer stand nur der **letzte** `lastSentQty` in der Datei. Die übrigen behielten ihren alten Zähler, ihr `delta` blieb positiv — und der nächste Versand buchte **dieselben Mengen ein zweites Mal** nach Rentman. Auf einer Produktion sind das reale Kabel auf einem realen Lieferschein.

Der Kommentar an der Schleife behauptete das Gegenteil:

> sendBucket … updates project metadata after each push so the next iteration sees the fresh sentQty value.

Für den Store stimmte das. Für die Quelle, aus der gelesen wurde, nicht.

## Der Fix

- **`withSentQty`** als reine Funktion in `lib/rentmanCableMap.ts` — headless testbar. Sie schreibt den Eintrag *fort* statt ihn neu zu bauen; wer hier die bekannten Schlüssel aufzählt, löscht `mergedEquipmentIds` genau beim Senden, wo der Hinweis auf zusammengefasste Rentman-Artikel am nötigsten ist (dieselbe Regel, die bei `setMapping` schon dokumentiert war).
- **`sendBucket` gibt die Karte zurück, `sendAll` fädelt sie durch.** Damit kann der Fehler strukturell nicht wiederkehren — die Schleife trägt ihren Zustand, statt ihn jede Runde neu zu holen.
- **Ohne Akkumulator** (Knopf in einer einzelnen Zeile) wird frisch aus dem Store gelesen statt aus der Closure — dasselbe Muster, das `RentmanImportDialog.tsx:495` schon nutzt.
- **Bei Fehler bleibt die Karte stehen**, damit die schon gebuchten Eimer der vorigen Runden nicht verlorengehen.

## Ehrlich zur Testabdeckung

Die sechs Tests von `withSentQty` prüfen den **neuen** Helfer — den gab es am alten Stand nicht, sie hätten den Fehler also nicht fangen können. Der Fehler sass im Aufrufmuster des Dialogs, und das ist eine React-Komponente; diese Suite deckt bewusst nur Logik ab.

Deshalb zusätzlich drei **Quell-Wächter**, die die Form festnageln: dass `sendAll` das Ergebnis in den Akkumulator zurückführt, dass `sendBucket` ohne Akkumulator aus dem Store liest, und dass der falsche Kommentar weg ist. Das ist schwächer als ein Verhaltenstest und steht so auch im Code — es fängt genau eine Sache, und die war der ganze Fehler.

**Gegengeprüft:** alle drei fallen am alten Dialog.

## Eine Korrektur in eigener Sache

Beim Anlegen der Tests habe ich `tests/rentmanCableMap.test.ts` mit `Write` überschrieben, ohne zu merken, dass die Datei schon existierte — zehn Tests zur `lastSyncedQty`-Migration aus ADR-003. Aufgefallen ist es an der gesunkenen Testzahl (508 → 507). Wiederhergestellt und meine Tests **angehängt** statt ersetzt; der Diff zeigt jetzt **124 Zeilen dazu, 0 gelöscht**.

## Prüfung

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npm test` **49 Dateien, 517 Tests grün** · `npm run lint` 0 Errors (10 vorbestehende Warnungen, keine in den geänderten Dateien).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_