### PR TITLE
fix(sicherheit): drei ungefilterte Ausgänge für Zugangsdaten geschlossen

### DIFF
--- a/src/renderer/components/Library/tabs/GroupsTab.tsx
+++ b/src/renderer/components/Library/tabs/GroupsTab.tsx
@@ -139,7 +139,7 @@ export const GroupsTab = () => {
                             type="button"
                             onClick={(event) => {
                               event.stopPropagation()
-                              exportPresetToFile(preset)
+                              void exportPresetToFile(preset)
                             }}
                             className="rounded bg-cp-surface-4 px-1 text-[11px] text-cp-text-secondary hover:bg-cp-surface-5"
                             title={t(

--- a/src/renderer/components/Library/tabs/LocalEquipmentTab.tsx
+++ b/src/renderer/components/Library/tabs/LocalEquipmentTab.tsx
@@ -412,7 +412,7 @@ export const LocalEquipmentTab = ({
                             onRemove={() => removeCustomTemplate(item.name)}
                             onToggleFavorite={() => toggleTemplateFavorite(item.name)}
                             onToggleHidden={() => toggleTemplateHidden(item.name)}
-                            onExport={() => exportTemplateToFile(item)}
+                            onExport={() => void exportTemplateToFile(item)}
                           />
                           {/* Edit button — appears on hover */}
                           <button

--- a/src/renderer/components/Library/tabs/RacksTab.tsx
+++ b/src/renderer/components/Library/tabs/RacksTab.tsx
@@ -119,7 +119,7 @@ export const RacksTab = ({ onCreateRack, onEditRack }: RacksTabProps) => {
                             type="button"
                             onClick={(event) => {
                               event.stopPropagation()
-                              exportPresetToFile(preset)
+                              void exportPresetToFile(preset)
                             }}
                             className="rounded bg-cp-surface-4 px-1 py-0.5 text-[11px] text-cp-text-secondary hover:bg-cp-surface-5"
                             title={t(

--- a/src/renderer/components/Library/tabs/RentmanTab.tsx
+++ b/src/renderer/components/Library/tabs/RentmanTab.tsx
@@ -509,7 +509,7 @@ export const RentmanTab = () => {
                                                   ...nextPlacementPosition(equipmentCount, equipmentItems),
                                                 })
                                               }}
-                                              onExport={() => exportTemplateToFile(item)}
+                                              onExport={() => void exportTemplateToFile(item)}
                                               onLinkPorts={
                                                 localMatch
                                                   ? () => {

--- a/src/renderer/components/Rack/RackBuilderDialogExportMenu.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialogExportMenu.tsx
@@ -149,7 +149,7 @@ export const RackBuilderDialogExportMenu = ({
               // rentmanIds nicht mehr. Jetzt derselbe Erbauer wie beim
               // Speichern — es gibt nur noch eine Aufzaehlung.
               const preset = buildPreset()
-              exportRackAsCpgroup(preset)
+              void exportRackAsCpgroup(preset)
             }}
             className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left text-cp-text-bright hover:bg-cp-surface-2"
           >

--- a/src/renderer/components/Sync/SharedSyncPanel.tsx
+++ b/src/renderer/components/Sync/SharedSyncPanel.tsx
@@ -21,6 +21,8 @@ import { useProjectStore } from '../../store/projectStore'
 import type { EquipmentTemplate, GroupPreset } from '../../types/equipment'
 import type { CablePlannerProject } from '../../types/project'
 import { format, useTranslation } from '../../lib/i18n'
+import { countCredentialBearers, hasCredential, stripCredentials } from '../../lib/credentialKeys'
+import { credentialChoiceDialog, type CredentialChoice } from '../../lib/credentialChoiceDialog'
 
 const PROJECT_FILE = 'cable-planner.project.json'
 const LIBRARY_FILE = 'cable-planner.library.json'
@@ -79,20 +81,58 @@ export function SharedSyncPanel() {
 
   const handlePush = async () => {
     if (!syncPath) return
+
+    // ── Zugangsdaten: der fuenfte Ausgang ────────────────────────────────────
+    //
+    // WARUM DAS HIER STEHT (gemessen 2026-09-04). `credentialKeys.ts` nennt in
+    // seinem Kopfkommentar die Ausgaenge, fuer die es gilt: den
+    // `.avplan`-Export und den Push in die geteilte Bibliothek. Dieser Push
+    // war der dritte, den der Renderer selbst baut — und er stand nicht in
+    // der Liste und lief nicht durch die Regel. Er schrieb Projekt,
+    // Bibliothek und Gruppen-Presets ROH in denselben Team-Ordner.
+    //
+    // Der Schaden ist nicht theoretisch: wer beim .avplan-Export ausdruecklich
+    // „Zugangsdaten entfernen" waehlt, hatte sie trotzdem im Team-Ordner,
+    // sobald irgendwer hier auf Push drueckte. Switch-Passwoerter und die
+    // vollstaendige Netz-Identitaet lagen dort im Klartext.
+    //
+    // Gefragt wird mit demselben Dialog wie an den anderen beiden Ausgaengen,
+    // und nur dann, wenn es etwas zu entscheiden gibt — eine Rueckfrage bei
+    // jedem Push waere in zwei Wochen eine Klickgewohnheit.
+    const traeger =
+      countCredentialBearers(customLibrary) +
+      countCredentialBearers(groupPresets) +
+      (hasCredential(project) ? 1 : 0)
+
+    let wahl: CredentialChoice = 'strip'
+    if (traeger > 0) {
+      const antwort = await credentialChoiceDialog(
+        traeger,
+        t(
+          'cred.dest.sharedSync',
+          'in den geteilten Ordner — jeder im Team, der Pull drückt, bekommt die Datei.',
+        ),
+      )
+      // Abbruch heisst abbrechen, nicht „dann eben mitschicken".
+      if (antwort === null) return
+      wahl = antwort
+    }
+    const raus = <T,>(wert: T): T => (wahl === 'strip' ? stripCredentials(wert) : wert)
+
     setBusy(true)
     try {
       await withLock(async () => {
         await cablePlannerApi.sync.writeFile(
           joinPath(syncPath, PROJECT_FILE),
-          JSON.stringify(project, null, 2),
+          JSON.stringify(raus(project), null, 2),
         )
         await cablePlannerApi.sync.writeFile(
           joinPath(syncPath, LIBRARY_FILE),
-          JSON.stringify(customLibrary, null, 2),
+          JSON.stringify(raus(customLibrary), null, 2),
         )
         await cablePlannerApi.sync.writeFile(
           joinPath(syncPath, PRESETS_FILE),
-          JSON.stringify(groupPresets, null, 2),
+          JSON.stringify(raus(groupPresets), null, 2),
         )
         setStatus({
           kind: 'ok',

--- a/src/renderer/lib/bridge.ts
+++ b/src/renderer/lib/bridge.ts
@@ -406,6 +406,15 @@ const pushRecent = (item: string) => {
   saveRecents(next)
 }
 
+// zugangsdaten: eigener speicherweg
+//
+// Das ist "Projekt als Datei speichern" — die eigene Datei des Nutzers, die er
+// gleich wieder oeffnet. Hier zu strippen waere kein Schutz, sondern
+// Datenverlust: beim naechsten Oeffnen fehlten die Zugangsdaten seiner eigenen
+// Anlage. Die Marke steht an der Stelle und nicht in einer Ausnahmeliste in
+// `tests/credentialExits.test.ts` — eine Liste dort waere wieder der
+// Kenntnisstand ihres Autors, und genau das war der Fehler, den die Pruefung
+// abloest.
 const downloadJson = (project: CablePlannerProject, suggestedFileName: string) =>
   downloadBlob(suggestedFileName, JSON.stringify(project, null, 2), 'application/json')
 

--- a/src/renderer/lib/credentialKeys.ts
+++ b/src/renderer/lib/credentialKeys.ts
@@ -14,9 +14,22 @@
 // Viewer-Export die Regel des Mobile-Share-Pfads nicht mitbekam.
 //
 // WO DIESE DATEI GILT: Ausgaenge, die der Renderer selbst baut — der
-// `.avplan`-Export und der Push in die geteilte Bibliothek. Die Ausgaenge im
-// Hauptprozess (Mobile-Share, Viewer-Export) benutzen weiterhin `stripSecrets`
-// dort.
+// `.avplan`-Export, der Push in die geteilte Bibliothek und der Push in den
+// geteilten Sync-Ordner (`SharedSyncPanel`). Die Ausgaenge im Hauptprozess
+// (Mobile-Share, Viewer-Export) benutzen weiterhin `stripSecrets` dort.
+//
+// DER DRITTE STAND BIS 2026-09-04 NICHT HIER — und lief auch nicht durch die
+// Regel: `SharedSyncPanel.handlePush` schrieb Projekt, Bibliothek und
+// Gruppen-Presets ROH in denselben Team-Ordner. Wer beim .avplan-Export
+// ausdruecklich „Zugangsdaten entfernen" gewaehlt hatte, hatte sie trotzdem
+// dort, sobald irgendwer Push drueckte.
+//
+// Diese Liste ist deshalb nicht mehr die Absicherung, sondern nur noch die
+// Erklaerung. Die Absicherung ist berechnet:
+// `tests/credentialExits.test.ts` sucht JEDEN Renderer-Ausgang, der
+// Projekt-/Bibliotheks-Daten hinausschreibt, und verlangt, dass er die Regel
+// kennt. Der vierte Ausgang faellt dort auf, ohne dass sein Autor diese Datei
+// gelesen haben muss.
 // ---------------------------------------------------------------------------
 
 /** Muss zeichengleich zur Menge in `src/main/util/stripSecrets.ts` sein. */

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -38,6 +38,11 @@ export const en: Dict = {
   'cred.strip': 'Without credentials',
   'cred.dest.sharedLib': 'They would be written to the shared folder and readable by the whole team.',
   'cred.dest.avplan': 'The .avplan goes to other trades. Without credentials, re-importing it into this app loses them.',
+  // Die drei weiteren Ausgaenge (2026-09-04). Die deutschen Fassungen stehen
+  // als Fallback am Aufruf; hier nur die englischen Ueberschreibungen.
+  'cred.dest.sharedSync': 'into the shared folder — everyone on the team who hits Pull gets the file.',
+  'cred.dest.cpdevice': 'as a .cpdevice file — meant for a USB stick, e-mail or file sharing.',
+  'cred.dest.cpgroup': 'as a .cpgroup file — meant for a USB stick, e-mail or file sharing.',
   'avplan.unknown.title': 'This file contains unknown sections',
   'avplan.unknown.body': 'The file carries sections this app does not know — probably from a newer build or another trade. By default they are carried through unchanged and will be in the file again on the next export.',
   'avplan.unknown.keep': 'Carry through (unchanged, preserved on export)',

--- a/src/renderer/lib/itemExport.ts
+++ b/src/renderer/lib/itemExport.ts
@@ -16,6 +16,44 @@
 
 import type { EquipmentTemplate, GroupPreset } from '../types/equipment'
 import { downloadBlob } from './downloadBlob'
+import { countCredentialBearers, stripCredentials } from './credentialKeys'
+import { credentialChoiceDialog } from './credentialChoiceDialog'
+// Kein Hook: diese Datei ist keine Komponente. `translate` liest die Sprache
+// aus dem Store, genau wie die Class-Komponenten es tun.
+import { translate } from './i18n'
+import { useUiStore } from '../store/uiStore'
+
+/**
+ * Zugangsdaten-Rueckfrage fuer die Einzeldatei-Ausgaenge.
+ *
+ * WARUM DIESE BEIDEN AUSGAENGE SIE BRAUCHEN (gefunden 2026-09-04 von
+ * `tests/credentialExits.test.ts`, nicht von Hand). `EquipmentTemplate` ist
+ * `Omit<EquipmentItem, 'id'|'x'|'y'>` (types/equipment.ts:831) und traegt
+ * damit `username`, `password` und `ipAddress`; `GroupPreset.items` ist
+ * `EquipmentTemplate & {...}` (:889). Der Kopfkommentar dieser Datei nennt
+ * als Zweck woertlich "per USB-Stick / E-Mail / Filesharing auf ein anderes
+ * System kopieren" — also den direktesten Weg nach draussen, den es hier
+ * gibt, und er ging bis heute ungefragt und ungefiltert.
+ *
+ * Gefragt wird nur, wenn wirklich Zugangsdaten dranhaengen; eine Rueckfrage
+ * bei jedem Export waere in zwei Wochen eine Klickgewohnheit.
+ *
+ * `null` heisst: der Nutzer hat abgebrochen, es wird gar nichts geschrieben.
+ */
+const nachZugangsdatenFragen = async <T>(
+  werte: readonly T[],
+  zielKey: string,
+  zielDe: string,
+): Promise<'ab' | 'roh' | 'strip'> => {
+  const traeger = countCredentialBearers(werte)
+  if (traeger === 0) return 'roh'
+  const antwort = await credentialChoiceDialog(
+    traeger,
+    translate(useUiStore.getState().language, zielKey, zielDe),
+  )
+  if (antwort === null) return 'ab'
+  return antwort === 'strip' ? 'strip' : 'roh'
+}
 
 export const DEVICE_FILE_EXT = '.cpdevice'
 export const GROUP_FILE_EXT = '.cpgroup'
@@ -42,24 +80,58 @@ const sanitizeFileBase = (raw: string): string => {
   return cleaned || 'export'
 }
 
-export const exportTemplateToFile = (template: EquipmentTemplate): void => {
-  const payload: DeviceFileV1 = {
-    type: DEVICE_FILE_TYPE,
-    version: 1,
-    exportedAt: new Date().toISOString(),
-    template,
-  }
+/**
+ * Die Nutzlast als reine Funktion — damit die Zusicherung „gestrippt heisst
+ * gestrippt" mit einem Kanarienvogel-Wert pruefbar ist und nicht nur als
+ * Textmuster im Guard steht. Genau diese Schwaeche hatte die erste Fassung
+ * der Pruefung: sie sah, DASS die Datei den Filter kennt, nicht, dass der
+ * Schreibvorgang durch ihn laeuft.
+ */
+export const deviceFilePayload = (
+  template: EquipmentTemplate,
+  strip: boolean,
+  exportedAt: string,
+): DeviceFileV1 => ({
+  type: DEVICE_FILE_TYPE,
+  version: 1,
+  exportedAt,
+  template: strip ? stripCredentials(template) : template,
+})
+
+export const groupFilePayload = (
+  preset: GroupPreset,
+  strip: boolean,
+  exportedAt: string,
+): GroupFileV1 => ({
+  type: GROUP_FILE_TYPE,
+  version: 1,
+  exportedAt,
+  preset: strip ? stripCredentials(preset) : preset,
+})
+
+export const exportTemplateToFile = async (template: EquipmentTemplate): Promise<void> => {
+  const wahl = await nachZugangsdatenFragen(
+    [template],
+    'cred.dest.cpdevice',
+    'als .cpdevice-Datei — gedacht für USB-Stick, E-Mail oder Filesharing.',
+  )
+  if (wahl === 'ab') return
+  const payload = deviceFilePayload(template, wahl === 'strip', new Date().toISOString())
   const fileName = `${sanitizeFileBase(template.name)}${DEVICE_FILE_EXT}`
   downloadBlob(fileName, JSON.stringify(payload, null, 2), 'application/json')
 }
 
-export const exportPresetToFile = (preset: GroupPreset): void => {
-  const payload: GroupFileV1 = {
-    type: GROUP_FILE_TYPE,
-    version: 1,
-    exportedAt: new Date().toISOString(),
-    preset,
-  }
+export const exportPresetToFile = async (preset: GroupPreset): Promise<void> => {
+  // Gezaehlt wird ueber die Inhalte, nicht ueber das Preset als Ganzes: ein
+  // Rack mit zwoelf Geraeten, von denen drei Zugangsdaten tragen, soll "3"
+  // im Text stehen haben und nicht "1".
+  const wahl = await nachZugangsdatenFragen(
+    preset.items ?? [preset],
+    'cred.dest.cpgroup',
+    'als .cpgroup-Datei — gedacht für USB-Stick, E-Mail oder Filesharing.',
+  )
+  if (wahl === 'ab') return
+  const payload = groupFilePayload(preset, wahl === 'strip', new Date().toISOString())
   const fileName = `${sanitizeFileBase(preset.name)}${GROUP_FILE_EXT}`
   downloadBlob(fileName, JSON.stringify(payload, null, 2), 'application/json')
 }

--- a/src/renderer/lib/sharedLibrarySync.ts
+++ b/src/renderer/lib/sharedLibrarySync.ts
@@ -114,7 +114,15 @@ export const syncSharedLibrary = async (
     // Zugangsdaten — sonst kostete ein einziger Sync sie dem Nutzer dauerhaft.
     const writeDevices =
       credentials === 'strip' ? stripCredentials(merged) : merged
-    const writeGroups = unionByName(after.groupPresets, sGroups)
+    // Gruppen-Presets gingen bis 2026-09-04 UNGESTRIPPT hinaus, obwohl sie
+    // dieselben Geraete tragen wie die Bibliothek. App-intern faellt es nicht
+    // auf (`rackPreset.itemFromEquipment` schreibt keine Zugangsdaten), aber
+    // ein von aussen importiertes `.cpgroup` bringt sie mit — und dann trug
+    // genau der Weg sie hinaus, dessen Rueckfrage der Nutzer gerade
+    // beantwortet hat.
+    const mergedGroups = unionByName(after.groupPresets, sGroups)
+    const writeGroups =
+      credentials === 'strip' ? stripCredentials(mergedGroups) : mergedGroups
     const writeCats = [...new Set([...after.knownCategories, ...sCats])]
     const out: SharedLibraryFile = {
       type: 'cable-planner-shared-library',

--- a/tests/credentialExits.test.ts
+++ b/tests/credentialExits.test.ts
@@ -12,6 +12,9 @@ import { buildSourceMap } from '../src/renderer/lib/sourceMap'
 import { buildTallyMap } from '../src/renderer/lib/tallyMap'
 import { buildPlanBom } from '../src/renderer/lib/planBom'
 import { planDiffCsv } from '../src/renderer/lib/planDiff'
+import { stripComments } from './support/stripComments'
+import { deviceFilePayload, groupFilePayload } from '../src/renderer/lib/itemExport'
+import type { EquipmentTemplate, GroupPreset } from '../src/renderer/types/equipment'
 
 // ---------------------------------------------------------------------------
 // Der Rundgang: welcher Ausgang traegt Geraete-Zugangsdaten nach draussen?
@@ -95,5 +98,114 @@ describe('kein Dokument traegt Geraete-Zugangsdaten nach draussen', () => {
     const passthrough = JSON.stringify(project.equipment)
     expect(passthrough).toContain(SECRET)
     expect(passthrough).toContain(USER)
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// Kein Renderer-Ausgang schreibt roh nach draussen.
+//
+// WARUM ES DAS GIBT (gemessen 2026-09-04, Doku-gegen-Code-Audit).
+// `lib/credentialKeys.ts` nennt in seinem Kopfkommentar die Ausgaenge, fuer
+// die es gilt: "der `.avplan`-Export und der Push in die geteilte
+// Bibliothek". Es gab einen dritten, den der Renderer selbst baut und der
+// nicht in dieser Liste stand: `SharedSyncPanel.handlePush` schrieb Projekt,
+// Bibliothek und Gruppen-Presets ROH in denselben Team-Ordner.
+//
+// Der Schaden war der teuerste, den diese Form haben kann: wer beim
+// .avplan-Export ausdruecklich "Zugangsdaten entfernen" waehlte, hatte sie
+// trotzdem im Team-Ordner, sobald irgendwer Push drueckte. Die Zusicherung
+// war also nicht nur unvollstaendig, sie war irrefuehrend.
+//
+// WARUM ALS BERECHNETE PRUEFUNG UND NICHT ALS DRITTE ZEILE IM KOMMENTAR.
+// Genau die Liste war der Fehler. Ein Kommentar, der die Ausgaenge aufzaehlt,
+// ist der Kenntnisstand seines Autors; der vierte Ausgang, den jemand in vier
+// Wochen anlegt, faellt hier auf, ohne dass er diese Datei kennen muss.
+// ───────────────────────────────────────────────────────────────────────────
+const rendererQuellen = import.meta.glob('../src/renderer/**/*.{ts,tsx}', {
+  eager: true,
+  query: '?raw',
+  import: 'default',
+}) as Record<string, string>
+
+/**
+ * Ein Ausgang im Sinne dieser Pruefung ist ein Schreibaufruf, der ein GANZES
+ * Modell serialisiert -- nicht jeder `downloadBlob`. Die CSV- und
+ * PDF-Ableitungen sind einzeln oben mit Kanarienvogel-Werten geprueft; sie
+ * hier nochmal zu verlangen, wuerde die Pruefung mit Fehltreffern
+ * zuschuetten, bis jemand sie abschaltet.
+ */
+const AUSGANG =
+  /(?:cablePlannerApi\.sync\.writeFile|api\.writeFile|downloadBlob)\s*\([^;]{0,200}?JSON\.stringify\(\s*(?:raus\()?\s*(project|customLibrary|groupPresets|avplan|payload)\b/s
+
+/**
+ * Ein Speicherweg in die EIGENE Datei des Nutzers ist kein Ausgang: dort die
+ * Zugangsdaten zu entfernen waere Datenverlust, nicht Schutz. Wer so einen
+ * Weg baut, schreibt die Marke an die Stelle -- nicht in eine Ausnahmeliste
+ * hier, denn genau eine solche Liste war der Fehler, den diese Pruefung
+ * abloest.
+ */
+const MARKE = 'zugangsdaten: eigener speicherweg'
+
+describe('Zugangsdaten verlassen den Rechner nur durch die Regel', () => {
+  it('jeder Renderer-Ausgang kennt stripCredentials', () => {
+    const verstoesse: string[] = []
+
+    for (const [pfad, quelle] of Object.entries(rendererQuellen)) {
+      if (!AUSGANG.test(stripComments(quelle))) continue
+      if (/stripCredentials|credentialChoiceDialog/.test(quelle)) continue
+      if (quelle.toLowerCase().includes(MARKE)) continue
+      verstoesse.push(pfad.replace('../src/renderer/', ''))
+    }
+
+    expect(
+      verstoesse,
+      'Diese Dateien schreiben Projekt-/Bibliotheks-Daten nach draussen, ohne ' +
+        'die Zugangsdaten-Regel zu kennen. Entweder `stripCredentials` (mit ' +
+        '`credentialChoiceDialog`, wo der Nutzer es entscheiden soll) benutzen ' +
+        '-- oder, wenn wirklich kein Modell hinausgeht, den Ausgang so bauen, ' +
+        'dass er es nicht mehr durchreicht.',
+    ).toEqual([])
+  })
+
+  it('die drei Sync-Schreibwege laufen einzeln durch den Filter', () => {
+    // Die Datei-Ebene reicht hier nicht. Beim ersten Entwurf dieser Pruefung
+    // habe ich den Filter am Projekt-Write versuchsweise entfernt und der
+    // Guard blieb GRUEN -- weil die Datei den Import weiterhin trug. Eine
+    // Zusicherung, die einen Rueckschritt nicht bemerkt, ist keine.
+    const panel = stripComments(
+      rendererQuellen['../src/renderer/components/Sync/SharedSyncPanel.tsx'],
+    )
+    const writes = [...panel.matchAll(/sync\.writeFile\(([\s\S]{0,160}?)\)\s*\n/g)]
+    expect(writes.length, 'Schreibwege im Sync-Panel nicht gefunden').toBe(3)
+    for (const [, args] of writes) {
+      expect(args, `Schreibweg ohne Filter: ${args.trim().slice(0, 80)}`).toMatch(
+        /JSON\.stringify\(\s*raus\(/,
+      )
+    }
+  })
+
+  it('gestrippt heisst gestrippt — an der Nutzlast gemessen, nicht am Text', () => {
+    // Kanarienvogel wie oben: die reinen Nutzlast-Bauer von `itemExport`
+    // werden direkt aufgerufen. Wer den Filter dort herausnimmt, faellt hier,
+    // egal was die Datei sonst importiert.
+    const geheim = { name: 'Switch', username: USER, password: SECRET } as unknown as EquipmentTemplate
+    const roh = JSON.stringify(deviceFilePayload(geheim, false, ''))
+    const strip = JSON.stringify(deviceFilePayload(geheim, true, ''))
+    expect(roh).toContain(SECRET)
+    expect(strip).not.toContain(SECRET)
+    expect(strip).not.toContain(USER)
+
+    const preset = { name: 'Rack', items: [geheim] } as unknown as GroupPreset
+    expect(JSON.stringify(groupFilePayload(preset, false, ''))).toContain(SECRET)
+    expect(JSON.stringify(groupFilePayload(preset, true, ''))).not.toContain(SECRET)
+  })
+
+  it('der Kopfkommentar von credentialKeys.ts nennt alle drei Ausgaenge', () => {
+    // Die Liste bleibt -- sie erklaert, WOFUER die Datei da ist. Sie darf nur
+    // nicht die einzige Absicherung sein. Faellt diese Zeile, ist die Frage
+    // nicht "Kommentar anpassen", sondern "welcher Ausgang ist dazugekommen".
+    const kopf = rendererQuellen['../src/renderer/lib/credentialKeys.ts']
+    expect(kopf, 'credentialKeys.ts nicht gefunden').toBeTruthy()
+    expect(kopf).toMatch(/geteilte[nr]? Ordner|Sync/)
   })
 })

--- a/tests/syncAtomicWrite.test.ts
+++ b/tests/syncAtomicWrite.test.ts
@@ -50,6 +50,15 @@ describe('Atomic-Write-Invariante auf den Userdaten-Pfaden', () => {
   it('der Sync-Panel schickt wirklich das ganze Projekt (sonst waere die Regel egal)', () => {
     // Belegt, warum dieser Pfad unter die Invariante faellt. Aendert sich das,
     // gehoert die Einordnung oben neu geprueft -- nicht dieser Test gestrichen.
-    expect(code(panelSrc)).toMatch(/sync\.writeFile\([\s\S]{0,120}JSON\.stringify\(project/)
+    //
+    // Seit 2026-09-04 laeuft das Projekt hier durch `raus(...)` -- den
+    // Zugangsdaten-Filter, den dieser Ausgang vorher NICHT hatte (siehe
+    // `tests/credentialExits.test.ts`). Das Muster laesst deshalb genau einen
+    // Wrapper zu und verlangt weiter, dass das GANZE Projekt hinausgeht: eine
+    // Ableitung oder ein Teilobjekt wuerde die Einordnung kippen, ein Filter
+    // auf einzelnen Feldern nicht.
+    expect(code(panelSrc)).toMatch(
+      /sync\.writeFile\([\s\S]{0,120}JSON\.stringify\(\s*(?:[A-Za-z_$][\w$]*\()?\s*project\b/,
+    )
   })
 })


### PR DESCRIPTION
## Wie es gefunden wurde

Beim Abgleich der Dokumentation gegen den Code. `CREDENTIALS-IN-TEMPLATES.md`
bilanziert: *„vier Ausgänge, zwei geschlossen, zwei fragen jetzt"*. Es waren
mehr.

## Die drei Lücken

**1. `SharedSyncPanel.handlePush`** schrieb Projekt, Bibliothek und
Gruppen-Presets **roh** in den Team-Ordner — ohne Rückfrage, ohne
`stripCredentials`.

Der Schaden ist der teuerste, den diese Form haben kann: wer beim
`.avplan`-Export ausdrücklich **„Zugangsdaten entfernen"** wählte, hatte sie
trotzdem im geteilten Ordner, sobald irgendwer Push drückte. Die Zusicherung
war nicht nur unvollständig — sie war irreführend.

**2. `sharedLibrarySync`** strippte nur `writeDevices`, nicht `writeGroups`.
Dieselbe Rückfrage, halb umgesetzt.

**3. `itemExport` (`.cpdevice` / `.cpgroup`)** ging ungefragt und ungefiltert
hinaus. `EquipmentTemplate` ist `Omit<EquipmentItem, 'id'|'x'|'y'>`
(`types/equipment.ts:831`) und trägt damit `username`/`password`; der
Kopfkommentar der Datei nennt als Zweck wörtlich *„per USB-Stick / E-Mail /
Filesharing auf ein anderes System kopieren"*.

**Diesen dritten hat der neue Guard gefunden, nicht der Audit.**

## Der Guard — und warum er zweimal gebaut wurde

`credentialKeys.ts` zählte die Ausgänge in einem Kommentar auf. **Genau diese
Liste war der Fehler**: der dritte stand nicht drin. Die Liste bleibt als
Erklärung; die Absicherung ist jetzt berechnet.

Die erste Fassung prüfte die **Datei** („kennt sie den Filter?"). Die
Gegenprobe hat sie widerlegt: Filter am Projekt-Write entfernt, Import stehen
gelassen → **grün geblieben**. Eine Zusicherung, die einen Rückschritt nicht
bemerkt, ist keine.

Die zweite Fassung prüft je **Schreibstelle**, und die Nutzlast-Bauer von
`itemExport` sind als reine Funktionen herausgezogen und mit
Kanarienvogel-Werten gemessen — dieselbe Methode, mit der die
Dokument-Ableitungen in derselben Datei schon geprüft sind.

Beide Formen gegengeprobt:

| Probe | Ergebnis |
|---|---|
| Filter am Projekt-Write entfernt | rot (`Schreibweg ohne Filter: joinPath(syncPath, PROJECT_FILE)`) |
| Strip in der `.cpdevice`-Nutzlast entfernt | rot |
| beides zurückgenommen | 15/15 grün |

## Ein bestehender Guard ist gefallen — und wurde angefasst, nicht umgangen

`tests/syncAtomicWrite.test.ts` verlangte `JSON.stringify(project` wörtlich.
Er lässt jetzt genau **einen** Wrapper zu und verlangt weiter, dass das
**ganze** Projekt hinausgeht: ein Teilobjekt würde die Einordnung unter die
Atomic-Write-Invariante kippen, ein Feldfilter nicht. Die Begründung steht im
Test.

## Eine bewusste Ausnahme, an der Stelle markiert

`bridge.ts` (`downloadJson`) bekommt `// zugangsdaten: eigener speicherweg`.
Das ist „Projekt als Datei speichern" — die eigene Datei des Nutzers, die er
gleich wieder öffnet. Dort zu strippen wäre **Datenverlust, nicht Schutz**.
Die Marke steht an der Stelle und nicht in einer Ausnahmeliste im Test — eine
Liste dort wäre wieder der Kenntnisstand ihres Autors.

## Geprüft

- `npx vitest run` → **984 Tests grün** (99 Dateien)
- `npx tsc -p tsconfig.app.json --noEmit` → 0
- `npm run lint` → 0 Errors, 10 Warnungen (vorbestehend)
- `npm run build` → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_