### PR TITLE
bundle/i18n: Three.js lazy (−30 % Haupt-Chunk), de-Dict entenglischt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,8 +90,19 @@ Pfad-Validierung passiert **immer in main**, nie im Renderer.
 
 **Canvas & 3D:**
 - ReactFlow 11 mit Custom-Nodes/Edges in `src/renderer/components/Canvas/`.
-- Three.js (`@react-three/fiber`) **nur in `components/Rack/`** — Imports
-  außerhalb ziehen ~600 KB in den Hauptbundle.
+- Three.js (`@react-three/fiber`) **nur in `components/Rack/`** — plus
+  `lib/exportRack.ts`, das nur von dort aus erreicht wird.
+- **Was den Bundle wirklich klein hält, ist die Lazy-Grenze, nicht der
+  Import-Ort** (gemessen 2026-09-04). Solange irgendein statisch importiertes
+  Modul in `Rack/` hineinreicht, liegt Three im Haupt-Chunk — egal wie
+  diszipliniert die Imports sind. Genau das war der Fall: `LibraryPanel`
+  importierte `RackBuilderDialog` statisch.
+  Die beiden Eintritte sind deshalb `lazy` + `Suspense` und werden nur
+  gemountet, wenn sie offen sind: `RackBuilderDialog` (in `LibraryPanel`) und
+  `RackEditorDialog` (in `App.tsx`). **Gemessen: Haupt-Chunk 4.193 → 2.938 kB
+  (gzip 1.165 → 822 kB).** Wer einen dritten Eintritt nach `Rack/` anlegt,
+  macht ihn genauso lazy — sonst ist der ganze Gewinn wieder weg, und zwar
+  unbemerkt. `tests/threeBundleGrenze.test.ts` hält das fest.
 
 **Domänen-Typen:** `src/renderer/types/` (`CablePlannerProject`, `EquipmentItem`,
 `Cable`, `LocationFrame`, …). Berechnungen/Helper in `src/renderer/lib/`.

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,6 +1,6 @@
 import { hasDrops } from './types/loadReport'
 import { hasMobileDrops } from './types/mobileReport'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, lazy, Suspense } from 'react'
 import { useIsNarrow } from './hooks/useBreakpoint'
 import { CanvasArea } from './components/Canvas/CanvasArea'
 import { CableDialog } from './components/Cable/CableDialog'
@@ -26,7 +26,7 @@ import { AtemAudioRouterDialog } from './components/Atem/AtemAudioRouterDialog'
 import { DrumMicingDialog } from './components/DrumMicing/DrumMicingDialog'
 import { WirelessRigDialog } from './components/Wireless/WirelessRigDialog'
 import { LocationBomDialog } from './components/Project/LocationBomDialog'
-import { RackEditorDialog } from './components/Rack/RackEditorDialog'
+
 import { CableContextMenu } from './components/Canvas/CableContextMenu'
 import { LayerVisibilityChips } from './components/Canvas/LayerVisibilityChips'
 import { ExportDialog } from './components/Export/ExportDialog'
@@ -35,6 +35,24 @@ import { AnnotationsPanel } from './components/Annotations/AnnotationsPanel'
 // v7.9.3 — Hook-Wrapper damit das Annotations-Panel auf
 // uiStore.annotationsPanelOpen reagiert. Direkt im JSX würde
 // useUiStore.getState() nur beim ersten Render gelesen.
