### PR TITLE
fix: Zugangsdaten aus dem Viewer-Export streichen + der vollständige Rundgang der Ausgänge

### DIFF
--- a/src/main/ipc/projectIpc.ts
+++ b/src/main/ipc/projectIpc.ts
@@ -2,6 +2,7 @@ import { app, dialog, ipcMain, type BrowserWindow } from 'electron'
 import { access, mkdir, readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { atomicWriteFile } from '../util/atomicWrite.js'
+import { stripSecrets } from '../util/stripSecrets.js'
 import { takePendingLaunchPath } from '../services/fileOpenService.js'
 
 const RECENT_PATH = path.join(app.getPath('userData'), 'recent-projects.json')
@@ -160,7 +161,14 @@ export const registerProjectIpc = () => {
     // mode='viewer' erzwingen; bestehende Annotations aber NICHT
     // wegwerfen (der Plan-Eigentümer kann auch Pre-Annotations setzen,
     // z.B. "TODO: Cable XY checken" für die Freelancer).
-    const safe = JSON.parse(JSON.stringify(project)) as Record<string, unknown>
+    // Zugangsdaten der Geraete raus, BEVOR die Datei aus dem Haus geht.
+    // Dieselbe Regel, die der mobileShareServer schon anwendet — sie galt
+    // hier nur nicht, obwohl dieser Weg der ungeschuetztere ist: die
+    // .cpviewer-Datei geht ausdruecklich an externe Reviewer, waehrend die
+    // Mobile-Ansicht wenigstens token-gated im eigenen LAN haengt. Weder
+    // src/viewer/ noch src/mobile/ liest diese Felder (nachgesehen), es
+    // geht also nichts verloren.
+    const safe = stripSecrets(JSON.parse(JSON.stringify(project))) as Record<string, unknown>
     safe.mode = 'viewer'
     // viewerSession beim Export leeren — der Reviewer setzt seinen
     // eigenen Namen beim ersten Öffnen.

--- a/src/main/services/mobileShareServer.ts
+++ b/src/main/services/mobileShareServer.ts
@@ -42,6 +42,7 @@ import { relative as pathRelative, resolve as pathResolve, sep as pathSep } from
 import { networkInterfaces } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { randomBytes } from 'node:crypto'
+import { stripSecrets } from '../util/stripSecrets.js'
 
 const MIME_TYPES: Record<string, string> = {
   '.html': 'text/html; charset=utf-8',
@@ -179,23 +180,6 @@ const denyUnauthorized = (req: IncomingMessage, res: ServerResponse): void => {
   res.statusCode = 401
   res.setHeader('Content-Type', 'application/json; charset=utf-8')
   res.end('{"error":"unauthorized"}')
-}
-
-/** Recursively strip secret-bearing fields (device passwords etc.) from
- *  a project before it leaves the desktop. The mobile viewer never needs
- *  them, and the share server is reachable by the whole LAN. */
-const SECRET_KEYS = new Set(['password', 'passphrase', 'apiKey', 'secret', 'token'])
-const stripSecrets = (value: unknown): unknown => {
-  if (Array.isArray(value)) return value.map(stripSecrets)
-  if (value && typeof value === 'object') {
-    const out: Record<string, unknown> = {}
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      if (SECRET_KEYS.has(k)) continue
-      out[k] = stripSecrets(v)
-    }
-    return out
-  }
-  return value
 }
 
 /** Lookup non-internal IPv4 addresses across all network interfaces. */

--- a/src/main/util/stripSecrets.ts
+++ b/src/main/util/stripSecrets.ts
@@ -1,0 +1,47 @@
+/**
+ * Geheimnis-tragende Felder aus einem Projekt entfernen, bevor es den
+ * Rechner in Richtung einer ANDEREN Person verlaesst.
+ *
+ * Die Regel stand bisher nur im `mobileShareServer` und galt damit nur fuer
+ * einen der Ausgaenge: „Recursively strip secret-bearing fields (device
+ * passwords etc.) from a project before it leaves the desktop." Sie ist
+ * richtig — aber der Viewer-Export (`.cpviewer`, ausdruecklich fuer externe
+ * Reviewer) ging daran vorbei und schrieb `username`/`password` jedes
+ * Geraets in die Datei. Die Variable dort hiess `safe`.
+ *
+ * Gefunden wurde das beim Aufzaehlen der Felder fuer den Plan-Vergleich
+ * (#639): dieselben zwei Felder, dritter Ausgang. Deshalb liegt die Regel
+ * jetzt an einer Stelle und wird von beiden Wegen benutzt.
+ *
+ * WAS HIER NICHT HINEINGEHOERT. Wege, auf denen die Datei beim EIGENTUEMER
+ * bleibt (`project:save`, `project:save-as`) oder auf denen bewusst
+ * gemeinsam am selben Plan gearbeitet wird (CRDT-Sync unter Planern). Wer
+ * seinen eigenen Plan speichert, will seine Zugangsdaten behalten.
+ *
+ * `username` steht mit auf der Liste, obwohl es allein kein Passwort ist:
+ * es ist Zugangsdatum, kein Konsument im Viewer oder in der Mobile-Ansicht
+ * liest es (nachgesehen), und kein anderer Typ im Projekt fuehrt ein Feld
+ * dieses Namens — das rekursive Streichen trifft also nichts Fremdes.
+ */
+export const SECRET_KEYS = new Set([
+  'password',
+  'username',
+  'passphrase',
+  'apiKey',
+  'secret',
+  'token',
+])
+
+/** Rekursiv alle Felder aus `SECRET_KEYS` entfernen. Arrays bleiben Arrays. */
+export const stripSecrets = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(stripSecrets)
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (SECRET_KEYS.has(k)) continue
+      out[k] = stripSecrets(v)
+    }
+    return out
+  }
+  return value
+}

--- a/src/renderer/lib/avplan.ts
+++ b/src/renderer/lib/avplan.ts
@@ -71,6 +71,27 @@ const EMPTY_VENUE: AvVenue = { name: 'Venue', persons: [], walls: [], stageObjec
 /** Baut eine .avplan aus dem aktuellen Cable-Projekt. Der cabling-Slot ist das
  *  Projekt ohne sein avForeign-Feld (das wandert auf die Top-Ebene zurueck),
  *  geteilter Raum + Kamera-/Licht-Domaenen kommen aus dem bewahrten avForeign. */
+/**
+ * OFFENER BEFUND — Geraete-Zugangsdaten gehen mit.
+ *
+ * Der Rest-Spread unten schiebt das Projekt unveraendert nach
+ * `domains.cabling`, also auch `username`/`password` jedes Geraets. Gemessen
+ * mit einem Kanarienvogel-Wert (tests/credentialExits.test.ts nennt den
+ * Rundgang), nicht vermutet: von allen reinen Ableitungen ist das die
+ * einzige, die sie durchreicht.
+ *
+ * Das ist trotzdem KEIN Fehler, den man hier nebenbei behebt. Der Import
+ * liest `domains.cabling` als ganzes Projekt zurueck (siehe `MenuBar.tsx`),
+ * ein Strippen waere also ein echter Verlust beim Round-Trip — ADR-005 in die
+ * andere Richtung. Die Abwaegung („darf eine Austausch-Datei, die an einen
+ * Lichtplaner geht, Switch-Passwoerter enthalten?") gehoert dem Eigentuemer;
+ * sie steht als Messung in `CREDENTIALS-IN-TEMPLATES.md` in der Suite, neben
+ * demselben Feld-Paar auf dem Weg in ein geteiltes Bibliotheks-Template.
+ *
+ * Der bereits entschiedene Nachbarfall zur Abgrenzung: der Viewer-Export
+ * (`.cpviewer`) streicht sie, weil dort niemand sie liest und nichts
+ * verloren geht.
+ */
 export function cableToAvPlan(
   project: { avForeign?: { venue?: unknown; cameras?: unknown; lighting?: unknown } },
   meta: { appVersion: string; exportedAt: string },

--- a/tests/credentialExits.test.ts
+++ b/tests/credentialExits.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import type { CablePlannerProject } from '../src/renderer/types/project'
+import {
+  pullListTable,
+  terminationListTable,
+  cableScheduleTable,
+  cableBomTable,
+} from '../src/renderer/lib/installerLists'
+import { assetRegisterTable } from '../src/renderer/lib/assetRegister'
+import { handoverTable } from '../src/renderer/lib/handoverPackage'
+import { buildSourceMap } from '../src/renderer/lib/sourceMap'
+import { buildTallyMap } from '../src/renderer/lib/tallyMap'
+import { buildPlanBom } from '../src/renderer/lib/planBom'
+import { planDiffCsv } from '../src/renderer/lib/planDiff'
+
+// ---------------------------------------------------------------------------
+// Der Rundgang: welcher Ausgang traegt Geraete-Zugangsdaten nach draussen?
+//
+// `EquipmentItem` fuehrt `username`/`password`. Beim Aufzaehlen der Felder
+// fuer den Plan-Vergleich (#639) fiel auf, dass die Regel dagegen zwar
+// existierte, aber nur an einem der Ausgaenge griff. Statt es beim einen
+// gefundenen Fall zu belassen, sind hier ALLE reinen Ableitungen einmal
+// gegen einen Kanarienvogel-Wert laufen gelassen worden — messen statt
+// nachdenken, weil ein Ausgang, der das ganze Item durchreicht, es nirgends
+// erwaehnt und darum von keiner Textsuche gefunden wird.
+//
+// Genau so ist `cableToAvPlan` aufgefallen: `const { avForeign, ...cabling }
+// = project` schiebt die Geraete unveraendert in die `.avplan`-Datei. Das
+// steht bewusst NICHT in diesem Test — es ist keine Luecke, sondern eine
+// offene Frage: der Import liest `domains.cabling` als ganzes Projekt zurueck
+// (`MenuBar.tsx`), ein Strippen waere also ein echter Verlust beim
+// Round-Trip und damit ein ADR-005-Verstoss in die andere Richtung. Der
+// Befund liegt beim Eigentuemer, siehe den Kommentar in `lib/avplan.ts` und
+// `CREDENTIALS-IN-TEMPLATES.md` in der Suite.
+//
+// Dieser Test haelt fest, was ohne Entscheidung gilt: die Dokument-
+// Ableitungen tragen sie nicht, und sie sollen es auch nie tun.
+// ---------------------------------------------------------------------------
+
+const SECRET = 'PASSWORT-KANARIENVOGEL'
+const USER = 'BENUTZER-KANARIENVOGEL'
+
+const project = {
+  metadata: { name: 'Halle', description: '', createdAt: '', updatedAt: '' },
+  equipment: [
+    {
+      id: 'A',
+      name: 'Switch',
+      category: 'Netzwerk',
+      inputs: [{ id: 'A-in', name: 'IN 1', type: 'port', connectorType: 'RJ45' }],
+      outputs: [{ id: 'A-out', name: 'OUT 1', type: 'port', connectorType: 'RJ45' }],
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 100,
+      ipAddress: '10.0.0.2',
+      username: USER,
+      password: SECRET,
+    },
+  ],
+  cables: [],
+  canvasState: { x: 0, y: 0, zoom: 1 },
+} as unknown as CablePlannerProject
+
+/** Jede Ableitung, die ein Blatt, eine Datei oder eine Liste erzeugt. */
+const derivations: Array<[string, () => unknown]> = [
+  ['pullListTable', () => pullListTable(project)],
+  ['terminationListTable', () => terminationListTable(project)],
+  ['cableScheduleTable', () => cableScheduleTable(project)],
+  ['cableBomTable', () => cableBomTable(project)],
+  ['assetRegisterTable', () => assetRegisterTable(project)],
+  ['handoverTable', () => handoverTable(project)],
+  ['buildTallyMap', () => buildTallyMap(project)],
+  ['buildPlanBom', () => buildPlanBom(project.equipment, [], [])],
+  [
+    'buildSourceMap',
+    () => buildSourceMap(project, { appVersion: '0.0.0', exportedAt: '2026-01-01T00:00:00Z' }),
+  ],
+  ['planDiffCsv', () => planDiffCsv(project, project)],
+]
+
+describe('kein Dokument traegt Geraete-Zugangsdaten nach draussen', () => {
+  for (const [name, run] of derivations) {
+    it(`${name} schreibt weder Benutzer noch Passwort`, () => {
+      const out = JSON.stringify(run())
+      expect(out).not.toContain(SECRET)
+      expect(out).not.toContain(USER)
+    })
+  }
+
+  it('der Kanarienvogel wuerde auffallen, wenn eine Ableitung ihn durchreicht', () => {
+    // Gegenprobe zum Test selbst: eine Ableitung, die das Item unveraendert
+    // weitergibt, faellt hier auf. Ohne diese Zeile koennte die ganze Suite
+    // gruen sein, weil der Wert nie im Projekt stand.
+    const passthrough = JSON.stringify(project.equipment)
+    expect(passthrough).toContain(SECRET)
+    expect(passthrough).toContain(USER)
+  })
+})

--- a/tests/stripSecrets.test.ts
+++ b/tests/stripSecrets.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { SECRET_KEYS, stripSecrets } from '../src/main/util/stripSecrets'
+import projectIpcSrc from '../src/main/ipc/projectIpc.ts?raw'
+import mobileShareSrc from '../src/main/services/mobileShareServer.ts?raw'
+import equipmentTypesSrc from '../src/renderer/types/equipment.ts?raw'
+
+// Zugangsdaten von Geraeten stehen in der Projektdatei. Sie duerfen mit,
+// solange die Datei beim Eigentuemer bleibt — und nicht, sobald sie an
+// jemand anderen geht. Diese Datei haelt beide Haelften fest.
+//
+// Der Befund, aus dem sie entstanden ist: die Regel existierte, aber nur an
+// EINEM der Ausgaenge. Der Viewer-Export schrieb `username`/`password` jedes
+// Geraets in eine Datei, die ausdruecklich fuer externe Reviewer gedacht ist.
+
+describe('stripSecrets', () => {
+  it('entfernt Zugangsdaten rekursiv, auch in Listen', () => {
+    const project = {
+      metadata: { name: 'Halle' },
+      equipment: [
+        { id: 'A', name: 'Switch', ipAddress: '10.0.0.2', username: 'admin', password: 'geheim' },
+        { id: 'B', name: 'Kamera' },
+      ],
+    }
+    expect(stripSecrets(project)).toEqual({
+      metadata: { name: 'Halle' },
+      equipment: [
+        { id: 'A', name: 'Switch', ipAddress: '10.0.0.2' },
+        { id: 'B', name: 'Kamera' },
+      ],
+    })
+  })
+
+  it('laesst alles andere unangetastet, inklusive Datentypen', () => {
+    const value = { n: 1, b: false, s: '', nil: null, list: [1, 2], nested: { deep: [{ x: 1 }] } }
+    expect(stripSecrets(value)).toEqual(value)
+  })
+
+  it('deckt beide Felder ab, die EquipmentItem als Zugangsdaten fuehrt', () => {
+    // Kommt ein drittes dazu, faellt zuerst der Klassifizierungs-Guard in
+    // planDiff.test.ts — und wer es dort als `sensitive` einordnet, aber hier
+    // vergisst, faellt an dieser Zeile.
+    expect(SECRET_KEYS.has('username')).toBe(true)
+    expect(SECRET_KEYS.has('password')).toBe(true)
+    expect(equipmentTypesSrc).toContain('username?: string')
+    expect(equipmentTypesSrc).toContain('password?: string')
+  })
+})
+
+describe('die Ausgaenge, die das Haus verlassen', () => {
+  it('streicht der Viewer-Export die Zugangsdaten', () => {
+    // Quell-Zusicherung statt Verhaltenstest: der Handler haengt an
+    // electron `dialog` und ist headless nicht aufrufbar. Geprueft wird
+    // deshalb, dass der geschriebene Wert durch `stripSecrets` geht.
+    const handler = projectIpcSrc.slice(
+      projectIpcSrc.indexOf("ipcMain.handle('project:export-viewer'"),
+    )
+    const body = handler.slice(0, handler.indexOf('ipcMain.handle', 1))
+    expect(body).toContain('stripSecrets(')
+    expect(body).toContain('atomicWriteFile(target')
+  })
+
+  it('streicht die Mobile-Ansicht die Zugangsdaten', () => {
+    expect(mobileShareSrc).toContain('stripSecrets(project)')
+  })
+
+  it('haelt die Regel an genau einer Stelle', () => {
+    // Zwei Kopien waren der Grund, warum ein Ausgang sie hatte und der
+    // andere nicht. Beide Dateien importieren sie jetzt, statt sie zu
+    // definieren.
+    for (const src of [projectIpcSrc, mobileShareSrc]) {
+      expect(src).toContain("from '../util/stripSecrets.js'")
+      expect(src).not.toContain('const stripSecrets =')
+      expect(src).not.toContain('const SECRET_KEYS =')
+    }
+  })
+})


### PR DESCRIPTION
Nebenbefund aus #639, deshalb eigener PR statt angehängt.

Beim Aufzählen aller 146 Felder von `Cable`/`EquipmentItem` für den
Plan-Vergleich fiel auf, dass `EquipmentItem` **`username`/`password`** führt —
Geräte-Zugangsdaten, die in der Projektdatei stehen. Statt beim ersten Fund
stehen zu bleiben, sind **alle** Ausgänge einmal abgegangen worden.

## Der Rundgang

Ein Ausgang, der das ganze Item durchreicht, erwähnt die Felder nirgends und ist
per Textsuche nicht zu finden. Deshalb gemessen statt nachgedacht: ein
Kanarienvogel-Wert durch jede reine Ableitung.

| Ausgang | Empfänger | Stand |
| --- | --- | --- |
| `project:save` / `save-as` | der Eigentümer selbst | trägt sie — richtig so |
| CRDT-Sync | Mit-Planer am selben Plan | trägt sie — richtig so |
| `mobileShareServer` | LAN-Ansicht, token-gated | strippt sie |
| `project:export-viewer` (`.cpviewer`) | **externe Reviewer** | **trug sie — hier gefixt** |
| Pull-Liste, Termination, Kabel-Schedule, Kabel-BOM, Asset-Register, Übergabe, Tally-Map, Plan-BOM, Source-Map, Plan-Vergleich | Papier / CSV | sauber — jetzt per Test festgehalten |
| `cableToAvPlan` (`.avplan`) | andere Apps, andere Leute | **trägt sie — bewusst nicht gefixt, siehe unten** |
| `templateFromEquipment` → geteilte Bibliothek | das Team | trägt sie — Design-Frage 5 |

## Was gefixt ist

Der ungeschütztere der beiden Fremd-Wege war der ungeschützte: die
`.cpviewer`-Datei geht ausdrücklich an externe Reviewer, während die
Mobile-Ansicht wenigstens token-gated im eigenen LAN hängt. Die Variable im
Viewer-Export hiess `safe`.

* `stripSecrets` + `SECRET_KEYS` liegen jetzt in `src/main/util/stripSecrets.ts`;
  beide Wege importieren sie. **Zwei Kopien waren der Grund**, warum ein Ausgang
  sie hatte und der andere nicht — deshalb wird die Regel nicht dupliziert,
  sondern verschoben.
* `username` kommt mit auf die Liste: Zugangsdatum, weder `src/viewer/` noch
  `src/mobile/` liest es (nachgesehen), und kein anderer Projekt-Typ führt ein
  Feld dieses Namens — das rekursive Streichen trifft nichts Fremdes. Am Viewer
  geht keine Funktion verloren.

## Was ausdrücklich NICHT gefixt ist

`cableToAvPlan` schiebt per Rest-Spread das ganze Projekt nach `domains.cabling`.
Ein Strippen wäre hier **kein** Gewinn ohne Preis: der Import liest
`domains.cabling` als ganzes Projekt zurück (`MenuBar.tsx`), ein Round-Trip
verlöre die Zugangsdaten also still — ADR-005 in die andere Richtung. Die
Abwägung („darf eine Austausch-Datei, die an einen Lichtplaner geht,
Switch-Passwörter enthalten?") gehört dem Eigentümer und steht als Kommentar an
der Funktion.

Damit sind es **drei belegte Austrittsstellen desselben Feld-Paars**: eine
geschlossen (Viewer), zwei beim Eigentümer (`.avplan`, geteilte Templates —
`CREDENTIALS-IN-TEMPLATES.md`).

## Prüfung

* `tests/stripSecrets.test.ts` (6) + `tests/credentialExits.test.ts` (11, mit
  Gegenprobe am Test selbst), 678 Tests grün, 3× `tsc --noEmit` 0 Errors,
  Lint 0 Errors, Build grün.
* Gegengeprüft durch Zurückbauen des Fixes: der Viewer-Test fällt dann.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT