### PR TITLE
ports: ein AI-Vorschlag brachte die Datenblatt-Prüfung zum Schweigen

### DIFF
--- a/src/renderer/components/Properties/sections/PortAiSuggestButton.tsx
+++ b/src/renderer/components/Properties/sections/PortAiSuggestButton.tsx
@@ -53,7 +53,23 @@ export const PortAiSuggestButton = ({
       mode === 'replace' ? synthesized.inputs : [...equipment.inputs, ...synthesized.inputs]
     const newOutputs =
       mode === 'replace' ? synthesized.outputs : [...equipment.outputs, ...synthesized.outputs]
-    updateEquipment(equipment.id, { inputs: newInputs, outputs: newOutputs })
+    // Festhalten, dass diese Ports GERATEN sind — aus dem Geraetenamen, von
+    // einem Modell. Ohne diese Zeile standen sie ununterscheidbar neben von
+    // Hand eingetragenen, und Pruefung 18 („reale Anschluesse aus dem
+    // Datenblatt ergaenzen") verstummte, weil ueberhaupt Ports da waren.
+    // Genau die Pruefung, die einen Menschen zu belegten Daten zwingen soll.
+    const beleg = {
+      value: `${newInputs.length} In / ${newOutputs.length} Out`,
+      source: t(
+        'props.aiPorts.source',
+        'AI-Vorschlag aus dem Gerätenamen — nicht aus einem Datenblatt',
+      ),
+    }
+    updateEquipment(equipment.id, {
+      inputs: newInputs,
+      outputs: newOutputs,
+      specSource: { ...(equipment.specSource ?? {}), inputs: beleg, outputs: beleg },
+    })
     setHints(null)
     setError(null)
   }

--- a/src/renderer/components/Properties/sections/PortsSection.tsx
+++ b/src/renderer/components/Properties/sections/PortsSection.tsx
@@ -26,9 +26,24 @@ export const PortsSection = ({ equipment }: { equipment: EquipmentItem }) => {
     const inputs = patch.inputs ?? equipment.inputs
     const outputs = patch.outputs ?? equipment.outputs
     const clearMarker = equipment.portsUnknown && (inputs.length > 0 || outputs.length > 0)
+    // Fasst ein Mensch die Ports an, ist der AI-Beleg ueberholt: die Zahl
+    // daneben stammt jetzt von ihm, nicht mehr aus dem Vorschlag. Ihn stehen
+    // zu lassen hiesse, die Warnung „Ports geraten" gegen jemanden zu
+    // erheben, der sie gerade geprueft hat — und der Beleg wuerde einen Wert
+    // behaupten, den er nicht mehr stuetzt.
+    const stale = equipment.specSource?.inputs || equipment.specSource?.outputs
+    const clearedSource = stale
+      ? (() => {
+          const rest = { ...(equipment.specSource ?? {}) }
+          delete rest.inputs
+          delete rest.outputs
+          return Object.keys(rest).length > 0 ? rest : undefined
+        })()
+      : undefined
     updateEquipment(equipment.id, {
       ...patch,
       ...(clearMarker ? { portsUnknown: undefined } : {}),
+      ...(stale ? { specSource: clearedSource } : {}),
     })
   }
 

--- a/src/renderer/lib/drawingChecks.ts
+++ b/src/renderer/lib/drawingChecks.ts
@@ -574,6 +574,20 @@ export const runDrawingChecks = (
         equipmentId: e.id,
       })
     }
