### PR TITLE
checks: Pruefung 18 nennt die aufgezeichnete Port-Quelle statt einer festen

### DIFF
--- a/src/renderer/lib/drawingChecks.ts
+++ b/src/renderer/lib/drawingChecks.ts
@@ -581,11 +581,23 @@ export const runDrawingChecks = (
     // soll, wurde von einer Vermutung beantwortet. Ports tragen die ganze
     // Verkabelung: ein erfundener Port ist ein Kabel, das es nicht gibt.
     else if (e.specSource?.inputs || e.specSource?.outputs) {
+      // Die Meldung nennt die AUFGEZEICHNETE Herkunft, statt eine zu behaupten.
+      // Vorher stand hier fest „AI-Vorschlag" — richtig, solange der
+      // Port-Vorschlag die einzige Quelle ohne Datenblatt war. Sobald eine
+      // zweite dazukommt (die Suite-Shell schiebt ihr Projekt als Seed in den
+      // eingebetteten Planer und legt daraus Ports an), benennt derselbe Satz
+      // die falsche Quelle — und zwar ausgerechnet in der Pruefung, die zu
+      // belegten Daten zwingen soll. `specSource.source` traegt den Beleg
+      // ohnehin als ganzen Satz; er wird hier gelesen statt nacherzaehlt.
+      // Leerer Beleg zaehlt wie keiner: `??` faengt nur null/undefined, und ein
+      // leerer Text ergaebe „Ports stammen aus  —" statt einer Aussage.
+      const belegText = (e.specSource?.inputs?.source || e.specSource?.outputs?.source || '').trim()
+      const beleg = belegText || undefined
       findings.push({
         id: `ports-guessed:${e.id}`,
         severity: 'warning',
         category: 'Ports geraten',
-        message: `${e.name}: Ports stammen aus einem AI-Vorschlag, nicht aus einem Datenblatt — gegen die realen Anschlüsse prüfen`,
+        message: `${e.name}: Ports stammen aus ${beleg ?? 'einer Quelle ohne Datenblatt'} — gegen die realen Anschlüsse prüfen`,
         equipmentId: e.id,
       })
     }

--- a/tests/portsGuessed.test.ts
+++ b/tests/portsGuessed.test.ts
@@ -144,3 +144,41 @@ describe('die beiden Haelften am Quelltext', () => {
     expect(portsSectionSrc).toContain("from '../../../lib/portProvenance'")
   })
 })
+
+describe('drawingChecks — die Meldung nennt die aufgezeichnete Quelle', () => {
+  // WARUM DIESER TEST. Bis hierher stand die Quelle als fester Text in der
+  // Meldung („AI-Vorschlag"), waehrend `specSource.source` sie als Datum
+  // fuehrte. Solange es nur eine Quelle ohne Datenblatt gab, fiel das nicht
+  // auf. Mit der zweiten (Suite-Seed) wuerde dieselbe Zeile eine falsche
+  // Herkunft behaupten — in genau der Pruefung, die zu belegten Daten zwingen
+  // soll. Der Test haelt beide Richtungen fest: der Beleg wird gelesen, und
+  // ohne Beleg wird nichts erfunden.
+  const mitBeleg = (quelle: string): EquipmentItem => ({
+    id: 'e9',
+    name: 'Gerät',
+    category: 'Sonstiges',
+    inputs: [{ id: 'i1', name: 'IN', type: 'BNC', connectorType: 'BNC' }],
+    outputs: [],
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 160,
+    specSource: { inputs: { value: '1 In / 0 Out', source: quelle } },
+  })
+
+  it('gibt den Text aus specSource.source wieder', () => {
+    const quelle = 'Suite-Seed aus dem Shell-Projekt — nicht aus einem Datenblatt'
+    const { findings } = runDrawingChecks({ equipment: [mitBeleg(quelle)], cables: [] })
+    const f = findings.find((x) => x.id === 'ports-guessed:e9')
+    expect(f?.message).toContain(quelle)
+    expect(f?.message).not.toContain('AI-Vorschlag')
+  })
+
+  it('behauptet ohne Beleg-Text keine Quelle', () => {
+    const eq = mitBeleg('')
+    eq.specSource = { inputs: { value: '1 In / 0 Out', source: '' } }
+    const { findings } = runDrawingChecks({ equipment: [eq], cables: [] })
+    const f = findings.find((x) => x.id === 'ports-guessed:e9')
+    expect(f?.message).toContain('ohne Datenblatt')
+  })
+})


### PR DESCRIPTION
## Befund

Der zweite Zweig von Pruefung 18 (`drawingChecks.ts`, Kategorie „Ports geraten") schrieb die Herkunft der Ports als **festen Text** in die Meldung:

```
${e.name}: Ports stammen aus einem AI-Vorschlag, nicht aus einem Datenblatt — …
```

`EquipmentItem.specSource` fuehrt den Beleg aber ohnehin als ganzen Satz (`{ value, source }`) — die Meldung erzaehlte ihn nach, statt ihn zu lesen. Solange der Port-Vorschlag die einzige Quelle ohne Datenblatt war, fiel das nicht auf.

## Warum es jetzt auffaellt

Es kommt eine zweite Quelle dazu: die Suite-Shell schiebt ihr Projekt als Seed in den eingebetteten Planer (`av-planner-suite`, Projekt-Fluss Shell → Planer) und legt daraus Ports an. Die sind ebenso wenig aus einem Datenblatt wie ein Vorschlag — stammen aber von woanders her. Ausgerechnet die Pruefung, die einen Menschen zu belegten Daten zwingen soll, wuerde dann eine falsche Herkunft behaupten.

## Aenderung

* Die Meldung liest `specSource.inputs?.source ?? specSource.outputs?.source`.
* Ein **leerer** Beleg zaehlt wie keiner. `??` faengt nur `null`/`undefined`; ein leerer Text ergaebe „Ports stammen aus  — gegen die realen Anschluesse pruefen", also einen Satz ohne Aussage. Das hat der Test aufgedeckt, nicht das Lesen — die erste Fassung war genau so falsch.
* Zwei Tests in `tests/portsGuessed.test.ts`: der Beleg wird wiedergegeben, und ohne Beleg wird keine Quelle erfunden.

Kein Verhaltenswechsel an der Pruefung selbst — dieselben Geraete werden gemeldet, nur mit richtiger Herkunft. Die bestehenden Tests pruefen die Finding-Id, nicht den Meldungstext, und bleiben gruen.

## Test

```
npx vitest run tests/portsGuessed.test.ts tests/drawingChecksPortsUnknown.test.ts   # 13 gruen
npx tsc -p tsconfig.app.json --noEmit                                               # 0 Fehler
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_