### PR TITLE
feat(intercom): herstellerneutrales Austauschformat (B-8, Inkrement 1)

### DIFF
--- a/src/renderer/components/Export/GreenGoExportDialog.tsx
+++ b/src/renderer/components/Export/GreenGoExportDialog.tsx
@@ -6,6 +6,12 @@ import type { GreenGoConfig, GreenGoGroup, GreenGoUser } from '../../types/green
 import { defaultGreenGoConfig } from '../../types/greengo'
 import { buildGg5File } from '../../lib/exportGreengo'
 import {
+  fromIntercomExchange,
+  parseIntercomExchange,
+  serializeIntercomExchange,
+  toIntercomExchange,
+} from '../../lib/intercomExchange'
+import {
   autoMatchEquipment,
   detectDeviceType,
   isParseError,
@@ -47,6 +53,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
 
   const fileInputRef = useRef<HTMLInputElement>(null)
   const xlsxInputRef = useRef<HTMLInputElement>(null)
+  const neutralInputRef = useRef<HTMLInputElement>(null)
   const [importResult, setImportResult] = useState<Gg5ImportResult | null>(null)
   const [importError, setImportError] = useState<string | null>(null)
   const [xlsxImportNotice, setXlsxImportNotice] = useState<string | null>(null)
@@ -270,6 +277,53 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
     updateGreenGoConfig(config)
     // v7.9.116 — Einheitlicher Stempel, gg5-Endung beibehalten.
     downloadFile(buildExportFilenameWithSuffix(config.systemName || 'GreenGo', 'config', 'gg5'), buildGg5File(config))
+  }
+
+  // ── Herstellerneutraler Austausch (B-8) ───────────────────────────────────
+  //
+  // Der .gg5-Export bleibt der Weg IN die Anlage. Dieser hier ist der Weg aus
+  // dem Haus: eine Datei, die auch jemand lesen kann, der Riedel oder
+  // Clear-Com aufbaut. Beide Knoepfe stehen bewusst nebeneinander -- ein
+  // Format, das nur im Code existiert, ist kein Austauschformat.
+  const handleNeutralExport = () => {
+    if (exportBlocked) return
+    updateGreenGoConfig(config)
+    const file = toIntercomExchange(config, { exportedAt: new Date().toISOString() })
+    downloadFile(
+      buildExportFilenameWithSuffix(config.systemName || 'Intercom', 'neutral', 'json'),
+      serializeIntercomExchange(file),
+    )
+  }
+
+  const handleNeutralSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    e.target.value = ''
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = (ev) => {
+      const gelesen = parseIntercomExchange((ev.target?.result as string) ?? '')
+      if (!gelesen) {
+        setImportError(
+          t(
+            'intercom.import.invalid',
+            'Keine gültige neutrale Intercom-Datei (avplan-intercom) — oder sie stammt aus einer neueren Version.',
+          ),
+        )
+        return
+      }
+      setImportError(null)
+      // Bewusst ohne Geraete-Zuordnung: die neutrale Datei kennt
+      // `equipmentId` nur, wenn sie aus DIESEM Plan stammt. Was sie mitbringt,
+      // uebernimmt `fromIntercomExchange`; was sie nicht hat, wird nicht
+      // geraten.
+      setConfig(fromIntercomExchange(gelesen))
+      setXlsxImportNotice(
+        t('intercom.import.done', '{n} Sprechstellen und {g} Konferenzen übernommen.')
+          .replace('{n}', String(gelesen.stations.length))
+          .replace('{g}', String(gelesen.channels.length)),
+      )
+    }
+    reader.readAsText(file)
   }
 
   // ── GreenGo device filter (equipment with 'greengo' or 'intercom' in category/name) ──
@@ -727,6 +781,35 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
             >
               <Icon icon={FileSpreadsheet} size="xs" className="mr-1 inline-block align-text-bottom" />
               {t('greengo.import.xlsx', 'Excel-Matrix importieren')}
+            </button>
+            <input
+              ref={neutralInputRef}
+              type="file"
+              accept=".json,application/json"
+              className="hidden"
+              onChange={handleNeutralSelected}
+            />
+            <button
+              type="button"
+              onClick={() => neutralInputRef.current?.click()}
+              className="rounded border border-cp-surface-5 px-3 py-1.5 text-cp-xs text-cp-text-muted hover:border-violet-700 hover:text-violet-300"
+              title={t('intercom.import.title', 'Herstellerneutrale Intercom-Datei (avplan-intercom) importieren.')}
+            >
+              <Icon icon={Upload} size="xs" className="mr-1 inline-block align-text-bottom" />
+              {t('intercom.import.button', 'Neutral importieren')}
+            </button>
+            <button
+              type="button"
+              onClick={handleNeutralExport}
+              disabled={exportBlocked}
+              title={
+                exportBlocked
+                  ? t('greengo.export.blocked', 'Ohne mindestens eine Station oder Gruppe entsteht keine gültige .gg5 — lege zuerst eine an.')
+                  : t('intercom.export.title', 'Herstellerneutrale Intercom-Datei — Sprechstellen, Konferenzen und wer spricht/hört, lesbar auch außerhalb von GreenGo.')
+              }
+              className="rounded border border-cp-surface-5 px-3 py-1.5 text-cp-xs text-cp-text-muted hover:border-violet-700 hover:text-violet-300 disabled:cursor-not-allowed disabled:text-cp-text-muted"
+            >
+              {t('intercom.export.button', 'Neutral exportieren')}
             </button>
             <button
               type="button"

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -1470,6 +1470,17 @@ export const en: Dict = {
   'greengo.export.xlsxTitle':
     'Download current GreenGo configuration as an intercom-matrix Excel (for print / hand-off).',
   'greengo.export.xlsx': 'Export Excel matrix',
+  // B-8 — herstellerneutrales Austauschformat. Nur im englischen Dict; die
+  // deutsche Quellsprache steht als Fallback am Aufruf.
+  'intercom.export.button': 'Export neutral',
+  'intercom.export.title':
+    'Vendor-neutral intercom file — stations, conferences and who talks/listens, readable outside GreenGo too.',
+  'intercom.import.button': 'Import neutral',
+  'intercom.import.title': 'Import a vendor-neutral intercom file (avplan-intercom).',
+  'intercom.import.invalid':
+    'Not a valid vendor-neutral intercom file (avplan-intercom) — or it comes from a newer version.',
+  // Die Platzhalter {n} und {g} werden im Code ersetzt und muessen bleiben.
+  'intercom.import.done': '{n} stations and {g} conferences imported.',
   'greengo.saveProject': 'Save in project',
   'greengo.export.gg5': 'Export as .gg5',
   'greengo.importOverlay.title': 'Import .gg5 — link devices',

--- a/src/renderer/lib/intercomExchange.ts
+++ b/src/renderer/lib/intercomExchange.ts
@@ -1,0 +1,172 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Green-GO <-> herstellerneutrales Austauschformat (B-8, Inkrement 1).
+//
+// Die Uebersetzung in beide Richtungen, als reine Funktionen: keine Uhr, kein
+// Store, kein Datei-IO. Der Aufrufer setzt `exportedAt` und schreibt die
+// Datei — dieselbe Aufteilung wie bei `inventoryPortable.ts`, und aus
+// demselben Grund testbar.
+//
+// WAS DIE RUECKRICHTUNG NICHT KANN, UND WARUM SIE ES SAGT. Green-GO adressiert
+// Nutzer und Gruppen ueber ZAHLEN (Slot 1-12, Gruppe 1-9); das neutrale Format
+// benutzt Zeichenketten-Ids, weil kein Hersteller sich auf dieselbe Nummerierung
+// festlegen laesst. Beim Zurueckwandeln werden die Nummern deshalb NEU vergeben,
+// in Reihenfolge der Datei. Wer eine bestehende Anlage bespielt, will das nicht
+// -- dafuer gibt es `basePreset`, das den Anlagenstand traegt. Der Import hier
+// baut eine Konfiguration aus einer neutralen Datei, er repariert keine.
+// ───────────────────────────────────────────────────────────────────────────
+import type { GreenGoConfig, GreenGoGroup, GreenGoUser } from '../types/greengo'
+import {
+  INTERCOM_FORMAT,
+  INTERCOM_FORMAT_VERSION,
+  type IntercomChannel,
+  type IntercomExchangeFile,
+  type IntercomStation,
+} from '../types/intercomExchange'
+
+const channelId = (id: number): string => `ch-${id}`
+const stationId = (id: number): string => `st-${id}`
+
+/**
+ * Aus einer Green-GO-Konfiguration eine neutrale Datei bauen.
+ *
+ * `derivedFrom` ist kein Schmuck: Green-GO fuehrt die Zugehoerigkeit als EINE
+ * Liste, also sind talk und listen hier beide gesetzt. Wer die Datei liest,
+ * muss wissen, dass das die Quelle ist und keine Messung -- sonst traegt er
+ * eine Sprechberechtigung in ein fremdes System, die so nie geplant war.
+ */
+export const toIntercomExchange = (
+  cfg: GreenGoConfig,
+  meta?: { exportedAt?: string },
+): IntercomExchangeFile => {
+  const channels: IntercomChannel[] = cfg.groups.map((g) => ({
+    id: channelId(g.id),
+    name: g.name,
+  }))
+  const bekannt = new Set(cfg.groups.map((g) => g.id))
+
+  const stations: IntercomStation[] = cfg.users.map((u) => ({
+    id: stationId(u.id),
+    name: u.name,
+    // Nur uebernehmen, wenn er sich vom Namen unterscheidet -- ein
+    // `displayName`, der den Namen wiederholt, ist keine Kurzform.
+    ...(u.displayName && u.displayName !== u.name ? { shortName: u.displayName } : {}),
+    memberships: u.groupIds
+      // Eine Zugehoerigkeit zu einer Gruppe, die es nicht gibt, waere in der
+      // Datei ein Verweis ins Leere. Lieber weglassen als exportieren.
+      .filter((gid) => bekannt.has(gid))
+      .map((gid) => ({ channelId: channelId(gid), talk: true, listen: true })),
+    ...(u.equipmentId ? { equipmentId: u.equipmentId } : {}),
+  }))
+
+  return {
+    format: INTERCOM_FORMAT,
+    version: INTERCOM_FORMAT_VERSION,
+    exportedAt: meta?.exportedAt,
+    systemName: cfg.systemName,
+    description: cfg.description,
+    channels,
+    stations,
+    vendor: {
+      greengo: {
+        multicastAddress: cfg.multicastAddress,
+        sampleRate: cfg.sampleRate,
+        groupColors: Object.fromEntries(
+          cfg.groups.filter((g) => g.color != null).map((g) => [channelId(g.id), g.color]),
+        ),
+        userColors: Object.fromEntries(
+          cfg.users.filter((u) => u.color != null).map((u) => [stationId(u.id), u.color]),
+        ),
+      },
+    },
+    derivedFrom:
+      'Green-GO-Konfiguration. Dort ist die Zugehoerigkeit EINE Liste je ' +
+      'Sprechstelle; talk und listen sind deshalb beide gesetzt und nicht ' +
+      'getrennt gemessen.',
+  }
+}
+
+/** Ein gelesener Wert, der eine neutrale Intercom-Datei sein soll. */
+export const parseIntercomExchange = (text: string): IntercomExchangeFile | null => {
+  let roh: unknown
+  try {
+    roh = JSON.parse(text)
+  } catch {
+    return null
+  }
+  const f = roh as Partial<IntercomExchangeFile> | null
+  if (!f || typeof f !== 'object') return null
+  if (f.format !== INTERCOM_FORMAT) return null
+  // Eine ZU NEUE Datei wird abgelehnt statt halb gelesen -- dieselbe Regel wie
+  // beim portablen Lager. Aeltere Dateien bleiben lesbar.
+  if (typeof f.version !== 'number' || f.version > INTERCOM_FORMAT_VERSION) return null
+  if (!Array.isArray(f.channels) || !Array.isArray(f.stations)) return null
+  return {
+    format: INTERCOM_FORMAT,
+    version: f.version,
+    exportedAt: typeof f.exportedAt === 'string' ? f.exportedAt : undefined,
+    systemName: typeof f.systemName === 'string' ? f.systemName : 'Intercom',
+    description: typeof f.description === 'string' ? f.description : undefined,
+    channels: f.channels.filter((c): c is IntercomChannel => !!c && typeof c.id === 'string'),
+    stations: f.stations.filter((s): s is IntercomStation => !!s && typeof s.id === 'string'),
+    vendor: (f.vendor as Record<string, unknown> | undefined) ?? undefined,
+    derivedFrom: typeof f.derivedFrom === 'string' ? f.derivedFrom : undefined,
+  }
+}
+
+interface GreengoVendorBlock {
+  multicastAddress?: unknown
+  sampleRate?: unknown
+  groupColors?: Record<string, unknown>
+  userColors?: Record<string, unknown>
+}
+
+/**
+ * Aus einer neutralen Datei eine Green-GO-Konfiguration bauen.
+ *
+ * Nummern werden neu vergeben (siehe Kopfkommentar). Der `greengo`-Block unter
+ * `vendor` wird gelesen, wenn er da ist -- eine Datei aus einem fremden System
+ * hat ihn nicht, und dann greifen die Vorgaben.
+ */
+export const fromIntercomExchange = (file: IntercomExchangeFile): GreenGoConfig => {
+  const v = (file.vendor?.greengo ?? {}) as GreengoVendorBlock
+  const gruppenNr = new Map<string, number>()
+  const groups: GreenGoGroup[] = file.channels.map((c, i) => {
+    gruppenNr.set(c.id, i + 1)
+    const farbe = v.groupColors?.[c.id]
+    return { id: i + 1, name: c.name, ...(typeof farbe === 'number' ? { color: farbe } : {}) }
+  })
+
+  const users: GreenGoUser[] = file.stations.map((s, i) => {
+    const farbe = v.userColors?.[s.id]
+    return {
+      id: i + 1,
+      name: s.name,
+      ...(s.shortName ? { displayName: s.shortName } : {}),
+      ...(typeof farbe === 'number' ? { color: farbe } : {}),
+      // Green-GO kennt die Trennung nicht: eine Stelle, die spricht ODER
+      // hoert, gehoert zur Gruppe. Das ist Informationsverlust und keine
+      // Uebersetzung -- er faellt beim Hin-und-Zurueck nur deshalb nicht auf,
+      // weil die Hinrichtung beide Flags setzt.
+      groupIds: s.memberships
+        .filter((m) => m.talk || m.listen)
+        .map((m) => gruppenNr.get(m.channelId))
+        .filter((n): n is number => typeof n === 'number'),
+      ...(s.equipmentId ? { equipmentId: s.equipmentId } : {}),
+    }
+  })
+
+  const rate = v.sampleRate === 48000 ? 48000 : 32000
+  return {
+    systemName: file.systemName,
+    description: file.description ?? '',
+    multicastAddress:
+      typeof v.multicastAddress === 'string' ? v.multicastAddress : '239.1.160.1',
+    sampleRate: rate,
+    users,
+    groups,
+  }
+}
+
+/** Serialisiert die neutrale Datei als JSON (zwei Leerzeichen, wie das Lager). */
+export const serializeIntercomExchange = (file: IntercomExchangeFile): string =>
+  JSON.stringify(file, null, 2)

--- a/src/renderer/types/intercomExchange.ts
+++ b/src/renderer/types/intercomExchange.ts
@@ -1,0 +1,96 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Herstellerneutrales Intercom-Austauschformat (B-8, Inkrement 1).
+//
+// WARUM ES DAS GIBT. Der Green-GO-Round-Trip ist seit `cable#653` verlustfrei
+// — aber er ist auch das Einzige, was es gibt. Wer die Anlage bei Riedel oder
+// Clear-Com aufbaut, faengt bei null an; das Segment-Dossier fuehrt die Luecke
+// woertlich als "no interchange format from anyone". Ein Plan, der die
+// Sprechstellen und Konferenzen kennt, kann sie herausgeben, statt sie
+// zweimal tippen zu lassen.
+//
+// WAS NEUTRAL HEISST UND WAS NICHT. Neutral ist die FACHLICHE Struktur:
+// Sprechstellen, Konferenzen, wer spricht und wer hoert. Nicht neutral sind
+// Transport und Anlagen-Details (Multicast-Adresse, Abtastrate, Farbindizes) —
+// die haengen am Hersteller und stehen deshalb unter `vendor`, nach Hersteller
+// getrennt. Sie mitzunehmen, aber als das zu kennzeichnen, was sie sind, ist
+// ehrlicher als sie wegzuwerfen (der Round-Trip verloere sonst) oder sie in
+// den neutralen Teil zu heben (dann waere er nicht neutral).
+//
+// TALK UND LISTEN GETRENNT — das ist der eigentliche Gehalt.
+// `GreenGoUser.groupIds` ist EINE Liste: "diese Konferenzen gehen den Nutzer
+// etwas an". In jeder realen Anlage sind das zwei Fragen. Die Regie hoert den
+// Kamera-Kanal mit, spricht aber nur auf PGM; eine Kamera hoert PGM, spricht
+// aber nur zur Regie. Wer das in einer Liste fuehrt, kann den Unterschied
+// nicht ausdruecken, und beim Uebertragen in ein anderes System raet jemand.
+// Aus einer Green-GO-Konfiguration lesen wir deshalb beide Richtungen als
+// gesetzt (mehr weiss die Quelle nicht) und SAGEN das im Feld `derivedFrom` —
+// statt eine Genauigkeit zu behaupten, die die Quelle nicht hergibt.
+// ───────────────────────────────────────────────────────────────────────────
+
+export const INTERCOM_FORMAT = 'avplan-intercom'
+
+/**
+ * Version 1. Erhoehen, sobald ein Feld dazukommt, dessen Fehlen beim
+ * Re-Export etwas LOESCHT — dieselbe Regel wie beim portablen Lager
+ * (`inventoryPortable.ts`), und aus demselben Grund: eine Versionsnummer,
+ * die nur mitzaehlt, sagt einem Leser nichts.
+ */
+export const INTERCOM_FORMAT_VERSION = 1
+
+/** Eine Konferenz / ein Kanal ("PGM", "CAM", "Ton"). */
+export interface IntercomChannel {
+  /** Stabil innerhalb der Datei; keine Anlagen-Nummer. */
+  id: string
+  name: string
+  /** Freitext, was auf dem Kanal besprochen wird. */
+  purpose?: string
+}
+
+/** Wie eine Sprechstelle an einer Konferenz haengt. */
+export interface IntercomMembership {
+  channelId: string
+  /** Die Stelle kann auf diesen Kanal sprechen. */
+  talk: boolean
+  /** Die Stelle hoert diesen Kanal mit. */
+  listen: boolean
+}
+
+/** Eine Sprechstelle / Rolle ("Regie", "Kamera 1"). */
+export interface IntercomStation {
+  id: string
+  /** Rollenname, wie er in der Regie gesagt wird. */
+  name: string
+  /** Kurzform fuer das Display der Sprechstelle, wenn eine gepflegt ist. */
+  shortName?: string
+  memberships: IntercomMembership[]
+  /**
+   * Geraet im Plan, an dem die Stelle haengt — die Bruecke zurueck in die
+   * Verkabelung. Bewusst der Plan-eigene Bezeichner und keine Seriennummer:
+   * das Format beschreibt einen PLAN, keine Inventur.
+   */
+  equipmentId?: string
+}
+
+export interface IntercomExchangeFile {
+  format: typeof INTERCOM_FORMAT
+  version: number
+  /** ISO-Zeitstempel, vom Aufrufer gesetzt — hier keine Uhr. */
+  exportedAt?: string
+  /** Name der Anlage/Produktion. */
+  systemName: string
+  description?: string
+  channels: IntercomChannel[]
+  stations: IntercomStation[]
+  /**
+   * Herstellerspezifische Reste, nach Hersteller getrennt. Wer die Datei in
+   * ein anderes System traegt, ignoriert den Block; wer sie zurueck in
+   * dasselbe traegt, verliert nichts.
+   */
+  vendor?: Record<string, unknown>
+  /**
+   * Woraus die Datei gebaut wurde, im Klartext. Steht in der Datei, nicht nur
+   * im Code: wer sie in vier Wochen oeffnet, sieht sofort, welche Angaben
+   * gemessen und welche aus einer aermeren Quelle abgeleitet sind.
+   */
+  derivedFrom?: string
+}

--- a/tests/intercomAustauschformat.test.ts
+++ b/tests/intercomAustauschformat.test.ts
@@ -1,0 +1,197 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Herstellerneutrales Intercom-Austauschformat (B-8, Inkrement 1).
+//
+// WAS HIER GEPRUEFT WIRD UND WAS NICHT. Nicht "das Format ist gut" -- das
+// zeigt erst der zweite Hersteller. Geprueft wird, dass es die drei Dinge
+// tut, wegen denen es existiert:
+//
+//   1. Der Round-Trip verliert nichts, was die Quelle hatte.
+//   2. Die Trennung talk/listen ist im Format DA -- auch wenn die heutige
+//      Quelle sie nicht liefert -- und die Datei SAGT, dass sie abgeleitet
+//      ist. Ein Format, das die Unterscheidung nicht kennt, kann sie auch
+//      spaeter nicht bekommen, ohne alle Dateien zu brechen.
+//   3. Der neutrale Teil bleibt neutral: Multicast, Abtastrate und
+//      Farbindizes stehen unter `vendor`, nicht daneben.
+//
+// Der Vertrag ist eingefroren wie beim portablen Lager: wer ein Feld
+// umbenennt, faellt hier auf, nicht beim Nutzer, der eine alte Datei oeffnet.
+// ───────────────────────────────────────────────────────────────────────────
+import { describe, expect, it } from 'vitest'
+import type { GreenGoConfig } from '../src/renderer/types/greengo'
+import {
+  INTERCOM_FORMAT,
+  INTERCOM_FORMAT_VERSION,
+} from '../src/renderer/types/intercomExchange'
+import {
+  fromIntercomExchange,
+  parseIntercomExchange,
+  serializeIntercomExchange,
+  toIntercomExchange,
+} from '../src/renderer/lib/intercomExchange'
+
+const anlage = (): GreenGoConfig => ({
+  systemName: 'Sendung Freitag',
+  description: 'Studio 2',
+  multicastAddress: '239.1.160.7',
+  sampleRate: 48000,
+  groups: [
+    { id: 1, name: 'PGM', color: 3 },
+    { id: 2, name: 'CAM' },
+  ],
+  users: [
+    { id: 1, name: 'Regie', displayName: 'REG', color: 5, groupIds: [1, 2], equipmentId: 'eq-regie' },
+    { id: 2, name: 'Kamera 1', groupIds: [2] },
+  ],
+})
+
+describe('Neutrale Datei aus einer Green-GO-Konfiguration', () => {
+  it('traegt Konferenzen und Sprechstellen fachlich, nicht als Anlagen-Nummern', () => {
+    const f = toIntercomExchange(anlage())
+    expect(f.format).toBe(INTERCOM_FORMAT)
+    expect(f.version).toBe(INTERCOM_FORMAT_VERSION)
+    expect(f.channels.map((c) => c.name)).toEqual(['PGM', 'CAM'])
+    expect(f.stations.map((s) => s.name)).toEqual(['Regie', 'Kamera 1'])
+    // Ids sind Zeichenketten -- kein Hersteller laesst sich auf dieselbe
+    // Nummerierung festlegen.
+    expect(f.channels.every((c) => typeof c.id === 'string')).toBe(true)
+  })
+
+  it('sagt in der Datei, dass talk/listen abgeleitet ist', () => {
+    const f = toIntercomExchange(anlage())
+    const regie = f.stations.find((s) => s.name === 'Regie')!
+    expect(regie.memberships).toEqual([
+      { channelId: 'ch-1', talk: true, listen: true },
+      { channelId: 'ch-2', talk: true, listen: true },
+    ])
+    // Das ist der Punkt: die Flags sind beide gesetzt, WEIL die Quelle nur
+    // eine Liste kennt -- und die Datei sagt es, statt Genauigkeit zu
+    // behaupten. Ohne diesen Satz traegt jemand eine Sprechberechtigung in
+    // ein fremdes System, die so nie geplant war.
+    expect(f.derivedFrom).toMatch(/talk und listen/i)
+  })
+
+  it('haelt Hersteller-Details unter `vendor`, nicht im neutralen Teil', () => {
+    const f = toIntercomExchange(anlage())
+    const gg = f.vendor?.greengo as Record<string, unknown>
+    expect(gg.multicastAddress).toBe('239.1.160.7')
+    expect(gg.sampleRate).toBe(48000)
+    expect(gg.groupColors).toEqual({ 'ch-1': 3 })
+    expect(gg.userColors).toEqual({ 'st-1': 5 })
+    // Gegenprobe: im neutralen Teil taucht nichts davon auf.
+    const neutral = JSON.stringify({ channels: f.channels, stations: f.stations })
+    expect(neutral).not.toContain('239.1.160.7')
+    expect(neutral).not.toContain('48000')
+  })
+
+  it('exportiert keine Zugehoerigkeit zu einer Gruppe, die es nicht gibt', () => {
+    const kaputt = anlage()
+    kaputt.users[1].groupIds = [2, 99]
+    const f = toIntercomExchange(kaputt)
+    const cam = f.stations.find((s) => s.name === 'Kamera 1')!
+    expect(cam.memberships.map((m) => m.channelId)).toEqual(['ch-2'])
+  })
+
+  it('wiederholt den Namen nicht als Kurzform', () => {
+    const cfg = anlage()
+    cfg.users[0].displayName = 'Regie'
+    expect(toIntercomExchange(cfg).stations[0].shortName).toBeUndefined()
+  })
+})
+
+describe('Round-Trip', () => {
+  it('Green-GO -> neutral -> Green-GO behaelt, was die Quelle hatte', () => {
+    const vorher = anlage()
+    const zurueck = fromIntercomExchange(toIntercomExchange(vorher))
+
+    expect(zurueck.systemName).toBe(vorher.systemName)
+    expect(zurueck.description).toBe(vorher.description)
+    expect(zurueck.multicastAddress).toBe(vorher.multicastAddress)
+    expect(zurueck.sampleRate).toBe(vorher.sampleRate)
+    expect(zurueck.groups).toEqual(vorher.groups)
+    expect(zurueck.users).toEqual(vorher.users)
+  })
+
+  it('ueber die serialisierte Datei genauso', () => {
+    const vorher = anlage()
+    const text = serializeIntercomExchange(toIntercomExchange(vorher))
+    const gelesen = parseIntercomExchange(text)
+    expect(gelesen).not.toBeNull()
+    expect(fromIntercomExchange(gelesen!)).toEqual(vorher)
+  })
+
+  it('eine Datei aus einem FREMDEN System laesst sich lesen', () => {
+    // Kein `vendor`-Block, andere Id-Form, talk und listen getrennt -- so
+    // saehe eine Datei aus, die nicht von hier stammt. Genau dafuer gibt es
+    // das Format; wenn nur die eigenen Dateien gelesen werden, ist es keins.
+    const fremd = JSON.stringify({
+      format: 'avplan-intercom',
+      version: 1,
+      systemName: 'Fremdanlage',
+      channels: [{ id: 'prod', name: 'Production' }, { id: 'cam', name: 'Cameras' }],
+      stations: [
+        {
+          id: 'director',
+          name: 'Director',
+          memberships: [
+            { channelId: 'prod', talk: true, listen: true },
+            { channelId: 'cam', talk: false, listen: true },
+          ],
+        },
+      ],
+    })
+    const cfg = fromIntercomExchange(parseIntercomExchange(fremd)!)
+    expect(cfg.groups.map((g) => g.name)).toEqual(['Production', 'Cameras'])
+    expect(cfg.users[0].name).toBe('Director')
+    // Green-GO kennt die Trennung nicht -- eine Stelle, die NUR hoert, gehoert
+    // dort trotzdem zur Gruppe. Der Verlust ist echt und am Code benannt.
+    expect(cfg.users[0].groupIds).toEqual([1, 2])
+    expect(cfg.multicastAddress).toBe('239.1.160.1')
+    expect(cfg.sampleRate).toBe(32000)
+  })
+})
+
+describe('Der Vertrag ist eingefroren', () => {
+  it('die Feldnamen der Datei aendern sich nicht unbemerkt', () => {
+    const f = toIntercomExchange(anlage())
+    expect(Object.keys(f).sort()).toEqual([
+      'channels',
+      'derivedFrom',
+      'description',
+      'exportedAt',
+      'format',
+      'stations',
+      'systemName',
+      'vendor',
+      'version',
+    ])
+    expect(Object.keys(f.stations[0]).sort()).toEqual([
+      'equipmentId',
+      'id',
+      'memberships',
+      'name',
+      'shortName',
+    ])
+    expect(Object.keys(f.stations[0].memberships[0]).sort()).toEqual([
+      'channelId',
+      'listen',
+      'talk',
+    ])
+  })
+
+  it('eine zu NEUE Datei wird abgelehnt statt halb gelesen', () => {
+    const zuNeu = JSON.stringify({
+      format: 'avplan-intercom',
+      version: INTERCOM_FORMAT_VERSION + 1,
+      systemName: 'x',
+      channels: [],
+      stations: [],
+    })
+    expect(parseIntercomExchange(zuNeu)).toBeNull()
+  })
+
+  it('fremdes JSON und Muell werden abgelehnt', () => {
+    expect(parseIntercomExchange('{"format":"avplan-inventory","version":2}')).toBeNull()
+    expect(parseIntercomExchange('kein json')).toBeNull()
+    expect(parseIntercomExchange('null')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Die Lücke

Der Green-GO-Round-Trip ist seit `cable#653` verlustfrei — und das **Einzige,
was es gibt**. Wer die Anlage bei Riedel oder Clear-Com aufbaut, fängt bei null
an. Das Segment-Dossier führt die Lücke wörtlich als *„no interchange format
from anyone"*.

## Was dieser PR baut

| | |
|---|---|
| `types/intercomExchange.ts` | `avplan-intercom`, Version 1 |
| `lib/intercomExchange.ts` | beide Richtungen als reine Funktionen + `parseIntercomExchange` |
| `GreenGoExportDialog.tsx` | zwei Knöpfe neben .gg5 und Excel-Matrix |
| `tests/intercomAustauschformat.test.ts` | 11 Tests |

Der Dialog-Teil ist nicht Beiwerk: **ein Format, das nur im Code existiert, ist
kein Austauschformat.**

## Was „neutral" heißt — und was nicht

Neutral ist die **fachliche** Struktur: Sprechstellen, Konferenzen, wer spricht
und wer hört. Nicht neutral sind Transport und Anlagen-Details (Multicast,
Abtastrate, Farbindizes) — die hängen am Hersteller und stehen unter `vendor`,
nach Hersteller getrennt.

Sie mitzunehmen, aber als das zu kennzeichnen, was sie sind, ist ehrlicher als
sie wegzuwerfen (der Round-Trip verlöre) oder sie in den neutralen Teil zu
heben (dann wäre er nicht neutral). Ein Test hält beides fest — inklusive der
Gegenprobe, dass im neutralen Teil weder die Multicast-Adresse noch die
Abtastrate auftaucht.

## Talk und Listen getrennt — der eigentliche Gehalt

`GreenGoUser.groupIds` ist **eine** Liste: „diese Konferenzen gehen den Nutzer
etwas an". In jeder realen Anlage sind das **zwei** Fragen:

> Die Regie hört den Kamera-Kanal mit, spricht aber nur auf PGM.
> Eine Kamera hört PGM, spricht aber nur zur Regie.

Wer das in einer Liste führt, kann den Unterschied nicht ausdrücken — und beim
Übertragen in ein anderes System **rät jemand**.

Das Format führt deshalb beide Flags. Die Green-GO-Quelle setzt beide, weil sie
nicht mehr weiß — und die Datei **sagt das** im Feld `derivedFrom`, statt eine
Genauigkeit zu behaupten, die sie nicht hat. Ohne diese Trennung *im Format*
ließe sie sich später nicht nachrüsten, ohne alle Dateien zu brechen.

Die Rückrichtung benennt denselben Verlust am Code: eine Stelle, die in einer
fremden Datei **nur hört**, gehört in Green-GO trotzdem zur Gruppe. Ein Test
prüft genau diesen Fall mit einer Datei, die *nicht von hier stammt* (kein
`vendor`-Block, andere Id-Form, talk und listen getrennt) — wenn nur die
eigenen Dateien gelesen werden, ist es kein Austauschformat.

## Gegengeprobt

Bei neuem Code ist „fällt ohne die Änderung um" trivial, also die zwei
tragenden Zusicherungen einzeln kaputtgemacht:

- Hersteller-Details in den neutralen Teil gehoben → **rot**
- Versionsprüfung entfernt (zu neue Datei durchgelassen) → **rot**

Zurückgenommen → 11/11 grün.

## Der i18n-Guard hat mich korrigiert

Nach dem Verdrahten meldete `tests/i18nErreichbarkeit.test.ts` sechs Schlüssel
ohne englische Fassung — nicht ich. Ergänzt. Genau dafür ist er da, und es ist
das zweite Mal heute, dass ein Guard einen echten Rückschritt gestoppt hat
statt nur eine Neuerung zu quittieren.

## Geprüft

- `npx vitest run` → **980 Tests grün** (99 Dateien)
- `npx tsc -p tsconfig.app.json --noEmit` → 0
- `npm run lint` → 0 Errors, 10 Warnungen (vorbestehend)
- `npm run build` → 0

## Bleibt offen

**B-8 bleibt `PARTIAL`.** Ein Riedel-/Clear-Com-Adapter fehlt, und ob das
Format taugt, zeigt erst der zweite Hersteller — bis dahin ist es eine
begründete Struktur, kein bewiesener Standard. Der Backlog-Eintrag wird
entsprechend fortgeschrieben statt abgehakt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_