### PR TITLE
main: drei Schutzwege, die je einen Aufrufer auslassen

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import fs from 'node:fs'
 import { registerCredentialsIpc } from './ipc/credentialsIpc.js'
+import { appendLogCapped } from './util/appendLogCapped.js'
 import { registerRentmanIpc } from './ipc/rentmanIpc.js'
 import { registerNetboxIpc } from './ipc/netboxIpc.js'
 import { openExternalProject, registerProjectIpc } from './ipc/projectIpc.js'
@@ -59,24 +60,6 @@ if (!gotInstanceLock) {
   })
 }
 
-// Append to a log file with a hard size cap so a crash-loop can't fill
-// the user's disk. When the file passes the cap it is rotated to `.1`.
-const LOG_MAX_BYTES = 2 * 1024 * 1024 // 2 MB
-const appendLogCapped = (fileName: string, msg: string): void => {
-  try {
-    const file = path.join(app.getPath('userData'), fileName)
-    try {
-      if (fs.statSync(file).size > LOG_MAX_BYTES) {
-        fs.renameSync(file, `${file}.1`)
-      }
-    } catch {
-      /* no existing file → fine */
-    }
-    fs.appendFileSync(file, msg)
-  } catch {
-    /* ignore */
-  }
-}
 
 // Prevents black-screen rendering issues seen on some Windows GPU drivers.
 if (process.platform === 'win32') {

--- a/src/main/ipc/credentialsIpc.ts
+++ b/src/main/ipc/credentialsIpc.ts
@@ -6,6 +6,15 @@ import { createRentmanApiClient } from '../services/rentmanApiClient.js'
 export const registerCredentialsIpc = () => {
   ipcMain.handle('credentials:get-token', () => credentialsService.getToken())
 
+  // Nach dem Vorbild von `netbox:has-token`: wer nur wissen will, OB ein
+  // Token hinterlegt ist, bekommt einen Boolean statt des Klartexts.
+  //
+  // `App.tsx` holte beim Start das echte Token nur, um `Boolean(token)` zu
+  // bilden -- das Geheimnis lag danach fuer die ganze Sitzung im Renderer,
+  // ohne dass es dort jemand brauchte. Der Klartext-Weg bleibt fuer den
+  // Einstellungs-Dialog, der das Token wirklich anzeigt.
+  ipcMain.handle('credentials:has-token', async () => Boolean(await credentialsService.getToken()))
+
   ipcMain.handle('credentials:save-token', async (_event, token: string) => {
     if (!token?.trim()) {
       throw new Error('Token is required.')

--- a/src/main/ipc/logIpc.ts
+++ b/src/main/ipc/logIpc.ts
@@ -1,14 +1,13 @@
-import { app, ipcMain } from 'electron'
-import fs from 'node:fs'
-import path from 'node:path'
+import { ipcMain } from 'electron'
+import { appendLogCapped } from '../util/appendLogCapped.js'
 
 export const registerLogIpc = () => {
   ipcMain.on('logs:renderer-error', (_event, payload: { message: string; stack?: string; source?: string }) => {
-    try {
-      const line = `[${new Date().toISOString()}] [renderer] ${payload.source ?? 'error'}: ${payload.message}\n${payload.stack ?? ''}\n`
-      fs.appendFileSync(path.join(app.getPath('userData'), 'renderer-error.log'), line)
-    } catch {
-      /* ignore */
-    }
+    const line = `[${new Date().toISOString()}] [renderer] ${payload.source ?? 'error'}: ${payload.message}\n${payload.stack ?? ''}\n`
+    // Dieser Kanal ist der Weg, ueber den eine Absturzschleife im Renderer
+    // ihre Fehler meldet -- also genau der, fuer den die 2-MB-Kappung
+    // geschrieben wurde. Er schrieb bis hierher mit blankem
+    // `fs.appendFileSync` in dieselbe Datei, die `index.ts` gekappt fuellt.
+    appendLogCapped('renderer-error.log', line)
   })
 }

--- a/src/main/ipc/printIpc.ts
+++ b/src/main/ipc/printIpc.ts
@@ -152,6 +152,17 @@ export const registerPrintIpc = (): void => {
         if (resolved) return
         resolved = true
         try { win.destroy() } catch { /* ignore */ }
+        // Die Temp-Datei wurde bis hierher nie geloescht: jeder Druck liess
+        // ein `cable-planner-print-<timestamp>.pdf` in tmpdir zurueck --
+        // dauerhaft, und mit dem kompletten Plan darin. Der Handler direkt
+        // darueber raeumt seine Datei auf (Zeile 127); dieser nicht.
+        //
+        // `settle` ist der einzige Ausgang (Erfolg, did-fail-load, 60-s-
+        // Notbremse, abgelehntes loadURL), also der richtige Ort. Erst
+        // `win.destroy()`, dann loeschen: unter Windows scheitert das
+        // Loeschen, solange das Fenster die Datei offen haelt -- deshalb
+        // best effort statt Fehlerpfad.
+        void unlink(tmpFile).catch(() => {})
         resolve(ok)
       }
       // Sicherheitsnetz: wenn die print-Pipeline hängt, nach 60 s aufgeben

--- a/src/main/preload.cts
+++ b/src/main/preload.cts
@@ -3,6 +3,7 @@ import { contextBridge, ipcRenderer } from 'electron'
 contextBridge.exposeInMainWorld('cablePlanner', {
   credentials: {
     getToken: () => ipcRenderer.invoke('credentials:get-token') as Promise<string | null>,
+    hasToken: () => ipcRenderer.invoke('credentials:has-token') as Promise<boolean>,
     saveToken: (token: string) => ipcRenderer.invoke('credentials:save-token', token) as Promise<boolean>,
     deleteToken: () => ipcRenderer.invoke('credentials:delete-token') as Promise<boolean>,
     testToken: () =>

--- a/src/main/util/appendLogCapped.ts
+++ b/src/main/util/appendLogCapped.ts
@@ -1,0 +1,41 @@
+import { app } from 'electron'
+import fs from 'node:fs'
+import path from 'node:path'
+
+/**
+ * An eine Logdatei anhaengen, mit harter Groessengrenze.
+ *
+ * Der Grund steht seit jeher im Kommentar der urspruenglichen Fassung in
+ * `main/index.ts`: **"so a crash-loop can't fill the user's disk"**. Eine
+ * Absturzschleife schreibt dieselbe Zeile tausendfach; ohne Grenze laeuft
+ * davon die Platte voll, und zwar auf einem Rechner, der ohnehin gerade nicht
+ * mehr laeuft.
+ *
+ * WARUM DIE FUNKTION HIER LIEGT UND NICHT MEHR IN `index.ts`. Sie schuetzte
+ * zwei von drei Schreibern derselben Datei. `renderer-error.log` bekommt
+ * Eintraege aus `index.ts` (zweimal, ueber diese Funktion) und aus
+ * `ipc/logIpc.ts` -- und der dritte schrieb mit blankem `fs.appendFileSync`,
+ * ohne Kappung.
+ *
+ * Ausgerechnet der ungeschuetzte war der Weg, fuer den die Kappung gedacht
+ * ist: `logs:renderer-error` ist der Kanal, ueber den eine Absturzschleife im
+ * Renderer ihre Fehler meldet. Als gemeinsame Datei in `util/` kann kein
+ * Aufrufer sie mehr uebersehen.
+ */
+const LOG_MAX_BYTES = 2 * 1024 * 1024 // 2 MB
+
+export const appendLogCapped = (fileName: string, msg: string): void => {
+  try {
+    const file = path.join(app.getPath('userData'), fileName)
+    try {
+      if (fs.statSync(file).size > LOG_MAX_BYTES) {
+        fs.renameSync(file, `${file}.1`)
+      }
+    } catch {
+      /* no existing file → fine */
+    }
+    fs.appendFileSync(file, msg)
+  } catch {
+    /* ignore */
+  }
+}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -508,9 +508,10 @@ export default function App() {
 
   useEffect(() => {
     void refreshRecent()
-    cablePlannerApi.credentials.getToken().then((token) => {
-      setHasToken(Boolean(token))
-    })
+    // Nur die Ja/Nein-Frage -- das Klartext-Token muss dafuer nicht in den
+    // Renderer. Es lag hier bisher ab dem Start fuer die ganze Sitzung im
+    // Speicher, ohne dass es jemand brauchte.
+    cablePlannerApi.credentials.hasToken().then(setHasToken)
   }, [refreshRecent, setHasToken])
 
   // #pre-sale — OS-Dateiverknüpfung: beim Kaltstart die per Doppelklick

--- a/src/renderer/lib/bridge.ts
+++ b/src/renderer/lib/bridge.ts
@@ -104,6 +104,7 @@ export interface DiscoveredCollabSession {
 type CablePlannerApi = {
   credentials: {
     getToken: () => Promise<string | null>
+    hasToken: () => Promise<boolean>
     saveToken: (token: string) => Promise<boolean>
     deleteToken: () => Promise<boolean>
     testToken: () => Promise<{ ok: boolean; message: string }>
@@ -530,6 +531,7 @@ const webFallbackApi: CablePlannerApi = {
       const stored = localStorage.getItem(TOKEN_KEY)
       return stored ? normalizeToken(stored) : null
     },
+    hasToken: async () => Boolean(normalizeToken(localStorage.getItem(TOKEN_KEY) ?? '')),
     saveToken: async (token: string) => {
       const clean = normalizeToken(token)
       if (!clean) {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,6 +5,7 @@ declare global {
     cablePlanner?: {
       credentials: {
         getToken: () => Promise<string | null>
+        hasToken: () => Promise<boolean>
         saveToken: (token: string) => Promise<boolean>
         deleteToken: () => Promise<boolean>
         testToken: () => Promise<{ ok: boolean; message: string }>

--- a/tests/schutzwegeVollstaendig.test.ts
+++ b/tests/schutzwegeVollstaendig.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import indexSrc from '../src/main/index.ts?raw'
+import logIpcSrc from '../src/main/ipc/logIpc.ts?raw'
+import printIpcSrc from '../src/main/ipc/printIpc.ts?raw'
+import credIpcSrc from '../src/main/ipc/credentialsIpc.ts?raw'
+import appSrc from '../src/renderer/App.tsx?raw'
+import { stripComments } from './support/stripComments'
+
+// Dreimal dasselbe Muster, dreimal derselbe Test: ein Schutz EXISTIERT, ist
+// begruendet -- und ein Weg laesst ihn aus. Und zwar jedes Mal der Weg, fuer
+// den der Schutz eigentlich gedacht war.
+//
+// Diese Datei haelt fest, dass die Wege jetzt vollstaendig sind.
+
+const code = (s: string) => stripComments(s)
+
+describe('Log-Kappung gilt fuer ALLE Schreiber derselben Datei', () => {
+  it('logs:renderer-error schreibt gekappt', () => {
+    const c = code(logIpcSrc)
+    expect(c).toContain('appendLogCapped(')
+    // Der Kanal, ueber den eine Absturzschleife meldet, darf nicht ungekappt
+    // in dieselbe Datei schreiben, die index.ts gekappt fuellt.
+    expect(c).not.toMatch(/appendFileSync\(/)
+  })
+
+  it('die Kappung liegt gemeinsam in util/, nicht lokal in index.ts', () => {
+    const c = code(indexSrc)
+    expect(c).toContain("from './util/appendLogCapped.js'")
+    expect(c).not.toMatch(/const appendLogCapped\s*=/)
+  })
+})
+
+describe('Der Druck-Zwischenspeicher wird aufgeraeumt', () => {
+  it('print:pdf-bytes loescht seine Temp-Datei', () => {
+    const c = code(printIpcSrc)
+    const start = c.indexOf("ipcMain.handle('print:pdf-bytes'")
+    expect(start).toBeGreaterThan(0)
+    const body = c.slice(start)
+    // Im einzigen Ausgang (settle) muss die Datei wieder verschwinden.
+    expect(body).toMatch(/unlink\(tmpFile\)/)
+  })
+})
+
+describe('Das Rentman-Token bleibt im Hauptprozess, wo es nicht gebraucht wird', () => {
+  it('es gibt einen Ja/Nein-Kanal wie bei NetBox', () => {
+    expect(code(credIpcSrc)).toContain("'credentials:has-token'")
+  })
+
+  it('der Start holt nur den Boolean, nicht den Klartext', () => {
+    const c = code(appSrc)
+    expect(c).toContain('credentials.hasToken()')
+    expect(c).not.toContain('credentials.getToken()')
+  })
+})


### PR DESCRIPTION
Drei unabhängige Befunde, **ein Muster**: ein Schutz existiert, ist im Code
begründet — und ein Weg lässt ihn aus. Und zwar jedes Mal ausgerechnet der Weg,
für den er gedacht war. Sie stehen zusammen, weil sie dieselbe Reparatur sind;
wer sie getrennt haben will, sagt es.

---

## 1. Die Log-Kappung schützte nicht den Absturz-Kanal

`appendLogCapped` trägt den Grund im eigenen Kommentar:

> Append to a log file with a hard size cap **so a crash-loop can't fill the
> user's disk.**

2 MB, mit Rotation nach `.1`. Sie schützte zwei Schreiber von
`renderer-error.log` (`index.ts:197` und `:235`).

**Der dritte schrieb ungekappt in dieselbe Datei:** `logIpc.ts` mit blankem
`fs.appendFileSync`. Und das ist der Kanal `logs:renderer-error` — der Weg,
über den eine **Absturzschleife im Renderer** ihre Fehler meldet. Genau das
Szenario, für das die Kappung geschrieben wurde, lief an ihr vorbei.

Die Funktion liegt jetzt in `util/appendLogCapped.ts`; beide Seiten importieren
sie, kein Aufrufer kann sie mehr übersehen.

## 2. Der Druck ließ jedes Mal ein PDF liegen

`print:pdf-bytes` schreibt je Druckvorgang ein
`cable-planner-print-<timestamp>.pdf` nach `tmpdir()` — und löschte es **nie**.
Mit dem kompletten Plan darin.

Der Handler direkt darüber räumt seine Temp-Datei auf (`printIpc.ts:127`).
Dieser nicht.

Aufgeräumt wird jetzt in `settle` — dem **einzigen** Ausgang (Erfolg,
`did-fail-load`, 60-Sekunden-Notbremse, abgelehntes `loadURL`). Erst
`win.destroy()`, dann löschen, und bewusst *best effort*: unter Windows
scheitert das Löschen, solange ein Fenster die Datei offen hält — das ist kein
Fehlerpfad, sondern der Normalfall, den man wegwerfen darf.

## 3. Das Rentman-Token reiste in den Renderer, um dort gezählt zu werden

`App.tsx:511` holte beim Start das **Klartext-Token** — nur um daraus
`Boolean(token)` zu bilden. Danach lag das Geheimnis für die gesamte Sitzung
im Renderer-Speicher, ohne dass es dort irgendjemand brauchte.

Der neuere NetBox-Pfad zeigt das richtige Muster längst: `netbox:has-token`
liefert einen Boolean, das Token bleibt im Hauptprozess. Rentman ist der
ältere Pfad und hatte nur `get-token`.

Neu: `credentials:has-token`, und `App.tsx` benutzt es.

**Der Klartext-Weg bleibt** — `IntegrationsTab` füllt damit das Eingabefeld,
in dem der Nutzer sein Token sieht und ändert. Das ist eine bewusste
Oberfläche, keine Panne, und sie hier mitzuändern wäre eine UX-Entscheidung,
die mir nicht zusteht.

---

## Prüfung

* **826 Tests grün** (5 neue), `tsc` für App, Main und Preload je 0 Errors,
  Lint 0 Errors — an den Exit-Codes.
* **Gegengeprüft, jeder Weg einzeln:** Kappung ausgebaut → 1 Test fällt;
  Aufräumen ausgebaut → 1 Test fällt.
* Der Typ-Check hat beim Hinzufügen des Kanals selbst mitgeholfen: die
  Browser-Fallback-Bridge (`dev:renderer`, Desktop-Features inert) musste
  `hasToken` ebenfalls bekommen, sonst wäre sie unvollständig gewesen.
* IPC-Fläche bleibt symmetrisch: **72 gerufen, 72 behandelt**, keine Waisen in
  beide Richtungen.

## Herkunft

Alle drei aus dem Implementierungs-Audit, jeder einzeln am Code nachgeprüft,
bevor er hier gelandet ist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_