### PR TITLE
rack: zwei Wege bauten das Rack aus dem Plan und verloren dabei

### DIFF
--- a/src/renderer/components/Library/LibraryPanel.tsx
+++ b/src/renderer/components/Library/LibraryPanel.tsx
@@ -20,6 +20,7 @@ import { suggestFromWeb } from '../../lib/webPortSuggestions'
 import { ALL_CONNECTOR_TYPES } from '../../types/equipment'
 import type { ConnectorType, EquipmentTemplate } from '../../types/equipment'
 import { nextPlacementPosition } from '../../lib/library'
+import { presetFromBlackBoxRack, presetFromEquipmentSelection } from '../../lib/rackPreset'
 import {
   clearNetBoxIndexCache,
   importNetBoxDeviceType,
@@ -133,48 +134,21 @@ export const LibraryPanel = () => {
   const newRackBuilderTrigger = useUiStore((s) => s.newRackBuilderTrigger)
   useEffect(() => {
     if (!rackBuilderSeedTrigger || rackBuilderSeedTrigger.length === 0) return
-    // Resolve the selected equipment to a synthesized GroupPreset
-    // shape. Stack them top-to-bottom by HE size; non-rack devices
-    // default to 1 HE. Cables connecting selected devices are NOT
-    // included (the user can wire them later in the sub-canvas).
+    // Die markierten Geraete zu einem Rack-Preset stapeln. Die Umwandlung
+    // steht in lib/rackPreset.ts neben der Gegenrichtung — hier stand sie
+    // frueher als eigene Aufzaehlung und liess dabei Tiefe, STL-Geometrie,
+    // Patchblenden-Marker und Rentman-Id liegen (ADR-005, Regel 1).
     const items = rackBuilderSeedTrigger
       .map((id) => equipmentItems.find((e) => e.id === id))
       .filter((e): e is NonNullable<typeof e> => e != null)
-    if (items.length === 0) {
+    const synthesized = presetFromEquipmentSelection(
+      items,
+      `__seed-${Date.now().toString(36)}`,
+      'Neues Rack aus Auswahl',
+    )
+    if (!synthesized) {
       clearRackBuilderSeedTrigger()
       return
-    }
-    let cursorUnit = 1
-    const placements = items.map((eq, index) => {
-      const heightUnits = Math.max(1, eq.rackUnits ?? 1)
-      const placement = { itemIndex: index, startUnit: cursorUnit, heightUnits }
-      cursorUnit += heightUnits
-      return placement
-    })
-    const synthesized: import('../../types/equipment').GroupPreset = {
-      id: `__seed-${Date.now().toString(36)}`,
-      name: 'Neues Rack aus Auswahl',
-      rack: {
-        totalUnits: Math.max(cursorUnit + 3, 12),
-        placements,
-      },
-      items: items.map((eq) => ({
-        name: eq.name,
-        category: eq.category ?? 'Sonstiges',
-        inputs: eq.inputs,
-        outputs: eq.outputs,
-        isRackDevice: eq.isRackDevice ?? !!eq.rackUnits,
-        rackUnits: Math.max(1, eq.rackUnits ?? 1),
-        frontPanelImageUrl: eq.frontPanelImageUrl,
-        rearPanelImageUrl: eq.rearPanelImageUrl,
-        frontPanelCrop: eq.frontPanelCrop,
-        rearPanelCrop: eq.rearPanelCrop,
-        width: eq.width ?? 240,
-        height: eq.height ?? 80,
-        offsetX: 0,
-        offsetY: 0,
-      })),
-      cables: [],
     }
     // eslint-disable-next-line react-hooks/set-state-in-effect -- One-shot Store-Trigger (Rack-Builder seeden), danach Trigger clearen
     setSeedPreset(synthesized)
@@ -214,60 +188,20 @@ export const LibraryPanel = () => {
     }
     const candidateName = eq.name.replace(/\s*\(Rack\)\s*$/, '').trim()
     if (eq.rackInternalSnapshot) {
-      // Wir bauen aus dem Snapshot + equipment.inputs/outputs ein
-      // temporaeres Preset zum Bearbeiten. Ports rekonstruieren wir aus
-      // equipment.inputs/outputs (via rackOriginDeviceIndex), damit
-      // sie im Dialog editierbar erscheinen.
-      const snap = eq.rackInternalSnapshot
-      const itemsByIndex = snap.items
-      const inputsByItem = new Map<number, import('../../types/equipment').Port[]>()
-      const outputsByItem = new Map<number, import('../../types/equipment').Port[]>()
-      for (const p of eq.inputs) {
-        if (typeof p.rackOriginDeviceIndex !== 'number') continue
-        const list = inputsByItem.get(p.rackOriginDeviceIndex) ?? []
-        list.push({ ...p, name: p.rackOriginPortName ?? p.name })
-        inputsByItem.set(p.rackOriginDeviceIndex, list)
-      }
-      for (const p of eq.outputs) {
-        if (typeof p.rackOriginDeviceIndex !== 'number') continue
-        const list = outputsByItem.get(p.rackOriginDeviceIndex) ?? []
-        list.push({ ...p, name: p.rackOriginPortName ?? p.name })
-        outputsByItem.set(p.rackOriginDeviceIndex, list)
-      }
-      const synth: import('../../types/equipment').GroupPreset = {
-        id: `__edit-blackbox-${Date.now().toString(36)}`,
-        name: candidateName,
-        rack: {
-          totalUnits: snap.totalUnits,
-          placements: itemsByIndex.map((it, idx) => ({
-            itemIndex: idx,
-            startUnit: it.startUnit,
-            heightUnits: it.rackUnits,
-          })),
-        },
-        items: itemsByIndex.map((it, idx) => ({
-          name: it.name,
-          category: 'Sonstiges',
-          inputs: inputsByItem.get(idx) ?? [],
-          outputs: outputsByItem.get(idx) ?? [],
-          isRackDevice: true,
-          rackUnits: it.rackUnits,
-          width: 240,
-          height: 80,
-          offsetX: 0,
-          offsetY: 0,
-        })),
-        cables: snap.cables.map((c) => ({
-          fromItemIndex: c.fromItemIndex,
-          fromPortName: c.fromPortName,
-          toItemIndex: c.toItemIndex,
-          toPortName: c.toPortName,
-          name: '',
-          type: 'unbekannt',
-          length: 0,
-          color: c.color,
-          standard: 'unbekannt',
-        })),
+      // Rueckbau aus dem Snapshot — die Umwandlung steht in
+      // lib/rackPreset.ts. Ports kommen aus den aussen liegenden Ports des
+      // Racks (via rackOriginDeviceIndex), damit sie im Dialog editierbar
+      // sind. Hier stand sie frueher als eigene Aufzaehlung und warf dabei
+      // die Rentman-Ids weg, die der Snapshot ausdruecklich traegt
+      // (#335 / ADR-005, Regel 1).
+      const synth = presetFromBlackBoxRack(
+        eq,
+        `__edit-blackbox-${Date.now().toString(36)}`,
+        candidateName,
+      )
+      if (!synth) {
+        clearRackBuilderEditFromBlackBoxTrigger()
+        return
       }
       // eslint-disable-next-line react-hooks/set-state-in-effect -- One-shot Store-Trigger (Rack aus Black-Box editieren), danach clearen
       setSeedPreset(synth)

--- a/src/renderer/lib/rackPreset.ts
+++ b/src/renderer/lib/rackPreset.ts
@@ -29,7 +29,7 @@
 // Gegenrichtung (ist allerdings verwaist, siehe dort).
 // ───────────────────────────────────────────────────────────────────────────
 import { v4 as uuidv4 } from 'uuid'
-import type { GroupPreset } from '../types/equipment'
+import type { EquipmentItem, GroupPreset } from '../types/equipment'
 import type { RackPlacementDraft, InternalCableDraft } from '../components/Rack/rackBuilderTypes'
 
 export interface RackPresetDraft {
@@ -149,5 +149,190 @@ export const presetFromDraft = (
     },
     items,
     cables,
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Die GEGENRICHTUNG: Equipment → GroupPreset.
+//
+// `presetFromDraft` oben ist die Hinrichtung. Es gibt aber zwei Wege, auf
+// denen ein Rack-Preset NICHT aus einem Draft entsteht, sondern aus Geraeten,
+// die schon im Plan liegen — beide standen als eigene Aufzaehlung im
+// LibraryPanel, mitten in je einem `useEffect`:
+//
+//   1. „Rack Builder aus Auswahl" — der User markiert Geraete auf dem Canvas
+//      und laesst daraus ein Rack bauen.
+//   2. „Rack bearbeiten" auf einem platzierten Black-Box-Rack — der Inhalt
+//      wird aus `rackInternalSnapshot` zurueckgebaut.
+//
+// ADR-005, Inkrement 4, Regel 1 — beide verloren, was sie nicht aufzaehlten,
+// obwohl der Draft und `presetFromDraft` es tragen:
+//
+//   Weg 1 liess `depthMm`, `stlDataUri`, `isPatchPanel`, `isRackShelf` und
+//   `rentmanId` liegen. Ein 800-mm-Geraet mit STL-Modell und Patchblenden-
+//   Marker kam als tiefenloses Kaestchen ohne 3D-Geometrie im Rack an; die
+//   3D-Ansicht kann dann nicht mehr pruefen, ob hinter dem Geraet noch etwas
+//   passt (genau wofuer #170 die Felder eingefuehrt hat).
+//
+//   Weg 2 liess `rentmanId` liegen — sowohl die des Racks (Kombi-Id) als auch
+//   die je Inhalt. Der Snapshot traegt sie ausdruecklich („#335 — Rentman-ID
+//   des Inhalts mitschnappen (fuer spaeteren Sync/Export)"), und der Typ sagt
+//   „Bleibt ueber Save/Reload erhalten". Genau der Save/Reload-Weg warf sie
+//   weg: einmal „Rack bearbeiten" und speichern, und die Rentman-Herkunft des
+//   ganzen Racks war aus dem Snapshot verschwunden.
+//
+// Warum hier und nicht dort: eine Aufzaehlung dieser Struktur an einer
+// vierten Stelle im Code haette dasselbe Schicksal gehabt wie die dritte
+// (#626). Hier stehen sie neben der Hinrichtung — wer ein Feld ergaenzt,
+// sieht beide Seiten auf einem Bildschirm.
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Felder des `RackPlacementDraft`, die NICHT aus dem Geraet kommen koennen —
+ * sie beschreiben die Lage IM Rack, nicht das Geraet.
+ *
+ * Der Test `rackPresetFromEquipment` prueft diese Liste gegen den echten
+ * Interface-Rumpf: kommt ein Feld dazu, das ein Geraet mitbringen koennte,
+ * faellt er. Bewusst als AUSSCHLUSS-Liste (Subtraktion) — ein neues Feld
+ * reist damit im Zweifel MIT, statt still liegen zu bleiben.
+ */
+export const RACK_DRAFT_FIELDS_NOT_FROM_EQUIPMENT = [
+  'id',            // frisch vergeben
+  'templateName',  // Herkunfts-Name im Builder
+  'startUnit',     // Lage im Rack
+  'canvasX',       // Position in der internen 2D-Ansicht
+  'canvasY',
+  'mountSide',     // Front/Rear/Full — im Rack gesetzt, nicht am Geraet
+  'shelfOffsetX',  // Shelf-Position im Rack
+  'shelfOffsetZ',
+] as const
+
+/** Die Geraete-Felder, die ein Rack-Inhalt vom Equipment erbt. */
+const itemFromEquipment = (eq: EquipmentItem): GroupPreset['items'][number] => ({
+  name: eq.name,
+  category: eq.category ?? 'Sonstiges',
+  inputs: eq.inputs,
+  outputs: eq.outputs,
+  isRackDevice: eq.isRackDevice ?? !!eq.rackUnits,
+  rackUnits: Math.max(1, eq.rackUnits ?? 1),
+  frontPanelImageUrl: eq.frontPanelImageUrl,
+  rearPanelImageUrl: eq.rearPanelImageUrl,
+  frontPanelCrop: eq.frontPanelCrop,
+  rearPanelCrop: eq.rearPanelCrop,
+  // v7.9.73 / #170 — Engineering-/3D-Daten. Ohne sie rendert das Rack das
+  // Geraet ohne Tiefe und ohne Geometrie.
+  depthMm: eq.depthMm,
+  stlDataUri: eq.stlDataUri,
+  // v7.9.75 / #170 — Patchblende/Shelf sind Eigenschaften des Geraets.
+  isPatchPanel: eq.isPatchPanel,
+  isRackShelf: eq.isRackShelf,
+  width: eq.width ?? 240,
+  height: eq.height ?? 80,
+  offsetX: 0,
+  offsetY: 0,
+  // #335 — Rentman-Id des Inhalts erhalten (nur wenn gesetzt).
+  ...(eq.rentmanId ? { rentmanId: eq.rentmanId } : {}),
+})
+
+/**
+ * „Rack Builder aus Auswahl": markierte Canvas-Geraete zu einem Rack-Preset
+ * stapeln, von oben nach unten nach HE-Groesse.
+ *
+ * Interne Kabel bleiben ausdruecklich leer — der User verkabelt im Sub-Canvas.
+ * Das ist eine Entscheidung, kein Verlust: die Kabel zwischen den markierten
+ * Geraeten liegen weiter im Plan.
+ */
+export const presetFromEquipmentSelection = (
+  items: EquipmentItem[],
+  presetId: string,
+  name: string,
+): GroupPreset | null => {
+  if (items.length === 0) return null
+  let cursorUnit = 1
+  const placements = items.map((eq, index) => {
+    const heightUnits = Math.max(1, eq.rackUnits ?? 1)
+    const placement = { itemIndex: index, startUnit: cursorUnit, heightUnits }
+    cursorUnit += heightUnits
+    return placement
+  })
+  return {
+    id: presetId,
+    name,
+    rack: {
+      totalUnits: Math.max(cursorUnit + 3, 12),
+      placements,
+    },
+    items: items.map(itemFromEquipment),
+    cables: [],
+  }
+}
+
+/**
+ * „Rack bearbeiten" auf einem platzierten Black-Box-Rack: den Inhalt aus
+ * `rackInternalSnapshot` zurueckbauen, die Ports aus den aussen liegenden
+ * Ports des Racks (via `rackOriginDeviceIndex`).
+ */
+export const presetFromBlackBoxRack = (
+  eq: EquipmentItem,
+  presetId: string,
+  name: string,
+): GroupPreset | null => {
+  const snap = eq.rackInternalSnapshot
+  if (!snap) return null
+
+  const portsByItem = (ports: EquipmentItem['inputs']): Map<number, EquipmentItem['inputs']> => {
+    const byItem = new Map<number, EquipmentItem['inputs']>()
+    for (const p of ports) {
+      if (typeof p.rackOriginDeviceIndex !== 'number') continue
+      const list = byItem.get(p.rackOriginDeviceIndex) ?? []
+      list.push({ ...p, name: p.rackOriginPortName ?? p.name })
+      byItem.set(p.rackOriginDeviceIndex, list)
+    }
+    return byItem
+  }
+  const inputsByItem = portsByItem(eq.inputs)
+  const outputsByItem = portsByItem(eq.outputs)
+
+  return {
+    id: presetId,
+    name,
+    rack: {
+      totalUnits: snap.totalUnits,
+      // #335 — die Kombi-Id des Racks. Das Equipment traegt sie (siehe
+      // insertBlackBoxRack), der Rueckbau liess sie bisher liegen.
+      ...(eq.rentmanId ? { rentmanId: eq.rentmanId } : {}),
+      placements: snap.items.map((it, idx) => ({
+        itemIndex: idx,
+        startUnit: it.startUnit,
+        heightUnits: it.rackUnits,
+      })),
+    },
+    items: snap.items.map((it, idx) => ({
+      name: it.name,
+      category: 'Sonstiges',
+      inputs: inputsByItem.get(idx) ?? [],
+      outputs: outputsByItem.get(idx) ?? [],
+      isRackDevice: true,
+      rackUnits: it.rackUnits,
+      width: 240,
+      height: 80,
+      offsetX: 0,
+      offsetY: 0,
+      // #335 — Rentman-Id je Inhalt. Der Snapshot traegt sie ausdruecklich
+      // „fuer spaeteren Sync/Export"; ohne diese Zeile war sie nach dem
+      // ersten Bearbeiten weg.
+      ...(it.rentmanId ? { rentmanId: it.rentmanId } : {}),
+    })),
+    cables: snap.cables.map((c) => ({
+      fromItemIndex: c.fromItemIndex,
+      fromPortName: c.fromPortName,
+      toItemIndex: c.toItemIndex,
+      toPortName: c.toPortName,
+      name: '',
+      type: 'unbekannt',
+      length: 0,
+      color: c.color,
+      standard: 'unbekannt',
+    })),
   }
 }

--- a/tests/rackPresetFromEquipment.test.ts
+++ b/tests/rackPresetFromEquipment.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest'
+import {
+  RACK_DRAFT_FIELDS_NOT_FROM_EQUIPMENT,
+  presetFromBlackBoxRack,
+  presetFromEquipmentSelection,
+} from '../src/renderer/lib/rackPreset'
+import { interfaceKeys } from './support/interfaceKeys'
+import draftTypesSrc from '../src/renderer/components/Rack/rackBuilderTypes.ts?raw'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+
+// ADR-005, Inkrement 4, Regel 1 — was das Rack aus dem Plan uebernimmt.
+//
+// Zwei Wege bauen ein Rack-Preset aus Geraeten, die schon im Plan liegen.
+// Beide standen als eigene Aufzaehlung im LibraryPanel, in je einem
+// useEffect, und beide liessen liegen, was sie nicht aufzaehlten — obwohl
+// der Draft und `presetFromDraft` die Felder tragen. Das ist dieselbe Klasse
+// wie #626: eine zweite (hier: dritte und vierte) Aufzaehlung derselben
+// Struktur, die niemand nachzieht.
+
+const port = (id: string, name: string, deviceIndex?: number) => ({
+  id,
+  name,
+  type: 'port',
+  connectorType: 'BNC',
+  ...(deviceIndex != null ? { rackOriginDeviceIndex: deviceIndex, rackOriginPortName: name } : {}),
+})
+
+const eq = (over: Partial<EquipmentItem> = {}): EquipmentItem =>
+  ({
+    id: 'e1',
+    name: 'ATEM 4 M/E',
+    category: 'Mischer',
+    inputs: [port('e1-in', 'SDI IN 1')],
+    outputs: [port('e1-out', 'SDI OUT 1')],
+    x: 0,
+    y: 0,
+    width: 240,
+    height: 80,
+    ...over,
+  }) as unknown as EquipmentItem
+
+describe('presetFromEquipmentSelection — Rack Builder aus Auswahl', () => {
+  it('nimmt Tiefe, STL-Geometrie und die Rack-Marker mit', () => {
+    // Genau die fuenf Felder, die die alte Aufzaehlung nicht kannte. Ohne sie
+    // kam ein 800-mm-Geraet mit 3D-Modell als tiefenloses Kaestchen im Rack
+    // an — und die 3D-Ansicht kann dann nicht mehr pruefen, ob dahinter noch
+    // eine Patchblende passt (wofuer #170 die Felder eingefuehrt hat).
+    const preset = presetFromEquipmentSelection(
+      [
+        eq({
+          rackUnits: 4,
+          depthMm: 800,
+          stlDataUri: 'data:model/stl;base64,AAAA',
+          isPatchPanel: true,
+          isRackShelf: false,
+          rentmanId: 'rm-4711',
+        } as Partial<EquipmentItem>),
+      ],
+      'p1',
+      'Rack A',
+    )!
+    const item = preset.items[0]
+    expect(item.depthMm).toBe(800)
+    expect(item.stlDataUri).toBe('data:model/stl;base64,AAAA')
+    expect(item.isPatchPanel).toBe(true)
+    expect(item.isRackShelf).toBe(false)
+    expect(item.rentmanId).toBe('rm-4711')
+  })
+
+  it('stapelt nach HE-Groesse von oben nach unten', () => {
+    const preset = presetFromEquipmentSelection(
+      [eq({ id: 'a', rackUnits: 2 }), eq({ id: 'b', rackUnits: 1 }), eq({ id: 'c', rackUnits: 3 })],
+      'p1',
+      'Rack A',
+    )!
+    expect(preset.rack?.placements.map((p) => [p.startUnit, p.heightUnits])).toEqual([
+      [1, 2],
+      [3, 1],
+      [4, 3],
+    ])
+    // Der Rahmen bekommt Luft, mindestens aber 12 HE.
+    expect(preset.rack?.totalUnits).toBe(12)
+  })
+
+  it('haelt interne Kabel leer — das ist Absicht, kein Verlust', () => {
+    // Die Kabel zwischen den markierten Geraeten liegen weiter im Plan; im
+    // Rack verkabelt der User im Sub-Canvas. Ausdruecklich festgehalten,
+    // damit es niemand fuer denselben Fehler wie #626 haelt.
+    const preset = presetFromEquipmentSelection([eq()], 'p1', 'Rack A')!
+    expect(preset.cables).toEqual([])
+  })
+
+  it('gibt bei leerer Auswahl null zurueck', () => {
+    expect(presetFromEquipmentSelection([], 'p1', 'Rack A')).toBeNull()
+  })
+})
+
+describe('presetFromBlackBoxRack — Rack bearbeiten', () => {
+  const blackBox = eq({
+    id: 'rack1',
+    name: 'Regie 1 (Rack)',
+    category: 'Rack',
+    rentmanId: 'rm-kombi-1',
+    inputs: [port('p1', 'SDI IN 1', 0), port('p2', 'MADI IN', 1)],
+    outputs: [port('p3', 'SDI OUT 1', 0)],
+    rackInternalSnapshot: {
+      totalUnits: 24,
+      items: [
+        { name: 'ATEM', startUnit: 1, rackUnits: 4, rentmanId: 'rm-atem' },
+        { name: 'DirectOut', startUnit: 5, rackUnits: 1, rentmanId: 'rm-do' },
+      ],
+      cables: [
+        { fromItemIndex: 0, fromPortName: 'SDI OUT 2', toItemIndex: 1, toPortName: 'IN', color: '#f00' },
+      ],
+    },
+  } as Partial<EquipmentItem>)
+
+  it('behaelt die Rentman-Ids — die des Racks UND die je Inhalt', () => {
+    // Der Snapshot traegt sie ausdruecklich („#335 — Rentman-ID des Inhalts
+    // mitschnappen (fuer spaeteren Sync/Export)"), und der Typ verspricht
+    // „Bleibt ueber Save/Reload erhalten". Genau der Save/Reload-Weg warf sie
+    // weg: einmal bearbeiten und speichern, und die Herkunft war fort.
+    const preset = presetFromBlackBoxRack(blackBox, 'p1', 'Regie 1')!
+    expect(preset.rack?.rentmanId).toBe('rm-kombi-1')
+    expect(preset.items.map((i) => i.rentmanId)).toEqual(['rm-atem', 'rm-do'])
+  })
+
+  it('setzt die Ports je Geraet aus den aussen liegenden Ports zusammen', () => {
+    const preset = presetFromBlackBoxRack(blackBox, 'p1', 'Regie 1')!
+    expect(preset.items[0].inputs.map((p) => p.name)).toEqual(['SDI IN 1'])
+    expect(preset.items[0].outputs.map((p) => p.name)).toEqual(['SDI OUT 1'])
+    expect(preset.items[1].inputs.map((p) => p.name)).toEqual(['MADI IN'])
+    expect(preset.items[1].outputs).toEqual([])
+  })
+
+  it('nimmt die internen Kabel und die Lage mit', () => {
+    const preset = presetFromBlackBoxRack(blackBox, 'p1', 'Regie 1')!
+    expect(preset.rack?.totalUnits).toBe(24)
+    expect(preset.rack?.placements).toEqual([
+      { itemIndex: 0, startUnit: 1, heightUnits: 4 },
+      { itemIndex: 1, startUnit: 5, heightUnits: 1 },
+    ])
+    expect(preset.cables).toHaveLength(1)
+    expect(preset.cables[0].color).toBe('#f00')
+  })
+
+  it('setzt keine rentmanId, wo keine ist', () => {
+    const ohne = eq({
+      id: 'r2',
+      rackInternalSnapshot: { totalUnits: 4, items: [{ name: 'X', startUnit: 1, rackUnits: 1 }], cables: [] },
+    } as Partial<EquipmentItem>)
+    const preset = presetFromBlackBoxRack(ohne, 'p1', 'R2')!
+    expect('rentmanId' in (preset.rack ?? {})).toBe(false)
+    expect('rentmanId' in preset.items[0]).toBe(false)
+  })
+
+  it('gibt ohne Snapshot null zurueck', () => {
+    expect(presetFromBlackBoxRack(eq(), 'p1', 'X')).toBeNull()
+  })
+})
+
+describe('die Ausschluss-Liste bleibt vollstaendig', () => {
+  it('deckt jedes Draft-Feld ab, das nicht vom Geraet kommt', () => {
+    // Subtraktion statt Aufzaehlung: alles am Draft, was NICHT in der
+    // Ausschluss-Liste steht, muss ein Geraete-Feld sein und mitreisen.
+    // Kommt ein Feld dazu, faellt dieser Test — und zwar an der Stelle, an
+    // der jemand entscheiden MUSS, auf welche Seite es gehoert. Das ist die
+    // Umkehrung des Fehlers: ein vergessenes Feld reist mit, statt still
+    // liegen zu bleiben.
+    const draftKeys = interfaceKeys(draftTypesSrc, 'RackPlacementDraft')
+    const notFromEquipment = [...RACK_DRAFT_FIELDS_NOT_FROM_EQUIPMENT]
+    const fromEquipment = draftKeys.filter((k) => !notFromEquipment.includes(k))
+
+    // Stand bei Einfuehrung — die Zeugen dieser Aufteilung.
+    expect(fromEquipment).toEqual([
+      'category',
+      'depthMm',
+      'frontPanelCrop',
+      'frontPanelImageUrl',
+      'inputs',
+      'isPatchPanel',
+      'isRackDevice',
+      'isRackShelf',
+      'name',
+      'outputs',
+      'rackUnits',
+      'rearPanelCrop',
+      'rearPanelImageUrl',
+      'rentmanId',
+      'stlDataUri',
+    ])
+    // Und die Ausschluss-Liste enthaelt nichts, was es am Draft nicht gibt.
+    expect(notFromEquipment.filter((k) => !draftKeys.includes(k))).toEqual([])
+  })
+})


### PR DESCRIPTION
## Der Fund

#626 hat eine zweite Aufzählung derselben Umwandlung gefunden und gelöscht. Es
gab noch **zwei weitere** — beide bauen ein `GroupPreset` nicht aus dem
Builder-Draft, sondern aus Geräten, die schon im Plan liegen, und beide standen
als eigene Aufzählung mitten in je einem `useEffect` im `LibraryPanel`.

**Weg 1 — „Rack Builder aus Auswahl"** (`LibraryPanel.tsx:154`)
Verlor `depthMm`, `stlDataUri`, `isPatchPanel`, `isRackShelf` und `rentmanId`.
Ein 800-mm-Gerät mit STL-Modell und Patchblenden-Marker kam als tiefenloses
Kästchen ohne Geometrie im Rack an. Die 3D-Ansicht kann dann nicht mehr prüfen,
ob hinter dem Gerät noch eine Patchblende passt — genau wofür #170 diese Felder
eingeführt hat. Der Draft (`RackPlacementDraft`) und `presetFromDraft` tragen
alle fünf; nur der Weg dorthin ließ sie liegen.

**Weg 2 — „Rack bearbeiten" auf einem platzierten Black-Box-Rack**
(`LibraryPanel.tsx:237`)
Verlor **beide** Rentman-Ids: die Kombi-Id des Racks (`eq.rentmanId`) und die je
Inhalt (`snap.items[].rentmanId`). Der Snapshot trägt sie ausdrücklich —

> `// #335 — Rentman-ID des Inhalts mitschnappen (für späteren Sync/Export).`

— und der Typ verspricht *„Bleibt über Save/Reload erhalten"*. Genau der
Save/Reload-Weg warf sie weg: einmal „Rack bearbeiten" und speichern, und die
Rentman-Herkunft des ganzen Racks war aus dem Snapshot verschwunden.

## Der Fix

Beide wandern als `presetFromEquipmentSelection` und `presetFromBlackBoxRack`
nach `lib/rackPreset.ts` — **neben die Gegenrichtung**. Eine vierte Aufzählung
an einer vierten Stelle hätte dasselbe Schicksal gehabt wie die dritte.

## Gemessen, nicht behauptet

Die alten Blöcke wortgleich aus git gezogen und gegen die neuen Funktionen
laufen lassen:

- **Weg 1** fällt an genau den fünf Feldern; nach deren Abzug sind alt und neu
  `toEqual`-identisch.
- **Weg 2** fällt an genau den zwei Ids; nach deren Abzug identisch.

Der Umbau ändert also nichts außer dem Fehler.

## Der Guard ist eine Ausschluss-Liste

`RACK_DRAFT_FIELDS_NOT_FROM_EQUIPMENT` führt die Draft-Felder, die die **Lage im
Rack** beschreiben (`startUnit`, `mountSide`, `shelfOffsetX/Z`, …). Der Test
liest den echten Interface-Rumpf von `RackPlacementDraft` und prüft: alles, was
nicht in der Liste steht, ist ein Geräte-Feld und muss mitreisen.

Das ist die Umkehrung des Fehlers — ein neu hinzugefügtes Feld lässt den Test
fallen, an genau der Stelle, an der jemand entscheiden **muss**, auf welche
Seite es gehört. Vergessen heißt dann „reist mit", nicht „bleibt still liegen".
Die Form ist die aus
[TEMPLATE-FIELD-MEASUREMENT.md](https://github.com/larszu/av-planner-suite/blob/main/docs/research/synthesis/TEMPLATE-FIELD-MEASUREMENT.md):
ableiten durch Subtraktion.

## Ausdrücklich nicht geändert

`cables: []` bleibt in Weg 1 leer. Das ist Absicht und steht jetzt unter einem
Test, damit es niemand für denselben Fehler wie #626 hält: die Kabel zwischen
den markierten Geräten liegen weiter im Plan, im Rack verkabelt der Nutzer im
Sub-Canvas.

Design-Frage 2 (Modell- vs. Instanz-Felder) bleibt unberührt: die Grenze hier
ist der Feldsatz, den der Draft **ohnehin schon** trägt. `priceEUR` und die
anderen Handels-Felder stehen nicht im Draft und kommen hier nicht vor.

## Grün

- `npm test` — 563 Tests (10 neu), 53 Dateien
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npx eslint` auf beide geänderten Dateien — 0 Errors, keine neue Warnung

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_