### PR TITLE
fix(release): der macOS-Universal-Build hat nie ein Artefakt erzeugt — v8.3.3 hat 0 Assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,14 @@ jobs:
         run: npm run test:signaling
       - name: Build
         run: npm run build
+      # Fragt die action.yml jedes Pins nach ihrer Node-Version, statt sie in
+      # einem Kommentar zu behaupten. Am 2026-09-05 liefen fuenf Actions auf
+      # node20 -- und die Kommentare im Workflow gaben dazu einen Stand von Mai
+      # wieder, der laengst nicht mehr galt. Der Lauf folgt eine Ebene in
+      # Composite-Actions hinein: upload-pages-artifact@v3 hatte node20 nur im
+      # Inneren, von aussen sah der Pin sauber aus.
+      - name: Actions laufen auf einer unterstuetzten Node-Version
+        run: npm run actions:check
 
   # ---------------------------------------------------------------------------
   # UI-Smoke: startet die gebaute Electron-App headless, oeffnet jedes Top-Menu
@@ -107,7 +115,7 @@ jobs:
         run: xvfb-run -a npm run ui:smoke
       - name: Screenshots bei Fehlschlag
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ui-smoke-screenshots
           path: /tmp/cable-planner-ui-shots

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,10 +23,12 @@ permissions:
   pages: write
   id-token: write
 
-# Node-20-Actions (configure/upload/deploy-pages) auf Node 24 zwingen, solange
-# sie noch keine v-Bump-Releases haben (analog release.yml). Nur Warnung sonst.
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+# Kein FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 mehr. Hier stand, die Pages-Actions
+# haetten "noch keine v-Bump-Releases" — am 2026-09-05 hatten sie alle welche:
+# configure-pages v6, deploy-pages v5, upload-pages-artifact v5, alle node24.
+# Der letzte war der interessante Fall: er ist selbst ein Composite und zog
+# ueber `actions/upload-artifact@v4` node20 herein, ohne dass man das der
+# gepinnten Zeile ansieht. `npm run actions:check` sieht genau da nach.
 
 # Immer nur ein Deploy gleichzeitig; laufende abbrechen wenn ein neuer kommt.
 concurrency:
@@ -53,8 +55,8 @@ jobs:
       # integration"). Daher EINMALIG manuell aktivieren:
       #   Settings → Pages → Build and deployment → Source = "GitHub Actions".
       # Danach deployt dieser Workflow bei jedem Push auf main automatisch.
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: dist/renderer
 
@@ -66,4 +68,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,46 @@ jobs:
         with:
           path: artifacts
 
+      - name: Release-Vollstaendigkeit pruefen
+        # v8.3.3 hat NULL Assets. Der macOS-Job brach beim Universal-Merge ab,
+        # `release` haengt an `needs: build`, also wurde auch die fertige
+        # Windows-.exe nie angehaengt — und die Release-Seite sah dabei aus wie
+        # jede andere. Fuenf Wochen lang hat das niemand bemerkt.
+        #
+        # Dieser Schritt macht den Teil-Ausfall laut. Er prueft nicht, dass
+        # IRGENDWAS da ist (das tut `if-no-files-found: error` schon je Job),
+        # sondern dass JEDE Gattung da ist: beide Installer und die drei
+        # Dateien, die der eingebaute Auto-Updater braucht. Faellt eine weg,
+        # bricht der Lauf ab, statt ein halbes Release zu veroeffentlichen.
+        shell: bash
+        run: |
+          set -eu
+          echo "--- heruntergeladene Artefakte ---"
+          find artifacts -type f | sort
+          echo "----------------------------------"
+          fehlt=0
+          pruefe() {
+            anzahl="$(find artifacts -type f -name "$1" | wc -l | tr -d ' ')"
+            if [ "$anzahl" -ge 1 ]; then
+              echo "ok   $1 ($anzahl)"
+            else
+              echo "FEHLT $1 -- $2"
+              fehlt=1
+            fi
+          }
+          pruefe '*.exe'          'Windows-Installer/Portable (windows-Job)'
+          pruefe '*.dmg'          'macOS-Download (macos-Job)'
+          pruefe '*.zip'          'macOS-Auto-Update: Squirrel.Mac spielt nur aus einem zip ein'
+          pruefe 'latest.yml'     'Update-Manifest Windows'
+          pruefe 'latest-mac.yml' 'Update-Manifest macOS'
+          if [ "$fehlt" -ne 0 ]; then
+            echo
+            echo "Ein halbes Release ist schlimmer als keines: es sieht auf der"
+            echo "Release-Seite vollstaendig aus. Erst den fehlenden Build-Job"
+            echo "reparieren, dann den Tag neu setzen."
+            exit 1
+          fi
+
       - name: Create GitHub Release
         # Nicht nur die Installer: die App bringt einen Auto-Updater mit
         # (`services/updaterService.ts` ruft `checkForUpdatesAndNotify()`), und

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,13 @@ on:
 permissions:
   contents: write
 
-# actions/checkout@v5 and actions/setup-node@v5 ship Node 24 natively.
-# Three actions still don't have a Node-24 release as of May 2026:
-# actions/upload-artifact@v4, actions/download-artifact@v4, and
-# softprops/action-gh-release@v2 — so we keep the env flag to force them
-# onto Node 24 too. Drop it once all four publish a v5.
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+# Kein FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 mehr. Hier stand, drei Actions
+# haetten "as of May 2026" noch kein Node-24-Release — das galt am 2026-09-05
+# fuer keine einzige mehr: upload-artifact ist bei v6/v7, download-artifact bei
+# v7/v8, action-gh-release bei v3, alle node24. Der Satz war nicht bloss
+# veraltet, er war die Begruendung dafuer, nicht nachzusehen.
+# `npm run actions:check` fragt jetzt die action.yml jedes Pins statt zu
+# behaupten, was es gibt.
 
 # Centralised Node version for the build matrix. Node 24 LTS is the
 # active LTS as of October 2025 — bump here if you move to a newer LTS.
@@ -112,7 +112,7 @@ jobs:
         run: ls -lh release/ || true
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cable-planner-${{ matrix.name }}
           path: |
@@ -133,7 +133,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
 
@@ -187,7 +187,7 @@ jobs:
         # Leere. Das mac-`.zip` gehoert dazu, weil `latest-mac.yml` darauf
         # zeigt (Squirrel.Mac aktualisiert nicht aus einem DMG), die
         # `.blockmap`s ermoeglichen den differenziellen Download.
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             artifacts/**/*.exe

--- a/electron-builder.js
+++ b/electron-builder.js
@@ -58,6 +58,33 @@ export default {
       { target: 'zip', arch: 'universal' },
     ],
     artifactName: '${productName}-${version}-${arch}.${ext}',
+    // OHNE DIESE ZEILE GIBT ES KEIN macOS-ARTEFAKT. Gemessen an v8.3.3
+    // (Lauf 30617724085, 2026-07-31): der Universal-Build bricht ab mit
+    //   Detected file ".../@julusian/freetype2/prebuilds/
+    //   freetype2-darwin-arm64/node-napi-v7.node" that's the same in both
+    //   x64 and arm64 builds and not covered by the x64ArchFiles rule
+    // und da `release` auf `needs: build` steht, wurde danach auch die
+    // fertige Windows-.exe nie ans Release gehaengt: v8.3.3 hat NULL Assets.
+    //
+    // WARUM. `@julusian/freetype2` liefert seine Binaries nicht gebaut,
+    // sondern fertig aus — ein Verzeichnis je Plattform+Arch unter
+    // `prebuilds/`, ausgewaehlt zur Laufzeit von `pkg-prebuilds/bindings.js`
+    // ueber `os.arch()`. Beide Teil-Builds (x64 und arm64) enthalten deshalb
+    // denselben vollstaendigen `prebuilds/`-Baum, Byte fuer Byte gleich.
+    // `@electron/universal` erwartet bei einer Mach-O-Datei, die in beiden
+    // Builds identisch ist, eine ausdrueckliche Ansage — sonst koennte es
+    // ebenso gut ein vergessenes Rebuild sein — und bricht ab. `lipo` waere
+    // hier auch falsch: die Auswahl passiert ueber den PFAD, nicht ueber eine
+    // Fat-Binary.
+    //
+    // Der Name der Option ist irrefuehrend („x64ArchFiles"), ihre Wirkung ist
+    // genau die richtige: „identisch ist in Ordnung, eine Kopie behalten".
+    // Sie greift ausschliesslich im Gleichheitsfall — unterscheiden sich die
+    // beiden Dateien, laeuft weiterhin lipo. Das Muster deckt bewusst die
+    // FORM ab (per Pfad benannte Prebuild-Verzeichnisse), nicht das eine
+    // Paket: das naechste Paket dieser Bauart faellt sonst genauso um.
+    // `tests/macUniversalBuild.test.ts` haelt das fest.
+    x64ArchFiles: '**/prebuilds/*darwin*/**',
     icon: 'build/icon.png',
     // Ad-hoc sign the app so macOS Gatekeeper doesn't reject the binary
     // outright with "Cable Planner is damaged and can't be opened" on

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.7.0",
         "happy-dom": "^20.10.6",
+        "minimatch": "^10.2.5",
         "playwright-core": "^1.61.1",
         "png-to-ico": "^3.0.1",
         "postcss": "^8.5.15",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "test:signaling": "npm run build:main && node scripts/signaling-relay-check.mjs",
     "relay": "node scripts/signaling-server.mjs",
     "dist": "npm run build && electron-builder",
-    "notices": "node scripts/generate-notices.mjs"
+    "notices": "node scripts/generate-notices.mjs",
+    "actions:check": "node scripts/actions-node-runtime.mjs"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.7.0",
     "happy-dom": "^20.10.6",
+    "minimatch": "^10.2.5",
     "playwright-core": "^1.61.1",
     "png-to-ico": "^3.0.1",
     "postcss": "^8.5.15",

