### PR TITLE
laden: eine fremde JSON-Datei stürzte den Renderer ab

### DIFF
--- a/src/renderer/components/Project/PlanCompareDialog.tsx
+++ b/src/renderer/components/Project/PlanCompareDialog.tsx
@@ -10,6 +10,7 @@ import { buildExportFilenameWithSuffix } from '../../lib/exportFilename'
 import { planDiff, planDiffCsv, planDiffSummary, type PlanDiff } from '../../lib/planDiff'
 import { changeImpact, changeImpactSummary, type ChangeImpact } from '../../lib/changeImpact'
 import { planFingerprint } from '../../lib/documentStamp'
+import { looksLikeProject } from '../../lib/looksLikeProject'
 import type { CablePlannerProject, ProjectRevision } from '../../types/project'
 
 // Roadmap-Initiative 5 — hier laufen beide Ableitungen zusammen.
@@ -54,13 +55,6 @@ type Loaded = {
   /** Dateipfad oder Revisions-Label — was im Dialog neben der Auswahl steht. */
   label: string
   project: CablePlannerProject
-}
-
-/** Plausibilitaet statt Vertrauen: eine fremde Datei ist erst mal nur JSON. */
-const looksLikeProject = (data: unknown): data is CablePlannerProject => {
-  if (typeof data !== 'object' || data === null) return false
-  const p = data as Record<string, unknown>
-  return Array.isArray(p.equipment) && Array.isArray(p.cables) && typeof p.metadata === 'object'
 }
 
 const VERDICT_STYLE: Record<string, string> = {

--- a/src/renderer/hooks/useProject.ts
+++ b/src/renderer/hooks/useProject.ts
@@ -6,6 +6,7 @@ import { projectHistory } from '../store/projectHistory'
 import type { CablePlannerProject } from '../types/project'
 import { promptDialog } from '../lib/promptDialog'
 import { infoDialog } from '../lib/infoDialog'
+import { looksLikeProject } from '../lib/looksLikeProject'
 import { translate } from '../lib/i18n'
 
 interface OpenProjectResponse {
@@ -53,6 +54,30 @@ export const useProject = () => {
           y: e.y,
         })),
       })
+      // Die Datei-Tuer. `healProjectPositions` greift ungeschuetzt auf
+      // `equipment`/`cables` zu; gueltiges JSON, das kein Projekt ist, laesst
+      // den Renderer sonst in die ErrorBoundary laufen. Der Autosave-Pfad
+      // prueft das seit laengerem, diese Tuer nicht — nachgewiesen mit
+      // `TypeError: Cannot read properties of undefined (reading 'filter')`.
+      //
+      // Abgelehnt statt repariert: ein auf `[]` aufgefuelltes Projekt saehe
+      // aus, als waere die Arbeit des Nutzers weg.
+      if (!looksLikeProject(result.data)) {
+        const lang = useUiStore.getState().language
+        await infoDialog(
+          translate(lang, 'project.open.notAPlanTitle', 'Diese Datei ist kein Cable-Planner-Projekt'),
+          {
+            body: translate(
+              lang,
+              'project.open.notAPlan',
+              'Die Datei ließ sich lesen, enthält aber keine Geräte- und Kabel-Liste. ' +
+                'Es wurde nichts geladen — das offene Projekt bleibt unverändert.',
+            ),
+            tone: 'warning',
+          },
+        )
+        return
+      }
       // Sync metadata.name with filename if project still has the default name.
       const incoming = result.data
       if (

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3469,6 +3469,9 @@ export const en: Dict = {
   // useProject viewer name prompt (translate() from hook)
   'project.viewerName.prompt':
     'Viewer file — enter name\n\nYou are opening a viewer file for review. Please enter your name — it will be attached to all annotations you create in this session.',
+  'project.open.notAPlanTitle': 'This file is not a Cable Planner project',
+  'project.open.notAPlan':
+    'The file could be read but contains no equipment and cable list. Nothing was loaded — the open project is unchanged.',
   'project.viewerName.missingTitle': 'Name missing',
   'project.viewerName.missingBody':
     'Without a name no annotations can be made. The file will not be loaded.',

--- a/src/renderer/lib/looksLikeProject.ts
+++ b/src/renderer/lib/looksLikeProject.ts
@@ -1,0 +1,35 @@
+import type { CablePlannerProject } from '../types/project'
+
+/**
+ * Plausibilitaet statt Vertrauen: eine fremde Datei ist erst mal nur JSON.
+ *
+ * WARUM DAS AN DER TUER STEHEN MUSS. `healProjectPositions` — die
+ * Schema-Migrationsschicht, durch die jedes geladene Projekt laeuft — greift
+ * ungeschuetzt auf `project.equipment` und `project.cables` zu. Eine Datei, die
+ * gueltiges JSON ist, aber kein Projekt (die falsche Datei erwischt, der Export
+ * eines anderen Programms, ein von Hand zusammengebautes Fragment), laesst den
+ * Renderer mit `TypeError: Cannot read properties of undefined` in die
+ * ErrorBoundary laufen.
+ *
+ * Der Autosave-Pfad kennt genau diesen Fall und prueft ihn seit laengerem —
+ * `loadAutosavedProject` in `projectStore.ts` sagt im eigenen Kommentar, dass
+ * ein kaputter Stand "den Renderer downstream mit `cannot read .map of
+ * undefined` crasht". Die Datei-Tuer hatte dieselbe Pruefung nicht. Eine von
+ * zwei Tueren verriegelt zu haben ist kein Schutz.
+ *
+ * WARUM ABLEHNEN UND NICHT REPARIEREN. Naheliegend waere, fehlende Listen mit
+ * `[]` aufzufuellen. Das waere die schlechtere Antwort: der Nutzer saehe einen
+ * leeren Plan unter dem Namen seiner Datei und muesste glauben, seine Arbeit
+ * sei weg. Eine Ablehnung mit Begruendung ist unangenehm, eine stille "Reparatur"
+ * zu einem leeren Projekt ist ein erfundener Zustand.
+ *
+ * Die Bedingung ist bewusst schwach: `equipment` und `cables` als Listen,
+ * `metadata` als Objekt. Sie soll den Fehlgriff abfangen, nicht das Schema
+ * validieren — dafuer ist `healProjectPositions` da, und die darf ein altes
+ * Projekt nie wegen eines fehlenden Feldes ablehnen.
+ */
+export const looksLikeProject = (data: unknown): data is CablePlannerProject => {
+  if (typeof data !== 'object' || data === null) return false
+  const p = data as Record<string, unknown>
+  return Array.isArray(p.equipment) && Array.isArray(p.cables) && typeof p.metadata === 'object'
+}

--- a/tests/openProjectGuard.test.ts
+++ b/tests/openProjectGuard.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { looksLikeProject } from '../src/renderer/lib/looksLikeProject'
+import { useProjectStore } from '../src/renderer/store/projectStore'
+import type { CablePlannerProject } from '../src/renderer/types/project'
+import hookSrc from '../src/renderer/hooks/useProject.ts?raw'
+
+// Eine Datei, die gueltiges JSON ist, aber kein Projekt, liess den Renderer
+// abstuerzen: `healProjectPositions` greift ungeschuetzt auf `equipment` und
+// `cables` zu. Der Autosave-Pfad prueft das seit laengerem und nennt den
+// Absturz im eigenen Kommentar -- die Datei-Tuer hatte dieselbe Pruefung nicht.
+//
+// Diese Datei haelt beide Haelften fest: dass der Store ohne Pruefung wirklich
+// wirft (sonst wuerde die Pruefung etwas Erfundenes abwehren), und dass die
+// Tuer sie hat.
+
+const bad: Array<[string, unknown]> = [
+  ['fehlendes equipment', { metadata: { name: 'x' }, cables: [] }],
+  ['fehlende cables', { metadata: { name: 'x' }, equipment: [] }],
+  ['fehlende metadata', { equipment: [], cables: [] }],
+  ['equipment ist kein Array', { metadata: {}, equipment: {}, cables: [] }],
+  ['leeres Objekt', {}],
+  ['null', null],
+  ['eine Zahl', 42],
+  ['ein Array', []],
+]
+
+describe('looksLikeProject', () => {
+  for (const [name, value] of bad) {
+    it(`weist ab: ${name}`, () => expect(looksLikeProject(value)).toBe(false))
+  }
+
+  it('laesst ein mageres, aber echtes Projekt durch', () => {
+    // Bewusst schwach: die Pruefung soll den Fehlgriff abfangen, nicht das
+    // Schema validieren. Ein altes Projekt ohne neuere Felder muss laden.
+    expect(looksLikeProject({ metadata: { name: 'A' }, equipment: [], cables: [] })).toBe(true)
+  })
+})
+
+describe('der Schaden, den die Pruefung abwehrt, ist echt', () => {
+  it('loadProject wirft bei fehlendem equipment', () => {
+    // Faellt dieser Test, weil nichts mehr wirft, ist die Pruefung an der Tuer
+    // vielleicht ueberfluessig geworden -- dann hier nachsehen, nicht einfach
+    // den Test streichen.
+    const fremd = { metadata: { name: 'x' }, cables: [] } as unknown as CablePlannerProject
+    expect(() => useProjectStore.getState().loadProject(fremd, '/tmp/x.cableplan')).toThrow(
+      /Cannot read properties of undefined/,
+    )
+  })
+})
+
+describe('die Tuer selbst', () => {
+  it('der gemeinsame Oeffnen-Pfad prueft, bevor er laedt', () => {
+    // Quelltext-Guard: `applyOpenedProject` ist der einzige Loader fuer Dialog,
+    // Kaltstart-Doppelklick und Doppelklick bei laufender App. Verschwindet die
+    // Pruefung dort, faellt dieser Test -- nicht erst ein Nutzer.
+    expect(hookSrc).toContain('looksLikeProject(result.data)')
+    const i = hookSrc.indexOf('looksLikeProject(result.data)')
+    const j = hookSrc.indexOf('loadProject(incoming, result.filePath)')
+    expect(i).toBeGreaterThan(0)
+    expect(j).toBeGreaterThan(i)
+  })
+})


### PR DESCRIPTION
## Der Defekt

`healProjectPositions` — die Schema-Migrationsschicht, durch die **jedes**
geladene Projekt läuft — greift ungeschützt auf `project.equipment` und
`project.cables` zu. Eine Datei, die gültiges JSON ist, aber kein Projekt
(die falsche Datei erwischt, der Export eines anderen Programms, ein von Hand
zusammengebautes Fragment), lässt den Renderer damit in die ErrorBoundary
laufen.

Nachgewiesen, nicht vermutet:

```
TypeError: Cannot read properties of undefined (reading 'filter')
```

## Warum das besonders ärgerlich ist

**Der Autosave-Pfad kennt genau diesen Fall und prüft ihn seit längerem.**
`loadAutosavedProject` in `projectStore.ts` validiert `Array.isArray(...)` und
sagt im eigenen Kommentar, warum:

> A corrupt autosave … crashes the renderer downstream with `cannot read .map
> of undefined` — which surfaces as React #185 boot loops via the ErrorBoundary
> re-mount.

Die Datei-Tür hatte dieselbe Prüfung nicht. Eine von zwei Türen verriegelt zu
haben ist kein Schutz — und die unverriegelte ist die, durch die fremde Dateien
hereinkommen.

## Die Änderung

`looksLikeProject` gab es bereits — als lokale Kopie im `PlanCompareDialog`,
wo eine fremde Vergleichsdatei schon immer geprüft wurde. Sie liegt jetzt in
`lib/looksLikeProject.ts` und wird von beiden benutzt.

Die Prüfung sitzt in `applyOpenedProject`, dem **gemeinsamen** Loader für alle
drei Öffnen-Wege: Dialog, OS-Doppelklick beim Kaltstart, Doppelklick bei
laufender App.

### Abgelehnt, nicht repariert

Naheliegend wäre, fehlende Listen mit `[]` aufzufüllen. Das wäre die
schlechtere Antwort: der Nutzer sähe einen **leeren Plan unter dem Namen seiner
Datei** und müsste glauben, seine Arbeit sei weg. Die Meldung sagt deshalb
ausdrücklich, dass nichts geladen wurde und das offene Projekt unverändert
bleibt.

Die Bedingung ist bewusst schwach — `equipment`/`cables` als Listen, `metadata`
als Objekt. Sie soll den Fehlgriff abfangen, nicht das Schema validieren; dafür
ist `healProjectPositions` da, und die darf ein altes Projekt nie wegen eines
fehlenden Feldes ablehnen. Ein Test hält genau das fest („lässt ein mageres,
aber echtes Projekt durch").

## Prüfung

* **817 Tests grün** (11 neue), `tsc` 0 Errors, Lint 0 Errors — an den
  Exit-Codes geprüft.
* Unter den neuen Tests einer, der **den Schaden selbst nachweist**: der Store
  *muss* ohne Prüfung werfen. Täte er das nicht, wehrte die Prüfung etwas
  Erfundenes ab — und der Test sagt im Kommentar, dass man dann hier nachsehen
  soll, statt ihn zu streichen.
* Dazu ein Quelltext-Guard: die Prüfung muss im gemeinsamen Öffnen-Pfad *vor*
  `loadProject` stehen. **Gegengeprüft:** Prüfung ausgebaut → dieser Test fällt.

## Wie es gefunden wurde

Aus dem Implementierungs-Audit über alle acht Repos — ein Agent stufte den
Ladepfad als `BROKEN` ein. Drei andere Befunde desselben Laufs haben die
Nachprüfung nicht überlebt; dieser hier schon, und der Nachweis steht jetzt als
Test im Repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_