+/**
+ * Three.js kostet ~26 MB im node_modules und landet gebuendelt im Haupt-Chunk.
+ * `CLAUDE.md` verspricht dagegen: "Three.js nur in `components/Rack/` --
+ * Imports ausserhalb ziehen ~600 KB in den Hauptbundle."
+ *
+ * Das Versprechen hielt nicht, und zwar unabhaengig von der Import-Regel: der
+ * Rack-Dialog wurde hier STATISCH importiert und unbedingt gerendert (er gibt
+ * intern `null` zurueck, solange er zu ist). Damit lag Three im Haupt-Chunk,
+ * auch wenn kein einziger Import ausserhalb von `Rack/` stand.
+ *
+ * Jetzt wird er nur gemountet, wenn er offen ist, und per `lazy` nachgeladen.
+ * Der Fallback ist `null`: der Dialog erscheint einen Wimpernschlag spaeter,
+ * und zwar erst, wenn ihn jemand oeffnet.
+ */
+const RackEditorDialog = lazy(() =>
+  import('./components/Rack/RackEditorDialog').then((m) => ({ default: m.RackEditorDialog })),
+)
+
 const AnnotationsPanelHost = () => {
   const open = useUiStore((s) => s.annotationsPanelOpen)
   const setOpen = useUiStore((s) => s.setAnnotationsPanelOpen)
@@ -177,6 +195,9 @@ export default function App() {
     refreshRecent,
   } = useProject()
   const settingsOpen = useUiStore((s) => s.settingsOpen)
+  // Nur der Offen-Zustand: der Rack-Dialog (und mit ihm Three.js) wird erst
+  // gemountet und nachgeladen, wenn ihn jemand oeffnet.
+  const rackEditorOpen = useUiStore((s) => s.rackEditor.open)
   const settingsSection = useUiStore((s) => s.settingsSection)
   const setSettingsOpen = (open: boolean) =>
     open ? useUiStore.getState().openSettings() : useUiStore.getState().closeSettings()
@@ -1165,7 +1186,11 @@ export default function App() {
       <DrumMicingDialog />
       <WirelessRigDialog />
       <LocationBomDialog />
-      <RackEditorDialog />
+      {rackEditorOpen && (
+        <Suspense fallback={null}>
+          <RackEditorDialog />
+        </Suspense>
+      )}
       <MobileShareDialog />
       <AboutDialog />
       <PatchListDialog />

--- a/src/renderer/components/Library/LibraryPanel.tsx
+++ b/src/renderer/components/Library/LibraryPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState, lazy, Suspense } from 'react'
 import { Settings, Ruler, Globe, Sparkles, ExternalLink } from 'lucide-react'
 import { v4 as uuidv4 } from 'uuid'
 import { Icon } from '../shared/Icon'
@@ -27,7 +27,7 @@ import {
   searchNetBoxDeviceTypes,
   type NetBoxDeviceTypeSearchResult,
 } from '../../lib/netboxImport'
-import { RackBuilderDialog } from '../Rack/RackBuilderDialog'
+const RackBuilderDialog = lazy(() => import('../Rack/RackBuilderDialog').then((m) => ({ default: m.RackBuilderDialog })))
 import { TemplateMergeDialog } from './TemplateMergeDialog'
 import { FloatingPanelShell } from '../Layout/FloatingPanelShell'
 import { triggerCanvasFitView } from '../../lib/canvasViewport'
@@ -1250,45 +1250,53 @@ export const LibraryPanel = () => {
         </div>
       )}
 
-      <RackBuilderDialog
-        open={showRackBuilderDialog}
-        templates={rackBuilderTemplates}
-        initialPreset={
-          editingRackPresetId
-            ? groupPresets.find((p) => p.id === editingRackPresetId) ?? null
-            : // v7.9.0 / Issue #120 — wenn der RackBuilder via Toolbar-Seed
-              // geöffnet wurde, übergeben wir die synthetisierte Preset
-              // als initialPreset. Beim Speichern wird id durch addGroupPreset
-              // ggf. überschrieben (Upsert).
-              seedPreset
-        }
-        onClose={() => {
-          setShowRackBuilderDialog(false)
-          setEditingRackPresetId(null)
-          setSeedPreset(null)
-          setEditingCanvasRackEquipmentId(null)
-        }}
-        onSave={(preset) => {
-          // v7.9.105 / Issue #224 — Wenn der Dialog aus dem Canvas-
-          // Toolbar-'Rack bearbeiten'-Button geoeffnet wurde, schreiben
-          // wir die Aenderungen ins Canvas-Equipment zurueck (Ports +
-          // Snapshot), nicht in die Library-Preset.
-          if (editingCanvasRackEquipmentId) {
-            replaceCanvasRackWithPreset(editingCanvasRackEquipmentId, preset)
-          } else {
-            // addGroupPreset upserts by id, so edit-mode reuses the same
-            // id and simply overwrites the existing entry. For seed-mode
-            // the synthetic __seed- id is replaced by a fresh uuid in
-            // saveRack already.
-            addGroupPreset(preset)
-          }
-          setShowRackBuilderDialog(false)
-          setEditingRackPresetId(null)
-          setSeedPreset(null)
-          setEditingCanvasRackEquipmentId(null)
-          setTab('racks')
-        }}
-      />
+      {/* Der Rack-Builder zieht Three.js (~1,25 MB) nach. Er wird deshalb erst
+          gemountet und nachgeladen, wenn ihn jemand oeffnet -- das haelt den
+          Haupt-Chunk um genau diesen Betrag kleiner. `open` bleibt am Dialog,
+          damit sein Vertrag unveraendert ist. */}
+      {showRackBuilderDialog && (
+        <Suspense fallback={null}>
+          <RackBuilderDialog
+            open={showRackBuilderDialog}
+            templates={rackBuilderTemplates}
+            initialPreset={
+              editingRackPresetId
+                ? groupPresets.find((p) => p.id === editingRackPresetId) ?? null
+                : // v7.9.0 / Issue #120 — wenn der RackBuilder via Toolbar-Seed
+                  // geöffnet wurde, übergeben wir die synthetisierte Preset
+                  // als initialPreset. Beim Speichern wird id durch addGroupPreset
+                  // ggf. überschrieben (Upsert).
+                  seedPreset
+            }
+            onClose={() => {
+              setShowRackBuilderDialog(false)
+              setEditingRackPresetId(null)
+              setSeedPreset(null)
+              setEditingCanvasRackEquipmentId(null)
+            }}
+            onSave={(preset) => {
+              // v7.9.105 / Issue #224 — Wenn der Dialog aus dem Canvas-
+              // Toolbar-'Rack bearbeiten'-Button geoeffnet wurde, schreiben
+              // wir die Aenderungen ins Canvas-Equipment zurueck (Ports +
+              // Snapshot), nicht in die Library-Preset.
+              if (editingCanvasRackEquipmentId) {
+                replaceCanvasRackWithPreset(editingCanvasRackEquipmentId, preset)
+              } else {
+                // addGroupPreset upserts by id, so edit-mode reuses the same
+                // id and simply overwrites the existing entry. For seed-mode
+                // the synthetic __seed- id is replaced by a fresh uuid in
+                // saveRack already.
+                addGroupPreset(preset)
+              }
+              setShowRackBuilderDialog(false)
+              setEditingRackPresetId(null)
+              setSeedPreset(null)
+              setEditingCanvasRackEquipmentId(null)
+              setTab('racks')
+            }}
+          />
+        </Suspense>
+      )}
 
       {netBoxConflict && (
         <div className="fixed inset-0 z-[75] flex items-center justify-center bg-black/70 p-6">

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -4147,25 +4147,25 @@ export const en: Dict = {
 export const de: Dict = {
   // Cable catalog notes
   'catalog.cable.xlr-3pin-audio.notes':
-    'Balanced analog audio or AES3 (digital). Gender: male → female.',
+    'Symmetrisches Analog-Audio oder AES3 (digital). Steckrichtung: männlich → weiblich.',
   'catalog.cable.sdi-3g.notes':
-    'Works for SD/HD/3G. Use 75Ω coax (Belden 1694A or similar).',
+    'Für SD/HD/3G geeignet. 75-Ω-Koax verwenden (Belden 1694A oder vergleichbar).',
   'catalog.cable.sdi-6g.notes':
-    '6G needs higher-quality coax; mix with 3G only via down-converter.',
+    '6G braucht hochwertigeres Koax; mit 3G nur über einen Down-Converter mischen.',
   'catalog.cable.sdi-12g.notes':
-    'Use 4K-rated 12G coax (e.g. Belden 4694R). Downscale to 3G requires a scaler/converter.',
+    '4K-taugliches 12G-Koax verwenden (z. B. Belden 4694R). Herunterskalieren auf 3G braucht einen Scaler/Converter.',
   'catalog.cable.hdmi-2.0.notes':
-    'Passive copper limited to ~10 m; use optical HDMI for longer runs.',
+    'Passives Kupfer nur bis ca. 10 m; für längere Strecken optisches HDMI verwenden.',
   'catalog.cable.hdmi-2.1.notes':
-    'Ultra-high speed cables required; pairing with HDMI 1.4 device limits to 1.4.',
-  'catalog.cable.cat6a.notes': 'Required for 10GBASE-T over full 100 m runs.',
+    'Erfordert Ultra-High-Speed-Kabel; zusammen mit einem HDMI-1.4-Gerät fällt die Strecke auf 1.4 zurück.',
+  'catalog.cable.cat6a.notes': 'Nötig für 10GBASE-T über die vollen 100 m.',
   'catalog.cable.fiber-sm-lc.notes':
-    'Single-mode (yellow jacket). Long distance (>300 m).',
+    'Singlemode (gelber Mantel). Lange Strecken (>300 m).',
   'catalog.cable.fiber-mm-lc.notes':
-    'Multi-mode (aqua jacket). Short haul in racks/venue.',
-  'catalog.cable.iec-230v.notes': 'Standard device power cable ("kettle lead").',
+    'Multimode (aquafarbener Mantel). Kurze Wege im Rack oder in der Halle.',
+  'catalog.cable.iec-230v.notes': 'Standard-Gerätenetzkabel (Kaltgerätekabel).',
   'catalog.cable.powercon-tru1.notes':
-    'Locking, touring-grade power. Do not mix with classic powerCON (grey/blue).',
+    'Verriegelnder Strom-Steckverbinder für den Tourbetrieb. Nicht mit klassischem powerCON (grau/blau) mischen.',
   'catalog.cable.thunderbolt-3.notes':
     'USB-C Stecker, passiv bis 2 m. Aktives TB3-Kabel bis ~50 cm. Vorwärtskompatibel mit Thunderbolt 4.',
   'catalog.cable.thunderbolt-4.notes':

--- a/tests/deutschesDictIstDeutsch.test.ts
+++ b/tests/deutschesDictIstDeutsch.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import dictSrc from '../src/renderer/lib/i18n/dicts.ts?raw'
+
+// Das deutsche Woerterbuch enthielt englische Texte -- und zwar nicht
+// irgendwo, sondern bei den Kabel-Notizen. Die landen NICHT nur in der
+// Oberflaeche: `CableDialog.tsx` loest `t(spec.notesKey, '')` auf und schreibt
+// das Ergebnis in `Cable.notes`, also in die Projektdatei. Ein deutscher
+// Nutzer bekam damit englische Notizen in seine eigenen Daten geschrieben.
+//
+// Es waren 11 Eintraege, und alle elf waren WOERTLICHE Kopien der englischen
+// Fassung -- jemand hat sie beim Anlegen des de-Dicts uebernommen und nie
+// uebersetzt. Eine Wortlisten-Heuristik fand davon nur 8; die restlichen drei
+// kamen erst heraus, als dieser Test de gegen en verglich statt gegen eine
+// Liste englischer Woerter. Deshalb steht hier der Vergleich und nicht die
+// Heuristik.
+//
+// Dieser Test rechnet das aus dem Quelltext, statt es zu behaupten: kein
+// Wert im de-Dict darf mit seinem en-Gegenstueck identisch sein, es sei denn,
+// er steht ausdruecklich auf der Ausnahmeliste.
+
+const lines = dictSrc.split('\n')
+const deStart = lines.findIndex((l) => l.startsWith('export const de'))
+
+/** Sammelt Schluessel -> Wert aus einem Abschnitt (Wert darf in der naechsten Zeile stehen). */
+const parse = (region: string[]): Map<string, string> => {
+  const out = new Map<string, string>()
+  for (let i = 0; i < region.length; i += 1) {
+    const m = /^(\s*)'([\w.\-]+)':\s*(.*)$/.exec(region[i])
+    if (!m) continue
+    let raw = m[3].trim()
+    if (raw === '') raw = (region[i + 1] ?? '').trim()
+    raw = raw.replace(/,$/, '').trim()
+    if (raw.startsWith("'") && raw.endsWith("'")) out.set(m[2], raw.slice(1, -1))
+  }
+  return out
+}
+
+/**
+ * Werte, die in beiden Sprachen absichtlich gleich sind -- Eigennamen,
+ * Einheiten, Protokollnamen. Wer hier etwas eintraegt, sagt: das ist auf
+ * Deutsch wirklich dasselbe Wort.
+ */
+const GLEICH_ERLAUBT = new Set<string>([])
+
+describe('das deutsche Woerterbuch ist deutsch', () => {
+  it('findet beide Abschnitte (sonst prueft der Test nichts)', () => {
+    expect(deStart).toBeGreaterThan(0)
+    expect(parse(lines.slice(deStart)).size).toBeGreaterThan(20)
+  })
+
+  it('kein deutscher Wert ist eine woertliche Kopie des englischen', () => {
+    const en = parse(lines.slice(0, deStart))
+    const de = parse(lines.slice(deStart))
+    const kopien: string[] = []
+    for (const [key, deVal] of de) {
+      if (GLEICH_ERLAUBT.has(key)) continue
+      const enVal = en.get(key)
+      if (enVal !== undefined && enVal === deVal && deVal.trim().length > 0) {
+        kopien.push(`${key}: "${deVal.slice(0, 60)}"`)
+      }
+    }
+    expect(kopien, `unuebersetzt im de-Dict:\n  ${kopien.join('\n  ')}`).toEqual([])
+  })
+
+  it('die Kabel-Notizen sind auf Deutsch — sie landen in der Projektdatei', () => {
+    // `CableDialog` schreibt das aufgeloeste `notesKey`-Ergebnis in
+    // `Cable.notes`. Was hier steht, steht spaeter im .cableplan des Nutzers.
+    const de = parse(lines.slice(deStart))
+    const notizen = [...de].filter(([k]) => /^catalog\.cable\..*\.notes$/.test(k))
+    expect(notizen.length).toBeGreaterThan(5)
+    for (const [k, v] of notizen) {
+      expect(/\b(the|with|for|and|Use|use|required|needs|limited)\b/.test(v), `${k} klingt englisch: ${v}`).toBe(false)
+    }
+  })
+})

--- a/tests/threeBundleGrenze.test.ts
+++ b/tests/threeBundleGrenze.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import appSrc from '../src/renderer/App.tsx?raw'
+import libSrc from '../src/renderer/components/Library/LibraryPanel.tsx?raw'
+import { stripComments } from './support/stripComments'
+
+// Die Architektur-Invariante in CLAUDE.md lautete: "Three.js nur in
+// components/Rack/ -- Imports ausserhalb ziehen ~600 KB in den Hauptbundle."
+//
+// Der Satz war irrefuehrend. Gemessen ist nicht der Import-ORT entscheidend,
+// sondern die LAZY-GRENZE: solange ein statisch importiertes Modul nach
+// `Rack/` hineinreicht, liegt Three im Haupt-Chunk, egal wie diszipliniert
+// die Imports sind. Genau so war es -- `LibraryPanel` importierte
+// `RackBuilderDialog` statisch, und Three lag im Haupt-Chunk (8 Marker),
+// obwohl bis auf `lib/exportRack.ts` alle Three-Importe brav in `Rack/`
+// standen.
+//
+// Nach der Umstellung: Haupt-Chunk 4.193 -> 2.938 kB (gzip 1.165 -> 822),
+// Three-Marker im Haupt-Chunk 8 -> 0.
+//
+// Dieser Test bewacht die zwei Eintritte. Er kann den Bundle nicht messen
+// (dafuer braeuchte es einen Build), aber er faengt den Rueckbau auf einen
+// statischen Import -- und das ist der Weg, auf dem der Gewinn verloren ginge.
+
+const code = (s: string) => stripComments(s)
+
+describe('Three.js bleibt hinter der Lazy-Grenze', () => {
+  it('App laedt den Rack-Editor lazy', () => {
+    const c = code(appSrc)
+    expect(c).toMatch(/lazy\(\(\) =>\s*import\('\.\/components\/Rack\/RackEditorDialog'\)/)
+    expect(c).not.toMatch(/^import \{[^}]*RackEditorDialog[^}]*\} from/m)
+  })
+
+  it('LibraryPanel laedt den Rack-Builder lazy', () => {
+    const c = code(libSrc)
+    expect(c).toMatch(/lazy\(\(\) => import\('\.\.\/Rack\/RackBuilderDialog'\)/)
+    expect(c).not.toMatch(/^import \{[^}]*RackBuilderDialog[^}]*\} from/m)
+  })
+
+  it('beide werden nur gemountet, wenn sie offen sind', () => {
+    // `lazy` allein genuegt NICHT: ein unbedingt gerendertes Element zieht
+    // seinen Chunk sofort beim ersten Render nach. Der Dialog gibt intern
+    // `null` zurueck, solange er zu ist -- das half dem Bundle nicht.
+    expect(code(appSrc)).toContain('rackEditorOpen && (')
+    expect(code(libSrc)).toContain('showRackBuilderDialog && (')
+  })
+
+  it('kein weiterer statischer Eintritt nach components/Rack/', () => {
+    for (const [name, src] of [['App', appSrc], ['LibraryPanel', libSrc]] as const) {
+      const statisch = code(src).match(/^import .*from '[^']*(?:components\/)?Rack\/[^']*'/gm) ?? []
+      // Typ-Importe sind erlaubt (werden beim Build geloescht).
+      const wert = statisch.filter((l) => !l.startsWith('import type'))
+      expect(wert, `${name} hat einen statischen Rack-Import: ${wert.join(', ')}`).toEqual([])
+    }
+  })
+})


### PR DESCRIPTION
Zwei Befunde aus dem laufenden Audit, beide am Artefakt bzw. am Quelltext gemessen:

1. **bundle** — Three.js lag trotz eingehaltener Import-Regel im Haupt-Chunk. Lazy-Grenze gezogen: 4.193 kB → 2.938 kB.
2. **i18n** — 11 Werte im deutschen Dictionary waren wörtliche Kopien der englischen Fassung, und sie landen in der Projektdatei des Nutzers.

---

## 1. Die Invariante versprach etwas, das sie nicht hielt

`CLAUDE.md` sagte:

> Three.js (`@react-three/fiber`) **nur in `components/Rack/`** — Imports
> außerhalb ziehen ~600 KB in den Hauptbundle.

Der Satz legt nahe, der **Import-Ort** sei entscheidend. Gemessen ist er es
nicht — entscheidend ist die **Lazy-Grenze**. Solange irgendein statisch
importiertes Modul nach `Rack/` hineinreicht, liegt Three im Haupt-Chunk, egal
wie diszipliniert die Importe sind.

Genau so war es: **8 Three-Marker im Haupt-Chunk**, obwohl bis auf
`lib/exportRack.ts` alle Three-Importe brav in `Rack/` standen. Der Weg hinein:

```
LibraryPanel.tsx:30  →  RackBuilderDialog  →  RackBuilder3DTab  →  Rack3DView
```

### Die Messung

| | vorher | nachher |
| --- | ---: | ---: |
| `main-*.js` | 4.193,47 kB | **2.937,91 kB** |
| davon gzip | 1.164,71 kB | **822,35 kB** |
| Three-Marker in `main` | 8 | **0** |
| neuer `RackBuilderDialog`-Chunk | — | 1.250,22 kB (gzip 341,05) |

**−1.255 kB roh, −342 kB gzip.** Rund 30 % des Haupt-Chunks, und mehr als das
Doppelte der in `CLAUDE.md` genannten ~600 KB. Der Rack-Chunk lädt erst, wenn
jemand den Rack-Builder öffnet.

### Warum `lazy` allein nicht reicht

Das ist die Stelle, an der es leicht schiefgeht: ein **unbedingt gerendertes**
`<RackBuilderDialog />` zieht seinen Chunk sofort beim ersten Render nach —
auch als `lazy`. Beide Dialoge geben intern `null` zurück, solange sie zu sind;
dem Bundle half das nichts. Sie werden deshalb jetzt zusätzlich **nur
gemountet, wenn sie offen sind**.

### Ein Irrtum, den die Zahl korrigiert hat

Mein erster Versuch machte nur `RackEditorDialog` in `App.tsx` lazy — die
Stelle, die beim Lesen ins Auge fiel. Ergebnis: **3,4 kB**. Praktisch nichts.

Hätte ich dort aufgehört, wäre das Ergebnis schlimmer als nichts gewesen: es
hätte ausgesehen, als sei „das Three-Problem angefasst", während die 1,25 MB
unverändert im Haupt-Chunk lagen. Die Zahl hat den Irrtum gezeigt, nicht die
Überlegung — deshalb weitergemessen, bis der echte Eintritt gefunden war.

### Was bleibt und warum

`lib/exportRack.ts` importiert Three weiterhin außerhalb von `Rack/`. Das ist
jetzt **harmlos**: die Datei wird nur von `RackBuilderDialogExportMenu`
erreicht, liegt also innerhalb der Lazy-Grenze. Den Import allein zu
verschieben hätte die Regel *erfüllt aussehen* lassen, ohne ein Byte zu
bewegen — genau die Sorte grüner Haken, die weniger bedeutet als sie aussieht.

---

## 2. Das deutsche Dictionary enthielt englische Texte

Elf Werte im `de`-Dict waren **wörtliche Kopien** ihrer `en`-Gegenstücke —
beim Anlegen übernommen und nie übersetzt.

Das ist nicht nur ein Oberflächen-Fehler. `CableDialog.tsx:174` macht

```ts
setNotes(spec.notesKey ? t(spec.notesKey, '') : (spec.notes ?? ''))
```

Der aufgelöste String landet in `Cable.notes` und wird in die `.cableplan`-Datei
geschrieben. Ein deutscher Nutzer bekam also englische Notizen **in seine
eigenen Projektdaten** — dort bleiben sie auch, wenn das Dict später korrigiert
wird.

### Warum der Guard vergleicht statt zu raten

Mein erster Ansatz war eine Wortlisten-Heuristik („enthält `the`, `with`,
`required` …"). Die fand **8 von 11**. Die restlichen drei kamen erst heraus,
als der Test `de` gegen `en` verglich statt gegen eine Liste englischer Wörter.
Damit lag der ursprüngliche Audit-Befund (11) richtig und meine Zwischenzahl (8)
falsch — der Test steht deshalb jetzt in der Form, die das gemerkt hat.

`tests/deutschesDictIstDeutsch.test.ts` prüft: kein `de`-Wert darf mit seinem
`en`-Gegenstück identisch sein (Ausnahmeliste explizit und derzeit leer), und die
`catalog.cable.*.notes` enthalten keine englischen Funktionswörter.

## Prüfung

* **833 Tests grün** (82 Dateien), `tsc -p tsconfig.app.json --noEmit` 0 Errors —
  an den Exit-Codes, nicht an gefilterter Ausgabe.
* Bundle-Wirkung **am gebauten Artefakt** nachgewiesen, nicht am Quelltext:
  Three-Marker in `main` 8 → 0, im Rack-Chunk 0 → 8.
* Beide Guards gegengeprüft, indem der Fehler wieder eingebaut wurde:
  statischer Three-Import zurück → 2 Tests fallen; eine Übersetzung
  zurückgedreht → der de-Guard fällt und nennt den Schlüssel.
* `CLAUDE.md` berichtigt: die Regel nennt jetzt die Lazy-Grenze als das
  Entscheidende, mit den gemessenen Zahlen und dem Hinweis, dass ein dritter
  Eintritt genauso lazy sein muss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT