### PR TITLE
network: Haus-IT-Anforderungsblatt, Rack-Tür-Blatt und VLAN-Tabelle aus einem Modell (Bedarf 22, 23)

### DIFF
--- a/docs/app-structure.html
+++ b/docs/app-structure.html
@@ -240,7 +240,7 @@
   <aside>
     <h1>Cable-Planner</h1>
     <div class="subtitle">
-      App-Struktur · v9.0.0 · ~442 TS/TSX-Module · ~128.7k LOC<br>
+      App-Struktur · v9.0.0 · ~443 TS/TSX-Module · ~129.2k LOC<br>
       <small style="color:#64748b">Diese Übersicht zeigt nur die ~62 wichtigsten Module. Für die vollständige Architektur siehe <a href="./architecture.md" style="color:#94a3b8">architecture.md</a>.</small>
     </div>
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Invarianten der App. Sie ist die Pflicht-Lektüre, bevor strukturelle Änderunge
 gemacht werden. Für die interaktive Modul-Übersicht siehe [`app-structure.html`](./app-structure.html),
 für einen Wettbewerber-Vergleich [`comparison.html`](./comparison.html).
 
-Stand: v9.0.0 · ~442 TS/TSX-Module · ~128.7k LOC
+Stand: v9.0.0 · ~443 TS/TSX-Module · ~129.2k LOC
 
 ---
 
@@ -553,7 +553,7 @@ optionales Cloud-Backend (`y-websocket`, Auth/Permissions) bleiben offen.
 `vitest` ist eingerichtet (`npm test` / `npm run test:watch`); dazu kommen
 gezielte Node-Checks (`npm run test:crdt`, `npm run test:signaling`), ein
 UI-Smoke-Skript (`npm run ui:smoke`) und ein headless Drag-/Interaktions-Test
-(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~128.7k LOC
+(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~129.2k LOC
 bleibt der Ausbau der Abdeckung wichtig — empfohlene Schwerpunkte:
 - Snapshot-Tests auf `healProjectPositions` mit echten
   Beispiel-Projekt-JSONs.

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -62,14 +62,14 @@
 <header>
   <h1>Cable-Planner — Strukturvergleich mit ähnlichen Tools</h1>
   <div class="subtitle">Architektur, Tech-Stack und Domänen-Tiefe im Vergleich zu kommerziellen und Open-Source-Alternativen</div>
-  <div class="meta">Stand: 2026-06 · v9.0.0 · ~442 TS/TSX-Module · ~128.7k LOC · ~5.2 MB src/</div>
+  <div class="meta">Stand: 2026-06 · v9.0.0 · ~443 TS/TSX-Module · ~129.2k LOC · ~5.2 MB src/</div>
 </header>
 
 <h2>1 · Cable-Planner — Architektur-Kennzahlen</h2>
 
 <div class="stat-grid">
-  <div class="stat"><div class="num">442</div><div class="label">TS/TSX-Module</div></div>
-  <div class="stat"><div class="num">128.7k</div><div class="label">Lines of Code</div></div>
+  <div class="stat"><div class="num">443</div><div class="label">TS/TSX-Module</div></div>
+  <div class="stat"><div class="num">129.2k</div><div class="label">Lines of Code</div></div>
   <div class="stat"><div class="num">~75</div><div class="label">Modul-Dependencies</div></div>
   <div class="stat"><div class="num">7</div><div class="label">User-Flows</div></div>
 </div>

--- a/src/renderer/components/Analysis/AnalysisDialog.tsx
+++ b/src/renderer/components/Analysis/AnalysisDialog.tsx
@@ -30,6 +30,12 @@ import {
   type SwitchPortMap,
 } from '../../lib/switchPortMap'
 import { csvFromTable } from '../../lib/documentStamp'
+import {
+  buildVenueNetworkRequest,
+  rackDoorSheetTable,
+  venueRequestTable,
+  vlanTable,
+} from '../../lib/venueNetworkRequest'
 import { RF_BANDS, bandsForFrequency, bandLabel } from '../../lib/rfBands'
 
 type Tab = 'weight' | 'network' | 'redundancy' | 'rf'
@@ -340,6 +346,64 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
     )
   }
 
+  // Bedarf 22/23 — die Netz-Dokumente aus DEMSELBEN Modell. Kein zweites
+  // Datenmodell fuer das Blatt: „Export artefacts other departments actually
+  // consume, generated from one model."
+  const request = useMemo(() => buildVenueNetworkRequest(equipment, cables), [equipment, cables])
+
+  // Ausgeschriebene Beschriftungen statt `t(`...${key}`)`: ein zusammengesetzter
+  // Schluessel ist fuer den i18n-Abdeckungs-Test unsichtbar, und der deutsche
+  // Rueckfall waere der nackte Schluessel („igmpQuerier") gewesen — in BEIDEN
+  // Sprachen.
+  const venueItemLabel = (key: string): string => {
+    switch (key) {
+      case 'vlans':
+        return t('analysis.venue.item.vlans', 'VLANs')
+      case 'subnets':
+        return t('analysis.venue.item.subnets', 'Adressbereiche')
+      case 'ports':
+        return t('analysis.venue.item.ports', 'Netz-Ports')
+      case 'bandwidth':
+        return t('analysis.venue.item.bandwidth', 'Medien-Bandbreite')
+      case 'multicast':
+        return t('analysis.venue.item.multicast', 'Multicast-Standards')
+      case 'poe':
+        return t('analysis.venue.item.poe', 'PoE')
+      case 'igmpQuerier':
+        return t('analysis.venue.item.igmpQuerier', 'IGMP-Querier')
+      case 'dhcp':
+        return t('analysis.venue.item.dhcp', 'DHCP')
+      case 'qos':
+        return t('analysis.venue.item.qos', 'QoS / DSCP')
+      case 'jointTest':
+        return t('analysis.venue.item.jointTest', 'Gemeinsamer Testtermin')
+      default:
+        return key
+    }
+  }
+
+  const exportVenueRequest = () => {
+    downloadBlob(
+      buildExportFilenameWithSuffix(projectName, 'haus-it-anforderung', 'csv'),
+      csvFromTable(venueRequestTable(request)),
+      'text/csv',
+    )
+  }
+  const exportRackDoor = () => {
+    downloadBlob(
+      buildExportFilenameWithSuffix(projectName, 'rack-tuer', 'csv'),
+      csvFromTable(rackDoorSheetTable(equipment)),
+      'text/csv',
+    )
+  }
+  const exportVlans = () => {
+    downloadBlob(
+      buildExportFilenameWithSuffix(projectName, 'vlan-tabelle', 'csv'),
+      csvFromTable(vlanTable(equipment)),
+      'text/csv',
+    )
+  }
+
   const exportAddressPlan = () => {
     const csvRows = addressPlanTable(plan, label, [
       t('analysis.network.device', 'Gerät'),
@@ -564,7 +628,70 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
           ))}
         </div>
       )}
