### PR TITLE
delivery + lager: Encoder-Machbarkeit, Ablaufblatt, Container-Ausgabe (Bedarf 15, 33, 36)

### DIFF
--- a/docs/app-structure.html
+++ b/docs/app-structure.html
@@ -240,7 +240,7 @@
   <aside>
     <h1>Cable-Planner</h1>
     <div class="subtitle">
-      App-Struktur · v9.0.0 · ~444 TS/TSX-Module · ~129.6k LOC<br>
+      App-Struktur · v9.0.0 · ~445 TS/TSX-Module · ~130.0k LOC<br>
       <small style="color:#64748b">Diese Übersicht zeigt nur die ~62 wichtigsten Module. Für die vollständige Architektur siehe <a href="./architecture.md" style="color:#94a3b8">architecture.md</a>.</small>
     </div>
 

--- a/docs/app-structure.html
+++ b/docs/app-structure.html
@@ -240,7 +240,7 @@
   <aside>
     <h1>Cable-Planner</h1>
     <div class="subtitle">
-      App-Struktur · v9.0.0 · ~445 TS/TSX-Module · ~130.0k LOC<br>
+      App-Struktur · v9.0.0 · ~448 TS/TSX-Module · ~130.8k LOC<br>
       <small style="color:#64748b">Diese Übersicht zeigt nur die ~62 wichtigsten Module. Für die vollständige Architektur siehe <a href="./architecture.md" style="color:#94a3b8">architecture.md</a>.</small>
     </div>
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Invarianten der App. Sie ist die Pflicht-Lektüre, bevor strukturelle Änderunge
 gemacht werden. Für die interaktive Modul-Übersicht siehe [`app-structure.html`](./app-structure.html),
 für einen Wettbewerber-Vergleich [`comparison.html`](./comparison.html).
 
-Stand: v9.0.0 · ~445 TS/TSX-Module · ~130.0k LOC
+Stand: v9.0.0 · ~448 TS/TSX-Module · ~130.8k LOC
 
 ---
 
@@ -553,7 +553,7 @@ optionales Cloud-Backend (`y-websocket`, Auth/Permissions) bleiben offen.
 `vitest` ist eingerichtet (`npm test` / `npm run test:watch`); dazu kommen
 gezielte Node-Checks (`npm run test:crdt`, `npm run test:signaling`), ein
 UI-Smoke-Skript (`npm run ui:smoke`) und ein headless Drag-/Interaktions-Test
-(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~130.0k LOC
+(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~130.8k LOC
 bleibt der Ausbau der Abdeckung wichtig — empfohlene Schwerpunkte:
 - Snapshot-Tests auf `healProjectPositions` mit echten
   Beispiel-Projekt-JSONs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Invarianten der App. Sie ist die Pflicht-Lektüre, bevor strukturelle Änderunge
 gemacht werden. Für die interaktive Modul-Übersicht siehe [`app-structure.html`](./app-structure.html),
 für einen Wettbewerber-Vergleich [`comparison.html`](./comparison.html).
 
-Stand: v9.0.0 · ~444 TS/TSX-Module · ~129.6k LOC
+Stand: v9.0.0 · ~445 TS/TSX-Module · ~130.0k LOC
 
 ---
 
@@ -553,7 +553,7 @@ optionales Cloud-Backend (`y-websocket`, Auth/Permissions) bleiben offen.
 `vitest` ist eingerichtet (`npm test` / `npm run test:watch`); dazu kommen
 gezielte Node-Checks (`npm run test:crdt`, `npm run test:signaling`), ein
 UI-Smoke-Skript (`npm run ui:smoke`) und ein headless Drag-/Interaktions-Test
-(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~129.6k LOC
+(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~130.0k LOC
 bleibt der Ausbau der Abdeckung wichtig — empfohlene Schwerpunkte:
 - Snapshot-Tests auf `healProjectPositions` mit echten
   Beispiel-Projekt-JSONs.

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -62,14 +62,14 @@
 <header>
   <h1>Cable-Planner — Strukturvergleich mit ähnlichen Tools</h1>
   <div class="subtitle">Architektur, Tech-Stack und Domänen-Tiefe im Vergleich zu kommerziellen und Open-Source-Alternativen</div>
-  <div class="meta">Stand: 2026-06 · v9.0.0 · ~445 TS/TSX-Module · ~130.0k LOC · ~5.2 MB src/</div>
+  <div class="meta">Stand: 2026-06 · v9.0.0 · ~448 TS/TSX-Module · ~130.8k LOC · ~5.3 MB src/</div>
 </header>
 
 <h2>1 · Cable-Planner — Architektur-Kennzahlen</h2>
 
 <div class="stat-grid">
-  <div class="stat"><div class="num">445</div><div class="label">TS/TSX-Module</div></div>
-  <div class="stat"><div class="num">130.0k</div><div class="label">Lines of Code</div></div>
+  <div class="stat"><div class="num">448</div><div class="label">TS/TSX-Module</div></div>
+  <div class="stat"><div class="num">130.8k</div><div class="label">Lines of Code</div></div>
   <div class="stat"><div class="num">~75</div><div class="label">Modul-Dependencies</div></div>
   <div class="stat"><div class="num">7</div><div class="label">User-Flows</div></div>
 </div>

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -62,14 +62,14 @@
 <header>
   <h1>Cable-Planner — Strukturvergleich mit ähnlichen Tools</h1>
   <div class="subtitle">Architektur, Tech-Stack und Domänen-Tiefe im Vergleich zu kommerziellen und Open-Source-Alternativen</div>
-  <div class="meta">Stand: 2026-06 · v9.0.0 · ~444 TS/TSX-Module · ~129.6k LOC · ~5.2 MB src/</div>
+  <div class="meta">Stand: 2026-06 · v9.0.0 · ~445 TS/TSX-Module · ~130.0k LOC · ~5.2 MB src/</div>
 </header>
 
 <h2>1 · Cable-Planner — Architektur-Kennzahlen</h2>
 
 <div class="stat-grid">
-  <div class="stat"><div class="num">444</div><div class="label">TS/TSX-Module</div></div>
-  <div class="stat"><div class="num">129.6k</div><div class="label">Lines of Code</div></div>
+  <div class="stat"><div class="num">445</div><div class="label">TS/TSX-Module</div></div>
+  <div class="stat"><div class="num">130.0k</div><div class="label">Lines of Code</div></div>
   <div class="stat"><div class="num">~75</div><div class="label">Modul-Dependencies</div></div>
   <div class="stat"><div class="num">7</div><div class="label">User-Flows</div></div>
 </div>

--- a/src/renderer/components/Delivery/DeliveryDialog.tsx
+++ b/src/renderer/components/Delivery/DeliveryDialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { X, Plus, Trash2, AlertTriangle, Radio, Eye, EyeOff, Download } from 'lucide-react'
+import { X, Plus, Trash2, AlertTriangle, Radio, Eye, EyeOff, Download, Cpu, FileText } from 'lucide-react'
 import { useProjectStore } from '../../store/projectStore'
 import { useUiStore } from '../../store/uiStore'
 import { useTranslation, format } from '../../lib/i18n'
@@ -9,6 +9,13 @@ import { buildExportFilenameWithSuffix } from '../../lib/exportFilename'
 import { csvFromTable, stampForRows } from '../../lib/documentStamp'
 import { checkDelivery, deliveryTable, deliveryTableForProject, type DeliveryIssue } from '../../lib/deliveryParity'
 import { srtLatencyAdvice, uplinkBudget } from '../../lib/transportParams'
+import {
+  ENCODERS,
+  checkEncoderFeasibility,
+  runOfShowSheet,
+  runOfShowSheetForProject,
+  type FeasibilityFinding,
+} from '../../lib/encoderFeasibility'
 import {
   DELIVERY_PLATFORMS,
   DEFAULT_ENCODING,
@@ -73,6 +80,12 @@ export const DeliveryDialog = () => {
     () => uplinkBudget(uplinkMbps, report.primaryKbps),
     [uplinkMbps, report.primaryKbps],
   )
+  // Bedarf 36: je Encoder ein eigener Befundsatz. NICHT zusammengeworfen — wer
+  // vMix fährt, interessiert die OBS-Zeile nicht, und umgekehrt.
+  const feasibility = useMemo(
+    () => ENCODERS.map((e) => ({ encoder: e, findings: checkEncoderFeasibility(list, e) })),
+    [list],
+  )
 
   if (!open) return null
 
@@ -107,6 +120,34 @@ export const DeliveryDialog = () => {
         })
       case 'needs-port-forward':
         return t('delivery.issue.portForward', 'SRT-Listener: Portfreigabe nötig')
+    }
+  }
+
+  // Ausgeschriebener switch statt `t(`delivery.enc.${f.kind}`)`: ein dynamisch
+  // zusammengesetzter Schluessel ist fuer den i18n-Deckungs-Guard unsichtbar
+  // und faellt im EN-Betrieb still auf den nackten Slug zurueck.
+  const feasibilityText = (f: FeasibilityFinding): string => {
+    switch (f.kind) {
+      case 'too-many-destinations':
+        return format(
+          t('delivery.encoder.tooMany', '{n} gleichzeitige Ziele, das Werkzeug führt {max}'),
+          { n: f.values?.[0] ?? '', max: f.values?.[1] ?? '' },
+        )
+      case 'per-destination-quality-unsupported':
+        return t(
+          'delivery.encoder.noPerDestination',
+          'Der Plan verlangt je Ziel eine eigene Qualität — dieses Werkzeug sendet allen dieselbe',
+        )
+      case 'per-destination-quality-unknown':
+        return t(
+          'delivery.encoder.perDestinationUnknown',
+          'Der Plan verlangt je Ziel eine eigene Qualität — ob dieses Werkzeug das kann, ist ungeklärt',
+        )
+      case 'must-match-differs':
+        return format(
+          t('delivery.encoder.mustMatch', '{field} muss über alle Ziele gleich sein, ist aber {values}'),
+          { field: String(f.field ?? ''), values: (f.values ?? []).join(' / ') },
+        )
     }
   }
 
@@ -152,6 +193,18 @@ export const DeliveryDialog = () => {
     downloadBlob(buildExportFilenameWithSuffix(projectName, 'ausspielung', 'csv'), csv, 'text/csv')
   }
 
+  // Bedarf 33, der Teil ohne fremdes Schema: das Blatt, das am Showtag neben
+  // dem Encoder liegt. Der Stream-Key steht darauf als VERWEIS auf den
+  // Schluesselbund, nie als Wert — ein Regieplatz ist der letzte Ort dafuer.
+  const exportRunOfShow = () => {
+    const csv = csvFromTable(
+      runOfShowSheet(list),
+      stampForRows(project, runOfShowSheetForProject, new Date()),
+      'ablaufblatt',
+    )
+    downloadBlob(buildExportFilenameWithSuffix(projectName, 'ablaufblatt', 'csv'), csv, 'text/csv')
+  }
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
       <div className="flex max-h-[88vh] w-full max-w-5xl flex-col overflow-hidden rounded-lg border border-cp-border bg-cp-surface-1 shadow-xl">
@@ -162,6 +215,14 @@ export const DeliveryDialog = () => {
           <div className="flex items-center gap-2">
             <button type="button" onClick={exportCsv} className="flex items-center gap-1 rounded border border-cp-border px-2 py-1 text-cp-sm text-cp-text-secondary hover:text-cp-text">
               <Download size={13} /> CSV
+            </button>
+            <button
+              type="button"
+              onClick={exportRunOfShow}
+              title={t('delivery.runOfShowHint', 'Ein Blatt für den Showtag — Stream-Keys stehen darauf nur als Verweis auf den Schlüsselbund')}
+              className="flex items-center gap-1 rounded border border-cp-border px-2 py-1 text-cp-sm text-cp-text-secondary hover:text-cp-text"
+            >
+              <FileText size={13} /> {t('delivery.runOfShow', 'Ablaufblatt')}
             </button>
             <button type="button" onClick={() => setOpen(false)} aria-label={t('common.close', 'Schließen')} className="text-cp-text-muted hover:text-cp-text">
               <X size={18} />
@@ -202,6 +263,43 @@ export const DeliveryDialog = () => {
               {budget.usable.formula} · {budget.usable.source}
             </p>
           </div>
+
+          {/* Bedarf 36 — kann das Werkzeug, was der Plan verlangt? Der Block
+              erscheint nur, wenn es etwas zu sagen gibt: unter zwei
+              Primaerwegen ist die Frage gegenstandslos, und ein Kasten, der
+              dann „alles in Ordnung" meldet, verlernt sich. */}
+          {feasibility.some((f) => f.findings.length > 0) && (
+            <div className="mb-4 rounded border border-cp-warn/40 bg-cp-surface-2 p-2.5">
+              <h3 className="mb-1.5 flex items-center gap-1.5 text-cp-sm font-medium text-cp-text">
+                <Cpu size={14} /> {t('delivery.encoder.title', 'Encoder-Machbarkeit')}
+              </h3>
+              <ul className="flex flex-col gap-2">
+                {feasibility
+                  .filter((f) => f.findings.length > 0)
+                  .map(({ encoder, findings }) => (
+                    <li key={encoder.id}>
+                      <div className="text-cp-sm text-cp-text-secondary">{encoder.label}</div>
+                      <ul className="flex flex-col gap-0.5">
+                        {findings.map((f, idx) => (
+                          <li
+                            key={`${f.kind}-${String(f.field ?? idx)}`}
+                            className="flex items-start gap-1 text-cp-xs text-cp-warn"
+                          >
+                            <AlertTriangle size={12} className="mt-0.5 flex-none" />
+                            <span>
+                              {feasibilityText(f)}
+                              {/* Die Fundstelle steht dabei: ein Befund ueber
+                                  fremde Software ohne Beleg ist eine Behauptung. */}
+                              <span className="ml-1 text-cp-text-faint">({f.source})</span>
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    </li>
+                  ))}
+              </ul>
+            </div>
+          )}
 
           {list.length === 0 ? (
             <p className="py-6 text-center text-cp-sm text-cp-text-muted">

--- a/src/renderer/components/Inventory/InventoryDialog.tsx
+++ b/src/renderer/components/Inventory/InventoryDialog.tsx
@@ -20,6 +20,8 @@ import {
   Camera,
   Download,
   Upload,
+  Truck,
+  AlertTriangle,
 } from 'lucide-react'
 import QRCode from 'qrcode'
 import { ModalShell } from '../shared/ModalShell'
@@ -45,6 +47,17 @@ import type {
   PhysicalDimensions,
   SetComponent,
 } from '../../types/inventory'
+import { useCheckoutStore } from '../../store/checkoutStore'
+import {
+  containerContents,
+  checkoutSheet,
+  discrepancyTable,
+  openCheckoutsTable,
+  overdueCheckouts,
+  type CheckoutRefusal,
+} from '../../lib/containerCheckout'
+import { toCsv } from '../../lib/csv'
+import { downloadBlob } from '../../lib/downloadBlob'
 import {
   nodePathLabel,
   itemsInNode,
@@ -86,7 +99,7 @@ export interface InventoryDialogProps {
   onClose: () => void
 }
 
-type Tab = 'items' | 'locations' | 'units' | 'sets' | 'labels' | 'reports'
+type Tab = 'items' | 'locations' | 'units' | 'sets' | 'checkout' | 'labels' | 'reports'
 type ItemFormState = InventoryItemInput & { id?: string }
 
 const inputCls = 'mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5'
@@ -123,6 +136,9 @@ export const InventoryDialog = ({ open, onClose }: InventoryDialogProps) => {
   const removeItem = useInventoryStore((s) => s.removeItem)
   const seedFromEquipment = useInventoryStore((s) => s.seedFromEquipment)
   const exportSnapshot = useInventoryStore((s) => s.exportSnapshot)
+  // Bedarf 15 — die Zahl am Reiter ist die Zahl der offenen Vorgaenge. Ein
+  // Reiter, der nicht sagt, dass drei Cases draussen sind, wird nicht geoeffnet.
+  const offeneAusgaben = useCheckoutStore((s) => s.records.filter((r) => !r.in).length)
   const importSnapshot = useInventoryStore((s) => s.importSnapshot)
   const equipment = useProjectStore((s) => s.project.equipment)
 
@@ -446,6 +462,7 @@ export const InventoryDialog = ({ open, onClose }: InventoryDialogProps) => {
             { id: 'locations' as Tab, icon: Warehouse, label: format(t('inventory.tabLocations', 'Lagerorte ({n})'), { n: nodes.length }) },
             { id: 'units' as Tab, icon: Tags, label: format(t('inventory.tabUnits', 'Einheiten ({n})'), { n: units.length }) },
             { id: 'sets' as Tab, icon: Layers, label: format(t('inventory.tabSets', 'Sets ({n})'), { n: sets.length }) },
+            { id: 'checkout' as Tab, icon: Truck, label: format(t('inventory.tabCheckout', 'Ausgabe ({n})'), { n: offeneAusgaben }) },
             { id: 'labels' as Tab, icon: QrCodeIcon, label: t('inventory.tabLabels', 'Labels') },
             { id: 'reports' as Tab, icon: BarChart3, label: t('inventory.tabReports', 'Auswertung') },
           ]).map((tb) => (
@@ -659,6 +676,7 @@ export const InventoryDialog = ({ open, onClose }: InventoryDialogProps) => {
         {tab === 'locations' && <LocationsTab dimsEditor={dimsEditor} formatDims={formatDims} codeCell={codeCell} />}
         {tab === 'units' && <UnitsTab codeCell={codeCell} />}
         {tab === 'sets' && <SetsTab />}
+        {tab === 'checkout' && <CheckoutTab />}
         {tab === 'labels' && <LabelsTab />}
         {tab === 'reports' && <ReportsTab />}
 
@@ -1489,6 +1507,267 @@ const LabelsTab = () => {
 }
 
 // ── Reports-Tab ──────────────────────────────────────────────────────────────
+// ───────────────────────────────────────────────────────────────────────────
+// Bedarf 15 — Ausgabe und Rueckgabe auf Container-Ebene.
+//
+// EIN Knopf gibt das Transport-Case samt allem darin aus; der Inhalt folgt
+// mit, weil er im Baum haengt und nicht angefasst wird. Genau das ist der
+// Unterschied zu der halben Stunde Klickerei, die snipe-it#9517 beschreibt.
+//
+// KEIN DOKUMENT-STEMPEL auf diesen Blaettern. Der Stempel (ADR-004) bindet
+// ein Blatt an einen PLAN-Stand; ein Ausgabeschein haengt am Lager und nicht
+// am geoeffneten Projekt. Einen Plan-Fingerabdruck daraufzuschreiben waere
+// eine Aussage ueber etwas, das dieses Blatt nicht beschreibt.
+// ───────────────────────────────────────────────────────────────────────────
+const CheckoutTab = () => {
+  const t = useTranslation()
+  const items = useInventoryStore((s) => s.items)
+  const nodes = useInventoryStore((s) => s.nodes)
+  const units = useInventoryStore((s) => s.units)
+  const records = useCheckoutStore((s) => s.records)
+  const checkOut = useCheckoutStore((s) => s.checkOut)
+  const checkIn = useCheckoutStore((s) => s.checkIn)
+  const removeRecord = useCheckoutStore((s) => s.removeRecord)
+
+  const [nodeId, setNodeId] = useState('')
+  const [to, setTo] = useState('')
+  const [projectName, setProjectName] = useState('')
+  const [dueBack, setDueBack] = useState('')
+  const [refusal, setRefusal] = useState<CheckoutRefusal | null>(null)
+
+  const snap = useMemo(() => ({ items, nodes, units }), [items, nodes, units])
+  const container = useMemo(() => nodes.filter((n) => isContainerKind(n.kind)), [nodes])
+  const offen = useMemo(() => records.filter((r) => !r.in), [records])
+  const zurueck = useMemo(() => records.filter((r) => r.in), [records])
+  // Der Stichtag kommt EINMAL aus der Uhr und wird durchgereicht — sonst
+  // beantwortet dieselbe Zeile in zwei Zellen zwei verschiedene Tage.
+  const heute = new Date().toISOString().slice(0, 10)
+  const ueberfaellig = useMemo(() => new Set(overdueCheckouts(records, heute).map((r) => r.id)), [records, heute])
+
+  // Was WUERDE rausgehen — vor dem Klick sichtbar. Ein Knopf, der ungesehen
+  // vierzig Positionen ausbucht, wird beim ersten Fehlgriff nicht mehr benutzt.
+  const vorschau = useMemo(
+    () => (nodeId ? containerContents(snap, nodeId) : []),
+    [snap, nodeId],
+  )
+
+  const ausgeben = () => {
+    if (!nodeId || !to.trim()) return
+    const r = checkOut(snap, nodeId, {
+      to: to.trim(),
+      ...(projectName.trim() ? { projectName: projectName.trim() } : {}),
+      ...(dueBack ? { dueBack } : {}),
+    })
+    setRefusal(r ?? null)
+    if (!r) {
+      setNodeId('')
+      setTo('')
+      setProjectName('')
+      setDueBack('')
+    }
+  }
+
+  const refusalLabel = (r: CheckoutRefusal): string => {
+    switch (r) {
+      case 'not-a-container':
+        return t('inventory.checkout.notContainer', 'Kein Container: nur Cases und Transport-Cases lassen sich ausgeben')
+      case 'already-out':
+        return t('inventory.checkout.alreadyOut', 'Bereits ausgegeben')
+      case 'inside-checked-out':
+        return t('inventory.checkout.insideOut', 'Liegt in einem bereits ausgegebenen Container')
+      case 'unknown-node':
+        return t('inventory.checkout.unknownNode', 'Unbekannter Lager-Knoten')
+    }
+  }
+
+  const csv = (name: string, table: { headers: string[]; rows: (string | number | null | undefined)[][] }) =>
+    downloadBlob(name, toCsv(table.headers, table.rows), 'text/csv')
+
+  return (
+    <div className="space-y-3">
+      <p className="text-cp-sm leading-snug text-cp-text-secondary">
+        {t(
+          'inventory.checkout.intro',
+          'Ein Container geht als Ganzes raus — was darin liegt, folgt über alle Ebenen mit. Die Ausgabe hält fest, was tatsächlich drin war; bei der Rückgabe wird verglichen und die Abweichung berichtet, nicht stillschweigend verrechnet.',
+        )}
+      </p>
+
+      {/* Ausgeben */}
+      <div className="rounded border border-cp-border bg-cp-surface-2 p-2.5">
+        <div className="mb-2 flex flex-wrap items-center gap-2">
+          <select
+            value={nodeId}
+            onChange={(e) => {
+              setNodeId(e.target.value)
+              setRefusal(null)
+            }}
+            aria-label={t('inventory.checkout.container', 'Container')}
+            className="rounded border border-cp-border bg-cp-surface-3 p-1.5"
+          >
+            <option value="">{t('inventory.checkout.pick', '— Container wählen —')}</option>
+            {container.map((n) => (
+              <option key={n.id} value={n.id}>
+                {nodePathLabel(nodes, n.id)}
+              </option>
+            ))}
+          </select>
+          <input
+            value={to}
+            onChange={(e) => setTo(e.target.value)}
+            placeholder={t('inventory.checkout.to', 'An (Person, Truck, Kunde)')}
+            aria-label={t('inventory.checkout.to', 'An (Person, Truck, Kunde)')}
+            className="min-w-[12rem] rounded border border-cp-border bg-cp-surface-3 p-1.5"
+          />
+          <input
+            value={projectName}
+            onChange={(e) => setProjectName(e.target.value)}
+            placeholder={t('inventory.checkout.show', 'Show (optional)')}
+            aria-label={t('inventory.checkout.show', 'Show (optional)')}
+            className="min-w-[10rem] rounded border border-cp-border bg-cp-surface-3 p-1.5"
+          />
+          <label className="flex items-center gap-1.5 text-cp-text-secondary">
+            {t('inventory.checkout.dueBack', 'Zurück bis')}
+            <input
+              type="date"
+              value={dueBack}
+              onChange={(e) => setDueBack(e.target.value)}
+              className="rounded border border-cp-border bg-cp-surface-3 p-1.5"
+            />
+          </label>
+          <button
+            type="button"
+            onClick={ausgeben}
+            disabled={!nodeId || !to.trim()}
+            className="flex items-center gap-1 rounded border border-cp-border px-2.5 py-1 text-cp-text-secondary hover:text-cp-text disabled:opacity-40"
+          >
+            <Truck size={13} /> {t('inventory.checkout.doOut', 'Ausgeben')}
+          </button>
+        </div>
+
+        {refusal && (
+          <div className="flex items-start gap-1 text-cp-danger">
+            <AlertTriangle size={12} className="mt-0.5 flex-none" />
+            <span>{refusalLabel(refusal)}</span>
+          </div>
+        )}
+
+        {nodeId && !refusal && (
+          <div className="text-cp-text-muted">
+            {vorschau.length === 0
+              ? t('inventory.checkout.empty', 'Dieser Container ist leer — es ginge nichts raus.')
+              : format(t('inventory.checkout.preview', '{n} Positionen gehen mit: {list}'), {
+                  n: vorschau.length,
+                  list: vorschau.slice(0, 8).map((l) => l.label).join(', ') + (vorschau.length > 8 ? ' …' : ''),
+                })}
+          </div>
+        )}
+      </div>
+
+      {/* Offene Vorgaenge */}
+      <div className="rounded border border-cp-border">
+        <div className="flex items-center justify-between border-b border-cp-border-muted bg-cp-surface-2 px-2 py-1">
+          <span className="font-medium">
+            {format(t('inventory.checkout.openTitle', 'Draußen ({n})'), { n: offen.length })}
+          </span>
+          <button
+            type="button"
+            disabled={offen.length === 0}
+            onClick={() => csv('ausgaben-offen.csv', openCheckoutsTable(records, nodes, heute))}
+            className="flex items-center gap-1 text-cp-text-secondary hover:text-cp-text disabled:opacity-40"
+          >
+            <Download size={12} /> CSV
+          </button>
+        </div>
+        {offen.length === 0 ? (
+          <div className="px-2 py-1.5 text-cp-text-muted">{t('inventory.checkout.nothingOut', 'Nichts draußen.')}</div>
+        ) : (
+          <table className="w-full text-left">
+            <tbody>
+              {offen.map((r) => (
+                <tr key={r.id} className="border-t border-cp-border-muted align-top">
+                  <td className="px-2 py-1">
+                    <div className="font-medium text-cp-text">{r.nodeLabel}</div>
+                    <div className="text-cp-text-muted">
+                      {format(t('inventory.checkout.outLine', 'an {to} · {n} Positionen'), {
+                        to: r.out.to,
+                        n: r.contents.length,
+                      })}
+                      {r.out.projectName ? ` · ${r.out.projectName}` : ''}
+                    </div>
+                  </td>
+                  <td className="px-2 py-1 text-cp-text-secondary">
+                    {r.out.dueBack ?? '—'}
+                    {ueberfaellig.has(r.id) && (
+                      <span className="ml-1 text-cp-danger">{t('inventory.checkout.overdue', 'überfällig')}</span>
+                    )}
+                  </td>
+                  <td className="px-2 py-1 text-right">
+                    <button
+                      type="button"
+                      onClick={() => csv(`ausgabeschein-${r.nodeLabel}.csv`, checkoutSheet(r))}
+                      className="mr-2 text-cp-text-secondary hover:text-cp-text"
+                    >
+                      {t('inventory.checkout.sheet', 'Schein')}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => checkIn(snap, r.id)}
+                      className="mr-2 text-cp-text-secondary hover:text-cp-text"
+                    >
+                      {t('inventory.checkout.doIn', 'Zurückbuchen')}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => removeRecord(r.id)}
+                      aria-label={t('inventory.checkout.remove', 'Beleg löschen')}
+                      className="text-cp-text-faint hover:text-cp-danger"
+                    >
+                      <Trash2 size={13} />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* Rueckgabe-Befunde — nur die mit Abweichung. Ein Blatt, auf dem auch
+          die glatten Rueckgaben stehen, wird nicht gelesen. */}
+      {zurueck.some((r) => r.in!.missing.length > 0 || r.in!.extra.length > 0) && (
+        <div className="rounded border border-cp-warn/40">
+          <div className="flex items-center justify-between border-b border-cp-border-muted bg-cp-surface-2 px-2 py-1">
+            <span className="flex items-center gap-1.5 font-medium">
+              <AlertTriangle size={13} /> {t('inventory.checkout.discrepancy', 'Rückgabe-Befunde')}
+            </span>
+            <button
+              type="button"
+              onClick={() => csv('rueckgabe-befunde.csv', discrepancyTable(records))}
+              className="flex items-center gap-1 text-cp-text-secondary hover:text-cp-text"
+            >
+              <Download size={12} /> CSV
+            </button>
+          </div>
+          <ul className="flex flex-col gap-0.5 px-2 py-1.5">
+            {zurueck
+              .filter((r) => r.in!.missing.length > 0 || r.in!.extra.length > 0)
+              .map((r) => (
+                <li key={r.id} className="text-cp-warn">
+                  {format(t('inventory.checkout.discrepancyLine', '{node} (an {to}): {missing} fehlen, {extra} zusätzlich'), {
+                    node: r.nodeLabel,
+                    to: r.out.to,
+                    missing: r.in!.missing.length,
+                    extra: r.in!.extra.length,
+                  })}
+                </li>
+              ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}
+
 const ReportsTab = () => {
   const t = useTranslation()
   const items = useInventoryStore((s) => s.items)

--- a/src/renderer/lib/containerCheckout.ts
+++ b/src/renderer/lib/containerCheckout.ts
@@ -1,0 +1,264 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Bedarf 15 — Ausgabe und Rueckgabe auf Container-Ebene.
+//
+// REIN: keine Uhr, kein Store, kein IO. Der Zeitstempel kommt herein, damit
+// derselbe Vorgang zweimal dasselbe Ergebnis liefert.
+//
+// Die vier Regeln, die hier durchgesetzt werden, stehen alle im Bedarf:
+//
+//  1. Der INHALT FOLGT MIT, ueber beliebig viele Ebenen -- aus dem Baum
+//     abgeleitet, nicht mitgeschleppt.
+//  2. Was tatsaechlich drin war, wird EINGEFROREN. Nicht die Kit-Vorlage:
+//     „Kits contain models, not the specific physical assets".
+//  3. NICHTS GEHT ZWEIMAL RAUS. Weder derselbe Container noch einer, der in
+//     einem bereits ausgegebenen liegt -- das waere dasselbe Blech in zwei
+//     Vorgaengen, und beide Listen waeren falsch.
+//  4. Der Unterschied bei der Rueckgabe wird BERICHTET, nicht geheilt.
+// ───────────────────────────────────────────────────────────────────────────
+import type {
+  InventoryItem,
+  InventoryUnit,
+  StorageNode,
+} from '../types/inventory'
+import type { CheckoutLine, CheckoutRecord } from '../types/checkout'
+import { descendantNodeIds, isContainerKind, nodePathLabel } from './storageTree'
+import type { CsvCell, CsvTable } from './csv'
+
+/** Der Bestand, aus dem eine Ausgabe entsteht. */
+export interface InventorySnapshotIn {
+  items: InventoryItem[]
+  nodes: StorageNode[]
+  units: InventoryUnit[]
+}
+
+/**
+ * Was in `nodeId` liegt -- ueber alle Ebenen, in stabiler Reihenfolge.
+ *
+ * Verschachtelte Container erscheinen als eigene Zeile UND ihr Inhalt
+ * einzeln. Beides, weil beide Fragen gestellt werden: „ist Case 2 wieder
+ * da?" und „sind die drei Objektive aus Case 2 wieder da?". Nur den
+ * Container zu fuehren waere genau das erfundene Eltern-Asset aus
+ * `snipe-it#9517`, das nur fuer sich selbst Auskunft gibt.
+ */
+export const containerContents = (
+  snap: InventorySnapshotIn,
+  nodeId: string,
+): CheckoutLine[] => {
+  const inner = descendantNodeIds(snap.nodes, nodeId)
+  const scope = new Set(inner)
+  scope.add(nodeId)
+
+  const lines: CheckoutLine[] = []
+
+  for (const n of snap.nodes) {
+    if (!inner.has(n.id)) continue
+    lines.push({ kind: 'node', refId: n.id, label: n.name, quantity: 1 })
+  }
+  for (const u of snap.units) {
+    if (!u.locationId || !scope.has(u.locationId)) continue
+    // Die Einheit unter ihrer eigenen Identitaet -- Seriennummer, wenn es eine
+    // gibt, sonst der Code. Ein blosses „1 x Modell" beantwortet die Frage
+    // „welche fehlt?" nicht.
+    const kennung = u.serial ?? u.code ?? u.id
+    lines.push({ kind: 'unit', refId: u.id, label: kennung, quantity: 1 })
+  }
+  for (const it of snap.items) {
+    if (!it.locationId || !scope.has(it.locationId)) continue
+    lines.push({ kind: 'item', refId: it.id, label: it.model, quantity: it.quantity })
+  }
+
+  // Stabil sortiert: Container, dann Einheiten, dann Mengen-Artikel; innerhalb
+  // nach Bezeichnung. Ohne feste Reihenfolge waere jede zweite Ausgabeliste
+  // eine andere Datei -- und der Dokument-Stempel damit wertlos.
+  const rang: Record<CheckoutLine['kind'], number> = { node: 0, unit: 1, item: 2 }
+  return lines.sort(
+    (a, b) => rang[a.kind] - rang[b.kind] || a.label.localeCompare(b.label, 'de') || a.refId.localeCompare(b.refId),
+  )
+}
+
+export type CheckoutRefusal =
+  /** Der Knoten ist kein Container (Depot, Raum, Regal, Fach). */
+  | 'not-a-container'
+  /** Dieser Container ist bereits ausgegeben. */
+  | 'already-out'
+  /** Er liegt in einem bereits ausgegebenen Container. */
+  | 'inside-checked-out'
+  /** Es gibt ihn nicht. */
+  | 'unknown-node'
+
+/**
+ * Darf `nodeId` jetzt raus? `undefined` heisst ja.
+ *
+ * Regel 3 hat zwei Haelften, und die zweite ist die, die man vergisst: ein
+ * Case IM ausgegebenen Transport-Case ist bereits draussen. Es noch einmal
+ * auszugeben ergaebe zwei Vorgaenge ueber dasselbe Blech, von denen die
+ * Rueckgabe des einen den anderen stillschweigend falsch macht.
+ */
+export const checkoutRefusal = (
+  snap: InventorySnapshotIn,
+  open: CheckoutRecord[],
+  nodeId: string,
+): CheckoutRefusal | undefined => {
+  const node = snap.nodes.find((n) => n.id === nodeId)
+  if (!node) return 'unknown-node'
+  if (!isContainerKind(node.kind)) return 'not-a-container'
+  const offen = open.filter((r) => !r.in)
+  if (offen.some((r) => r.nodeId === nodeId)) return 'already-out'
+  for (const r of offen) {
+    if (descendantNodeIds(snap.nodes, r.nodeId).has(nodeId)) return 'inside-checked-out'
+  }
+  return undefined
+}
+
+/**
+ * Den Vorgang bauen. Wirft NICHT -- die Absage ist ein Rueckgabewert, denn
+ * „darf nicht" ist hier eine normale Antwort und keine Ausnahme.
+ */
+export const buildCheckout = (
+  snap: InventorySnapshotIn,
+  open: CheckoutRecord[],
+  nodeId: string,
+  out: CheckoutRecord['out'],
+  id: string,
+): { record: CheckoutRecord } | { refusal: CheckoutRefusal } => {
+  const refusal = checkoutRefusal(snap, open, nodeId)
+  if (refusal) return { refusal }
+  const node = snap.nodes.find((n) => n.id === nodeId)!
+  return {
+    record: {
+      id,
+      nodeId,
+      nodeLabel: node.name,
+      out,
+      contents: containerContents(snap, nodeId),
+    },
+  }
+}
+
+const lineKey = (l: CheckoutLine): string => `${l.kind}:${l.refId}`
+
+/**
+ * Der Unterschied zwischen Ausgabeliste und dem, was jetzt drin liegt.
+ *
+ * NICHT GEHEILT. Ein Werkzeug, das die fehlende Zeile beim Einchecken einfach
+ * aus der Liste nimmt, meldet eine vollstaendige Rueckgabe -- und der
+ * Verlust faellt erst beim naechsten Job auf, wenn niemand mehr weiss, auf
+ * welcher Show es war.
+ *
+ * Eine kleinere Stueckzahl zaehlt als Fehlmenge in Hoehe der Differenz, keine
+ * ganze Zeile: kommen von fuenf Kabeln vier zurueck, fehlt eins.
+ */
+export const checkinDifference = (
+  record: CheckoutRecord,
+  jetzt: CheckoutLine[],
+): { missing: CheckoutLine[]; extra: CheckoutLine[] } => {
+  const nachher = new Map(jetzt.map((l) => [lineKey(l), l]))
+  const vorher = new Map(record.contents.map((l) => [lineKey(l), l]))
+
+  const missing: CheckoutLine[] = []
+  for (const l of record.contents) {
+    const da = nachher.get(lineKey(l))
+    const fehlt = l.quantity - (da?.quantity ?? 0)
+    if (fehlt > 0) missing.push({ ...l, quantity: fehlt })
+  }
+
+  const extra: CheckoutLine[] = []
+  for (const l of jetzt) {
+    const war = vorher.get(lineKey(l))
+    const zuviel = l.quantity - (war?.quantity ?? 0)
+    if (zuviel > 0) extra.push({ ...l, quantity: zuviel })
+  }
+
+  return { missing, extra }
+}
+
+/** Den Vorgang schliessen. Liefert einen NEUEN Datensatz -- der alte bleibt
+ *  unberuehrt, weil ein Beleg nicht nachtraeglich anders lauten darf. */
+export const closeCheckout = (
+  record: CheckoutRecord,
+  jetzt: CheckoutLine[],
+  at: string,
+  note?: string,
+): CheckoutRecord => {
+  const { missing, extra } = checkinDifference(record, jetzt)
+  return { ...record, in: { at, missing, extra, ...(note ? { note } : {}) } }
+}
+
+/** Offene Vorgaenge (noch nicht zurueck). */
+export const openCheckouts = (records: CheckoutRecord[]): CheckoutRecord[] =>
+  records.filter((r) => !r.in)
+
+/**
+ * Ueberfaellige Vorgaenge zu einem Stichtag. Ohne `dueBack` ist ein Vorgang
+ * NICHT ueberfaellig -- ein fehlendes Rueckgabedatum ist keine Frist.
+ */
+export const overdueCheckouts = (records: CheckoutRecord[], heute: string): CheckoutRecord[] =>
+  openCheckouts(records).filter((r) => r.out.dueBack !== undefined && r.out.dueBack < heute)
+
+const ART: Record<CheckoutLine['kind'], string> = {
+  node: 'Container',
+  unit: 'Einheit',
+  item: 'Artikel',
+}
+
+/**
+ * Der Ausgabeschein: EIN Container, seine Inhaltsliste, zum Abhaken.
+ * Kanonisches Deutsch -- er wandert als CSV und wird in Excel geoeffnet.
+ */
+export const checkoutSheet = (record: CheckoutRecord): CsvTable => ({
+  headers: ['Art', 'Bezeichnung', 'Menge', 'Kennung'],
+  rows: record.contents.map((l): CsvCell[] => [ART[l.kind], l.label, l.quantity, l.refId]),
+})
+
+/**
+ * Die Uebersicht: was ist draussen, bei wem, seit wann, bis wann.
+ *
+ * Der Lagerort steht als PFAD dabei und nicht als blosser Knotenname: „Case 2"
+ * gibt es dreimal, „Depot › Raum 1 › Regal A3 › Case 2" einmal.
+ */
+export const openCheckoutsTable = (
+  records: CheckoutRecord[],
+  nodes: StorageNode[],
+  heute: string,
+): CsvTable => ({
+  headers: ['Container', 'Lagerort', 'An', 'Show', 'Ausgegeben', 'Zurueck bis', 'Positionen', 'Status'],
+  rows: openCheckouts(records).map((r): CsvCell[] => [
+    r.nodeLabel,
+    nodePathLabel(nodes, r.nodeId) || '',
+    r.out.to,
+    r.out.projectName ?? '',
+    r.out.at,
+    r.out.dueBack ?? '',
+    r.contents.length,
+    r.out.dueBack !== undefined && r.out.dueBack < heute ? 'ueberfaellig' : 'offen',
+  ]),
+})
+
+/**
+ * Der Rueckgabe-Befund: EINE ZEILE JE ABWEICHUNG, keine je Vorgang.
+ *
+ * Ein glatter Vorgang faellt damit von selbst heraus -- er hat weder eine
+ * Fehl- noch eine Zuviel-Zeile. Hier stand zuerst zusaetzlich ein
+ * `.filter(...)`, der dasselbe noch einmal behauptete; er war wirkungslos,
+ * denn eine leere Liste erzeugt ohnehin keine Zeile. Die Gegenprobe, die ihn
+ * entfernte, blieb gruen -- und ein Filter, den nichts prueft, mit einem
+ * Kommentar, der eine Regel behauptet, ist schlimmer als keiner: der naechste
+ * Leser haelt die Regel fuer bewacht.
+ *
+ * Bewacht ist sie jetzt an der Stelle, an der sie brechen KANN: ein Test
+ * baut das Blatt aus lauter glatten Rueckgaben und verlangt, dass es leer
+ * bleibt. Wer eine „alles in Ordnung"-Zeile ergaenzt, faellt darueber.
+ */
+export const discrepancyTable = (records: CheckoutRecord[]): CsvTable => ({
+  headers: ['Container', 'An', 'Zurueck am', 'Befund', 'Art', 'Bezeichnung', 'Menge', 'Kennung'],
+  rows: records
+    .filter((r) => r.in)
+    .flatMap((r) => [
+      ...r.in!.missing.map((l): CsvCell[] => [
+        r.nodeLabel, r.out.to, r.in!.at, 'fehlt', ART[l.kind], l.label, l.quantity, l.refId,
+      ]),
+      ...r.in!.extra.map((l): CsvCell[] => [
+        r.nodeLabel, r.out.to, r.in!.at, 'zusaetzlich', ART[l.kind], l.label, l.quantity, l.refId,
+      ]),
+    ]),
+})

--- a/src/renderer/lib/documentRegistry.ts
+++ b/src/renderer/lib/documentRegistry.ts
@@ -20,6 +20,7 @@ import {
 import { assetRegisterTable } from './assetRegister'
 import { handoverTable } from './handoverPackage'
 import { deliveryTableForProject } from './deliveryParity'
+import { runOfShowSheetForProject } from './encoderFeasibility'
 import type { CsvTable } from './csv'
 
 const ofTable =
@@ -50,6 +51,12 @@ export const DOCUMENT_STANDS: Record<string, (project: CablePlannerProject) => s
   // (anders als `kabel-bom` mit seinem Reserve-Aufschlag) und keine Sprache
   // (die Tabelle traegt kanonisches Deutsch, siehe `deliveryIssueText`).
   ausspielung: ofTable(deliveryTableForProject),
+  // Bedarf 33 — das Ablaufblatt fuer den Showtag. Aus demselben Grund
+  // reproduzierbar wie `ausspielung`: sein Inhalt folgt allein aus
+  // `project.deliveryDestinations`, es traegt keine Nutzer-Einstellung und
+  // kanonisches Deutsch. Der Stream-Key steht darauf als Verweis, nicht als
+  // Wert -- der Fingerabdruck misst also nichts Geheimes.
+  ablaufblatt: ofTable(runOfShowSheetForProject),
 }
 
 /**
@@ -83,6 +90,7 @@ export const DOCUMENT_LABELS: Record<string, string> = {
   uebergabe: 'Übergabe-Dokument',
   'kabel-bom': 'Kabel-Stückliste',
   ausspielung: 'Ausspielung',
+  ablaufblatt: 'Ablaufblatt',
 }
 
 /**

--- a/src/renderer/lib/encoderFeasibility.ts
+++ b/src/renderer/lib/encoderFeasibility.ts
@@ -1,0 +1,235 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Kann der Encoder, was der Plan verlangt? (Bedarfe 33 und 36, beide P1)
+//
+// BEDARF 36 BESCHREIBT EINEN WIDERSPRUCH ZWISCHEN PLAN UND WERKZEUG:
+//
+//   > vMix disables multi-bitrate the moment a second destination is added
+//   > and defaults all targets to identical quality; the OBS multi-RTMP
+//   > plugin's per-destination quality question is open and unanswered; the
+//   > recommended workaround gives up quality control to protect the CPU.
+//
+// Und Bedarf 31 sagt, was heute stattdessen passiert: „nothing validates
+// them, so the only proof the backup works is deliberately killing the
+// primary during rehearsal".
+//
+// Der Plan KANN Qualität je Ziel führen — das ist richtig so, denn Twitch
+// nimmt 6.000 kbit/s und YouTube 12.000. Was fehlte, ist die Auskunft, ob das
+// Werkzeug am Showtag das auch liefern kann. Genau die gibt diese Datei, und
+// zwar aus BELEGTEN Herstellerangaben statt aus Erfahrung.
+//
+// ─── WAS HIER BEWUSST NICHT ENTSTEHT ───────────────────────────────────────
+//
+// Keine OBS-Profil-Datei, kein vMix-Preset, kein NOALBS-JSON. Bedarf 33
+// nennt sie als Ziel („best-effort, versioned exporters"), aber die genauen
+// Schlüssel dieser Formate liegen in dieser Recherche NICHT vor — vom NOALBS-
+// Konfigurationsumfang ist die FELDLISTE gelesen, nicht das Schema. Eine
+// Datei mit erfundenen Schlüsselnamen, die „OBS-Profil" heisst, sieht geprüft
+// aus und ist geraten; sie kostet am Showtag mehr Zeit als das Abtippen, weil
+// jemand erst herausfinden muss, warum das Werkzeug sie nicht liest.
+//
+// Was stattdessen entsteht, ist der Teil, den Bedarf 33 ebenfalls nennt und
+// der ohne fremdes Schema auskommt: **das Ablauf-Blatt**, „a printable
+// destination sheet for the run of show" — mit dem Stream-Key als VERWEIS,
+// nie als Wert („secrets as references"). Wer die Exporter später baut, hat
+// mit `deliveryDestinations` das Modell dafür; ihm fehlt nur noch das Schema.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { DeliveryDestination, EncodingProfile } from '../types/delivery'
+import { checkDelivery } from './deliveryParity'
+import type { CsvCell, CsvTable } from './csv'
+
+/** Encoder, über die diese Recherche eine belegte Aussage hat. */
+export type EncoderId = 'vmix' | 'obs-multi-rtmp'
+
+export interface EncoderSpec {
+  id: EncoderId
+  label: string
+  /** Wie viele gleichzeitige Ziele das Werkzeug führt. `undefined` = keine
+   *  belegte Grenze; dann wird auch keine behauptet. */
+  maxDestinations?: number
+  /**
+   * Kann es je Ziel eine EIGENE Qualität senden? `false` heisst belegt-nein,
+   * `unknown` heisst: die Frage ist gestellt und unbeantwortet — und das ist
+   * ein eigener Zustand, kein Nein. Ein Werkzeug, dessen Verhalten niemand
+   * kennt, sollte nicht als „geht nicht" im Plan stehen.
+   */
+  perDestinationQuality: false | 'unknown'
+  /** Felder, die über alle Ziele gleich sein müssen. */
+  mustMatch: ReadonlyArray<keyof EncodingProfile>
+  source: string
+}
+
+/**
+ * ZWEI EINTRÄGE, NICHT ZEHN. Hier steht nur, wofür diese Recherche eine
+ * Fundstelle hat. Ein Katalog mit zehn Encodern und geratenen Grenzen wäre
+ * schlimmer als diese zwei Zeilen: er sähe vollständig aus.
+ */
+export const ENCODERS: ReadonlyArray<EncoderSpec> = [
+  {
+    id: 'vmix',
+    label: 'vMix',
+    // „up to three destinations"
+    maxDestinations: 3,
+    // „multi-bitrate support is *disabled* when using multiple destinations,
+    // and … by default all three destinations use the same quality settings —
+    // video bitrate, audio bitrate, encode size — and … keyframe frequency and
+    // master frame rate must match for every additional streaming target"
+    perDestinationQuality: false,
+    mustMatch: ['videoBitrateKbps', 'audioBitrateKbps', 'width', 'height', 'keyframeSec', 'fps'],
+    source: 'vmix.com/help23/StreamingMultipleDestinations.html · vmix.com/help23/StreamingMultiBitrate.html',
+  },
+  {
+    id: 'obs-multi-rtmp',
+    label: 'OBS + obs-multi-rtmp',
+    // Keine belegte Zielgrenze — also wird keine behauptet.
+    // Die Qualitätsfrage je Ziel ist gestellt und unbeantwortet:
+    // sorayuki/obs-multi-rtmp#448, offen seit 2024-10-26, ohne Antwort des
+    // Betreuers; der empfohlene Ausweg („Get from OBS") gibt sie ausdruecklich
+    // auf, um die CPU zu schonen.
+    perDestinationQuality: 'unknown',
+    mustMatch: [],
+    source: 'github.com/sorayuki/obs-multi-rtmp/issues/448 (offen, ohne Antwort)',
+  },
+]
+
+export type FeasibilityKind =
+  /** Mehr gleichzeitige Ziele, als das Werkzeug führt. */
+  | 'too-many-destinations'
+  /** Der Plan verlangt je Ziel eine andere Qualität; das Werkzeug kann es nicht. */
+  | 'per-destination-quality-unsupported'
+  /** Dasselbe, aber die Quelle sagt „unbeantwortet" statt „nein". */
+  | 'per-destination-quality-unknown'
+  /** Ein Feld, das über alle Ziele gleich sein muss, weicht ab. */
+  | 'must-match-differs'
+
+export interface FeasibilityFinding {
+  kind: FeasibilityKind
+  encoder: EncoderId
+  /** Bei `must-match-differs`: welches Feld. */
+  field?: keyof EncodingProfile
+  /** Die abweichenden Werte im Klartext, in Zielreihenfolge. */
+  values?: string[]
+  /** Die Fundstelle der Herstellerangabe. Ohne sie kein Befund. */
+  source: string
+}
+
+/**
+ * Den Plan gegen einen Encoder halten.
+ *
+ * Gezählt werden die PRIMÄRWEGE — ein Backup läuft im Havariefall und nicht
+ * daneben; es als viertes gleichzeitiges Ziel zu zählen ergäbe einen Befund,
+ * den es nicht gibt. Dieselbe Regel wie im Uplink-Budget.
+ */
+export function checkEncoderFeasibility(
+  destinations: DeliveryDestination[],
+  encoder: EncoderSpec,
+): FeasibilityFinding[] {
+  const primaries = checkDelivery(destinations).primaries
+  const out: FeasibilityFinding[] = []
+  if (primaries.length < 2) return out
+
+  if (encoder.maxDestinations !== undefined && primaries.length > encoder.maxDestinations) {
+    out.push({
+      kind: 'too-many-destinations',
+      encoder: encoder.id,
+      values: [String(primaries.length), String(encoder.maxDestinations)],
+      source: encoder.source,
+    })
+  }
+
+  // Weicht überhaupt eine Qualität ab? Sonst ist die ganze Frage gegenstandslos
+  // und eine Warnung darüber wäre Rauschen auf einem korrekten Aufbau.
+  const abweichend = (f: keyof EncodingProfile): boolean =>
+    new Set(primaries.map((d) => String(d.encoding[f]))).size > 1
+
+  const qualitaetsFelder: ReadonlyArray<keyof EncodingProfile> = [
+    'videoBitrateKbps',
+    'audioBitrateKbps',
+    'width',
+    'height',
+    'fps',
+    'keyframeSec',
+    'videoCodec',
+  ]
+  const unterschiedlich = qualitaetsFelder.some(abweichend)
+
+  if (unterschiedlich) {
+    out.push({
+      kind:
+        encoder.perDestinationQuality === false
+          ? 'per-destination-quality-unsupported'
+          : 'per-destination-quality-unknown',
+      encoder: encoder.id,
+      source: encoder.source,
+    })
+  }
+
+  for (const f of encoder.mustMatch) {
+    if (!abweichend(f)) continue
+    out.push({
+      kind: 'must-match-differs',
+      encoder: encoder.id,
+      field: f,
+      values: primaries.map((d) => String(d.encoding[f])),
+      source: encoder.source,
+    })
+  }
+  return out
+}
+
+/** Alle bekannten Encoder auf einmal. */
+export function checkAllEncoders(destinations: DeliveryDestination[]): FeasibilityFinding[] {
+  return ENCODERS.flatMap((e) => checkEncoderFeasibility(destinations, e))
+}
+
+/**
+ * DAS ABLAUF-BLATT (Bedarf 33, der Teil ohne fremdes Schema).
+ *
+ * „a printable destination sheet for the run of show" — was am Showtag neben
+ * dem Encoder liegt. Der Stream-Key steht als **Verweis** darauf, nicht als
+ * Wert: „secrets as references" sagt der Bedarf, und ein Blatt, das auf einem
+ * Regieplatz liegt, ist der letzte Ort für ein Geheimnis.
+ */
+export function runOfShowSheet(destinations: DeliveryDestination[]): CsvTable {
+  const nameById = new Map(destinations.map((d) => [d.id, d.name]))
+  return {
+    headers: [
+      'Ziel',
+      'Rolle',
+      'Plattform',
+      'Transport',
+      'Ingest-URL',
+      'Stream-Key',
+      'Bild',
+      'Video',
+      'Keyframe',
+      'Audio',
+      'Konto',
+      'Notiz',
+    ],
+    rows: destinations.map((d): CsvCell[] => [
+      d.name,
+      d.backupOfId ? `Backup von ${nameById.get(d.backupOfId) ?? d.backupOfId}` : 'Primaerweg',
+      d.platform,
+      d.transport,
+      d.ingestUrl ?? '',
+      // Der VERWEIS, nicht der Wert.
+      d.hasStreamKey ? `Schluesselbund: stream-key:${d.id}` : 'nicht hinterlegt',
+      `${d.encoding.width}x${d.encoding.height}p${d.encoding.fps}`,
+      `${d.encoding.videoBitrateKbps} kbit/s ${d.encoding.videoCodec}`,
+      `${d.encoding.keyframeSec} s`,
+      `${d.encoding.audioCodec} ${d.encoding.audioSampleRate} Hz ${d.encoding.audioBitrateKbps} kbit/s`,
+      d.account ?? '',
+      d.note ?? '',
+    ]),
+  }
+}
+
+/** Fuer den Stempel: dieselbe Tabelle aus einem Projekt (oder dessen Snapshot)
+ *  gebaut, damit der Fingerabdruck denselben Inhalt misst und keine zweite,
+ *  nachgebaute Wahrheit ueber dasselbe Blatt. */
+export const runOfShowSheetForProject = (project: {
+  deliveryDestinations?: DeliveryDestination[]
+}): CsvTable => runOfShowSheet(project.deliveryDestinations ?? [])

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3665,6 +3665,36 @@ export const en: Dict = {
   'inventory.summary3': '{items} items · {units} units · {nodes} locations · {sets} sets',
   'inventory.tabLocations': 'Locations ({n})',
   'inventory.tabSets': 'Sets ({n})',
+
+  /* Bedarf 15 — Ausgabe/Rueckgabe auf Container-Ebene. */
+  'inventory.tabCheckout': 'Check-out ({n})',
+  'inventory.checkout.intro':
+    'A container goes out as a whole \u2014 whatever sits inside follows across every level. The check-out records what was ACTUALLY in it; on return the difference is reported, not quietly settled.',
+  'inventory.checkout.container': 'Container',
+  'inventory.checkout.pick': '\u2014 pick a container \u2014',
+  'inventory.checkout.to': 'To (person, truck, client)',
+  'inventory.checkout.show': 'Show (optional)',
+  'inventory.checkout.dueBack': 'Due back',
+  'inventory.checkout.doOut': 'Check out',
+  'inventory.checkout.doIn': 'Check in',
+  'inventory.checkout.sheet': 'Sheet',
+  'inventory.checkout.remove': 'Delete record',
+  'inventory.checkout.empty': 'This container is empty \u2014 nothing would go out.',
+  // {n} und {list} werden vom Aufrufer ersetzt.
+  'inventory.checkout.preview': '{n} positions go with it: {list}',
+  // {n} wird vom Aufrufer ersetzt.
+  'inventory.checkout.openTitle': 'Out ({n})',
+  'inventory.checkout.nothingOut': 'Nothing out.',
+  // {to} und {n} werden vom Aufrufer ersetzt.
+  'inventory.checkout.outLine': 'to {to} \u00b7 {n} positions',
+  'inventory.checkout.overdue': 'overdue',
+  'inventory.checkout.discrepancy': 'Return findings',
+  // {node}, {to}, {missing} und {extra} werden vom Aufrufer ersetzt.
+  'inventory.checkout.discrepancyLine': '{node} (to {to}): {missing} missing, {extra} extra',
+  'inventory.checkout.notContainer': 'Not a container: only cases and transport cases can be checked out',
+  'inventory.checkout.alreadyOut': 'Already checked out',
+  'inventory.checkout.insideOut': 'Sits inside a container that is already checked out',
+  'inventory.checkout.unknownNode': 'Unknown storage node',
   'inventory.location': 'Location / case',
   'inventory.noLocation': '— no location —',
   'inventory.locationsHint': 'Storage locations and cases — every node scannable, nestable at will (case in case in transport case).',

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3847,6 +3847,22 @@ export const en: Dict = {
   'delivery.issue.overBitrate': 'Bitrate {actual} above the platform limit {expected}',
   'delivery.issue.keyframe': 'Keyframe interval {actual}, required is {expected}',
   'delivery.issue.portForward': 'SRT listener: port forward required',
+
+  /* Bedarfe 33 und 36 — das Ablaufblatt und die Encoder-Machbarkeit.
+     Eigener Namensraum `delivery.encoder.*`: `delivery.enc.*` daruber sind die
+     Encoding-FELDER (Breite, fps, Keyframe), hier geht es um das WERKZEUG. */
+  'delivery.runOfShow': 'Run sheet',
+  'delivery.runOfShowHint':
+    'One sheet for show day \u2014 stream keys appear on it only as a reference to the keychain',
+  'delivery.encoder.title': 'Encoder feasibility',
+  // {n} und {max} werden vom Aufrufer ersetzt.
+  'delivery.encoder.tooMany': '{n} simultaneous destinations, the tool handles {max}',
+  'delivery.encoder.noPerDestination':
+    'The plan asks for per-destination quality \u2014 this tool sends all of them the same',
+  'delivery.encoder.perDestinationUnknown':
+    'The plan asks for per-destination quality \u2014 whether this tool can do that is unresolved',
+  // {field} und {values} werden vom Aufrufer ersetzt.
+  'delivery.encoder.mustMatch': '{field} must match across all destinations, but is {values}',
   'wireless.title': 'Wireless / vocals',
   'wireless.channel': 'Channel',
   'wireless.addChannel': 'Channel',

--- a/src/renderer/lib/storageKeys.ts
+++ b/src/renderer/lib/storageKeys.ts
@@ -30,6 +30,17 @@ export const STORAGE_KEYS = {
   settings: 'cable-planner:settings',
   /** Inventory-Store (Phase 2 — zentraler, planübergreifender Bestand). */
   inventory: 'cable-planner:inventory',
+  /**
+   * Bedarf 15 — Ausgabe-/Rueckgabe-Belege der Container.
+   *
+   * EIGENER KEY, nicht im Inventory-Blob. Der Bestand ist ein Katalog und
+   * wandert per `avplan-inventory` zwischen den drei Apps; ein Ausgabe-Beleg
+   * ist Betriebszustand EINES Lagers und hat dort nichts zu suchen. Ihn in
+   * den Envelope zu legen hiesse, das in allen drei Repos byte-identisch
+   * eingefrorene Format zu brechen, damit multicam und light ein Feld
+   * durchreichen, das sie nie fuellen.
+   */
+  checkouts: 'cable-planner:checkouts',
   /** ATEM-Switcher Discovery-Cache. */
   rentmanTemplateCacheV1: 'cable-planner:rentmanTemplateCache:v1',
   /** NetBox device-type-library Index-Cache. */

--- a/src/renderer/store/checkoutStore.ts
+++ b/src/renderer/store/checkoutStore.ts
@@ -1,0 +1,152 @@
+import { create } from 'zustand'
+import { v4 as uuidv4 } from 'uuid'
+import { STORAGE_KEYS } from '../lib/storageKeys'
+import type { CheckoutLine, CheckoutRecord } from '../types/checkout'
+import {
+  buildCheckout,
+  closeCheckout,
+  containerContents,
+  type CheckoutRefusal,
+  type InventorySnapshotIn,
+} from '../lib/containerCheckout'
+
+/**
+ * Bedarf 15 — die Ausgabe-Belege. Eigener Store, eigener localStorage-Key.
+ *
+ * WARUM NICHT IM INVENTORY-STORE: dessen `exportSnapshot` ist das portable
+ * Format `avplan-inventory`, dessen Envelope in allen drei Apps
+ * byte-identisch eingefroren ist (`tests/inventoryContract.test.ts`). Der
+ * Bestand ist ein KATALOG und wandert zwischen den Apps; ein Ausgabe-Beleg
+ * ist Betriebszustand EINES Lagers. Ihn dort einzuhaengen hiesse, das Format
+ * in drei Repos zu brechen, damit multicam und light ein Feld durchreichen,
+ * das sie nie fuellen.
+ *
+ * Der Store haelt KEINE Bestandsdaten. Wer eine Ausgabe baut, reicht den
+ * Bestand als Argument herein — so gibt es keine zweite Kopie des Lagers,
+ * die veralten koennte, und die Ableitung bleibt pruefbar ohne Store.
+ */
+
+const KEY = STORAGE_KEYS.checkouts
+
+const istZeile = (v: unknown): v is CheckoutLine => {
+  if (!v || typeof v !== 'object') return false
+  const l = v as Partial<CheckoutLine>
+  return (
+    (l.kind === 'item' || l.kind === 'unit' || l.kind === 'node') &&
+    typeof l.refId === 'string' &&
+    typeof l.label === 'string' &&
+    typeof l.quantity === 'number' &&
+    Number.isFinite(l.quantity)
+  )
+}
+
+/** Heilt einen geladenen Beleg. Ein Beleg ohne Container, ohne Empfaenger
+ *  oder ohne Zeitpunkt ist keiner — er wird abgewiesen statt ergaenzt. */
+const healRecord = (raw: unknown): CheckoutRecord | null => {
+  if (!raw || typeof raw !== 'object') return null
+  const r = raw as Partial<CheckoutRecord>
+  if (typeof r.id !== 'string' || typeof r.nodeId !== 'string') return null
+  if (!r.out || typeof r.out.at !== 'string' || typeof r.out.to !== 'string') return null
+  const contents = Array.isArray(r.contents) ? r.contents.filter(istZeile) : []
+  const rec: CheckoutRecord = {
+    id: r.id,
+    nodeId: r.nodeId,
+    nodeLabel: typeof r.nodeLabel === 'string' ? r.nodeLabel : r.nodeId,
+    out: {
+      at: r.out.at,
+      to: r.out.to,
+      ...(typeof r.out.projectName === 'string' ? { projectName: r.out.projectName } : {}),
+      ...(typeof r.out.dueBack === 'string' ? { dueBack: r.out.dueBack } : {}),
+      ...(typeof r.out.note === 'string' ? { note: r.out.note } : {}),
+    },
+    contents,
+  }
+  if (r.in && typeof r.in.at === 'string') {
+    rec.in = {
+      at: r.in.at,
+      missing: Array.isArray(r.in.missing) ? r.in.missing.filter(istZeile) : [],
+      extra: Array.isArray(r.in.extra) ? r.in.extra.filter(istZeile) : [],
+      ...(typeof r.in.note === 'string' ? { note: r.in.note } : {}),
+    }
+  }
+  return rec
+}
+
+const load = (): CheckoutRecord[] => {
+  try {
+    const raw = localStorage.getItem(KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return []
+    return parsed.map(healRecord).filter((r): r is CheckoutRecord => r !== null)
+  } catch {
+    return []
+  }
+}
+
+const persist = (records: CheckoutRecord[]) => {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(records))
+  } catch {
+    /* ignore */
+  }
+}
+
+interface CheckoutState {
+  records: CheckoutRecord[]
+  /**
+   * Container ausgeben. Liefert die Absage, wenn er nicht raus darf —
+   * „darf nicht" ist hier eine normale Antwort und keine Ausnahme.
+   */
+  checkOut: (
+    snap: InventorySnapshotIn,
+    nodeId: string,
+    out: Omit<CheckoutRecord['out'], 'at'>,
+  ) => CheckoutRefusal | undefined
+  /**
+   * Container zurueckbuchen. Der aktuelle Inhalt wird aus dem Bestand
+   * ABGELEITET und gegen die Ausgabeliste gehalten; der Unterschied landet im
+   * Beleg, statt still verrechnet zu werden.
+   */
+  checkIn: (snap: InventorySnapshotIn, recordId: string, note?: string) => void
+  /** Einen Beleg loeschen (Fehleingabe). Die Historie hat sonst kein Ventil. */
+  removeRecord: (recordId: string) => void
+}
+
+export const useCheckoutStore = create<CheckoutState>((set, get) => ({
+  records: load(),
+
+  checkOut: (snap, nodeId, out) => {
+    const gebaut = buildCheckout(
+      snap,
+      get().records,
+      nodeId,
+      { ...out, at: new Date().toISOString() },
+      uuidv4(),
+    )
+    if ('refusal' in gebaut) return gebaut.refusal
+    set((state) => {
+      const records = [...state.records, gebaut.record]
+      persist(records)
+      return { records }
+    })
+    return undefined
+  },
+
+  checkIn: (snap, recordId, note) =>
+    set((state) => {
+      const at = new Date().toISOString()
+      const records = state.records.map((r) =>
+        r.id === recordId && !r.in ? closeCheckout(r, containerContents(snap, r.nodeId), at, note) : r,
+      )
+      persist(records)
+      return { records }
+    }),
+
+  removeRecord: (recordId) =>
+    set((state) => {
+      const records = state.records.filter((r) => r.id !== recordId)
+      persist(records)
+      return { records }
+    }),
+}))

--- a/src/renderer/types/checkout.ts
+++ b/src/renderer/types/checkout.ts
@@ -1,0 +1,97 @@
+/**
+ * Bedarf 15 (P1) — den Container ein- und auschecken, nicht den Artikel.
+ *
+ * Der Befund steht in zwei offenen Snipe-IT-Ausgaben, beide von AV-Leuten:
+ *
+ *   > cameras + lenses + audio + cards that "travel together at all times" —
+ *   > "a good half hour of repetitive clicking"     (snipe-it#9517, 2021-04-30,
+ *                                                    2025-08 immer noch offen)
+ *
+ * Der dortige Ausweg ist ein erfundenes „Eltern-Asset", auf das alles gebucht
+ * wird -- und das dann als Einziges benachrichtigt. Der zweite Satz des
+ * Befundes ist der wichtigere:
+ *
+ *   > Kits contain models, not the specific physical assets that are actually
+ *   > in the case.
+ *
+ * DARAUS FOLGT DIE ENTSCHEIDENDE REGEL DIESER DATEI: eine Ausgabe haelt fest,
+ * WAS TATSAECHLICH DRIN WAR, nicht was die Kit-Vorlage sagt. Eine Liste aus
+ * der Vorlage waere zum Zeitpunkt der Rueckgabe wertlos: sie beschriebe ein
+ * gedachtes Case, und die Frage bei der Rueckgabe lautet „fehlt etwas?".
+ *
+ * KEIN ZWEITER ZUSTAND AM KNOTEN. Der Lager-Baum (LPN, `storageTree.ts`) sagt
+ * bereits, was in einem Container liegt -- verschachtelt ueber beliebig viele
+ * Ebenen. „Der Inhalt folgt mit" ist deshalb keine Funktion, die etwas
+ * mitbewegt, sondern eine Eigenschaft des Baums: wer den Container ausgibt,
+ * gibt seinen Teilbaum aus, ohne dass ein einziges Kind angefasst wird. Genau
+ * das ist der Unterschied zum halbstuendigen Klicken.
+ *
+ * EINE SERIALISIERTE EINHEIT GEHT UNTER IHRER EIGENEN IDENTITAET RAUS, nicht
+ * als „1 x Modell". Das ist die Halbierung, die der Bedarf ausdruecklich
+ * nennt („children keep their own ERP identities"): kommt eine von drei
+ * Funkstrecken nicht zurueck, muss auf dem Blatt stehen, WELCHE.
+ */
+
+/** Was in einer Ausgabe steht: ein Mengen-Artikel, eine Einheit oder ein
+ *  verschachtelter Container. Drei Arten, weil sie drei verschiedene
+ *  Identitaeten haben -- nicht als Geschmacksfrage. */
+export type CheckoutLineKind = 'item' | 'unit' | 'node'
+
+/**
+ * Eine Zeile der eingefrorenen Inhaltsliste.
+ *
+ * `label` wird MITGESCHRIEBEN und nicht beim Anzeigen nachgeschlagen. Ein
+ * Artikel, der waehrend der Ausgabe umbenannt oder geloescht wird, macht die
+ * Rueckgabe-Liste sonst unlesbar -- und genau dann braucht sie jemand.
+ */
+export interface CheckoutLine {
+  kind: CheckoutLineKind
+  /** `InventoryItem.id`, `InventoryUnit.id` oder `StorageNode.id`. */
+  refId: string
+  /** Name zum Zeitpunkt der Ausgabe. */
+  label: string
+  /** Stueckzahl. Bei `unit` und `node` immer 1 -- sie sind einzeln. */
+  quantity: number
+}
+
+/** Der Vorgang der Ausgabe. */
+export interface CheckoutOut {
+  /** ISO-Zeitstempel. */
+  at: string
+  /** An wen -- Person, Truck, Kunde. Freitext, weil ein Lager sie alle kennt. */
+  to: string
+  /** Fuer welche Show, wenn bekannt. */
+  projectName?: string
+  /** Erwartete Rueckgabe (ISO-Datum). */
+  dueBack?: string
+  note?: string
+}
+
+/** Der Vorgang der Rueckgabe, mit dem Unterschied zur Ausgabe. */
+export interface CheckoutIn {
+  at: string
+  /** Was auf der Ausgabeliste stand und bei der Rueckgabe nicht da war. */
+  missing: CheckoutLine[]
+  /** Was zurueckkam, ohne auf der Ausgabeliste zu stehen. */
+  extra: CheckoutLine[]
+  note?: string
+}
+
+/**
+ * Ein Ausgabe-Vorgang. Append-only: `in` wird einmal gesetzt und nie wieder
+ * geaendert. Ein Vorgang, der sich ruecklaufend korrigieren laesst, ist kein
+ * Beleg mehr -- und ein Beleg ist genau das, was hier gebraucht wird, wenn
+ * drei Wochen spaeter jemand fragt, wo das Objektiv geblieben ist.
+ */
+export interface CheckoutRecord {
+  id: string
+  /** Der ausgegebene Container (`StorageNode.id`). */
+  nodeId: string
+  /** Sein Name zum Zeitpunkt der Ausgabe -- aus demselben Grund wie `label`. */
+  nodeLabel: string
+  out: CheckoutOut
+  /** Was tatsaechlich drin war, eingefroren. */
+  contents: CheckoutLine[]
+  /** Fehlt, solange der Vorgang offen ist. */
+  in?: CheckoutIn
+}

--- a/tests/changeImpact.test.ts
+++ b/tests/changeImpact.test.ts
@@ -120,10 +120,16 @@ describe('changeImpact — die Vorwärts-Frage', () => {
     // Ausgenommen sind die Ableitungen, die NICHT an `equipment` haengen und
     // deshalb auch auf diesem Torso ein gueltiges (leeres) Ergebnis liefern.
     // `plan` war das von Anfang an; `ausspielung` (Initiative 9) kam dazu, weil
-    // ihr Inhalt allein aus `deliveryDestinations` folgt. Beide hier zu
-    // erzwingen hiesse, ein ehrliches „leer" in ein „weiss ich nicht" zu
-    // faelschen -- und genau das wirft dieser Test dem Gegenteil vor.
-    const ohneGeraetebezug = new Set(['plan', 'ausspielung'])
+    // ihr Inhalt allein aus `deliveryDestinations` folgt, und `ablaufblatt`
+    // (Bedarf 33) aus demselben Grund -- es ist dieselbe Datenquelle in einer
+    // anderen Spaltenform. Sie hier zu erzwingen hiesse, ein ehrliches „leer"
+    // in ein „weiss ich nicht" zu faelschen -- und genau das wirft dieser Test
+    // dem Gegenteil vor.
+    //
+    // Die Liste ist bewusst benannt und nicht „alles, was durchkommt": waechst
+    // sie um einen Bezeichner, der doch an `equipment` haengt, faellt das beim
+    // Eintragen auf statt still.
+    const ohneGeraetebezug = new Set(['plan', 'ausspielung', 'ablaufblatt'])
     expect(
       impact.documents.some((d) => d.verdict === 'unaffected' && !ohneGeraetebezug.has(d.docId)),
     ).toBe(false)

--- a/tests/containerCheckout.test.ts
+++ b/tests/containerCheckout.test.ts
@@ -1,0 +1,381 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildCheckout,
+  checkinDifference,
+  checkoutRefusal,
+  checkoutSheet,
+  closeCheckout,
+  containerContents,
+  discrepancyTable,
+  openCheckouts,
+  openCheckoutsTable,
+  overdueCheckouts,
+  type InventorySnapshotIn,
+} from '../src/renderer/lib/containerCheckout'
+import type { CheckoutLine, CheckoutRecord } from '../src/renderer/types/checkout'
+import type { InventoryItem, InventoryUnit, StorageNode } from '../src/renderer/types/inventory'
+import quelle from '../src/renderer/lib/containerCheckout.ts?raw'
+import dialogQuelle from '../src/renderer/components/Inventory/InventoryDialog.tsx?raw'
+import dictsQuelle from '../src/renderer/lib/i18n/dicts.ts?raw'
+import storeQuelle from '../src/renderer/store/checkoutStore.ts?raw'
+import inventoryStoreQuelle from '../src/renderer/store/inventoryStore.ts?raw'
+import keysQuelle from '../src/renderer/lib/storageKeys.ts?raw'
+import { stripComments } from './support/stripComments'
+
+// ---------------------------------------------------------------------------
+// Bedarf 15 -- den Container ein- und auschecken, nicht den Artikel.
+//
+// Der Befund kommt aus zwei offenen Snipe-IT-Ausgaben von AV-Leuten:
+// „a good half hour of repetitive clicking" (snipe-it#9517), und der Ausweg
+// dort ist ein erfundenes Eltern-Asset, das nur fuer sich selbst Auskunft
+// gibt. Der zweite Satz ist der wichtigere: „Kits contain models, not the
+// specific physical assets that are actually in the case."
+//
+// Geprueft wird deshalb vor allem, was NICHT passiert: keine Kit-Vorlage
+// statt echtem Inhalt, keine zwei Vorgaenge ueber dasselbe Blech, keine
+// stillschweigend geheilte Fehlmenge.
+// ---------------------------------------------------------------------------
+
+const zeit = '2026-09-06T10:00:00.000Z'
+
+const node = (id: string, name: string, kind: StorageNode['kind'], parentId?: string): StorageNode => ({
+  id, name, kind, parentId, createdAt: zeit, updatedAt: zeit,
+})
+
+const item = (id: string, model: string, quantity: number, locationId?: string): InventoryItem => ({
+  id, model, quantity, locationId, createdAt: zeit, updatedAt: zeit,
+})
+
+const unit = (id: string, itemId: string, serial: string, locationId?: string): InventoryUnit => ({
+  id, itemId, serial, locationId, condition: 'ok', history: [], createdAt: zeit, updatedAt: zeit,
+})
+
+/**
+ * Ein Transport-Case mit einem Case darin -- die Verschachtelung, um die es
+ * dem Bedarf geht.
+ *
+ *   Depot
+ *     Regal A3
+ *       Transport-Case 1        <- wird ausgegeben
+ *         Case 2
+ *           Objektiv 24-70 (Einheit S-1)
+ *           Klettband x5
+ *         Kamera (Einheit S-2)
+ *     Regal B1
+ *       Stativ x2               <- liegt NICHT im Case
+ */
+const lager = (): InventorySnapshotIn => ({
+  nodes: [
+    node('depot', 'Depot', 'depot'),
+    node('a3', 'Regal A3', 'shelf', 'depot'),
+    node('b1', 'Regal B1', 'shelf', 'depot'),
+    node('tc1', 'Transport-Case 1', 'transportCase', 'a3'),
+    node('c2', 'Case 2', 'case', 'tc1'),
+  ],
+  items: [
+    item('klett', 'Klettband', 5, 'c2'),
+    item('stativ', 'Stativ', 2, 'b1'),
+  ],
+  units: [
+    unit('u1', 'obj', 'S-1', 'c2'),
+    unit('u2', 'cam', 'S-2', 'tc1'),
+  ],
+})
+
+const ausgabe = (over: Partial<CheckoutRecord['out']> = {}): CheckoutRecord['out'] => ({
+  at: zeit, to: 'Truck 1', ...over,
+})
+
+describe('der Inhalt folgt mit -- ueber alle Ebenen', () => {
+  it('nimmt das verschachtelte Case UND dessen Inhalt', () => {
+    const lines = containerContents(lager(), 'tc1')
+    expect(lines.map((l) => `${l.kind}:${l.label}`)).toEqual([
+      'node:Case 2',
+      'unit:S-1',
+      'unit:S-2',
+      'item:Klettband',
+    ])
+  })
+
+  it('nimmt NICHTS mit, was ausserhalb liegt', () => {
+    // Das Stativ liegt in Regal B1. Waere es dabei, ginge Material raus, das
+    // niemand eingepackt hat -- und bei der Rueckgabe fehlte es „aus dem Case".
+    const lines = containerContents(lager(), 'tc1')
+    expect(lines.some((l) => l.label === 'Stativ')).toBe(false)
+  })
+
+  it('fuehrt den verschachtelten Container ALS ZEILE und seinen Inhalt einzeln', () => {
+    // Beide Fragen werden gestellt: „ist Case 2 wieder da?" und „sind die
+    // Objektive aus Case 2 wieder da?". Nur den Container zu fuehren waere das
+    // erfundene Eltern-Asset aus snipe-it#9517.
+    const lines = containerContents(lager(), 'tc1')
+    expect(lines.filter((l) => l.kind === 'node')).toHaveLength(1)
+    expect(lines.filter((l) => l.kind !== 'node').length).toBeGreaterThan(1)
+  })
+
+  it('gibt jede Einheit unter ihrer eigenen Kennung aus, nicht als Modell-Menge', () => {
+    // „children keep their own ERP identities": kommt eine von drei
+    // Funkstrecken nicht zurueck, muss auf dem Blatt stehen, WELCHE.
+    const lines = containerContents(lager(), 'tc1')
+    const einheiten = lines.filter((l) => l.kind === 'unit')
+    expect(einheiten.map((l) => l.label)).toEqual(['S-1', 'S-2'])
+    expect(einheiten.every((l) => l.quantity === 1)).toBe(true)
+  })
+
+  it('sortiert stabil', () => {
+    const a = containerContents(lager(), 'tc1')
+    const gedreht: InventorySnapshotIn = {
+      ...lager(),
+      items: [...lager().items].reverse(),
+      units: [...lager().units].reverse(),
+      nodes: [...lager().nodes].reverse(),
+    }
+    // Ohne feste Reihenfolge waere jede zweite Ausgabeliste eine andere Datei
+    // -- und der Dokument-Stempel damit wertlos.
+    expect(containerContents(gedreht, 'tc1')).toEqual(a)
+  })
+})
+
+describe('nichts geht zweimal raus', () => {
+  it('weist einen Nicht-Container ab', () => {
+    expect(checkoutRefusal(lager(), [], 'a3')).toBe('not-a-container')
+  })
+
+  it('weist einen bereits ausgegebenen Container ab', () => {
+    const erste = buildCheckout(lager(), [], 'tc1', ausgabe(), 'r1')
+    expect('record' in erste).toBe(true)
+    const offen = [(erste as { record: CheckoutRecord }).record]
+    expect(checkoutRefusal(lager(), offen, 'tc1')).toBe('already-out')
+  })
+
+  it('weist ein Case IN einem ausgegebenen Transport-Case ab', () => {
+    // Die Haelfte, die man vergisst. Zwei Vorgaenge ueber dasselbe Blech, und
+    // die Rueckgabe des einen macht den anderen stillschweigend falsch.
+    const erste = buildCheckout(lager(), [], 'tc1', ausgabe(), 'r1')
+    const offen = [(erste as { record: CheckoutRecord }).record]
+    expect(checkoutRefusal(lager(), offen, 'c2')).toBe('inside-checked-out')
+  })
+
+  it('laesst ein Case wieder raus, nachdem der Vorgang geschlossen ist', () => {
+    const erste = buildCheckout(lager(), [], 'tc1', ausgabe(), 'r1')
+    const rec = (erste as { record: CheckoutRecord }).record
+    const zu = closeCheckout(rec, containerContents(lager(), 'tc1'), '2026-09-08T09:00:00.000Z')
+    expect(checkoutRefusal(lager(), [zu], 'tc1')).toBeUndefined()
+  })
+})
+
+describe('die Ausgabe friert den TATSAECHLICHEN Inhalt ein', () => {
+  it('behaelt die Liste, wenn der Artikel danach umbenannt wird', () => {
+    // Der Kern des Bedarfs: eine Liste aus der Kit-Vorlage beschriebe ein
+    // gedachtes Case. Bei der Rueckgabe zaehlt, was drin WAR.
+    const rec = (buildCheckout(lager(), [], 'tc1', ausgabe(), 'r1') as { record: CheckoutRecord }).record
+    expect(rec.contents.find((l) => l.refId === 'klett')?.label).toBe('Klettband')
+
+    const spaeter = lager()
+    spaeter.items[0] = { ...spaeter.items[0], model: 'Klettband schwarz' }
+    // Der Datensatz ist unberuehrt -- er schlaegt nichts nach.
+    expect(rec.contents.find((l) => l.refId === 'klett')?.label).toBe('Klettband')
+  })
+
+  it('behaelt den Container-Namen der Ausgabe', () => {
+    const rec = (buildCheckout(lager(), [], 'tc1', ausgabe(), 'r1') as { record: CheckoutRecord }).record
+    expect(rec.nodeLabel).toBe('Transport-Case 1')
+  })
+})
+
+describe('der Unterschied bei der Rueckgabe wird berichtet, nicht geheilt', () => {
+  const rec = (): CheckoutRecord =>
+    (buildCheckout(lager(), [], 'tc1', ausgabe(), 'r1') as { record: CheckoutRecord }).record
+
+  it('meldet eine fehlende Einheit mit ihrer Kennung', () => {
+    const zurueck = containerContents(lager(), 'tc1').filter((l) => l.refId !== 'u1')
+    const { missing, extra } = checkinDifference(rec(), zurueck)
+    expect(missing.map((l) => l.label)).toEqual(['S-1'])
+    expect(extra).toEqual([])
+  })
+
+  it('meldet eine Teilmenge als Differenz, nicht als ganze Zeile', () => {
+    // Von fuenf Kabeln kommen vier zurueck: es fehlt EINS, nicht „Klettband".
+    const zurueck = containerContents(lager(), 'tc1').map((l): CheckoutLine =>
+      l.refId === 'klett' ? { ...l, quantity: 4 } : l,
+    )
+    const { missing } = checkinDifference(rec(), zurueck)
+    expect(missing).toEqual([{ kind: 'item', refId: 'klett', label: 'Klettband', quantity: 1 }])
+  })
+
+  it('meldet Zusaetzliches', () => {
+    const zurueck: CheckoutLine[] = [
+      ...containerContents(lager(), 'tc1'),
+      { kind: 'item', refId: 'fremd', label: 'Fremdes Kabel', quantity: 1 },
+    ]
+    const { extra } = checkinDifference(rec(), zurueck)
+    expect(extra.map((l) => l.label)).toEqual(['Fremdes Kabel'])
+  })
+
+  it('meldet bei glatter Rueckgabe nichts', () => {
+    const { missing, extra } = checkinDifference(rec(), containerContents(lager(), 'tc1'))
+    expect(missing).toEqual([])
+    expect(extra).toEqual([])
+  })
+
+  it('laesst den Ausgabe-Datensatz unveraendert', () => {
+    // Ein Beleg, der sich ruecklaufend korrigieren laesst, ist keiner mehr.
+    const r = rec()
+    const vorher = JSON.stringify(r)
+    closeCheckout(r, [], '2026-09-08T09:00:00.000Z')
+    expect(JSON.stringify(r)).toBe(vorher)
+  })
+
+  it('schreibt den Befund in den geschlossenen Vorgang', () => {
+    const zu = closeCheckout(rec(), [], '2026-09-08T09:00:00.000Z', 'Kunde meldet Verlust')
+    expect(zu.in?.missing).toHaveLength(4)
+    expect(zu.in?.note).toBe('Kunde meldet Verlust')
+    expect(openCheckouts([zu])).toEqual([])
+  })
+})
+
+describe('Fristen', () => {
+  const mit = (dueBack?: string): CheckoutRecord =>
+    (buildCheckout(lager(), [], 'tc1', ausgabe({ dueBack }), 'r1') as { record: CheckoutRecord }).record
+
+  it('ohne Rueckgabedatum ist nichts ueberfaellig', () => {
+    // Ein fehlendes Datum ist keine Frist. Es als „sofort faellig" zu lesen
+    // faerbte jede Ausgabe rot und macht die Liste unlesbar.
+    expect(overdueCheckouts([mit(undefined)], '2030-01-01')).toEqual([])
+  })
+
+  it('ueberfaellig ist, was vor dem Stichtag zurueck sollte', () => {
+    expect(overdueCheckouts([mit('2026-09-07')], '2026-09-09')).toHaveLength(1)
+    expect(overdueCheckouts([mit('2026-09-10')], '2026-09-09')).toEqual([])
+  })
+})
+
+describe('die Blaetter', () => {
+  const rec = (): CheckoutRecord =>
+    (buildCheckout(lager(), [], 'tc1', ausgabe({ projectName: 'Messe', dueBack: '2026-09-07' }), 'r1') as {
+      record: CheckoutRecord
+    }).record
+
+  it('der Ausgabeschein zaehlt jede Position mit Kennung auf', () => {
+    const t = checkoutSheet(rec())
+    expect(t.headers).toEqual(['Art', 'Bezeichnung', 'Menge', 'Kennung'])
+    expect(t.rows).toHaveLength(4)
+    expect(t.rows.every((r) => String(r[3] ?? '').length > 0)).toBe(true)
+  })
+
+  it('die Uebersicht nennt den Lagerort als PFAD', () => {
+    // „Case 2" gibt es dreimal, „Depot > Regal A3 > Transport-Case 1" einmal.
+    const t = openCheckoutsTable([rec()], lager().nodes, '2026-09-09')
+    expect(String(t.rows[0][1])).toContain('Depot')
+    expect(String(t.rows[0][1])).toContain('Regal A3')
+    expect(t.rows[0][7]).toBe('ueberfaellig')
+  })
+
+  it('der Rueckgabe-Befund bleibt LEER, wenn alles glatt zurueckkam', () => {
+    // Die Regel, die hier bewacht wird: ein Blatt, auf dem auch die glatten
+    // Rueckgaben stehen, wird nicht gelesen. Sie ist an der Zeilenstruktur
+    // aufgehaengt -- eine Zeile je Abweichung, keine je Vorgang -- und genau
+    // deshalb faellt hier um, wer eine „alles in Ordnung"-Zeile ergaenzt.
+    const glatt = closeCheckout(rec(), containerContents(lager(), 'tc1'), '2026-09-08T09:00:00.000Z')
+    expect(glatt.in?.missing).toEqual([])
+    expect(discrepancyTable([glatt, { ...glatt, id: 'r3' }]).rows).toEqual([])
+  })
+
+  it('der Rueckgabe-Befund nennt die fehlende Position mit Kennung', () => {
+    const glatt = closeCheckout(rec(), containerContents(lager(), 'tc1'), '2026-09-08T09:00:00.000Z')
+    const schief = closeCheckout(
+      { ...rec(), id: 'r2' },
+      containerContents(lager(), 'tc1').filter((l) => l.refId !== 'u1'),
+      '2026-09-08T09:00:00.000Z',
+    )
+    const t = discrepancyTable([glatt, schief])
+    expect(t.rows).toHaveLength(1)
+    expect(t.rows[0][3]).toBe('fehlt')
+    expect(t.rows[0][5]).toBe('S-1')
+  })
+})
+
+describe('was die Datei NICHT tut', () => {
+  it('holt sich die Zeit nicht selbst', () => {
+    // Ein Beleg, dessen Zeitstempel die Funktion selbst zieht, laesst sich
+    // nicht zweimal gleich bauen -- und ein Test darauf pruefte nur die Uhr.
+    expect(quelle).not.toMatch(/new Date\(\)|Date\.now\(\)/)
+  })
+
+  it('baut die Inhaltsliste NICHT aus den Kit-Vorlagen', () => {
+    // Der ausdrueckliche Befund: „Kits contain models, not the specific
+    // physical assets that are actually in the case."
+    expect(quelle).not.toMatch(/InventorySet|availabilityOfSet|\bsets\b/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ERREICHBARKEIT. Ein Lager-Modul, das kein Reiter oeffnet, spart niemandem
+// die halbe Stunde Klickerei.
+// ---------------------------------------------------------------------------
+describe('Erreichbarkeit im Lager-Dialog', () => {
+  it('hat einen eigenen Reiter mit der Zahl der offenen Vorgaenge', () => {
+    expect(dialogQuelle).toContain("id: 'checkout' as Tab")
+    expect(dialogQuelle).toContain('<CheckoutTab />')
+    // Ein Reiter, der nicht sagt, dass drei Cases draussen sind, wird nicht
+    // geoeffnet.
+    expect(dialogQuelle).toMatch(/records\.filter\(\(r\) => !r\.in\)\.length/)
+  })
+
+  it('gibt aus und bucht zurueck ueber den Store', () => {
+    expect(dialogQuelle).toContain("from '../../store/checkoutStore'")
+    expect(dialogQuelle).toMatch(/checkOut\(snap, nodeId,/)
+    expect(dialogQuelle).toMatch(/checkIn\(snap, r\.id\)/)
+  })
+
+  it('zeigt VOR dem Klick, was mitginge', () => {
+    // Ein Knopf, der ungesehen vierzig Positionen ausbucht, wird beim ersten
+    // Fehlgriff nicht mehr benutzt.
+    expect(dialogQuelle).toMatch(/containerContents\(snap, nodeId\)/)
+    expect(dialogQuelle).toContain("'inventory.checkout.preview'")
+  })
+
+  it('nennt die Absage auf dem Schirm, statt sie zu verschlucken', () => {
+    for (const key of [
+      'inventory.checkout.notContainer',
+      'inventory.checkout.alreadyOut',
+      'inventory.checkout.insideOut',
+      'inventory.checkout.unknownNode',
+    ]) {
+      expect(dialogQuelle).toContain(`'${key}'`)
+      expect(dictsQuelle).toContain(`'${key}'`)
+    }
+    // Ausgeschriebener switch, kein `t(`inventory.checkout.${r}`)`: ein
+    // dynamischer Schluessel ist fuer den Deckungs-Guard unsichtbar.
+    expect(dialogQuelle).not.toMatch(/t\(`inventory\.checkout\./)
+  })
+
+  it('setzt KEINEN Dokument-Stempel auf die Lager-Blaetter', () => {
+    // Der Stempel (ADR-004) bindet ein Blatt an einen PLAN-Stand. Ein
+    // Ausgabeschein haengt am Lager und nicht am geoeffneten Projekt; ein
+    // Plan-Fingerabdruck darauf waere eine Aussage ueber etwas anderes.
+    const tabAb = dialogQuelle.indexOf('const CheckoutTab')
+    const tabBis = dialogQuelle.indexOf('const ReportsTab')
+    const tab = dialogQuelle.slice(tabAb, tabBis)
+    expect(tabAb).toBeGreaterThan(-1)
+    expect(tab).not.toMatch(/stampForRows|csvFromTable|planFingerprint/)
+  })
+})
+
+describe('die Belege bleiben aus dem portablen Lager-Format heraus', () => {
+  it('haengt nicht am Inventory-Store', () => {
+    // `avplan-inventory` ist in allen drei Apps byte-identisch eingefroren
+    // (`inventoryContract.test.ts`). Einen Ausgabe-Beleg dort einzuhaengen
+    // hiesse, das Format in drei Repos zu brechen, damit multicam und light
+    // ein Feld durchreichen, das sie nie fuellen.
+    // Ohne `stripComments` traefe die Regex die Begruendung im Kopfkommentar
+    // -- der Guard pruefte dann seine eigene Erklaerung statt des Codes.
+    expect(stripComments(storeQuelle)).not.toMatch(/inventoryStore|serializeInventory|exportSnapshot/)
+    expect(stripComments(inventoryStoreQuelle)).not.toMatch(/checkout|Checkout/i)
+  })
+
+  it('benutzt einen eigenen localStorage-Key aus der Registry', () => {
+    expect(storeQuelle).toContain('STORAGE_KEYS.checkouts')
+    expect(keysQuelle).toContain("checkouts: 'cable-planner:checkouts'")
+  })
+})

--- a/tests/dokumentBezeichnerRegistriert.test.ts
+++ b/tests/dokumentBezeichnerRegistriert.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+import { DOCUMENT_STANDS, DOCUMENT_LABELS, UNJUDGEABLE_DOCUMENTS } from '../src/renderer/lib/documentRegistry'
+import { stripComments } from './support/stripComments'
+
+// ---------------------------------------------------------------------------
+// WAS DIESER TEST GEFUNDEN HAT (2026-09-06).
+//
+// Beim Bau des Ablaufblatts (Bedarf 33) bekam der Export den Bezeichner
+// `'ablaufblatt'` mit -- und niemand trug ihn in `documentRegistry` ein. Alle
+// 117 Testdateien blieben gruen. Der Bezeichner landet im Stempel auf dem
+// Blatt, und `docStandStatus` haette darauf geantwortet: „Dokument unbekannt",
+// obwohl das Blatt aus dem Plan heraus perfekt nachrechenbar ist.
+//
+// Der Fehler ist NICHT der vergessene Eintrag -- den macht jeder. Der Fehler
+// ist, dass ihn nichts bemerkt: es gab einen Guard dafuer, dass jeder
+// EINGETRAGENE Bezeichner ein Label hat (`documentRegistry.test.ts`), aber
+// keinen dafuer, dass jeder BENUTZTE Bezeichner eingetragen ist. Die Richtung
+// war falsch herum -- ein Register kann nur pruefen, was in ihm steht.
+//
+// Dieser Test dreht sie um: er liest die Aufrufstellen und haelt sie gegen das
+// Register. Ein Blatt mit einem Stempel, den niemand deuten kann, ist
+// schlimmer als eins ohne Stempel: es sieht pruefbar aus.
+// ---------------------------------------------------------------------------
+
+const sources = import.meta.glob('../src/**/*.{ts,tsx,cts}', {
+  eager: true,
+  query: '?raw',
+  import: 'default',
+}) as Record<string, string>
+
+/**
+ * Die Argumente eines `csvFromTable(...)`-Aufrufs, ueber balancierte Klammern
+ * getrennt statt per Regex. Der erste Versuch war eine Regex, und sie hat
+ * `csvFromTable(planDiffTable(before, after))` fuer einen berechneten
+ * Bezeichner gehalten: das Komma INNERHALB der inneren Klammer sah aus wie
+ * ein Argument-Trenner. Ein Argument-Trenner ist es nur auf Ebene null.
+ */
+const argumente = (code: string, ab: number): string[] | null => {
+  let i = ab
+  let tiefe = 0
+  let quote: string | null = null
+  const args: string[] = []
+  let aktuell = ''
+  for (; i < code.length; i++) {
+    const c = code[i]
+    if (quote) {
+      aktuell += c
+      if (c === '\\') {
+        aktuell += code[++i] ?? ''
+      } else if (c === quote) {
+        quote = null
+      }
+      continue
+    }
+    if (c === "'" || c === '"' || c === '`') {
+      quote = c
+      aktuell += c
+      continue
+    }
+    if (c === '(' || c === '[' || c === '{') {
+      tiefe++
+      if (tiefe === 1) continue
+    }
+    if (c === ')' || c === ']' || c === '}') {
+      tiefe--
+      if (tiefe === 0) {
+        args.push(aktuell.trim())
+        return args
+      }
+    }
+    if (c === ',' && tiefe === 1) {
+      args.push(aktuell.trim())
+      aktuell = ''
+      continue
+    }
+    aktuell += c
+  }
+  return null
+}
+
+const benutzte = new Map<string, string[]>()
+const berechnete: string[] = []
+
+for (const [pfad, roh] of Object.entries(sources)) {
+  const code = stripComments(roh)
+  let von = code.indexOf('csvFromTable(')
+  while (von !== -1) {
+    const args = argumente(code, von + 'csvFromTable'.length)
+    const dritt = args?.[2]
+    if (dritt) {
+      const literal = /^'([a-z0-9-]+)'$/.exec(dritt)
+      if (literal) {
+        const id = literal[1]
+        benutzte.set(id, [...(benutzte.get(id) ?? []), pfad])
+      } else {
+        // Ein Bezeichner aus einer Variablen laesst sich statisch nicht
+        // aufloesen. Er wird nicht verboten, aber benannt -- sonst waechst
+        // hier eine Luecke, die aussieht wie „keine Fundstelle".
+        berechnete.push(`${pfad}: ${dritt}`)
+      }
+    }
+    von = code.indexOf('csvFromTable(', von + 1)
+  }
+}
+
+const bekannt = (id: string): boolean => id in DOCUMENT_STANDS || id in UNJUDGEABLE_DOCUMENTS
+
+describe('jeder ausgegebene Dokument-Bezeichner ist registriert', () => {
+  it('findet ueberhaupt Aufrufstellen', () => {
+    // Ohne diese Zeile waere der Test tautologisch: eine Regex, die nichts
+    // trifft, bestaetigt jede Behauptung ueber ihre Treffer.
+    expect(benutzte.size).toBeGreaterThanOrEqual(5)
+  })
+
+  it('kennt jeden benutzten Bezeichner', () => {
+    const unbekannt = [...benutzte.entries()]
+      .filter(([id]) => !bekannt(id))
+      .map(([id, orte]) => `${id} (${orte.join(', ')})`)
+    expect(unbekannt, 'nicht in DOCUMENT_STANDS oder UNJUDGEABLE_DOCUMENTS').toEqual([])
+  })
+
+  it('hat fuer jeden benutzten Bezeichner einen lesbaren Namen', () => {
+    const ohneLabel = [...benutzte.keys()].filter((id) => !DOCUMENT_LABELS[id])
+    expect(ohneLabel).toEqual([])
+  })
+
+  it('benennt Aufrufstellen mit berechnetem Bezeichner', () => {
+    // Heute keine. Wer die erste baut, sieht hier, dass dieser Guard sie
+    // nicht mehr pruefen kann, und entscheidet bewusst.
+    expect(berechnete).toEqual([])
+  })
+})

--- a/tests/encoderFeasibility.test.ts
+++ b/tests/encoderFeasibility.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest'
+import {
+  checkAllEncoders,
+  checkEncoderFeasibility,
+  ENCODERS,
+  runOfShowSheet,
+} from '../src/renderer/lib/encoderFeasibility'
+import { DEFAULT_ENCODING, type DeliveryDestination } from '../src/renderer/types/delivery'
+import dialogQuelle from '../src/renderer/components/Delivery/DeliveryDialog.tsx?raw'
+import dictsQuelle from '../src/renderer/lib/i18n/dicts.ts?raw'
+
+// ---------------------------------------------------------------------------
+// Kann der Encoder, was der Plan verlangt? (Bedarfe 33 und 36)
+//
+// Bedarf 36 beschreibt einen Widerspruch zwischen Plan und Werkzeug:
+//
+//   > vMix disables multi-bitrate the moment a second destination is added and
+//   > defaults all targets to identical quality; the OBS multi-RTMP plugin's
+//   > per-destination quality question is open and unanswered.
+//
+// Und Bedarf 31 sagt, was heute stattdessen passiert: „nothing validates
+// them, so the only proof the backup works is deliberately killing the primary
+// during rehearsal".
+//
+// Der Plan DARF Qualitaet je Ziel fuehren -- Twitch nimmt 6.000 kbit/s und
+// YouTube 12.000. Was fehlte, ist die Auskunft, ob das Werkzeug am Showtag das
+// auch liefern kann.
+//
+// Geprueft wird deshalb: dass die Grenzen aus BELEGTEN Herstellerangaben
+// kommen, dass „unbeantwortet" ein eigener Zustand bleibt und nicht zu „nein"
+// wird, und dass auf einem einfachen Aufbau gar nichts gemeldet wird.
+// ---------------------------------------------------------------------------
+
+const ziel = (name: string, over: Partial<DeliveryDestination> = {}): DeliveryDestination => ({
+  id: `id-${name}`,
+  name,
+  platform: 'custom',
+  transport: 'RTMP',
+  ingestUrl: 'rtmp://example.test/live',
+  hasStreamKey: true,
+  encoding: { ...DEFAULT_ENCODING },
+  ...over,
+})
+
+const vmix = ENCODERS.find((e) => e.id === 'vmix')!
+const obs = ENCODERS.find((e) => e.id === 'obs-multi-rtmp')!
+
+describe('ein einfacher Aufbau meldet nichts', () => {
+  it('schweigt bei einem einzigen Ziel', () => {
+    expect(checkEncoderFeasibility([ziel('YouTube')], vmix)).toEqual([])
+  })
+
+  it('schweigt bei zwei Zielen mit gleicher Qualitaet', () => {
+    // Der Normalfall eines Simulcasts. Eine Warnung darueber waere Rauschen
+    // auf einem korrekten Aufbau -- und nach dem zweiten Mal wird auch die
+    // richtige daneben ignoriert.
+    expect(checkEncoderFeasibility([ziel('YouTube'), ziel('Twitch')], vmix)).toEqual([])
+  })
+
+  it('zaehlt Backups NICHT als gleichzeitige Ziele', () => {
+    // Ein Backup laeuft im Havariefall, nicht daneben. Es als viertes Ziel zu
+    // zaehlen ergaebe einen Befund, den es nicht gibt -- dieselbe Regel wie im
+    // Uplink-Budget.
+    const viele = [
+      ziel('A'),
+      ziel('B'),
+      ziel('C'),
+      ziel('A-Backup', { backupOfId: 'id-A' }),
+      ziel('B-Backup', { backupOfId: 'id-B' }),
+    ]
+    expect(checkEncoderFeasibility(viele, vmix).filter((f) => f.kind === 'too-many-destinations')).toEqual([])
+  })
+})
+
+describe('vMix — belegte Grenzen', () => {
+  it('meldet mehr als drei gleichzeitige Ziele', () => {
+    // „up to three destinations" (vmix.com/help23).
+    const f = checkEncoderFeasibility([ziel('A'), ziel('B'), ziel('C'), ziel('D')], vmix)
+    const zuViele = f.find((x) => x.kind === 'too-many-destinations')
+    expect(zuViele?.values).toEqual(['4', '3'])
+    expect(zuViele?.source).toContain('vmix.com')
+  })
+
+  it('meldet Qualitaet je Ziel als NICHT unterstuetzt', () => {
+    // „multi-bitrate support is disabled when using multiple destinations".
+    // Twitch 6.000 und YouTube 12.000 nebeneinander ist genau der Fall, in dem
+    // der Plan recht hat und das Werkzeug nicht mitkommt.
+    const f = checkEncoderFeasibility(
+      [
+        ziel('Twitch', { encoding: { ...DEFAULT_ENCODING, videoBitrateKbps: 6000 } }),
+        ziel('YouTube', { encoding: { ...DEFAULT_ENCODING, videoBitrateKbps: 12000 } }),
+      ],
+      vmix,
+    )
+    expect(f.map((x) => x.kind)).toContain('per-destination-quality-unsupported')
+  })
+
+  it('nennt jedes Feld, das gleich sein muss, einzeln', () => {
+    // Wer den Aufbau anpassen will, braucht die Liste der Felder und nicht die
+    // Zahl. „keyframe frequency and master frame rate must match for every
+    // additional streaming target".
+    const f = checkEncoderFeasibility(
+      [
+        ziel('A', { encoding: { ...DEFAULT_ENCODING, fps: 25, keyframeSec: 2 } }),
+        ziel('B', { encoding: { ...DEFAULT_ENCODING, fps: 30, keyframeSec: 4 } }),
+      ],
+      vmix,
+    )
+    const felder = f.filter((x) => x.kind === 'must-match-differs').map((x) => x.field)
+    expect(felder).toContain('fps')
+    expect(felder).toContain('keyframeSec')
+    const fpsBefund = f.find((x) => x.field === 'fps')
+    expect(fpsBefund?.values).toEqual(['25', '30'])
+  })
+})
+
+describe('OBS — „unbeantwortet" ist kein „nein"', () => {
+  it('meldet die Qualitaetsfrage als UNBEKANNT, nicht als nicht unterstuetzt', () => {
+    // sorayuki/obs-multi-rtmp#448 ist offen und ohne Antwort des Betreuers.
+    // Ein Werkzeug, dessen Verhalten niemand kennt, als „geht nicht" in den
+    // Plan zu schreiben waere eine Behauptung ueber fremden Code.
+    const f = checkEncoderFeasibility(
+      [
+        ziel('A', { encoding: { ...DEFAULT_ENCODING, videoBitrateKbps: 6000 } }),
+        ziel('B', { encoding: { ...DEFAULT_ENCODING, videoBitrateKbps: 12000 } }),
+      ],
+      obs,
+    )
+    expect(f.map((x) => x.kind)).toContain('per-destination-quality-unknown')
+    expect(f.map((x) => x.kind)).not.toContain('per-destination-quality-unsupported')
+  })
+
+  it('behauptet fuer OBS keine Zielgrenze', () => {
+    // Es liegt keine belegte vor. Eine erfundene waere schlimmer als keine.
+    expect(obs.maxDestinations).toBeUndefined()
+    const f = checkEncoderFeasibility([ziel('A'), ziel('B'), ziel('C'), ziel('D'), ziel('E')], obs)
+    expect(f.map((x) => x.kind)).not.toContain('too-many-destinations')
+  })
+})
+
+describe('jeder Eintrag traegt seine Fundstelle', () => {
+  it('kein Encoder ohne Quelle, kein Befund ohne Quelle', () => {
+    // Dieselbe Regel wie beim Transport-Rechner: „an unattributed value would
+    // be worse than none".
+    for (const e of ENCODERS) expect(e.source.length).toBeGreaterThan(10)
+    const f = checkAllEncoders([
+      ziel('A', { encoding: { ...DEFAULT_ENCODING, fps: 25 } }),
+      ziel('B', { encoding: { ...DEFAULT_ENCODING, fps: 30 } }),
+    ])
+    expect(f.length).toBeGreaterThan(0)
+    for (const x of f) expect(x.source.length).toBeGreaterThan(10)
+  })
+
+  it('fuehrt nur Encoder, fuer die eine Fundstelle vorliegt', () => {
+    // Ein Katalog mit zehn Encodern und geratenen Grenzen saehe vollstaendig
+    // aus. Zwei belegte Zeilen sind ehrlicher.
+    expect(ENCODERS.map((e) => e.id).sort()).toEqual(['obs-multi-rtmp', 'vmix'])
+  })
+})
+
+describe('das Ablauf-Blatt', () => {
+  it('nennt den Stream-Key als VERWEIS, nie als Wert', () => {
+    // „secrets as references" sagt der Bedarf, und ein Blatt, das auf einem
+    // Regieplatz liegt, ist der letzte Ort fuer ein Geheimnis.
+    const t = runOfShowSheet([ziel('YouTube', { account: 'Kanal Kunde' })])
+    expect(t.rows[0][5]).toBe('Schluesselbund: stream-key:id-YouTube')
+    expect(JSON.stringify(t)).not.toMatch(/live-[a-z0-9-]{8,}/)
+  })
+
+  it('sagt es, wenn kein Key hinterlegt ist', () => {
+    const t = runOfShowSheet([ziel('YouTube', { hasStreamKey: false })])
+    expect(t.rows[0][5]).toBe('nicht hinterlegt')
+  })
+
+  it('nennt die Rolle, damit am Showtag klar ist, was der Ausweichweg ist', () => {
+    const t = runOfShowSheet([ziel('Haupt'), ziel('Backup', { backupOfId: 'id-Haupt' })])
+    expect(t.rows[0][1]).toBe('Primaerweg')
+    expect(t.rows[1][1]).toBe('Backup von Haupt')
+  })
+})
+
+describe('kein erfundenes Fremdformat', () => {
+  it('erzeugt weder OBS-Profil noch vMix-Preset noch NOALBS-JSON', async () => {
+    // Bedarf 33 nennt sie als Ziel, aber die genauen Schluessel dieser Formate
+    // liegen in dieser Recherche NICHT vor -- vom NOALBS-Umfang ist die
+    // Feldliste gelesen, nicht das Schema. Eine Datei mit erfundenen
+    // Schluesselnamen, die „OBS-Profil" heisst, sieht geprueft aus und ist
+    // geraten; sie kostet am Showtag mehr Zeit als das Abtippen.
+    const quelle = (await import('../src/renderer/lib/encoderFeasibility.ts?raw')).default as string
+    expect(quelle).not.toMatch(/JSON\.stringify|\.json"|profile\s*=|preset\s*=/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ERREICHBARKEIT. Der wiederkehrende Fehler in diesem Projekt ist nicht der
+// falsche Rechenweg, sondern das gebaute Modul, das kein Knopf aufruft: es ist
+// getestet, es ist richtig, und niemand sieht es je. Deshalb prueft dieser
+// Block den DIALOG und nicht die Bibliothek.
+// ---------------------------------------------------------------------------
+describe('Erreichbarkeit im Ausspiel-Dialog', () => {
+  const dialog = dialogQuelle
+
+  it('ruft die Machbarkeitspruefung auf', () => {
+    expect(dialog).toContain("from '../../lib/encoderFeasibility'")
+    expect(dialog).toContain('checkEncoderFeasibility')
+    // Nicht nur importiert, sondern angewendet -- ein Import allein rendert
+    // nichts.
+    expect(dialog).toMatch(/ENCODERS\.map\(/)
+  })
+
+  it('bietet das Ablaufblatt zum Ausgeben an', () => {
+    expect(dialog).toContain('runOfShowSheet')
+    expect(dialog).toMatch(/onClick=\{exportRunOfShow\}/)
+    // Mit Stempel wie jede andere Liste (ADR-004, Inkrement 3): ein Blatt, das
+    // per Mail wandert, muss seinen Stand nennen koennen.
+    expect(dialog).toContain('stampForRows(project, runOfShowSheetForProject')
+  })
+
+  it('setzt die Befundtexte NICHT dynamisch zusammen', () => {
+    // Ein `t(\`delivery.encoder.${f.kind}\`)` ist fuer den i18n-Deckungs-Guard
+    // unsichtbar und faellt im EN-Betrieb still auf den nackten Slug zurueck.
+    // Genau dieser Fehler ist in `venueRequestTable` schon einmal passiert.
+    expect(dialog).not.toMatch(/t\(`delivery\.encoder\./)
+    for (const key of [
+      'delivery.encoder.tooMany',
+      'delivery.encoder.noPerDestination',
+      'delivery.encoder.perDestinationUnknown',
+      'delivery.encoder.mustMatch',
+    ]) {
+      expect(dialog).toContain(`'${key}'`)
+      expect(dictsQuelle).toContain(`'${key}'`)
+    }
+  })
+})


### PR DESCRIPTION
Drei P1-Bedarfe: zwei aus dem Ausspiel-Dossier, einer aus dem Lager-Dossier.

---

## Bedarf 36 — ein Widerspruch zwischen Plan und Werkzeug

> vMix disables multi-bitrate the moment a second destination is added and defaults all targets to identical quality; the OBS multi-RTMP plugin's per-destination quality question is open and unanswered; the recommended workaround gives up quality control to protect the CPU.

Und Bedarf 31 sagt, was heute stattdessen passiert:

> nothing validates them, so the only proof the backup works is deliberately killing the primary during rehearsal.

Der Plan **darf** Qualität je Ziel führen — Twitch nimmt 6.000 kbit/s und YouTube 12.000, das ist kein Fehler. Was fehlte, ist die Auskunft, ob das Werkzeug das auch liefern kann.

**Zwei Einträge im Katalog, nicht zehn.** `ENCODERS` führt nur, wofür diese Recherche eine Fundstelle hat:

| Encoder | Zielgrenze | Qualität je Ziel | Muss übereinstimmen |
| --- | --- | --- | --- |
| vMix | **3** (belegt) | **nein** (belegt) | Video-kbit/s, Audio-kbit/s, Breite, Höhe, Keyframe, fps |
| OBS + obs-multi-rtmp | **keine belegte** | **ungeklärt** | — |

Ein Katalog mit zehn Encodern und geratenen Grenzen wäre schlimmer als diese zwei Zeilen: er sähe vollständig aus. Aus demselben Grund trägt obs-multi-rtmp **keine** Zielgrenze — es gibt dafür keinen Beleg, also wird keine behauptet. Eine Gegenprobe, die ihm eine erfindet, macht den Lauf rot.

**„Unbeantwortet" ist ein eigener Zustand, kein Nein.** Die Frage nach Qualität je Ziel ist bei obs-multi-rtmp gestellt und unbeantwortet ([`sorayuki/obs-multi-rtmp#448`](https://github.com/sorayuki/obs-multi-rtmp/issues/448), offen seit 2024-10-26, ohne Antwort des Betreuers). Daraus ein „geht nicht" zu machen hiesse, eine offene Frage im Plan als Tatsache zu führen.

Zwei Regeln gegen Rauschen: gezählt werden die **Primärwege** (ein Backup läuft im Havariefall, nicht daneben), und unter zwei Zielen schweigt die Prüfung ganz. Jeder Befund trägt seine **Fundstelle** im Text — ein Befund über fremde Software ohne Beleg ist eine Behauptung.

---

## Bedarf 33 — was bewusst *nicht* entsteht

Der Bedarf nennt „best-effort, versioned exporters" als Ziel. Es entsteht **keine** OBS-Profil-Datei, **kein** vMix-Preset, **kein** NOALBS-JSON — die genauen Schlüssel dieser Formate liegen in dieser Recherche nicht vor; vom NOALBS-Konfigurationsumfang ist die *Feldliste* gelesen, nicht das Schema. Eine Datei mit erfundenen Schlüsselnamen, die „OBS-Profil" heisst, sieht geprüft aus und ist geraten. Ein Test prüft den Quelltext darauf.

Was stattdessen entsteht, ist der Teil, der ohne fremdes Schema auskommt: **das Ablaufblatt**, „a printable destination sheet for the run of show" — mit dem Stream-Key als **Verweis** (`Schluesselbund: stream-key:<id>`), nie als Wert. „Secrets as references" sagt der Bedarf, und ein Blatt, das auf einem Regieplatz liegt, ist der letzte Ort für ein Geheimnis.

---

## Bedarf 15 — den Container ausgeben, nicht den Artikel

> cameras + lenses + audio + cards that "travel together at all times" — "a good half hour of repetitive clicking"

([`snipe-it#9517`](https://github.com/grokability/snipe-it/issues/9517), 2021-04-30, im August 2025 immer noch offen.) Der dortige Ausweg ist ein erfundenes „Eltern-Asset", das dann als Einziges benachrichtigt. Der zweite Satz ist der wichtigere: *„Kits contain models, not the specific physical assets that are actually in the case."*

**Der Inhalt folgt mit, weil er nicht angefasst wird.** Der Lager-Baum (LPN) sagt bereits, was in einem Container liegt, verschachtelt über beliebig viele Ebenen. „Ein Klick statt vierzig" ist deshalb keine Funktion, die etwas mitbewegt, sondern eine Eigenschaft des Baums.

| Regel | Warum |
| --- | --- |
| Die Ausgabe friert ein, was **tatsächlich** drin war | Eine Liste aus der Kit-Vorlage beschriebe ein gedachtes Case; die Frage bei der Rückgabe lautet „fehlt etwas?" |
| Bezeichnungen werden **mitgeschrieben**, nicht nachgeschlagen | Ein währenddessen umbenannter Artikel macht die Rückgabeliste genau dann unlesbar, wenn sie jemand braucht |
| Eine Einheit geht unter **ihrer eigenen Kennung** raus | Kommt eine von drei Funkstrecken nicht zurück, steht auf dem Blatt, welche |
| Ein Case **im** ausgegebenen Transport-Case darf nicht raus | Zwei Vorgänge über dasselbe Blech — die Rückgabe des einen macht den anderen still falsch |
| Der verschachtelte Container erscheint **als Zeile und** sein Inhalt einzeln | Beide Fragen werden gestellt; nur den Container zu führen wäre wieder das Eltern-Asset |
| Die Fehlmenge zählt als **Differenz**, nicht als ganze Zeile | Von fünf Kabeln kommen vier zurück: es fehlt eins |
| Der geschlossene Beleg ist ein **neuer** Datensatz | Ein Beleg, der sich rücklaufend korrigieren lässt, ist keiner mehr |
| Ohne Rückgabedatum ist **nichts** überfällig | Ein fehlendes Datum ist keine Frist; sonst wäre die Liste durchgehend rot |

**Eigener Store, eigener Key.** Der Bestand ist ein *Katalog* und wandert per `avplan-inventory` zwischen den drei Apps — dessen Envelope ist in allen dreien byte-identisch eingefroren. Ein Ausgabe-Beleg ist Betriebszustand *eines* Lagers; ihn dort einzuhängen hiesse, das Format in drei Repos zu brechen, damit multicam und light ein Feld durchreichen, das sie nie füllen.

**Kein Dokument-Stempel** auf diesen Blättern: der Stempel bindet ein Blatt an einen *Plan*-Stand, ein Ausgabeschein hängt am Lager.

---

## Ein Guard, den es hätte geben müssen

Der Ablaufblatt-Export bekam den Bezeichner `'ablaufblatt'` mit, und niemand trug ihn in `documentRegistry` ein. **Alle 117 Testdateien blieben grün.** `docStandStatus` hätte auf den Stempel geantwortet „Dokument unbekannt", obwohl das Blatt nachrechenbar ist.

Der Fehler ist nicht der vergessene Eintrag — den macht jeder. Der Fehler ist, dass ihn nichts bemerkt: es gab einen Guard dafür, dass jeder **eingetragene** Bezeichner ein Label hat, aber keinen dafür, dass jeder **benutzte** Bezeichner eingetragen ist. Die Richtung war falsch herum. `tests/dokumentBezeichnerRegistriert.test.ts` dreht sie um.

Der erste Versuch dieses Guards war eine Regex, und sie hielt `csvFromTable(planDiffTable(before, after))` für einen berechneten Bezeichner: das Komma *innerhalb* der inneren Klammer sah aus wie ein Argument-Trenner. Jetzt werden die Argumente über balancierte Klammern getrennt.

## Eine Gegenprobe blieb grün — und hat einen echten Fehler gezeigt

`discrepancyTable` trug einen `.filter(...)`, der nur die Vorgänge mit Abweichung durchliess, mit einem Kommentar, der daraus eine Regel machte. **Der Filter war wirkungslos:** eine leere Fehl-/Zuviel-Liste erzeugt ohnehin keine Zeile. Ein Filter, den nichts prüft, mit einem Kommentar, der eine Regel behauptet, ist schlimmer als keiner — der nächste Leser hält die Regel für bewacht. Der Filter ist raus, der Kommentar sagt jetzt, dass die Zeilenstruktur die Regel trägt, und der Test hängt an der Stelle, an der sie brechen *kann*: ein Blatt aus lauter glatten Rückgaben muss leer bleiben.

Dazu entfiel `refusalText` wieder: die Absage landet nie in einem Dokument, nur auf dem Schirm. Kanonisches Deutsch für etwas, das kein Dokument je trägt, ist Code ohne Leser.

## i18n

Eigener Namensraum `delivery.encoder.*` — die `delivery.enc.*` daneben sind die Encoding-**Felder** (Breite, fps, Keyframe), hier geht es um das **Werkzeug**. Beide Befundtext-Funktionen stehen als ausgeschriebener `switch` da und nicht als ``t(`…${kind}`)``: ein dynamisch zusammengesetzter Schlüssel ist für den Deckungs-Guard unsichtbar und fällt im EN-Betrieb still auf den nackten Slug zurück. Genau dieser Fehler ist beim Haus-IT-Blatt (`#705`) schon einmal passiert.

## Erreichbar

- **Ausspielung** → Machbarkeits-Block über der Zielliste, *nur wenn es etwas zu sagen gibt*; ein Kasten, der sonst „alles in Ordnung" meldet, verlernt sich. Daneben der Knopf **Ablaufblatt**.
- **Lager → Ausgabe** → Container wählen, Empfänger, Rückgabedatum; **vor** dem Klick steht da, was mitginge. Darunter „Draußen (n)" mit Ausgabeschein, Zurückbuchen und den Rückgabe-Befunden. Die Zahl steht am Reiter — einer, der nicht sagt, dass drei Cases draußen sind, wird nicht geöffnet.

## Gegenproben

Sechsundzwanzig Fehler eingespritzt, jeder hat Tests umgeworfen:

| Bereich | Eingespritzt |
| --- | --- |
| Encoder (7) | Backup als gleichzeitiges Ziel zählen · `unknown` wie `false` behandeln · Key im Klartext aufs Blatt · Befund ohne Fundstelle · vMix-Grenze verfälscht · Warnung ohne Abweichung · erfundene OBS-Grenze |
| Ausspiel-UI (5) | Machbarkeit nicht berechnet · Ablaufblatt-Knopf entfernt · dynamischer i18n-Schlüssel · EN-Eintrag gelöscht · Blatt ohne Stempel |
| Register (2) | Bezeichner nicht registriert · Label fehlt |
| Lager (12) | Inhalt folgt nur eine Ebene · Einheit als Modell-Menge · verschachteltes Case zweimal raus · Teilmenge verschwiegen · Beleg nachträglich verändert · ohne Frist überfällig · Uhr in der Bibliothek · „alles in Ordnung"-Zeile · Reiter ohne Zahl · keine Vorschau · Beleg am Inventory-Store · Absage verschluckt |

## Geprüft

`tsc -p tsconfig.app.json --noEmit` (0 Fehler) · `eslint` (0 Fehler, 10 vorbestehende Warnungen) · `vitest` **1238/1240** (2 skipped), davon 53 neu · `npm run build` · `docs:stats` nachgezogen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT