### PR TITLE
network: Schnittstellen je Gerät, Switch-Port-Karte, Plan gegen Vorgefundenes (Bedarf 19, 21, 24)

### DIFF
--- a/docs/app-structure.html
+++ b/docs/app-structure.html
@@ -240,7 +240,7 @@
   <aside>
     <h1>Cable-Planner</h1>
     <div class="subtitle">
-      App-Struktur · v9.0.0 · ~439 TS/TSX-Module · ~128.1k LOC<br>
+      App-Struktur · v9.0.0 · ~442 TS/TSX-Module · ~128.7k LOC<br>
       <small style="color:#64748b">Diese Übersicht zeigt nur die ~62 wichtigsten Module. Für die vollständige Architektur siehe <a href="./architecture.md" style="color:#94a3b8">architecture.md</a>.</small>
     </div>
 

--- a/docs/app-structure.html
+++ b/docs/app-structure.html
@@ -240,7 +240,7 @@
   <aside>
     <h1>Cable-Planner</h1>
     <div class="subtitle">
-      App-Struktur · v9.0.0 · ~435 TS/TSX-Module · ~127.1k LOC<br>
+      App-Struktur · v9.0.0 · ~439 TS/TSX-Module · ~128.1k LOC<br>
       <small style="color:#64748b">Diese Übersicht zeigt nur die ~62 wichtigsten Module. Für die vollständige Architektur siehe <a href="./architecture.md" style="color:#94a3b8">architecture.md</a>.</small>
     </div>
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Invarianten der App. Sie ist die Pflicht-Lektüre, bevor strukturelle Änderunge
 gemacht werden. Für die interaktive Modul-Übersicht siehe [`app-structure.html`](./app-structure.html),
 für einen Wettbewerber-Vergleich [`comparison.html`](./comparison.html).
 
-Stand: v9.0.0 · ~439 TS/TSX-Module · ~128.1k LOC
+Stand: v9.0.0 · ~442 TS/TSX-Module · ~128.7k LOC
 
 ---
 
@@ -124,7 +124,7 @@ isoliert testbar ist.
 
 ### 3.2 · Komponenten
 
-`src/renderer/components/` ist in 27 Subdomänen aufgeteilt:
+`src/renderer/components/` ist in 28 Subdomänen aufgeteilt:
 
 ```
 About/         Analysis/      Annotations/   Atem/          Cable/
@@ -553,7 +553,7 @@ optionales Cloud-Backend (`y-websocket`, Auth/Permissions) bleiben offen.
 `vitest` ist eingerichtet (`npm test` / `npm run test:watch`); dazu kommen
 gezielte Node-Checks (`npm run test:crdt`, `npm run test:signaling`), ein
 UI-Smoke-Skript (`npm run ui:smoke`) und ein headless Drag-/Interaktions-Test
-(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~128.1k LOC
+(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~128.7k LOC
 bleibt der Ausbau der Abdeckung wichtig — empfohlene Schwerpunkte:
 - Snapshot-Tests auf `healProjectPositions` mit echten
   Beispiel-Projekt-JSONs.
@@ -590,3 +590,4 @@ standalone, keine Edits. Wird über `.github/workflows/pages.yml`
 | Neues Geheimnis (Token, Key) | `credentialsService.ts` (`keytar`) + eigener IPC-Namensraum — **niemals** ein Feld im Projekt |
 | Neues gestempeltes Dokument | Tabelle in `lib/`, Eintrag in `DOCUMENT_STANDS` (`documentRegistry.ts`), Export via `csvFromTable(..., stamp, docId)` |
 | Alle Adressen eines Geräts lesen | `lib/networkInterfaces.ts#deviceInterfaces` — **nicht** `item.ipAddress` (das ist nur Schnittstelle 0) |
+| CSV lesen | `lib/csvParse.ts#parseCsv` — die eine Stelle; ein zweiter Parser antwortet beim ersten Semikolon im Feld anders |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Invarianten der App. Sie ist die Pflicht-Lektüre, bevor strukturelle Änderunge
 gemacht werden. Für die interaktive Modul-Übersicht siehe [`app-structure.html`](./app-structure.html),
 für einen Wettbewerber-Vergleich [`comparison.html`](./comparison.html).
 
-Stand: v9.0.0 · ~435 TS/TSX-Module · ~127.1k LOC
+Stand: v9.0.0 · ~439 TS/TSX-Module · ~128.1k LOC
 
 ---
 
@@ -245,6 +245,20 @@ CablePlannerProject
   Projekt, weil eine `.avplan` per Mail wandert, in Dropbox liegt und in den
   Mobile-/Web-Viewer geht. Beim Laden wird das Häkchen nachgefragt, nicht
   geglaubt.
+
+**NetworkInterface** (Bedarf 19, `types/network.ts`):
+- `role` (`media-primary` | `media-secondary` | `control` | `management` |
+  `unspecified`), `ipAddress?`, `subnetMask?`, `gateway?`, `macAddress?`,
+  `vlanId?`, `switchEquipmentId?`, `switchPort?`, `portId?`
+- **Die vier Netz-Felder am Gerät SIND Schnittstelle 0**; `networkInterfaces`
+  hält 1..n. Es gibt also je Adresse genau ein Zuhause — keine Spiegelung. Wer
+  ALLE Schnittstellen braucht, nimmt die Engstelle
+  `lib/networkInterfaces.ts#deviceInterfaces`, nicht `item.ipAddress`.
+  Der Grund für die Bauform steht in `types/network.ts`: `ipAddress` steht an
+  95 Stellen in 36 Dateien, und ein Umzug in einem Schritt hätte jede
+  übersehene Stelle still `undefined` lesen lassen.
+- `role` ist ohne Angabe `unspecified` — geraten wird nicht: ob die eine IP
+  einer Kamera ihre Steuerung oder ihr Medienweg ist, weiss der Plan nicht.
 
 **LocationFrame**:
 - `id`, `name`, `x`, `y`, `width`, `height`, `color`
@@ -539,7 +553,7 @@ optionales Cloud-Backend (`y-websocket`, Auth/Permissions) bleiben offen.
 `vitest` ist eingerichtet (`npm test` / `npm run test:watch`); dazu kommen
 gezielte Node-Checks (`npm run test:crdt`, `npm run test:signaling`), ein
 UI-Smoke-Skript (`npm run ui:smoke`) und ein headless Drag-/Interaktions-Test
-(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~127.1k LOC
+(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~128.1k LOC
 bleibt der Ausbau der Abdeckung wichtig — empfohlene Schwerpunkte:
 - Snapshot-Tests auf `healProjectPositions` mit echten
   Beispiel-Projekt-JSONs.
@@ -575,3 +589,4 @@ standalone, keine Edits. Wird über `.github/workflows/pages.yml`
 | Neuer Settings-Tab | `src/renderer/components/Settings/tabs/` + Eintrag in `SettingsDialog.tsx` Sidebar |
 | Neues Geheimnis (Token, Key) | `credentialsService.ts` (`keytar`) + eigener IPC-Namensraum — **niemals** ein Feld im Projekt |
 | Neues gestempeltes Dokument | Tabelle in `lib/`, Eintrag in `DOCUMENT_STANDS` (`documentRegistry.ts`), Export via `csvFromTable(..., stamp, docId)` |
+| Alle Adressen eines Geräts lesen | `lib/networkInterfaces.ts#deviceInterfaces` — **nicht** `item.ipAddress` (das ist nur Schnittstelle 0) |

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -62,14 +62,14 @@
 <header>
   <h1>Cable-Planner — Strukturvergleich mit ähnlichen Tools</h1>
   <div class="subtitle">Architektur, Tech-Stack und Domänen-Tiefe im Vergleich zu kommerziellen und Open-Source-Alternativen</div>
-  <div class="meta">Stand: 2026-06 · v9.0.0 · ~435 TS/TSX-Module · ~127.1k LOC · ~5.1 MB src/</div>
+  <div class="meta">Stand: 2026-06 · v9.0.0 · ~439 TS/TSX-Module · ~128.1k LOC · ~5.2 MB src/</div>
 </header>
 
 <h2>1 · Cable-Planner — Architektur-Kennzahlen</h2>
 
 <div class="stat-grid">
-  <div class="stat"><div class="num">435</div><div class="label">TS/TSX-Module</div></div>
-  <div class="stat"><div class="num">127.1k</div><div class="label">Lines of Code</div></div>
+  <div class="stat"><div class="num">439</div><div class="label">TS/TSX-Module</div></div>
+  <div class="stat"><div class="num">128.1k</div><div class="label">Lines of Code</div></div>
   <div class="stat"><div class="num">~75</div><div class="label">Modul-Dependencies</div></div>
   <div class="stat"><div class="num">7</div><div class="label">User-Flows</div></div>
 </div>

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -62,14 +62,14 @@
 <header>
   <h1>Cable-Planner — Strukturvergleich mit ähnlichen Tools</h1>
   <div class="subtitle">Architektur, Tech-Stack und Domänen-Tiefe im Vergleich zu kommerziellen und Open-Source-Alternativen</div>
-  <div class="meta">Stand: 2026-06 · v9.0.0 · ~439 TS/TSX-Module · ~128.1k LOC · ~5.2 MB src/</div>
+  <div class="meta">Stand: 2026-06 · v9.0.0 · ~442 TS/TSX-Module · ~128.7k LOC · ~5.2 MB src/</div>
 </header>
 
 <h2>1 · Cable-Planner — Architektur-Kennzahlen</h2>
 
 <div class="stat-grid">
-  <div class="stat"><div class="num">439</div><div class="label">TS/TSX-Module</div></div>
-  <div class="stat"><div class="num">128.1k</div><div class="label">Lines of Code</div></div>
+  <div class="stat"><div class="num">442</div><div class="label">TS/TSX-Module</div></div>
+  <div class="stat"><div class="num">128.7k</div><div class="label">Lines of Code</div></div>
   <div class="stat"><div class="num">~75</div><div class="label">Modul-Dependencies</div></div>
   <div class="stat"><div class="num">7</div><div class="label">User-Flows</div></div>
 </div>
@@ -84,7 +84,7 @@
   <tr><td>Import/Export</td><td>GraphML · XLSX · PDF (jsPDF) · PNG (html-to-image) · STL (three-stdlib)</td></tr>
   <tr><td>Hardware-Integration</td><td>ATEM-UDP (atem-connection) · Bonjour-Discovery · Future: NDI/Dante-Discovery</td></tr>
   <tr><td>Domäne</td><td>AV/Broadcast-Verkabelung mit Layer (Video/Audio/Stromnetz), Patchfeldern, Racks, Locations</td></tr>
-  <tr><td>Modul-Layout</td><td>main/ipc · main/services · renderer/components (27 Subdomänen) · renderer/store · renderer/lib</td></tr>
+  <tr><td>Modul-Layout</td><td>main/ipc · main/services · renderer/components (28 Subdomänen) · renderer/store · renderer/lib</td></tr>
   <tr><td>IPC-Modell</td><td>contextBridge + typed preload · ipcMain.handle pro Domäne (project, library, atem, ...)</td></tr>
   <tr><td>Update-Modell</td><td>Patch-Versionen (8.2.x), ~1-3 Releases/Woche, manueller Build</td></tr>
 </table>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -69,6 +69,7 @@ import { ProjectionCalculatorDialog } from './components/Calculators/ProjectionC
 import { BulkConnectDialog } from './components/Canvas/BulkConnectDialog'
 import { AnalysisDialog } from './components/Analysis/AnalysisDialog'
 import { DeliveryDialog } from './components/Delivery/DeliveryDialog'
+import { ReconcileDialog } from './components/Network/ReconcileDialog'
 import { setStreamKeyDropper } from './store/slices/deliverySlice'
 import { PlanCheckPanel } from './components/Analysis/PlanCheckPanel'
 import { InventoryDialog } from './components/Inventory/InventoryDialog'
@@ -1279,6 +1280,7 @@ export default function App() {
       <DrumMicingDialog />
       <WirelessRigDialog />
       <DeliveryDialog />
+      <ReconcileDialog />
       <LocationBomDialog />
       {rackEditorOpen && (
         <Suspense fallback={null}>

--- a/src/renderer/components/Analysis/AnalysisDialog.tsx
+++ b/src/renderer/components/Analysis/AnalysisDialog.tsx
@@ -23,6 +23,13 @@ import { effectiveDeviceResources, effectiveWatts } from '../../lib/equipmentSel
 import { checkDanteName } from '../../lib/danteNaming'
 import { subnetCidr } from '../../lib/subnet'
 import { addressPlanTable, buildAddressPlan, type AddressIssue } from '../../lib/addressPlan'
+import {
+  buildSwitchPortMaps,
+  switchPortDescriptionBlock,
+  switchPortTable,
+  type SwitchPortMap,
+} from '../../lib/switchPortMap'
+import { csvFromTable } from '../../lib/documentStamp'
 import { RF_BANDS, bandsForFrequency, bandLabel } from '../../lib/rfBands'
 
 type Tab = 'weight' | 'network' | 'redundancy' | 'rf'
@@ -244,6 +251,7 @@ const issueLabel = (t: ReturnType<typeof useTranslation>) => (issue: AddressIssu
 const NetworkTab = ({ projectName }: { projectName: string }) => {
   const t = useTranslation()
   const equipment = useProjectStore((s) => s.project.equipment)
+  const cables = useProjectStore((s) => s.project.cables)
 
   const { rows, duplicates, vlanCounts, danteIssues, subnets } = useMemo(() => {
     const rows = equipment
@@ -304,6 +312,34 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
   }
 
   /** Der Adressplan als eigene Datei -- die Liste, die der Netzmensch abarbeitet. */
+  // Bedarf 24 — die Karten je Switch. `cables` kommt aus demselben Store wie
+  // `equipment`: Switch, Port und das Kabel darin stehen in EINEM Graphen, und
+  // genau das verlangt der Bedarf.
+  const portMaps = useMemo(() => buildSwitchPortMaps(equipment, cables), [equipment, cables])
+
+  // OHNE Dokument-Stempel, und das ist eine Aussage: das Register in
+  // `documentRegistry.ts` fuehrt EINEN Stand je Dokument-Bezeichner, und hier
+  // gibt es eine Karte JE SWITCH. Ein gemeinsamer Bezeichner ergaebe einen
+  // Stand, der bei jedem zweiten Switch nicht passt — schlimmer als keiner.
+  // Ein Stempel je Switch braucht einen Bezeichner je Switch; das ist ein
+  // eigener Schritt und keine Zeile hier.
+  const exportPortMap = (m: SwitchPortMap) => {
+    const table = switchPortTable(m)
+    downloadBlob(
+      buildExportFilenameWithSuffix(`${projectName}-${m.switchName}`, 'port-karte', 'csv'),
+      csvFromTable(table),
+      'text/csv',
+    )
+  }
+
+  const exportPortDescriptions = (m: SwitchPortMap) => {
+    downloadBlob(
+      buildExportFilenameWithSuffix(`${projectName}-${m.switchName}`, 'port-beschriftung', 'txt'),
+      switchPortDescriptionBlock(m),
+      'text/plain',
+    )
+  }
+
   const exportAddressPlan = () => {
     const csvRows = addressPlanTable(plan, label, [
       t('analysis.network.device', 'Gerät'),
@@ -448,6 +484,84 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
               ))}
             </ul>
           )}
+        </div>
+      )}
+      {/* Bedarf 24 — die Switch-Port-Karte. Erzeugt statt gepflegt: die
+          deutsche Praxis dafuer ist eine Excel-Mappe mit einem Reiter je
+          Switch, und die ist die zweite Wahrheit neben dem Plan. */}
+      {portMaps.length > 0 && (
+        <div className="rounded border border-[var(--cp-border)] p-2">
+          <div className="mb-1 flex items-center justify-between">
+            <span className="font-semibold">{t('analysis.switchPorts.title', 'Switch-Port-Karte')}</span>
+            <span className="text-cp-xs text-[var(--cp-text-muted)]">
+              {format(t('analysis.switchPorts.count', '{n} Switches'), { n: portMaps.length })}
+            </span>
+          </div>
+          {portMaps.map((m) => (
+            <div key={m.switchId} className="mb-2">
+              <div className="mb-1 flex items-center justify-between">
+                <span className="text-cp-xs font-medium">{m.switchName}</span>
+                <div className="flex items-center gap-1">
+                  <span className="text-[10px] text-[var(--cp-text-faint)]">
+                    {format(t('analysis.switchPorts.used', '{u} von {n} belegt'), {
+                      u: m.usedCount,
+                      n: m.rows.length,
+                    })}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => exportPortMap(m)}
+                    className="inline-flex items-center gap-1 rounded border border-[var(--cp-border)] px-1.5 py-0.5 text-[10px] hover:bg-[var(--cp-surface-2)]"
+                  >
+                    <Icon icon={Download} size="xs" /> CSV
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => exportPortDescriptions(m)}
+                    title={t(
+                      'analysis.switchPorts.descHint',
+                      'Herstellerneutraler Text zum Einfügen. Der Plan schickt nichts an den Switch — lies, was du einfügst.',
+                    )}
+                    className="inline-flex items-center gap-1 rounded border border-[var(--cp-border)] px-1.5 py-0.5 text-[10px] hover:bg-[var(--cp-surface-2)]"
+                  >
+                    <Icon icon={Download} size="xs" />{' '}
+                    {t('analysis.switchPorts.descriptions', 'Beschriftung')}
+                  </button>
+                </div>
+              </div>
+              <ul className="flex flex-col gap-0.5">
+                {m.rows.map((r) => (
+                  <li key={r.port} className="flex items-center gap-2 text-cp-xs">
+                    <span className="w-14 shrink-0 font-mono text-[var(--cp-text-muted)]">{r.port}</span>
+                    <span className={r.device ? '' : 'text-[var(--cp-text-faint)]'}>
+                      {r.device ?? t('analysis.switchPorts.free', 'frei')}
+                    </span>
+                    {r.nicLabel && (
+                      <span className="text-[10px] text-[var(--cp-text-faint)]">{r.nicLabel}</span>
+                    )}
+                    {r.ipAddress && <span className="font-mono text-[10px]">{r.ipAddress}</span>}
+                    {r.vlanId !== undefined && (
+                      <span className="text-[10px] text-[var(--cp-text-muted)]">VLAN {r.vlanId}</span>
+                    )}
+                    {r.source && (
+                      <span className="text-[10px] text-[var(--cp-text-faint)]">
+                        {r.source === 'interface'
+                          ? t('analysis.switchPorts.fromNic', 'Schnittstelle')
+                          : t('analysis.switchPorts.fromCable', 'Kabel')}
+                      </span>
+                    )}
+                    {r.conflict && (
+                      <span className="text-amber-300/90">
+                        {format(t('analysis.switchPorts.conflict', 'Kabel sagt: {name}'), {
+                          name: r.conflict,
+                        })}
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
         </div>
       )}
       <div className="flex justify-end gap-2">

--- a/src/renderer/components/Import/CsvImportDialog.tsx
+++ b/src/renderer/components/Import/CsvImportDialog.tsx
@@ -15,6 +15,7 @@ import { Icon } from '../shared/Icon'
 import { Button } from '../shared/Button'
 import { infoDialog } from '../../lib/infoDialog'
 import { useTranslation, format } from '../../lib/i18n'
+import { parseCsv } from '../../lib/csvParse'
 import type { EquipmentTemplate } from '../../types/equipment'
 
 type FieldKey = 'name' | 'category' | 'watts' | 'weight' | 'serial' | 'ip' | 'rackUnits' | 'subtitle'
@@ -28,41 +29,6 @@ const ALIASES: Record<FieldKey, string[]> = {
   ip: ['ip', 'ip-adresse', 'ipaddress', 'ip address', 'ip adresse'],
   rackUnits: ['he', 'rackunits', 'ru', 'höheneinheiten', 'hoeheneinheiten'],
   subtitle: ['untertitel', 'subtitle', 'hersteller', 'manufacturer', 'marke', 'brand'],
-}
-
-/** CSV → Zeilen. Quote-fähig, Trenner (; oder ,) aus der Kopfzeile erkannt. */
-const parseCsv = (text: string): string[][] => {
-  const t = text.replace(/\r\n?/g, '\n').replace(/^\u{FEFF}/u, '').trim()
-  if (!t) return []
-  const firstLine = t.split('\n')[0] ?? ''
-  const delim = (firstLine.match(/;/g)?.length ?? 0) >= (firstLine.match(/,/g)?.length ?? 0) ? ';' : ','
-  const rows: string[][] = []
-  let row: string[] = []
-  let field = ''
-  let inQ = false
-  for (let i = 0; i < t.length; i++) {
-    const c = t[i]
-    if (inQ) {
-      if (c === '"') {
-        if (t[i + 1] === '"') {
-          field += '"'
-          i++
-        } else inQ = false
-      } else field += c
-    } else if (c === '"') inQ = true
-    else if (c === delim) {
-      row.push(field)
-      field = ''
-    } else if (c === '\n') {
-      row.push(field)
-      rows.push(row)
-      row = []
-      field = ''
-    } else field += c
-  }
-  row.push(field)
-  rows.push(row)
-  return rows.filter((r) => r.some((cell) => cell.trim() !== ''))
 }
 
 const mapHeader = (header: string[]): Partial<Record<FieldKey, number>> => {

--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -730,6 +730,9 @@ export const MenuBar = ({
           <MenuItem onClick={() => useUiStore.getState().setDeliveryOpen(true)} icon={<Icon icon={Radio} size="sm" />}>
             {t('app.menu.tools.delivery', 'Ausspielung (Streaming-Ziele)…')}
           </MenuItem>
+          <MenuItem onClick={() => useUiStore.getState().setReconcileOpen(true)} icon={<Icon icon={ClipboardCheck} size="sm" />}>
+            {t('app.menu.tools.reconcile', 'Plan gegen Vorgefundenes…')}
+          </MenuItem>
 
           <MenuSectionHeader>{t('app.menu.tools.group.build', 'Erstellen & verwalten')}</MenuSectionHeader>
           <MenuItem

--- a/src/renderer/components/Network/ReconcileDialog.tsx
+++ b/src/renderer/components/Network/ReconcileDialog.tsx
@@ -1,0 +1,213 @@
+import { useMemo, useState } from 'react'
+import { FileUp, Download, X, AlertTriangle } from 'lucide-react'
+import { useProjectStore } from '../../store/projectStore'
+import { useUiStore } from '../../store/uiStore'
+import { useTranslation, format } from '../../lib/i18n'
+import { Icon } from '../shared/Icon'
+import { pickTextFile } from '../../lib/pickFile'
+import { downloadBlob } from '../../lib/downloadBlob'
+import { buildExportFilenameWithSuffix } from '../../lib/exportFilename'
+import { csvFromTable } from '../../lib/documentStamp'
+import {
+  parseArpTable,
+  parseScanCsv,
+  reconcileNetwork,
+  reconcileTable,
+  type NetworkScan,
+  type ReconcileReport,
+  type ReconcileVerdict,
+} from '../../lib/networkReconcile'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plan gegen Vorgefundenes (Bedarf 21).
+//
+// EIN MENSCH LEGT EINE DATEI AB, und dieser Dialog rechnet die Abweichung aus.
+// Kein Knopf „jetzt scannen": der Bedarf schreibt „Deliberate, timestamped,
+// user-initiated — never a live feed", und die Dossiers sagen, warum das nicht
+// Bequemlichkeit ist (Dantes API ist lizenz-gebunden, die offene Alternative
+// erklaert sich selbst fuer untauglich, die offene ST-2110-Analyse ist
+// eingestellt).
+//
+// Der Zeitpunkt kommt aus DIESEM Dialog und nicht aus dem Rechenmodul: derselbe
+// Datei-Inhalt muss zweimal dasselbe Ergebnis geben, sonst ist der Bericht
+// nicht nachvollziehbar.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ReconcileDialog = () => {
+  const t = useTranslation()
+  const open = useUiStore((s) => s.reconcileOpen)
+  const setOpen = useUiStore((s) => s.setReconcileOpen)
+  const equipment = useProjectStore((s) => s.project.equipment)
+  const projectName = useProjectStore((s) => s.project.metadata.name)
+
+  const [scan, setScan] = useState<NetworkScan | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const report: ReconcileReport | null = useMemo(
+    () => (scan ? reconcileNetwork(equipment, scan) : null),
+    [equipment, scan],
+  )
+
+  if (!open) return null
+
+  const load = async () => {
+    setError(null)
+    const picked = await pickTextFile('.txt,.csv,text/plain,text/csv')
+    if (!picked) return
+    // Die Form wird am INHALT erkannt und nicht an der Endung: eine
+    // ARP-Ausgabe, die jemand als .csv gespeichert hat, ist immer noch eine
+    // ARP-Ausgabe.
+    const looksCsv = /[;,]/.test(picked.content.split('\n')[0] ?? '') && !/\bat\b|lladdr/.test(picked.content)
+    const entries = looksCsv ? parseScanCsv(picked.content) : parseArpTable(picked.content)
+    if (entries.length === 0) {
+      setError(
+        t(
+          'reconcile.error.empty',
+          'In der Datei stand kein Gerät, das sich lesen lässt. Erwartet: eine ARP-/Neighbour-Ausgabe oder eine CSV mit einer Spalte Name, IP oder MAC.',
+        ),
+      )
+      setScan(null)
+      return
+    }
+    setScan({ takenAt: new Date().toISOString(), source: picked.name, entries })
+  }
+
+  const exportCsv = () => {
+    if (!report) return
+    downloadBlob(
+      buildExportFilenameWithSuffix(projectName, 'abgleich', 'csv'),
+      csvFromTable(reconcileTable(report)),
+      'text/csv',
+    )
+  }
+
+  const verdictText = (v: ReconcileVerdict): string => {
+    switch (v) {
+      case 'match':
+        return t('reconcile.v.match', 'stimmt')
+      case 'address-mismatch':
+        return t('reconcile.v.address', 'Adresse weicht ab')
+      case 'name-mismatch':
+        return t('reconcile.v.name', 'Name weicht ab')
+      case 'renamed':
+        return t('reconcile.v.renamed', 'umbenannt (Kollisionsform)')
+      case 'missing':
+        return t('reconcile.v.missing', 'nicht gefunden')
+      case 'unexpected':
+        return t('reconcile.v.unexpected', 'nicht im Plan')
+      case 'ambiguous':
+        return t('reconcile.v.ambiguous', 'nicht eindeutig — keine Zuordnung')
+    }
+  }
+
+  const tone = (v: ReconcileVerdict): string =>
+    v === 'match' ? 'text-cp-text-muted' : v === 'renamed' ? 'text-cp-text-secondary' : 'text-amber-300/90'
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+      <div className="flex max-h-[88vh] w-full max-w-4xl flex-col overflow-hidden rounded-lg border border-cp-border bg-cp-surface-1 shadow-xl">
+        <div className="flex items-center justify-between border-b border-cp-border px-4 py-2.5">
+          <h2 className="text-cp-base font-semibold text-cp-text">
+            {t('reconcile.title', 'Plan gegen Vorgefundenes')}
+          </h2>
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            aria-label={t('common.close', 'Schließen')}
+            className="text-cp-text-muted hover:text-cp-text"
+          >
+            <Icon icon={X} size="sm" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4">
+          <p className="mb-3 text-cp-sm leading-snug text-cp-text-secondary">
+            {t(
+              'reconcile.intro',
+              'Was vom LKW kam, unter welchen Namen und mit welchen Adressen — gegen das, was der Plan sagt. Der Plan fragt kein Gerät: du legst eine Datei ab (ARP-/Neighbour-Ausgabe oder CSV), und der Abgleich rechnet die Abweichung aus.',
+            )}
+          </p>
+
+          <div className="mb-3 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => void load()}
+              className="inline-flex items-center gap-1 rounded border border-cp-border px-2.5 py-1 text-cp-sm text-cp-text-secondary hover:text-cp-text"
+            >
+              <Icon icon={FileUp} size="sm" /> {t('reconcile.load', 'Datei einlesen')}
+            </button>
+            {report && (
+              <>
+                <span className="text-cp-xs text-cp-text-muted">
+                  {format(t('reconcile.taken', '{source} · {when}'), {
+                    source: report.source,
+                    when: new Date(report.takenAt).toLocaleString(),
+                  })}
+                </span>
+                <button
+                  type="button"
+                  onClick={exportCsv}
+                  className="ml-auto inline-flex items-center gap-1 rounded border border-cp-border px-2 py-1 text-cp-sm text-cp-text-secondary hover:text-cp-text"
+                >
+                  <Icon icon={Download} size="sm" /> CSV
+                </button>
+              </>
+            )}
+          </div>
+
+          {error && (
+            <div className="mb-3 flex items-start gap-2 rounded border border-amber-700/60 bg-amber-900/20 p-2 text-cp-xs text-amber-200">
+              <Icon icon={AlertTriangle} size="xs" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          {!report ? (
+            <p className="py-6 text-center text-cp-sm text-cp-text-muted">
+              {t('reconcile.empty', 'Noch keine Datei eingelesen.')}
+            </p>
+          ) : (
+            <>
+              <div className="mb-2 flex flex-wrap gap-3 text-cp-xs text-cp-text-muted">
+                {(
+                  ['match', 'renamed', 'address-mismatch', 'name-mismatch', 'missing', 'unexpected', 'ambiguous'] as const
+                ).map((v) =>
+                  report.counts[v] > 0 ? (
+                    <span key={v}>
+                      {report.counts[v]} × {verdictText(v)}
+                    </span>
+                  ) : null,
+                )}
+              </div>
+              <ul className="flex flex-col gap-1">
+                {report.rows.map((r, i) => (
+                  <li
+                    key={`${r.verdict}-${r.planned ?? ''}-${r.found ?? ''}-${i}`}
+                    className="flex flex-wrap items-center gap-2 rounded border border-cp-border-muted bg-cp-surface-2 px-2 py-1 text-cp-xs"
+                  >
+                    <span className={`w-44 shrink-0 ${tone(r.verdict)}`}>{verdictText(r.verdict)}</span>
+                    <span className="text-cp-text">{r.planned ?? '—'}</span>
+                    {r.plannedIp && <span className="font-mono text-cp-text-muted">{r.plannedIp}</span>}
+                    {r.found && r.found !== r.planned && (
+                      <span className="text-cp-text-secondary">
+                        {format(t('reconcile.foundAs', 'gefunden als {name}'), { name: r.found })}
+                      </span>
+                    )}
+                    {r.foundIp && r.foundIp !== r.plannedIp && (
+                      <span className="font-mono text-amber-300/90">{r.foundIp}</span>
+                    )}
+                    {r.matchedBy && (
+                      <span className="ml-auto text-[10px] text-cp-text-faint">
+                        {format(t('reconcile.matchedBy', 'über {basis}'), { basis: r.matchedBy.toUpperCase() })}
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/Properties/sections/ExtraInterfacesPanel.tsx
+++ b/src/renderer/components/Properties/sections/ExtraInterfacesPanel.tsx
@@ -1,0 +1,203 @@
+import { Plus, Trash2 } from 'lucide-react'
+import { useCanvasProjectStore as useProjectStore } from '../../../store/projectStoreContext'
+import { useTranslation } from '../../../lib/i18n'
+import { Icon } from '../../shared/Icon'
+import { detectNetworkDevice } from '../../../lib/deviceKind'
+import { NETWORK_INTERFACE_ROLES, type NetworkInterface, type NetworkInterfaceRole } from '../../../types/network'
+import type { EquipmentItem } from '../../../types/equipment'
+
+/**
+ * Bedarf 19 — die WEITEREN Netzwerk-Schnittstellen eines Geraets.
+ *
+ * Steht bewusst unter den Basis-Feldern und nicht daneben: die vier Felder
+ * darueber SIND Schnittstelle 0 (siehe `types/network.ts`). Wer hier etwas
+ * anlegt, legt die zweite an — Dante sekundaer, ST 2110 blau, getrennte
+ * Steuerung. Genau die Faelle, fuer die eine Excel-Mappe eine zweite Zeile
+ * oder eine zusaetzliche Spalte bekommt und danach auseinanderlaeuft.
+ *
+ * Der Switch-Bezug (`switchEquipmentId` + `switchPort`) haengt hier und nicht
+ * am Switch: eine Schnittstelle weiss, wo sie steckt; ein Switch mit 48
+ * Feldern waere ein Formular, das niemand ausfuellt.
+ */
+export const ExtraInterfacesPanel = ({ equipment }: { equipment: EquipmentItem }) => {
+  const t = useTranslation()
+  const updateEquipment = useProjectStore((state) => state.updateEquipment)
+  const allEquipment = useProjectStore((state) => state.project.equipment)
+  const switches = allEquipment.filter((e) => detectNetworkDevice(e) === 'switch')
+
+  const nics = equipment.networkInterfaces ?? []
+  const commit = (next: NetworkInterface[]) =>
+    updateEquipment(equipment.id, { networkInterfaces: next.length > 0 ? next : undefined })
+
+  const patch = (id: string, p: Partial<NetworkInterface>) =>
+    commit(nics.map((n) => (n.id === id ? { ...n, ...p } : n)))
+
+  const add = () =>
+    commit([
+      ...nics,
+      {
+        id: `${equipment.id}#nic${nics.length + 1}-${Math.random().toString(36).slice(2, 8)}`,
+        role: 'unspecified',
+        label: '',
+      },
+    ])
+
+  const roleLabel = (r: NetworkInterfaceRole): string => {
+    switch (r) {
+      case 'media-primary':
+        return t('nic.role.mediaPrimary', 'Medien primär')
+      case 'media-secondary':
+        return t('nic.role.mediaSecondary', 'Medien sekundär')
+      case 'control':
+        return t('nic.role.control', 'Steuerung')
+      case 'management':
+        return t('nic.role.management', 'Management')
+      case 'unspecified':
+        return t('nic.role.unspecified', 'nicht angegeben')
+    }
+  }
+
+  const inputCls = 'w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono'
+
+  return (
+    <div className="mt-3 border-t border-cp-border-muted pt-2">
+      <div className="mb-1 flex items-center justify-between">
+        <span className="text-cp-text-secondary">
+          {t('nic.title', 'Weitere Netzwerk-Schnittstellen')}
+        </span>
+        <button
+          type="button"
+          onClick={add}
+          className="flex items-center gap-1 rounded border border-cp-border px-2 py-0.5 text-cp-xs text-cp-text-secondary hover:text-cp-text"
+        >
+          <Icon icon={Plus} size="xs" /> {t('nic.add', 'Hinzufügen')}
+        </button>
+      </div>
+      <p className="mb-2 text-cp-xs text-cp-text-muted">
+        {t(
+          'nic.hint',
+          'Die Felder oben sind die erste Schnittstelle. Hier stehen die weiteren — Dante sekundär, ST 2110 blau, getrennte Steuerung.',
+        )}
+      </p>
+
+      <label className="mb-2 block">
+        <span className="mb-1 block text-cp-text-secondary">{t('nic.primaryRole', 'Rolle der ersten Schnittstelle')}</span>
+        <select
+          value={equipment.primaryInterfaceRole ?? 'unspecified'}
+          onChange={(e) =>
+            updateEquipment(equipment.id, {
+              primaryInterfaceRole:
+                e.target.value === 'unspecified' ? undefined : (e.target.value as NetworkInterfaceRole),
+            })
+          }
+          className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
+        >
+          {NETWORK_INTERFACE_ROLES.map((r) => (
+            <option key={r} value={r}>{roleLabel(r)}</option>
+          ))}
+        </select>
+      </label>
+
+      {nics.length === 0 ? (
+        <p className="text-cp-xs text-cp-text-faint">{t('nic.none', 'Keine weiteren Schnittstellen.')}</p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {nics.map((n) => (
+            <li key={n.id} className="rounded border border-cp-border-muted bg-cp-surface-2 p-2">
+              <div className="mb-1 flex items-center gap-2">
+                <input
+                  value={n.label ?? ''}
+                  onChange={(e) => patch(n.id, { label: e.target.value })}
+                  placeholder={t('nic.label', 'Beschriftung, z. B. „Dante Sec"')}
+                  aria-label={t('nic.label', 'Beschriftung, z. B. „Dante Sec"')}
+                  className="flex-1 rounded border border-cp-border bg-cp-surface-1 p-1.5"
+                />
+                <select
+                  value={n.role}
+                  onChange={(e) => patch(n.id, { role: e.target.value as NetworkInterfaceRole })}
+                  aria-label={t('nic.role', 'Rolle')}
+                  className="rounded border border-cp-border bg-cp-surface-1 p-1.5"
+                >
+                  {NETWORK_INTERFACE_ROLES.map((r) => (
+                    <option key={r} value={r}>{roleLabel(r)}</option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  onClick={() => commit(nics.filter((x) => x.id !== n.id))}
+                  aria-label={t('nic.remove', 'Schnittstelle entfernen')}
+                  className="text-cp-text-faint hover:text-cp-danger"
+                >
+                  <Icon icon={Trash2} size="sm" />
+                </button>
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <input
+                  value={n.ipAddress ?? ''}
+                  onChange={(e) => patch(n.id, { ipAddress: e.target.value || undefined })}
+                  placeholder="10.0.1.10"
+                  aria-label={t('eq.field.ipAddress', 'IP Address')}
+                  className={inputCls}
+                />
+                <input
+                  value={n.subnetMask ?? ''}
+                  onChange={(e) => patch(n.id, { subnetMask: e.target.value || undefined })}
+                  placeholder="255.255.255.0"
+                  aria-label={t('eq.field.subnet', 'Subnet Mask')}
+                  className={inputCls}
+                />
+                <input
+                  value={n.gateway ?? ''}
+                  onChange={(e) => patch(n.id, { gateway: e.target.value || undefined })}
+                  placeholder="Gateway"
+                  aria-label={t('nic.gateway', 'Gateway')}
+                  className={inputCls}
+                />
+                <input
+                  value={n.macAddress ?? ''}
+                  onChange={(e) => patch(n.id, { macAddress: e.target.value || undefined })}
+                  placeholder="MAC"
+                  aria-label={t('nic.mac', 'MAC-Adresse')}
+                  className={inputCls}
+                />
+                <input
+                  type="number"
+                  min={0}
+                  max={4094}
+                  value={n.vlanId ?? ''}
+                  onChange={(e) => {
+                    const v = Number(e.target.value)
+                    patch(n.id, { vlanId: e.target.value === '' || !Number.isInteger(v) ? undefined : v })
+                  }}
+                  placeholder="VLAN"
+                  aria-label={t('nic.vlan', 'VLAN')}
+                  className={inputCls}
+                />
+                <div className="flex gap-1">
+                  <select
+                    value={n.switchEquipmentId ?? ''}
+                    onChange={(e) => patch(n.id, { switchEquipmentId: e.target.value || undefined })}
+                    aria-label={t('nic.switch', 'Switch')}
+                    className="min-w-0 flex-1 rounded border border-cp-border bg-cp-surface-1 p-2"
+                  >
+                    <option value="">{t('nic.noSwitch', '— kein Switch —')}</option>
+                    {switches.map((s) => (
+                      <option key={s.id} value={s.id}>{s.name}</option>
+                    ))}
+                  </select>
+                  <input
+                    value={n.switchPort ?? ''}
+                    onChange={(e) => patch(n.id, { switchPort: e.target.value || undefined })}
+                    placeholder={t('nic.switchPort', 'Port')}
+                    aria-label={t('nic.switchPort', 'Port')}
+                    className="w-20 rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
+                  />
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/Properties/sections/NetworkAccessSection.tsx
+++ b/src/renderer/components/Properties/sections/NetworkAccessSection.tsx
@@ -4,6 +4,7 @@ import { useCanvasProjectStore as useProjectStore } from '../../../store/project
 import { useTranslation } from '../../../lib/i18n'
 import { SortableSection } from '../SortableSection'
 import { Icon } from '../../shared/Icon'
+import { ExtraInterfacesPanel } from './ExtraInterfacesPanel'
 import type { EquipmentItem } from '../../../types/equipment'
 
 /**
@@ -125,6 +126,7 @@ export const NetworkAccessSection = ({ equipment }: { equipment: EquipmentItem }
           className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
         />
       </label>
+      <ExtraInterfacesPanel equipment={equipment} />
     </SortableSection>
   )
 }

--- a/src/renderer/lib/addressPlan.ts
+++ b/src/renderer/lib/addressPlan.ts
@@ -32,9 +32,11 @@
 // das wären Vermutungen, und eine Warnung, die falsch anschlägt, wird nach dem
 // zweiten Mal ignoriert — dann auch die vier richtigen daneben.
 // ───────────────────────────────────────────────────────────────────────────
-import type { EquipmentItem, Port } from '../types/equipment'
+import type { ConnectorType, EquipmentItem, Port } from '../types/equipment'
 import type { SignalStandard } from '../types/cableSpec'
+import type { NetworkInterfaceRole } from '../types/network'
 import { networkAddress, parseIpv4, subnetCidr } from './subnet'
+import { allDeviceInterfaces, deviceInterfaces, interfaceLabel, primaryInterfaceId } from './networkInterfaces'
 
 /** Standards, die über ein IP-Netz laufen. Aus `SignalStandard`, nicht geraten. */
 const IP_STANDARDS: ReadonlySet<SignalStandard> = new Set<SignalStandard>([
@@ -46,8 +48,31 @@ const IP_STANDARDS: ReadonlySet<SignalStandard> = new Set<SignalStandard>([
   'PTP',
 ])
 
-/** Anschlussformen, die ein Netzwerkkabel aufnehmen. */
-const NETWORK_CONNECTORS = new Set(['RJ45', 'etherCON'])
+/**
+ * Anschlussformen, die ein Netzwerkkabel aufnehmen.
+ *
+ * BERICHTIGT: hier standen `'RJ45'` und `'etherCON'` — **beide gibt es in
+ * `ConnectorType` nicht.** Die Union kennt `'Ethernet/RJ45'` und `'GG45'`; der
+ * Anschluss-Rueckfall traf damit kein einziges echtes Geraet, und der Test, der
+ * ihn belegte, trug ein Fixture mit `connectorType: 'RJ45'` — einen Wert, den
+ * kein Katalog-Geraet je haben kann. Verglichen worden war der Feldname, nicht
+ * der Wertebereich; genau derselbe Fehler wie bei der Rollen-Id gegen
+ * `guide_server.py` (`cable#674`).
+ *
+ * Der Typ ist deshalb jetzt `ConnectorType` und nicht `string`: ein Tippfehler
+ * faellt beim Uebersetzen auf, nicht beim Kunden. `tests/addressPlan.test.ts`
+ * prueft zusaetzlich, dass jeder Eintrag in `ALL_CONNECTOR_TYPES` vorkommt —
+ * ein Typ allein haette den alten Wert auch abgefangen, aber nur, wenn jemand
+ * ihn ueberhaupt annotiert.
+ *
+ * SFP, SFP+ und Fiber stehen bewusst NICHT dabei: ueber sie laeuft genauso oft
+ * SDI. Fuer sie greift die erste Regel (ein IP-Standard am Port), und die ist
+ * ein Beleg statt einer Bauform-Vermutung.
+ */
+export const NETWORK_CONNECTORS: ReadonlySet<ConnectorType> = new Set<ConnectorType>([
+  'Ethernet/RJ45',
+  'GG45',
+])
 
 /**
  * Der Port, der ein Gerät netzfähig macht — oder `null`.
@@ -59,7 +84,7 @@ const networkPort = (item: EquipmentItem): Port | null => {
   const ports = [...(item.inputs ?? []), ...(item.outputs ?? [])]
   return (
     ports.find((p) => p.standard && IP_STANDARDS.has(p.standard)) ??
-    ports.find((p) => NETWORK_CONNECTORS.has(p.connectorType as string)) ??
+    ports.find((p) => NETWORK_CONNECTORS.has(p.connectorType)) ??
     null
   )
 }
@@ -78,8 +103,20 @@ export interface AddressIssue {
 }
 
 export interface AddressPlanRow {
+  /** Geraete-Id. Mehrere Zeilen desselben Geraets teilen sie sich. */
   id: string
   name: string
+  /**
+   * Welche Schnittstelle diese Zeile ist (Bedarf 19). Zeilen sind **je
+   * Schnittstelle** und nicht je Geraet: ein Geraet mit Dante primaer und
+   * sekundaer hat zwei Adressen, und eine Doppel-IP-Pruefung, die nur die
+   * erste sieht, uebersieht genau die Haelfte eines redundanten Aufbaus.
+   */
+  nicId: string
+  /** Beschriftung der Schnittstelle („Dante Sec"). Fehlt bei Schnittstelle 0. */
+  nicLabel?: string
+  /** Wofuer die Schnittstelle da ist. `unspecified`, wenn niemand es sagte. */
+  role: NetworkInterfaceRole
   ip?: string
   mask?: string
   gateway?: string
@@ -134,66 +171,102 @@ const spansNetwork = (mask: string): boolean => {
  * das Sortieren gehört der Ansicht.
  */
 export function buildAddressPlan(equipment: EquipmentItem[]): AddressPlan {
+  // Bedarf 19 — ueber SCHNITTSTELLEN, nicht ueber Geraete. Ein Geraet mit
+  // Dante primaer und sekundaer traegt zwei Adressen; die alte Fassung sah nur
+  // `item.ipAddress` und uebersah damit genau die Haelfte eines redundanten
+  // Aufbaus — ausgerechnet in der Pruefung, die vor Doppel-IPs warnt.
+  const nics = allDeviceInterfaces(equipment)
+
   // Doppelte Adressen einmal vorab, damit jede Zeile die ANDEREN nennen kann.
-  const byIp = new Map<string, string[]>()
-  for (const e of equipment) {
-    if (!e.ipAddress) continue
-    byIp.set(e.ipAddress, [...(byIp.get(e.ipAddress) ?? []), e.name])
+  // Der Schluessel ist die SCHNITTSTELLE und nicht das Geraet: sonst meldete
+  // ein Geraet mit zwei Karten sich selbst.
+  const byIp = new Map<string, Array<{ nicId: string; label: string }>>()
+  for (const { equipment: e, nic } of nics) {
+    if (!nic.ipAddress) continue
+    byIp.set(nic.ipAddress, [
+      ...(byIp.get(nic.ipAddress) ?? []),
+      { nicId: nic.id, label: interfaceLabel(e, nic) },
+    ])
   }
 
-  const rows: AddressPlanRow[] = equipment.map((e) => {
-    const port = networkPort(e)
-    // Eine gesetzte Adresse macht ein Gerät ebenfalls zu einem Netzgerät —
-    // auch wenn seine Ports nichts davon sagen. Sonst fiele ein von Hand
-    // gepflegtes Gerät aus der Doppel-IP-Prüfung heraus, und ausgerechnet die
-    // ist der Befund mit den handfestesten Folgen.
-    const networked = !!port || !!e.ipAddress
-    const issues: AddressIssue[] = []
+  const rows: AddressPlanRow[] = []
 
-    if (networked && !e.ipAddress) {
-      issues.push({ kind: 'missing-address' })
+  for (const e of equipment) {
+    const own = deviceInterfaces(e)
+    const port = networkPort(e)
+    // Netzfaehig, wenn ein Port es sagt ODER irgendeine Schnittstelle eine
+    // Adresse traegt. Sonst fiele ein von Hand gepflegtes Geraet aus der
+    // Doppel-IP-Pruefung heraus — der Befund mit den handfestesten Folgen.
+    const networked = !!port || own.length > 0
+    const evidence = port
+      ? port.standard
+        ? `${port.name} (${port.standard})`
+        : `${port.name} (${port.connectorType})`
+      : undefined
+
+    if (own.length === 0) {
+      // Nichts eingetragen, an keiner Schnittstelle. EINE Zeile, damit die
+      // Arbeitsliste das Geraet nennt statt zu schweigen.
+      rows.push({
+        id: e.id,
+        name: e.name,
+        nicId: primaryInterfaceId(e.id),
+        role: e.primaryInterfaceRole ?? 'unspecified',
+        networked,
+        ...(evidence ? { evidence } : {}),
+        issues: networked ? [{ kind: 'missing-address' as const }] : [],
+      })
+      continue
     }
 
-    if (e.ipAddress) {
-      const others = (byIp.get(e.ipAddress) ?? []).filter((n) => n !== e.name)
-      if (others.length > 0) issues.push({ kind: 'duplicate-address', others })
-      if (!e.subnetMask) {
-        // Die Netz-Übersicht nimmt hier still /24 an. Angenommen ist nicht
-        // gewusst: sobald jemand nach dem Subnetz fragt, hängt die Antwort an
-        // einer Vorgabe, die niemand gesetzt hat.
-        issues.push({ kind: 'missing-mask' })
+    for (const nic of own) {
+      const issues: AddressIssue[] = []
+      if (!nic.ipAddress) {
+        issues.push({ kind: 'missing-address' })
       } else {
-        if (spansNetwork(e.subnetMask)) {
-          const net = networkAddress(e.ipAddress, e.subnetMask)
-          const bc = broadcastAddress(e.ipAddress, e.subnetMask)
-          if (e.ipAddress === net || e.ipAddress === bc) {
-            issues.push({ kind: 'network-or-broadcast-address' })
+        const others = (byIp.get(nic.ipAddress) ?? [])
+          .filter((o) => o.nicId !== nic.id)
+          .map((o) => o.label)
+        if (others.length > 0) issues.push({ kind: 'duplicate-address', others })
+        if (!nic.subnetMask) {
+          // Die Netz-Uebersicht nimmt hier still /24 an. Angenommen ist nicht
+          // gewusst: sobald jemand nach dem Subnetz fragt, haengt die Antwort
+          // an einer Vorgabe, die niemand gesetzt hat.
+          issues.push({ kind: 'missing-mask' })
+        } else {
+          if (spansNetwork(nic.subnetMask)) {
+            const net = networkAddress(nic.ipAddress, nic.subnetMask)
+            const bc = broadcastAddress(nic.ipAddress, nic.subnetMask)
+            if (nic.ipAddress === net || nic.ipAddress === bc) {
+              issues.push({ kind: 'network-or-broadcast-address' })
+            }
+          }
+          if (nic.gateway) {
+            const ownNet = networkAddress(nic.ipAddress, nic.subnetMask)
+            const gw = networkAddress(nic.gateway, nic.subnetMask)
+            if (ownNet && gw && ownNet !== gw) issues.push({ kind: 'gateway-outside-subnet' })
           }
         }
-        if (e.gateway) {
-          const own = networkAddress(e.ipAddress, e.subnetMask)
-          const gw = networkAddress(e.gateway, e.subnetMask)
-          if (own && gw && own !== gw) issues.push({ kind: 'gateway-outside-subnet' })
-        }
       }
-    }
 
-    return {
-      id: e.id,
-      name: e.name,
-      ...(e.ipAddress ? { ip: e.ipAddress } : {}),
-      ...(e.subnetMask ? { mask: e.subnetMask } : {}),
-      ...(e.gateway ? { gateway: e.gateway } : {}),
-      ...(e.ipAddress && e.subnetMask
-        ? { cidr: subnetCidr(e.ipAddress, e.subnetMask) ?? undefined }
-        : {}),
-      networked,
-      ...(port
-        ? { evidence: port.standard ? `${port.name} (${port.standard})` : `${port.name} (${port.connectorType})` }
-        : {}),
-      issues,
+      rows.push({
+        id: e.id,
+        name: e.name,
+        nicId: nic.id,
+        ...(nic.label ? { nicLabel: nic.label } : {}),
+        role: nic.role,
+        ...(nic.ipAddress ? { ip: nic.ipAddress } : {}),
+        ...(nic.subnetMask ? { mask: nic.subnetMask } : {}),
+        ...(nic.gateway ? { gateway: nic.gateway } : {}),
+        ...(nic.ipAddress && nic.subnetMask
+          ? { cidr: subnetCidr(nic.ipAddress, nic.subnetMask) ?? undefined }
+          : {}),
+        networked: true,
+        ...(evidence ? { evidence } : {}),
+        issues,
+      })
     }
-  })
+  }
 
   return {
     rows,
@@ -214,7 +287,7 @@ export function addressPlanTable(
     ...plan.rows
       .filter((r) => r.networked)
       .map((r) => [
-        r.name,
+        r.nicLabel ? `${r.name} · ${r.nicLabel}` : r.name,
         r.ip ?? '',
         r.mask ?? '',
         r.gateway ?? '',

--- a/src/renderer/lib/csvParse.ts
+++ b/src/renderer/lib/csvParse.ts
@@ -1,0 +1,47 @@
+// ───────────────────────────────────────────────────────────────────────────
+// CSV lesen — die eine Stelle.
+//
+// Stand bis Bedarf 21 als private Funktion in `CsvImportDialog.tsx`, also
+// genau dort, wo kein zweiter Leser sie erreichen konnte. Der Netz-Abgleich
+// braucht dieselbe Arbeit (Quote-Behandlung, Trenner-Erkennung, BOM), und ein
+// zweiter Parser daneben haette bei der ersten Datei mit einem Semikolon im
+// Anlagennamen anders geantwortet als der erste.
+//
+// Hochgezogen, nicht neu geschrieben — dieselbe Bauform wie `resolvePortLabel`
+// (ADR-001 Inkrement 2) und `deviceInterfaces` (Bedarf 19).
+// ───────────────────────────────────────────────────────────────────────────
+
+/** CSV → Zeilen. Quote-fähig, Trenner (; oder ,) aus der Kopfzeile erkannt. */
+export const parseCsv = (text: string): string[][] => {
+  const t = text.replace(/\r\n?/g, '\n').replace(/^\u{FEFF}/u, '').trim()
+  if (!t) return []
+  const firstLine = t.split('\n')[0] ?? ''
+  const delim = (firstLine.match(/;/g)?.length ?? 0) >= (firstLine.match(/,/g)?.length ?? 0) ? ';' : ','
+  const rows: string[][] = []
+  let row: string[] = []
+  let field = ''
+  let inQ = false
+  for (let i = 0; i < t.length; i++) {
+    const c = t[i]
+    if (inQ) {
+      if (c === '"') {
+        if (t[i + 1] === '"') {
+          field += '"'
+          i++
+        } else inQ = false
+      } else field += c
+    } else if (c === '"') inQ = true
+    else if (c === delim) {
+      row.push(field)
+      field = ''
+    } else if (c === '\n') {
+      row.push(field)
+      rows.push(row)
+      row = []
+      field = ''
+    } else field += c
+  }
+  row.push(field)
+  rows.push(row)
+  return rows.filter((r) => r.some((cell) => cell.trim() !== ''))
+}

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3758,6 +3758,29 @@ export const en: Dict = {
   // Funkstrecken / Gesang (Wireless-Rig)
   'app.menu.tools.wirelessRig': 'Wireless / vocals…',
   'app.menu.tools.delivery': 'Delivery (streaming destinations)…',
+  'app.menu.tools.reconcile': 'Plan vs. found…',
+
+  /* Bedarf 21 — Plan gegen Vorgefundenes. Keys: reconcile.* */
+  'reconcile.title': 'Plan vs. found',
+  'reconcile.intro':
+    'What came off the truck, under which names and with which addresses \u2014 against what the plan says. The plan asks no device: you supply a file (ARP/neighbour output or CSV) and the reconciliation computes the delta.',
+  'reconcile.load': 'Load file',
+  'reconcile.empty': 'No file loaded yet.',
+  'reconcile.error.empty':
+    'No readable device in that file. Expected an ARP/neighbour dump or a CSV with a name, IP or MAC column.',
+  // {source} und {when} werden vom Aufrufer ersetzt.
+  'reconcile.taken': '{source} \u00b7 {when}',
+  // {name} wird vom Aufrufer ersetzt.
+  'reconcile.foundAs': 'found as {name}',
+  // {basis} wird vom Aufrufer ersetzt.
+  'reconcile.matchedBy': 'via {basis}',
+  'reconcile.v.match': 'matches',
+  'reconcile.v.address': 'address differs',
+  'reconcile.v.name': 'name differs',
+  'reconcile.v.renamed': 'renamed (collision form)',
+  'reconcile.v.missing': 'not found',
+  'reconcile.v.unexpected': 'not in the plan',
+  'reconcile.v.ambiguous': 'not unique \u2014 no match made',
 
   /* Initiative 9 — die Ausspielung. Keys: delivery.* */
   'delivery.title': 'Delivery',

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3985,6 +3985,43 @@ export const en: Dict = {
   'analysis.address.coverage': '{done} of {total} networked devices addressed',
   'analysis.address.clean': 'Nothing open: every networked device has an address, a mask and a gateway that fits.',
   'analysis.address.export': 'Address plan as CSV',
+
+  /* Bedarf 24 — die Switch-Port-Karte. Keys: analysis.switchPorts.* */
+  'analysis.switchPorts.title': 'Switch port map',
+  // {n} wird vom Aufrufer ersetzt.
+  'analysis.switchPorts.count': '{n} switches',
+  // {u} und {n} werden vom Aufrufer ersetzt.
+  'analysis.switchPorts.used': '{u} of {n} occupied',
+  'analysis.switchPorts.free': 'free',
+  'analysis.switchPorts.fromNic': 'interface',
+  'analysis.switchPorts.fromCable': 'cable',
+  // {name} wird vom Aufrufer ersetzt.
+  'analysis.switchPorts.conflict': 'cable says: {name}',
+  'analysis.switchPorts.descriptions': 'Descriptions',
+  'analysis.switchPorts.descHint':
+    'Vendor-neutral text to paste. The plan sends nothing to the switch \u2014 read what you paste.',
+
+  /* Bedarf 19 — weitere Netzwerk-Schnittstellen. Keys: nic.* */
+  'nic.title': 'Additional network interfaces',
+  'nic.add': 'Add',
+  'nic.none': 'No additional interfaces.',
+  'nic.hint':
+    'The fields above are the first interface. These are the further ones \u2014 Dante secondary, ST 2110 blue, separate control.',
+  'nic.primaryRole': 'Role of the first interface',
+  'nic.label': 'Label, e.g. \u201eDante Sec\u201c',
+  'nic.role': 'Role',
+  'nic.remove': 'Remove interface',
+  'nic.gateway': 'Gateway',
+  'nic.mac': 'MAC address',
+  'nic.vlan': 'VLAN',
+  'nic.switch': 'Switch',
+  'nic.switchPort': 'Port',
+  'nic.noSwitch': '\u2014 no switch \u2014',
+  'nic.role.mediaPrimary': 'Media primary',
+  'nic.role.mediaSecondary': 'Media secondary',
+  'nic.role.control': 'Control',
+  'nic.role.management': 'Management',
+  'nic.role.unspecified': 'not stated',
   'analysis.address.mask': 'Mask',
   'analysis.address.evidence': 'Evidence',
   'analysis.address.finding': 'Finding',

--- a/src/renderer/lib/modelFields.ts
+++ b/src/renderer/lib/modelFields.ts
@@ -43,6 +43,11 @@ export const MODEL_FIELDS = [
   'deviceTypeId',
   'categoryProps',
   'libraryRef',
+  // Bedarf 19 — wofuer die Adresse in den Alt-Feldern da ist. Ein
+  // Datenblatt-Fakt ueber den TYP („dieser Anschluss ist der
+  // Dante-Sekundaerweg"), nicht ueber dieses Exemplar; die Adresse selbst
+  // steht unten bei den Instanz-Feldern.
+  'primaryInterfaceRole',
   'netboxPath',
   'manufacturerUrl',
   // Der Beleg gehoert zum TYP: er sagt, woher die Angaben dieses Modells
@@ -152,6 +157,13 @@ export const INSTANCE_FIELDS = [
   'firmware',
   'username',
   'password',
+  // Bedarf 19 — die weiteren Schnittstellen gehoeren zur selben Netz-Identitaet
+  // wie `ipAddress` darueber und aus demselben Grund hierher: eine Vorlage mit
+  // fest eingebauter Dante-Sekundaeradresse erzeugt beim zweiten Herausziehen
+  // zwei Adresskonflikte statt einem. Die ROLLE dagegen ist ein Datenblatt-Fakt
+  // („dieser Port ist der Dante-Sekundaerweg") und steht deshalb unten bei den
+  // Modell-Feldern.
+  'networkInterfaces',
 
   // Zustand dieses Exemplars
   'activeModeId',

--- a/src/renderer/lib/networkInterfaces.ts
+++ b/src/renderer/lib/networkInterfaces.ts
@@ -1,0 +1,138 @@
+// ───────────────────────────────────────────────────────────────────────────
+// DIE ENGSTELLE fuer Netzwerk-Schnittstellen (Bedarf 19).
+//
+// Wer wissen will, welche Adressen ein Geraet hat, fragt hier — nicht
+// `item.ipAddress`. Die Alt-Felder sind Schnittstelle 0 und bleiben gueltig;
+// diese Funktion setzt sie mit `networkInterfaces` zu der einen Liste
+// zusammen, die es fachlich gibt.
+//
+// WARUM EINE ENGSTELLE UND KEIN UMZUG. Dieselbe Bauform wie
+// `resolvePortLabel` in ADR-001 Inkrement 2, und aus demselben Grund: dort
+// stand die Aufloesung als private Funktion an einer Stelle, die kein Exporter
+// erreichen konnte, und wurde hochgezogen statt neu geschrieben. Hier ist es
+// umgekehrt herum dieselbe Lage — 95 Aufrufer lesen ein Feld, das kuenftig nur
+// noch die halbe Antwort ist. Eine Engstelle macht aus 95 Umbauten einen und
+// laesst die uebrigen 94 richtig bleiben, bis sie drankommen.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { EquipmentItem } from '../types/equipment'
+import type { NetworkInterface, NetworkInterfaceRole } from '../types/network'
+import { interfaceIsEmpty, NETWORK_INTERFACE_ROLES } from '../types/network'
+
+/** Die Id, unter der Schnittstelle 0 erscheint. Abgeleitet und nie
+ *  gespeichert — sonst koennte sie von den Alt-Feldern abweichen. */
+export const primaryInterfaceId = (equipmentId: string): string => `${equipmentId}#nic0`
+
+/**
+ * Alle Netzwerk-Schnittstellen eines Geraets, Schnittstelle 0 zuerst.
+ *
+ * Schnittstelle 0 entsteht aus den Alt-Feldern und faellt weg, wenn dort
+ * nichts steht: ein Geraet, das nur eine zweite Karte gepflegt hat, soll
+ * keine leere erste vorgesetzt bekommen.
+ *
+ * Die Rolle von Schnittstelle 0 ist `unspecified`, solange niemand etwas
+ * anderes gesagt hat. Sie zu raten waere billig und falsch: ob die eine IP
+ * einer Kamera ihre Steuerung oder ihr Medienweg ist, weiss der Plan nicht.
+ */
+export function deviceInterfaces(item: EquipmentItem): NetworkInterface[] {
+  const out: NetworkInterface[] = []
+  const primary: NetworkInterface = {
+    id: primaryInterfaceId(item.id),
+    role: item.primaryInterfaceRole ?? 'unspecified',
+    ...(item.ipAddress ? { ipAddress: item.ipAddress } : {}),
+    ...(item.subnetMask ? { subnetMask: item.subnetMask } : {}),
+    ...(item.gateway ? { gateway: item.gateway } : {}),
+    ...(item.macAddress ? { macAddress: item.macAddress } : {}),
+    ...(item.managementVlanId !== undefined ? { vlanId: item.managementVlanId } : {}),
+  }
+  if (!interfaceIsEmpty(primary)) out.push(primary)
+  for (const n of item.networkInterfaces ?? []) {
+    if (!interfaceIsEmpty(n)) out.push(n)
+  }
+  return out
+}
+
+/**
+ * Wie `deviceInterfaces`, aber auch die leeren — fuer die Oberflaeche, die ein
+ * frisch angelegtes Formular anzeigen muss.
+ */
+export function deviceInterfacesIncludingEmpty(item: EquipmentItem): NetworkInterface[] {
+  return [
+    {
+      id: primaryInterfaceId(item.id),
+      role: item.primaryInterfaceRole ?? 'unspecified',
+      ...(item.ipAddress ? { ipAddress: item.ipAddress } : {}),
+      ...(item.subnetMask ? { subnetMask: item.subnetMask } : {}),
+      ...(item.gateway ? { gateway: item.gateway } : {}),
+      ...(item.macAddress ? { macAddress: item.macAddress } : {}),
+      ...(item.managementVlanId !== undefined ? { vlanId: item.managementVlanId } : {}),
+    },
+    ...(item.networkInterfaces ?? []),
+  ]
+}
+
+/** Ist das Schnittstelle 0 (also die Alt-Felder) dieses Geraets? Die
+ *  Oberflaeche muss sie anders schreiben als die uebrigen. */
+export const isPrimaryInterface = (item: EquipmentItem, nicId: string): boolean =>
+  nicId === primaryInterfaceId(item.id)
+
+/** Alle Schnittstellen im Projekt, mit ihrem Geraet daneben. */
+export interface DeviceInterface {
+  equipment: EquipmentItem
+  nic: NetworkInterface
+  /** Schnittstelle 0? Dann liegen ihre Werte in den Alt-Feldern. */
+  primary: boolean
+}
+
+export function allDeviceInterfaces(equipment: EquipmentItem[]): DeviceInterface[] {
+  const out: DeviceInterface[] = []
+  for (const e of equipment) {
+    for (const nic of deviceInterfaces(e)) {
+      out.push({ equipment: e, nic, primary: isPrimaryInterface(e, nic.id) })
+    }
+  }
+  return out
+}
+
+/** Lesbarer Name einer Schnittstelle fuer Listen: „Kamera 1 · Dante Sec". */
+export const interfaceLabel = (e: EquipmentItem, nic: NetworkInterface): string =>
+  nic.label?.trim() ? `${e.name} · ${nic.label.trim()}` : e.name
+
+/**
+ * Rohsatz aus einer Projektdatei zu einer gueltigen Schnittstelle — oder
+ * `null`. Eine Schnittstelle ohne Id und ohne einen einzigen gefuellten Wert
+ * ist kein Datensatz, sondern Ballast in jedem Projektfile.
+ */
+export function normaliseNetworkInterface(
+  raw: unknown,
+  fallbackId: string,
+  roleOk: (r: unknown) => r is NetworkInterfaceRole,
+): NetworkInterface | null {
+  if (!raw || typeof raw !== 'object') return null
+  const r = raw as Record<string, unknown>
+  const str = (v: unknown): string | undefined =>
+    typeof v === 'string' && v.trim() ? v.trim() : undefined
+  const nic: NetworkInterface = {
+    id: str(r.id) ?? fallbackId,
+    role: roleOk(r.role) ? r.role : 'unspecified',
+  }
+  const label = str(r.label)
+  if (label) nic.label = label
+  for (const k of ['ipAddress', 'subnetMask', 'gateway', 'macAddress', 'switchPort', 'portId'] as const) {
+    const v = str(r[k])
+    if (v) nic[k] = v
+  }
+  const sw = str(r.switchEquipmentId)
+  if (sw) nic.switchEquipmentId = sw
+  if (typeof r.vlanId === 'number' && Number.isInteger(r.vlanId) && r.vlanId >= 0 && r.vlanId <= 4094) {
+    nic.vlanId = r.vlanId
+  }
+  return interfaceIsEmpty(nic) && !nic.label ? null : nic
+}
+
+/** Typwaechter fuer die Rolle — an einer Stelle, damit Store und Test dieselbe
+ *  Liste benutzen und nicht zwei. */
+export const isNetworkInterfaceRole = (r: unknown): r is NetworkInterfaceRole =>
+  (NETWORK_INTERFACE_ROLES as readonly unknown[]).includes(r)

--- a/src/renderer/lib/networkReconcile.ts
+++ b/src/renderer/lib/networkReconcile.ts
@@ -1,0 +1,362 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Plan gegen Vorgefundenes (Bedarf 21, P1).
+//
+// Die Bedarfs-Datenbank nennt ihn „the highest-value item in the dossier and
+// nothing in the AV planning market does it", und sie beschreibt die Arbeit,
+// die er heute ersetzt:
+//
+//   > Nobody schedules the load-in reconciliation pass, but everybody does it:
+//   > what came off the truck, under which names, with which addresses, versus
+//   > what the plan says. Kit returns from the previous job with the previous
+//   > job's names — Dante silently auto-renames collisions to 'Fred(2)'.
+//
+// ─── DREI REGELN, ALLE AUS DER RECHERCHE ───────────────────────────────────
+//
+// 1. **KEIN LIVE-FEED.** Der Bedarf schreibt es vor: „Deliberate, timestamped,
+//    user-initiated — never a live feed." Und die Dossiers sagen, warum das
+//    nicht Bequemlichkeit ist: Dantes API ist lizenz-gebunden („requires access
+//    to the Dante Managed API … through a Dante Cloud Beta account or Dante
+//    Domain Manager"), die offene Alternative erklaert sich selbst fuer
+//    untauglich („not ready for anything other than a test environment … could
+//    make the devices behave unexpectedly"), und die offene ST-2110-Analyse ist
+//    eingestellt („Use at Your Own Risk"). Dieses Modul liest deshalb eine
+//    DATEI, die ein Mensch abgelegt hat, und beruehrt kein Geraet.
+//
+// 2. **EINDEUTIG ODER GAR NICHT.** Aus `netboxlabs/orb-agent#558`: eine
+//    Verbindung nur anlegen, wenn „both endpoints can be identified uniquely".
+//    Hier heisst das: zwei Plan-Schnittstellen mit derselben MAC ergeben keine
+//    Zuordnung, sondern einen Befund. Eine geratene Zuordnung waere schlimmer
+//    als keine — sie erklaerte ein fehlendes Geraet fuer anwesend.
+//
+// 3. **DIE UMBENENNUNG IST EIN EIGENER BEFUND.** Dante haengt bei einer
+//    Namenskollision still „(2)" an. Wer das nicht kennt, sieht in der Liste
+//    ein FEHLENDES „Stagebox" und ein UNERWARTETES „Stagebox (2)" — zwei
+//    Befunde fuer einen Vorgang, und beide fuehren in die Irre. `renamed` sagt,
+//    was wirklich passiert ist.
+//
+// ─── WORAUF ZUGEORDNET WIRD, IN DIESER REIHENFOLGE ─────────────────────────
+//
+//   MAC  — eine Messung. Ein Geraet traegt sie, egal wie es heisst.
+//   IP   — eine Messung des Augenblicks. Adressen wandern, aber wenn eine
+//          passt, passt sie.
+//   Name — eine Konvention. Zuletzt, und mit der Dante-Regel darin.
+//
+// Jede Zuordnung traegt mit, WORAUF sie beruht (`matchedBy`) — dieselbe Regel
+// wie beim Kamera-Abgleich in `sony-camera-bridge#14`: wer eine Zeile fuer
+// falsch haelt, soll sehen, warum sie dasteht.
+//
+// REIN: keine Uhr, kein Store, kein IO. Der Zeitstempel kommt von aussen,
+// damit dieselbe Datei zweimal dasselbe Ergebnis gibt.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { EquipmentItem } from '../types/equipment'
+import { allDeviceInterfaces, interfaceLabel } from './networkInterfaces'
+import { parseCsv } from './csvParse'
+import type { CsvCell, CsvTable } from './csv'
+
+/** Ein Geraet, wie es die Abtastung vorgefunden hat. */
+export interface ScanEntry {
+  name?: string
+  ipAddress?: string
+  macAddress?: string
+  switchName?: string
+  switchPort?: string
+}
+
+/** Eine abgelegte Abtastung: was gefunden wurde, wann, und woraus gelesen. */
+export interface NetworkScan {
+  /** ISO-Zeitpunkt. Kommt von aussen — dieses Modul kennt keine Uhr. */
+  takenAt: string
+  /** Dateiname oder Quelle im Klartext, fuer den Bericht. */
+  source: string
+  entries: ScanEntry[]
+}
+
+export type MatchBasis = 'mac' | 'ip' | 'name'
+
+export type ReconcileVerdict =
+  /** Plan und Fund stimmen ueberein. */
+  | 'match'
+  /** Zugeordnet, aber die Adresse weicht ab. */
+  | 'address-mismatch'
+  /** Zugeordnet, aber der Name weicht ab. */
+  | 'name-mismatch'
+  /** Zugeordnet, und der Name ist die Dante-Kollisionsform des geplanten. */
+  | 'renamed'
+  /** Im Plan, nicht gefunden. */
+  | 'missing'
+  /** Gefunden, nicht im Plan. */
+  | 'unexpected'
+  /** Mehr als eine Zuordnung moeglich — bewusst KEINE getroffen. */
+  | 'ambiguous'
+
+export interface ReconcileRow {
+  verdict: ReconcileVerdict
+  /** Wie die Zeile im Plan heisst. Fehlt bei `unexpected`. */
+  planned?: string
+  plannedIp?: string
+  plannedMac?: string
+  /** Wie sie vorgefunden wurde. Fehlt bei `missing`. */
+  found?: string
+  foundIp?: string
+  foundMac?: string
+  /** Worauf die Zuordnung beruht. Fehlt, wo keine getroffen wurde. */
+  matchedBy?: MatchBasis
+}
+
+export interface ReconcileReport {
+  takenAt: string
+  source: string
+  rows: ReconcileRow[]
+  counts: Record<ReconcileVerdict, number>
+}
+
+/** MAC auf Vergleichsform: nur Hex, klein. Deckt `aa:bb:..`, `AA-BB-..` und
+ *  Ciscos `aabb.ccdd.eeff` in einem ab. */
+export const normaliseMac = (mac: string): string => mac.toLowerCase().replace(/[^0-9a-f]/g, '')
+
+/**
+ * Dantes Kollisionsform: „Stagebox (2)" oder „Stagebox(2)" → „Stagebox".
+ *
+ * Die Klammer-Zahl am ENDE, nichts anderes: „Cam (Backup)" bleibt, wie es ist,
+ * und „Stagebox 2" auch — das ist eine Nummer im Namen und keine Umbenennung.
+ */
+export const stripDanteCollisionSuffix = (name: string): string =>
+  name.replace(/\s*\((\d+)\)\s*$/, '').trim()
+
+const norm = (s?: string): string => (s ?? '').trim().toLowerCase()
+
+/**
+ * Eine ARP-/Neighbour-Tabelle lesen.
+ *
+ * Zwei Formen, beide woertlich so, wie die Werkzeuge sie ausgeben:
+ *   `arp -a`   → `? (10.0.0.5) at aa:bb:cc:dd:ee:ff [ether] on eth0`
+ *   `ip neigh` → `10.0.0.5 dev eth0 lladdr aa:bb:cc:dd:ee:ff REACHABLE`
+ *
+ * Ein Name steht in keiner von beiden, wenn er nicht aufloest — dann bleibt
+ * er leer, statt aus der Adresse einen zu basteln.
+ */
+export function parseArpTable(text: string): ScanEntry[] {
+  const out: ScanEntry[] = []
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim()
+    if (!line) continue
+    // Drei Schreibweisen, weil drei Werkzeuge sie so ausgeben: Doppelpunkt
+    // (Linux/macOS), Bindestrich (Windows `arp -a`) und Ciscos Vierergruppen.
+    // Nur den Doppelpunkt zu nehmen hiesse, die Windows-Ausgabe halb zu lesen
+    // — Adresse ja, MAC nein — und ausgerechnet die MAC ist die Messung, auf
+    // die der Abgleich zuerst zugreift.
+    const mac =
+      line.match(/\b([0-9a-fA-F]{2}(?:[:-][0-9a-fA-F]{2}){5})\b/)?.[1] ??
+      line.match(/\b([0-9a-fA-F]{4}(?:\.[0-9a-fA-F]{4}){2})\b/)?.[1]
+    // `arp -a`: Adresse in Klammern; `ip neigh`: Adresse am Zeilenanfang.
+    const ip =
+      line.match(/\((\d{1,3}(?:\.\d{1,3}){3})\)/)?.[1] ??
+      line.match(/^(\d{1,3}(?:\.\d{1,3}){3})\b/)?.[1]
+    if (!mac && !ip) continue
+    // Der Hostname vor der Klammer bei `arp -a`. `?` heisst „nicht aufgeloest".
+    const host = line.match(/^([^\s(]+)\s+\(/)?.[1]
+    const entry: ScanEntry = {}
+    if (host && host !== '?') entry.name = host
+    if (ip) entry.ipAddress = ip
+    if (mac) entry.macAddress = mac
+    out.push(entry)
+  }
+  return out
+}
+
+const SCAN_ALIASES: Record<keyof ScanEntry, string[]> = {
+  name: ['name', 'gerät', 'geraet', 'device', 'hostname', 'host', 'bezeichnung'],
+  ipAddress: ['ip', 'ip-adresse', 'ipaddress', 'ip address', 'ip adresse', 'address', 'adresse'],
+  macAddress: ['mac', 'mac-adresse', 'macaddress', 'mac address', 'hardware address', 'lladdr'],
+  switchName: ['switch', 'switchname', 'neighbor', 'nachbar'],
+  switchPort: ['port', 'switchport', 'switch port', 'interface', 'schnittstelle'],
+}
+
+/**
+ * Eine Abtastung aus einer CSV lesen — mit Spalten-Zuordnung ueber die
+ * Kopfzeile.
+ *
+ * Warum eine CSV mit Aliasen und kein Parser fuer ein bestimmtes Werkzeug:
+ * Bedarf 6 verlangt fuer fremde Tabellen ausdruecklich „arbitrary column
+ * names, arbitrary sheet, with user-defined column mapping". Und fuer die
+ * Dante-Controller-Ausgabe gilt derselbe Grund noch einmal: ihr genaues Format
+ * liegt in dieser Recherche nicht vor. Einen Parser dafuer zu schreiben hiesse,
+ * Spaltennamen zu erfinden und ihn „Dante-Import" zu nennen — er saehe geprueft
+ * aus und waere geraten. Die Alias-Liste nimmt an, was dasteht.
+ */
+export function parseScanCsv(text: string): ScanEntry[] {
+  const rows = parseCsv(text)
+  if (rows.length < 2) return []
+  const header = rows[0].map((h) => h.trim().toLowerCase())
+  const map: Partial<Record<keyof ScanEntry, number>> = {}
+  header.forEach((h, i) => {
+    for (const [field, aliases] of Object.entries(SCAN_ALIASES) as [keyof ScanEntry, string[]][]) {
+      if (map[field] == null && aliases.includes(h)) map[field] = i
+    }
+  })
+  const at = (r: string[], k: keyof ScanEntry): string | undefined => {
+    const i = map[k]
+    const v = i == null ? undefined : r[i]?.trim()
+    return v || undefined
+  }
+  const out: ScanEntry[] = []
+  for (const r of rows.slice(1)) {
+    const e: ScanEntry = {}
+    for (const k of Object.keys(SCAN_ALIASES) as (keyof ScanEntry)[]) {
+      const v = at(r, k)
+      if (v) e[k] = v
+    }
+    // Eine Zeile ohne einen einzigen Griff ist kein Fund.
+    if (e.name || e.ipAddress || e.macAddress) out.push(e)
+  }
+  return out
+}
+
+interface PlanEntry {
+  label: string
+  ip?: string
+  mac?: string
+}
+
+/**
+ * Plan gegen Abtastung.
+ *
+ * Der Plan kommt als Geraeteliste; gelesen werden seine SCHNITTSTELLEN
+ * (Bedarf 19), damit die zweite Karte eines redundanten Aufbaus nicht als
+ * „unerwartet" auftaucht.
+ */
+export function reconcileNetwork(equipment: EquipmentItem[], scan: NetworkScan): ReconcileReport {
+  const planned: PlanEntry[] = allDeviceInterfaces(equipment).map(({ equipment: e, nic }) => ({
+    label: interfaceLabel(e, nic),
+    ...(nic.ipAddress ? { ip: nic.ipAddress } : {}),
+    ...(nic.macAddress ? { mac: normaliseMac(nic.macAddress) } : {}),
+  }))
+
+  const rows: ReconcileRow[] = []
+  const usedPlan = new Set<number>()
+
+  const candidates = (e: ScanEntry): { idx: number[]; basis: MatchBasis } | null => {
+    const mac = e.macAddress ? normaliseMac(e.macAddress) : undefined
+    if (mac) {
+      const hit = planned.flatMap((p, i) => (p.mac === mac ? [i] : []))
+      if (hit.length > 0) return { idx: hit, basis: 'mac' }
+    }
+    if (e.ipAddress) {
+      const hit = planned.flatMap((p, i) => (p.ip === e.ipAddress ? [i] : []))
+      if (hit.length > 0) return { idx: hit, basis: 'ip' }
+    }
+    if (e.name) {
+      const wanted = norm(stripDanteCollisionSuffix(e.name))
+      const hit = planned.flatMap((p, i) =>
+        norm(stripDanteCollisionSuffix(p.label)) === wanted ? [i] : [],
+      )
+      if (hit.length > 0) return { idx: hit, basis: 'name' }
+    }
+    return null
+  }
+
+  for (const found of scan.entries) {
+    const c = candidates(found)
+    if (!c) {
+      rows.push({
+        verdict: 'unexpected',
+        ...(found.name ? { found: found.name } : {}),
+        ...(found.ipAddress ? { foundIp: found.ipAddress } : {}),
+        ...(found.macAddress ? { foundMac: found.macAddress } : {}),
+      })
+      continue
+    }
+    // Eindeutig oder gar nicht (orb-agent#558). Eine geratene Zuordnung
+    // erklaerte ein fehlendes Geraet fuer anwesend.
+    const fresh = c.idx.filter((i) => !usedPlan.has(i))
+    if (fresh.length !== 1) {
+      rows.push({
+        verdict: 'ambiguous',
+        ...(found.name ? { found: found.name } : {}),
+        ...(found.ipAddress ? { foundIp: found.ipAddress } : {}),
+        ...(found.macAddress ? { foundMac: found.macAddress } : {}),
+        matchedBy: c.basis,
+      })
+      continue
+    }
+    const i = fresh[0]
+    usedPlan.add(i)
+    const p = planned[i]
+
+    let verdict: ReconcileVerdict = 'match'
+    if (found.ipAddress && p.ip && found.ipAddress !== p.ip) {
+      verdict = 'address-mismatch'
+    } else if (found.name && norm(found.name) !== norm(p.label)) {
+      // Die Dante-Kollisionsform ist ein eigener Befund und keine Abweichung:
+      // „Stagebox (2)" IST die geplante Stagebox, nur unter dem Namen, den ihr
+      // die Anlage gegeben hat.
+      verdict =
+        norm(stripDanteCollisionSuffix(found.name)) === norm(stripDanteCollisionSuffix(p.label)) &&
+        norm(found.name) !== norm(p.label)
+          ? 'renamed'
+          : 'name-mismatch'
+    }
+
+    rows.push({
+      verdict,
+      planned: p.label,
+      ...(p.ip ? { plannedIp: p.ip } : {}),
+      ...(p.mac ? { plannedMac: p.mac } : {}),
+      ...(found.name ? { found: found.name } : {}),
+      ...(found.ipAddress ? { foundIp: found.ipAddress } : {}),
+      ...(found.macAddress ? { foundMac: found.macAddress } : {}),
+      matchedBy: c.basis,
+    })
+  }
+
+  // Was der Plan kennt und die Abtastung nicht gefunden hat.
+  planned.forEach((p, i) => {
+    if (usedPlan.has(i)) return
+    rows.push({
+      verdict: 'missing',
+      planned: p.label,
+      ...(p.ip ? { plannedIp: p.ip } : {}),
+      ...(p.mac ? { plannedMac: p.mac } : {}),
+    })
+  })
+
+  const counts = {
+    match: 0,
+    'address-mismatch': 0,
+    'name-mismatch': 0,
+    renamed: 0,
+    missing: 0,
+    unexpected: 0,
+    ambiguous: 0,
+  } as Record<ReconcileVerdict, number>
+  for (const r of rows) counts[r.verdict]++
+
+  return { takenAt: scan.takenAt, source: scan.source, rows, counts }
+}
+
+/** Der Bericht als Tabelle. Kanonisches Deutsch — sie kann gestempelt werden. */
+export function reconcileTable(report: ReconcileReport): CsvTable {
+  const label: Record<ReconcileVerdict, string> = {
+    match: 'stimmt',
+    'address-mismatch': 'Adresse weicht ab',
+    'name-mismatch': 'Name weicht ab',
+    renamed: 'umbenannt (Kollisionsform)',
+    missing: 'nicht gefunden',
+    unexpected: 'nicht im Plan',
+    ambiguous: 'nicht eindeutig — keine Zuordnung',
+  }
+  const basis: Record<MatchBasis, string> = { mac: 'MAC', ip: 'IP', name: 'Name' }
+  return {
+    headers: ['Befund', 'Im Plan', 'Plan-IP', 'Vorgefunden', 'Gefundene IP', 'MAC', 'Zugeordnet ueber'],
+    rows: report.rows.map((r): CsvCell[] => [
+      label[r.verdict],
+      r.planned ?? '',
+      r.plannedIp ?? '',
+      r.found ?? '',
+      r.foundIp ?? '',
+      r.foundMac ?? '',
+      r.matchedBy ? basis[r.matchedBy] : '',
+    ]),
+  }
+}

--- a/src/renderer/lib/planDiff.ts
+++ b/src/renderer/lib/planDiff.ts
@@ -208,6 +208,11 @@ export const EQUIPMENT_FIELD_CLASS: Record<string, FieldClass> = {
   vlans: 'substantive',
   portVlans: 'substantive',
   managementVlanId: 'substantive',
+  // Bedarf 19 — eine geaenderte Schnittstelle aendert, wohin ein Kabel geht
+  // und welche Adresse dort erwartet wird. Beides steht auf den Listen, die
+  // schon draussen sind.
+  networkInterfaces: 'substantive',
+  primaryInterfaceRole: 'substantive',
   mgmtUrl: 'substantive',
   firmware: 'substantive',
 

--- a/src/renderer/lib/switchPortMap.ts
+++ b/src/renderer/lib/switchPortMap.ts
@@ -1,0 +1,231 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Die Switch-Port-Karte (Bedarf 24, P1).
+//
+// DER BEFUND, AUS DEM SIE KOMMT:
+//
+//   > Switch port descriptions are often the only documentation physically
+//   > co-located with the hardware, and they go stale first; when they do,
+//   > tracing a cable becomes a physical task.
+//
+// Die deutsche Praxis dazu ist eine Excel-Mappe mit einem Reiter je Switch,
+// Ports als Spalten und VLANs als Zeilen, von Hand gepflegt
+// (lancom-forum.de, mcseboard.de, vorlagesheet.com/switch-port-belegung/).
+// Genau diese Mappe ist die zweite Wahrheit neben dem Plan — und sie ist die,
+// die zuerst veraltet.
+//
+// DIE LOESUNG DER BEDARFS-DATENBANK, woertlich: „Model switch, port, and the
+// cable that occupies it as part of the same connection graph the cable
+// planner already holds, then generate the port map and the port-description
+// list rather than maintaining them."
+//
+// GENAU DAS TUT DIESE DATEI — UND NICHT MEHR. Der Satz geht weiter: „Do NOT
+// push config to live switches — generating a paste-able description block is
+// the defensible" Weg. Hier entsteht also Text zum Einfuegen, kein
+// Konfigurationskanal. Wer die Beschriftung einspielt, ist ein Mensch mit
+// einer Konsole, der vorher gelesen hat, was er einfuegt.
+//
+// ZWEI QUELLEN JE BELEGUNG, und die Karte sagt welche:
+//   `interface` — eine Schnittstelle nennt Switch und Port ausdruecklich.
+//                 Das ist die gepflegte Angabe.
+//   `cable`     — ein Kabel im Plan endet an einem Port dieses Switches.
+//                 Das ist die abgeleitete: der Plan weiss, was dort steckt,
+//                 auch wenn niemand es in die Netz-Maske getippt hat.
+// Eine Belegung ohne Herkunft waere eine Behauptung; mit ihr kann jemand
+// entscheiden, welcher er glaubt, wenn beide etwas sagen.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { Cable } from '../types/cable'
+import type { EquipmentItem, Port } from '../types/equipment'
+import type { CsvCell, CsvTable } from './csv'
+import { portDisplayLabel } from './portLabel'
+import { allDeviceInterfaces } from './networkInterfaces'
+import { detectNetworkDevice } from './deviceKind'
+
+/** Woher die Belegung eines Switch-Ports stammt. */
+export type PortOccupancySource = 'interface' | 'cable'
+
+export interface SwitchPortRow {
+  /** Port am Switch, wie er dort aufgedruckt ist. */
+  port: string
+  /** Was dort haengt — Geraetename. Leer heisst: frei. */
+  device?: string
+  deviceId?: string
+  /** Die Schnittstelle am Gegenueber, wenn sie benannt ist. */
+  nicLabel?: string
+  ipAddress?: string
+  vlanId?: number
+  /** Woher die Belegung kommt. Fehlt bei freien Ports. */
+  source?: PortOccupancySource
+  /**
+   * Beide Quellen sagen etwas, und sie widersprechen sich — die
+   * Schnittstelle nennt einen anderen Port als das Kabel.
+   * Der Text nennt den jeweils anderen, damit jemand nachsehen kann.
+   */
+  conflict?: string
+}
+
+export interface SwitchPortMap {
+  switchId: string
+  switchName: string
+  rows: SwitchPortRow[]
+  /** Wie viele der aufgefuehrten Ports belegt sind. */
+  usedCount: number
+}
+
+/**
+ * Ein Geraet gilt als Switch, wenn `detectNetworkDevice` es sagt.
+ *
+ * NICHT selbst geraten: der erste Entwurf hier stand auf
+ * `category === 'network' || /switch/i.test(deviceTypeId)`. Beides war falsch —
+ * die Kategorien sind deutsch (`Netzwerk`), und die Geraetetyp-Id ist eine
+ * GUID ohne sprechenden Text. `detectNetworkDevice` loest zuerst ueber das
+ * Katalog-Register auf (Datenblatt-Tatsache, ADR-002) und faellt erst danach
+ * auf Namen und Port-Struktur zurueck. Eine zweite Erkennung neben dieser
+ * waere genau die zweite Wahrheit, gegen die ADR-001 geschrieben ist.
+ */
+const isSwitch = (e: EquipmentItem): boolean => detectNetworkDevice(e) === 'switch'
+
+/**
+ * Die Ports eines Switches, in der Reihenfolge, in der sie am Geraet stehen.
+ * Ein Switch fuehrt seine Ports als `inputs`/`outputs` wie jedes andere
+ * Geraet; fuer die Karte zaehlt die Beschriftung, nicht die Richtung.
+ */
+const switchPorts = (sw: EquipmentItem): Port[] => [...(sw.inputs ?? []), ...(sw.outputs ?? [])]
+
+/**
+ * Port-Karten fuer alle Switches im Plan.
+ *
+ * `switches` kann von aussen eingeschraenkt werden (etwa auf ein ausgewaehltes
+ * Geraet); ohne Angabe werden alle gefunden.
+ */
+export function buildSwitchPortMaps(
+  equipment: EquipmentItem[],
+  cables: Cable[],
+  onlySwitchId?: string,
+): SwitchPortMap[] {
+  const byId = new Map(equipment.map((e) => [e.id, e]))
+  const switches = equipment.filter(
+    (e) => (onlySwitchId ? e.id === onlySwitchId : isSwitch(e)),
+  )
+  const nics = allDeviceInterfaces(equipment)
+
+  return switches.map((sw) => {
+    const ports = switchPorts(sw)
+    const portNames = ports.map((p) => portDisplayLabel(p) || p.id)
+
+    // 1. Belegungen aus den Schnittstellen — die gepflegte Angabe.
+    const fromNic = new Map<string, SwitchPortRow>()
+    for (const { equipment: e, nic } of nics) {
+      if (nic.switchEquipmentId !== sw.id || !nic.switchPort) continue
+      fromNic.set(nic.switchPort, {
+        port: nic.switchPort,
+        device: e.name,
+        deviceId: e.id,
+        ...(nic.label ? { nicLabel: nic.label } : {}),
+        ...(nic.ipAddress ? { ipAddress: nic.ipAddress } : {}),
+        ...(nic.vlanId !== undefined ? { vlanId: nic.vlanId } : {}),
+        source: 'interface',
+      })
+    }
+
+    // 2. Belegungen aus dem Kabelgraphen — was der Plan ohnehin weiss.
+    const fromCable = new Map<string, SwitchPortRow>()
+    for (const c of cables) {
+      const ends: Array<[string, string, string, string]> = [
+        [c.fromEquipmentId, c.fromPortId, c.toEquipmentId, c.toPortId],
+        [c.toEquipmentId, c.toPortId, c.fromEquipmentId, c.fromPortId],
+      ]
+      for (const [nearEq, nearPort, farEq, farPort] of ends) {
+        if (nearEq !== sw.id) continue
+        const p = ports.find((x) => x.id === nearPort)
+        if (!p) continue
+        const far = byId.get(farEq)
+        if (!far) continue
+        const farPortObj = [...(far.inputs ?? []), ...(far.outputs ?? [])].find((x) => x.id === farPort)
+        fromCable.set(portDisplayLabel(p) || p.id, {
+          port: portDisplayLabel(p) || p.id,
+          device: far.name,
+          deviceId: far.id,
+          ...(farPortObj ? { nicLabel: portDisplayLabel(farPortObj) } : {}),
+          ...(far.ipAddress ? { ipAddress: far.ipAddress } : {}),
+          source: 'cable',
+        })
+      }
+    }
+
+    // 3. Zusammenfuehren. Die Schnittstelle gewinnt, weil sie jemand von Hand
+    //    gepflegt hat; der Widerspruch bleibt trotzdem sichtbar, statt
+    //    stillschweigend weggeraeumt zu werden.
+    const rows: SwitchPortRow[] = []
+    const seen = new Set<string>()
+    for (const name of portNames) {
+      seen.add(name)
+      const nicRow = fromNic.get(name)
+      const cableRow = fromCable.get(name)
+      if (nicRow && cableRow && nicRow.deviceId !== cableRow.deviceId) {
+        rows.push({ ...nicRow, conflict: cableRow.device })
+      } else {
+        rows.push(nicRow ?? cableRow ?? { port: name })
+      }
+    }
+    // Schnittstellen, die einen Port nennen, den der Switch gar nicht fuehrt.
+    // Nicht wegwerfen: das ist genau der Tippfehler, den die Karte finden soll.
+    for (const [name, row] of fromNic) {
+      if (!seen.has(name)) rows.push(row)
+    }
+
+    return {
+      switchId: sw.id,
+      switchName: sw.name,
+      rows,
+      usedCount: rows.filter((r) => !!r.device).length,
+    }
+  })
+}
+
+/** Die Port-Karte eines Switches als Tabelle. Kanonisches Deutsch — sie kann
+ *  gestempelt werden, und ein Fingerabdruck ueber uebersetzten Text waere
+ *  sprachabhaengig. */
+export function switchPortTable(map: SwitchPortMap): CsvTable {
+  return {
+    headers: ['Port', 'Geraet', 'Schnittstelle', 'IP', 'VLAN', 'Quelle', 'Widerspruch'],
+    rows: map.rows.map((r): CsvCell[] => [
+      r.port,
+      r.device ?? '',
+      r.nicLabel ?? '',
+      r.ipAddress ?? '',
+      r.vlanId ?? '',
+      r.source === 'interface' ? 'Schnittstelle' : r.source === 'cable' ? 'Kabel' : '',
+      r.conflict ? `Kabel sagt: ${r.conflict}` : '',
+    ]),
+  }
+}
+
+/**
+ * Der einfuegbare Beschreibungsblock — das, was Bedarf 24 als den
+ * vertretbaren Weg benennt.
+ *
+ * Bewusst herstellerneutral: `interface <port>` / `description <text>` ist die
+ * Form, die Cisco-IOS, Aruba, FS und die meisten Web-Oberflaechen entweder
+ * direkt annehmen oder in der jemand die Zeile ablesen kann. Eine Datei im
+ * Format genau eines Herstellers waere fuer alle anderen unbrauchbar und
+ * wuerde behaupten, geprueft zu sein.
+ *
+ * Freie Ports kommen NICHT vor: eine Beschreibung, die einen Port leert, den
+ * jemand ausserhalb dieses Plans belegt hat, richtet Schaden an.
+ */
+export function switchPortDescriptionBlock(map: SwitchPortMap): string {
+  const lines: string[] = [
+    `! ${map.switchName} — Port-Beschreibungen aus dem Plan`,
+    '! Herstellerneutral. Vor dem Einspielen lesen; freie Ports stehen bewusst nicht drin.',
+  ]
+  for (const r of map.rows) {
+    if (!r.device) continue
+    const text = [r.device, r.nicLabel, r.ipAddress].filter(Boolean).join(' ')
+    lines.push(`interface ${r.port}`)
+    lines.push(`  description ${text}`)
+  }
+  return lines.join('\n')
+}

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -71,6 +71,8 @@ import {
   sourceIdentityIdSet,
 } from '../lib/sourceIdentity'
 import { normaliseDeliveryDestinations } from '../lib/deliveryNormalise'
+import { isNetworkInterfaceRole, normaliseNetworkInterface } from '../lib/networkInterfaces'
+import type { NetworkInterface } from '../types/network'
 
 const CUSTOM_LIB_KEY = STORAGE_KEYS.customLibrary
 const PROJECT_AUTOSAVE_KEY = STORAGE_KEYS.projectAutosave
@@ -616,6 +618,22 @@ const healProjectPositions = (
       // undefined — nur Videohub-Geraete bekommen das Feld ueberhaupt, und
       // erst wenn der Nutzer routet. Ein leerer Block auf jedem Geraet waere
       // Ballast in jedem Projektfile.
+      // Bedarf 19 — Netzwerk-Schnittstellen normalisieren. Sie werden nur
+      // angefasst, wenn das Geraet welche fuehrt: ein leeres Feld auf jedem
+      // Geraet waere Ballast in jedem Projektfile, und die Alt-Felder bleiben
+      // ohnehin Schnittstelle 0.
+      if (item.networkInterfaces !== undefined) {
+        const seen = new Set<string>()
+        const nics: NetworkInterface[] = []
+        ;(Array.isArray(item.networkInterfaces) ? item.networkInterfaces : []).forEach((raw, idx) => {
+          const nic = normaliseNetworkInterface(raw, `${item.id}#nic${idx + 1}`, isNetworkInterfaceRole)
+          if (!nic || seen.has(nic.id)) return
+          seen.add(nic.id)
+          nics.push(nic)
+        })
+        item = nics.length > 0 ? { ...item, networkInterfaces: nics } : { ...item, networkInterfaces: undefined }
+      }
+
       if (item.videohubRouting !== undefined) {
         item = { ...item, videohubRouting: normaliseVideohubRouting(item.videohubRouting) }
       }

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -767,6 +767,9 @@ interface UiState extends PersistedUiState {
   /** Initiative 9 — Register der Ausspielziele. */
   deliveryOpen: boolean
   setDeliveryOpen: (open: boolean) => void
+  /** Bedarf 21 — Plan gegen Vorgefundenes. */
+  reconcileOpen: boolean
+  setReconcileOpen: (open: boolean) => void
   atemMvLayout: { open: boolean }
   openAtemMvLayout: () => void
   closeAtemMvLayout: () => void
@@ -1279,6 +1282,8 @@ export const useUiStore = create<UiState>((set) => ({
   setWirelessRigOpen: (open) => set({ wirelessRigOpen: open }),
   deliveryOpen: false,
   setDeliveryOpen: (open) => set({ deliveryOpen: open }),
+  reconcileOpen: false,
+  setReconcileOpen: (open) => set({ reconcileOpen: open }),
   atemMvLayout: { open: false },
   openAtemMvLayout: () => set({ atemMvLayout: { open: true } }),
   closeAtemMvLayout: () => set({ atemMvLayout: { open: false } }),

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -403,10 +403,32 @@ export interface EquipmentItem {
   y: number
   width: number
   height: number
-  /** Optional network/access info for devices that have it (cameras, switches, servers). */
+  /** Optional network/access info for devices that have it (cameras, switches, servers).
+   *
+   *  **Diese vier Felder SIND Schnittstelle 0** (Bedarf 19, siehe
+   *  `types/network.ts`). Weitere Schnittstellen stehen in
+   *  `networkInterfaces`; wer ALLE braucht, nimmt die Engstelle
+   *  `lib/networkInterfaces.ts#deviceInterfaces` und nicht diese Felder
+   *  direkt. Sie hier zu lassen ist Absicht: `ipAddress` steht an 95 Stellen
+   *  in 36 Dateien, und jede uebersehene liest nach einem Umzug still
+   *  `undefined` statt einer Adresse. */
   ipAddress?: string
   subnetMask?: string
   macAddress?: string
+  /**
+   * Bedarf 19 — die WEITEREN Netzwerk-Schnittstellen (Dante sekundaer,
+   * ST 2110 blau, getrennte Steuerung). Schnittstelle 0 sind die Felder
+   * darueber; hier stehen 1..n, damit es je Adresse genau ein Zuhause gibt.
+   * Optional → alte Projekte heilen zu [].
+   */
+  networkInterfaces?: import('./network').NetworkInterface[]
+  /**
+   * Wofuer die Adresse in den Alt-Feldern da ist. Ohne Angabe gilt
+   * `unspecified` — geraten wird nicht: ob die eine IP einer Kamera ihre
+   * Steuerung oder ihr Medienweg ist, weiss der Plan nicht, und eine geratene
+   * Rolle erschiene in jeder Liste als Aussage.
+   */
+  primaryInterfaceRole?: import('./network').NetworkInterfaceRole
   username?: string
   password?: string
   notes?: string

--- a/src/renderer/types/network.ts
+++ b/src/renderer/types/network.ts
@@ -1,0 +1,100 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Netzwerk-Schnittstellen je Geraet (Bedarf 19) und ihre Lage am Switch
+// (Bedarf 24). Beide P1.
+//
+// WARUM DAS EIN EIGENES OBJEKT IST. Die Bedarfs-Datenbank beschreibt das
+// Problem und warnt gleichzeitig vor dem Zeitpunkt:
+//
+//   > Spreadsheet IP plans have one IP column per device. Real AV devices have
+//   > 2-4 NICs: Dante primary/secondary, 2110 red/blue media plus separate
+//   > control, camera control vs tally vs media. Engineers work around it with
+//   > extra columns or extra rows, and the two halves drift apart.
+//   > … Getting this wrong at schema level is expensive to fix later.
+//
+// Belegt an SSL (Dante-Sekundaernetz) und Arista (ST 2110 rot/blau). Der Plan
+// hatte genau die eine Spalte, ueber die sich die Quelle beschwert:
+// `EquipmentItem.ipAddress`.
+//
+// ─── DIE EINE REGEL, DIE MAN KENNEN MUSS ───────────────────────────────────
+//
+// **Die Alt-Felder am Geraet SIND Schnittstelle 0.** `ipAddress`,
+// `subnetMask`, `gateway` und `macAddress` bleiben, wo sie sind, und
+// `networkInterfaces` haelt die Schnittstellen 1..n. Es gibt also weiterhin
+// genau EIN Zuhause je Adresse — keine Spiegelung, keine zweite Wahrheit.
+//
+// Warum nicht alles umziehen: `ipAddress` steht an 95 Stellen in 36 Dateien,
+// dazu 39-mal `subnetMask` und 49-mal VLAN-Bezuege. Ein Umzug in einem Schritt
+// waere ein Umbau quer durch Import, Export, Analyse, NetBox, GraphML, Rentman,
+// Mobile und Viewer — und jede uebersehene Stelle liest danach still `undefined`
+// statt einer Adresse. Der cable-planner hat fuer genau diese Lage eine
+// Bauform, die sich bewaehrt hat (ADR-001, Inkrement 2): eine **Engstelle**
+// hochziehen, durch die alle gehen, statt 95 Aufrufer gleichzeitig anzufassen.
+// Diese Engstelle ist `lib/networkInterfaces.ts#deviceInterfaces`.
+//
+// ─── WAS HIER BEWUSST NICHT STEHT ──────────────────────────────────────────
+//
+// Ein Weg, Konfiguration auf einen laufenden Switch zu schreiben. Die
+// Bedarfs-Datenbank sagt es fuer Bedarf 24 ausdruecklich: „Do NOT push config
+// to live switches — generating a paste-able description block is the
+// defensible" Weg. Der Plan erzeugt die Beschriftung; wer sie einspielt, ist
+// ein Mensch mit einer Konsole.
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Wofuer eine Schnittstelle da ist.
+ *
+ * Genau die vier aus der Bedarfs-Datenbank („role: media-primary |
+ * media-secondary | control | management"), plus `unspecified` fuer den
+ * ehrlichen Fall: ein Altbestand-Geraet mit einer IP sagt nicht, wofuer sie
+ * ist, und eine geratene Rolle waere schlimmer als keine — sie erschiene in
+ * jeder Liste als Aussage.
+ */
+export type NetworkInterfaceRole =
+  | 'media-primary'
+  | 'media-secondary'
+  | 'control'
+  | 'management'
+  | 'unspecified'
+
+export const NETWORK_INTERFACE_ROLES: ReadonlyArray<NetworkInterfaceRole> = [
+  'media-primary',
+  'media-secondary',
+  'control',
+  'management',
+  'unspecified',
+]
+
+export interface NetworkInterface {
+  id: string
+  /** Beschriftung am Geraet („NET 1", „Dante Sec", „SFP+ 2"). */
+  label?: string
+  role: NetworkInterfaceRole
+  ipAddress?: string
+  subnetMask?: string
+  gateway?: string
+  macAddress?: string
+  /** VLAN-Id, in der die Schnittstelle liegt. */
+  vlanId?: number
+  /**
+   * Der Switch, an dem sie haengt — als Geraete-Id im selben Plan, nicht als
+   * Name. Ein Name veraltet beim Umbenennen; die Id nicht. Ist der Switch
+   * geloescht, raeumt die Normalisierung den Zeiger weg, statt ihn stehen zu
+   * lassen: ein Fehlzeiger sieht in der Port-Karte aus wie eine Belegung.
+   */
+  switchEquipmentId?: string
+  /** Port-Bezeichnung am Switch, wie sie dort aufgedruckt ist („1/0/12"). */
+  switchPort?: string
+  /**
+   * Der Port am EIGENEN Geraet, ueber den diese Schnittstelle laeuft — als
+   * `Port.id`. Damit haengt die Schnittstelle am Kabelgraphen und nicht daneben:
+   * genau das verlangt Bedarf 24 („Model switch, port, and the cable that
+   * occupies it as part of the same connection graph").
+   */
+  portId?: string
+}
+
+/** Ist an dieser Schnittstelle ueberhaupt etwas eingetragen? Eine leere
+ *  Schnittstelle ist kein Befund, sondern ein leeres Formular. */
+export const interfaceIsEmpty = (n: NetworkInterface): boolean =>
+  !n.ipAddress && !n.subnetMask && !n.gateway && !n.macAddress &&
+  n.vlanId === undefined && !n.switchEquipmentId && !n.switchPort

--- a/tests/addressPlan.test.ts
+++ b/tests/addressPlan.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { buildAddressPlan, addressPlanTable } from '../src/renderer/lib/addressPlan'
+import { buildAddressPlan, addressPlanTable, NETWORK_CONNECTORS } from '../src/renderer/lib/addressPlan'
+import { ALL_CONNECTOR_TYPES } from '../src/renderer/types/equipment'
 import type { EquipmentItem, Port } from '../src/renderer/types/equipment'
 import type { SignalStandard } from '../src/renderer/types/cableSpec'
 
@@ -42,7 +43,7 @@ const geraet = (name: string, over: Partial<EquipmentItem> = {}): EquipmentItem 
   }) as unknown as EquipmentItem
 
 const netzPort = (standard: SignalStandard) =>
-  port('NET 1', { connectorType: 'RJ45', standard })
+  port('NET 1', { connectorType: 'Ethernet/RJ45', standard })
 
 describe('wer eine Adresse braucht', () => {
   it('leitet die Netzfaehigkeit aus einem IP-Standard am Port ab', () => {
@@ -66,10 +67,10 @@ describe('wer eine Adresse braucht', () => {
     expect(plan.rows[0].evidence).toBe('SFP 1 (ST2110-30)')
   })
 
-  it('nimmt auch den blossen RJ45-Anschluss, ohne erklaerten Standard', () => {
+  it('nimmt auch den blossen Ethernet-Anschluss, ohne erklaerten Standard', () => {
     // Nicht jedes Katalog-Geraet traegt einen Standard am Port. Die Bauform
     // allein sagt trotzdem: hier geht ein Netzwerkkabel hinein.
-    const plan = buildAddressPlan([geraet('Switch', { outputs: [port('1', { connectorType: 'RJ45' })] })])
+    const plan = buildAddressPlan([geraet('Switch', { outputs: [port('1', { connectorType: 'Ethernet/RJ45' })] })])
     expect(plan.rows[0].networked).toBe(true)
   })
 
@@ -95,9 +96,9 @@ describe('wer eine Adresse braucht', () => {
     const plan = buildAddressPlan([geraet('Stagebox', { inputs: [netzPort('AES67')] })])
     expect(plan.rows[0].evidence).toBe('NET 1 (AES67)')
     const ohneStandard = buildAddressPlan([
-      geraet('Switch', { outputs: [port('Uplink', { connectorType: 'RJ45' })] }),
+      geraet('Switch', { outputs: [port('Uplink', { connectorType: 'Ethernet/RJ45' })] }),
     ])
-    expect(ohneStandard.rows[0].evidence).toBe('Uplink (RJ45)')
+    expect(ohneStandard.rows[0].evidence).toBe('Uplink (Ethernet/RJ45)')
   })
 })
 
@@ -189,5 +190,100 @@ describe('CSV', () => {
     expect(rows[1][0]).toBe('Stagebox')
     expect(rows[1][5]).toBe('NET 1 (Dante)')
     expect(rows[1][6]).toBe('missing-address')
+  })
+})
+
+describe('die Anschluss-Liste besteht aus echten Steckertypen', () => {
+  it('kennt nur Werte, die es in ALL_CONNECTOR_TYPES gibt', () => {
+    // DER GRUND FUER DIESEN TEST, und er ist ein Fund und keine Vorsichtsmassnahme:
+    // hier standen `'RJ45'` und `'etherCON'`. Die Union heisst `'Ethernet/RJ45'`
+    // und `'GG45'` -- der Anschluss-Rueckfall traf also KEIN EINZIGES echtes
+    // Geraet, und die zwei Tests, die ihn belegten, trugen ein Fixture mit
+    // `connectorType: 'RJ45'`: einen Wert, den kein Katalog-Geraet je haben kann.
+    //
+    // Verglichen worden war der Feldname, nicht der Wertebereich -- derselbe
+    // Fehler wie bei der Rollen-Id gegen `guide_server.py` (`cable#674`). Ein
+    // Test, der seine Eingabe selbst erfindet, prueft nur sich selbst.
+    for (const c of NETWORK_CONNECTORS) {
+      expect(ALL_CONNECTOR_TYPES, `kein echter Steckertyp: ${c}`).toContain(c)
+    }
+  })
+
+  it('nimmt SFP, SFP+ und Fiber bewusst NICHT als Beleg', () => {
+    // Ueber sie laeuft genauso oft SDI. Fuer sie greift die erste Regel (ein
+    // IP-Standard am Port), und die ist ein Beleg statt einer Bauform-Vermutung.
+    for (const c of ['SFP', 'SFP+', 'Fiber'] as const) {
+      const plan = buildAddressPlan([geraet(c, { inputs: [port('1', { connectorType: c })] })])
+      expect(plan.rows[0].networked, `${c} sollte kein Beleg sein`).toBe(false)
+    }
+  })
+})
+
+describe('mehrere Schnittstellen je Geraet (Bedarf 19)', () => {
+  it('fuehrt jede Schnittstelle als eigene Zeile', () => {
+    // Der Kern der Erweiterung. Vorher sah der Plan nur `item.ipAddress` und
+    // uebersah damit die zweite Karte eines redundanten Dante-Aufbaus.
+    const plan = buildAddressPlan([
+      geraet('Stagebox', {
+        ipAddress: '10.0.0.5',
+        subnetMask: '255.255.255.0',
+        networkInterfaces: [
+          { id: 'n2', label: 'Dante Sec', role: 'media-secondary', ipAddress: '10.1.0.5', subnetMask: '255.255.255.0' },
+        ],
+      }),
+    ])
+    expect(plan.rows).toHaveLength(2)
+    expect(plan.rows.map((r) => r.ip)).toEqual(['10.0.0.5', '10.1.0.5'])
+    expect(plan.rows[1].nicLabel).toBe('Dante Sec')
+    expect(plan.rows[1].role).toBe('media-secondary')
+  })
+
+  it('findet eine Doppel-IP zwischen ZWEI Schnittstellen verschiedener Geraete', () => {
+    // Der Fall, der vorher unsichtbar war: die Kollision sitzt auf der zweiten
+    // Karte, nicht auf der ersten.
+    const plan = buildAddressPlan([
+      geraet('Stagebox', {
+        ipAddress: '10.0.0.5',
+        networkInterfaces: [{ id: 'n2', label: 'Sec', role: 'media-secondary', ipAddress: '10.1.0.9' }],
+      }),
+      geraet('Pult', {
+        ipAddress: '10.0.0.7',
+        networkInterfaces: [{ id: 'n3', label: 'Sec', role: 'media-secondary', ipAddress: '10.1.0.9' }],
+      }),
+    ])
+    const dup = plan.rows.filter((r) => r.issues.some((i) => i.kind === 'duplicate-address'))
+    expect(dup).toHaveLength(2)
+    expect(dup[0].issues.find((i) => i.kind === 'duplicate-address')?.others).toEqual(['Pult · Sec'])
+  })
+
+  it('meldet ein Geraet NICHT gegen sich selbst', () => {
+    // Der Fehler, den eine Spiegelung der Alt-Felder in `networkInterfaces`
+    // machen wuerde: dieselbe Adresse zweimal, also ein Dauer-Fehlalarm auf
+    // jedem gepflegten Geraet.
+    const plan = buildAddressPlan([
+      geraet('Kamera', {
+        ipAddress: '10.0.0.5',
+        networkInterfaces: [{ id: 'n2', label: 'Control', role: 'control', ipAddress: '192.168.1.5' }],
+      }),
+    ])
+    expect(plan.rows.some((r) => r.issues.some((i) => i.kind === 'duplicate-address'))).toBe(false)
+  })
+
+  it('behaelt eine Zeile fuer ein netzfaehiges Geraet ohne jede Adresse', () => {
+    const plan = buildAddressPlan([geraet('Stagebox', { inputs: [netzPort('Dante')] })])
+    expect(plan.rows).toHaveLength(1)
+    expect(plan.missing.map((r) => r.name)).toEqual(['Stagebox'])
+  })
+
+  it('traegt die Schnittstelle im CSV mit', () => {
+    const plan = buildAddressPlan([
+      geraet('Stagebox', {
+        ipAddress: '10.0.0.5',
+        networkInterfaces: [{ id: 'n2', label: 'Dante Sec', role: 'media-secondary', ipAddress: '10.1.0.5' }],
+      }),
+    ])
+    const rows = addressPlanTable(plan, (i) => i.kind, ['Gerät', 'IP', 'Maske', 'Gateway', 'Subnetz', 'Beleg', 'Befund'])
+    expect(rows[1][0]).toBe('Stagebox')
+    expect(rows[2][0]).toBe('Stagebox · Dante Sec')
   })
 })

--- a/tests/networkInterfaces.test.ts
+++ b/tests/networkInterfaces.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest'
+import {
+  allDeviceInterfaces,
+  deviceInterfaces,
+  deviceInterfacesIncludingEmpty,
+  isPrimaryInterface,
+  isNetworkInterfaceRole,
+  normaliseNetworkInterface,
+  primaryInterfaceId,
+} from '../src/renderer/lib/networkInterfaces'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+
+// ---------------------------------------------------------------------------
+// Mehrere Netzwerk-Schnittstellen je Geraet (Bedarf 19, P1).
+//
+// Der Bedarf sagt, was fehlte, und warnt im selben Atemzug vor dem Zeitpunkt:
+//
+//   > Real AV devices have 2-4 NICs: Dante primary/secondary, 2110 red/blue
+//   > media plus separate control … Getting this wrong at schema level is
+//   > expensive to fix later.
+//
+// Die Regel dieses Moduls ist eine einzige, und alles darunter prueft sie:
+// DIE ALT-FELDER SIND SCHNITTSTELLE 0. Es gibt je Adresse genau ein Zuhause;
+// `networkInterfaces` haelt 1..n. Wer das umdreht, bekommt zwei Wahrheiten
+// ueber dieselbe IP -- und die Doppel-IP-Pruefung des Adressplans meldet
+// danach jedes Geraet gegen sich selbst.
+// ---------------------------------------------------------------------------
+
+const geraet = (name: string, over: Partial<EquipmentItem> = {}): EquipmentItem =>
+  ({
+    id: `id-${name}`,
+    name,
+    category: 'Sonstiges',
+    inputs: [],
+    outputs: [],
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 100,
+    ...over,
+  }) as unknown as EquipmentItem
+
+describe('die Alt-Felder sind Schnittstelle 0', () => {
+  it('macht aus ipAddress/Maske/Gateway/MAC die erste Schnittstelle', () => {
+    const nics = deviceInterfaces(
+      geraet('Kamera', {
+        ipAddress: '10.0.0.5',
+        subnetMask: '255.255.255.0',
+        gateway: '10.0.0.1',
+        macAddress: 'aa:bb:cc:dd:ee:ff',
+      }),
+    )
+    expect(nics).toHaveLength(1)
+    expect(nics[0]).toMatchObject({
+      ipAddress: '10.0.0.5',
+      subnetMask: '255.255.255.0',
+      gateway: '10.0.0.1',
+      macAddress: 'aa:bb:cc:dd:ee:ff',
+    })
+    expect(nics[0].id).toBe(primaryInterfaceId('id-Kamera'))
+  })
+
+  it('nimmt das Management-VLAN als VLAN der ersten Schnittstelle', () => {
+    const nics = deviceInterfaces(geraet('Switch', { ipAddress: '10.0.0.2', managementVlanId: 99 }))
+    expect(nics[0].vlanId).toBe(99)
+  })
+
+  it('raet die Rolle NICHT', () => {
+    // Ob die eine IP einer Kamera ihre Steuerung oder ihr Medienweg ist, weiss
+    // der Plan nicht. Eine geratene Rolle erschiene in jeder Liste als Aussage.
+    expect(deviceInterfaces(geraet('Kamera', { ipAddress: '10.0.0.5' }))[0].role).toBe('unspecified')
+  })
+
+  it('nimmt eine gesetzte Rolle fuer die erste Schnittstelle', () => {
+    const e = geraet('Kamera', { ipAddress: '10.0.0.5', primaryInterfaceRole: 'control' })
+    expect(deviceInterfaces(e)[0].role).toBe('control')
+  })
+
+  it('laesst die erste Schnittstelle weg, wenn dort nichts steht', () => {
+    // Ein Geraet, das nur eine zweite Karte gepflegt hat, soll keine leere
+    // erste vorgesetzt bekommen -- sonst zaehlt jede Liste eine Schnittstelle
+    // mehr, als es gibt.
+    const e = geraet('Stagebox', {
+      networkInterfaces: [{ id: 'n2', role: 'media-secondary', ipAddress: '10.1.0.5' }],
+    })
+    const nics = deviceInterfaces(e)
+    expect(nics).toHaveLength(1)
+    expect(nics[0].id).toBe('n2')
+  })
+
+  it('zeigt der Oberflaeche die leere erste trotzdem', () => {
+    // Sonst gaebe es kein Formular, in das jemand die erste Adresse eintraegt.
+    expect(deviceInterfacesIncludingEmpty(geraet('Neu'))).toHaveLength(1)
+  })
+})
+
+describe('mehrere Schnittstellen', () => {
+  const danteRig = () =>
+    geraet('Stagebox', {
+      ipAddress: '10.0.0.5',
+      subnetMask: '255.255.255.0',
+      primaryInterfaceRole: 'media-primary',
+      networkInterfaces: [
+        { id: 'n2', label: 'Dante Sec', role: 'media-secondary', ipAddress: '10.1.0.5' },
+        { id: 'n3', label: 'Control', role: 'control', ipAddress: '192.168.1.5' },
+      ],
+    })
+
+  it('liefert alle drei, die erste zuerst', () => {
+    const nics = deviceInterfaces(danteRig())
+    expect(nics.map((n) => n.ipAddress)).toEqual(['10.0.0.5', '10.1.0.5', '192.168.1.5'])
+    expect(nics.map((n) => n.role)).toEqual(['media-primary', 'media-secondary', 'control'])
+  })
+
+  it('sagt, welche die erste ist', () => {
+    const e = danteRig()
+    const nics = deviceInterfaces(e)
+    expect(isPrimaryInterface(e, nics[0].id)).toBe(true)
+    expect(isPrimaryInterface(e, nics[1].id)).toBe(false)
+  })
+
+  it('zaehlt keine Adresse doppelt', () => {
+    // Der Fehler, den eine Spiegelung machen wuerde: die Alt-Felder AUCH in
+    // `networkInterfaces` zu fuehren. Dann meldete die Doppel-IP-Pruefung
+    // jedes Geraet gegen sich selbst.
+    const adressen = deviceInterfaces(danteRig()).map((n) => n.ipAddress)
+    expect(new Set(adressen).size).toBe(adressen.length)
+  })
+
+  it('ueberspringt leere Zusatz-Schnittstellen', () => {
+    const e = geraet('X', {
+      ipAddress: '10.0.0.5',
+      networkInterfaces: [{ id: 'n2', role: 'control' }],
+    })
+    expect(deviceInterfaces(e)).toHaveLength(1)
+  })
+
+  it('sammelt sie ueber den ganzen Plan mit ihrem Geraet', () => {
+    const alle = allDeviceInterfaces([danteRig(), geraet('Kamera', { ipAddress: '10.0.0.9' })])
+    expect(alle).toHaveLength(4)
+    expect(alle.filter((d) => d.primary)).toHaveLength(2)
+    expect(alle[0].equipment.name).toBe('Stagebox')
+  })
+})
+
+describe('Normalisierung beim Laden', () => {
+  // Derselbe Waechter, den der Store benutzt — zwei Listen waeren zwei
+  // Wahrheiten darueber, welche Rollen es gibt.
+  const roleOk = isNetworkInterfaceRole
+
+  it('faellt bei unbekannter Rolle auf unspecified zurueck', () => {
+    const n = normaliseNetworkInterface({ id: 'n2', role: 'telepathy', ipAddress: '10.0.0.5' }, 'x', roleOk)
+    expect(n?.role).toBe('unspecified')
+  })
+
+  it('vergibt eine Id, wenn die Datei keine mitbringt', () => {
+    expect(normaliseNetworkInterface({ ipAddress: '10.0.0.5' }, 'gen-3', roleOk)?.id).toBe('gen-3')
+  })
+
+  it('wirft eine voellig leere Schnittstelle weg', () => {
+    // Ballast in jedem Projektfile, und in der Port-Karte eine Zeile ohne Inhalt.
+    expect(normaliseNetworkInterface({ id: 'n2', role: 'control' }, 'x', roleOk)).toBeNull()
+    // Eine nur beschriftete bleibt: „SFP+ 2" ohne Adresse ist eine Aussage.
+    expect(normaliseNetworkInterface({ id: 'n2', label: 'SFP+ 2' }, 'x', roleOk)).not.toBeNull()
+  })
+
+  it('nimmt nur VLAN-Ids, die es geben kann', () => {
+    for (const bad of [-1, 4095, 1.5, '12']) {
+      expect(
+        normaliseNetworkInterface({ ipAddress: '10.0.0.5', vlanId: bad }, 'x', roleOk)?.vlanId,
+        `VLAN ${String(bad)}`,
+      ).toBeUndefined()
+    }
+    expect(normaliseNetworkInterface({ ipAddress: '10.0.0.5', vlanId: 100 }, 'x', roleOk)?.vlanId).toBe(100)
+  })
+
+  it('gibt bei Unsinn null statt zu werfen', () => {
+    expect(normaliseNetworkInterface(null, 'x', roleOk)).toBeNull()
+    expect(normaliseNetworkInterface('nein', 'x', roleOk)).toBeNull()
+  })
+})

--- a/tests/networkReconcile.test.ts
+++ b/tests/networkReconcile.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from 'vitest'
+import {
+  normaliseMac,
+  parseArpTable,
+  parseScanCsv,
+  reconcileNetwork,
+  reconcileTable,
+  stripDanteCollisionSuffix,
+  type NetworkScan,
+} from '../src/renderer/lib/networkReconcile'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+
+// ---------------------------------------------------------------------------
+// Plan gegen Vorgefundenes (Bedarf 21, P1).
+//
+// Die Bedarfs-Datenbank nennt ihn „the highest-value item in the dossier and
+// nothing in the AV planning market does it", und beschreibt die Arbeit:
+//
+//   > what came off the truck, under which names, with which addresses, versus
+//   > what the plan says. Kit returns from the previous job with the previous
+//   > job's names -- Dante silently auto-renames collisions to 'Fred(2)'.
+//
+// Geprueft wird deshalb genau das, woran der Abgleich schaedlich statt
+// nuetzlich wuerde: eine geratene Zuordnung (die erklaert ein fehlendes Geraet
+// fuer anwesend), und eine Dante-Umbenennung, die als fehlend PLUS unerwartet
+// erscheint -- zwei Befunde fuer einen Vorgang, beide irrefuehrend.
+// ---------------------------------------------------------------------------
+
+const geraet = (name: string, over: Partial<EquipmentItem> = {}): EquipmentItem =>
+  ({
+    id: `id-${name}`,
+    name,
+    category: 'Sonstiges',
+    inputs: [],
+    outputs: [],
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 100,
+    ...over,
+  }) as unknown as EquipmentItem
+
+const scan = (entries: NetworkScan['entries']): NetworkScan => ({
+  takenAt: '2026-09-06T08:00:00.000Z',
+  source: 'arp.txt',
+  entries,
+})
+
+describe('ARP-/Neighbour-Tabelle lesen', () => {
+  it('liest die Ausgabe von `arp -a`', () => {
+    const e = parseArpTable('stagebox.local (10.0.0.5) at aa:bb:cc:dd:ee:ff [ether] on eth0')
+    expect(e).toEqual([{ name: 'stagebox.local', ipAddress: '10.0.0.5', macAddress: 'aa:bb:cc:dd:ee:ff' }])
+  })
+
+  it('liest die Ausgabe von `ip neigh`', () => {
+    const e = parseArpTable('10.0.0.5 dev eth0 lladdr aa:bb:cc:dd:ee:ff REACHABLE')
+    expect(e).toEqual([{ ipAddress: '10.0.0.5', macAddress: 'aa:bb:cc:dd:ee:ff' }])
+  })
+
+  it('bastelt aus einem unaufgeloesten Namen keinen', () => {
+    // `arp -a` schreibt `?`, wenn der Name nicht aufloest. Daraus einen zu
+    // machen hiesse, dem Bericht einen Namen zu erfinden.
+    const e = parseArpTable('? (10.0.0.9) at 11:22:33:44:55:66 [ether] on eth0')
+    expect(e[0].name).toBeUndefined()
+    expect(e[0].ipAddress).toBe('10.0.0.9')
+  })
+
+  it('liest die Windows-Form von `arp -a`, samt Bindestrich-MAC', () => {
+    // Der Fall, den die erste Fassung halb gelesen haette: Adresse ja, MAC
+    // nein -- und ausgerechnet die MAC ist die Messung, auf die der Abgleich
+    // zuerst zugreift.
+    const e = parseArpTable(
+      'Interface: 10.0.0.1 --- 0x2\n  Internet Address      Physical Address      Type\n  10.0.0.5              aa-bb-cc-dd-ee-ff     dynamic',
+    )
+    expect(e).toEqual([{ ipAddress: '10.0.0.5', macAddress: 'aa-bb-cc-dd-ee-ff' }])
+  })
+
+  it('liest Ciscos Vierergruppen-MAC', () => {
+    const e = parseArpTable('10.0.0.5 dev eth0 lladdr aabb.ccdd.eeff REACHABLE')
+    expect(e[0].macAddress).toBe('aabb.ccdd.eeff')
+  })
+
+  it('macht aus Kopf- und Leerzeilen keine Geraete', () => {
+    expect(parseArpTable('Interface: 10.0.0.1 --- 0x2\n\n  Internet Address   Physical Address   Type')).toEqual([])
+  })
+})
+
+describe('CSV lesen', () => {
+  it('ordnet Spalten ueber die Kopfzeile zu, deutsch wie englisch', () => {
+    const e = parseScanCsv('Name;IP-Adresse;MAC\nStagebox;10.0.0.5;aa:bb:cc:dd:ee:ff')
+    expect(e).toEqual([{ name: 'Stagebox', ipAddress: '10.0.0.5', macAddress: 'aa:bb:cc:dd:ee:ff' }])
+  })
+
+  it('nimmt eine Zeile ohne jeden Griff nicht auf', () => {
+    expect(parseScanCsv('Name;IP\n;')).toEqual([])
+  })
+
+  it('kommt mit einem Trennzeichen im Feld zurecht', () => {
+    // Der Grund, warum der Parser hochgezogen wurde statt neu geschrieben:
+    // ein zweiter haette hier anders geantwortet als der erste.
+    const e = parseScanCsv('Name,IP\n"Stagebox, Halle A",10.0.0.5')
+    expect(e[0].name).toBe('Stagebox, Halle A')
+  })
+})
+
+describe('MAC und Dante-Namen normalisieren', () => {
+  it('vergleicht MACs unabhaengig von der Schreibweise', () => {
+    // Drei Schreibweisen desselben Geraets: Doppelpunkt, Bindestrich, Cisco.
+    const formen = ['aa:bb:cc:dd:ee:ff', 'AA-BB-CC-DD-EE-FF', 'aabb.ccdd.eeff']
+    expect(new Set(formen.map(normaliseMac)).size).toBe(1)
+  })
+
+  it('erkennt die Dante-Kollisionsform', () => {
+    expect(stripDanteCollisionSuffix('Stagebox (2)')).toBe('Stagebox')
+    expect(stripDanteCollisionSuffix('Stagebox(2)')).toBe('Stagebox')
+  })
+
+  it('laesst eine echte Nummer im Namen in Ruhe', () => {
+    // „Stagebox 2" ist ein Name, keine Umbenennung. Ihn zu kuerzen wuerde zwei
+    // verschiedene Geraete zu einem machen.
+    expect(stripDanteCollisionSuffix('Stagebox 2')).toBe('Stagebox 2')
+    expect(stripDanteCollisionSuffix('Cam (Backup)')).toBe('Cam (Backup)')
+  })
+})
+
+describe('der Abgleich', () => {
+  const plan = () => [
+    geraet('Stagebox', { ipAddress: '10.0.0.5', macAddress: 'aa:bb:cc:dd:ee:ff' }),
+    geraet('Pult', { ipAddress: '10.0.0.6', macAddress: '11:22:33:44:55:66' }),
+  ]
+
+  it('ordnet ueber die MAC zu, auch wenn der Name anders ist', () => {
+    // Die MAC ist eine Messung; das Geraet traegt sie, egal wie es heisst.
+    const r = reconcileNetwork(plan(), scan([{ name: 'FOH-Box', macAddress: 'AA-BB-CC-DD-EE-FF', ipAddress: '10.0.0.5' }]))
+    const row = r.rows.find((x) => x.planned === 'Stagebox')
+    expect(row?.matchedBy).toBe('mac')
+    expect(row?.verdict).toBe('name-mismatch')
+  })
+
+  it('meldet eine abweichende Adresse als solche', () => {
+    const r = reconcileNetwork(plan(), scan([{ name: 'Stagebox', macAddress: 'aa:bb:cc:dd:ee:ff', ipAddress: '10.0.9.9' }]))
+    expect(r.rows[0].verdict).toBe('address-mismatch')
+    expect(r.rows[0].plannedIp).toBe('10.0.0.5')
+    expect(r.rows[0].foundIp).toBe('10.0.9.9')
+  })
+
+  it('erkennt die Dante-Umbenennung als EINEN Vorgang', () => {
+    // Ohne diese Regel steht in der Liste ein fehlendes „Stagebox" und ein
+    // unerwartetes „Stagebox (2)" -- zwei Befunde fuer einen Vorgang, und
+    // beide fuehren in die Irre.
+    const r = reconcileNetwork(plan(), scan([{ name: 'Stagebox (2)', ipAddress: '10.0.0.5' }]))
+    const row = r.rows.find((x) => x.planned === 'Stagebox')
+    expect(row?.verdict).toBe('renamed')
+    expect(r.counts.unexpected).toBe(0)
+  })
+
+  it('meldet ein Geraet, das der Plan nicht kennt', () => {
+    const r = reconcileNetwork(plan(), scan([{ name: 'Fremd', ipAddress: '10.0.0.99', macAddress: '99:99:99:99:99:99' }]))
+    expect(r.rows.find((x) => x.found === 'Fremd')?.verdict).toBe('unexpected')
+  })
+
+  it('meldet ein Geraet, das der Plan kennt und die Abtastung nicht fand', () => {
+    const r = reconcileNetwork(plan(), scan([{ name: 'Stagebox', ipAddress: '10.0.0.5', macAddress: 'aa:bb:cc:dd:ee:ff' }]))
+    expect(r.rows.filter((x) => x.verdict === 'missing').map((x) => x.planned)).toEqual(['Pult'])
+  })
+
+  it('ordnet NICHT zu, wenn es mehr als eine Moeglichkeit gibt', () => {
+    // Regel aus orb-agent#558: nur anlegen, wenn beide Enden eindeutig sind.
+    // Eine geratene Zuordnung erklaerte ein fehlendes Geraet fuer anwesend.
+    const doppelt = [
+      geraet('A', { ipAddress: '10.0.0.5' }),
+      geraet('B', { ipAddress: '10.0.0.5' }),
+    ]
+    const r = reconcileNetwork(doppelt, scan([{ ipAddress: '10.0.0.5' }]))
+    expect(r.rows[0].verdict).toBe('ambiguous')
+    expect(r.rows[0].matchedBy).toBe('ip')
+    // Und beide Plan-Zeilen bleiben „nicht gefunden" -- keine wird verbraucht.
+    expect(r.counts.missing).toBe(2)
+  })
+
+  it('sieht ALLE Schnittstellen eines Geraets', () => {
+    // Bedarf 19: sonst taucht die zweite Karte eines redundanten Aufbaus als
+    // „nicht im Plan" auf -- und der Techniker sucht ein Geraet, das dasteht.
+    const rig = [
+      geraet('Stagebox', {
+        ipAddress: '10.0.0.5',
+        networkInterfaces: [{ id: 'n2', label: 'Dante Sec', role: 'media-secondary', ipAddress: '10.1.0.5' }],
+      }),
+    ]
+    const r = reconcileNetwork(rig, scan([{ ipAddress: '10.1.0.5' }]))
+    expect(r.rows[0].verdict).toBe('match')
+    expect(r.rows[0].planned).toBe('Stagebox · Dante Sec')
+  })
+
+  it('traegt Zeitpunkt und Quelle mit', () => {
+    // „Deliberate, timestamped, user-initiated." Ein Bericht ohne beides
+    // liesse sich zwei Wochen spaeter nicht mehr einordnen.
+    const r = reconcileNetwork(plan(), scan([]))
+    expect(r.takenAt).toBe('2026-09-06T08:00:00.000Z')
+    expect(r.source).toBe('arp.txt')
+  })
+
+  it('zaehlt jede Sorte', () => {
+    const r = reconcileNetwork(
+      plan(),
+      scan([
+        { name: 'Stagebox', ipAddress: '10.0.0.5', macAddress: 'aa:bb:cc:dd:ee:ff' },
+        { name: 'Fremd', ipAddress: '10.0.0.99' },
+      ]),
+    )
+    expect(r.counts.match).toBe(1)
+    expect(r.counts.unexpected).toBe(1)
+    expect(r.counts.missing).toBe(1)
+  })
+})
+
+describe('das Modul beruehrt kein Geraet', () => {
+  it('kennt weder fetch noch IPC', async () => {
+    // „Deliberate, timestamped, user-initiated -- never a live feed." Der
+    // Bedarf sagt es, und die Dossiers sagen warum: Dantes API ist
+    // lizenz-gebunden, die offene Alternative erklaert sich selbst fuer
+    // untauglich, und die offene ST-2110-Analyse ist eingestellt.
+    const quelle = (await import('../src/renderer/lib/networkReconcile.ts?raw')).default as string
+    expect(quelle).not.toMatch(/fetch\(|ipcRenderer|\.invoke\(|axios|WebSocket/)
+  })
+})
+
+describe('CSV des Berichts', () => {
+  it('nennt Befund, Plan, Fund und die Zuordnungsgrundlage', () => {
+    const r = reconcileNetwork(
+      [geraet('Stagebox', { ipAddress: '10.0.0.5', macAddress: 'aa:bb:cc:dd:ee:ff' })],
+      scan([{ name: 'Stagebox (2)', ipAddress: '10.0.0.5', macAddress: 'aa:bb:cc:dd:ee:ff' }]),
+    )
+    const t = reconcileTable(r)
+    expect(t.headers[0]).toBe('Befund')
+    expect(t.rows[0][0]).toBe('umbenannt (Kollisionsform)')
+    expect(t.rows[0][6]).toBe('MAC')
+  })
+})

--- a/tests/switchPortMap.test.ts
+++ b/tests/switchPortMap.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildSwitchPortMaps,
+  switchPortDescriptionBlock,
+  switchPortTable,
+} from '../src/renderer/lib/switchPortMap'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem, Port } from '../src/renderer/types/equipment'
+
+// ---------------------------------------------------------------------------
+// Die Switch-Port-Karte (Bedarf 24, P1).
+//
+//   > Switch port descriptions are often the only documentation physically
+//   > co-located with the hardware, and they go stale first; when they do,
+//   > tracing a cable becomes a physical task.
+//
+// Die deutsche Praxis dazu ist eine Excel-Mappe mit einem Reiter je Switch,
+// von Hand gepflegt -- also die zweite Wahrheit neben dem Plan, und die, die
+// zuerst veraltet. Die Bedarfs-Datenbank verlangt deshalb, Switch, Port und
+// das Kabel darin in DENSELBEN Graphen zu nehmen und die Karte zu erzeugen.
+//
+// Geprueft wird genau das Ausrechnen: dass beide Quellen (gepflegte
+// Schnittstelle, verlegtes Kabel) gefunden werden, dass die Karte SAGT,
+// welche es war, und dass ein Widerspruch zwischen ihnen stehenbleibt statt
+// stillschweigend weggeraeumt zu werden.
+// ---------------------------------------------------------------------------
+
+const port = (id: string, name: string): Port =>
+  ({ id, name, type: 'port', connectorType: 'Ethernet/RJ45' }) as Port
+
+const geraet = (name: string, over: Partial<EquipmentItem> = {}): EquipmentItem =>
+  ({
+    id: `id-${name}`,
+    name,
+    category: 'Sonstiges',
+    inputs: [],
+    outputs: [],
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 100,
+    ...over,
+  }) as unknown as EquipmentItem
+
+/** Ein Geraet, das `detectNetworkDevice` als Switch erkennt — ueber den Namen,
+ *  wie es die Heuristik dort tut. Kein eigener Erkenner im Test: sonst pruefte
+ *  er eine Regel, die die Anwendung gar nicht benutzt. */
+const switchMit = (ports: Port[]): EquipmentItem =>
+  geraet('UniFi Switch', { inputs: ports })
+
+const kabel = (from: [string, string], to: [string, string]): Cable =>
+  ({
+    id: `c-${from[1]}-${to[1]}`,
+    fromEquipmentId: from[0],
+    fromPortId: from[1],
+    toEquipmentId: to[0],
+    toPortId: to[1],
+    type: 'Cat6',
+  }) as unknown as Cable
+
+describe('welche Geraete ueberhaupt Switches sind', () => {
+  it('nimmt die Erkennung der Anwendung, nicht eine eigene', () => {
+    const sw = switchMit([port('p1', '1')])
+    const kamera = geraet('Kamera 1', { ipAddress: '10.0.0.9' })
+    const maps = buildSwitchPortMaps([sw, kamera], [])
+    expect(maps.map((m) => m.switchName)).toEqual(['UniFi Switch'])
+  })
+
+  it('kann auf einen bestimmten Switch eingeschraenkt werden', () => {
+    const a = switchMit([port('p1', '1')])
+    const b = geraet('Netgear GS Switch', { inputs: [port('q1', '1')] })
+    expect(buildSwitchPortMaps([a, b], [], b.id).map((m) => m.switchName)).toEqual(['Netgear GS Switch'])
+  })
+})
+
+describe('woher eine Belegung kommt', () => {
+  it('nimmt die gepflegte Schnittstelle und sagt es', () => {
+    const sw = switchMit([port('p1', '1'), port('p2', '2')])
+    const kamera = geraet('Kamera 1', {
+      ipAddress: '10.0.0.9',
+      networkInterfaces: [
+        { id: 'n2', label: 'Control', role: 'control', ipAddress: '10.0.0.9', switchEquipmentId: sw.id, switchPort: '2', vlanId: 20 },
+      ],
+    })
+    const map = buildSwitchPortMaps([sw, kamera], [])[0]
+    const p2 = map.rows.find((r) => r.port === '2')
+    expect(p2).toMatchObject({ device: 'Kamera 1', nicLabel: 'Control', vlanId: 20, source: 'interface' })
+  })
+
+  it('leitet sie sonst aus dem Kabel ab und sagt AUCH das', () => {
+    // Der Plan weiss, was dort steckt, auch wenn niemand es in die Netz-Maske
+    // getippt hat. Eine Belegung ohne Herkunft waere eine Behauptung.
+    const sw = switchMit([port('p1', '1')])
+    const kamera = geraet('Kamera 1', { outputs: [port('k1', 'NET')] })
+    const map = buildSwitchPortMaps([sw, kamera], [kabel([kamera.id, 'k1'], [sw.id, 'p1'])])[0]
+    expect(map.rows[0]).toMatchObject({ device: 'Kamera 1', nicLabel: 'NET', source: 'cable' })
+  })
+
+  it('findet das Kabel in beide Richtungen', () => {
+    const sw = switchMit([port('p1', '1')])
+    const kamera = geraet('Kamera 1', { outputs: [port('k1', 'NET')] })
+    const map = buildSwitchPortMaps([sw, kamera], [kabel([sw.id, 'p1'], [kamera.id, 'k1'])])[0]
+    expect(map.rows[0].device).toBe('Kamera 1')
+  })
+
+  it('laesst einen freien Port frei, statt etwas zu erfinden', () => {
+    const map = buildSwitchPortMaps([switchMit([port('p1', '1'), port('p2', '2')])], [])[0]
+    expect(map.rows.map((r) => r.device)).toEqual([undefined, undefined])
+    expect(map.usedCount).toBe(0)
+  })
+})
+
+describe('wenn beide Quellen etwas sagen', () => {
+  it('nimmt die gepflegte Angabe und laesst den Widerspruch stehen', () => {
+    // Weggeraeumt waere er unsichtbar -- und genau dieser Widerspruch ist der
+    // Grund, warum die Excel-Mappe veraltet: jemand hat umgesteckt.
+    const sw = switchMit([port('p1', '1')])
+    const gepflegt = geraet('Pult', {
+      networkInterfaces: [{ id: 'n2', role: 'control', ipAddress: '10.0.0.4', switchEquipmentId: sw.id, switchPort: '1' }],
+    })
+    const verkabelt = geraet('Kamera 1', { outputs: [port('k1', 'NET')] })
+    const map = buildSwitchPortMaps(
+      [sw, gepflegt, verkabelt],
+      [kabel([verkabelt.id, 'k1'], [sw.id, 'p1'])],
+    )[0]
+    expect(map.rows[0].device).toBe('Pult')
+    expect(map.rows[0].conflict).toBe('Kamera 1')
+  })
+
+  it('meldet KEINEN Widerspruch, wenn beide dasselbe Geraet nennen', () => {
+    // Sonst leuchtete die Warnung auf jedem sauber gepflegten Aufbau.
+    const sw = switchMit([port('p1', '1')])
+    const kamera = geraet('Kamera 1', {
+      outputs: [port('k1', 'NET')],
+      networkInterfaces: [{ id: 'n2', role: 'control', ipAddress: '10.0.0.9', switchEquipmentId: sw.id, switchPort: '1' }],
+    })
+    const map = buildSwitchPortMaps([sw, kamera], [kabel([kamera.id, 'k1'], [sw.id, 'p1'])])[0]
+    expect(map.rows[0].conflict).toBeUndefined()
+  })
+
+  it('behaelt eine Schnittstelle, die einen Port nennt, den es nicht gibt', () => {
+    // Genau der Tippfehler, den die Karte finden soll. Wegwerfen hiesse, ihn
+    // zu verstecken.
+    const sw = switchMit([port('p1', '1')])
+    const pult = geraet('Pult', {
+      networkInterfaces: [{ id: 'n2', role: 'control', ipAddress: '10.0.0.4', switchEquipmentId: sw.id, switchPort: '48' }],
+    })
+    const map = buildSwitchPortMaps([sw, pult], [])[0]
+    expect(map.rows.map((r) => r.port)).toEqual(['1', '48'])
+  })
+})
+
+describe('der einfuegbare Beschreibungsblock', () => {
+  const aufbau = () => {
+    const sw = switchMit([port('p1', '1'), port('p2', '2')])
+    const kamera = geraet('Kamera 1', {
+      networkInterfaces: [{ id: 'n2', label: 'Control', role: 'control', ipAddress: '10.0.0.9', switchEquipmentId: sw.id, switchPort: '1' }],
+    })
+    return buildSwitchPortMaps([sw, kamera], [])[0]
+  }
+
+  it('schreibt je belegtem Port eine Beschreibung', () => {
+    const block = switchPortDescriptionBlock(aufbau())
+    expect(block).toContain('interface 1')
+    expect(block).toContain('description Kamera 1 Control 10.0.0.9')
+  })
+
+  it('laesst freie Ports aus', () => {
+    // Eine Beschreibung, die einen Port leert, den jemand ausserhalb dieses
+    // Plans belegt hat, richtet Schaden an.
+    expect(switchPortDescriptionBlock(aufbau())).not.toContain('interface 2')
+  })
+
+  it('schickt nichts an einen Switch — er erzeugt nur Text', () => {
+    // Die Bedarfs-Datenbank sagt es ausdruecklich: „Do NOT push config to live
+    // switches — generating a paste-able description block is the defensible"
+    // Weg. Ein Quelltext-Test, weil die Zusage sonst nur im Kommentar staende.
+    const src = new URL('../src/renderer/lib/switchPortMap.ts', import.meta.url)
+    return import(`${src.pathname}?raw`).then((m) => {
+      const quelle = m.default as string
+      expect(quelle).not.toMatch(/fetch\(|ipcRenderer|\.invoke\(|axios/)
+    })
+  })
+})
+
+describe('CSV', () => {
+  it('traegt Port, Geraet, Quelle und Widerspruch', () => {
+    const sw = switchMit([port('p1', '1')])
+    const kamera = geraet('Kamera 1', {
+      networkInterfaces: [{ id: 'n2', label: 'Control', role: 'control', ipAddress: '10.0.0.9', switchEquipmentId: sw.id, switchPort: '1', vlanId: 20 }],
+    })
+    const table = switchPortTable(buildSwitchPortMaps([sw, kamera], [])[0])
+    expect(table.headers[0]).toBe('Port')
+    expect(table.rows[0]).toEqual(['1', 'Kamera 1', 'Control', '10.0.0.9', 20, 'Schnittstelle', ''])
+  })
+})


### PR DESCRIPTION
Drei P1-Bedarfe des Netzwerk-Dossiers, die aufeinander aufbauen: **19** ist die Schema-Entscheidung, **24** und **21** reiten darauf.

---

## Bedarf 19 — mehrere Schnittstellen je Gerät

Die Bedarfs-Datenbank warnt ausdrücklich vor dem Zeitpunkt:

> Spreadsheet IP plans have one IP column per device. Real AV devices have 2–4 NICs: Dante primary/secondary, 2110 red/blue media plus separate control, camera control vs tally vs media. Engineers work around it with extra columns or extra rows, and the two halves drift apart. … **Getting this wrong at schema level is expensive to fix later.**

Belegt an SSL (Dante-Sekundärnetz) und Arista (ST 2110 rot/blau). Der Plan hatte genau die eine Spalte, über die sich die Quelle beschwert: `EquipmentItem.ipAddress`.

**Die Regel: die Alt-Felder *sind* Schnittstelle 0.** `ipAddress`, `subnetMask`, `gateway` und `macAddress` bleiben, wo sie sind; `networkInterfaces` hält 1..n. Je Adresse **genau ein Zuhause** — keine Spiegelung. Die Naht versteckt eine **Engstelle** (`lib/networkInterfaces.ts#deviceInterfaces`), dieselbe Bauform wie `resolvePortLabel` in ADR-001 Inkrement 2.

Gemessen statt vermutet, weil die Recherche vor genau diesem Schritt warnt:

| Feld | Fundstellen |
| --- | --- |
| `ipAddress` | **95** in 36 Dateien |
| `subnetMask` | 39 |
| VLAN-Bezüge | 49 |

Ein Umzug in einem Schritt wäre ein Umbau quer durch Import, Export, Analyse, NetBox, GraphML, Rentman, Mobile und Viewer — jede übersehene Stelle läse danach still `undefined` statt einer Adresse.

**Der Adressplan sieht jetzt alle Adressen.** Seine Zeilen sind je Schnittstelle statt je Gerät. Vorher sah die Doppel-IP-Prüfung nur `item.ipAddress` und übersah damit die Hälfte eines redundanten Dante-Aufbaus — ausgerechnet die Prüfung, die vor Doppel-IPs warnt. Der Doppel-Schlüssel ist die Schnittstelle, sonst meldete ein Gerät mit zwei Karten sich selbst.

### Ein ausgelieferter Fehler, gefunden beim Nachsehen der Wertebereiche

`addressPlan.ts` (aus `cable#701`, gemergt **und** in die Suite vendoriert) führte:

```ts
const NETWORK_CONNECTORS = new Set(['RJ45', 'etherCON'])
```

**Beide Werte gibt es in `ConnectorType` nicht.** Die Union kennt `'Ethernet/RJ45'` und `'GG45'`. Der Anschluss-Rückfall traf kein einziges echtes Gerät — und die zwei Tests, die ihn belegten, trugen ein Fixture mit `connectorType: 'RJ45'`: einen Wert, den kein Katalog-Gerät je haben kann. Verglichen worden war der **Feldname**, nicht der **Wertebereich** — derselbe Fehler wie bei der Rollen-Id gegen `guide_server.py` (`cable#674`).

Behoben; die Menge ist jetzt `ReadonlySet<ConnectorType>`, und ein Test prüft, dass jeder Eintrag in `ALL_CONNECTOR_TYPES` vorkommt. SFP, SFP+ und Fiber stehen bewusst nicht dabei: über sie läuft genauso oft SDI.

---

## Bedarf 24 — die erzeugte Switch-Port-Karte

> Switch port descriptions are often the only documentation physically co-located with the hardware, and they go stale first.

Die deutsche Praxis dafür ist eine Excel-Mappe mit einem Reiter je Switch — die zweite Wahrheit neben dem Plan, und die, die zuerst veraltet. `lib/switchPortMap.ts` **erzeugt** sie stattdessen, aus zwei Quellen, und sagt bei jeder Belegung welche es war: `interface` (gepflegt) oder `cable` (im Plan verlegt). Widersprechen sie sich, gewinnt die gepflegte Angabe und der **Widerspruch bleibt sichtbar** — genau er ist der Grund, warum die Mappe veraltet: jemand hat umgesteckt.

**Kein Konfigurationskanal.** Die Bedarfs-Datenbank sagt es wörtlich: *„Do NOT push config to live switches — generating a paste-able description block is the defensible"* Weg. Ein Quelltext-Test hält fest, dass das Modul weder `fetch` noch `ipcRenderer` kennt. Freie Ports kommen nicht vor: eine Beschreibung, die einen Port leert, den jemand ausserhalb dieses Plans belegt hat, richtet Schaden an.

Welche Geräte Switches sind, entscheidet `detectNetworkDevice`. Der erste Entwurf stand auf `category === 'network' || /switch/i.test(deviceTypeId)` — beides falsch: die Kategorien sind deutsch, und die Gerätetyp-Id ist eine GUID.

---

## Bedarf 21 — Plan gegen Vorgefundenes

Die Bedarfs-Datenbank nennt ihn *„the highest-value item in the dossier and nothing in the AV planning market does it"*:

> Nobody schedules the load-in reconciliation pass, but everybody does it: what came off the truck, under which names, with which addresses, versus what the plan says. Kit returns from the previous job with the previous job's names — Dante silently auto-renames collisions to 'Fred(2)'.

**Drei Regeln, alle aus der Recherche:**

1. **Kein Live-Feed** — *„Deliberate, timestamped, user-initiated — never a live feed."* Und die Dossiers sagen warum: Dantes API ist lizenz-gebunden, die offene Alternative erklärt sich selbst für untauglich (*„not ready for anything other than a test environment"*), die offene ST-2110-Analyse ist eingestellt (*„Use at Your Own Risk"*). Das Modul liest eine **Datei** und berührt kein Gerät; ein Test hält fest, dass es weder `fetch` noch `ipcRenderer` noch `WebSocket` kennt.
2. **Eindeutig oder gar nicht** — aus `netboxlabs/orb-agent#558`: nur anlegen, wenn *„both endpoints can be identified uniquely"*. Zwei Plan-Schnittstellen mit derselben Adresse ergeben `ambiguous`, und beide bleiben „nicht gefunden". Eine geratene Zuordnung erklärte ein fehlendes Gerät für anwesend.
3. **Die Dante-Umbenennung ist ein eigener Befund** — ohne sie steht ein fehlendes „Stagebox" *und* ein unerwartetes „Stagebox (2)" in der Liste: zwei Befunde für einen Vorgang, beide irreführend. Gekürzt wird nur die Klammer-Zahl am Ende; „Stagebox 2" und „Cam (Backup)" bleiben, wie sie sind.

Zugeordnet wird über **MAC → IP → Name**, und jede Zeile trägt mit, worauf — dieselbe Belegpflicht wie beim Kamera-Abgleich in `sony-camera-bridge#14`. Gelesen werden die **Schnittstellen** (Bedarf 19): sonst taucht die zweite Karte eines redundanten Aufbaus als „nicht im Plan" auf.

Drei Eingabeformen: `arp -a` (Linux/macOS **und** Windows), `ip neigh`, CSV mit Spalten-Zuordnung. **Kein eigener Dante-Parser** — ihr genaues Format liegt in dieser Recherche nicht vor, und einen zu schreiben hiesse, Spaltennamen zu erfinden und ihn „Dante-Import" zu nennen: er sähe geprüft aus und wäre geraten.

Beim Schreiben der Windows-Form fiel ein echter Mangel auf: die erste Fassung las nur Doppelpunkt-MACs. Windows schreibt `aa-bb-cc-dd-ee-ff`, Cisco `aabb.ccdd.eeff` — beide wären halb gelesen worden (Adresse ja, MAC nein), und ausgerechnet die MAC ist die Messung, auf die der Abgleich zuerst zugreift.

**CSV-Parser hochgezogen:** `parseCsv` stand als private Funktion in `CsvImportDialog.tsx`. Ein zweiter Parser daneben hätte bei der ersten Datei mit einem Semikolon im Anlagennamen anders geantwortet.

---

## Gegenproben

Achtzehn Fehler eingespritzt, jeder hat Tests umgeworfen:

| Eingespritzt | rot |
| --- | --- |
| `'RJ45'` zurückspielen | 3 |
| Dante-Umbenennung nicht erkennen | 3 |
| nur die erste Schnittstelle ansehen (Adressplan) | 3 |
| MAC nicht normalisieren | 2 |
| Doppel-Schlüssel auf Gerät statt Schnittstelle | 2 |
| Kabel-Quelle ignorieren | 2 |
| mehrdeutig trotzdem zuordnen · Widerspruch verschlucken · freie Ports beschreiben · unbekannten Port wegwerfen · Schreibkanal einbauen · Live-Feed einbauen · Bindestrich-MAC nicht lesen · nur erste Schnittstelle (Abgleich) | je 1 |

Die beiden Vollständigkeits-Register haben **von sich aus angeschlagen**: `modelFields` und `planDiff` verlangten eine Einordnung der neuen Felder. `networkInterfaces` ist Instanz (eine Vorlage mit fest eingebauter Dante-Sekundäradresse erzeugt beim zweiten Herausziehen zwei Adresskonflikte), `primaryInterfaceRole` ist Modell, beide `substantive` im Vergleich.

## Erreichbar

- Eigenschaften → **Network & Access**: die weiteren Schnittstellen samt Switch und Port
- Analysen → **Netzwerk**: Port-Karte je Switch, mit CSV und Beschriftungsblock
- Werkzeuge → **Plan gegen Vorgefundenes…**: Datei einlesen, Abweichung sehen, als CSV ausgeben

Die Port-Karte trägt bewusst **keinen** Dokument-Stempel: das Register führt einen Stand je Bezeichner, hier gibt es eine Karte je Switch. Ein gemeinsamer Bezeichner ergäbe einen Stand, der bei jedem zweiten Switch nicht passt.

## Geprüft

`tsc` auf allen drei Prozessen (0 Fehler) · `eslint` (0 Fehler) · `vitest` **1149/1151** (2 skipped), davon 57 neu · `npm run build` · `docs:stats` nachgezogen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT