### PR TITLE
templates: Modell-Eigenschaften hängen immer am Gerät (Design-Frage 2)

### DIFF
--- a/src/renderer/lib/modelFields.ts
+++ b/src/renderer/lib/modelFields.ts
@@ -1,0 +1,189 @@
+// ---------------------------------------------------------------------------
+// ADR-005 Design-Frage 2 — Modell- oder Instanz-Eigenschaft?
+//
+// DIE FRAGE. Die Template-Rekonstruktion trug 22 der 97 Felder von
+// `EquipmentItem` und liess 75 liegen. Der ADR nennt den Schaden: die
+// Modell-Gruppe laeuft in Stuecklisten weiter, „eine falsche Zuordnung
+// propagiert still falsche Preise".
+//
+// DIE ANTWORT DES EIGENTUEMERS: *„Alle Modell-Eigenschaften sollten in allen
+// Plaenen immer den Geraeten zugeordnet sein — egal ob in der Anwendung
+// abgefragt oder nicht."* Ein Template IST ein Geraetetyp (ADR-002), also
+// gehoert jede Modell-Eigenschaft hinein, auch die, die keine Maske heute
+// zeigt.
+//
+// DER WIDERSPRUCH, DEN DAS AUFGEDECKT HAT. Die Codebasis enthielt bereits das
+// richtige Urteil — an einer anderen Stelle. `healRentmanLibraryFromProject`
+// in `projectStore.ts` schreibt seit jeher:
+//
+//   „Bewusst NICHT uebernommen: ipAddress, macAddress, username, password,
+//    gateway, vlans und die uebrige Netz-Identitaet. Die beiden anderen
+//    Rekonstruktionen tragen sie, aber eine Library-Vorlage mit fest
+//    eingebauter IP erzeugt beim zweiten Herausziehen einen Adresskonflikt."
+//
+// Genau dieselben Felder traegt `templateFromEquipment` mit. Zwei
+// Rekonstruktionen desselben Programms, zwei entgegengesetzte Urteile.
+//
+// WAS DIESE DATEI TUT UND WAS NICHT. Sie klassifiziert alle 97 Felder und
+// macht daraus die Liste, die die Rekonstruktion tragen MUSS. Sie entfernt
+// NICHTS, was heute mitgeht: die Netz-Identitaet in Templates ist der
+// Ausroll-Nutzen, den Design-Frage 5 ausdruecklich als echt bezeichnet und
+// mit „beim Export fragen" beantwortet hat. Ihn hier nebenbei wegzunehmen
+// waere dieselbe Sorte Nebenbei-Entscheidung, die der Kommentar oben
+// zurueckgewiesen hat.
+// ---------------------------------------------------------------------------
+
+/** Gehoert dem Geraete-MODELL: bei jedem Exemplar dieses Typs gleich. */
+export const MODEL_FIELDS = [
+  // Identitaet des Typs
+  'name',
+  'shortName',
+  'subtitle',
+  'category',
+  'deviceTypeId',
+  'categoryProps',
+  'libraryRef',
+  'netboxPath',
+  'manufacturerUrl',
+
+  // Bestueckung
+  'inputs',
+  'outputs',
+  'portsUnknown',
+  'modes',
+
+  // Rolle im Signalfluss — Eigenschaft des Geraets, nicht des Exemplars
+  'isConverter',
+  'isDistributionAmp',
+  'isPatchPanel',
+  'tallyRole',
+  'tcRole',
+  'embedderRole',
+  'sdiCaps',
+  'atemMvConfig',
+  'atemMvCapabilitiesOverride',
+  'atemAudioConfig',
+  'resolution',
+  'displaySizeInch',
+
+  // Mechanik
+  'isRackDevice',
+  'isRackShelf',
+  'rackUnits',
+  'width',
+  'height',
+  'widthMm',
+  'heightMm',
+  'depthMm',
+  'weightKg',
+
+  // Strom
+  'powerConsumptionWatts',
+  'powerWatts',
+  'voltage',
+  'currentAmps',
+  'powerPhase',
+
+  // Preise — die Gruppe, die der ADR beim Namen nennt: sie laeuft in
+  // Stuecklisten weiter, eine falsche Zuordnung propagiert still falsche Zahlen
+  'priceEUR',
+  'rentPricePerDay',
+  'rentCurrency',
+
+  // Darstellung des TYPS (nicht des Exemplars auf dem Canvas)
+  'icon',
+  'imageUrl',
+  'frontPanelImageUrl',
+  'rearPanelImageUrl',
+  'frontPanelCrop',
+  'rearPanelCrop',
+  'stlDataUri',
+] as const
+
+/**
+ * Gehoert diesem EINEN Exemplar. Ein Template, das solche Felder traegt,
+ * erzeugt beim zweiten Herausziehen einen Konflikt — bei `ipAddress` einen
+ * Adresskonflikt, bei `assetTag` zwei Geraete mit derselben Inventarnummer.
+ */
+export const INSTANCE_FIELDS = [
+  'id',
+
+  // Wo dieses Exemplar steht
+  'x',
+  'y',
+  'rackInstanceId',
+  'rackInstanceLabel',
+  'rackInstanceStartUnit',
+  'rackInternalSnapshot',
+
+  // Wer dieses Exemplar ist
+  'assetTag',
+  'serialNumber',
+  'qrId',
+  'sourceIdentityId',
+  'installStatus',
+  'verifiedBy',
+
+  // Lebenslauf dieses Exemplars
+  'purchaseDate',
+  'warrantyUntil',
+  'maintenanceIntervalDays',
+  'serviceHistory',
+  'supplier',
+  'ownership',
+  'stockLocation',
+  'packed',
+
+  // Netz-Identitaet: pro Geraet einmalig. Steht heute trotzdem im Template —
+  // siehe Kopf dieser Datei, das ist Design-Frage 5 und nicht diese hier.
+  'ipAddress',
+  'subnetMask',
+  'macAddress',
+  'gateway',
+  'dnsServers',
+  'vlans',
+  'portVlans',
+  'managementVlanId',
+  'mgmtUrl',
+  'firmware',
+  'username',
+  'password',
+
+  // Zustand dieses Exemplars
+  'activeModeId',
+  'videohubRouting',
+  'notes',
+
+  // Herkunft dieses Exemplars
+  'importSource',
+  'graphmlId',
+  'netboxId',
+  'netboxSourceUrl',
+  'rentmanId',
+  'rentmanRemoved',
+
+  // Oberflaechen-Zustand am Canvas
+  'nodeColor',
+  'portsFlipped',
+  'collapsed',
+  'hidden',
+  'favorite',
+  'positionLocked',
+] as const
+
+export type ModelField = (typeof MODEL_FIELDS)[number]
+
+/**
+ * Die Modell-Eigenschaften eines Geraets herausziehen.
+ *
+ * `undefined` bleibt `undefined` und wird nicht zu einem Schluessel: ein
+ * Template mit `priceEUR: undefined` behauptet, der Preis sei bekannt und
+ * leer. `mergeDefined`-Disziplin, hier auf die Rekonstruktion angewandt.
+ */
+export const pickModelFields = (item: Record<string, unknown>): Record<string, unknown> => {
+  const out: Record<string, unknown> = {}
+  for (const field of MODEL_FIELDS) {
+    if (item[field] !== undefined) out[field] = item[field]
+  }
+  return out
+}

