### PR TITLE
test: Confirmed-State als Regel statt als Praxis (Initiative 10)

### DIFF
--- a/tests/deviceReadSites.test.ts
+++ b/tests/deviceReadSites.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, resolve, sep } from 'node:path'
+
+// ---------------------------------------------------------------------------
+// Initiative 10 — von der Praxis zur REGEL.
+//
+// WAS VORHER FEHLTE. `cable#647` hat die drei Stellen geheilt, an denen ein
+// Geraete-Befund still zur Absicht wurde, und `tests/atemLiveCompare.test.ts`
+// nennt sie namentlich. Genau das war der Rest, den die Neu-Ableitung
+// benannt hat: die Invariante galt an drei geprueften Stellen — eine VIERTE
+// waere ohne Zwang durchgekommen, weil ein Guard, der Dateien beim Namen
+// nennt, keine neue findet.
+//
+// WIE DIE LUECKE GEMESSEN WURDE — UND WAS DABEI SCHIEFGING. Beim Zaehlen der
+// Schnittmenge „liest ein Geraet UND schreibt in den Projekt-Store" ergab ein
+// ad-hoc-grep DREI Dateien, und das waren zufaellig genau die drei geheilten.
+// Ein bequemes Ergebnis — und falsch: das Muster suchte nach
+// `updateEquipment` und ein paar Setter-Namen und uebersah damit
+// `applyNetboxImport`. Die richtige Zahl ist VIER.
+//
+// Das ist der Fehler, den dieser Test verhindert, einmal am eigenen Leib
+// vorgefuehrt: ein Muster, das die Stellen erraet, uebersieht die, an die
+// niemand gedacht hat. Deshalb faengt der Test hier BEWUSST ZU BREIT — jede
+// Datei, die ein Geraet liest und den Projekt-Store ueberhaupt anfasst, muss
+// eingetragen sein, auch wenn sie nur liest. Eine Datei zu viel einzuordnen
+// kostet zwei Zeilen; eine zu wenig kostet den Fehler.
+//
+// WAS DIE EINORDNUNG VERLANGT. Nicht „ist das ok?", sondern die konkrete
+// Frage: WO landet der abgelesene Wert? Wer eine neue Datei hier eintraegt,
+// muss sie beantwortet haben.
+// ---------------------------------------------------------------------------
+
+const RENDERER = resolve(__dirname, '..', 'src', 'renderer')
+
+/** Ein Lese-Aufruf gegen ein Geraet oder ein Fremdsystem. */
+const READS_DEVICE = /cablePlannerApi\.(atem|videohub|netbox|rentman)\.(read|get)[A-Za-z]*/
+
+/**
+ * Beruehrt den Projekt-Store ueberhaupt. Absichtlich das grobe Kriterium:
+ * eine feinere Unterscheidung zwischen Lesen und Schreiben ist genau die
+ * Stelle, an der die Messung oben danebengegriffen hat.
+ */
+const TOUCHES_PLAN = /useProjectStore|projectStore/
+
+type Verdict =
+  /** Befund und Absicht sind getrennt: der gelesene Wert landet NICHT im Plan. */
+  | 'getrennt'
+  /** Schreibt in den Plan, aber nur additiv — ersetzt keinen geplanten Wert. */
+  | 'additiv'
+  /** Liest den Store nur, schreibt nicht hinein. */
+  | 'liest-nur'
+
+interface Site {
+  file: string
+  verdict: Verdict
+  /** Warum. Muss den naechsten Leser ueberzeugen, nicht den Autor. */
+  reason: string
+}
+
+const CLASSIFIED: Site[] = [
+  {
+    file: 'components/Atem/AtemAudioRouterDialog.tsx',
+    verdict: 'getrennt',
+    reason:
+      'cable#647: der Befund liegt in `live`, der Entwurf bleibt der Entwurf. ' +
+      'Vorher mischte `setDraft({ matrix: live.matrix ?? draft?.matrix })` beides ' +
+      'ohne Rueckfrage zusammen. Die Uebernahme ist jetzt ein eigener Klick.',
+  },
+  {
+    file: 'components/Atem/AtemMvConfigDialog.tsx',
+    verdict: 'getrennt',
+    reason:
+      'cable#647: der Befund liegt in `live`. Vorher ersetzte `setConfig(...)` die ' +
+      'geplante Fensteraufteilung; die Rueckfrage davor griff nur bei ' +
+      '`sourceId !== 0` und liess einen schwarz geplanten Multiviewer fallen.',
+  },
+  {
+    file: 'components/Export/VideohubExportDialog.tsx',
+    verdict: 'getrennt',
+    reason:
+      'ADR-003 Inkrement 0: der Status-Read geht nach `hubState`, das geplante ' +
+      'Routing bleibt stehen. Die Datei begruendet es selbst — „Was der Hub tut, ' +
+      'ist eine Beobachtung; was im Plan steht, eine Absicht."',
+  },
+  {
+    file: 'components/Netbox/NetboxImportDialog.tsx',
+    verdict: 'additiv',
+    reason:
+      '`applyNetboxImport` ist additiv per Konstruktion und sagt es im Slice: ' +
+      '„nur angehaengt und ergaenzt, nie ersetzt oder geloescht". Vorhandene ' +
+      'Geraete behalten jede manuelle Nacharbeit. Dass dabei `portsUnknown` ' +
+      'faellt, ist richtig: es fiel, WEIL echte Ports gelesen wurden — genau ' +
+      'die Bedingung, unter der die Unbekannt-Markierung nicht mehr gilt.',
+  },
+  {
+    file: 'components/Atem/AtemDialog.tsx',
+    verdict: 'liest-nur',
+    reason:
+      'Ein einziger Selektor holt das Geraet fuer die IP-Vorbelegung. Der ' +
+      'gelesene ATEM-State bleibt in lokalem `useState` und wird nie ' +
+      'persistiert. Steht hier, weil der Test bewusst zu breit faengt.',
+  },
+]
+
+const walk = (dir: string): string[] =>
+  readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry)
+    return statSync(full).isDirectory()
+      ? walk(full)
+      : /\.tsx?$/.test(entry)
+        ? [full]
+        : []
+  })
+
+/** Die Schnittmenge, aus dem Quelltext gerechnet — nicht aus einer Liste. */
+const measured = (): string[] =>
+  walk(RENDERER)
+    .filter((f) => {
+      const src = readFileSync(f, 'utf8')
+      return READS_DEVICE.test(src) && TOUCHES_PLAN.test(src)
+    })
+    .map((f) => relative(RENDERER, f).split(sep).join('/'))
+    .sort()
+
+describe('jede Stelle, die ein Geraet liest und den Plan beruehrt, ist eingeordnet', () => {
+  it('kennt genau die gemessenen Dateien — keine mehr, keine weniger', () => {
+    // Der eigentliche Zwang. Eine neue Datei in der Schnittmenge laesst diesen
+    // Test fallen, und wer sie eintraegt, muss dabei sagen, wo der abgelesene
+    // Wert landet. Das ist der Unterschied zwischen einer Regel und einer
+    // Gewohnheit.
+    expect(measured()).toEqual(CLASSIFIED.map((s) => s.file).sort())
+  })
+
+  it('gibt zu jeder Einordnung eine Begruendung, die etwas behauptet', () => {
+    for (const site of CLASSIFIED) {
+      expect(site.reason.length, site.file).toBeGreaterThan(80)
+    }
+  })
+
+  it('ordnet keine Datei doppelt ein', () => {
+    const files = CLASSIFIED.map((s) => s.file)
+    expect(new Set(files).size).toBe(files.length)
+  })
+})
+
+describe('die Messung selbst', () => {
+  it('findet die Datei, die das ad-hoc-Muster uebersehen hat', () => {
+    // Die Gegenprobe zum Fehler oben: `NetboxImportDialog` schreibt ueber
+    // `applyNetboxImport` in den Plan, nicht ueber `updateEquipment`. Ein
+    // Guard, der nach Setter-Namen sucht, uebersieht ihn — dieser hier nicht.
+    expect(measured()).toContain('components/Netbox/NetboxImportDialog.tsx')
+    const src = readFileSync(
+      join(RENDERER, 'components', 'Netbox', 'NetboxImportDialog.tsx'),
+      'utf8',
+    )
+    expect(src).not.toMatch(/updateEquipment/)
+    expect(src).toMatch(/applyNetboxImport/)
+  })
+
+  it('faengt weit genug, um eine reine Lese-Stelle mitzunehmen', () => {
+    // Wenn diese Zusicherung faellt, ist das Kriterium enger geworden — und
+    // damit wieder eine Liste, die raet, statt einer, die misst.
+    expect(measured()).toContain('components/Atem/AtemDialog.tsx')
+  })
+
+  it('nimmt eine Datei ohne Plan-Bezug NICHT mit', () => {
+    // `MultiviewerLayoutView` liest den ATEM und fasst den Store nicht an;
+    // sie gehoert nicht in die Liste und darf sie nicht aufblaehen.
+    expect(measured()).not.toContain('components/Atem/MultiviewerLayoutView.tsx')
+  })
+})


