### PR TITLE
fix(test): der neue Guard nahm an, node_modules liege neben package.json

### DIFF
--- a/tests/macUniversalBuild.test.ts
+++ b/tests/macUniversalBuild.test.ts
@@ -45,7 +45,7 @@
 // vorher passiert.
 // ───────────────────────────────────────────────────────────────────────────
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
-import { join, relative, sep } from 'node:path'
+import { join, sep } from 'node:path'
 import { minimatch } from 'minimatch'
 import { describe, expect, it } from 'vitest'
 import konfiguration from '../electron-builder.js'
@@ -123,10 +123,26 @@ type Fund = { pfad: string; segmente: string[] }
 const mac = (konfiguration as { mac?: { target?: unknown[]; x64ArchFiles?: string } }).mac ?? {}
 const muster = mac.x64ArchFiles
 
+/**
+ * Der Pfad ab dem LETZTEN `node_modules`-Segment -- genau so adressiert
+ * electron-builder die Datei im Paket.
+ *
+ * Nicht `relative(ROOT/node_modules, …)`: das setzt voraus, dass die
+ * Abhaengigkeiten direkt neben der `package.json` liegen. In der vendorten
+ * Kopie unter `av-planner-suite/apps/cable-planner/` sind sie an die
+ * Monorepo-Wurzel gehoistet, und der relative Pfad begann dann mit `../../..`
+ * -- das Muster traf nichts mehr, und der Guard meldete faelschlich einen
+ * Fehler (gemessen 2026-09-05, gefunden von genau dieser Kopie).
+ */
+const imBaum = (pfad: string): string[] => {
+  const teile = pfad.split(sep)
+  return teile.slice(teile.lastIndexOf('node_modules') + 1)
+}
+
 const alleNativen: Fund[] = produktionsBaum().flatMap(({ verzeichnis }) =>
   nodeDateien(verzeichnis).map((pfad) => {
-    const rel = relative(join(ROOT, 'node_modules'), pfad)
-    return { pfad: rel.split(sep).join('/'), segmente: rel.split(sep) }
+    const segmente = imBaum(pfad)
+    return { pfad: segmente.join('/'), segmente }
   }),
 )
 


### PR DESCRIPTION
## Befund

`tests/macUniversalBuild.test.ts` (aus #695) bildete den Pfad im Paket über `relative(ROOT/node_modules, datei)`. Das setzt voraus, dass die Abhängigkeiten direkt neben der `package.json` liegen.

In der vendorten Kopie unter `av-planner-suite/apps/cable-planner/` sind sie an die Monorepo-Wurzel gehoistet: der relative Pfad begann dort mit `../../..`, das Muster traf nichts mehr, und der Guard meldete **beide** freetype2-Prebuilds als ungedeckt — obwohl `mac.x64ArchFiles` sie deckt.

Ein Guard, der am selben Code je nach Verzeichnislage etwas anderes sagt, ist schlimmer als keiner: hier hätte er die Suite-CI rot gefärbt und den nächsten Leser dazu gebracht, ein funktionierendes Muster zu „reparieren".

## Fix

Der Pfad kommt jetzt vom **letzten** `node_modules`-Segment an — genau so adressiert electron-builder die Datei im Paket, unabhängig davon, wie tief das Paket installiert ist.

Gefunden hat das die vendorte Kopie selbst, beim ersten Lauf nach dem Vendoring. Das ist der Zweck eines Guards, der mitwandert: er misst die Kopie, nicht das Original.

## Geprüft

- Gegenproben erneut in beide Richtungen: ohne Muster meldet er beide freetype2-Dateien, mit `'**/*.node'` meldet er keytar
- `npx tsc -p tsconfig.app.json --noEmit` → 0 Errors
- `npm test` → 107 Dateien, 1023 Tests grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_