### PR TITLE
library: der Update-Prompt riss die Kabel ab und überschrieb die Netz-Identität

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -81,7 +81,7 @@ import {
   markDeviceSynced,
   markGroupSynced,
   findOutdatedEquipment,
-  applyDeviceTemplateUpdate,
+  stampDeviceLibraryRef,
   detectFolderDeletions,
   pushMissingItemsToFolder,
 } from './lib/librarySync'
@@ -389,7 +389,7 @@ export default function App() {
             `${lines.join('\n')}${more}\n\n` +
             t(
               'app.libUpdate.body',
-              'Im Bibliotheks-Ordner liegt eine neuere Version. Auf die aktuellen Library-Stände aktualisieren?\n\n(Geräte-Namen + Notizen bleiben erhalten. Rack/Gruppen-Updates müssen aktuell manuell neu platziert werden.)',
+              'Im Bibliotheks-Ordner liegt eine neuere Version. Auf die aktuellen Library-Stände aktualisieren?\n\nÜbernommen wird, was den Gerätetyp beschreibt: Kategorie, Ports, Rack-Maße, Bild und Symbol. Alles, was zum einzelnen Gerät gehört, bleibt — Name, Notizen, Position, Farbe, Netzwerk-Adresse und Zugangsdaten, Seriennummer, Status.\n\nKabel werden auf die neuen Ports mitgezogen (nach Steckertyp und Beschriftung). Findet ein Kabel keinen passenden Port mehr, wird es entfernt.\n\nRack/Gruppen-Updates müssen aktuell manuell neu platziert werden.',
             ),
           okLabel: t('app.libUpdate.okBtn', 'Aktualisieren'),
         },
@@ -403,8 +403,34 @@ export default function App() {
         if (!newTemplate) continue
         const oldEq = freshState.project.equipment.find((e) => e.id === item.equipmentId)
         if (!oldEq) continue
-        const updated = applyDeviceTemplateUpdate(oldEq, newTemplate)
-        freshState.updateEquipment(item.equipmentId, updated)
+        // ADR-005, Regel 1 und 2 — hier lief eine zweite, aermere Fassung des
+        // Template-Tauschs. `applyDeviceTemplateUpdate` legte das TEMPLATE als
+        // Basis unter das Geraet und rettete nur id/x/y/name/notes. Zwei
+        // Folgen, beide gemessen:
+        //
+        //   1. Die Ports des Templates ersetzten die des Geraets MITSAMT
+        //      ihren Ids — ohne dass irgendwer die Kabel nachzog. Nach einem
+        //      Klick auf „Aktualisieren" zeigten alle Kabel des Geraets auf
+        //      Port-Ids, die es nicht mehr gab. Sie blieben im Projekt, ohne
+        //      Anschluss.
+        //   2. Traegt das Template eine Netz-Identitaet (und das tut es:
+        //      `templateFromEquipment` speichert IP, Benutzer und Passwort),
+        //      ueberschrieb sie die des platzierten Geraets. Ein Typ-Update
+        //      setzte damit die Adresse und die Zugangsdaten EINER konkreten
+        //      Maschine auf die des Vorlagen-Geraets.
+        //
+        // `replaceEquipmentWithTemplate` (#314) macht denselben Tausch seit
+        // jeher richtig: es mappt die Ports ueber (connectorType,
+        // Beschriftung/Name) und dann positional, zieht die Kabel nach,
+        // verwirft nur, was sich nicht mappen laesst, und laesst das Geraet
+        // die Basis sein. Deshalb geht der Update-Prompt jetzt durch dieselbe
+        // Aktion. Das gestempelte Template, damit der neue fileVersion-Stand
+        // am libraryRef landet — sonst meldet der naechste Projekt-Start
+        // dasselbe Geraet wieder als veraltet.
+        freshState.replaceEquipmentWithTemplate(
+          item.equipmentId,
+          stampDeviceLibraryRef(newTemplate),
+        )
         applied += 1
       }
       const skipped = outdated.length - applied

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3110,7 +3110,7 @@ export const en: Dict = {
   'app.libUpdate.moreLines': '…and {n} more',
   'app.libUpdate.title': '{n} library item(s) in this project are out of date:',
   'app.libUpdate.body':
-    'A newer version is in the library folder. Update to the current library state?\n\n(Device names + notes are kept. Rack/group updates currently have to be replaced manually.)',
+    'A newer version is in the library folder. Update to the current library state?\n\nWhat gets adopted is what describes the device type: category, ports, rack dimensions, image and icon. Everything belonging to the individual device stays — name, notes, position, colour, network address and credentials, serial number, status.\n\nCables are carried over to the new ports (matched by connector type and label). A cable that no longer finds a matching port is removed.\n\nRack/group updates currently have to be replaced manually.',
   'app.libUpdate.okBtn': 'Update',
   'app.libUpdate.doneTitle': 'Update done',
   'app.libUpdate.doneAppliedBody': '{n} device(s) updated.',

--- a/src/renderer/lib/librarySync.ts
+++ b/src/renderer/lib/librarySync.ts
@@ -426,23 +426,19 @@ export const findOutdatedEquipment = (
  *  dangling if v2 of the template changed port IDs — the user is
  *  responsible for that (rare in practice because templates rarely
  *  recycle IDs). */
-export const applyDeviceTemplateUpdate = (
-  oldEq: EquipmentItem,
-  newTemplate: EquipmentTemplate,
-): EquipmentItem => {
-  const stamped = stampDeviceLibraryRef(newTemplate)
-  return {
-    ...stamped,
-    id: oldEq.id,
-    x: oldEq.x,
-    y: oldEq.y,
-    // Preserve user-local Edits am Equipment — Notizen + ggf. Rename
-    // sind nicht Teil des Library-Templates, der Update soll sie nicht
-    // wegwerfen.
-    name: oldEq.name,
-    notes: oldEq.notes,
-  }
-}
+// ADR-005, Inkrement 4 — `applyDeviceTemplateUpdate` stand hier und ist weg.
+//
+// Sie war die zweite, aermere Fassung des Template-Tauschs: sie legte das
+// TEMPLATE als Basis unter das Geraet und rettete nur id/x/y/name/notes.
+// Damit ersetzten die Template-Ports die des Geraets mitsamt ihren Ids, ohne
+// dass irgendwer die Kabel nachzog — nach einem Klick auf „Aktualisieren"
+// hingen alle Kabel des Geraets an Port-Ids, die es nicht mehr gab. Und trug
+// das Template eine Netz-Identitaet (`templateFromEquipment` speichert IP,
+// Benutzer und Passwort), ueberschrieb sie die der konkreten Maschine.
+//
+// `replaceEquipmentWithTemplate` im equipmentSlice (#314) macht denselben
+// Tausch seit jeher richtig — Port-Mapping, Kabel nachziehen, Geraet als
+// Basis. Der Update-Prompt in App.tsx geht jetzt durch diese eine Aktion.
 
 export const syncPresetsToFolder = (presets: GroupPreset[]): void => {
   const next = new Map(presets.map((p) => [p.name, p]))

--- a/src/renderer/lib/rackPreset.ts
+++ b/src/renderer/lib/rackPreset.ts
@@ -207,12 +207,33 @@ export const RACK_DRAFT_FIELDS_NOT_FROM_EQUIPMENT = [
   'shelfOffsetZ',
 ] as const
 
-/** Die Geraete-Felder, die ein Rack-Inhalt vom Equipment erbt. */
-const itemFromEquipment = (eq: EquipmentItem): GroupPreset['items'][number] => ({
+/**
+ * Die Geraete-Felder, die ein Preset-Inhalt vom Equipment erbt.
+ *
+ * Die Feldliste ist die VEREINIGUNG dessen, was die bisherigen Aufzaehlungen
+ * schon trugen — der Rack-Weg (Tiefe, STL, Rack-Marker, Fotos) und der
+ * Gruppen-Weg in `saveGroupPreset` (Notizen, IP, Aufloesung, Display-Groesse).
+ * Jedes Feld hier steht also, weil ein bestehender Weg es bereits mitnahm;
+ * keines ist eine neue Entscheidung.
+ *
+ * Die eine Ausnahme ist `deviceTypeId`, und die ist keine: ADR-002 macht sie
+ * zur Katalog-Identitaet, und `templateFromEquipment` traegt sie mit dem
+ * Hinweis, dass ihr Verlust ein Katalog-Geraet wieder zu einer Namens-
+ * Vermutung macht. Beide Preset-Wege liessen sie liegen — ein als Gruppe
+ * gespeichertes Geraet kam beim Platzieren ohne sie zurueck.
+ *
+ * Was hier NICHT steht, sind die Handels- und Bestands-Felder (Preise,
+ * Lieferant, Lagerort). Keine der bisherigen Aufzaehlungen trug sie; ob sie
+ * reisen sollen, ist die offene Modell-/Instanz-Frage und wird hier nicht
+ * nebenbei beantwortet.
+ */
+export const itemFromEquipment = (eq: EquipmentItem): GroupPreset['items'][number] => ({
   name: eq.name,
   category: eq.category ?? 'Sonstiges',
   inputs: eq.inputs,
   outputs: eq.outputs,
+  // ADR-002 — die Katalog-Identitaet muss die Umwandlung ueberleben.
+  deviceTypeId: eq.deviceTypeId,
   isRackDevice: eq.isRackDevice ?? !!eq.rackUnits,
   rackUnits: Math.max(1, eq.rackUnits ?? 1),
   frontPanelImageUrl: eq.frontPanelImageUrl,
@@ -226,6 +247,11 @@ const itemFromEquipment = (eq: EquipmentItem): GroupPreset['items'][number] => (
   // v7.9.75 / #170 — Patchblende/Shelf sind Eigenschaften des Geraets.
   isPatchPanel: eq.isPatchPanel,
   isRackShelf: eq.isRackShelf,
+  // Aus dem Gruppen-Weg: der stand dort seit jeher und fehlte dem Rack-Weg.
+  notes: eq.notes,
+  ipAddress: eq.ipAddress,
+  resolution: eq.resolution,
+  displaySizeInch: eq.displaySizeInch,
   width: eq.width ?? 240,
   height: eq.height ?? 80,
   offsetX: 0,

--- a/src/renderer/store/slices/groupPresetSlice.ts
+++ b/src/renderer/store/slices/groupPresetSlice.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid'
 import type { GroupPreset } from '../../types/equipment'
 import { persistGroupPresets } from '../groupPresetsPersist'
 import type { ProjectState } from '../projectStore'
+import { itemFromEquipment } from '../../lib/rackPreset'
 
 /**
  * #308 — GroupPreset-CRUD-Slice. Reine Verwaltungs-Actions auf
@@ -70,17 +71,20 @@ export const createGroupPresetSlice: StateCreator<ProjectState, [], [], GroupPre
       const preset: GroupPreset = {
         id: uuidv4(),
         name,
+        // ADR-005, Regel 1 — hier stand die fuenfte Aufzaehlung derselben
+        // Umwandlung, und sie war die aermste: zwoelf Felder von rund neunzig.
+        //
+        // Ein Rack-Geraet verlor beim „als Gruppe speichern" sein Rack-Flag,
+        // seine Hoehe, Tiefe, STL-Geometrie und die Panel-Fotos; jedes Geraet
+        // verlor seine `deviceTypeId`. `placeGroupPreset` spreizt den Eintrag
+        // spaeter direkt auf das neue EquipmentItem — was hier nicht steht,
+        // ist beim Platzieren endgueltig weg.
+        //
+        // Jetzt derselbe Erbauer wie im Rack-Weg (lib/rackPreset.ts). Nur die
+        // Versaetze sind hier andere: die Gruppe behaelt die Anordnung auf dem
+        // Canvas, das Rack stapelt nach HE.
         items: items.map((e) => ({
-          name: e.name,
-          category: e.category,
-          inputs: e.inputs,
-          outputs: e.outputs,
-          width: e.width,
-          height: e.height,
-          notes: e.notes,
-          ipAddress: e.ipAddress,
-          resolution: e.resolution,
-          displaySizeInch: e.displaySizeInch,
+          ...itemFromEquipment(e),
           offsetX: e.x - minX,
           offsetY: e.y - minY,
         })),

--- a/tests/groupPresetSaveFields.test.ts
+++ b/tests/groupPresetSaveFields.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { itemFromEquipment } from '../src/renderer/lib/rackPreset'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+
+// ADR-005, Inkrement 4, Regel 1 — die fuenfte Aufzaehlung derselben
+// Umwandlung, und sie war die aermste.
+//
+// „N markierte Geraete als Gruppe speichern" nannte zwoelf Felder von rund
+// neunzig. `placeGroupPreset` spreizt den Eintrag spaeter direkt auf das neue
+// EquipmentItem — was beim Speichern nicht aufgezaehlt war, ist beim
+// Platzieren endgueltig weg.
+//
+// Zwei Verluste stechen heraus:
+//   - `deviceTypeId`: die Katalog-Identitaet aus ADR-002. Ohne sie faellt der
+//     naechste Import auf Namens-Heuristiken zurueck — aus einer
+//     Datenblatt-Tatsache wird wieder ein Regex-Treffer. `templateFromEquipment`
+//     traegt sie mit genau diesem Hinweis; beide Preset-Wege taten es nicht.
+//   - Die Rack-Daten: ein 4-HE-Geraet mit STL-Modell kam als Gruppe gespeichert
+//     ohne Rack-Flag, ohne Hoehe, ohne Tiefe und ohne Geometrie zurueck.
+
+const eq = (over: Partial<EquipmentItem> = {}): EquipmentItem =>
+  ({
+    id: 'e1',
+    name: 'ATEM 4 M/E',
+    category: 'Mischer',
+    inputs: [{ id: 'i1', name: 'SDI 1', type: 'port', connectorType: 'BNC' }],
+    outputs: [],
+    x: 100,
+    y: 200,
+    width: 240,
+    height: 80,
+    ...over,
+  }) as unknown as EquipmentItem
+
+describe('itemFromEquipment — die gemeinsame Feldliste', () => {
+  it('traegt die Katalog-Identitaet (ADR-002)', () => {
+    expect(itemFromEquipment(eq({ deviceTypeId: 'dt-atem-4me' })).deviceTypeId).toBe('dt-atem-4me')
+  })
+
+  it('traegt die Rack-Daten — der Gruppen-Weg verlor sie', () => {
+    const item = itemFromEquipment(
+      eq({
+        isRackDevice: true,
+        rackUnits: 4,
+        depthMm: 800,
+        stlDataUri: 'data:model/stl;base64,AAAA',
+        isPatchPanel: true,
+      } as Partial<EquipmentItem>),
+    )
+    expect(item.isRackDevice).toBe(true)
+    expect(item.rackUnits).toBe(4)
+    expect(item.depthMm).toBe(800)
+    expect(item.stlDataUri).toBe('data:model/stl;base64,AAAA')
+    expect(item.isPatchPanel).toBe(true)
+  })
+
+  it('traegt Notiz, IP, Aufloesung und Display-Groesse — der Rack-Weg verlor sie', () => {
+    const item = itemFromEquipment(
+      eq({
+        notes: 'Regie links',
+        ipAddress: '192.168.1.10',
+        resolution: '1080p60',
+        displaySizeInch: 24,
+      } as Partial<EquipmentItem>),
+    )
+    expect(item.notes).toBe('Regie links')
+    expect(item.ipAddress).toBe('192.168.1.10')
+    expect(item.resolution).toBe('1080p60')
+    expect(item.displaySizeInch).toBe(24)
+  })
+
+  it('traegt die Handels-Felder ausdruecklich NICHT', () => {
+    // Keine der bisherigen Aufzaehlungen trug sie. Ob sie reisen sollen, ist
+    // die offene Modell-/Instanz-Frage — hier wird sie nicht nebenbei
+    // beantwortet.
+    const item = itemFromEquipment(
+      eq({ priceEUR: 12000, rentPricePerDay: 250, supplier: 'AV GmbH' } as Partial<EquipmentItem>),
+    ) as Record<string, unknown>
+    expect(item.priceEUR).toBeUndefined()
+    expect(item.rentPricePerDay).toBeUndefined()
+    expect(item.supplier).toBeUndefined()
+  })
+})
+
+describe('saveGroupPreset — der Weg, auf dem es wirklich passiert', () => {
+  beforeEach(() => localStorage.clear())
+
+  const save = async (items: EquipmentItem[]) => {
+    const { useProjectStore } = await import('../src/renderer/store/projectStore')
+    useProjectStore.setState({ groupPresets: [] })
+    useProjectStore.setState((s) => ({ project: { ...s.project, equipment: items, cables: [] } }))
+    useProjectStore.getState().saveGroupPreset('Regie-Block', items.map((i) => i.id))
+    return useProjectStore.getState().groupPresets.find((p) => p.name === 'Regie-Block')
+  }
+
+  it('die gespeicherte Gruppe behaelt Katalog-Identitaet und Rack-Daten', async () => {
+    const preset = await save([
+      eq({ id: 'a', deviceTypeId: 'dt-atem', isRackDevice: true, rackUnits: 4, depthMm: 800 } as Partial<EquipmentItem>),
+      eq({ id: 'b', name: 'Router', x: 400, deviceTypeId: 'dt-vhub' } as Partial<EquipmentItem>),
+    ])
+    expect(preset).toBeDefined()
+    expect(preset!.items.map((i) => i.deviceTypeId)).toEqual(['dt-atem', 'dt-vhub'])
+    expect(preset!.items[0].rackUnits).toBe(4)
+    expect(preset!.items[0].depthMm).toBe(800)
+  })
+
+  it('die Anordnung auf dem Canvas bleibt — dafuer sind die Versaetze da', async () => {
+    const preset = await save([
+      eq({ id: 'a', x: 100, y: 200 }),
+      eq({ id: 'b', name: 'Router', x: 400, y: 260 }),
+    ])
+    expect(preset!.items.map((i) => [i.offsetX, i.offsetY])).toEqual([
+      [0, 0],
+      [300, 60],
+    ])
+  })
+
+  it('speichert weiterhin nichts bei weniger als zwei Geraeten', async () => {
+    expect(await save([eq()])).toBeUndefined()
+  })
+})

--- a/tests/libraryUpdatePrompt.test.ts
+++ b/tests/libraryUpdatePrompt.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import appSrc from '../src/renderer/App.tsx?raw'
+import librarySyncSrc from '../src/renderer/lib/librarySync.ts?raw'
+import dictsSrc from '../src/renderer/lib/i18n/dicts.ts?raw'
+import type { EquipmentItem, EquipmentTemplate } from '../src/renderer/types/equipment'
+
+// ADR-005, Inkrement 4, Regeln 1 und 2 — der Update-Prompt beim Projekt-Start.
+//
+// Liegt im Bibliotheks-Ordner eine neuere Fassung eines Geraete-Templates,
+// fragt der Prompt einmal und aktualisiert dann ALLE veralteten Geraete.
+// Er lief dabei durch `applyDeviceTemplateUpdate` — eine zweite, aermere
+// Fassung des Template-Tauschs, die das TEMPLATE als Basis unter das Geraet
+// legte und nur id/x/y/name/notes rettete.
+//
+// Zwei Folgen, beide nachgemessen:
+//
+//   1. Die Template-Ports ersetzten die des Geraets MITSAMT ihren Ids, ohne
+//      dass irgendwer die Kabel nachzog. Nach einem Klick zeigten alle Kabel
+//      des Geraets auf Port-Ids, die es nicht mehr gab — sie blieben im
+//      Projekt, ohne Anschluss.
+//   2. Traegt das Template eine Netz-Identitaet — und das tut es, denn
+//      `templateFromEquipment` speichert IP, Benutzer und Passwort —, dann
+//      ueberschrieb sie die des platzierten Geraets. Ein TYP-Update setzte
+//      damit Adresse und Zugangsdaten EINER konkreten Maschine auf die des
+//      Vorlagen-Geraets.
+//
+// `replaceEquipmentWithTemplate` (#314) macht denselben Tausch seit jeher
+// richtig. Der Prompt geht jetzt durch diese eine Aktion.
+
+const atem = (): EquipmentItem =>
+  ({
+    id: 'e1', name: 'ATEM Regie', category: 'Mischer',
+    inputs: [{ id: 'in-alt', name: 'SDI 1', type: 'port', connectorType: 'BNC' }],
+    outputs: [{ id: 'out-alt', name: 'PGM', type: 'port', connectorType: 'BNC' }],
+    x: 10, y: 20, width: 240, height: 80,
+    ipAddress: '10.0.0.5', username: 'admin', password: 'geheim',
+    serialNumber: 'SN-4711', notes: 'Regie links', nodeColor: '#ff0000',
+  }) as unknown as EquipmentItem
+
+const cam = (): EquipmentItem =>
+  ({
+    id: 'e2', name: 'Kamera 1', category: 'Kamera',
+    inputs: [],
+    outputs: [{ id: 'cam-out', name: 'SDI OUT', type: 'port', connectorType: 'BNC' }],
+    x: 400, y: 0, width: 240, height: 80,
+  }) as unknown as EquipmentItem
+
+const cable = () =>
+  ({
+    id: 'c1', name: 'CAM1->ATEM', type: 'SDI', length: 20, color: '#fff',
+    fromEquipmentId: 'e2', fromPortId: 'cam-out',
+    toEquipmentId: 'e1', toPortId: 'in-alt', notes: '',
+  })
+
+/** Das Template, wie es der Bibliotheks-Ordner liefert: eigene Port-Ids, und
+ *  eine Netz-Identitaet, weil jemand ein konfiguriertes Geraet gespeichert hat. */
+const neueVorlage = (): EquipmentTemplate =>
+  ({
+    name: 'ATEM 4 M/E', category: 'Videomischer',
+    inputs: [{ id: 'in-neu', name: 'SDI 1', type: 'port', connectorType: 'BNC' }],
+    outputs: [{ id: 'out-neu', name: 'PGM', type: 'port', connectorType: 'BNC' }],
+    ipAddress: '192.168.1.10', username: 'root', password: 'werks',
+    rackUnits: 4, isRackDevice: true,
+  }) as unknown as EquipmentTemplate
+
+const runUpdate = async () => {
+  const { useProjectStore } = await import('../src/renderer/store/projectStore')
+  useProjectStore.setState((s) => ({
+    project: { ...s.project, equipment: [atem(), cam()], cables: [cable()] as never },
+  }))
+  useProjectStore.getState().replaceEquipmentWithTemplate('e1', neueVorlage())
+  return useProjectStore.getState().project
+}
+
+describe('Library-Update — das Kabel bleibt am Geraet', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('zieht das Kabel auf den neuen Port nach', async () => {
+    const p = await runUpdate()
+    const eq = p.equipment.find((e) => e.id === 'e1')!
+    const c = p.cables[0] as unknown as { toPortId: string }
+    const portIds = [...eq.inputs, ...eq.outputs].map((x) => x.id)
+    expect(p.cables).toHaveLength(1)
+    expect(portIds).toContain(c.toPortId)
+  })
+
+  it('uebernimmt die Typ-Angaben aus der Vorlage', async () => {
+    const p = await runUpdate()
+    const eq = p.equipment.find((e) => e.id === 'e1')!
+    expect(eq.category).toBe('Videomischer')
+    expect(eq.rackUnits).toBe(4)
+    expect(eq.isRackDevice).toBe(true)
+  })
+
+  it('laesst die Netz-Identitaet der konkreten Maschine in Ruhe', async () => {
+    // Das ist der Kern von Regel 2: die Vorlage beschreibt den TYP, nicht
+    // diese eine Maschine. Ihre Adresse und ihre Zugangsdaten sind nicht die
+    // des Vorlagen-Geraets.
+    const p = await runUpdate()
+    const eq = p.equipment.find((e) => e.id === 'e1')! as unknown as Record<string, unknown>
+    expect(eq.ipAddress).toBe('10.0.0.5')
+    expect(eq.username).toBe('admin')
+    expect(eq.password).toBe('geheim')
+    expect(eq.serialNumber).toBe('SN-4711')
+  })
+
+  it('behaelt Name, Notiz, Position und Farbe', async () => {
+    const p = await runUpdate()
+    const eq = p.equipment.find((e) => e.id === 'e1')!
+    expect(eq.name).toBe('ATEM Regie')
+    expect(eq.notes).toBe('Regie links')
+    expect([eq.x, eq.y]).toEqual([10, 20])
+    expect(eq.nodeColor).toBe('#ff0000')
+  })
+})
+
+describe('der Prompt geht durch die richtige Aktion und sagt, was passiert', () => {
+  it('ruft replaceEquipmentWithTemplate statt der aermeren Fassung', () => {
+    const src = appSrc.replace(/^\s*(\/\/|\*|\/\*).*$/gm, '')
+    expect(src).toContain('freshState.replaceEquipmentWithTemplate(')
+    expect(src).not.toContain('applyDeviceTemplateUpdate(oldEq')
+  })
+
+  it('die aermere Fassung existiert nicht mehr', () => {
+    expect(librarySyncSrc).not.toContain('export const applyDeviceTemplateUpdate')
+  })
+
+  it('stempelt das Template, sonst meldet der naechste Start dasselbe Geraet', () => {
+    // Ohne den Stempel landet der neue fileVersion-Stand nicht am libraryRef
+    // und findOutdatedEquipment fuehrt das Geraet beim naechsten Oeffnen
+    // wieder als veraltet.
+    expect(appSrc).toContain('stampDeviceLibraryRef(newTemplate)')
+  })
+
+  it('nennt die Kabel-Folge, bevor geklickt wird', () => {
+    // Ein Kabel, das keinen passenden Port mehr findet, wird entfernt. Das
+    // muss vor dem Klick dastehen, nicht danach.
+    expect(appSrc).toContain('Findet ein Kabel keinen passenden Port mehr, wird es entfernt.')
+    expect(dictsSrc).toContain('A cable that no longer finds a matching port is removed.')
+  })
+
+  it('behauptet nicht mehr nur „Namen + Notizen bleiben"', () => {
+    expect(appSrc).not.toContain('(Geräte-Namen + Notizen bleiben erhalten.')
+    expect(dictsSrc).not.toContain('(Device names + notes are kept.')
+  })
+})


### PR DESCRIPTION
## Der Fall

Liegt im Bibliotheks-Ordner eine neuere Fassung eines Geräte-Templates, fragt
der Prompt **beim Projekt-Start** einmal und aktualisiert dann **alle**
veralteten Geräte auf einmal. Er lief durch `applyDeviceTemplateUpdate`:

```ts
return {
  ...stamped,        // das TEMPLATE als Basis
  id: oldEq.id, x: oldEq.x, y: oldEq.y,
  name: oldEq.name, notes: oldEq.notes,
}
```

Zwei Folgen, **beide nachgemessen**, nicht hergeleitet:

### 1. Die Kabel hingen danach an nichts

Die Template-Ports ersetzten die des Geräts **mitsamt ihren Ids**, und niemand
zog die Kabel nach. Gemessen durch den Store:

| | |
|---|---|
| Kabel zeigt auf | `in-alt` |
| Gerät hat noch | `in-neu` |
| Kabel im Projekt | 1 — unverändert, ohne Anschluss |

Ein Klick auf „Aktualisieren", und jedes Kabel an jedem aktualisierten Gerät
war ab. Kein Hinweis, kein Verwerfen, kein Nachziehen.

### 2. Ein Typ-Update schrieb die Adresse *dieser* Maschine um

Trägt das Template eine Netz-Identität — und das tut es, `templateFromEquipment`
speichert IP, Benutzer und Passwort, der Tooltip verspricht es sogar —, dann
überschrieb sie die des platzierten Geräts:

```
ipAddress  10.0.0.5  →  192.168.1.10
username   admin     →  root
password   geheim    →  werks
```

Die Vorlage beschreibt den **Typ**, nicht diese eine Maschine im Rack.

*(Nicht bestätigt und hiermit ausgeräumt: Seriennummer, Asset-Tag,
Installations-Status, Knotenfarbe und Videohub-Routing überleben — `updateEquipment`
spreizt den Patch über das Gerät, und der Patch trägt diese Schlüssel gar nicht.
Der Fund war in diesem Punkt überzeichnet.)*

## Der Fix

`replaceEquipmentWithTemplate` (#314) macht **denselben Tausch** seit jeher
richtig: Port-Mapping über (connectorType, Beschriftung/Name) und dann
positional, Kabel nachziehen, nur Unmappbares verwerfen, das **Gerät** als
Basis. Der Prompt geht jetzt durch diese eine Aktion; die ärmere Fassung ist
gelöscht.

Das Template wird dabei gestempelt übergeben — sonst landet der neue
`fileVersion`-Stand nicht am `libraryRef` und der nächste Projekt-Start meldet
dasselbe Gerät wieder als veraltet.

## Der Dialogtext

Er sagte: *„(Geräte-Namen + Notizen bleiben erhalten.)"* — das war buchstäblich
alles, was er rettete. Jetzt steht dort, was übernommen wird (Typ-Angaben), was
bleibt (Name, Notizen, Position, Farbe, **Netzwerk und Zugangsdaten**,
Seriennummer, Status) und dass ein Kabel ohne passenden Port entfernt wird —
**vor** dem Klick, nicht danach.

## Mit drin: die fünfte Aufzählung

`saveGroupPreset` nannte **zwölf Felder von rund neunzig**. Ein Rack-Gerät
verlor beim „als Gruppe speichern" Rack-Flag, Höhe, Tiefe, STL-Geometrie und
Fotos; jedes Gerät seine `deviceTypeId` — die Katalog-Identität aus ADR-002,
ohne die der nächste Import wieder auf Namens-Heuristiken zurückfällt.
`placeGroupPreset` spreizt den Eintrag direkt aufs neue Gerät, was hier fehlt,
ist beim Platzieren endgültig weg.

Jetzt derselbe Erbauer wie im Rack-Weg (`lib/rackPreset.ts`, aus #631). Die
Feldliste ist die **Vereinigung** dessen, was beide Wege schon trugen, plus der
Katalog-Identität:

- vom Rack-Weg: Rack-Marker, Höhe, Tiefe, STL, Panel-Fotos, Rentman-Id
- vom Gruppen-Weg: Notiz, IP, Auflösung, Display-Größe
- neu: `deviceTypeId` (ADR-002 — keine Ermessensfrage)

Kein Feld ist eine neue Entscheidung. Die Handels-Felder (`priceEUR`,
`rentPricePerDay`, `supplier`, `stockLocation`) bleiben draußen — dafür gibt es
einen eigenen Test, damit die offene Modell-/Instanz-Frage nicht nebenbei
beantwortet wird.

## Gegengeprüft

Der Store-Test für `saveGroupPreset` fällt am alten Stand. Die Messungen zu (1)
und (2) oben stammen aus zwei Sonden gegen den echten Store, nicht aus dem
Lesen des Codes.

## Grün

- `npm test` — 606 Tests (16 neu), 58 Dateien
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npx eslint` auf alle geänderten Dateien — 0 Errors, keine neue Warnung

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_