### PR TITLE
rack: der .cpgroup-Export packte ein Rack ohne interne Verkabelung aus

### DIFF
--- a/src/renderer/components/Rack/RackBuilderDialog.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialog.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
-import { v4 as uuidv4 } from 'uuid'
 import type { EquipmentTemplate, GroupPreset } from '../../types/equipment'
 import { useSettingsStore } from '../../store/settingsStore'
 import { useProjectStore } from '../../store/projectStore'
@@ -25,6 +24,7 @@ import type {
   RackDraft,
   RackPlacementDraft,
 } from './rackBuilderTypes'
+import { presetFromDraft } from '../../lib/rackPreset'
 import { RACK_MOUNT_WIDTH_MM } from './rackBuilderTypes'
 import * as THREE from 'three'
 import { useDraggablePosition } from '../../hooks/useDraggablePosition'
@@ -567,103 +567,11 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
       setSaveError(null)
     }
 
-    const sorted = draft.placements.slice().sort((a, b) => a.startUnit - b.startUnit)
-
-    const itemRecords: GroupPreset['items'] = sorted.map((placement) => ({
-      name: placement.name,
-      category: placement.category,
-      inputs: placement.inputs,
-      outputs: placement.outputs,
-      isRackDevice: placement.isRackDevice,
-      rackUnits: placement.rackUnits,
-      frontPanelImageUrl: placement.frontPanelImageUrl,
-      rearPanelImageUrl: placement.rearPanelImageUrl,
-      frontPanelCrop: placement.frontPanelCrop,
-      rearPanelCrop: placement.rearPanelCrop,
-      // v7.9.73 / #170 — Engineering-Daten ans Item-Record durchreichen.
-      depthMm: placement.depthMm,
-      stlDataUri: placement.stlDataUri,
-      // v7.9.75 / #170 — Patchblende-/Shelf-Marker persistieren.
-      isPatchPanel: placement.isPatchPanel,
-      isRackShelf: placement.isRackShelf,
-      // #335 — Rentman-ID des Inhalts erhalten (nur wenn gesetzt).
-      ...(placement.rentmanId ? { rentmanId: placement.rentmanId } : {}),
-      width: 240,
-      height: 80 + Math.max(placement.inputs.length, placement.outputs.length, 3) * 22,
-      offsetX: 0,
-      offsetY: (placement.startUnit - 1) * 44,
-    }))
-
-    const rackPlacements = sorted.map((placement, index) => ({
-      itemIndex: index,
-      startUnit: placement.startUnit,
-      heightUnits: placement.rackUnits,
-      // v7.9.73 / #170 — mountSide nur persistieren wenn explizit gesetzt.
-      ...(placement.mountSide ? { mountSide: placement.mountSide } : {}),
-      // #521 — Shelf-Offsets persistieren wenn GESETZT (auch 0!). Vorher ein
-      // truthy-Check (`shelfOffsetX ? …`), der den gültigen Wert 0 (linke Kante
-      // / Front) verwarf → X/Z-Position ging beim Speichern verloren. `!= null`
-      // unterscheidet korrekt zwischen 0 (valide Position) und undefined.
-      ...(placement.shelfOffsetX != null ? { shelfOffsetX: placement.shelfOffsetX } : {}),
-      ...(placement.shelfOffsetZ != null ? { shelfOffsetZ: placement.shelfOffsetZ } : {}),
-    }))
-
-    // v7.8.5 — Map internal cables (referenced by placement id) onto the
-    // post-sort item indices for the persisted preset. Cables whose
-    // endpoints reference a placement that's been deleted are skipped.
-    const placementIdToSortedIndex = new Map<string, number>()
-    sorted.forEach((p, idx) => placementIdToSortedIndex.set(p.id, idx))
-    const persistedCables: GroupPreset['cables'] = []
-    for (const c of draft.internalCables) {
-      const fromIdx = placementIdToSortedIndex.get(c.fromPlacementId)
-      const toIdx = placementIdToSortedIndex.get(c.toPlacementId)
-      if (fromIdx == null || toIdx == null) continue
-      const entry: GroupPreset['cables'][number] = {
-        fromItemIndex: fromIdx,
-        fromPortName: c.fromPortName,
-        toItemIndex: toIdx,
-        toPortName: c.toPortName,
-        name: c.name,
-        type: c.type,
-        length: c.length,
-      }
-      if (c.color != null) entry.color = c.color
-      if (c.standard != null) entry.standard = c.standard
-      // v7.9.115 / Issue #223 — User-Waypoints im Preset persistieren
-      // damit Kabel-Positionen ueber Save/Reload erhalten bleiben.
-      if (c.waypoints && c.waypoints.length > 0) {
-        entry.waypoints = c.waypoints.map((wp) => ({ x: wp.x, y: wp.y }))
-      }
-      persistedCables.push(entry)
-    }
-
-    // v7.9.14 — Persistente Canvas-Positionen für den
-    // RackInternalCanvas. Nur Geräte mit User-gesetzten Positionen
-    // landen hier; andere bleiben beim nächsten Öffnen auf der
-    // Default-Position aus startUnit.
-    const internalCanvasPositions: Record<number, { x: number; y: number }> = {}
-    sorted.forEach((placement, index) => {
-      if (placement.canvasX != null && placement.canvasY != null) {
-        internalCanvasPositions[index] = { x: placement.canvasX, y: placement.canvasY }
-      }
-    })
-    const hasPositions = Object.keys(internalCanvasPositions).length > 0
-
-    const preset: GroupPreset = {
-      id: editingId ?? uuidv4(),
-      name: draft.rackName.trim(),
-      rack: {
-        totalUnits: draft.totalUnits,
-        // #335 — Kombi-ID des Racks erhalten (nur wenn aus Rentman-Import).
-        ...(draft.rentmanId ? { rentmanId: draft.rentmanId } : {}),
-        // v7.9.73 / #170 — Rack-Tiefe nur persistieren wenn vom User gesetzt.
-        ...(draft.depthMm ? { depthMm: draft.depthMm } : {}),
-        placements: rackPlacements,
-        ...(hasPositions ? { internalCanvasPositions } : {}),
-      },
-      items: itemRecords,
-      cables: persistedCables,
-    }
+    // ADR-005 — Der Draft wird an EINER Stelle in ein Preset uebersetzt
+    // (lib/rackPreset.ts). Vorher stand diese Aufzaehlung hier UND im
+    // Export-Menue daneben; die beiden liefen auseinander, und der Export
+    // verlor die komplette interne Verkabelung.
+    const preset = presetFromDraft(draft, editingId)
 
     onSave(preset)
     setLastSavedSnapshot(draftSnapshot)
@@ -699,8 +607,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
               rackName={draft.rackName}
               totalUnits={draft.totalUnits}
               depthMm={draft.depthMm}
-              placements={draft.placements}
-              editingId={editingId}
+              buildPreset={() => presetFromDraft(draft, editingId)}
               rackCanvasRef={rackCanvasRef}
               canvas3DRefs={canvas3DRefs}
             />

--- a/src/renderer/components/Rack/RackBuilderDialogExportMenu.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialogExportMenu.tsx
@@ -1,9 +1,8 @@
 import { useState, type RefObject } from 'react'
 import { Box, Camera, ChevronDown, Save } from 'lucide-react'
 import { Icon } from '../shared/Icon'
-import { v4 as uuidv4 } from 'uuid'
 import * as THREE from 'three'
-import type { EquipmentTemplate, GroupPreset } from '../../types/equipment'
+import type { GroupPreset } from '../../types/equipment'
 import { useTranslation } from '../../lib/i18n'
 import {
   exportRack2DAsPng,
@@ -20,36 +19,25 @@ import {
  *    1. das aktuell sichtbare 2D-Rack-DOM-Element (rackCanvasRef)
  *    2. die 3D-Renderer-Refs (gl/scene/camera) sobald der 3D-Tab
  *       initialisiert wurde
- *    3. den aktuellen Draft + ggf. die editingId fuer den
- *       .cpgroup-Snapshot. Snapshot-Logik bleibt 1:1 wie vorher. */
-
-export interface RackPlacementSnapshot {
-  name: string
-  category: string
-  inputs: EquipmentTemplate['inputs']
-  outputs: EquipmentTemplate['outputs']
-  isRackDevice: boolean
-  rackUnits: number
-  startUnit: number
-  frontPanelImageUrl?: string
-  rearPanelImageUrl?: string
-  frontPanelCrop?: EquipmentTemplate['frontPanelCrop']
-  rearPanelCrop?: EquipmentTemplate['rearPanelCrop']
-  depthMm?: number
-  stlDataUri?: string
-  isPatchPanel?: boolean
-  isRackShelf?: boolean
-  mountSide?: 'front' | 'rear' | 'full'
-  shelfOffsetX?: number
-  shelfOffsetZ?: number
-}
+ *    3. den Preset-Erbauer des Dialogs (buildPreset) fuer den
+ *       .cpgroup-Export.
+ *
+ *  ADR-005 — bis Inkrement 4 stand hier eine eigene Snapshot-Logik
+ *  („bleibt 1:1 wie vorher"), die neben dem Speichern-Pfad herlief und
+ *  dabei die interne Verkabelung, die Canvas-Positionen und die
+ *  Rentman-Ids verlor. Sie ist weg; beide Wege bauen jetzt gleich. */
 
 export interface RackBuilderDialogExportMenuProps {
   rackName: string
   totalUnits: number
   depthMm?: number
-  placements: RackPlacementSnapshot[]
-  editingId?: string
+  /**
+   * Baut den aktuellen Draft in ein `GroupPreset` — DIESELBE Funktion, die
+   * der Speichern-Pfad benutzt (lib/rackPreset.ts). Als Callback statt als
+   * Rohdaten, damit hier keine zweite Aufzaehlung entstehen kann: die letzte
+   * hat die interne Verkabelung des Racks verschluckt.
+   */
+  buildPreset: () => GroupPreset
   /** Ref auf das 2D-Rack-Canvas-DOM (fuer PNG-Export). Als Ref statt Wert
    *  uebergeben, damit der Parent .current nicht waehrend des Renders liest
    *  (react-hooks/refs). */
@@ -66,8 +54,7 @@ export const RackBuilderDialogExportMenu = ({
   rackName,
   totalUnits,
   depthMm,
-  placements,
-  editingId,
+  buildPreset,
   rackCanvasRef,
   canvas3DRefs,
 }: RackBuilderDialogExportMenuProps) => {
@@ -152,49 +139,14 @@ export const RackBuilderDialogExportMenu = ({
             type="button"
             onClick={() => {
               setOpen(false)
-              // Build the current preset snapshot ohne Save-Side-Effects.
-              const sorted = placements.slice().sort((a, b) => a.startUnit - b.startUnit)
-              const items: GroupPreset['items'] = sorted.map((p) => ({
-                name: p.name,
-                category: p.category,
-                inputs: p.inputs,
-                outputs: p.outputs,
-                isRackDevice: p.isRackDevice,
-                rackUnits: p.rackUnits,
-                frontPanelImageUrl: p.frontPanelImageUrl,
-                rearPanelImageUrl: p.rearPanelImageUrl,
-                frontPanelCrop: p.frontPanelCrop,
-                rearPanelCrop: p.rearPanelCrop,
-                depthMm: p.depthMm,
-                stlDataUri: p.stlDataUri,
-                isPatchPanel: p.isPatchPanel,
-                isRackShelf: p.isRackShelf,
-                width: 240,
-                height: 80 + Math.max(p.inputs.length, p.outputs.length, 3) * 22,
-                offsetX: 0,
-                offsetY: (p.startUnit - 1) * 44,
-              }))
-              const rackPlacements = sorted.map((p, i) => ({
-                itemIndex: i,
-                startUnit: p.startUnit,
-                heightUnits: p.rackUnits,
-                ...(p.mountSide ? { mountSide: p.mountSide } : {}),
-                // #521 — auch 0 persistieren (linke Kante/Front); `!= null`
-                // statt truthy, sonst geht Position 0 beim Export verloren.
-                ...(p.shelfOffsetX != null ? { shelfOffsetX: p.shelfOffsetX } : {}),
-                ...(p.shelfOffsetZ != null ? { shelfOffsetZ: p.shelfOffsetZ } : {}),
-              }))
-              const preset: GroupPreset = {
-                id: editingId ?? uuidv4(),
-                name: rackName.trim() || 'rack',
-                rack: {
-                  totalUnits,
-                  ...(depthMm ? { depthMm } : {}),
-                  placements: rackPlacements,
-                },
-                items,
-                cables: [],
-              }
+              // ADR-005 — Hier stand eine ZWEITE Aufzaehlung derselben
+              // Umwandlung, die neben dem Speichern-Pfad hergelaufen ist:
+              // sie schrieb `cables: []` (die komplette interne Verkabelung
+              // fiel weg, obwohl der Menuepunkt „Komplettes Rack" verspricht),
+              // keine internalCanvasPositions und seit #335 auch die
+              // rentmanIds nicht mehr. Jetzt derselbe Erbauer wie beim
+              // Speichern — es gibt nur noch eine Aufzaehlung.
+              const preset = buildPreset()
               exportRackAsCpgroup(preset)
             }}
             className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left text-cp-text-bright hover:bg-cp-surface-2"

--- a/src/renderer/lib/rackPreset.ts
+++ b/src/renderer/lib/rackPreset.ts
@@ -1,0 +1,153 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Draft → GroupPreset: die Hinrichtung des Rack-Roundtrips.
+//
+// WARUM ES DAS GIBT. Diese Umwandlung stand ZWEIMAL von Hand im Code: einmal
+// im Speichern-Pfad des RackBuilderDialog, einmal im Export-Menue daneben.
+// Zwei Aufzaehlungen derselben Struktur laufen auseinander, und genau das war
+// passiert — das Export-Menue schrieb:
+//
+//   - `cables: []`, also die KOMPLETTE interne Verkabelung des Racks nicht,
+//     obwohl der Menuepunkt „Komplettes Rack inkl. STL + Fotos" verspricht
+//     und das Format sie ausdruecklich traegt (itemExport.ts: „.cpgroup →
+//     ein GroupPreset (inkl. interne Kabel)"),
+//   - keine `internalCanvasPositions` (die selbst gesetzten Positionen der
+//     Geraete in der internen 2D-Ansicht),
+//   - kein `rack.rentmanId` und kein `rentmanId` je Geraet — die kamen mit
+//     #335 dazu, aber nur im Speichern-Pfad. Die zweite Aufzaehlung wurde
+//     nicht nachgezogen; niemand hatte einen Grund, dort zu suchen.
+//
+// Der Nutzer nahm sein Rack per USB-Stick mit und packte es am Zielrechner
+// ohne eine einzige interne Verbindung wieder aus.
+//
+// ADR-005, Regel 1 und 4 in einem: der Verlust war vermeidbar (die Daten
+// lagen im selben Dialog), und die Zusage stand ungeprueft daneben.
+//
+// Die Abhilfe ist nicht, die zweite Aufzaehlung zu ergaenzen — dann laufen
+// beim naechsten Feld wieder beide auseinander. Sie ist, sie zu LOESCHEN und
+// beide Wege durch diese eine Funktion zu schicken. Framework-frei, damit
+// headless testbar; `rackBuilderModel.ts` fuehrt mit `draftFromPreset` die
+// Gegenrichtung (ist allerdings verwaist, siehe dort).
+// ───────────────────────────────────────────────────────────────────────────
+import { v4 as uuidv4 } from 'uuid'
+import type { GroupPreset } from '../types/equipment'
+import type { RackPlacementDraft, InternalCableDraft } from '../components/Rack/rackBuilderTypes'
+
+export interface RackPresetDraft {
+  rackName: string
+  totalUnits: number
+  depthMm?: number
+  /** #335 — Rentman-Kombi-Id des Racks selbst. */
+  rentmanId?: string
+  placements: RackPlacementDraft[]
+  internalCables: InternalCableDraft[]
+}
+
+/** Zeilenhoehe eines Geraets auf dem Canvas — aus der Portzahl abgeleitet. */
+const itemHeight = (placement: RackPlacementDraft): number =>
+  80 + Math.max(placement.inputs.length, placement.outputs.length, 3) * 22
+
+/**
+ * Baut aus dem Draft das persistierbare `GroupPreset`.
+ *
+ * Sortiert nach `startUnit` — die Kabel referenzieren Geraete per INDEX in
+ * `items`, also muss die Reihenfolge feststehen, bevor die Indizes vergeben
+ * werden.
+ */
+export const presetFromDraft = (
+  draft: RackPresetDraft,
+  editingId?: string,
+): GroupPreset => {
+  const sorted = draft.placements.slice().sort((a, b) => a.startUnit - b.startUnit)
+
+  const items: GroupPreset['items'] = sorted.map((placement) => ({
+    name: placement.name,
+    category: placement.category,
+    inputs: placement.inputs,
+    outputs: placement.outputs,
+    isRackDevice: placement.isRackDevice,
+    rackUnits: placement.rackUnits,
+    frontPanelImageUrl: placement.frontPanelImageUrl,
+    rearPanelImageUrl: placement.rearPanelImageUrl,
+    frontPanelCrop: placement.frontPanelCrop,
+    rearPanelCrop: placement.rearPanelCrop,
+    // v7.9.73 / #170 — Engineering-Daten ans Item-Record durchreichen.
+    depthMm: placement.depthMm,
+    stlDataUri: placement.stlDataUri,
+    // v7.9.75 / #170 — Patchblende-/Shelf-Marker persistieren.
+    isPatchPanel: placement.isPatchPanel,
+    isRackShelf: placement.isRackShelf,
+    // #335 — Rentman-Id des Inhalts erhalten (nur wenn gesetzt).
+    ...(placement.rentmanId ? { rentmanId: placement.rentmanId } : {}),
+    width: 240,
+    height: itemHeight(placement),
+    offsetX: 0,
+    offsetY: (placement.startUnit - 1) * 44,
+  }))
+
+  const placements = sorted.map((placement, index) => ({
+    itemIndex: index,
+    startUnit: placement.startUnit,
+    heightUnits: placement.rackUnits,
+    // v7.9.73 / #170 — mountSide nur persistieren wenn explizit gesetzt.
+    ...(placement.mountSide ? { mountSide: placement.mountSide } : {}),
+    // #521 — Shelf-Offsets persistieren wenn GESETZT (auch 0!). Ein
+    // truthy-Check verwarf den gueltigen Wert 0 (linke Kante / Front).
+    ...(placement.shelfOffsetX != null ? { shelfOffsetX: placement.shelfOffsetX } : {}),
+    ...(placement.shelfOffsetZ != null ? { shelfOffsetZ: placement.shelfOffsetZ } : {}),
+  }))
+
+  // v7.8.5 — Interne Kabel referenzieren Geraete per Placement-Id; hier auf
+  // die Indizes NACH der Sortierung abgebildet. Kabel an geloeschte Geraete
+  // fallen raus — sie haetten keinen Endpunkt mehr.
+  const idToIndex = new Map<string, number>()
+  sorted.forEach((p, idx) => idToIndex.set(p.id, idx))
+  const cables: GroupPreset['cables'] = []
+  for (const c of draft.internalCables) {
+    const fromIdx = idToIndex.get(c.fromPlacementId)
+    const toIdx = idToIndex.get(c.toPlacementId)
+    if (fromIdx == null || toIdx == null) continue
+    const entry: GroupPreset['cables'][number] = {
+      fromItemIndex: fromIdx,
+      fromPortName: c.fromPortName,
+      toItemIndex: toIdx,
+      toPortName: c.toPortName,
+      name: c.name,
+      type: c.type,
+      length: c.length,
+    }
+    if (c.color != null) entry.color = c.color
+    if (c.standard != null) entry.standard = c.standard
+    // v7.9.115 / #223 — User-Waypoints erhalten, sonst springen die Kabel
+    // beim naechsten Oeffnen auf die berechnete Bahn zurueck.
+    if (c.waypoints && c.waypoints.length > 0) {
+      entry.waypoints = c.waypoints.map((wp) => ({ x: wp.x, y: wp.y }))
+    }
+    cables.push(entry)
+  }
+
+  // v7.9.14 — Nur Geraete mit selbst gesetzter Position; die uebrigen sollen
+  // beim Oeffnen wieder aus `startUnit` abgeleitet werden.
+  const internalCanvasPositions: Record<number, { x: number; y: number }> = {}
+  sorted.forEach((placement, index) => {
+    if (placement.canvasX != null && placement.canvasY != null) {
+      internalCanvasPositions[index] = { x: placement.canvasX, y: placement.canvasY }
+    }
+  })
+  const hasPositions = Object.keys(internalCanvasPositions).length > 0
+
+  return {
+    id: editingId ?? uuidv4(),
+    name: draft.rackName.trim() || 'rack',
+    rack: {
+      totalUnits: draft.totalUnits,
+      // #335 — Kombi-Id des Racks erhalten (nur wenn aus Rentman-Import).
+      ...(draft.rentmanId ? { rentmanId: draft.rentmanId } : {}),
+      // v7.9.73 / #170 — Rack-Tiefe nur persistieren wenn vom User gesetzt.
+      ...(draft.depthMm ? { depthMm: draft.depthMm } : {}),
+      placements,
+      ...(hasPositions ? { internalCanvasPositions } : {}),
+    },
+    items,
+    cables,
+  }
+}

--- a/tests/rackPreset.test.ts
+++ b/tests/rackPreset.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest'
+import { presetFromDraft, type RackPresetDraft } from '../src/renderer/lib/rackPreset'
+import type { RackPlacementDraft } from '../src/renderer/components/Rack/rackBuilderTypes'
+import exportMenuSrc from '../src/renderer/components/Rack/RackBuilderDialogExportMenu.tsx?raw'
+
+// ADR-005, Inkrement 4 — der .cpgroup-Export packte ein Rack ohne Kabel aus.
+//
+// Die Umwandlung Draft → GroupPreset stand ZWEIMAL von Hand im Code: im
+// Speichern-Pfad des RackBuilderDialog und im Export-Menue daneben. Die
+// zweite schrieb `cables: []` — die komplette interne Verkabelung fehlte in
+// der Datei, obwohl der Menuepunkt „Komplettes Rack inkl. STL + Fotos"
+// verspricht und itemExport.ts das Format als „inkl. interne Kabel" fuehrt.
+//
+// Dazu fehlten `internalCanvasPositions` und, seit #335, beide `rentmanId`.
+// Die kamen nur in den Speichern-Pfad; die zweite Aufzaehlung wurde nicht
+// nachgezogen, weil niemand einen Grund hatte, dort zu suchen.
+//
+// Der Nutzer nahm sein Rack per USB-Stick mit und packte es am Zielrechner
+// ohne eine einzige interne Verbindung wieder aus.
+//
+// Behoben, indem die zweite Aufzaehlung GELOESCHT wurde: beide Wege rufen
+// jetzt presetFromDraft. Diese Tests halten fest, was dabei mitkommen muss.
+
+const place = (over: Partial<RackPlacementDraft> & { id: string; startUnit: number }): RackPlacementDraft =>
+  ({
+    templateName: 'T',
+    name: `Gerät ${over.id}`,
+    category: 'Sonstiges',
+    rackUnits: 1,
+    inputs: [{ id: 'i1', name: 'IN 1', type: 'port', connectorType: 'BNC' }],
+    outputs: [{ id: 'o1', name: 'OUT 1', type: 'port', connectorType: 'BNC' }],
+    isRackDevice: true,
+    ...over,
+  }) as unknown as RackPlacementDraft
+
+const draft = (over: Partial<RackPresetDraft> = {}): RackPresetDraft => ({
+  rackName: 'Regie-Rack',
+  totalUnits: 24,
+  placements: [place({ id: 'a', startUnit: 3 }), place({ id: 'b', startUnit: 1 })],
+  internalCables: [],
+  ...over,
+})
+
+describe('presetFromDraft — was in die .cpgroup gehoert', () => {
+  it('traegt die interne Verkabelung mit — der eigentliche Fehler', () => {
+    const out = presetFromDraft(
+      draft({
+        internalCables: [
+          {
+            fromPlacementId: 'b',
+            fromPortName: 'OUT 1',
+            toPlacementId: 'a',
+            toPortName: 'IN 1',
+            name: 'Patch 1',
+            type: 'BNC',
+            length: 0.5,
+            color: '#ff0000',
+            standard: 'SDI',
+            waypoints: [{ x: 10, y: 20 }],
+          },
+        ],
+      }),
+    )
+    expect(out.cables).toHaveLength(1)
+    // Nach startUnit sortiert: b (1) -> Index 0, a (3) -> Index 1.
+    expect(out.cables[0]).toEqual({
+      fromItemIndex: 0,
+      fromPortName: 'OUT 1',
+      toItemIndex: 1,
+      toPortName: 'IN 1',
+      name: 'Patch 1',
+      type: 'BNC',
+      length: 0.5,
+      color: '#ff0000',
+      standard: 'SDI',
+      waypoints: [{ x: 10, y: 20 }],
+    })
+  })
+
+  it('bildet die Kabel auf die Indizes NACH der Sortierung ab', () => {
+    // Wuerde vor dem Sortieren indiziert, zeigte das Kabel auf das falsche
+    // Geraet — schlimmer als gar kein Kabel, weil es plausibel aussieht.
+    const out = presetFromDraft(
+      draft({
+        placements: [
+          place({ id: 'unten', startUnit: 10 }),
+          place({ id: 'oben', startUnit: 1 }),
+        ],
+        internalCables: [
+          {
+            fromPlacementId: 'unten',
+            fromPortName: 'OUT 1',
+            toPlacementId: 'oben',
+            toPortName: 'IN 1',
+            name: 'x',
+            type: 'BNC',
+            length: 1,
+          },
+        ],
+      }),
+    )
+    expect(out.items[0].name).toBe('Gerät oben')
+    expect(out.cables[0].fromItemIndex).toBe(1) // unten
+    expect(out.cables[0].toItemIndex).toBe(0) // oben
+  })
+
+  it('laesst Kabel an geloeschte Geraete fallen, statt kaputte Indizes zu schreiben', () => {
+    const out = presetFromDraft(
+      draft({
+        internalCables: [
+          {
+            fromPlacementId: 'a',
+            fromPortName: 'OUT 1',
+            toPlacementId: 'gibt-es-nicht',
+            toPortName: 'IN 1',
+            name: 'verwaist',
+            type: 'BNC',
+            length: 1,
+          },
+        ],
+      }),
+    )
+    expect(out.cables).toEqual([])
+  })
+
+  it('haelt die Canvas-Positionen der internen Ansicht', () => {
+    const out = presetFromDraft(
+      draft({
+        placements: [
+          place({ id: 'a', startUnit: 1, canvasX: 120, canvasY: 340 }),
+          place({ id: 'b', startUnit: 2 }),
+        ],
+      }),
+    )
+    expect(out.rack?.internalCanvasPositions).toEqual({ 0: { x: 120, y: 340 } })
+  })
+
+  it('laesst internalCanvasPositions weg, wenn niemand etwas verschoben hat', () => {
+    expect(presetFromDraft(draft()).rack?.internalCanvasPositions).toBeUndefined()
+  })
+
+  it('haelt beide Rentman-Ids (#335) — Rack und Inhalt', () => {
+    const out = presetFromDraft(
+      draft({
+        rentmanId: 'rm-rack-9',
+        placements: [place({ id: 'a', startUnit: 1, rentmanId: 'rm-dev-7' })],
+      }),
+    )
+    expect(out.rack?.rentmanId).toBe('rm-rack-9')
+    expect(out.items[0].rentmanId).toBe('rm-dev-7')
+  })
+
+  it('persistiert Shelf-Offset 0 (#521) — truthy haette die linke Kante verworfen', () => {
+    const out = presetFromDraft(
+      draft({ placements: [place({ id: 'a', startUnit: 1, shelfOffsetX: 0, shelfOffsetZ: 0 })] }),
+    )
+    expect(out.rack?.placements[0].shelfOffsetX).toBe(0)
+    expect(out.rack?.placements[0].shelfOffsetZ).toBe(0)
+  })
+
+  it('uebernimmt die editingId, damit ein Rack beim Bearbeiten nicht dupliziert', () => {
+    expect(presetFromDraft(draft(), 'bestehende-id').id).toBe('bestehende-id')
+    expect(presetFromDraft(draft()).id).not.toBe('bestehende-id')
+  })
+
+  it('faellt bei leerem Namen auf "rack" zurueck statt auf leer', () => {
+    expect(presetFromDraft(draft({ rackName: '   ' })).name).toBe('rack')
+  })
+})
+
+describe('das Export-Menue baut kein eigenes Preset mehr', () => {
+  // Der Fehler war nicht die Aufzaehlung selbst, sondern dass es ZWEI gab.
+  // Die zweite ist geloescht; dieser Waechter haelt fest, dass sie nicht
+  // zurueckkommt. Er ist schwaecher als ein Verhaltenstest — aber die
+  // Divergenz zweier Aufzaehlungen ist genau das, was er sehen kann.
+
+  it('ruft den Erbauer des Dialogs, statt selbst zu sammeln', () => {
+    expect(exportMenuSrc).toContain('const preset = buildPreset()')
+  })
+
+  it('enthaelt keine eigene Feld-Aufzaehlung mehr', () => {
+    // Kommentarzeilen raus: der Erklaertext oben ZITIERT `cables: []`, und
+    // genau daran ist dieser Waechter im ersten Anlauf haengengeblieben.
+    const code = exportMenuSrc
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('//') && !l.trim().startsWith('*'))
+      .join('\n')
+    expect(code).not.toContain('cables: []')
+    expect(code).not.toContain('itemIndex:')
+    expect(code).not.toMatch(/const preset: GroupPreset = \{/)
+  })
+})


### PR DESCRIPTION
Fünfter Fund aus **ADR-005 Inkrement 4**.

## Der Fund

Die Umwandlung Draft → `GroupPreset` stand **zweimal von Hand** im Code: im Speichern-Pfad des `RackBuilderDialog` und im Export-Menü daneben. Die zweite war ärmer:

| | Speichern | `.cpgroup`-Export |
| --- | --- | --- |
| interne Verkabelung | vollständig, mit Wegpunkten, Farbe, Standard | **`cables: []`** |
| `internalCanvasPositions` | ja | fehlt |
| `rack.rentmanId` (#335) | ja | fehlt |
| `rentmanId` je Gerät (#335) | ja | fehlt |

Und der Menüpunkt verspricht **„Komplettes Rack inkl. STL + Fotos zum Cross-PC-Transfer"** — während `itemExport.ts` das Format ausdrücklich als *„.cpgroup → ein GroupPreset (inkl. interne Kabel)"* führt.

Wer sein Rack per USB-Stick mitnahm, packte es am Zielrechner **ohne eine einzige interne Verbindung** wieder aus.

## Wie es entstanden ist

Nicht durch Nachlässigkeit, sondern durch **Drift zwischen zwei Aufzählungen**. Die `#335`-Kommentare zeigen es genau: `rentmanId` wurde nachträglich eingebaut — nur im Speichern-Pfad. Niemand hatte einen Grund, im Export-Menü zu suchen. Der Modulkopf dort sagte sogar beruhigend *„Snapshot-Logik bleibt 1:1 wie vorher"*; die Auslagerung (#310) hat den Verlust getreu mitgenommen.

## Der Fix

Die zweite Aufzählung ist **gelöscht**, nicht ergänzt — sonst laufen beim nächsten Feld wieder beide auseinander.

- `presetFromDraft` in `lib/rackPreset.ts`: die fehlende Hinrichtung des Roundtrips. (`rackBuilderModel.ts` führt mit `draftFromPreset` die Gegenrichtung und nennt sich selbst „Preset↔Draft-Roundtrip" — die Hinrichtung fehlte dort, deshalb wurde sie zweimal in Komponenten geschrieben.)
- Framework-frei, damit **headless testbar** — 9 Tests decken Kabel, Index-Abbildung nach der Sortierung, verwaiste Kabel, Canvas-Positionen, beide Rentman-Ids, Shelf-Offset 0 und den Namens-Fallback ab.
- Das Export-Menü nimmt einen `buildPreset`-Callback und sammelt nichts mehr selbst; **98 Zeilen** Handaufzählung im Speichern-Pfad sind durch einen Aufruf ersetzt.

## Äquivalenz geprüft

Ein Refactor am Speicher-Pfad ist das eigentliche Risiko dieses PRs. Also habe ich den **alten Block wörtlich aus git** als Funktion ausgeführt und gegen den neuen Erbauer gehalten — auf einem reichen Draft (drei Geräte, gemischte Offsets inklusive 0, ein verwaistes Kabel, Wegpunkte, beide `rentmanId`, Canvas-Positionen, Name mit Leerraum). **Identisches Preset.** Das Speichern ändert sich nicht.

Die Probe war Gerüst und ist nicht Teil des Commits.

## Zur Abgrenzung

`itemExport.ts` selbst ist **verlustfrei** — es schreibt `template` und `preset` als ganze Objekte und liest sie ganz zurück, ohne ein einziges Feld aufzuzählen. Der Pfad-Durchgang hatte den Verlust dort vermutet; er sass eine Ebene höher.

**Gegenprobe:** die beiden Quell-Wächter fallen am alten Export-Menü.

## Prüfung

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npm test` **50 Dateien, 528 Tests grün** · `npm run lint` 0 Errors (10 vorbestehende Warnungen, keine neue).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_