### PR TITLE
plangen: auch der generierte Plan sagt, dass er geraten ist

### DIFF
--- a/src/renderer/lib/planGeneration.ts
+++ b/src/renderer/lib/planGeneration.ts
@@ -82,6 +82,13 @@ const coerceConnector = (v: unknown): ConnectorType => {
   return 'Custom'
 }
 
+/**
+ * Der Beleg, den ein generiertes Geraet traegt. Wortlaut bewusst nah an dem
+ * des Port-Vorschlags: der Nutzer soll beide als dieselbe Sorte Angabe lesen.
+ */
+const AI_PLAN_SOURCE =
+  'AI-Plangenerierung aus einer Beschreibung — nicht aus einem Datenblatt'
+
 const makePort = (name: string, connector: ConnectorType): Port => ({
   id: uuid(),
   name,
@@ -122,6 +129,30 @@ export const generatePlanFromPrompt = async (description: string): Promise<Gener
       y: Math.floor(i / COLS) * ROW_H + 80,
       width: 220,
       height: 60,
+      // Dieselbe Kennzeichnung wie beim AI-Port-Vorschlag (#650): diese Ports
+      // hat ein Modell aus einer Beschreibung abgeleitet, nicht aus einem
+      // Datenblatt. Ohne sie stuenden sie ununterscheidbar neben geplanten,
+      // und Pruefung 18 bliebe still — hier sogar fuer einen ganzen Plan auf
+      // einmal.
+      //
+      // Nur die GERAETE tragen die Kennzeichnung. Ob und wie ein vom Modell
+      // erfundenes KABEL sie tragen soll, ist eine eigene Frage: `Cable` hat
+      // kein `specSource`, und eine erfundene Verbindung ist womoeglich mehr
+      // als eine Markierung wert. Sie hier nebenbei zu beantworten waere die
+      // Sorte Nebenbei-Entscheidung, die dieses Repo an mehreren Stellen
+      // ausdruecklich zurueckweist.
+      ...(inputs.length > 0 || outputs.length > 0
+        ? {
+            specSource: {
+              ...(inputs.length > 0
+                ? { inputs: { value: `${inputs.length} In`, source: AI_PLAN_SOURCE } }
+                : {}),
+              ...(outputs.length > 0
+                ? { outputs: { value: `${outputs.length} Out`, source: AI_PLAN_SOURCE } }
+                : {}),
+            },
+          }
+        : {}),
     }
     equipment.push(item)
     // Erstes Vorkommen eines Namens gewinnt.

--- a/tests/portsGuessed.test.ts
+++ b/tests/portsGuessed.test.ts
@@ -89,6 +89,37 @@ describe('Pruefung 18 verstummt nicht mehr durch eine Vermutung', () => {
   })
 })
 
+describe('die zweite Stelle: der ganze generierte Plan', () => {
+  it('markiert auch die Ports generierter Geraete', async () => {
+    // `#650` hat den Einzelfall geheilt (ein Klick, ein Geraet). Die
+    // Plangenerierung fuegt einen GANZEN Plan ein — Geraete, deren Ports und
+    // die Kabel dazwischen. Ohne dieselbe Kennzeichnung waere Pruefung 18
+    // dort fuer alle Geraete auf einmal still.
+    const src = (await import('../src/renderer/lib/planGeneration.ts?raw')).default
+    expect(src).toContain('AI_PLAN_SOURCE')
+    expect(src).toContain('specSource:')
+    // Und die Warnung greift dann wirklich.
+    const ids = befunde([
+      geraet({
+        inputs: [port('i1')],
+        specSource: { inputs: { value: '1 In', source: 'AI-Plangenerierung aus einer Beschreibung' } },
+      }),
+    ])
+    expect(ids).toContain('ports-guessed:e1')
+  })
+
+  it('haelt die offene Frage fest, statt sie stillschweigend zu beantworten', async () => {
+    // Ob ein vom Modell ERFUNDENES KABEL eine Kennzeichnung tragen soll — und
+    // ob eine Markierung dafuer ueberhaupt reicht — ist nicht entschieden.
+    // `Cable` hat kein `specSource`. Dieser Test haelt fest, dass das
+    // absichtlich so ist und nicht vergessen wurde.
+    const src = (await import('../src/renderer/lib/planGeneration.ts?raw')).default
+    expect(src).toContain('Nur die GERAETE tragen die Kennzeichnung')
+    const cableTypes = (await import('../src/renderer/types/cable.ts?raw')).default
+    expect(cableTypes).not.toContain('specSource')
+  })
+})
+
 describe('die beiden Haelften am Quelltext', () => {
   it('der AI-Knopf haelt fest, dass er geraten hat', () => {
     expect(aiButtonSrc).toContain('specSource:')


### PR DESCRIPTION
Die **zweite Stelle derselben Sorte**, beim Messen für `#650` gefunden.

Dort war es ein Klick für ein Gerät. Hier fügt `insertGeneratedPlan` einen **ganzen Plan** ein
— Geräte, deren Ports und die Kabel dazwischen — und zwar ohne jeden Herkunfts-Vermerk. Ohne
Kennzeichnung wäre Prüfung 18 (*„reale Anschlüsse aus dem Datenblatt ergänzen"*) für **alle
Geräte auf einmal** still.

## Was gebaut ist

Generierte Geräte tragen dieselbe Kennzeichnung wie beim AI-Port-Vorschlag, mit einem Wortlaut,
der bewusst nah daran liegt: der Nutzer soll beide als dieselbe Sorte Angabe lesen. **Das ist
keine neue Entscheidung**, sondern die in `#650` bereits getroffene, an der zweiten Stelle
angewandt.

## Was ausdrücklich nicht mitentschieden ist

Ob ein vom Modell **erfundenes Kabel** eine Kennzeichnung tragen soll — und ob eine Markierung
dafür überhaupt reicht. `Cable` hat kein `specSource`, und eine erfundene Verbindung ist
womöglich mehr wert als einen Vermerk: sie behauptet, dass zwei Ports zusammengehören.

Das ist eine Formfrage mit mehreren vertretbaren Antworten und gehört dem Eigentümer, nicht
einem Nebenbei-Commit. Dieses Repo weist genau diese Sorte Nebenbei-Entscheidung an mehreren
Stellen ausdrücklich zurück — etwa im Kommentar zu `healRentmanLibraryFromProject`.

**Ein Test hält die Lücke fest**, damit sie als gewollt erkennbar bleibt und nicht als
vergessen: er prüft, dass `Cable` weiterhin kein `specSource` trägt und dass die Begründung im
Quelltext steht.

## Prüfung

* `tests/portsGuessed.test.ts` wächst auf 8: die Kennzeichnung existiert, die Warnung greift für
  ein so markiertes Gerät wirklich, und die offene Frage ist festgehalten.
* **768 Tests grün**, `tsc --noEmit` 0 Errors, Lint 0 Errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_