### PR TITLE
export: die Passwörter der Intercom-Anlage gingen mit

### DIFF
--- a/src/main/util/stripSecrets.ts
+++ b/src/main/util/stripSecrets.ts
@@ -32,13 +32,42 @@ export const SECRET_KEYS = new Set([
   'token',
 ])
 
-/** Rekursiv alle Felder aus `SECRET_KEYS` entfernen. Arrays bleiben Arrays. */
+/**
+ * Fremde Roh-Dokumente, die als Ganzes nicht mitgehen.
+ *
+ * `SECRET_KEYS` streicht nach Feldnamen. Das setzt voraus, dass wir die Namen
+ * kennen — bei unseren eigenen Typen tun wir das. Bei einem eingelesenen
+ * Hersteller-Dokument nicht: `GreenGoConfig.basePreset` haelt die
+ * Anlagen-Konfiguration unveraendert, und ihr Kopf-Kommentar sagt ausdruecklich
+ * „und vor allem die PASSWOERTER der Anlage bleiben, wie sie waren".
+ *
+ * Sie heissen `ConfigPassword`, `AdminPassword`, `TechPincode` und
+ * `Security.Pincode` — keiner dieser Namen steht in `SECRET_KEYS`. Die
+ * Zugangsdaten der Geraete wurden also gestrichen, die der Intercom-Anlage
+ * gingen mit: in die `.cpviewer`-Datei fuer externe Reviewer und an jedes
+ * Handy in der Mobile-Ansicht. Das widerspricht der Regel im Kopf dieser
+ * Datei, nicht bloss dem guten Geschmack.
+ *
+ * Feldnamen nachzutragen waere die schlechtere Antwort: das Dokument gehoert
+ * einem Hersteller, und die naechste Firmware bringt ein Feld mit, das hier
+ * niemand aufgeschrieben hat. Deshalb geht das Roh-Dokument als Ganzes nicht
+ * mit — was nichts kostet, denn **kein Empfaenger liest es.** Nachgesehen:
+ * weder `src/mobile/` noch `src/viewer/` kennen GreenGo ueberhaupt, und
+ * `basePreset` wird nur im Renderer gelesen, auf dem Rechner des Eigentuemers.
+ * Beim eigenen Speichern bleibt es unangetastet — dieselbe Grenze wie oben.
+ */
+export const OPAQUE_KEYS = new Set(['basePreset'])
+
+/**
+ * Rekursiv alle Felder aus `SECRET_KEYS` und `OPAQUE_KEYS` entfernen. Arrays
+ * bleiben Arrays.
+ */
 export const stripSecrets = (value: unknown): unknown => {
   if (Array.isArray(value)) return value.map(stripSecrets)
   if (value && typeof value === 'object') {
     const out: Record<string, unknown> = {}
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      if (SECRET_KEYS.has(k)) continue
+      if (SECRET_KEYS.has(k) || OPAQUE_KEYS.has(k)) continue
       out[k] = stripSecrets(v)
     }
     return out

--- a/tests/stripSecrets.test.ts
+++ b/tests/stripSecrets.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { SECRET_KEYS, stripSecrets } from '../src/main/util/stripSecrets'
+import { OPAQUE_KEYS, SECRET_KEYS, stripSecrets } from '../src/main/util/stripSecrets'
+import greengoTypesSrc from '../src/renderer/types/greengo.ts?raw'
 import projectIpcSrc from '../src/main/ipc/projectIpc.ts?raw'
 import mobileShareSrc from '../src/main/services/mobileShareServer.ts?raw'
 import equipmentTypesSrc from '../src/renderer/types/equipment.ts?raw'
@@ -61,6 +62,61 @@ describe('die Ausgaenge, die das Haus verlassen', () => {
 
   it('streicht die Mobile-Ansicht die Zugangsdaten', () => {
     expect(mobileShareSrc).toContain('stripSecrets(project)')
+  })
+
+  // Zweiter Befund, dieselbe Regel, andere Sorte Feld. `SECRET_KEYS` streicht
+  // nach Namen — bei einem eingelesenen Hersteller-Dokument kennen wir die
+  // Namen nicht. `GreenGoConfig.basePreset` haelt die Anlagen-Konfiguration
+  // unveraendert, samt `ConfigPassword`, `AdminPassword`, `TechPincode` und
+  // `Security.Pincode`. Keiner dieser Namen steht in `SECRET_KEYS`: die
+  // Geraete-Zugangsdaten wurden gestrichen, die der Intercom-Anlage gingen mit.
+  describe('fremde Roh-Dokumente', () => {
+    const mitPreset = () => ({
+      metadata: { name: 'Anlage' },
+      greengoConfig: {
+        systemName: 'Produktion',
+        users: [{ id: 1, name: 'Regie', groupIds: [1] }],
+        basePreset: {
+          System: {
+            ConfigPassword: 'a1b2c3d4-e5f6-0000-1111-222233334444',
+            AdminPassword: '9988-7766-5544-3322',
+            TechPincode: '4711',
+          },
+          Security: { Pincode: '0815' },
+        },
+      },
+    })
+
+    it('das Roh-Dokument verlaesst den Rechner nicht', () => {
+      const out = stripSecrets(mitPreset()) as Record<string, Record<string, unknown>>
+      expect(out.greengoConfig.basePreset).toBeUndefined()
+    })
+
+    it('kein einziges der Anlagen-Geheimnisse steht noch im Ergebnis', () => {
+      // Die Probe auf das Ganze statt auf das Feld: der serialisierte Ausgang
+      // darf keinen der vier Werte mehr enthalten, egal an welcher Stelle.
+      const json = JSON.stringify(stripSecrets(mitPreset()))
+      for (const geheim of ['a1b2c3d4', '9988-7766', '4711', '0815']) {
+        expect(json, `${geheim} steht noch im Ausgang`).not.toContain(geheim)
+      }
+    })
+
+    it('der Plan-Teil der Intercom-Konfiguration bleibt', () => {
+      // Gestrichen wird das fremde Dokument, nicht die Planung. Sonst waere
+      // die Mobile-Ansicht um Information aermer, die kein Geheimnis ist.
+      const out = stripSecrets(mitPreset()) as Record<string, Record<string, unknown>>
+      expect(out.greengoConfig.systemName).toBe('Produktion')
+      expect(out.greengoConfig.users).toEqual([{ id: 1, name: 'Regie', groupIds: [1] }])
+    })
+
+    it('der Typ sagt selbst, dass dort Passwoerter liegen', () => {
+      // Der Grund steht nicht nur in diesem Test: `GreenGoConfig.basePreset`
+      // kuendigt es im eigenen Kommentar an. Faellt der Hinweis weg, faellt
+      // dieser Test — dann ist zu pruefen, ob das Feld noch opak sein muss.
+      expect(greengoTypesSrc).toContain('basePreset')
+      expect(greengoTypesSrc).toMatch(/PASSWOERTER|Passw/)
+      expect(OPAQUE_KEYS.has('basePreset')).toBe(true)
+    })
   })
 
   it('haelt die Regel an genau einer Stelle', () => {


### PR DESCRIPTION
## Der Befund

`stripSecrets` streicht **nach Feldnamen** — `password`, `username`, `passphrase`, `apiKey`, `secret`, `token`. Das trägt für unsere eigenen Typen, weil wir deren Namen kennen. Für ein eingelesenes Hersteller-Dokument trägt es nicht.

`GreenGoConfig.basePreset` hält die importierte Anlagen-Konfiguration unverändert. Ihr eigener Kopf-Kommentar sagt das ausdrücklich zu: *„Räume, Templates, Geräte, Netz-Einstellungen und vor allem die PASSWÖRTER der Anlage bleiben, wie sie waren."* Diese heissen `ConfigPassword`, `AdminPassword`, `TechPincode` und `Security.Pincode` — **keiner dieser Namen steht in `SECRET_KEYS`.**

Ergebnis: die Zugangsdaten der **Geräte** wurden gestrichen, die der **Intercom-Anlage** gingen mit. Auf beiden Wegen, die das Projekt an andere Leute geben:

* in die `.cpviewer`-Datei, ausdrücklich für externe Reviewer,
* an jedes Handy in der Mobile-Ansicht.

Das widerspricht der Regel im Kopf von `stripSecrets` selbst („bevor es den Rechner in Richtung einer ANDEREN Person verlässt"), und es widerspricht einer Zusage, die der Nutzer zu lesen bekommt. `MobileShareDialog` sagt wörtlich: *„Passwörter und Schlüssel werden aus dem Projekt entfernt, bevor es das Gerät verlässt."* Eine falsche Zusicherung ist schlimmer als keine.

## Warum nicht einfach die vier Feldnamen nachtragen

Weil das Raten wäre. Das Dokument gehört einem Hersteller, und die nächste Firmware bringt ein Feld mit, das hier niemand aufgeschrieben hat — genau die Sorte Lücke, die diesen Befund erzeugt hat.

Stattdessen `OPAQUE_KEYS`: **das Roh-Dokument geht als Ganzes nicht mit.** Der Grund steht als Kategorie da und nicht als Liste — „fremdes Dokument, dessen Felder wir nicht kennen" gilt auch für das nächste.

**Nachgesehen, dass das nichts kostet** (dieselbe Prüfung, die der Kommentar schon für `username` gemacht hat):

* weder `src/mobile/` noch `src/viewer/` kennen GreenGo überhaupt — kein Treffer im ganzen Verzeichnis;
* `basePreset` wird nur im Renderer gelesen (`GreenGoExportDialog`, `exportGreengo`), also auf dem Rechner des Eigentümers;
* `GreenGoUser` und `GreenGoGroup` tragen selbst keine Geheimnisse, der Plan-Teil bleibt also vollständig.

Beim eigenen Speichern (`project:save`) bleibt alles unangetastet — dieselbe Grenze, die `stripSecrets` schon zieht.

## Was das nicht entscheidet

Ob ein Techniker vor Ort den Pincode der Anlage **überhaupt** über die Mobile-Ansicht bekommen soll, ist eine Workflow-Frage und gehört dem Eigentümer. Dieser PR beantwortet sie nicht — er wendet nur die Regel an, die schon dasteht, auf Felder, die sie offensichtlich meint. Wenn der Pincode dort hin soll, ist das ein eigener, bewusster Weg und nicht ein Nebeneffekt davon, dass ein Feld anders heisst.

## Prüfung

* **806 Tests grün** (4 neue), `tsc` für App und Main 0 Errors, Lint 0 Errors.
* Darunter die Probe auf das Ganze statt auf das Feld: kein einziger der vier Geheimnis-Werte steht noch im serialisierten Ausgang, egal an welcher Stelle.
* Ein Test hängt am Kommentar des Typs selbst — verschwindet der Hinweis auf die Passwörter aus `GreenGoConfig`, fällt er, und dann ist zu prüfen, ob das Feld noch opak sein muss.
* **Gegengeprüft:** `OPAQUE_KEYS` aus der Schleife ausgebaut → zwei der vier fallen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_