### PR TITLE
greengo: „minimal but valid" stand unter keinem Test — und stimmte nicht ganz

### DIFF
--- a/src/renderer/components/Export/GreenGoExportDialog.tsx
+++ b/src/renderer/components/Export/GreenGoExportDialog.tsx
@@ -247,7 +247,22 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
     updateGreenGoConfig(config)
   }
 
+  /**
+   * ADR-005, Regel 4 — der Export verspricht im Modulkopf eine Datei, die
+   * „directly into the GreenGo Manager software (v5.x)" laedt. Fuer die
+   * leere Konfiguration stimmt das nachweislich nicht: `buildGg5File`
+   * schreibt dann eine .gg5, die der EIGENE Importer des Cable-Planners
+   * ablehnt („No users or groups found in the file. Is this a valid GreenGo
+   * 5.x .gg5 file?"). Eine Station ODER eine Gruppe reicht; erst beides leer
+   * bricht es.
+   *
+   * Statt eine Datei auszugeben, die wir selbst nicht wieder einlesen
+   * koennen, bleibt der Knopf aus und sagt warum.
+   */
+  const exportBlocked = config.users.length === 0 && config.groups.length === 0
+
   const handleExport = () => {
+    if (exportBlocked) return
     updateGreenGoConfig(config)
     // v7.9.116 — Einheitlicher Stempel, gg5-Endung beibehalten.
     downloadFile(buildExportFilenameWithSuffix(config.systemName || 'GreenGo', 'config', 'gg5'), buildGg5File(config))
@@ -728,7 +743,16 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
             <button
               type="button"
               onClick={handleExport}
-              className="rounded bg-emerald-600 px-3 py-1.5 text-cp-xs hover:bg-emerald-500"
+              disabled={exportBlocked}
+              title={
+                exportBlocked
+                  ? t(
+                      'greengo.export.blocked',
+                      'Ohne mindestens eine Station oder Gruppe entsteht keine gültige .gg5 — lege zuerst eine an.',
+                    )
+                  : undefined
+              }
+              className="rounded bg-emerald-600 px-3 py-1.5 text-cp-xs hover:bg-emerald-500 disabled:cursor-not-allowed disabled:bg-cp-surface-4 disabled:text-cp-text-muted disabled:hover:bg-cp-surface-4"
             >
               <Icon icon={Download} size="xs" className="mr-1 inline-block align-text-bottom" />{t('greengo.export.gg5', 'Als .gg5 exportieren')}
             </button>

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -1417,6 +1417,7 @@ export const en: Dict = {
   'greengo.importOverlay.matchRenamed': 'Slot {slots}: the station has a different name in the file — the mapping was guessed again.',
   'greengo.importOverlay.matchStale': 'Slot {slots}: the previously mapped device is no longer in the plan — guessed again.',
   'greengo.importOverlay.matchHint': 'Guessed mappings can be corrected per station below before the import is applied.',
+  'greengo.export.blocked': 'Without at least one station or group there is no valid .gg5 — create one first.',
   'greengo.importOverlay.unreadEntries': ' ({count} entries)',
   'greengo.importOverlay.importedGroups': 'Imported groups',
   'greengo.importOverlay.linkStations': 'Link stations → canvas devices',

--- a/tests/exportGreengoRoundTrip.test.ts
+++ b/tests/exportGreengoRoundTrip.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import { buildGg5File } from '../src/renderer/lib/exportGreengo'
+import { isParseError, parseGg5File } from '../src/renderer/lib/importGreengo'
+import dialogSrc from '../src/renderer/components/Export/GreenGoExportDialog.tsx?raw'
+import dictsSrc from '../src/renderer/lib/i18n/dicts.ts?raw'
+import type { GreenGoConfig } from '../src/renderer/types/greengo'
+
+// ADR-005, Inkrement 4, Regel 4 — eine Zusage muss pruefbar sein.
+//
+// Der Kopf von exportGreengo.ts verspricht seit jeher:
+//
+//   „Generates a minimal but valid GreenGo .gg5 JSON configuration file …
+//    The output can be loaded directly into the GreenGo Manager software
+//    (v5.x)."
+//
+// 290 Zeilen Erzeuger, und dazu stand KEINE einzige Zeile Test. Ob das
+// Ergebnis ueberhaupt wieder lesbar ist, wusste niemand.
+//
+// Der GreenGo Manager steht hier nicht zur Verfuegung; der schaerfste
+// verfuegbare Massstab ist der EIGENE Importer. Was der Cable-Planner
+// schreibt und selbst nicht mehr einlesen kann, ist auch fuer den Manager
+// kein guter Kandidat — und andersherum faengt dieser Test jede Aenderung am
+// Erzeuger, die das Format bricht.
+
+const parseBack = (config: GreenGoConfig) => {
+  const result = parseGg5File(buildGg5File(config))
+  if (isParseError(result)) throw new Error(`.gg5 nicht lesbar: ${result.error}`)
+  return result
+}
+
+const config: GreenGoConfig = {
+  systemName: 'Halle 7',
+  description: 'Zweite Regie, Ebene 3',
+  multicastAddress: '239.1.160.7',
+  sampleRate: 48000,
+  users: [
+    { id: 1, name: 'BPX1', displayName: 'Regie', color: 2, groupIds: [1, 2] },
+    { id: 2, name: 'WBPX2', groupIds: [2] },
+  ],
+  groups: [
+    { id: 1, name: 'PGM', color: 1 },
+    { id: 2, name: 'CAM' },
+  ],
+}
+
+describe('buildGg5File — was rausgeht, kommt wieder rein', () => {
+  it('der eigene Importer liest die erzeugte Datei', () => {
+    expect(() => parseBack(config)).not.toThrow()
+  })
+
+  it('System-Angaben ueberstehen die Runde', () => {
+    const back = parseBack(config).config
+    expect(back.systemName).toBe('Halle 7')
+    expect(back.description).toBe('Zweite Regie, Ebene 3')
+    expect(back.multicastAddress).toBe('239.1.160.7')
+    expect(back.sampleRate).toBe(48000)
+  })
+
+  it('Stationen behalten Name, Anzeigename, Farbe und Gruppen', () => {
+    const back = parseBack(config).config
+    expect(back.users).toHaveLength(2)
+    expect(back.users[0]).toMatchObject({
+      id: 1, name: 'BPX1', displayName: 'Regie', color: 2, groupIds: [1, 2],
+    })
+    expect(back.users[1]).toMatchObject({ id: 2, name: 'WBPX2', groupIds: [2] })
+  })
+
+  it('Gruppen behalten Nummer, Name und Farbe', () => {
+    const back = parseBack(config).config
+    expect(back.groups).toEqual([
+      { id: 1, name: 'PGM', color: 1 },
+      { id: 2, name: 'CAM', color: 0 },
+    ])
+  })
+
+  it('Umlaute ueberleben die JSON-Runde', () => {
+    const back = parseBack({ ...config, groups: [{ id: 1, name: 'Bühne Süd' }] }).config
+    expect(back.groups[0].name).toBe('Bühne Süd')
+  })
+
+  it('das volle 12-Stationen-/9-Gruppen-System geht durch', () => {
+    // MAX_USERS / MAX_GROUPS im Dialog. Die obere Grenze ist die
+    // interessante: dort haengen die Tastenbelegungen der Beltpacks.
+    const voll: GreenGoConfig = {
+      ...config,
+      users: Array.from({ length: 12 }, (_, i) => ({
+        id: i + 1, name: `BPX${i + 1}`, groupIds: [1, 2, 3],
+      })),
+      groups: Array.from({ length: 9 }, (_, i) => ({ id: i + 1, name: `G${i + 1}` })),
+    }
+    const back = parseBack(voll).config
+    expect(back.users).toHaveLength(12)
+    expect(back.groups).toHaveLength(9)
+    expect(back.users[11].groupIds).toEqual([1, 2, 3])
+  })
+
+  it('eine Station ODER eine Gruppe reicht — das ist das echte Minimum', () => {
+    const nurGruppe = { ...config, users: [], groups: [{ id: 1, name: 'PGM' }] }
+    const nurStation = { ...config, users: [{ id: 1, name: 'BPX1', groupIds: [] }], groups: [] }
+    expect(() => parseBack(nurGruppe)).not.toThrow()
+    expect(() => parseBack(nurStation)).not.toThrow()
+  })
+
+  it('bei BEIDEM leer entsteht eine Datei, die der eigene Importer ablehnt', () => {
+    // Das ist der Punkt, an dem „minimal but valid" nicht mehr stimmt.
+    // Deshalb steht im Dialog jetzt eine Sperre davor — hier festgehalten,
+    // damit klar bleibt, WARUM die Sperre da ist.
+    expect(() => parseBack({ ...config, users: [], groups: [] })).toThrow(/No users or groups/)
+  })
+})
+
+describe('der Dialog exportiert die leere Konfiguration gar nicht erst', () => {
+  it('sperrt den Knopf genau an dieser Grenze', () => {
+    const src = dialogSrc.replace(/^\s*(\/\/|\*|\/\*).*$/gm, '')
+    expect(src).toContain('config.users.length === 0 && config.groups.length === 0')
+    expect(src).toContain('disabled={exportBlocked}')
+  })
+
+  it('sagt statt zu schweigen, was fehlt', () => {
+    expect(dialogSrc).toContain('greengo.export.blocked')
+    expect(dictsSrc).toContain('Without at least one station or group')
+  })
+})


### PR DESCRIPTION
## Die Zusage

`exportGreengo.ts` verspricht seit jeher im Modulkopf:

> Generates a **minimal but valid** GreenGo .gg5 JSON configuration file …
> The output can be **loaded directly into the GreenGo Manager software (v5.x)**.

290 Zeilen Erzeuger — und dazu stand **keine einzige Zeile Test**. Ob das
Ergebnis überhaupt wieder lesbar ist, wusste niemand. ADR-005 Regel 4: eine
Zusage muss prüfbar sein.

## Der Maßstab

Der GreenGo Manager steht hier nicht zur Verfügung. Der schärfste verfügbare
Maßstab ist der **eigene Importer**: was der Cable-Planner schreibt und selbst
nicht mehr einlesen kann, ist auch für den Manager kein guter Kandidat — und
andersherum fängt der Test jede Änderung am Erzeuger, die das Format bricht.

## Das Ergebnis

Die Zusage hält — mit einer Ausnahme.

**Hält:** System-Name, Beschreibung, Multicast-Adresse, Sample-Rate, Stationen
(Name, Anzeigename, Farbe, Gruppen-Zugehörigkeit) und Gruppen kommen
unverändert zurück. Auch Umlaute und das volle 12-Stationen-/9-Gruppen-System.

**Hält nicht:** Sind Stationen **und** Gruppen leer, schreibt `buildGg5File`
eine Datei, die `parseGg5File` ablehnt:

> `No users or groups found in the file. Is this a valid GreenGo 5.x .gg5 file?`

Eine Station **oder** eine Gruppe reicht — erst beides leer bricht es. Der
Export-Knopf war dabei immer aktiv: der Nutzer bekam eine `.gg5`, die der
Cable-Planner selbst für ungültig hält.

## Der Fix

Statt eine Datei auszugeben, die wir selbst nicht wieder einlesen können,
bleibt der Knopf an genau dieser Grenze aus und sagt warum — im selben Ton wie
die Matrix-Hinweise, die schon dort stehen („Noch keine Stationen und Gruppen —
wechsle zu den Tabs …").

Die Grenze selbst steht als Test daneben, damit klar bleibt, **warum** die
Sperre da ist und nicht jemand sie als überflüssig entfernt.

## Grün

- `npm test` — 583 Tests (10 neu), 55 Dateien
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npx eslint` auf beide geänderten Dateien — 0 Errors, 0 Warnungen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_