+    // Zweiter Fall, und der stillere: Ports SIND da, aber geraten. Der
+    // AI-Vorschlag leitet sie aus dem Gerätenamen ab. Vorher brachte das die
+    // Warnung oben zum Schweigen — die Prüfung, die zu belegten Daten zwingen
+    // soll, wurde von einer Vermutung beantwortet. Ports tragen die ganze
+    // Verkabelung: ein erfundener Port ist ein Kabel, das es nicht gibt.
+    else if (e.specSource?.inputs || e.specSource?.outputs) {
+      findings.push({
+        id: `ports-guessed:${e.id}`,
+        severity: 'warning',
+        category: 'Ports geraten',
+        message: `${e.name}: Ports stammen aus einem AI-Vorschlag, nicht aus einem Datenblatt — gegen die realen Anschlüsse prüfen`,
+        equipmentId: e.id,
+      })
+    }
   }
 
   // — Check 17: Gateway nicht im Geräte-Subnetz (#346) -----------------------

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -4244,6 +4244,7 @@ export const de: Dict = {
   "atem.audio.loadedMatrix": "Matrix: {outputs} outputs × {sources} sources",
   "atem.audio.loadedTitle": "Audio config read from ATEM",
   "atem.audio.noAudio": "No Audio",
+  "props.aiPorts.source": "AI suggestion from the device name — not from a datasheet",
   "eq.field.manufacturerUrlInherited": "From catalog type {name}:",
   "atem.audio.live.title": "Read from the switcher",
   "atem.audio.live.differs": "{n} differences from the plan",

--- a/src/renderer/lib/modelFields.ts
+++ b/src/renderer/lib/modelFields.ts
@@ -45,6 +45,10 @@ export const MODEL_FIELDS = [
   'libraryRef',
   'netboxPath',
   'manufacturerUrl',
+  // Der Beleg gehoert zum TYP: er sagt, woher die Angaben dieses Modells
+  // stammen (Datenblatt, Katalog, oder — der Fall, der ihn noetig machte —
+  // ein Modell, das aus dem Geraetenamen geraten hat).
+  'specSource',
 
   // Bestueckung
   'inputs',

--- a/src/renderer/lib/planDiff.ts
+++ b/src/renderer/lib/planDiff.ts
@@ -275,6 +275,10 @@ export const EQUIPMENT_FIELD_CLASS: Record<string, FieldClass> = {
   rentmanId: 'bookkeeping',
   rentmanRemoved: 'bookkeeping',
   manufacturerUrl: 'bookkeeping',
+  // Die Klasse nennt „Provenienz-Marker" ausdruecklich; `verifiedBy` steht
+  // schon hier. Ein Beleg aendert nicht die physische Arbeit, ist aber auch
+  // nicht bloss Optik: er sagt, worauf die Zahl daneben sich stuetzt.
+  specSource: 'bookkeeping',
   libraryRef: 'bookkeeping',
   rackInternalSnapshot: 'bookkeeping',
   verifiedBy: 'bookkeeping',

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -507,6 +507,29 @@ export interface EquipmentItem {
   imageUrl?: string
   /** Optional manufacturer / product page URL (issue #38). */
   manufacturerUrl?: string
+  /**
+   * Woher einzelne Angaben stammen — Feldname -> Beleg.
+   *
+   * DER BEFUND, DER DAS FELD NOETIG MACHT. `PortAiSuggestButton` laesst ein
+   * Modell aus dem GERAETENAMEN Ports erraten und schrieb sie ununterscheidbar
+   * neben von Hand eingetragene. Das ist genau das, was `portsUnknown`
+   * verhindern soll — dessen Begruendung in `DECLARED_PROVENANCE` lautet:
+   * „Die Ports sind leer, weil keine erfunden wurden."
+   *
+   * Der Schaden ist konkret: Pruefung 18 in `drawingChecks` warnt, solange ein
+   * Geraet ohne Datenblatt-Treffer keine Ports hat („reale Anschluesse aus dem
+   * Datenblatt ergaenzen"). Ein Klick auf den AI-Vorschlag fuellte Ports ein
+   * und brachte die Warnung damit zum Schweigen — die Pruefung, die einen
+   * Menschen zu belegten Daten zwingen soll, wurde von einer Vermutung
+   * beantwortet. Ports tragen die ganze Verkabelung: ein erfundener Port ist
+   * ein Kabel, das es nicht gibt.
+   *
+   * GLEICHE FORM WIE IN DEN ANDEREN PLANERN. `Fixture.specSource`
+   * (light-planner) und `Camera.specSource` (multicam-planner) fuehren
+   * dasselbe Feld. Eine Idee, ein Vokabular — der Suite-Guard
+   * `scripts/spec-source-vocabulary.mjs` haelt die Kopien zusammen.
+   */
+  specSource?: Record<string, { value: string; source: string }>
   /** Issue #39: physical serial number, surfaces in location/frame BOM exports. */
   serialNumber?: string
   /**

--- a/tests/portsGuessed.test.ts
+++ b/tests/portsGuessed.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import { runDrawingChecks } from '../src/renderer/lib/drawingChecks'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+import aiButtonSrc from '../src/renderer/components/Properties/sections/PortAiSuggestButton.tsx?raw'
+import portsSectionSrc from '../src/renderer/components/Properties/sections/PortsSection.tsx?raw'
+
+// ---------------------------------------------------------------------------
+// Initiative 10 im cable-planner — die Stelle, die ich beim ersten Durchgang
+// uebersehen habe.
+//
+// DER BEFUND. `#647` und `#648` haben die drei Stellen geheilt, an denen ein
+// GERAETE-BEFUND still zur Absicht wurde. Beim Neu-Ableiten fiel auf, dass es
+// eine vierte Sorte gibt, nach der niemand gesucht hatte: eine Angabe, die
+// weder abgelesen noch geplant, sondern GERATEN ist.
+//
+// `PortAiSuggestButton` laesst ein Modell aus dem GERAETENAMEN Ports ableiten
+// und schrieb sie ununterscheidbar neben von Hand eingetragene. Das ist genau
+// das, was `portsUnknown` verhindern soll — dessen Begruendung in
+// `DECLARED_PROVENANCE` lautet woertlich: „Die Ports sind leer, weil keine
+// erfunden wurden — nicht, weil das Geraet keine haette."
+//
+// DER SCHADEN IST KONKRET UND WAR STILL. Pruefung 18 warnt, solange ein
+// Geraet ohne Datenblatt-Treffer keine Ports hat. Ihre Bedingung ist
+// `portsUnknown && inputs.length === 0 && outputs.length === 0`. Ein Klick auf
+// den AI-Vorschlag fuellte Ports ein — und brachte damit die Pruefung zum
+// Schweigen, die einen Menschen zu belegten Daten zwingen soll. Ports tragen
+// die ganze Verkabelung: ein erfundener Port ist ein Kabel, das es nicht gibt.
+// ---------------------------------------------------------------------------
+
+const geraet = (over: Partial<EquipmentItem> = {}): EquipmentItem =>
+  ({
+    id: 'e1',
+    name: 'Irgendein Mischer',
+    category: 'Video',
+    x: 0,
+    y: 0,
+    inputs: [],
+    outputs: [],
+    ...over,
+  }) as EquipmentItem
+
+const port = (id: string) => ({ id, name: id, type: 'BNC', connectorType: 'BNC' })
+
+const befunde = (items: EquipmentItem[]): string[] =>
+  runDrawingChecks({ equipment: items, cables: [] } as never).findings.map((f) => f.id)
+
+describe('Pruefung 18 verstummt nicht mehr durch eine Vermutung', () => {
+  it('warnt weiter, solange ein Geraet ohne Datenblatt keine Ports hat', () => {
+    expect(befunde([geraet({ portsUnknown: true })])).toContain('ports-unknown:e1')
+  })
+
+  it('warnt ANDERS, wenn die Ports aus dem AI-Vorschlag stammen', () => {
+    // Der eigentliche Fehler: vorher war dieser Fall komplett still.
+    const ids = befunde([
+      geraet({
+        inputs: [port('i1')],
+        outputs: [port('o1')],
+        specSource: {
+          inputs: { value: '1 In / 1 Out', source: 'AI-Vorschlag aus dem Gerätenamen' },
+          outputs: { value: '1 In / 1 Out', source: 'AI-Vorschlag aus dem Gerätenamen' },
+        },
+      }),
+    ])
+    expect(ids).toContain('ports-guessed:e1')
+  })
+
+  it('schweigt bei Ports, die niemand geraten hat', () => {
+    // Sonst waere die Warnung Laerm und wuerde ignoriert — dann haette sie
+    // niemandem geholfen.
+    const ids = befunde([geraet({ inputs: [port('i1')], outputs: [port('o1')] })])
+    expect(ids).not.toContain('ports-guessed:e1')
+    expect(ids).not.toContain('ports-unknown:e1')
+  })
+
+  it('meldet ein Geraet nicht zweimal', () => {
+    // `portsUnknown` UND geraten: die beiden Faelle schliessen einander aus,
+    // sonst stuenden zwei Warnungen zur selben Sache in der Liste.
+    const ids = befunde([
+      geraet({
+        portsUnknown: true,
+        inputs: [port('i1')],
+        specSource: { inputs: { value: '1 In / 0 Out', source: 'AI-Vorschlag' } },
+      }),
+    ])
+    // Nur die beiden Herkunfts-Befunde vergleichen: `open-ports` ist eine
+    // andere und voellig richtige Pruefung (ein Port ohne Kabel) und gehoert
+    // nicht in diese Gegenueberstellung.
+    expect(ids.filter((i) => i.startsWith('ports-'))).toEqual(['ports-guessed:e1'])
+  })
+})
+
+describe('die beiden Haelften am Quelltext', () => {
+  it('der AI-Knopf haelt fest, dass er geraten hat', () => {
+    expect(aiButtonSrc).toContain('specSource:')
+    expect(aiButtonSrc).toContain("'props.aiPorts.source'")
+  })
+
+  it('eine menschliche Aenderung raeumt den ueberholten Beleg ab', () => {
+    // Ohne diese Haelfte truege ein Geraet die Warnung „Ports geraten" auch
+    // dann noch, wenn jemand die Ports laengst geprueft und korrigiert hat —
+    // und der Beleg behauptete einen Wert, den er nicht mehr stuetzt.
+    expect(portsSectionSrc).toContain('delete rest.inputs')
+    expect(portsSectionSrc).toContain('delete rest.outputs')
+  })
+})


### PR DESCRIPTION
Beim Neu-Ableiten des Stands gefunden — und es **berichtigt, was ich in `#647`/`#648`
behauptet habe.** Dort habe ich die drei Stellen geheilt, an denen ein *Geräte-Befund* still
zur Absicht wurde, und den `cable-planner` danach als erledigt geführt. Es gibt eine **vierte
Sorte**, nach der ich nicht gesucht hatte: eine Angabe, die weder abgelesen noch geplant,
sondern **geraten** ist.

## Der Befund

`PortAiSuggestButton` lässt ein Modell aus dem **Gerätenamen** Ports ableiten und schrieb sie
ununterscheidbar neben von Hand eingetragene. Das ist genau das, was `portsUnknown` verhindern
soll — dessen Begründung in `DECLARED_PROVENANCE` wörtlich lautet:

> *„Beim Import gab es keinen Datenblatt-Treffer. Die Ports sind leer, weil keine erfunden
> wurden — nicht, weil das Gerät keine hätte."*

**Der Schaden war still.** Prüfung 18 in `drawingChecks` warnt, solange ein Gerät ohne
Datenblatt-Treffer keine Ports hat — ihre Bedingung ist
`portsUnknown && inputs.length === 0 && outputs.length === 0`. Ein Klick auf den AI-Vorschlag
füllte Ports ein und brachte damit **die Prüfung zum Schweigen, die einen Menschen zu belegten
Daten zwingen soll**. Ihre eigene Meldung lautet *„reale Anschlüsse aus dem Datenblatt
ergänzen"* — beantwortet von einem Modell, das den Gerätenamen gelesen hat.

Ports tragen die ganze Verkabelung: welche Verbindungen möglich sind, die Stückliste, die
Kabelliste. **Ein erfundener Port ist ein Kabel, das es nicht gibt.**

## Die Änderung

* **`EquipmentItem.specSource`** in derselben Form wie `Fixture.specSource` (light-planner) und
  `Camera.specSource` (multicam-planner). Eine Idee, ein Vokabular — jetzt in allen drei
  Planern, gehalten vom Suite-Guard `scripts/spec-source-vocabulary.mjs`.
* Der AI-Knopf hält fest, **dass** er geraten hat und **woraus**.
* **Prüfung 18 kennt den zweiten Fall**: Ports da, aber geraten → eigene Warnung *„gegen die
  realen Anschlüsse prüfen"* statt Schweigen. Die beiden Fälle schließen einander aus, sonst
  stünden zwei Warnungen zur selben Sache.
* Fasst ein Mensch die Ports an, **fällt der überholte Beleg weg** — sonst stünde die Warnung
  gegen jemanden, der gerade geprüft hat, und der Beleg behauptete einen Wert, den er nicht
  mehr stützt.

## Was die vorhandenen Guards dabei geleistet haben

Das Hinzufügen des Feldes ließ **sofort zwei Tests fallen** — `planDiff` und `modelFields`
verlangen, dass jedes Feld von `EquipmentItem` klassifiziert wird. Beide Klassen standen schon
bereit: `planDiff` nennt *„Provenienz-Marker"* ausdrücklich als `bookkeeping` (dort steht
`verifiedBy` bereits), `modelFields` führt es als Modell-Eigenschaft, weil der Beleg zum Typ
gehört. Genau dafür sind die beiden Registries gebaut.

## Prüfung

* `tests/portsGuessed.test.ts` (6): die alte Warnung bleibt, der geratene Fall bekommt eine
  eigene, ein von Hand gepflegtes Gerät bleibt still (sonst wäre die Warnung Lärm), und kein
  Gerät wird zweimal gemeldet.
* **766 Tests grün**, `tsc --noEmit` 0 Errors, Lint 0 Errors.
* **Gegengeprüft**: die Prüfungs-Erweiterung zurückgebaut → zwei Tests fallen.
* Eine erste Fassung meiner eigenen Zusicherung war zu streng — sie verlangte, dass für das
  Gerät *nur* der Herkunfts-Befund entsteht, und stolperte über `open-ports` (eine andere und
  völlig richtige Prüfung). Der Test vergleicht jetzt nur die beiden Herkunfts-Befunde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_