### PR TITLE
feat(collab): eigene STUN-/TURN-Server eintragbar (B-37)

### DIFF
--- a/docs/self-hosted-relay.md
+++ b/docs/self-hosted-relay.md
@@ -49,8 +49,28 @@ apt install coturn
 # /etc/turnserver.conf: realm, listening-port=3478, lt-cred-mech, user=...:...
 ```
 
-Die TURN-Zugangsdaten trägst du in der App unter **Zusammenarbeit → ICE-Server**
-ein (bzw. via `iceServers`-Feld). STUN allein reicht im WLAN meist.
+Die TURN-Zugangsdaten trägst du in der App unter **Zusammenarbeit →
+STUN-/TURN-Server** ein — eine Zeile je Server, Felder mit `|` getrennt:
+
+```
+stun:stun.example.com:3478
+turn:turn.example.com:3478|benutzer|geheim
+turns:turn.example.com:5349|benutzer|geheim
+```
+
+Getrennt wird mit `|` und nicht mit `:` oder `@`, weil coturn-Passwörter aus
+`lt-cred-mech` beides regelmäßig enthalten. Eine Zeile ohne bekanntes Schema —
+oder ein `turn:` ohne Zugangsdaten, das jede Allocation abwiese — meldet das
+Panel als „Nicht verwertbar", statt sie stillschweigend zu verwerfen.
+
+**Jeder Teilnehmer trägt seinen eigenen TURN-Server ein.** Die Zugangsdaten
+bleiben auf dem jeweiligen Rechner: sie stehen weder im Einladungslink noch in
+der mDNS-Ankündigung der Session. Ein Einladungslink wird in einen Chat
+gepastet — ein TURN-Passwort, das dort mitfährt, ist damit veröffentlicht.
+
+Ohne eingetragene Server gelten die Default-STUN-Server von y-webrtc. Die
+reichen im WLAN meist; zwischen zwei Netzen hinter symmetrischem NAT reichen
+sie nicht.
 
 ## 4. In der App eintragen
 

--- a/src/renderer/components/Sync/CollabPanel.tsx
+++ b/src/renderer/components/Sync/CollabPanel.tsx
@@ -5,7 +5,7 @@
 // eine klare „so treten andere bei"-Anleitung (#471). Logik liegt im
 // collabStore + lib/crdt/*; diese Komponente ist Anzeige + Steuerung.
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import {
   useCollabStore,
   type CollabMode,
@@ -16,6 +16,7 @@ import { hasDesktopBridge } from '../../lib/bridge'
 import { buildInviteLink } from '../../lib/collabInvite'
 import { useTranslation } from '../../lib/i18n'
 import { confirmDialog } from '../../lib/confirmDialog'
+import { ungueltigeIceZeilen } from '../../lib/crdt/iceServers'
 
 const statusLabel = (
   status: ReturnType<typeof useCollabStore.getState>['status'],
@@ -65,6 +66,8 @@ export const CollabPanel = () => {
   const localOnly = useCollabStore((s) => s.localOnly)
   const setLocalOnly = useCollabStore((s) => s.setLocalOnly)
   const setPassword = useCollabStore((s) => s.setPassword)
+  const iceServers = useCollabStore((s) => s.iceServers)
+  const setIceServers = useCollabStore((s) => s.setIceServers)
   const start = useCollabStore((s) => s.start)
   const stop = useCollabStore((s) => s.stop)
   const discovered = useCollabStore((s) => s.discovered)
@@ -74,6 +77,10 @@ export const CollabPanel = () => {
 
   const [copied, setCopied] = useState(false)
   const active = status === 'on' || status === 'connecting'
+  // Verworfene Zeilen benennen statt sie stumm zu schlucken: eine
+  // ignorierte Zeile sieht im Feld genauso aus wie eine akzeptierte, und
+  // der Nutzer sucht den Fehler dann in coturn statt in seinem Tippfehler.
+  const iceFehler = useMemo(() => ungueltigeIceZeilen(iceServers), [iceServers])
 
   // #516 — Einladungs-Link statt Text-Block: ein klickbarer Link (wie
   // Zoom/Teams), der die App öffnet und Raum/Modus/Signaling/Passwort
@@ -234,6 +241,40 @@ export const CollabPanel = () => {
               onChange={(e) => setPassword(e.target.value)}
               placeholder={t('collab.password.placeholder', 'verschlüsselt den Raum')}
             />
+          </label>
+        )}
+
+        {/* B-37 — STUN/TURN. Ohne eigene Server gelten die y-webrtc-Defaults:
+            die genügen im LAN und scheitern zwischen zwei Netzen hinter
+            symmetrischem NAT. `docs/self-hosted-relay.md` beschrieb dieses
+            Feld, bevor es es gab. */}
+        {mode === 'webrtc' && (
+          <label className="space-y-1">
+            <span className="block text-cp-xs text-[var(--cp-text-muted)]">
+              {t('collab.ice', 'STUN-/TURN-Server')}
+              <span className="text-[var(--cp-text-faint)]"> ({t('collab.optional', 'optional')})</span>
+            </span>
+            <textarea
+              rows={2}
+              spellCheck={false}
+              autoComplete="off"
+              className="w-full rounded border border-[var(--cp-border)] bg-[var(--cp-surface-3)] px-2 py-1 font-mono text-cp-xs disabled:opacity-50"
+              value={iceServers}
+              disabled={active}
+              onChange={(e) => setIceServers(e.target.value)}
+              placeholder={'turn:turn.example.com:3478|benutzer|geheim'}
+            />
+            <span className="block text-cp-xs text-[var(--cp-text-faint)]">
+              {t(
+                'collab.ice.hint',
+                'Eine Zeile je Server: URL|Benutzer|Passwort. Nur nötig, wenn die Gegenstelle in einem anderen Netz sitzt. Die Zugangsdaten bleiben auf diesem Rechner — sie stehen nicht im Einladungslink.',
+              )}
+            </span>
+            {iceFehler.length > 0 && (
+              <span className="block text-cp-xs text-[var(--cp-danger)]">
+                {t('collab.ice.invalid', 'Nicht verwertbar:')} {iceFehler.join(' · ')}
+              </span>
+            )}
           </label>
         )}
       </div>

--- a/src/renderer/lib/crdt/iceServers.ts
+++ b/src/renderer/lib/crdt/iceServers.ts
@@ -1,0 +1,80 @@
+// ───────────────────────────────────────────────────────────────────────────
+// ICE-/TURN-Server für die WebRTC-Kollaboration.
+//
+// WARUM ES DAS GIBT. `docs/self-hosted-relay.md` erklaert seit jeher die
+// coturn-Installation und weist den Nutzer dann an, die Zugangsdaten „in der
+// App unter Zusammenarbeit -> ICE-Server (bzw. via `iceServers`-Feld)"
+// einzutragen. Beides gab es nicht: `iceServers` kam im gesamten `src/` nicht
+// vor, und `attachWebrtcProvider` reichte an y-webrtc nur `signaling` und
+// `password` durch. Wer der Anleitung folgte, hatte einen laufenden
+// TURN-Server, den nichts benutzte — und keinen Hinweis, warum die Verbindung
+// zwischen zwei Standorten trotzdem scheiterte (B-37).
+//
+// Die Seite existiert fuer genau den Fall, in dem STUN nicht reicht: zwei
+// Netze hinter symmetrischem NAT. Dort ist TURN nicht Komfort, sondern die
+// Bedingung dafuer, dass ueberhaupt eine Verbindung zustande kommt.
+//
+// EINGABEFORMAT. Eine Zeile je Server:
+//
+//   stun:stun.example.com:3478
+//   turn:turn.example.com:3478|benutzer|geheim
+//   turns:turn.example.com:5349|benutzer|geheim
+//
+// Trennzeichen ist `|` und nicht `:` oder `@`: TURN-Passwoerter aus
+// `lt-cred-mech` enthalten regelmaessig beides, und ein Format, das an einem
+// gueltigen Passwort zerbricht, ist schlimmer als eines, das haesslich
+// aussieht.
+//
+// WAS HIER NICHT PASSIERT: Die Zugangsdaten wandern weder in den
+// Einladungslink noch in die mDNS-Ankuendigung der Session. Ein Einladungslink
+// wird in einen Chat gepastet; ein TURN-Passwort, das dort mitfaehrt, ist
+// damit veroeffentlicht. Jeder Teilnehmer traegt seinen eigenen Server ein —
+// das steht so auch in `docs/self-hosted-relay.md`.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Schemata, die ein ICE-Server-URL tragen darf. Alles andere ist ein Tippfehler. */
+const ERLAUBTE_SCHEMATA = ['stun:', 'stuns:', 'turn:', 'turns:']
+
+export interface IceServerConfig {
+  urls: string
+  username?: string
+  credential?: string
+}
+
+/**
+ * Liest das Eingabefeld in eine `RTCIceServer`-Liste.
+ *
+ * Bewusst tolerant gegenueber Leerzeilen und Rand-Leerraum, bewusst streng
+ * gegenueber unbekannten Schemata: eine stillschweigend verworfene Zeile sieht
+ * im Feld genauso aus wie eine akzeptierte, und der Nutzer sucht den Fehler
+ * dann in coturn statt in seinem Tippfehler. Deshalb meldet
+ * `pruefeIceServers` die verworfenen Zeilen namentlich zurueck.
+ */
+export const parseIceServers = (raw: string): IceServerConfig[] => gelesen(raw).server
+
+/** Zeilen, die kein bekanntes Schema tragen — fuer die Anzeige im Panel. */
+export const ungueltigeIceZeilen = (raw: string): string[] => gelesen(raw).ungueltig
+
+const gelesen = (raw: string): { server: IceServerConfig[]; ungueltig: string[] } => {
+  const server: IceServerConfig[] = []
+  const ungueltig: string[] = []
+  for (const zeile of (raw ?? '').split(/\r?\n/)) {
+    const text = zeile.trim()
+    if (!text) continue
+    const [url, benutzer, passwort] = text.split('|').map((t) => t.trim())
+    if (!url || !ERLAUBTE_SCHEMATA.some((s) => url.toLowerCase().startsWith(s))) {
+      ungueltig.push(text)
+      continue
+    }
+    // Ein TURN-Server ohne Zugangsdaten weist jede Allocation ab. Das ist kein
+    // Tippfehler im Schema, aber es ist auch kein brauchbarer Eintrag — als
+    // ungueltig melden statt ihn scheinbar zu uebernehmen.
+    const brauchtZugang = url.toLowerCase().startsWith('turn')
+    if (brauchtZugang && !(benutzer && passwort)) {
+      ungueltig.push(text)
+      continue
+    }
+    server.push(benutzer && passwort ? { urls: url, username: benutzer, credential: passwort } : { urls: url })
+  }
+  return { server, ungueltig }
+}

--- a/src/renderer/lib/crdt/webrtcProvider.ts
+++ b/src/renderer/lib/crdt/webrtcProvider.ts
@@ -19,6 +19,7 @@
 
 import type { ProjectCrdt } from './projectCrdt'
 import type { AwarenessLike } from './presence'
+import type { IceServerConfig } from './iceServers'
 
 export interface WebrtcOptions {
   /** Signaling-Server. Default: öffentliche y-webrtc-Server. Für LAN-only
@@ -26,7 +27,32 @@ export interface WebrtcOptions {
   signaling?: string[]
   /** Optionales Raum-Passwort (E2E-Verschlüsselung der Updates). */
   password?: string
+  /** Eigene STUN-/TURN-Server (B-37). Ohne Angabe gelten die Default-STUN-
+   *  Server von y-webrtc — die genügen im LAN und scheitern zwischen zwei
+   *  Netzen hinter symmetrischem NAT. */
+  iceServers?: IceServerConfig[]
 }
+
+/**
+ * Das Optionen-Objekt, das an `new WebrtcProvider` geht — als eigene, reine
+ * Funktion, damit die Weitergabe messbar ist und nicht nur behauptet.
+ *
+ * Das war der eigentliche Befund hinter B-37: `iceServers` ins Interface zu
+ * schreiben kostet eine Zeile, und ob der Wert unten auch ankommt, sieht man
+ * einer Typdefinition nicht an. `tests/iceServerErreichenDenProvider.test.ts`
+ * prüft deshalb dieses Objekt, nicht den Typ.
+ */
+export const webrtcProviderOptions = (opts: WebrtcOptions) => ({
+  signaling: opts.signaling,
+  password: opts.password,
+  // y-webrtc reicht `peerOpts` unverändert an simple-peer weiter, das daraus
+  // die RTCPeerConnection baut. Nur gesetzt, wenn wirklich Server konfiguriert
+  // sind: ein leeres `iceServers: []` würde die Defaults ABSCHALTEN statt sie
+  // zu ergänzen — dann fände sich im LAN gar nichts mehr.
+  ...(opts.iceServers && opts.iceServers.length > 0
+    ? { peerOpts: { config: { iceServers: opts.iceServers } } }
+    : {}),
+})
 
 export interface WebrtcHandle {
   /** Trennt die Verbindung und gibt den Provider frei. Das Doc bleibt. */
@@ -48,10 +74,7 @@ export const attachWebrtcProvider = async (
   opts: WebrtcOptions = {},
 ): Promise<WebrtcHandle> => {
   const { WebrtcProvider } = await import('y-webrtc')
-  const provider = new WebrtcProvider(room, crdt.doc, {
-    signaling: opts.signaling,
-    password: opts.password,
-  })
+  const provider = new WebrtcProvider(room, crdt.doc, webrtcProviderOptions(opts))
   return {
     awareness: provider.awareness as unknown as AwarenessLike,
     disconnect: () => {

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -100,6 +100,10 @@ export const en: Dict = {
   'collab.password': 'Room password',
   'collab.optional': 'optional',
   'collab.password.placeholder': 'encrypts the room',
+  'collab.ice': 'STUN/TURN servers',
+  'collab.ice.hint':
+    'One server per line: URL|user|password. Only needed when the other side sits in a different network. The credentials stay on this machine — they are not part of the invite link.',
+  'collab.ice.invalid': 'Not usable:',
   'collab.webrtc.noPassword':
     'Without a room password the room is unencrypted: anyone who knows the room name and signaling server (or finds the session on the LAN) can read the entire project. Set a password and share it only with your team.',
   'collab.peers.aloneTitle': 'Only you in the room',

--- a/src/renderer/store/collabStore.ts
+++ b/src/renderer/store/collabStore.ts
@@ -8,6 +8,7 @@
 import { create } from 'zustand'
 import { startCollaboration, type CollabMode, type CollabSession } from '../lib/crdt/collab'
 import { colorForId, type PresencePeer } from '../lib/crdt/presence'
+import { parseIceServers } from '../lib/crdt/iceServers'
 import { cablePlannerApi, hasDesktopBridge, type DiscoveredCollabSession } from '../lib/bridge'
 import { useUiStore } from './uiStore'
 import { useProjectStore } from './projectStore'
@@ -32,6 +33,11 @@ interface PersistedCollab {
    *  ausschließlich das lokale Netz (LAN-Signaling). Für sensible Umgebungen —
    *  nichts verlässt das eigene Netzwerk. */
   localOnly: boolean
+  /** Eigene STUN-/TURN-Server, Rohtext aus dem Panel (eine Zeile je Server,
+   *  `url|benutzer|passwort`). Rohtext und nicht die geparste Liste, damit ein
+   *  Tippfehler beim naechsten Oeffnen noch sichtbar ist statt still
+   *  verschwunden zu sein. Siehe `lib/crdt/iceServers.ts` (B-37). */
+  iceServers: string
 }
 
 const COLLAB_KEY = 'cable-planner.collab'
@@ -42,7 +48,7 @@ const COLLAB_KEY = 'cable-planner.collab'
  *  Discovery weiter, während im LAN der lokale Server gewinnt. */
 const PUBLIC_SIGNALING_FALLBACK = 'wss://y-webrtc-eu.fly.dev'
 
-const defaults: PersistedCollab = { mode: 'broadcast', room: 'cable-planner', name: '', signaling: '', password: '', localOnly: false }
+const defaults: PersistedCollab = { mode: 'broadcast', room: 'cable-planner', name: '', signaling: '', password: '', localOnly: false, iceServers: '' }
 
 /** Stabile Peer-Id pro Fenster/Tab. Bewusst sessionStorage (NICHT
  *  localStorage): mehrere Fenster derselben Maschine teilen sich
@@ -75,10 +81,35 @@ const load = (): PersistedCollab => {
       signaling: typeof p.signaling === 'string' ? p.signaling : defaults.signaling,
       password: typeof p.password === 'string' ? p.password : defaults.password,
       localOnly: typeof p.localOnly === 'boolean' ? p.localOnly : defaults.localOnly,
+      iceServers: typeof p.iceServers === 'string' ? p.iceServers : defaults.iceServers,
     }
   } catch {
     return defaults
   }
+}
+
+/**
+ * Einziger Schreibweg der Setter.
+ *
+ * Vorher wiederholte jeder der sechs Setter die vollstaendige Feldliste. Ein
+ * neues Feld haette in allen sechs ergaenzt werden muessen, und genau eine
+ * vergessene Stelle faellt niemandem auf: die Einstellung wirkt in der
+ * laufenden Sitzung und ist nach dem Neustart weg. Die Liste kommt jetzt aus
+ * `defaults` — ein Feld, das dort steht, wird zwangslaeufig mitgeschrieben.
+ */
+const merkeUndSetze = (
+  set: (patch: Partial<CollabState>) => void,
+  get: () => CollabState,
+  patch: Partial<PersistedCollab>,
+) => {
+  const zustand = get()
+  const raus = {} as PersistedCollab
+  for (const key of Object.keys(defaults) as (keyof PersistedCollab)[]) {
+    const wert = key in patch ? patch[key] : zustand[key]
+    ;(raus as unknown as Record<string, unknown>)[key] = wert
+  }
+  persist(raus)
+  set(patch as Partial<CollabState>)
 }
 
 const persist = (s: PersistedCollab) => {
@@ -118,6 +149,8 @@ interface CollabState {
   name: string
   signaling: string
   password: string
+  /** Rohtext der eigenen STUN-/TURN-Server (B-37). */
+  iceServers: string
   error?: string
   peers: PresencePeer[]
   selfId: string
@@ -136,6 +169,7 @@ interface CollabState {
   setPassword: (password: string) => void
   localOnly: boolean
   setLocalOnly: (localOnly: boolean) => void
+  setIceServers: (iceServers: string) => void
   /** Startet eine Session. `adopt` (Beitreten): eigenen Plan NICHT seeden, den
    *  Plan des Hosts übernehmen, und keinen eigenen Signaling-Server starten. */
   start: (opts?: { adopt?: boolean }) => Promise<void>
@@ -156,6 +190,7 @@ export const useCollabStore = create<CollabState>((set, get) => ({
   signaling: initial.signaling,
   password: initial.password,
   localOnly: initial.localOnly,
+  iceServers: initial.iceServers,
   error: undefined,
   peers: [],
   selfId,
@@ -164,34 +199,17 @@ export const useCollabStore = create<CollabState>((set, get) => ({
   discovered: [],
   discovering: false,
 
-  setMode: (mode) => {
-    persist({ mode, room: get().room, name: get().name, signaling: get().signaling, password: get().password, localOnly: get().localOnly })
-    set({ mode })
-  },
-  setRoom: (room) => {
-    persist({ mode: get().mode, room, name: get().name, signaling: get().signaling, password: get().password, localOnly: get().localOnly })
-    set({ room })
-  },
-  setName: (name) => {
-    persist({ mode: get().mode, room: get().room, name, signaling: get().signaling, password: get().password, localOnly: get().localOnly })
-    set({ name })
-  },
-  setSignaling: (signaling) => {
-    persist({ mode: get().mode, room: get().room, name: get().name, signaling, password: get().password, localOnly: get().localOnly })
-    set({ signaling })
-  },
-  setPassword: (password) => {
-    persist({ mode: get().mode, room: get().room, name: get().name, signaling: get().signaling, password, localOnly: get().localOnly })
-    set({ password })
-  },
-  setLocalOnly: (localOnly) => {
-    persist({ mode: get().mode, room: get().room, name: get().name, signaling: get().signaling, password: get().password, localOnly })
-    set({ localOnly })
-  },
+  setMode: (mode) => merkeUndSetze(set, get, { mode }),
+  setRoom: (room) => merkeUndSetze(set, get, { room }),
+  setName: (name) => merkeUndSetze(set, get, { name }),
+  setSignaling: (signaling) => merkeUndSetze(set, get, { signaling }),
+  setPassword: (password) => merkeUndSetze(set, get, { password }),
+  setLocalOnly: (localOnly) => merkeUndSetze(set, get, { localOnly }),
+  setIceServers: (iceServers) => merkeUndSetze(set, get, { iceServers }),
 
   start: async (opts) => {
     const adopt = opts?.adopt === true
-    const { status, mode, room, name, signaling, password, session, localOnly } = get()
+    const { status, mode, room, name, signaling, password, session, localOnly, iceServers } = get()
     if (status === 'connecting' || status === 'on') return
     if (session) session.stop()
     set({ status: 'connecting', error: undefined, session: null, peers: [] })
@@ -222,12 +240,21 @@ export const useCollabStore = create<CollabState>((set, get) => ({
     }
 
     const pw = password.trim()
+    // B-37: eigene STUN-/TURN-Server. Sie gehen NUR an den lokalen Provider —
+    // weder in den Einladungslink noch in die mDNS-Ankündigung (siehe
+    // `lib/crdt/iceServers.ts`): ein Einladungslink wird in einen Chat
+    // gepastet, und ein TURN-Passwort, das dort mitfährt, ist veröffentlicht.
+    const ice = parseIceServers(iceServers)
     // Nur ein WebRTC-Options-Objekt bauen, wenn es etwas zu setzen gibt
-    // (Signaling und/oder Passwort). Das Passwort verschlüsselt den Raum E2E —
-    // nur Peers mit demselben Passwort können das Projekt lesen.
+    // (Signaling, Passwort und/oder ICE-Server). Das Passwort verschlüsselt den
+    // Raum E2E — nur Peers mit demselben Passwort können das Projekt lesen.
     const webrtcOpts =
-      signalingList.length > 0 || pw
-        ? { ...(signalingList.length > 0 ? { signaling: signalingList } : {}), ...(pw ? { password: pw } : {}) }
+      signalingList.length > 0 || pw || ice.length > 0
+        ? {
+            ...(signalingList.length > 0 ? { signaling: signalingList } : {}),
+            ...(pw ? { password: pw } : {}),
+            ...(ice.length > 0 ? { iceServers: ice } : {}),
+          }
         : undefined
     try {
       const s = await startCollaboration({

--- a/tests/iceServerErreichenDenProvider.test.ts
+++ b/tests/iceServerErreichenDenProvider.test.ts
@@ -1,0 +1,127 @@
+// ───────────────────────────────────────────────────────────────────────────
+// B-37 — Die eingetragenen TURN-Server erreichen den Provider.
+//
+// WARUM DIESER TEST DAS OBJEKT PRUEFT UND NICHT DEN TYP. `docs/self-hosted-relay.md`
+// beschrieb ein `iceServers`-Feld, das es nirgends gab: `grep -rn iceServers src/`
+// lieferte null Treffer, und `attachWebrtcProvider` reichte an y-webrtc nur
+// `signaling` und `password` durch. Wer der Anleitung folgte, hatte einen
+// laufenden coturn, den nichts benutzte.
+//
+// Ein Feld ins Interface zu schreiben kostet eine Zeile, und ob der Wert unten
+// ankommt, sieht man einer Typdefinition nicht an — genau diese Luecke war der
+// Befund. Deshalb prueft dieser Test das Objekt, das `new WebrtcProvider`
+// tatsaechlich bekommt (`webrtcProviderOptions`), und nicht, dass ein Feld
+// existiert.
+// ───────────────────────────────────────────────────────────────────────────
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { webrtcProviderOptions } from '../src/renderer/lib/crdt/webrtcProvider'
+import { parseIceServers, ungueltigeIceZeilen } from '../src/renderer/lib/crdt/iceServers'
+import { buildInviteLink } from '../src/renderer/lib/collabInvite'
+
+describe('das Eingabefeld', () => {
+  it('liest STUN ohne und TURN mit Zugangsdaten', () => {
+    const roh = ['stun:stun.example.com:3478', 'turn:turn.example.com:3478|lars|geheim'].join('\n')
+    expect(parseIceServers(roh)).toEqual([
+      { urls: 'stun:stun.example.com:3478' },
+      { urls: 'turn:turn.example.com:3478', username: 'lars', credential: 'geheim' },
+    ])
+  })
+
+  it('trennt an `|`, damit ein Passwort `:` und `@` enthalten darf', () => {
+    // Der Grund fuer das ungewoehnliche Trennzeichen: coturn-Passwoerter aus
+    // `lt-cred-mech` enthalten beides regelmaessig. Ein Format, das an einem
+    // gueltigen Passwort zerbricht, ist schlimmer als eines, das haesslich
+    // aussieht.
+    expect(parseIceServers('turns:turn.example.com:5349|user@host|a:b@c')).toEqual([
+      { urls: 'turns:turn.example.com:5349', username: 'user@host', credential: 'a:b@c' },
+    ])
+  })
+
+  it('meldet unbrauchbare Zeilen, statt sie stumm zu schlucken', () => {
+    const roh = [
+      'wss://relay.example.com', // Signaling-Server, hier falsch eingetragen
+      'turn:turn.example.com:3478', // TURN ohne Zugangsdaten weist jede Allocation ab
+      '  ',
+      'stun:stun.example.com:3478',
+    ].join('\n')
+    expect(ungueltigeIceZeilen(roh)).toEqual(['wss://relay.example.com', 'turn:turn.example.com:3478'])
+    expect(parseIceServers(roh)).toEqual([{ urls: 'stun:stun.example.com:3478' }])
+  })
+
+  it('ein leeres Feld ergibt keine Server', () => {
+    expect(parseIceServers('')).toEqual([])
+    expect(parseIceServers('\n \n')).toEqual([])
+  })
+})
+
+describe('die Weitergabe an y-webrtc', () => {
+  it('legt die Server unter peerOpts.config.iceServers ab', () => {
+    // Das ist der Pfad, den simple-peer in die RTCPeerConnection reicht.
+    // Steht der Wert woanders, ist er wirkungslos und nichts meldet es.
+    const opts = webrtcProviderOptions({
+      signaling: ['wss://relay.example.com'],
+      iceServers: [{ urls: 'turn:turn.example.com:3478', username: 'lars', credential: 'geheim' }],
+    })
+    expect(opts).toMatchObject({
+      signaling: ['wss://relay.example.com'],
+      peerOpts: {
+        config: {
+          iceServers: [{ urls: 'turn:turn.example.com:3478', username: 'lars', credential: 'geheim' }],
+        },
+      },
+    })
+  })
+
+  it('ohne konfigurierte Server bleibt peerOpts WEG, nicht leer', () => {
+    // Ein leeres `iceServers: []` schaltet die Defaults von y-webrtc ab, statt
+    // sie zu ergaenzen — dann faende sich auch im LAN nichts mehr. Der
+    // Unterschied zwischen „nicht gesetzt" und „leer gesetzt" ist hier der
+    // Unterschied zwischen „funktioniert" und „funktioniert nirgends".
+    expect(webrtcProviderOptions({ signaling: ['wss://x'] })).not.toHaveProperty('peerOpts')
+    expect(webrtcProviderOptions({ signaling: ['wss://x'], iceServers: [] })).not.toHaveProperty('peerOpts')
+  })
+
+  it('Signaling und Passwort gehen unveraendert weiter', () => {
+    const opts = webrtcProviderOptions({ signaling: ['wss://x'], password: 'geheim' })
+    expect(opts.signaling).toEqual(['wss://x'])
+    expect(opts.password).toBe('geheim')
+  })
+})
+
+describe('die Zugangsdaten verlassen den Rechner nicht', () => {
+  // Ein Einladungslink wird in einen Chat gepastet. Ein TURN-Passwort, das
+  // dort mitfaehrt, ist damit veroeffentlicht -- und zwar an eine Stelle, die
+  // niemand spaeter widerruft. Das Raum-Passwort steht bewusst drin (ohne es
+  // kann der Eingeladene nicht beitreten); die TURN-Zugangsdaten gehoeren dem
+  // Server-Betreiber und haben dort nichts zu suchen.
+
+  it('buildInviteLink nimmt nur benannte Felder, nicht das ganze Objekt', () => {
+    // Der eigentliche Schutz ist, dass die Funktion eine Positivliste baut und
+    // nicht spreizt. Mit einem Kanarienwert gemessen statt im Kommentar
+    // behauptet: waere es ein Spread, stuende er im Link.
+    const link = buildInviteLink({
+      mode: 'webrtc',
+      room: 'raum',
+      signaling: 'wss://relay.example.com',
+      ...({ iceServers: 'turn:turn.example.com:3478|lars|KANARIENVOGEL' } as Record<string, string>),
+    })
+    const nutzlast = atob(link.split('#join=')[1].replace(/-/g, '+').replace(/_/g, '/'))
+    expect(nutzlast).not.toContain('KANARIENVOGEL')
+    expect(nutzlast).not.toContain('iceServers')
+    expect(nutzlast).toContain('wss://relay.example.com')
+  })
+
+  it('weder der Einladungslink noch die mDNS-Ankuendigung kennen das Feld', () => {
+    // Zweite, grobere Sperre fuer den Fall, dass jemand das Feld doch in die
+    // Positivliste aufnimmt: dann faellt es hier auf, bevor es ausgeliefert ist.
+    const wurzel = join(__dirname, '..', 'src', 'renderer')
+    const invite = readFileSync(join(wurzel, 'lib', 'collabInvite.ts'), 'utf8')
+    expect(invite, 'Der Einladungslink darf keine TURN-Zugangsdaten tragen.').not.toMatch(/iceServers/)
+
+    const store = readFileSync(join(wurzel, 'store', 'collabStore.ts'), 'utf8')
+    const ankuendigung = store.slice(store.indexOf('const advertiseSession'), store.indexOf('const unadvertiseSession'))
+    expect(ankuendigung, 'Die mDNS-Ankuendigung geht an jeden im LAN.').not.toMatch(/iceServers/)
+  })
+})


### PR DESCRIPTION
## Der Befund

`docs/self-hosted-relay.md:51` erklärt die coturn-Installation vollständig und weist dann an:

> Die TURN-Zugangsdaten trägst du in der App unter **Zusammenarbeit → ICE-Server** ein (bzw. via `iceServers`-Feld).

Beides gab es nicht.

| Geprüft | Ergebnis |
|---|---|
| `grep -rn iceServers src/` | **0 Treffer** |
| `CollabPanel.tsx` | genau ein Server-Feld — der Signaling-Server |
| `webrtcProvider.ts:51` | reicht an `WebrtcProvider` nur `signaling` und `password` durch |

Wer der Anleitung folgte, hatte einen laufenden TURN-Server, den nichts benutzte — und keinen Hinweis darauf, warum die Verbindung zwischen zwei Standorten trotzdem scheiterte. Die Seite existiert für genau den Fall, in dem STUN nicht reicht: zwei Netze hinter symmetrischem NAT. Dort ist TURN nicht Komfort, sondern die Bedingung dafür, dass überhaupt eine Verbindung zustande kommt.

Deshalb nicht die Doku gestrichen, sondern das Feld gebaut.

## Was dazukam

- **`lib/crdt/iceServers.ts`** — Parser für das Eingabefeld. Eine Zeile je Server, Felder mit `|` getrennt:
  ```
  stun:stun.example.com:3478
  turn:turn.example.com:3478|benutzer|geheim
  ```
  `|` und nicht `:` oder `@`, weil coturn-Passwörter aus `lt-cred-mech` beides regelmäßig enthalten. Ein Format, das an einem gültigen Passwort zerbricht, ist schlimmer als eines, das hässlich aussieht.
- **`webrtcProviderOptions`** — das Objekt für `new WebrtcProvider`, als eigene reine Funktion. Ein Feld ins Interface zu schreiben kostet eine Zeile, und ob der Wert unten ankommt, sieht man einer Typdefinition nicht an. Genau diese Lücke war der Befund, also prüft der Test das Objekt und nicht den Typ.
- **Leere Liste heißt nicht `iceServers: []`.** Das würde die y-webrtc-Defaults *abschalten* statt sie zu ergänzen — dann fände sich auch im LAN nichts mehr. Ohne konfigurierte Server bleibt `peerOpts` ganz weg.
- **`CollabPanel`** — Feld plus Anzeige der verworfenen Zeilen. Eine ignorierte Zeile sieht im Feld genauso aus wie eine akzeptierte; der Nutzer suchte den Fehler sonst in coturn statt in seinem Tippfehler. Ein `turn:` ohne Zugangsdaten (weist jede Allocation ab) gilt dabei ebenfalls als unbrauchbar.

## Die Nebenbaustelle im Store

`collabStore` hatte sechs Setter, von denen jeder die vollständige Feldliste wiederholte. Ein neues Feld hätte in allen sechs ergänzt werden müssen — und genau eine vergessene Stelle fällt niemandem auf: die Einstellung wirkt in der laufenden Sitzung und ist nach dem Neustart weg. Der Schreibweg leitet die Liste jetzt aus `defaults` ab; ein Feld, das dort steht, wird zwangsläufig mitgeschrieben.

## Die Zugangsdaten verlassen den Rechner nicht

Sie gehen **nur** an den lokalen Provider — weder in den Einladungslink noch in die mDNS-Ankündigung der Session. Ein Einladungslink wird in einen Chat gepastet; ein TURN-Passwort, das dort mitfährt, ist damit an einer Stelle veröffentlicht, die niemand später widerruft. Das Raum-Passwort steht bewusst drin (ohne es kann der Eingeladene nicht beitreten); die TURN-Zugangsdaten gehören dem Server-Betreiber. Jeder Teilnehmer trägt seinen eigenen ein — so steht es jetzt auch in der Doku.

Gemessen statt behauptet: der Test baut einen Invite mit einem Kanarienwert im `iceServers`-Feld und prüft, dass er in der Nutzlast nicht auftaucht — das belegt, dass `buildInviteLink` eine Positivliste baut und nicht spreizt. Eine zweite, gröbere Sperre prüft, dass weder `collabInvite.ts` noch die mDNS-Ankündigung das Feld überhaupt kennen.

## Gegenprobe

Mit entferntem `peerOpts` und mit durchgereichtem `iceServers` im Invite fallen **drei** Tests rot (Provider-Weitergabe, Kanarienwert, Quellsperre); nach dem Zurücksetzen wieder grün.

## Validierung

- `npm test` — **999 Tests, 101 Dateien**, grün
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm run lint` — 0 Errors (10 vorbestehende Warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_