### PR TITLE
docs(readme): die ausgelieferten Fähigkeiten benennen; IPC-Domänen-Guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,8 @@ strukturellen Änderungen.** Hier nur das Nötigste zum schnellen Einstieg:
 
 **IPC:** Alle Channels sind domain-präfixiert (`project:*`, `library:*`,
 `atem:*`, `videohub:*`, `sync:*`, `mobileShare:*`, `credentials:*`, `rentman:*`,
-`netbox:*`, `graphml:*`, `print:*`, `logs:*`, `signaling:*`, `collabDiscovery:*`). Definition in `src/main/ipc/<domain>Ipc.ts`,
+`netbox:*`, `graphml:*`, `print:*`, `logs:*`, `signaling:*`, `collabDiscovery:*`,
+`documentLog:*`). Definition in `src/main/ipc/<domain>Ipc.ts`,
 Aufruf via `window.cablePlanner.<domain>.<action>`. Ein Channel = eine Domäne.
 Pfad-Validierung passiert **immer in main**, nie im Renderer.
 

--- a/README.md
+++ b/README.md
@@ -133,12 +133,42 @@ Designed for Blackmagic Videohub infrastructure.
 
 ---
 
-### 🔗 Rentman Integration
-- Secure API integration with the Rentman rental-management platform
-- Import projects, equipment, and categories
-- Token-based authentication (encrypted local storage)
-- No credentials stored in source code
-- Selective import workflow (project/equipment filtering)
+### 🔗 Integrations & Interchange
+- **Rentman** — import projects, equipment and categories from the rental
+  platform, with a selective import workflow
+- **NetBox** — import racks, devices and cable paths from the DCIM side
+- **GraphML** — import existing diagrams, with a preview before anything lands
+  in the plan
+- **Green-GO** — intercom configuration export (`.gg5`), plus a
+  **vendor-neutral intercom exchange file** that someone building a Riedel or
+  Clear-Com system can also read
+- **`.avplan`** — the shared exchange format across the planner suite
+
+API tokens live in the **operating system's credential store** (macOS Keychain,
+Windows Credential Manager, libsecret) through `keytar` — not in the project
+file, not in browser storage, not in source. Exports strip them before writing.
+
+---
+
+### 👥 Live Collaboration
+- Real-time co-editing over **WebRTC** with a CRDT document — no server holds
+  your plan
+- Presence: who is in the room, and where they are working
+- Join by **invite link**, or find open sessions on the LAN automatically
+- **Room password** encrypts the session end-to-end; without it, anyone who
+  knows the room name can read along
+- Bring your own **signaling relay and STUN/TURN servers** for connections
+  across networks — or switch on **local-only** mode, where nothing leaves
+  your LAN
+- Collaborative undo takes back *your* edits, not other people's
+
+---
+
+### 🗄️ Inventory & Stock
+- Warehouse stock with storage locations, serial numbers and quantities
+- The plan's demand checked against what is actually in stock — including the
+  parts that are not equipment nodes (drum kits, wireless rigs, patch fields)
+- Portable stock file, importable and mergeable
 
 ---
 
@@ -160,11 +190,20 @@ Designed for Blackmagic Videohub infrastructure.
 
 ---
 
+## 📱 On Site
+- **Mobile build-day view** over the LAN, opened by QR code — no install, no
+  account. It is not read-only: the build team ticks off what is done, adds
+  cables it actually pulled, and files change requests, all of which come back
+  into the plan.
+- **Label sheets and QR labels** for cables and devices, print-ready.
+- **Read-only web viewer** for sharing a plan with someone who does not run the
+  app.
+
+---
+
 ## ⚙️ Experimental Features
 - 🌐 Shared network-drive sync for multi-planner collaboration *(experimental)*
 - 🗄️ 3D rack builder with STL export *(in progress)*
-- 🎧 GreenGo intercom configuration export *(experimental)*
-- 📱 Mobile build-day viewer (LAN + QR) for field technicians
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -320,3 +320,8 @@ Donations are completely optional — the app stays free to use. It is proprieta
 ## 📄 License
 
 Proprietär — © 2026 Lars Zumpe, alle Rechte vorbehalten. Nutzung der veröffentlichten Builds ist kostenlos; Weiterverbreitung und abgeleitete Werke sind es nicht. Siehe [LICENSE](LICENSE).
+
+Die gebündelten Fremdpakete behalten ihre eigenen Lizenzen; deren Texte und
+Copyright-Hinweise stehen vollständig in
+[THIRD-PARTY-LICENSES.md](THIRD-PARTY-LICENSES.md) (erzeugt von
+`scripts/generate-notices.mjs` aus dem Produktions-Dependency-Baum).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,6 +65,7 @@ Alle IPC-Channels sind nach Domäne präfixiert. Definitionen in
 | `logs:*` | `logIpc.ts` | `renderer-error` (Renderer → Main, one-way) |
 | `signaling:*` | `signalingIpc.ts` | LAN-Signaling-Relay für die Yjs/WebRTC-Kollaboration (#413) |
 | `collabDiscovery:*` | `collabDiscoveryIpc.ts` | Bonjour/mDNS-Discovery von Kollaborations-Peers im LAN |
+| `documentLog:*` | `documentLogIpc.ts` | `append`, `read`, `clear` — das Register der ausgegebenen Dokumente (ADR-004). Es überdauert die Sitzung und gehört damit auf die Platte. |
 
 **Invarianten**:
 1. **Ein Channel = eine Domäne**. Niemals einen Channel quer durch Domänen

--- a/tests/architekturAussagen.test.ts
+++ b/tests/architekturAussagen.test.ts
@@ -97,3 +97,39 @@ describe('Invariante 7 sagt, was gilt', () => {
     expect(aussen).toEqual([join('lib', 'exportRack.ts')])
   })
 })
+
+describe('jede IPC-Domaene ist irgendwo beschrieben', () => {
+  // Der Renderer kann nichts ausserhalb dieser Kanaele. Eine Domaene, die
+  // nirgends beschrieben ist, ist eine Faehigkeit, von der nur erfaehrt, wer
+  // `src/main/ipc/` durchblaettert -- gemessen 2026-09-04 traf das auf
+  // `documentLog` zu (das Register der ausgegebenen Dokumente aus ADR-004).
+  //
+  // Die Liste kommt aus dem Dateisystem, nicht aus einer Aufzaehlung: eine
+  // niedergeschriebene Liste waere am Tag ihrer Entstehung vollstaendig und am
+  // naechsten nicht mehr -- genau so ist die Luecke ueberhaupt entstanden.
+  const domaenen = readdirSync(join(ROOT, 'src', 'main', 'ipc'))
+    .filter((f) => f.endsWith('Ipc.ts'))
+    .map((f) => f.replace(/Ipc\.ts$/, ''))
+    .sort()
+
+  it('es gibt ueberhaupt Domaenen', () => {
+    expect(domaenen.length).toBeGreaterThan(10)
+  })
+
+  it('keine Domaene fehlt in README oder architecture.md', () => {
+    // Nutzerseitige Domaenen gehoeren ins README, infrastrukturelle in die
+    // Architektur-Doku. Welche wohin, entscheidet der Mensch; der Test verlangt
+    // nur, dass sie ueberhaupt irgendwo steht.
+    const readme = readFileSync(join(ROOT, 'README.md'), 'utf8').toLowerCase()
+    const arch = doku.toLowerCase()
+    const fehlend = domaenen.filter((d) => {
+      const n = d.toLowerCase()
+      return !readme.includes(n) && !arch.includes(n)
+    })
+    expect(
+      fehlend,
+      'Diese IPC-Domaenen sind nirgends beschrieben. Nutzerseitiges ins README, ' +
+        'Infrastruktur in die IPC-Tabelle von docs/architecture.md.',
+    ).toEqual([])
+  })
+})

--- a/tests/dokuErreichbar.test.ts
+++ b/tests/dokuErreichbar.test.ts
@@ -32,7 +32,13 @@ const ROOT = join(__dirname, '..')
 const EINSTIEGE = ['README.md', 'CLAUDE.md', 'CONTRIBUTING.md', 'TESTING.md', 'SECURITY.md']
 
 const alleDokumente = (): string[] => {
-  const treffer: string[] = []
+  // Auch die Dokumente in der Wurzel, nicht nur `docs/`: `THIRD-PARTY-LICENSES.md`
+  // war von nirgends verlinkt (gemessen 2026-09-04). Das ist ein
+  // Attributions-Artefakt, dessen Reproduktion die Fremdlizenzen VERLANGEN — es
+  // nutzt niemandem in einer Datei, die keiner findet.
+  const treffer: string[] = readdirSync(ROOT)
+    .filter((e) => /\.md$/i.test(e) && !EINSTIEGE.includes(e))
+    .map((e) => relative(ROOT, join(ROOT, e)))
   const lauf = (verzeichnis: string) => {
     for (const eintrag of readdirSync(verzeichnis)) {
       const pfad = join(verzeichnis, eintrag)


### PR DESCRIPTION
## Der Befund

Das README beschrieb den Stand von vor mehreren großen Features. Gegen den Code gemessen fehlte:

| Fehlte im README | Belegt durch |
|---|---|
| **Live-Zusammenarbeit — komplett** | `CollabPanel.tsx`, `lib/crdt/*`, `y-webrtc`, LAN-Discovery per Bonjour, Einladungslinks, E2E-Raumpasswort, seit `#687` auch eigene STUN-/TURN-Server |
| **NetBox** (DCIM-Import) | `NetboxImportDialog.tsx`, `netboxIpc.ts`, in `App.tsx` gemountet |
| **GraphML** (Diagramm-Import) | `GraphmlImportDialog.tsx` + `GraphmlViewer.tsx`, im Menü |
| **Lager/Inventar** samt Deckungsabgleich | `InventoryDialog.tsx`, `inventoryCoverage.ts` |
| **Etiketten-/QR-Bögen** | `labelSheets.test.ts`, `docQrPayload.test.ts` |

Die Live-Zusammenarbeit ist dabei nicht irgendein Punkt: wer das Tool bewertet, erfährt aus dem README nicht, dass mehrere Leute gleichzeitig an einem Plan arbeiten können.

## Zwei Formulierungen, die falsch waren

**„Token-based authentication (encrypted local storage)"** — die Tokens liegen im **OS-Credential-Store** (Keychain, Credential Manager, libsecret) über `keytar`. Das ist eine *stärkere* Zusage als die, die dort stand; „encrypted local storage" legt zudem eine selbstgebaute Verschlüsselung nahe, die es nicht gibt.

**„Mobile build-day viewer"** unter *Experimental* — die Mobile-Ansicht hat drei token-gesicherte Rückwege (Bauteam-Häkchen, neu gezogene Kabel, Änderungswünsche). Sie ist kein Viewer, und sie ist auch nicht experimentell. Sie steht jetzt unter **On Site**, zusammen mit den Etiketten-Bögen und dem echten read-only Web-Viewer.

Als experimentell bleiben nur **3D-Rack-Builder** und **Netzlaufwerk-Sync** stehen — beides zu Recht.

## Der Nebenbefund und sein Guard

Die IPC-Domäne **`documentLog`** (Register der ausgegebenen Dokumente, ADR-004) war weder im README noch in `docs/architecture.md` beschrieben, und `CLAUDE.md` ließ sie in ihrer Domänen-Aufzählung aus. Der Renderer kann nichts außerhalb dieser Kanäle — eine undokumentierte Domäne ist also eine Fähigkeit, von der nur erfährt, wer `src/main/ipc/` durchblättert.

Neuer Guard: jede Domäne unter `src/main/ipc/` muss in README **oder** Architektur-Doku vorkommen. Die Liste kommt aus dem **Dateisystem**, nicht aus einer Aufzählung — eine niedergeschriebene Liste wäre am Tag ihrer Entstehung vollständig und am nächsten nicht mehr, und genau so ist die Lücke entstanden. Welche Domäne wohin gehört (nutzerseitig ins README, Infrastruktur in die IPC-Tabelle), entscheidet weiterhin der Mensch; der Test verlangt nur, dass sie überhaupt irgendwo steht.

**Gegenprobe gemacht:** streicht man die `documentLog`-Zeile aus der IPC-Tabelle, fällt der Guard rot und nennt die Domäne.

## Zweiter Commit: `THIRD-PARTY-LICENSES.md` war unauffindbar

Der Erreichbarkeits-Guard aus `#689` sah bisher nur `docs/`. Auf die Wurzel-Dokumente angewandt, meldet er sofort `THIRD-PARTY-LICENSES.md` — von keiner Einstiegsseite aus verlinkt.

Das ist hier kein Komfortthema. Die gebündelten Fremdpakete **verlangen** die Reproduktion ihrer Lizenztexte und Copyright-Hinweise; ein Attributions-Artefakt, das niemand findet, erfüllt diese Auflage nur dem Buchstaben nach. Der Lizenz-Abschnitt verweist jetzt darauf und sagt dazu, woraus die Datei erzeugt wird. Der Guard nimmt die Wurzel-`*.md` (außer den Einstiegsseiten) mit auf — Gegenprobe gemacht.

## Validierung

- `npm test` — **1009 Tests, 103 Dateien**, grün
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT