### PR TITLE
fix(test): der neue Guard griff wieder auf `ROOT/node_modules` zu

### DIFF
--- a/tests/macUniversalBuild.test.ts
+++ b/tests/macUniversalBuild.test.ts
@@ -279,8 +279,19 @@ describe('der macOS-Universal-Build laesst sich zusammenfuegen', () => {
     // Ab `@electron/universal@3` schreibt es in dem Fall `index.mjs`; die
     // Forderung faellt dann von selbst weg, ohne dass jemand diese Datei
     // anfassen muss.
+    // NICHT `join(ROOT, 'node_modules', ...)`: in der vendorten Kopie unter
+    // `av-planner-suite/apps/cable-planner/` liegen die Abhaengigkeiten an der
+    // Monorepo-Wurzel. Genau dieser Fehler steckte schon in der Pfad-Bildung
+    // dieses Tests (#696) -- `paketVerzeichnis` laeuft die `node_modules`
+    // hoch und trifft beide Lagen.
+    const universalDir = paketVerzeichnis('@electron/universal', ROOT)
+    expect(
+      universalDir,
+      '@electron/universal ist nicht auffindbar -- ohne das Paket hat diese Pruefung ' +
+        'keine Grundlage, und sie darf dann nicht stillschweigend durchgehen.',
+    ).not.toBeNull()
     const universalPaket = JSON.parse(
-      readFileSync(join(ROOT, 'node_modules', '@electron', 'universal', 'package.json'), 'utf8'),
+      readFileSync(join(universalDir!, 'package.json'), 'utf8'),
     ) as { version: string }
     const major = Number(universalPaket.version.split('.')[0])
     const universal = ((mac.target ?? []) as { arch?: string }[]).some((z) => z.arch === 'universal')


### PR DESCRIPTION
## Befund

Der Shim-Guard aus #698 las `@electron/universal` über `join(ROOT, 'node_modules', ...)`. In der vendorten Kopie unter `av-planner-suite/apps/cable-planner/` liegen die Abhängigkeiten an der Monorepo-Wurzel — der Pfad zeigt dort ins Leere, und der Test starb mit `ENOENT` statt zu prüfen.

**Das ist derselbe Fehler wie in #696, im selben File, zwei Stunden später.** Beim ersten Mal war es die Pfad-Bildung für die entpackten Dateien, jetzt das Nachschlagen der Paket-Version. Die Datei hat seit #696 einen Resolver, der die `node_modules` hochläuft und beide Lagen trifft — `paketVerzeichnis`. Der neue Guard hat ihn nur nicht benutzt.

Gefunden hat es wieder **die Kopie**, beim ersten Lauf nach dem Vendoring. Das ist der Zweck eines Guards, der mitwandert — und diesmal hat er einen Fehler in einem Guard gefunden.

## Fix

`paketVerzeichnis('@electron/universal', ROOT)` statt des festen Pfads. Findet er das Paket nicht, fällt der Test jetzt mit klarer Ansage durch statt mit `ENOENT`: ohne `@electron/universal` hat die Prüfung keine Grundlage, und sie darf dann nicht stillschweigend durchgehen.

## Geprüft

- Gegenprobe erneut: `extraMetadata` entfernt → Test rot
- `npx tsc -p tsconfig.app.json --noEmit` → 0 Errors
- `npm test` → 107 Dateien, 1025 Tests grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_