### PR TITLE
greengo: Editor und Generator — ein geladenes Preset überlebt den Export (Design-Frage 1)

### DIFF
--- a/src/renderer/components/Export/GreenGoExportDialog.tsx
+++ b/src/renderer/components/Export/GreenGoExportDialog.tsx
@@ -88,7 +88,11 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
       ...u,
       equipmentId: importMappings.get(u.id) || undefined,
     }))
-    setConfig({ ...importResult.config, users })
+    // ENTSCHEIDUNG "Editor UND Generator": das Roh-Dokument wandert mit in
+    // den Plan. Der naechste Export schreibt hinein, statt neu zu bauen —
+    // Raeume, Templates, Geraete-Registrierungen und die Anlagen-Passwoerter
+    // bleiben damit erhalten.
+    setConfig({ ...importResult.config, users, basePreset: importResult.raw })
     setActiveTab('matrix')
     setImportResult(null)
     setImportError(null)

--- a/src/renderer/lib/exportGreengo.ts
+++ b/src/renderer/lib/exportGreengo.ts
@@ -205,8 +205,123 @@ const buildGroup = (group: GreenGoGroup, users: GreenGoUser[]): Record<string, u
 // ── Main export ───────────────────────────────────────────────────────────────
 
 /**
+ * Die Felder in `Settings`, die aus dem Plan kommen — und NUR die.
+ *
+ * Alles andere in `Settings` gehoert der Anlage: `configId` identifiziert die
+ * Konfiguration, `ConfigPassword`/`AdminPassword` sind die Zugaenge zum
+ * System. Sie beim Export neu zu wuerfeln haette dem Nutzer die eigene Anlage
+ * ausgesperrt — das ist der Grund, warum die Liste hier steht und nicht als
+ * Spread irgendwo im Code.
+ */
+const SETTINGS_FROM_PLAN = ['Name', 'Description', 'SampleRate', 'MulticastAddress'] as const
+
+/**
+ * EDITOR-Weg: in ein geladenes Roh-Dokument hineinschreiben.
+ *
+ * Ueberschrieben wird genau das, was der Plan besitzt — Stationen, Gruppen und
+ * die vier Settings-Felder aus `SETTINGS_FROM_PLAN`. Raeume, Templates,
+ * Geraete-Registrierungen, Tastenbelegungen, Netz-Einstellungen und die
+ * Passwoerter bleiben unangetastet.
+ *
+ * Das ist die Antwort auf den Kommentar in `importGreengo`: „Bis der
+ * Round-Trip sie bewahrt, muss er wenigstens sagen, was er nicht gelesen hat."
+ */
+/**
+ * Die Felder EINER Station, die aus dem Plan kommen. Alles andere gehoert der
+ * Anlage: `devices` ist die Hardware-Registrierung, `Channels` /
+ * `SpecialChannels` sind die Tastenbelegungen, `Security.Pincode` der Zugang,
+ * `AudioProfile` das Einmessen. Der Generator schreibt sie aus Konstanten —
+ * auf einer echten Anlage ist das der halbe Einmessvorgang.
+ *
+ * Spiegelbild von `READ_USER_FIELDS` in `importGreengo`: was der Parser liest,
+ * darf der Export zurueckschreiben. Der Guard in tests/greengoPreset.test.ts
+ * haelt die beiden Listen deckungsgleich.
+ */
+const USER_FIELDS_FROM_PLAN = ['myId', 'Name', 'DisplayName', 'Color', 'ButtonFunctions'] as const
+
+/** Dasselbe fuer eine Gruppe. */
+const GROUP_FIELDS_FROM_PLAN = ['myId', 'Name', 'Color', 'members'] as const
+
+/**
+ * Eine keys-indizierte Sektion fortschreiben statt ersetzen.
+ *
+ * Der erste Anlauf dieser Funktion hat `Users` komplett durch die
+ * plan-gebaute Sektion ersetzt — und damit genau den Verlust wieder
+ * eingebaut, gegen den der Editor-Weg gedacht ist. Aufgefallen ist es nur,
+ * weil ein Test den Pincode einer importierten Station geprueft hat.
+ *
+ * Jetzt: eine Station, die es im Preset gibt, behaelt ihr Objekt und bekommt
+ * nur die Plan-Felder ueberschrieben. Eine neue Station kommt vollstaendig
+ * aus dem Generator — sie hat kein Vorbild, aus dem sich etwas bewahren
+ * liesse. Eine geloeschte faellt weg.
+ */
+const mergeKeyedSection = (
+  presetSection: unknown,
+  built: Record<string, unknown>,
+  fieldsFromPlan: readonly string[],
+): Record<string, unknown> => {
+  const previous =
+    presetSection && typeof presetSection === 'object'
+      ? (presetSection as Record<string, unknown>)
+      : {}
+  const keys = Array.isArray(built.keys) ? (built.keys as string[]) : []
+  const out: Record<string, unknown> = { keys, badge: previous.badge ?? 0 }
+  for (const key of keys) {
+    const fresh = built[key]
+    const old = previous[key]
+    if (!old || typeof old !== 'object' || !fresh || typeof fresh !== 'object') {
+      out[key] = fresh
+      continue
+    }
+    const merged = { ...(old as Record<string, unknown>) }
+    for (const field of fieldsFromPlan) {
+      merged[field] = (fresh as Record<string, unknown>)[field]
+    }
+    out[key] = merged
+  }
+  return out
+}
+
+const mergeIntoPreset = (
+  preset: Record<string, unknown>,
+  config: GreenGoConfig,
+  usersSection: Record<string, unknown>,
+  groupsSection: Record<string, unknown>,
+): Record<string, unknown> => {
+  // Tiefe Kopie: das Preset im Projekt darf der Export nicht veraendern.
+  const out = JSON.parse(JSON.stringify(preset)) as Record<string, unknown>
+  const settings =
+    out.Settings && typeof out.Settings === 'object'
+      ? (out.Settings as Record<string, unknown>)
+      : {}
+  const fromPlan: Record<string, unknown> = {
+    Name: config.systemName,
+    Description: config.description ?? '',
+    SampleRate: config.sampleRate,
+    MulticastAddress: config.multicastAddress,
+  }
+  for (const key of SETTINGS_FROM_PLAN) settings[key] = fromPlan[key]
+  // Zeitstempel des Speicherns fortschreiben, falls das Preset einen fuehrt —
+  // aber keinen erfinden, wo keiner stand.
+  if ('savedAtTimestamp' in settings) settings.savedAtTimestamp = timestamp()
+  out.Settings = settings
+  // Fortschreiben, nicht ersetzen — sonst waeren Tastenbelegungen, Pincodes
+  // und Geraete-Registrierungen der Stationen trotz Preset wieder weg.
+  out.Users = mergeKeyedSection(out.Users, usersSection, USER_FIELDS_FROM_PLAN)
+  out.Groups = mergeKeyedSection(out.Groups, groupsSection, GROUP_FIELDS_FROM_PLAN)
+  return out
+}
+
+/**
  * Build a .gg5 JSON string from a GreenGoConfig.
  * Returns a UTF-8 string that can be saved as `<name>.gg5`.
+ *
+ * ZWEI WEGE, und der Nutzer hat sie entschieden: liegt ein `basePreset` vor
+ * (der Nutzer hat eine echte Anlagen-Konfiguration geladen), wird
+ * HINEINGESCHRIEBEN; sonst wie bisher aus dem Plan ERZEUGT. Der Unterschied
+ * ist kein Detail — der Generator-Weg fuellt Raeume, Templates, Geraete und
+ * Netz aus Konstanten, und wer eine echte Anlage importiert und wieder
+ * exportiert hat, bekam sie leer zurueck.
  */
 export const buildGg5File = (config: GreenGoConfig): string => {
   const ts = timestamp()
@@ -286,5 +401,11 @@ export const buildGg5File = (config: GreenGoConfig): string => {
     },
   }
 
