### PR TITLE
impact: die Vorwärts-Frage — was macht diese Änderung ungültig (Initiative 5)

### DIFF
--- a/src/renderer/lib/changeImpact.ts
+++ b/src/renderer/lib/changeImpact.ts
@@ -1,0 +1,167 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Roadmap-Initiative 5 — „was macht diese Änderung ungültig?"
+//
+// Das Strategiepapier sagt dazu: „Change-impact analysis answers a question no
+// product in the corpus answers." Der Grund, warum sie hier billig ist und
+// dort nirgends existiert, steht in ADR-004: dieses Projekt kann den Stand
+// eines Dokuments *ausrechnen*, statt ihn nur auf das Blatt zu stempeln.
+//
+// WAS HEUTE SCHON GEHT — und was nicht. `documentRegistry.DOCUMENT_STANDS`
+// beantwortet je Dokument „welchen Stand hätte es JETZT". Zusammen mit dem
+// Stempel auf dem Papier ergibt das `docStandStatus`: die RÜCKWÄRTS-Frage,
+// gestellt mit dem Blatt in der Hand — „gilt dieser Ausdruck noch?".
+//
+// Die VORWÄRTS-Frage konnte niemand stellen: „ich habe gerade das geändert —
+// welche Blätter sind damit hin?" Genau die ist der Schmerzpunkt: der
+// Rehearsal-Day-Edit, nach dem niemand weiss, welche der zwölf ausgedruckten
+// Listen noch stimmen.
+//
+// Dieses Inkrement PERSISTIERT NICHTS. Reine Funktion über zwei Projekt-
+// Stände — dieselbe Reihenfolge, die ADR-001 gewählt hat und die dort zwei
+// Fehler gefunden hat, die kein Review gefunden hätte. Erst wenn die Ableitung
+// steht, weiss man, was ein Register überhaupt festhalten müsste.
+//
+// DIE TRAGENDE ENTSCHEIDUNG: „weiss ich nicht" ist ein eigenes Ergebnis.
+//
+// `DOCUMENT_STANDS` lässt `kabel-bom` bewusst aus — sein Inhalt hängt am
+// Reserve-Aufschlag, der nicht im Projekt steht, also ist er aus dem Plan
+// allein nicht reproduzierbar. `currentStand` gibt dafür `undefined` zurück,
+// und sein Docstring sagt ausdrücklich: der Aufrufer macht daraus ein
+// `unknown` statt einer Behauptung.
+//
+// Eine Impact-Liste, die solche Dokumente als „unberührt" führt, wäre die
+// schlimmere Antwort: sie sieht aus wie eine Freigabe. Sie nennt sie deshalb
+// als `unknown` — Design-Regel 1 aus der Strategie, auf Dokumente angewandt:
+// niemals einen unbestätigten Wert als Tatsache zeigen.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { CablePlannerProject } from '../types/project'
+import {
+  DOCUMENT_LABELS,
+  DOCUMENT_STANDS,
+  UNJUDGEABLE_DOCUMENTS,
+} from './documentRegistry'
+
+export type ImpactVerdict =
+  /** Der Stand hat sich geändert — ein Ausdruck von vorher ist überholt. */
+  | 'invalidated'
+  /** Derselbe Stand, das Blatt gilt weiter. */
+  | 'unaffected'
+  /** Nicht aus dem Plan allein reproduzierbar. Keine Aussage, kein Freibrief. */
+  | 'unknown'
+
+export interface DocumentImpact {
+  docId: string
+  label: string
+  verdict: ImpactVerdict
+  /** Warum nicht beurteilbar. Nur bei `unknown` gesetzt. */
+  reason?: string
+  /** Stand vor der Änderung. Fehlt bei `unknown`. */
+  before?: string
+  /** Stand nach der Änderung. Fehlt bei `unknown`. */
+  after?: string
+}
+
+export interface ChangeImpact {
+  /** Alle bekannten Dokumente, stabil sortiert: erst betroffen, dann unklar. */
+  documents: DocumentImpact[]
+  /** Kurzfassung für die Oberfläche. */
+  invalidated: number
+  unknown: number
+  /** Ob sich am Plan selbst etwas geändert hat. */
+  planChanged: boolean
+}
+
+/** Reihenfolge im Bericht: Was zu tun ist, steht oben. */
+const VERDICT_ORDER: Record<ImpactVerdict, number> = {
+  invalidated: 0,
+  unknown: 1,
+  unaffected: 2,
+}
+
+/**
+ * Welche registrierten Dokumente die Änderung von `before` nach `after`
+ * ungültig macht.
+ *
+ * Beide Stände sind vollständige Projekte — kein Diff, keine Änderungsliste.
+ * Der Grund ist derselbe wie bei den Stempeln selbst: der Stand eines
+ * Dokuments hängt an seiner ABLEITUNG, nicht an den angefassten Feldern. Eine
+ * Änderung an einem Kabel-Typ berührt die Pull-Liste und nicht das
+ * Asset-Register; welches von beiden, entscheidet die Ableitung und nicht eine
+ * Heuristik über die Felder.
+ */
+export const changeImpact = (
+  before: CablePlannerProject,
+  after: CablePlannerProject,
+): ChangeImpact => {
+  const documents: DocumentImpact[] = []
+
+  for (const docId of Object.keys(DOCUMENT_STANDS)) {
+    const label = DOCUMENT_LABELS[docId] ?? docId
+    const derive = DOCUMENT_STANDS[docId]
+    let standBefore: string | undefined
+    let standAfter: string | undefined
+    try {
+      standBefore = derive(before)
+      standAfter = derive(after)
+    } catch {
+      // Eine Ableitung, die an einem der beiden Stände scheitert, ist keine
+      // Aussage. Sie als „unberührt" zu führen waere das Gegenteil von
+      // vorsichtig; `unknown` ist die ehrliche Antwort.
+      documents.push({
+        docId,
+        label,
+        verdict: 'unknown',
+        reason: 'Die Ableitung dieses Dokuments ist an diesem Plan gescheitert.',
+      })
+      continue
+    }
+    documents.push({
+      docId,
+      label,
+      verdict: standBefore === standAfter ? 'unaffected' : 'invalidated',
+      before: standBefore,
+      after: standAfter,
+    })
+  }
+
+  // Bekannt, aber nicht beurteilbar — ausdrücklich genannt statt weggelassen.
+  // Verschweigen sieht in einer Freigabe-Liste wie „unberührt" aus, und genau
+  // das ist der Schaden, gegen den ADR-005 geschrieben ist.
+  for (const [docId, reason] of Object.entries(UNJUDGEABLE_DOCUMENTS)) {
+    if (docId in DOCUMENT_STANDS) continue // reproduzierbar geworden: der Guard meldet es
+    documents.push({
+      docId,
+      label: DOCUMENT_LABELS[docId] ?? docId,
+      verdict: 'unknown',
+      reason,
+    })
+  }
+
+  // Dokumente, die das Register in KEINER der beiden Listen kennt, kann diese
+  // Funktion nicht beurteilen — und sie tut auch nicht so.
+
+  documents.sort((a, b) => {
+    const byVerdict = VERDICT_ORDER[a.verdict] - VERDICT_ORDER[b.verdict]
+    return byVerdict !== 0 ? byVerdict : a.docId.localeCompare(b.docId)
+  })
+
+  return {
+    documents,
+    invalidated: documents.filter((d) => d.verdict === 'invalidated').length,
+    unknown: documents.filter((d) => d.verdict === 'unknown').length,
+    planChanged:
+      documents.find((d) => d.docId === 'plan')?.verdict === 'invalidated',
+  }
+}
+
+/**
+ * Einzeiler für eine Meldung. Bewusst ohne i18n-Abhängigkeit — diese Datei
+ * bleibt eine reine Funktion; der Aufrufer übersetzt.
+ */
+export const changeImpactSummary = (impact: ChangeImpact): string => {
+  const parts: string[] = []
+  if (impact.invalidated > 0) parts.push(`${impact.invalidated} überholt`)
+  if (impact.unknown > 0) parts.push(`${impact.unknown} nicht beurteilbar`)
+  return parts.length > 0 ? parts.join(', ') : 'keine Auswirkung'
+}

--- a/src/renderer/lib/documentRegistry.ts
+++ b/src/renderer/lib/documentRegistry.ts
@@ -46,6 +46,27 @@ export const DOCUMENT_STANDS: Record<string, (project: CablePlannerProject) => s
   uebergabe: ofTable(handoverTable),
 }
 
+/**
+ * Dokumente, die es GIBT, deren Stand aber nicht aus dem Plan allein
+ * reproduzierbar ist — mit dem Grund im Klartext.
+ *
+ * Bis Roadmap-Initiative 5 stand diese Kenntnis nur im Kommentar über
+ * `DOCUMENT_STANDS`. Ein Kommentar kann eine Impact-Liste nicht warnen: sie
+ * hätte `kabel-bom` einfach nicht genannt, und Verschweigen sieht aus wie
+ * „unberührt". Als Daten statt als Prosa kann `changeImpact` daraus ein
+ * ausdrückliches `unknown` machen.
+ *
+ * Wer ein Dokument hier einträgt, sagt damit: es ist bekannt UND nicht
+ * beurteilbar. Wer es reproduzierbar macht, verschiebt es nach
+ * `DOCUMENT_STANDS` — beides gleichzeitig fängt der Guard in
+ * `tests/changeImpact.test.ts`.
+ */
+export const UNJUDGEABLE_DOCUMENTS: Record<string, string> = {
+  'kabel-bom':
+    'Der Inhalt hängt am Reserve-Aufschlag, den der Nutzer beim Export einstellt; ' +
+    'dieser Prozentsatz steht nicht im Stempel.',
+}
+
 /** Lesbarer Name eines Dokument-Bezeichners für Meldungen. */
 export const DOCUMENT_LABELS: Record<string, string> = {
   plan: 'Plan',
@@ -54,6 +75,7 @@ export const DOCUMENT_LABELS: Record<string, string> = {
   'kabel-schedule': 'Kabel-Schedule',
   'asset-register': 'Asset-Register',
   uebergabe: 'Übergabe-Dokument',
+  'kabel-bom': 'Kabel-Stückliste',
 }
 
 /**

--- a/tests/changeImpact.test.ts
+++ b/tests/changeImpact.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest'
+import { changeImpact, changeImpactSummary } from '../src/renderer/lib/changeImpact'
+import {
+  DOCUMENT_STANDS,
+  DOCUMENT_LABELS,
+  UNJUDGEABLE_DOCUMENTS,
+} from '../src/renderer/lib/documentRegistry'
+import registrySrc from '../src/renderer/lib/documentRegistry.ts?raw'
+import type { CablePlannerProject } from '../src/renderer/types/project'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+
+// Roadmap-Initiative 5, Inkrement 1 — „was macht diese Änderung ungültig?"
+//
+// Bis hierhin konnte man nur die RÜCKWÄRTS-Frage stellen: mit dem Blatt in der
+// Hand, per Stempel, „gilt dieser Ausdruck noch?" (`docStandStatus`). Die
+// VORWÄRTS-Frage konnte niemand stellen — „ich habe gerade das geändert,
+// welche Blätter sind damit hin?" —, und genau die ist der Schmerzpunkt: der
+// Rehearsal-Day-Edit, nach dem niemand weiss, welche der zwölf ausgedruckten
+// Listen noch stimmen.
+//
+// Dieses Inkrement persistiert nichts: reine Funktion über zwei Projekt-Stände.
+// Dieselbe Reihenfolge wie in ADR-001, wo genau diese Wahl zwei Fehler gefunden
+// hat, die kein Diff-Review gefunden hätte.
+
+const eq = (id: string, name: string, over: Partial<EquipmentItem> = {}): EquipmentItem =>
+  ({
+    id,
+    name,
+    category: 'Sonstiges',
+    inputs: [{ id: `${id}-in`, name: 'IN 1', type: 'port', connectorType: 'BNC' }],
+    outputs: [{ id: `${id}-out`, name: 'OUT 1', type: 'port', connectorType: 'BNC' }],
+    x: 0, y: 0, width: 200, height: 100,
+    ...over,
+  }) as unknown as EquipmentItem
+
+const cable = (id: string, over: Partial<Cable> = {}): Cable =>
+  ({
+    id, name: `Kabel ${id}`, type: 'SDI', length: 10, color: '#fff',
+    fromEquipmentId: 'A', fromPortId: 'A-out',
+    toEquipmentId: 'B', toPortId: 'B-in', notes: '',
+    ...over,
+  }) as Cable
+
+const project = (over: Partial<CablePlannerProject> = {}): CablePlannerProject =>
+  ({
+    metadata: { name: 'Testanlage', description: '', createdAt: '', updatedAt: '' },
+    equipment: [eq('A', 'Kamera 1'), eq('B', 'Switcher')],
+    cables: [cable('c1')],
+    canvasState: { x: 0, y: 0, zoom: 1 },
+    ...over,
+  }) as CablePlannerProject
+
+const verdictOf = (impact: ReturnType<typeof changeImpact>, docId: string) =>
+  impact.documents.find((d) => d.docId === docId)?.verdict
+
+describe('changeImpact — die Vorwärts-Frage', () => {
+  it('nennt keine Auswirkung, wenn sich nichts geändert hat', () => {
+    const p = project()
+    const impact = changeImpact(p, p)
+    expect(impact.invalidated).toBe(0)
+    expect(impact.planChanged).toBe(false)
+    // „Keine Auswirkung" heisst NICHT „alles unberührt": die Kabel-Stückliste
+    // bleibt unbeurteilbar, und die Zusammenfassung sagt das auch. Eine
+    // Freigabe, die das verschweigt, waere die schlechtere Antwort.
+    expect(impact.documents.filter((d) => d.verdict === 'unaffected').length).toBe(
+      Object.keys(DOCUMENT_STANDS).length,
+    )
+    expect(impact.unknown).toBe(Object.keys(UNJUDGEABLE_DOCUMENTS).length)
+    expect(changeImpactSummary(impact)).toBe('1 nicht beurteilbar')
+  })
+
+  it('erkennt, dass ein geänderter Kabel-Typ die Pull-Liste überholt', () => {
+    const before = project()
+    const after = project({ cables: [cable('c1', { type: 'Cat6' })] })
+    const impact = changeImpact(before, after)
+    expect(verdictOf(impact, 'pull-liste')).toBe('invalidated')
+    expect(impact.planChanged).toBe(true)
+    expect(impact.invalidated).toBeGreaterThan(0)
+  })
+
+  it('gibt für jedes betroffene Dokument beide Stände an', () => {
+    // Ohne die zwei Fingerabdrücke ist die Meldung nicht nachprüfbar — und der
+    // Nutzer soll den Stand auf dem Blatt wiedererkennen können.
+    const impact = changeImpact(project(), project({ cables: [cable('c1', { length: 42 })] }))
+    const hit = impact.documents.find((d) => d.verdict === 'invalidated')!
+    expect(hit.before).toMatch(/^[0-9a-f]{8}$/)
+    expect(hit.after).toMatch(/^[0-9a-f]{8}$/)
+    expect(hit.before).not.toBe(hit.after)
+  })
+
+  it('trifft nicht alle Dokumente pauschal', () => {
+    // Der Punkt der Ableitung: eine Änderung an einem Kabel berührt die
+    // Kabel-Listen und nicht zwangsläufig das Asset-Register. Eine Heuristik
+    // über angefasste Felder könnte das nicht unterscheiden.
+    const impact = changeImpact(project(), project({ cables: [cable('c1', { length: 42 })] }))
+    expect(verdictOf(impact, 'asset-register')).toBe('unaffected')
+  })
+
+  it('sortiert das zu Erledigende nach oben', () => {
+    const impact = changeImpact(project(), project({ cables: [cable('c1', { type: 'Cat6' })] }))
+    const order = impact.documents.map((d) => d.verdict)
+    const firstUnaffected = order.indexOf('unaffected')
+    const lastInvalidated = order.lastIndexOf('invalidated')
+    if (firstUnaffected >= 0 && lastInvalidated >= 0) {
+      expect(lastInvalidated).toBeLessThan(firstUnaffected)
+    }
+    // Bei gleichem Urteil stabil nach Bezeichner — sonst springt die Liste.
+    const invalidated = impact.documents.filter((d) => d.verdict === 'invalidated').map((d) => d.docId)
+    expect(invalidated).toEqual([...invalidated].sort())
+  })
+
+  it('nennt eine Ableitung, die scheitert, „unknown" statt „unberührt"', () => {
+    // Ein Projekt ohne `equipment` bringt die Tabellen-Ableitungen zum
+    // Stolpern. Das Ergebnis muss „weiss ich nicht" sein — als „unberührt"
+    // gefuehrt wuerde es wie eine Freigabe aussehen.
+    const broken = { metadata: { name: 'x' } } as unknown as CablePlannerProject
+    const impact = changeImpact(broken, broken)
+    expect(impact.documents.filter((d) => d.verdict === 'unknown').length).toBeGreaterThan(1)
+    expect(impact.documents.some((d) => d.verdict === 'unaffected' && d.docId !== 'plan')).toBe(false)
+    // Zwei verschiedene Gruende fuer dasselbe Urteil — die Meldung darf sie
+    // nicht vermischen.
+    const reasons = new Set(
+      impact.documents.filter((d) => d.verdict === 'unknown').map((d) => d.reason),
+    )
+    expect(reasons.size).toBe(2)
+  })
+
+  it('die Zusammenfassung verschweigt das Unbeurteilbare nicht', () => {
+    const broken = { metadata: { name: 'x' } } as unknown as CablePlannerProject
+    expect(changeImpactSummary(changeImpact(broken, broken))).toContain('nicht beurteilbar')
+  })
+})
+
+describe('der Guard: das Register ist die einzige Liste', () => {
+  it('beurteilt genau die registrierten Dokumente — beide Listen, nicht mehr', () => {
+    const impact = changeImpact(project(), project())
+    expect(impact.documents.map((d) => d.docId).sort()).toEqual(
+      [...Object.keys(DOCUMENT_STANDS), ...Object.keys(UNJUDGEABLE_DOCUMENTS)].sort(),
+    )
+  })
+
+  it('kein Dokument steht in beiden Listen', () => {
+    // Beides gleichzeitig waere ein Widerspruch: reproduzierbar UND nicht
+    // beurteilbar. Der Vorrang liegt bei DOCUMENT_STANDS, aber der
+    // Widerspruch soll auffallen statt still aufgelöst zu werden.
+    const both = Object.keys(UNJUDGEABLE_DOCUMENTS).filter((id) => id in DOCUMENT_STANDS)
+    expect(both).toEqual([])
+  })
+
+  it('jedes beurteilte Dokument hat einen lesbaren Namen', () => {
+    for (const d of changeImpact(project(), project()).documents) {
+      expect(d.label, `Label fehlt fuer ${d.docId}`).toBeTruthy()
+      expect(d.label).toBe(DOCUMENT_LABELS[d.docId])
+    }
+  })
+
+  it('kabel-bom wird als „nicht beurteilbar" GENANNT, nicht weggelassen', () => {
+    // Vorher stand diese Kenntnis nur im Kommentar über DOCUMENT_STANDS. Ein
+    // Kommentar kann eine Freigabe-Liste nicht warnen: sie hätte kabel-bom
+    // einfach nicht genannt, und Verschweigen sieht aus wie „unberührt".
+    expect(Object.keys(DOCUMENT_STANDS)).not.toContain('kabel-bom')
+    const bom = changeImpact(project(), project()).documents.find((d) => d.docId === 'kabel-bom')
+    expect(bom).toBeDefined()
+    expect(bom!.verdict).toBe('unknown')
+    expect(bom!.reason).toMatch(/Reserve-Aufschlag/)
+    expect(bom!.label).toBe('Kabel-Stückliste')
+  })
+
+  it('der Grund steht als Daten da, nicht nur als Prosa', () => {
+    expect(registrySrc).toContain('UNJUDGEABLE_DOCUMENTS')
+    for (const [id, reason] of Object.entries(UNJUDGEABLE_DOCUMENTS)) {
+      expect(reason, `Grund fehlt fuer ${id}`).toBeTruthy()
+      expect(DOCUMENT_LABELS[id], `Label fehlt fuer ${id}`).toBeTruthy()
+    }
+  })
+})


### PR DESCRIPTION
Roadmap-Initiative 5, Inkrement 1. Nach dem gemessenen Stand in
larszu/av-planner-suite#46 die einzige Initiative mit Score ≥ 22, die noch
vollständig offen war — und sie hängt an keiner der geparkten Entscheidungen.

## Die Frage, die niemand stellen konnte

Bis hierhin ging nur die **Rückwärts**-Frage: mit dem Blatt in der Hand, per
Stempel — *„gilt dieser Ausdruck noch?"* (`docStandStatus`).

Die **Vorwärts**-Frage konnte niemand stellen: *„ich habe gerade das geändert —
welche Blätter sind damit hin?"* Genau die ist der Schmerzpunkt: der
Rehearsal-Day-Edit, nach dem niemand weiß, welche der zwölf ausgedruckten Listen
noch stimmen. Das Strategiepapier führt sie als die Frage, die **kein Produkt im
Korpus beantwortet**.

Billig ist sie hier nur wegen ADR-004: dieses Projekt kann den Stand eines
Dokuments **ausrechnen**, statt ihn nur aufs Blatt zu stempeln.

## Kein Feld-Diff, sondern die Ableitung

`changeImpact(before, after)` nimmt zwei **vollständige** Projekt-Stände, keine
Änderungsliste. Der Grund ist derselbe wie bei den Stempeln: der Stand eines
Dokuments hängt an seiner Ableitung, nicht an den angefassten Feldern.

Nachgewiesen: ein geänderter Kabel-Typ überholt die Pull-Liste und lässt das
Asset-Register in Ruhe. Eine Heuristik über angefasste Felder könnte das nicht
unterscheiden.

Inkrement 1 **persistiert nichts** — reine Funktion, dieselbe Reihenfolge wie
ADR-001 Inkrement 1, wo genau diese Wahl zwei Fehler gefunden hat, die kein
Diff-Review gefunden hätte.

## Der Fund: eine Kenntnis, die nur als Kommentar existierte

Das Register wusste seit ADR-004, dass `kabel-bom` **nicht reproduzierbar** ist —
der Reserve-Aufschlag steht nicht im Stempel. Aber es wusste es nur als
**Kommentar** über `DOCUMENT_STANDS`.

Ein Kommentar kann eine Freigabe-Liste nicht warnen. Sie hätte das Dokument
einfach nicht genannt — und **Verschweigen sieht aus wie „unberührt"**. Das ist
derselbe Schaden, gegen den ADR-005 geschrieben ist, nur eine Ebene höher.

Die Kenntnis ist jetzt **Daten**: `UNJUDGEABLE_DOCUMENTS` trägt den Grund im
Klartext, und die Impact-Liste nennt `kabel-bom` ausdrücklich als *nicht
beurteilbar*, mit Begründung. „Keine Auswirkung" heißt damit nicht mehr
„alles unberührt" — die Zusammenfassung sagt `1 nicht beurteilbar`.

Ein Guard fängt den Widerspruch, wenn ein Dokument je in **beiden** Listen
stünde (reproduzierbar *und* unbeurteilbar).

## Was die Sonde noch gefunden hat

Einen **toten Zweig in meinem eigenen Entwurf**: die `undefined`-Prüfung war
unerreichbar, weil `DOCUMENT_STANDS` Funktionen mit Rückgabetyp `string` führt.
Entfernt — dead code mit einem Kommentar, der einen Zweck behauptet, ist genau
das, was #636 ausgeräumt hat.

Und gemessen statt vermutet: an einem kaputten Projekt werfen **fünf der sechs**
Ableitungen, nur `planFingerprint` läuft durch. Die `catch`-Behandlung ist also
wirklich erreichbar, und sie sagt `unknown` mit eigenem Grund — die Meldung
vermischt die zwei Ursachen für dasselbe Urteil nicht.

## Was Inkrement 2 wäre

Erst die Ableitung sagt, was ein Register überhaupt festhalten müsste. Offen und
bewusst nicht vorweggenommen: woher der *vorherige* Stand kommt. Kandidaten sind
`projectHistory` (Undo-Schnappschüsse) und die tatsächlich ausgegebenen
Dokumente. Das ist eine Persistenz-Entscheidung und gehört nicht als
Nebenwirkung hierher.

## Grün

- `npm test` — 638 Tests (12 neu), 61 Dateien
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npx eslint` auf beide Dateien — 0 Errors, 0 Warnungen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_