### PR TITLE
ci(ui-smoke): der Menü-Smoke-Test läuft wieder — und jetzt bei jedem Merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,18 @@ name: CI
 # groessten Repos -- nicht mangels Pruefung, sondern weil die vorhandene nie
 # lief.
 #
+# Seit 2026-09-05 zusaetzlich als eigener Job: `ui:smoke` (siehe unten).
+#
 # Bewusst NICHT hier: electron-builder (`npm run dist`) — das gehoert zu
-# release.yml und braucht Signatur-Material. Ebenso `ui:smoke` und
-# `test:drag`: die brauchen wirklich einen laufenden Renderer
-# (`dev:renderer`), und dafuer stimmt die alte Begruendung.
+# release.yml und braucht Signatur-Material. Ebenso `test:drag`: der braucht
+# wirklich einen laufenden Renderer (`dev:renderer`).
+#
+# Korrektur an derselben Begruendung: sie zaehlte `ui:smoke` mit auf, und das
+# war falsch. `ui:smoke` startet die GEBAUTE App (`electron .` gegen `dist/`),
+# nicht den Dev-Server. Nachgemessen 2026-09-05: unter `xvfb-run` mit
+# installiertem `libsecret-1-0` laeuft er durch. Eine Begruendung, die zwei
+# Laeufe zusammenfasst, von denen nur einer sie traegt, haelt den anderen
+# jahrelang aus der CI heraus.
 
 on:
   pull_request:
@@ -68,3 +76,39 @@ jobs:
         run: npm run test:signaling
       - name: Build
         run: npm run build
+
+  # ---------------------------------------------------------------------------
+  # UI-Smoke: startet die gebaute Electron-App headless, oeffnet jedes Top-Menu
+  # und meldet ein Menu ohne Eintraege. Mit genau diesem Harness wurde #549
+  # gefunden -- und danach lief er bei keinem Merge mehr, weil er in der
+  # CI-Begruendung faelschlich mit `test:drag` in einen Topf geworfen war.
+  #
+  # Eigener Job, weil er `npm run build` und einen X-Server braucht: so
+  # verlaengert er den Merge-Gate nicht, sondern laeuft daneben.
+  #
+  # Warum `libsecret-1-0` (Laufzeit) UND `libsecret-1-dev` (Kompilieren):
+  # gemessen bricht der Main-Prozess sonst beim `require('keytar')` mit
+  # "libsecret-1.so.0: cannot open shared object file" ab, bevor ein Fenster
+  # entsteht -- der Smoke-Lauf meldete dann nur einen 30-Sekunden-Timeout ohne
+  # Ursache.
+  ui-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev libsecret-1-0 xvfb
+      - run: npm ci
+      - name: Build
+        run: npm run build
+      - name: UI-Smoke (headless)
+        run: xvfb-run -a npm run ui:smoke
+      - name: Screenshots bei Fehlschlag
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-smoke-screenshots
+          path: /tmp/cable-planner-ui-shots
+          if-no-files-found: ignore

--- a/scripts/ui-smoke.mjs
+++ b/scripts/ui-smoke.mjs
@@ -37,12 +37,40 @@ await shot('01-launch')
 
 // Erststart-Overlays (Welcome-Dialog / Onboarding-Tour) wegklicken, damit die
 // Menüleiste frei bedienbar ist.
