### PR TITLE
docs(architektur): drei Aussagen berichtigt, die gegen den Code messbar sind

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,8 +58,8 @@ strukturellen Änderungen.** Hier nur das Nötigste zum schnellen Einstieg:
   **Bleibt CommonJS** — niemals auf ESM umstellen.
 - `src/renderer/` — React-App. **Kein Node-Zugriff**; alles File-/Netzwerk-IO
   läuft über IPC.
-- `src/mobile/` — statische LAN-View, von `mobileShareServer` (Express) an
-  Smartphones ausgeliefert. Kein Editor, aber auch nicht read-only: drei
+- `src/mobile/` — statische LAN-View, von `mobileShareServer` (`node:http`, kein
+  Express) an Smartphones ausgeliefert. Kein Editor, aber auch nicht read-only: drei
   token-gated Schreibwege zurück (`/checks`, `/cables`, `/pending-changes`).
 - `src/viewer/` — eigener Vite-Entry (`viewer.html`) für read-only Web-Viewer,
   auf GitHub Pages deployt.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,7 @@ plus einem optionalen HTTP-Renderer für Mobile-Geräte.
            v
 +-----------------------+
 |  mobileShareServer    |
-|  Express (ephemeral)  |
+|  node:http (ephemeral)|
 |  serves src/mobile/   |
 +-----------------------+
 ```
@@ -367,7 +367,8 @@ Score-Schwelle).
 
 ### 6.6 · Mobile-Share
 
-`mobileShareServer.ts` startet Express auf ephemerem Port,
+`mobileShareServer.ts` startet einen `node:http`-Server auf ephemerem Port
+(kein Express — die App hat kein Web-Framework als Abhängigkeit),
 liefert `src/mobile/` an Smartphones im LAN. Bidirektional:
 - Main → Mobile: aktuelle Projekt-Snapshot (Pull-Endpunkt), Passwörter und
   Schlüssel vorher via `stripSecrets` entfernt.
@@ -415,7 +416,9 @@ nirgendwo hardcoded.
 
 **Native Deps** (achten!):
 - `keytar` — OS-Credentials (Rentman-Token).
-- `@julusian/freetype2` (transitiv via Three) — GreenGo-PDF-Export-Fonts.
+- `@julusian/freetype2` — **transitiv via `atem-connection`**, nicht via Three
+  und nirgends direkt importiert (`grep -rn freetype src/` ist leer). Er steht
+  hier trotzdem, weil `npmRebuild` ihn für die Electron-ABI neu bauen muss.
 - `electron-rebuild` muss nach jedem Electron-Update laufen.
 
 ---
@@ -430,7 +433,15 @@ Das Wichtigste in Listenform. Niemals brechen ohne expliziten Architektur-Review
 4. **`preload.cts` bleibt CommonJS** — Electron's contextBridge braucht das.
 5. **Pfad-Validierung passiert in `main`**, nie im Renderer.
 6. **`projectStore` ist Single Source of Truth** für Projekt-Daten.
-7. **Three.js-Imports nur in `components/Rack/`** — Bundle-Size-Schutz.
+7. **Three.js bleibt hinter der Lazy-Grenze** — Bundle-Size-Schutz. Der
+   Import-*Ort* ist dabei nicht das Kriterium: solange ein statisch
+   importiertes Modul nach `Rack/` hineinreicht, liegt Three im Haupt-Chunk,
+   egal wie diszipliniert die Importe sind. Genau so war es — bis auf
+   `lib/exportRack.ts` standen alle Three-Importe brav in `Rack/`, und
+   `LibraryPanel` zog den `RackBuilderDialog` statisch herein. Die beiden
+   Eintritte (`RackBuilderDialog`, `RackEditorDialog`) sind deshalb `lazy` und
+   werden nur gemountet, wenn sie offen sind; gemessen 4.193 → 2.938 kB (gzip
+   1.165 → 822). `tests/threeBundleGrenze.test.ts` hält das fest.
 8. **Connection-Locks bei externen Services** (ATEM `connectInFlight`).
 9. **Patch-Versionen bevorzugt** — keine großen Sprünge (Standing User Directive).
 10. **Keine Emojis im Code** außer auf expliziten Wunsch.

--- a/tests/architekturAussagen.test.ts
+++ b/tests/architekturAussagen.test.ts
@@ -1,0 +1,99 @@
+// ───────────────────────────────────────────────────────────────────────────
+// `docs/architecture.md` ist Pflicht-Lektuere vor strukturellen Aenderungen.
+// Genau deshalb sind falsche Aussagen dort teurer als anderswo: wer sie liest,
+// liest sie STATT in den Code zu sehen.
+//
+// Drei gemessene Befunde (2026-09-04):
+//
+//   (a) „mobileShareServer startet Express" — zweimal, im ASCII-Diagramm und
+//       im Prosa-Abschnitt, und zusaetzlich in `CLAUDE.md`. Die App hat kein
+//       Web-Framework in den Dependencies; `mobileShareServer.ts` nutzt
+//       `node:http`. Wer Express erwartet, sucht Middleware, Router und
+//       `app.use` — und findet nichts davon.
+//   (b) „`@julusian/freetype2` (transitiv via Three)". Er kommt via
+//       `atem-connection`. Die falsche Herkunft ist keine Kleinigkeit: sie
+//       legt nahe, dass ein Three-Update den nativen Rebuild betrifft.
+//   (c) Invariante 7 lautete „Three.js-Imports nur in `components/Rack/`".
+//       `lib/exportRack.ts` importiert Three und tat das schon damals. Der
+//       Satz war ausserdem in der Sache irrefuehrend — was den Bundle klein
+//       haelt, ist die Lazy-Grenze, nicht der Import-Ort.
+//
+// WAS DIESER TEST NICHT PRUEFT: die Doku als ganze. Er prueft die drei
+// Aussagen, die sich gegen den Code rechnen lassen — und (c) als Regel ueber
+// ALLE Three-Importe statt ueber die zwei bekannten Dateien.
+// ───────────────────────────────────────────────────────────────────────────
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const ROOT = join(__dirname, '..')
+const doku = readFileSync(join(ROOT, 'docs', 'architecture.md'), 'utf8')
+const paket = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')) as {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+}
+
+describe('die Doku nennt keine Abhaengigkeit, die es nicht gibt', () => {
+  it('Express steht weder im package.json noch als Behauptung in der Doku', () => {
+    // Beide Richtungen, damit die Aussage nicht einseitig veraltet: kaeme
+    // Express je dazu, muesste die „kein Express"-Klammer wieder weg.
+    const hatExpress = Boolean(paket.dependencies?.express || paket.devDependencies?.express)
+    expect(hatExpress, 'Express ist neu dabei — dann stimmt die Doku-Klammer nicht mehr.').toBe(false)
+    expect(doku, 'Die Doku behauptet wieder Express.').not.toMatch(/startet Express/)
+  })
+
+  it('freetype2 wird nicht Three zugeschrieben', () => {
+    // Er ist keine direkte Abhaengigkeit; die Herkunft steht in
+    // `atem-connection`. Eine falsche Herkunftsangabe schickt den naechsten
+    // Leser beim naechsten nativen Rebuild in die falsche Richtung.
+    expect(paket.dependencies?.['@julusian/freetype2']).toBeUndefined()
+    expect(doku).not.toMatch(/freetype2[^\n]*transitiv via Three/)
+    expect(doku).toMatch(/freetype2[^\n]*atem-connection/)
+  })
+})
+
+describe('Invariante 7 sagt, was gilt', () => {
+  /** Alle Renderer-Dateien, die Three (oder R3F) importieren — gemessen, nicht gelistet. */
+  const dreiImporte = (): string[] => {
+    const treffer: string[] = []
+    const lauf = (verzeichnis: string) => {
+      for (const eintrag of readdirSync(verzeichnis)) {
+        const pfad = join(verzeichnis, eintrag)
+        if (statSync(pfad).isDirectory()) {
+          lauf(pfad)
+          continue
+        }
+        if (!/\.tsx?$/.test(eintrag)) continue
+        const inhalt = readFileSync(pfad, 'utf8')
+        if (/from\s+['"](three|three-stdlib|@react-three\/[^'"]+)['"]/.test(inhalt)) {
+          treffer.push(relative(join(ROOT, 'src', 'renderer'), pfad))
+        }
+      }
+    }
+    lauf(join(ROOT, 'src', 'renderer'))
+    return treffer.sort()
+  }
+
+  it('es gibt Three-Importe ausserhalb von components/Rack/ — die Invariante darf das nicht leugnen', () => {
+    const aussen = dreiImporte().filter((p) => !p.startsWith(join('components', 'Rack')))
+    // Der Befund ist nicht „es gibt sie", sondern „die Doku behauptete das
+    // Gegenteil". Solange es welche gibt, darf der Satz „nur in
+    // components/Rack/" nicht dastehen.
+    if (aussen.length > 0) {
+      expect(
+        doku,
+        `Three wird auch ausserhalb von components/Rack/ importiert (${aussen.join(', ')}) — ` +
+          'die Invariante darf nicht „Imports nur in components/Rack/" behaupten.',
+      ).not.toMatch(/Three\.js-Imports nur in/)
+    }
+    // Und die heute geltende Formulierung nennt das, was tatsaechlich schuetzt.
+    expect(doku).toMatch(/Three\.js bleibt hinter der Lazy-Grenze/)
+  })
+
+  it('die genannte Ausnahme ist noch die richtige', () => {
+    // `lib/exportRack.ts` ist der einzige Three-Import ausserhalb von `Rack/`.
+    // Kaeme ein zweiter dazu, waere die Erklaerung in der Invariante unvollstaendig.
+    const aussen = dreiImporte().filter((p) => !p.startsWith(join('components', 'Rack')))
+    expect(aussen).toEqual([join('lib', 'exportRack.ts')])
+  })
+})


### PR DESCRIPTION
`docs/architecture.md` ist laut `CLAUDE.md` **Pflicht-Lektüre vor strukturellen Änderungen**. Genau deshalb sind falsche Aussagen dort teurer als anderswo: wer sie liest, liest sie *statt* in den Code zu sehen.

| Aussage | Gemessen |
|---|---|
| „`mobileShareServer` startet **Express**" (ASCII-Diagramm Z. 32, Abschnitt 6.6, und `CLAUDE.md`) | `mobileShareServer.ts:39` importiert `createServer` aus `node:http`. Kein Web-Framework in den Dependencies. |
| „`@julusian/freetype2` (**transitiv via Three**)" | `npm ls` → `cable-planner → atem-connection → @julusian/freetype2`. `grep -rn freetype src/` ist leer. |
| Invariante 7: „**Three.js-Imports nur in `components/Rack/`**" | `lib/exportRack.ts` importiert Three — und tat das schon, als der Satz geschrieben wurde. |

Wer Express erwartet, sucht Middleware, Router und `app.use` und findet nichts davon. Die falsche Herkunft von freetype2 ist ebenfalls keine Kleinigkeit: sie legt nahe, ein Three-Update betreffe den nativen Rebuild — betroffen ist in Wahrheit ein `atem-connection`-Update.

## Invariante 7 war nicht nur unvollständig, sondern in der Sache falsch

Der Import-*Ort* ist nicht das Kriterium. Solange irgendein statisch importiertes Modul nach `Rack/` hineinreicht, liegt Three im Haupt-Chunk — egal wie diszipliniert die Importe sind. Genau so war es: bis auf `lib/exportRack.ts` standen alle Three-Importe in `Rack/`, und `LibraryPanel` zog den `RackBuilderDialog` trotzdem statisch herein. Was gewirkt hat, war die Lazy-Grenze (4.193 → 2.938 kB, gzip 1.165 → 822). Die Invariante sagt das jetzt, mit den Zahlen und mit dem Verweis auf `tests/threeBundleGrenze.test.ts`, der sie hält.

Die drei Korrekturen sind damit auch inhaltlich verschieden: zwei waren veraltete Tatsachenangaben, die dritte war ein falsches mentales Modell, das jemanden dazu gebracht hätte, die falsche Sache zu bewachen.

## Der Guard

`tests/architekturAussagen.test.ts` rechnet alle drei gegen den Code:

- **Express in beide Richtungen** — käme er je als Dependency dazu, muss die „kein Express"-Klammer wieder raus; taucht „startet Express" wieder in der Doku auf, fällt es auf.
- **Herkunft von freetype2** — nicht direkt in `dependencies`, und die Doku darf sie nicht Three zuschreiben.
- **Invariante 7 als Regel über ALLE Three-Importe**, nicht über zwei bekannte Dateien: der Test sammelt jeden Renderer-Import von `three`/`three-stdlib`/`@react-three/*` und verlangt, dass die Invariante keine Ausschließlichkeit behauptet, solange davon etwas außerhalb `components/Rack/` liegt. Ein zweiter Test hält fest, dass `lib/exportRack.ts` heute die einzige solche Datei ist — käme eine zweite dazu, ist die Erklärung in der Invariante unvollständig.

**Gegenprobe gemacht:** mit den alten Formulierungen fallen zwei Tests rot, danach wieder grün.

## Validierung

- `npm test` — **1003 Tests, 102 Dateien**, grün
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_