### PR TITLE
docs(types): powerWatts/weightKg-Doku nannte Konsumenten, die es nicht gibt (B-15)

### DIFF
--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -564,9 +564,34 @@ export interface EquipmentItem {
    *  lock from #177. */
   positionLocked?: boolean
   /** v7.9.70 / #167 — Engineering-Daten aus dem Rentman-Katalog (oder
-   *  manuell gepflegt). Werden in den Properties angezeigt und vom
-   *  3D-Rack-Builder (Issue #170) für die Tiefen-Visualisierung genutzt.
-   *  Alle Werte sind optional, damit alte Datenstände kompatibel bleiben. */
+   *  manuell gepflegt). Alle Werte sind optional, damit alte Datenstände
+   *  kompatibel bleiben.
+   *
+   *  WAS HIER FRÜHER STAND, WAR FALSCH (nachgemessen 2026-09-04). Der
+   *  Kommentar behauptete, beide Felder würden „in den Properties angezeigt
+   *  und vom 3D-Rack-Builder (#170) für die Tiefen-Visualisierung genutzt".
+   *  Gemessen: `components/Rack/` enthält weder `powerWatts` noch `weightKg`
+   *  kein einziges Mal — die Tiefe kommt aus `depthMm`
+   *  (`RackPlacementProperties.tsx:276`). Eine Typ-Doku, die Konsumenten
+   *  nennt, die es nicht gibt, ist schlimmer als keine: sie lässt ein Feld
+   *  benutzt aussehen und hält damit genau die Nachfrage ab, die den Defekt
+   *  finden würde.
+   *
+   *  WAS TATSÄCHLICH LIEST:
+   *  - `weightKg` — Properties über `categorySchemas.ts` (Kategorie-Feld
+   *    „Eigengewicht"), dazu `AnalysisDialog`, `LocationBomDialog`
+   *    (Logistik-Zeile), `InventoryDialog`, CSV-Import.
+   *  - `powerWatts` — NICHTS. Geschrieben von Rentman-Import und
+   *    Template-Merge, persistiert, gediffed, gecacht, aber von keiner
+   *    Anzeige und keiner Summe gelesen.
+   *
+   *  Die Leistungskette nimmt bewusst `powerConsumptionWatts` (#76) und den
+   *  Modus-Wert, nicht dieses Feld: `effectiveWatts` in
+   *  `lib/equipmentSelectors.ts`, festgehalten in
+   *  `tests/effektiveLeistung.test.ts`. Ob `powerWatts` dazugehören soll, ist
+   *  eine Eigentümer-Entscheidung (B-15 / E-8 im Suite-Backlog) — es würde die
+   *  Zahlen bestehender Projekte verändern. Diese Korrektur nimmt sie nicht
+   *  vorweg, sie beschreibt nur den Stand richtig. */
   powerWatts?: number
   weightKg?: number
   /** #354 — Optionaler Stückpreis bzw. Tagesmietpreis in EUR. Wird im

--- a/tests/effektiveLeistung.test.ts
+++ b/tests/effektiveLeistung.test.ts
@@ -5,6 +5,7 @@ import analysisSrc from '../src/renderer/components/Analysis/AnalysisDialog.tsx?
 import calculatorSrc from '../src/renderer/components/Calculators/CalculatorsDialog.tsx?raw'
 import locationBomSrc from '../src/renderer/components/Project/LocationBomDialog.tsx?raw'
 import drawingChecksSrc from '../src/renderer/lib/drawingChecks.ts?raw'
+import equipmentTypesSrc from '../src/renderer/types/equipment.ts?raw'
 import { stripComments } from './support/stripComments'
 
 // Die effektive Leistung eines Geraets stand in VIER Kopien im Renderer, und
@@ -119,5 +120,64 @@ describe('effektive Leistung — keine neue Kopie', () => {
         /activeModeId[\s\S]{0,120}?\?\.powerWatts/,
       )
     }
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// Die Typ-Doku von `powerWatts`/`weightKg` gegen den gemessenen Stand.
+//
+// WARUM ES DAS GIBT (2026-09-04). Der Kommentar an den beiden Feldern in
+// `types/equipment.ts` behauptete, sie wuerden "in den Properties angezeigt
+// und vom 3D-Rack-Builder (#170) fuer die Tiefen-Visualisierung genutzt".
+// Beides war falsch: `components/Rack/` nennt keines der beiden Felder, die
+// Tiefe kommt aus `depthMm` (`RackPlacementProperties.tsx:276`).
+//
+// Der Schaden lag nicht im falschen Satz, sondern darin, was er verhindert
+// hat: `powerWatts` sah benutzt aus. Wer nach stummen Feldern sucht, haette
+// es uebersprungen -- und genau das ist ueber acht Fundstellen hinweg
+// passiert (B-15 im Suite-Backlog).
+//
+// WARUM ALS BERECHNETE PRUEFUNG. Die Korrektur ist eine Messung, und eine
+// Messung, die nur als Prosa dasteht, ist am naechsten Tag wieder eine
+// Behauptung. Diese Pruefung faellt, sobald `Rack/` eines der Felder
+// benutzt -- nicht um das zu verbieten (ein Gewichts-Hinweis am Rack waere
+// sinnvoll), sondern damit derselbe Satz nicht ein zweites Mal stehenbleibt,
+// waehrend die Welt sich darunter bewegt.
+// ───────────────────────────────────────────────────────────────────────────
+const rackQuellen = import.meta.glob('../src/renderer/components/Rack/*.ts*', {
+  eager: true,
+  query: '?raw',
+  import: 'default',
+}) as Record<string, string>
+
+describe('Typ-Doku powerWatts/weightKg', () => {
+  it('Rack/ liest weder powerWatts noch weightKg — sonst gehoert die Doku nachgezogen', () => {
+    const dateien = Object.keys(rackQuellen)
+    expect(dateien.length, 'Rack-Glob hat nichts gefunden — dann misst diese Pruefung nichts').toBeGreaterThan(0)
+
+    const treffer = dateien.flatMap((pfad) =>
+      ['powerWatts', 'weightKg']
+        .filter((feld) => stripComments(rackQuellen[pfad]).includes(feld))
+        .map((feld) => `${pfad.split('/').pop()}: ${feld}`),
+    )
+
+    expect(
+      treffer,
+      'Rack/ benutzt jetzt eines der Felder. Das ist erlaubt — aber die Typ-Doku ' +
+        'an EquipmentItem.powerWatts/weightKg sagt derzeit ausdruecklich, dass es ' +
+        'das NICHT tut. Diesen Absatz mit anpassen, sonst steht dort wieder eine ' +
+        'Behauptung statt einer Messung.',
+    ).toEqual([])
+  })
+
+  it('die Typ-Doku behauptet keine Rack-Nutzung mehr', () => {
+    const start = equipmentTypesSrc.indexOf('v7.9.70 / #167')
+    expect(start, 'Doku-Block zu powerWatts nicht gefunden').toBeGreaterThan(-1)
+    const block = equipmentTypesSrc.slice(start, equipmentTypesSrc.indexOf('powerWatts?: number', start))
+
+    expect(
+      /Werden in den Properties angezeigt und vom[\s*]+3D-Rack-Builder/.test(block),
+      'Der widerlegte Satz steht wieder in der Typ-Doku.',
+    ).toBe(false)
   })
 })


### PR DESCRIPTION
## Der falsche Satz

Die Typ-Doku an `EquipmentItem.powerWatts` / `weightKg` (`types/equipment.ts`)
sagte:

> Werden in den Properties angezeigt und vom 3D-Rack-Builder (Issue #170) für
> die Tiefen-Visualisierung genutzt.

Gemessen: `components/Rack/` nennt **keines der beiden Felder** — kein einziges
Mal. Die Tiefe kommt aus `depthMm` (`RackPlacementProperties.tsx:276`).

## Was tatsächlich liest

| Feld | Gelesen von |
|---|---|
| `weightKg` | Properties über `categorySchemas.ts` („Eigengewicht", zwei Kategorien), `AnalysisDialog`, `LocationBomDialog` (Logistik-Zeile), `InventoryDialog`, CSV-Import |
| `powerWatts` | **nichts** — geschrieben von Rentman-Import und Template-Merge, persistiert, gediffed, gecacht, aber von keiner Anzeige und keiner Summe gelesen |

## Warum das mehr ist als ein Doku-Fehler

Der Schaden lag nicht im falschen Satz, sondern darin, was er verhindert hat:
`powerWatts` **sah benutzt aus**. Wer nach stummen Feldern sucht, überspringt
ein Feld, dessen Doku zwei Konsumenten nennt — und genau das ist über acht
Fundstellen hinweg passiert. Eine Typ-Doku, die Konsumenten erfindet, ist
schlimmer als keine: sie hält die Nachfrage ab, die den Defekt finden würde.

Das ist dieselbe Form, die diese Sitzung mehrfach getroffen hat: **der Beleg,
der als stärkster gilt, ist der, den niemand nachprüft.**

## Zwei berechnete Prüfungen statt einer Prosa-Korrektur

Eine Messung, die nur als Kommentar dasteht, ist am nächsten Tag wieder eine
Behauptung. `tests/effektiveLeistung.test.ts` hält sie deshalb fest:

1. `Rack/` benutzt keines der beiden Felder (Kommentare via `stripComments`
   ausgenommen). Die Prüfung **verbietet** das nicht — ein Gewichts-Hinweis am
   Rack wäre sinnvoll —, sie erzwingt nur, dass die Doku mitwandert. Die
   Fehlermeldung sagt genau das.
2. Der widerlegte Satz steht nicht wieder in der Typ-Doku.

Beide **gegengeprobt**: je einzeln rot gemacht (eine echte `weightKg`-Zeile in
`RackPlacementProperties.tsx`, der alte Satz zurück in die Doku), Fehlschlag
bestätigt, dann zurückgenommen. Die erste Probe war zusätzlich nützlich: ein
bloßer `// probe weightKg`-Kommentar lässt die Prüfung grün — `stripComments`
wirkt.

## Ausdrücklich nicht entschieden

Ob `powerWatts` in die Leistungskette gehört. Das würde die Zahlen bestehender
Projekte verändern (jeder Plan mit Rentman-Import springt von 0 W auf einen
echten Wert) und ist eine Eigentümer-Entscheidung (E-8 im Suite-Backlog).
`effectiveWatts` und `tests/effektiveLeistung.test.ts` („nimmt `powerWatts` des
GERAETS bewusst NICHT auf") bleiben unverändert. Dieser PR korrigiert nur die
Beschreibung des Stands, nicht den Stand.

## Geprüft

- `npx vitest run` → **946 Tests grün** (95 Dateien; +2 gegenüber 944)
- `npx tsc -p tsconfig.app.json --noEmit` → 0
- `npm run lint` → 0 Errors, 10 Warnungen (vorbestehend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_