-for (const rx of [/Decide later|Später/i, /Skip|Überspringen|End tour|Beenden|Fertig/i]) {
-  const b = win.getByRole('button', { name: rx })
-  if (await b.count()) await b.first().click({ timeout: 1500 }).catch(() => {})
+//
+// Vorher standen hier zwei feste Klickversuche und ein Escape, Fehler
+// verschluckt. Das genügte auf einem Profil, das die Tour schon gesehen hatte —
+// und CI hat IMMER ein frisches Profil. Gemessen 2026-09-05: mit gelöschtem
+// `~/.config/cable-planner` bleibt die Getting-Started-Tour (Schritt 1/7)
+// stehen, ihr `.cp-modal-backdrop` fängt jeden Klick ab, und der erste
+// Menü-Klick läuft 30 Sekunden in einen Timeout. Genau deshalb lief dieser
+// Lauf nie in CI: er kann dort in der alten Form gar nicht durchkommen.
+//
+// Jetzt wird auf den ZUSTAND geschleift statt auf eine feste Zahl von
+// Versuchen: solange ein Backdrop steht, wird weiter zugemacht. Ein Overlay,
+// das später dazukommt (das Dismissen des Welcome-Dialogs startet die Tour),
+// wird damit auch erwischt.
+const overlayWeg = async () => {
+  const abweisungen =
+    /End tour|Tour beenden|Beenden|Skip|Überspringen|Fertig|Decide later|Später|Schließen|Close/i
+  for (let runde = 0; runde < 6; runde++) {
+    if ((await win.locator('.cp-modal-backdrop').count()) === 0) return
+    const b = win.getByRole('button', { name: abweisungen })
+    if (await b.count()) await b.first().click({ timeout: 1500 }).catch(() => {})
+    await win.keyboard.press('Escape').catch(() => {})
+    await win.waitForTimeout(400)
+  }
+  const rest = await win.locator('.cp-modal-backdrop').count()
+  if (rest > 0) {
+    // Laut scheitern statt weiterlaufen: sonst folgt ein 30-Sekunden-Timeout
+    // beim ersten Menü-Klick, und der sagt nichts über die Ursache.
+    throw new Error(
+      `Erststart-Overlay liess sich nicht schliessen (${rest} Backdrop(s) offen). ` +
+        'Screenshot 01-launch.png zeigt, was steht.',
+    )
+  }
 }
-await win.keyboard.press('Escape').catch(() => {})
-await win.waitForTimeout(500)
+await overlayWeg()
 await shot('02-main')
 
 // Top-Menüs öffnen — sprach-unabhängig über die Menü-Buttons.

--- a/tests/ciFaehrtJedePruefung.test.ts
+++ b/tests/ciFaehrtJedePruefung.test.ts
@@ -77,10 +77,6 @@ const OHNE_CI: Record<string, string> = {
     'Braucht einen laufenden `dev:renderer` auf localhost:5173 und einen echten Browser. ' +
     'Ein CI-Job dafuer muesste den Dev-Server hochfahren und wieder abraeumen; bis jemand das baut, ' +
     'ist der Lauf ein Werkzeug fuer die Hand, keine Zusicherung.',
-  'ui:smoke':
-    'Startet die GEBAUTE Electron-App und braucht dafuer `npm run build`, fuer Electron gebaute ' +
-    'native Module und unter Linux `xvfb-run`. Das ist ein eigener, langsamer Job — er gehoert in CI, ' +
-    'aber als bewusste Erweiterung mit Zeitbudget, nicht nebenbei. Backlog-Punkt, kein Versehen.',
 }
 
 const workflowsAus = (wurzel: string): string => {


### PR DESCRIPTION
Der Lauf, mit dem seinerzeit `#549` gefunden wurde, stand seit Monaten in `package.json` und in `CLAUDE.md` — und lief bei keinem Merge. Der `ci:complete`-Guard aus `#691` hat ihn benannt. Nachgemessen gab es **zwei** Gründe, und keiner war Absicht.

## 1 · Die CI-Begründung war falsch

`ci.yml` zählte `ui:smoke` zusammen mit `test:drag` auf:

> Ebenso `ui:smoke` und `test:drag`: die brauchen wirklich einen laufenden Renderer (`dev:renderer`)

Das stimmt für `test:drag`. **`ui:smoke` startet die gebaute App** (`electron .` gegen `dist/`) und braucht keinen Dev-Server. Eine Begründung, die zwei Läufe zusammenfasst, von denen nur einer sie trägt, hält den anderen jahrelang aus der CI heraus.

## 2 · Er konnte in CI gar nicht durchkommen

Gemessen mit gelöschtem `~/.config/cable-planner` — also dem Zustand, den **CI immer hat**:

- Die Getting-Started-Tour (Schritt 1/7) bleibt stehen.
- Ihr `.cp-modal-backdrop` fängt jeden Klick ab.
- Der erste Menü-Klick läuft 30 Sekunden in einen Timeout, dessen Meldung nichts über die Ursache sagt.

Die Abweis-Logik bestand aus **zwei festen Klickversuchen und einem Escape, Fehler verschluckt**. Das genügte auf einem Profil, das die Tour schon gesehen hatte — und genau so wurde der Lauf je von Hand gefahren. Auf dem zweiten Lauf in Folge ist er grün, auf dem ersten nie.

`scripts/ui-smoke.mjs` schleift jetzt auf den **Zustand** statt auf eine feste Zahl von Versuchen: solange ein Backdrop steht, wird weiter zugemacht. Das erwischt auch das Overlay, das erst später dazukommt (das Schließen des Welcome-Dialogs *startet* die Tour). Bleibt am Ende eines stehen, fällt der Lauf **laut mit Ursache** aus, statt in den Menü-Timeout zu rennen.

## Der neue Job

Eigener Job `ui-smoke`, bewusst getrennt vom Merge-Gate: er braucht `npm run build` und einen X-Server, läuft so daneben statt davor und verlängert das Gate nicht.

`libsecret-1-0` (Laufzeit) **zusätzlich** zu `libsecret-1-dev` (Kompilieren) — sonst bricht der Main-Prozess beim `require('keytar')` mit `libsecret-1.so.0: cannot open shared object file` ab, bevor überhaupt ein Fenster entsteht; der Smoke-Lauf meldete dann nur den 30-Sekunden-Timeout. Screenshots werden bei Fehlschlag als Artefakt hochgeladen.

Damit fällt die `ui:smoke`-Ausnahme in `tests/ciFaehrtJedePruefung.test.ts` weg — und der Guard prüft von sich aus, dass keine überflüssige Ausnahme stehen bleibt. Die Kette hat hier vollständig funktioniert: Guard benennt den Lauf → Messung zeigt zwei Ursachen → Fix → Ausnahme entfällt automatisch.

## Nachweis

```
rm -rf ~/.config/cable-planner && xvfb-run -a npm run ui:smoke
→ 5 Menüs, 0 ohne Einträge, Exit 0
```

Vorher an derselben Stelle reproduzierbar rot (`.cp-modal-backdrop intercepts pointer events`).

## Validierung

- `npm test` — **1013 Tests, 2 übersprungen**, grün
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm run lint` — 0 Errors (10 vorbestehende Warnings)
- `xvfb-run -a npm run ui:smoke` auf frischem Profil — grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_