### PR TITLE
library: der 23-Feld-Nachbau löscht den Bibliothekseintrag nicht mehr leer

### DIFF
--- a/src/renderer/lib/inventoryMerge.ts
+++ b/src/renderer/lib/inventoryMerge.ts
@@ -25,6 +25,12 @@
 /**
  * `over` ueber `base` legen, aber nur dort, wo `over` einen Wert HAT.
  * `undefined` heisst „keine Aussage", nicht „loeschen".
+ *
+ * Die Regel ist nicht auf das Lager beschraenkt: `saveEquipmentAsTemplate`
+ * (store/slices/templateSlice.ts) benutzt sie aus demselben Grund — der
+ * 23-Feld-Nachbau eines Templates darf die reicheren Felder eines
+ * vorhandenen Bibliothekseintrags nicht loeschen. Der Helfer wohnt hier,
+ * weil er hier entstanden ist.
  */
 export const mergeDefined = <T extends object>(base: T, over: T): T => {
   const out = { ...base } as Record<string, unknown>

--- a/src/renderer/store/slices/templateSlice.ts
+++ b/src/renderer/store/slices/templateSlice.ts
@@ -2,6 +2,9 @@ import type { StateCreator } from 'zustand'
 import type { EquipmentItem, EquipmentTemplate } from '../../types/equipment'
 import { LIMITS } from '../../lib/layoutConstants'
 import { upsertCachedRentmanTemplate } from '../../lib/rentmanTemplateCache'
+// Dieselbe Regel wie beim Lager-Import (#628): was die neue Fassung nicht
+// sagt, loescht nichts. Der Helfer wohnt dort, weil er dort entstanden ist.
+import { mergeDefined } from '../../lib/inventoryMerge'
 import { persistCustomLibrary, persistKnownCategories } from '../libraryPersist'
 import type { ProjectState } from '../projectStore'
 
@@ -145,11 +148,36 @@ export const createTemplateSlice: StateCreator<ProjectState, [], [], TemplateSli
       const item = state.project.equipment.find((e) => e.id === equipmentId)
       if (!item) return {}
       const existing = state.customLibrary.find((t) => t.name === item.name)
-      const template = templateFromEquipment(item, { preserveFlags: existing })
-      const next = [
-        ...state.customLibrary.filter((t) => t.name !== template.name),
-        template,
-      ]
+      const rebuilt = templateFromEquipment(item, { preserveFlags: existing })
+      // ADR-005, Regel 2 — der aermere Nachbau darf nicht loeschen.
+      //
+      // `templateFromEquipment` nennt 23 Felder. Die Bibliothek traegt aber
+      // mehr: Rack-Hoehe und Rack-Flag, Front-/Rear-Foto samt Zuschnitt,
+      // Tiefe, Gewicht, Leistung, Aufloesung, Display-Groesse, NetBox-Pfad —
+      // alles, was ein Rentman- oder NetBox-Import eingetragen hat. Das
+      // Ersetzen loeschte sie: ein aus Rentman importiertes Rack-Geraet war
+      // nach einem Klick auf „Als Standard-Vorlage ueberschreiben" kein
+      // Rack-Geraet mehr und konnte in kein Rack.
+      //
+      // `upsertCachedRentmanTemplate` (lib/rentmanTemplateCache.ts) fuehrt
+      // genau diese Regel seit ADR-005 fuer den CACHE — mit derselben
+      // Begruendung. Die Bibliothek selbst hatte sie nie.
+      //
+      // `mergeDefined` und nicht `{ ...alt, ...neu }`: der Nachbau setzt
+      // Felder AUSDRUECKLICH auf `undefined`, ein Spread wuerde sie damit
+      // ebenfalls ausloeschen. Was das Geraet SAGT, gewinnt weiterhin — auch
+      // ein leerer String, denn ein geleertes Feld ist eine Aussage (die
+      // Eingabefelder schreiben `event.target.value`, also '').
+      //
+      // Welche der ueberzaehligen Felder der Nachbau kuenftig selbst tragen
+      // soll, ist die offene Modell-/Instanz-Frage. Diese Regel entscheidet
+      // sie nicht — sie sorgt nur dafuer, dass bis dahin nichts verschwindet.
+      const template = existing ? mergeDefined(existing, rebuilt) : rebuilt
+      // In-place ersetzen statt ans Ende haengen: der Eintrag behaelt seine
+      // Stelle in der Bibliothek.
+      const next = existing
+        ? state.customLibrary.map((t) => (t.name === template.name ? template : t))
+        : [...state.customLibrary, template]
       persistCustomLibrary(next)
       if (template.rentmanId) upsertCachedRentmanTemplate(template)
       return { customLibrary: next }

--- a/tests/templateSaveMerge.test.ts
+++ b/tests/templateSaveMerge.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import type { EquipmentItem, EquipmentTemplate } from '../src/renderer/types/equipment'
+
+// ADR-005, Inkrement 4, Regel 2 — der aermere Nachbau darf nicht loeschen.
+//
+// „Als Standard-Vorlage ueberschreiben" baut den Bibliothekseintrag aus
+// `templateFromEquipment` NEU — 23 Felder. Die Bibliothek traegt aber mehr:
+// Rack-Hoehe und Rack-Flag, Front-/Rear-Foto samt Zuschnitt, Tiefe, Gewicht,
+// Leistung, Aufloesung, NetBox-Pfad. Alles, was ein Rentman- oder
+// NetBox-Import eingetragen hat.
+//
+// Der alte Stand hat den vorhandenen Eintrag herausgefiltert und den Nachbau
+// angehaengt. Ein aus Rentman importiertes Rack-Geraet war damit nach einem
+// Klick kein Rack-Geraet mehr — und konnte in kein Rack.
+//
+// Eine Datei weiter fuehrt `upsertCachedRentmanTemplate` genau diese Regel
+// seit ADR-005 fuer den CACHE, mit derselben Begruendung. Die Bibliothek
+// selbst hatte sie nie.
+
+const item = (over: Partial<EquipmentItem> = {}): EquipmentItem =>
+  ({
+    id: 'e1',
+    name: 'ATEM Mini Extreme',
+    category: 'Videomischer',
+    inputs: [{ id: 'in1', name: 'SDI 1', type: 'port', connectorType: 'BNC' }],
+    outputs: [],
+    x: 10,
+    y: 20,
+    width: 240,
+    height: 80,
+    ...over,
+  }) as unknown as EquipmentItem
+
+/** Ein Eintrag, wie ihn ein Rentman-/NetBox-Import hinterlaesst. */
+const richTemplate = (): EquipmentTemplate =>
+  ({
+    name: 'ATEM Mini Extreme',
+    category: 'Videomischer',
+    inputs: [],
+    outputs: [],
+    isRackDevice: true,
+    rackUnits: 2,
+    depthMm: 480,
+    weightKg: 12.4,
+    powerWatts: 350,
+    resolution: '1080p60',
+    displaySizeInch: 7,
+    netboxPath: 'blackmagic/atem-mini-extreme',
+    frontPanelImageUrl: 'data:image/png;base64,AAAA',
+    frontPanelCrop: { x: 0, y: 0, width: 1, height: 1 },
+    ipAddress: '192.168.1.10',
+  }) as unknown as EquipmentTemplate
+
+const saveOver = async (existing: EquipmentTemplate, placed: EquipmentItem) => {
+  const { useProjectStore } = await import('../src/renderer/store/projectStore')
+  useProjectStore.setState({ customLibrary: [existing] })
+  useProjectStore.setState((s) => ({ project: { ...s.project, equipment: [placed] } }))
+  useProjectStore.getState().saveEquipmentAsTemplate(placed.id)
+  return useProjectStore.getState().customLibrary
+}
+
+describe('saveEquipmentAsTemplate — was der Eintrag schon wusste, bleibt', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('behaelt Rack-Flag und Rack-Hoehe', async () => {
+    // Der Kern: ein Rack-Geraet bleibt eines. Sonst faellt es aus jedem Rack.
+    const lib = await saveOver(richTemplate(), item())
+    const t = lib.find((x) => x.name === 'ATEM Mini Extreme')!
+    expect(t.isRackDevice).toBe(true)
+    expect(t.rackUnits).toBe(2)
+  })
+
+  it('behaelt die Engineering-Daten', async () => {
+    const lib = await saveOver(richTemplate(), item())
+    const t = lib.find((x) => x.name === 'ATEM Mini Extreme')!
+    expect(t.depthMm).toBe(480)
+    expect(t.weightKg).toBe(12.4)
+    expect(t.powerWatts).toBe(350)
+    expect(t.resolution).toBe('1080p60')
+    expect(t.displaySizeInch).toBe(7)
+  })
+
+  it('behaelt Foto, Zuschnitt und NetBox-Herkunft', async () => {
+    const lib = await saveOver(richTemplate(), item())
+    const t = lib.find((x) => x.name === 'ATEM Mini Extreme')!
+    expect(t.frontPanelImageUrl).toBe('data:image/png;base64,AAAA')
+    expect(t.frontPanelCrop).toEqual({ x: 0, y: 0, width: 1, height: 1 })
+    expect(t.netboxPath).toBe('blackmagic/atem-mini-extreme')
+  })
+
+  it('das Geraet gewinnt weiterhin, wo es etwas SAGT', async () => {
+    // Der Sinn des Knopfes bleibt: was am Geraet steht, wird zur Vorlage.
+    const lib = await saveOver(richTemplate(), item({ ipAddress: '10.0.0.5' }))
+    const t = lib.find((x) => x.name === 'ATEM Mini Extreme')!
+    expect(t.ipAddress).toBe('10.0.0.5')
+    expect(t.inputs).toHaveLength(1)
+  })
+
+  it('ein geleertes Feld ist eine Aussage und loescht', async () => {
+    // Die Eingabefelder schreiben `event.target.value`, ein geleertes Feld
+    // ist also '' und nicht undefined — der Unterschied ist der ganze Punkt.
+    const lib = await saveOver(richTemplate(), item({ ipAddress: '' }))
+    expect(lib.find((x) => x.name === 'ATEM Mini Extreme')!.ipAddress).toBe('')
+  })
+
+  it('haelt den Eintrag an seiner Stelle in der Bibliothek', async () => {
+    const { useProjectStore } = await import('../src/renderer/store/projectStore')
+    const other = { name: 'Zzz Letzte', category: 'Sonstiges', inputs: [], outputs: [] } as unknown as EquipmentTemplate
+    useProjectStore.setState({ customLibrary: [richTemplate(), other] })
+    useProjectStore.setState((s) => ({ project: { ...s.project, equipment: [item()] } }))
+    useProjectStore.getState().saveEquipmentAsTemplate('e1')
+    expect(useProjectStore.getState().customLibrary.map((t) => t.name)).toEqual([
+      'ATEM Mini Extreme',
+      'Zzz Letzte',
+    ])
+  })
+
+  it('legt ohne vorhandenen Eintrag weiterhin einfach an', async () => {
+    const { useProjectStore } = await import('../src/renderer/store/projectStore')
+    useProjectStore.setState({ customLibrary: [] })
+    useProjectStore.setState((s) => ({ project: { ...s.project, equipment: [item()] } }))
+    useProjectStore.getState().saveEquipmentAsTemplate('e1')
+    const lib = useProjectStore.getState().customLibrary
+    expect(lib).toHaveLength(1)
+    expect(lib[0].name).toBe('ATEM Mini Extreme')
+    expect(lib[0].isRackDevice).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Der Fall

„Als Standard-Vorlage überschreiben" baut den Bibliothekseintrag aus
`templateFromEquipment` **neu** — 23 Felder — und hat den vorhandenen dabei
herausgefiltert:

```ts
const template = templateFromEquipment(item, { preserveFlags: existing })
const next = [
  ...state.customLibrary.filter((t) => t.name !== template.name),
  template,
]
```

Alles, was der Eintrag mehr wusste, war damit weg: **Rack-Flag und Rack-Höhe**,
Front-/Rear-Foto samt Zuschnitt, Tiefe, Gewicht, Leistung, Auflösung,
Display-Größe, NetBox-Pfad — also genau das, was ein Rentman- oder
NetBox-Import eingetragen hatte.

Ein aus Rentman importiertes Rack-Gerät war nach **einem Klick** kein
Rack-Gerät mehr und konnte in kein Rack.

## Die Regel gibt es hier schon — eine Datei weiter

`upsertCachedRentmanTemplate` in `lib/rentmanTemplateCache.ts` führt seit
ADR-005 exakt diese Regel für den **Cache**, mit dieser Begründung:

> Drei Funktionen bauen in dieser Codebase ein Template aus einem
> EquipmentItem, und sie sind sich nicht einig, was dazugehört … Ein Ersetzen
> ließ deshalb immer die ärmste Rekonstruktion gewinnen, die zuletzt vorbeikam.

Der Cache war geschützt. **Die Bibliothek selbst nie.**

## Was sich ändert

- **`mergeDefined` statt Ersetzen** — und ausdrücklich nicht `{ ...alt, ...neu }`:
  der Nachbau setzt Felder ausdrücklich auf `undefined`, ein Spread würde sie
  ebenfalls auslöschen. Derselbe Grund wie beim Lager-Import in #628, deshalb
  derselbe Helfer.
- **Was das Gerät *sagt*, gewinnt weiterhin** — auch ein leerer String. Ein
  geleertes Feld ist eine Aussage (die Eingabefelder schreiben
  `event.target.value`, also `''`), `undefined` ist keine.
- **Der Eintrag behält seine Stelle** in der Bibliothek, statt ans Ende zu
  wandern. Kleine Verhaltensänderung, hier ausdrücklich genannt.

## Was das *nicht* entscheidet

Die geparkte Modell-/Instanz-Frage bleibt offen. Welche der überzähligen Felder
der Nachbau künftig **selbst** tragen soll — und auf welche Seite die
Handels-Felder (`priceEUR`, `rentPricePerDay`, `ownership`, `supplier`,
`stockLocation`) gehören —, entscheidet dieser PR nicht. Er sorgt nur dafür,
dass bis dahin nichts verschwindet.

Ein Fund am Rande, der die Frage aber **schärft**: `toTemplateFromEquipment`
im Rentman-Cache trägt 37 Felder — alle aus Gruppe B der
[Messung](https://github.com/larszu/av-planner-suite/blob/main/docs/research/synthesis/TEMPLATE-FIELD-MEASUREMENT.md)
(Rack-Höhe, Tiefe, Gewicht, Leistung, Fotos …) und **keins** aus Gruppe C
(Preise, Lieferant, Lagerort). Die Codebase hat für B also längst eine Antwort
und schweigt zu C — genau die Aufteilung, die die Messung vorgeschlagen hat.

## Gegengeprüft

Vier der sieben Tests fallen am alten Stand. Die drei, die auf **beiden**
Ständen grün sind, halten fest, was sich *nicht* geändert hat: das Gerät
gewinnt, ein geleertes Feld löscht, ein neuer Eintrag wird schlicht angelegt.

## Grün

- `npm test` — 590 Tests (7 neu), 56 Dateien
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npx eslint` auf beide geänderten Dateien — 0 Errors, 0 Warnungen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_