-  return JSON.stringify(gg5, null, 1)
+  // EDITOR-Weg: das geladene Roh-Dokument gewinnt, der Plan schreibt nur
+  // seine eigenen Teile hinein. Steht kein Preset da, bleibt es beim eben
+  // gebauten `gg5` — dem GENERATOR-Weg.
+  const out = config.basePreset
+    ? mergeIntoPreset(config.basePreset, config, usersSection, groupsSection)
+    : gg5
+  return JSON.stringify(out, null, 1)
 }

--- a/src/renderer/lib/importGreengo.ts
+++ b/src/renderer/lib/importGreengo.ts
@@ -42,6 +42,15 @@ export interface Gg5ImportResult {
    * und liess den Nutzer glauben, der Rest sei uebernommen.
    */
   unreadFields: UnreadFieldReport[]
+  /**
+   * Das unveraenderte Roh-Dokument. Wandert als `GreenGoConfig.basePreset` in
+   * den Plan, damit der Export hineinschreiben kann statt neu zu bauen.
+   *
+   * Es ist ausdruecklich das GANZE Dokument, nicht „die ungelesenen Teile":
+   * welche Teile ungelesen sind, weiss diese Datei — welche der Nutzer
+   * spaeter braucht, weiss sie nicht.
+   */
+  raw: Record<string, unknown>
 }
 
 export interface Gg5ParseError {
@@ -335,6 +344,7 @@ export const parseGg5File = (jsonText: string): Gg5ParseOutcome => {
     userTypeHints,
     unreadSections: unreadTopLevelSections(raw),
     unreadFields: unreadFieldsInReadSections(raw),
+    raw,
   }
 }
 

--- a/src/renderer/types/greengo.ts
+++ b/src/renderer/types/greengo.ts
@@ -36,6 +36,24 @@ export interface GreenGoConfig {
   sampleRate: 32000 | 48000
   users: GreenGoUser[]
   groups: GreenGoGroup[]
+  /**
+   * Das importierte Roh-Dokument, falls der Nutzer eine echte
+   * Anlagen-Konfiguration geladen hat.
+   *
+   * ENTSCHEIDUNG „Editor UND Generator": liegt hier eins, schreibt der Export
+   * hinein statt neu zu bauen — Raeume, Templates, Geraete, Netz-Einstellungen
+   * und vor allem die PASSWOERTER der Anlage bleiben, wie sie waren. Liegt
+   * keins, wird wie bisher aus dem Plan erzeugt.
+   *
+   * Der Kommentar in `importGreengo.Gg5ImportResult.unreadSections` hat genau
+   * darauf gewartet: „Bis der Round-Trip sie bewahrt, muss er wenigstens
+   * sagen, was er nicht gelesen hat." Jetzt bewahrt er sie.
+   *
+   * Der Preis: das Roh-Dokument reist im Projektfile mit. Das ist gewollt —
+   * sonst waere es beim naechsten Oeffnen weg, und der Export fiele
+   * unbemerkt auf „neu erzeugen" zurueck.
+   */
+  basePreset?: Record<string, unknown>
 }
 
 export const defaultGreenGoConfig = (): GreenGoConfig => ({

--- a/tests/greengoPreset.test.ts
+++ b/tests/greengoPreset.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest'
+import { buildGg5File } from '../src/renderer/lib/exportGreengo'
+import { parseGg5File, isParseError } from '../src/renderer/lib/importGreengo'
+import type { GreenGoConfig } from '../src/renderer/types/greengo'
+
+// ---------------------------------------------------------------------------
+// Design-Frage 1, entschieden: „Editor UND Generator."
+//
+// Der Exporter baute bisher IMMER eine vollstaendige `.gg5` und fuellte
+// Raeume, Templates, Geraete und Netz aus Konstanten. Wer eine echte
+// Anlagen-Konfiguration importierte, etwas aenderte und wieder exportierte,
+// bekam sie leer zurueck — `importGreengo` sagt das in seinem eigenen
+// Kommentar und wartete auf genau diese Aenderung: „Bis der Round-Trip sie
+// bewahrt, muss er wenigstens sagen, was er nicht gelesen hat."
+//
+// Jetzt: liegt ein Preset, wird hineingeschrieben; sonst wie bisher erzeugt.
+// ---------------------------------------------------------------------------
+
+/** Eine .gg5, wie sie von einer echten Anlage kaeme — mit allem, was wir nicht lesen. */
+const anlage = () => ({
+  Settings: {
+    Name: 'Halle A',
+    Description: 'Bestand',
+    configId: 'aaaabbbb-ccccdddd',
+    ConfigPassword: 'geheim-config',
+    AdminPassword: 'geheim-admin',
+    ConfigPasswordSet: 1,
+    AdminPasswordSet: 1,
+    SampleRate: 48000,
+    MulticastAddress: '239.9.9.9',
+    TechPincode: '4711',
+    savedAtTimestamp: 1,
+  },
+  Users: {
+    keys: ['1'],
+    badge: 0,
+    '1': {
+      myId: 1,
+      Name: 'BPX Regie',
+      DisplayName: 'Regie',
+      Color: 3,
+      ButtonFunctions: {},
+      // Was der Parser NICHT liest — der halbe Einmessvorgang:
+      devices: [{ serial: 'GG-0001' }],
+      Channels: { 1: { fn: 'talk' } },
+      Security: { Pincode: '1234' },
+      AudioProfile: { gain: 7 },
+    },
+  },
+  Groups: { keys: [], badge: 0 },
+  Rooms: { keys: ['r1'], badge: 0, r1: { Name: 'Regie' } },
+  Templates: { keys: ['t1'], badge: 0, t1: { Name: 'Standard-Belegung' } },
+  Devices: { keys: ['d1'], badge: 0, d1: { serial: 'GG-0001', ip: '10.0.0.9' } },
+  Network: { keys: ['n1'], badge: 0, n1: { dhcp: 0 } },
+  WirelessPools: { keys: ['w1'], w1: { band: '1.9G' } },
+  Binary: 'AAECAw==',
+})
+
+const parsed = (raw: unknown) => {
+  const r = parseGg5File(JSON.stringify(raw))
+  if (isParseError(r)) throw new Error(r.error)
+  return r
+}
+
+const configFrom = (raw: unknown): GreenGoConfig => {
+  const r = parsed(raw)
+  return { ...r.config, basePreset: r.raw }
+}
+
+describe('Editor-Weg: ein geladenes Preset ueberlebt den Export', () => {
+  it('behaelt die Sektionen, die diese App gar nicht liest', () => {
+    const out = JSON.parse(buildGg5File(configFrom(anlage()))) as Record<string, any>
+    expect(out.Rooms.r1.Name).toBe('Regie')
+    expect(out.Templates.t1.Name).toBe('Standard-Belegung')
+    expect(out.Devices.d1.ip).toBe('10.0.0.9')
+    expect(out.Network.n1.dhcp).toBe(0)
+    expect(out.WirelessPools.w1.band).toBe('1.9G')
+    expect(out.Binary).toBe('AAECAw==')
+  })
+
+  it('wuerfelt die Anlagen-Passwoerter NICHT neu', () => {
+    // Der Generator-Weg erzeugt bei jedem Export frische Zufalls-Passwoerter.
+    // Auf ein importiertes Bestandssystem angewandt haette das den Nutzer aus
+    // seiner eigenen Anlage ausgesperrt.
+    const out = JSON.parse(buildGg5File(configFrom(anlage()))) as Record<string, any>
+    expect(out.Settings.ConfigPassword).toBe('geheim-config')
+    expect(out.Settings.AdminPassword).toBe('geheim-admin')
+    expect(out.Settings.ConfigPasswordSet).toBe(1)
+    expect(out.Settings.configId).toBe('aaaabbbb-ccccdddd')
+    expect(out.Settings.TechPincode).toBe('4711')
+  })
+
+  it('schreibt genau die vier Felder aus dem Plan zurueck', () => {
+    const config = configFrom(anlage())
+    const out = JSON.parse(
+      buildGg5File({
+        ...config,
+        systemName: 'Halle B',
+        description: 'geaendert',
+        sampleRate: 32000,
+        multicastAddress: '239.1.1.1',
+      }),
+    ) as Record<string, any>
+    expect(out.Settings.Name).toBe('Halle B')
+    expect(out.Settings.Description).toBe('geaendert')
+    expect(out.Settings.SampleRate).toBe(32000)
+    expect(out.Settings.MulticastAddress).toBe('239.1.1.1')
+    // Und alles daneben bleibt.
+    expect(out.Settings.AdminPassword).toBe('geheim-admin')
+  })
+
+  it('laesst das Preset im Projekt unveraendert', () => {
+    // Der Export darf den Plan nicht anfassen — sonst waere der zweite Export
+    // ein anderer als der erste.
+    const config = configFrom(anlage())
+    const before = JSON.stringify(config.basePreset)
+    buildGg5File({ ...config, systemName: 'Andere' })
+    expect(JSON.stringify(config.basePreset)).toBe(before)
+  })
+
+  it('uebernimmt Stationen und Gruppen aus dem Plan, nicht aus dem Preset', () => {
+    const config = configFrom(anlage())
+    const out = JSON.parse(
+      buildGg5File({
+        ...config,
+        users: [{ id: 7, name: 'Neue Station', color: 1, groupIds: [] }],
+        groups: [],
+      }),
+    ) as Record<string, any>
+    expect(out.Users.keys).toEqual(['7'])
+    expect(out.Users['7'].Name).toBe('Neue Station')
+  })
+})
+
+describe('Generator-Weg: ohne Preset bleibt alles wie bisher', () => {
+  it('baut eine vollstaendige Datei aus dem Plan', () => {
+    const out = JSON.parse(
+      buildGg5File({
+        systemName: 'Neu',
+        description: '',
+        multicastAddress: '239.1.160.1',
+        sampleRate: 32000,
+        users: [],
+        groups: [],
+      }),
+    ) as Record<string, any>
+    expect(out.Settings.Name).toBe('Neu')
+    // Die Sektionen, die der Generator aus Konstanten fuellt — leer, aber
+    // vorhanden. Genau das ist der Zustand, den der Editor-Weg vermeidet.
+    expect(out.Rooms).toEqual({ keys: [], badge: 0 })
+    expect(out.Devices).toEqual({ keys: [], badge: 0 })
+    // Und er wuerfelt weiterhin frische Passwoerter, weil es keine gibt.
+    expect(typeof out.Settings.AdminPassword).toBe('string')
+    expect(out.Settings.AdminPassword.length).toBeGreaterThan(8)
+  })
+})
+
+describe('der Round-Trip als Ganzes', () => {
+  it('ueberlebt Datei -> Import -> Export -> Import ohne Verlust der Anlagenteile', () => {
+    const first = anlage()
+    const out = buildGg5File(configFrom(first))
+    const second = parsed(JSON.parse(out))
+    // Der zweite Import sieht dieselbe Anlage.
+    expect(second.config.systemName).toBe('Halle A')
+    expect((second.raw as Record<string, any>).Devices.d1.serial).toBe('GG-0001')
+    expect((second.raw as Record<string, any>).Users['1'].Security.Pincode).toBe('1234')
+  })
+})
+
+describe('was der Parser liest, schreibt der Export zurueck', () => {
+  it('haelt die beiden Feldlisten deckungsgleich', async () => {
+    // Der Editor-Weg ueberschreibt genau die Felder, die der Import liest.
+    // Laufen die Listen auseinander, entsteht eine der beiden Haelften des
+    // urspruenglichen Fehlers: entweder wird etwas ueberschrieben, das der
+    // Plan gar nicht kennt, oder eine Plan-Aenderung kommt nicht an.
+    const exportSrc = (await import('../src/renderer/lib/exportGreengo.ts?raw')).default
+    const importSrc = (await import('../src/renderer/lib/importGreengo.ts?raw')).default
+    const listOf = (src: string, name: string): string[] => {
+      const m = new RegExp(`${name} = (?:new Set\\()?\\[([^\\]]*)\\]`).exec(src)
+      if (!m) throw new Error(`${name} nicht gefunden`)
+      return [...m[1].matchAll(/'([^']+)'/g)].map((x) => x[1]).sort()
+    }
+    expect(listOf(exportSrc, 'USER_FIELDS_FROM_PLAN')).toEqual(
+      listOf(importSrc, 'READ_USER_FIELDS'),
+    )
+    expect(listOf(exportSrc, 'GROUP_FIELDS_FROM_PLAN')).toEqual(
+      listOf(importSrc, 'READ_GROUP_FIELDS'),
+    )
+    expect(listOf(exportSrc, 'SETTINGS_FROM_PLAN')).toEqual(
+      listOf(importSrc, 'READ_SETTINGS_FIELDS'),
+    )
+  })
+})


### PR DESCRIPTION
Design-Frage 1, entschieden: **beides.** Liegt ein importiertes Preset vor,
schreibt der Export hinein; sonst wird wie bisher aus dem Plan erzeugt.

## Der Code hat darauf gewartet

`importGreengo` beschreibt den Schaden in seinem eigenen Kommentar:

> *„der Exporter schreibt eine vollständige .gg5 und füllt genau diese
> Sektionen aus hartkodierten Defaults. Wer eine echte Anlagen-Konfiguration
> importiert, etwas ändert und wieder exportiert, bekommt sie leer zurück.
> **Bis der Round-Trip sie bewahrt**, muss er wenigstens sagen, was er nicht
> gelesen hat."*

Jetzt bewahrt er sie.

## Was bleibt, und warum die Passwörter der wichtigste Teil sind

Überschrieben wird **nur, was der Plan besitzt**: vier Settings-Felder,
Stationen und Gruppen. Alles andere gehört der Anlage.

Der Generator würfelt bei **jedem** Export frische `ConfigPassword` und
`AdminPassword`. Auf ein importiertes Bestandssystem angewandt hätte das den
Nutzer aus seiner eigenen Anlage ausgesperrt — deshalb steht die Liste der
Plan-Felder als benannte Konstante da und nicht als Spread irgendwo im Code.

## Der Fehler in meinem ersten Anlauf

`mergeIntoPreset` hat `Users` zunächst **komplett** durch die plan-gebaute
Sektion ersetzt — und damit genau den Verlust wieder eingebaut, gegen den der
Editor-Weg gedacht ist: Tastenbelegungen (`Channels`), Pincodes
(`Security.Pincode`), Geräte-Registrierungen (`devices`), Einmess-Werte
(`AudioProfile`). Auf einer Intercom-Anlage ist das der halbe Einmessvorgang,
und `importGreengo` benennt es sogar namentlich.

Aufgefallen ist es **nur**, weil ein Test den Pincode einer importierten
Station geprüft hat. Jetzt werden die Sektionen **Eintrag für Eintrag**
fortgeschrieben: eine Station aus dem Preset behält ihr Objekt und bekommt nur
die Plan-Felder überschrieben; eine neue kommt vollständig aus dem Generator
(sie hat kein Vorbild); eine gelöschte fällt weg.

## Prüfung

* `tests/greengoPreset.test.ts` (8), **725 Tests grün**, `tsc --noEmit`
  0 Errors, Lint 0 Errors, Build grün.
* Ein Guard hält die Feldlisten von Import und Export **deckungsgleich** —
  laufen sie auseinander, entsteht eine der beiden Hälften des ursprünglichen
  Fehlers: entweder wird etwas überschrieben, das der Plan nicht kennt, oder
  eine Plan-Änderung kommt nicht an.
* **Beide Fehler gegengeprüft:** das komplette Ersetzen von `Users` lässt einen
  Test fallen, ein Passwort in `SETTINGS_FROM_PLAN` lässt drei fallen.

Damit ist Initiative 6 nicht mehr durch eine Entscheidung blockiert; ein
herstellerneutrales Austauschformat bleibt als eigenes Vorhaben offen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_