### PR TITLE
cable: geschätzte Längen tragen ihre Herkunft, ein Strang trägt fünf Dienste (Bedarf 13)

### DIFF
--- a/docs/app-structure.html
+++ b/docs/app-structure.html
@@ -240,7 +240,7 @@
   <aside>
     <h1>Cable-Planner</h1>
     <div class="subtitle">
-      App-Struktur · v9.0.0 · ~448 TS/TSX-Module · ~130.8k LOC<br>
+      App-Struktur · v9.0.0 · ~449 TS/TSX-Module · ~131.3k LOC<br>
       <small style="color:#64748b">Diese Übersicht zeigt nur die ~62 wichtigsten Module. Für die vollständige Architektur siehe <a href="./architecture.md" style="color:#94a3b8">architecture.md</a>.</small>
     </div>
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Invarianten der App. Sie ist die Pflicht-Lektüre, bevor strukturelle Änderunge
 gemacht werden. Für die interaktive Modul-Übersicht siehe [`app-structure.html`](./app-structure.html),
 für einen Wettbewerber-Vergleich [`comparison.html`](./comparison.html).
 
-Stand: v9.0.0 · ~448 TS/TSX-Module · ~130.8k LOC
+Stand: v9.0.0 · ~449 TS/TSX-Module · ~131.3k LOC
 
 ---
 
@@ -553,7 +553,7 @@ optionales Cloud-Backend (`y-websocket`, Auth/Permissions) bleiben offen.
 `vitest` ist eingerichtet (`npm test` / `npm run test:watch`); dazu kommen
 gezielte Node-Checks (`npm run test:crdt`, `npm run test:signaling`), ein
 UI-Smoke-Skript (`npm run ui:smoke`) und ein headless Drag-/Interaktions-Test
-(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~130.8k LOC
+(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~131.3k LOC
 bleibt der Ausbau der Abdeckung wichtig — empfohlene Schwerpunkte:
 - Snapshot-Tests auf `healProjectPositions` mit echten
   Beispiel-Projekt-JSONs.

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -62,14 +62,14 @@
 <header>
   <h1>Cable-Planner — Strukturvergleich mit ähnlichen Tools</h1>
   <div class="subtitle">Architektur, Tech-Stack und Domänen-Tiefe im Vergleich zu kommerziellen und Open-Source-Alternativen</div>
-  <div class="meta">Stand: 2026-06 · v9.0.0 · ~448 TS/TSX-Module · ~130.8k LOC · ~5.3 MB src/</div>
+  <div class="meta">Stand: 2026-06 · v9.0.0 · ~449 TS/TSX-Module · ~131.3k LOC · ~5.3 MB src/</div>
 </header>
 
 <h2>1 · Cable-Planner — Architektur-Kennzahlen</h2>
 
 <div class="stat-grid">
-  <div class="stat"><div class="num">448</div><div class="label">TS/TSX-Module</div></div>
-  <div class="stat"><div class="num">130.8k</div><div class="label">Lines of Code</div></div>
+  <div class="stat"><div class="num">449</div><div class="label">TS/TSX-Module</div></div>
+  <div class="stat"><div class="num">131.3k</div><div class="label">Lines of Code</div></div>
   <div class="stat"><div class="num">~75</div><div class="label">Modul-Dependencies</div></div>
   <div class="stat"><div class="num">7</div><div class="label">User-Flows</div></div>
 </div>

--- a/src/renderer/components/Analysis/AnalysisDialog.tsx
+++ b/src/renderer/components/Analysis/AnalysisDialog.tsx
@@ -30,6 +30,7 @@ import {
   type SwitchPortMap,
 } from '../../lib/switchPortMap'
 import { csvFromTable } from '../../lib/documentStamp'
+import { cableRunFindings, cableRunTable, type RunFinding } from '../../lib/cableRunChecks'
 import {
   buildVenueNetworkRequest,
   rackDoorSheetTable,
@@ -38,7 +39,7 @@ import {
 } from '../../lib/venueNetworkRequest'
 import { RF_BANDS, bandsForFrequency, bandLabel } from '../../lib/rfBands'
 
-type Tab = 'weight' | 'network' | 'redundancy' | 'rf'
+type Tab = 'weight' | 'network' | 'redundancy' | 'rf' | 'runs'
 
 const WATT_TO_BTU = 3.412
 
@@ -1125,11 +1126,117 @@ const RfTab = ({ projectName }: { projectName: string }) => {
 
 /* ------------------------------------------------------------- Container -- */
 
+// ───────────────────────────────────────────────────────────────────────────
+// Bedarf 13 — die Kabelwege. Was die Laenge behauptet, und ob sie noch gilt.
+//
+// Der Befund nennt das stille Veralten beim Namen: „a moved position SILENTLY
+// invalidates the cable call". Diese Ansicht macht es laut — und nennt bei
+// einem Hybrid-Kamerakabel dazu, wie viele Dienste an dem einen Strang
+// haengen: „one wrong SMPTE run kills video, return, comms, tally and power
+// at once."
+// ───────────────────────────────────────────────────────────────────────────
+const RunsTab = ({ projectName }: { projectName: string }) => {
+  const t = useTranslation()
+  const cables = useProjectStore((s) => s.project.cables)
+  const equipment = useProjectStore((s) => s.project.equipment)
+
+  const findings = useMemo(() => cableRunFindings(cables, equipment), [cables, equipment])
+
+  // Ausgeschriebener switch, ein Schluessel je Fall. Einen Schluessel aus dem
+  // kind-Feld zusammenzusetzen waere fuer den i18n-Deckungs-Guard unsichtbar
+  // und fiele im EN-Betrieb still auf den nackten Slug zurueck. (Die verbotene
+  // Form steht hier bewusst NICHT als Beispiel: sie stuende dann im Quelltext,
+  // und der Guard, der sie sucht, findet den Kommentar.)
+  const text = (f: RunFinding): string => {
+    const kern = (() => {
+      switch (f.kind) {
+        case 'derived-length-stale':
+          return format(
+            t(
+              'analysis.runs.stale',
+              'Länge {alt} m wurde geschätzt; seither um {px} px verschoben, die Schätzung ergäbe jetzt {neu} m',
+            ),
+            { alt: f.values[0], neu: f.values[1], px: f.values[2] },
+          )
+        case 'over-max-length':
+          return format(
+            t('analysis.runs.overMax', 'Länge {laenge} m über der Reichweite von {max} m ({typ})'),
+            { laenge: f.values[0], max: f.values[1], typ: f.values[2] },
+          )
+        case 'endpoint-missing':
+          return t(
+            'analysis.runs.endpointMissing',
+            'Abgeleitete Länge, aber ein Endgerät fehlt — sie lässt sich nicht mehr nachrechnen',
+          )
+      }
+    })()
+    return f.services
+      ? `${kern} — ${format(t('analysis.runs.bundled', 'ein Strang, {n} Dienste: {liste}'), {
+          n: f.services.length,
+          liste: f.services.join(', '),
+        })}`
+      : kern
+  }
+
+  const exportCsv = () => {
+    downloadBlob(
+      buildExportFilenameWithSuffix(projectName, 'kabelwege', 'csv'),
+      csvFromTable(cableRunTable(cables, equipment)),
+      'text/csv',
+    )
+  }
+
+  return (
+    <div className="space-y-3 p-4 text-cp-base">
+      <p className="text-cp-xs text-[var(--cp-text-muted)]">
+        {t(
+          'analysis.runs.intro',
+          'Geschätzte Längen tragen ihre Herkunft. Wird ein Gerät verschoben, veraltet die Schätzung — hier steht es, statt still zu bleiben. Von Hand eingetragene Längen werden NICHT gegen die Luftlinie gehalten: ein echter Kabelweg wird verlegt, nicht gespannt.',
+        )}
+      </p>
+
+      {findings.length === 0 ? (
+        <p className="text-cp-xs text-[var(--cp-text-muted)]">
+          {t('analysis.runs.none', 'Keine Befunde: keine überholte Schätzung, keine Länge über der Reichweite.')}
+        </p>
+      ) : (
+        <>
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={exportCsv}
+              className="rounded border border-cp-border px-2 py-1 text-cp-xs text-cp-text-secondary hover:text-cp-text"
+            >
+              CSV
+            </button>
+          </div>
+          <ul className="space-y-1">
+            {findings.map((f) => (
+              <li
+                key={`${f.kind}-${f.cableId}`}
+                className={
+                  f.kind === 'over-max-length'
+                    ? 'rounded border border-red-700/60 bg-red-900/30 p-2 text-cp-xs text-red-200'
+                    : 'rounded border border-amber-700/60 bg-amber-900/30 p-2 text-cp-xs text-amber-200'
+                }
+              >
+                <span className="font-semibold">{f.cableLabel}</span> — {text(f)}
+                {f.source && <span className="ml-1 opacity-70">({f.source})</span>}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  )
+}
+
 const TABS: { id: Tab; labelKey: string; fallback: string }[] = [
   { id: 'weight', labelKey: 'analysis.tab.weight', fallback: 'Gewicht & Wärme' },
   { id: 'network', labelKey: 'analysis.tab.network', fallback: 'Netzwerk' },
   { id: 'redundancy', labelKey: 'analysis.tab.redundancy', fallback: 'Redundanz' },
   { id: 'rf', labelKey: 'analysis.tab.rf', fallback: 'RF / Funk' },
+  { id: 'runs', labelKey: 'analysis.tab.runs', fallback: 'Kabelwege' },
 ]
 
 export const AnalysisDialog = () => {
@@ -1169,6 +1276,7 @@ export const AnalysisDialog = () => {
       {active === 'network' && <NetworkTab projectName={projectName} />}
       {active === 'redundancy' && <RedundancyTab projectName={projectName} />}
       {active === 'rf' && <RfTab projectName={projectName} />}
+      {active === 'runs' && <RunsTab projectName={projectName} />}
     </ModalShell>
   )
 }

--- a/src/renderer/lib/cableLengthEstimate.ts
+++ b/src/renderer/lib/cableLengthEstimate.ts
@@ -5,7 +5,7 @@
 // manuelle Längen-Tippen für grobe Planung. Eine spätere Stufe kann die
 // echten Waypoint-/A*-Pfade statt der Luftlinie nutzen (siehe Issue #350).
 
-import type { Cable } from '../types/cable'
+import type { Cable, DerivedLengthOrigin } from '../types/cable'
 import type { EquipmentItem } from '../types/equipment'
 import type { LengthEstimationScheme } from '../types/project'
 
@@ -15,7 +15,10 @@ export const DEFAULT_LENGTH_ESTIMATION: LengthEstimationScheme = {
   roundUp: true,
 }
 
-const centerOf = (e: EquipmentItem): { x: number; y: number } => ({
+/** Canvas-Mittelpunkt eines Geraets. EXPORTIERT, weil die Veraltungs-Pruefung
+ *  denselben Punkt braucht: zwei Rechnungen mit zwei Mittelpunkt-Begriffen
+ *  meldeten einen Versatz, den es nicht gibt. */
+export const centerOf = (e: EquipmentItem): { x: number; y: number } => ({
   x: e.x + (e.width ?? 220) / 2,
   y: e.y + (e.height ?? 60) / 2,
 })
@@ -42,6 +45,9 @@ export const estimateCableLength = (
 export interface EstimateResult {
   /** id → neue Länge für alle Kabel, die geschätzt werden konnten. */
   updates: Map<string, number>
+  /** id → Geometrie und Maßstab, aus denen sie entstand (Bedarf 13).
+   *  Ohne diese Spur sieht eine geschätzte Länge aus wie eine gemessene. */
+  origins: Map<string, DerivedLengthOrigin>
   estimated: number
   skipped: number
 }
@@ -54,11 +60,27 @@ export const estimateAllCableLengths = (
 ): EstimateResult => {
   const eqById = new Map(equipment.map((e) => [e.id, e]))
   const updates = new Map<string, number>()
+  const origins = new Map<string, DerivedLengthOrigin>()
   let skipped = 0
   for (const c of cables) {
     const len = estimateCableLength(c, eqById, scheme)
-    if (len == null) skipped += 1
-    else updates.set(c.id, len)
+    if (len == null) {
+      skipped += 1
+      continue
+    }
+    updates.set(c.id, len)
+    const from = eqById.get(c.fromEquipmentId)!
+    const to = eqById.get(c.toEquipmentId)!
+    // Der URSPRUNG, nicht der Mittelpunkt — siehe `DerivedLengthOrigin`:
+    // nur er ueberlebt die Raster-Heilung beim Laden unveraendert.
+    origins.set(c.id, {
+      fromX: from.x,
+      fromY: from.y,
+      toX: to.x,
+      toY: to.y,
+      metersPer100px: scheme.metersPer100px,
+      slackPercent: scheme.slackPercent,
+    })
   }
-  return { updates, estimated: updates.size, skipped }
+  return { updates, origins, estimated: updates.size, skipped }
 }

--- a/src/renderer/lib/cableRunChecks.ts
+++ b/src/renderer/lib/cableRunChecks.ts
@@ -1,0 +1,226 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Bedarf 13 (P1) — die Kabellänge als ABGELEITETE Grösse, mit Grenzen.
+//
+// DER BEFUND nennt drei Dinge in einem Satz:
+//
+//   > Run lengths are assumed, drums are picked by hand, and a moved position
+//   > SILENTLY invalidates the cable call; one wrong SMPTE run kills video,
+//   > return, comms, tally and power at once.
+//
+// Und die Bedarfs-Datenbank sagt, was daraus folgt: „recompute run length /
+// drum / path / patch when a camera position moves, warn on run-length …
+// limits, and FLAG THAT A SINGLE RUN FAILURE IS A FIVE-SERVICE FAILURE."
+//
+// ─── DAS STILLE VERALTEN ───────────────────────────────────────────────────
+//
+// `estimateCableLengths` schrieb bis hierher eine Zahl nach `length` und
+// hinterliess keine Spur. Danach sah eine geschaetzte Laenge aus wie eine
+// gemessene — und ein verschobenes Geraet machte sie falsch, ohne dass es
+// jemand erfuhr. Genau das Wort „silently" aus dem Befund.
+//
+// Mit `lengthDerivedFrom` laesst sich beides trennen: eine Laenge OHNE die
+// Angabe ist von Hand eingetragen und geht dieses Modul nichts an; eine MIT
+// ihr ist abgeleitet und kann veralten. Dieselbe Unterscheidung wie beim
+// PTZ-Preset im MultiCam-Planer.
+//
+// ─── WAS BEWUSST NICHT GEMELDET WIRD ───────────────────────────────────────
+//
+// Dass eine VON HAND eingetragene Laenge nicht zur Canvas-Geometrie passt.
+// Das ist der Normalfall: ein echter Kabelweg wird verlegt und nicht
+// gespannt, er laeuft an der Wand entlang und durch die Kabelrinne. Die
+// Schaetzung ist eine Luftlinie mit Zuschlag; sie gegen eine gemessene Laenge
+// zu halten meldete auf jedem gepflegten Plan jede Zeile.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+import type { Cable } from '../types/cable'
+import type { EquipmentItem } from '../types/equipment'
+import { cableCatalog, type CableSpec } from '../types/cableSpec'
+import { centerOf } from './cableLengthEstimate'
+import type { CsvCell, CsvTable } from './csv'
+
+/**
+ * Ab wie vielen Canvas-Pixeln Versatz eine abgeleitete Laenge als ueberholt
+ * gilt.
+ *
+ * 20 px. Der Massstab ist per Vorgabe 1 m je 100 px, also rund 20 cm — unter
+ * der Genauigkeit, mit der ueberhaupt jemand ein Geraet auf dem Canvas
+ * platziert. Eine kleinere Schwelle meldete das Nachziehen eines Knotens als
+ * Befund. Das ist eine Aussage ueber den PLAN, keine ueber das Kabel.
+ */
+export const MOVE_TOLERANCE_PX = 20
+
+/**
+ * Dienste, die auf EINEM Strang liegen.
+ *
+ * Nur wo die Recherche es belegt. Ein Hybrid-Kamerakabel nach SMPTE 304M/311M
+ * fuehrt Bild, Rueckbild, Intercom, Tally und Strom in einem Stecker — der
+ * Befund sagt es woertlich: „one wrong SMPTE run kills video, return, comms,
+ * tally and power at once". Triax traegt dieselbe Buendelung in der aelteren,
+ * koaxialen Form.
+ *
+ * KEIN EINTRAG FUER SDI, CAT ODER XLR. Die tragen genau einen Dienst; ihnen
+ * eine Liste anzuhaengen machte aus einem Befund eine Floskel.
+ */
+export const BUNDLED_SERVICES: Readonly<Record<string, readonly string[]>> = {
+  'SMPTE-304M': ['Bild', 'Rueckbild', 'Intercom', 'Tally', 'Strom'],
+  'SMPTE-311M': ['Bild', 'Rueckbild', 'Intercom', 'Tally', 'Strom'],
+}
+
+/** Traegt dieses Kabel mehrere Dienste? Liefert die Liste oder `null`. */
+export const bundledServices = (spec: CableSpec | undefined): readonly string[] | null => {
+  if (!spec) return null
+  for (const std of spec.standards) {
+    const dienste = BUNDLED_SERVICES[std]
+    if (dienste) return dienste
+  }
+  return null
+}
+
+export type RunFindingKind =
+  /** Die abgeleitete Laenge stammt aus einer Geometrie, die es nicht mehr gibt. */
+  | 'derived-length-stale'
+  /** Die Laenge liegt ueber der Reichweite des Kabeltyps. */
+  | 'over-max-length'
+  /** Ein abgeleitetes Kabel, dessen Endgeraet es nicht mehr gibt. */
+  | 'endpoint-missing'
+
+export interface RunFinding {
+  kind: RunFindingKind
+  cableId: string
+  cableLabel: string
+  /** Werte im Klartext, in fester Reihenfolge je `kind`. */
+  values: string[]
+  /** Die Dienste auf diesem Strang, wenn es mehrere sind. Ein Ausfall trifft
+   *  sie alle — der Befund nennt das ausdruecklich. */
+  services?: readonly string[]
+  /** Fundstelle der Grenze, wo es eine gibt. */
+  source?: string
+}
+
+const specOf = (c: Cable): CableSpec | undefined =>
+  c.cableSpecId ? cableCatalog.find((s) => s.id === c.cableSpecId) : undefined
+
+const labelOf = (c: Cable): string => c.name || c.id
+
+/**
+ * Alle Befunde zu den Kabelwegen.
+ *
+ * Sortiert nach Kabelbezeichnung, damit dieselbe Liste zweimal dieselbe Datei
+ * ergibt — sie wandert als CSV.
+ */
+export const cableRunFindings = (cables: Cable[], equipment: EquipmentItem[]): RunFinding[] => {
+  const eqById = new Map(equipment.map((e) => [e.id, e]))
+  const out: RunFinding[] = []
+
+  for (const c of cables) {
+    if (c.wireless) continue
+    const spec = specOf(c)
+    const dienste = bundledServices(spec)
+
+    // ── Reichweite ──
+    // Gilt fuer JEDE Laenge, ob geschaetzt oder gemessen: die Grenze ist eine
+    // Eigenschaft des Kabels und nicht der Herkunft der Zahl.
+    if (spec?.maxLengthMeters && typeof c.length === 'number' && c.length > spec.maxLengthMeters) {
+      out.push({
+        kind: 'over-max-length',
+        cableId: c.id,
+        cableLabel: labelOf(c),
+        values: [String(c.length), String(spec.maxLengthMeters), spec.name],
+        ...(dienste ? { services: dienste } : {}),
+        source: 'Kabelkatalog (`cableSpec.ts`)',
+      })
+    }
+
+    // ── Stilles Veralten ──
+    const herkunft = c.lengthDerivedFrom
+    if (!herkunft) continue
+
+    const from = eqById.get(c.fromEquipmentId)
+    const to = eqById.get(c.toEquipmentId)
+    if (!from || !to) {
+      out.push({
+        kind: 'endpoint-missing',
+        cableId: c.id,
+        cableLabel: labelOf(c),
+        values: [],
+        ...(dienste ? { services: dienste } : {}),
+      })
+      continue
+    }
+
+    // Verglichen werden die GERAETE-URSPRUENGE, nicht die Mittelpunkte: nur
+    // sie ueberleben die Raster-Heilung beim Laden unveraendert, und nur sie
+    // beantworten die Frage des Bedarfs — „a moved position". Ein Knoten,
+    // dessen Breite sich aendert, wurde nicht verschoben.
+    const versatz = Math.max(
+      Math.hypot(from.x - herkunft.fromX, from.y - herkunft.fromY),
+      Math.hypot(to.x - herkunft.toX, to.y - herkunft.toY),
+    )
+    if (versatz <= MOVE_TOLERANCE_PX) continue
+
+    // Was die Schaetzung HEUTE ergaebe, mit dem Massstab von damals: sonst
+    // vermischte die Meldung zwei Aenderungen und benennt keine.
+    const a = centerOf(from)
+    const b = centerOf(to)
+    const px = Math.hypot(b.x - a.x, b.y - a.y)
+    const jetzt = (px / 100) * herkunft.metersPer100px * (1 + herkunft.slackPercent / 100)
+
+    out.push({
+      kind: 'derived-length-stale',
+      cableId: c.id,
+      cableLabel: labelOf(c),
+      values: [
+        String(c.length ?? ''),
+        String(Math.max(1, Math.ceil(jetzt))),
+        String(Math.round(versatz)),
+      ],
+      ...(dienste ? { services: dienste } : {}),
+    })
+  }
+
+  return out.sort(
+    (a, b) => a.cableLabel.localeCompare(b.cableLabel, 'de') || a.cableId.localeCompare(b.cableId),
+  )
+}
+
+/** Kanonisches Deutsch — die Befunde landen auf einem Blatt. */
+export const runFindingText = (f: RunFinding): string => {
+  const kern = (() => {
+    switch (f.kind) {
+      case 'derived-length-stale':
+        return `Laenge ${f.values[0]} m wurde geschaetzt; seither um ${f.values[2]} px verschoben, die Schaetzung ergaebe jetzt ${f.values[1]} m`
+      case 'over-max-length':
+        return `Laenge ${f.values[0]} m ueber der Reichweite von ${f.values[1]} m (${f.values[2]})`
+      case 'endpoint-missing':
+        return 'Abgeleitete Laenge, aber ein Endgeraet fehlt — sie laesst sich nicht mehr nachrechnen'
+    }
+  })()
+  // Der Zusatz, den der Bedarf ausdruecklich verlangt: ein Strang, fuenf
+  // Dienste. Wer die Zeile liest, soll nicht erst nachschlagen muessen, was
+  // ausser dem Bild noch ausfaellt.
+  return f.services ? `${kern} — ein Strang, ${f.services.length} Dienste: ${f.services.join(', ')}` : kern
+}
+
+const ART: Record<RunFindingKind, string> = {
+  'derived-length-stale': 'Schaetzung ueberholt',
+  'over-max-length': 'Ueber Reichweite',
+  'endpoint-missing': 'Endgeraet fehlt',
+}
+
+/** Die Befunde als Blatt. */
+export const cableRunTable = (cables: Cable[], equipment: EquipmentItem[]): CsvTable => ({
+  headers: ['Kabel', 'Befund', 'Beschreibung', 'Dienste auf dem Strang'],
+  rows: cableRunFindings(cables, equipment).map((f): CsvCell[] => [
+    f.cableLabel,
+    ART[f.kind],
+    runFindingText(f),
+    f.services ? f.services.join(', ') : '',
+  ]),
+})
+
+/** Fuer den Stempel: dieselbe Tabelle aus einem Projekt. */
+export const cableRunTableForProject = (project: {
+  cables?: Cable[]
+  equipment?: EquipmentItem[]
+}): CsvTable => cableRunTable(project.cables ?? [], project.equipment ?? [])

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -4136,6 +4136,21 @@ export const en: Dict = {
   'analysis.redundancy.st2110': 'ST 2110 without 2110-7 redundancy (only one network path)',
   'analysis.redundancy.none': 'No obvious single power feeds found.',
   'analysis.tab.rf': 'RF / wireless',
+  'analysis.tab.runs': 'Cable runs',
+
+  /* Bedarf 13 — die Kabelwege: was die Laenge behauptet, und ob sie noch gilt. */
+  'analysis.runs.intro':
+    'Estimated lengths carry their origin. Move a device and the estimate goes stale \u2014 it is stated here instead of staying silent. Hand-entered lengths are NOT held against the straight line: a real cable run is laid, not stretched.',
+  'analysis.runs.none': 'No findings: no stale estimate, no length beyond reach.',
+  // {alt}, {neu} und {px} werden vom Aufrufer ersetzt.
+  'analysis.runs.stale':
+    'Length {alt} m was estimated; moved {px} px since, the estimate would now give {neu} m',
+  // {laenge}, {max} und {typ} werden vom Aufrufer ersetzt.
+  'analysis.runs.overMax': 'Length {laenge} m beyond the reach of {max} m ({typ})',
+  'analysis.runs.endpointMissing':
+    'Derived length, but an end device is gone \u2014 it can no longer be recomputed',
+  // {n} und {liste} werden vom Aufrufer ersetzt.
+  'analysis.runs.bundled': 'one run, {n} services: {liste}',
   'analysis.rf.intro': 'Wireless links (wireless cables) with frequency/channel. Conflict heuristic: frequency spacing < 0.4 MHz or same channel. Plus 3rd-order intermodulation (2·f₁−f₂) — the most common interference source for wireless mics/IEM.',
   'analysis.rf.im3': 'IM3: 2×{a} − {b} = {prod} MHz hits {c} ({cmhz} MHz)',
   'analysis.rf.imTitle': '3rd-order intermodulation',

--- a/src/renderer/lib/planDiff.ts
+++ b/src/renderer/lib/planDiff.ts
@@ -99,6 +99,13 @@ export const CABLE_FIELD_CLASS: Record<string, FieldClass> = {
   standard: 'substantive',
   cableSpecId: 'substantive',
   length: 'substantive',
+  // Bedarf 13 — die Herkunft einer geschaetzten Laenge. `bookkeeping` und
+  // nicht `substantive`: an der Zahl aendert sich nichts, wenn sie sich
+  // aendert, und niemand muss deswegen ein Kabel anders ziehen. Sie ist auch
+  // nicht `cosmetic` — dort stuende „daran muss niemand nochmal ran", und
+  // genau das waere falsch: aus ihr faellt der Befund, dass die Laenge
+  // ueberholt ist. Sie gehoert zu den Feldern, die der naechste Lauf liest.
+  lengthDerivedFrom: 'bookkeeping',
   fromEquipmentId: 'substantive',
   fromPortId: 'substantive',
   toEquipmentId: 'substantive',

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -704,6 +704,24 @@ const healProjectPositions = (
       if (!patched.layer) {
         patched = { ...patched, layer: detectLayerForConnector(patched.type) }
       }
+      // Bedarf 13 — die HERKUNFT einer geschaetzten Laenge sind Canvas-
+      // Koordinaten und muss deshalb dieselbe Rasterung mitmachen wie die
+      // Geraete darueber. Ohne diese Zeilen meldete ein Projekt, das nur
+      // GELADEN wurde, seine Schaetzungen als ueberholt: das Raster hat die
+      // Geraete verschoben, die gespeicherte Herkunft nicht.
+      if (patched.lengthDerivedFrom) {
+        const o = patched.lengthDerivedFrom
+        patched = {
+          ...patched,
+          lengthDerivedFrom: {
+            ...o,
+            fromX: r(o.fromX),
+            fromY: r(o.fromY),
+            toX: r(o.toX),
+            toY: r(o.toY),
+          },
+        }
+      }
       // v7.9.112 / Issue #234 — Legacy labelHidden=true wird ersetzt
       // durch labelPosition='none'. labelHidden bleibt aus Backward-
       // Compat im Schema, wird aber nicht mehr aktiv genutzt.

--- a/src/renderer/store/slices/cableSlice.ts
+++ b/src/renderer/store/slices/cableSlice.ts
@@ -248,6 +248,13 @@ export const createCableSlice: StateCreator<ProjectState, [], [], CableSlice> = 
           cables: state.project.cables.map((item) => {
             if (item.id !== id) return item
             const merged = { ...item, ...patch }
+            // Bedarf 13 — wer die Laenge von HAND setzt, loescht damit ihre
+            // Herkunft. Ohne diese Zeile bliebe eine berichtigte Laenge als
+            // „ueberholte Schaetzung" stehen, und der Befund waere unbeirrbar:
+            // man koennte ihn nicht abstellen, indem man die Zahl korrigiert.
+            if (patch.length !== undefined && patch.lengthDerivedFrom === undefined) {
+              delete (merged as { lengthDerivedFrom?: unknown }).lengthDerivedFrom
+            }
             if (!inheritType) return merged
             const typePatch = cableTypePatchFromPorts(merged, state.project.equipment)
             return typePatch ? { ...merged, ...typePatch } : merged
@@ -279,7 +286,7 @@ export const createCableSlice: StateCreator<ProjectState, [], [], CableSlice> = 
     const state = get()
     if (isProjectLocked(state)) return 0
     const scheme = state.project.metadata.lengthEstimation ?? DEFAULT_LENGTH_ESTIMATION
-    const { updates } = estimateAllCableLengths(
+    const { updates, origins } = estimateAllCableLengths(
       state.project.cables,
       state.project.equipment,
       scheme,
@@ -289,7 +296,12 @@ export const createCableSlice: StateCreator<ProjectState, [], [], CableSlice> = 
       project: touchProject({
         ...s.project,
         cables: s.project.cables.map((c) =>
-          updates.has(c.id) ? { ...c, length: updates.get(c.id)! } : c,
+          updates.has(c.id)
+            // Bedarf 13 — die Herkunft wird MITGESCHRIEBEN. Ohne sie sieht eine
+            // geschaetzte Laenge aus wie eine gemessene, und ein verschobenes
+            // Geraet macht sie still falsch.
+            ? { ...c, length: updates.get(c.id)!, lengthDerivedFrom: origins.get(c.id) }
+            : c,
         ),
       }),
     }))

--- a/src/renderer/types/cable.ts
+++ b/src/renderer/types/cable.ts
@@ -160,4 +160,46 @@ export interface Cable {
    *  Verknüpft das physische Etikett mit dem digitalen Datensatz
    *  ("Was ist dieses Kabel? Wo geht es hin?"). */
   qrId?: string
+  /**
+   * Bedarf 13 — WORAUS die Länge geschätzt wurde.
+   *
+   * Der Befund benennt genau diese Lücke: „a moved position **silently**
+   * invalidates the cable call". `estimateCableLengths` schreibt heute eine
+   * Zahl nach `length` und hinterlässt keine Spur — danach sieht eine
+   * geschätzte Länge aus wie eine gemessene, und ein verschobenes Gerät
+   * macht sie falsch, ohne dass es jemand erfährt.
+   *
+   * Mit dieser Angabe lässt sich beides trennen: eine Länge OHNE sie ist von
+   * Hand eingetragen und geht niemanden etwas an; eine MIT ihr ist abgeleitet
+   * und kann veralten. Genau dieselbe Unterscheidung wie beim PTZ-Preset.
+   *
+   * Undefined = von Hand eingetragen. Das ist der Normalfall und kein Mangel.
+   */
+  lengthDerivedFrom?: DerivedLengthOrigin
+}
+
+/**
+ * Geometrie und Maßstab zum Zeitpunkt der Schätzung (Bedarf 13).
+ *
+ * Gespeichert werden die **Geräte-Ursprünge** (`x`/`y`), nicht die
+ * Mittelpunkte. Der Grund ist die Raster-Heilung beim Laden: sie snappt `x`
+ * und `y` der Geräte auf Vielfache der Rasterweite. Ein Mittelpunkt
+ * (`x + width/2`) landet dabei irgendwo zwischen zwei Rasterpunkten, und die
+ * gespeicherte Kopie liesse sich nicht auf denselben Wert heilen — ein
+ * Projekt, das nur GELADEN wurde, meldete dann seine Schätzungen als
+ * überholt. Mit dem Ursprung heilt beides identisch.
+ *
+ * Es ist ausserdem die Frage, die der Bedarf stellt: „a moved position".
+ * Ein Knoten, dessen Breite sich ändert, wurde nicht verschoben.
+ */
+export interface DerivedLengthOrigin {
+  /** Canvas-Ursprung (`x`/`y`) der beiden Endgeräte, als die Länge entstand. */
+  fromX: number
+  fromY: number
+  toX: number
+  toY: number
+  /** Der Maßstab, mit dem gerechnet wurde. Ändert er sich, ist die Länge
+   *  genauso überholt wie nach einem Verschieben — die Zahl hängt an beidem. */
+  metersPer100px: number
+  slackPercent: number
 }

--- a/tests/cableRunChecks.test.ts
+++ b/tests/cableRunChecks.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BUNDLED_SERVICES,
+  MOVE_TOLERANCE_PX,
+  bundledServices,
+  cableRunFindings,
+  cableRunTable,
+  runFindingText,
+} from '../src/renderer/lib/cableRunChecks'
+import { estimateAllCableLengths, DEFAULT_LENGTH_ESTIMATION } from '../src/renderer/lib/cableLengthEstimate'
+import { cableCatalog } from '../src/renderer/types/cableSpec'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+import quelle from '../src/renderer/lib/cableRunChecks.ts?raw'
+import sliceQuelle from '../src/renderer/store/slices/cableSlice.ts?raw'
+import storeQuelle from '../src/renderer/store/projectStore.ts?raw'
+import analyseQuelle from '../src/renderer/components/Analysis/AnalysisDialog.tsx?raw'
+import dictsQuelle from '../src/renderer/lib/i18n/dicts.ts?raw'
+import { stripComments } from './support/stripComments'
+
+// ---------------------------------------------------------------------------
+// Bedarf 13 -- die Kabellaenge als abgeleitete Groesse.
+//
+//   > Run lengths are assumed, drums are picked by hand, and a moved position
+//   > SILENTLY invalidates the cable call; one wrong SMPTE run kills video,
+//   > return, comms, tally and power at once.
+//
+// Der teuerste Fehler waere, jede Abweichung zwischen einer von Hand
+// eingetragenen Laenge und der Luftlinie zu melden: ein echter Kabelweg wird
+// verlegt und nicht gespannt. Der groesste Teil dieser Tests haelt fest, was
+// NICHT gemeldet wird.
+// ---------------------------------------------------------------------------
+
+const eq = (id: string, x: number, y: number): EquipmentItem =>
+  ({ id, name: id, category: 'Sonstiges', x, y, width: 200, height: 100, inputs: [], outputs: [] }) as unknown as EquipmentItem
+
+const cable = (over: Partial<Cable> = {}): Cable =>
+  ({
+    id: 'c1',
+    name: 'CAM 1 → CCU',
+    type: 'SDI',
+    length: 10,
+    color: '#fff',
+    fromEquipmentId: 'A',
+    fromPortId: 'A-out',
+    toEquipmentId: 'B',
+    toPortId: 'B-in',
+    notes: '',
+    ...over,
+  }) as Cable
+
+const smpteSpec = cableCatalog.find((s) => s.id === 'smpte-304m-lemo')!
+const sdiSpec = cableCatalog.find((s) => s.standards.includes('SDI-3G') && !s.standards.includes('SMPTE-304M'))!
+
+describe('was NICHT gemeldet wird', () => {
+  it('eine von Hand eingetragene Laenge, die nicht zur Luftlinie passt', () => {
+    // Der Normalfall. Ein echter Kabelweg laeuft an der Wand entlang und durch
+    // die Kabelrinne; ihn gegen die Luftlinie zu halten meldete auf jedem
+    // gepflegten Plan jede Zeile.
+    const c = cable({ length: 240 })
+    expect(cableRunFindings([c], [eq('A', 0, 0), eq('B', 300, 0)])).toEqual([])
+  })
+
+  it('eine abgeleitete Laenge, deren Geraete stehen geblieben sind', () => {
+    const geraete = [eq('A', 0, 0), eq('B', 500, 0)]
+    const { updates, origins } = estimateAllCableLengths([cable()], geraete, DEFAULT_LENGTH_ESTIMATION)
+    const c = cable({ length: updates.get('c1')!, lengthDerivedFrom: origins.get('c1') })
+    expect(cableRunFindings([c], geraete)).toEqual([])
+  })
+
+  it('einen Versatz unterhalb der Toleranz', () => {
+    // Darunter liegt die Genauigkeit, mit der jemand ein Geraet auf dem Canvas
+    // platziert -- ein nachgezogener Knoten ist kein Befund.
+    const geraete = [eq('A', 0, 0), eq('B', 500, 0)]
+    const { updates, origins } = estimateAllCableLengths([cable()], geraete, DEFAULT_LENGTH_ESTIMATION)
+    const c = cable({ length: updates.get('c1')!, lengthDerivedFrom: origins.get('c1') })
+    const kaum = [eq('A', MOVE_TOLERANCE_PX - 1, 0), eq('B', 500, 0)]
+    expect(cableRunFindings([c], kaum)).toEqual([])
+  })
+
+  it('ein Funk-Kabel', () => {
+    expect(cableRunFindings([cable({ wireless: true, length: 99999 })], [])).toEqual([])
+  })
+
+  it('eine Laenge innerhalb der Reichweite', () => {
+    const c = cable({ cableSpecId: sdiSpec.id, length: 1 })
+    expect(cableRunFindings([c], [eq('A', 0, 0), eq('B', 10, 0)])).toEqual([])
+  })
+})
+
+describe('das stille Veralten', () => {
+  const geraete = [eq('A', 0, 0), eq('B', 500, 0)]
+  const abgeleitet = (): Cable => {
+    const { updates, origins } = estimateAllCableLengths([cable()], geraete, DEFAULT_LENGTH_ESTIMATION)
+    return cable({ length: updates.get('c1')!, lengthDerivedFrom: origins.get('c1') })
+  }
+
+  it('meldet den Versatz mit alter und neuer Schaetzung', () => {
+    const verschoben = [eq('A', 0, 0), eq('B', 1500, 0)]
+    const [f] = cableRunFindings([abgeleitet()], verschoben)
+    expect(f.kind).toBe('derived-length-stale')
+    expect(Number(f.values[1])).toBeGreaterThan(Number(f.values[0]))
+    expect(Number(f.values[2])).toBe(1000)
+  })
+
+  it('rechnet die neue Schaetzung mit dem Massstab von DAMALS', () => {
+    // Sonst vermischte die Meldung zwei Aenderungen -- ein Verschieben und
+    // eine geaenderte Skala -- und benennte keine von beiden.
+    const c = abgeleitet()
+    const verschoben = [eq('A', 0, 0), eq('B', 1500, 0)]
+    const [f] = cableRunFindings([c], verschoben)
+    const erwartet = Math.ceil((1500 / 100) * c.lengthDerivedFrom!.metersPer100px * (1 + c.lengthDerivedFrom!.slackPercent / 100))
+    expect(Number(f.values[1])).toBe(erwartet)
+  })
+
+  it('meldet ein fehlendes Endgeraet als eigenen Fall', () => {
+    const [f] = cableRunFindings([abgeleitet()], [eq('A', 0, 0)])
+    expect(f.kind).toBe('endpoint-missing')
+  })
+})
+
+describe('ein Strang, fuenf Dienste', () => {
+  it('nennt sie bei einem Hybrid-Kamerakabel', () => {
+    // Der Befund woertlich: „one wrong SMPTE run kills video, return, comms,
+    // tally and power at once."
+    expect(bundledServices(smpteSpec)).toEqual(['Bild', 'Rueckbild', 'Intercom', 'Tally', 'Strom'])
+    expect(bundledServices(smpteSpec)!.length).toBe(5)
+  })
+
+  it('nennt KEINE bei einem Kabel, das genau einen Dienst traegt', () => {
+    // Eine Liste an jedem Kabel machte aus dem Befund eine Floskel.
+    expect(bundledServices(sdiSpec)).toBeNull()
+    expect(bundledServices(undefined)).toBeNull()
+  })
+
+  it('haengt die Dienste an den Befund, nicht nur an den Katalog', () => {
+    const c = cable({ cableSpecId: smpteSpec.id, length: smpteSpec.maxLengthMeters! + 1 })
+    const [f] = cableRunFindings([c], [eq('A', 0, 0), eq('B', 10, 0)])
+    expect(f.services).toHaveLength(5)
+    expect(runFindingText(f)).toContain('5 Dienste')
+    expect(runFindingText(f)).toContain('Tally')
+  })
+
+  it('fuehrt nur belegte Buendel', () => {
+    // Nur SMPTE 304M/311M -- dafuer nennt die Recherche die fuenf Dienste.
+    // Wer hier etwas ergaenzt, braucht dieselbe Art Beleg.
+    expect(Object.keys(BUNDLED_SERVICES).sort()).toEqual(['SMPTE-304M', 'SMPTE-311M'])
+  })
+})
+
+describe('die Reichweite', () => {
+  it('meldet eine Laenge ueber der Katalog-Grenze', () => {
+    const c = cable({ cableSpecId: sdiSpec.id, length: sdiSpec.maxLengthMeters! + 1 })
+    const [f] = cableRunFindings([c], [eq('A', 0, 0), eq('B', 10, 0)])
+    expect(f.kind).toBe('over-max-length')
+    expect(f.source).toBeTruthy()
+  })
+
+  it('gilt fuer gemessene Laengen genauso wie fuer geschaetzte', () => {
+    // Die Grenze ist eine Eigenschaft des KABELS und nicht der Herkunft der
+    // Zahl. Sie nur auf Schaetzungen anzuwenden liesse den gefaehrlicheren
+    // Fall durch: die von Hand eingetragene, zu lange Strecke.
+    const c = cable({ cableSpecId: sdiSpec.id, length: sdiSpec.maxLengthMeters! + 1 })
+    expect(c.lengthDerivedFrom).toBeUndefined()
+    expect(cableRunFindings([c], [eq('A', 0, 0), eq('B', 10, 0)])).toHaveLength(1)
+  })
+})
+
+describe('das Blatt', () => {
+  it('fuehrt Befund, Beschreibung und die Dienste', () => {
+    const c = cable({ cableSpecId: smpteSpec.id, length: smpteSpec.maxLengthMeters! + 1 })
+    const t = cableRunTable([c], [eq('A', 0, 0), eq('B', 10, 0)])
+    expect(t.headers).toEqual(['Kabel', 'Befund', 'Beschreibung', 'Dienste auf dem Strang'])
+    expect(String(t.rows[0][3])).toContain('Tally')
+  })
+
+  it('sortiert stabil', () => {
+    const a = cable({ id: 'x', name: 'Zebra', cableSpecId: sdiSpec.id, length: 9999 })
+    const b = cable({ id: 'y', name: 'Anton', cableSpecId: sdiSpec.id, length: 9999 })
+    const geraete = [eq('A', 0, 0), eq('B', 10, 0)]
+    expect(cableRunTable([a, b], geraete).rows.map((r) => r[0])).toEqual(['Anton', 'Zebra'])
+    expect(cableRunTable([b, a], geraete).rows.map((r) => r[0])).toEqual(['Anton', 'Zebra'])
+  })
+})
+
+describe('die Herkunft wird gefuehrt', () => {
+  it('die Schaetzung schreibt sie mit', () => {
+    const { origins } = estimateAllCableLengths([cable()], [eq('A', 0, 0), eq('B', 500, 0)], DEFAULT_LENGTH_ESTIMATION)
+    const o = origins.get('c1')!
+    // Der URSPRUNG der Geraete, nicht der Mittelpunkt: nur er ueberlebt die
+    // Raster-Heilung beim Laden unveraendert.
+    expect(o).toEqual({ fromX: 0, fromY: 0, toX: 500, toY: 0, metersPer100px: 1, slackPercent: 15 })
+  })
+
+  it('der Store haengt sie an das Kabel', () => {
+    expect(sliceQuelle).toMatch(/lengthDerivedFrom: origins\.get\(c\.id\)/)
+  })
+
+  it('eine von HAND gesetzte Laenge loescht sie', () => {
+    // Ohne diese Regel bliebe eine berichtigte Laenge als „ueberholte
+    // Schaetzung" stehen, und der Befund waere unbeirrbar: man koennte ihn
+    // nicht abstellen, indem man die Zahl korrigiert.
+    expect(sliceQuelle).toMatch(/patch\.length !== undefined && patch\.lengthDerivedFrom === undefined/)
+    expect(sliceQuelle).toMatch(/delete \(merged as \{ lengthDerivedFrom\?: unknown \}\)\.lengthDerivedFrom/)
+  })
+
+  it('die Raster-Heilung fasst sie mit an', () => {
+    // Ohne diese Zeilen meldete ein Projekt, das nur GELADEN wurde, seine
+    // Schaetzungen als ueberholt: das Raster hat die Geraete verschoben, die
+    // gespeicherte Herkunft nicht.
+    expect(storeQuelle).toMatch(/if \(patched\.lengthDerivedFrom\)/)
+    expect(storeQuelle).toMatch(/fromX: r\(o\.fromX\)/)
+  })
+})
+
+describe('was die Datei NICHT tut', () => {
+  it('holt sich weder Zeit noch Store', () => {
+    expect(quelle).not.toMatch(/new Date\(\)|Date\.now\(\)|useProjectStore|useUiStore/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ERREICHBARKEIT. Ein Befund, den kein Reiter zeigt, bleibt genauso still wie
+// das Veralten, das er meldet.
+// ---------------------------------------------------------------------------
+describe('Erreichbarkeit in der Analyse', () => {
+  it('hat einen eigenen Reiter', () => {
+    expect(analyseQuelle).toContain("id: 'runs'")
+    expect(analyseQuelle).toContain('<RunsTab projectName={projectName} />')
+    expect(analyseQuelle).toMatch(/cableRunFindings\(cables, equipment\)/)
+  })
+
+  it('gibt die Befunde als Blatt aus', () => {
+    expect(analyseQuelle).toMatch(/csvFromTable\(cableRunTable\(cables, equipment\)\)/)
+  })
+
+  it('setzt die Befundtexte NICHT dynamisch zusammen', () => {
+    // `stripComments`, weil der Kommentar daneben die verbotene Form ZITIERT,
+    // um zu erklaeren, warum sie nicht benutzt wird. Genau dieser Fehler ist
+    // in dieser Sitzung schon dreimal passiert.
+    expect(stripComments(analyseQuelle)).not.toMatch(/t\(`analysis\.runs\./)
+    for (const key of [
+      'analysis.runs.stale',
+      'analysis.runs.overMax',
+      'analysis.runs.endpointMissing',
+      'analysis.runs.bundled',
+    ]) {
+      expect(analyseQuelle).toContain(`'${key}'`)
+      expect(dictsQuelle).toContain(`'${key}'`)
+    }
+  })
+
+  it('sagt ausdruecklich, wenn es nichts zu melden gibt', () => {
+    // Ein leerer Reiter beantwortet die Frage „habe ich das schon geprueft?"
+    // nicht. Ein Satz tut es.
+    expect(analyseQuelle).toContain("'analysis.runs.none'")
+  })
+})


### PR DESCRIPTION
P1 aus dem Kamera-Dossier. Der Befund nennt drei Dinge in einem Satz:

> Run lengths are assumed, drums are picked by hand, and a moved position **silently** invalidates the cable call; one wrong SMPTE run kills video, return, comms, tally and power at once.

---

## Das Wort „silently" war wörtlich zu nehmen

`estimateCableLengths` schrieb eine Zahl nach `length` und hinterliess **keine Spur**. Danach sah eine geschätzte Länge aus wie eine gemessene — und ein verschobenes Gerät machte sie falsch, ohne dass es jemand erfuhr.

Jetzt trägt sie `lengthDerivedFrom`: die Geometrie und den Massstab, aus denen sie entstand. Damit lassen sich zwei Fälle trennen, die vorher gleich aussahen:

| | |
| --- | --- |
| Länge **ohne** die Angabe | von Hand eingetragen — geht die Prüfung nichts an |
| Länge **mit** ihr | abgeleitet — kann veralten |

Dieselbe Unterscheidung wie beim PTZ-Preset in `multicam#92`.

## Was bewusst *nicht* gemeldet wird

Dass eine von **Hand** eingetragene Länge nicht zur Luftlinie passt. Das ist der Normalfall: ein echter Kabelweg wird verlegt und nicht gespannt, er läuft an der Wand entlang und durch die Kabelrinne. Die Schätzung ist eine Luftlinie mit Zuschlag; sie gegen eine gemessene Länge zu halten meldete auf jedem gepflegten Plan **jede** Zeile.

## Der Ursprung, nicht der Mittelpunkt

Gespeichert werden `x`/`y` der Endgeräte, nicht ihre Mittelpunkte. Grund ist die **Raster-Heilung beim Laden**: sie snappt `x` und `y` auf Vielfache der Rasterweite. Ein Mittelpunkt (`x + width/2`) landet dabei zwischen zwei Rasterpunkten, und die gespeicherte Kopie liesse sich nicht auf denselben Wert heilen — ein Projekt, das nur *geladen* wurde, meldete dann alle seine Schätzungen als überholt. Mit dem Ursprung heilt beides identisch, und `healProjectPositions` fasst die Herkunft ausdrücklich mit an.

Es ist ausserdem die Frage, die der Bedarf stellt: *„a moved position"*. Ein Knoten, dessen Breite sich ändert, wurde nicht verschoben.

## Drei weitere Regeln

- **Wer die Länge von Hand setzt, löscht ihre Herkunft** (`updateCable`). Ohne diese Regel bliebe eine berichtigte Länge als „überholte Schätzung" stehen, und der Befund wäre unbeirrbar: man könnte ihn nicht abstellen, indem man die Zahl korrigiert.
- Die neue Schätzung im Befund wird mit dem Massstab von **damals** gerechnet. Sonst vermischte die Meldung zwei Änderungen — ein Verschieben und eine geänderte Skala — und benennte keine von beiden.
- Toleranz **20 px**. Der Massstab ist per Vorgabe 1 m je 100 px, also rund 20 cm — unter der Genauigkeit, mit der jemand ein Gerät auf dem Canvas platziert. Eine Aussage über den *Plan*, keine über das Kabel.

## Ein Strang, fünf Dienste

`BUNDLED_SERVICES` führt nur, wofür die Recherche es belegt: **SMPTE 304M/311M** trägt Bild, Rückbild, Intercom, Tally und Strom in einem Stecker — der Befund sagt es wörtlich. **Kein Eintrag für SDI, Cat oder XLR:** die tragen genau einen Dienst, und ihnen eine Liste anzuhängen machte aus einem Befund eine Floskel.

Die **Reichweiten-Prüfung** gilt für gemessene Längen genauso wie für geschätzte: die Grenze ist eine Eigenschaft des *Kabels* und nicht der Herkunft der Zahl. Sie nur auf Schätzungen anzuwenden liesse den gefährlicheren Fall durch — die von Hand eingetragene, zu lange Strecke.

## Erreichbar

**Analyse → Kabelwege**, mit CSV. Sagt ausdrücklich, wenn es nichts zu melden gibt — ein leerer Reiter beantwortet die Frage „habe ich das schon geprüft?" nicht.

`planDiff` verlangte eine Einstufung und hat sie bekommen: `lengthDerivedFrom` ist **`bookkeeping`**. Nicht `substantive` (an der Zahl ändert sich nichts, niemand zieht deswegen ein Kabel anders) und nicht `cosmetic` — dort stünde „daran muss niemand nochmal ran", und genau das wäre falsch: aus ihr fällt der Befund.

## Ein Test fiel über seinen eigenen Kommentar — zum vierten Mal in dieser Sitzung

Der Guard gegen dynamisch zusammengesetzte i18n-Schlüssel traf den Kommentar, der die verbotene Form als Beispiel *zitierte*. `stripComments` half diesmal nicht: der Schneider behandelt Backticks als String-Grenze, und das Beispiel stand in einem — die Grenze ist in seinem eigenen Kopfkommentar benannt. Der Kommentar nennt die Form jetzt nicht mehr und sagt stattdessen, warum er sie nicht nennt.

## Gegenproben

Elf Fehler eingespritzt, jeder hat Tests umgeworfen:

| Eingespritzt | rot |
| --- | --- |
| Reichweite nur bei Schätzungen prüfen | 5 |
| Herkunft nicht mitschreiben · Mittelpunkt statt Ursprung speichern | je 4 |
| Handeingaben mitprüfen · Herkunft bei Handeingabe stehen lassen · Raster-Heilung ohne die Herkunft · Dienste an jedem Kabel behaupten · neue Schätzung mit falschem Massstab · Toleranz auf null · Reiter nicht gerendert · unsortierte Ausgabe | je 1 |

## Geprüft

`tsc -p tsconfig.app.json --noEmit` (0 Fehler) · `eslint` (0 Fehler, 10 vorbestehende Warnungen) · `vitest` **1263/1265** (2 skipped), davon 25 neu · `npm run build` · `docs:stats` nachgezogen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_