--- a/src/renderer/store/slices/templateSlice.ts
+++ b/src/renderer/store/slices/templateSlice.ts
@@ -1,5 +1,6 @@
 import type { StateCreator } from 'zustand'
 import type { EquipmentItem, EquipmentTemplate } from '../../types/equipment'
+import { pickModelFields } from '../../lib/modelFields'
 import { LIMITS } from '../../lib/layoutConstants'
 import { upsertCachedRentmanTemplate } from '../../lib/rentmanTemplateCache'
 // Dieselbe Regel wie beim Lager-Import (#628): was die neue Fassung nicht
@@ -42,10 +43,29 @@ export type TemplateSlice = Pick<
   | 'setCustomLibrary'
 >
 
+/**
+ * ADR-005 Design-Frage 2, entschieden: *„Alle Modell-Eigenschaften sollten in
+ * allen Plaenen immer den Geraeten zugeordnet sein — egal ob in der Anwendung
+ * abgefragt oder nicht."*
+ *
+ * Ein Template IST ein Geraetetyp (ADR-002), also gehoert jede
+ * Modell-Eigenschaft hinein — auch die, die keine Maske heute zeigt. Vorher
+ * trug diese Funktion 22 der 97 Felder; die uebrigen Modell-Eigenschaften
+ * (Masse, Gewicht, Leistung, Preise, Rollen im Signalfluss, Bilder) fielen
+ * beim Anlegen einer Vorlage weg und mussten von Hand nachgetragen werden.
+ *
+ * `pickModelFields` kommt ZUERST, die ausdruecklichen Felder danach: so
+ * gewinnt eine bewusste Angabe (der `override`-Name, die normalisierte
+ * Kategorie) gegen die Rohuebernahme, und der Rest kommt vollstaendig mit.
+ * Welches Feld Modell und welches Instanz ist, steht als Daten in
+ * `lib/modelFields.ts` — mit Laufzeit-Guard, damit ein neues Feld nicht
+ * stillschweigend unklassifiziert bleibt.
+ */
 const templateFromEquipment = (
   item: EquipmentItem,
   override: { name?: string; category?: string; preserveFlags?: EquipmentTemplate } = {},
 ): EquipmentTemplate => ({
+  ...(pickModelFields(item as unknown as Record<string, unknown>) as Partial<EquipmentTemplate>),
   name: override.name ?? item.name,
   category: (override.category || item.category || 'Sonstiges').trim() || 'Sonstiges',
   // ADR-002/ADR-005 — ein Template IST ein Geraetetyp; die stabile

--- a/tests/modelFields.test.ts
+++ b/tests/modelFields.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { INSTANCE_FIELDS, MODEL_FIELDS, pickModelFields } from '../src/renderer/lib/modelFields'
+import { topLevelKeys } from './support/topLevelKeys'
+import equipmentTypesSrc from '../src/renderer/types/equipment.ts?raw'
+import templateSliceSrc from '../src/renderer/store/slices/templateSlice.ts?raw'
+import projectStoreSrc from '../src/renderer/store/projectStore.ts?raw'
+
+// ---------------------------------------------------------------------------
+// ADR-005 Design-Frage 2 — Modell- oder Instanz-Eigenschaft?
+//
+// Entschieden: *„Alle Modell-Eigenschaften sollten in allen Plaenen immer den
+// Geraeten zugeordnet sein — egal ob in der Anwendung abgefragt oder nicht."*
+//
+// Gemessener Ausgangszustand: `templateFromEquipment` trug 22 der 97 Felder.
+// Der ADR nennt den Schaden — die Modell-Gruppe laeuft in Stuecklisten weiter,
+// „eine falsche Zuordnung propagiert still falsche Preise".
+// ---------------------------------------------------------------------------
+
+describe('die Klassifizierung ist vollstaendig', () => {
+  it('ordnet jedes Feld von EquipmentItem genau einer Seite zu', () => {
+    // Der eigentliche Guard, gleiche Machart wie die 146 Felder in planDiff:
+    // ein neues Feld bleibt nicht stillschweigend unklassifiziert, sondern
+    // bricht hier — und wer es klassifiziert, muss dabei entscheiden, ob es
+    // in Stuecklisten weiterlaeuft.
+    const all = topLevelKeys(equipmentTypesSrc, 'EquipmentItem')
+    const classified = [...MODEL_FIELDS, ...INSTANCE_FIELDS].sort()
+    expect(classified).toEqual(all)
+  })
+
+  it('ordnet kein Feld beiden Seiten zu', () => {
+    const both = MODEL_FIELDS.filter((f) => (INSTANCE_FIELDS as readonly string[]).includes(f))
+    expect(both).toEqual([])
+  })
+
+  it('fuehrt die Preis-Gruppe als Modell', () => {
+    // Die Gruppe, die der ADR beim Namen nennt.
+    for (const field of ['priceEUR', 'rentPricePerDay', 'rentCurrency', 'powerConsumptionWatts', 'heightMm', 'modes', 'shortName']) {
+      expect(MODEL_FIELDS as readonly string[], field).toContain(field)
+    }
+  })
+
+  it('fuehrt die Exemplar-Gruppe als Instanz', () => {
+    for (const field of ['assetTag', 'serialNumber', 'qrId', 'installStatus', 'videohubRouting']) {
+      expect(INSTANCE_FIELDS as readonly string[], field).toContain(field)
+    }
+  })
+})
+
+describe('pickModelFields', () => {
+  it('nimmt die Modell-Felder mit und laesst die Instanz-Felder liegen', () => {
+    const item = {
+      id: 'A',
+      name: 'ETC S4',
+      priceEUR: 1200,
+      heightMm: 44,
+      assetTag: 'INV-0001',
+      ipAddress: '10.0.0.2',
+      x: 5,
+      y: 6,
+    }
+    const picked = pickModelFields(item)
+    expect(picked.name).toBe('ETC S4')
+    expect(picked.priceEUR).toBe(1200)
+    expect(picked.heightMm).toBe(44)
+    expect(picked.assetTag).toBeUndefined()
+    expect(picked.ipAddress).toBeUndefined()
+    expect(picked.id).toBeUndefined()
+  })
+
+  it('macht aus einem fehlenden Wert keinen leeren Schluessel', () => {
+    // `priceEUR: undefined` behauptete, der Preis sei bekannt und leer.
+    const picked = pickModelFields({ name: 'X', priceEUR: undefined })
+    expect('priceEUR' in picked).toBe(false)
+    expect(Object.keys(picked)).toEqual(['name'])
+  })
+})
+
+describe('die Rekonstruktion traegt sie wirklich', () => {
+  it('templateFromEquipment beginnt mit den Modell-Feldern', () => {
+    // Zuerst die Rohuebernahme, danach die ausdruecklichen Felder: so gewinnt
+    // eine bewusste Angabe (override-Name, normalisierte Kategorie) und der
+    // Rest kommt trotzdem vollstaendig mit.
+    expect(templateSliceSrc).toContain('...(pickModelFields(')
+    const start = templateSliceSrc.indexOf('const templateFromEquipment')
+    const pick = templateSliceSrc.indexOf('pickModelFields(item', start)
+    const name = templateSliceSrc.indexOf('name: override.name', start)
+    expect(pick).toBeGreaterThan(-1)
+    expect(pick).toBeLessThan(name)
+  })
+})
+
+describe('der Widerspruch, den die Frage aufgedeckt hat', () => {
+  it('die zweite Rekonstruktion urteilt weiterhin anders — und sagt es', () => {
+    // `healRentmanLibraryFromProject` traegt die Netz-Identitaet bewusst NICHT
+    // und begruendet es: „eine Library-Vorlage mit fest eingebauter IP erzeugt
+    // beim zweiten Herausziehen einen Adresskonflikt."
+    //
+    // `templateFromEquipment` traegt sie. Zwei Rekonstruktionen desselben
+    // Programms, zwei entgegengesetzte Urteile — und das bleibt vorerst so:
+    // die Netz-Identitaet im Template ist der Ausroll-Nutzen, den
+    // Design-Frage 5 als echt bezeichnet und mit „beim Export fragen"
+    // beantwortet hat. Ihn hier nebenbei wegzunehmen waere genau die
+    // Nebenbei-Entscheidung, die der Kommentar selbst zurueckweist.
+    //
+    // Dieser Test haelt den Widerspruch fest, statt ihn zu verstecken: wer
+    // eine der beiden Seiten aendert, kommt hier vorbei.
+    expect(projectStoreSrc).toContain('Bewusst NICHT uebernommen')
+    expect(templateSliceSrc).toContain('password: item.password')
+    expect(INSTANCE_FIELDS as readonly string[]).toContain('password')
+  })
+})


### PR DESCRIPTION
ADR-005 **Design-Frage 2**, entschieden:

> *„Alle Modell-Eigenschaften sollten in allen Plänen immer den Geräten
> zugeordnet sein — egal ob in der Anwendung abgefragt oder nicht."*

Ein Template **ist** ein Gerätetyp (ADR-002), also gehört jede
Modell-Eigenschaft hinein — auch die, die keine Maske heute zeigt.

## Gemessener Ausgangszustand

`templateFromEquipment` trug **22 der 97** Felder. Maße, Gewicht, Leistung,
Preise, Rollen im Signalfluss und die Panel-Bilder fielen beim Anlegen einer
Vorlage weg und mussten von Hand nachgetragen werden. Der ADR nennt den
Schaden beim Namen: die Modell-Gruppe läuft in Stücklisten weiter, *„eine
falsche Zuordnung propagiert still falsche Preise"*.

## Die Änderung

* **`lib/modelFields.ts`** klassifiziert **alle 97** Felder als Modell oder
  Instanz — als **Daten mit Laufzeit-Guard**, gleiche Machart wie die 146
  Felder in `planDiff`. Ein neues Feld bleibt nicht stillschweigend
  unklassifiziert, sondern bricht den Test — und wer es klassifiziert, muss
  dabei entscheiden, ob es in Stücklisten weiterläuft.
* **`pickModelFields`** macht aus einem fehlenden Wert keinen leeren
  Schlüssel: `priceEUR: undefined` behauptete, der Preis sei bekannt und leer.
* Die Rohübernahme steht **zuerst** im Objekt, die ausdrücklichen Felder
  danach — so gewinnt eine bewusste Angabe (`override`-Name, normalisierte
  Kategorie) und der Rest kommt trotzdem vollständig mit.

## Was die Frage nebenbei aufgedeckt hat

Die Codebasis enthielt das richtige Urteil **bereits — an anderer Stelle**.
`healRentmanLibraryFromProject` schreibt seit jeher:

> *„Bewusst NICHT übernommen: `ipAddress`, `macAddress`, `username`,
> `password`, `gateway`, `vlans` … eine Library-Vorlage mit fest eingebauter
> IP erzeugt beim zweiten Herausziehen einen Adresskonflikt. Ob das dort
> richtig ist, ist eine eigene Frage — sie hier nebenbei mitzuentscheiden wäre
> falsch."*

`templateFromEquipment` trägt genau diese Felder mit. **Zwei Rekonstruktionen
desselben Programms, zwei entgegengesetzte Urteile.**

Das bleibt vorerst so, und zwar bewusst: die Netz-Identität im Template ist der
Ausroll-Nutzen, den **Design-Frage 5** ausdrücklich als echt bezeichnet und mit
„beim Export fragen" beantwortet hat (#642). Ihn hier nebenbei wegzunehmen wäre
genau die Nebenbei-Entscheidung, die der zitierte Kommentar selbst zurückweist.
Ein Test hält den Widerspruch **fest, statt ihn zu verstecken** — wer eine der
beiden Seiten ändert, kommt dort vorbei.

## Prüfung

* `tests/modelFields.test.ts` (8), **733 Tests grün**, `tsc --noEmit` 0 Errors,
  Lint 0 Errors, Build grün.
* **Beide Guards gegengeprüft:** ein Feld, das aus der Klassifizierung fällt,
  lässt einen Test fallen; ein Feld auf beiden Seiten zwei.

Damit ist die letzte der sieben Design-Fragen umgesetzt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_