### PR TITLE
identity: die Exporter übernehmen den Resolver (ADR-001 Inkrement 2)

### DIFF
--- a/src/renderer/components/Project/LocationBomDialog.tsx
+++ b/src/renderer/components/Project/LocationBomDialog.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from '../../lib/i18n'
 import { formatCategoryProps } from '../../lib/categorySchemas'
 import { effectiveDeviceResources } from '../../lib/equipmentSelectors'
 import type { Lang } from '../../lib/categoryTranslations'
+import { portDisplayLabel } from '../../lib/portLabel'
 
 /**
  * Issue #39 — Frame-scoped Bill of Materials. For a selected location/frame
@@ -95,7 +96,13 @@ export const LocationBomDialog = () => {
     const eq = equipmentById.get(eqId)
     if (!eq) return '?'
     const p = [...eq.inputs, ...eq.outputs].find((p) => p.id === portId)
-    const portName = p?.contentLabel || p?.name || p?.id || '?'
+    // ADR-001 Inkrement 2 — hier stand die Aufloesung ein drittes Mal von
+    // Hand, und diese Fassung wich ab: OHNE `.trim()`. Ein contentLabel aus
+    // reinen Leerzeichen war damit truthy und gewann gegen den Port-Namen —
+    // die Stueckliste zeigte eine leere Port-Spalte, wo der Resolver den
+    // Namen genommen haette. Der Ausweg auf `p.id` bleibt, denn ein '?' in
+    // einer Stueckliste sagt nichts.
+    const portName = (p ? portDisplayLabel(p) : '') || p?.id || '?'
     const externalTag = !insideIds.has(eqId) ? ' (extern)' : ''
     return `${eq.name} · ${portName}${externalTag}`
   }

--- a/src/renderer/components/Properties/sections/ReplaceDeviceSection.tsx
+++ b/src/renderer/components/Properties/sections/ReplaceDeviceSection.tsx
@@ -10,6 +10,7 @@ import {
 import { blackmagicTemplates } from '../../../lib/blackmagicCatalog'
 import { SortableSection } from '../SortableSection'
 import type { EquipmentItem, EquipmentTemplate, Port } from '../../../types/equipment'
+import { resolvePortLabel } from '../../../lib/portLabel'
 
 /**
  * #314 — "Gerät ersetzen…" — tauscht das aktuell ausgewaehlte Equipment
@@ -31,7 +32,10 @@ const previewMapping = (
 ): { mapped: number; lost: number } => {
   const used = new Set<number>()
   let mapped = 0
-  const oldKey = (p: Port) => (p.contentLabel || p.name || '').trim().toLowerCase()
+  // ADR-001 Inkrement 2 — dieselbe Engstelle wie im equipmentSlice, damit
+  // Vorschau und Ausfuehrung denselben Key sehen. Vorher trimmten beide erst
+  // NACH dem Fallback und wichen damit gleich zweimal vom Resolver ab.
+  const oldKey = (p: Port) => resolvePortLabel(p).text.toLowerCase()
   for (const op of oldPorts) {
     const ok = oldKey(op)
     const idx = newPorts.findIndex(

--- a/src/renderer/lib/exportDevicePdf.ts
+++ b/src/renderer/lib/exportDevicePdf.ts
@@ -26,7 +26,7 @@ import type { EquipmentItem, Port } from '../types/equipment'
 import { pdfText } from './pdfHelpers'
 import { sanitizeForPdf } from './sanitizeForPdf'
 import { buildExportFilename, buildExportFilenameWithSuffix } from './exportFilename'
-import { portLabelPair } from './portLabel'
+import { portDisplayLabel, portLabelPair } from './portLabel'
 
 interface CableEndpointSummary {
   /** Human-readable label for the cable (name OR fallback to type+length). */
@@ -73,7 +73,21 @@ const summarizeEndpoint = (
   return {
     cableLabel,
     otherDeviceName: other?.name ?? 'unbekannt',
-    otherPortName: otherPort?.name ?? null,
+    // ADR-001 Inkrement 2 — das Gegenende stand hier roh.
+    //
+    // Das Blatt fuehrt die EIGENEN Ports des Geraets seit #286 ueber
+    // `portLabelPair` (siehe drawSide unten): Haupt-Label „PGM", Subline
+    // „1 SDI 3G PGM (1080p50/60)". Das Gegenende dagegen nahm den nackten
+    // `port.name`. Auf einem Blatt standen damit beide Konventionen
+    // nebeneinander — links „PGM", rechts „an ATEM - 1 SDI 3G PGM
+    // (1080p50/60)" fuer denselben Steckverbinder.
+    //
+    // Das ist die eine Umstellung dieses Schritts, die die AUSGABE aendert:
+    // wo das Gegenport ein contentLabel hat, steht jetzt dieses. Bewusst so —
+    // die Treue-Regel aus ADR-001 Inkrement 1 verlangt, dass der Kandidat
+    // sagt, was der Exporter sendet, und ein Blatt mit zwei Konventionen ist
+    // die schlechtere Wahrheit.
+    otherPortName: otherPort ? portDisplayLabel(otherPort) || null : null,
     otherPortConnectorType: otherPort?.connectorType ? String(otherPort.connectorType) : null,
     cable,
   }

--- a/src/renderer/lib/installerLists.ts
+++ b/src/renderer/lib/installerLists.ts
@@ -17,16 +17,32 @@ import type { Cable } from '../types/cable'
 import type { EquipmentItem, Port } from '../types/equipment'
 import { INSTALL_STATUS_LABEL } from '../types/lifecycle'
 import { cableLabelId } from './docIds'
+import { portDisplayLabel } from './portLabel'
 import type { CsvCell, CsvTable } from './csv'
 import { csvFromTable, type DocumentStamp } from './documentStamp'
 
+/**
+ * ADR-001 Inkrement 2 — hier stand die Aufloesung ein zweites Mal von Hand.
+ *
+ * Sie war nicht falsch: `contentLabel?.trim() || name` ist wortgleich, was
+ * `portDisplayLabel` tut. Der Unterschied lag allein im letzten Ausweg — sie
+ * fiel auf die rohe `portId` zurueck. Das bleibt so und ist Absicht: eine
+ * leere Zelle sagt einem Installateur weniger als eine Id, und der Docstring
+ * von `portDisplayLabel` haelt ausdruecklich fest, dass der Caller diesen
+ * Ausweg entscheidet. Die Ausgabe aendert sich durch die Umstellung also
+ * NICHT — geprueft in tests/portLabelAdoption.test.ts.
+ *
+ * Der Gewinn ist trotzdem echt: die Kette steht nur noch an einer Stelle, und
+ * ein spaeteres Feld (etwa ein Rollen-Name aus der Identitaets-Spine) erreicht
+ * diese Liste jetzt mit.
+ */
 const portName = (eq: EquipmentItem | undefined, portId: string): string => {
   if (!eq) return ''
   const p =
     eq.outputs.find((x) => x.id === portId) ??
     eq.inputs.find((x) => x.id === portId)
   if (!p) return portId
-  return p.contentLabel?.trim() || p.name || portId
+  return portDisplayLabel(p) || portId
 }
 
 const portObj = (eq: EquipmentItem | undefined, portId: string): Port | undefined =>

--- a/src/renderer/lib/labelDerivation.ts
+++ b/src/renderer/lib/labelDerivation.ts
@@ -33,7 +33,11 @@ import type { EquipmentItem, Port } from '../types/equipment'
 import type { SourceIdentity } from '../types/sourceIdentity'
 import type { CheckFinding } from './drawingChecks'
 import { detectDeviceKind } from './deviceKind'
-import { portDisplayLabel, shortenForAtem } from './portLabel'
+import {
+  resolvePortLabel,
+  shortenForAtem,
+  type PortLabelProvenance,
+} from './portLabel'
 import { effectiveShortName } from './shortName'
 import { suggestDanteName } from './danteNaming'
 import { umdAddressClashes } from './sourceIdentity'
@@ -45,10 +49,15 @@ import {
   type LabelTargetId,
 } from './labelTargets'
 
-/** Woher der Wunschtext eines Kandidaten stammt. */
+/**
+ * Woher der Wunschtext eines Kandidaten stammt.
+ *
+ * Die Port-Haelfte kommt aus `portLabel.ts` — eine Vokabel, nicht zwei. Bis
+ * ADR-001 Inkrement 2 standen hier alle fuenf Werte ausgeschrieben, neben
+ * einer privaten `portText`, die dieselbe Aufloesung ein zweites Mal fuehrte.
+ */
 export type LabelProvenance =
-  | 'port-content-label'
-  | 'port-name'
+  | PortLabelProvenance
   | 'device-short-name'
   | 'device-name'
   | 'source-identity'
@@ -229,14 +238,17 @@ export const resolveSignalSource = (
 // ── Wunschtexte ──────────────────────────────────────────────────────────────
 
 /**
- * Der Text, den die Exporter fuer einen Port abgeben — `portDisplayLabel`,
- * plus die Herkunft. Leerer Text heisst: der Exporter sendet fuer diesen Port
- * nichts, also gibt es auch nichts zu pruefen.
+ * Der Text, den die Exporter fuer einen Port abgeben, plus die Herkunft.
+ * Leerer Text heisst: der Exporter sendet fuer diesen Port nichts, also gibt
+ * es auch nichts zu pruefen.
+ *
+ * Duenner Adapter auf `resolvePortLabel` — die Aufloesung selbst stand bis
+ * ADR-001 Inkrement 2 hier als private Kopie und war damit fuer die Exporter
+ * unerreichbar, obwohl ADR-001 sie genau fuer sie vorgesehen hatte.
  */
 const portText = (port: Port): { raw: string; provenance: LabelProvenance } => {
-  const content = port.contentLabel?.trim()
-  if (content) return { raw: content, provenance: 'port-content-label' }
-  return { raw: portDisplayLabel(port).trim(), provenance: 'port-name' }
+  const { text, provenance } = resolvePortLabel(port)
+  return { raw: text, provenance }
 }
 
 /**

--- a/src/renderer/lib/portLabel.ts
+++ b/src/renderer/lib/portLabel.ts
@@ -13,12 +13,58 @@ import type { Port } from '../types/equipment'
  *   2. `port.name` als Fallback
  *   3. Leerer String wenn beides leer (sollte nicht passieren; UI
  *      faellt dann auf port.id zurueck, der Caller entscheidet).
+ *
+ * Duenner Aufsatz auf `resolvePortLabel` unten — wer die Herkunft braucht,
+ * nimmt die. Dass der Caller den letzten Ausweg entscheidet (Punkt 3), bleibt
+ * ausdruecklich so: `installerLists` haengt `|| portId` an, weil ein leeres
+ * Feld in einer Installateurs-Liste weniger sagt als eine Id.
  */
-export const portDisplayLabel = (port: Pick<Port, 'name' | 'contentLabel'>): string => {
-  const content = port.contentLabel?.trim()
-  if (content) return content
-  return port.name ?? ''
+/**
+ * Woher der Text eines Port-Labels stammt.
+ *
+ * ADR-001 hat als tragende Zusage aus dem `minimal`-Entwurf uebernommen:
+ * „Keiner liefert zurueck, *woher* der Text stammt. Eine Engstelle mit
+ * Provenienz im Rueckgabewert loest das." Genau das ist dieser Typ.
+ *
+ * `labelDerivation.ts` setzt seine `LabelProvenance` aus diesem hier plus den
+ * Geraete-Quellen zusammen — eine Vokabel, nicht zwei. Der Typ wohnt HIER und
+ * nicht dort, weil `labelDerivation` `portLabel` importiert; die andere
+ * Richtung waere ein Zyklus.
+ */
+export type PortLabelProvenance = 'port-content-label' | 'port-name' | 'none'
+
+export interface ResolvedPortLabel {
+  /** Der Text, den ein Exporter fuer diesen Port abgibt. Leer heisst: nichts. */
+  text: string
+  provenance: PortLabelProvenance
 }
+
+/**
+ * Die Engstelle. Ein Aufrufer, der wissen muss, WOHER der Text kommt, nimmt
+ * diese Funktion; wer nur den Text braucht, nimmt `portDisplayLabel` darunter.
+ *
+ * Sie stand bis ADR-001 Inkrement 2 als private `portText` in
+ * `labelDerivation.ts` — also genau dort, wo KEIN Exporter sie erreichen
+ * konnte. Die Ableitungsschicht brauchte die Provenienz fuer ihre Kandidaten
+ * und hat sie sich deshalb selbst gebaut; die Exporter, fuer die ADR-001 sie
+ * vorgesehen hatte, blieben ohne. Hochgezogen, nicht neu geschrieben.
+ *
+ * `.trim()` auch auf dem Fallback: die private Fassung tat das, die oeffentliche
+ * nicht. Ein Port-Name mit angehaengtem Leerzeichen ergab damit zwei
+ * verschiedene Texte, je nachdem wer fragte.
+ */
+export const resolvePortLabel = (
+  port: Pick<Port, 'name' | 'contentLabel'>,
+): ResolvedPortLabel => {
+  const content = port.contentLabel?.trim()
+  if (content) return { text: content, provenance: 'port-content-label' }
+  const name = port.name?.trim() ?? ''
+  if (name) return { text: name, provenance: 'port-name' }
+  return { text: '', provenance: 'none' }
+}
+
+export const portDisplayLabel = (port: Pick<Port, 'name' | 'contentLabel'>): string =>
+  resolvePortLabel(port).text
 
 /**
  * #410 — Kompaktes Symbol fuer das Steckverbinder-Geschlecht. Leerer

--- a/src/renderer/store/slices/equipmentSlice.ts
+++ b/src/renderer/store/slices/equipmentSlice.ts
@@ -8,6 +8,7 @@ import { upsertCachedRentmanTemplateFromEquipment } from '../../lib/rentmanTempl
 import { isProjectLocked, sanitizePort, touchProject } from '../projectStoreHelpers'
 import { scheduleProjectAutosave } from '../projectAutosave'
 import type { ProjectState } from '../projectStore'
+import { resolvePortLabel } from '../../lib/portLabel'
 
 /**
  * #308 — Equipment-Slice. Equipment-CRUD-Actions:
@@ -313,7 +314,7 @@ export const createEquipmentSlice: StateCreator<ProjectState, [], [], EquipmentS
 
   // #314 — Geraet auf dem Canvas durch ein anderes Template ersetzen,
   // ohne die Kabel zu verlieren. Ports werden gematcht nach
-  //  1. (connectorType, contentLabel||name)  — beste Uebereinstimmung
+  //  1. (connectorType, aufgeloester Port-Text)  — beste Uebereinstimmung
   //  2. (connectorType, positional) fuer noch nicht zugeordnete Ports
   // Cables die kein Mapping kriegen werden geloescht (sonst zeigt
   // ReactFlow ein "broken edge" auf einen nicht-existenten Port).
@@ -337,8 +338,19 @@ export const createEquipmentSlice: StateCreator<ProjectState, [], [], EquipmentS
       const buildMap = (oldPorts: Port[], newPorts: Port[]): Map<string, string> => {
         const map = new Map<string, string>()
         const used = new Set<string>()
-        const oldKey = (p: Port) => (p.contentLabel || p.name || '').trim().toLowerCase()
-        // Pass 1: exact (connectorType, contentLabel||name) match
+        // ADR-001 Inkrement 2 — auch der MATCH-Key geht durch die Engstelle.
+        //
+        // Hier stand `(p.contentLabel || p.name || '').trim()`: getrimmt wurde
+        // erst NACH dem Fallback. Ein contentLabel aus reinen Leerzeichen war
+        // damit truthy, gewann gegen den Port-Namen und ergab einen LEEREN
+        // Key — und ein leerer Key faellt wegen `ok &&` unten aus Pass 1 heraus
+        // und landet in der positionellen Zuordnung. Der Resolver trimmt vor
+        // dem Fallback und liefert den Namen, also matcht Pass 1.
+        //
+        // Das ist nach #635 keine Kosmetik: dieser Pfad entscheidet beim
+        // Library-Update, welche Kabel ihren Port wiederfinden.
+        const oldKey = (p: Port) => resolvePortLabel(p).text.toLowerCase()
+        // Pass 1: exact (connectorType, aufgeloester Port-Text) match
         for (const op of oldPorts) {
           const ok = oldKey(op)
           const m = newPorts.find(

--- a/tests/portLabelAdoption.test.ts
+++ b/tests/portLabelAdoption.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { portDisplayLabel, resolvePortLabel } from '../src/renderer/lib/portLabel'
+import { buildPullListRows } from '../src/renderer/lib/installerLists'
+import devicePdfSrc from '../src/renderer/lib/exportDevicePdf.ts?raw'
+import locationBomSrc from '../src/renderer/components/Project/LocationBomDialog.tsx?raw'
+import type { CablePlannerProject } from '../src/renderer/types/project'
+import type { EquipmentItem, EquipmentTemplate, Port } from '../src/renderer/types/equipment'
+
+// ADR-001, Inkrement 2 — die Exporter uebernehmen den Resolver.
+//
+// ADR-001 hat als tragende Zusage aus dem `minimal`-Entwurf uebernommen:
+//
+//   „Es fehlt kein Datensatz, es fehlt ein Resolver. [...] Keiner liefert
+//    zurueck, WOHER der Text stammt. Eine Engstelle mit Provenienz im
+//    Rueckgabewert loest das."
+//
+// Der eigentliche Fund beim Nachlesen: diese Engstelle EXISTIERTE schon — als
+// private `portText` in labelDerivation.ts, also genau dort, wo kein Exporter
+// sie erreichen konnte. Die Ableitungsschicht brauchte die Provenienz fuer ihre
+// Kandidaten und hat sie sich selbst gebaut; die Exporter, fuer die ADR-001 sie
+// vorgesehen hatte, blieben ohne. Sie ist jetzt in portLabel.ts hochgezogen,
+// nicht neu geschrieben.
+//
+// ADR-001s Liste der Umgeher war dabei in zwei von vier Punkten veraltet:
+// cableLabel.ts und exportVideohub.ts benutzen den Resolver inzwischen. Dafuer
+// nennt sie zwei Stellen NICHT, die dieselbe Kette fuehren — die Match-Keys in
+// equipmentSlice und ReplaceDeviceSection. Wieder das bekannte Muster: der
+// Hinweis sagt zuverlaessig, WO man nachsieht, und unzuverlaessig, WAS dort ist.
+
+describe('resolvePortLabel — die Engstelle mit Provenienz', () => {
+  it('nennt das contentLabel als Herkunft, wenn es gesetzt ist', () => {
+    expect(resolvePortLabel({ name: '1 SDI 3G PGM', contentLabel: 'PGM' })).toEqual({
+      text: 'PGM',
+      provenance: 'port-content-label',
+    })
+  })
+
+  it('faellt auf den Port-Namen zurueck und sagt das auch', () => {
+    expect(resolvePortLabel({ name: '1 SDI 3G PGM', contentLabel: undefined })).toEqual({
+      text: '1 SDI 3G PGM',
+      provenance: 'port-name',
+    })
+  })
+
+  it('behandelt ein contentLabel aus Leerzeichen als NICHT gesetzt', () => {
+    // Genau hier wichen drei der fuenf Kopien ab: sie trimmten erst NACH dem
+    // Fallback, `'  '` war damit truthy und gewann gegen den Namen.
+    expect(resolvePortLabel({ name: 'SDI 1', contentLabel: '   ' })).toEqual({
+      text: 'SDI 1',
+      provenance: 'port-name',
+    })
+  })
+
+  it('sagt „none", wenn es nichts zu sagen gibt', () => {
+    // Nicht der leere String allein: ein Aufrufer muss unterscheiden koennen,
+    // ob der Text leer IST oder ob er fehlt — sonst raet er wieder selbst.
+    expect(resolvePortLabel({ name: '', contentLabel: '' })).toEqual({
+      text: '',
+      provenance: 'none',
+    })
+    expect(resolvePortLabel({ name: '  ', contentLabel: undefined }).provenance).toBe('none')
+  })
+
+  it('portDisplayLabel bleibt der duenne Aufsatz darauf', () => {
+    // Alle bisherigen Aufrufer sehen denselben Text wie vorher — sonst waere
+    // die Umstellung keine Umstellung, sondern eine Aenderung.
+    for (const port of [
+      { name: '1 SDI 3G PGM', contentLabel: 'PGM' },
+      { name: '1 SDI 3G PGM', contentLabel: undefined },
+      { name: 'SDI 1', contentLabel: '   ' },
+      { name: '', contentLabel: '' },
+    ]) {
+      expect(portDisplayLabel(port)).toBe(resolvePortLabel(port).text)
+    }
+  })
+})
+
+// ── Weg 1: installerLists — die Umstellung aendert die Ausgabe NICHT ────────
+
+const port = (over: Partial<Port>): Port =>
+  ({ id: 'p1', name: 'OUT 1', type: 'port', connectorType: 'BNC', ...over }) as unknown as Port
+
+const project = (equipment: EquipmentItem[], cables: unknown[]): CablePlannerProject =>
+  ({
+    metadata: { name: 'Halle 7' },
+    equipment,
+    cables,
+    canvasState: { x: 0, y: 0, zoom: 1 },
+  }) as unknown as CablePlannerProject
+
+const twoDevices = (fromPort: Partial<Port>, toPort: Partial<Port>) =>
+  project(
+    [
+      {
+        id: 'a', name: 'ATEM', category: 'Mischer', x: 0, y: 0, width: 240, height: 80,
+        inputs: [], outputs: [port({ id: 'a-out', ...fromPort })],
+      } as unknown as EquipmentItem,
+      {
+        id: 'b', name: 'Router', category: 'Router', x: 400, y: 0, width: 240, height: 80,
+        inputs: [port({ id: 'b-in', ...toPort })], outputs: [],
+      } as unknown as EquipmentItem,
+    ],
+    [
+      {
+        id: 'c1', name: 'K1', type: 'SDI', length: 10, color: '#fff',
+        fromEquipmentId: 'a', fromPortId: 'a-out',
+        toEquipmentId: 'b', toPortId: 'b-in', notes: '',
+      },
+    ],
+  )
+
+describe('installerLists — dieselbe Ausgabe, eine Kette weniger', () => {
+  it('nimmt das contentLabel, wenn es gesetzt ist', () => {
+    const rows = buildPullListRows(twoDevices({ contentLabel: 'PGM' }, { contentLabel: 'IN 3' }))
+    expect(rows[0].fromPort).toBe('PGM')
+    expect(rows[0].toPort).toBe('IN 3')
+  })
+
+  it('nimmt den Port-Namen, wenn keins gesetzt ist', () => {
+    const rows = buildPullListRows(twoDevices({ name: 'SDI OUT 1' }, { name: 'SDI IN 3' }))
+    expect(rows[0].fromPort).toBe('SDI OUT 1')
+    expect(rows[0].toPort).toBe('SDI IN 3')
+  })
+
+  it('behaelt den Ausweg auf die Port-Id — eine leere Zelle sagt weniger', () => {
+    // Das ist der EINE Punkt, in dem die alte Kette vom Resolver abwich, und
+    // er bleibt bewusst: `portDisplayLabel` gibt '' zurueck und ueberlaesst
+    // dem Caller den letzten Ausweg (so steht es in seinem Docstring).
+    const rows = buildPullListRows(twoDevices({ name: '', contentLabel: '' }, { name: '' }))
+    expect(rows[0].fromPort).toBe('a-out')
+    expect(rows[0].toPort).toBe('b-in')
+  })
+
+  it('behandelt ein Leerzeichen-contentLabel wie vorher — hier war nichts kaputt', () => {
+    // Ausdruecklich KEIN Fix: `installerLists` trimmte schon vorher, seine
+    // Kette war wortgleich zum Resolver. Der erste Entwurf dieses Tests hat
+    // das Gegenteil behauptet; die Gegenprobe am alten Stand hat es widerlegt.
+    // Er bleibt als Regressionsschutz stehen, nicht als Beweis eines Fixes.
+    const rows = buildPullListRows(twoDevices({ name: 'SDI OUT 1', contentLabel: '  ' }, {}))
+    expect(rows[0].fromPort).toBe('SDI OUT 1')
+  })
+})
+
+// ── Weg 2: der Match-Key im Port-Mapping — der folgenreichste ───────────────
+
+describe('Port-Mapping beim Template-Tausch — der Key geht durch die Engstelle', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('ein Port mit Leerzeichen-contentLabel findet seinen Namensvetter wieder', async () => {
+    // Der alte Key `(contentLabel || name || '').trim()` ergab fuer
+    // contentLabel='  ' einen LEEREN Key; ein leerer Key faellt wegen `ok &&`
+    // aus Pass 1 heraus und landet in der positionellen Zuordnung.
+    //
+    // Der Aufbau ist bewusst so gewaehlt, dass die Position FALSCH liegt: ein
+    // einziger alter Port, und in der neuen Vorlage steht ein Koeder derselben
+    // Steckerart davor. Der erste Entwurf dieses Tests hatte zwei alte Ports —
+    // da hatte Pass 1 den Koeder schon verbraucht und Pass 2 lag zufaellig
+    // richtig, sodass der Test auf beiden Staenden gruen war. Die Gegenprobe
+    // hat das aufgedeckt.
+    //
+    // Nach #635 laeuft der Library-Update-Prompt durch genau diesen Pfad.
+    const { useProjectStore } = await import('../src/renderer/store/projectStore')
+
+    const eq = {
+      id: 'e1', name: 'Router', category: 'Router', x: 0, y: 0, width: 240, height: 80,
+      inputs: [port({ id: 'in-madi', name: 'MADI', contentLabel: '  ', connectorType: 'BNC' })],
+      outputs: [],
+    } as unknown as EquipmentItem
+    const cam = {
+      id: 'e2', name: 'Kamera', category: 'Kamera', x: 400, y: 0, width: 240, height: 80,
+      inputs: [], outputs: [port({ id: 'cam-out', name: 'SDI OUT', connectorType: 'BNC' })],
+    } as unknown as EquipmentItem
+
+    useProjectStore.setState((s) => ({
+      project: {
+        ...s.project,
+        equipment: [eq, cam],
+        cables: [
+          {
+            id: 'c1', name: 'K1', type: 'SDI', length: 10, color: '#fff',
+            fromEquipmentId: 'e2', fromPortId: 'cam-out',
+            toEquipmentId: 'e1', toPortId: 'in-madi', notes: '',
+          },
+        ] as never,
+      },
+    }))
+
+    // Koeder zuerst: positionell landet das Kabel auf SDI, nicht auf MADI.
+    const tpl = {
+      name: 'Router', category: 'Router',
+      inputs: [
+        port({ id: 't-sdi', name: 'SDI', connectorType: 'BNC' }),
+        port({ id: 't-madi', name: 'MADI', connectorType: 'BNC' }),
+      ],
+      outputs: [],
+    } as unknown as EquipmentTemplate
+
+    useProjectStore.getState().replaceEquipmentWithTemplate('e1', tpl)
+
+    const st = useProjectStore.getState().project
+    const router = st.equipment.find((e) => e.id === 'e1')!
+    const cable = st.cables[0] as unknown as { toPortId: string }
+    const madi = router.inputs.find((p) => p.name === 'MADI')!
+    const sdi = router.inputs.find((p) => p.name === 'SDI')!
+    expect(cable.toPortId).toBe(madi.id)
+    expect(cable.toPortId).not.toBe(sdi.id)
+  })
+})
+
+// ── Weg 3 und 4: zwei Stellen ohne Test-Naht, als Quell-Zusage ──────────────
+//
+// `summarizeEndpoint` in exportDevicePdf.ts und `portOf` in
+// LocationBomDialog.tsx sind privat und haengen an jsPDF bzw. React. Fuer sie
+// haelt dieser Abschnitt die Quelle fest — ausdruecklich eine schwaechere
+// Zusage als ein Verhaltenstest, aber genauer als keine.
+describe('die beiden Stellen ohne Test-Naht', () => {
+  it('das Device-PDF fuehrt das Gegenende nicht mehr roh', () => {
+    // Vorher: `otherPortName: otherPort?.name ?? null` — waehrend die EIGENEN
+    // Ports des Blatts seit #286 durch portLabelPair gehen. Auf einem Blatt
+    // standen damit beide Konventionen: links „PGM", rechts
+    // „an ATEM - 1 SDI 3G PGM (1080p50/60)" fuer denselben Steckverbinder.
+    const src = devicePdfSrc.replace(/^\s*(\/\/|\*|\/\*).*$/gm, '')
+    expect(src).not.toContain('otherPortName: otherPort?.name')
+    expect(src).toContain('otherPortName: otherPort ? portDisplayLabel(otherPort)')
+  })
+
+  it('die Standort-Stueckliste geht durch den Resolver', () => {
+    const src = locationBomSrc.replace(/^\s*(\/\/|\*|\/\*).*$/gm, '')
+    expect(src).not.toContain("p?.contentLabel || p?.name")
+    expect(src).toContain('portDisplayLabel(p)')
+  })
+})
+
+// ── Der Guard: keine sechste Kopie ──────────────────────────────────────────
+
+const rendererSources = import.meta.glob('../src/renderer/**/*.{ts,tsx}', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+/** Kommentarzeilen weg, bevor gesucht wird — sonst findet der Guard die
+ *  Erklaerung, warum er existiert, und meldet sie als Verstoss. Genau das ist
+ *  in diesem Repo schon einmal passiert. */
+const withoutComments = (src: string) =>
+  src
+    .split('\n')
+    .filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l))
+    .join('\n')
+
+describe('die Kette steht nur noch an einer Stelle', () => {
+  it('findet die Renderer-Quellen ueberhaupt', () => {
+    // Ohne diese Zeile prueft der Guard bei einem kaputten Glob still nichts.
+    expect(Object.keys(rendererSources).length).toBeGreaterThan(100)
+  })
+
+  it('niemand baut die contentLabel-Kette selbst nach', () => {
+    const offenders = Object.entries(rendererSources)
+      .filter(([path]) => !path.endsWith('lib/portLabel.ts'))
+      .filter(([, src]) => /contentLabel[^)\n]{0,40}\|\|/.test(withoutComments(src)))
+      .map(([path]) => path.split('/src/renderer/')[1])
+      .sort()
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
ADR-001 hatte als nächsten Schritt festgelegt: *„die Exporter den Resolver
übernehmen zu lassen"*. Beim Nachlesen war der Befund ein anderer als die Liste
im ADR sagte.

## Die Engstelle existierte schon — privat

ADR-001 hat aus dem `minimal`-Entwurf diese Zusage übernommen:

> Es fehlt kein Datensatz, es fehlt ein *Resolver*. […] Keiner liefert zurück,
> **woher** der Text stammt. Eine Engstelle mit Provenienz im Rückgabewert löst
> das.

Genau die stand schon im Code — als **private** `portText` in
`labelDerivation.ts:236`:

```ts
const portText = (port: Port): { raw: string; provenance: LabelProvenance } => {
  const content = port.contentLabel?.trim()
  if (content) return { raw: content, provenance: 'port-content-label' }
  return { raw: portDisplayLabel(port).trim(), provenance: 'port-name' }
}
```

Also dort, wo **kein Exporter sie erreichen konnte**. Die Ableitungsschicht
brauchte die Provenienz für ihre Kandidaten und hat sich die Auflösung selbst
gebaut; die Exporter, für die ADR-001 sie vorgesehen hatte, blieben ohne.

Sie ist jetzt als `resolvePortLabel` in `portLabel.ts` **hochgezogen, nicht neu
geschrieben**. `portDisplayLabel` ist der dünne Aufsatz darauf — alle bisherigen
Aufrufer sehen denselben Text wie vorher, und ein Test hält das fest.
`LabelProvenance` setzt sich aus `PortLabelProvenance` plus den Geräte-Quellen
zusammen: eine Vokabel, nicht zwei.

## ADR-001s Liste war in zwei Punkten veraltet — und unvollständig

| Genannt | Befund |
|---|---|
| `cableLabel.ts:19` | **behoben** seit dem ADR — `portText` wickelt `portDisplayLabel` |
| `exportVideohub.ts` | **benutzt** den Resolver an beiden Stellen |
| `installerLists.ts:22` | Umgeher, bestätigt |
| `LocationBomDialog.tsx:98` | Umgeher, bestätigt |
| *nicht genannt* | `exportDevicePdf.ts` — nur die **eigenen** Ports gehen durch den Resolver, das Gegenende stand roh |
| *nicht genannt* | `equipmentSlice.ts:340` und `ReplaceDeviceSection.tsx:34` — derselbe Trim-Fehler im **Match**-Key |

Wieder das Muster, das dieses Projekt inzwischen dokumentiert: *ein Hinweis sagt
zuverlässig, wo man nachsehen soll, und unzuverlässig, was dort falsch ist.*

## Fünf Stellen, jede mit ihrer Ausgabe-Folge

**`installerLists`** — wortgleiche Kette, nur der letzte Ausweg wich ab (rohe
`portId` statt `''`). Der bleibt **bewusst**: eine leere Zelle sagt einem
Installateur weniger als eine Id, und `portDisplayLabel` überlässt dem Caller
laut eigenem Docstring genau diesen Ausweg. **Keine Ausgabe-Änderung.**

**`LocationBomDialog`** — trimmte erst *nach* dem Fallback. Ein `contentLabel`
aus reinen Leerzeichen war damit truthy und gewann gegen den Port-Namen: die
Stückliste zeigte eine **leere Port-Spalte**.

**`exportDevicePdf`** — das Gegenende stand roh, während die eigenen Ports des
Blatts seit #286 durch `portLabelPair` gehen. Auf einem Blatt standen damit
beide Konventionen für denselben Steckverbinder: links „PGM", rechts
„an ATEM - 1 SDI 3G PGM (1080p50/60)". Das ist die eine Umstellung, die die
**Ausgabe sichtbar ändert** — bewusst, denn ein Blatt mit zwei Konventionen ist
die schlechtere Wahrheit.

**`equipmentSlice` + `ReplaceDeviceSection`** — der Match-Key, beide mit
demselben Trim-Fehler. Nach #635 entscheidet dieser Pfad beim Library-Update,
welche Kabel ihren Port wiederfinden.

## Die Gegenprobe hat einen Fehler in *meinem* Test gefunden

Der erste Entwurf des Match-Key-Tests hatte **zwei** alte Ports. Da hatte Pass 1
den Köder schon verbraucht und die positionelle Zuordnung lag zufällig richtig —
der Test war auf **beiden** Ständen grün, also wertlos. Nur der Guard fiel.

Mit einem **einzigen** alten Port und einem Köder davor fällt er am alten Stand:
das Kabel landet auf `SDI` statt auf `MADI`.

Und der von mir behauptete Whitespace-Fix in `installerLists` war schlicht
falsch — dessen Kette trimmte schon vorher. Der Test bleibt als
Regressionsschutz stehen und sagt das jetzt auch.

## Der Guard

Keine sechste Kopie der Kette: ein Test scannt alle Renderer-Quellen und lässt
nur `portLabel.ts` durch. Er streift Kommentarzeilen ab, bevor er sucht — sonst
findet er die Erklärung, warum er existiert (in diesem Repo schon einmal
passiert). Und er prüft zuerst, dass der Glob überhaupt Dateien findet.

## Grün

- `npm test` — 626 Tests (14 neu), 60 Dateien
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npx eslint` auf alle sieben geänderten Dateien — 0 Errors, 0 Warnungen

Damit ist ADR-001s benannter nächster Schritt getan. Er ist die Voraussetzung
für Roadmap-Initiative 2 (Tally-Map aus dem Plan, Score 24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_