### PR TITLE
stempel: der Aufbaustand gehört in den Plan-Fingerabdruck

### DIFF
--- a/src/renderer/lib/documentStamp.ts
+++ b/src/renderer/lib/documentStamp.ts
@@ -72,6 +72,13 @@ export const fingerprint = (input: string): string => {
  */
 const SEP = '\u001F'
 const ROW_SEP = '\u001E'
+/**
+ * Trenner zwischen den Bloecken eines Plan-Fingerabdrucks (Geraete, Kabel,
+ * Orte, Haken). Stand bisher als rohes Steuerzeichen im Aufruf; als Konstante
+ * ist im Quelltext sichtbar, dass es drei verschiedene Ebenen von Trennern
+ * gibt. Der Wert ist unveraendert — bestehende Fingerabdruecke bleiben gueltig.
+ */
+const BLOCK_SEP = '\u001D'
 
 const joinRows = (headers: string[], rows: CsvCell[][]): string =>
   [headers, ...rows]
@@ -83,10 +90,49 @@ export const documentFingerprint = (headers: string[], rows: CsvCell[][]): strin
   fingerprint(joinRows(headers, rows))
 
 /**
+ * Die Haken, die wirklich auf dem Blatt stehen.
+ *
+ * Der Mobile-Viewer schickt gesteckte Ports zurueck (`checkState.ports`,
+ * Schluessel `geraet|port`), und `EquipmentNode` zeichnet dafuer ein gruenes
+ * Haekchen an den Port. Beide Plan-Export-Wege nehmen das mit: der Raster-Weg
+ * fotografiert das Viewport-DOM, der Vektor-Weg klont es. Ein gesetzter Haken
+ * ist damit eine sichtbar andere Zeichnung — und stand bisher trotzdem nicht im
+ * Fingerabdruck. Ein Blatt, das den Aufbaustand von gestern zeigt, meldete sich
+ * im Dokument-Register als aktueller Stand.
+ *
+ * Gefiltert wird auf das, was wirklich gezeichnet wird:
+ *
+ *  - **Nur `ports`.** Kabel-Haken (`checkState.cables`) stehen ausschliesslich
+ *    im Kontextmenue, nicht auf der Zeichnung. Sie mitzuzaehlen hiesse, eine
+ *    Abweichung zu behaupten, die auf dem Papier niemand sehen kann — derselbe
+ *    Fehler wie eine verschwiegene, nur andersherum.
+ *  - **Nur Haken, zu denen es Geraet UND Port gibt.** `EquipmentNode` laeuft
+ *    ueber die Port-Listen und schlaegt den Haken nach; ein Schluessel ohne
+ *    Port zeichnet nichts. Solche Leichen bleiben liegen (beim Loeschen eines
+ *    Geraets raeumt niemand `checkState` auf) und duerfen den Stand nicht
+ *    bewegen.
+ */
+const visiblePortChecks = (project: CablePlannerProject | RevisionSnapshot): string[] => {
+  const checks = project.checkState?.ports
+  if (!checks) return []
+  const out: string[] = []
+  for (const item of project.equipment ?? []) {
+    for (const port of [...(item.inputs ?? []), ...(item.outputs ?? [])]) {
+      if (checks[`${item.id}|${port.id}`]) out.push([item.id, port.id].join(SEP))
+    }
+  }
+  return out.sort()
+}
+
+/**
  * Fingerabdruck über den *Zeichnungs*-Inhalt eines Plans — für Ausdrucke, die
  * das Bild zeigen (PDF/PNG). Hier zählen Positionen mit: ein verschobenes Gerät
  * ist auf dem Blatt sichtbar anders. Viewport/Zoom zählen nicht, die stehen
  * nicht auf dem Papier.
+ *
+ * Ebenfalls auf dem Papier: die Häkchen der bereits gesteckten Ports — siehe
+ * `visiblePortChecks` für die Abgrenzung, welche davon wirklich gezeichnet
+ * werden.
  */
 export const planFingerprint = (project: CablePlannerProject | RevisionSnapshot): string => {
   const equipment = (project.equipment ?? [])
@@ -109,8 +155,19 @@ export const planFingerprint = (project: CablePlannerProject | RevisionSnapshot)
   const locations = (project.locations ?? [])
     .map((l) => [l.id, l.name, l.x, l.y, l.width, l.height].join(SEP))
     .sort()
+  const checks = visiblePortChecks(project)
+  // Der Haken-Block wird nur angehaengt, wenn es Haken gibt. Sonst waere der
+  // Fingerabdruck JEDES bestehenden Ausdrucks ein anderer (ein Trenner mehr)
+  // — und jedes Blatt an jeder Wand meldete sich schlagartig als veraltet,
+  // obwohl sich an der Zeichnung nichts geaendert hat. Neu ist der Wert genau
+  // dort, wo der alte falsch war: in Plaenen mit Aufbaustand.
   return fingerprint(
-    [equipment.join(ROW_SEP), cables.join(ROW_SEP), locations.join(ROW_SEP)].join(''),
+    [
+      equipment.join(ROW_SEP),
+      cables.join(ROW_SEP),
+      locations.join(ROW_SEP),
+      ...(checks.length > 0 ? [checks.join(ROW_SEP)] : []),
+    ].join(BLOCK_SEP),
   )
 }
 

--- a/tests/documentStamp.test.ts
+++ b/tests/documentStamp.test.ts
@@ -112,6 +112,18 @@ describe('documentFingerprint', () => {
   })
 })
 
+/** Projekt mit Aufbaustand — Port-Schluessel sind `${geraet}|${port}`. */
+const checked = (ports: Record<string, boolean>): CablePlannerProject =>
+  project({ checkState: { ports, cables: {} } })
+
+/**
+ * Der Plan-Fingerabdruck des Test-Projekts OHNE Haken, so wie ihn die Fassung
+ * vor dem Aufbaustand berechnet hat. Fest verdrahtet als Regressionsanker:
+ * schlaegt er an, hat jemand die Blockbildung so geaendert, dass bestehende
+ * Ausdrucke ihren Stand verlieren.
+ */
+const FINGERPRINT_OHNE_HAKEN = 'a712d27f'
+
 describe('planFingerprint', () => {
   it('reagiert auf eine verschobene Position — die steht auf dem Blatt', () => {
     const before = planFingerprint(project())
@@ -131,6 +143,65 @@ describe('planFingerprint', () => {
     const a = project({ equipment: [eq('A', 'Kamera 1'), eq('B', 'Switcher')] })
     const b = project({ equipment: [eq('B', 'Switcher'), eq('A', 'Kamera 1')] })
     expect(planFingerprint(a)).toBe(planFingerprint(b))
+  })
+
+  // Der Aufbaustand steht auf dem Blatt: `EquipmentNode` zeichnet fuer jeden
+  // gesteckt gemeldeten Port ein Haekchen, und beide PDF-Wege nehmen das DOM
+  // mit. Bis hierher fehlte er im Fingerabdruck — ein Ausdruck von gestern
+  // Abend meldete sich als aktueller Stand, obwohl seitdem zwoelf Ports
+  // abgehakt wurden.
+  it('reagiert auf einen gesetzten Port-Haken — der steht auf dem Blatt', () => {
+    const before = planFingerprint(project())
+    const after = planFingerprint(checked({ 'A|A-out': true }))
+    expect(before).not.toBe(after)
+  })
+
+  it('unterscheidet, WELCHER Port abgehakt ist', () => {
+    expect(planFingerprint(checked({ 'A|A-out': true }))).not.toBe(
+      planFingerprint(checked({ 'B|B-in': true })),
+    )
+  })
+
+  it('ist unabhaengig von der Reihenfolge, in der die Haken zusammenkommen', () => {
+    // Zwei Quellen von Unordnung, und nur eine davon ist die gefaehrliche: die
+    // Schluessel-Reihenfolge im Haken-Objekt spielt ohnehin keine Rolle, weil
+    // ueber die Geraete gelaufen wird. Die Geraete-Reihenfolge dagegen schlaegt
+    // durch — ohne Sortierung haetten dieselben Haken zwei Fingerabdruecke.
+    const ports = { 'A|A-out': true, 'B|B-in': true }
+    const a = project({ equipment: [eq('A', 'Kamera 1'), eq('B', 'Switcher')],
+      checkState: { ports, cables: {} } })
+    const b = project({ equipment: [eq('B', 'Switcher'), eq('A', 'Kamera 1')],
+      checkState: { ports: { 'B|B-in': true, 'A|A-out': true }, cables: {} } })
+    expect(planFingerprint(a)).toBe(planFingerprint(b))
+  })
+
+  it('zaehlt einen abgeraeumten Haken (false) nicht mit', () => {
+    expect(planFingerprint(checked({ 'A|A-out': false }))).toBe(planFingerprint(project()))
+  })
+
+  // Die andere Richtung derselben Regel: keine Abweichung behaupten, die auf
+  // dem Papier niemand sehen kann.
+  it('ignoriert Kabel-Haken — die stehen nur im Kontextmenue', () => {
+    const withCableCheck = project({ checkState: { ports: {}, cables: { c1: true } } })
+    expect(planFingerprint(withCableCheck)).toBe(planFingerprint(project()))
+  })
+
+  it('ignoriert Haken auf Geraeten und Ports, die es nicht gibt', () => {
+    // Beim Loeschen eines Geraets raeumt niemand `checkState` auf. Solche
+    // Leichen zeichnen nichts und duerfen den Stand nicht bewegen.
+    const leichen = checked({ 'geloescht|port-1': true, 'A|gibt-es-nicht': true })
+    expect(planFingerprint(leichen)).toBe(planFingerprint(project()))
+  })
+
+  it('laesst den Fingerabdruck ohne Haken unveraendert — Ausdrucke bleiben gueltig', () => {
+    // Der Haken-Block wird nur angehaengt, wenn es Haken gibt. Ohne diese
+    // Bedingung haette die Aenderung jedes bereits gedruckte Blatt auf einen
+    // Schlag als veraltet gemeldet. Der Wert ist hier fest verdrahtet, damit
+    // genau das nicht unbemerkt passieren kann.
+    expect(planFingerprint(project())).toBe(FINGERPRINT_OHNE_HAKEN)
+    expect(planFingerprint(project({ checkState: { ports: {}, cables: {} } }))).toBe(
+      FINGERPRINT_OHNE_HAKEN,
+    )
   })
 })
 


### PR DESCRIPTION
Der Befund liegt auf Code aus **#644** — dem Dokument-Register, das ich heute selbst gebaut habe.

## Was falsch war

`planFingerprint` ließ `checkState` aus. Es deckt Geräte (`id, name, x, y, width, height`), Kabel und Orte ab — die Häkchen der gesteckten Ports nicht.

Die stehen aber auf dem Blatt. `EquipmentNode` zeichnet für jeden vom Mobile-Viewer als gesteckt gemeldeten Port ein grünes Häkchen an den Port, und **beide** Plan-Export-Wege nehmen es mit: der Raster-Weg fotografiert das Viewport-DOM (`toPng`/`toJpeg`, und der `baseFilter` entfernt nur Minimap, Controls und Background), der Vektor-Weg klont dasselbe DOM.

Folge: ein Ausdruck von gestern Abend meldet sich als `current`, obwohl seitdem zwölf Ports abgehakt wurden — auf einem Blatt, dessen einziger Zweck während des Aufbaus genau dieser Stand ist.

Das ist keine neue Regel, sondern die vorhandene, nicht zu Ende umgesetzt. **ADR-004 Regel 1** sagt bereits wörtlich: *„Ein Dokument, zwei Ableitungen, jede über das, was tatsächlich auf dem Papier steht."*

## Was gezählt wird — und was ausdrücklich nicht

Der Filter ist der eigentliche Inhalt der Änderung, denn die Gegenrichtung wäre derselbe Fehler:

* **Nur `checkState.ports`.** Kabel-Haken stehen ausschließlich im Kontextmenü (`CableContextMenu`), nie auf der Zeichnung. Mitzuzählen hieße, eine Abweichung zu behaupten, die auf dem Papier niemand sehen kann.
* **Nur Haken, zu denen es Gerät UND Port gibt.** `EquipmentNode` läuft über die Port-Listen und schlägt den Haken nach; ein Schlüssel ohne Port zeichnet nichts. Beim Löschen eines Geräts räumt niemand `checkState` auf — solche Leichen dürfen den Stand nicht bewegen.

## Warum bestehende Ausdrucke gültig bleiben

Der Haken-Block wird **nur angehängt, wenn es Haken gibt**. Ohne diese Bedingung hätte allein der zusätzliche Trenner den Fingerabdruck jedes Projekts verschoben — und jedes Blatt an jeder Wand hätte sich schlagartig als veraltet gemeldet, obwohl sich an der Zeichnung nichts geändert hat. Gemessen: `a712d27f` vor und nach der Änderung für dasselbe Projekt ohne Haken. Der Wert steht als Regressionsanker im Test, damit das nicht unbemerkt kippen kann.

Neu ist der Fingerabdruck genau dort, wo der alte falsch war.

Nebenbei: der Trenner zwischen den Blöcken stand bisher als rohes Steuerzeichen (U+001D) im Aufruf und war im Quelltext unsichtbar. Jetzt `BLOCK_SEP`, Wert unverändert.

## Prüfung

* **797 Tests grün**, `tsc --noEmit` 0 Errors, Lint 0 Errors.
* 8 neue Tests, **jeder einzeln gegengeprüft**: Filter entfernt → *„ignoriert Haken auf Geräten und Ports, die es nicht gibt"* fällt; Kabel-Haken mitgezählt → *„ignoriert Kabel-Haken"* fällt; Block immer angehängt → *„lässt den Fingerabdruck ohne Haken unverändert"* fällt; Sortierung entfernt → der Reihenfolge-Test fällt.
* Die erste Fassung des Reihenfolge-Tests variierte die Schlüssel im Haken-Objekt und **fiel bei entfernter Sortierung nicht** — die Reihenfolge kommt aus dem Geräte-Array, nicht aus dem Objekt. Test korrigiert, bis er die Drift wirklich fängt.
* `changeImpact` braucht nichts: es rechnet über `DOCUMENT_STANDS` neu, statt Felder aufzuzählen, und nimmt die Änderung von selbst mit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_