### PR TITLE
docs: Inhaltsverzeichnis für docs/ + Erreichbarkeits-Guard

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,42 @@
+# Code of Conduct
+
+`CONTRIBUTING.md` said "this project ships a Code of Conduct" and linked to this
+file, which did not exist (measured 2026-09-04). It does now.
+
+This is a short, project-specific document. It is deliberately **not** the
+Contributor Covenant — if you were looking for that text, this is not it.
+
+## What is expected
+
+- Be civil. Disagree with the argument, not the person.
+- Assume the other side is acting in good faith until shown otherwise.
+- Keep technical discussion technical. A bug report is about the bug.
+- Respect the maintainer's time: search before opening, and include what is
+  needed to reproduce.
+
+## What is not acceptable
+
+- Harassment, threats, or personal attacks — in issues, pull requests, commit
+  messages, or private contact arising from this project.
+- Demeaning remarks about a person's origin, gender, sexuality, religion,
+  disability, age, or appearance.
+- Publishing someone's private information without their explicit permission.
+- Persistent disruption after being asked to stop.
+
+## Scope
+
+This applies in every space this project uses — the GitHub repository, its
+issues and pull requests, and any direct contact that starts from them.
+
+## Reporting
+
+Report unacceptable behaviour to **lars@zumpe.dev**. Reports are read by the
+maintainer and handled confidentially. You do not need to have participated in
+the project to report something.
+
+## Consequences
+
+The maintainer may edit or remove comments, close issues or pull requests, and
+block accounts. Which of these applies depends on what happened; a single
+heated message is not the same as a pattern. Where a decision is not obvious,
+the maintainer will say what was decided and why.

--- a/README.md
+++ b/README.md
@@ -246,6 +246,10 @@ npm run dist
 ---
 
 ## 📚 Documentation
+- [**`docs/README.md`**](docs/README.md) — index of everything in `docs/`,
+  grouped by operations, development, domain concepts and dated audits.
+- [`docs/self-hosted-relay.md`](docs/self-hosted-relay.md) — run your own
+  signaling relay and TURN server for live collaboration across networks.
 - [`docs/architecture.md`](docs/architecture.md) — Process model, IPC, store
   architecture, build & release workflow, non-negotiable invariants.
 - [`docs/app-structure.html`](docs/app-structure.html) — interactive module

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,64 @@
+# Dokumentation — Übersicht
+
+Diese Seite ist das Inhaltsverzeichnis für `docs/`. Sie existiert, weil bis zum
+2026-09-04 **zwölf von dreizehn** Dokumenten in diesem Ordner von keiner
+Einstiegsseite aus verlinkt waren — auch nicht
+[`self-hosted-relay.md`](self-hosted-relay.md), also ausgerechnet die Seite, die
+jemand sucht, wenn die Zusammenarbeit über Mobilfunk nicht zustande kommt. Ein
+Dokument, das nur findet, wer den Ordner durchblättert, ist praktisch nicht
+vorhanden. `tests/dokuErreichbar.test.ts` hält das jetzt fest: jedes Dokument
+unter `docs/` muss von einer Einstiegsseite aus über Links erreichbar sein.
+
+## Betrieb & Einrichtung
+
+- [`self-hosted-relay.md`](self-hosted-relay.md) — eigener Signaling-Relay und
+  eigener TURN-Server für die Live-Zusammenarbeit über Mobilfunk oder zwischen
+  zwei Netzen. Enthält die coturn-Einrichtung und das Eingabeformat der
+  STUN-/TURN-Zeilen im Collab-Panel.
+
+## Für Entwicklung
+
+- [`architecture.md`](architecture.md) — Drei-Prozess-Modell, IPC-Domänen,
+  Store-Aufbau, Build/Release und die nicht-verhandelbaren Invarianten.
+  **Pflicht-Lektüre vor strukturellen Änderungen.**
+- [`app-structure.html`](app-structure.html) — interaktive Modulübersicht
+  (im Browser öffnen).
+- [`comparison.html`](comparison.html) — Strukturvergleich mit kommerziellen und
+  frei verfügbaren Alternativen.
+- [`monorepo-plan.md`](monorepo-plan.md) — die Begründung hinter
+  `av-planner-suite`; der Monorepo ist inzwischen umgesetzt.
+
+## Domänen-Konzepte
+
+Diese Dokumente begründen, warum ein Bereich so gebaut ist, wie er gebaut ist.
+Der Status steht jeweils im Kopf des Dokuments — mehrere sind vollständig
+umgesetzt und stehen hier als Begründung, nicht als Vorhaben.
+
+- [`device-identity-concept.md`](device-identity-concept.md) — stabile
+  Gerätetyp-Identität (Datenblatt-GUID) statt Namens-Heuristik.
+- [`inventory-rental-readiness.md`](inventory-rental-readiness.md) — Lager- und
+  Inventarverwaltung für Festinstallation und Vermietung.
+- [`festinstallation-readiness.md`](festinstallation-readiness.md) — was fehlt,
+  damit der Planer dauerhafte Festinstallationen dokumentiert statt nur
+  Show-Verkabelung.
+- [`drum-micing-and-field-builder-concept.md`](drum-micing-and-field-builder-concept.md)
+  — Drum-Mikrofonierung und der Feld-Builder der Audio-Domäne.
+- [`modular-ui-concept.md`](modular-ui-concept.md) — wie die Oberfläche mitwächst,
+  ohne zur eierlegenden Wollmilchsau zu werden.
+
+## Bestandsaufnahmen
+
+Momentaufnahmen mit Datum. Sie werden nicht fortgeschrieben — wer sie liest,
+liest den Stand des genannten Tages.
+
+- [`ui-audit.md`](ui-audit.md) — UI/UX-Bestandsaufnahme und Härtungs-Tracker.
+- [`ux-audit.md`](ux-audit.md) — Renderer-weite UX-Durchsicht (2026-05-29).
+- [`issue-verification-2026-06.md`](issue-verification-2026-06.md) — 320
+  geschlossene Issues gegen den Quellcode nachgeprüft (2026-06-22).
+
+## Material
+
+- [`screenshots/README.md`](screenshots/README.md) — Benennung und Aufnahme der
+  README-Bilder.
+- [`suite-mockup/README.md`](suite-mockup/README.md) — frühe Design-Studie einer
+  gemeinsamen App-Shell.

--- a/tests/dokuErreichbar.test.ts
+++ b/tests/dokuErreichbar.test.ts
@@ -1,0 +1,109 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Jedes Dokument unter `docs/` ist von einer Einstiegsseite aus erreichbar.
+//
+// WARUM ES DAS GIBT. Gemessen 2026-09-04: von dreizehn Dokumenten in `docs/`
+// waren ZWÖLF von keiner Einstiegsseite aus verlinkt — README, CLAUDE.md,
+// CONTRIBUTING, TESTING, SECURITY nannten sie nicht, und untereinander
+// verlinkten sie sich auch nicht. Darunter `self-hosted-relay.md`: ausgerechnet
+// die Seite, die jemand sucht, wenn die Live-Zusammenarbeit über Mobilfunk
+// nicht zustande kommt.
+//
+// Das ist dieselbe Form wie der Sprachschalter, der existierte, aber in einer
+// nie gerenderten Datei lag (B-13): die Sache ist da, sie ist sorgfältig
+// gemacht, und sie liegt außerhalb des Weges, der zu ihr führt. Ein Dokument,
+// das nur findet, wer den Ordner durchblättert, ist praktisch nicht vorhanden.
+//
+// WIE ER PRUEFT. Nicht „steht jedes Dokument im Index" — dann wäre der Index
+// selbst die Liste, die veraltet. Er läuft den LINK-GRAPHEN von den
+// Einstiegsseiten aus ab: ein Dokument zählt als erreichbar, wenn irgendein
+// erreichbares Dokument darauf verlinkt. Ein neuer Unterordner mit eigener
+// Index-Seite funktioniert damit ohne Änderung an diesem Test.
+//
+// WAS ER NICHT PRUEFT: ob der Link-Text zum Ziel passt, und ob das Dokument
+// inhaltlich stimmt. Nur, dass ein Weg dorthin existiert.
+// ───────────────────────────────────────────────────────────────────────────
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { dirname, join, normalize, relative, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const ROOT = join(__dirname, '..')
+
+/** Wo ein Leser anfängt. Alles andere muss von hier aus verlinkt sein. */
+const EINSTIEGE = ['README.md', 'CLAUDE.md', 'CONTRIBUTING.md', 'TESTING.md', 'SECURITY.md']
+
+const alleDokumente = (): string[] => {
+  const treffer: string[] = []
+  const lauf = (verzeichnis: string) => {
+    for (const eintrag of readdirSync(verzeichnis)) {
+      const pfad = join(verzeichnis, eintrag)
+      if (statSync(pfad).isDirectory()) {
+        if (eintrag === 'node_modules' || eintrag.startsWith('.')) continue
+        lauf(pfad)
+        continue
+      }
+      if (/\.md$/i.test(eintrag)) treffer.push(relative(ROOT, pfad))
+    }
+  }
+  lauf(join(ROOT, 'docs'))
+  return treffer.sort()
+}
+
+/** Relative Markdown-Links einer Datei, auf Repo-Wurzel normalisiert. */
+const linksIn = (relativerPfad: string): string[] => {
+  const voll = join(ROOT, relativerPfad)
+  if (!existsSync(voll)) return []
+  const inhalt = readFileSync(voll, 'utf8')
+  const ziele: string[] = []
+  for (const treffer of inhalt.matchAll(/\]\(([^)\s]+?\.md)(?:#[^)]*)?\)/g)) {
+    const ziel = treffer[1]
+    if (/^[a-z]+:\/\//i.test(ziel)) continue
+    ziele.push(normalize(relative(ROOT, resolve(join(ROOT, dirname(relativerPfad)), ziel))))
+  }
+  return ziele
+}
+
+const erreichbar = (): Set<string> => {
+  const gesehen = new Set<string>()
+  const offen = [...EINSTIEGE]
+  while (offen.length > 0) {
+    const aktuell = offen.pop()!
+    if (gesehen.has(aktuell)) continue
+    gesehen.add(aktuell)
+    offen.push(...linksIn(aktuell))
+  }
+  return gesehen
+}
+
+describe('Dokumentation ist auffindbar', () => {
+  it('die Einstiegsseiten existieren', () => {
+    // Ohne diese Prüfung wäre ein umbenanntes README ein grüner, leerer Lauf.
+    for (const e of EINSTIEGE) expect(existsSync(join(ROOT, e)), `${e} fehlt`).toBe(true)
+  })
+
+  it('es gibt überhaupt Dokumente zu prüfen', () => {
+    expect(alleDokumente().length).toBeGreaterThan(5)
+  })
+
+  it('kein Dokument unter docs/ ist verwaist', () => {
+    const gesehen = erreichbar()
+    const waisen = alleDokumente().filter((d) => !gesehen.has(d))
+    expect(
+      waisen,
+      'Diese Dokumente sind von keiner Einstiegsseite aus verlinkt. Ein Dokument, ' +
+        'das nur findet, wer den Ordner durchblättert, ist praktisch nicht vorhanden — ' +
+        'in `docs/README.md` eintragen (oder von dort aus in einen Unter-Index).',
+    ).toEqual([])
+  })
+
+  it('jeder Link zeigt auf eine Datei, die es gibt', () => {
+    // Ein toter Link macht ein Dokument genauso unerreichbar wie gar kein Link,
+    // sieht aber im Index nach Vollständigkeit aus.
+    const tot: string[] = []
+    for (const quelle of [...EINSTIEGE, ...alleDokumente()]) {
+      for (const ziel of linksIn(quelle)) {
+        if (!existsSync(join(ROOT, ziel))) tot.push(`${quelle} -> ${ziel}`)
+      }
+    }
+    expect(tot).toEqual([])
+  })
+})


### PR DESCRIPTION
## Der Befund

Von **dreizehn** Dokumenten in `docs/` waren **zwölf** von keiner Einstiegsseite aus verlinkt (gemessen 2026-09-04). README, `CLAUDE.md`, `CONTRIBUTING.md`, `TESTING.md` und `SECURITY.md` nannten sie nicht, und untereinander verlinkten sie sich auch nicht.

Darunter [`docs/self-hosted-relay.md`](https://github.com/larszu/cable-planner/blob/main/docs/self-hosted-relay.md) — ausgerechnet die Seite, die jemand sucht, wenn die Live-Zusammenarbeit über Mobilfunk nicht zustande kommt. Sie ist sorgfältig geschrieben, sie ist seit `#687` auch korrekt, und sie findet nur, wer den Ordner durchblättert.

Das ist dieselbe Form wie der Sprachschalter, der existierte, aber in einer nie gerenderten Datei lag: die Sache ist da, sie ist gut gemacht, und sie liegt außerhalb des Weges, der zu ihr führt.

## Was dazukam

- **`docs/README.md`** — Inhaltsverzeichnis, gruppiert nach Betrieb, Entwicklung, Domänen-Konzepten, datierten Bestandsaufnahmen und Material. Vom README aus verlinkt, zusammen mit einem Direktlink auf `self-hosted-relay.md`.
- **`CODE_OF_CONDUCT.md`** — `CONTRIBUTING.md` sagte seit jeher „this project ships a Code of Conduct" und verlinkte auf diese Datei. Es gab sie nicht. **Der Guard hat den toten Link im ersten Lauf gefunden**, bevor irgendjemand danach gesucht hatte. Bewusst ein kurzes, selbst geschriebenes Dokument und ausdrücklich *nicht* der Contributor Covenant — einen lizenzierten Text aus dem Gedächtnis zu reproduzieren wäre schlechter als ein ehrliches eigenes.

## Der Guard

`tests/dokuErreichbar.test.ts` prüft **nicht** „steht jedes Dokument im Index" — dann wäre der Index selbst die Liste, die veraltet, und genau das ist die Fehlerform, die diese Sitzung durchgehend misst. Er läuft den **Link-Graphen** von den Einstiegsseiten ab: erreichbar ist, worauf irgendein erreichbares Dokument verlinkt. Ein neuer Unterordner mit eigener Index-Seite funktioniert damit ohne Änderung am Test.

Zwei weitere Prüfungen, weil beide Ausfallarten lautlos wären:

- **Tote Links.** Ein toter Link macht ein Dokument genauso unerreichbar wie gar kein Link, sieht im Index aber nach Vollständigkeit aus.
- **Die Einstiegsseiten existieren.** Ein umbenanntes README wäre sonst ein grüner, leerer Lauf.

**Gegenprobe gemacht:** nimmt man zwei Dokumenten ihren einzigen Link, fällt der Guard rot und nennt beide namentlich.

## Nebenbefund

Der Lizenz-Guard aus `#686` hat den ersten Entwurf dieses Inhaltsverzeichnisses gefangen: er schrieb „quelloffenen Alternativen" in einem Dokument ohne Fremd-Marker. Umformuliert. Zwei Tage alter Guard, erste echte Fundstelle — und zwar an meinem eigenen Text.

## Validierung

- `npm test` — **1007 Tests, 103 Dateien**, grün
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm run lint` — 0 Errors (10 vorbestehende Warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_