### PR TITLE
ci: CRDT- und Signaling-Prüfung laufen jetzt mit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,24 @@ name: CI
 #   npm test                                vitest
 #   npm run build                           main + preload + renderer
 #
+# Dazu die beiden headless Node-Checks fuer die Live-Kollaboration:
+#
+#   npm run test:crdt        CRDT-Konvergenz (reine Rechnung, ~0,4 s)
+#   npm run test:signaling   Signaling-Relay gegen den echten Server (~2,6 s)
+#
+# Die standen bis 2026-09-04 nicht hier, mit der Begruendung, sie "erwarten
+# einen laufenden Renderer bzw. Netzwerk". Nachgemessen stimmt das fuer diese
+# beiden nicht: `test:crdt` ist ein reines Node-Skript ohne jedes IO, und
+# `signaling-relay-check.mjs` startet den echten Server selbst und traegt im
+# eigenen Kopf "Exit 0 = alle Asserts gruen, Exit 1 = Fehler (CI-tauglich)".
+# Kollaboration war damit die am schlechtesten abgesicherte Funktion des
+# groessten Repos -- nicht mangels Pruefung, sondern weil die vorhandene nie
+# lief.
+#
 # Bewusst NICHT hier: electron-builder (`npm run dist`) — das gehoert zu
-# release.yml und braucht Signatur-Material, und die gezielten Node-Checks
-# (test:crdt, test:signaling, ui:smoke, test:drag), die einen laufenden
-# Renderer bzw. Netzwerk erwarten.
+# release.yml und braucht Signatur-Material. Ebenso `ui:smoke` und
+# `test:drag`: die brauchen wirklich einen laufenden Renderer
+# (`dev:renderer`), und dafuer stimmt die alte Begruendung.
 
 on:
   pull_request:
@@ -48,5 +62,9 @@ jobs:
         run: npm run lint
       - name: Tests
         run: npm test
+      - name: CRDT-Konvergenz
+        run: npm run test:crdt
+      - name: Signaling-Relay
+        run: npm run test:signaling
       - name: Build
         run: npm run build


### PR DESCRIPTION
## Der Befund

Beide Skripte gibt es längst — `npm run test:crdt` und `npm run test:signaling`.
Keines lief je in CI. Die Live-Kollaboration war damit die **am schlechtesten
abgesicherte Funktion des größten Repos**: nicht mangels Prüfung, sondern weil
die vorhandene nie lief.

## Die Begründung im Workflow stimmte nicht

Der Kopfkommentar von `ci.yml` schloss vier Skripte in einem Satz aus:

> Bewusst NICHT hier: … die gezielten Node-Checks (test:crdt, test:signaling,
> ui:smoke, test:drag), die einen laufenden Renderer bzw. Netzwerk erwarten.

Nachgemessen trifft das auf **zwei der vier** nicht zu:

| Skript | Gemessen | Braucht wirklich einen Renderer? |
| --- | --- | --- |
| `test:crdt` | **0,4 s**, reines Node-Skript ohne jedes IO | nein |
| `test:signaling` | **2,6 s**, startet den echten Server selbst | nein |
| `ui:smoke` | — | ja |
| `test:drag` | — | ja (`CLAUDE.md`: „braucht laufenden dev:renderer") |

`scripts/signaling-relay-check.mjs` trägt die Antwort sogar im eigenen Kopf:

> Exit 0 = alle Asserts grün, Exit 1 = Fehler (**CI-tauglich**).

Es war für CI geschrieben und nie eingehängt. Vier Skripte waren in einen Satz
zusammengefasst, und für zwei davon galt er nicht — dieselbe Sorte
Pauschal-Begründung, die heute schon an anderer Stelle gekippt ist.

## Was jetzt geprüft wird

* **CRDT-Konvergenz:** Peer-Edits überleben ein fremdes `undo()`, kein
  Clobbering, `redo()` stellt nur das eigene wieder her.
* **Signaling-Relay:** Subscribe → Publish erreicht alle Topic-Abonnenten,
  Ping → Pong, **Topic-Isolation** (ein fremdes Topic empfängt nichts) und
  Unsubscribe.

Der Kommentar ist berichtigt und benennt für `ui:smoke`/`test:drag` weiterhin
den richtigen Grund.

## Prüfung

Lokal an den Exit-Codes geprüft, nicht an gefilterter Ausgabe:

| Schritt | Ergebnis |
| --- | --- |
| `npm run test:crdt` | Exit 0 — „ALLE KONVERGENZ-ASSERTS GRUEN" (0,39 s) |
| `npm run test:signaling` | Exit 0 — 6 Asserts grün (2,59 s) |

Zusammen unter drei Sekunden; es gibt kein Laufzeit-Argument gegen die
Aufnahme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_