### PR TITLE
inventory: der Merge-Import nahm dem Bestand die deviceTypeId weg

### DIFF
--- a/src/renderer/lib/inventoryMerge.ts
+++ b/src/renderer/lib/inventoryMerge.ts
@@ -1,0 +1,48 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Zusammenfuehren beim Lager-Import im Modus „merge".
+//
+// ADR-005, Regel 2: eine Projektion darf nicht ueberschreiben. Der Import
+// nahm den eingehenden Datensatz bisher ALS GANZES:
+//
+//   for (const x of add) byId.set(x.id, x)
+//
+// Damit loescht eine aeltere Datei still, was sie nicht kennt. Konkret: eine
+// v1-Datei (vor ADR-002) traegt keine `deviceTypeId`. Steht im lokalen Lager
+// derselbe Artikel MIT bestaetigter Typ-Identitaet, ist sie nach dem Import
+// weg — und mit ihr die autoritative Aufloesung auf das Datenblatt, die genau
+// deshalb eingefuehrt wurde, damit nicht mehr ueber Namen geraten wird.
+//
+// Im cable-planner ist es schaerfer als anderswo: `healItem` setzt fehlende
+// Felder AUSDRUECKLICH auf `undefined`, der eingehende Artikel traegt sie
+// also als gesetzte Schluessel. Ein einfaches `{ ...alt, ...neu }` wuerde den
+// vorhandenen Wert damit ebenfalls ausloeschen.
+//
+// Deshalb: nur DEFINIERTE Werte uebernehmen. Was die Datei nicht sagt, sagt
+// nichts — und loescht nichts. Wer den Datensatz wirklich ersetzen will,
+// nimmt den Modus „replace"; genau dafuer gibt es ihn.
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * `over` ueber `base` legen, aber nur dort, wo `over` einen Wert HAT.
+ * `undefined` heisst „keine Aussage", nicht „loeschen".
+ */
+export const mergeDefined = <T extends object>(base: T, over: T): T => {
+  const out = { ...base } as Record<string, unknown>
+  for (const [key, value] of Object.entries(over)) {
+    if (value !== undefined) out[key] = value
+  }
+  return out as T
+}
+
+/**
+ * Eingehende Datensaetze in den Bestand mischen: bekannte Ids feldweise
+ * fortschreiben, unbekannte anhaengen.
+ */
+export const mergeById = <T extends { id: string }>(base: T[], add: T[]): T[] => {
+  const byId = new Map(base.map((x) => [x.id, x]))
+  for (const incoming of add) {
+    const existing = byId.get(incoming.id)
+    byId.set(incoming.id, existing ? mergeDefined(existing, incoming) : incoming)
+  }
+  return [...byId.values()]
+}

--- a/src/renderer/lib/inventoryPortable.ts
+++ b/src/renderer/lib/inventoryPortable.ts
@@ -15,6 +15,14 @@ export const INVENTORY_FORMAT = 'avplan-inventory'
 // neu auf, ein Stand ohne dieses Feld wuerde es beim Re-Export also STILL
 // verlieren. Mit der Version weigert er sich stattdessen (siehe unten:
 // `f.version > INVENTORY_FORMAT_VERSION`). Aeltere Dateien lesen wir weiter.
+//
+// ADR-005, Inkrement 4 — der Satz oben deckt nur EINE Richtung ab: eine zu
+// NEUE Datei, die dieser Stand nicht vollstaendig versteht. Die andere fehlte:
+// eine zu ALTE Datei, die beim Zusammenfuehren etwas WEGNIMMT. Genau das tat
+// der Import — er ersetzte den lokalen Artikel als Ganzes, eine v1-Datei
+// loeschte also die bestaetigte deviceTypeId. Dafuer ist jetzt
+// `lib/inventoryMerge.ts` da; die Version kann das nicht leisten, weil eine
+// alte Datei zu lesen ausdruecklich erlaubt bleibt.
 export const INVENTORY_FORMAT_VERSION = 2
 
 export interface InventorySnapshot {

--- a/src/renderer/store/inventoryStore.ts
+++ b/src/renderer/store/inventoryStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { v4 as uuidv4 } from 'uuid'
+import { mergeById } from '../lib/inventoryMerge'
 import { STORAGE_KEYS } from '../lib/storageKeys'
 import type {
   InventoryItem,
@@ -715,11 +716,11 @@ export const useInventoryStore = create<InventoryState>((set, get) => ({
     const inUnits = keep('unit', snap.units ?? [], healUnit)
     const total = inItems.length + inNodes.length + inSets.length + inUnits.length
     set((state) => {
-      const mergeById = <T extends { id: string }>(base: T[], add: T[]): T[] => {
-        const byId = new Map(base.map((x) => [x.id, x]))
-        for (const x of add) byId.set(x.id, x)
-        return [...byId.values()]
-      }
+      // ADR-005, Regel 2 — hier stand `byId.set(x.id, x)`: der eingehende
+      // Datensatz ersetzte den vorhandenen als Ganzes. Eine v1-Datei ohne
+      // `deviceTypeId` loeschte damit still die bestaetigte Typ-Identitaet
+      // des lokalen Artikels. `mergeById` schreibt jetzt feldweise fort;
+      // wer wirklich ersetzen will, nimmt den Modus 'replace'.
       const items = mode === 'replace' ? inItems : mergeById(state.items, inItems)
       const nodes = mode === 'replace' ? inNodes : mergeById(state.nodes, inNodes)
       const sets = mode === 'replace' ? inSets : mergeById(state.sets, inSets)

--- a/tests/inventoryMerge.test.ts
+++ b/tests/inventoryMerge.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { mergeById, mergeDefined } from '../src/renderer/lib/inventoryMerge'
+import { useInventoryStore } from '../src/renderer/store/inventoryStore'
+
+// ADR-005, Inkrement 4, Regel 2 — eine Projektion darf nicht ueberschreiben.
+//
+// Der Lager-Import nahm im Modus „merge" den eingehenden Datensatz als
+// GANZES (`byId.set(x.id, x)`). Eine v1-Datei aus der Zeit vor ADR-002 traegt
+// keine `deviceTypeId`; stand im lokalen Lager derselbe Artikel MIT
+// bestaetigter Typ-Identitaet, war sie nach dem Import weg.
+//
+// Der Kopf von inventoryPortable.ts hatte die Gefahr sogar benannt — aber nur
+// fuer die andere Richtung (eine zu NEUE Datei, die der Stand nicht kennt).
+// Die aeltere Datei, die etwas WEGNIMMT, stand nirgends.
+
+interface Item {
+  id: string
+  model: string
+  deviceTypeId?: string
+  notes?: string
+  updatedAt?: string
+}
+
+describe('mergeDefined — was die Datei nicht sagt, loescht nichts', () => {
+  it('haelt den vorhandenen Wert, wenn der eingehende undefined ist', () => {
+    const base = { id: 'a', model: 'X', deviceTypeId: 'dt-1' }
+    const over = { id: 'a', model: 'X', deviceTypeId: undefined }
+    expect(mergeDefined(base, over).deviceTypeId).toBe('dt-1')
+  })
+
+  it('uebernimmt einen gesetzten Wert — auch einen leeren String', () => {
+    // Leerer String ist eine Aussage („der Nutzer hat die Notiz geleert"),
+    // undefined ist keine. Der Unterschied ist der ganze Punkt.
+    const base = { id: 'a', model: 'X', notes: 'alt' }
+    const over = { id: 'a', model: 'X', notes: '' }
+    expect(mergeDefined(base, over).notes).toBe('')
+  })
+
+  it('uebernimmt auch 0 und false', () => {
+    const base = { quantity: 5, locked: true }
+    const over = { quantity: 0, locked: false }
+    expect(mergeDefined(base, over)).toEqual({ quantity: 0, locked: false })
+  })
+
+  it('fasst die Eingaben nicht an', () => {
+    const base = { id: 'a', model: 'X', deviceTypeId: 'dt-1' }
+    const over = { id: 'a', model: 'Y', deviceTypeId: undefined }
+    const before = JSON.stringify([base, over])
+    mergeDefined(base, over)
+    expect(JSON.stringify([base, over])).toBe(before)
+  })
+})
+
+describe('mergeById — der eigentliche Fall', () => {
+  const local: Item[] = [
+    { id: 'i1', model: 'ULXD2', deviceTypeId: 'dt-shure-ulxd2', notes: 'Regal A3' },
+    { id: 'i2', model: 'SM58' },
+  ]
+
+  it('eine aeltere v1-Datei loescht die bestaetigte deviceTypeId NICHT mehr', () => {
+    // Genau der Fehler: healItem setzt fehlende Felder ausdruecklich auf
+    // undefined, der eingehende Artikel traegt sie also als gesetzte
+    // Schluessel. Ein `{ ...alt, ...neu }` haette hier ebenfalls geloescht.
+    const v1: Item[] = [{ id: 'i1', model: 'ULXD2', deviceTypeId: undefined, notes: undefined }]
+    const out = mergeById(local, v1)
+    const merged = out.find((x) => x.id === 'i1')!
+    expect(merged.deviceTypeId).toBe('dt-shure-ulxd2')
+    expect(merged.notes).toBe('Regal A3')
+  })
+
+  it('haengt unbekannte Artikel an, statt sie zu verwerfen', () => {
+    const out = mergeById(local, [{ id: 'i9', model: 'Neu' }])
+    expect(out.map((x) => x.id)).toEqual(['i1', 'i2', 'i9'])
+  })
+
+  it('schreibt gesetzte Felder fort — der Import bleibt ein Import', () => {
+    const out = mergeById(local, [
+      { id: 'i1', model: 'ULXD2', notes: 'Case 7', updatedAt: '2026-01-01' },
+    ])
+    const merged = out.find((x) => x.id === 'i1')!
+    expect(merged.notes).toBe('Case 7')
+    expect(merged.updatedAt).toBe('2026-01-01')
+    // ... und die Typ-Identitaet ueberlebt trotzdem.
+    expect(merged.deviceTypeId).toBe('dt-shure-ulxd2')
+  })
+
+  it('haelt die Reihenfolge des Bestands', () => {
+    const out = mergeById(local, [{ id: 'i2', model: 'SM58' }, { id: 'i0', model: 'Vorne' }])
+    expect(out.map((x) => x.id)).toEqual(['i1', 'i2', 'i0'])
+  })
+})
+
+describe('importSnapshot merge — der Weg, auf dem es wirklich passiert', () => {
+  // Die Tests oben pruefen den neuen Helfer; der existierte am alten Stand
+  // nicht. DIESER Test geht durch den Store und faellt am alten Code.
+  beforeEach(() => {
+    localStorage.clear()
+    useInventoryStore.setState({ items: [], nodes: [], sets: [], units: [] })
+  })
+
+  it('eine v1-Datei nimmt dem lokalen Artikel die deviceTypeId nicht weg', () => {
+    const st = useInventoryStore.getState()
+    const id = st.addItem({ model: 'ULXD2', quantity: 4, deviceTypeId: 'dt-shure-ulxd2' })
+    expect(useInventoryStore.getState().items[0].deviceTypeId).toBe('dt-shure-ulxd2')
+
+    // So sieht ein Artikel aus einer Datei VOR ADR-002 aus: dasselbe Geraet,
+    // dieselbe Id, nur ohne Typ-Identitaet.
+    const report = useInventoryStore.getState().importSnapshot(
+      { items: [{ id, model: 'ULXD2', quantity: 6 }] },
+      'merge',
+    )
+    expect(report.imported).toBe(1)
+
+    const after = useInventoryStore.getState().items
+    expect(after).toHaveLength(1)
+    expect(after[0].quantity).toBe(6) // die Datei hat etwas zu sagen: uebernommen
+    expect(after[0].deviceTypeId).toBe('dt-shure-ulxd2') // und sie nimmt nichts weg
+  })
+
+  it("'replace' ersetzt weiterhin vollstaendig — dafuer ist der Modus da", () => {
+    const st = useInventoryStore.getState()
+    const id = st.addItem({ model: 'ULXD2', quantity: 4, deviceTypeId: 'dt-shure-ulxd2' })
+    useInventoryStore.getState().importSnapshot(
+      { items: [{ id, model: 'ULXD2', quantity: 6 }] },
+      'replace',
+    )
+    expect(useInventoryStore.getState().items[0].deviceTypeId).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Siebter Fund aus **ADR-005 Inkrement 4**, und der erste, der **alle drei Apps** gleichzeitig betrifft — das Lager-Format ist app-übergreifend, also muss auch sein Zusammenführen überall dasselbe tun.

Geschwister: `larszu/light-planner` und `larszu/multicam-planner`, gleicher Branch.

## Der Fund

`importSnapshot` nahm im Modus **„merge"** den eingehenden Datensatz als Ganzes:

```ts
for (const x of add) byId.set(x.id, x)
```

Eine v1-Datei aus der Zeit vor ADR-002 trägt keine `deviceTypeId`. Stand im lokalen Lager derselbe Artikel **mit** bestätigter Typ-Identität, war sie nach dem Import weg — und mit ihr die autoritative Auflösung auf das Datenblatt, die genau deshalb eingeführt wurde, damit nicht mehr über Namen geraten wird.

**Hier ist es schärfer als in den Nachbar-Apps:** `healItem` setzt fehlende Felder *ausdrücklich* auf `undefined`, der eingehende Artikel trägt sie also als gesetzte Schlüssel. Ein naives `{ ...alt, ...neu }` hätte ebenfalls gelöscht. Deshalb übernimmt `mergeDefined` nur **definierte** Werte: `undefined` heisst „keine Aussage", nicht „löschen". Ein leerer String, `0` und `false` sind Aussagen und werden übernommen — der Import bleibt ein Import.

Wer wirklich ersetzen will, nimmt den Modus `replace`; genau dafür gibt es ihn, und der Test hält fest, dass er unverändert ersetzt.

## Der Kopfkommentar deckte nur eine Richtung ab

`inventoryPortable.ts` begründete die Versionserhöhung ausführlich — aber nur für den Fall einer zu **neuen** Datei, die dieser Stand nicht versteht. Die andere Richtung fehlte: eine zu **alte** Datei, die beim Zusammenführen etwas *wegnimmt*. Die Version kann das auch gar nicht leisten, weil eine alte Datei zu lesen ausdrücklich erlaubt bleibt.

In den Nachbar-Apps war derselbe Absatz **sachlich falsch** — dazu mehr in deren PRs.

## Zur Testabdeckung, offen gesagt

Die acht Tests der reinen Funktion prüfen den **neuen** Helfer; den gab es am alten Stand nicht, sie hätten den Fehler nicht fangen können. Deshalb geht der neunte Test durch `importSnapshot` selbst — **er fällt am alten Code**, und der `replace`-Test bleibt in beiden Ständen grün, wie er soll.

## Prüfung

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npm test` **51 Dateien, 543 Tests grün** · `npm run lint` 0 Errors (10 vorbestehende Warnungen, keine neue).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_