### PR TITLE
docs(lizenz): Open-Source-Behauptungen gegen die eigene Lizenz beseitigt

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@
 
 ## ✨ Overview
 
-**CablePlanner** is free, open-source **broadcast cable planning software** for designing and visualizing **SDI signal flow**, **ATEM multiviewer** layouts and **Blackmagic Videohub routing** on a node-based canvas. It runs **fully offline** on macOS and Windows, so every audio, video and data run is documented before you ever pull cable on site.
+**CablePlanner** is free-to-use **broadcast cable planning software** for designing and visualizing **SDI signal flow**, **ATEM multiviewer** layouts and **Blackmagic Videohub routing** on a node-based canvas. It runs **fully offline** on macOS and Windows, so every audio, video and data run is documented before you ever pull cable on site.
 
-Built with **Electron, React, and TypeScript**, it is designed for real-world production environments such as studios, OB vans, and live event setups — a modern, open alternative to legacy AV/broadcast wiring tools.
+Built with **Electron, React, and TypeScript**, it is designed for real-world production environments such as studios, OB vans, and live event setups — a modern alternative to legacy AV/broadcast wiring tools. The source is public to read; the licence is proprietary (see [LICENSE](LICENSE)).
 
 ✔ Fully offline desktop application  
 ✔ macOS & Windows support  

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -1,23 +1,27 @@
 # Third-Party Licenses
 
+<!-- lizenzaussage: fremd — diese Datei listet Fremdpaket-Lizenzen, nicht die eigene -->
+
 Cable Planner (eigener Code: proprietär, © Lars Zumpe — siehe LICENSE) bündelt die folgenden Open-Source-Pakete.
 Die unten gelisteten Lizenzen gelten für die Fremdpakete und bleiben davon unberührt.
 Diese Datei reproduziert deren Lizenz-/Copyright-Notices wie von den
 jeweiligen Lizenzen gefordert. Automatisch generiert via
 `scripts/generate-notices.mjs` aus dem Produktions-Dependency-Baum.
 
-Stand: 2026-06-15 · 308 Pakete
+Stand: 2026-09-04 · 325 Pakete
 
 ---
 
 ## Lizenz-Übersicht
 
-- MIT: 244
-- ISC: 25
+- MIT: 257
+- ISC: 26
 - Apache-2.0: 18
+- BlueOak-1.0.0: 2
 - BSD-3-Clause: 2
 - OFL-1.1: 1
-- BlueOak-1.0.0: 1
+- Apache-2.0 AND LGPL-3.0-or-later AND MIT: 1
+- Python-2.0: 1
 - (MPL-2.0 OR Apache-2.0): 1
 - (MIT OR WTFPL): 1
 - BSD: 1
@@ -299,7 +303,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-## @emnapi/core (1.10.0)
+## @emnapi/core (1.11.1)
 
 - **License:** MIT
 - **Author:** toyobayashi
@@ -329,7 +333,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-## @emnapi/runtime (1.10.0)
+## @emnapi/runtime (1.11.1)
 
 - **License:** MIT
 - **Author:** toyobayashi
@@ -359,7 +363,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-## @emnapi/wasi-threads (1.2.1)
+## @emnapi/wasi-threads (1.2.2)
 
 - **License:** MIT
 - **Author:** toyobayashi
@@ -491,6 +495,125 @@ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
 OTHER DEALINGS IN THE FONT SOFTWARE.
 ```
 
+## @img/sharp-wasm32 (0.35.2)
+
+- **License:** Apache-2.0 AND LGPL-3.0-or-later AND MIT
+- **Author:** Lovell Fuller <npm@lovell.info>
+- **Source:** https://github.com/lovell/sharp
+
+```
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided
+…(gekürzt)…
+```
+
 ## @julusian/freetype2 (1.3.1)
 
 - **License:** MIT
@@ -588,14 +711,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-## @napi-rs/wasm-runtime (1.1.4)
+## @napi-rs/wasm-runtime (1.1.6)
 
 - **License:** MIT
 - **Author:** LongYinan
 - **Source:** https://github.com/napi-rs/napi-rs
 
 
-## @nodable/entities (2.1.0)
+## @nodable/entities (2.2.0)
 
 - **License:** MIT
 - **Author:** Amit Gupta (https://solothought.com)
@@ -844,7 +967,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
-## @tybys/wasm-util (0.10.2)
+## @tybys/wasm-util (0.10.3)
 
 - **License:** MIT
 - **Author:** toyobayashi
@@ -1808,7 +1931,7 @@ MIT License
     SOFTWARE
 ```
 
-## @types/node (25.8.0)
+## @types/node (26.0.1)
 
 - **License:** MIT
 - **Source:** https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -1953,7 +2076,7 @@ MIT License
     SOFTWARE
 ```
 
-## @types/react (19.2.14)
+## @types/react (19.2.17)
 
 - **License:** MIT
 - **Source:** https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -2301,6 +2424,171 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
+## anynum (1.0.1)
+
+- **License:** MIT
+- **Author:** Amit Gupta (https://solothought.work/)
+- **Source:** https://github.com/NaturalIntelligence/anynum
+
+```
+MIT License
+
+Copyright (c) 2026 Natural Intelligence
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## argparse (2.0.1)
+
+- **License:** Python-2.0
+- **Source:** nodeca/argparse
+
+```
+A. HISTORY OF THE SOFTWARE
+==========================
+
+Python was created in the early 1990s by Guido van Rossum at Stichting
+Mathematisch Centrum (CWI, see http://www.cwi.nl) in the Netherlands
+as a successor of a language called ABC.  Guido remains Python's
+principal author, although it includes many contributions from others.
+
+In 1995, Guido continued his work on Python at the Corporation for
+National Research Initiatives (CNRI, see http://www.cnri.reston.va.us)
+in Reston, Virginia where he released several versions of the
+software.
+
+In May 2000, Guido and the Python core development team moved to
+BeOpen.com to form the BeOpen PythonLabs team.  In October of the same
+year, the PythonLabs team moved to Digital Creations, which became
+Zope Corporation.  In 2001, the Python Software Foundation (PSF, see
+https://www.python.org/psf/) was formed, a non-profit organization
+created specifically to own Python-related Intellectual Property.
+Zope Corporation was a sponsoring member of the PSF.
+
+All Python releases are Open Source (see http://www.opensource.org for
+the Open Source Definition).  Historically, most, but not all, Python
+releases have also been GPL-compatible; the table below summarizes
+the various releases.
+
+    Release         Derived     Year        Owner       GPL-
+                    from                                compatible? (1)
+
+    0.9.0 thru 1.2              1991-1995   CWI         yes
+    1.3 thru 1.5.2  1.2         1995-1999   CNRI        yes
+    1.6             1.5.2       2000        CNRI        no
+    2.0             1.6         2000        BeOpen.com  no
+    1.6.1           1.6         2001        CNRI        yes (2)
+    2.1             2.0+1.6.1   2001        PSF         no
+    2.0.1           2.0+1.6.1   2001        PSF         yes
+    2.1.1           2.1+2.0.1   2001        PSF         yes
+    2.1.2           2.1.1       2002        PSF         yes
+    2.1.3           2.1.2       2002        PSF         yes
+    2.2 and above   2.1.1       2001-now    PSF         yes
+
+Footnotes:
+
+(1) GPL-compatible doesn't mean that we're distributing Python under
+    the GPL.  All Python licenses, unlike the GPL, let you distribute
+    a modified version without making your changes open source.  The
+    GPL-compatible licenses make it possible to combine Python with
+    other software that is released under the GPL; the others don't.
+
+(2) According to Richard Stallman, 1.6.1 is not GPL-compatible,
+    because its license has a choice of law clause.  According to
+    CNRI, however, Stallman's lawyer has told CNRI's lawyer that 1.6.1
+    is "not incompatible" with the GPL.
+
+Thanks to the many outside volunteers who have worked under Guido's
+direction to make these releases possible.
+
+
+B. TERMS AND CONDITIONS FOR ACCESSING OR OTHERWISE USING PYTHON
+===============================================================
+
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+--------------------------------------------
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+("PSF"), and the Individual or Organization ("Licensee") accessing and
+otherwise using this software ("Python") in source or binary form and
+its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF hereby
+grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+analyze, test, perform and/or display publicly, prepare derivative works,
+distribute, and otherwise use Python alone or in any derivative version,
+provided, however, that PSF's License Agreement and PSF's notice of copyright,
+i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020 Python Software Foundation;
+All Rights Reserved" are retained in Python alone or in any derivative version
+prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
+
+4. PSF is making Python available to Licensee on an "AS IS"
+basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee.  This License Agreement does not grant permission to use PSF
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.
+
+
+BEOPEN.COM LICENSE AGREEMENT FOR PYTHON 2.0
+-------------------------------------------
+
+BEOPEN PYTHON OPEN SOURCE LICENSE AGREEMENT VERSION 1
+
+1. This LICENSE AGREEMENT is between BeOpen.com ("BeOpen"), having an
+office at 160 Saratoga Avenue, Santa Clara, CA 95051, and the
+Individual or Organization ("Licensee") accessing and otherwise using
+this software in source or binary form and its associated
+documentation ("the Software").
+
+2. Subject to the terms and conditions of this BeOpen Python License
+Agreement, BeOpen hereby grants Licensee a non-exclusive,
+royalty-free, world-wide license to reproduce, analyze, test, perform
+and/or display 
+…(gekürzt)…
+```
+
 ## asynckit (0.4.0)
 
 - **License:** MIT
@@ -2360,7 +2648,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-## axios (1.16.1)
+## axios (1.18.1)
 
 - **License:** MIT
 - **Author:** Matt Zabriskie
@@ -2525,7 +2813,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-## bonjour-service (1.3.0)
+## bonjour-service (1.4.2)
 
 - **License:** MIT
 - **Author:** ON LX Lited <team@onlx.ltd> (https://onlx.ltd)
@@ -2590,6 +2878,36 @@ THE SOFTWARE.
 ## bufferutil ()
 
 _Lizenz-Metadaten nicht auflösbar._
+
+## builder-util-runtime (9.7.0)
+
+- **License:** MIT
+- **Author:** Vladimir Krivosheev
+- **Source:** https://github.com/electron-userland/electron-builder
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Loopline Systems
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
 
 ## byte-data (16.0.3)
 
@@ -4042,6 +4360,36 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
+## electron-updater (6.8.9)
+
+- **License:** MIT
+- **Author:** Vladimir Krivosheev
+- **Source:** https://github.com/electron-userland/electron-builder
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Loopline Systems
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
 ## emoji-regex (8.0.0)
 
 - **License:** MIT
@@ -4459,7 +4807,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-## fast-xml-parser (5.8.0)
+## fast-xml-parser (5.9.3)
 
 - **License:** MIT
 - **Author:** Amit Gupta (https://solothought.com)
@@ -4621,6 +4969,30 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+```
+
+## fs-extra (10.1.0)
+
+- **License:** MIT
+- **Author:** JP Richardson <jprichardson@gmail.com>
+- **Source:** https://github.com/jprichardson/node-fs-extra
+
+```
+(The MIT License)
+
+Copyright (c) 2011-2017 JP Richardson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files
+(the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify,
+ merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
 ## function-bind (1.1.2)
@@ -4817,6 +5189,29 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+```
+
+## graceful-fs (4.2.11)
+
+- **License:** ISC
+- **Source:** https://github.com/isaacs/node-graceful-fs
+
+```
+The ISC License
+
+Copyright (c) 2011-2022 Isaac Z. Schlueter, Ben Noordhuis, and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ```
 
 ## has-symbols (1.1.0)
@@ -5257,6 +5652,36 @@ THE SOFTWARE.
 - **Source:** git://github.com/nisaacson/is-running
 
 
+## is-unsafe (1.0.1)
+
+- **License:** MIT
+- **Author:** Amit Gupta (https://solothought.work/)
+- **Source:** https://github.com/NaturalIntelligence/is-unsafe
+
+```
+MIT License
+
+Copyright (c) 2026 Natural Intelligence
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
 ## isexe (2.0.0)
 
 - **License:** ISC
@@ -5341,6 +5766,67 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
+## js-yaml (4.1.1)
+
+- **License:** MIT
+- **Author:** Vladimir Zapparov <dervus.grim@gmail.com>
+- **Source:** nodeca/js-yaml
+
+```
+(The MIT License)
+
+Copyright (C) 2011-2015 by Vitaly Puzrin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```
+
+## jsbarcode (3.12.3)
+
+- **License:** MIT
+- **Author:** Johan Lindell
+- **Source:** https://github.com/lindell/JsBarcode
+
+
+## jsonfile (6.2.1)
+
+- **License:** MIT
+- **Author:** JP Richardson <jprichardson@gmail.com>
+- **Source:** git@github.com:jprichardson/node-jsonfile
+
+```
+(The MIT License)
+
+Copyright (c) 2012-2015, JP Richardson <jprichardson@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files
+(the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify,
+ merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
 ## jspdf (4.2.1)
 
 - **License:** MIT
@@ -5398,6 +5884,13 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
+
+## lazy-val (1.0.5)
+
+- **License:** MIT
+- **Author:** Vladimir Krivosheev
+- **Source:** develar/lazy-val
+
 
 ## lib0 (0.2.117)
 
@@ -5462,7 +5955,119 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-## lucide-react (1.17.0)
+## lodash.escaperegexp (4.1.2)
+
+- **License:** MIT
+- **Author:** John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+- **Source:** lodash/lodash
+
+```
+Copyright jQuery Foundation and other contributors <https://jquery.org/>
+
+Based on Underscore.js, copyright Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/lodash/lodash
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+====
+
+Copyright and related rights for sample code are waived via CC0. Sample
+code is defined as all source code displayed within the prose of the
+documentation.
+
+CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+====
+
+Files located in the node_modules and vendor directories are externally
+maintained libraries used by this software which have their own
+licenses; we recommend you read them, as their terms may differ from the
+terms above.
+```
+
+## lodash.isequal (4.5.0)
+
+- **License:** MIT
+- **Author:** John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+- **Source:** lodash/lodash
+
+```
+Copyright JS Foundation and other contributors <https://js.foundation/>
+
+Based on Underscore.js, copyright Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/lodash/lodash
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+====
+
+Copyright and related rights for sample code are waived via CC0. Sample
+code is defined as all source code displayed within the prose of the
+documentation.
+
+CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+====
+
+Files located in the node_modules and vendor directories are externally
+maintained libraries used by this software which have their own
+licenses; we recommend you read them, as their terms may differ from the
+terms above.
+```
+
+## lucide-react (1.21.0)
 
 - **License:** ISC
 - **Author:** Eric Fennis
@@ -6560,7 +7165,7 @@ SOFTWARE.
 - **Source:** https://github.com/dominictarr/rc
 
 
-## react (19.2.6)
+## react (19.2.7)
 
 - **License:** MIT
 - **Source:** https://github.com/facebook/react
@@ -6589,7 +7194,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-## react-dom (19.2.6)
+## react-dom (19.2.7)
 
 - **License:** MIT
 - **Source:** https://github.com/facebook/react
@@ -6915,6 +7520,70 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
+## sax (1.6.0)
+
+- **License:** BlueOak-1.0.0
+- **Author:** Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
+- **Source:** ssh://git@github.com/isaacs/sax-js
+
+```
+# Blue Oak Model License
+
+Version 1.0.0
+
+## Purpose
+
+This license gives everyone as much permission to work with
+this software as possible, while protecting contributors
+from liability.
+
+## Acceptance
+
+In order to receive this license, you must agree to its
+rules.  The rules of this license are both obligations
+under that agreement and conditions to your license.
+You must not do anything with this software that triggers
+a rule that you cannot or will not follow.
+
+## Copyright
+
+Each contributor licenses you to do everything with this
+software that would otherwise infringe that contributor's
+copyright in it.
+
+## Notices
+
+You must ensure that everyone who gets a copy of
+any part of this software from you, with or without
+changes, also gets the text of this license or a link to
+<https://blueoakcouncil.org/license/1.0.0>.
+
+## Excuse
+
+If anyone notifies you in writing that you have not
+complied with [Notices](#notices), you can keep your
+license by taking all practical steps to comply within 30
+days after the notice.  If you do not do so, your license
+ends immediately.
+
+## Patent
+
+Each contributor licenses you to do everything with this
+software that would otherwise infringe any patent claims
+they can license or become able to license.
+
+## Reliability
+
+No contributor can revoke this license.
+
+## No Liability
+
+***As far as the law allows, this software comes as is,
+without any warranty or condition, and no contributor
+will be liable to anyone for any damages related to this
+software or this license, under any kind of legal claim.***
+```
+
 ## scheduler (0.27.0)
 
 - **License:** MIT
@@ -6944,7 +7613,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-## semver (7.8.0)
+## semver (7.7.4, 7.8.0)
 
 - **License:** ISC
 - **Author:** GitHub Inc.
@@ -7373,7 +8042,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 _Lizenz-Metadaten nicht auflösbar._
 
-## strnum (2.3.0)
+## strnum (2.4.1)
 
 - **License:** MIT
 - **Author:** Amit Gupta (https://solothought.work/)
@@ -7583,7 +8252,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-## three (0.170.0, 0.184.0)
+## three (0.170.0, 0.185.0)
 
 - **License:** MIT
 - **Author:** mrdoob
@@ -7701,6 +8370,36 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+```
+
+## tiny-typed-emitter (2.1.0)
+
+- **License:** MIT
+- **Author:** Zurab Benashvili <zura.benashvili@gmail.com>
+- **Source:** https://github.com/binier/tiny-typed-emitter
+
+```
+MIT License
+
+Copyright (c) 2020 Zurab Benashvili (binier) <zura.bena@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
 
 ## troika-three-text (0.52.4)
@@ -7958,7 +8657,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-## undici-types (7.24.6)
+## undici-types (8.3.0)
 
 - **License:** MIT
 - **Source:** https://github.com/nodejs/undici
@@ -7985,6 +8684,35 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+```
+
+## universalify (2.0.1)
+
+- **License:** MIT
+- **Author:** Ryan Zimmerman <opensrc@ryanzim.com>
+- **Source:** https://github.com/RyanZim/universalify
+
+```
+(The MIT License)
+
+Copyright (c) 2017, Ryan Zimmerman <opensrc@ryanzim.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the 'Software'), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
 ## use-sync-external-store (1.6.0)
@@ -8143,7 +8871,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-## uuid (14.0.0)
+## uuid (14.0.1)
 
 - **License:** MIT
 - **Source:** https://github.com/uuidjs/uuid
@@ -8921,7 +9649,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-## zustand (4.5.7, 5.0.13)
+## zustand (4.5.7, 5.0.14)
 
 - **License:** MIT
 - **Author:** Paul Henschel

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<!-- lizenzaussage: fremd — dieses Dokument vergleicht Fremdprodukte und deren Lizenzen -->
 <html lang="de">
 <head>
 <meta charset="UTF-8" />

--- a/docs/festinstallation-readiness.md
+++ b/docs/festinstallation-readiness.md
@@ -1,5 +1,7 @@
 # Cable-Planner für Festinstallationen — Bedarfsanalyse & Roadmap
 
+<!-- lizenzaussage: fremd — nennt Fremdsysteme (NetBox u. a.) samt deren Lizenzmodell -->
+
 > Strategie-Dokument. Es beantwortet die Frage: *Was muss Cable-Planner
 > können, damit es nicht nur Show-/Event-Verkabelung plant, sondern
 > dauerhafte Festinstallationen dokumentiert, die nach der Erstinstallation

--- a/docs/index.html
+++ b/docs/index.html
@@ -32,10 +32,10 @@
   "url": "https://larszu.github.io/cable-planner/",
   "downloadUrl": "https://github.com/larszu/cable-planner/releases/latest",
   "softwareHelp": "https://github.com/larszu/cable-planner#readme",
-  "description": "Free, open-source broadcast cable planning software with a node-based canvas for SDI signal flow, ATEM multiviewer layouts, Blackmagic Videohub routing, Rentman import and PDF export. Offline-first desktop app for macOS and Windows.",
+  "description": "Free-to-use broadcast cable planning software with a node-based canvas for SDI signal flow, ATEM multiviewer layouts, Blackmagic Videohub routing, Rentman import and PDF export. Offline-first desktop app for macOS and Windows.",
   "image": "https://larszu.github.io/cable-planner/screenshots/hero.png",
   "screenshot": "https://larszu.github.io/cable-planner/screenshots/hero.png",
-  "license": "LICENSE",
+  "license": "https://github.com/larszu/cable-planner/blob/main/LICENSE",
   "isAccessibleForFree": true,
   "author": { "@type": "Person", "name": "Lars Zumpe" },
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
@@ -941,7 +941,7 @@
     <div class="section-head reveal">
       <div class="eyebrow">Latest release</div>
       <h2>Download CablePlanner</h2>
-      <p>Free, open source, proprietary (free to use). Pick the build for your machine — no account required.</p>
+      <p>Free to use, proprietary licence. Pick the build for your machine — no account required.</p>
     </div>
 
     <div class="card release-card reveal">

--- a/docs/monorepo-plan.md
+++ b/docs/monorepo-plan.md
@@ -1,12 +1,16 @@
 # Monorepo-Plan: cable-planner · multicam-planner · light-planner
 
-> Status: **Vorschlag / Konzept** — noch nichts migriert.
+> Status: **umgesetzt** — der Monorepo existiert als eigenes Repo
+> [`av-planner-suite`](https://github.com/larszu/av-planner-suite); die drei Apps
+> liegen dort unter `apps/` (vendoriert, nicht verschoben — die Einzel-Repos
+> bleiben die Quelle, ein Drift-Guard haelt die Kopien nach).
+> Dieses Dokument bleibt als Begruendung der damaligen Entscheidung stehen.
 > Ziel: Die drei eigenständigen Broadcast-Planungs-Apps unter ein Dach bringen,
 > ohne laufende Feature-Arbeit (aktuell multicam) zu blockieren.
 
 ## 1. Warum überhaupt
 
-Die drei Apps stammen vom selben Autor, sind MIT-lizenziert, offline-first und
+Die drei Apps stammen vom selben Autor, sind proprietär lizenziert (kostenlos nutzbar), offline-first und
 zielen auf dieselbe Domäne (Broadcast-Produktionsplanung) und dieselben
 Plattformen (macOS/Windows). Der Stack ist nahezu deckungsgleich:
 

--- a/scripts/generate-notices.mjs
+++ b/scripts/generate-notices.mjs
@@ -3,7 +3,8 @@
  * #pre-sale — Generiert THIRD-PARTY-LICENSES.md aus allen PRODUKTIONS-
  * Dependencies (transitiv). Pflicht-Attribution: für MIT/BSD/Apache/ISC u.a.
  * müssen Lizenztext + Copyright-Notices der gebündelten Pakete reproduziert
- * werden. Eigener App-Code bleibt davon unberührt (App-Lizenz: MIT).
+ * werden. Eigener App-Code bleibt davon unberührt (App-Lizenz: proprietär,
+ * siehe LICENSE).
  *
  * Quelle des Baums: `npm ls --omit=dev --all --json`. Lizenztext: LICENSE*-
  * Datei im jeweiligen node_modules/<pkg>, sonst das `license`-Feld.
@@ -47,7 +48,10 @@ let unresolved = 0
 const out = []
 out.push('# Third-Party Licenses')
 out.push('')
-out.push(`Cable Planner (eigener Code: MIT) bündelt die folgenden Open-Source-Pakete.`)
+out.push('<!-- lizenzaussage: fremd — diese Datei listet Fremdpaket-Lizenzen, nicht die eigene -->')
+out.push('')
+out.push('Cable Planner (eigener Code: proprietär, © Lars Zumpe — siehe LICENSE) bündelt die folgenden Open-Source-Pakete.')
+out.push('Die unten gelisteten Lizenzen gelten für die Fremdpakete und bleiben davon unberührt.')
 out.push(`Diese Datei reproduziert deren Lizenz-/Copyright-Notices wie von den`)
 out.push(`jeweiligen Lizenzen gefordert. Automatisch generiert via`)
 out.push('`scripts/generate-notices.mjs` aus dem Produktions-Dependency-Baum.')

--- a/tests/lizenzaussage.test.ts
+++ b/tests/lizenzaussage.test.ts
@@ -1,0 +1,160 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Kein Dokument darf die eigene Software als Open Source ausgeben.
+//
+// WARUM ES DAS GIBT. Gemessen 2026-09-04: `README.md` Zeile 44 sagte
+// „CablePlanner is free, open-source broadcast cable planning software", waehrend
+// `LICENSE` und Zeile 273 desselben Dokuments proprietaer sagen. Dieselbe Aussage
+// stand in der JSON-LD-Beschreibung von `docs/index.html` (die Google als
+// Rich-Result ausliefert) und im Download-Absatz derselben Seite als
+// „Free, open source, proprietary (free to use)" — ein Satz, der sich selbst
+// widerspricht. `scripts/generate-notices.mjs` schrieb ausserdem weiterhin
+// „Cable Planner (eigener Code: MIT)"; die erzeugte Datei war von Hand
+// korrigiert, ihre Quelle nicht — der naechste Lauf haette es zurueckgeschrieben.
+//
+// Das ist keine Formulierungsfrage. Eine Lizenzangabe ist eine Rechtsaussage:
+// wer „open source" liest, darf forken und weiterverbreiten. Genau das erlaubt
+// die Lizenz nicht.
+//
+// WIE ER PRUEFT. Nicht gegen eine Liste bekannter Stellen — die waere am Tag
+// ihrer Niederschrift vollstaendig und am naechsten nicht mehr. Er laeuft ueber
+// JEDES nutzerseitige Dokument (README + alles unter `docs/`) und meldet jedes
+// Open-Source-Wort, das nicht verneint ist.
+//
+// AUSNAHMEN stehen nicht hier, sondern als Marker `lizenzaussage: fremd` IM
+// jeweiligen Dokument — dort sieht sie, wer die Datei liest, und nicht nur, wer
+// diesen Test liest. Drei Dokumente reden legitim ueber FREMDE Lizenzen
+// (Fremdpaket-Notices, Konkurrenzvergleich, Bedarfsanalyse mit NetBox). Ihre
+// Zahl wird mitgezaehlt: wer einen vierten Marker setzt, faellt hier auf und
+// muss ihn begruenden, statt den Guard still auszuhebeln.
+//
+// WAS ER NICHT PRUEFT: ob die Lizenz die richtige ist. Er prueft, dass die
+// Dokumente dieselbe Aussage machen wie `LICENSE`.
+// ───────────────────────────────────────────────────────────────────────────
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const ROOT = join(__dirname, '..')
+
+/** Marker, mit dem ein Dokument sich als „redet ueber fremde Lizenzen" ausweist. */
+const FREMD_MARKER = 'lizenzaussage: fremd'
+
+/**
+ * Woerter, die eine Open-Source-Lizenzierung behaupten. Bewusst nur die
+ * Behauptung, nicht jede Lizenznennung: „Apache 2.0" oder „GPL" neben einem
+ * Fremdprodukt ist eine Tatsache ueber das Fremdprodukt, nicht ueber uns.
+ */
+const BEHAUPTUNG_QUELLE = 'open[-\\s]?source|opensource|quelloffen|MIT[-\\s](?:Lizenz|lizenziert|licen[cs]e[d]?)'
+/** Frisch pro Aufruf: ein geteiltes /g/-RegExp traegt `lastIndex` mit und ueberspringt Treffer. */
+const behauptung = () => new RegExp(BEHAUPTUNG_QUELLE, 'gi')
+
+/** Verneinung unmittelbar davor — „not open source" ist die Klarstellung, nicht der Fehler. */
+const VERNEINT = /\b(?:not|no|nicht|kein|keine|keinen)\b[^.!?\n]{0,40}$/i
+
+const nutzerDokumente = (): string[] => {
+  const treffer: string[] = []
+  const lauf = (verzeichnis: string) => {
+    for (const eintrag of readdirSync(verzeichnis)) {
+      const pfad = join(verzeichnis, eintrag)
+      if (statSync(pfad).isDirectory()) {
+        if (eintrag === 'node_modules' || eintrag.startsWith('.')) continue
+        lauf(pfad)
+        continue
+      }
+      if (/\.(md|html)$/i.test(eintrag)) treffer.push(pfad)
+    }
+  }
+  for (const datei of readdirSync(ROOT)) {
+    const pfad = join(ROOT, datei)
+    if (statSync(pfad).isFile() && /\.md$/i.test(datei)) treffer.push(pfad)
+  }
+  lauf(join(ROOT, 'docs'))
+  return treffer
+}
+
+type Fund = { datei: string; zeile: number; text: string }
+
+const behauptungenIn = (pfad: string): Fund[] => {
+  const inhalt = readFileSync(pfad, 'utf8')
+  const funde: Fund[] = []
+  inhalt.split('\n').forEach((zeile, i) => {
+    // Der Marker selbst enthaelt kein Behauptungswort, aber der Kommentar um ihn
+    // herum koennte eines enthalten — die Marker-Zeile zaehlt nie als Befund.
+    if (zeile.includes(FREMD_MARKER)) return
+    for (const treffer of zeile.matchAll(behauptung())) {
+      const davor = zeile.slice(0, treffer.index)
+      if (VERNEINT.test(davor)) continue
+      funde.push({ datei: relative(ROOT, pfad), zeile: i + 1, text: zeile.trim().slice(0, 140) })
+    }
+  })
+  return funde
+}
+
+describe('Lizenzaussage in der Dokumentation', () => {
+  const dokumente = nutzerDokumente()
+
+  it('die Praemisse stimmt noch: LICENSE ist proprietaer', () => {
+    // Wuerde die Lizenz auf Open Source wechseln, waere dieser ganze Test falsch
+    // herum. Er soll dann rot werden und gelesen — nicht still zur Attrappe.
+    const lizenz = readFileSync(join(ROOT, 'LICENSE'), 'utf8')
+    expect(lizenz).toMatch(/PROPRIET/i)
+  })
+
+  it('findet ueberhaupt Dokumente', () => {
+    // Ein leerer Suchlauf ist gruen und wertlos. Der haeufigste Weg dorthin ist
+    // ein umbenanntes Verzeichnis, nicht eine geloeschte Doku.
+    expect(dokumente.length).toBeGreaterThan(10)
+    expect(dokumente.some((d) => d.endsWith('README.md'))).toBe(true)
+    expect(dokumente.some((d) => d.endsWith(join('docs', 'index.html')))).toBe(true)
+  })
+
+  it('genau drei Dokumente sind als „redet ueber fremde Lizenzen" markiert', () => {
+    const markiert = dokumente
+      .filter((d) => readFileSync(d, 'utf8').includes(FREMD_MARKER))
+      .map((d) => relative(ROOT, d))
+      .sort()
+    expect(
+      markiert,
+      'Ein neuer Marker schaltet ein ganzes Dokument aus der Pruefung. ' +
+        'Wer einen setzt, traegt ihn hier nach und begruendet ihn im Commit.',
+    ).toEqual([
+      'THIRD-PARTY-LICENSES.md',
+      join('docs', 'comparison.html'),
+      join('docs', 'festinstallation-readiness.md'),
+    ])
+  })
+
+  it('kein unmarkiertes Dokument behauptet Open Source', () => {
+    const funde = dokumente
+      .filter((d) => !readFileSync(d, 'utf8').includes(FREMD_MARKER))
+      .flatMap(behauptungenIn)
+    expect(
+      funde.map((f) => `${f.datei}:${f.zeile}  ${f.text}`),
+      'LICENSE sagt proprietaer. Entweder die Stelle umformulieren, oder — wenn ' +
+        'sie ueber ein Fremdprodukt spricht — das Dokument mit „' +
+        FREMD_MARKER +
+        '" markieren.',
+    ).toEqual([])
+  })
+
+  it('auch der Generator der Fremdpaket-Notices behauptet nichts Falsches', () => {
+    // THIRD-PARTY-LICENSES.md ist generiert. Eine Korrektur an der Datei haelt
+    // nur bis zum naechsten `node scripts/generate-notices.mjs`; die Aussage muss
+    // in der Quelle stehen. Genau daran ist die MIT-Behauptung ueberlebt.
+    const generator = readFileSync(join(ROOT, 'scripts', 'generate-notices.mjs'), 'utf8')
+    // Nicht nur die eine Ausgabezeile: der Kopfkommentar desselben Skripts sagte
+    // ebenfalls „App-Lizenz: MIT". Eine Behauptung ueber die EIGENE Lizenz darf im
+    // Generator an keiner Stelle MIT lauten — egal ob Kommentar oder Ausgabe.
+    expect(generator).not.toMatch(/(?:App-Lizenz|eigene[rs]? (?:Code|Lizenz))\s*[:=]\s*MIT/i)
+    expect(generator).toMatch(/eigener Code:\s*proprietär/i)
+    expect(generator).toContain(FREMD_MARKER)
+  })
+
+  it('die Verneinungs-Ausnahme greift nur bei echter Verneinung', () => {
+    // Selbstprobe: sonst waere „kein" irgendwo weiter vorn in der Zeile ein
+    // Freifahrtschein fuer eine Behauptung dahinter.
+    expect(VERNEINT.test('It is proprietary software, not ')).toBe(true)
+    expect(VERNEINT.test('CablePlanner is free, ')).toBe(false)
+    expect(behauptung().test('free, open-source broadcast')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Der Befund

`LICENSE` sagt seit dem 2026-08-29 **proprietär**. Vier nutzerseitige Stellen sagten weiterhin das Gegenteil — teilweise im selben Dokument, in dem zwanzig Zeilen später „It is proprietary software, not open source" steht:

| Stelle | Aussage |
|---|---|
| `README.md:44` | „CablePlanner is free, **open-source** broadcast cable planning software" |
| `docs/index.html:35` | JSON-LD `description`: „Free, **open-source** broadcast cable planning software…" — das ist die Beschreibung, die Google als Rich-Result ausliefert |
| `docs/index.html:944` | Download-Absatz: „Free, **open source**, proprietary (free to use)" — ein Satz, der sich selbst widerspricht |
| `docs/monorepo-plan.md:9` | „Die drei Apps … sind **MIT-lizenziert**" |

Das ist keine Formulierungsfrage. Eine Lizenzangabe ist eine Rechtsaussage: wer „open source" liest, darf forken und weiterverbreiten. Genau das erlaubt die Lizenz nicht.

## Die Stelle, die keine Textkorrektur war

`scripts/generate-notices.mjs` schrieb weiterhin `Cable Planner (eigener Code: MIT)` und trug im Kopfkommentar `App-Lizenz: MIT`. Die erzeugte `THIRD-PARTY-LICENSES.md` war irgendwann von Hand korrigiert, ihre **Quelle** nicht — der nächste Generatorlauf hätte den Widerspruch zurückgeschrieben. Generator korrigiert und die Datei neu erzeugt (Stand `2026-06-15 · 308 Pakete` → `2026-09-04 · 325 Pakete`; sie war ohnehin knapp drei Monate alt und ist ein Compliance-Artefakt, das abbilden muss, was tatsächlich ausgeliefert wird).

Nebenbefund derselben Datei: das JSON-LD-Feld `"license"` zeigte auf den Literalstring `"LICENSE"` statt auf eine URL — schema.org erwartet dort eine URL oder ein `CreativeWork`. Jetzt die GitHub-URL der Lizenzdatei.

Und `docs/monorepo-plan.md` stand noch auf „Status: Vorschlag / Konzept — noch nichts migriert", während der Monorepo seit Wochen als `av-planner-suite` existiert und die drei Apps unter `apps/` liegen.

## Der Guard

`tests/lizenzaussage.test.ts` prüft **nicht gegen eine Liste bekannter Stellen** — die wäre am Tag ihrer Niederschrift vollständig und am nächsten nicht mehr; genau deshalb hat die JSON-LD-Zeile die Korrektur des README überlebt. Er läuft über **jedes** nutzerseitige Dokument (README + alles unter `docs/`) und meldet jedes Open-Source-Wort, das nicht verneint ist.

Ausnahmen stehen nicht im Test, sondern als Marker `lizenzaussage: fremd` **im jeweiligen Dokument** — dort sieht sie, wer die Datei liest, und nicht nur, wer den Test liest. Drei Dokumente reden legitim über fremde Lizenzen (`THIRD-PARTY-LICENSES.md`, `docs/comparison.html`, `docs/festinstallation-readiness.md`). Ihre Zahl wird mitgezählt: wer einen vierten Marker setzt, fällt auf und muss ihn begründen, statt den Guard still auszuhebeln.

Zwei weitere Eigenschaften, die der Test selbst prüft, weil beide Ausfallarten lautlos wären:
- **Die Prämisse**: wechselt `LICENSE` je auf Open Source, wird der Test rot statt zur Attrappe.
- **Der leere Suchlauf**: ein umbenanntes `docs/` würde sonst grün und wertlos durchlaufen.

**Gegenprobe gemacht:** mit den alten Formulierungen in `README.md:44` und `generate-notices.mjs` fällt er rot (beide Befunde namentlich im Fehlertext), mit den neuen grün.

## Validierung

- `npm test` — 990 Tests, 100 Dateien, grün
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm run lint` — 0 Errors (10 vorbestehende Warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_