### PR TITLE
greengo + netbox: zwei Werte, die als Tatsache weiterrechnen, obwohl sie geraten sind

### DIFF
--- a/src/renderer/components/Export/GreenGoExportDialog.tsx
+++ b/src/renderer/components/Export/GreenGoExportDialog.tsx
@@ -852,7 +852,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                   <div className="mt-1.5 text-[11px] text-cp-text-muted">
                     {t(
                       'greengo.importOverlay.unreadHint',
-                      'Ein Export aus dem Cable-Planner erzeugt eine neue .gg5 und füllt diese Abschnitte und Felder mit Standardwerten. Er ersetzt die Original-Datei nicht — bewahre sie auf.',
+                      'Diese Abschnitte und Felder liest der Cable-Planner nicht — beim Export aus der geladenen Datei reisen sie unverändert mit. Nur ohne geladene Datei werden sie mit Standardwerten neu erzeugt. Die Original-Datei ersetzt der Export nie — bewahre sie trotzdem auf.',
                     )}
                   </div>
                 </div>

--- a/src/renderer/lib/exportGreengo.ts
+++ b/src/renderer/lib/exportGreengo.ts
@@ -237,7 +237,31 @@ const SETTINGS_FROM_PLAN = ['Name', 'Description', 'SampleRate', 'MulticastAddre
  * darf der Export zurueckschreiben. Der Guard in tests/greengoPreset.test.ts
  * haelt die beiden Listen deckungsgleich.
  */
-const USER_FIELDS_FROM_PLAN = ['myId', 'Name', 'DisplayName', 'Color', 'ButtonFunctions'] as const
+const USER_FIELDS_FROM_PLAN = ['myId', 'Name', 'DisplayName', 'Color'] as const
+
+/**
+ * Felder, die der Plan ERGAENZT statt sie zu ersetzen — die dritte Kategorie.
+ *
+ * DER BEFUND. `ButtonFunctions` stand bis hierher in der Liste oben und wurde
+ * damit bei jedem Export ueberschrieben. Das war der letzte verbliebene
+ * Datenverlust im Editor-Weg, und ausgerechnet der einzige, vor dem der
+ * Import-Hinweis nicht warnt: das Feld steht in `READ_USER_FIELDS`, also
+ * meldet `unreadFields` es per Konstruktion nie als ungelesen.
+ *
+ * WARUM DER PLAN HIER NICHT ENTSCHEIDEN DARF. Er kennt die Tastenpositionen
+ * gar nicht. `GreenGoUser` fuehrt nur `groupIds` — eine MENGE von Gruppen.
+ * Der Parser liest `ButtonFunctions` auch nur als Rueckfallweg, um diese
+ * Menge zu fuellen (`importGreengo.ts:302-311`), und wirft die Positionen
+ * dabei weg. Der Generator erfand sie beim Export neu, positionsweise aus der
+ * Array-Reihenfolge, und setzte Seite 2 auf lauter Nullen.
+ *
+ * Auf einem Beltpack ist das die Tastenbelegung. Der Verlust faellt nicht am
+ * Bildschirm auf, sondern in der Probe.
+ *
+ * Das ist ADR-005 Regel 2 woertlich: eine Projektion darf nicht ueberschreiben,
+ * was sie nicht modelliert.
+ */
+const USER_FIELDS_MERGED_FROM_PLAN = ['ButtonFunctions'] as const
 
 /** Dasselbe fuer eine Gruppe. */
 const GROUP_FIELDS_FROM_PLAN = ['myId', 'Name', 'Color', 'members'] as const
@@ -255,10 +279,60 @@ const GROUP_FIELDS_FROM_PLAN = ['myId', 'Name', 'Color', 'members'] as const
  * aus dem Generator — sie hat kein Vorbild, aus dem sich etwas bewahren
  * liesse. Eine geloeschte faellt weg.
  */
+/**
+ * Die Tastenkarte fortschreiben, ohne die Positionen anzufassen.
+ *
+ * Was der Plan beitragen kann, ist ausschliesslich die MENGE der Gruppen. Also:
+ *  - Positionen kommen aus dem Preset und werden nie neu vergeben.
+ *  - Eine Gruppe, die der Plan neu kennt und die auf keiner Taste liegt,
+ *    kommt auf die erste freie Taste (Wert 0) der ersten Seite.
+ *  - Eine Gruppe, die der Plan nicht mehr kennt, wird auf ihrer Taste auf 0
+ *    gesetzt — die Taste bleibt, die Belegung geht.
+ *  - Jede weitere Seite bleibt unberuehrt. Der Plan weiss von ihr nichts.
+ */
+export const mergeButtonFunctions = (preset: unknown, fresh: unknown): unknown => {
+  if (!preset || typeof preset !== 'object') return fresh
+  const pages = preset as Record<string, unknown>
+  const freshPage1 =
+    fresh && typeof fresh === 'object'
+      ? (((fresh as Record<string, unknown>)['1'] ?? {}) as Record<string, unknown>)
+      : {}
+  // Die Gruppen, die der Plan heute vorsieht.
+  const planGroups = new Set(
+    Object.values(freshPage1)
+      .map((v) => Number(v))
+      .filter((n) => !Number.isNaN(n) && n > 0),
+  )
+  const page1 = { ...((pages['1'] ?? {}) as Record<string, unknown>) }
+  const stillThere = new Set<number>()
+  for (const [button, value] of Object.entries(page1)) {
+    const gid = Number(value)
+    if (Number.isNaN(gid) || gid <= 0) continue
+    if (planGroups.has(gid)) stillThere.add(gid)
+    else page1[button] = 0
+  }
+  // Neue Gruppen auf freie Tasten, in aufsteigender Tastenreihenfolge.
+  const frei = Object.keys(page1)
+    .filter((b) => Number(page1[b]) === 0)
+    .sort((a, b) => Number(a) - Number(b))
+  for (const gid of planGroups) {
+    if (stillThere.has(gid)) continue
+    const taste = frei.shift()
+    if (taste === undefined) break // Karte voll — lieber nichts verdraengen.
+    page1[taste] = gid
+  }
+  return { ...pages, '1': page1 }
+}
+
+const MERGE_RULES: Record<string, (preset: unknown, fresh: unknown) => unknown> = {
+  ButtonFunctions: mergeButtonFunctions,
+}
+
 const mergeKeyedSection = (
   presetSection: unknown,
   built: Record<string, unknown>,
   fieldsFromPlan: readonly string[],
+  mergedFields: readonly string[] = [],
 ): Record<string, unknown> => {
   const previous =
     presetSection && typeof presetSection === 'object'
@@ -276,6 +350,11 @@ const mergeKeyedSection = (
     const merged = { ...(old as Record<string, unknown>) }
     for (const field of fieldsFromPlan) {
       merged[field] = (fresh as Record<string, unknown>)[field]
+    }
+    // Die dritte Kategorie: zusammenfuehren statt ersetzen.
+    for (const field of mergedFields) {
+      const rule = MERGE_RULES[field]
+      if (rule) merged[field] = rule(merged[field], (fresh as Record<string, unknown>)[field])
     }
     out[key] = merged
   }
@@ -307,7 +386,12 @@ const mergeIntoPreset = (
   out.Settings = settings
   // Fortschreiben, nicht ersetzen — sonst waeren Tastenbelegungen, Pincodes
   // und Geraete-Registrierungen der Stationen trotz Preset wieder weg.
-  out.Users = mergeKeyedSection(out.Users, usersSection, USER_FIELDS_FROM_PLAN)
+  out.Users = mergeKeyedSection(
+    out.Users,
+    usersSection,
+    USER_FIELDS_FROM_PLAN,
+    USER_FIELDS_MERGED_FROM_PLAN,
+  )
   out.Groups = mergeKeyedSection(out.Groups, groupsSection, GROUP_FIELDS_FROM_PLAN)
   return out
 }

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -1468,7 +1468,7 @@ export const en: Dict = {
   'greengo.importOverlay.title': 'Import .gg5 — link devices',
   'greengo.importOverlay.system': 'System:',
   'greengo.importOverlay.unreadTitle': 'This file contains sections the import does not read',
-  'greengo.importOverlay.unreadHint': 'An export from Cable Planner creates a new .gg5 and fills those sections and fields with defaults. It does not replace the original file — keep it.',
+  'greengo.importOverlay.unreadHint': 'Cable Planner does not read these sections and fields — when you export from the loaded file they travel through unchanged. Only without a loaded file are they regenerated with defaults. The export never replaces the original file, but keep it anyway.',
   'greengo.importOverlay.matchTitle': 'Mapping to canvas devices',
   'greengo.importOverlay.matchKept': '{count} hand-set mappings are preserved (slot {slots}).',
   'greengo.importOverlay.matchRenamed': 'Slot {slots}: the station has a different name in the file — the mapping was guessed again.',

--- a/src/renderer/lib/netboxMapping.ts
+++ b/src/renderer/lib/netboxMapping.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid'
 import type { Cable, CableType } from '../types/cable'
 import type { ConnectorType, EquipmentItem, Port } from '../types/equipment'
 import type { LocationFrame } from '../types/location'
+import { bitsToMask, maskToBits } from './subnet'
 import type {
   NetboxCable,
   NetboxComponent,
@@ -585,7 +586,17 @@ export const buildNetboxImportPlan = (
       width: NODE_WIDTH,
       height: nodeHeight(built.inputs, built.outputs),
       ...(uHeight > 0 ? { isRackDevice: true, rackUnits: Math.max(1, Math.round(uHeight)) } : {}),
+      // NetBox liefert `10.0.5.7/26`. Die Praefixlaenge wurde hier
+      // weggeworfen — und Pruefung 17 rechnete danach auf einer erfundenen
+      // /24 (`e.subnetMask || '255.255.255.0'`). Sie stand die ganze Zeit in
+      // der Antwort; sie mitzunehmen kostet nichts.
       ...(primaryIp ? { ipAddress: primaryIp.split('/')[0] } : {}),
+      ...(primaryIp && primaryIp.includes('/')
+        ? (() => {
+            const mask = bitsToMask(maskToBits(primaryIp.split('/')[1]))
+            return mask ? { subnetMask: mask } : {}
+          })()
+        : {}),
       importSource: 'netbox',
       netboxId,
       netboxSourceUrl: baseUrl,

--- a/src/renderer/lib/subnet.ts
+++ b/src/renderer/lib/subnet.ts
@@ -47,6 +47,28 @@ export const maskToBits = (mask: string | undefined): number | null => {
   return bits
 }
 
+/**
+ * Praefixlaenge -> gepunktete Maske. Die Umkehrung von `maskToBits`.
+ *
+ * WOFUER. NetBox liefert die primaere Adresse als CIDR (`10.0.5.7/26`). Der
+ * Import behielt davon nur die Adresse und warf die Praefixlaenge weg — und
+ * Pruefung 17 rechnete danach auf einer ERFUNDENEN /24 weiter
+ * (`e.subnetMask || '255.255.255.0'`). Auf einem /26- oder /22-Netz erzeugt
+ * das beides: eine Gateway-Warnung, die nicht haette kommen duerfen, und eine
+ * echte Fehlkonfiguration, die niemand meldet.
+ *
+ * Die Laenge stand die ganze Zeit in der Antwort. Sie wegzuwerfen und dann zu
+ * raten ist derselbe Fehler wie ueberall sonst heute: ein unbestaetigter Wert,
+ * der als Tatsache weiterrechnet.
+ */
+export const bitsToMask = (bits: number | null | undefined): string | null => {
+  if (bits === null || bits === undefined || !Number.isInteger(bits)) return null
+  if (bits < 0 || bits > 32) return null
+  const octets = [0, 0, 0, 0]
+  for (let i = 0; i < bits; i++) octets[Math.floor(i / 8)] |= 1 << (7 - (i % 8))
+  return octets.join('.')
+}
+
 /** Netzwerk-Adresse (Dotted) aus IP + Maske, oder null. */
 export const networkAddress = (ip: string | undefined, mask: string | undefined): string | null => {
   const ipv4 = parseIpv4(ip)

--- a/tests/greengoPreset.test.ts
+++ b/tests/greengoPreset.test.ts
@@ -39,7 +39,14 @@ const anlage = () => ({
       Name: 'BPX Regie',
       DisplayName: 'Regie',
       Color: 3,
-      ButtonFunctions: {},
+      // Eine ECHTE Tastenkarte. Sie stand hier als `{}` — und genau deshalb
+      // konnte kein Test den Verlust sehen: es gab nichts zu verlieren.
+      // Seite 1 ist bewusst nicht aufsteigend belegt und hat Luecken, Seite 2
+      // traegt etwas, das der Plan gar nicht kennen kann.
+      ButtonFunctions: {
+        '1': { '1': 9, '2': 4, '3': 7, '4': 0, '5': 0, '6': 0 },
+        '2': { '1': 2, '2': 0, '3': 0 },
+      },
       // Was der Parser NICHT liest — der halbe Einmessvorgang:
       devices: [{ serial: 'GG-0001' }],
       Channels: { 1: { fn: 'talk' } },
@@ -155,6 +162,54 @@ describe('Generator-Weg: ohne Preset bleibt alles wie bisher', () => {
   })
 })
 
+describe('die Tastenkarte ueberlebt den Export', () => {
+  // Der letzte verbliebene Datenverlust im Editor-Weg — und der einzige, vor
+  // dem der Import-Hinweis nicht warnte, weil `ButtonFunctions` in
+  // `READ_USER_FIELDS` steht und `unreadFields` es deshalb nie meldet.
+  //
+  // Der Plan kennt keine Tastenpositionen: `GreenGoUser` fuehrt nur
+  // `groupIds`, eine Menge. Der Export erfand die Positionen aus der
+  // Array-Reihenfolge neu und setzte Seite 2 auf Nullen. Auf einem Beltpack
+  // ist das die Tastenbelegung; es faellt in der Probe auf, nicht am Schirm.
+
+  const users = (raw: unknown) =>
+    (JSON.parse(buildGg5File(raw as GreenGoConfig)) as Record<string, any>).Users
+
+  it('laesst die Positionen stehen, wenn sich an den Gruppen nichts aendert', () => {
+    const config = configFrom(anlage())
+    // Der Parser hat aus der Karte {9,4,7} als groupIds gelesen.
+    const out = users({ ...config, users: [{ id: 1, name: 'BPX Regie', groupIds: [9, 4, 7] }] })
+    expect(out['1'].ButtonFunctions['1']).toEqual({ '1': 9, '2': 4, '3': 7, '4': 0, '5': 0, '6': 0 })
+  })
+
+  it('fasst Seite 2 nicht an — der Plan weiss von ihr nichts', () => {
+    const config = configFrom(anlage())
+    const out = users({ ...config, users: [{ id: 1, name: 'BPX Regie', groupIds: [9, 4, 7] }] })
+    expect(out['1'].ButtonFunctions['2']).toEqual({ '1': 2, '2': 0, '3': 0 })
+  })
+
+  it('legt eine neue Gruppe auf die erste freie Taste, statt umzusortieren', () => {
+    const config = configFrom(anlage())
+    const out = users({ ...config, users: [{ id: 1, name: 'BPX Regie', groupIds: [9, 4, 7, 5] }] })
+    // 9/4/7 bleiben, wo sie waren; die 5 kommt auf Taste 4.
+    expect(out['1'].ButtonFunctions['1']).toEqual({ '1': 9, '2': 4, '3': 7, '4': 5, '5': 0, '6': 0 })
+  })
+
+  it('raeumt eine entfernte Gruppe von ihrer Taste, ohne die anderen zu verschieben', () => {
+    const config = configFrom(anlage())
+    const out = users({ ...config, users: [{ id: 1, name: 'BPX Regie', groupIds: [9, 7] }] })
+    expect(out['1'].ButtonFunctions['1']).toEqual({ '1': 9, '2': 0, '3': 7, '4': 0, '5': 0, '6': 0 })
+  })
+
+  it('erzeugt fuer eine neue Station weiterhin eine ganze Karte', () => {
+    // Der Generator-Weg bleibt, wo es kein Preset fuer diese Station gibt.
+    const config = configFrom(anlage())
+    const out = users({ ...config, users: [{ id: 7, name: 'Neu', groupIds: [3] }] })
+    expect(Object.keys(out['7'].ButtonFunctions['1'])).toHaveLength(18)
+    expect(out['7'].ButtonFunctions['1']['1']).toBe(3)
+  })
+})
+
 describe('der Round-Trip als Ganzes', () => {
   it('ueberlebt Datei -> Import -> Export -> Import ohne Verlust der Anlagenteile', () => {
     const first = anlage()
@@ -180,9 +235,16 @@ describe('was der Parser liest, schreibt der Export zurueck', () => {
       if (!m) throw new Error(`${name} nicht gefunden`)
       return [...m[1].matchAll(/'([^']+)'/g)].map((x) => x[1]).sort()
     }
-    expect(listOf(exportSrc, 'USER_FIELDS_FROM_PLAN')).toEqual(
-      listOf(importSrc, 'READ_USER_FIELDS'),
-    )
+    // Drei Kategorien statt zwei: was der Export ERSETZT, was er ERGAENZT, und
+    // zusammen muss das sein, was der Import liest. Die alte Fassung verlangte
+    // Gleichheit der Ersetz-Liste mit der Lese-Liste — und zementierte damit,
+    // dass `ButtonFunctions` ueberschrieben wird.
+    expect(
+      [
+        ...listOf(exportSrc, 'USER_FIELDS_FROM_PLAN'),
+        ...listOf(exportSrc, 'USER_FIELDS_MERGED_FROM_PLAN'),
+      ].sort(),
+    ).toEqual(listOf(importSrc, 'READ_USER_FIELDS'))
     expect(listOf(exportSrc, 'GROUP_FIELDS_FROM_PLAN')).toEqual(
       listOf(importSrc, 'READ_GROUP_FIELDS'),
     )

--- a/tests/subnetMaskFromNetbox.test.ts
+++ b/tests/subnetMaskFromNetbox.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { bitsToMask, maskToBits, networkAddress } from '../src/renderer/lib/subnet'
+import netboxMappingSrc from '../src/renderer/lib/netboxMapping.ts?raw'
+
+// ---------------------------------------------------------------------------
+// Die Praefixlaenge stand in der Antwort und wurde weggeworfen.
+//
+// NetBox liefert die primaere Adresse als CIDR — `10.0.5.7/26`. Der Import
+// behielt `split('/')[0]` und liess `subnetMask` leer. Pruefung 17 in
+// `drawingChecks.ts` faellt dann auf `e.subnetMask || '255.255.255.0'` zurueck
+// und rechnet auf einer ERFUNDENEN /24 weiter.
+//
+// Das ist derselbe Fehler wie ueberall sonst an diesem Tag: ein Wert, den
+// niemand bestaetigt hat, rechnet als Tatsache weiter. Nur ist er hier
+// besonders aergerlich, weil die richtige Angabe zwei Zeichen weiter rechts
+// stand.
+//
+// Der Schaden geht in BEIDE Richtungen und das ist der Punkt:
+//   - /26: zwei Adressen im selben echten Subnetz liegen unter der geratenen
+//     /24 zusammen — eine echte Fehlkonfiguration wird NICHT gemeldet.
+//   - /22: Gateway und Geraet liegen unter der geratenen /24 auseinander —
+//     eine Warnung erscheint, die es nicht geben duerfte.
+// ---------------------------------------------------------------------------
+
+describe('bitsToMask', () => {
+  it('kehrt maskToBits um', () => {
+    for (const bits of [8, 16, 22, 24, 26, 30, 32, 0]) {
+      expect(maskToBits(bitsToMask(bits)), `${bits}`).toBe(bits)
+    }
+  })
+
+  it('nennt die ueblichen Masken beim Namen', () => {
+    expect(bitsToMask(24)).toBe('255.255.255.0')
+    expect(bitsToMask(26)).toBe('255.255.255.192')
+    expect(bitsToMask(22)).toBe('255.255.252.0')
+  })
+
+  it('gibt null statt einer erfundenen Maske', () => {
+    expect(bitsToMask(null)).toBeNull()
+    expect(bitsToMask(undefined)).toBeNull()
+    expect(bitsToMask(33)).toBeNull()
+    expect(bitsToMask(-1)).toBeNull()
+    expect(bitsToMask(24.5)).toBeNull()
+  })
+})
+
+describe('was die geratene /24 anrichtet', () => {
+  it('/26: die erfundene Maske verschweigt eine echte Trennung', () => {
+    // .7 und .70 liegen in verschiedenen /26-Netzen, aber in derselben /24.
+    expect(networkAddress('10.0.5.7', '255.255.255.192')).not.toBe(
+      networkAddress('10.0.5.70', '255.255.255.192'),
+    )
+    expect(networkAddress('10.0.5.7', '255.255.255.0')).toBe(
+      networkAddress('10.0.5.70', '255.255.255.0'),
+    )
+  })
+
+  it('/22: die erfundene Maske erfindet eine Trennung', () => {
+    // .5.7 und .6.1 liegen in derselben /22, aber in verschiedenen /24.
+    expect(networkAddress('10.0.5.7', '255.255.252.0')).toBe(
+      networkAddress('10.0.6.1', '255.255.252.0'),
+    )
+    expect(networkAddress('10.0.5.7', '255.255.255.0')).not.toBe(
+      networkAddress('10.0.6.1', '255.255.255.0'),
+    )
+  })
+})
+
+describe('der Import traegt die Laenge mit', () => {
+  it('setzt subnetMask aus dem CIDR-Praefix', () => {
+    expect(netboxMappingSrc).toContain('bitsToMask(maskToBits(primaryIp.split')
+    expect(netboxMappingSrc).toContain('subnetMask: mask')
+  })
+
+  it('erfindet keine Maske, wenn NetBox keine liefert', () => {
+    // Ohne `/` bleibt das Feld leer — lieber keine Angabe als eine geratene.
+    // Genau das ist der Unterschied zum Fallback in Pruefung 17.
+    expect(netboxMappingSrc).toContain("primaryIp && primaryIp.includes('/')")
+  })
+})


### PR DESCRIPTION
Zwei Befunde aus derselben Messung, beide von derselben Sorte: **ein Wert, den niemand
bestätigt hat, rechnet als Tatsache weiter.** Sie liegen in verschiedenen Dateien und hängen
nicht voneinander ab — sie stehen zusammen in einem PR, weil sie zusammen gefunden wurden und
dieselbe Regel verletzen. Wer sie getrennt haben will, sagt es; dann teile ich sie.

---

# 1. Die Tastenkarte überlebt den Export — Korrektur zu `#645`

**Das berichtigt eine Zusage aus `#645`.** Dort steht „macht ihn verlustfrei" — im PR-Body, im
Commit und in der Roadmap-Zeile. Das war falsch.

`ButtonFunctions` stand in `USER_FIELDS_FROM_PLAN` und wurde bei jedem Export durch eine neu
erfundene Karte ersetzt. `buildButtonFunctions` vergibt die Tasten **positionsweise aus der
Array-Reihenfolge** und setzt Seite 2 auf lauter Nullen.

Der gemessene Fall: Seite 1 `{1:9, 2:4, 3:7}` wird zu `{1:4, 2:7, 3:9, 4..18:0}`, Seite 2 leer.

Auf einem Beltpack ist das die Tastenbelegung. Der Verlust fällt **nicht am Bildschirm auf,
sondern in der Probe** — und danach belegt der Techniker zwölf Beltpacks von Hand nach.

### Zwei Dinge haben es verdeckt, beide von mir

1. **Die Test-Fixture** setzte `ButtonFunctions: {}`. Es gab nichts zu verlieren, also konnte
   kein Test den Verlust sehen.
2. **Der Paritäts-Guard** verlangte Gleichheit von `USER_FIELDS_FROM_PLAN` und
   `READ_USER_FIELDS` — und zementierte damit das Überschreiben.

Dazu: es war der **einzige Verlust ohne Warnung.** Das Feld steht in `READ_USER_FIELDS`, also
meldet `unreadFields` es per Konstruktion nie als ungelesen.

### Die Änderung

Dritte Kategorie `USER_FIELDS_MERGED_FROM_PLAN`: der Plan **ergänzt** das Feld, statt es zu
ersetzen — ADR-005 Regel 2 wörtlich, *eine Projektion darf nicht überschreiben, was sie nicht
modelliert*. Und der Plan modelliert die Positionen nicht: `GreenGoUser` führt nur `groupIds`,
eine Menge; der Parser liest `ButtonFunctions` nur als Rückfallweg und wirft die Positionen weg.

* Positionen kommen aus dem Preset und werden nie neu vergeben.
* Eine neue Gruppe kommt auf die **erste freie Taste**, eine entfernte wird auf 0 gesetzt.
* Jede weitere Seite bleibt unberührt. Ohne Preset erzeugt der Generator weiter eine volle Karte.

Der **Warntext** sagte seit `#645` das Gegenteil des Verhaltens — er warnte vor dem, was
bewahrt wird. Berichtigt, DE und EN.

---

# 2. Die Präfixlänge nicht wegwerfen und dann raten

NetBox liefert die primäre Adresse als CIDR — `10.0.5.7/26`. Der Import behielt
`split('/')[0]` und ließ `subnetMask` leer. **Prüfung 17 fällt dann auf
`e.subnetMask || '255.255.255.0'` zurück und rechnet auf einer erfundenen /24 weiter.**

Die richtige Angabe stand zwei Zeichen weiter rechts.

**Der Schaden geht in beide Richtungen**, und das ist der Punkt:

* **/26** — zwei Adressen in verschiedenen echten Subnetzen liegen unter der geratenen /24
  zusammen: eine echte Fehlkonfiguration bleibt stumm.
* **/22** — Gerät und Gateway liegen unter der geratenen /24 auseinander: eine Warnung
  erscheint, die es nicht geben dürfte.

`bitsToMask` ist die Umkehrung des vorhandenen `maskToBits` (das Präfixe ohnehin schon annimmt).
Der Import trägt die Maske mit, **wenn** NetBox eine liefert — ohne `/` bleibt das Feld leer.
Lieber keine Angabe als eine geratene; genau das ist der Unterschied zum Fallback in Prüfung 17.

---

## Prüfung

* **790 Tests grün**, `tsc --noEmit` 0 Errors, Lint 0 Errors.
* Green-GO: Fixture auf eine **echte** Tastenkarte (Seite 1 mit Lücken und nicht aufsteigend,
  Seite 2 mit Inhalt, den der Plan nicht kennen kann), 5 neue Tests, Guard auf drei Kategorien.
  **Gegengeprüft**: altes Überschreiben wiederhergestellt → vier der fünf neuen Tests fallen.
* NetBox: 7 Tests, darunter **beide Schadensrichtungen an konkreten Adressen**.

## Wie das gefunden wurde

Durch eine Messung mit Gegenprobe: sechs Agenten haben die offenen Roadmap-Initiativen gegen den
Code gemessen, und jede „X fehlt"-Behauptung ging an einen zweiten Agenten mit dem Auftrag, sie
zu **widerlegen**. Sechs von 24 Behauptungen sind gefallen. Der Green-GO-Befund ist in die
Gegenrichtung gefallen — er wurde **verschärft**, mit einem zweiten unabhängigen Beleg (der
Fixture), an den der erste Melder nicht gedacht hatte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT