### PR TITLE
docs: Dokument-Code auf die Listen-Ausdrucke (ADR-004 Inkrement 3)

### DIFF
--- a/src/renderer/lib/assetRegister.ts
+++ b/src/renderer/lib/assetRegister.ts
@@ -116,4 +116,4 @@ export const assetRegisterTable = (project: CablePlannerProject): CsvTable => {
 export const assetRegisterCsv = (
   project: CablePlannerProject,
   stamp?: DocumentStamp,
-): string => csvFromTable(assetRegisterTable(project), stamp)
+): string => csvFromTable(assetRegisterTable(project), stamp, 'asset-register')

--- a/src/renderer/lib/documentStamp.ts
+++ b/src/renderer/lib/documentStamp.ts
@@ -25,6 +25,7 @@
  *     Zustand.
  */
 import { toCsv, type CsvCell, type CsvTable } from './csv'
+import { buildDocQrPayload } from './qrPayload'
 import type { CablePlannerProject, ProjectRevision, RevisionSnapshot } from '../types/project'
 
 export interface DocumentStamp {
@@ -272,8 +273,34 @@ export const stampLine = (stamp: DocumentStamp): string => {
  * die die erste Zeile als Header liest. Hinten steht sie da, wo eine Fußzeile
  * hingehört — auf dem Ausdruck unten, und in Excel in der letzten Zeile.
  */
-export const csvStampRow = (stamp: DocumentStamp, columns: number): CsvCell[] => {
-  const row: CsvCell[] = [`# ${stampLine(stamp)}`]
+export const csvStampRow = (
+  stamp: DocumentStamp,
+  columns: number,
+  docId?: string,
+): CsvCell[] => {
+  // ADR-004 Inkrement 3 — der Dokument-Code auf dem Listen-Ausdruck selbst.
+  //
+  // WARUM ALS TEXT UND NICHT ALS QR. Ein CSV kann kein Bild tragen, und ein
+  // Listen-Ausdruck entsteht aus Excel — jeder QR, den wir hier erzeugten,
+  // ueberlebte den Weg nicht. Der Code als Text ueberlebt ihn, ist abtippbar
+  // und wird, wenn jemand das Blatt fotografiert, von derselben Suche
+  // gefunden wie ein gescannter.
+  //
+  // WAS ER GEGENUEBER DEN ACHT ZEICHEN KANN. Die acht Zeichen allein sagen im
+  // Mobile-Viewer entweder "aktueller Stand" oder "gehoert zu keinem aktuellen
+  // Blatt". Der Code nennt zusaetzlich das DOKUMENT — und damit wird aus
+  // "unbekannt" die brauchbare Antwort: "Pull-Liste: VERALTET, aktueller
+  // Stand #xyz". Auf der Baustelle ist das der Unterschied zwischen "irgendwas
+  // stimmt nicht" und "hol dir die neue Pull-Liste".
+  //
+  // `stampLine` bleibt unangetastet: sie ist das Format, das alle drei Planer
+  // teilen, und `stamp:parity` in der Suite haelt sie Zeichen fuer Zeichen
+  // gegeneinander. Der Code haengt hinten dran, wo er nur den cable-planner
+  // betrifft -- die anderen beiden haben kein Dokument-Register.
+  const zeile = docId
+    ? `# ${stampLine(stamp)}  ·  ${buildDocQrPayload(docId, stamp.fingerprint, stamp.revision)}`
+    : `# ${stampLine(stamp)}`
+  const row: CsvCell[] = [zeile]
   while (row.length < Math.max(1, columns)) row.push('')
   return row
 }
@@ -283,8 +310,12 @@ export const csvStampRow = (stamp: DocumentStamp, columns: number): CsvCell[] =>
  * Ohne Stempel identisch zu `toCsv` — der Aufrufer entscheidet, ob das Dokument
  * einen tragen soll (ein Zwischenexport in Excel braucht keinen).
  */
-export const csvFromTable = (table: CsvTable, stamp?: DocumentStamp): string =>
+export const csvFromTable = (
+  table: CsvTable,
+  stamp?: DocumentStamp,
+  docId?: string,
+): string =>
   toCsv(
     table.headers,
-    stamp ? [...table.rows, csvStampRow(stamp, table.headers.length)] : table.rows,
+    stamp ? [...table.rows, csvStampRow(stamp, table.headers.length, docId)] : table.rows,
   )

--- a/src/renderer/lib/handoverPackage.ts
+++ b/src/renderer/lib/handoverPackage.ts
@@ -11,6 +11,7 @@ import type { CsvTable } from './csv'
 import { buildAssetRows, assetRegisterTable } from './assetRegister'
 import { buildCableBomRows, cableBomTable } from './installerLists'
 import { stampLine, type DocumentStamp } from './documentStamp'
+import { buildDocQrPayload } from './qrPayload'
 import { INSTALL_STATUS_LABEL, type InstallStatus } from './../types/lifecycle'
 
 const fmtDate = (iso?: string): string => {
@@ -222,6 +223,12 @@ export const buildHandoverManifest = (
   if (stamp) {
     lines.push('')
     lines.push(`_${stampLine(stamp)}_`)
+    // ADR-004 Inkrement 3 — der Dokument-Code auch auf diesem Blatt. Die acht
+    // Zeichen darueber sagen im Mobile-Viewer "aktuell" oder "gehoert zu
+    // keinem aktuellen Blatt"; der Code nennt zusaetzlich das Dokument und
+    // macht daraus "Uebergabe: VERALTET, aktueller Stand #xyz".
+    lines.push('')
+    lines.push(`\`${buildDocQrPayload('uebergabe', stamp.fingerprint, stamp.revision)}\``)
   }
   return lines.join('\n')
 }

--- a/src/renderer/lib/installerLists.ts
+++ b/src/renderer/lib/installerLists.ts
@@ -156,7 +156,7 @@ export const pullListTable = (project: CablePlannerProject): CsvTable => {
 }
 
 export const pullListCsv = (project: CablePlannerProject, stamp?: DocumentStamp): string =>
-  csvFromTable(pullListTable(project), stamp)
+  csvFromTable(pullListTable(project), stamp, 'pull-liste')
 
 // --- Termination-Liste ----------------------------------------------------
 
@@ -221,7 +221,7 @@ export const terminationListTable = (project: CablePlannerProject): CsvTable => 
 export const terminationListCsv = (
   project: CablePlannerProject,
   stamp?: DocumentStamp,
-): string => csvFromTable(terminationListTable(project), stamp)
+): string => csvFromTable(terminationListTable(project), stamp, 'termination-liste')
 
 // --- Kabel-Schedule (Design-Register) -------------------------------------
 
@@ -267,7 +267,7 @@ export const cableScheduleTable = (project: CablePlannerProject): CsvTable => {
 export const cableScheduleCsv = (
   project: CablePlannerProject,
   stamp?: DocumentStamp,
-): string => csvFromTable(cableScheduleTable(project), stamp)
+): string => csvFromTable(cableScheduleTable(project), stamp, 'kabel-schedule')
 
 // --- Kabel-BOM mit Reserve ------------------------------------------------
 
@@ -352,4 +352,4 @@ export const cableBomCsv = (
   project: CablePlannerProject,
   reservePercent = 10,
   stamp?: DocumentStamp,
-): string => csvFromTable(cableBomTable(project, reservePercent), stamp)
+): string => csvFromTable(cableBomTable(project, reservePercent), stamp, 'kabel-bom')

--- a/tests/documentStamp.test.ts
+++ b/tests/documentStamp.test.ts
@@ -10,7 +10,16 @@ import {
   stampForRows,
   stampLine,
 } from '../src/renderer/lib/documentStamp'
-import { pullListTable, pullListCsv } from '../src/renderer/lib/installerLists'
+import {
+  cableBomCsv,
+  cableScheduleCsv,
+  pullListCsv,
+  pullListTable,
+  terminationListCsv,
+} from '../src/renderer/lib/installerLists'
+import { assetRegisterCsv } from '../src/renderer/lib/assetRegister'
+import { parseDocQrPayload } from '../src/renderer/lib/qrPayload'
+import { currentStand } from '../src/renderer/lib/documentRegistry'
 import { buildHandoverManifest, handoverTable } from '../src/renderer/lib/handoverPackage'
 import type { CablePlannerProject, ProjectRevision } from '../src/renderer/types/project'
 import type { Cable } from '../src/renderer/types/cable'
@@ -350,5 +359,89 @@ describe('Übergabe-Dokument', () => {
     expect(buildHandoverManifest(p)).toBe(buildHandoverManifest(p, undefined))
     // Kein Stempel-Fussnoten-Block (die '#' der Markdown-Ueberschriften bleiben).
     expect(buildHandoverManifest(p)).not.toMatch(/_Testanlage {2}·/)
+  })
+})
+
+describe('Dokument-Code auf dem Listen-Ausdruck (ADR-004 Inkrement 3)', () => {
+  // Bis hierher trug nur das Plan-PDF einen Dokument-Code (als QR). Die Listen
+  // trugen die acht Zeichen als Text -- und die sagen im Mobile-Viewer
+  // entweder "aktueller Stand" oder "gehoert zu keinem aktuellen Blatt". Der
+  // Code nennt zusaetzlich das DOKUMENT, und damit wird aus "unbekannt" die
+  // brauchbare Antwort: "Pull-Liste: VERALTET, aktueller Stand #xyz".
+  //
+  // Als TEXT und nicht als QR, weil ein CSV kein Bild traegt und der Ausdruck
+  // aus Excel entsteht: ein hier erzeugter QR ueberlebte den Weg nicht, der
+  // Code ueberlebt ihn und ist abtippbar.
+  const NOW2 = new Date('2026-09-06T08:00:00.000Z')
+
+  it('haengt den Code an die Fussnote, wenn das Dokument einen hat', () => {
+    const p = project()
+    const csv = pullListCsv(p, buildDocumentStamp(p, 'deadbeef', undefined, NOW2))
+    const letzte = csv.replace(/^﻿/, '').split('\r\n').at(-1) ?? ''
+    expect(letzte).toContain('#deadbeef')
+    expect(letzte).toContain('cableplanner://doc/pull-liste?s=deadbeef')
+  })
+
+  it('nennt die Revision im Code, wenn eine festgeschrieben ist', () => {
+    // Der Viewer kann damit auch dann etwas sagen, wenn der Stand nicht mehr
+    // passt: welche Revision das Blatt behauptet.
+    const base = project()
+    const p = {
+      ...base,
+      revisions: [revision(base)],
+      metadata: { ...base.metadata, revision: 'Rev 1' },
+    } as CablePlannerProject
+    const csv = pullListCsv(p, stampForRows(p, pullListTable, NOW2))
+    expect(csv).toContain('&r=Rev%201')
+  })
+
+  it('laesst die geteilte Stempelzeile unangetastet', () => {
+    // `stampLine` ist das Format, das alle drei Planer teilen; `stamp:parity`
+    // in der Suite haelt es Zeichen fuer Zeichen gegeneinander. Der Code haengt
+    // HINTER der Zeile, er veraendert sie nicht.
+    const p = project()
+    const stamp = buildDocumentStamp(p, 'deadbeef', undefined, NOW2)
+    const csv = pullListCsv(p, stamp)
+    expect(csv).toContain(`# ${stampLine(stamp)}  ·  `)
+  })
+
+  it('bleibt ohne Dokument-Kennung bei der blossen Stempelzeile', () => {
+    // Ein Aufrufer ohne Dokument-Begriff (eine beliebige Tabelle) bekommt
+    // genau das alte Verhalten -- sonst waere das eine stille Formataenderung.
+    const stamp = buildDocumentStamp(project(), 'deadbeef', undefined, NOW2)
+    expect(String(csvStampRow(stamp, 3)[0])).toBe(`# ${stampLine(stamp)}`)
+    expect(String(csvStampRow(stamp, 3)[0])).not.toContain('cableplanner://')
+  })
+
+  it('traegt ihn auf allen fuenf CSV-Listen und im Uebergabe-Dokument', () => {
+    // Der Punkt der ganzen Uebung: nicht eine Liste, sondern jede. Eine
+    // Ausnahme waere genau das Blatt, bei dem spaeter jemand raet.
+    const p = project()
+    const stamp = buildDocumentStamp(p, 'deadbeef', undefined, NOW2)
+    expect(pullListCsv(p, stamp)).toContain('doc/pull-liste')
+    expect(terminationListCsv(p, stamp)).toContain('doc/termination-liste')
+    expect(cableScheduleCsv(p, stamp)).toContain('doc/kabel-schedule')
+    expect(cableBomCsv(p, 10, stamp)).toContain('doc/kabel-bom')
+    expect(assetRegisterCsv(p, stamp)).toContain('doc/asset-register')
+    expect(buildHandoverManifest(p, stamp)).toContain('doc/uebergabe')
+  })
+
+  it('nutzt dieselben Kennungen, die das Dokument-Register fuehrt', () => {
+    // Ein Code mit einer Kennung, die das Register nicht kennt, ist im Viewer
+    // "Stand nicht pruefbar" -- also schlimmer als keiner, weil er Genauigkeit
+    // vortaeuscht.
+    const p = project()
+    const stamp = buildDocumentStamp(p, 'deadbeef', undefined, NOW2)
+    for (const [csv, id] of [
+      [pullListCsv(p, stamp), 'pull-liste'],
+      [terminationListCsv(p, stamp), 'termination-liste'],
+      [cableScheduleCsv(p, stamp), 'kabel-schedule'],
+      [cableBomCsv(p, 10, stamp), 'kabel-bom'],
+      [assetRegisterCsv(p, stamp), 'asset-register'],
+    ] as const) {
+      const ref = parseDocQrPayload(csv.slice(csv.indexOf('cableplanner://')).split(/[\r\n";]/)[0])
+      expect(ref?.docId).toBe(id)
+      expect(currentStand(id, p)).not.toBeNull()
+    }
   })
 })


### PR DESCRIPTION
## Worum es geht

Bis hierher trug **nur das Plan-PDF** einen Dokument-Code, und zwar als QR. Die sechs Installateur-Dokumente trugen die acht Zeichen als Text — und die sagen im Mobile-Viewer entweder „aktueller Stand" oder „gehört zu keinem aktuellen Blatt".

Der Code nennt zusätzlich **das Dokument**, und damit wird aus „unbekannt" die brauchbare Antwort: *„Pull-Liste: VERALTET, aktueller Stand #xyz"*. Auf der Baustelle ist das der Unterschied zwischen „irgendwas stimmt nicht" und „hol dir die neue Pull-Liste". ADR-004 führt das als Inkrement 3.

## Als Text und nicht als QR

Das ist keine Abkürzung, sondern die Folge des Mediums: ein CSV trägt kein Bild, und der Listen-Ausdruck entsteht aus Excel. Jeder QR, den wir hier erzeugten, überlebte den Weg nicht.

Der Code als Text überlebt ihn, ist abtippbar, und wenn jemand das Blatt fotografiert, findet ihn dieselbe Suche wie einen gescannten — `parseDocQrPayload` ist auf genau diese Toleranz gebaut.

## Was sich ändert

- **`csvStampRow` und `csvFromTable`** nehmen eine optionale Dokument-Kennung. Ohne sie bleibt alles beim Alten — ein Aufrufer ohne Dokument-Begriff bekommt exakt die bisherige Zeile, sonst wäre das eine stille Formatänderung.
- **Alle fünf CSV-Listen und das Übergabe-Dokument** geben ihre Kennung mit: `pull-liste`, `termination-liste`, `kabel-schedule`, `kabel-bom`, `asset-register`, `uebergabe`. Das sind die Kennungen des Dokument-Registers — ein Code mit einer Kennung, die das Register nicht kennt, wäre im Viewer „Stand nicht prüfbar", also **schlimmer als keiner**, weil er Genauigkeit vortäuscht. Ein Test prüft jede einzeln gegen `currentStand`.
- **`stampLine` bleibt unangetastet.** Sie ist das Format, das alle drei Planer teilen, und `stamp:parity` in der Suite hält sie Zeichen für Zeichen gegeneinander. Der Code hängt *hinter* der Zeile; light- und multicam-planner haben kein Dokument-Register und bekommen ihn nicht.

## Geprüft

6 neue Tests in `tests/documentStamp.test.ts` (37 dort, 1048 gesamt).

**Gegengeprobt** — alle vier machen den Lauf rot:

| Probe | Ergebnis |
|---|---|
| eine Liste ohne Dokument-Code | rot |
| Kennung, die das Register nicht kennt | rot |
| geteilte Stempelzeile verändert (Revision fällt weg) | rot |
| Übergabe-Dokument ohne Code | rot |

Lokal grün: `tsc --noEmit`, `lint` (0 Fehler), `vitest` (1048 Tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_