### PR TITLE
dialoge: der Guard suchte nur `window.alert(` — drei echte Stellen blieben stehen

### DIFF
--- a/src/renderer/components/Canvas/BulkConnectDialog.tsx
+++ b/src/renderer/components/Canvas/BulkConnectDialog.tsx
@@ -4,6 +4,7 @@ import { useProjectStore } from '../../store/projectStore'
 import { projectHistory } from '../../store/projectHistory'
 import { useTranslation, format } from '../../lib/i18n'
 import { ModalShell } from '../shared/ModalShell'
+import { infoDialog } from '../../lib/infoDialog'
 import { cableCatalog } from '../../types/cableSpec'
 import type { CableType } from '../../types/cable'
 
@@ -92,11 +93,14 @@ export const BulkConnectDialog = () => {
     })
     const result = projectHistory.transact(() => addCablesBulk(drafts))
     if (result.skipped > 0) {
-      alert(
+      // Rohes `alert()` bis hierher — die Suite hatte es laengst ersetzt, nur
+      // suchte der Guard ausschliesslich nach `window.alert(`.
+      void infoDialog(
         format(
           t('bulk.resultSkipped', '{created} Kabel angelegt, {skipped} übersprungen (Ziel-Port belegt oder ungültig).'),
           { created: result.created, skipped: result.skipped },
         ),
+        { tone: 'warning' },
       )
     }
     close()

--- a/src/renderer/components/Rack/RackBuilderDialogExportMenu.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialogExportMenu.tsx
@@ -4,6 +4,7 @@ import { Icon } from '../shared/Icon'
 import * as THREE from 'three'
 import type { GroupPreset } from '../../types/equipment'
 import { useTranslation } from '../../lib/i18n'
+import { infoDialog } from '../../lib/infoDialog'
 import {
   exportRack2DAsPng,
   exportRack3DAsPngs,
@@ -100,7 +101,7 @@ export const RackBuilderDialogExportMenu = ({
               setOpen(false)
               const refs = canvas3DRefs.current
               if (!refs) {
-                alert(t('rack.export.no3dInit', '3D-Tab muss zuerst geöffnet worden sein um die 3D-Szene zu initialisieren.'))
+                await infoDialog(t('rack.export.no3dInit', '3D-Tab muss zuerst geöffnet worden sein um die 3D-Szene zu initialisieren.'), { tone: 'warning' })
                 return
               }
               await exportRack3DAsPngs(refs.gl, refs.scene, refs.camera, {
@@ -123,7 +124,8 @@ export const RackBuilderDialogExportMenu = ({
               setOpen(false)
               const refs = canvas3DRefs.current
               if (!refs) {
-                alert(t('rack.export.no3dInit', '3D-Tab muss zuerst geöffnet worden sein um die 3D-Szene zu initialisieren.'))
+                // Dieser Handler ist nicht async (der PNG-Export daneben schon).
+                void infoDialog(t('rack.export.no3dInit', '3D-Tab muss zuerst geöffnet worden sein um die 3D-Szene zu initialisieren.'), { tone: 'warning' })
                 return
               }
               exportRackAsStl(refs.scene, rackName || 'rack')

--- a/tests/nativeDialogs.test.ts
+++ b/tests/nativeDialogs.test.ts
@@ -24,14 +24,38 @@ const sources = import.meta.glob('../src/renderer/**/*.{ts,tsx}', {
 /** Die drei Ersatz-Dialoge selbst duerfen die nativen Namen nennen. */
 const ERSATZ = /\/lib\/(confirmDialog|infoDialog|promptDialog)\.tsx$/
 
+/**
+ * Beide Schreibweisen, und das ist der Punkt.
+ *
+ * Die erste Fassung dieses Tests suchte nur `window.alert(`. Sie meldete
+ * daraufhin null Treffer, waehrend drei rohe `alert(`-Aufrufe im selben
+ * durchsuchten Baum standen (`BulkConnectDialog`, `RackBuilderDialogExportMenu`
+ * zweimal). `window.` ist optional -- die globalen Funktionen heissen einfach
+ * `alert`, `confirm`, `prompt`, und so werden sie ueblicherweise auch
+ * geschrieben.
+ *
+ * Ein Guard, der die haeufigere Schreibweise nicht kennt, ist schlimmer als
+ * keiner: er beantwortet die Frage mit „nein" statt mit „weiss ich nicht".
+ * Gefunden hat das nicht dieser Test, sondern ein Durchlauf, der Suite- und
+ * Upstream-Fassungen verglich -- die Suite hatte die drei Stellen laengst
+ * ersetzt.
+ *
+ * `[^.\w$]` davor schliesst Eigenschaftszugriffe (`foo.alert(`) und laengere
+ * Bezeichner (`confirmDialog(`, `onConfirm(`) aus; das optionale `window.`
+ * holt die qualifizierte Schreibweise wieder herein. Beim Reparieren hatte ich
+ * genau die verloren -- eine Blindstelle gegen die andere getauscht. Der
+ * Gegentest unten faehrt deshalb alle vier Formen durch.
+ */
+const NATIVE_CALL = /(^|[^.\w$])(?:window\.)?(confirm|alert|prompt)\s*\(/g
+
 const nativeCalls = (): string[] => {
   const hits: string[] = []
   for (const [path, src] of Object.entries(sources)) {
     if (ERSATZ.test(path)) continue
     const code = stripComments(src)
-    for (const m of code.matchAll(/window\.(confirm|alert|prompt)\s*\(/g)) {
+    for (const m of code.matchAll(NATIVE_CALL)) {
       const line = code.slice(0, m.index).split('\n').length
-      hits.push(`${path.replace('../', '')}:${line} — window.${m[1]}()`)
+      hits.push(`${path.replace('../', '')}:${line} — ${m[2]}()`)
     }
   }
   return hits.sort()


### PR DESCRIPTION
## Der Befund

`tests/nativeDialogs.test.ts` aus `#655` sucht mit

```js
/window\.(confirm|alert|prompt)\s*\(/g
```

Die globalen Funktionen heissen aber `alert`, `confirm`, `prompt` — `window.` ist **optional und wird ueblicherweise weggelassen.** Der Guard meldete deshalb seit `#655` null Treffer, waehrend drei rohe Aufrufe im exakt durchsuchten Baum standen:

* `renderer/components/Canvas/BulkConnectDialog.tsx` — das Ergebnis-Feedback nach dem Bulk-Anlegen
* `renderer/components/Rack/RackBuilderDialogExportMenu.tsx` ×2 — der „3D-Tab muss zuerst geöffnet worden sein"-Guard vor PNG- und STL-Export

Ein Guard, der die haeufigere Schreibweise nicht kennt, ist **schlimmer als keiner**: er beantwortet die Frage mit „nein" statt mit „weiss ich nicht". Genau der Fehler, gegen den er gebaut wurde — diesmal im Werkzeug selbst.

## Wie es gefunden wurde

Nicht vom Test. Ein Durchlauf über 53 Dateien hat Suite- gegen Upstream-Fassungen verglichen, um den fehlenden **Rückweg Suite → upstream** zu prüfen. Die Suite hatte diese drei Stellen längst auf `infoDialog` umgestellt; upstream hat den Fix nie bekommen, und der Guard, der ihn hätte melden müssen, war blind für die Schreibweise.

Dieselbe Ursache wie bei `CollabPanel` in `#655`: eine Verbesserung entsteht in der Suite und erreicht upstream nie.

## Die Änderung

```js
/(^|[^.\w$])(?:window\.)?(confirm|alert|prompt)\s*\(/g
```

`[^.\w$]` davor schliesst Eigenschaftszugriffe (`foo.alert(`) und laengere Bezeichner (`confirmDialog(`, `onConfirm(`) aus; das optionale `window.` holt die qualifizierte Schreibweise wieder herein.

Alle drei Stellen jetzt `infoDialog(..., { tone: 'warning' })`. Der STL-Handler ist **nicht** async — der PNG-Export direkt daneben schon — dort `void` statt `await`.

## Eine Zwischenstufe, die ich selbst kaputt gemacht habe

Meine erste Reparatur lautete `/(^|[^.\w$])(confirm|alert|prompt)\s*\(/` — und verlor damit `window.alert(`, weil der Punkt vom Ausschluss getroffen wird. **Eine Blindstelle gegen die andere getauscht.** Aufgefallen ist das nur, weil der Gegentest jede Form einzeln einspeist statt „grün genügt" zu lesen.

Der Gegentest faehrt deshalb jetzt **alle sechs Formen** durch — `alert(`, `window.alert(`, `confirm(`, `window.confirm(`, `prompt(`, `window.prompt(` — und jede wird mit Datei, Zeile und Funktionsnamen gemeldet:

```
  'alert('          -> BulkConnectDialog.tsx:88 — alert()
  'window.alert('   -> BulkConnectDialog.tsx:88 — alert()
  'window.confirm(' -> BulkConnectDialog.tsx:88 — confirm()
  'confirm('        -> BulkConnectDialog.tsx:88 — confirm()
  'prompt('         -> BulkConnectDialog.tsx:88 — prompt()
  'window.prompt('  -> BulkConnectDialog.tsx:88 — prompt()
```

Keine Fehltreffer: `confirmDialog(`, `infoDialog(` und Kommentare bleiben unberuehrt (Kommentare werden ohnehin vor der Suche gestrichen).

## Prüfung

* **806 Tests grün**, `tsc` für App und Main 0 Errors, Lint 0 Errors — an den Exit-Codes geprüft, nicht an gefilterter Ausgabe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_