### PR TITLE
sourcemap: eine Rolle mit zwei Geräten verschwieg die zweite Beschriftung

### DIFF
--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -157,14 +157,41 @@ export const MenuBar = ({
   // Eine Tally-Maschine soll nicht ein ganzes Kabelprojekt parsen muessen, um
   // zu erfahren, dass "Kamera 1" auf ATEM-Eingang 3 liegt.
   const sourceMapImportRef = useRef<HTMLInputElement | null>(null)
-  const handleExportSourceMap = () => {
+  const handleExportSourceMap = async () => {
     const project = useProjectStore.getState().project
-    const map = buildSourceMap(project, {
+    const { map, ambiguousLabels } = buildSourceMap(project, {
       appVersion: __APP_VERSION__,
       exportedAt: new Date().toISOString(),
     })
     const safe = (project.metadata?.name || 'projekt').replace(/[^a-zA-Z0-9_-]+/g, '_')
     downloadBlob(`${safe}.avsourcemap`, JSON.stringify(map, null, 2), 'application/json')
+    // ADR-005 — `labels` steht einmal je Rolle, wird aber je Geraet
+    // beschrieben: bei mehreren Geraeten ueberlebt nur das zuletzt gelesene.
+    // Der Import sagt seit jeher, was er nicht uebernehmen konnte; der Export
+    // sagte nichts. Jetzt sagt er es auch.
+    if (ambiguousLabels.length > 0) {
+      await infoDialog(t('sourceMap.export.ambiguousTitle', 'Karte geschrieben — mit einer Einschränkung'), {
+        bodyNode: (
+          <div className="flex flex-col gap-2 text-cp-xs text-cp-text-secondary">
+            <span>
+              {t(
+                'sourceMap.export.ambiguousIntro',
+                'Diese Rollen haben mehr als ein Gerät. Die Datei trägt die Ziel-Beschriftung nur EINMAL je Rolle — in ihr steht die des zuletzt gelesenen Geräts, nicht die aller:',
+              )}
+            </span>
+            <ul className="flex list-disc flex-col gap-1 pl-4">
+              {ambiguousLabels.map((a) => (
+                <li key={a.name}>
+                  <span className="font-semibold">{a.name}</span>
+                  {': '}
+                  {a.devices.join(', ')}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ),
+      })
+    }
   }
   const handleImportSourceMap = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]

--- a/src/renderer/lib/sourceMap.ts
+++ b/src/renderer/lib/sourceMap.ts
@@ -130,10 +130,38 @@ const collectExtra = (
  * Format transportiert Identitaet, und ohne Rolle gibt es keine. Was dabei
  * offen bleibt, steht dann umso deutlicher in `unresolved`.
  */
+/**
+ * ADR-005, Inkrement 4 — was beim Schreiben nicht abgebildet werden konnte.
+ *
+ * Die Import-Seite hat so einen Kanal laengst (`SourceMapMergeResult`), die
+ * Export-Seite hatte keinen: `buildSourceMap` gab nur die Datei zurueck, und
+ * was dabei flach fiel, fiel still.
+ */
+export interface SourceMapBuildResult {
+  map: SourceMap
+  /**
+   * Rollen mit MEHR ALS EINEM Geraet. `labels` steht einmal je Rolle, wird
+   * aber in der Schleife ueber die Geraete beschrieben — es ueberlebt also
+   * nur das zuletzt gelesene, und welches das ist, entscheidet die
+   * Reihenfolge in `project.equipment`.
+   *
+   * Der Typ verspricht „was das jeweilige Zielsystem nach seinem
+   * Zeichenbudget wirklich zeigt". Bei einer Rolle mit Haupt- und
+   * Backup-Kamera auf zwei ATEM-Eingaengen zeigt es zwei verschiedene
+   * Beschriftungen — in der Datei steht eine davon, ohne Hinweis darauf,
+   * welche. Beim Namen genannt, statt still das letzte zu behaupten.
+   *
+   * Die Datei RICHTIG zu machen hiesse, `labels` in die `bindings` zu ziehen
+   * (dort steht die Geraete-Id ohnehin) — das aendert das Draht-Format und
+   * ist deshalb eine Entscheidung, die nicht hierher gehoert.
+   */
+  ambiguousLabels: Array<{ name: string; devices: string[] }>
+}
+
 export const buildSourceMap = (
   project: Pick<CablePlannerProject, 'equipment' | 'cables' | 'sourceIdentities'>,
   meta: { app?: string; appVersion: string; exportedAt: string },
-): SourceMap => {
+): SourceMapBuildResult => {
   const identities: SourceIdentity[] = project.sourceIdentities ?? []
   const { candidates, sources, unanswered } = deriveLabels({
     equipment: project.equipment,
@@ -151,8 +179,16 @@ export const buildSourceMap = (
     return value || undefined
   }
 
+  const ambiguousLabels: SourceMapBuildResult['ambiguousLabels'] = []
+
   const entries: SourceMapEntry[] = identities.map((identity) => {
     const devices = project.equipment.filter((e) => e.sourceIdentityId === identity.id)
+    // ADR-005 — `labels` unten ist EIN Objekt je Rolle, beschrieben in der
+    // Schleife ueber die Geraete. Bei mehreren Geraeten ueberlebt nur das
+    // letzte. Melden statt behaupten.
+    if (devices.length > 1) {
+      ambiguousLabels.push({ name: identity.name, devices: devices.map((d) => d.name) })
+    }
     const labels: Partial<Record<LabelTargetId, string>> = {}
     const bindings: SourceMapBinding[] = devices.map((device) => {
       const link = sources.find((s) => s.sourceEquipmentId === device.id)
@@ -188,7 +224,7 @@ export const buildSourceMap = (
     }
   })
 
-  return {
+  const map: SourceMap = {
     kind: SOURCE_MAP_KIND,
     formatVersion: SOURCE_MAP_VERSION,
     app: meta.app ?? 'cable-planner',
@@ -202,6 +238,7 @@ export const buildSourceMap = (
       reason: u.reason,
     })),
   }
+  return { map, ambiguousLabels }
 }
 
 // ── Lesen ────────────────────────────────────────────────────────────────────

--- a/tests/sourceMap.test.ts
+++ b/tests/sourceMap.test.ts
@@ -66,7 +66,7 @@ const scene = () => ({
 
 describe('buildSourceMap', () => {
   it('schreibt die Rolle mit Anker, Bindung und Eingangsnummer', () => {
-    const map = buildSourceMap(scene(), META)
+    const { map } = buildSourceMap(scene(), META)
     expect(map).toMatchObject({ kind: SOURCE_MAP_KIND, formatVersion: SOURCE_MAP_VERSION })
     expect(map.sources).toHaveLength(1)
     expect(map.sources[0]).toMatchObject({
@@ -85,7 +85,7 @@ describe('buildSourceMap', () => {
   })
 
   it('markiert jeden Wert als geplant — der Planer misst nicht', () => {
-    const map = buildSourceMap(scene(), META)
+    const { map } = buildSourceMap(scene(), META)
     expect(map.sources[0].provenance).toEqual({
       name: 'planned',
       number: 'planned',
@@ -94,7 +94,7 @@ describe('buildSourceMap', () => {
   })
 
   it('schreibt die Labels so, wie das Zielsystem sie wirklich zeigt', () => {
-    const map = buildSourceMap(scene(), META)
+    const { map } = buildSourceMap(scene(), META)
     // ATEM-Kurzname ist 4 Byte: aus "Kamera 1" wird "KAME".
     expect(map.sources[0].labels['atem-input-short']).toBe('KAME')
     expect(map.sources[0].labels['atem-input-long']).toBe('Kamera 1')
@@ -105,7 +105,7 @@ describe('buildSourceMap', () => {
     const s = scene()
     s.equipment[1].sourceIdentityId = undefined
     s.sourceIdentities = []
-    const map = buildSourceMap(s, META)
+    const { map } = buildSourceMap(s, META)
     expect(map.sources).toEqual([])
     expect(map.unresolved).toHaveLength(1)
     expect(map.unresolved[0]).toMatchObject({ field: 'umd-address', equipmentId: 'cam1' })
@@ -114,13 +114,13 @@ describe('buildSourceMap', () => {
   it('liefert eine leere Rollenliste, wenn es keine Rollen gibt', () => {
     // Das ist die richtige Antwort, kein Fehler: das Format transportiert
     // Identität, und ohne Rolle gibt es keine.
-    const map = buildSourceMap({ equipment: [], cables: [], sourceIdentities: [] }, META)
+    const { map } = buildSourceMap({ equipment: [], cables: [], sourceIdentities: [] }, META)
     expect(map.sources).toEqual([])
     expect(map.unresolved).toEqual([])
   })
 
   it('kommt mit einer Rolle ohne verkabeltes Gerät klar', () => {
-    const map = buildSourceMap(
+    const { map } = buildSourceMap(
       { equipment: [], cables: [], sourceIdentities: [{ id: 'r1', name: 'Kamera 1' }] },
       META,
     )
@@ -131,7 +131,7 @@ describe('buildSourceMap', () => {
 
 describe('parseSourceMap', () => {
   it('liest, was buildSourceMap geschrieben hat', () => {
-    const map = buildSourceMap(scene(), META)
+    const { map } = buildSourceMap(scene(), META)
     const back = parseSourceMap(JSON.stringify(map))
     expect(back.sources[0]).toMatchObject({ id: 'r1', name: 'Kamera 1', umdAddress: 3 })
   })
@@ -224,7 +224,7 @@ describe('mergeSourceMap', () => {
 describe('Rundreise', () => {
   it('überlebt build → parse → merge ohne Verlust', () => {
     const s = scene()
-    const map = buildSourceMap(s, META)
+    const { map } = buildSourceMap(s, META)
     const back = parseSourceMap(JSON.stringify(map))
     const merged = mergeSourceMap([], back)
     expect(merged.identities).toEqual(s.sourceIdentities)
@@ -281,5 +281,89 @@ describe('mergeSourceMap — Provenienz, die der Plan nicht halten kann (ADR-005
     // waere eigener Schaden.
     const r = mergeSourceMap([], mapWith({ umdAddress: 'confirmed' }))
     expect(r.identities[0].umdAddress).toBe(4)
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// ADR-005, Inkrement 4 — eine Rolle mit zwei Geraeten.
+//
+// `labels` steht EINMAL je Rolle, wird aber in der Schleife ueber die Geraete
+// beschrieben. Bei Haupt- und Backup-Kamera auf zwei ATEM-Eingaengen ueberlebt
+// nur das zuletzt gelesene Geraet — und welches das ist, entscheidet die
+// Reihenfolge in `project.equipment`.
+//
+// Der Typ verspricht „was das jeweilige Zielsystem nach seinem Zeichenbudget
+// wirklich zeigt". Es zeigt zwei verschiedene Beschriftungen; in der Datei
+// steht eine, ohne Hinweis darauf, welche.
+//
+// Die Datei RICHTIG zu machen hiesse, `labels` in die `bindings` zu ziehen —
+// das aendert das Draht-Format und ist deshalb nicht Sache dieses Fixes. Was
+// hier geht und Regel 3 verlangt: es sagen.
+describe('buildSourceMap — Rolle mit mehreren Geraeten', () => {
+  const zweiGeraete = () => ({
+    equipment: [
+      eq({
+        id: 'atem',
+        name: 'ATEM Mini Extreme',
+        inputs: [
+          port('in1', 'In 1', { contentLabel: 'Kamera 1 Haupt' }),
+          port('in2', 'In 2', { contentLabel: 'Kamera 1 Backup' }),
+        ],
+      }),
+      eq({
+        id: 'cam-haupt',
+        name: 'URSA Haupt',
+        category: 'Kameras',
+        outputs: [port('haupt-out', 'SDI Out')],
+        sourceIdentityId: 'r1',
+      }),
+      eq({
+        id: 'cam-backup',
+        name: 'URSA Backup',
+        category: 'Kameras',
+        outputs: [port('backup-out', 'SDI Out')],
+        sourceIdentityId: 'r1',
+      }),
+    ],
+    cables: [
+      cable(['cam-haupt', 'haupt-out'], ['atem', 'in1']),
+      cable(['cam-backup', 'backup-out'], ['atem', 'in2']),
+    ],
+    sourceIdentities: [{ id: 'r1', name: 'Kamera 1', number: 1, umdAddress: 3 }],
+  })
+
+  it('meldet die Rolle, statt still eine der beiden Beschriftungen zu behaupten', () => {
+    const { ambiguousLabels } = buildSourceMap(zweiGeraete(), META)
+    expect(ambiguousLabels).toEqual([
+      { name: 'Kamera 1', devices: ['URSA Haupt', 'URSA Backup'] },
+    ])
+  })
+
+  it('schreibt trotzdem beide Bindungen — die Datei verliert die Geraete nicht', () => {
+    // Wichtig fuer die Einordnung: NUR `labels` ist flach. `bindings` traegt
+    // beide Geraete samt Eingang. Deshalb waere die Datei auch reparabel,
+    // ohne etwas dazuzuerfinden.
+    const { map } = buildSourceMap(zweiGeraete(), META)
+    expect(map.sources[0].bindings.map((b) => b.equipmentId)).toEqual([
+      'cam-haupt',
+      'cam-backup',
+    ])
+    expect(map.sources[0].bindings.map((b) => b.input)).toEqual([1, 2])
+  })
+
+  it('haelt fest, WAS verloren geht: nur eine Beschriftung steht in der Datei', () => {
+    // Dieser Test beschreibt den heutigen, falschen Zustand — bewusst. Wer
+    // `labels` in die `bindings` zieht, bringt ihn zu Fall und muss ihn
+    // anfassen, statt die Aenderung unbemerkt vorbeizuschieben.
+    const { map } = buildSourceMap(zweiGeraete(), META)
+    const labels = map.sources[0].labels
+    // Zwei Eingaenge, zwei Beschriftungen — in der Datei steht die des
+    // ZULETZT gelesenen Geraets, hier also die des Backups.
+    expect(labels['atem-input-long']).toBe('Kamera 1 Backup')
+    expect(Object.keys(labels).filter((k) => k.startsWith('atem-input'))).toHaveLength(2)
+  })
+
+  it('meldet nichts, wenn die Rolle nur ein Geraet hat', () => {
+    expect(buildSourceMap(scene(), META).ambiguousLabels).toEqual([])
   })
 })


### PR DESCRIPTION
Neunter Fund aus **ADR-005 Inkrement 4**.

## Der Fund

In `buildSourceMap` steht `labels` **einmal je Rolle** — beschrieben wird es aber in der Schleife über **alle Geräte** dieser Rolle:

```ts
const labels: Partial<Record<LabelTargetId, string>> = {}   // einmal
const bindings = devices.map((device) => {                  // je Gerät
  if (long) labels['atem-input-long'] = long                // überschreibt
  if (umd) labels['tsl-umd-v31'] = umd
  …
})
```

Bei Haupt- und Backup-Kamera auf zwei ATEM-Eingängen überlebt nur das **zuletzt gelesene** Gerät — und welches das ist, entscheidet die Reihenfolge in `project.equipment`.

Der Typ verspricht:

> Was das jeweilige Zielsystem nach seinem Zeichenbudget **wirklich zeigt**.

Es zeigt zwei verschiedene Beschriftungen. In der Datei stand eine, ohne Hinweis darauf, welche.

## Der Fix — und was er bewusst nicht tut

Die Import-Seite hat seit jeher einen Kanal für „konnte ich nicht abbilden" (`SourceMapMergeResult` mit `conflicts`, `rejected`, `unrepresented`), und ihr Kommentar formuliert genau das Prinzip:

> Ein Schlüssel, dessen Namen wir kennen und den wir trotzdem nicht halten können, ist schlimmer als ein unbekannter — der Mechanismus geht über ihn hinweg, statt ihn aufzufangen. **Also melden.**

Der Export hatte keinen solchen Kanal. Jetzt schon: `buildSourceMap` gibt `SourceMapBuildResult` zurück (`map` + `ambiguousLabels`), und der Export-Dialog nennt die betroffenen Rollen samt Geräten.

**Nicht behoben, weil es das Draht-Format ändert:** `labels` gehört in die `bindings`. Dort steht die Geräte-Id ohnehin, und ein Test in diesem PR zeigt, dass **beide** Geräte samt Eingangsnummer bereits in der Datei stehen — sie wäre also reparabel, ohne etwas zu erfinden. Das ist aber eine Entscheidung über einen eingefrorenen Vertrag mit externem Konsumenten (Tally-/UMD-Runtime) und gehört nicht in einen Melde-Fix. Sie gehört zu dir.

## Ein Test, der den falschen Zustand festhält

Einer der neuen Tests prüft ausdrücklich, dass in der Datei die Beschriftung des **Backups** steht — also den heutigen, falschen Zustand. Absichtlich: wer `labels` später in die `bindings` zieht, bringt ihn zu Fall und muss ihn anfassen, statt die Änderung unbemerkt vorbeizuschieben.

## Beinahe mein eigener Fehler

Nach dem Signaturwechsel gab `buildSourceMap` ein Objekt zurück, der Aufrufer schrieb aber weiter `JSON.stringify(map, …)` in die Datei. **`tsc` blieb stumm** — `JSON.stringify` nimmt jede Form. Der Export hätte ab da die falsche Struktur geschrieben. Aufgefallen ist es nur, weil ich den Aufrufer aufgemacht habe; der Aufrufer destrukturiert jetzt explizit, und die acht bestehenden Tests, die dabei brachen, waren das zweite Netz.

## Prüfung

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npm test` **51 Dateien, 547 Tests grün** · `npm run lint` 0 Errors (10 vorbestehende Warnungen, keine neue).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_