### PR TITLE
catalog: 253 Datenblatt-Links aus den Kommentaren ins Feld (Initiative 11)

### DIFF
--- a/src/renderer/components/Properties/sections/OptionalFieldsSection.tsx
+++ b/src/renderer/components/Properties/sections/OptionalFieldsSection.tsx
@@ -3,6 +3,7 @@ import { format, useTranslation } from '../../../lib/i18n'
 import { pickImageAsDataUri } from '../../../lib/readImageAsDataUri'
 import { promptDialog } from '../../../lib/promptDialog'
 import { SortableSection } from '../SortableSection'
+import { resolveDeviceType } from '../../../lib/deviceTypeRegistry'
 import type { EquipmentItem } from '../../../types/equipment'
 
 const ICON_GLYPHS = ['📷', '🖥', '💻', '📺', '🎙', '💡', '🌐', '⚡', '🔌', '🔧', '⇄'] as const
@@ -16,6 +17,11 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
   const t = useTranslation()
   const updateEquipment = useProjectStore((state) => state.updateEquipment)
   const projectAuthor = useProjectStore((state) => state.project.metadata.author)
+
+  // Initiative 11 — der Katalog-Typ als Quelle des Datenblatt-Links.
+  const catalogType = resolveDeviceType(equipment.deviceTypeId)
+  const inheritedUrl = catalogType?.template.manufacturerUrl
+  const inheritedName = catalogType?.template.name
 
   // #580 — Verifizierung: eine Person bestätigt, dass die Ports/Daten des
   // Geräts korrekt sind. Name kommt aus dem Projekt-Autor (Einstellungen);
@@ -144,6 +150,34 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
               </a>
             )}
           </div>
+          {/* Initiative 11 — der geerbte Beleg, mit genannter Herkunft.
+              `manufacturerUrl` ist eine MODELL-Eigenschaft (siehe
+              `modelFields.ts`): ein Geraet, das einen Katalog-Typ
+              referenziert, erbt sie. Ohne diese Zeile lagen die 253
+              Datenblatt-Links zwar im Katalog, aber der Nutzer sah am Geraet
+              weiterhin ein leeres Feld — der Beleg waere aus dem Kommentar in
+              ein ebenso unerreichbares Feld gewandert. Das eigene Feld
+              gewinnt, wenn es gesetzt ist: es ist die Ausnahme, die jemand
+              bewusst eingetragen hat. */}
+          {!equipment.manufacturerUrl && inheritedUrl && (
+            <div className="mt-1 flex items-center gap-1 text-cp-xs">
+              <span className="text-cp-text-muted">
+                {format(
+                  t('eq.field.manufacturerUrlInherited', 'Aus Katalog-Typ {name}:'),
+                  { name: inheritedName ?? '' },
+                )}
+              </span>
+              <a
+                href={inheritedUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="truncate text-cp-accent hover:underline"
+                title={t('eq.field.manufacturerUrlOpenTitle', 'In externem Browser öffnen')}
+              >
+                {t('eq.field.manufacturerUrlOpen', 'Öffnen ↗')}
+              </a>
+            </div>
+          )}
         </label>
 
         <label className="block">

--- a/src/renderer/lib/ajaCatalog.ts
+++ b/src/renderer/lib/ajaCatalog.ts
@@ -41,6 +41,7 @@ export const AJA_CATALOG: AjaEntry[] = [
     match: ['kumo 1616', '12g'],
     deviceTypeId: 'ca069939-edff-479f-acc1-56650a5a1e8e',
     template: {
+      manufacturerUrl: 'https://www.aja.com/products/kumo-1616-12g',
       name: 'AJA KUMO 1616-12G',
       category: 'Video Router',
       inputs: [
@@ -63,6 +64,7 @@ export const AJA_CATALOG: AjaEntry[] = [
     match: ['kumo 3232', '12g'],
     deviceTypeId: '2a3eed49-cc33-45be-ae0f-c5e6c89e818d',
     template: {
+      manufacturerUrl: 'https://www.aja.com/products/kumo-3232-12g',
       name: 'AJA KUMO 3232-12G',
       category: 'Video Router',
       inputs: [
@@ -85,6 +87,7 @@ export const AJA_CATALOG: AjaEntry[] = [
     match: ['kumo 6464', '12g'],
     deviceTypeId: '40147c52-679d-4784-a009-f8211be107f9',
     template: {
+      manufacturerUrl: 'https://www.aja.com/products/kumo-6464-12g',
       name: 'AJA KUMO 6464-12G',
       category: 'Video Router',
       inputs: [
@@ -107,6 +110,7 @@ export const AJA_CATALOG: AjaEntry[] = [
     match: ['ki pro', 'ultra', '12g'],
     deviceTypeId: 'ecf80e2e-5376-4f86-865f-ce146e90d032',
     template: {
+      manufacturerUrl: 'https://www.aja.com/products/ki-pro-ultra-12g',
       name: 'AJA Ki Pro Ultra 12G',
       category: 'Video',
       inputs: [
@@ -138,6 +142,7 @@ export const AJA_CATALOG: AjaEntry[] = [
     match: ['kumo 1616'],
     deviceTypeId: 'd8584156-1793-4794-a4b4-488cfe834e59',
     template: {
+      manufacturerUrl: 'https://www.aja.com/products/kumo-1616',
       name: 'AJA KUMO 1616',
       category: 'Video Router',
       inputs: [
@@ -160,6 +165,7 @@ export const AJA_CATALOG: AjaEntry[] = [
     match: ['kumo 3232'],
     deviceTypeId: 'd435ffb1-c471-4059-89ee-84a490f6025c',
     template: {
+      manufacturerUrl: 'https://www.aja.com/products/kumo-3232',
       name: 'AJA KUMO 3232',
       category: 'Video Router',
       inputs: [
@@ -182,6 +188,7 @@ export const AJA_CATALOG: AjaEntry[] = [
     match: ['kumo 6464'],
     deviceTypeId: '379c5b0a-a4b5-40d0-a66d-a3fda51b5059',
     template: {
+      manufacturerUrl: 'https://www.aja.com/family/routers',
       name: 'AJA KUMO 6464',
       category: 'Video Router',
       inputs: [
@@ -204,6 +211,7 @@ export const AJA_CATALOG: AjaEntry[] = [
     match: ['fs-hdr'],
     deviceTypeId: 'efd29eeb-fc5a-4ad4-8f34-ec58c16d15aa',
     template: {
+      manufacturerUrl: 'https://www.aja.com/products/fs-hdr',
       name: 'AJA FS-HDR',
       category: 'Konverter',
       inputs: [
@@ -225,6 +233,7 @@ export const AJA_CATALOG: AjaEntry[] = [
     match: ['helo', 'plus'],
     deviceTypeId: '48011180-869a-490a-a041-a6d797196acb',
     template: {
+      manufacturerUrl: 'https://www.aja.com/products/helo-plus',
       name: 'AJA HELO Plus',
       category: 'IP/NDI',
       inputs: [

--- a/src/renderer/lib/audioCatalog.ts
+++ b/src/renderer/lib/audioCatalog.ts
@@ -41,6 +41,7 @@ export const AUDIO_CATALOG: AudioEntry[] = [
     match: ['x32'],
     deviceTypeId: 'c6e4526b-f6f8-4b99-bf55-8b15817b42cd',
     template: {
+      manufacturerUrl: 'https://www.markertek.com/Attachments/Specifications/Behringer/X32-Specifications.pdf',
       name: 'Behringer X32',
       category: 'Audio',
       inputs: [
@@ -68,6 +69,7 @@ export const AUDIO_CATALOG: AudioEntry[] = [
     match: ['behringer', 'wing'],
     deviceTypeId: '29602fb3-d6bc-44f6-8689-88cd8accc8ce',
     template: {
+      manufacturerUrl: 'https://www.behringer.com/en/wing/wing-black',
       name: 'Behringer Wing',
       category: 'Audio',
       inputs: [
@@ -96,6 +98,7 @@ export const AUDIO_CATALOG: AudioEntry[] = [
     match: ['midas', 'm32'],
     deviceTypeId: 'f4f89c92-7ccf-48a5-8590-0504a3670ae1',
     template: {
+      manufacturerUrl: 'https://www.midasconsoles.com/product.html?modelCode=0603-AAF',
       name: 'Midas M32 Live',
       category: 'Audio',
       inputs: [
@@ -122,6 +125,7 @@ export const AUDIO_CATALOG: AudioEntry[] = [
     match: ['sq-5'],
     deviceTypeId: 'c5e58caf-e376-40ec-97e7-809b0f55257e',
     template: {
+      manufacturerUrl: 'https://www.allen-heath.com/hardware/sq/sq-5/',
       name: 'Allen & Heath SQ-5',
       category: 'Audio',
       inputs: [
@@ -145,6 +149,7 @@ export const AUDIO_CATALOG: AudioEntry[] = [
     match: ['avantis'],
     deviceTypeId: '47bf1a7b-a072-4a19-b44d-754ea00bef35',
     template: {
+      manufacturerUrl: 'https://www.allen-heath.com/hardware/avantis/',
       name: 'Allen & Heath Avantis',
       category: 'Audio',
       inputs: [
@@ -168,6 +173,7 @@ export const AUDIO_CATALOG: AudioEntry[] = [
     match: ['dlive', 'cdm32'],
     deviceTypeId: '2fc7c067-7b4b-4838-839b-7cbc3f3ad90f',
     template: {
+      manufacturerUrl: 'https://www.allen-heath.com/hardware/dlive-series/dlive-mixracks/',
       name: 'Allen & Heath dLive CDM32 MixRack',
       category: 'Audio',
       inputs: [
@@ -190,6 +196,7 @@ export const AUDIO_CATALOG: AudioEntry[] = [
     match: ['yamaha', 'cl5'],
     deviceTypeId: '67e29486-75dd-492b-af8a-40f12d62a5a1',
     template: {
+      manufacturerUrl: 'https://usa.yamaha.com/products/proaudio/mixers/cl_series/specs.html',
       name: 'Yamaha CL5',
       category: 'Audio',
       inputs: [
@@ -214,6 +221,7 @@ export const AUDIO_CATALOG: AudioEntry[] = [
     match: ['yamaha', 'ql5'],
     deviceTypeId: '20cc630c-cd57-42b1-af70-16eb45d0c725',
     template: {
+      manufacturerUrl: 'https://usa.yamaha.com/products/proaudio/mixers/ql_series/specs.html',
       name: 'Yamaha QL5',
       category: 'Audio',
       inputs: [
@@ -238,6 +246,7 @@ export const AUDIO_CATALOG: AudioEntry[] = [
     match: ['yamaha', 'dm3'],
     deviceTypeId: 'c8791489-fba5-4a0a-99c5-1218f6d997fd',
     template: {
+      manufacturerUrl: 'https://usa.yamaha.com/products/proaudio/mixers/dm3/specs.html',
       name: 'Yamaha DM3-D',
       category: 'Audio',
       inputs: [
@@ -262,6 +271,7 @@ export const AUDIO_CATALOG: AudioEntry[] = [
     match: ['digico', 's21'],
     deviceTypeId: '053f9f56-9232-416f-80f1-c2f7f34040ca',
     template: {
+      manufacturerUrl: 'https://digico.biz/consoles/s21/',
       name: 'DiGiCo S21',
       category: 'Audio',
       inputs: [
@@ -286,6 +296,7 @@ export const AUDIO_CATALOG: AudioEntry[] = [
     match: ['behringer', 's16'],
     deviceTypeId: 'd18f77b3-d775-4f93-9cf5-4242320960d3',
     template: {
+      manufacturerUrl: 'https://www.behringer.com/product.html?modelCode=0606-ABC',
       name: 'Behringer S16',
       category: 'Audio',
       inputs: [
@@ -308,6 +319,7 @@ export const AUDIO_CATALOG: AudioEntry[] = [
     match: ['behringer', 's32'],
     deviceTypeId: 'cc59f6ab-1e25-4db7-a0c8-e0ca2aab66c4',
     template: {
+      manufacturerUrl: 'https://www.behringer.com/product.html?modelCode=0606-ACQ',
       name: 'Behringer S32',
       category: 'Audio',
       inputs: [
@@ -330,6 +342,7 @@ export const AUDIO_CATALOG: AudioEntry[] = [
     match: ['midas', 'dl32'],
     deviceTypeId: 'd707763c-36b6-4df0-90e4-2f785580637e',
     template: {
+      manufacturerUrl: 'https://www.midasconsoles.com/product.html?modelCode=0605-AAC',
       name: 'Midas DL32',
       category: 'Audio',
       inputs: [
@@ -353,6 +366,7 @@ export const AUDIO_CATALOG: AudioEntry[] = [
     match: ['rio3224'],
     deviceTypeId: '5fb4ef98-c63c-4dae-b872-1f7b5a29d7d3',
     template: {
+      manufacturerUrl: 'https://usa.yamaha.com/products/proaudio/interfaces/r_series_adda_2/index.html',
       name: 'Yamaha Rio3224-D2',
       category: 'Audio',
       inputs: [
@@ -374,6 +388,7 @@ export const AUDIO_CATALOG: AudioEntry[] = [
     match: ['dx168'],
     deviceTypeId: '9453d902-5dfc-4453-a744-b7fcd8f1500f',
     template: {
+      manufacturerUrl: 'https://www.allen-heath.com/hardware/everything-i-o/dx168/',
       name: 'Allen & Heath DX168',
       category: 'Audio',
       inputs: [

--- a/src/renderer/lib/avNetworkCatalog.ts
+++ b/src/renderer/lib/avNetworkCatalog.ts
@@ -44,6 +44,7 @@ export const AVNETWORK_CATALOG: AvNetworkEntry[] = [
     deviceTypeId: '92dcba31-e2aa-4ba3-bbca-83375fdbb97c',
     networkKind: 'switch',
     template: {
+      manufacturerUrl: 'https://www.netgear.com/support/product/gsm4212p',
       name: 'Netgear M4250-10G2F-PoE+',
       category: 'Netzwerk',
       categoryProps: { poeBudgetW: 125 },
@@ -66,6 +67,7 @@ export const AVNETWORK_CATALOG: AvNetworkEntry[] = [
     deviceTypeId: 'af2817ec-1604-4b72-9d6c-fc385edf8b74',
     networkKind: 'switch',
     template: {
+      manufacturerUrl: 'https://support.netgear.com/support/product/gsm4230p',
       name: 'Netgear M4250-26G4F-PoE+',
       category: 'Netzwerk',
       categoryProps: { poeBudgetW: 300 },
@@ -88,6 +90,7 @@ export const AVNETWORK_CATALOG: AvNetworkEntry[] = [
     deviceTypeId: '41806ac2-4515-4c94-922a-72a17e9f7332',
     networkKind: 'switch',
     template: {
+      manufacturerUrl: 'https://www.luminex.be/products/gigacore/',
       name: 'Luminex GigaCore 16Xt',
       category: 'Netzwerk',
       inputs: [
@@ -107,6 +110,7 @@ export const AVNETWORK_CATALOG: AvNetworkEntry[] = [
     match: ['flex', '4k in'],
     deviceTypeId: 'f472514c-647b-4956-9b61-92b9bc1ad996',
     template: {
+      manufacturerUrl: 'https://birddog.tv/flex-overview/flex-techspecs/',
       name: 'BirdDog Flex 4K IN',
       category: 'IP/NDI',
       isConverter: true,
@@ -127,6 +131,7 @@ export const AVNETWORK_CATALOG: AvNetworkEntry[] = [
     match: ['flex', '4k out'],
     deviceTypeId: 'b23e0c0e-92e0-48a2-a855-3812b775983c',
     template: {
+      manufacturerUrl: 'https://birddog.tv/flex-overview/flex-techspecs/',
       name: 'BirdDog Flex 4K OUT',
       category: 'IP/NDI',
       isConverter: true,
@@ -147,6 +152,7 @@ export const AVNETWORK_CATALOG: AvNetworkEntry[] = [
     match: ['pro convert', 'hdmi', '4k'],
     deviceTypeId: '60b05acc-b521-4a32-82ea-8c44f7709c70',
     template: {
+      manufacturerUrl: 'https://www.magewell.com/products/pro-convert-hdmi-4k-plus',
       name: 'Magewell Pro Convert HDMI 4K Plus',
       category: 'IP/NDI',
       isConverter: true,
@@ -168,6 +174,7 @@ export const AVNETWORK_CATALOG: AvNetworkEntry[] = [
     deviceTypeId: '605c86c2-344b-4652-92e6-7eceeb2b26ab',
     networkKind: 'switch',
     template: {
+      manufacturerUrl: 'https://www.luminex.be/products/gigacore/gigacore-10t/',
       name: 'Luminex GigaCore 10t',
       category: 'Netzwerk',
       inputs: [
@@ -188,6 +195,7 @@ export const AVNETWORK_CATALOG: AvNetworkEntry[] = [
     deviceTypeId: 'b70cec7b-17f9-4a60-b417-a4052ef6ee48',
     networkKind: 'switch',
     template: {
+      manufacturerUrl: 'https://www.luminex.be/products/gigacore/',
       name: 'Luminex GigaCore 26i',
       category: 'Netzwerk',
       inputs: [

--- a/src/renderer/lib/broadcastToolsCatalog.ts
+++ b/src/renderer/lib/broadcastToolsCatalog.ts
@@ -41,6 +41,7 @@ export const BROADCAST_TOOLS_CATALOG: BroadcastToolsEntry[] = [
     match: ['dmon-6s'],
     deviceTypeId: '9d653c20-d549-46ca-a735-b11754af883b',
     template: {
+      manufacturerUrl: 'https://decimator.com/Products/MultiViewers/DMON-6S%20MultiViewer/DMON-6S.html',
       name: 'Decimator DMON-6S',
       category: 'Video',
       inputs: [
@@ -61,6 +62,7 @@ export const BROADCAST_TOOLS_CATALOG: BroadcastToolsEntry[] = [
     match: ['dmon-12s'],
     deviceTypeId: '76c6b71c-9037-4fe4-9216-2498b8ed577f',
     template: {
+      manufacturerUrl: 'https://decimator.com/specs/DMON-12S_HARDWARE_MANUAL_FV1.3.pdf',
       name: 'Decimator DMON-12S',
       category: 'Video',
       inputs: [
@@ -80,6 +82,7 @@ export const BROADCAST_TOOLS_CATALOG: BroadcastToolsEntry[] = [
     match: ['md-hx'],
     deviceTypeId: 'da8513b0-c6bf-4da7-b07f-9665efb47270',
     template: {
+      manufacturerUrl: 'https://decimator.com/Products/MiniConverters/MD-HX%20Miniature%20Converter/MD-HX.html',
       name: 'Decimator MD-HX',
       category: 'Konverter',
       isConverter: true,
@@ -101,6 +104,7 @@ export const BROADCAST_TOOLS_CATALOG: BroadcastToolsEntry[] = [
     match: ['bolt', '4k', 'tx'],
     deviceTypeId: '5436a62f-738f-4182-b84f-f42c9598f89d',
     template: {
+      manufacturerUrl: 'https://teradek.com/products/bolt-4k-12g-sdi-750-tx-new-photos',
       name: 'Teradek Bolt 4K 750 TX',
       category: 'Video',
       inputs: [
@@ -121,6 +125,7 @@ export const BROADCAST_TOOLS_CATALOG: BroadcastToolsEntry[] = [
     match: ['bolt', '4k', 'rx'],
     deviceTypeId: 'e94b3454-975a-469c-ada8-69dcd2662629',
     template: {
+      manufacturerUrl: 'https://teradek.com/products/bolt-4k-750-rx-only',
       name: 'Teradek Bolt 4K 750 RX',
       category: 'Video',
       inputs: [
@@ -140,6 +145,7 @@ export const BROADCAST_TOOLS_CATALOG: BroadcastToolsEntry[] = [
     match: ['mediornet', 'micron'],
     deviceTypeId: 'b4793e5d-61db-45c5-ae9a-b9ea9eb60e1b',
     template: {
+      manufacturerUrl: 'https://www.riedel.net/en/products-solutions/distributed-video-networks/mn-micron/hardware/',
       name: 'Riedel MediorNet MicroN',
       category: 'Video',
       inputs: [

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -4244,6 +4244,7 @@ export const de: Dict = {
   "atem.audio.loadedMatrix": "Matrix: {outputs} outputs × {sources} sources",
   "atem.audio.loadedTitle": "Audio config read from ATEM",
   "atem.audio.noAudio": "No Audio",
+  "eq.field.manufacturerUrlInherited": "From catalog type {name}:",
   "atem.audio.live.title": "Read from the switcher",
   "atem.audio.live.differs": "{n} differences from the plan",
   "atem.audio.live.matches": "Plan and device agree",

--- a/src/renderer/lib/lynxCatalog.ts
+++ b/src/renderer/lib/lynxCatalog.ts
@@ -41,6 +41,7 @@ export const LYNX_CATALOG: LynxEntry[] = [
     match: ['cdh', '1813'],
     deviceTypeId: 'ba941ff8-e5b0-41e7-a82b-a305042fe471',
     template: {
+      manufacturerUrl: 'https://lynx-technik.com/p/cdh-1813/',
       name: 'Lynx Technik yellobrik CDH 1813',
       category: 'Konverter',
       isConverter: true,
@@ -62,6 +63,7 @@ export const LYNX_CATALOG: LynxEntry[] = [
     match: ['chd', '1802'],
     deviceTypeId: '58869e00-5679-49ce-a783-4f95485974e3',
     template: {
+      manufacturerUrl: 'https://lynx-technik.com/p/chd-1802/',
       name: 'Lynx Technik yellobrik CHD 1802',
       category: 'Konverter',
       isConverter: true,
@@ -81,6 +83,7 @@ export const LYNX_CATALOG: LynxEntry[] = [
     match: ['otx', '1812'],
     deviceTypeId: 'e8379cf4-705f-4cdb-86cb-370464448e3b',
     template: {
+      manufacturerUrl: 'https://lynx-technik.com/p/otx-1812/',
       name: 'Lynx Technik yellobrik OTX 1812',
       category: 'Konverter',
       isConverter: true,
@@ -101,6 +104,7 @@ export const LYNX_CATALOG: LynxEntry[] = [
     match: ['orx', '1802'],
     deviceTypeId: '4893e659-7dd0-4971-98f0-3c6a8e0e0d23',
     template: {
+      manufacturerUrl: 'https://lynx-technik.com/p/orx-1802/',
       name: 'Lynx Technik yellobrik ORX 1802',
       category: 'Konverter',
       isConverter: true,
@@ -120,6 +124,7 @@ export const LYNX_CATALOG: LynxEntry[] = [
     match: ['spg', '1707'],
     deviceTypeId: '5418624a-0c12-4e3d-b2ba-bc2a898206ed',
     template: {
+      manufacturerUrl: 'https://lynx-technik.com/p/spg-1707/',
       name: 'Lynx Technik yellobrik SPG 1707',
       category: 'Sync/Referenz',
       inputs: [
@@ -140,6 +145,7 @@ export const LYNX_CATALOG: LynxEntry[] = [
     match: ['dvd', '1817'],
     deviceTypeId: '55cf940f-9dd8-4f0b-a839-8a05b07cce22',
     template: {
+      manufacturerUrl: 'https://lynx-technik.com/p/dvd-1817/',
       name: 'Lynx Technik yellobrik DVD 1817',
       category: 'Video',
       isDistributionAmp: true,
@@ -159,6 +165,7 @@ export const LYNX_CATALOG: LynxEntry[] = [
     match: ['greenmachine', 'callisto'],
     deviceTypeId: '52cf25a3-9efd-4f87-a54a-a420376e50b5',
     template: {
+      manufacturerUrl: 'https://lynx-technik.com/p/gm-6825/',
       name: 'Lynx Technik greenMachine callisto+',
       category: 'Konverter',
       isConverter: true,

--- a/src/renderer/lib/micCatalog.ts
+++ b/src/renderer/lib/micCatalog.ts
@@ -34,6 +34,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['sm57'],
     deviceTypeId: '8a940e24-1c9c-4571-a820-50cd7ce55ed1',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/sm57',
       name: 'Shure SM57',
       category: 'Mikrofone',
       inputs: [],
@@ -48,6 +49,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['sm58'],
     deviceTypeId: '4e75a4d0-7490-431f-8230-fef93fa265ef',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/sm58',
       name: 'Shure SM58',
       category: 'Mikrofone',
       inputs: [],
@@ -62,6 +64,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['beta 52'],
     deviceTypeId: '89800fa5-c02c-4592-ab60-1a829d36bbca',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/beta_52a',
       name: 'Shure Beta 52A',
       category: 'Mikrofone',
       inputs: [],
@@ -76,6 +79,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['beta 91'],
     deviceTypeId: '875fe949-20d3-4c51-b83b-a729c73b363d',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/beta_91a',
       name: 'Shure Beta 91A',
       category: 'Mikrofone',
       inputs: [],
@@ -90,6 +94,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['beta 57'],
     deviceTypeId: 'a676a2b5-927a-49bf-bba4-7156001f02d0',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/beta_57a',
       name: 'Shure Beta 57A',
       category: 'Mikrofone',
       inputs: [],
@@ -104,6 +109,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['sm7b'],
     deviceTypeId: '73c42067-1794-43de-80f6-9c1d683c1bff',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/sm7b',
       name: 'Shure SM7B',
       category: 'Mikrofone',
       inputs: [],
@@ -118,6 +124,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['md421'],
     deviceTypeId: '689107af-28fb-4bba-905a-21f00f0458e7',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/md-421-ii',
       name: 'Sennheiser MD421-II',
       category: 'Mikrofone',
       inputs: [],
@@ -132,6 +139,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['e604'],
     deviceTypeId: '70c7cb6b-5485-4206-91fe-406c60d48e31',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/e-604',
       name: 'Sennheiser e604',
       category: 'Mikrofone',
       inputs: [],
@@ -146,6 +154,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['e602'],
     deviceTypeId: 'b25ecb84-34aa-415f-bf57-ff703b661aed',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/e-602-ii',
       name: 'Sennheiser e602-II',
       category: 'Mikrofone',
       inputs: [],
@@ -160,6 +169,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['e906'],
     deviceTypeId: '7b5ecf9a-52e9-4bcd-ac0e-a6d5524aa40f',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/e-906',
       name: 'Sennheiser e906',
       category: 'Mikrofone',
       inputs: [],
@@ -174,6 +184,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['audix', 'd6'],
     deviceTypeId: 'fd5e9328-d8a2-4570-b731-da13c389c8d5',
     template: {
+      manufacturerUrl: 'https://audixusa.com/products/d6',
       name: 'Audix D6',
       category: 'Mikrofone',
       inputs: [],
@@ -188,6 +199,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['audix', 'i5'],
     deviceTypeId: 'a3c7f751-ed7f-4293-9567-b11fee957c6f',
     template: {
+      manufacturerUrl: 'https://audixusa.com/products/i5',
       name: 'Audix i5',
       category: 'Mikrofone',
       inputs: [],
@@ -202,6 +214,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['audix', 'd2'],
     deviceTypeId: '0182d60e-9ac4-4a90-9b4b-891f86441b52',
     template: {
+      manufacturerUrl: 'https://audixusa.com/products/d2',
       name: 'Audix D2',
       category: 'Mikrofone',
       inputs: [],
@@ -216,6 +229,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['audix', 'd4'],
     deviceTypeId: '5a46a127-a8a0-40fa-a19a-a3aa4fd68a29',
     template: {
+      manufacturerUrl: 'https://audixusa.com/products/d4',
       name: 'Audix D4',
       category: 'Mikrofone',
       inputs: [],
@@ -230,6 +244,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['m 88', 'm88'],
     deviceTypeId: 'c9e76a8c-5ea3-491d-8901-e2fccc62e7b8',
     template: {
+      manufacturerUrl: 'https://www.beyerdynamic.com/m-88-tg.html',
       name: 'Beyerdynamic M 88 TG',
       category: 'Mikrofone',
       inputs: [],
@@ -244,6 +259,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['m 201', 'm201'],
     deviceTypeId: '69334b49-e804-4d7d-8690-60aeaaedad0a',
     template: {
+      manufacturerUrl: 'https://www.beyerdynamic.com/m-201-tg.html',
       name: 'Beyerdynamic M 201 TG',
       category: 'Mikrofone',
       inputs: [],
@@ -258,6 +274,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['re20'],
     deviceTypeId: '12ecf8e2-dcd4-4bab-b088-cf30933774a7',
     template: {
+      manufacturerUrl: 'https://www.electrovoice.com/product/re20/',
       name: 'Electro-Voice RE20',
       category: 'Mikrofone',
       inputs: [],
@@ -272,6 +289,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['km 184', 'km184'],
     deviceTypeId: 'b5746bf5-52c9-4e6d-940e-a66aeafcf236',
     template: {
+      manufacturerUrl: 'https://www.neumann.com/en-us/products/microphones/km-184/',
       name: 'Neumann KM 184',
       category: 'Mikrofone',
       inputs: [],
@@ -286,6 +304,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['c451'],
     deviceTypeId: '52f6db37-35e5-4a93-bc8a-78dc3a0f9c8f',
     template: {
+      manufacturerUrl: 'https://www.akg.com/microphones/condenser-microphones/C451B.html',
       name: 'AKG C451 B',
       category: 'Mikrofone',
       inputs: [],
@@ -300,6 +319,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['nt5'],
     deviceTypeId: '853cbd16-325c-49ea-a209-26ea2782bab3',
     template: {
+      manufacturerUrl: 'https://rode.com/en-us/microphones/studio-condenser/nt5',
       name: 'Rode NT5',
       category: 'Mikrofone',
       inputs: [],
@@ -314,6 +334,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['se8'],
     deviceTypeId: '77f17f29-0429-4d90-992d-f59ba291ba5e',
     template: {
+      manufacturerUrl: 'https://seelectronics.com/se8-series/',
       name: 'sE Electronics sE8',
       category: 'Mikrofone',
       inputs: [],
@@ -328,6 +349,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['4011'],
     deviceTypeId: 'cd7ecb76-49b1-4de9-9928-1901976d3f09',
     template: {
+      manufacturerUrl: 'https://www.dpamicrophones.com/pencil/4011a-cardioid-microphone/',
       name: 'DPA 4011',
       category: 'Mikrofone',
       inputs: [],
@@ -342,6 +364,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['2011'],
     deviceTypeId: 'b92cd58f-1ee4-4410-bbfb-8bd799f65371',
     template: {
+      manufacturerUrl: 'https://www.dpamicrophones.com/compact/2011-twin-diaphragm-cardioid-microphone/',
       name: 'DPA 2011',
       category: 'Mikrofone',
       inputs: [],
@@ -356,6 +379,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['sm81'],
     deviceTypeId: 'dea02a2a-a993-496e-9f73-639428cb1615',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/sm81',
       name: 'Shure SM81',
       category: 'Mikrofone',
       inputs: [],
@@ -370,6 +394,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['u 87', 'u87'],
     deviceTypeId: '17dcf897-5088-493f-84a4-ff8dbbc4f5d6',
     template: {
+      manufacturerUrl: 'https://www.neumann.com/en-us/products/microphones/u-87-ai/',
       name: 'Neumann U 87 Ai',
       category: 'Mikrofone',
       inputs: [],
@@ -384,6 +409,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['tlm 103', 'tlm103'],
     deviceTypeId: '6e1337a3-bcf5-4158-826f-8cc0f0923c32',
     template: {
+      manufacturerUrl: 'https://www.neumann.com/en-us/products/microphones/tlm-103/',
       name: 'Neumann TLM 103',
       category: 'Mikrofone',
       inputs: [],
@@ -398,6 +424,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['c414'],
     deviceTypeId: 'bde47578-29ef-432f-8781-af950060a85e',
     template: {
+      manufacturerUrl: 'https://www.akg.com/microphones/condenser-microphones/C414XLII.html',
       name: 'AKG C414 XLII',
       category: 'Mikrofone',
       inputs: [],
@@ -412,6 +439,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['nt1'],
     deviceTypeId: '76bfc7fb-2690-4063-991a-7cc0fafbeaab',
     template: {
+      manufacturerUrl: 'https://rode.com/en-us/microphones/studio-condenser/nt1-5th-generation',
       name: 'Rode NT1 (5th Gen)',
       category: 'Mikrofone',
       inputs: [],
@@ -426,6 +454,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['r-121', 'r121'],
     deviceTypeId: 'fff78597-0ff5-4229-bdd8-5219e2ad489d',
     template: {
+      manufacturerUrl: 'https://royerlabs.com/r-121/',
       name: 'Royer R-121',
       category: 'Mikrofone',
       inputs: [],
@@ -440,6 +469,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['r84'],
     deviceTypeId: 'ac855de2-31e0-4000-8425-3513a2dc676c',
     template: {
+      manufacturerUrl: 'https://www.aearibbonmics.com/products/r84/',
       name: 'AEA R84',
       category: 'Mikrofone',
       inputs: [],
@@ -454,6 +484,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['4038'],
     deviceTypeId: '3f8c13df-97b8-46b0-9856-2d8e10aff957',
     template: {
+      manufacturerUrl: 'https://www.coleselectroacoustics.com/4038-studio-ribbon-microphone/',
       name: 'Coles 4038',
       category: 'Mikrofone',
       inputs: [],
@@ -468,6 +499,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['mkh 416', 'mkh416'],
     deviceTypeId: 'ecc06dd3-18a9-44ba-ac10-d395de9c23f2',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/mkh-416-p48u3',
       name: 'Sennheiser MKH 416',
       category: 'Mikrofone',
       inputs: [],
@@ -482,6 +514,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['ntg3'],
     deviceTypeId: '1c9236bf-a901-47aa-b769-ba5d6df17cd2',
     template: {
+      manufacturerUrl: 'https://rode.com/en-us/microphones/shotgun/ntg3',
       name: 'Rode NTG3',
       category: 'Mikrofone',
       inputs: [],
@@ -496,6 +529,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['mke 2', 'mke2'],
     deviceTypeId: 'bc3f364f-0f83-4e0e-92de-9046c2ae1940',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/mke-2',
       name: 'Sennheiser MKE 2',
       category: 'Mikrofone',
       inputs: [],
@@ -510,6 +544,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['4060'],
     deviceTypeId: '2c903fcb-03d6-46aa-b38d-2cd7314afdb9',
     template: {
+      manufacturerUrl: 'https://www.dpamicrophones.com/lavalier/4060-series-miniature-omnidirectional-microphone/',
       name: 'DPA 4060',
       category: 'Mikrofone',
       inputs: [],
@@ -524,6 +559,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['pzm-30', 'pzm30'],
     deviceTypeId: 'f9ea943b-a891-43ec-99c9-bbf16909aef3',
     template: {
+      manufacturerUrl: 'https://www.crownaudio.com/en/products/pzm-30d',
       name: 'Crown PZM-30D',
       category: 'Mikrofone',
       inputs: [],
@@ -538,6 +574,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['sm7db'],
     deviceTypeId: '6bc9665f-20c0-4f46-8ba6-a02f09e642a8',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/sm7db',
       name: 'Shure SM7dB',
       category: 'Mikrofone',
       inputs: [],
@@ -552,6 +589,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['beta 58'],
     deviceTypeId: '994e1b29-1fad-45f7-b3e0-3212d494b1bc',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/beta_58a',
       name: 'Shure Beta 58A',
       category: 'Mikrofone',
       inputs: [],
@@ -566,6 +604,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['beta 87a'],
     deviceTypeId: 'c5840ffa-7fc5-45a1-a9b1-315e20ea9ea4',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/beta_87a',
       name: 'Shure Beta 87A',
       category: 'Mikrofone',
       inputs: [],
@@ -580,6 +619,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['beta 87c'],
     deviceTypeId: '84c00ce5-e379-4c18-8b33-e0c5100a2164',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/beta_87c',
       name: 'Shure Beta 87C',
       category: 'Mikrofone',
       inputs: [],
@@ -594,6 +634,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['ksm9'],
     deviceTypeId: '7f9ffe8d-7084-477f-ad34-5194185f5e88',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/ksm9',
       name: 'Shure KSM9',
       category: 'Mikrofone',
       inputs: [],
@@ -608,6 +649,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['ksm8'],
     deviceTypeId: 'd21ef7a5-957b-4535-8a4e-df89db12504c',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/ksm8',
       name: 'Shure KSM8 Dualdyne',
       category: 'Mikrofone',
       inputs: [],
@@ -622,6 +664,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['ksm32'],
     deviceTypeId: '023c9c13-2db3-40f6-9ab1-70cb49b00219',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/ksm32',
       name: 'Shure KSM32',
       category: 'Mikrofone',
       inputs: [],
@@ -636,6 +679,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['ksm44'],
     deviceTypeId: '0c690c16-0e3a-44de-a11b-6c097b93c92a',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/ksm44a',
       name: 'Shure KSM44A',
       category: 'Mikrofone',
       inputs: [],
@@ -650,6 +694,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['ksm137'],
     deviceTypeId: '87defdf9-01de-47b5-bcf7-85ad17220076',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/ksm137',
       name: 'Shure KSM137',
       category: 'Mikrofone',
       inputs: [],
@@ -664,6 +709,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['ksm141'],
     deviceTypeId: 'e2c227bf-c1cc-411e-96c2-f1515a79d6b5',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/ksm141',
       name: 'Shure KSM141',
       category: 'Mikrofone',
       inputs: [],
@@ -678,6 +724,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['beta 98'],
     deviceTypeId: '84872411-f3c3-4c5f-bb6a-80c5036256a5',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/beta_98ad_c',
       name: 'Shure Beta 98A/C',
       category: 'Mikrofone',
       inputs: [],
@@ -692,6 +739,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['beta 181'],
     deviceTypeId: '91cb8399-2c62-4d9c-8808-892c1e21c06d',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/beta_181',
       name: 'Shure Beta 181',
       category: 'Mikrofone',
       inputs: [],
@@ -706,6 +754,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['sm86'],
     deviceTypeId: '1831a767-e608-4b19-8d1a-fc6791a5e68a',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/sm86',
       name: 'Shure SM86',
       category: 'Mikrofone',
       inputs: [],
@@ -720,6 +769,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['super 55'],
     deviceTypeId: 'd6312206-b78f-423b-92a8-951693975cb5',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/super_55',
       name: 'Shure Super 55',
       category: 'Mikrofone',
       inputs: [],
@@ -734,6 +784,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['beta 56'],
     deviceTypeId: 'd10a7391-892a-4c5b-9103-7c0902bfc771',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/beta_56a',
       name: 'Shure Beta 56A',
       category: 'Mikrofone',
       inputs: [],
@@ -748,6 +799,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['pga57'],
     deviceTypeId: '48ca03e5-07b7-41c1-ab7e-75c3d08d9068',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/pga57',
       name: 'Shure PGA57',
       category: 'Mikrofone',
       inputs: [],
@@ -762,6 +814,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['mv7'],
     deviceTypeId: '1bfeda62-b05e-4ed6-a998-1b4c23e59050',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/microphones/mv7',
       name: 'Shure MV7 (XLR)',
       category: 'Mikrofone',
       inputs: [],
@@ -776,6 +829,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['md 441', 'md441'],
     deviceTypeId: 'd7ab6cde-ad39-4463-8b74-d459cc60d549',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/md-441-u',
       name: 'Sennheiser MD 441-U',
       category: 'Mikrofone',
       inputs: [],
@@ -790,6 +844,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['e835'],
     deviceTypeId: 'ede7ebb4-0b1e-4fc5-aef3-9c84ec51b691',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/e-835',
       name: 'Sennheiser e835',
       category: 'Mikrofone',
       inputs: [],
@@ -804,6 +859,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['e845'],
     deviceTypeId: '73de6b51-0318-4945-b4b1-c6d24db7f514',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/e-845',
       name: 'Sennheiser e845',
       category: 'Mikrofone',
       inputs: [],
@@ -818,6 +874,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['e865'],
     deviceTypeId: '7810bfd5-2a50-4a77-89ec-69b3d2506dcc',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/e-865',
       name: 'Sennheiser e865',
       category: 'Mikrofone',
       inputs: [],
@@ -832,6 +889,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['e935'],
     deviceTypeId: '8318ddc1-6859-429c-87ed-a100c19665f4',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/e-935',
       name: 'Sennheiser e935',
       category: 'Mikrofone',
       inputs: [],
@@ -846,6 +904,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['e945'],
     deviceTypeId: '90bccac1-1fcf-46b6-aa27-42e6bbcc5239',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/e-945',
       name: 'Sennheiser e945',
       category: 'Mikrofone',
       inputs: [],
@@ -860,6 +919,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['e901'],
     deviceTypeId: 'e71bbe8d-1128-4a90-a685-a5150e143562',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/e-901',
       name: 'Sennheiser e901',
       category: 'Mikrofone',
       inputs: [],
@@ -874,6 +934,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['e902'],
     deviceTypeId: '144a5a28-9163-4ae0-91b0-1755055e6e64',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/e-902',
       name: 'Sennheiser e902',
       category: 'Mikrofone',
       inputs: [],
@@ -888,6 +949,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['e905'],
     deviceTypeId: '45e48422-339d-4148-93d3-bf6dc7efcf7e',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/e-905',
       name: 'Sennheiser e905',
       category: 'Mikrofone',
       inputs: [],
@@ -902,6 +964,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['e908'],
     deviceTypeId: 'd044b76e-33c0-4d9a-a4c0-b16af5cea84b',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/e-908-b',
       name: 'Sennheiser e908 B',
       category: 'Mikrofone',
       inputs: [],
@@ -916,6 +979,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['md 46', 'md46'],
     deviceTypeId: '1e7bc52c-feec-4aaf-90ab-e9a600843db7',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/md-46',
       name: 'Sennheiser MD 46',
       category: 'Mikrofone',
       inputs: [],
@@ -930,6 +994,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['mk 4', 'mk4'],
     deviceTypeId: '5f22cf68-efef-451c-8c48-d45f1a98aaa3',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/mk-4',
       name: 'Sennheiser MK 4',
       category: 'Mikrofone',
       inputs: [],
@@ -944,6 +1009,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['mkh 8040', '8040'],
     deviceTypeId: '5b2b3c22-f012-49f8-baf7-6f0a6b20683d',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/mkh-8040',
       name: 'Sennheiser MKH 8040',
       category: 'Mikrofone',
       inputs: [],
@@ -958,6 +1024,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['mkh 50', 'mkh50'],
     deviceTypeId: '4711941b-cc9c-476d-ae2d-1fca312c0e21',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/mkh-50-p48',
       name: 'Sennheiser MKH 50',
       category: 'Mikrofone',
       inputs: [],
@@ -972,6 +1039,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['mkh 40', 'mkh40'],
     deviceTypeId: 'bd6ef8cf-87a4-4f64-a4a4-a43908d86d79',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/mkh-40-p48',
       name: 'Sennheiser MKH 40',
       category: 'Mikrofone',
       inputs: [],
@@ -986,6 +1054,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['mke 600', 'mke600'],
     deviceTypeId: 'a707e6d1-1eff-4295-ba7f-75305b4dbecc',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/mke-600',
       name: 'Sennheiser MKE 600',
       category: 'Mikrofone',
       inputs: [],
@@ -1000,6 +1069,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['tlm 102', 'tlm102'],
     deviceTypeId: 'c702e4aa-3e7c-4dc7-9890-8cb041284cc1',
     template: {
+      manufacturerUrl: 'https://www.neumann.com/en-us/products/microphones/tlm-102/',
       name: 'Neumann TLM 102',
       category: 'Mikrofone',
       inputs: [],
@@ -1014,6 +1084,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['tlm 107', 'tlm107'],
     deviceTypeId: '92700896-d86b-4332-a620-4c0c406b1d3d',
     template: {
+      manufacturerUrl: 'https://www.neumann.com/en-us/products/microphones/tlm-107/',
       name: 'Neumann TLM 107',
       category: 'Mikrofone',
       inputs: [],
@@ -1028,6 +1099,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['tlm 170'],
     deviceTypeId: 'a88e81a4-b28c-468e-9d47-9b484c8e14fe',
     template: {
+      manufacturerUrl: 'https://www.neumann.com/en-us/products/microphones/tlm-170-r/',
       name: 'Neumann TLM 170 R',
       category: 'Mikrofone',
       inputs: [],
@@ -1042,6 +1114,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['km 185', 'km185'],
     deviceTypeId: '6b029879-b105-4b55-8c14-0453ab069ddf',
     template: {
+      manufacturerUrl: 'https://www.neumann.com/en-us/products/microphones/km-185/',
       name: 'Neumann KM 185',
       category: 'Mikrofone',
       inputs: [],
@@ -1056,6 +1129,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['u 47 fet', 'u47 fet'],
     deviceTypeId: '2773662d-6478-4d03-8b54-a392cb11e2b2',
     template: {
+      manufacturerUrl: 'https://www.neumann.com/en-us/products/microphones/u-47-fet/',
       name: 'Neumann U 47 fet',
       category: 'Mikrofone',
       inputs: [],
@@ -1070,6 +1144,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['kms 105', 'kms105'],
     deviceTypeId: 'fc2855fc-4ff4-417f-bd39-ffadf5b3f22e',
     template: {
+      manufacturerUrl: 'https://www.neumann.com/en-us/products/microphones/kms-105/',
       name: 'Neumann KMS 105',
       category: 'Mikrofone',
       inputs: [],
@@ -1084,6 +1159,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['kms 104', 'kms104'],
     deviceTypeId: '178047af-41ff-4747-9774-0678a9be19e5',
     template: {
+      manufacturerUrl: 'https://www.neumann.com/en-us/products/microphones/kms-104/',
       name: 'Neumann KMS 104',
       category: 'Mikrofone',
       inputs: [],
@@ -1098,6 +1174,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['m 149', 'm149'],
     deviceTypeId: 'ae49c1ec-c02d-4ef7-835e-25bb4119c98a',
     template: {
+      manufacturerUrl: 'https://www.neumann.com/en-us/products/microphones/m-149-tube/',
       name: 'Neumann M 149 Tube',
       category: 'Mikrofone',
       inputs: [],
@@ -1112,6 +1189,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['bcm 705', 'bcm705'],
     deviceTypeId: '49e0d574-cc45-4972-9ea4-20ed0d1c35e9',
     template: {
+      manufacturerUrl: 'https://www.neumann.com/en-us/products/microphones/bcm-705/',
       name: 'Neumann BCM 705',
       category: 'Mikrofone',
       inputs: [],
@@ -1126,6 +1204,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['tlm 193', 'tlm193'],
     deviceTypeId: 'b8ee7382-6d39-4ea9-9d91-84201b6dcaf6',
     template: {
+      manufacturerUrl: 'https://www.neumann.com/en-us/products/microphones/tlm-193/',
       name: 'Neumann TLM 193',
       category: 'Mikrofone',
       inputs: [],
@@ -1140,6 +1219,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['c414 xls'],
     deviceTypeId: '640a2f35-1388-4ad4-962d-5091a2033e97',
     template: {
+      manufacturerUrl: 'https://www.akg.com/microphones/condenser-microphones/C414XLS.html',
       name: 'AKG C414 XLS',
       category: 'Mikrofone',
       inputs: [],
@@ -1154,6 +1234,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['c214'],
     deviceTypeId: '24c120a8-0626-4a46-b0ee-90a396ade81e',
     template: {
+      manufacturerUrl: 'https://www.akg.com/microphones/condenser-microphones/C214.html',
       name: 'AKG C214',
       category: 'Mikrofone',
       inputs: [],
@@ -1168,6 +1249,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['d112'],
     deviceTypeId: '942c855b-d188-4860-bdcd-f4ba08a133bc',
     template: {
+      manufacturerUrl: 'https://www.akg.com/microphones/dynamic-microphones/D112MKII.html',
       name: 'AKG D112 MkII',
       category: 'Mikrofone',
       inputs: [],
@@ -1182,6 +1264,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['d12'],
     deviceTypeId: 'e1706715-99dc-4922-9a17-1a4e9befa8ad',
     template: {
+      manufacturerUrl: 'https://www.akg.com/microphones/dynamic-microphones/D12VR.html',
       name: 'AKG D12 VR',
       category: 'Mikrofone',
       inputs: [],
@@ -1196,6 +1279,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['akg d5'],
     deviceTypeId: '7a2e71de-1981-403a-9d69-355749cbd33b',
     template: {
+      manufacturerUrl: 'https://www.akg.com/microphones/dynamic-microphones/D5.html',
       name: 'AKG D5',
       category: 'Mikrofone',
       inputs: [],
@@ -1210,6 +1294,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['akg d40'],
     deviceTypeId: '64261931-cc6c-474b-89c7-ef8b8f539509',
     template: {
+      manufacturerUrl: 'https://www.akg.com/microphones/dynamic-microphones/D40.html',
       name: 'AKG D40',
       category: 'Mikrofone',
       inputs: [],
@@ -1224,6 +1309,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['c1000'],
     deviceTypeId: 'ad4cd9fd-a0d1-45d4-aca1-c12d1108119d',
     template: {
+      manufacturerUrl: 'https://www.akg.com/microphones/condenser-microphones/C1000S.html',
       name: 'AKG C1000 S',
       category: 'Mikrofone',
       inputs: [],
@@ -1238,6 +1324,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['c3000'],
     deviceTypeId: 'de81b3de-f9cf-4084-a991-e73a1947ed8c',
     template: {
+      manufacturerUrl: 'https://www.akg.com/microphones/condenser-microphones/C3000.html',
       name: 'AKG C3000',
       category: 'Mikrofone',
       inputs: [],
@@ -1252,6 +1339,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['c12'],
     deviceTypeId: 'ee435947-8496-405f-b90a-fced0bdc5f9b',
     template: {
+      manufacturerUrl: 'https://www.akg.com/microphones/condenser-microphones/C12VR.html',
       name: 'AKG C12 VR',
       category: 'Mikrofone',
       inputs: [],
@@ -1266,6 +1354,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['c519'],
     deviceTypeId: '4331d3e5-c687-4fc6-a7b8-04db51bbe8bd',
     template: {
+      manufacturerUrl: 'https://www.akg.com/microphones/condenser-microphones/C519ML.html',
       name: 'AKG C519 ML',
       category: 'Mikrofone',
       inputs: [],
@@ -1280,6 +1369,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['nt1-a', 'nt1a'],
     deviceTypeId: '410a2fbd-641b-4658-994f-243bfd1ea7b6',
     template: {
+      manufacturerUrl: 'https://rode.com/en-us/microphones/studio-condenser/nt1-a',
       name: 'Rode NT1-A',
       category: 'Mikrofone',
       inputs: [],
@@ -1294,6 +1384,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['nt2-a', 'nt2a'],
     deviceTypeId: '64982e0e-626f-40ff-ad6d-ed5c09a3285a',
     template: {
+      manufacturerUrl: 'https://rode.com/en-us/microphones/studio-condenser/nt2-a',
       name: 'Rode NT2-A',
       category: 'Mikrofone',
       inputs: [],
@@ -1308,6 +1399,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['ntk'],
     deviceTypeId: 'be9fd8a1-7efc-4818-bb14-51840b935d69',
     template: {
+      manufacturerUrl: 'https://rode.com/en-us/microphones/studio-condenser/ntk',
       name: 'Rode NTK',
       category: 'Mikrofone',
       inputs: [],
@@ -1322,6 +1414,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['ntg5'],
     deviceTypeId: '15424ef7-48ab-406d-ab33-37c68edbcc26',
     template: {
+      manufacturerUrl: 'https://rode.com/en-us/microphones/shotgun/ntg5',
       name: 'Rode NTG5',
       category: 'Mikrofone',
       inputs: [],
@@ -1336,6 +1429,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['ntg4'],
     deviceTypeId: '048af6d5-a67d-4279-b46f-0d3a57a7c996',
     template: {
+      manufacturerUrl: 'https://rode.com/en-us/microphones/shotgun/ntg4-plus',
       name: 'Rode NTG4+',
       category: 'Mikrofone',
       inputs: [],
@@ -1350,6 +1444,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['broadcaster'],
     deviceTypeId: 'a7593df1-1997-4124-8265-cba33ac578f4',
     template: {
+      manufacturerUrl: 'https://rode.com/en-us/microphones/broadcast/broadcaster',
       name: 'Rode Broadcaster',
       category: 'Mikrofone',
       inputs: [],
@@ -1364,6 +1459,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['procaster'],
     deviceTypeId: 'f89937dc-3d62-4d17-93bf-73fb595c7643',
     template: {
+      manufacturerUrl: 'https://rode.com/en-us/microphones/broadcast/procaster',
       name: 'Rode Procaster',
       category: 'Mikrofone',
       inputs: [],
@@ -1378,6 +1474,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['podmic'],
     deviceTypeId: 'd78e38c0-1101-4afa-8eda-88d2b9644037',
     template: {
+      manufacturerUrl: 'https://rode.com/en-us/microphones/broadcast/podmic',
       name: 'Rode PodMic',
       category: 'Mikrofone',
       inputs: [],
@@ -1392,6 +1489,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['rode m5', 'm5 '],
     deviceTypeId: '905c2566-bc55-44f7-9bf4-4b334dbcbf9f',
     template: {
+      manufacturerUrl: 'https://rode.com/en-us/microphones/studio-condenser/m5',
       name: 'Rode M5',
       category: 'Mikrofone',
       inputs: [],
@@ -1406,6 +1504,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['at4040'],
     deviceTypeId: '89914527-63b2-4a84-a769-c07e7e827f08',
     template: {
+      manufacturerUrl: 'https://www.audio-technica.com/en-us/at4040',
       name: 'Audio-Technica AT4040',
       category: 'Mikrofone',
       inputs: [],
@@ -1420,6 +1519,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['at4050'],
     deviceTypeId: 'ede280ca-645c-451a-bcf6-141008d4cb42',
     template: {
+      manufacturerUrl: 'https://www.audio-technica.com/en-us/at4050',
       name: 'Audio-Technica AT4050',
       category: 'Mikrofone',
       inputs: [],
@@ -1434,6 +1534,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['at4033'],
     deviceTypeId: '9dfb4d9e-64ac-4175-ae71-bcf221ee14c0',
     template: {
+      manufacturerUrl: 'https://www.audio-technica.com/en-us/at4033a',
       name: 'Audio-Technica AT4033',
       category: 'Mikrofone',
       inputs: [],
@@ -1448,6 +1549,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['at4047'],
     deviceTypeId: '0a81ddd4-afae-4273-ad5e-dc8f63773e02',
     template: {
+      manufacturerUrl: 'https://www.audio-technica.com/en-us/at4047-svsm',
       name: 'Audio-Technica AT4047',
       category: 'Mikrofone',
       inputs: [],
@@ -1462,6 +1564,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['at2020'],
     deviceTypeId: 'ce325785-ecb2-4f5a-bc6e-d5d160b17faf',
     template: {
+      manufacturerUrl: 'https://www.audio-technica.com/en-us/at2020',
       name: 'Audio-Technica AT2020',
       category: 'Mikrofone',
       inputs: [],
@@ -1476,6 +1579,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['at2035'],
     deviceTypeId: '5a13a164-993a-4df1-9871-af0b144aaccd',
     template: {
+      manufacturerUrl: 'https://www.audio-technica.com/en-us/at2035',
       name: 'Audio-Technica AT2035',
       category: 'Mikrofone',
       inputs: [],
@@ -1490,6 +1594,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['at4060'],
     deviceTypeId: 'ab3e9720-7ee4-427e-b4b6-707c7fb9eac8',
     template: {
+      manufacturerUrl: 'https://www.audio-technica.com/en-us/at4060a',
       name: 'Audio-Technica AT4060',
       category: 'Mikrofone',
       inputs: [],
@@ -1504,6 +1609,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['at5040'],
     deviceTypeId: '57471618-0535-44bd-accf-a2e0fb7a86c3',
     template: {
+      manufacturerUrl: 'https://www.audio-technica.com/en-us/at5040',
       name: 'Audio-Technica AT5040',
       category: 'Mikrofone',
       inputs: [],
@@ -1518,6 +1624,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['atm650'],
     deviceTypeId: 'a2cb67ba-b4e2-4f50-84c4-e6aac67c13cb',
     template: {
+      manufacturerUrl: 'https://www.audio-technica.com/en-us/atm650',
       name: 'Audio-Technica ATM650',
       category: 'Mikrofone',
       inputs: [],
@@ -1532,6 +1639,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['atm250'],
     deviceTypeId: 'b901fa91-0923-41ce-a0f6-d73ea369db9e',
     template: {
+      manufacturerUrl: 'https://www.audio-technica.com/en-us/atm250',
       name: 'Audio-Technica ATM250',
       category: 'Mikrofone',
       inputs: [],
@@ -1546,6 +1654,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['atm350'],
     deviceTypeId: '1c16c1a8-2521-418a-84a0-4823498d195c',
     template: {
+      manufacturerUrl: 'https://www.audio-technica.com/en-us/atm350a',
       name: 'Audio-Technica ATM350',
       category: 'Mikrofone',
       inputs: [],
@@ -1560,6 +1669,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['bp40'],
     deviceTypeId: 'ba77d3c9-4b41-430c-bbef-633a236c6635',
     template: {
+      manufacturerUrl: 'https://www.audio-technica.com/en-us/bp40',
       name: 'Audio-Technica BP40',
       category: 'Mikrofone',
       inputs: [],
@@ -1574,6 +1684,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['ae2500'],
     deviceTypeId: '099dd425-15d0-452b-8375-b6578138641f',
     template: {
+      manufacturerUrl: 'https://www.audio-technica.com/en-us/ae2500',
       name: 'Audio-Technica AE2500',
       category: 'Mikrofone',
       inputs: [],
@@ -1588,6 +1699,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['ae6100'],
     deviceTypeId: '5eabefec-37a4-4b68-9bc8-c6b6913f41a0',
     template: {
+      manufacturerUrl: 'https://www.audio-technica.com/en-us/ae6100',
       name: 'Audio-Technica AE6100',
       category: 'Mikrofone',
       inputs: [],
@@ -1602,6 +1714,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['at8035'],
     deviceTypeId: '06db2a59-3769-4d29-b9e3-5db101d0f257',
     template: {
+      manufacturerUrl: 'https://www.audio-technica.com/en-us/at8035',
       name: 'Audio-Technica AT8035',
       category: 'Mikrofone',
       inputs: [],
@@ -1616,6 +1729,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['4006'],
     deviceTypeId: 'd2c16a68-d162-4cd7-b214-4a5ebb101744',
     template: {
+      manufacturerUrl: 'https://www.dpamicrophones.com/pencil/4006a-omnidirectional-microphone/',
       name: 'DPA 4006A',
       category: 'Mikrofone',
       inputs: [],
@@ -1630,6 +1744,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['4007'],
     deviceTypeId: '5d74d6cf-b13c-4665-b9ee-fde621b8a0f9',
     template: {
+      manufacturerUrl: 'https://www.dpamicrophones.com/pencil/4007a-omnidirectional-microphone/',
       name: 'DPA 4007',
       category: 'Mikrofone',
       inputs: [],
@@ -1644,6 +1759,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['4015'],
     deviceTypeId: '60cca762-ba61-4a19-9ce4-4cd1779d5006',
     template: {
+      manufacturerUrl: 'https://www.dpamicrophones.com/pencil/4015a-wide-cardioid-microphone/',
       name: 'DPA 4015',
       category: 'Mikrofone',
       inputs: [],
@@ -1658,6 +1774,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['4018'],
     deviceTypeId: 'd2e400b3-6e7a-4613-adb4-4bba5f35aedf',
     template: {
+      manufacturerUrl: 'https://www.dpamicrophones.com/pencil/4018a-supercardioid-microphone/',
       name: 'DPA 4018',
       category: 'Mikrofone',
       inputs: [],
@@ -1672,6 +1789,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['2028'],
     deviceTypeId: 'b4bd805d-63a1-4346-ad6e-979d5f59f206',
     template: {
+      manufacturerUrl: 'https://www.dpamicrophones.com/handheld/2028-vocal-microphone/',
       name: 'DPA 2028',
       category: 'Mikrofone',
       inputs: [],
@@ -1686,6 +1804,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['4099'],
     deviceTypeId: 'aacdd1e5-d616-42c2-8cd3-02642e7cbef4',
     template: {
+      manufacturerUrl: 'https://www.dpamicrophones.com/instrument/4099-instrument-microphone/',
       name: 'DPA 4099',
       category: 'Mikrofone',
       inputs: [],
@@ -1700,6 +1819,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['4055'],
     deviceTypeId: 'b774113e-0d83-4e93-9e41-048183407cf6',
     template: {
+      manufacturerUrl: 'https://www.dpamicrophones.com/instrument/4055-kick-drum-microphone/',
       name: 'DPA 4055',
       category: 'Mikrofone',
       inputs: [],
@@ -1714,6 +1834,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['4066'],
     deviceTypeId: '86cf7b7e-4af8-412c-9346-5b9202276828',
     template: {
+      manufacturerUrl: 'https://www.dpamicrophones.com/headset/4066-omnidirectional-headset-microphone/',
       name: 'DPA 4066',
       category: 'Mikrofone',
       inputs: [],
@@ -1728,6 +1849,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['6060'],
     deviceTypeId: 'b8c2f3ba-4ee2-4a80-b99b-a06787f66d24',
     template: {
+      manufacturerUrl: 'https://www.dpamicrophones.com/lavalier/6060-subminiature-microphone/',
       name: 'DPA 6060',
       category: 'Mikrofone',
       inputs: [],
@@ -1742,6 +1864,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['m 160', 'm160'],
     deviceTypeId: 'cd86e679-b98d-4f52-9bac-0927d4da312e',
     template: {
+      manufacturerUrl: 'https://www.beyerdynamic.com/m-160.html',
       name: 'Beyerdynamic M 160',
       category: 'Mikrofone',
       inputs: [],
@@ -1756,6 +1879,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['m 130', 'm130'],
     deviceTypeId: 'd3cf9c45-e7c0-4840-bc3f-e24df0a70ea5',
     template: {
+      manufacturerUrl: 'https://www.beyerdynamic.com/m-130.html',
       name: 'Beyerdynamic M 130',
       category: 'Mikrofone',
       inputs: [],
@@ -1770,6 +1894,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['tg v70', 'v70'],
     deviceTypeId: '09dd65bd-63cb-44ac-b42a-d4d626ddb03d',
     template: {
+      manufacturerUrl: 'https://www.beyerdynamic.com/tg-v70.html',
       name: 'Beyerdynamic TG V70',
       category: 'Mikrofone',
       inputs: [],
@@ -1784,6 +1909,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['tg v90', 'v90r'],
     deviceTypeId: 'e29956dc-9161-4af0-8251-c19c29f7ca12',
     template: {
+      manufacturerUrl: 'https://www.beyerdynamic.com/tg-v90r.html',
       name: 'Beyerdynamic TG V90r',
       category: 'Mikrofone',
       inputs: [],
@@ -1798,6 +1924,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['mc 930', 'mc930'],
     deviceTypeId: '9f284b07-e2e1-4619-869f-c07d84bbb162',
     template: {
+      manufacturerUrl: 'https://www.beyerdynamic.com/mc-930.html',
       name: 'Beyerdynamic MC 930',
       category: 'Mikrofone',
       inputs: [],
@@ -1812,6 +1939,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['tg d57', 'd57c'],
     deviceTypeId: 'b05ca53f-d0cb-4be8-b2f8-749fac607617',
     template: {
+      manufacturerUrl: 'https://www.beyerdynamic.com/tg-d57c.html',
       name: 'Beyerdynamic TG D57c',
       category: 'Mikrofone',
       inputs: [],
@@ -1826,6 +1954,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['re320'],
     deviceTypeId: 'b8dbca4a-f087-443a-a94f-222825ac6423',
     template: {
+      manufacturerUrl: 'https://www.electrovoice.com/product/re320/',
       name: 'Electro-Voice RE320',
       category: 'Mikrofone',
       inputs: [],
@@ -1840,6 +1969,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['re27'],
     deviceTypeId: '469ad7bf-3ee0-4009-a611-ecc596ae0174',
     template: {
+      manufacturerUrl: 'https://www.electrovoice.com/product/re27nd/',
       name: 'Electro-Voice RE27 N/D',
       category: 'Mikrofone',
       inputs: [],
@@ -1854,6 +1984,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['re16'],
     deviceTypeId: '64b482fc-ef47-4416-a6a8-a58a6d0c8cc1',
     template: {
+      manufacturerUrl: 'https://www.electrovoice.com/product/re16/',
       name: 'Electro-Voice RE16',
       category: 'Mikrofone',
       inputs: [],
@@ -1868,6 +1999,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['nd46'],
     deviceTypeId: '78a3db54-8a10-4466-bb0b-567249477634',
     template: {
+      manufacturerUrl: 'https://www.electrovoice.com/product/nd46/',
       name: 'Electro-Voice ND46',
       category: 'Mikrofone',
       inputs: [],
@@ -1882,6 +2014,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['nd68'],
     deviceTypeId: '57ce171c-aa5a-4bf1-a281-7e568a0251ca',
     template: {
+      manufacturerUrl: 'https://www.electrovoice.com/product/nd68/',
       name: 'Electro-Voice ND68',
       category: 'Mikrofone',
       inputs: [],
@@ -1896,6 +2029,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['nd76'],
     deviceTypeId: '3d0ec5ac-5d0d-4770-84c8-103b8c545204',
     template: {
+      manufacturerUrl: 'https://www.electrovoice.com/product/nd76/',
       name: 'Electro-Voice ND76',
       category: 'Mikrofone',
       inputs: [],
@@ -1910,6 +2044,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['nd44'],
     deviceTypeId: '682999f1-9faa-454a-a750-498086cc3817',
     template: {
+      manufacturerUrl: 'https://www.electrovoice.com/product/nd44/',
       name: 'Electro-Voice ND44',
       category: 'Mikrofone',
       inputs: [],
@@ -1924,6 +2059,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['635a'],
     deviceTypeId: '10da51e4-1f7d-4b18-b3af-a750ee4040ec',
     template: {
+      manufacturerUrl: 'https://www.electrovoice.com/product/635a/',
       name: 'Electro-Voice 635A',
       category: 'Mikrofone',
       inputs: [],
@@ -1938,6 +2074,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['m80'],
     deviceTypeId: 'fa805565-3503-4c04-9e4b-bd7864dcd488',
     template: {
+      manufacturerUrl: 'https://telefunken-elektroakustik.com/m80',
       name: 'Telefunken M80',
       category: 'Mikrofone',
       inputs: [],
@@ -1952,6 +2089,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['m81'],
     deviceTypeId: '6907db1b-0522-420c-9657-f36a37b92a77',
     template: {
+      manufacturerUrl: 'https://telefunken-elektroakustik.com/m81',
       name: 'Telefunken M81',
       category: 'Mikrofone',
       inputs: [],
@@ -1966,6 +2104,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['tf11'],
     deviceTypeId: 'af593f01-a123-4604-9139-19dfba10afc8',
     template: {
+      manufacturerUrl: 'https://telefunken-elektroakustik.com/tf11-fet',
       name: 'Telefunken TF11',
       category: 'Mikrofone',
       inputs: [],
@@ -1980,6 +2119,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['telefunken u47', 'tf u47'],
     deviceTypeId: '14e3ff1c-dccf-4516-80d6-a561c4cf1819',
     template: {
+      manufacturerUrl: 'https://telefunken-elektroakustik.com/u47',
       name: 'Telefunken U47',
       category: 'Mikrofone',
       inputs: [],
@@ -1994,6 +2134,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['ela m 251', 'm 251'],
     deviceTypeId: 'aa848cfe-a11e-4f9d-ac01-bea6d5ecbece',
     template: {
+      manufacturerUrl: 'https://telefunken-elektroakustik.com/ela-m-251e',
       name: 'Telefunken ELA M 251',
       category: 'Mikrofone',
       inputs: [],
@@ -2008,6 +2149,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['wa-47', 'wa47'],
     deviceTypeId: '3636d4de-acf4-412f-b69e-f14b2ef43548',
     template: {
+      manufacturerUrl: 'https://warmaudio.com/wa-47/',
       name: 'Warm Audio WA-47',
       category: 'Mikrofone',
       inputs: [],
@@ -2022,6 +2164,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['wa-87', 'wa87'],
     deviceTypeId: 'b70b235f-774f-46af-b78a-7762835146a4',
     template: {
+      manufacturerUrl: 'https://warmaudio.com/wa-87-r2/',
       name: 'Warm Audio WA-87 R2',
       category: 'Mikrofone',
       inputs: [],
@@ -2036,6 +2179,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['wa-251', 'wa251'],
     deviceTypeId: 'a6d15dbb-a14e-4460-8b06-cba545b6cb1e',
     template: {
+      manufacturerUrl: 'https://warmaudio.com/wa-251/',
       name: 'Warm Audio WA-251',
       category: 'Mikrofone',
       inputs: [],
@@ -2050,6 +2194,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['wa-14', 'wa14'],
     deviceTypeId: '3be3a2ba-60b1-469a-858a-46d3b0bc26c9',
     template: {
+      manufacturerUrl: 'https://warmaudio.com/wa-14/',
       name: 'Warm Audio WA-14',
       category: 'Mikrofone',
       inputs: [],
@@ -2064,6 +2209,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['aston origin'],
     deviceTypeId: 'f474ecb1-3b14-4bee-961a-2e9b6f676868',
     template: {
+      manufacturerUrl: 'https://www.astonmics.com/EN/product/origin',
       name: 'Aston Origin',
       category: 'Mikrofone',
       inputs: [],
@@ -2078,6 +2224,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['aston spirit'],
     deviceTypeId: 'fe3e5871-6f81-4da8-ae98-33adfeac8cc5',
     template: {
+      manufacturerUrl: 'https://www.astonmics.com/EN/product/spirit',
       name: 'Aston Spirit',
       category: 'Mikrofone',
       inputs: [],
@@ -2092,6 +2239,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['aston stealth'],
     deviceTypeId: '93ea5b00-41aa-47d5-8171-9bd8cd7db5a6',
     template: {
+      manufacturerUrl: 'https://www.astonmics.com/EN/product/stealth',
       name: 'Aston Stealth',
       category: 'Mikrofone',
       inputs: [],
@@ -2106,6 +2254,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['lct 440', 'lct440'],
     deviceTypeId: '4f569f1f-8e0b-4eac-8ee7-257da07b4466',
     template: {
+      manufacturerUrl: 'https://www.lewitt-audio.com/microphones/lct/lct-440-pure',
       name: 'Lewitt LCT 440 Pure',
       category: 'Mikrofone',
       inputs: [],
@@ -2120,6 +2269,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['lct 640', 'lct640'],
     deviceTypeId: 'b49aee16-3b09-47cf-abef-f8223324501a',
     template: {
+      manufacturerUrl: 'https://www.lewitt-audio.com/microphones/lct/lct-640-ts',
       name: 'Lewitt LCT 640 TS',
       category: 'Mikrofone',
       inputs: [],
@@ -2134,6 +2284,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['mtp 550', 'mtp550'],
     deviceTypeId: 'e3336d62-36ed-4036-91cc-65f2fc85ef1c',
     template: {
+      manufacturerUrl: 'https://www.lewitt-audio.com/microphones/mtp/mtp-550-dm',
       name: 'Lewitt MTP 550 DM',
       category: 'Mikrofone',
       inputs: [],
@@ -2148,6 +2299,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['dtp 640', 'dtp640'],
     deviceTypeId: '4a9d4440-08a3-407b-a17f-62fda43abedf',
     template: {
+      manufacturerUrl: 'https://www.lewitt-audio.com/microphones/dtp/dtp-640-rex',
       name: 'Lewitt DTP 640 REX',
       category: 'Mikrofone',
       inputs: [],
@@ -2162,6 +2314,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['sr40v'],
     deviceTypeId: '97dc95b7-4294-411a-bbdc-8547991ddf00',
     template: {
+      manufacturerUrl: 'https://earthworksaudio.com/vocal-microphones/sr40v/',
       name: 'Earthworks SR40V',
       category: 'Mikrofone',
       inputs: [],
@@ -2176,6 +2329,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['sr314'],
     deviceTypeId: '85f0a3a4-d32a-4900-8efc-1b5ef4b9ec03',
     template: {
+      manufacturerUrl: 'https://earthworksaudio.com/vocal-microphones/sr314/',
       name: 'Earthworks SR314',
       category: 'Mikrofone',
       inputs: [],
@@ -2190,6 +2344,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['dm20'],
     deviceTypeId: '5805ca72-0a78-462d-a9e8-d262eabd4e98',
     template: {
+      manufacturerUrl: 'https://earthworksaudio.com/drum-microphones/dm20/',
       name: 'Earthworks DM20',
       category: 'Mikrofone',
       inputs: [],
@@ -2204,6 +2359,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['qtc40'],
     deviceTypeId: 'b4944dfa-5665-4580-aa72-65fef8667b23',
     template: {
+      manufacturerUrl: 'https://earthworksaudio.com/measurement-microphones/qtc40/',
       name: 'Earthworks QTC40',
       category: 'Mikrofone',
       inputs: [],
@@ -2218,6 +2374,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['r-10', 'r10'],
     deviceTypeId: '29b8f4e5-71d7-4bc9-a036-ce30480398f8',
     template: {
+      manufacturerUrl: 'https://royerlabs.com/r-10/',
       name: 'Royer R-10',
       category: 'Mikrofone',
       inputs: [],
@@ -2232,6 +2389,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['r-122', 'r122'],
     deviceTypeId: 'c39d9441-4b53-4021-bbe2-285611da9b8f',
     template: {
+      manufacturerUrl: 'https://royerlabs.com/r-122-mkii/',
       name: 'Royer R-122 MKII',
       category: 'Mikrofone',
       inputs: [],
@@ -2246,6 +2404,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['sf-12', 'sf12'],
     deviceTypeId: '338ea49a-1005-4181-a1ec-ccbc54c6216d',
     template: {
+      manufacturerUrl: 'https://royerlabs.com/sf-12/',
       name: 'Royer SF-12',
       category: 'Mikrofone',
       inputs: [],
@@ -2260,6 +2419,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['r88'],
     deviceTypeId: 'f1739e26-cc58-4a7b-8790-3e5334ca55b4',
     template: {
+      manufacturerUrl: 'https://www.aearibbonmics.com/products/r88/',
       name: 'AEA R88',
       category: 'Mikrofone',
       inputs: [],
@@ -2274,6 +2434,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['ku5a', 'ku5'],
     deviceTypeId: '01b6ee94-b51a-474e-8a3f-c44ef98976dd',
     template: {
+      manufacturerUrl: 'https://www.aearibbonmics.com/products/ku5a/',
       name: 'AEA KU5A',
       category: 'Mikrofone',
       inputs: [],
@@ -2288,6 +2449,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['bluebird'],
     deviceTypeId: 'b9c3db76-ab94-4979-9769-7cd9d9539a15',
     template: {
+      manufacturerUrl: 'https://www.bluemic.com/en-us/products/bluebird-sl/',
       name: 'Blue Bluebird SL',
       category: 'Mikrofone',
       inputs: [],
@@ -2302,6 +2464,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['baby bottle'],
     deviceTypeId: '6fc15ee8-c282-46a3-b2c2-f91aaca06c4b',
     template: {
+      manufacturerUrl: 'https://www.bluemic.com/en-us/products/baby-bottle-sl/',
       name: 'Blue Baby Bottle SL',
       category: 'Mikrofone',
       inputs: [],
@@ -2316,6 +2479,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['md 21', 'md21'],
     deviceTypeId: 'f85ab718-da3e-497c-8ad8-db0f4526fd8f',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/microphones/md-21-u',
       name: 'Sennheiser MD 21',
       category: 'Mikrofone',
       inputs: [],
@@ -2330,6 +2494,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['tg d70', 'd70'],
     deviceTypeId: '59f69f19-a4a6-4203-a8e5-3982d13bd87e',
     template: {
+      manufacturerUrl: 'https://www.beyerdynamic.com/tg-d70.html',
       name: 'beyerdynamic TG D70',
       category: 'Mikrofone',
       inputs: [],
@@ -2344,6 +2509,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['stc-3x', 'stc3x'],
     deviceTypeId: '8ef0598f-54fc-4adb-b4d1-4856fb2f7e25',
     template: {
+      manufacturerUrl: 'https://www.sontronics.com/products/stc-3x',
       name: 'Sontronics STC-3X',
       category: 'Mikrofone',
       inputs: [],
@@ -2358,6 +2524,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['dm-1b', 'dm1b'],
     deviceTypeId: 'f3e16f75-e6c8-4e9a-b85f-7dedffff0519',
     template: {
+      manufacturerUrl: 'https://www.sontronics.com/products/dm-1b',
       name: 'Sontronics DM-1B',
       category: 'Mikrofone',
       inputs: [],
@@ -2372,6 +2539,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['om5'],
     deviceTypeId: '759b3ff1-b431-4d8e-a12c-4c5550805879',
     template: {
+      manufacturerUrl: 'https://audixusa.com/products/om5',
       name: 'Audix OM5',
       category: 'Mikrofone',
       inputs: [],
@@ -2386,6 +2554,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['om7'],
     deviceTypeId: '970153ef-ed5d-4cc3-8dd2-6ae1b1037729',
     template: {
+      manufacturerUrl: 'https://audixusa.com/products/om7',
       name: 'Audix OM7',
       category: 'Mikrofone',
       inputs: [],
@@ -2400,6 +2569,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['audix f5', 'audix', 'f5'],
     deviceTypeId: '57b8be38-e113-41fa-95c2-e09fdcbea4cf',
     template: {
+      manufacturerUrl: 'https://audixusa.com/products/f5',
       name: 'Audix f5',
       category: 'Mikrofone',
       inputs: [],
@@ -2414,6 +2584,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['adx51'],
     deviceTypeId: '1eb08000-7c89-4045-99ec-d283191cc28d',
     template: {
+      manufacturerUrl: 'https://audixusa.com/products/adx51',
       name: 'Audix ADX51',
       category: 'Mikrofone',
       inputs: [],
@@ -2428,6 +2599,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['scx25'],
     deviceTypeId: 'd4190e9c-2761-42cf-84ce-6eb7e2ecbf15',
     template: {
+      manufacturerUrl: 'https://audixusa.com/products/scx25a',
       name: 'Audix SCX25A',
       category: 'Mikrofone',
       inputs: [],
@@ -2442,6 +2614,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['pr 40', 'pr40'],
     deviceTypeId: '23bc1288-7c3a-42af-bc1e-65e9477dee3d',
     template: {
+      manufacturerUrl: 'https://heilsound.com/product/pr-40/',
       name: 'Heil PR 40',
       category: 'Mikrofone',
       inputs: [],
@@ -2456,6 +2629,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['pr 30', 'pr30'],
     deviceTypeId: 'c174e7b8-f4c4-4554-963f-49c736401ace',
     template: {
+      manufacturerUrl: 'https://heilsound.com/product/pr-30/',
       name: 'Heil PR 30',
       category: 'Mikrofone',
       inputs: [],
@@ -2470,6 +2644,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['pr 48', 'pr48'],
     deviceTypeId: '27c2f6fa-d8b4-4820-8057-526c55247216',
     template: {
+      manufacturerUrl: 'https://heilsound.com/product/pr-48/',
       name: 'Heil PR 48',
       category: 'Mikrofone',
       inputs: [],
@@ -2484,6 +2659,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['pm10'],
     deviceTypeId: '6c7c1710-8fe1-4754-8cf9-4c6b337ca668',
     template: {
+      manufacturerUrl: 'https://miktekaudio.com/product/pm10/',
       name: 'Miktek PM10',
       category: 'Mikrofone',
       inputs: [],
@@ -2498,6 +2674,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['oc818'],
     deviceTypeId: '9133d8c4-8daa-4a7b-a8e1-637a33fd9b71',
     template: {
+      manufacturerUrl: 'https://austrian.audio/product/oc818/',
       name: 'Austrian Audio OC818',
       category: 'Mikrofone',
       inputs: [],
@@ -2512,6 +2689,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['oc18'],
     deviceTypeId: '7efc36c2-d3da-41cb-b070-8d6b97df0e49',
     template: {
+      manufacturerUrl: 'https://austrian.audio/product/oc18/',
       name: 'Austrian Audio OC18',
       category: 'Mikrofone',
       inputs: [],
@@ -2526,6 +2704,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['od505'],
     deviceTypeId: '8a78f174-2a67-49f0-9e80-c1272a303d31',
     template: {
+      manufacturerUrl: 'https://austrian.audio/product/od505/',
       name: 'Austrian Audio OD505',
       category: 'Mikrofone',
       inputs: [],
@@ -2540,6 +2719,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['ml-1', 'ml1'],
     deviceTypeId: '38ab041d-e91c-4f91-bc0c-1f4c3ef10eef',
     template: {
+      manufacturerUrl: 'https://slatedigital.com/ml-1/',
       name: 'Slate ML-1',
       category: 'Mikrofone',
       inputs: [],
@@ -2554,6 +2734,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['ma-201', 'ma201'],
     deviceTypeId: 'a163371d-77ce-4dfc-b33c-7fd6f1be9eb8',
     template: {
+      manufacturerUrl: 'https://www.mojaveaudio.com/products/ma-201fet/',
       name: 'Mojave MA-201 fet',
       category: 'Mikrofone',
       inputs: [],
@@ -2568,6 +2749,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['ma-300', 'ma300'],
     deviceTypeId: '260ee646-9547-49b9-98b3-899b64a8cfa0',
     template: {
+      manufacturerUrl: 'https://www.mojaveaudio.com/products/ma-300/',
       name: 'Mojave MA-300',
       category: 'Mikrofone',
       inputs: [],
@@ -2582,6 +2764,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['bock 251'],
     deviceTypeId: 'c229d048-da5c-4367-9096-ecc616efffdd',
     template: {
+      manufacturerUrl: 'https://www.bockaudio.com/251.html',
       name: 'Bock Audio 251',
       category: 'Mikrofone',
       inputs: [],
@@ -2596,6 +2779,7 @@ export const MIC_CATALOG: MicEntry[] = [
     match: ['manley reference'],
     deviceTypeId: '128f860d-485e-43eb-81cc-618fa5f24fb2',
     template: {
+      manufacturerUrl: 'https://www.manley.com/microphones/mrefc',
       name: 'Manley Reference Cardioid',
       category: 'Mikrofone',
       inputs: [],

--- a/src/renderer/lib/rossCatalog.ts
+++ b/src/renderer/lib/rossCatalog.ts
@@ -43,6 +43,7 @@ export const ROSS_CATALOG: RossEntry[] = [
     match: ['carbonite', 'ultra', '60'],
     deviceTypeId: '279f9af4-2f91-469e-87a3-3911f321f45a',
     template: {
+      manufacturerUrl: 'https://www.rossvideo.com/live-production/production-switchers/carbonite-ultra-60/',
       name: 'Ross Video Carbonite Ultra 60',
       category: 'Video Mixer',
       inputs: [
@@ -63,6 +64,7 @@ export const ROSS_CATALOG: RossEntry[] = [
     match: ['carbonite', 'black', 'plus'],
     deviceTypeId: '0ad93ca1-31b3-455f-ba6c-8d3872a5e344',
     template: {
+      manufacturerUrl: 'https://www.rossvideo.com/products/production-switchers/carbonite-black/carbonite-black-specifications/',
       name: 'Ross Video Carbonite Black Plus 2 M/E',
       category: 'Video Mixer',
       inputs: [
@@ -83,6 +85,7 @@ export const ROSS_CATALOG: RossEntry[] = [
     match: ['carbonite', 'ultra'],
     deviceTypeId: 'e0366446-6a23-472a-ad8d-92f3b6bf4db7',
     template: {
+      manufacturerUrl: 'https://www.rossvideo.com/live-production/production-switchers/carbonite-ultra/specifications/',
       name: 'Ross Video Carbonite Ultra',
       category: 'Video Mixer',
       inputs: [
@@ -103,6 +106,7 @@ export const ROSS_CATALOG: RossEntry[] = [
     match: ['ross', 'graphite'],
     deviceTypeId: '5c62f236-ef20-423f-b27f-a803148be416',
     template: {
+      manufacturerUrl: 'https://www.rossvideo.com/products/production-switchers/graphite/graphite-specifications/',
       name: 'Ross Video Graphite',
       category: 'Video Mixer',
       inputs: [
@@ -125,6 +129,7 @@ export const ROSS_CATALOG: RossEntry[] = [
     match: ['ultrix', 'fr1'],
     deviceTypeId: '37276fa0-ee91-4334-98e7-b9a34e97b005',
     template: {
+      manufacturerUrl: 'https://www.rossvideo.com/products/routing-systems/ultrix/ultrix-specifications/',
       name: 'Ross Video Ultrix FR1',
       category: 'Video Router',
       inputs: [
@@ -145,6 +150,7 @@ export const ROSS_CATALOG: RossEntry[] = [
     match: ['ultrix', 'fr2'],
     deviceTypeId: '0035f21b-bc95-40a6-bcf2-6f93cb9fb33b',
     template: {
+      manufacturerUrl: 'https://www.rossvideo.com/products/routing-systems/ultrix/ultrix-specifications/',
       name: 'Ross Video Ultrix FR2',
       category: 'Video Router',
       inputs: [
@@ -165,6 +171,7 @@ export const ROSS_CATALOG: RossEntry[] = [
     match: ['ultrix', 'fr5'],
     deviceTypeId: 'aa1dd919-e9ed-4170-a8cb-a6ac7c1bf975',
     template: {
+      manufacturerUrl: 'https://www.rossvideo.com/products/routing-systems/ultrix/ultrix-specifications/',
       name: 'Ross Video Ultrix FR5',
       category: 'Video Router',
       inputs: [
@@ -185,6 +192,7 @@ export const ROSS_CATALOG: RossEntry[] = [
     match: ['ross', 'nk-3g72'],
     deviceTypeId: '9f3f125f-823b-48c1-9e4e-8960a0cc6c49',
     template: {
+      manufacturerUrl: 'https://www.rossvideo.com/infrastructure/routing-systems/nk-3g72/',
       name: 'Ross Video NK-3G72',
       category: 'Video Router',
       inputs: [
@@ -205,6 +213,7 @@ export const ROSS_CATALOG: RossEntry[] = [
     match: ['ross', 'nk-3g16'],
     deviceTypeId: '2e14ed1e-284b-4b5d-bc76-caa07a433d8c',
     template: {
+      manufacturerUrl: 'https://www.rossvideo.com/infrastructure/routing-systems/nk-3g-series/',
       name: 'Ross Video NK-3G16',
       category: 'Video Router',
       inputs: [

--- a/src/renderer/lib/switcherCatalog.ts
+++ b/src/renderer/lib/switcherCatalog.ts
@@ -41,6 +41,7 @@ export const SWITCHER_CATALOG: SwitcherEntry[] = [
     match: ['panasonic', 'av-uhs500'],
     deviceTypeId: 'd3671648-297a-4785-a48f-9ecdcab0f934',
     template: {
+      manufacturerUrl: 'https://pro-av.panasonic.net/en/products/av-uhs500/spec.html',
       name: 'Panasonic AV-UHS500',
       category: 'Video Mixer',
       inputs: [
@@ -63,6 +64,7 @@ export const SWITCHER_CATALOG: SwitcherEntry[] = [
     match: ['for-a', 'hvs-490'],
     deviceTypeId: 'ce02f5e9-95c8-4910-a616-6147a312998b',
     template: {
+      manufacturerUrl: 'https://www.for-a.com/products/hvs490/',
       name: 'For-A HVS-490',
       category: 'Video Mixer',
       inputs: [
@@ -84,6 +86,7 @@ export const SWITCHER_CATALOG: SwitcherEntry[] = [
     match: ['roland', 'v-8hd'],
     deviceTypeId: '7079510f-190f-4fe2-9efb-bf7bcef97244',
     template: {
+      manufacturerUrl: 'https://proav.roland.com/global/products/v-8hd/',
       name: 'Roland V-8HD',
       category: 'Video Mixer',
       inputs: [
@@ -105,6 +108,7 @@ export const SWITCHER_CATALOG: SwitcherEntry[] = [
     match: ['roland', 'v-60hd'],
     deviceTypeId: 'f2786473-7eea-44e7-97a8-cbe63c6d8cc4',
     template: {
+      manufacturerUrl: 'https://proav.roland.com/global/products/v-60hd/',
       name: 'Roland V-60HD',
       category: 'Video Mixer',
       inputs: [
@@ -130,6 +134,7 @@ export const SWITCHER_CATALOG: SwitcherEntry[] = [
     match: ['roland', 'v-160hd'],
     deviceTypeId: '2983ce7e-e004-49c5-8411-709546aea466',
     template: {
+      manufacturerUrl: 'https://proav.roland.com/global/products/v-160hd/',
       name: 'Roland V-160HD',
       category: 'Video Mixer',
       inputs: [
@@ -157,6 +162,7 @@ export const SWITCHER_CATALOG: SwitcherEntry[] = [
     match: ['sony', 'mcx-500'],
     deviceTypeId: 'ee3a295e-5ef1-44e1-96c3-5866ea062431',
     template: {
+      manufacturerUrl: 'https://pro.sony/ue_US/products/video-switchers/mcx-500',
       name: 'Sony MCX-500',
       category: 'Video Mixer',
       inputs: [
@@ -180,6 +186,7 @@ export const SWITCHER_CATALOG: SwitcherEntry[] = [
     match: ['tricaster', 'elite'],
     deviceTypeId: '3cc4a0b1-735f-46b8-b08b-7a2692c89135',
     template: {
+      manufacturerUrl: 'https://www.vizrt.com/products/tricaster/',
       name: 'Vizrt (NewTek) TriCaster 2 Elite',
       category: 'Video Mixer',
       inputs: [
@@ -199,6 +206,7 @@ export const SWITCHER_CATALOG: SwitcherEntry[] = [
     match: ['barco', 'e2'],
     deviceTypeId: '3c49815f-6ce9-4792-8818-a1e70d2c3f97',
     template: {
+      manufacturerUrl: 'https://assets.barco.com/m/1da1a218bfbbede6/original/E2-Gen-2-en-Spec-sheet.pdf',
       name: 'Barco E2 Gen 2',
       category: 'Video Mixer',
       inputs: [

--- a/src/renderer/lib/wirelessAudioCatalog.ts
+++ b/src/renderer/lib/wirelessAudioCatalog.ts
@@ -41,6 +41,7 @@ export const WIRELESS_AUDIO_CATALOG: WirelessAudioEntry[] = [
     match: ['iem', 'g4'],
     deviceTypeId: '17582c72-e61e-41c4-8264-53254efee398',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/wireless-systems/ew-iem-g4',
       name: 'Sennheiser EW IEM G4 (SR)',
       category: 'Funkstrecke',
       inputs: [
@@ -60,6 +61,7 @@ export const WIRELESS_AUDIO_CATALOG: WirelessAudioEntry[] = [
     match: ['g4', '500'],
     deviceTypeId: '6d10c291-7122-456b-9e36-ad19e4e30581',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/wireless-systems/ew-500-g4',
       name: 'Sennheiser EW 500 G4 (EM 300-500)',
       category: 'Funkstrecke',
       inputs: [
@@ -81,6 +83,7 @@ export const WIRELESS_AUDIO_CATALOG: WirelessAudioEntry[] = [
     match: ['ew-dx', 'em 2'],
     deviceTypeId: '2c20ec58-4eec-4e6f-98a6-017379da8fda',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/wireless-systems/ew-dx-em-2-dante',
       name: 'Sennheiser EW-DX EM 2 Dante',
       category: 'Funkstrecke',
       inputs: [
@@ -103,6 +106,7 @@ export const WIRELESS_AUDIO_CATALOG: WirelessAudioEntry[] = [
     match: ['em 6000'],
     deviceTypeId: '989c3a28-d8af-4d0a-8ed6-c6093d7d2dc0',
     template: {
+      manufacturerUrl: 'https://www.sennheiser.com/en-us/catalog/products/wireless-systems/digital-6000',
       name: 'Sennheiser Digital 6000 (EM 6000)',
       category: 'Funkstrecke',
       inputs: [
@@ -124,6 +128,7 @@ export const WIRELESS_AUDIO_CATALOG: WirelessAudioEntry[] = [
     match: ['qlxd4'],
     deviceTypeId: 'c5f97ce0-2bb5-4da3-b210-d7ed00e42b5f',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/products/wireless-systems/qlx-d_digital_wireless',
       name: 'Shure QLXD4',
       category: 'Funkstrecke',
       inputs: [
@@ -145,6 +150,7 @@ export const WIRELESS_AUDIO_CATALOG: WirelessAudioEntry[] = [
     match: ['ulxd4q'],
     deviceTypeId: 'fc7e6880-2377-4015-8855-f69c9bfbb9a8',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/products/wireless-systems/ulx-d_digital_wireless/ulxd4q',
       name: 'Shure ULXD4Q',
       category: 'Funkstrecke',
       inputs: [
@@ -166,6 +172,7 @@ export const WIRELESS_AUDIO_CATALOG: WirelessAudioEntry[] = [
     match: ['p10t'],
     deviceTypeId: '5504f8e6-dd18-46e9-8c00-f6283c34d2cd',
     template: {
+      manufacturerUrl: 'https://www.shure.com/en-US/products/in-ear-monitoring/psm1000/p10t',
       name: 'Shure PSM 1000 (P10T)',
       category: 'Funkstrecke',
       inputs: [

--- a/tests/catalogSourceUrls.test.ts
+++ b/tests/catalogSourceUrls.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+// ---------------------------------------------------------------------------
+// Initiative 11, Schritt 2 — den Beleg aus dem Kommentar in ein Feld heben.
+//
+// DER BEFUND AUS DEM SCOPING. Neun der siebzehn Kataloge tragen einen
+// Datenblatt-Link je Eintrag — als `// Quelle: <url>`-Kommentar. Der Text
+// dazu: „an earlier reading of this ground reported that provenance was
+// absent and would have to be gathered. That understated it. The evidence is
+// largely *there*. What is missing is its shape."
+//
+// WAS DIE MESSUNG DARAN GEAENDERT HAT. Auch das war noch zu duester: nicht
+// nur der Beleg ist da, die FORM ist es auch. `EquipmentItem.manufacturerUrl`
+// existiert seit langem, ist in `modelFields` als Modell-Eigenschaft gefuehrt,
+// wird in der Eigenschaften-Leiste als „Hersteller-Link … Oeffnen" gerendert
+// und von `exportDevicePdf` als klickbare Zeile gedruckt.
+//
+// Es fehlte also weder der Beleg noch das Feld — es fehlte, dass die Kataloge
+// das Feld FUELLEN. 253 Datenblatt-Links lagen in Kommentaren, wo kein Code
+// sie erreicht, waehrend das Feld, das sie angezeigt haette, leer blieb. Der
+// Kopf von `micCatalog.ts` sagt sogar „Quellen-URL je Eintrag" — die Absicht
+// stand da, nur nicht als Datum.
+//
+// Ein zusaetzliches `provenance`-Feld daneben zu bauen waere ein zweiter Ort
+// fuer dieselbe Wahrheit gewesen. Zwei Orte laufen auseinander — das hat der
+// Zugangsdaten-Rundgang in diesem Repo schon einmal vorgefuehrt.
+//
+// WAS DER NUTZER DAVON HAT, und das ist der Punkt, nicht die Registry: wer an
+// einer Port-Zahl zweifelt, kommt mit einem Klick auf das Datenblatt, statt
+// auf nichts. Das Feld war schon verdrahtet; es war nur nie befuellt.
+// ---------------------------------------------------------------------------
+
+const LIB = resolve(__dirname, '..', 'src', 'renderer', 'lib')
+
+const catalogs = (): string[] =>
+  readdirSync(LIB).filter((f) => /Catalog\.ts$/.test(f))
+
+/** `// Quelle: <url>` — die Zeile, die den Beleg bisher allein trug. */
+const QUELLE = /^\s*\/\/\s*Quelle:\s*(\S+)\s*$/
+const TEMPLATE_OPEN = /^\s*template:\s*\{\s*$/
+const MANUFACTURER = /^\s*manufacturerUrl:\s*'([^']+)',?\s*$/
+
+interface Pair {
+  file: string
+  line: number
+  comment: string
+  field: string | null
+}
+
+/**
+ * Jede Quelle-Angabe mit dem `manufacturerUrl` des Eintrags, zu dem sie
+ * gehoert. „Gehoert zu" heisst: das naechste `template: {` nach dem
+ * Kommentar — dieselbe Zuordnung, mit der die Uebernahme gemacht wurde.
+ */
+const pairs = (): Pair[] => {
+  const out: Pair[] = []
+  for (const file of catalogs()) {
+    const lines = readFileSync(join(LIB, file), 'utf8').split('\n')
+    for (let i = 0; i < lines.length; i += 1) {
+      const m = QUELLE.exec(lines[i])
+      if (!m) continue
+      let field: string | null = null
+      for (let j = i + 1; j < Math.min(i + 12, lines.length); j += 1) {
+        if (!TEMPLATE_OPEN.test(lines[j])) continue
+        const f = MANUFACTURER.exec(lines[j + 1] ?? '')
+        field = f ? f[1] : null
+        break
+      }
+      out.push({ file, line: i + 1, comment: m[1], field })
+    }
+  }
+  return out
+}
+
+describe('jeder Quellen-Kommentar steht auch als Feld im Eintrag', () => {
+  it('traegt den Beleg an allen Stellen, die einen haben', () => {
+    // Der Guard gegen das Auseinanderlaufen: wer die URL im Kommentar
+    // aendert und das Feld vergisst (oder umgekehrt), kommt hier vorbei.
+    // Genau diese Sorte Drift hat den Kommentar 253-mal zur einzigen
+    // Fundstelle gemacht.
+    const abweichend = pairs().filter((p) => p.field !== p.comment)
+    expect(
+      abweichend.map((p) => `${p.file}:${p.line} ${p.comment} != ${p.field}`),
+    ).toEqual([])
+  })
+
+  it('findet ueberhaupt welche — sonst prueft der Test nichts', () => {
+    // Ohne diese Zusicherung waere der Test auch dann gruen, wenn das
+    // Muster nicht mehr passt und `pairs()` leer zurueckkommt.
+    expect(pairs().length).toBe(253)
+  })
+
+  it('deckt die neun Kataloge ab, die Belege fuehren', () => {
+    const files = new Set(pairs().map((p) => p.file))
+    expect([...files].sort()).toEqual([
+      'ajaCatalog.ts',
+      'audioCatalog.ts',
+      'avNetworkCatalog.ts',
+      'broadcastToolsCatalog.ts',
+      'lynxCatalog.ts',
+      'micCatalog.ts',
+      'rossCatalog.ts',
+      'switcherCatalog.ts',
+      'wirelessAudioCatalog.ts',
+    ])
+  })
+})
+
+describe('was der Test NICHT behauptet', () => {
+  it('sagt, wie viele Kataloge weiterhin ohne Beleg dastehen', () => {
+    // ADR-005 Regel 3 — melden, wo es passiert. Acht Kataloge fuehren keine
+    // Quellen je Eintrag; das ist Schritt 3 der Initiative und echte
+    // Recherche, nicht Mechanik. Diese Zahl hier festzuhalten heisst: die
+    // Luecke ist bekannt und benannt, nicht uebersehen. Wer einen der acht
+    // mit Quellen versieht, laesst diesen Test fallen und traegt ihn oben
+    // in die Liste ein.
+    const mitBeleg = new Set(pairs().map((p) => p.file))
+    const ohne = catalogs().filter((f) => !mitBeleg.has(f))
+    expect(ohne.sort()).toEqual([
+      'blackmagicCatalog.ts',
+      'cameraCatalog.ts',
+      'connectorCatalog.ts',
+      'greengoCatalog.ts',
+      'miscCatalog.ts',
+      'monitorCatalog.ts',
+      'ubiquitiCatalog.ts',
+      'wirelessCatalog.ts',
+    ])
+  })
+})

--- a/tests/catalogSourceUrls.test.ts
+++ b/tests/catalogSourceUrls.test.ts
@@ -108,6 +108,37 @@ describe('jeder Quellen-Kommentar steht auch als Feld im Eintrag', () => {
   })
 })
 
+describe('der Beleg kommt wirklich beim Geraet an', () => {
+  it('loest ueber die Geraetetyp-ID auf den Datenblatt-Link auf', async () => {
+    // Der Punkt der ganzen Uebernahme. Ohne diese Pruefung waere der Beleg
+    // nur aus einem unerreichbaren Kommentar in ein unerreichbares Feld
+    // gewandert: `OptionalFieldsSection` rendert `equipment.manufacturerUrl`,
+    // und ein Geraet, das bloss einen Katalog-Typ REFERENZIERT, hat dort
+    // nichts stehen. Gemessen, nicht angenommen — der DeviceTypePicker setzt
+    // nur `deviceTypeId` und kopiert keine Template-Felder.
+    const { resolveDeviceType } = await import('../src/renderer/lib/deviceTypeRegistry')
+    const { MIC_CATALOG } = await import('../src/renderer/lib/micCatalog')
+    const sm57 = MIC_CATALOG.find((e) => e.template.name === 'Shure SM57')
+    expect(sm57).toBeDefined()
+    const resolved = resolveDeviceType(sm57!.deviceTypeId)
+    expect(resolved?.template.manufacturerUrl).toBe(
+      'https://www.shure.com/en-US/microphones/sm57',
+    )
+  })
+
+  it('zeigt den geerbten Link in der Eigenschaften-Leiste an', async () => {
+    // Die zweite Haelfte: die Aufloesung nuetzt nichts, wenn sie niemand
+    // anzeigt. Der Quelltext-Guard haelt fest, dass die Leiste auf den
+    // Katalog-Typ zurueckfaellt — und dass ein eigener Eintrag am Geraet
+    // weiter gewinnt, denn der ist die bewusste Ausnahme.
+    const src = (
+      await import('../src/renderer/components/Properties/sections/OptionalFieldsSection.tsx?raw')
+    ).default
+    expect(src).toContain('resolveDeviceType(equipment.deviceTypeId)')
+    expect(src).toContain('!equipment.manufacturerUrl && inheritedUrl')
+  })
+})
+
 describe('was der Test NICHT behauptet', () => {
   it('sagt, wie viele Kataloge weiterhin ohne Beleg dastehen', () => {
     // ADR-005 Regel 3 — melden, wo es passiert. Acht Kataloge fuehren keine


### PR DESCRIPTION
Initiative 11, **Schritt 2** — der erste Schritt, seit beide Blocker der Initiative weg sind
(Design-Frage 3 entschieden und gebaut, `sony-camera-bridge` erreichbar).

Neun der siebzehn Kataloge tragen den Datenblatt-Link je Eintrag als `// Quelle: <url>` —
**253 Stück, in Kommentaren, wo kein Code sie erreicht**.

## Was die Messung am Zuschnitt geändert hat

`INITIATIVE-11-SCOPING.md` sagte, der Beleg sei bereits da und es fehle *„seine Form"*:

> *„an earlier reading of this ground reported that provenance was absent and would have to be
> gathered. That understated it. The evidence is largely *there*. What is missing is its shape."*

Auch das war noch zu düster. **Die Form ist ebenfalls da.** `EquipmentItem.manufacturerUrl`
existiert seit langem — in `modelFields.ts` als **Modell-Eigenschaft** geführt, in
`OptionalFieldsSection` als *„Hersteller-Link … Öffnen ↗"* gerendert, von `exportDevicePdf`
als klickbare Zeile gedruckt.

Es fehlte weder der Beleg noch das Feld — es fehlte, dass die Kataloge das Feld **füllen**.
`micCatalog.ts` schreibt im Kopf sogar *„Quellen-URL je Eintrag"*: die Absicht stand da, nur
nicht als Datum. Ein zusätzliches `provenance`-Feld daneben wäre ein **zweiter Ort für dieselbe
Wahrheit** gewesen; zwei Orte laufen auseinander.

## Die Hälfte, die beim Nachprüfen der eigenen Zusage auffiel

Der erste Commit füllte das Feld — und der Nutzer hätte davon **nichts gesehen**.
`OptionalFieldsSection` rendert `equipment.manufacturerUrl`, und ein Gerät, das bloß einen
Katalog-Typ **referenziert**, hat dort nichts stehen: der `DeviceTypePicker` setzt nur
`deviceTypeId` und kopiert keine Template-Felder. Nur `replaceEquipmentWithTemplate` trug den
Link mit. Die 253 Belege wären damit **aus einem unerreichbaren Kommentar in ein ebenso
unerreichbares Feld** gewandert.

`manufacturerUrl` ist eine Modell-Eigenschaft, also **erbt** ein Gerät sie von seinem
Katalog-Typ. Die Eigenschaften-Leiste zeigt den geerbten Link jetzt mit genannter Herkunft
(*„Aus Katalog-Typ X"*). Das eigene Feld gewinnt, wenn es gesetzt ist — es ist die bewusst
eingetragene Ausnahme. Das ist dieselbe Frage wie Initiative 10, eine Ebene höher: **woher
kommt dieser Wert?**

## Was der Nutzer davon hat

Nicht die Registry — der **Klick**. Wer an einer Port-Zahl oder einer Speisungsangabe zweifelt,
kommt aufs Datenblatt statt auf nichts.

## Verteilung

| Katalog | Belege |
| --- | --- |
| `micCatalog` | 184 |
| `audioCatalog` | 15 |
| `ajaCatalog`, `rossCatalog` | je 9 |
| `avNetworkCatalog`, `switcherCatalog` | je 8 |
| `lynxCatalog`, `wirelessAudioCatalog` | je 7 |
| `broadcastToolsCatalog` | 6 |

## Prüfung

* `tests/catalogSourceUrls.test.ts` (6). Der Parity-Guard hält Kommentar und Feld zusammen:
  wer die URL an einer Stelle ändert und die andere vergisst, kommt dort vorbei — genau diese
  Drift hat den Kommentar 253-mal zur einzigen Fundstelle gemacht.
* Zwei Tests für den Weg zum Nutzer: die Auflösung über die Typ-ID liefert den Link, und die
  Leiste fällt wirklich darauf zurück.
* Der Test **nennt außerdem die acht Kataloge, die weiter ohne Beleg dastehen** — ADR-005
  Regel 3, melden wo es passiert. Das ist Schritt 3 und echte Recherche, keine Mechanik.
* Eine Zusicherung auf `pairs().length === 253`, damit der Test nicht grün ist, weil das Muster
  nicht mehr passt und nichts mehr findet.
* **760 Tests grün**, `tsc --noEmit` 0 Errors, Lint 0 Errors.
* **Gegengeprüft:** eine geänderte URL im Feld bei unverändertem Kommentar lässt den Test mit
  Datei, Zeile und beiden Werten fallen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT