### PR TITLE
fix(release): `mergeASARs:false` machte die App unstartbar — dritte Stufe

### DIFF
--- a/electron-builder.js
+++ b/electron-builder.js
@@ -14,6 +14,35 @@ export default {
   // doppelt hochladen" — die publish-CONFIG bleibt im Paket eingebettet.
   publish: [{ provider: 'github', owner: 'larszu', repo: 'cable-planner', releaseType: 'release' }],
   files: ['dist/**/*', 'package.json'],
+  // DIE VERPACKTE package.json DARF KEIN `type: module` TRAGEN.
+  //
+  // Gemessen an der ausgelieferten Suite-App `v0.1.1`, die beim Start
+  // abstuerzt -- dieselbe Konstellation steckt hier:
+  //
+  //   ReferenceError: exports is not defined in ES module scope
+  //   ... app.asar/package.json contains "type": "module"
+  //   at app.asar/index.js:5:23
+  //
+  // `index.js` ist nicht unser Code, sondern der Einsprung-Shim, den
+  // `@electron/universal` bei `mergeASARs: false` erzeugt: er waehlt zur
+  // Laufzeit zwischen `app-x64.asar` und `app-arm64.asar`. Der Shim ist
+  // CommonJS (`exports`, `require`), heisst `index.js` -- und daneben legt
+  // @electron/universal eine KOPIE UNSERER package.json. Steht dort
+  // `type: module`, parst Node den Shim als ESM und die App ist tot, bevor
+  // eine Zeile eigener Code laeuft.
+  //
+  // `@electron/universal@3.x` behebt das (es schreibt dann `index.mjs`), ist
+  // hier aber nicht zu haben: `app-builder-lib` pinnt 2.0.3 exakt, und ein
+  // npm-`overrides` liesse sich nur mit einer vollstaendigen Neuaufloesung
+  // des Lockfiles anwenden.
+  //
+  // `extraMetadata` aendert NUR die verpackte package.json, nicht die im
+  // Repo: `eslint.config.js`, `vite.config.ts` und diese Datei bleiben ESM.
+  // Was dadurch ESM verliert, bekommt es zurueck: `scripts/mark-main-esm.mjs`
+  // legt bei jedem `build:main` ein `dist/main/package.json` mit
+  // `type: module` ab -- der Main-Prozess ist der einzige Node-geladene
+  // ESM-Code im Paket.
+  extraMetadata: { type: 'commonjs' },
   directories: {
     buildResources: 'build',
     output: 'release',

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "dev:preload": "tsc -p tsconfig.preload.json --watch",
     "dev:electron": "wait-on http-get://localhost:5173 dist/main/index.js dist/main/preload.cjs && cross-env VITE_DEV_SERVER_URL=http://localhost:5173 electron .",
     "build": "npm run build:main && npm run build:preload && npm run build:renderer",
-    "build:main": "tsc -p tsconfig.main.json",
+    "build:main": "tsc -p tsconfig.main.json && node scripts/mark-main-esm.mjs",
     "build:preload": "tsc -p tsconfig.preload.json",
     "build:renderer": "vite build",
     "lint": "eslint .",

--- a/scripts/mark-main-esm.mjs
+++ b/scripts/mark-main-esm.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// ───────────────────────────────────────────────────────────────────────────
+// `dist/main/` bekommt eine eigene `package.json` mit `type: module`.
+//
+// WARUM ES DAS GIBT. Der Main-Prozess ist ESM (`tsconfig.main.json`, node16):
+// `.js`-Dateien mit `import`/`export`. Node entscheidet das an der
+// NAECHSTGELEGENEN `package.json` -- bisher war das die des Repos, und die
+// sagt `type: module`.
+//
+// Im PAKET gilt das nicht mehr: dort steht `type: commonjs` (siehe
+// `extraMetadata` in `electron-builder.js`), weil der Einsprung-Shim des
+// macOS-Universal-Builds sonst als ESM geparst wird und die App beim Start
+// stirbt -- gemessen an der ausgelieferten Suite-App `v0.1.1`:
+//
+//   ReferenceError: exports is not defined in ES module scope
+//   ... app.asar/package.json contains "type": "module"
+//
+// Ohne diese Datei waere der Main-Prozess im Installer CommonJS und die App
+// startete gar nicht mehr ("Cannot use import statement outside a module").
+// Sie kostet nichts und steht deshalb bei JEDEM Build, nicht nur beim mac-Build:
+// eine Datei, die nur manchmal entsteht, ist die naechste Fehlerquelle.
+// ───────────────────────────────────────────────────────────────────────────
+import { existsSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const ZIEL = join(ROOT, 'dist', 'main')
+
+if (!existsSync(ZIEL)) {
+  console.error(`FEHLER: ${ZIEL} gibt es nicht -- lief \`tsc -p tsconfig.main.json\` vorher?`)
+  process.exit(1)
+}
+
+writeFileSync(join(ZIEL, 'package.json'), `${JSON.stringify({ type: 'module' }, null, 2)}\n`)
+console.log('[mark-main-esm] dist/main/package.json geschrieben (type: module)')

--- a/tests/macUniversalBuild.test.ts
+++ b/tests/macUniversalBuild.test.ts
@@ -265,6 +265,43 @@ describe('der macOS-Universal-Build laesst sich zusammenfuegen', () => {
     }
   })
 
+  it('die verpackte package.json bringt den Einsprung-Shim nicht um', () => {
+    // Die DRITTE Stufe, an der der Universal-Build reisst -- und sie entsteht
+    // erst durch `mergeASARs: false`. Gemessen an der ausgelieferten Suite-App
+    // v0.1.1: `ReferenceError: exports is not defined in ES module scope`,
+    // geworfen in `app.asar/index.js`.
+    //
+    // Das ist nicht unser Code: `@electron/universal` legt bei
+    // `mergeASARs: false` einen CommonJS-Shim als `index.js` ab und daneben
+    // eine KOPIE unserer package.json. Sagt die `type: module`, parst Node den
+    // Shim als ESM, und die App stirbt vor der ersten eigenen Zeile.
+    //
+    // Ab `@electron/universal@3` schreibt es in dem Fall `index.mjs`; die
+    // Forderung faellt dann von selbst weg, ohne dass jemand diese Datei
+    // anfassen muss.
+    const universalPaket = JSON.parse(
+      readFileSync(join(ROOT, 'node_modules', '@electron', 'universal', 'package.json'), 'utf8'),
+    ) as { version: string }
+    const major = Number(universalPaket.version.split('.')[0])
+    const universal = ((mac.target ?? []) as { arch?: string }[]).some((z) => z.arch === 'universal')
+    if (!universal || mac.mergeASARs !== false || major >= 3) return
+
+    const eigenes = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')) as { type?: string }
+    // `extraMetadata` gewinnt ueber die package.json im Repo -- genau dafuer
+    // ist es da, und genau das landet spaeter im Archiv.
+    const konfig = konfiguration as { extraMetadata?: { type?: string } }
+    const effektiv = konfig.extraMetadata?.type ?? eigenes.type
+
+    expect(
+      effektiv,
+      `@electron/universal@${universalPaket.version} legt bei mergeASARs:false einen ` +
+        'CommonJS-Shim als `index.js` neben eine Kopie dieser package.json. Mit ' +
+        '`type: module` startet die App nicht -- "exports is not defined in ES module ' +
+        "scope\". Abhilfe: `extraMetadata: { type: 'commonjs' }`, und der ESM-Teil " +
+        'bekommt seine eigene package.json (scripts/mark-main-esm.mjs).',
+    ).not.toBe('module')
+  })
+
   it('die pro Arch gebauten Module sind NICHT gedeckt', () => {
     // Die Gegenrichtung. `x64ArchFiles: '**/*.node'` macht den Build gruen und
     // die Universal-App kaputt: keytar laege dann in beiden Architekturen als


### PR DESCRIPTION
## Befund

Die ausgelieferte Suite-App `v0.1.1` **startet nicht**:

```
ReferenceError: exports is not defined in ES module scope
... app.asar/package.json contains "type": "module"
at app.asar/index.js:5:23
```

`index.js` ist **nicht unser Code**. Es ist der Einsprung-Shim, den `@electron/universal` bei `mergeASARs: false` erzeugt — also durch die Änderung aus #697. Er wählt zur Laufzeit zwischen `app-x64.asar` und `app-arm64.asar`, ist CommonJS (`exports`, `require`), heißt `index.js` — und daneben legt @electron/universal eine **Kopie unserer package.json**. Steht dort `type: module`, parst Node ihn als ESM, und die App ist tot, bevor eine Zeile eigener Code läuft.

**Dieses Repo hat dieselbe Konstellation** (`type: module` im Root, seit #697 `mergeASARs: false`). Der nächste Tag wäre hier genauso gestorben.

## Zwei Wege, die es nicht sind

- **`@electron/universal@3.x`** behebt es (schreibt dann `index.mjs`, erkannt über `detectEntrypointModule`). Nicht zu haben: `app-builder-lib` pinnt `2.0.3` **exakt**, und npm wendet ein `overrides` nur bei vollständiger Neuauflösung des Lockfiles an — die scheitert an einem npm-Bug (`Cannot read properties of null (reading 'edgesOut')`, npm 10.9.7). Gegengeprobt: der Crash kommt **auch ohne** den Override; das Lockfile des Suite-Workspace lässt sich derzeit gar nicht von Grund auf neu auflösen.
- **`type: module` aus der Repo-`package.json` nehmen.** Das trifft `eslint.config.js`, `vite.config.ts`, `electron-builder.js` und den ganzen Main-Prozess — viel Fläche für ein Problem, das nur im Paket existiert.

## Fix

`extraMetadata: { type: 'commonjs' }` ändert **nur die verpackte** package.json, nicht die im Repo; die Werkzeuge bleiben ESM.

Was dadurch ESM verliert, bekommt es zurück: `scripts/mark-main-esm.mjs` legt bei jedem `build:main` ein `dist/main/package.json` mit `type: module` ab. Der Main-Prozess ist der einzige Node-geladene ESM-Code im Paket; ohne diese Datei stürbe die App im Installer mit „Cannot use import statement outside a module".

## Am echten Paket nachgemessen, nicht hergeleitet

`electron-builder --linux dir --config.npmRebuild=false` läuft in dieser Umgebung durch. Im erzeugten Archiv steht:

```
app.asar/package.json           ->  type = commonjs, main = dist/main/index.js
app.asar/dist/main/package.json ->  { "type": "module" }
```

Bei der Gelegenheit die **Schätzung aus #697 durch eine Messung ersetzt**: das Paket entpackt **523 Dateien**, das Merge-Muster wäre **68.600 Zeichen** lang. Die Schätzung lag bei 568 / 66.564 — andere Zahl, gleicher Schluss, und die Untergrenze war als Untergrenze richtig ausgewiesen.

## Guard

`tests/macUniversalBuild.test.ts` hält die Kombination fest: Universal-Ziel **und** `mergeASARs: false` **und** `@electron/universal` unter 3 ⇒ die verpackte package.json darf nicht `type: module` sagen. Ab Version 3 fällt die Forderung von selbst weg.

**Gegenprobe:** `extraMetadata` entfernt → Test rot mit genau der Fehlermeldung aus dem Absturz.

## Geprüft

- `npx tsc -p tsconfig.app.json --noEmit` → 0 Errors
- `npm test` → 107 Dateien, 1025 Tests grün
- `npm run lint` → 0 Errors
- Linux-Paket gebaut und das Archiv inspiziert (siehe oben)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_