### PR TITLE
test(ci): der Guard schaltet sich in der Suite-Kopie nicht ab

### DIFF
--- a/tests/ciFaehrtJedePruefung.test.ts
+++ b/tests/ciFaehrtJedePruefung.test.ts
@@ -20,11 +20,41 @@
 // faellt ebenfalls auf. Damit ist „laeuft nicht in CI" eine sichtbare
 // Entscheidung statt eines Versehens.
 // ───────────────────────────────────────────────────────────────────────────
-import { readFileSync, readdirSync } from 'node:fs'
-import { join } from 'node:path'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { dirname, join, relative } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const ROOT = join(__dirname, '..')
+
+/**
+ * Diese Datei laeuft auch in der vendorierten Kopie unter
+ * `av-planner-suite/apps/cable-planner/`. Dort gibt es KEIN `ci.yml` — die
+ * Suite faehrt die Tests der Kopie ueber `npm run test --workspaces`, und
+ * verschachtelte `.github/workflows/` sind im Monorepo ohnehin inert.
+ *
+ * Der Unterschied wird gemessen, nicht geraten: vendoriert ist die Kopie dann,
+ * wenn ein Elternverzeichnis eine `package.json` mit `workspaces` hat, unter
+ * die dieses Verzeichnis faellt. Und er fuehrt NICHT zu einem stillen
+ * Ueberspringen — in der Kopie wird stattdessen geprueft, dass die Suite die
+ * Tests dieses Workspace ueberhaupt faehrt. Ein Guard, der sich in der Kopie
+ * einfach abschaltet, waere genau der Fehler, gegen den er gebaut ist.
+ */
+const suiteWurzel = ((): string | null => {
+  let verzeichnis = dirname(ROOT)
+  for (let i = 0; i < 4; i++) {
+    const pj = join(verzeichnis, 'package.json')
+    if (existsSync(pj)) {
+      const inhalt = JSON.parse(readFileSync(pj, 'utf8')) as { workspaces?: string[] }
+      const muster = inhalt.workspaces ?? []
+      const rel = relative(verzeichnis, ROOT).split(/[\\/]/)[0]
+      if (muster.some((m) => m.split('/')[0] === rel)) return verzeichnis
+    }
+    const oben = dirname(verzeichnis)
+    if (oben === verzeichnis) break
+    verzeichnis = oben
+  }
+  return null
+})()
 const skripte = (JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')) as {
   scripts: Record<string, string>
 }).scripts
@@ -53,17 +83,18 @@ const OHNE_CI: Record<string, string> = {
     'aber als bewusste Erweiterung mit Zeitbudget, nicht nebenbei. Backlog-Punkt, kein Versehen.',
 }
 
-const workflows = (): string => {
-  const verzeichnis = join(ROOT, '.github', 'workflows')
+const workflowsAus = (wurzel: string): string => {
+  const verzeichnis = join(wurzel, '.github', 'workflows')
+  if (!existsSync(verzeichnis)) return ''
   return readdirSync(verzeichnis)
     .filter((f) => /\.ya?ml$/.test(f))
     .map((f) => readFileSync(join(verzeichnis, f), 'utf8'))
     .join('\n')
 }
 
-describe('CI faehrt jede Pruefung', () => {
+describe.skipIf(suiteWurzel !== null)('CI faehrt jede Pruefung (eigenes Repo)', () => {
   const alle = Object.keys(skripte).filter(istPruefung).sort()
-  const yml = workflows()
+  const yml = workflowsAus(ROOT)
 
   it('findet ueberhaupt Pruef-Laeufe und Workflows', () => {
     // Ein leerer Suchlauf ist gruen und wertlos; der haeufigste Weg dorthin ist
@@ -93,5 +124,28 @@ describe('CI faehrt jede Pruefung', () => {
     // hat — und der naechste Leser haelt ihn weiter fuer ungeprueft.
     const ueberfluessig = Object.keys(OHNE_CI).filter((n) => yml.includes(`npm run ${n}`))
     expect(ueberfluessig).toEqual([])
+  })
+})
+
+describe.skipIf(suiteWurzel === null)('CI faehrt jede Pruefung (vendorierte Kopie)', () => {
+  // Hier gibt es kein eigenes `ci.yml`. Statt sich abzuschalten, prueft der
+  // Guard, was in dieser Lage die tatsaechliche Zusicherung ist: dass die
+  // Suite die Tests dieses Workspace ueberhaupt faehrt.
+  it('die Suite faehrt die Tests dieses Workspace', () => {
+    const yml = workflowsAus(suiteWurzel!)
+    expect(yml.length, 'Die Suite hat keine Workflows — dann faehrt hier gar nichts.').toBeGreaterThan(200)
+    expect(
+      /npm run test --workspaces/.test(yml),
+      'Die Suite-CI faehrt `npm run test --workspaces` nicht — die Tests dieser Kopie liefen dann bei keinem Merge.',
+    ).toBe(true)
+  })
+
+  it('und die Suite prueft ihre eigene Guard-Liste', () => {
+    // Das Gegenstueck zu diesem Test auf Suite-Ebene ist `npm run ci:complete`.
+    // Gibt es das nicht mehr, faellt die Kette hier auf.
+    const suitePaket = JSON.parse(readFileSync(join(suiteWurzel!, 'package.json'), 'utf8')) as {
+      scripts?: Record<string, string>
+    }
+    expect(suitePaket.scripts?.['ci:complete']).toBeDefined()
   })
 })


### PR DESCRIPTION
Nachtrag zu `#691`, gefunden beim Vendorieren.

## Der Befund

Die Kopie unter `av-planner-suite/apps/cable-planner/` hat **kein `ci.yml`** — verschachtelte `.github/workflows/` sind im Monorepo inert, und die Suite fährt die Tests der Kopie über `npm run test --workspaces`.

Der Guard aus `#691` hätte dort `test`, `test:crdt` und `test:signaling` als „steht in keinem Workflow" gemeldet und die Suite-CI rot gefärbt. Ein Guard, der beim Vendorieren einen Fehler erfindet, ist genauso schlecht wie einer, der einen echten übersieht.

## Warum nicht einfach überspringen

Die naheliegende Abhilfe wäre `describe.skip` in der Kopie gewesen. Das ist **genau der Fehler, gegen den dieser Guard gebaut ist**: ein Guard, der sich in der Kopie abschaltet, ist dort eine Notiz — und die Kopie ist der Ort, an dem die Suite ihre Zusicherungen hernimmt.

## Was er in der Kopie stattdessen prüft

Was in dieser Lage die *tatsächliche* Zusicherung ist:

| Prüfung | Warum |
|---|---|
| Die Suite-CI fährt `npm run test --workspaces` | Sonst liefen die Tests dieser Kopie bei keinem Merge — dieselbe Frage, andere Ebene. |
| Die Suite hat ihren eigenen `ci:complete` | Damit ist die Kette geschlossen statt unterbrochen: die Kopie verlässt sich auf die Suite, und die Suite prüft ihre eigene Guard-Liste (`suite#87`). |

Vendoriert oder nicht wird **gemessen, nicht geraten**: ein Elternverzeichnis mit einer `package.json`, deren `workspaces` dieses Verzeichnis abdeckt.

## Vier Gegenproben, in beiden Lagen

**Upstream** (4 Tests aktiv, 2 übersprungen):
- Lauf aus dem Workflow entfernt → rot, mit Namen
- überflüssige Ausnahme eingetragen → rot

**In der Kopie** (2 Tests aktiv, 4 übersprungen):
- `npm run test --workspaces` aus der Suite-CI entfernt → rot
- `ci:complete` aus der Suite-`package.json` entfernt → rot

## Validierung

- `npm test` — **1013 Tests, 2 übersprungen**, grün
- Innerhalb von `av-planner-suite/apps/cable-planner`: 2 aktiv, 4 übersprungen, grün
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_