### PR DESCRIPTION
Der Rest, den die Neu-Ableitung von Initiative 10 als einziges Offenes benannt hat.

`#647` hat die drei Stellen geheilt, an denen ein Geräte-Befund still zur Absicht wurde, und
`tests/atemLiveCompare.test.ts` nennt sie **namentlich**. Damit galt die Invariante als
*Praxis* an drei geprüften Stellen — eine **vierte wäre ohne Zwang durchgekommen**, weil ein
Guard, der Dateien beim Namen nennt, keine neue findet.

## Was der Test tut

Er rechnet die Schnittmenge *„liest ein Gerät UND berührt den Projekt-Store"* aus dem
Quelltext und verlangt zu jeder Datei eine Einordnung. Nicht *„ist das ok?"*, sondern die
konkrete Frage: **wo landet der abgelesene Wert?** Eine neue Datei lässt den Test fallen, und
wer sie einträgt, muss die Frage beantwortet haben. Das ist der Unterschied zwischen einer
Regel und einer Gewohnheit.

## Der Fehler, der den Test begründet — am eigenen Leib

Beim Messen der Schnittmenge ergab ein ad-hoc-grep **drei** Dateien, und das waren zufällig
genau die drei geheilten. Ein bequemes Ergebnis, und falsch: das Muster suchte nach
`updateEquipment` und ein paar Setter-Namen und übersah damit `applyNetboxImport`. Die
richtige Zahl ist **vier**.

Genau das verhindert dieser Test — ein Muster, das die Stellen errät, übersieht die, an die
niemand gedacht hat. Deshalb fängt das Kriterium **bewusst zu breit**: auch eine Datei, die
den Store nur liest (`AtemDialog`), muss eingetragen sein. Eine Datei zu viel einzuordnen
kostet zwei Zeilen; eine zu wenig kostet den Fehler.

## Die fünf Einordnungen

| Datei | Urteil | Warum |
| --- | --- | --- |
| `AtemAudioRouterDialog` | getrennt | `#647` — der Befund liegt in `live`, der Entwurf bleibt der Entwurf |
| `AtemMvConfigDialog` | getrennt | `#647` — dito; die Rückfrage steht jetzt an der Übernahme |
| `VideohubExportDialog` | getrennt | Inkrement 0 — der Status-Read geht nach `hubState` |
| `NetboxImportDialog` | **additiv** | Der Slice ist additiv per Konstruktion und sagt es: *„nur angehängt und ergänzt, nie ersetzt oder gelöscht"* |
| `AtemDialog` | liest-nur | Ein Selektor für die IP-Vorbelegung; der ATEM-State bleibt lokal |

`NetboxImportDialog` ist eingeordnet, aber **kein Fehler**. Dass dabei `portsUnknown` fällt,
ist richtig: es fiel, *weil* echte Ports gelesen wurden — genau die Bedingung, unter der die
Unbekannt-Markierung nicht mehr gilt. Das ist ADR-003 richtig herum angewandt.

## Prüfung

* **754 Tests grün**, `tsc --noEmit` 0 Errors, Lint 0 Errors.
* **Gegengeprüft mit einer eingebauten Sonde**: eine neu angelegte Komponente, die
  `atem.readMvConfig()` liest und das Ergebnis per `updateEquipment` persistiert, lässt den
  Test fallen und wird namentlich genannt. Sonde danach entfernt.
* Die drei Messungs-Tests sichern das Kriterium selbst ab: es findet die vom ad-hoc-Muster
  übersehene Datei, es fängt weit genug für eine reine Lese-Stelle, und es nimmt eine Datei
  ohne Plan-Bezug (`MultiviewerLayoutView`) nicht mit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_