+      {/* Bedarf 23 — das Blatt fuer die Haus-IT. Jede Zeile sagt, ob sie
+          abgeleitet ist oder eine Frage: ein Blatt, das die DHCP-Reichweite
+          des Hauses „ausfuellt", legt dem Administrator eine Behauptung ueber
+          sein eigenes Netz vor. */}
+      <div className="rounded border border-[var(--cp-border)] p-2">
+        <div className="mb-1 flex items-center justify-between">
+          <span className="font-semibold">{t('analysis.venue.title', 'Anforderung an die Haus-IT')}</span>
+          <button
+            type="button"
+            onClick={exportVenueRequest}
+            className="inline-flex items-center gap-1 rounded border border-[var(--cp-border)] px-2 py-1 text-cp-xs font-medium text-[var(--cp-text)] hover:bg-[var(--cp-surface-2)]"
+          >
+            <Icon icon={Download} size="xs" /> CSV
+          </button>
+        </div>
+        <p className="mb-1.5 text-cp-xs text-[var(--cp-text-muted)]">
+          {t(
+            'analysis.venue.intro',
+            'Die Design-Literatur schreibt den Inhalt vor und einen gemeinsamen Testtermin, aber kein Dokument. Was der Plan weiß, steht mit Zahl da; was er nicht wissen kann, steht als Frage.',
+          )}
+        </p>
+        {request.igmpConflict && (
+          <div className="mb-1.5 rounded border border-amber-700/60 bg-amber-900/20 p-2 text-cp-xs text-amber-200">
+            {format(
+              t(
+                'analysis.venue.igmpConflict',
+                'Der Plan trägt beides: {audio} (Feldrat der Audio-Hersteller: IGMP-Snooping aus) und {video} (funktioniert ohne Multicast-Verwaltung nicht). Diese beiden Ratschläge schließen sich auf einem gemeinsamen Netz aus — das gehört vor den Aufbau, nicht in die Nacht.',
+              ),
+              { audio: request.igmpConflict.audio.join(', '), video: request.igmpConflict.video.join(', ') },
+            )}
+          </div>
+        )}
+        <ul className="flex flex-col gap-0.5">
+          {request.items.map((i) => (
+            <li key={i.key} className="flex flex-wrap items-baseline gap-2 text-cp-xs">
+              <span className="w-52 shrink-0 text-[var(--cp-text-muted)]">{venueItemLabel(i.key)}</span>
+              {i.origin === 'derived' ? (
+                <span className="font-mono text-[var(--cp-text)]">{i.value}</span>
+              ) : (
+                <span className="flex-1 text-amber-300/90">{i.why}</span>
+              )}
+              {i.source && (
+                <span className="w-full pl-52 text-[10px] text-[var(--cp-text-faint)]">{i.source}</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+
       <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={exportRackDoor}
+          className="inline-flex items-center gap-1 rounded border border-[var(--cp-border)] px-2 py-1 text-cp-xs font-medium text-[var(--cp-text)] hover:bg-[var(--cp-surface-2)]"
+        >
+          <Icon icon={Download} size="xs" /> {t('analysis.venue.rackDoor', 'Rack-Tür-Blatt')}
+        </button>
+        <button
+          type="button"
+          onClick={exportVlans}
+          className="inline-flex items-center gap-1 rounded border border-[var(--cp-border)] px-2 py-1 text-cp-xs font-medium text-[var(--cp-text)] hover:bg-[var(--cp-surface-2)]"
+        >
+          <Icon icon={Download} size="xs" /> {t('analysis.venue.vlanTable', 'VLAN-Tabelle')}
+        </button>
         <button
           type="button"
           onClick={exportAddressPlan}

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -4009,6 +4009,26 @@ export const en: Dict = {
   'analysis.address.clean': 'Nothing open: every networked device has an address, a mask and a gateway that fits.',
   'analysis.address.export': 'Address plan as CSV',
 
+  /* Bedarfe 22/23 — Netz-Dokumente aus einem Modell. Keys: analysis.venue.* */
+  'analysis.venue.title': 'Request to the venue IT',
+  'analysis.venue.intro':
+    'The design literature prescribes the content and a joint test session, but no document. What the plan knows is stated with a number; what it cannot know is stated as a question.',
+  // {audio} und {video} werden vom Aufrufer ersetzt.
+  'analysis.venue.igmpConflict':
+    'The plan carries both: {audio} (audio vendors\u2019 field advice: turn IGMP snooping off) and {video} (does not work without multicast management). On a shared network those two pieces of advice are mutually exclusive \u2014 that belongs before the build, not into the night.',
+  'analysis.venue.rackDoor': 'Rack-door sheet',
+  'analysis.venue.vlanTable': 'VLAN table',
+  'analysis.venue.item.vlans': 'VLANs',
+  'analysis.venue.item.subnets': 'Address ranges',
+  'analysis.venue.item.ports': 'Network ports',
+  'analysis.venue.item.bandwidth': 'Media bandwidth',
+  'analysis.venue.item.multicast': 'Multicast standards',
+  'analysis.venue.item.poe': 'PoE',
+  'analysis.venue.item.igmpQuerier': 'IGMP querier',
+  'analysis.venue.item.dhcp': 'DHCP',
+  'analysis.venue.item.qos': 'QoS / DSCP',
+  'analysis.venue.item.jointTest': 'Joint test session',
+
   /* Bedarf 24 — die Switch-Port-Karte. Keys: analysis.switchPorts.* */
   'analysis.switchPorts.title': 'Switch port map',
   // {n} wird vom Aufrufer ersetzt.

--- a/src/renderer/lib/venueNetworkRequest.ts
+++ b/src/renderer/lib/venueNetworkRequest.ts
@@ -1,0 +1,364 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Das Haus-IT-Anforderungsblatt und die Netz-Dokumente (Bedarfe 23 und 22,
+// beide P1).
+//
+// BEDARF 23 IST EIN ORGANISATIONS-PROBLEM MIT EINER TECHNISCHEN URSACHE:
+//
+//   > There is no agreed document for asking a venue's IT department for
+//   > VLANs, address ranges, multicast, IGMP querier behaviour, DHCP scope,
+//   > port count, PoE and bandwidth.
+//
+// Der Rollen-Bericht sagt dasselbe mit Quellen: die AV-over-IP-Literatur
+// (Crestron, Ruckus) schreibt den INHALT vor — VLANs, IP-Bereiche,
+// Multicast-Unterstuetzung, Switch-Faehigkeit, QoS — und einen gemeinsamen
+// Testtermin, aber KEIN Dokument. Church Productions praktische Empfehlung
+// ist ein monatliches Treffen zwischen AV und IT: eine organisatorische
+// Notloesung fuer ein fehlendes Blatt. Die Bedarfs-Datenbank nennt den Bau
+// „low build cost, and it addresses the role's most-cited organisational
+// blocker".
+//
+// ─── DIE REGEL, DIE DAS BLATT BRAUCHBAR MACHT ──────────────────────────────
+//
+// **Jede Zeile sagt, ob sie ABGELEITET oder eine FRAGE ist.** Der Plan kennt
+// seine VLANs, seine Adressbereiche, seine Portzahl und seine Bandbreite — die
+// stehen mit Zahlen da. Er kennt die DHCP-Reichweite des Hauses NICHT, und er
+// kennt dessen IGMP-Verhalten nicht. Beides trotzdem auszufuellen hiesse, dem
+// Netzwerk-Administrator eine Behauptung ueber sein eigenes Netz vorzulegen —
+// und genau daran scheitert das Gespraech, das dieses Blatt eroeffnen soll.
+//
+// ─── DER WIDERSPRUCH, DER DRINBLEIBT ───────────────────────────────────────
+//
+// Der Rollen-Bericht haelt ihn ausdruecklich fest:
+//
+//   > Note the contradiction the engineer is standing in the middle of: the
+//   > audio vendor's field advice is *turn multicast management off*, and the
+//   > video/2110 side cannot work without it. On a shared event network those
+//   > two pieces of advice are mutually exclusive, and resolving that per
+//   > venue is unpaid design work.
+//
+// Belegt auf beiden Seiten: „turning on IGMP snooping on certain switches can
+// disable 100 % of the Dante multicast traffic and kill it dead" und
+// Audinates Empfehlung, Switches „neutral" zu lassen (kein DHCP, kein
+// Multicast-Filter, kein IGMP-Snooping) — gegen ST 2110, das ohne
+// Multicast-Verwaltung nicht traegt.
+//
+// Dieses Modul LOEST den Widerspruch nicht auf. Es erkennt ihn im Plan (beide
+// Sorten vorhanden) und schreibt ihn samt beider Quellen auf das Blatt, damit
+// er VOR dem Aufbau verhandelt wird statt um zwei Uhr nachts entdeckt.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { Cable } from '../types/cable'
+import type { EquipmentItem } from '../types/equipment'
+import type { SignalStandard } from '../types/cableSpec'
+import { bandwidthMbpsForStandard } from '../types/cableSpec'
+import { allDeviceInterfaces } from './networkInterfaces'
+import { buildAddressPlan } from './addressPlan'
+import { subnetCidr } from './subnet'
+import type { CsvCell, CsvTable } from './csv'
+
+/**
+ * Standards, die im Netz mit Multicast arbeiten — und damit vom IGMP-Verhalten
+ * des Hauses abhaengen.
+ *
+ * Getrennt nach Lager, weil genau daran der Widerspruch haengt: die
+ * Audio-Seite bekommt vom Hersteller den Rat, Multicast-Verwaltung
+ * abzuschalten; die 2110-Seite kann ohne sie nicht arbeiten.
+ */
+export const AUDIO_MULTICAST: ReadonlySet<SignalStandard> = new Set<SignalStandard>([
+  'Dante',
+  'AES67',
+  'ST2110-30',
+])
+
+export const VIDEO_MULTICAST: ReadonlySet<SignalStandard> = new Set<SignalStandard>([
+  'ST2110-20',
+  'ST2110-40',
+])
+
+/** Licht ueber IP — eigene Multicast-Gruppen, und im Haus-Netz derselbe Fall. */
+export const LIGHTING_MULTICAST: ReadonlySet<SignalStandard> = new Set<SignalStandard>([
+  'sACN',
+  'Art-Net',
+])
+
+/** Woher der Inhalt einer Zeile kommt. */
+export type RequestOrigin =
+  /** Aus dem Plan gerechnet. Steht mit Zahl da. */
+  | 'derived'
+  /** Kann der Plan nicht wissen — es ist eine Frage an das Haus. */
+  | 'question'
+
+export interface RequestItem {
+  /** Stabiler Schluessel; die Oberflaeche uebersetzt ihn. */
+  key: string
+  origin: RequestOrigin
+  /** Der abgeleitete Wert im Klartext. Fehlt bei `question`. */
+  value?: string
+  /** Warum der Plan es nicht wissen kann — nur bei `question`. */
+  why?: string
+  /** Fundstelle, wo eine Zahl aus einer Quelle stammt. */
+  source?: string
+}
+
+export interface VenueNetworkRequest {
+  items: RequestItem[]
+  /** Der belegte Widerspruch, wenn der Plan beide Sorten traegt. */
+  igmpConflict?: { audio: string[]; video: string[] }
+  /** VLANs im Plan, aufsteigend. */
+  vlans: number[]
+  /** Subnetze im Plan, in CIDR-Schreibweise. */
+  subnets: string[]
+  /** Netzfaehige Schnittstellen — die Portzahl, die das Haus stellen muss. */
+  interfaceCount: number
+  /** Summe der Medien-Bandbreite in Mbit/s. */
+  mediaMbps: number
+}
+
+const nummer = (v: unknown): number | undefined =>
+  typeof v === 'number' && Number.isFinite(v) ? v : undefined
+
+/**
+ * Das Anforderungsblatt aus dem Plan.
+ *
+ * `equipment` und `cables` sind alles, was gebraucht wird — das Blatt ist eine
+ * Ableitung und kein zweites Datenmodell. Genau das ist die Zusage aus
+ * Bedarf 22: „Export artefacts other departments actually consume, generated
+ * from one model."
+ */
+export function buildVenueNetworkRequest(
+  equipment: EquipmentItem[],
+  cables: Cable[],
+): VenueNetworkRequest {
+  const nics = allDeviceInterfaces(equipment)
+  const plan = buildAddressPlan(equipment)
+
+  // VLANs: aus den Schnittstellen und aus den VLAN-Definitionen der Switches.
+  const vlanSet = new Set<number>()
+  for (const { nic } of nics) if (nic.vlanId !== undefined) vlanSet.add(nic.vlanId)
+  for (const e of equipment) {
+    if (e.managementVlanId !== undefined) vlanSet.add(e.managementVlanId)
+    for (const v of e.vlans ?? []) {
+      const id = nummer((v as { id?: unknown }).id)
+      if (id !== undefined) vlanSet.add(id)
+    }
+  }
+  const vlans = [...vlanSet].sort((a, b) => a - b)
+
+  // Subnetze: aus dem Adressplan, also aus denselben Geraete-Datensaetzen.
+  const subnetSet = new Set<string>()
+  for (const r of plan.rows) {
+    if (r.ip && r.mask) {
+      const c = subnetCidr(r.ip, r.mask)
+      if (c) subnetSet.add(c)
+    }
+  }
+  const subnets = [...subnetSet].sort()
+
+  // Bandbreite: nur Medien, nicht Link-Kapazitaet. Dieselbe Trennung, die der
+  // Netz-Budget-Rechner nach dem Befund von 2026-09-04 einhaelt.
+  let mediaMbps = 0
+  const audio = new Set<string>()
+  const video = new Set<string>()
+  const licht = new Set<string>()
+  for (const c of cables) {
+    const std = (c as { standard?: SignalStandard }).standard
+    const mbps = bandwidthMbpsForStandard(std)
+    if (mbps) mediaMbps += mbps
+    if (std && AUDIO_MULTICAST.has(std)) audio.add(std)
+    if (std && VIDEO_MULTICAST.has(std)) video.add(std)
+    if (std && LIGHTING_MULTICAST.has(std)) licht.add(std)
+  }
+  // Auch Ports zaehlen: ein Plan kann ein Geraet fuehren, dessen Kabel noch
+  // fehlt, und die Multicast-Frage haengt am Geraet und nicht am Kabel.
+  for (const e of equipment) {
+    for (const p of [...(e.inputs ?? []), ...(e.outputs ?? [])]) {
+      const std = p.standard
+      if (std && AUDIO_MULTICAST.has(std)) audio.add(std)
+      if (std && VIDEO_MULTICAST.has(std)) video.add(std)
+      if (std && LIGHTING_MULTICAST.has(std)) licht.add(std)
+    }
+  }
+
+  // PoE: nur, wo ein Geraet es ausdruecklich fuehrt. Aus der Portzahl auf PoE
+  // zu schliessen waere geraten — die meisten AV-Geraete haben ein Netzteil.
+  let poeBudget = 0
+  const poeStandards = new Set<string>()
+  for (const e of equipment) {
+    const props = e.categoryProps ?? {}
+    const w = nummer(props.poeBudgetW)
+    if (w) poeBudget += w
+    const std = props.poeStandard
+    if (typeof std === 'string' && std && std !== 'none') poeStandards.add(std)
+  }
+
+  const items: RequestItem[] = [
+    {
+      key: 'vlans',
+      origin: 'derived',
+      value: vlans.length > 0 ? vlans.join(', ') : '—',
+    },
+    {
+      key: 'subnets',
+      origin: 'derived',
+      value: subnets.length > 0 ? subnets.join(', ') : '—',
+    },
+    {
+      key: 'ports',
+      origin: 'derived',
+      value: String(nics.length),
+    },
+    {
+      key: 'bandwidth',
+      origin: 'derived',
+      value: `${mediaMbps} Mbit/s`,
+      source:
+        'Summe der Medien-Standards im Plan; Link-Kapazitaet zaehlt bewusst nicht mit. ' +
+        'Planungsrichtwert fuer eine Konferenz mit drei Streams: mindestens 100 Mbit/s ' +
+        'dedizierter Upload, getrennt vom Besuchernetz (trivisionstudios.com)',
+    },
+    {
+      key: 'multicast',
+      origin: 'derived',
+      value:
+        [...audio, ...video, ...licht].length > 0
+          ? [...audio, ...video, ...licht].join(', ')
+          : '—',
+      source:
+        'Shure, „Dante networks and IGMP snooping"; Arista, Multicast Addressing (ST 2110)',
+    },
+    poeStandards.size > 0 || poeBudget > 0
+      ? {
+          key: 'poe',
+          origin: 'derived' as const,
+          value: `${poeBudget} W${poeStandards.size > 0 ? ` (${[...poeStandards].join(', ')})` : ''}`,
+        }
+      : {
+          key: 'poe',
+          origin: 'question' as const,
+          why: 'Kein Geraet im Plan fuehrt ein PoE-Budget. Aus der Portzahl darauf zu schliessen waere geraten — die meisten AV-Geraete haben ein Netzteil.',
+        },
+    {
+      key: 'igmpQuerier',
+      origin: 'question',
+      why:
+        'Wer im Haus ist IGMP-Querier, und ist es genau einer? Der Plan kann das nicht wissen. ' +
+        'Die Praxis nennt beide Fehler: „only one IGMP querier should be turned on", und ' +
+        '„turning on IGMP snooping on certain switches can disable 100 % of the Dante multicast traffic".',
+      source: 'Blue Room, Dante switch performance; ControlBooth 47261',
+    },
+    {
+      key: 'dhcp',
+      origin: 'question',
+      why:
+        'Gibt es DHCP in diesen VLANs, und in welchem Bereich? Der Plan arbeitet mit festen ' +
+        'Adressen; ein zweiter, unbekannter DHCP-Dienst im selben Netz ist ein benannter ' +
+        'Ausfallgrund. Audinates Feldrat fuer AV-Switches lautet ausdruecklich: kein DHCP anbieten.',
+      source: 'Blue Room, Dante switch performance',
+    },
+    {
+      key: 'qos',
+      origin: 'question',
+      why:
+        'Welche QoS-/DSCP-Behandlung ist im Haus gesetzt, und bleibt sie ueber alle beteiligten ' +
+        'Switches gleich? Die Design-Literatur schreibt QoS als Inhalt vor, nennt aber keine Werte; ' +
+        'und uneinheitliche Switches sind selbst die Gefahr: „if the network uses different types of ' +
+        'switches, the configurations may not behave as intended even if set correctly".',
+      source: 'Crestron, AV-over-IP Network Design; Ruckus; ControlBooth 47261',
+    },
+    {
+      key: 'jointTest',
+      origin: 'question',
+      why:
+        'Wann findet der gemeinsame Testtermin statt? Die Design-Literatur schreibt ihn vor und ' +
+        'liefert kein Dokument dafuer; die praktische Ersatzloesung der Branche ist ein monatliches ' +
+        'Treffen zwischen AV und IT — eine Organisationsform fuer ein fehlendes Blatt.',
+      source: 'Crestron; Ruckus; Church Production',
+    },
+  ]
+
+  const out: VenueNetworkRequest = {
+    items,
+    vlans,
+    subnets,
+    interfaceCount: nics.length,
+    mediaMbps,
+  }
+  if (audio.size > 0 && video.size > 0) {
+    out.igmpConflict = { audio: [...audio], video: [...video] }
+  }
+  return out
+}
+
+/** Das Anforderungsblatt als Tabelle. Kanonisches Deutsch. */
+export function venueRequestTable(req: VenueNetworkRequest): CsvTable {
+  const label: Record<string, string> = {
+    vlans: 'VLANs',
+    subnets: 'Adressbereiche',
+    ports: 'Netz-Ports (Schnittstellen im Plan)',
+    bandwidth: 'Medien-Bandbreite',
+    multicast: 'Multicast-Standards im Plan',
+    poe: 'PoE',
+    igmpQuerier: 'IGMP-Querier',
+    dhcp: 'DHCP',
+    qos: 'QoS / DSCP',
+    jointTest: 'Gemeinsamer Testtermin',
+  }
+  return {
+    headers: ['Punkt', 'Art', 'Aus dem Plan', 'Frage an das Haus', 'Quelle'],
+    rows: req.items.map((i): CsvCell[] => [
+      label[i.key] ?? i.key,
+      i.origin === 'derived' ? 'abgeleitet' : 'Frage',
+      i.value ?? '',
+      i.why ?? '',
+      i.source ?? '',
+    ]),
+  }
+}
+
+/**
+ * Das Rack-Tuer-Blatt (Bedarf 22): welches Geraet, welche Adresse, welches
+ * VLAN — das Blatt, das an der Rack-Tuer haengt und die Frage „was ist die IP
+ * von X?" beantwortet, ohne dass jemand auf Comms fragen muss.
+ *
+ * Getrennt vom Adressplan, weil es einen anderen Zweck hat: der Adressplan
+ * zeigt, was FEHLT; dieses Blatt zeigt, was IST, und nur das. Befunde stehen
+ * bewusst nicht drauf — an der Rack-Tuer hilft eine Warnung nicht, dort hilft
+ * eine Zahl.
+ */
+export function rackDoorSheetTable(equipment: EquipmentItem[]): CsvTable {
+  const rows: CsvCell[][] = []
+  for (const { equipment: e, nic } of allDeviceInterfaces(equipment)) {
+    if (!nic.ipAddress) continue
+    rows.push([
+      e.name,
+      nic.label ?? '',
+      nic.ipAddress,
+      nic.subnetMask ?? '',
+      nic.gateway ?? '',
+      nic.vlanId ?? '',
+      nic.macAddress ?? '',
+    ])
+  }
+  return {
+    headers: ['Geraet', 'Schnittstelle', 'IP', 'Maske', 'Gateway', 'VLAN', 'MAC'],
+    rows,
+  }
+}
+
+/** Die VLAN-Tabelle (Bedarf 22): welches VLAN traegt was. */
+export function vlanTable(equipment: EquipmentItem[]): CsvTable {
+  const byVlan = new Map<number, string[]>()
+  for (const { equipment: e, nic } of allDeviceInterfaces(equipment)) {
+    if (nic.vlanId === undefined) continue
+    const name = nic.label ? `${e.name} · ${nic.label}` : e.name
+    byVlan.set(nic.vlanId, [...(byVlan.get(nic.vlanId) ?? []), name])
+  }
+  return {
+    headers: ['VLAN', 'Geraete', 'Anzahl'],
+    rows: [...byVlan.entries()]
+      .sort((a, b) => a[0] - b[0])
+      .map(([id, names]): CsvCell[] => [id, names.join(', '), names.length]),
+  }
+}

--- a/tests/venueNetworkRequest.test.ts
+++ b/tests/venueNetworkRequest.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildVenueNetworkRequest,
+  rackDoorSheetTable,
+  venueRequestTable,
+  vlanTable,
+} from '../src/renderer/lib/venueNetworkRequest'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem, Port } from '../src/renderer/types/equipment'
+import type { SignalStandard } from '../src/renderer/types/cableSpec'
+
+// ---------------------------------------------------------------------------
+// Das Haus-IT-Anforderungsblatt (Bedarf 23) und die Netz-Dokumente (Bedarf 22).
+//
+//   > There is no agreed document for asking a venue's IT department for
+//   > VLANs, address ranges, multicast, IGMP querier behaviour, DHCP scope,
+//   > port count, PoE and bandwidth.
+//
+// Die Design-Literatur schreibt den INHALT vor und einen gemeinsamen
+// Testtermin, aber kein Dokument; die Ersatzloesung der Branche ist ein
+// monatliches Treffen zwischen AV und IT.
+//
+// Geprueft wird die eine Regel, an der das Blatt brauchbar oder schaedlich
+// wird: JEDE ZEILE SAGT, OB SIE ABGELEITET IST ODER EINE FRAGE. Ein Blatt, das
+// die DHCP-Reichweite des Hauses „ausfuellt", legt dem Administrator eine
+// Behauptung ueber sein eigenes Netz vor — und daran scheitert das Gespraech,
+// das es eroeffnen soll.
+// ---------------------------------------------------------------------------
+
+const port = (name: string, standard?: SignalStandard): Port =>
+  ({ id: `${name}-id`, name, type: 'port', connectorType: 'Ethernet/RJ45', standard }) as Port
+
+const geraet = (name: string, over: Partial<EquipmentItem> = {}): EquipmentItem =>
+  ({
+    id: `id-${name}`,
+    name,
+    category: 'Sonstiges',
+    inputs: [],
+    outputs: [],
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 100,
+    ...over,
+  }) as unknown as EquipmentItem
+
+const kabel = (standard: SignalStandard): Cable =>
+  ({
+    id: `c-${standard}-${Math.random()}`,
+    fromEquipmentId: 'a',
+    fromPortId: 'p',
+    toEquipmentId: 'b',
+    toPortId: 'q',
+    type: 'Cat6',
+    standard,
+  }) as unknown as Cable
+
+const item = (req: ReturnType<typeof buildVenueNetworkRequest>, key: string) =>
+  req.items.find((i) => i.key === key)
+
+describe('was der Plan weiss, steht mit Zahl da', () => {
+  it('leitet VLANs aus Schnittstellen und Management-VLAN ab', () => {
+    const req = buildVenueNetworkRequest(
+      [
+        geraet('Switch', { managementVlanId: 99 }),
+        geraet('Stagebox', {
+          ipAddress: '10.0.0.5',
+          networkInterfaces: [{ id: 'n2', role: 'media-primary', ipAddress: '10.1.0.5', vlanId: 20 }],
+        }),
+      ],
+      [],
+    )
+    expect(req.vlans).toEqual([20, 99])
+    expect(item(req, 'vlans')?.origin).toBe('derived')
+  })
+
+  it('leitet die Adressbereiche aus denselben Geraete-Datensaetzen ab', () => {
+    // „generated from one model" — kein zweites Datenmodell fuer das Blatt.
+    const req = buildVenueNetworkRequest(
+      [
+        geraet('A', { ipAddress: '10.0.0.5', subnetMask: '255.255.255.0' }),
+        geraet('B', { ipAddress: '10.0.1.5', subnetMask: '255.255.255.0' }),
+      ],
+      [],
+    )
+    expect(req.subnets).toEqual(['10.0.0.0/24', '10.0.1.0/24'])
+  })
+
+  it('zaehlt die Schnittstellen und nicht die Geraete', () => {
+    // Die Portzahl ist das, was das Haus stellen muss. Ein Geraet mit drei
+    // Karten braucht drei Ports.
+    const req = buildVenueNetworkRequest(
+      [
+        geraet('Stagebox', {
+          ipAddress: '10.0.0.5',
+          networkInterfaces: [
+            { id: 'n2', role: 'media-secondary', ipAddress: '10.1.0.5' },
+            { id: 'n3', role: 'control', ipAddress: '192.168.1.5' },
+          ],
+        }),
+      ],
+      [],
+    )
+    expect(req.interfaceCount).toBe(3)
+  })
+
+  it('summiert nur Medien-Bandbreite, nicht Link-Kapazitaet', () => {
+    // Dieselbe Trennung, die der Netz-Budget-Rechner seit dem Befund von
+    // 2026-09-04 einhaelt: ein gezeichnetes Cat6a-Kabel ist keine Last.
+    const req = buildVenueNetworkRequest([], [kabel('Dante'), kabel('Eth-10G')])
+    expect(req.mediaMbps).toBe(49)
+  })
+})
+
+describe('was der Plan NICHT weiss, steht als Frage da', () => {
+  it('fuellt die DHCP-Reichweite des Hauses nicht aus', () => {
+    const req = buildVenueNetworkRequest([geraet('A', { ipAddress: '10.0.0.5' })], [])
+    const dhcp = item(req, 'dhcp')
+    expect(dhcp?.origin).toBe('question')
+    expect(dhcp?.value).toBeUndefined()
+    expect(dhcp?.why).toContain('feste')
+  })
+
+  it('behauptet nichts ueber den IGMP-Querier', () => {
+    const req = buildVenueNetworkRequest([], [kabel('Dante')])
+    expect(item(req, 'igmpQuerier')?.origin).toBe('question')
+    expect(item(req, 'igmpQuerier')?.value).toBeUndefined()
+  })
+
+  it('nennt den gemeinsamen Testtermin, den die Literatur vorschreibt', () => {
+    const req = buildVenueNetworkRequest([], [])
+    expect(item(req, 'jointTest')?.origin).toBe('question')
+  })
+
+  it('schliesst aus der Portzahl NICHT auf PoE', () => {
+    // Die meisten AV-Geraete haben ein Netzteil. Ein erfundenes PoE-Budget
+    // liesse das Haus eine Einspeisung planen, die niemand braucht.
+    const req = buildVenueNetworkRequest([geraet('Kamera', { ipAddress: '10.0.0.5' })], [])
+    expect(item(req, 'poe')?.origin).toBe('question')
+  })
+
+  it('nimmt PoE aber mit, wo ein Geraet es fuehrt', () => {
+    const req = buildVenueNetworkRequest(
+      [geraet('Switch', { categoryProps: { poeBudgetW: 370, poeStandard: 'at' } })],
+      [],
+    )
+    const poe = item(req, 'poe')
+    expect(poe?.origin).toBe('derived')
+    expect(poe?.value).toContain('370 W')
+    expect(poe?.value).toContain('at')
+  })
+
+  it('haengt an jede Frage einen Grund', () => {
+    // Eine Frage ohne Grund liest sich wie ein Formular; mit Grund wie ein
+    // Argument. Genau das ist der Unterschied, an dem dieses Gespraech haengt.
+    const req = buildVenueNetworkRequest([], [])
+    for (const i of req.items.filter((x) => x.origin === 'question')) {
+      expect(i.why, `ohne Grund: ${i.key}`).toBeTruthy()
+      expect((i.why ?? '').length).toBeGreaterThan(40)
+    }
+  })
+})
+
+describe('der Widerspruch bleibt stehen', () => {
+  it('meldet ihn, wenn der Plan Audio- UND 2110-Multicast traegt', () => {
+    // „the audio vendor's field advice is turn multicast management off, and
+    // the video/2110 side cannot work without it … those two pieces of advice
+    // are mutually exclusive". Das Blatt loest das nicht auf — es legt es dem
+    // Haus VOR dem Aufbau hin.
+    const req = buildVenueNetworkRequest([], [kabel('Dante'), kabel('ST2110-20')])
+    expect(req.igmpConflict?.audio).toEqual(['Dante'])
+    expect(req.igmpConflict?.video).toEqual(['ST2110-20'])
+  })
+
+  it('meldet ihn NICHT bei nur einer Sorte', () => {
+    // Sonst leuchtete er auf jedem reinen Audio- und jedem reinen Video-Plan,
+    // und eine Warnung, die immer dasteht, wird nicht gelesen.
+    expect(buildVenueNetworkRequest([], [kabel('Dante')]).igmpConflict).toBeUndefined()
+    expect(buildVenueNetworkRequest([], [kabel('ST2110-20')]).igmpConflict).toBeUndefined()
+  })
+
+  it('findet die Standards auch an Ports ohne Kabel', () => {
+    // Ein Plan kann ein Geraet fuehren, dessen Kabel noch fehlt — die
+    // Multicast-Frage haengt am Geraet und nicht am Kabel.
+    const req = buildVenueNetworkRequest(
+      [geraet('Stagebox', { inputs: [port('NET', 'Dante')] }), geraet('Cam', { outputs: [port('SFP', 'ST2110-20')] })],
+      [],
+    )
+    expect(req.igmpConflict).toBeDefined()
+  })
+})
+
+describe('die Netz-Dokumente (Bedarf 22)', () => {
+  it('das Rack-Tuer-Blatt zeigt, was IST — ohne Befunde', () => {
+    // An der Rack-Tuer hilft keine Warnung, dort hilft eine Zahl. Der
+    // Adressplan zeigt, was FEHLT; dieses Blatt zeigt, was da ist.
+    const t = rackDoorSheetTable([
+      geraet('Stagebox', {
+        ipAddress: '10.0.0.5',
+        subnetMask: '255.255.255.0',
+        networkInterfaces: [{ id: 'n2', label: 'Dante Sec', role: 'media-secondary', ipAddress: '10.1.0.5', vlanId: 20 }],
+      }),
+      geraet('Ohne Adresse'),
+    ])
+    expect(t.rows).toHaveLength(2)
+    expect(t.rows[0][2]).toBe('10.0.0.5')
+    expect(t.rows[1][1]).toBe('Dante Sec')
+    expect(t.rows[1][5]).toBe(20)
+    expect(t.headers).not.toContain('Befund')
+  })
+
+  it('die VLAN-Tabelle zaehlt je VLAN', () => {
+    const t = vlanTable([
+      geraet('A', { ipAddress: '10.0.0.5', managementVlanId: 20 }),
+      geraet('B', {
+        networkInterfaces: [{ id: 'n2', role: 'control', ipAddress: '10.0.0.6', vlanId: 20 }],
+      }),
+    ])
+    expect(t.rows).toHaveLength(1)
+    expect(t.rows[0][0]).toBe(20)
+    expect(t.rows[0][2]).toBe(2)
+  })
+
+  it('das Anforderungsblatt trennt abgeleitet und Frage in einer eigenen Spalte', () => {
+    const t = venueRequestTable(buildVenueNetworkRequest([], []))
+    expect(t.headers).toEqual(['Punkt', 'Art', 'Aus dem Plan', 'Frage an das Haus', 'Quelle'])
+    const arten = new Set(t.rows.map((r) => r[1]))
+    expect(arten).toEqual(new Set(['abgeleitet', 'Frage']))
+  })
+})


### PR DESCRIPTION
## Bedarf 23 — ein Organisations-Problem mit technischer Ursache

> There is no agreed document for asking a venue's IT department for VLANs, address ranges, multicast, IGMP querier behaviour, DHCP scope, port count, PoE and bandwidth.

Der Rollen-Bericht sagt dasselbe mit Quellen: die AV-over-IP-Literatur (Crestron, Ruckus) schreibt den **Inhalt** vor — VLANs, IP-Bereiche, Multicast, Switch-Fähigkeit, QoS — und einen gemeinsamen Testtermin, aber **kein Dokument**. Church Productions praktische Empfehlung ist ein *monatliches Treffen zwischen AV und IT*: eine Organisationsform für ein fehlendes Blatt. Die Bedarfs-Datenbank nennt den Bau *„low build cost, and it addresses the role's most-cited organisational blocker"*.

## Die Regel, die das Blatt brauchbar macht

**Jede Zeile sagt, ob sie abgeleitet ist oder eine Frage.**

| abgeleitet (mit Zahl) | Frage an das Haus (mit Grund) |
| --- | --- |
| VLANs · Adressbereiche · Netz-Ports · Medien-Bandbreite · Multicast-Standards · PoE (wo geführt) | IGMP-Querier · DHCP · QoS/DSCP · gemeinsamer Testtermin · PoE (wo keins geführt) |

Der Plan kennt seine VLANs, Adressbereiche, Portzahl und Bandbreite. Er kennt die **DHCP-Reichweite des Hauses nicht** und dessen **IGMP-Verhalten nicht**. Beides trotzdem auszufüllen hiesse, dem Netzwerk-Administrator eine Behauptung über sein eigenes Netz vorzulegen — und genau daran scheitert das Gespräch, das dieses Blatt eröffnen soll. Jede Frage trägt ihren Grund: eine Frage ohne Grund liest sich wie ein Formular, mit Grund wie ein Argument.

## Der Widerspruch bleibt stehen

Der Rollen-Bericht hält ihn ausdrücklich fest:

> the audio vendor's field advice is *turn multicast management off*, and the video/2110 side cannot work without it. On a shared event network those two pieces of advice are mutually exclusive, and resolving that per venue is unpaid design work.

Belegt auf beiden Seiten: *„turning on IGMP snooping on certain switches can disable 100 % of the Dante multicast traffic and kill it dead"* und Audinates Rat, Switches „neutral" zu lassen — gegen ST 2110, das ohne Multicast-Verwaltung nicht trägt.

Das Modul **löst ihn nicht auf.** Es erkennt ihn im Plan (beide Sorten vorhanden) und legt ihn samt beider Seiten vor den Aufbau. Und **nur dann** — bei einer einzigen Sorte schweigt es, sonst leuchtete die Warnung auf jedem reinen Audio- und jedem reinen Video-Plan.

## Was bewusst nicht geraten wird

- **PoE** nur, wo ein Gerät ein Budget führt. Aus der Portzahl darauf zu schliessen liesse das Haus eine Einspeisung planen, die niemand braucht — die meisten AV-Geräte haben ein Netzteil.
- **Bandbreite** nur aus Medien-Standards. Link-Kapazität zählt nicht mit; dieselbe Trennung, die der Netz-Budget-Rechner seit dem Befund vom 2026-09-04 einhält.
- Die **Multicast-Frage hängt am Gerät**, nicht nur am Kabel: ein Plan kann ein Gerät führen, dessen Kabel noch fehlt.

## Bedarf 22 — dieselben Daten, andere Leser

*„Export artefacts other departments actually consume, generated from one model."* Aus demselben Modell entstehen zusätzlich:

- **Rack-Tür-Blatt** — Gerät, Schnittstelle, IP, Maske, Gateway, VLAN, MAC. Zeigt bewusst **nur, was ist** — keine Befunde. Der Adressplan zeigt, was fehlt; an der Rack-Tür hilft keine Warnung, dort hilft eine Zahl. Es beantwortet den achten Zeitfresser des Rollen-Berichts: *„what's the IP of X?"*, mitten in der Show, ohne dass jemand auf Comms fragen muss.
- **VLAN-Tabelle** — welches VLAN trägt was, mit Anzahl.

## Gegenproben

| Eingespritzt | rot |
| --- | --- |
| DHCP als abgeleitet behaupten | 1 |
| PoE aus der Portzahl raten | 1 |
| den Widerspruch immer melden | 1 |
| Link-Kapazität in die Bandbreite nehmen | 1 |
| die Ports beim Multicast-Fund überspringen | 1 |
| Befunde aufs Rack-Tür-Blatt setzen | 1 |

Die Beschriftungen der Blattzeilen stehen **ausgeschrieben** statt als `` t(`...${key}`) ``: ein zusammengesetzter Schlüssel ist für den i18n-Abdeckungs-Test unsichtbar, und der deutsche Rückfall wäre der nackte Schlüssel gewesen — in beiden Sprachen.

## Erreichbar

Analysen → **Netzwerk**: das Anforderungsblatt steht dort, mit CSV je Blatt (Anforderung, Rack-Tür, VLAN-Tabelle).

## Geprüft

`tsc` auf allen drei Prozessen (0 Fehler) · `eslint` (0 Fehler) · `vitest` **1165/1167** (2 skipped), davon 16 neu · `npm run build` · `docs:stats` nachgezogen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_