### PR TITLE
feat(labels): die Rolle besitzt Mischer- und Router-Labels (B-28)

### DIFF
--- a/src/renderer/components/Atem/AtemDialog.tsx
+++ b/src/renderer/components/Atem/AtemDialog.tsx
@@ -5,6 +5,7 @@ import { cablePlannerApi, type AtemStateSummary, type AtemInputSummary } from '.
 import { useProjectStore } from '../../store/projectStore'
 import { useUiStore } from '../../store/uiStore'
 import { portDisplayLabel, shortenForAtem } from '../../lib/portLabel'
+import { roleLabelsByPort } from '../../lib/labelDerivation'
 import { getEquipmentById } from '../../lib/equipmentSelectors'
 import { ModalShell } from '../shared/ModalShell'
 import { useTranslation, format } from '../../lib/i18n'
@@ -106,6 +107,19 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
     preselectedDeviceId ? getEquipmentById(state.project.equipment, preselectedDeviceId) : undefined,
   )
   const openAtemMvLayout = useUiStore((state) => state.openAtemMvLayout)
+  const allEquipment = useProjectStore((state) => state.project.equipment)
+  const cables = useProjectStore((state) => state.project.cables)
+  const sourceIdentities = useProjectStore((state) => state.project.sourceIdentities)
+
+  // B-28 — portId → Rollenname der Quelle, die an diesem ATEM-Eingang
+  // ankommt. Bis 2026-09-04 hing der Long-/Short-Name allein am Portnamen:
+  // ein Umbenennen der Rolle aenderte UMD-Text, `.avsourcemap` und Tally-CSV,
+  // aber nicht den Namen auf dem Mischer — also genau in dem System, in das
+  // ihn sonst jemand von Hand tippt. Dieselbe Karte liest `deriveLabels`.
+  const roleLabels = useMemo(
+    () => roleLabelsByPort(allEquipment, cables, sourceIdentities ?? []),
+    [allEquipment, cables, sourceIdentities],
+  )
 
   const [ip, setIp] = useState(equipment?.ipAddress ?? '')
   const [status, setStatus] = useState<'idle' | 'connecting' | 'connected' | 'error'>('idle')
@@ -129,10 +143,13 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
   //  Canvas-Port-Name ("1 SDI 3G PGM (1080p50/60)" → "PGM").
   const projectInputNames = useMemo(() => {
     if (!equipment) return [] as string[]
-    return equipment.inputs.map((p) => portDisplayLabel(p))
-  }, [equipment])
+    // B-28 — die gebundene Rolle gewinnt gegen den Portnamen.
+    return equipment.inputs.map((p) => roleLabels.get(p.id) ?? portDisplayLabel(p))
+  }, [equipment, roleLabels])
   const projectOutputNames = useMemo(() => {
     if (!equipment) return [] as string[]
+    // B-28: Ausgang, keine Rolle — ein ATEM-Ausgang (ME/AUX/MV) traegt das
+    // Ziel, nicht die Quelle; eine Quell-Rolle gibt es dort nicht.
     return equipment.outputs.map((p) => portDisplayLabel(p))
   }, [equipment])
 

--- a/src/renderer/components/Export/VideohubExportDialog.tsx
+++ b/src/renderer/components/Export/VideohubExportDialog.tsx
@@ -8,7 +8,7 @@ import {
   mergeLegacySalvos,
   routingDifferences,
 } from '../../lib/videohubRouting'
-import type { VideohubSalvo } from '../../types/equipment'
+import type { Port, VideohubSalvo } from '../../types/equipment'
 import { useTranslation, format as fmt } from '../../lib/i18n'
 import { videohubPresetForDevice } from '../../lib/deviceKind'
 import { downloadBlob } from '../../lib/downloadBlob'
@@ -29,6 +29,7 @@ import { VideohubRoutingMatrix } from './VideohubRoutingMatrix'
 import { VideohubRoutingList } from './VideohubRoutingList'
 import { cablePlannerApi, hasDesktopBridge, type VideohubState } from '../../lib/bridge'
 import { portDisplayLabel } from '../../lib/portLabel'
+import { roleLabelsByPort } from '../../lib/labelDerivation'
 import { isWithinDistance } from '../../lib/levenshtein'
 import { promptDialog } from '../../lib/promptDialog'
 
@@ -83,6 +84,18 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
   const equipment = useProjectStore((s) => s.project.equipment)
   const cables = useProjectStore((s) => s.project.cables)
   const updateEquipment = useProjectStore((s) => s.updateEquipment)
+  const sourceIdentities = useProjectStore((s) => s.project.sourceIdentities)
+
+  // B-28 — portId → Rollenname. Dieselbe Karte fuer JEDEN Ausgabeweg dieses
+  // Dialogs: Vorschau, .txt-Download, Label-PDF, TCP-Push und die Tabelle in
+  // der Oberflaeche. Vier davon standen vorher mit eigenem `portDisplayLabel`
+  // da; genau so entsteht ein Weg, der die Rolle nicht kennt.
+  const roleLabels = useMemo(
+    () => roleLabelsByPort(equipment, cables, sourceIdentities ?? []),
+    [equipment, cables, sourceIdentities],
+  )
+  const labelOf = (port: Port | undefined, fallback: string): string =>
+    (port ? roleLabels.get(port.id) ?? portDisplayLabel(port) : '') || fallback
   const [deviceId, setDeviceId] = useState<string>(() => {
     if (preselectedDeviceId && equipment.some((e) => e.id === preselectedDeviceId)) {
       return preselectedDeviceId
@@ -580,6 +593,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
       return buildVideohubLabelTxt(device, {
         totalInputs: preset.inputs,
         totalOutputs: preset.outputs,
+        roleLabels,
       })
     }
     return buildVideohubRoutingDump(device, {
@@ -588,8 +602,9 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
       totalInputs: preset.inputs,
       totalOutputs: preset.outputs,
       routing,
+      roleLabels,
     })
-  }, [device, format, preset, friendlyName, routing])
+  }, [device, format, preset, friendlyName, routing, roleLabels])
 
   const handleExport = () => {
     if (!device) return
@@ -667,14 +682,14 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
     Array.from({ length: preset.inputs }, (_, i) => {
       // #286 — contentLabel (PGM/PVW/Cam1) gewinnt vor port.name.
       const port = device?.inputs[i]
-      const portName = port ? portDisplayLabel(port) || `In ${i + 1}` : `In ${i + 1}`
+      const portName = labelOf(port, `In ${i + 1}`)
       const conn = connections.inputConn.get(i)
       return conn ? `${portName} <- ${conn.sourceName}` : portName
     })
   const computeEffectiveOutputLabels = (): string[] =>
     Array.from({ length: preset.outputs }, (_, i) => {
       const port = device?.outputs[i]
-      const portName = port ? portDisplayLabel(port) || `Out ${i + 1}` : `Out ${i + 1}`
+      const portName = labelOf(port, `Out ${i + 1}`)
       const conn = connections.outputConn.get(i)
       return conn ? `${portName} -> ${conn.destName}` : portName
     })
@@ -993,7 +1008,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
               if (hubLabel) return { port: hubLabel }
               // #286 — Canvas-Port: contentLabel bevorzugt vor port.name.
               const p = device?.inputs[i]
-              const portName = p ? portDisplayLabel(p) || `In ${i + 1}` : `In ${i + 1}`
+              const portName = labelOf(p, `In ${i + 1}`)
               const conn = connections.inputConn.get(i)
               if (!conn || !showConnections) return { port: portName }
               return {
@@ -1016,7 +1031,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                     : ''
               if (hubLabel) return { port: hubLabel, lockBadge }
               const p = device?.outputs[i]
-              const portName = p ? portDisplayLabel(p) || `Out ${i + 1}` : `Out ${i + 1}`
+              const portName = labelOf(p, `Out ${i + 1}`)
               const conn = connections.outputConn.get(i)
               if (!conn || !showConnections) return { port: portName, lockBadge }
               return {

--- a/src/renderer/lib/exportVideohub.ts
+++ b/src/renderer/lib/exportVideohub.ts
@@ -1,4 +1,4 @@
-import type { EquipmentItem } from '../types/equipment'
+import type { EquipmentItem, Port } from '../types/equipment'
 import { portDisplayLabel } from './portLabel'
 
 /**
@@ -63,9 +63,35 @@ export const parseVideohubLabelsTxt = (text: string): ParsedVideohubLabels => {
  * emitted with just the channel number so the file has `totalInputs`/
  * `totalOutputs` rows (Videohub Control expects sequential numbering).
  */
+/**
+ * Der Text, den dieser Videohub-Eingang/-Ausgang bekommt.
+ *
+ * B-28 — `roleLabels` ist die Karte aus `labelDerivation.roleLabelsByPort`:
+ * je EINGANGSPORT der Name der Rolle, die dort ankommt. Sie gewinnt gegen den
+ * Portnamen, damit ein Umbenennen der Rolle im Videohub ankommt statt nur im
+ * UMD-Text. Ausgaenge stehen nicht in der Karte (dort traegt der Kreuzpunkt
+ * das Ziel, nicht die Verkabelung) und fallen deshalb immer auf den Portnamen.
+ *
+ * Weitergereicht statt hier berechnet: dieses Modul ist rein und kennt weder
+ * Kabel noch Rollen. Wer den Graphen hat, gibt die Karte mit; wer nicht,
+ * bekommt exakt das bisherige Verhalten.
+ */
+const displayFor = (
+  port: Port | undefined,
+  roleLabels: ReadonlyMap<string, string> | undefined,
+): string => {
+  if (!port) return ''
+  return (port.id ? roleLabels?.get(port.id) : undefined) ?? portDisplayLabel(port)
+}
+
 export const buildVideohubLabelTxt = (
   device: Pick<EquipmentItem, 'inputs' | 'outputs'>,
-  opts: { totalInputs?: number; totalOutputs?: number } = {},
+  opts: {
+    totalInputs?: number
+    totalOutputs?: number
+    /** B-28 — portId → Rollenname, aus `labelDerivation.roleLabelsByPort`. */
+    roleLabels?: ReadonlyMap<string, string>
+  } = {},
 ): string => {
   const totalIn = opts.totalInputs ?? device.inputs.length
   const totalOut = opts.totalOutputs ?? device.outputs.length
@@ -73,13 +99,14 @@ export const buildVideohubLabelTxt = (
   for (let i = 0; i < totalIn; i++) {
     const port = device.inputs[i]
     // #286 — contentLabel ("PGM", "Cam1") gewinnt gegen port.name wenn gesetzt.
-    const display = port ? portDisplayLabel(port) : ''
+    // B-28 — die gebundene Rolle gewinnt gegen beides.
+    const display = displayFor(port, opts.roleLabels)
     const label = display ? `${i + 1} ${display}`.trim() : `${i + 1}`
     lines.push(`Input, ${i + 1}, ${label}`)
   }
   for (let i = 0; i < totalOut; i++) {
     const port = device.outputs[i]
-    const display = port ? portDisplayLabel(port) : ''
+    const display = displayFor(port, opts.roleLabels)
     const label = display ? `${i + 1} ${display}`.trim() : `${i + 1}`
     lines.push(`Output, ${i + 1}, ${label}`)
   }
@@ -126,6 +153,8 @@ export const buildVideohubRoutingDump = (
     totalOutputs?: number
     /** output-index → input-index mapping; missing entries default to 0 */
     routing?: Record<number, number>
+    /** B-28 — portId → Rollenname, aus `labelDerivation.roleLabelsByPort`. */
+    roleLabels?: ReadonlyMap<string, string>
   } = {},
 ): string => {
   const totalIn = opts.totalInputs ?? device.inputs.length
@@ -160,7 +189,8 @@ export const buildVideohubRoutingDump = (
   for (let i = 0; i < totalIn; i++) {
     const port = device.inputs[i]
     // #286 — bevorzugt contentLabel (PGM/PVW) vor port.name.
-    const display = port ? portDisplayLabel(port) : ''
+    // B-28 — die gebundene Rolle gewinnt gegen beides.
+    const display = displayFor(port, opts.roleLabels)
     const label = display ? `${i + 1} ${display}`.trim() : `${i + 1}`
     out.push(`${i} ${label}`)
   }
@@ -168,7 +198,7 @@ export const buildVideohubRoutingDump = (
   out.push('OUTPUT LABELS:')
   for (let i = 0; i < totalOut; i++) {
     const port = device.outputs[i]
-    const display = port ? portDisplayLabel(port) : ''
+    const display = displayFor(port, opts.roleLabels)
     const label = display ? `${i + 1} ${display}`.trim() : `${i + 1}`
     out.push(`${i} ${label}`)
   }

--- a/src/renderer/lib/labelDerivation.ts
+++ b/src/renderer/lib/labelDerivation.ts
@@ -171,6 +171,66 @@ export const routerLinkFor = (
     )[0]
 }
 
+/**
+ * Je EINGANGSPORT eines Routers/Mischers der Name der ROLLE, die dort
+ * tatsaechlich ankommt — oder kein Eintrag, wenn keine gebunden ist.
+ *
+ * WARUM DIESE KARTE UEBERHAUPT EXISTIERT (B-28, gemessen 2026-09-04). Ein
+ * Umbenennen der `SourceIdentity` aenderte den UMD-Text, die `.avsourcemap`
+ * und die Tally-CSV — aber NICHT den ATEM-Lang-/Kurznamen und NICHT die
+ * Videohub-Labels. Ausgerechnet die beiden Systeme, in die der Name sonst von
+ * Hand getippt wird, hingen nicht an der Rolle. Initiative 1 heisst "Rename
+ * kostet eine Aenderung"; solange diese zwei Ausgabewege am Portnamen hingen,
+ * kostete es drei.
+ *
+ * WARUM ALS EINE KARTE UND NICHT ALS ZEILE IN JEDEM EXPORTER. Die TREUE-REGEL
+ * oben verlangt, dass die Ableitung nur behauptet, was der Exporter WIRKLICH
+ * sendet. Ein Vorrang, den `deriveLabels` kennt und `exportVideohub` nicht,
+ * bricht sie sofort: der Plan-Check meldete dann Kollisionen auf Texten, die
+ * nie ein Geraet erreichen. Deshalb liefert diese Funktion die Aufloesung, und
+ * beide Seiten lesen dieselbe.
+ *
+ * VORRANG. Die Rolle gewinnt gegen den Portnamen — dieselbe Begruendung wie
+ * beim UMD-Text: "Kamera 1" bleibt "Kamera 1", auch wenn die Havarie-Kamera
+ * einspringt. Wer den Portnamen sehen will, bindet keine Rolle.
+ *
+ * NUR EINGAENGE. Ein Router-AUSGANG traegt das Ziel, nicht die Quelle, und
+ * welches Ziel das ist, entscheidet der Kreuzpunkt zur Laufzeit — nicht die
+ * Verkabelung. Das ist ein eigener Schritt und wird hier bewusst nicht
+ * geraten.
+ */
+const roleNameOf = (
+  source: EquipmentItem | undefined,
+  identityById: ReadonlyMap<string, SourceIdentity>,
+): string | undefined => {
+  const identity = source?.sourceIdentityId
+    ? identityById.get(source.sourceIdentityId)
+    : undefined
+  return identity?.name?.trim() || undefined
+}
+
+export const roleLabelsByPort = (
+  equipment: EquipmentItem[],
+  cables: Cable[],
+  sourceIdentities: SourceIdentity[],
+): Map<string, string> => {
+  const ctx = buildGraphContext(equipment, cables)
+  const identityById = new Map(sourceIdentities.map((s) => [s.id, s]))
+  const out = new Map<string, string>()
+
+  for (const device of equipment) {
+    const kind = detectDeviceKind(device)
+    if (kind !== 'atem' && kind !== 'videohub') continue
+    for (const port of device.inputs) {
+      const resolved = resolveSignalSource(port.id, ctx)
+      const source = resolved ? ctx.eqById.get(resolved.equipmentId) : undefined
+      const name = roleNameOf(source, identityById)
+      if (name) out.set(port.id, name)
+    }
+  }
+  return out
+}
+
 export type AnchorField = 'umd-address'
 
 export interface UnansweredAnchor {
@@ -448,7 +508,15 @@ export const deriveLabels = ({
           sinkKind: kind,
         })
       }
-      const { raw, provenance } = portText(port)
+      // B-28 — die Rolle gewinnt gegen den Portnamen, und zwar HIER, wo
+      // beide Exporter sie ablesen (`roleLabelsByPort` liefert dieselbe
+      // Aufloesung ueber `roleNameOf`). Wuerde nur diese Ableitung sie
+      // kennen, braeche die TREUE-REGEL am Kopf der Datei: der Plan-Check
+      // meldete Kollisionen auf Texten, die nie ein Geraet erreichen.
+      const roleName = roleNameOf(source, identityById)
+      const fromPort = portText(port)
+      const raw = roleName ?? fromPort.raw
+      const provenance: LabelProvenance = roleName ? 'source-identity' : fromPort.provenance
       if (!raw) {
         // Kein Label heisst nicht: keine Quelle. Der UMD-Text haengt an der
         // Quelle, nicht am Portnamen — deshalb erst hier abbrechen.

--- a/tests/rolleBesitztLabels.test.ts
+++ b/tests/rolleBesitztLabels.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest'
+import { deriveLabels, roleLabelsByPort } from '../src/renderer/lib/labelDerivation'
+import {
+  buildVideohubLabelTxt,
+  buildVideohubRoutingDump,
+} from '../src/renderer/lib/exportVideohub'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem, Port } from '../src/renderer/types/equipment'
+import type { SourceIdentity } from '../src/renderer/types/sourceIdentity'
+
+// ───────────────────────────────────────────────────────────────────────────
+// B-28 — die Rolle besitzt die Mischer- und Router-Labels.
+//
+// GEMESSENER AUSGANGSZUSTAND (2026-09-04, Runde 10). Ein Umbenennen der
+// `SourceIdentity` aenderte den UMD-Text, die `.avsourcemap` und die
+// Tally-CSV -- aber NICHT den ATEM-Lang-/Kurznamen und NICHT die
+// Videohub-Labels. Beide hingen allein am Portnamen
+// (`AtemDialog.tsx:132`, `exportVideohub.ts:76/163`).
+//
+// Warum ausgerechnet diese zwei: es sind die Systeme, in die der Name sonst
+// von Hand getippt wird. Initiative 1 heisst "Rename kostet eine Aenderung";
+// solange sie nicht an der Rolle hingen, kostete es drei. Die
+// Bedarfs-Datenbank nennt es achtmal aus acht Berufen (P1 #5, #9): "Stop
+// typing camera identity into six to eight systems."
+//
+// WAS DIESE DATEI PRUEFT, IST NICHT "der Name steht drin", sondern: EIN
+// Umbenennen erreicht ALLE Ausgabewege -- Ableitung, Labels.txt und
+// Protokoll-Dump. Ein Test je Weg waere derselbe Test dreimal; der
+// Unterschied liegt darin, dass sie GEMEINSAM aus einer Aufloesung kommen.
+// ───────────────────────────────────────────────────────────────────────────
+
+const port = (id: string, name: string, over: Partial<Port> = {}): Port => ({
+  id,
+  name,
+  type: 'BNC',
+  connectorType: 'BNC',
+  ...over,
+})
+
+const eq = (over: Partial<EquipmentItem>): EquipmentItem => ({
+  id: 'e1',
+  name: 'Gerät',
+  category: 'Video',
+  inputs: [],
+  outputs: [],
+  x: 0,
+  y: 0,
+  width: 200,
+  height: 160,
+  ...over,
+})
+
+const cable = (from: [string, string], to: [string, string]): Cable => ({
+  id: `${from[1]}->${to[1]}`,
+  name: `${from[1]}->${to[1]}`,
+  type: 'BNC',
+  length: 10,
+  color: '#fff',
+  fromEquipmentId: from[0],
+  fromPortId: from[1],
+  toEquipmentId: to[0],
+  toPortId: to[1],
+  notes: '',
+})
+
+/**
+ * Kamera → Videohub In 1 → (Kreuzpunkt) → Videohub Out 1 → ATEM In 1.
+ *
+ * Bewusst MIT Router dazwischen: die Kette, um die es geht, ist nicht die
+ * direkt verkabelte. Ohne gesetzten Kreuzpunkt haelt die Rueckwaertssuche am
+ * Router an -- der letzte Fall unten haengt genau daran.
+ */
+const szenario = (opts: { rolle?: string; kreuzpunkt?: boolean } = {}) => {
+  const { rolle = 'Kamera 1', kreuzpunkt = true } = opts
+
+  const identity: SourceIdentity = { id: 'role-1', name: rolle }
+  const kamera = eq({
+    id: 'cam1',
+    name: 'URSA Broadcast G2',
+    category: 'Kameras',
+    sourceIdentityId: 'role-1',
+    outputs: [port('cam1-out', 'SDI Out')],
+  })
+  const videohub = eq({
+    id: 'vh',
+    name: 'Smart Videohub 12x12',
+    inputs: [port('vh-in1', 'In 1', { contentLabel: 'Tippfehler' })],
+    outputs: [port('vh-out1', 'Out 1')],
+    ...(kreuzpunkt ? { videohubRouting: { planned: { 0: 0 } } } : {}),
+  })
+  const atem = eq({
+    id: 'atem',
+    name: 'ATEM Mini Extreme',
+    inputs: [port('atem-in1', 'In 1', { contentLabel: 'Von Hand getippt' })],
+  })
+
+  return {
+    equipment: [kamera, videohub, atem],
+    cables: [
+      cable(['cam1', 'cam1-out'], ['vh', 'vh-in1']),
+      cable(['vh', 'vh-out1'], ['atem', 'atem-in1']),
+    ],
+    sourceIdentities: [identity],
+    videohub,
+  }
+}
+
+describe('roleLabelsByPort', () => {
+  it('bindet den ATEM-Eingang an die Rolle — durch den Router hindurch', () => {
+    const { equipment, cables, sourceIdentities } = szenario()
+    const karte = roleLabelsByPort(equipment, cables, sourceIdentities)
+
+    expect(karte.get('atem-in1')).toBe('Kamera 1')
+    expect(karte.get('vh-in1')).toBe('Kamera 1')
+  })
+
+  it('laesst Ausgaenge aus — dort traegt der Kreuzpunkt das Ziel, nicht das Kabel', () => {
+    const { equipment, cables, sourceIdentities } = szenario()
+    const karte = roleLabelsByPort(equipment, cables, sourceIdentities)
+
+    expect(karte.has('vh-out1')).toBe(false)
+  })
+
+  it('ohne gesetzten Kreuzpunkt endet die Kette am Router — der ATEM-Eingang bleibt ohne Rolle', () => {
+    const { equipment, cables, sourceIdentities } = szenario({ kreuzpunkt: false })
+    const karte = roleLabelsByPort(equipment, cables, sourceIdentities)
+
+    // Der Router-Eingang kennt die Kamera weiterhin; der Mischer-Eingang
+    // nicht. Geraten wird hier nichts -- ein Router mit 12 Eingaengen hat 12
+    // gleich plausible Antworten.
+    expect(karte.get('vh-in1')).toBe('Kamera 1')
+    expect(karte.has('atem-in1')).toBe(false)
+  })
+
+  it('ein Geraet ohne gebundene Rolle taucht nicht auf', () => {
+    const { equipment, cables } = szenario()
+    const karte = roleLabelsByPort(equipment, cables, [])
+
+    expect(karte.size).toBe(0)
+  })
+})
+
+describe('Ein Umbenennen erreicht alle drei Ausgabewege', () => {
+  const textFuer = (targetId: string, rolle: string): string[] => {
+    const { equipment, cables, sourceIdentities } = szenario({ rolle })
+    return deriveLabels({ equipment, cables, sourceIdentities })
+      .candidates.filter((c) => c.targetId === targetId)
+      .map((c) => c.raw)
+  }
+
+  it('ATEM-Langname folgt der Rolle statt dem von Hand getippten Portnamen', () => {
+    expect(textFuer('atem-input-long', 'Kamera 1')).toEqual(['Kamera 1'])
+    expect(textFuer('atem-input-long', 'Moderation')).toEqual(['Moderation'])
+  })
+
+  it('ATEM-Kurzname folgt mit', () => {
+    // `raw` ist der Wunschtext VOR dem Zuschnitt aufs Zielbudget -- der
+    // 4-Zeichen-Schnitt passiert erst in `fitToTarget`. Geprueft wird hier
+    // also, dass der Kurzname aus der ROLLE gebildet wird und nicht aus dem
+    // Portnamen; wie kurz er danach wird, ist Sache des Zielsystems.
+    expect(textFuer('atem-input-short', 'Kamera 1')).toEqual(['KAMERA1'])
+    expect(textFuer('atem-input-short', 'Moderation')).toEqual(['MODERATION'])
+  })
+
+  it('Videohub-Eingangslabel folgt, das Ausgangslabel nicht', () => {
+    const { equipment, cables, sourceIdentities } = szenario()
+    const vh = deriveLabels({ equipment, cables, sourceIdentities }).candidates.filter(
+      (c) => c.targetId === 'videohub-label',
+    )
+
+    expect(vh.find((c) => c.key === 'videohub-in:vh-in1')?.raw).toBe('Kamera 1')
+    expect(vh.find((c) => c.key === 'videohub-out:vh-out1')?.raw).toBe('Out 1')
+  })
+
+  it('die Herkunft sagt es auch — sonst sieht der Nutzer den Vorrang nicht', () => {
+    const { equipment, cables, sourceIdentities } = szenario()
+    const long = deriveLabels({ equipment, cables, sourceIdentities }).candidates.find(
+      (c) => c.targetId === 'atem-input-long',
+    )
+
+    expect(long?.provenance).toBe('source-identity')
+    expect(long?.sourceText).toBe('Kamera 1')
+  })
+
+  it('Labels.txt und Protokoll-Dump tragen dieselbe Rolle', () => {
+    const { equipment, cables, sourceIdentities, videohub } = szenario()
+    const roleLabels = roleLabelsByPort(equipment, cables, sourceIdentities)
+
+    const txt = buildVideohubLabelTxt(videohub, { roleLabels })
+    const dump = buildVideohubRoutingDump(videohub, { roleLabels })
+
+    expect(txt).toContain('Input, 1, 1 Kamera 1')
+    expect(dump).toContain('0 1 Kamera 1')
+    // Der Ausgang bleibt beim Portnamen -- in beiden Formaten.
+    expect(txt).toContain('Output, 1, 1 Out 1')
+    expect(dump).toContain('OUTPUT LABELS:')
+  })
+
+  it('ohne Karte verhalten sich beide Exporter exakt wie vorher', () => {
+    const { videohub } = szenario()
+
+    // Gegenprobe zur Zeile darueber: die Rolle darf nicht auf einem anderen
+    // Weg hereinkommen. Ohne `roleLabels` gewinnt weiterhin `contentLabel`.
+    expect(buildVideohubLabelTxt(videohub)).toContain('Input, 1, 1 Tippfehler')
+    expect(buildVideohubRoutingDump(videohub)).toContain('0 1 Tippfehler')
+  })
+})
+
+describe('Die Ableitung und die Exporter lesen dieselbe Aufloesung', () => {
+  // WARUM DIESER TEST DER WICHTIGSTE IST. Die TREUE-REGEL am Kopf von
+  // `labelDerivation.ts` verlangt, dass ein Kandidat nur behauptet, was der
+  // Exporter WIRKLICH sendet. Ein Vorrang, den die Ableitung kennt und der
+  // Exporter nicht, meldete Kollisionen auf Texten, die nie ein Geraet
+  // erreichen -- und das ist schwerer zu bemerken als ein fehlender Name,
+  // weil der Plan-Check dann gruen luegt statt still zu bleiben.
+  it('derselbe Text im Kandidaten wie in der Labels.txt', () => {
+    const { equipment, cables, sourceIdentities, videohub } = szenario({ rolle: 'Weitwinkel' })
+    const roleLabels = roleLabelsByPort(equipment, cables, sourceIdentities)
+
+    const ausAbleitung = deriveLabels({ equipment, cables, sourceIdentities }).candidates.find(
+      (c) => c.key === 'videohub-in:vh-in1',
+    )?.raw
+    const ausExport = buildVideohubLabelTxt(videohub, { roleLabels })
+      .split('\r\n')[0]
+      .replace('Input, 1, 1 ', '')
+
+    expect(ausAbleitung).toBe('Weitwinkel')
+    expect(ausExport).toBe(ausAbleitung)
+  })
+})

--- a/tests/rolleErreichtAlleExporter.test.ts
+++ b/tests/rolleErreichtAlleExporter.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import atemDialogSrc from '../src/renderer/components/Atem/AtemDialog.tsx?raw'
+import videohubDialogSrc from '../src/renderer/components/Export/VideohubExportDialog.tsx?raw'
+import exportVideohubSrc from '../src/renderer/lib/exportVideohub.ts?raw'
+
+// ───────────────────────────────────────────────────────────────────────────
+// Kein zweiter Ausgabeweg, der die Rolle nicht kennt.
+//
+// WARUM ES DAS GIBT. B-28 war nicht "ein Exporter vergass die Rolle", sondern
+// "fuenf Wege lasen denselben Portnamen, und keiner davon die Rolle": Vorschau,
+// .txt, Label-PDF, TCP-Push und die Tabelle in der Oberflaeche. Repariert
+// wurden alle fuenf, indem sie EINE Aufloesung lesen.
+//
+// Damit ist die Reparatur genau so haltbar wie die naechste hinzugefuegte
+// Zeile. Dieselbe Sitzung hat das schon einmal gemessen (B-29): die
+// Port-Beschriftung war auf eine Stelle zusammengezogen, mit Guard -- und der
+// Guard globte `src/renderer/**`, waehrend `src/mobile/` danebenlag und roh
+// `{p.name}` rendere. Eine Engstelle ohne Pruefung ist eine Absichtserklaerung.
+//
+// DIE REGEL. In den drei Dateien, die Videohub-/ATEM-Labels erzeugen, darf
+// `portDisplayLabel(` nur dort stehen, wo auch die Rollen-Karte gelesen wird.
+// Wer bewusst daran vorbei will, schreibt den Grund als Marke an die Stelle
+// (`B-28: Ausgang, keine Rolle`) -- nicht in eine Ausnahmeliste in diesem
+// Test. Eine Liste hier waere der Kenntnisstand von heute; die Marke steht
+// dort, wo jemand sie beim Schreiben der Zeile liest.
+// ───────────────────────────────────────────────────────────────────────────
+
+const DATEIEN: Array<[string, string]> = [
+  ['components/Atem/AtemDialog.tsx', atemDialogSrc],
+  ['components/Export/VideohubExportDialog.tsx', videohubDialogSrc],
+  ['lib/exportVideohub.ts', exportVideohubSrc],
+]
+
+const MARKE = 'B-28: Ausgang, keine Rolle'
+
+/**
+ * Reine Kommentarzeilen fallen raus; der Rest bleibt MIT Zeilennummern
+ * stehen. `stripComments` waere hier falsch: die Marke IST ein Kommentar,
+ * und ein Strippen verschoebe ausserdem die Nummern gegen die Rohdatei --
+ * gemessen an genau dieser Stelle, die Meldung zeigte Zeile 142 fuer eine
+ * Zeile, die in der Datei bei 146 steht.
+ */
+const istKommentar = (zeile: string): boolean =>
+  /^\s*(\/\/|\*|\/\*)/.test(zeile)
+
+describe('Jeder Label-Ausgabeweg liest die Rollen-Karte', () => {
+  it.each(DATEIEN)('%s', (_name, quelle) => {
+    const roh = quelle.split('\n')
+
+    const verstoesse: string[] = []
+    roh.forEach((zeile, i) => {
+      if (istKommentar(zeile)) return
+      if (!zeile.includes('portDisplayLabel(')) return
+      if (zeile.includes('roleLabels')) return
+      // Marke an der Zeile selbst oder in den zwei Zeilen darueber.
+      const umfeld = roh.slice(Math.max(0, i - 2), i + 1).join('\n')
+      if (umfeld.includes(MARKE)) return
+      verstoesse.push(`Zeile ${i + 1}: ${zeile.trim()}`)
+    })
+
+    expect(
+      verstoesse,
+      `portDisplayLabel() ohne Rollen-Karte. Entweder die Karte lesen ` +
+        `(\`roleLabels.get(port.id) ?? portDisplayLabel(port)\`) oder — wenn ` +
+        `der Port wirklich keine Quell-Rolle haben kann — die Marke ` +
+        `"${MARKE}" mit Begruendung danebenschreiben.`,
+    ).toEqual([])
+  })
+
+  it('die Marke misst etwas — sie kommt genau einmal vor', () => {
+    // Gegenprobe gegen die bequeme Reparatur: wer den Guard mit Marken
+    // zuschuettet, macht ihn wertlos. Faellt diese Zeile, ist die Frage nicht
+    // "Zahl erhoehen", sondern "warum hat der dritte Ausgang keine Rolle".
+    const treffer = DATEIEN.reduce(
+      (n, [, quelle]) => n + quelle.split(MARKE).length - 1,
+      0,
+    )
+    expect(treffer).toBe(1)
+  })
+
+  it('die Rollen-Karte kommt aus der Ableitung, nicht aus einer zweiten Kopie', () => {
+    for (const [name, quelle] of DATEIEN) {
+      if (!quelle.includes('roleLabels')) continue
+      const importiertKarte = /import \{[^}]*roleLabelsByPort[^}]*\} from/.test(quelle)
+      if (name === 'lib/exportVideohub.ts') {
+        // Rein: bekommt die Karte durchgereicht, baut sie nicht. Der
+        // Doku-Kommentar dort NENNT `roleLabelsByPort` -- deshalb wird auf
+        // die Import-Anweisung geprueft, nicht auf das blosse Vorkommen.
+        expect(importiertKarte, `${name} baut die Karte selbst`).toBe(false)
+        continue
+      }
+      expect(importiertKarte, `${name} baut die Karte selbst statt sie abzuleiten`).toBe(true)
+    }
+  })
+})

--- a/tests/sourceMap.test.ts
+++ b/tests/sourceMap.test.ts
@@ -355,11 +355,23 @@ describe('buildSourceMap — Rolle mit mehreren Geraeten', () => {
     // Dieser Test beschreibt den heutigen, falschen Zustand — bewusst. Wer
     // `labels` in die `bindings` zieht, bringt ihn zu Fall und muss ihn
     // anfassen, statt die Aenderung unbemerkt vorbeizuschieben.
+    //
+    // GENAU DAS IST PASSIERT (B-28, 2026-09-04). Seit die gebundene Rolle
+    // gegen den Portnamen gewinnt, tragen BEIDE Eingaenge "Kamera 1" statt
+    // "Kamera 1 Haupt" / "Kamera 1 Backup". Der Verlust, den dieser Test
+    // festhaelt, ist derselbe geblieben — flach ist flach —, aber seine
+    // Gestalt hat gewechselt: vorher ueberschrieb die zweite Beschriftung
+    // die erste und man sah, WELCHE gewonnen hat; jetzt sind sie gleich.
+    //
+    // Das ist die richtige Richtung und nicht bloss eine andere: eine Rolle
+    // heisst in jedem Zielsystem gleich, auch wenn die Havarie-Kamera
+    // einspringt — dafuer gibt es sie. Die Zuordnung, welches GERAET an
+    // welchem Eingang haengt, geht dabei nicht verloren, sie steht in
+    // `bindings` (Test darueber). Und `ambiguousLabels` meldet den Fall
+    // weiterhin, statt ihn stillschweigend hinzunehmen.
     const { map } = buildSourceMap(zweiGeraete(), META)
     const labels = map.sources[0].labels
-    // Zwei Eingaenge, zwei Beschriftungen — in der Datei steht die des
-    // ZULETZT gelesenen Geraets, hier also die des Backups.
-    expect(labels['atem-input-long']).toBe('Kamera 1 Backup')
+    expect(labels['atem-input-long']).toBe('Kamera 1')
     expect(Object.keys(labels).filter((k) => k.startsWith('atem-input'))).toHaveLength(2)
   })
 


### PR DESCRIPTION
## Der Befund

Ein Umbenennen der `SourceIdentity` änderte den UMD-Text, die `.avsourcemap`
und die Tally-CSV — aber **nicht** den ATEM-Lang-/Kurznamen und **nicht** die
Videohub-Labels. Beide hingen allein am Portnamen (`AtemDialog.tsx:132`,
`exportVideohub.ts:76/163`).

Ausgerechnet die zwei Systeme, in die der Name sonst **von Hand getippt** wird.
Initiative 1 heißt „Rename kostet eine Änderung"; solange das so war, kostete es
drei. Die Bedarfs-Datenbank nennt es achtmal aus acht Berufen (P1 #5, #9):
*„Stop typing camera identity into six to eight systems."*

## Eine Auflösung, von allen gelesen

`roleLabelsByPort(equipment, cables, sourceIdentities)` in `labelDerivation.ts`
liefert je **Eingangsport** eines Routers/Mischers den Namen der Rolle, die dort
ankommt — durch Router-Kreuzpunkte hindurch (`resolveSignalSource`, seit
`cable#675`).

Warum eine Karte und nicht eine Zeile je Exporter: die **TREUE-REGEL** am Kopf
von `labelDerivation.ts` verlangt, dass ein Kandidat nur behauptet, was der
Exporter wirklich sendet. Ein Vorrang, den die Ableitung kennt und der Exporter
nicht, hätte den Plan-Check Kollisionen auf Texten melden lassen, die nie ein
Gerät erreichen — grün lügen ist schwerer zu bemerken als still bleiben.

| Weg | vorher | jetzt |
|---|---|---|
| `deriveLabels` (ATEM long/short, Videohub-Eingang) | Portname | Rolle, `provenance: 'source-identity'` |
| `buildVideohubLabelTxt` / `buildVideohubRoutingDump` | Portname | Rolle, wenn `roleLabels` mitgegeben — ohne Karte **exakt** wie vorher |
| `VideohubExportDialog` (Vorschau, .txt, Label-PDF, TCP-Push, Tabelle) | fünfmal eigenes `portDisplayLabel` | eine Karte, ein `labelOf` |
| `AtemDialog` Long-/Short-Vorschlag | Portname | Rolle |

`exportVideohub.ts` bleibt rein: es bekommt die Karte durchgereicht und kennt
weder Kabel noch Rollen.

## Was bewusst nicht passiert

- **Router-Ausgänge** bleiben beim Portnamen. Dort trägt der Kreuzpunkt zur
  Laufzeit das Ziel, nicht die Verkabelung — geraten wird nichts.
- **ATEM-Ausgänge** (ME/AUX/MV) ebenso; sie tragen das Ziel, nicht die Quelle.
  Begründet mit einer Marke **an der Stelle**, nicht in einer Liste im Test.
- Ohne gesetzten Kreuzpunkt endet die Kette am Router, und der Mischer-Eingang
  bleibt ohne Rolle statt eine zu erfinden (eigener Test).

## Zwei Prüfungen, beide gegengeprobt

`tests/rolleBesitztLabels.test.ts` — 11 Tests über die Kette Kamera → Videohub
→ ATEM. **Gegen den alten Stand fallen 10 davon**; der elfte ist die
Nicht-Regression („ohne Karte verhalten sich beide Exporter exakt wie vorher")
und muss beidseitig grün sein.

`tests/rolleErreichtAlleExporter.test.ts` — fängt einen **neuen** Ausgabeweg,
der die Karte nicht liest. Das ist die Lehre aus B-29 in derselben Sitzung: die
Port-Beschriftung war schon einmal auf eine Stelle zusammengezogen, mit Guard —
und der Guard globte `src/renderer/**`, während `src/mobile/` danebenlag und roh
`{p.name}` rendern durfte. Eine Engstelle ohne Prüfung ist eine
Absichtserklärung.

Ausnahmen brauchen die Marke `B-28: Ausgang, keine Rolle` **an der Zeile** —
und die Marke wird **gezählt** (genau eine), damit niemand den Guard mit Marken
zuschüttet. Beide Richtungen gegengeprobt: eine zurückgedrehte Zeile wird
gemeldet, eine zweite Marke lässt den Zähler fallen.

## Ein bestehender Test ist gefallen — und wurde angefasst, nicht umgangen

`tests/sourceMap.test.ts` („haelt fest, WAS verloren geht") hatte im eigenen
Kommentar vorhergesagt: *„Wer `labels` in die `bindings` zieht, bringt ihn zu
Fall und muss ihn anfassen, statt die Änderung unbemerkt vorbeizuschieben."*

Genau das ist eingetreten. Bei zwei Geräten an einer Rolle trugen die beiden
ATEM-Eingänge vorher `Kamera 1 Haupt` / `Kamera 1 Backup`, jetzt beide
`Kamera 1`. Der Verlust ist derselbe geblieben — flach ist flach —, aber seine
Gestalt hat gewechselt. Das ist die richtige Richtung: eine Rolle heißt in jedem
Zielsystem gleich, auch wenn die Havarie-Kamera einspringt. `bindings` trägt
beide Geräte samt Eingang weiter, `ambiguousLabels` meldet den Fall weiter. Die
Begründung steht im Test.

## Geprüft

- `npx vitest run` → **962 Tests grün** (97 Dateien)
- `npx tsc -p tsconfig.app.json --noEmit` → 0
- `npm run lint` → 0 Errors, 10 Warnungen (vorbestehend)
- `npm run build` → 0

Closes B-28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_