### PR TITLE
feat(netz): Ausspielweg im Modell — SRT, RTMP, HLS (B-10, erste Hälfte)

### DIFF
--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -4644,6 +4644,8 @@ export const en: Dict = {
     'NDI / NDI-HX over standard Gigabit Ethernet. Keep NDI and Dante on separate VLANs/links to avoid congestion.',
   'catalog.cable.dante-cat6.notes':
     'Dante / AES67 audio-over-IP. Requires PTP clocking; QoS/DSCP recommended on managed switches.',
+  'catalog.cable.stream-uplink-cat6.notes':
+    'Outbound stream leg: SRT (contribution, with retransmit reserve), RTMP (platform ingest) or HLS (delivery ladder). Physically the same Cat6 as any other link — kept separate so the network budget shows the uplink as delivery, not as another production source. The budget figures are guide values for one 1080p50 path.',
   'catalog.cable.st2110-fiber.notes':
     'SMPTE ST 2110 (-20 video / -30 audio / -40 ANC) over fiber. Needs a PTP grandmaster; typically 10/25/100 GbE.',
   'catalog.cable.blackburst-bnc.notes':
@@ -4752,6 +4754,8 @@ export const de: Dict = {
     'NDI / NDI-HX über normales Gigabit-Ethernet. NDI und Dante auf getrennten VLANs/Links halten, um Überlast zu vermeiden.',
   'catalog.cable.dante-cat6.notes':
     'Dante / AES67 Audio-over-IP. Benötigt PTP-Clocking; QoS/DSCP auf Managed Switches empfohlen.',
+  'catalog.cable.stream-uplink-cat6.notes':
+    'Ausspielweg nach draußen: SRT (Beitrag, mit Retransmit-Reserve), RTMP (Plattform-Ingest) oder HLS (Ausspiel-Leiter). Physisch dasselbe Cat6 wie jeder andere Link — getrennt geführt, damit das Netz-Budget den Uplink als Ausspielung zeigt und nicht als weitere Produktionsquelle. Die Budget-Zahlen sind Richtwerte für einen 1080p50-Weg.',
   'catalog.cable.st2110-fiber.notes':
     'SMPTE ST 2110 (-20 Video / -30 Audio / -40 ANC) über Faser. Benötigt PTP-Grandmaster; typ. 10/25/100 GbE.',
   'catalog.cable.blackburst-bnc.notes':

--- a/src/renderer/types/cableSpec.ts
+++ b/src/renderer/types/cableSpec.ts
@@ -41,6 +41,9 @@ export type SignalStandard =
   | 'ST2110-20'
   | 'ST2110-30'
   | 'ST2110-40'
+  | 'SRT'
+  | 'RTMP'
+  | 'HLS'
   | 'Blackburst'
   | 'Tri-Level'
   | 'Word-Clock'
@@ -77,6 +80,7 @@ export const ALL_SIGNAL_STANDARDS: SignalStandard[] = [
   'Thunderbolt-3', 'Thunderbolt-4',
   'MADI', 'DVB-ASI', 'SMPTE-297', 'SMPTE-304M', 'SMPTE-311M',
   'NDI', 'NDI-HX', 'Dante', 'AES67', 'ST2110-20', 'ST2110-30', 'ST2110-40',
+  'SRT', 'RTMP', 'HLS',
   'Blackburst', 'Tri-Level', 'Word-Clock', 'PTP', 'LTC',
   'RF-UHF', 'RF-VHF', 'RF-2.4G', 'RF-5G',
   'RS-232', 'RS-422', 'RS-485', 'DMX512', 'RDM', 'Art-Net', 'sACN',
@@ -252,6 +256,18 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 100,
     color: '#14b8a6',
     notesKey: 'catalog.cable.dante-cat6.notes',
+  },
+  {
+    // B-10 — die Ausspiel-Haelfte. Physisch dasselbe Cat6-Kabel wie
+    // `cat6a`; getrennt gefuehrt, damit der Weg im Netz-Budget als
+    // Ausspielung erkennbar ist und nicht als weiteres Produktionssignal.
+    id: 'stream-uplink-cat6',
+    name: 'Stream-Uplink (SRT/RTMP/HLS)',
+    connectorType: 'Ethernet/RJ45',
+    standards: ['Eth-100', 'Eth-1G', 'SRT', 'RTMP', 'HLS'],
+    maxLengthMeters: 100,
+    color: '#a855f7',
+    notesKey: 'catalog.cable.stream-uplink-cat6.notes',
   },
   {
     id: 'st2110-fiber',
@@ -728,6 +744,34 @@ export const bandwidthMbpsForStandard = (s: SignalStandard | undefined): number 
       return 2 // ANC/Metadaten
     case 'ST2110-20':
       return 3000 // 1080p unkomprimiert (≈2160p → 12000)
+
+    // ── Delivery / Contribution (B-10) ──────────────────────────────────
+    //
+    // Bis hierher kannte das Modell nur die PRODUKTIONS-Seite des Netzes:
+    // NDI, Dante, ST 2110 — alles, was im Haus bleibt. Die Ausspiel-Haelfte
+    // fehlte vollstaendig; `SRT`, `RTMP` und `HLS` kamen im Quelltext
+    // nirgends vor, obwohl jeder Stream-Job an ihnen haengt.
+    //
+    // WAS DIESE ZAHLEN SIND UND WAS NICHT. Es sind Richtwerte fuer EINEN
+    // 1080p50-Beitragsweg bei ueblicher Encoder-Einstellung, nicht die
+    // Spitzenlast und nicht die Summe einer ABR-Leiter:
+    //   SRT   12 Mbps — Beitrag mit Overhead/Retransmit-Reserve (8-10 netto)
+    //   RTMP   6 Mbps — was YouTube/Twitch fuer 1080p als Richtwert nennen
+    //   HLS   10 Mbps — Ausspiel-Leiter (mehrere Renditionen zusammen)
+    // Wer eine 4K-Kette plant, setzt den Wert am Kabel selbst hoeher; das
+    // Modell soll die Groessenordnung tragen, nicht eine Genauigkeit
+    // behaupten, die es nicht hat.
+    //
+    // WARUM SIE TROTZDEM IN DIE LAST GEHOEREN. Ein Ausspielweg teilt sich
+    // das Netz mit der Produktion — genau das ist die Regel im Docstring
+    // oben. Ein Uplink, der neben zwanzig NDI-Quellen liegt, ist der Weg,
+    // der als Erstes klemmt, und er fehlte in der Summe komplett.
+    case 'SRT':
+      return 12
+    case 'RTMP':
+      return 6
+    case 'HLS':
+      return 10
     default:
       // Eth-100/1G/10G stehen hier BEWUSST nicht mehr. Siehe unten.
       return undefined

--- a/tests/ausspielwegImNetzBudget.test.ts
+++ b/tests/ausspielwegImNetzBudget.test.ts
@@ -1,0 +1,85 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Der Ausspielweg zählt im Netz-Budget mit (B-10).
+//
+// GEMESSENER AUSGANGSZUSTAND (2026-09-04). Das Modell kannte nur die
+// PRODUKTIONS-Haelfte des Netzes: NDI, NDI-HX, Dante, AES67 und
+// ST 2110-20/30/40 sind vollwertige `SignalStandard`-Mitglieder mit
+// Bandbreite, Netz-Budget und Plan-Pruefungen. `SRT`, `RTMP` und `HLS` kamen
+// im gesamten Quelltext NICHT VOR -- obwohl an ihnen jeder Stream-Job haengt.
+//
+// Der Schaden lag nicht darin, dass etwas falsch gerechnet wurde, sondern
+// darin, WAS in der Summe fehlte: der Uplink ist der Weg, der neben zwanzig
+// NDI-Quellen als Erstes klemmt, und er war im Budget schlicht nicht
+// vorhanden. Ein Plan konnte "1 GbE reicht" sagen und dabei den einzigen
+// Weg uebersehen, der das Haus verlaesst.
+//
+// WAS DIESE DATEI PRUEFT. Nicht "die Zahlen stimmen" -- es sind Richtwerte
+// fuer einen 1080p50-Weg und als solche im Quelltext gekennzeichnet. Geprueft
+// wird, dass die drei Standards ERREICHBAR sind: waehlbar am Kabel, mit einer
+// Bandbreite hinterlegt, und als LAST gezaehlt statt als Kapazitaet.
+// ───────────────────────────────────────────────────────────────────────────
+import { describe, expect, it } from 'vitest'
+import {
+  cableCatalog,
+  ALL_SIGNAL_STANDARDS,
+  bandwidthMbpsForStandard,
+  linkCapacityMbpsForStandard,
+  pickHighestSdiStandard,
+  type SignalStandard,
+} from '../src/renderer/types/cableSpec'
+
+const DELIVERY: SignalStandard[] = ['SRT', 'RTMP', 'HLS']
+
+describe('Delivery-Standards sind erreichbar', () => {
+  it('stehen in der Auswahlliste der Oberflaeche', () => {
+    // `ALL_SIGNAL_STANDARDS` ist die Liste, aus der die Standard-Auswahl am
+    // Kabel gerendert wird. Ein Typ-Mitglied ohne Eintrag hier waere im Code
+    // vorhanden und fuer den Nutzer unerreichbar -- die Form, die diese
+    // Sitzung mehrfach gefunden hat.
+    for (const std of DELIVERY) expect(ALL_SIGNAL_STANDARDS).toContain(std)
+  })
+
+  it('haben eine Bandbreite und zaehlen damit im Budget', () => {
+    for (const std of DELIVERY) {
+      expect(bandwidthMbpsForStandard(std), `${std} ohne Bandbreite`).toBeGreaterThan(0)
+    }
+  })
+
+  it('zaehlen als LAST, nicht als Leitungs-Kapazitaet', () => {
+    // Derselbe Kategoriefehler wie bei Eth-100/1G/10G: ein Ausspielweg TEILT
+    // sich das Netz, er IST nicht das Netz. Stuende er in
+    // `linkCapacityMbpsForStandard`, wuerde der Rechner ihn ueberspringen
+    // (`continue`) und die Last waere wieder zu niedrig.
+    for (const std of DELIVERY) expect(linkCapacityMbpsForStandard(std)).toBeUndefined()
+  })
+
+  it('es gibt ein Katalog-Kabel, das sie traegt', () => {
+    const uplink = cableCatalog.find((c) => c.id === 'stream-uplink-cat6')
+    expect(uplink, 'Katalog-Eintrag stream-uplink-cat6 fehlt').toBeDefined()
+    for (const std of DELIVERY) expect(uplink!.standards).toContain(std)
+    expect(uplink!.notesKey).toBeTruthy()
+  })
+
+  it('der Vorgabewert des Uplink-Kabels ist der breiteste Weg, nicht der letzte', () => {
+    // Dieselbe Falle wie bei ST 2110 und NDI (siehe
+    // `netzBudgetLastNichtKapazitaet.test.ts`): `pickHighestSdiStandard`
+    // faellt ohne SDI-Mitglied auf den breitesten BEKANNTEN Standard zurueck.
+    // Bei diesem Kabel muss das SRT sein (12) und nicht RTMP (6) -- und schon
+    // gar nicht ein Eth-Standard, der gar keine Medienlast traegt.
+    const uplink = cableCatalog.find((c) => c.id === 'stream-uplink-cat6')!
+    expect(pickHighestSdiStandard(uplink.standards)).toBe('SRT')
+  })
+})
+
+describe('Die Produktions-Haelfte bleibt unberuehrt', () => {
+  it('kein Ethernet-Standard hat durch diese Aenderung eine Last bekommen', () => {
+    const ethernet = ALL_SIGNAL_STANDARDS.filter((s) => s.startsWith('Eth-'))
+    expect(ethernet.filter((s) => bandwidthMbpsForStandard(s) !== undefined)).toEqual([])
+  })
+
+  it('die bekannten Produktions-Bandbreiten stehen unveraendert', () => {
+    expect(bandwidthMbpsForStandard('ST2110-20')).toBe(3000)
+    expect(bandwidthMbpsForStandard('NDI')).toBe(250)
+    expect(bandwidthMbpsForStandard('Dante')).toBe(49)
+  })
+})


### PR DESCRIPTION
## Der Befund

Das Modell kannte nur die **Produktions-Hälfte** des Netzes: NDI, NDI-HX,
Dante, AES67 und ST 2110-20/30/40 sind vollwertige `SignalStandard`-Mitglieder
mit Bandbreite, Netz-Budget und Plan-Prüfungen.

`SRT`, `RTMP` und `HLS` kamen im **gesamten Quelltext nicht vor** — obwohl an
ihnen jeder Stream-Job hängt.

Der Schaden lag nicht in einer falschen Zahl, sondern in dem, was in der Summe
**fehlte**: der Uplink ist der Weg, der neben zwanzig NDI-Quellen als Erstes
klemmt. Ein Plan konnte „1 GbE reicht" sagen und dabei den einzigen Weg
übersehen, der das Haus verlässt.

## Was dieser PR macht

| | |
|---|---|
| `SignalStandard` | drei neue Mitglieder: `SRT`, `RTMP`, `HLS` |
| `ALL_SIGNAL_STANDARDS` | eingetragen → am Kabel **auswählbar** |
| `bandwidthMbpsForStandard` | SRT 12 · RTMP 6 · HLS 10 Mbps → zählen automatisch im Netz-Budget |
| `linkCapacityMbpsForStandard` | **bewusst nicht** — siehe unten |
| `cableCatalog` | `stream-uplink-cat6` mit zweisprachiger Notiz |

## Was die Zahlen sind — und was nicht

Richtwerte für **einen** 1080p50-Weg bei üblicher Encoder-Einstellung, im
Quelltext als solche gekennzeichnet:

- **SRT 12 Mbps** — Beitrag mit Overhead/Retransmit-Reserve (8–10 netto)
- **RTMP 6 Mbps** — was YouTube/Twitch für 1080p als Richtwert nennen
- **HLS 10 Mbps** — Ausspiel-Leiter (mehrere Renditionen zusammen)

Keine Spitzenlast, keine ABR-Summe. Wer eine 4K-Kette plant, setzt den Wert am
Kabel selbst höher. Das Modell soll die **Größenordnung** tragen und keine
Genauigkeit behaupten, die es nicht hat — deshalb steht das genau so am Code
und in der Katalog-Notiz.

## Last, nicht Kapazität

Die drei stehen absichtlich **nicht** in `linkCapacityMbpsForStandard`. Ein
Ausspielweg *teilt sich* das Netz, er *ist* nicht das Netz — derselbe
Kategoriefehler, der bei Eth-100/1G/10G in `cable#676` repariert wurde. Stünden
sie dort, würde der Rechner sie mit `continue` überspringen und die Last wäre
wieder zu niedrig. Ein Test hält das fest.

## Geprüft

- `tests/ausspielwegImNetzBudget.test.ts`, 7 Tests. **Gegen den alten Stand
  fallen 4 davon**; die übrigen drei sind Nicht-Regressionen und müssen
  beidseitig grün sein.
- Darunter der Vorgabewert des neuen Kabels: `pickHighestSdiStandard` muss
  **SRT (12)** liefern, nicht RTMP (6) und schon gar keinen Eth-Standard —
  dieselbe Falle, die bei ST 2110 und NDI den schmalsten statt des breitesten
  Wegs zum Default machte.
- Zwei Tests halten fest, dass die Produktions-Hälfte unberührt bleibt
  (`ST2110-20` = 3000, `NDI` = 250, `Dante` = 49; kein Eth-Standard hat eine
  Last bekommen).
- `npx vitest run` → **969 Tests grün** (98 Dateien)
- `npx tsc -p tsconfig.app.json --noEmit` → 0
- `npm run lint` → 0 Errors, 10 Warnungen (vorbestehend)
- `npm run build` → 0

## Ausdrücklich nicht enthalten

CDN-Modell, ABR-Leiter als eigene Struktur, Ausspiel-Ziele als Gerätetyp.
**B-10 bleibt offen** — das hier ist die erste Hälfte, nicht die ganze Kette,
und der Backlog-Eintrag wird entsprechend fortgeschrieben statt abgehakt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_