--- a/scripts/actions-node-runtime.mjs
+++ b/scripts/actions-node-runtime.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+// ───────────────────────────────────────────────────────────────────────────
+// Keine GitHub-Action laeuft mehr auf einer abgekuendigten Node-Version.
+//
+// WARUM ES DAS GIBT. Am Ende jedes Release-Laufs steht seit Monaten:
+//
+//   Node.js 20 is deprecated. The following actions target Node.js 20 but are
+//   being forced to run on Node.js 24: actions/upload-artifact@v4
+//
+// Eine Warnung, die in jedem Lauf steht, liest nach dem dritten Mal niemand
+// mehr. Gemessen 2026-09-05 waren es hier vier Actions -- und die Kommentare
+// im Workflow behaupteten dazu etwas, das nicht mehr stimmte („Three actions
+// still don't have a Node-24 release as of May 2026"). Inzwischen haben ALLE
+// verwendeten Actions ein node24-Major; die Repos hingen bis zu drei Majors
+// zurueck.
+//
+// WIE ER PRUEFT. Er fragt die Action selbst, nicht eine Tabelle: fuer jedes
+// `uses:` in `.github/workflows/` wird deren `action.yml` an genau dem
+// gepinnten Ref gelesen und `runs.using` ausgewertet. Eine Liste im Skript
+// waere genau das, was hier schon einmal veraltet ist -- ein Kommentar, der
+// den Stand von Mai behauptet.
+//
+// Er folgt dabei EINE Ebene in Composite-Actions hinein. Das ist nicht
+// Gruendlichkeit um ihrer selbst willen, sondern der einzige Weg, den
+// interessantesten Fall zu sehen: `actions/upload-pages-artifact@v3` ist
+// selbst ein Composite (also ohne eigene Node-Version) und ruft intern
+// `actions/upload-artifact@v4` auf -- node20, unsichtbar von aussen. Wer nur
+// die aeussere Zeile prueft, haelt diesen Pin fuer sauber.
+//
+// WAS ER NICHT PRUEFT: ob ein neueres Major sonst kompatibel ist. Welche
+// `with:`-Schluessel eine Action kennt, steht in ihrer `action.yml` -- wer ein
+// Major anhebt, gleicht das ab (beim Sprung von 2026-09-05 wurde jeder
+// verwendete Schluessel einzeln gegen das Ziel-Major geprueft).
+//
+// OHNE NETZ prueft er nichts und sagt das. Das ist kein stilles Ueberspringen:
+// der Grund steht in der Ausgabe, und der Lauf bleibt gruen, damit ein
+// Netz-Aussetzer keinen fremden PR blockiert -- dieselbe Regel wie beim
+// Drift-Guard der Suite.
+// ───────────────────────────────────────────────────────────────────────────
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const WORKFLOWS = join(ROOT, '.github', 'workflows')
+
+/** Aelter als das gilt als abgekuendigt. */
+const MINDESTENS = 24
+
+/**
+ * Verschachtelte Actions, die wir NICHT selbst pinnen und deshalb auch nicht
+ * anheben koennen. Der Text ist Pflicht -- er ist der ganze Zweck der Tabelle.
+ * Eine Ausnahme fuer etwas, das gar nicht mehr auftaucht, faellt unten auf.
+ */
+const NICHT_UNSER_PIN = {}
+
+const referenzen = () => {
+  if (!existsSync(WORKFLOWS)) return []
+  const treffer = new Set()
+  for (const datei of readdirSync(WORKFLOWS).filter((f) => /\.ya?ml$/.test(f))) {
+    for (const m of readFileSync(join(WORKFLOWS, datei), 'utf8').matchAll(/^\s*-?\s*uses:\s*(\S+)/gm)) {
+      treffer.add(m[1].replace(/['"]/g, ''))
+    }
+  }
+  return [...treffer].sort()
+}
+
+/** `owner/repo/unterpfad@ref` -> die action.yml-URLs, die dafuer in Frage kommen. */
+const urls = (referenz) => {
+  const [pfad, ref] = referenz.split('@')
+  const teile = pfad.split('/')
+  const [owner, repo, ...unter] = teile
+  const basis = `https://raw.githubusercontent.com/${owner}/${repo}/${ref}`
+  const rest = unter.length > 0 ? `/${unter.join('/')}` : ''
+  return [`${basis}${rest}/action.yml`, `${basis}${rest}/action.yaml`]
+}
+
+const holen = async (referenz) => {
+  for (const url of urls(referenz)) {
+    const antwort = await fetch(url)
+    if (antwort.ok) return await antwort.text()
+    if (antwort.status !== 404) throw new Error(`${url} -> HTTP ${antwort.status}`)
+  }
+  return null
+}
+
+const laufzeit = (inhalt) => {
+  const m = inhalt.match(/^\s*using:\s*['"]?([\w.-]+)['"]?/m)
+  return m ? m[1] : null
+}
+
+const inneresUses = (inhalt) => [
+  ...new Set([...inhalt.matchAll(/^\s*uses:\s*['"]?(\S+?)['"]?\s*(?:#.*)?$/gm)].map((m) => m[1])),
+]
+
+/** Lokale Pfade und Docker-Referenzen haben kein action.yml auf GitHub. */
+const pruefbar = (referenz) =>
+  referenz.includes('@') && !referenz.startsWith('.') && !referenz.startsWith('docker://')
+
+const maengel = []
+const gesehen = new Map()
+
+/**
+ * Erst ALLE eigenen Pins, dann das Innere der Composites. Die Reihenfolge ist
+ * kein Detail: taucht dieselbe Action beides Mal auf, soll die Meldung an dem
+ * Pin haengen, den man tatsaechlich anheben kann -- an unserem.
+ */
+const pruefe = async (referenz, ueber) => {
+  if (!pruefbar(referenz) || gesehen.has(referenz)) return null
+  gesehen.set(referenz, true)
+  const inhalt = await holen(referenz)
+  if (inhalt === null) {
+    maengel.push(`${referenz}: keine action.yml an diesem Ref gefunden (Tippfehler im Pin?)`)
+    return null
+  }
+  const art = laufzeit(inhalt)
+  if (art === 'composite') return { referenz, innen: inneresUses(inhalt) }
+  const version = art && art.startsWith('node') ? Number(art.slice(4)) : null
+  if (version !== null && version < MINDESTENS) {
+    if (ueber && referenz in NICHT_UNSER_PIN) return null
+    maengel.push(
+      ueber
+        ? `${referenz} laeuft auf ${art} (verschachtelt in ${ueber}) -- gepinnt wird ` +
+          `${ueber}, also dort das Major anheben.`
+        : `${referenz} laeuft auf ${art} -- ein neueres Major anheben.`,
+    )
+  }
+  return null
+}
+
+const alle = referenzen()
+if (alle.length === 0) {
+  console.error('FEHLER: keine `uses:`-Zeilen in .github/workflows/ gefunden -- greift der Suchlauf daneben?')
+  process.exit(1)
+}
+
+try {
+  let offen = alle.map((referenz) => ({ referenz, ueber: null }))
+  while (offen.length > 0) {
+    const naechste = []
+    for (const { referenz, ueber } of offen) {
+      const composite = await pruefe(referenz, ueber)
+      if (composite) {
+        for (const innen of composite.innen) naechste.push({ referenz: innen, ueber: composite.referenz })
+      }
+    }
+    offen = naechste
+  }
+} catch (fehler) {
+  // Kein stilles Ueberspringen: der Grund steht hier, und er steht im Log.
+  console.log(`NICHT GEPRUEFT: die Actions waren nicht erreichbar (${fehler.message}).`)
+  console.log('Der Lauf bleibt gruen, damit ein Netz-Aussetzer keinen PR blockiert.')
+  process.exit(0)
+}
+
+for (const [referenz, grund] of Object.entries(NICHT_UNSER_PIN)) {
+  if (!gesehen.has(referenz)) {
+    maengel.push(`NICHT_UNSER_PIN nennt "${referenz}" -- die Action kommt gar nicht mehr vor.`)
+  }
+  if (!grund || grund.trim().length < 40) maengel.push(`NICHT_UNSER_PIN["${referenz}"] ohne Begruendung.`)
+}
+
+if (maengel.length === 0) {
+  console.log(`OK: ${gesehen.size} Action-Referenz(en) geprueft, alle auf node${MINDESTENS} oder neuer.`)
+  process.exit(0)
+}
+
+console.error(`FEHLER: ${maengel.length} Action(s) auf abgekuendigter Node-Version:\n`)
+for (const m of maengel) console.error(`  ! ${m}`)
+console.error(
+  '\nGitHub faehrt sie derzeit noch ersatzweise auf node24 und schreibt eine Warnung\n' +
+    'ans Ende jedes Laufs. Das ist eine Frist, kein Zustand.',
+)
+process.exit(1)

--- a/tests/ciFaehrtJedePruefung.test.ts
+++ b/tests/ciFaehrtJedePruefung.test.ts
@@ -79,12 +79,30 @@ const OHNE_CI: Record<string, string> = {
     'ist der Lauf ein Werkzeug fuer die Hand, keine Zusicherung.',
 }
 
+/**
+ * Der Workflow-Text OHNE reine Kommentarzeilen.
+ *
+ * Gemessen 2026-09-05: ein Kommentar, der `npm run actions:check` bloss
+ * ERWAEHNT, hat diesen Guard zufriedengestellt -- der Lauf stand nirgends als
+ * Schritt und waere bei keinem Merge gefahren. Genau die Zusicherung, die
+ * dieser Test geben soll, war damit von einem Satz Prosa zu haben. Ein Guard,
+ * den ein Kommentar besaenftigt, ist keiner.
+ *
+ * Nur ganze Kommentarzeilen fallen weg; ein `#` mitten in einer Zeile bleibt
+ * stehen (es steckt in URLs und in Shell-Zeilen, und ein zu eifriges
+ * Wegschneiden waere die naechste stille Fehlerquelle).
+ */
 const workflowsAus = (wurzel: string): string => {
   const verzeichnis = join(wurzel, '.github', 'workflows')
   if (!existsSync(verzeichnis)) return ''
   return readdirSync(verzeichnis)
     .filter((f) => /\.ya?ml$/.test(f))
-    .map((f) => readFileSync(join(verzeichnis, f), 'utf8'))
+    .map((f) =>
+      readFileSync(join(verzeichnis, f), 'utf8')
+        .split('\n')
+        .filter((zeile) => !/^\s*#/.test(zeile))
+        .join('\n'),
+    )
     .join('\n')
 }
 

--- a/tests/macUniversalBuild.test.ts
+++ b/tests/macUniversalBuild.test.ts
@@ -1,0 +1,190 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Der macOS-Universal-Build laesst sich zusammenfuegen.
+//
+// WARUM ES DAS GIBT. `v8.3.3` hat NULL Assets. Kein DMG, keine EXE, nichts —
+// und das steht seit dem 2026-07-31 unbemerkt so auf der Release-Seite. Der
+// macOS-Job brach beim Verschmelzen der beiden Teil-Builds ab:
+//
+//   Detected file "Contents/Resources/app.asar.unpacked/node_modules/
+//   @julusian/freetype2/prebuilds/freetype2-darwin-arm64/node-napi-v7.node"
+//   that's the same in both x64 and arm64 builds and not covered by the
+//   x64ArchFiles rule: "undefined"
+//
+// Weil der `release`-Job auf `needs: build` steht, riss der macOS-Fehler auch
+// die bereits fertig gebaute Windows-.exe mit ins Nichts. Ein einziger nicht
+// gesetzter Konfigurationswert hat damit ZWEI Plattformen um ihr Artefakt
+// gebracht, und die Release-Seite sah dabei aus wie immer.
+//
+// `@julusian/freetype2` baut nichts, es liefert fertige Binaries aus: ein
+// Verzeichnis je Plattform+Arch unter `prebuilds/`, zur Laufzeit ausgewaehlt
+// von `pkg-prebuilds/bindings.js` ueber `os.arch()`. Beide Teil-Builds
+// enthalten deshalb denselben vollstaendigen Baum, Byte fuer Byte gleich.
+// `@electron/universal` verlangt fuer eine in beiden Builds identische
+// Mach-O-Datei eine ausdrueckliche Ansage (`mac.x64ArchFiles`) — sonst waere
+// ein vergessenes Rebuild nicht von einer absichtlich geteilten Datei zu
+// unterscheiden.
+//
+// WIE ER PRUEFT. In BEIDE Richtungen, und das ist der Punkt:
+//
+//  1. Jede per Pfad ausgewaehlte darwin-Prebuild-Datei im Produktions-Baum
+//     MUSS vom Muster gedeckt sein — sonst bricht der Build ab.
+//  2. Jede pro Arch NEU GEBAUTE Datei (keytar & Co. unter `build/Release/`)
+//     darf es NICHT sein. Der bequemste Weg, Fehler 1 loszuwerden, ist
+//     `x64ArchFiles: '**/*.node'` — der Build wird gruen, und die
+//     Universal-App traegt dann in beiden Architekturen die x64-Variante von
+//     keytar. Das faellt nicht beim Bauen auf, sondern auf einem Apple-
+//     Silicon-Rechner beim ersten Zugriff auf den Schluesselbund.
+//
+// Gemessen wird am echten `node_modules`, nicht an einer Liste hier: das
+// naechste Paket dieser Bauart faellt damit von selbst auf. Der Abgleich
+// laeuft mit `minimatch` und denselben Optionen, die `@electron/universal`
+// benutzt (`matchBase: true`) — eine nachgebaute Pfadlogik wuerde raten.
+//
+// WAS ER NICHT PRUEFT: ob `lipo` die zusammengefuegten Binaries akzeptiert.
+// Das braucht einen macOS-Runner; hier geht es um den Abbruch, der schon
+// vorher passiert.
+// ───────────────────────────────────────────────────────────────────────────
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+import { minimatch } from 'minimatch'
+import { describe, expect, it } from 'vitest'
+import konfiguration from '../electron-builder.js'
+
+const ROOT = join(__dirname, '..')
+
+/** So heisst die Datei spaeter IM Paket — genau diesen Pfad sieht der Merge. */
+const imPaket = (relativZuNodeModules: string): string =>
+  ['Contents', 'Resources', 'app.asar.unpacked', 'node_modules', relativZuNodeModules].join('/')
+
+/** node-Aufloesung von Hand: von `start` aus die `node_modules` hochlaufen. */
+const paketVerzeichnis = (name: string, start: string): string | null => {
+  let verzeichnis = start
+  for (;;) {
+    const kandidat = join(verzeichnis, 'node_modules', name)
+    if (existsSync(join(kandidat, 'package.json'))) return kandidat
+    const oben = join(verzeichnis, '..')
+    if (oben === verzeichnis) return null
+    verzeichnis = oben
+  }
+}
+
+/**
+ * Der Baum, den electron-builder verpackt: `dependencies` transitiv,
+ * `devDependencies` NICHT. Genau diese Grenze ist die entscheidende — ein
+ * Prebuild-Paket, das nur ein Build-Werkzeug mitbringt, landet nie im
+ * Installer und darf den Guard nicht beschaeftigen.
+ */
+const produktionsBaum = (): { name: string; verzeichnis: string }[] => {
+  const wurzel = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')) as {
+    dependencies?: Record<string, string>
+  }
+  const gesehen = new Set<string>()
+  const treffer: { name: string; verzeichnis: string }[] = []
+  const offen = Object.keys(wurzel.dependencies ?? {}).map((n) => ({ name: n, von: ROOT }))
+  while (offen.length > 0) {
+    const { name, von } = offen.pop()!
+    const verzeichnis = paketVerzeichnis(name, von)
+    if (!verzeichnis || gesehen.has(verzeichnis)) continue
+    gesehen.add(verzeichnis)
+    treffer.push({ name, verzeichnis })
+    const pj = JSON.parse(readFileSync(join(verzeichnis, 'package.json'), 'utf8')) as {
+      dependencies?: Record<string, string>
+    }
+    for (const kind of Object.keys(pj.dependencies ?? {})) offen.push({ name: kind, von: verzeichnis })
+  }
+  return treffer
+}
+
+const nodeDateien = (verzeichnis: string): string[] => {
+  const treffer: string[] = []
+  const lauf = (d: string) => {
+    for (const eintrag of readdirSync(d)) {
+      if (eintrag === 'node_modules') continue
+      const pfad = join(d, eintrag)
+      if (statSync(pfad).isDirectory()) lauf(pfad)
+      else if (eintrag.endsWith('.node')) treffer.push(pfad)
+    }
+  }
+  lauf(verzeichnis)
+  return treffer
+}
+
+/**
+ * Per Pfad ausgewaehlt heisst: ein `prebuilds`-Segment, und irgendein Segment
+ * darunter nennt die Plattform. Solche Dateien sind in beiden Teil-Builds
+ * identisch, weil nichts sie neu baut.
+ */
+const istPfadPrebuild = (segmente: string[]): boolean =>
+  segmente.includes('prebuilds') &&
+  segmente.some((s, i) => i > segmente.indexOf('prebuilds') && /darwin|win32|linux/.test(s))
+
+type Fund = { pfad: string; segmente: string[] }
+
+const mac = (konfiguration as { mac?: { target?: unknown[]; x64ArchFiles?: string } }).mac ?? {}
+const muster = mac.x64ArchFiles
+
+const alleNativen: Fund[] = produktionsBaum().flatMap(({ verzeichnis }) =>
+  nodeDateien(verzeichnis).map((pfad) => {
+    const rel = relative(join(ROOT, 'node_modules'), pfad)
+    return { pfad: rel.split(sep).join('/'), segmente: rel.split(sep) }
+  }),
+)
+
+const darwinPrebuilds = alleNativen.filter(
+  (f) => istPfadPrebuild(f.segmente) && f.segmente.some((s) => s.includes('darwin')),
+)
+const proArchGebaut = alleNativen.filter((f) => !istPfadPrebuild(f.segmente))
+
+describe('der macOS-Universal-Build laesst sich zusammenfuegen', () => {
+  it('die mac-Ziele enthalten einen Universal-Build', () => {
+    // Die Voraussetzung dieses Guards, ausgesprochen statt stillschweigend
+    // angenommen: nur beim Universal-Build laeuft der Merge, um den es hier
+    // geht. Wer die Ziele bewusst aendert, aendert diese Datei mit — das ist
+    // eine sichtbare Entscheidung, kein stilles Ueberspringen.
+    const ziele = (mac.target ?? []) as { arch?: string }[]
+    expect(ziele.some((z) => z.arch === 'universal')).toBe(true)
+  })
+
+  it('findet ueberhaupt native Module im Produktions-Baum', () => {
+    // Ein leerer Suchlauf waere gruen und wertlos — etwa nach einem
+    // Umbau der Abhaengigkeiten oder ohne `npm install`.
+    expect(
+      alleNativen.length,
+      'Keine .node-Dateien im Produktions-Baum gefunden — lief `npm install`?',
+    ).toBeGreaterThan(0)
+    expect(
+      darwinPrebuilds.length,
+      'Keine per Pfad ausgewaehlten darwin-Prebuilds gefunden. Entweder liefert kein ' +
+        'Paket mehr welche aus (dann darf dieser Guard weg) oder der Suchlauf greift daneben.',
+    ).toBeGreaterThan(0)
+  })
+
+  it('jedes per Pfad ausgewaehlte darwin-Prebuild ist von x64ArchFiles gedeckt', () => {
+    const ungedeckt = darwinPrebuilds
+      .filter((f) => !muster || !minimatch(imPaket(f.pfad), muster, { matchBase: true }))
+      .map((f) => f.pfad)
+    expect(
+      ungedeckt,
+      'Diese Dateien sind in beiden Teil-Builds identisch und von `mac.x64ArchFiles` ' +
+        `nicht gedeckt (Muster: ${JSON.stringify(muster)}). @electron/universal bricht ` +
+        'daran ab — und weil der release-Job auf needs: build steht, faellt damit auch ' +
+        'das Windows-Artefakt aus. Muster in electron-builder.js erweitern.',
+    ).toEqual([])
+  })
+
+  it('die pro Arch gebauten Module sind NICHT gedeckt', () => {
+    // Die Gegenrichtung. `x64ArchFiles: '**/*.node'` macht den Build gruen und
+    // die Universal-App kaputt: keytar laege dann in beiden Architekturen als
+    // x64-Binary bei, und der Schluesselbund-Zugriff stirbt erst auf einem
+    // Apple-Silicon-Rechner beim Nutzer.
+    const faelschlichGedeckt = proArchGebaut
+      .filter((f) => muster && minimatch(imPaket(f.pfad), muster, { matchBase: true }))
+      .map((f) => f.pfad)
+    expect(
+      faelschlichGedeckt,
+      'Diese Module baut @electron/rebuild pro Architektur neu; sie MUESSEN von lipo ' +
+        'zusammengefuehrt werden. Deckt x64ArchFiles sie ab, wird stattdessen die ' +
+        'x64-Variante fuer beide Architekturen behalten.',
+    ).toEqual([])
+  })
+})

--- a/tests/releaseArtefaktnamen.test.ts
+++ b/tests/releaseArtefaktnamen.test.ts
@@ -1,0 +1,108 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Zwei Build-Ziele duerfen nicht auf dieselbe Datei schreiben.
+//
+// WARUM ES DAS GIBT. Gemessen am Suite-Release v0.1.0 (Lauf 33970319571,
+// 2026-09-05): dort steht `artifactName` nur einmal unter `win`, und NSIS und
+// Portable erben ihn beide. Im Log steht es woertlich —
+//
+//   • building  target=nsis     file=release\AV Planner Suite-0.1.0-x64.exe
+//   • building  target=portable file=release\AV Planner Suite-0.1.0-x64.exe
+//
+// — und `ls release/` zeigt danach EINE .exe. Der Portable-Build hat den
+// Installer ueberschrieben. Kein Fehler, keine Warnung: electron-builder baut
+// beide Ziele brav, das zweite legt sich auf das erste, und im Release haengt
+// eine Datei, wo zwei erwartet werden.
+//
+// Der Cable Planner hat den Zusammenstoss nur deshalb nicht, weil sein
+// `portable`-Block einen eigenen Namen setzt. Das ist kein Zustand, auf den
+// man sich verlassen sollte — es ist eine Zeile, die jemand einmal geschrieben
+// hat und die beim naechsten neuen Ziel fehlt.
+//
+// WIE ER PRUEFT. Er loest die Namen so auf, wie electron-builder es tut:
+// zielspezifischer Block (`nsis.artifactName`, `portable.artifactName`, …)
+// schlaegt Plattform-Block (`win.artifactName`), Makros werden eingesetzt, und
+// die Endung kommt vom Ziel. Danach muessen alle Namen einer Plattform
+// verschieden sein. Gezaehlt wird ueber die Ziele in der Konfiguration, nicht
+// ueber eine Liste hier.
+//
+// WAS ER NICHT PRUEFT: ob die Datei am Ende auch am Release haengt. Das
+// entscheidet der Workflow, nicht diese Datei.
+// ───────────────────────────────────────────────────────────────────────────
+import { describe, expect, it } from 'vitest'
+import konfiguration from '../electron-builder.js'
+
+/** Endung je Ziel — so benennt electron-builder die Ausgabe. */
+const ENDUNG: Record<string, string> = {
+  nsis: 'exe',
+  portable: 'exe',
+  msi: 'msi',
+  appx: 'appx',
+  dmg: 'dmg',
+  zip: 'zip',
+  pkg: 'pkg',
+  mas: 'pkg',
+  AppImage: 'AppImage',
+  deb: 'deb',
+  rpm: 'rpm',
+}
+
+type Ziel = { target: string; arch?: string }
+type Block = { target?: (Ziel | string)[]; artifactName?: string }
+
+const konfig = konfiguration as Record<string, unknown> & {
+  productName?: string
+}
+
+const einsetzen = (vorlage: string, ziel: Ziel): string =>
+  vorlage
+    .replaceAll('${productName}', konfig.productName ?? 'App')
+    .replaceAll('${name}', konfig.productName ?? 'App')
+    .replaceAll('${version}', '0.0.0')
+    .replaceAll('${arch}', ziel.arch ?? 'x64')
+    .replaceAll('${ext}', ENDUNG[ziel.target] ?? ziel.target)
+    .replaceAll('${os}', 'os')
+
+const zieleVon = (plattform: string): Ziel[] => {
+  const block = konfig[plattform] as Block | undefined
+  return (block?.target ?? []).map((z) => (typeof z === 'string' ? { target: z } : z))
+}
+
+const namenVon = (plattform: string): { ziel: string; datei: string }[] => {
+  const block = konfig[plattform] as Block | undefined
+  return zieleVon(plattform).map((ziel) => {
+    // Genau die Reihenfolge, die electron-builder anwendet.
+    const zielBlock = konfig[ziel.target] as { artifactName?: string } | undefined
+    const vorlage =
+      zielBlock?.artifactName ??
+      block?.artifactName ??
+      (konfig.artifactName as string | undefined) ??
+      '${productName}-${version}-${arch}.${ext}'
+    return { ziel: `${ziel.target}/${ziel.arch ?? 'x64'}`, datei: einsetzen(vorlage, ziel) }
+  })
+}
+
+describe('kein Build-Ziel ueberschreibt das Artefakt eines anderen', () => {
+  const plattformen = ['win', 'mac', 'linux'].filter((p) => zieleVon(p).length > 0)
+
+  it('findet ueberhaupt Ziele', () => {
+    // Ein leerer Suchlauf waere gruen und wertlos.
+    expect(plattformen.length, 'Keine Build-Ziele in electron-builder.js gefunden.').toBeGreaterThan(0)
+    expect(plattformen.flatMap(zieleVon).length).toBeGreaterThan(1)
+  })
+
+  for (const plattform of plattformen) {
+    it(`${plattform}: jedes Ziel schreibt in eine eigene Datei`, () => {
+      const namen = namenVon(plattform)
+      const zusammenstoesse = namen
+        .filter((a, i) => namen.some((b, j) => i !== j && a.datei === b.datei))
+        .map((n) => `${n.ziel} -> ${n.datei}`)
+      expect(
+        zusammenstoesse,
+        'Diese Ziele schreiben auf denselben Dateinamen. electron-builder baut beide ' +
+          'ohne Warnung, das spaeter gebaute ueberschreibt das frueher gebaute, und im ' +
+          'Release fehlt eines davon. Abhilfe: eigener `artifactName` im Ziel-Block ' +
+          '(z. B. `portable: { artifactName: "${productName}-${version}-portable.${ext}" }`).',
+      ).toEqual([])
+    })
+  }
+})


### PR DESCRIPTION
## Befund

**`v8.3.3` hat keine einzige Datei am Release.** Kein DMG, keine EXE, nichts — und das steht seit dem 2026-07-31 unbemerkt so auf der Release-Seite. Der heutige Suite-Tag `v0.1.0` ist an derselben Stelle gescheitert.

Der macOS-Job bricht beim Verschmelzen der beiden Teil-Builds ab ([Lauf 30617724085](https://github.com/larszu/cable-planner/actions/runs/30617724085)):

```
⨯ Detected file "Contents/Resources/app.asar.unpacked/node_modules/@julusian/freetype2/
  prebuilds/freetype2-darwin-arm64/node-napi-v7.node" that's the same in both x64 and
  arm64 builds and not covered by the x64ArchFiles rule: "undefined"
```

`@julusian/freetype2` baut nichts, es liefert fertige Binaries aus — ein Verzeichnis je Plattform+Arch unter `prebuilds/`, zur Laufzeit ausgewählt von `pkg-prebuilds/bindings.js` über `os.arch()`. Beide Teil-Builds tragen deshalb denselben vollständigen Baum, Byte für Byte gleich. `@electron/universal` verlangt für eine in beiden Builds identische Mach-O-Datei eine ausdrückliche Ansage — sonst wäre ein vergessenes Rebuild nicht von einer absichtlich geteilten Datei zu unterscheiden — und bricht sonst ab. `lipo` wäre hier auch falsch: die Auswahl passiert über den **Pfad**, nicht über eine Fat-Binary.

Das ist kein Zufallstreffer von v8.3.3, sondern der Zustand **seit der Umstellung auf den Universal-Build (#592)**: `v8.3.2` baute noch `--x64 --arm64` getrennt und war grün. Der Universal-Build hat also nie ein Artefakt erzeugt.

## Tragweite

Weil `release` auf `needs: build` steht, hat der macOS-Fehler auch die längst fertige **Windows-.exe** mitgerissen. Ein einziger nicht gesetzter Konfigurationswert hat zwei Plattformen um ihr Artefakt gebracht — und die Release-Seite sah dabei aus wie jede andere.

Das in #694 gelöschte `mac-build.yml` war keine Rückfalloption: es rief `--mac dmg --universal` auf und lief in exakt denselben Abbruch.

## Was drin ist

- **`mac.x64ArchFiles: '**/prebuilds/*darwin*/**'`.** Der Name der Option ist irreführend, ihre Wirkung ist die richtige: „identisch ist in Ordnung, eine Kopie behalten". Sie greift ausschließlich im Gleichheitsfall — unterscheiden sich die Dateien, läuft weiterhin `lipo`. Das Muster deckt bewusst die **Form** ab (per Pfad benannte Prebuild-Verzeichnisse), nicht das eine Paket.

- **`tests/macUniversalBuild.test.ts`** prüft in **beide** Richtungen, und das ist der Punkt:
  1. Jede per Pfad ausgewählte darwin-Prebuild-Datei im Produktions-Baum **muss** gedeckt sein.
  2. Jede pro Arch neu gebaute Datei (keytar) darf es **nicht** sein. Der bequemste Weg, den Abbruch loszuwerden, ist `'**/*.node'` — der Build wird grün, und die Universal-App trägt dann in beiden Architekturen die x64-Variante von keytar. Das fällt nicht beim Bauen auf, sondern auf einem Apple-Silicon-Rechner beim ersten Schlüsselbund-Zugriff.

  Gemessen wird am echten `node_modules`, verglichen mit `minimatch` und denselben Optionen wie in `@electron/universal` (eine nachgebaute Pfadlogik würde raten). Gegenproben in beide Richtungen gemacht: ohne Muster meldet er beide freetype2-Dateien, mit `'**/*.node'` meldet er keytar.

- **`tests/releaseArtefaktnamen.test.ts`**: zwei Build-Ziele dürfen nicht auf dieselbe Datei schreiben. Im Suite-Lauf von heute passiert genau das — NSIS und Portable erben denselben `artifactName`, electron-builder baut beide ohne Warnung, das zweite legt sich auf das erste, und im Release hängt **eine** .exe statt zwei. Cable hat den Zusammenstoß nur deshalb nicht, weil sein `portable`-Block einen eigenen Namen setzt — eine Zeile, die jemand einmal geschrieben hat und die beim nächsten Ziel fehlt. Gegenprobe: Zeile entfernt, Test rot.

- **`release.yml` → Schritt „Release-Vollständigkeit prüfen"**. Er prüft nicht, dass *irgendwas* da ist (das tut `if-no-files-found: error` je Job), sondern dass **jede Gattung** da ist: `*.exe`, `*.dmg`, `*.zip`, `latest.yml`, `latest-mac.yml`. Ein halbes Release ist schlimmer als keines — es sieht auf der Release-Seite vollständig aus.

- **`minimatch` als devDependency deklariert.** Sie war bisher nur transitiv da, und der Test hängt daran — genau die Kante, gegen die #694 den Guard gebaut hat.

## Geprüft

- `npx tsc -p tsconfig.app.json --noEmit` → 0 Errors
- `npm test` → 107 Dateien, 1023 Tests grün
- Beide neuen Guards in beide Richtungen gegengeprobt

**Vorbehalt:** `electron-builder` lässt sich in dieser Umgebung nicht ausführen (der Egress-Filter blockiert die node-gyp-Header für `freetype2`). Der Befund steht auf der gelesenen Abbruchlogik in `@electron/universal/dist/cjs/index.js` und auf den echten Lauf-Logs beider Repos; die Probe ist der nächste Tag-Build.

## Danach

`main` trägt `package.json` noch auf `8.3.2`, weil der `sync-version-to-main`-Job von v8.3.3 nie lief (er hängt an `release`). Nach dem Merge einen neuen Tag setzen — `v8.3.3` selbst ist als Release verbrannt, das Asset-Upload läuft nur beim Tag-Push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_