### PR TITLE
export: zwei Ausgabewege versprachen mehr, als sie liefern

### DIFF
--- a/src/renderer/components/Export/ExportDialog.tsx
+++ b/src/renderer/components/Export/ExportDialog.tsx
@@ -352,9 +352,15 @@ const PlanSection = ({
               <span>
                 <span className="flex items-center gap-1"><Icon icon={Sparkles} size="xs" /> {t('export.render.vector', 'Vektor')}</span>
                 <span className="block text-[10px] text-cp-text-muted">
+                  {/* ADR-005, Regel 4 — hier standen nur die Vorteile. Der
+                      Vektor-Pfad klont das Canvas-DOM und druckt es via
+                      Chromium; einen Titelblock baut er nicht. Revision,
+                      Stand-Fingerprint und QR, die der Raster-Pfad zeichnet,
+                      fehlen im Vektor-PDF also. Wer zwischen zwei Wegen
+                      waehlt, muss beide Seiten kennen. */}
                   {t(
                     'export.render.vectorHint',
-                    'Chromium printToPDF. Text bleibt selektierbar & scharf bei jedem Zoom. Kleinere Dateigröße.',
+                    'Chromium printToPDF. Text bleibt selektierbar & scharf bei jedem Zoom. Kleinere Dateigröße. Ohne Titelblock — Revision, Stand-Fingerprint und QR-Code stehen nur im Raster-PDF.',
                   )}
                 </span>
               </span>

--- a/src/renderer/lib/exportStagePlot.ts
+++ b/src/renderer/lib/exportStagePlot.ts
@@ -25,7 +25,13 @@ export const exportStagePlotSvg = (project: CablePlannerProject): string => {
     }
   }
   const fromAudio = project.equipment.filter((e) => audioIds.has(e.id))
-  const devices = fromAudio.length > 0 ? fromAudio : project.equipment
+  // ADR-005, Regel 4 — der Rueckfall auf ALLE Geraete bleibt (eine
+  // Positions-Uebersicht ist auch ohne Audio-Kabel nuetzlich), aber die
+  // Unterzeile darf danach nicht weiter „Audio-Quellen/-Ziele" behaupten.
+  // Ein Plan ohne ein einziges Audio-Kabel wies sonst Kameras, Mischer und
+  // Router als Audio-Quellen aus — auf einem Blatt, das an die Halle geht.
+  const audioFound = fromAudio.length > 0
+  const devices = audioFound ? fromAudio : project.equipment
 
   let minX = Infinity
   let minY = Infinity
@@ -64,7 +70,11 @@ export const exportStagePlotSvg = (project: CablePlannerProject): string => {
     `<text x="${minX - pad + 8}" y="${minY - pad - titleH + 34}" fill="#e2e8f0" font-size="26" font-weight="700">Stage-Plot — ${esc(project.metadata?.name ?? 'Plan')}</text>`,
   )
   parts.push(
-    `<text x="${minX - pad + 8}" y="${minY - pad - titleH + 52}" fill="#94a3b8" font-size="13">${ordered.length} Audio-Quellen/-Ziele</text>`,
+    `<text x="${minX - pad + 8}" y="${minY - pad - titleH + 52}" fill="#94a3b8" font-size="13">${
+      audioFound
+        ? `${ordered.length} Audio-Quellen/-Ziele`
+        : `${ordered.length} Geräte — kein Audio-Kabel im Plan, daher alle`
+    }</text>`,
   )
 
   ordered.forEach((e, i) => {

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3218,7 +3218,7 @@ export const en: Dict = {
   'export.render.rasterHint': 'JPEG snapshot. Reliable, but text blurs at high zoom in the PDF.',
   'export.render.vector': 'Vector',
   'export.render.vectorHint':
-    'Chromium printToPDF. Text stays selectable & sharp at any zoom. Smaller file size.',
+    'Chromium printToPDF. Text stays selectable & sharp at any zoom. Smaller file size. No title block — revision, state fingerprint and QR code are in the raster PDF only.',
   'export.patch.perDeviceHint': '— or create one patch sheet per device:',
   'export.patch.devicesCount': 'Devices',
   'export.patch.selectAll': 'Select all',

--- a/tests/exportStagePlot.test.ts
+++ b/tests/exportStagePlot.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import { exportStagePlotSvg } from '../src/renderer/lib/exportStagePlot'
+import exportDialogSrc from '../src/renderer/components/Export/ExportDialog.tsx?raw'
+import dictsSrc from '../src/renderer/lib/i18n/dicts.ts?raw'
+import type { CablePlannerProject } from '../src/renderer/types/project'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+import type { Cable } from '../src/renderer/types/cable'
+
+// ADR-005, Inkrement 4, Regel 4 — der Stage-Plot behauptete Audio, wo keins war.
+//
+// Der Export sammelt die Endpunkte aller Audio-Layer-Kabel. Findet er keine,
+// faellt er auf ALLE Geraete des Plans zurueck — das ist als Positions-
+// Uebersicht durchaus nuetzlich und bleibt so. Die Unterzeile lief dabei
+// unveraendert weiter und schrieb „N Audio-Quellen/-Ziele".
+//
+// Ein Video-Plan ohne ein einziges Audio-Kabel erzeugte damit ein Blatt, das
+// Kameras, Mischer und Router als Audio-Quellen ausweist — und das Blatt geht
+// an die Halle.
+
+const eq = (id: string, name: string, x: number, y: number): EquipmentItem =>
+  ({
+    id,
+    name,
+    category: 'Sonstiges',
+    inputs: [{ id: `${id}-in`, name: 'IN 1', type: 'port', connectorType: 'XLR' }],
+    outputs: [{ id: `${id}-out`, name: 'OUT 1', type: 'port', connectorType: 'XLR' }],
+    x,
+    y,
+    width: 240,
+    height: 80,
+  }) as unknown as EquipmentItem
+
+const cable = (from: string, to: string, layer: string): Cable =>
+  ({
+    id: `${from}->${to}`,
+    name: `${from}->${to}`,
+    type: 'XLR',
+    length: 10,
+    color: '#fff',
+    layer,
+    fromEquipmentId: from,
+    fromPortId: `${from}-out`,
+    toEquipmentId: to,
+    toPortId: `${to}-in`,
+    notes: '',
+  }) as unknown as Cable
+
+const project = (equipment: EquipmentItem[], cables: Cable[]): CablePlannerProject =>
+  ({
+    metadata: { name: 'Halle 7' },
+    equipment,
+    cables,
+    canvasState: { x: 0, y: 0, zoom: 1 },
+  }) as unknown as CablePlannerProject
+
+describe('exportStagePlotSvg — was die Unterzeile behauptet', () => {
+  it('nennt Audio-Quellen, wenn es Audio-Kabel gibt', () => {
+    const svg = exportStagePlotSvg(
+      project(
+        [eq('mic', 'SM58', 0, 0), eq('pult', 'X32', 400, 0), eq('cam', 'URSA', 800, 0)],
+        [cable('mic', 'pult', 'audio')],
+      ),
+    )
+    // Nur die beiden Audio-Endpunkte, und sie heissen zu Recht so.
+    expect(svg).toContain('2 Audio-Quellen/-Ziele')
+    expect(svg).toContain('SM58')
+    expect(svg).toContain('X32')
+    expect(svg).not.toContain('URSA')
+  })
+
+  it('behauptet ohne Audio-Kabel KEIN Audio mehr — und sagt, warum alle da sind', () => {
+    const svg = exportStagePlotSvg(
+      project(
+        [eq('cam', 'URSA', 0, 0), eq('atem', 'ATEM', 400, 0)],
+        [cable('cam', 'atem', 'video')],
+      ),
+    )
+    expect(svg).not.toContain('Audio-Quellen/-Ziele')
+    expect(svg).toContain('2 Geräte — kein Audio-Kabel im Plan, daher alle')
+  })
+
+  it('faellt weiterhin auf alle Geraete zurueck — die Uebersicht bleibt nuetzlich', () => {
+    // Der Rueckfall ist Absicht und soll bleiben; falsch war nur die
+    // Beschriftung. Deshalb hier ausdruecklich festgehalten.
+    const svg = exportStagePlotSvg(
+      project(
+        [eq('cam', 'URSA', 0, 0), eq('atem', 'ATEM', 400, 0)],
+        [cable('cam', 'atem', 'video')],
+      ),
+    )
+    expect(svg).toContain('URSA')
+    expect(svg).toContain('ATEM')
+  })
+
+  it('kommt mit einem leeren Plan klar', () => {
+    const svg = exportStagePlotSvg(project([], []))
+    expect(svg).toContain('<svg')
+    expect(svg).toContain('0 Geräte — kein Audio-Kabel im Plan, daher alle')
+  })
+})
+
+// Zweiter Fund derselben Flaeche und derselben Klasse (Regel 4): der
+// Vektor-PDF-Hinweis nannte nur Vorteile. Der Vektor-Pfad klont das
+// Canvas-DOM und druckt es via Chromium — einen Titelblock baut er nicht.
+// Revision, Stand-Fingerprint und QR, die der Raster-Pfad mit jsPDF zeichnet,
+// fehlen im Vektor-PDF also. Wer zwischen zwei Wegen waehlt, muss beide
+// Seiten kennen; der Hinweis ist genau die Stelle, an der gewaehlt wird.
+//
+// Den Titelblock im Vektor-Pfad NACHZUBAUEN waere ein Feature, kein
+// Melde-Fix — deshalb hier nur die Zusage geradegerueckt.
+describe('der Vektor-PDF-Hinweis nennt auch, was fehlt', () => {
+  it('sagt im deutschen Fallback, dass der Titelblock fehlt', () => {
+    expect(exportDialogSrc).toContain('Ohne Titelblock')
+    expect(exportDialogSrc).toContain('Stand-Fingerprint')
+  })
+
+  it('sagt es auch auf Englisch', () => {
+    expect(dictsSrc).toContain('No title block')
+    expect(dictsSrc).toContain('state fingerprint')
+  })
+})


### PR DESCRIPTION
Zehnter Fund aus **ADR-005 Inkrement 4** — beide aus dem systematischen Durchgang durch die reinen Ausgabewege, beide dieselbe Klasse wie der MVR-Fall aus Inkrement 3: **kein Rückweg, trotzdem falsch, weil die Zusage nicht stimmt.**

## 1 · Der Stage-Plot behauptete Audio, wo keins war

Der Export sammelt die Endpunkte aller Audio-Layer-Kabel. Findet er keine, fällt er auf **alle** Geräte des Plans zurück:

```ts
const devices = fromAudio.length > 0 ? fromAudio : project.equipment
```

Der Rückfall ist sinnvoll — eine Positions-Übersicht hilft auch ohne Audio — und **bleibt**. Die Unterzeile lief aber unverändert weiter:

```ts
`${ordered.length} Audio-Quellen/-Ziele`
```

Ein Video-Plan ohne ein einziges Audio-Kabel erzeugte damit ein Blatt, das **Kameras, Mischer und Router als Audio-Quellen ausweist**. Und dieses Blatt geht an die Halle.

Sie sagt jetzt, was zutrifft: *„N Geräte — kein Audio-Kabel im Plan, daher alle"*.

## 2 · Der Vektor-PDF-Hinweis nannte nur Vorteile

> Chromium printToPDF. Text bleibt selektierbar & scharf bei jedem Zoom. Kleinere Dateigröße.

Der Vektor-Pfad klont das Canvas-DOM und lässt es von Chromium drucken — **einen Titelblock baut er nicht**. `Revision`, `Stand`-Fingerprint und der QR-Code, die der Raster-Pfad mit jsPDF zeichnet, fehlen im Vektor-PDF also vollständig.

Wer zwischen zwei Wegen wählt, muss beide Seiten kennen, und der Hinweis ist genau die Stelle, an der gewählt wird. Er nennt die Einschränkung jetzt, in beiden Sprachen.

**Den Titelblock im Vektor-Pfad nachzubauen wäre ein Feature**, kein Melde-Fix: der Pfad hat gar keine Titelblock-Struktur, und ein QR müsste als Data-URI ins Print-HTML. Regel 3 verlangt hier zunächst nur, es dort zu sagen, wo gewählt wird.

## Gegenprobe

Die beiden Stage-Plot-Tests, die das neue Verhalten prüfen, **fallen am alten Stand**. Die beiden, die den Rückfall als *gewollt* festhalten (er soll ja bleiben), sind in beiden Ständen grün — genau so soll ein Test aussehen, der eine bewusste Entscheidung schützt statt sie zu verwechseln.

## Nebenbei aufgefallen, nicht angefasst

`dicts.ts` trägt zwei Schlüsselsätze für dieselbe Sache: `export.render.*` (live) und `pdfExport.render.*` (von niemandem gelesen). Kein Fehler im Verhalten, nur Altlast — gehört nicht in diesen PR.

## Prüfung

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npm test` **52 Dateien, 553 Tests grün** · `npm run lint` 0 Errors (10 vorbestehende Warnungen, keine neue).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_