### PR TITLE
audio: eine Kanalliste mit fünf Sichten, und der Stage-Plot als Ein-Seiten-Lieferung (Bedarf 37, 38)

### DIFF
--- a/docs/app-structure.html
+++ b/docs/app-structure.html
@@ -240,7 +240,7 @@
   <aside>
     <h1>Cable-Planner</h1>
     <div class="subtitle">
-      App-Struktur · v9.0.0 · ~443 TS/TSX-Module · ~129.2k LOC<br>
+      App-Struktur · v9.0.0 · ~444 TS/TSX-Module · ~129.5k LOC<br>
       <small style="color:#64748b">Diese Übersicht zeigt nur die ~62 wichtigsten Module. Für die vollständige Architektur siehe <a href="./architecture.md" style="color:#94a3b8">architecture.md</a>.</small>
     </div>
 

--- a/docs/app-structure.html
+++ b/docs/app-structure.html
@@ -240,7 +240,7 @@
   <aside>
     <h1>Cable-Planner</h1>
     <div class="subtitle">
-      App-Struktur · v9.0.0 · ~444 TS/TSX-Module · ~129.5k LOC<br>
+      App-Struktur · v9.0.0 · ~444 TS/TSX-Module · ~129.6k LOC<br>
       <small style="color:#64748b">Diese Übersicht zeigt nur die ~62 wichtigsten Module. Für die vollständige Architektur siehe <a href="./architecture.md" style="color:#94a3b8">architecture.md</a>.</small>
     </div>
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Invarianten der App. Sie ist die Pflicht-Lektüre, bevor strukturelle Änderunge
 gemacht werden. Für die interaktive Modul-Übersicht siehe [`app-structure.html`](./app-structure.html),
 für einen Wettbewerber-Vergleich [`comparison.html`](./comparison.html).
 
-Stand: v9.0.0 · ~444 TS/TSX-Module · ~129.5k LOC
+Stand: v9.0.0 · ~444 TS/TSX-Module · ~129.6k LOC
 
 ---
 
@@ -553,7 +553,7 @@ optionales Cloud-Backend (`y-websocket`, Auth/Permissions) bleiben offen.
 `vitest` ist eingerichtet (`npm test` / `npm run test:watch`); dazu kommen
 gezielte Node-Checks (`npm run test:crdt`, `npm run test:signaling`), ein
 UI-Smoke-Skript (`npm run ui:smoke`) und ein headless Drag-/Interaktions-Test
-(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~129.5k LOC
+(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~129.6k LOC
 bleibt der Ausbau der Abdeckung wichtig — empfohlene Schwerpunkte:
 - Snapshot-Tests auf `healProjectPositions` mit echten
   Beispiel-Projekt-JSONs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Invarianten der App. Sie ist die Pflicht-Lektüre, bevor strukturelle Änderunge
 gemacht werden. Für die interaktive Modul-Übersicht siehe [`app-structure.html`](./app-structure.html),
 für einen Wettbewerber-Vergleich [`comparison.html`](./comparison.html).
 
-Stand: v9.0.0 · ~443 TS/TSX-Module · ~129.2k LOC
+Stand: v9.0.0 · ~444 TS/TSX-Module · ~129.5k LOC
 
 ---
 
@@ -553,7 +553,7 @@ optionales Cloud-Backend (`y-websocket`, Auth/Permissions) bleiben offen.
 `vitest` ist eingerichtet (`npm test` / `npm run test:watch`); dazu kommen
 gezielte Node-Checks (`npm run test:crdt`, `npm run test:signaling`), ein
 UI-Smoke-Skript (`npm run ui:smoke`) und ein headless Drag-/Interaktions-Test
-(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~129.2k LOC
+(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~129.5k LOC
 bleibt der Ausbau der Abdeckung wichtig — empfohlene Schwerpunkte:
 - Snapshot-Tests auf `healProjectPositions` mit echten
   Beispiel-Projekt-JSONs.

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -62,14 +62,14 @@
 <header>
   <h1>Cable-Planner — Strukturvergleich mit ähnlichen Tools</h1>
   <div class="subtitle">Architektur, Tech-Stack und Domänen-Tiefe im Vergleich zu kommerziellen und Open-Source-Alternativen</div>
-  <div class="meta">Stand: 2026-06 · v9.0.0 · ~443 TS/TSX-Module · ~129.2k LOC · ~5.2 MB src/</div>
+  <div class="meta">Stand: 2026-06 · v9.0.0 · ~444 TS/TSX-Module · ~129.5k LOC · ~5.2 MB src/</div>
 </header>
 
 <h2>1 · Cable-Planner — Architektur-Kennzahlen</h2>
 
 <div class="stat-grid">
-  <div class="stat"><div class="num">443</div><div class="label">TS/TSX-Module</div></div>
-  <div class="stat"><div class="num">129.2k</div><div class="label">Lines of Code</div></div>
+  <div class="stat"><div class="num">444</div><div class="label">TS/TSX-Module</div></div>
+  <div class="stat"><div class="num">129.5k</div><div class="label">Lines of Code</div></div>
   <div class="stat"><div class="num">~75</div><div class="label">Modul-Dependencies</div></div>
   <div class="stat"><div class="num">7</div><div class="label">User-Flows</div></div>
 </div>

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -62,14 +62,14 @@
 <header>
   <h1>Cable-Planner — Strukturvergleich mit ähnlichen Tools</h1>
   <div class="subtitle">Architektur, Tech-Stack und Domänen-Tiefe im Vergleich zu kommerziellen und Open-Source-Alternativen</div>
-  <div class="meta">Stand: 2026-06 · v9.0.0 · ~444 TS/TSX-Module · ~129.5k LOC · ~5.2 MB src/</div>
+  <div class="meta">Stand: 2026-06 · v9.0.0 · ~444 TS/TSX-Module · ~129.6k LOC · ~5.2 MB src/</div>
 </header>
 
 <h2>1 · Cable-Planner — Architektur-Kennzahlen</h2>
 
 <div class="stat-grid">
   <div class="stat"><div class="num">444</div><div class="label">TS/TSX-Module</div></div>
-  <div class="stat"><div class="num">129.5k</div><div class="label">Lines of Code</div></div>
+  <div class="stat"><div class="num">129.6k</div><div class="label">Lines of Code</div></div>
   <div class="stat"><div class="num">~75</div><div class="label">Modul-Dependencies</div></div>
   <div class="stat"><div class="num">7</div><div class="label">User-Flows</div></div>
 </div>

--- a/src/renderer/components/Patch/PatchListDialog.tsx
+++ b/src/renderer/components/Patch/PatchListDialog.tsx
@@ -20,6 +20,17 @@ import { Cable as CableIcon, Tag, Download } from 'lucide-react'
 import { ModalShell } from '../shared/ModalShell'
 import { Icon } from '../shared/Icon'
 import { useTranslation } from '../../lib/i18n'
+import { csvFromTable } from '../../lib/documentStamp'
+import {
+  bandView,
+  buildChannelList,
+  consoleView,
+  monitorPaths,
+  monitorView,
+  stageView,
+  venueView,
+  type ChannelViewId,
+} from '../../lib/channelList'
 import type { Cable } from '../../types/cable'
 import type { EquipmentItem, Port } from '../../types/equipment'
 
@@ -65,6 +76,7 @@ export const PatchListDialog = () => {
   const [sortKey, setSortKey] = useState<SortKey>('fromDevice')
   // #349 — Ziel-Format fuer den Label-Drucker-CSV-Export.
   const [labelCsvFormat, setLabelCsvFormat] = useState<LabelCsvFormat>('generic')
+  const [channelView, setChannelView] = useState<ChannelViewId>('venue')
 
   const rows = useMemo<PatchRow[]>(() => {
     if (!open) return []
@@ -238,6 +250,13 @@ export const PatchListDialog = () => {
     })
   }, [rows, filter, layerFilter])
 
+
+  // Bedarf 37 — die Kanalliste. VOR dem frueh zurueckkehrenden Zweig, weil
+  // Hooks in jeder Runde in derselben Reihenfolge laufen muessen; unten neben
+  // den Export-Funktionen stehend liefe sie nur, wenn der Dialog offen ist,
+  // und React beschwert sich zu Recht.
+  const channels = useMemo(() => buildChannelList(equipment, cables), [equipment, cables])
+  const monitors = useMemo(() => monitorPaths(equipment, cables), [equipment, cables])
 
   if (!open) return null
 
@@ -437,32 +456,30 @@ export const PatchListDialog = () => {
     )
   }
 
-  // #353 — Audio-Eingangsliste: die Audio-Layer-Kabel als nummerierte
-  // Kanal-Liste (Ch · Quelle · Port · Stecker · nach Gerät · Länge). Der
-  // klassische FOH-Deliverable; baut auf den vorhandenen Patch-Rows auf.
-  const exportInputList = () => {
-    const audioRows = filtered.filter((r) => r.layer === 'audio')
-    const escape = (v: unknown) => {
-      const s = sanitizeForPdf(String(v ?? ''))
-      return /[";\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
-    }
-    const header = [
-      t('inputList.col.ch', 'Ch'),
-      t('inputList.col.source', 'Quelle'),
-      t('inputList.col.port', 'Port'),
-      t('inputList.col.connector', 'Stecker'),
-      t('inputList.col.toDevice', 'nach Gerät'),
-      t('export.bom.csv.lengthM', 'Länge (m)'),
-    ]
-    const lines = [
-      header.join(';'),
-      ...audioRows.map((r, i) =>
-        [String(i + 1), r.fromDevice, r.fromPort, r.type, r.toDevice, r.length || ''].map(escape).join(';'),
-      ),
-    ]
+  // Bedarf 37 — EINE Kanalliste, FUENF Sichten.
+  //
+  // Hier stand bis dahin genau EINE CSV: die Eingangsliste aus `#353`, im
+  // Dialog gebaut und nur fuer einen Leser richtig. Die Bedarfs-Datenbank sagt
+  // woertlich, was der naechste Schritt ist: „Next step is PROJECTIONS of one
+  // dataset, NOT MORE FIELDS: band view, venue view (port), monitor-mix view,
+  // stage view, console view." Die Ableitung liegt deshalb jetzt in
+  // `lib/channelList.ts` und nicht mehr in diesem Dialog — sie hat fuenf Leser
+  // und gehoert keinem davon.
+
+  const exportChannelView = (view: ChannelViewId) => {
+    const table =
+      view === 'band'
+        ? bandView(channels)
+        : view === 'venue'
+          ? venueView(channels)
+          : view === 'stage'
+            ? stageView(channels)
+            : view === 'console'
+              ? consoleView(channels)
+              : monitorView(monitors)
     downloadBlob(
-      buildExportFilenameWithSuffix(projectName || 'cable-planner', 'eingangsliste', 'csv'),
-      '﻿' + lines.join('\r\n'),
+      buildExportFilenameWithSuffix(projectName || 'cable-planner', `kanalliste-${view}`, 'csv'),
+      csvFromTable(table),
       'text/csv;charset=utf-8',
     )
   }
@@ -531,15 +548,39 @@ export const PatchListDialog = () => {
             >
               {t('patchList.exportLabelCsv', '🏷 Etiketten-CSV')}
             </button>
-            {/* #353 — Audio-Eingangsliste (nur sichtbar wenn Audio-Kabel da). */}
-            {filtered.some((r) => r.layer === 'audio') && (
-              <button
-                type="button"
-                onClick={exportInputList}
-                className="rounded bg-purple-700 px-3 py-1 text-cp-xs hover:bg-purple-600"
-              >
-                {t('patchList.exportInputList', '🎚 Eingangsliste')}
-              </button>
+            {/* Bedarf 37 — die fuenf Sichten auf dieselbe Kanalliste. Sichtbar,
+                sobald es Audio-Kanaele gibt; die Monitor-Sicht zusaetzlich nur,
+                wenn es Monitor-Wege gibt — ein leeres Blatt anzubieten waere
+                ein Versprechen ohne Inhalt. */}
+            {channels.length > 0 && (
+              <>
+                <select
+                  value={channelView}
+                  onChange={(e) => setChannelView(e.target.value as ChannelViewId)}
+                  title={t('channelList.view', 'Sicht auf die Kanalliste')}
+                  aria-label={t('channelList.view', 'Sicht auf die Kanalliste')}
+                  className="rounded border border-cp-border bg-cp-surface-3 px-1 py-1 text-cp-xs"
+                >
+                  <option value="band">{t('channelList.view.band', 'Band (Rider)')}</option>
+                  <option value="venue">{t('channelList.view.venue', 'Haus (Patch)')}</option>
+                  <option value="stage">{t('channelList.view.stage', 'Bühne (Position)')}</option>
+                  <option value="console">{t('channelList.view.console', 'Pult (Namen)')}</option>
+                  {monitors.length > 0 && (
+                    <option value="monitor">{t('channelList.view.monitor', 'Monitor-Wege')}</option>
+                  )}
+                </select>
+                <button
+                  type="button"
+                  onClick={() => exportChannelView(channelView)}
+                  title={t(
+                    'channelList.exportHint',
+                    'Dieselbe Kanalliste, für diesen Leser geschnitten. Die Monitor-Sicht zeigt Wege, nicht Mix-Inhalte — die kennt der Plan nicht.',
+                  )}
+                  className="rounded bg-purple-700 px-3 py-1 text-cp-xs hover:bg-purple-600"
+                >
+                  {t('channelList.export', '🎚 Kanalliste')}
+                </button>
+              </>
             )}
           </div>
         </div>

--- a/src/renderer/lib/channelList.ts
+++ b/src/renderer/lib/channelList.ts
@@ -1,0 +1,287 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Eine Kanalliste, fuenf Sichten (Bedarf 37, P1).
+//
+// DER BEFUND, und er ist eine Kette aus Abschriften:
+//
+//   > Band's rider in Word/Pages -> e-mail -> house input list in Excel ->
+//   > console scene -> stage box labels. A working engineer reports having to
+//   > fill out a standalone patch list AND a second one inside the tech rider
+//   > section of the same tool.
+//
+// Belegt an `SoundDocs/sounddocs#111` (2025-10-10): jemand muss dieselbe
+// Patch-Liste zweimal ausfuellen und bittet darum, dass die eine die andere
+// referenziert, damit Aenderungen durchschlagen.
+//
+// ─── DIE ANWEISUNG DER BEDARFS-DATENBANK IST WOERTLICH UND SCHARF ──────────
+//
+//   > cable-planner #353 already ships the input-list deliverable with the
+//   > right fields. Next step is PROJECTIONS of one dataset, NOT MORE FIELDS:
+//   > band view, venue view (port), monitor-mix view, stage view, console view.
+//
+// Also: kein neues Datenmodell, keine neuen Felder. Was hier entsteht, ist die
+// Zusammenstellung dessen, was der Plan schon weiss — einmal berechnet, fuenf
+// Mal anders geschnitten. Wer eine Sicht liest, sieht seine Spalten und nicht
+// die der anderen; wer die Quelle aendert, aendert alle fuenf.
+//
+// ─── DIE MONITOR-SICHT ZEIGT WEGE, NICHT MIX-INHALTE ───────────────────────
+//
+// Was in einem Monitor-Mix liegt, entscheidet der Monitormann am Pult; der
+// Plan kann es nicht wissen, und ein Feld dafuer waeren genau die „more
+// fields", die der Bedarf ausschliesst. Was der Plan WEISS, ist der Weg:
+// welcher Mischer-Ausgang auf welchen Wedge oder welche IEM-Strecke geht. Das
+// steht im Kabelgraphen und ist nachpruefbar. Die Sicht heisst deshalb
+// „Monitor-Wege" und nicht „Monitor-Mixe" — der Unterschied ist der zwischen
+// einer Ableitung und einer Behauptung.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { Cable } from '../types/cable'
+import type { EquipmentItem, Port } from '../types/equipment'
+import type { CsvCell, CsvTable } from './csv'
+import { topLayer, detectLayerForConnector } from './cableLayers'
+import { portDisplayLabel } from './portLabel'
+import { fitToTarget, LABEL_TARGETS } from './labelTargets'
+
+/** Eine Zeile der EINEN Kanalliste. Alle fuenf Sichten schneiden hieraus. */
+export interface ChannelRow {
+  /** Kanalnummer, 1-basiert, in der Reihenfolge der Liste. */
+  ch: number
+  /** Das Kabel, aus dem die Zeile stammt — der Beleg. */
+  cableId: string
+  /** Quelle: das Geraet am anderen Ende (Mikro, DI, Playback …). */
+  source: string
+  /** Was die Quelle ist, soweit der Katalog es sagt (Untertitel/Kategorie). */
+  sourceKind?: string
+  /** Port an der Quelle. */
+  sourcePort: string
+  /** Ziel: Stagebox, Pult, Interface. */
+  destination: string
+  /** Port am Ziel — die Patch-Nummer, die auf dem Blech steht. */
+  destinationPort: string
+  /** Steckverbinder. */
+  connector: string
+  /** Kabellaenge in Metern, wenn gepflegt. */
+  lengthM?: number
+  /** Position der Quelle auf der Buehne, in Plan-Einheiten. */
+  x?: number
+  y?: number
+}
+
+/**
+ * Die Kanalliste aus dem Plan.
+ *
+ * Grundlage sind die Kabel der Audio-Ebene — dieselbe Auswahl, die die
+ * Eingangsliste aus `#353` trifft, nur an einer Stelle statt im Dialog. Die
+ * Ebene wird abgeleitet, wenn sie nicht gepflegt ist: `detectLayerForConnector`
+ * ist die Regel, die der Planer beim Anlegen ohnehin anwendet. Ein Kabel ohne
+ * gepflegte Ebene faellt sonst aus der Liste, obwohl sein XLR-Stecker
+ * eindeutig ist.
+ */
+export function buildChannelList(equipment: EquipmentItem[], cables: Cable[]): ChannelRow[] {
+  const byId = new Map(equipment.map((e) => [e.id, e]))
+  const portOf = (e: EquipmentItem | undefined, id: string): Port | undefined =>
+    e ? [...(e.inputs ?? []), ...(e.outputs ?? [])].find((p) => p.id === id) : undefined
+
+  const audio = cables.filter((c) => {
+    const gepflegt = topLayer(c.layer)
+    if (gepflegt) return gepflegt === 'audio'
+    return detectLayerForConnector(c.type) === 'audio'
+  })
+
+  // Sortiert nach Ziel-Port, dann Quelle: das ist die Reihenfolge, in der
+  // jemand die Stagebox absteckt. Eine Liste in Anlege-Reihenfolge waere fuer
+  // jeden der fuenf Leser die falsche.
+  const rows = audio
+    .map((c) => {
+      const from = byId.get(c.fromEquipmentId)
+      const to = byId.get(c.toEquipmentId)
+      const fromPort = portOf(from, c.fromPortId)
+      const toPort = portOf(to, c.toPortId)
+      return {
+        cableId: c.id,
+        source: from?.name ?? '',
+        sourceKind: from?.subtitle || from?.category || undefined,
+        sourcePort: fromPort ? portDisplayLabel(fromPort) : '',
+        destination: to?.name ?? '',
+        destinationPort: toPort ? portDisplayLabel(toPort) : '',
+        connector: String(c.type ?? ''),
+        lengthM: c.length || undefined,
+        x: from?.x,
+        y: from?.y,
+      }
+    })
+    .sort((a, b) =>
+      a.destination === b.destination
+        ? a.destinationPort.localeCompare(b.destinationPort, 'de', { numeric: true })
+        : a.destination.localeCompare(b.destination, 'de'),
+    )
+
+  return rows.map((r, i) => ({ ch: i + 1, ...r }))
+}
+
+/**
+ * SICHT 1 — die Band.
+ *
+ * Was im Rider steht: Kanal, was gespielt wird, womit abgenommen. Kein
+ * Stagebox-Port, keine Kabellaenge — das interessiert dort niemanden, und eine
+ * Spalte, die niemand liest, macht das Blatt unlesbar.
+ */
+export function bandView(rows: ChannelRow[]): CsvTable {
+  return {
+    headers: ['Ch', 'Quelle', 'Art', 'Abnahme'],
+    rows: rows.map((r): CsvCell[] => [r.ch, r.source, r.sourceKind ?? '', r.sourcePort]),
+  }
+}
+
+/**
+ * SICHT 2 — das Haus.
+ *
+ * Die Patch-Sicht: welcher Kanal auf welchen Port, mit welchem Stecker und
+ * welcher Laenge. Das ist die Liste, die beim Abstecken in der Hand liegt.
+ */
+export function venueView(rows: ChannelRow[]): CsvTable {
+  return {
+    headers: ['Ch', 'Quelle', 'Ziel', 'Port', 'Stecker', 'Laenge (m)'],
+    rows: rows.map((r): CsvCell[] => [
+      r.ch,
+      r.source,
+      r.destination,
+      r.destinationPort,
+      r.connector,
+      r.lengthM ?? '',
+    ]),
+  }
+}
+
+/**
+ * SICHT 3 — die Buehne.
+ *
+ * Kanal und Position. Die Koordinaten stehen im Plan; sie hier auszugeben ist
+ * eine Projektion und keine neue Angabe. Wo eine Quelle nicht platziert ist,
+ * bleibt die Spalte leer statt (0|0) zu behaupten — das waere die Buehnenmitte.
+ */
+export function stageView(rows: ChannelRow[]): CsvTable {
+  return {
+    headers: ['Ch', 'Quelle', 'X', 'Y'],
+    rows: rows.map((r): CsvCell[] => [
+      r.ch,
+      r.source,
+      r.x === undefined ? '' : Math.round(r.x),
+      r.y === undefined ? '' : Math.round(r.y),
+    ]),
+  }
+}
+
+/**
+ * SICHT 4 — das Pult.
+ *
+ * Kanal und Name, zugeschnitten auf das Zeichenbudget, das an Dante-Namen
+ * haengt (1–31 Zeichen, DNS-SD-konform; `labelTargets.ts#dante-device`).
+ *
+ * WARUM AUSGERECHNET DIESES BUDGET und nicht ein erfundenes Pult-Limit: die
+ * Regel in `labelTargets.ts` lautet *kein Anker ohne Ziel-Spec*, und fuer
+ * Mischpult-Kanalnamen liegt in dieser Recherche KEIN belegtes Limit vor. Das
+ * Dante-Budget dagegen ist belegt (Audinate) und in derselben Kette wirksam:
+ * der Kanalname wandert ueber die Stagebox, und dort gilt er.
+ *
+ * `fitToTarget` liefert mit, OB gekuerzt wurde — eine stillschweigend
+ * abgeschnittene Beschriftung ist genau die Sorte Fehler, die erst am Pult
+ * auffaellt.
+ */
+export function consoleView(rows: ChannelRow[]): CsvTable {
+  return {
+    headers: ['Ch', 'Name', 'Gekuerzt'],
+    rows: rows.map((r): CsvCell[] => {
+      const fitted = fitToTarget(r.source, LABEL_TARGETS['dante-device'])
+      // `truncated` UND die nicht transportierbaren Zeichen: ein Name, der nur
+      // seine Umlaute verliert, ist nicht gekuerzt und trotzdem ein anderer.
+      const hinweis =
+        fitted.truncated || fitted.value !== fitted.raw ? `aus: ${r.source}` : ''
+      return [r.ch, fitted.value, hinweis]
+    }),
+  }
+}
+
+/** Ein Monitor-Weg: welcher Ausgang speist welches Geraet. */
+export interface MonitorPath {
+  /** Der Mischer/das Pult. */
+  console: string
+  /** Ausgang am Pult. */
+  outputPort: string
+  /** Wedge, IEM-Sender, Kopfhoerer-Amp. */
+  sink: string
+  sinkPort: string
+  cableId: string
+}
+
+/**
+ * SICHT 5 — die Monitor-WEGE.
+ *
+ * Nicht die Mix-Inhalte: was in einem Mix liegt, entscheidet der Monitormann
+ * am Pult, und ein Feld dafuer waeren genau die „more fields", die der Bedarf
+ * ausschliesst. Der Weg dagegen steht im Kabelgraphen.
+ *
+ * Erkannt wird er an der Senke: ein Geraet, dessen Kategorie oder Name es als
+ * Wedge, IEM-Strecke oder Kopfhoererverstaerker ausweist, und das ueber ein
+ * Audio-Kabel von einem Ausgang gespeist wird. `monitorSinks` ist die Liste
+ * dieser Kennungen und steht als Daten da, damit sie erweiterbar ist, ohne die
+ * Ableitung anzufassen.
+ */
+export const MONITOR_SINK_PATTERNS: ReadonlyArray<RegExp> = [
+  /\bwedge\b/i,
+  /\bmonitor\b/i,
+  /\biem\b/i,
+  /in[- ]?ear/i,
+  /\bsidefill\b/i,
+  /kopfh(oe|ö)rer/i,
+  /\bheadphone/i,
+]
+
+export function monitorPaths(equipment: EquipmentItem[], cables: Cable[]): MonitorPath[] {
+  const byId = new Map(equipment.map((e) => [e.id, e]))
+  const isMonitorSink = (e: EquipmentItem): boolean =>
+    MONITOR_SINK_PATTERNS.some((re) => re.test(e.name) || re.test(e.category ?? ''))
+
+  const out: MonitorPath[] = []
+  for (const c of cables) {
+    const layer = topLayer(c.layer) ?? detectLayerForConnector(c.type)
+    if (layer !== 'audio') continue
+    const from = byId.get(c.fromEquipmentId)
+    const to = byId.get(c.toEquipmentId)
+    if (!from || !to || !isMonitorSink(to)) continue
+    const fromPort = [...(from.inputs ?? []), ...(from.outputs ?? [])].find((p) => p.id === c.fromPortId)
+    const toPort = [...(to.inputs ?? []), ...(to.outputs ?? [])].find((p) => p.id === c.toPortId)
+    out.push({
+      console: from.name,
+      outputPort: fromPort ? portDisplayLabel(fromPort) : '',
+      sink: to.name,
+      sinkPort: toPort ? portDisplayLabel(toPort) : '',
+      cableId: c.id,
+    })
+  }
+  return out.sort((a, b) =>
+    a.console === b.console
+      ? a.outputPort.localeCompare(b.outputPort, 'de', { numeric: true })
+      : a.console.localeCompare(b.console, 'de'),
+  )
+}
+
+export function monitorView(paths: MonitorPath[]): CsvTable {
+  return {
+    headers: ['Pult', 'Ausgang', 'Ziel', 'Eingang'],
+    rows: paths.map((p): CsvCell[] => [p.console, p.outputPort, p.sink, p.sinkPort]),
+  }
+}
+
+/** Die fuenf Sichten mit ihrem Schluessel — damit die Oberflaeche sie
+ *  aufzaehlen kann, ohne die Liste ein zweites Mal zu fuehren. */
+export type ChannelViewId = 'band' | 'venue' | 'stage' | 'console' | 'monitor'
+
+export const CHANNEL_VIEWS: ReadonlyArray<ChannelViewId> = [
+  'band',
+  'venue',
+  'stage',
+  'console',
+  'monitor',
+]

--- a/src/renderer/lib/exportStagePlot.ts
+++ b/src/renderer/lib/exportStagePlot.ts
@@ -1,22 +1,62 @@
-// #353 — Stage-Plot als Deliverable (nativ).
+// ───────────────────────────────────────────────────────────────────────────
+// Der Stage-Plot als EIN-SEITEN-LIEFERUNG (Bedarf 38, P1).
 //
-// Erzeugt eine top-down SVG-Übersicht der "Audio-Welt" des Plans: alle Geräte,
-// die an mindestens einem Audio-Layer-Kabel hängen (Mics/DIs/Stageboxen/Pulte),
-// an ihrer Canvas-Position, nummeriert + beschriftet — als Stage-Plot/Input-
-// Positions-Übersicht zum Mitschicken. Self-contained (nur Projektdaten +
-// Layer-Heuristik), damit kein DOM/Store nötig ist.
+// WOFUER. Der Markt-Standard fuer dieses Blatt ist gestorben: StagePlotPro
+// gilt als „highly regarded", aber „the official purchase channels have been
+// discontinued, making this excellent software inaccessible". Die Folge steht
+// als Zaehlung im Dossier: **21 unabhaengige Repositories namens „stageplot"**
+// auf GitHub zwischen 2016 und 2026 — jeder baut es sich neu. Und der Grund,
+// warum ein Textfeld nicht reicht, steht daneben: „Promoters expect a
+// drawing, not a text field."
 //
-// Hinweis: bewusst eine schlanke, native Variante. Eine reichere Stage-Plot-
-// Symbolik (Instrumenten-Icons o.ä.) wäre ein Folgeausbau.
+// WAS DIE BEDARFS-DATENBANK VERLANGT, und es ist mehr als ein Bild:
+//
+//   > Stage plot as a first-class, offline, one-page deliverable **that also
+//   > generates the input list and monitor mix list from the same objects**.
+//
+// Genau das ist der Unterschied zwischen einer Zeichnung und einer Lieferung:
+// Zeichnung UND Legende auf EINEM Blatt, aus DENSELBEN Objekten, mit
+// DERSELBEN Nummer.
+//
+// ─── DIE NUMMER IST DER KANAL ──────────────────────────────────────────────
+//
+// Bis hierher nummerierte dieses Blatt nach Canvas-Position (oben nach unten,
+// links nach rechts). Seit `cable#706` nummeriert die Kanalliste nach
+// Absteck-Reihenfolge (Ziel-Port). Zwei verschiedene Nummern fuer dasselbe
+// Mikrofon auf einem Blatt sind schlimmer als gar keine: der Techniker liest
+// „3" im Plot, sucht Kanal 3 auf der Stagebox und findet ein anderes Geraet.
+//
+// Die Nummer im Plot ist deshalb die KANALNUMMER. Geraete, die kein Kanal
+// sind (Stagebox, Pult, Wedge), bekommen keine — sie sind Ziel und nicht
+// Quelle, und eine Nummer an ihnen waere eine Behauptung ueber die Patchliste.
+//
+// Self-contained (nur Projektdaten + die Kanal-Ableitung), damit kein DOM und
+// kein Store noetig ist — „offline, account-free" ist Teil des Bedarfs.
+// ───────────────────────────────────────────────────────────────────────────
 
 import type { CablePlannerProject } from '../types/project'
 import { topLayer } from './cableLayers'
+import { buildChannelList, monitorPaths } from './channelList'
 
 const esc = (s: string): string =>
   s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 
 export const exportStagePlotSvg = (project: CablePlannerProject): string => {
-  // Audio-Geräte = Endpunkte von Audio-Layer-Kabeln.
+  // Die Kanalliste ist DIESELBE wie in der Patchliste (Bedarf 37) — nicht eine
+  // zweite Ableitung daneben. Genau das verlangt Bedarf 38: „generates the
+  // input list … from the same objects".
+  const channels = buildChannelList(project.equipment, project.cables)
+  const monitors = monitorPaths(project.equipment, project.cables)
+  const chByEquipment = new Map<string, number>()
+  const byCableId = new Map(project.cables.map((c) => [c.id, c]))
+  for (const row of channels) {
+    const cable = byCableId.get(row.cableId)
+    if (cable && !chByEquipment.has(cable.fromEquipmentId)) {
+      chByEquipment.set(cable.fromEquipmentId, row.ch)
+    }
+  }
+
+  // Audio-Geraete = Endpunkte von Audio-Layer-Kabeln.
   const audioIds = new Set<string>()
   for (const c of project.cables) {
     if (topLayer(c.layer) === 'audio') {
@@ -53,12 +93,20 @@ export const exportStagePlotSvg = (project: CablePlannerProject): string => {
   }
   const pad = 60
   const titleH = 60
+  // Die Legende steht RECHTS neben der Zeichnung, auf demselben Blatt. Ein
+  // zweites Blatt waere genau die Trennung, an der der Bedarf haengt: das
+  // Bild geht an den Promoter, die Liste an den Tontechniker, und beide
+  // veralten getrennt.
+  const zeilen = channels.length + (monitors.length > 0 ? monitors.length + 2 : 0)
+  const legendW = zeilen > 0 ? 420 : 0
+  const legendH = 40 + zeilen * 22
   const vx = minX - pad
   const vy = minY - pad - titleH
-  const vw = maxX - minX + 2 * pad
-  const vh = maxY - minY + 2 * pad + titleH
+  const vw = maxX - minX + 2 * pad + legendW
+  const vh = Math.max(maxY - minY + 2 * pad + titleH, legendH + titleH + pad)
 
-  // Reihenfolge: oben→unten, links→rechts (stabile Nummerierung).
+  // Reihenfolge: oben→unten, links→rechts (stabile Zeichen-Reihenfolge). Die
+  // NUMMER kommt aus der Kanalliste, nicht aus dieser Sortierung.
   const ordered = [...devices].sort((a, b) => a.y - b.y || a.x - b.x)
 
   const parts: string[] = []
@@ -72,25 +120,30 @@ export const exportStagePlotSvg = (project: CablePlannerProject): string => {
   parts.push(
     `<text x="${minX - pad + 8}" y="${minY - pad - titleH + 52}" fill="#94a3b8" font-size="13">${
       audioFound
-        ? `${ordered.length} Audio-Quellen/-Ziele`
+        ? `${ordered.length} Audio-Quellen/-Ziele · ${channels.length} Kanäle`
         : `${ordered.length} Geräte — kein Audio-Kabel im Plan, daher alle`
     }</text>`,
   )
 
-  ordered.forEach((e, i) => {
+  ordered.forEach((e) => {
     const w = e.width ?? 240
     const h = e.height ?? 80
     const accent = e.nodeColor ?? '#ef4444'
+    const ch = chByEquipment.get(e.id)
     parts.push(
       `<rect x="${e.x}" y="${e.y}" width="${w}" height="${h}" rx="8" fill="#1e293b" stroke="${esc(accent)}" stroke-width="2"/>`,
     )
-    // Nummern-Kreis links oben.
-    parts.push(`<circle cx="${e.x + 16}" cy="${e.y + 16}" r="13" fill="${esc(accent)}"/>`)
+    // Die Nummer ist der KANAL. Ein Geraet ohne Kanal (Stagebox, Pult, Wedge)
+    // bekommt keine: es ist Ziel und nicht Quelle, und eine Nummer an ihm
+    // waere eine Behauptung ueber die Patchliste.
+    if (ch !== undefined) {
+      parts.push(`<circle cx="${e.x + 16}" cy="${e.y + 16}" r="13" fill="${esc(accent)}"/>`)
+      parts.push(
+        `<text x="${e.x + 16}" y="${e.y + 21}" fill="#0f172a" font-size="14" font-weight="700" text-anchor="middle">${ch}</text>`,
+      )
+    }
     parts.push(
-      `<text x="${e.x + 16}" y="${e.y + 21}" fill="#0f172a" font-size="14" font-weight="700" text-anchor="middle">${i + 1}</text>`,
-    )
-    parts.push(
-      `<text x="${e.x + 36}" y="${e.y + 21}" fill="#ffffff" font-size="13" font-weight="600">${esc(e.name)}</text>`,
+      `<text x="${e.x + (ch !== undefined ? 36 : 12)}" y="${e.y + 21}" fill="#ffffff" font-size="13" font-weight="600">${esc(e.name)}</text>`,
     )
     if (e.subtitle) {
       parts.push(
@@ -103,6 +156,39 @@ export const exportStagePlotSvg = (project: CablePlannerProject): string => {
       `<text x="${e.x + 12}" y="${e.y + h - 10}" fill="#64748b" font-size="11">${inCount} In · ${outCount} Out</text>`,
     )
   })
+
+  // ── Die Legende: die Eingangsliste auf demselben Blatt ──────────────────
+  if (zeilen > 0) {
+    const lx = maxX + pad
+    let ly = minY - pad + 24
+    parts.push(
+      `<text x="${lx}" y="${ly}" fill="#e2e8f0" font-size="15" font-weight="700">Eingangsliste</text>`,
+    )
+    ly += 22
+    for (const row of channels) {
+      const abnahme = row.sourcePort ? ` · ${row.sourcePort}` : ''
+      parts.push(
+        `<text x="${lx}" y="${ly}" fill="#cbd5e1" font-size="12">${row.ch}. ${esc(row.source)}${esc(abnahme)}</text>`,
+      )
+      parts.push(
+        `<text x="${lx + 300}" y="${ly}" fill="#64748b" font-size="11">${esc(row.destinationPort)}</text>`,
+      )
+      ly += 22
+    }
+    if (monitors.length > 0) {
+      ly += 14
+      parts.push(
+        `<text x="${lx}" y="${ly}" fill="#e2e8f0" font-size="15" font-weight="700">Monitor-Wege</text>`,
+      )
+      ly += 22
+      for (const m of monitors) {
+        parts.push(
+          `<text x="${lx}" y="${ly}" fill="#cbd5e1" font-size="12">${esc(m.outputPort)} → ${esc(m.sink)}</text>`,
+        )
+        ly += 22
+      }
+    }
+  }
 
   parts.push('</svg>')
   return parts.join('\n')

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3442,12 +3442,18 @@ export const en: Dict = {
   'patchList.labelCsv.brother': 'Brother P-touch (TXT)',
   'patchList.labelCsv.dymo': 'Dymo (CSV)',
   // #353 Audio input list
-  'patchList.exportInputList': '🎚 Input list',
-  'inputList.col.ch': 'Ch',
-  'inputList.col.source': 'Source',
-  'inputList.col.port': 'Port',
-  'inputList.col.connector': 'Connector',
-  'inputList.col.toDevice': 'To device',
+  /* Bedarf 37 — eine Kanalliste, fuenf Sichten. Keys: channelList.*
+     Die alten `patchList.exportInputList` und `inputList.col.*` sind weg: die
+     Eingangsliste war EINE Sicht von fuenf und baute ihre Spalten im Dialog. */
+  'channelList.view': 'View of the channel list',
+  'channelList.view.band': 'Band (rider)',
+  'channelList.view.venue': 'Venue (patch)',
+  'channelList.view.stage': 'Stage (position)',
+  'channelList.view.console': 'Console (names)',
+  'channelList.view.monitor': 'Monitor paths',
+  'channelList.export': '🎚 Channel list',
+  'channelList.exportHint':
+    'The same channel list, cut for this reader. The monitor view shows paths, not mix contents \u2014 the plan does not know those.',
   // #314 Replace device section
   'replaceDevice.title': 'Replace device',
   'replaceDevice.subtitle': 'Preserve cabling',

--- a/tests/channelList.test.ts
+++ b/tests/channelList.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest'
+import {
+  bandView,
+  buildChannelList,
+  CHANNEL_VIEWS,
+  consoleView,
+  monitorPaths,
+  monitorView,
+  stageView,
+  venueView,
+} from '../src/renderer/lib/channelList'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem, Port } from '../src/renderer/types/equipment'
+
+// ---------------------------------------------------------------------------
+// Eine Kanalliste, fuenf Sichten (Bedarf 37, P1).
+//
+// Der Befund ist eine Kette aus Abschriften: „Band's rider in Word/Pages ->
+// e-mail -> house input list in Excel -> console scene -> stage box labels."
+// Belegt an `SoundDocs/sounddocs#111`: jemand fuellt dieselbe Patch-Liste
+// zweimal aus und bittet darum, dass die eine die andere referenziert.
+//
+// Die Anweisung der Bedarfs-Datenbank ist woertlich und scharf:
+//
+//   > Next step is PROJECTIONS of one dataset, NOT MORE FIELDS.
+//
+// Geprueft wird deshalb genau das: dass alle fuenf Sichten aus DERSELBEN
+// Zeile schneiden, dass jede nur ihre eigenen Spalten zeigt, und dass die
+// Monitor-Sicht WEGE zeigt statt Mix-Inhalte -- die kennt der Plan nicht, und
+// ein Feld dafuer waeren genau die ausgeschlossenen „more fields".
+// ---------------------------------------------------------------------------
+
+const port = (id: string, name: string): Port =>
+  ({ id, name, type: 'port', connectorType: 'XLR' }) as Port
+
+const geraet = (name: string, over: Partial<EquipmentItem> = {}): EquipmentItem =>
+  ({
+    id: `id-${name}`,
+    name,
+    category: 'Audio',
+    inputs: [],
+    outputs: [],
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 100,
+    ...over,
+  }) as unknown as EquipmentItem
+
+const kabel = (
+  from: [string, string],
+  to: [string, string],
+  over: Partial<Cable> = {},
+): Cable =>
+  ({
+    id: `c-${from[1]}-${to[1]}`,
+    name: '',
+    type: 'XLR',
+    length: 10,
+    color: '#fff',
+    fromEquipmentId: from[0],
+    fromPortId: from[1],
+    toEquipmentId: to[0],
+    toPortId: to[1],
+    notes: '',
+    layer: 'audio',
+    ...over,
+  }) as unknown as Cable
+
+const aufbau = () => {
+  const mic = geraet('SM58 Lead Vox', { subtitle: 'Shure', outputs: [port('m1', 'OUT')], x: 300, y: 120 })
+  const di = geraet('DI Bass', { subtitle: 'Radial', outputs: [port('d1', 'OUT')], x: 500, y: 200 })
+  const box = geraet('Stagebox A', { inputs: [port('s1', '1'), port('s2', '2')] })
+  return {
+    equipment: [mic, di, box],
+    cables: [kabel([di.id, 'd1'], [box.id, 's2']), kabel([mic.id, 'm1'], [box.id, 's1'])],
+  }
+}
+
+describe('die eine Liste', () => {
+  it('nimmt die Audio-Ebene und nummeriert in Absteck-Reihenfolge', () => {
+    // Sortiert nach Ziel-Port, nicht nach Anlege-Reihenfolge: das ist die
+    // Reihenfolge, in der jemand die Stagebox absteckt. Die Anlege-Reihenfolge
+    // waere fuer jeden der fuenf Leser die falsche.
+    const { equipment, cables } = aufbau()
+    const rows = buildChannelList(equipment, cables)
+    expect(rows.map((r) => r.ch)).toEqual([1, 2])
+    expect(rows.map((r) => r.source)).toEqual(['SM58 Lead Vox', 'DI Bass'])
+    expect(rows.map((r) => r.destinationPort)).toEqual(['1', '2'])
+  })
+
+  it('leitet die Ebene ab, wenn sie nicht gepflegt ist', () => {
+    // Ein XLR-Kabel ohne gepflegte Ebene ist trotzdem Audio. Sonst faellt es
+    // aus der Liste, obwohl sein Stecker eindeutig ist.
+    const { equipment, cables } = aufbau()
+    const ohneLayer = cables.map((c) => ({ ...c, layer: undefined }) as Cable)
+    expect(buildChannelList(equipment, ohneLayer)).toHaveLength(2)
+  })
+
+  it('laesst Kabel anderer Ebenen draussen', () => {
+    const { equipment, cables } = aufbau()
+    const mitVideo = [...cables, kabel(['x', 'p'], ['y', 'q'], { type: 'BNC', layer: 'video' })]
+    expect(buildChannelList(equipment, mitVideo)).toHaveLength(2)
+  })
+
+  it('traegt das Kabel als Beleg mit', () => {
+    // Wer eine Zeile fuer falsch haelt, soll das Kabel finden, aus dem sie
+    // stammt -- dieselbe Belegpflicht wie im Adressplan.
+    const { equipment, cables } = aufbau()
+    for (const r of buildChannelList(equipment, cables)) {
+      expect(cables.some((c) => c.id === r.cableId)).toBe(true)
+    }
+  })
+})
+
+describe('fuenf Sichten, ein Datensatz', () => {
+  const rows = () => buildChannelList(aufbau().equipment, aufbau().cables)
+
+  it('die Band sieht ihre Spalten und nicht die des Hauses', () => {
+    const t = bandView(rows())
+    expect(t.headers).toEqual(['Ch', 'Quelle', 'Art', 'Abnahme'])
+    // Kein Stagebox-Port, keine Laenge: eine Spalte, die niemand liest, macht
+    // das Blatt unlesbar.
+    expect(t.headers).not.toContain('Port')
+    expect(t.headers).not.toContain('Laenge (m)')
+    expect(t.rows[0]).toEqual([1, 'SM58 Lead Vox', 'Shure', 'OUT'])
+  })
+
+  it('das Haus sieht Port, Stecker und Laenge', () => {
+    const t = venueView(rows())
+    expect(t.rows[0]).toEqual([1, 'SM58 Lead Vox', 'Stagebox A', '1', 'XLR', 10])
+  })
+
+  it('die Buehne sieht Positionen — und behauptet keine, wo keine ist', () => {
+    // (0|0) waere die Buehnenmitte. Eine leere Spalte ist ehrlicher.
+    const t = stageView([
+      ...rows(),
+      { ch: 3, cableId: 'c3', source: 'Ohne Platz', sourcePort: '', destination: '', destinationPort: '', connector: '' },
+    ])
+    expect(t.rows[0]).toEqual([1, 'SM58 Lead Vox', 300, 120])
+    expect(t.rows[2]).toEqual([3, 'Ohne Platz', '', ''])
+  })
+
+  it('das Pult sieht Namen im belegten Zeichenbudget', () => {
+    // 31 Zeichen, DNS-SD-konform (Audinate) -- das einzige in dieser Recherche
+    // BELEGTE Budget in dieser Kette. Ein erfundenes Pult-Limit waere ein
+    // Anker ohne Ziel-Spec, und genau das verbietet `labelTargets.ts`.
+    const lang = 'Ein sehr langer Kanalname der ueber einunddreissig Zeichen geht'
+    const t = consoleView([
+      { ch: 1, cableId: 'c1', source: lang, sourcePort: '', destination: '', destinationPort: '', connector: '' },
+    ])
+    expect(String(t.rows[0][1]).length).toBeLessThanOrEqual(31)
+    // Und die Kuerzung wird GENANNT: eine stillschweigend abgeschnittene
+    // Beschriftung faellt erst am Pult auf.
+    expect(String(t.rows[0][2])).toContain('aus:')
+  })
+
+  it('das Pult meldet nichts, wo nichts zu melden ist', () => {
+    const t = consoleView([
+      { ch: 1, cableId: 'c1', source: 'Lead-Vox', sourcePort: '', destination: '', destinationPort: '', connector: '' },
+    ])
+    expect(t.rows[0][2]).toBe('')
+  })
+
+  it('alle Sichten haben gleich viele Zeilen wie die Liste', () => {
+    // Der eigentliche Test der Zusage: EIN Datensatz, fuenf Schnitte. Verliert
+    // eine Sicht Zeilen, ist sie eine eigene Liste geworden.
+    const r = rows()
+    for (const t of [bandView(r), venueView(r), stageView(r), consoleView(r)]) {
+      expect(t.rows).toHaveLength(r.length)
+    }
+  })
+
+  it('fuehrt die fuenf Sichten an einer Stelle', () => {
+    expect([...CHANNEL_VIEWS].sort()).toEqual(['band', 'console', 'monitor', 'stage', 'venue'])
+  })
+})
+
+describe('die Monitor-Sicht zeigt WEGE', () => {
+  const monitorAufbau = () => {
+    const pult = geraet('Monitorpult', { outputs: [port('o1', 'Aux 1'), port('o2', 'Aux 2')] })
+    const wedge = geraet('Wedge SL', { inputs: [port('w1', 'IN')] })
+    const iem = geraet('IEM Sender Gitarre', { inputs: [port('i1', 'IN')] })
+    const box = geraet('Stagebox A', { inputs: [port('s1', '1')] })
+    return {
+      equipment: [pult, wedge, iem, box],
+      cables: [
+        kabel([pult.id, 'o1'], [wedge.id, 'w1']),
+        kabel([pult.id, 'o2'], [iem.id, 'i1']),
+        // Kein Monitor-Weg: ein Mikro auf die Stagebox.
+        kabel([box.id, 's1'], [box.id, 's1']),
+      ],
+    }
+  }
+
+  it('findet Wedge und IEM als Monitor-Ziele', () => {
+    const { equipment, cables } = monitorAufbau()
+    const wege = monitorPaths(equipment, cables)
+    expect(wege.map((w) => w.sink)).toEqual(['Wedge SL', 'IEM Sender Gitarre'])
+    expect(wege[0].outputPort).toBe('Aux 1')
+  })
+
+  it('nimmt eine gewoehnliche Audio-Strecke NICHT als Monitor-Weg', () => {
+    const { equipment, cables } = monitorAufbau()
+    expect(monitorPaths(equipment, cables)).toHaveLength(2)
+  })
+
+  it('behauptet keine Mix-Inhalte', () => {
+    // Was in einem Mix liegt, entscheidet der Monitormann am Pult. Ein Feld
+    // dafuer waeren genau die „more fields", die der Bedarf ausschliesst --
+    // und es waere geraten.
+    const { equipment, cables } = monitorAufbau()
+    const t = monitorView(monitorPaths(equipment, cables))
+    expect(t.headers).toEqual(['Pult', 'Ausgang', 'Ziel', 'Eingang'])
+    for (const kopf of ['Mix', 'Kanal', 'Pegel', 'Send']) {
+      expect(t.headers, `behauptet Mix-Inhalt: ${kopf}`).not.toContain(kopf)
+    }
+  })
+})

--- a/tests/exportStagePlot.test.ts
+++ b/tests/exportStagePlot.test.ts
@@ -119,3 +119,100 @@ describe('der Vektor-PDF-Hinweis nennt auch, was fehlt', () => {
     expect(dictsSrc).toContain('state fingerprint')
   })
 })
+
+// ---------------------------------------------------------------------------
+// Bedarf 38 — der Plot als EIN-SEITEN-LIEFERUNG.
+//
+// Der Markt-Standard fuer dieses Blatt ist gestorben: StagePlotPro gilt als
+// „highly regarded", aber „the official purchase channels have been
+// discontinued". Die Folge steht als Zaehlung im Dossier: 21 unabhaengige
+// Repositories namens „stageplot" auf GitHub. Und: „Promoters expect a
+// drawing, not a text field."
+//
+// Die Bedarfs-Datenbank verlangt mehr als ein Bild:
+//
+//   > Stage plot as a first-class, offline, one-page deliverable that ALSO
+//   > GENERATES the input list and monitor mix list FROM THE SAME OBJECTS.
+//
+// Geprueft wird deshalb genau die Verbindung: dass die Nummer im Plot die
+// KANALNUMMER ist und nicht eine zweite Zaehlung daneben. Zwei verschiedene
+// Nummern fuer dasselbe Mikrofon auf einem Blatt sind schlimmer als keine --
+// der Techniker liest „3", sucht Kanal 3 auf der Stagebox und findet ein
+// anderes Geraet.
+// ---------------------------------------------------------------------------
+describe('Bedarf 38 — Zeichnung und Liste auf einem Blatt', () => {
+  const mitKanaelen = () => {
+    // Absichtlich so gelegt, dass die Canvas-Reihenfolge (oben nach unten)
+    // der Absteck-Reihenfolge (Ziel-Port) WIDERSPRICHT: das Mikro auf Port 2
+    // liegt oben. Nummerierte der Plot nach Position, stuende dort „1".
+    const mic1 = eq('mic1', 'SM58 Vox', 0, 0)
+    const mic2 = eq('mic2', 'DI Bass', 0, 400)
+    const box = {
+      ...eq('box', 'Stagebox A', 600, 200),
+      inputs: [
+        { id: 'box-1', name: '1', type: 'port', connectorType: 'XLR' },
+        { id: 'box-2', name: '2', type: 'port', connectorType: 'XLR' },
+      ],
+    } as unknown as EquipmentItem
+    const c1 = { ...cable('mic1', 'box', 'audio'), toPortId: 'box-2' } as unknown as Cable
+    const c2 = { ...cable('mic2', 'box', 'audio'), toPortId: 'box-1' } as unknown as Cable
+    return project([mic1, mic2, box], [c1, c2])
+  }
+
+  it('nummeriert nach KANAL und nicht nach Position', () => {
+    const svg = exportStagePlotSvg(mitKanaelen())
+    // „DI Bass" haengt auf Stagebox-Port 1 und ist damit Kanal 1 — obwohl es
+    // im Canvas UNTEN liegt.
+    const kreise = [...svg.matchAll(/font-weight="700" text-anchor="middle">(\d+)</g)].map((m) => m[1])
+    expect(kreise.sort()).toEqual(['1', '2'])
+    // Und die Zuordnung stimmt: die Nummer neben „DI Bass" ist die 1.
+    const diY = 400
+    const beiDi = svg.split('\n').filter((l) => l.includes(`y="${diY + 21}"`))
+    expect(beiDi.some((l) => l.includes('>1<'))).toBe(true)
+  })
+
+  it('gibt einem Ziel-Geraet KEINE Nummer', () => {
+    // Die Stagebox ist Ziel und nicht Quelle. Eine Nummer an ihr waere eine
+    // Behauptung ueber die Patchliste.
+    const svg = exportStagePlotSvg(mitKanaelen())
+    const beiBox = svg.split('\n').filter((l) => l.includes('Stagebox A'))
+    expect(beiBox.some((l) => l.includes('circle'))).toBe(false)
+  })
+
+  it('traegt die Eingangsliste auf DEMSELBEN Blatt', () => {
+    // Ein zweites Blatt waere genau die Trennung, an der der Bedarf haengt:
+    // das Bild geht an den Promoter, die Liste an den Tontechniker, und beide
+    // veralten getrennt.
+    const svg = exportStagePlotSvg(mitKanaelen())
+    expect(svg).toContain('Eingangsliste')
+    expect(svg).toContain('1. DI Bass')
+    expect(svg).toContain('2. SM58 Vox')
+  })
+
+  it('macht das Blatt breit genug fuer die Legende', () => {
+    // Sonst steht sie ausserhalb des viewBox und ist auf dem Ausdruck weg.
+    const svg = exportStagePlotSvg(mitKanaelen())
+    const vb = svg.match(/viewBox="(-?\d+(?:\.\d+)?) (-?\d+(?:\.\d+)?) (\d+(?:\.\d+)?) (\d+(?:\.\d+)?)"/)
+    expect(vb).toBeTruthy()
+    const [, vx, , vw] = vb!.map(Number)
+    // Der Legenden-Text beginnt bei maxX + pad = 600 + 240 + 60.
+    expect(vx + vw).toBeGreaterThan(900)
+  })
+
+  it('haengt die Monitor-Wege an, wenn es welche gibt', () => {
+    const pult = eq('pult', 'Monitorpult', 0, 800)
+    const wedge = eq('wedge', 'Wedge SL', 600, 800)
+    const p = project(
+      [...mitKanaelen().equipment, pult, wedge],
+      [...mitKanaelen().cables, cable('pult', 'wedge', 'audio')],
+    )
+    const svg = exportStagePlotSvg(p)
+    expect(svg).toContain('Monitor-Wege')
+    expect(svg).toContain('Wedge SL')
+  })
+
+  it('laesst den Monitor-Block weg, wenn es keine gibt', () => {
+    // Eine leere Ueberschrift ist ein Versprechen ohne Inhalt.
+    expect(exportStagePlotSvg(mitKanaelen())).not.toContain('Monitor-Wege')
+  })
+})


### PR DESCRIPTION
Zwei P1-Bedarfe des Ton-Dossiers, und der zweite baut auf dem ersten.

---

## Bedarf 37 — der Befund ist eine Kette aus Abschriften

> Band's rider in Word/Pages → e-mail → house input list in Excel → console scene → stage box labels. A working engineer reports having to fill out a standalone patch list **AND** a second one inside the tech rider section of the same tool.

Belegt an [`SoundDocs/sounddocs#111`](https://github.com/SoundDocs/sounddocs/issues/111) (2025-10-10): jemand füllt dieselbe Patch-Liste zweimal aus und bittet darum, dass die eine die andere referenziert.

Die Anweisung der Bedarfs-Datenbank ist wörtlich und scharf:

> cable-planner #353 already ships the input-list deliverable with the right fields. **Next step is PROJECTIONS of one dataset, NOT MORE FIELDS**: band view, venue view (port), monitor-mix view, stage view, console view.

Bis hierher gab es genau **eine** CSV — die Eingangsliste aus `#353`, im Patchlisten-Dialog gebaut und nur für einen Leser richtig. Die Ableitung liegt jetzt in `lib/channelList.ts`: sie hat fünf Leser und gehört keinem davon.

| Sicht | Spalten | Was bewusst fehlt |
| --- | --- | --- |
| **Band** (Rider) | Ch, Quelle, Art, Abnahme | Stagebox-Port, Länge — eine Spalte, die niemand liest, macht das Blatt unlesbar |
| **Haus** (Patch) | Ch, Quelle, Ziel, Port, Stecker, Länge | — |
| **Bühne** | Ch, Quelle, X, Y | wo keine Position ist, bleibt die Spalte **leer** statt (0\|0) — das wäre die Bühnenmitte |
| **Pult** | Ch, Name im Zeichenbudget, „gekürzt aus…" | — |
| **Monitor** | Pult, Ausgang, Ziel, Eingang | **Mix-Inhalte** |

**Warum die Pult-Sicht am Dante-Budget hängt:** `labelTargets.ts` schreibt *kein Anker ohne Ziel-Spec* vor, und für Mischpult-Kanalnamen liegt in dieser Recherche kein belegtes Limit vor. Das Dante-Budget ist belegt (Audinate: 1–31 Zeichen, DNS-SD-konform) und in derselben Kette wirksam. Die Kürzung wird **genannt** — eine stillschweigend abgeschnittene Beschriftung fällt erst am Pult auf.

**Warum die Monitor-Sicht Wege zeigt und keine Mix-Inhalte:** was in einem Mix liegt, entscheidet der Monitormann am Pult; ein Feld dafür wären genau die *„more fields"*, die der Bedarf ausschliesst. Was der Plan **weiss**, steht im Kabelgraphen: welcher Ausgang auf welchen Wedge geht. Ein Test hält fest, dass die Kopfzeile weder „Mix" noch „Send" noch „Pegel" führt.

Dazu zwei Details: **sortiert in Absteck-Reihenfolge** (Ziel-Port), nicht in Anlege-Reihenfolge; und die **Ebene wird abgeleitet**, wenn sie nicht gepflegt ist — ein XLR-Kabel ohne Layer ist trotzdem Audio.

---

## Bedarf 38 — der Stage-Plot als Lieferung, nicht als Bild

Der Markt-Standard für dieses Blatt ist **gestorben**: StagePlotPro gilt als *„highly regarded"*, aber *„the official purchase channels have been discontinued, making this excellent software inaccessible"*. Die Folge steht als Zählung im Dossier: **21 unabhängige Repositories namens „stageplot"** auf GitHub zwischen 2016 und 2026 — jeder baut es sich neu. Und: *„Promoters expect a drawing, not a text field."*

> Stage plot as a first-class, offline, one-page deliverable **that also generates the input list and monitor mix list from the same objects**.

**Die Nummer ist jetzt der Kanal.** Bis hierher nummerierte das Blatt nach Canvas-Position; die Kanalliste nummeriert nach Absteck-Reihenfolge. Zwei verschiedene Nummern für dasselbe Mikrofon auf einem Blatt sind schlimmer als gar keine: der Techniker liest „3", sucht Kanal 3 auf der Stagebox und findet ein anderes Gerät. Ein Test legt die Geräte absichtlich so, dass Canvas- und Absteck-Reihenfolge einander widersprechen.

**Ein Ziel-Gerät bekommt keine Nummer** — Stagebox, Pult und Wedge sind Ziel und nicht Quelle; eine Nummer an ihnen wäre eine Behauptung über die Patchliste.

**Die Legende steht auf demselben Blatt**, rechts neben der Zeichnung, und die Fläche wächst dafür mit. Ein zweites Blatt wäre genau die Trennung, an der der Bedarf hängt: das Bild geht an den Promoter, die Liste an den Tontechniker, und beide veralten getrennt. Die Monitor-Wege hängen darunter — aber nur, wenn es welche gibt.

Die Liste kommt aus `buildChannelList`, also aus **derselben** Ableitung wie die Patchlisten-Sichten. Genau das meint *„from the same objects"*.

---

## Gegenproben

Zwölf Fehler eingespritzt, jeder hat Tests umgeworfen:

| Eingespritzt | rot |
| --- | --- |
| in Anlege-Reihenfolge sortieren | 4 |
| jedes Audio-Kabel als Monitor-Weg nehmen · Legende weglassen | je 2 |
| Ebene nicht ableiten · Band-Sicht mit Haus-Spalten aufblähen · (0\|0) statt leer · Kürzung verschweigen · Mix-Inhalt behaupten · wieder nach Position nummerieren · Ziel-Geräte nummerieren · Blatt nicht verbreitern · leeren Monitor-Block schreiben | je 1 |

Beim Verdrahten kam ein echter Fehler dazu und wieder weg: die beiden `useMemo` standen zuerst **nach** `if (!open) return null` und liefen damit nur bei offenem Dialog — die Hook-Reihenfolge wäre von Runde zu Runde verschieden gewesen. `eslint` hat es gefangen.

## Erreichbar

- Patchliste → Sicht wählen → **Kanalliste** als CSV, mit Dokument-Stempel. Die Monitor-Sicht erscheint nur, wenn es Monitor-Wege gibt.
- Der Stage-Plot-Export trägt die Eingangsliste und die Monitor-Wege auf demselben Blatt.

Die alten Schlüssel `patchList.exportInputList` und `inputList.col.*` sind weg — die Eingangsliste war eine Sicht von fünf und baute ihre Spalten im Dialog.

## Geprüft

`tsc` auf allen drei Prozessen (0 Fehler) · `eslint` (0 Fehler) · `vitest` **1185/1187** (2 skipped), davon 20 neu · `npm run build` · `docs:stats` nachgezogen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT