### PR TITLE
greengo: der Verlust-Hinweis endete auf Top-Level

### DIFF
--- a/src/renderer/components/Export/GreenGoExportDialog.tsx
+++ b/src/renderer/components/Export/GreenGoExportDialog.tsx
@@ -779,7 +779,8 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                   Der Export schreibt diese Sektionen aus Defaults; wer eine echte
                   Anlagen-Konfiguration hier durchreicht, bekommt sie leer zurueck.
                   Bis der Round-Trip sie bewahrt, sagt er es wenigstens. */}
-              {importResult.unreadSections.length > 0 && (
+              {(importResult.unreadSections.length > 0 ||
+                importResult.unreadFields.length > 0) && (
                 <div className="rounded border border-cp-warn/50 bg-cp-warn/10 p-3">
                   <div className="mb-1 text-cp-xs font-semibold text-cp-warn">
                     {t(
@@ -787,13 +788,35 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                       'Diese Datei enthält Abschnitte, die der Import nicht liest',
                     )}
                   </div>
-                  <div className="font-mono text-[11px] text-cp-text-secondary">
-                    {importResult.unreadSections.join(', ')}
-                  </div>
+                  {importResult.unreadSections.length > 0 && (
+                    <div className="font-mono text-[11px] text-cp-text-secondary">
+                      {importResult.unreadSections.join(', ')}
+                    </div>
+                  )}
+                  {/* ADR-005, Inkrement 4 — die Zeile darueber nannte nur
+                      TOP-LEVEL-Sektionen. Weil Settings/Users/Groups als
+                      „gelesen" gelten, konnte sie nie sagen, dass INNERHALB
+                      davon das meiste liegen bleibt: die Hardware-Registrierung
+                      der Beltpacks, die Tastenbelegungen, Pincodes, die
+                      eingemessenen Gains. Der Nutzer las „Devices, Rooms,
+                      Templates" und schloss, seine Stationen seien uebernommen. */}
+                  {importResult.unreadFields.map((u) => (
+                    <div key={u.section} className="mt-1 text-[11px] text-cp-text-secondary">
+                      <span className="font-semibold">{u.section}</span>
+                      {u.section === 'Settings'
+                        ? ''
+                        : format(
+                            t('greengo.importOverlay.unreadEntries', ' ({count} Einträge)'),
+                            { count: u.entries },
+                          )}
+                      {': '}
+                      <span className="font-mono">{u.fields.join(', ')}</span>
+                    </div>
+                  ))}
                   <div className="mt-1.5 text-[11px] text-cp-text-muted">
                     {t(
                       'greengo.importOverlay.unreadHint',
-                      'Ein Export aus dem Cable-Planner erzeugt eine neue .gg5 und füllt diese Abschnitte mit Standardwerten. Er ersetzt die Original-Datei nicht — bewahre sie auf.',
+                      'Ein Export aus dem Cable-Planner erzeugt eine neue .gg5 und füllt diese Abschnitte und Felder mit Standardwerten. Er ersetzt die Original-Datei nicht — bewahre sie auf.',
                     )}
                   </div>
                 </div>

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -1411,7 +1411,8 @@ export const en: Dict = {
   'greengo.importOverlay.title': 'Import .gg5 — link devices',
   'greengo.importOverlay.system': 'System:',
   'greengo.importOverlay.unreadTitle': 'This file contains sections the import does not read',
-  'greengo.importOverlay.unreadHint': 'An export from Cable Planner creates a new .gg5 and fills those sections with defaults. It does not replace the original file — keep it.',
+  'greengo.importOverlay.unreadHint': 'An export from Cable Planner creates a new .gg5 and fills those sections and fields with defaults. It does not replace the original file — keep it.',
+  'greengo.importOverlay.unreadEntries': ' ({count} entries)',
   'greengo.importOverlay.importedGroups': 'Imported groups',
   'greengo.importOverlay.linkStations': 'Link stations → canvas devices',
   'greengo.importOverlay.linkHint':

--- a/src/renderer/lib/importGreengo.ts
+++ b/src/renderer/lib/importGreengo.ts
@@ -36,6 +36,12 @@ export interface Gg5ImportResult {
    * sagen, was er nicht gelesen hat — schweigen ist der Schaden.
    */
   unreadSections: string[]
+  /**
+   * ADR-005 — was INNERHALB von Settings/Users/Groups ungelesen bleibt.
+   * `unreadSections` allein sagte nur, welche Top-Level-Sektionen fehlen,
+   * und liess den Nutzer glauben, der Rest sei uebernommen.
+   */
+  unreadFields: UnreadFieldReport[]
 }
 
 export interface Gg5ParseError {
@@ -270,11 +276,95 @@ export const parseGg5File = (jsonText: string): Gg5ParseOutcome => {
     },
     userTypeHints,
     unreadSections: unreadTopLevelSections(raw),
+    unreadFields: unreadFieldsInReadSections(raw),
   }
 }
 
 /** Von diesem Modul gelesene Sektionen einer .gg5. Alles andere ist ungelesen. */
 const READ_SECTIONS = new Set(['Settings', 'Users', 'Groups'])
+
+/**
+ * ADR-005, Inkrement 4 — die Felder, die dieses Modul INNERHALB der gelesenen
+ * Sektionen anfasst.
+ *
+ * Warum das eine eigene Ebene braucht: `unreadTopLevelSections` konnte per
+ * Konstruktion nie etwas melden, was unter Settings/Users/Groups liegt — die
+ * drei stehen ja in READ_SECTIONS. Der Nutzer las im Hinweis „Devices, Rooms,
+ * Templates" und schloss daraus, seine Stationen seien gelesen worden.
+ *
+ * Waren sie nicht. Pro Station liest der Parser fuenf Felder; der Exporter
+ * schreibt den Rest aus Konstanten zurueck (exportGreengo.buildUser):
+ * `devices: []` (die Hardware-Registrierung), `Channels`/`SpecialChannels`
+ * leer (die Tastenbelegungen), `Security.Pincode` leer, `AudioProfile` auf
+ * Standard-Gain. Auf einer Intercom-Anlage ist das der halbe Einmessvorgang.
+ *
+ * Wie oben gilt: aus dem Rohdokument ableiten, nicht aus einer zweiten
+ * gepflegten Liste — sonst laeuft sie von den Lesemengen auseinander, sobald
+ * der Parser ein Feld dazubekommt.
+ */
+const READ_SETTINGS_FIELDS = new Set(['Name', 'Description', 'MulticastAddress', 'SampleRate'])
+const READ_USER_FIELDS = new Set(['myId', 'Name', 'DisplayName', 'Color', 'ButtonFunctions'])
+const READ_GROUP_FIELDS = new Set(['myId', 'Name', 'Color', 'members'])
+
+/** Ungelesene Felder einer Sektion, plus wie viele Eintraege betroffen sind. */
+export interface UnreadFieldReport {
+  section: 'Settings' | 'Users' | 'Groups'
+  /** Feldnamen, die in der Datei stehen und hier niemand liest. */
+  fields: string[]
+  /** Betroffene Eintraege — bei Settings immer 1. */
+  entries: number
+}
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+  !!v && typeof v === 'object' && !Array.isArray(v)
+
+/** Vereinigung der ungelesenen Feldnamen ueber alle Eintraege einer Sektion. */
+const unreadFieldsOf = (
+  section: UnreadFieldReport['section'],
+  entries: Record<string, unknown>[],
+  read: Set<string>,
+): UnreadFieldReport | null => {
+  const fields = new Set<string>()
+  let affected = 0
+  for (const entry of entries) {
+    const own = Object.keys(entry).filter((k) => !read.has(k))
+    if (own.length === 0) continue
+    affected++
+    for (const k of own) fields.add(k)
+  }
+  if (fields.size === 0) return null
+  return { section, fields: [...fields].sort(), entries: affected }
+}
+
+/** Eintraege einer keys-indizierten Sektion (Users/Groups) als Objekte. */
+const keyedEntries = (raw: Record<string, unknown>): Record<string, unknown>[] => {
+  const keys = Array.isArray(raw['keys']) ? (raw['keys'] as string[]) : []
+  return keys.map((k) => raw[k]).filter(isRecord)
+}
+
+/**
+ * Der Verlust EINE EBENE TIEFER als `unreadTopLevelSections`. Zusammen decken
+ * die beiden ab, was der Import fallen laesst; einzeln taeuscht die obere.
+ */
+const unreadFieldsInReadSections = (raw: Record<string, unknown>): UnreadFieldReport[] => {
+  const out: UnreadFieldReport[] = []
+  const settings = raw['Settings']
+  if (isRecord(settings)) {
+    const r = unreadFieldsOf('Settings', [settings], READ_SETTINGS_FIELDS)
+    if (r) out.push(r)
+  }
+  const users = raw['Users']
+  if (isRecord(users)) {
+    const r = unreadFieldsOf('Users', keyedEntries(users), READ_USER_FIELDS)
+    if (r) out.push(r)
+  }
+  const groups = raw['Groups']
+  if (isRecord(groups)) {
+    const r = unreadFieldsOf('Groups', keyedEntries(groups), READ_GROUP_FIELDS)
+    if (r) out.push(r)
+  }
+  return out
+}
 
 /**
  * ADR-005 — Welche Sektionen die Datei mitbringt, die hier niemand anfasst.

--- a/tests/importGreengoUnread.test.ts
+++ b/tests/importGreengoUnread.test.ts
@@ -63,3 +63,110 @@ describe('parseGg5File — meldet ungelesene Abschnitte (ADR-005)', () => {
     }
   })
 })
+
+// ───────────────────────────────────────────────────────────────────────────
+// ADR-005, Inkrement 4 — der Hinweis endete auf TOP-LEVEL.
+//
+// Die Tests oben pruefen `unreadSections`, und einer davon nagelt fest, dass
+// Settings/Users/Groups NICHT als ungelesen gemeldet werden. Das ist als
+// Aussage ueber eine Top-Level-Liste richtig — und in der Wirkung irrefuehrend:
+// weil die drei als „gelesen" gelten, konnte die Meldung per Konstruktion nie
+// sagen, dass INNERHALB davon das meiste liegen bleibt.
+//
+// Pro Station liest der Parser fuenf Felder. Der Exporter schreibt den Rest
+// aus Konstanten zurueck: `devices: []` (die Hardware-Registrierung der
+// Beltpacks), `Channels`/`SpecialChannels` leer (die Tastenbelegungen),
+// `Security.Pincode` leer, `AudioProfile` auf Standard-Gain. Der Operator las
+// „Devices, Rooms, Templates", schloss daraus, seine Stationen seien
+// uebernommen, benannte zwei um und exportierte zurueck.
+
+const richerGg5 = () =>
+  JSON.stringify({
+    Settings: {
+      Name: 'Halle',
+      MulticastAddress: '239.1.160.1',
+      SampleRate: 48000,
+      Colors: { '1': 16711680, '2': 65280 },
+    },
+    Users: {
+      keys: ['u1', 'u2'],
+      u1: {
+        myId: 1,
+        Name: 'BPX Regie',
+        Color: 1,
+        devices: [{ serial: 'GG-0001' }],
+        Channels: { '1': { Id: 3 } },
+        Security: { Pincode: '4711' },
+        AudioProfile: { '1': { Gain: 52 } },
+      },
+      u2: { myId: 2, Name: 'BPX Buehne', Gpio: { Input1: {} } },
+    },
+    Groups: {
+      keys: ['g1'],
+      g1: { myId: 1, Name: 'Produktion', Description: 'PGM-Kreis', members: {} },
+    },
+  })
+
+describe('parseGg5File — meldet auch den Verlust INNERHALB der gelesenen Sektionen', () => {
+  it('nennt die ungelesenen Felder je Sektion', () => {
+    const r = parseGg5File(richerGg5())
+    expect(isParseError(r)).toBe(false)
+    if (isParseError(r)) return
+    const bySection = Object.fromEntries(r.unreadFields.map((u) => [u.section, u]))
+
+    expect(bySection.Users.fields).toEqual([
+      'AudioProfile',
+      'Channels',
+      'Gpio',
+      'Security',
+      'devices',
+    ])
+    expect(bySection.Settings.fields).toEqual(['Colors'])
+    expect(bySection.Groups.fields).toEqual(['Description'])
+  })
+
+  it('zaehlt die betroffenen Eintraege — eine Station oder zwoelf ist ein Unterschied', () => {
+    const r = parseGg5File(richerGg5())
+    if (isParseError(r)) return
+    const users = r.unreadFields.find((u) => u.section === 'Users')
+    expect(users?.entries).toBe(2)
+  })
+
+  it('meldet nichts, wenn die Eintraege nur Gelesenes enthalten', () => {
+    const r = parseGg5File(gg5())
+    expect(isParseError(r)).toBe(false)
+    if (isParseError(r)) return
+    // Die Basis-Fixture oben hat pro Eintrag ein `Settings: {}` — das ist
+    // ungelesen und SOLL gemeldet werden. Ohne dieses Feld bleibt es leer.
+    const clean = parseGg5File(
+      JSON.stringify({
+        Settings: { Name: 'H', MulticastAddress: 'x', SampleRate: 48000 },
+        Users: { keys: ['u1'], u1: { myId: 1, Name: 'A' } },
+        Groups: { keys: ['g1'], g1: { myId: 1, Name: 'G' } },
+      }),
+    )
+    if (isParseError(clean)) return
+    expect(clean.unreadFields).toEqual([])
+  })
+
+  it('leitet auch hier aus der Datei ab, nicht aus einer gepflegten Liste', () => {
+    const r = parseGg5File(
+      JSON.stringify({
+        Settings: { Name: 'H', MulticastAddress: 'x', SampleRate: 48000 },
+        Users: { keys: ['u1'], u1: { myId: 1, Name: 'A', FeldVonMorgen: 1 } },
+        Groups: { keys: [] },
+      }),
+    )
+    if (isParseError(r)) return
+    expect(r.unreadFields.find((u) => u.section === 'Users')?.fields).toEqual(['FeldVonMorgen'])
+  })
+
+  it('haelt die alte Top-Level-Meldung unveraendert — die beiden ergaenzen sich', () => {
+    const r = parseGg5File(richerGg5())
+    if (isParseError(r)) return
+    expect(r.unreadSections).toEqual([])
+    expect(r.unreadFields.length).toBeGreaterThan(0)
+    // Genau der Fall, der frueher STILL war: keine Top-Level-Sektion fehlt,
+    // und trotzdem geht bei jedem Beltpack die Registrierung verloren.
+  })
+})


### PR DESCRIPTION
Sechster Fund aus **ADR-005 Inkrement 4** — und der schwerste, weil die bestehende Abhilfe aus Inkrement 3 den Fehler nicht nur nicht abdeckte, sondern **von ihm wegzeigte**.

## Der Fund

`unreadTopLevelSections` leitet die Meldung aus den Top-Level-Schlüsseln ab und filtert `READ_SECTIONS = {Settings, Users, Groups}` heraus. Damit konnte sie **per Konstruktion nie** etwas nennen, was unter diesen dreien liegt.

Der Operator las im gelben Kasten „Devices, Rooms, Templates" — `Users` stand nicht dabei. Also nahm er an, seine Stationen seien gelesen worden.

Waren sie nicht. Pro Station liest der Parser **fünf** Felder (`myId`, `Name`, `DisplayName`, `Color`, `ButtonFunctions`). Den Rest schreibt `buildUser` beim Export aus Konstanten zurück:

| Feld | zurückgeschrieben als | was das ist |
| --- | --- | --- |
| `devices` | `[]` | die Hardware-Registrierung der Beltpacks |
| `Channels`, `SpecialChannels` | `{}` | die Tastenbelegungen |
| `Security.Pincode` | `''` | die Sperre |
| `AudioProfile` | Standard-Gain 35 | der Einmessvorgang je Station |
| `Gpio`, `LineInOut` | Platzhalter | |

Auf einer Intercom-Anlage ist das der halbe Rüsttag.

## Warum der bestehende Test das nicht sah

`importGreengoUnread.test.ts` aus Inkrement 3 hält ausdrücklich fest:

```
it('meldet die gelesenen Sektionen NICHT als ungelesen', …)
```

Als Aussage über eine Top-Level-Liste ist das richtig. In der Wirkung war es das implizite Dementi — grün festgenagelt. Der Testkopf von damals benennt den Schaden sogar selbst („Channels, SpecialChannels, ScriptSettings und UserSettings … auf einer Intercom-Anlage sind das die Tastenbelegungen") — alle vier sind Kinder von `Users`, also genau das, was die Meldung strukturell nie erreichen konnte.

## Der Fix

Eine zweite Ebene, `unreadFields`: je Sektion die ungelesenen Feldnamen **plus die Zahl betroffener Einträge** — eine Station oder zwölf ist für die Entscheidung ein Unterschied.

Abgeleitet wie schon auf Top-Level **aus dem Rohdokument**, nicht aus einer zweiten gepflegten Liste. Das ist der Grundsatz, den die Datei für sich selbst formuliert hat; er gilt hier genauso, sonst läuft die Liste auseinander, sobald der Parser ein Feld dazubekommt. Ein Test prüft das mit einem `FeldVonMorgen`, das es noch nicht gibt.

`unreadSections` bleibt unverändert — die vier bestehenden Tests laufen unberührt weiter, die beiden Ebenen ergänzen sich.

## Was dieser PR ausdrücklich **nicht** tut

Der Round-Trip **bewahrt die Felder weiterhin nicht**. Dafür müsste das Rohdokument (oder je Station ein `_raw`-Block) im Projekt mitgeführt und beim Export unter die berechneten Felder gemischt werden — dann wäre auch die Zusage „minimal but valid" wieder ehrlich. Das ist eine Modelländerung und gehört nicht in einen Hinweis-Fix.

Regel 3 verlangt hier zunächst nur eines: es dort zu sagen, wo es passiert.

## Gegenprobe

Am alten Stand fallen **alle fünf neuen Tests**, die vier bestehenden bleiben grün. Der letzte hält den früher stillen Fall fest: `unreadSections` ist **leer**, `unreadFields` nicht — keine Top-Level-Sektion fehlt, und trotzdem verliert jedes Beltpack seine Registrierung.

## Prüfung

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npm test` **50 Dateien, 533 Tests grün** · `npm run lint` 0 Errors (10 vorbestehende Warnungen, keine neue).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_