### PR TITLE
sync: das ganze Projekt ging nicht-atomar aufs Netzlaufwerk

### DIFF
--- a/src/main/ipc/syncIpc.ts
+++ b/src/main/ipc/syncIpc.ts
@@ -19,6 +19,7 @@
 import { ipcMain } from 'electron'
 import { readFile, writeFile, mkdir, access, unlink } from 'node:fs/promises'
 import path from 'node:path'
+import { atomicWriteFile } from '../util/atomicWrite.js'
 
 const LOCK_FILE = '.cable-planner-sync.lock'
 const LOCK_TTL_MS = 2 * 60 * 60 * 1000 // 2 hours
@@ -136,9 +137,22 @@ export function registerSyncIpc() {
 
   // ── sync:write-file ─────────────────────────────────────────────────────────
   ipcMain.handle('sync:write-file', async (_event, filePath: string, data: string): Promise<void> => {
+    // Hier geht das GANZE Projekt raus (`SharedSyncPanel` schickt
+    // `JSON.stringify(project)`), und zwar auf ein Netzlaufwerk. Bis hierher
+    // mit blankem `writeFile` — genau das, was die Invariante in CLAUDE.md
+    // ausschliesst: Userdaten immer atomar ueber `atomicWriteFile`.
+    //
+    // Der Weg mit der unzuverlaessigsten Ablage war der einzige ohne den
+    // Schutz. `project:save` und `library:write` haben ihn seit jeher; diese
+    // Datei importierte `atomicWrite` nicht einmal.
+    //
+    // atomicWriteFile legt das Verzeichnis selbst an (mkdir recursive), das
+    // frühere `ensureDir` hier ist damit ueberfluessig. Seine In-Flight-Sperre
+    // ist auf einem GETEILTEN Laufwerk zusaetzlich willkommen: zwei
+    // gleichzeitige Schreibvorgaenge auf dieselbe Datei sind dort der
+    // Normalfall, nicht die Ausnahme.
     const safe = assertSafeFilePath(filePath)
-    await ensureDir(path.dirname(safe))
-    await writeFile(safe, String(data ?? ''), 'utf-8')
+    await atomicWriteFile(safe, String(data ?? ''))
   })
 
   // ── sync:exists ─────────────────────────────────────────────────────────────

--- a/tests/syncAtomicWrite.test.ts
+++ b/tests/syncAtomicWrite.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import syncSrc from '../src/main/ipc/syncIpc.ts?raw'
+import projectSrc from '../src/main/ipc/projectIpc.ts?raw'
+import librarySrc from '../src/main/ipc/libraryIpc.ts?raw'
+import panelSrc from '../src/renderer/components/Sync/SharedSyncPanel.tsx?raw'
+import { stripComments } from './support/stripComments'
+
+// CLAUDE.md, nicht verhandelbar: "Schreibvorgaenge fuer Userdaten IMMER atomic
+// via src/main/util/atomicWrite.ts. Niemals direkt fs.writeFile."
+//
+// `sync:write-file` hat sich daran nicht gehalten -- und ausgerechnet dieser
+// Weg schreibt das GANZE Projekt auf ein NETZLAUFWERK, also dorthin, wo ein
+// abgebrochener Schreibvorgang am wahrscheinlichsten ist. `project:save` und
+// `library:write` hatten den Schutz seit jeher; syncIpc importierte
+// `atomicWrite` nicht einmal.
+//
+// Nicht mitgezaehlt wird bewusst app-lokaler Zustand (Fenster-Geometrie,
+// Zuletzt-geoeffnet): beide Leser sind vollstaendig defensiv und fallen auf
+// Defaults zurueck, ein zerrissener Schreibvorgang heilt sich dort selbst.
+
+const code = (src: string) => stripComments(src)
+
+describe('Atomic-Write-Invariante auf den Userdaten-Pfaden', () => {
+  it('sync:write-file schreibt atomar', () => {
+    const c = code(syncSrc)
+    expect(c).toContain('atomicWriteFile(safe')
+  })
+
+  it('kein blankes writeFile mehr im sync-Schreibpfad', () => {
+    // Der Handler-Rumpf von `sync:write-file`, isoliert betrachtet.
+    const c = code(syncSrc)
+    const start = c.indexOf("ipcMain.handle('sync:write-file'")
+    expect(start).toBeGreaterThan(0)
+    const body = c.slice(start, c.indexOf('ipcMain.handle', start + 1))
+    expect(body).not.toMatch(/\bawait writeFile\(/)
+  })
+
+  it('die drei Userdaten-Schreibwege benutzen denselben Helfer', () => {
+    // Faellt einer davon zurueck auf blankes writeFile, faellt dieser Test --
+    // und nennt den Weg, der aus der Reihe getanzt ist.
+    for (const [name, src] of [
+      ['syncIpc', syncSrc],
+      ['projectIpc', projectSrc],
+      ['libraryIpc', librarySrc],
+    ] as const) {
+      expect(code(src), `${name} importiert atomicWrite nicht`).toContain('atomicWrite')
+    }
+  })
+
+  it('der Sync-Panel schickt wirklich das ganze Projekt (sonst waere die Regel egal)', () => {
+    // Belegt, warum dieser Pfad unter die Invariante faellt. Aendert sich das,
+    // gehoert die Einordnung oben neu geprueft -- nicht dieser Test gestrichen.
+    expect(code(panelSrc)).toMatch(/sync\.writeFile\([\s\S]{0,120}JSON\.stringify\(project/)
+  })
+})


### PR DESCRIPTION
## Der Befund

`sync:write-file` schrieb mit blankem `await writeFile(safe, …)`.

Darüber geht **das ganze Projekt**: `SharedSyncPanel.tsx:87` schickt
`JSON.stringify(project, null, 2)`. Ziel ist ein **Netzlaufwerk** — also genau
die Ablage, auf der ein abgebrochener Schreibvorgang am wahrscheinlichsten ist
(Verbindung weg, Share nicht mehr gemountet, zweiter Rechner schreibt
gleichzeitig).

`CLAUDE.md` nennt die Regel nicht verhandelbar:

> Schreibvorgänge für Userdaten **immer atomic** via
> `src/main/util/atomicWrite.ts` (tmp → .bak-Rotation → rename). Niemals direkt
> `fs.writeFile`.

`project:save` und `library:write` halten sie seit jeher. **`syncIpc.ts`
importierte `atomicWrite` nicht einmal.** Der Weg mit der unzuverlässigsten
Ablage war der einzige ohne den Schutz — dasselbe Muster wie schon zweimal
heute: die Absicherung existiert, ist begründet, und eine von mehreren Türen
hat sie nicht.

## Die Änderung

`atomicWriteFile(safe, …)` statt `writeFile`. Das frühere `ensureDir` an dieser
Stelle entfällt — `atomicWriteFile` legt das Verzeichnis selbst an
(`mkdir` recursive).

Die **In-Flight-Sperre** ist auf einem geteilten Laufwerk ein zusätzlicher
Gewinn, kein Nebeneffekt: zwei gleichzeitige Schreibvorgänge auf dieselbe Datei
sind dort der Normalfall, nicht die Ausnahme. Bisher hätten sie sich
überschrieben.

## Was ausdrücklich NICHT mitgezählt wird

Beim Prüfen der Invariante fielen zwei weitere `writeFile`-Stellen auf —
Fenster-Geometrie (`main/index.ts:135`) und die Zuletzt-geöffnet-Liste
(`projectIpc.ts:37/46`). **Die habe ich nachgesehen und bewusst gelassen:**
beide Leser sind vollständig defensiv (`readRecent` fängt alles und gibt `[]`
zurück, der Geometrie-Leser typprüft jedes Feld und fällt auf Defaults
zurück). Ein zerrissener Schreibvorgang heilt sich dort selbst, und es sind
keine Nutzerdaten. Sie als Verstoß zu melden wäre ein Fehlalarm gewesen.

## Prüfung

* **821 Tests grün** (4 neue), `tsc` für Main und App 0 Errors, Lint 0 Errors —
  an den Exit-Codes.
* Unter den Tests einer, der belegt **warum** dieser Pfad unter die Invariante
  fällt (der Panel schickt wirklich das ganze Projekt) — ändert sich das,
  gehört die Einordnung neu geprüft statt der Test gestrichen.
* Und einer, der alle drei Userdaten-Schreibwege zusammenhält: fällt einer
  zurück auf blankes `writeFile`, nennt der Test den Ausreißer beim Namen.
* **Gegengeprüft:** auf blankes `writeFile` zurückgedreht → zwei der vier
  Tests fallen.

## Herkunft

Aus dem Implementierungs-Audit. Der Befund stand dort als `PARTIAL` bei
`sync: Netzlaufwerk read/write/exists` — verifiziert, bevor er hier gelandet
ist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_