### PR TITLE
lager, impact, papier, ERP: fünf P1-Bedarfe (16, 17, 26, 27, 28)

### DIFF
--- a/docs/app-structure.html
+++ b/docs/app-structure.html
@@ -240,7 +240,7 @@
   <aside>
     <h1>Cable-Planner</h1>
     <div class="subtitle">
-      App-Struktur · v9.0.0 · ~449 TS/TSX-Module · ~131.3k LOC<br>
+      App-Struktur · v9.0.0 · ~449 TS/TSX-Module · ~131.4k LOC<br>
       <small style="color:#64748b">Diese Übersicht zeigt nur die ~62 wichtigsten Module. Für die vollständige Architektur siehe <a href="./architecture.md" style="color:#94a3b8">architecture.md</a>.</small>
     </div>
 

--- a/docs/app-structure.html
+++ b/docs/app-structure.html
@@ -240,7 +240,7 @@
   <aside>
     <h1>Cable-Planner</h1>
     <div class="subtitle">
-      App-Struktur · v9.0.0 · ~449 TS/TSX-Module · ~131.4k LOC<br>
+      App-Struktur · v9.0.0 · ~449 TS/TSX-Module · ~131.6k LOC<br>
       <small style="color:#64748b">Diese Übersicht zeigt nur die ~62 wichtigsten Module. Für die vollständige Architektur siehe <a href="./architecture.md" style="color:#94a3b8">architecture.md</a>.</small>
     </div>
 

--- a/docs/app-structure.html
+++ b/docs/app-structure.html
@@ -240,7 +240,7 @@
   <aside>
     <h1>Cable-Planner</h1>
     <div class="subtitle">
-      App-Struktur · v9.0.0 · ~450 TS/TSX-Module · ~131.9k LOC<br>
+      App-Struktur · v9.0.0 · ~451 TS/TSX-Module · ~132.2k LOC<br>
       <small style="color:#64748b">Diese Übersicht zeigt nur die ~62 wichtigsten Module. Für die vollständige Architektur siehe <a href="./architecture.md" style="color:#94a3b8">architecture.md</a>.</small>
     </div>
 

--- a/docs/app-structure.html
+++ b/docs/app-structure.html
@@ -240,7 +240,7 @@
   <aside>
     <h1>Cable-Planner</h1>
     <div class="subtitle">
-      App-Struktur · v9.0.0 · ~449 TS/TSX-Module · ~131.6k LOC<br>
+      App-Struktur · v9.0.0 · ~450 TS/TSX-Module · ~131.9k LOC<br>
       <small style="color:#64748b">Diese Übersicht zeigt nur die ~62 wichtigsten Module. Für die vollständige Architektur siehe <a href="./architecture.md" style="color:#94a3b8">architecture.md</a>.</small>
     </div>
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Invarianten der App. Sie ist die Pflicht-Lektüre, bevor strukturelle Änderunge
 gemacht werden. Für die interaktive Modul-Übersicht siehe [`app-structure.html`](./app-structure.html),
 für einen Wettbewerber-Vergleich [`comparison.html`](./comparison.html).
 
-Stand: v9.0.0 · ~449 TS/TSX-Module · ~131.6k LOC
+Stand: v9.0.0 · ~450 TS/TSX-Module · ~131.9k LOC
 
 ---
 
@@ -553,7 +553,7 @@ optionales Cloud-Backend (`y-websocket`, Auth/Permissions) bleiben offen.
 `vitest` ist eingerichtet (`npm test` / `npm run test:watch`); dazu kommen
 gezielte Node-Checks (`npm run test:crdt`, `npm run test:signaling`), ein
 UI-Smoke-Skript (`npm run ui:smoke`) und ein headless Drag-/Interaktions-Test
-(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~131.6k LOC
+(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~131.9k LOC
 bleibt der Ausbau der Abdeckung wichtig — empfohlene Schwerpunkte:
 - Snapshot-Tests auf `healProjectPositions` mit echten
   Beispiel-Projekt-JSONs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Invarianten der App. Sie ist die Pflicht-Lektüre, bevor strukturelle Änderunge
 gemacht werden. Für die interaktive Modul-Übersicht siehe [`app-structure.html`](./app-structure.html),
 für einen Wettbewerber-Vergleich [`comparison.html`](./comparison.html).
 
-Stand: v9.0.0 · ~449 TS/TSX-Module · ~131.3k LOC
+Stand: v9.0.0 · ~449 TS/TSX-Module · ~131.4k LOC
 
 ---
 
@@ -553,7 +553,7 @@ optionales Cloud-Backend (`y-websocket`, Auth/Permissions) bleiben offen.
 `vitest` ist eingerichtet (`npm test` / `npm run test:watch`); dazu kommen
 gezielte Node-Checks (`npm run test:crdt`, `npm run test:signaling`), ein
 UI-Smoke-Skript (`npm run ui:smoke`) und ein headless Drag-/Interaktions-Test
-(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~131.3k LOC
+(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~131.4k LOC
 bleibt der Ausbau der Abdeckung wichtig — empfohlene Schwerpunkte:
 - Snapshot-Tests auf `healProjectPositions` mit echten
   Beispiel-Projekt-JSONs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Invarianten der App. Sie ist die Pflicht-Lektüre, bevor strukturelle Änderunge
 gemacht werden. Für die interaktive Modul-Übersicht siehe [`app-structure.html`](./app-structure.html),
 für einen Wettbewerber-Vergleich [`comparison.html`](./comparison.html).
 
-Stand: v9.0.0 · ~449 TS/TSX-Module · ~131.4k LOC
+Stand: v9.0.0 · ~449 TS/TSX-Module · ~131.6k LOC
 
 ---
 
@@ -553,7 +553,7 @@ optionales Cloud-Backend (`y-websocket`, Auth/Permissions) bleiben offen.
 `vitest` ist eingerichtet (`npm test` / `npm run test:watch`); dazu kommen
 gezielte Node-Checks (`npm run test:crdt`, `npm run test:signaling`), ein
 UI-Smoke-Skript (`npm run ui:smoke`) und ein headless Drag-/Interaktions-Test
-(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~131.4k LOC
+(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~131.6k LOC
 bleibt der Ausbau der Abdeckung wichtig — empfohlene Schwerpunkte:
 - Snapshot-Tests auf `healProjectPositions` mit echten
   Beispiel-Projekt-JSONs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Invarianten der App. Sie ist die Pflicht-Lektüre, bevor strukturelle Änderunge
 gemacht werden. Für die interaktive Modul-Übersicht siehe [`app-structure.html`](./app-structure.html),
 für einen Wettbewerber-Vergleich [`comparison.html`](./comparison.html).
 
-Stand: v9.0.0 · ~450 TS/TSX-Module · ~131.9k LOC
+Stand: v9.0.0 · ~451 TS/TSX-Module · ~132.2k LOC
 
 ---
 
@@ -553,7 +553,7 @@ optionales Cloud-Backend (`y-websocket`, Auth/Permissions) bleiben offen.
 `vitest` ist eingerichtet (`npm test` / `npm run test:watch`); dazu kommen
 gezielte Node-Checks (`npm run test:crdt`, `npm run test:signaling`), ein
 UI-Smoke-Skript (`npm run ui:smoke`) und ein headless Drag-/Interaktions-Test
-(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~131.9k LOC
+(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~132.2k LOC
 bleibt der Ausbau der Abdeckung wichtig — empfohlene Schwerpunkte:
 - Snapshot-Tests auf `healProjectPositions` mit echten
   Beispiel-Projekt-JSONs.

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -62,14 +62,14 @@
 <header>
   <h1>Cable-Planner — Strukturvergleich mit ähnlichen Tools</h1>
   <div class="subtitle">Architektur, Tech-Stack und Domänen-Tiefe im Vergleich zu kommerziellen und Open-Source-Alternativen</div>
-  <div class="meta">Stand: 2026-06 · v9.0.0 · ~449 TS/TSX-Module · ~131.4k LOC · ~5.3 MB src/</div>
+  <div class="meta">Stand: 2026-06 · v9.0.0 · ~449 TS/TSX-Module · ~131.6k LOC · ~5.3 MB src/</div>
 </header>
 
 <h2>1 · Cable-Planner — Architektur-Kennzahlen</h2>
 
 <div class="stat-grid">
   <div class="stat"><div class="num">449</div><div class="label">TS/TSX-Module</div></div>
-  <div class="stat"><div class="num">131.4k</div><div class="label">Lines of Code</div></div>
+  <div class="stat"><div class="num">131.6k</div><div class="label">Lines of Code</div></div>
   <div class="stat"><div class="num">~75</div><div class="label">Modul-Dependencies</div></div>
   <div class="stat"><div class="num">7</div><div class="label">User-Flows</div></div>
 </div>

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -62,14 +62,14 @@
 <header>
   <h1>Cable-Planner — Strukturvergleich mit ähnlichen Tools</h1>
   <div class="subtitle">Architektur, Tech-Stack und Domänen-Tiefe im Vergleich zu kommerziellen und Open-Source-Alternativen</div>
-  <div class="meta">Stand: 2026-06 · v9.0.0 · ~450 TS/TSX-Module · ~131.9k LOC · ~5.3 MB src/</div>
+  <div class="meta">Stand: 2026-06 · v9.0.0 · ~451 TS/TSX-Module · ~132.2k LOC · ~5.3 MB src/</div>
 </header>
 
 <h2>1 · Cable-Planner — Architektur-Kennzahlen</h2>
 
 <div class="stat-grid">
-  <div class="stat"><div class="num">450</div><div class="label">TS/TSX-Module</div></div>
-  <div class="stat"><div class="num">131.9k</div><div class="label">Lines of Code</div></div>
+  <div class="stat"><div class="num">451</div><div class="label">TS/TSX-Module</div></div>
+  <div class="stat"><div class="num">132.2k</div><div class="label">Lines of Code</div></div>
   <div class="stat"><div class="num">~75</div><div class="label">Modul-Dependencies</div></div>
   <div class="stat"><div class="num">7</div><div class="label">User-Flows</div></div>
 </div>

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -62,14 +62,14 @@
 <header>
   <h1>Cable-Planner — Strukturvergleich mit ähnlichen Tools</h1>
   <div class="subtitle">Architektur, Tech-Stack und Domänen-Tiefe im Vergleich zu kommerziellen und Open-Source-Alternativen</div>
-  <div class="meta">Stand: 2026-06 · v9.0.0 · ~449 TS/TSX-Module · ~131.3k LOC · ~5.3 MB src/</div>
+  <div class="meta">Stand: 2026-06 · v9.0.0 · ~449 TS/TSX-Module · ~131.4k LOC · ~5.3 MB src/</div>
 </header>
 
 <h2>1 · Cable-Planner — Architektur-Kennzahlen</h2>
 
 <div class="stat-grid">
   <div class="stat"><div class="num">449</div><div class="label">TS/TSX-Module</div></div>
-  <div class="stat"><div class="num">131.3k</div><div class="label">Lines of Code</div></div>
+  <div class="stat"><div class="num">131.4k</div><div class="label">Lines of Code</div></div>
   <div class="stat"><div class="num">~75</div><div class="label">Modul-Dependencies</div></div>
   <div class="stat"><div class="num">7</div><div class="label">User-Flows</div></div>
 </div>

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -62,14 +62,14 @@
 <header>
   <h1>Cable-Planner — Strukturvergleich mit ähnlichen Tools</h1>
   <div class="subtitle">Architektur, Tech-Stack und Domänen-Tiefe im Vergleich zu kommerziellen und Open-Source-Alternativen</div>
-  <div class="meta">Stand: 2026-06 · v9.0.0 · ~449 TS/TSX-Module · ~131.6k LOC · ~5.3 MB src/</div>
+  <div class="meta">Stand: 2026-06 · v9.0.0 · ~450 TS/TSX-Module · ~131.9k LOC · ~5.3 MB src/</div>
 </header>
 
 <h2>1 · Cable-Planner — Architektur-Kennzahlen</h2>
 
 <div class="stat-grid">
-  <div class="stat"><div class="num">449</div><div class="label">TS/TSX-Module</div></div>
-  <div class="stat"><div class="num">131.6k</div><div class="label">Lines of Code</div></div>
+  <div class="stat"><div class="num">450</div><div class="label">TS/TSX-Module</div></div>
+  <div class="stat"><div class="num">131.9k</div><div class="label">Lines of Code</div></div>
   <div class="stat"><div class="num">~75</div><div class="label">Modul-Dependencies</div></div>
   <div class="stat"><div class="num">7</div><div class="label">User-Flows</div></div>
 </div>

--- a/src/renderer/components/Analysis/AnalysisDialog.tsx
+++ b/src/renderer/components/Analysis/AnalysisDialog.tsx
@@ -31,6 +31,7 @@ import {
 } from '../../lib/switchPortMap'
 import { csvFromTable } from '../../lib/documentStamp'
 import { cableRunFindings, cableRunTable, type RunFinding } from '../../lib/cableRunChecks'
+import { lookUpSheet, type SheetLookup } from '../../lib/sheetLookup'
 import {
   buildVenueNetworkRequest,
   rackDoorSheetTable,
@@ -39,7 +40,7 @@ import {
 } from '../../lib/venueNetworkRequest'
 import { RF_BANDS, bandsForFrequency, bandLabel } from '../../lib/rfBands'
 
-type Tab = 'weight' | 'network' | 'redundancy' | 'rf' | 'runs'
+type Tab = 'weight' | 'network' | 'redundancy' | 'rf' | 'runs' | 'sheet'
 
 const WATT_TO_BTU = 3.412
 
@@ -1231,12 +1232,119 @@ const RunsTab = ({ projectName }: { projectName: string }) => {
   )
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// Bedarf 27 — der Rueckweg vom Papier.
+//
+// „Gilt dieses Blatt noch?" konnte `documentRegistry` seit ADR-004
+// beantworten, und niemand konnte fragen: `docStandStatus` und `findByStand`
+// waren gebaut, getestet und von KEINEM Knopf erreichbar. Hier ist der Knopf.
+//
+// Der Bedarf nennt die Frist: „Must complete in under ten seconds or it will
+// not be used in the last two hours before doors." Deshalb ein Feld und kein
+// Formular — acht Zeichen abtippen, Enter.
+// ───────────────────────────────────────────────────────────────────────────
+const SheetTab = () => {
+  const t = useTranslation()
+  const project = useProjectStore((s) => s.project)
+  const [draft, setDraft] = useState('')
+  const [treffer, setTreffer] = useState<SheetLookup | null>(null)
+
+  const pruefen = () => setTreffer(lookUpSheet(draft, project))
+
+  // Ausgeschriebener switch, ein Schluessel je Fall — ein aus dem `kind`
+  // gebauter waere fuer den i18n-Deckungs-Guard unsichtbar.
+  const text = (r: SheetLookup): string => {
+    switch (r.kind) {
+      case 'identified':
+        switch (r.status) {
+          case 'current':
+            return format(t('analysis.sheet.current', '{label}: Stand {stand} — aktuell'), {
+              label: r.label ?? '',
+              stand: r.stand ?? '',
+            })
+          case 'stale':
+            return format(
+              t('analysis.sheet.stale', '{label}: Stand {stand} — ÜBERHOLT, der Plan ist seither weiter'),
+              { label: r.label ?? '', stand: r.stand ?? '' },
+            )
+          default:
+            return format(
+              t('analysis.sheet.unknown', '{label}: Stand {stand} — nicht beurteilbar ({grund})'),
+              { label: r.label ?? '', stand: r.stand ?? '', grund: r.reason ?? '' },
+            )
+        }
+      case 'matched-by-stand':
+        return format(t('analysis.sheet.matched', '{label}: aktuell (Stand {stand})'), {
+          label: r.label ?? '',
+          stand: r.stand ?? '',
+        })
+      case 'stale-or-foreign':
+        return format(
+          t(
+            'analysis.sheet.foreign',
+            'Stand {stand} gehört zu keinem Dokument dieses Plans — vermutlich ein überholter Ausdruck',
+          ),
+          { stand: r.stand ?? '' },
+        )
+      case 'unreadable':
+        return t(
+          'analysis.sheet.unreadable',
+          'Kein Dokument-Code und kein Stand — acht Zeichen vom Fuß des Blatts oder der ganze Code',
+        )
+    }
+  }
+
+  const ton = (r: SheetLookup): string => {
+    if (r.kind === 'identified' && r.status === 'current') return 'text-cp-text-secondary'
+    if (r.kind === 'matched-by-stand') return 'text-cp-text-secondary'
+    if (r.kind === 'unreadable') return 'text-cp-text-muted'
+    // „Ueberholt" und „gehoert zu keinem Dokument" sind dieselbe Nachricht in
+    // zwei Schaerfen: das Blatt in der Hand stimmt nicht mehr.
+    return 'text-cp-warn'
+  }
+
+  return (
+    <div className="space-y-3 p-4 text-cp-base">
+      <p className="text-cp-xs text-[var(--cp-text-muted)]">
+        {t(
+          'analysis.sheet.intro',
+          'Ein Blatt in der Hand: den Stand vom Fuß abtippen (acht Zeichen) oder den ganzen Dokument-Code einlesen. Die Antwort sagt, welches Dokument es ist und ob der Plan seither weiter ist.',
+        )}
+      </p>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') pruefen()
+          }}
+          placeholder={t('analysis.sheet.placeholder', '1a2b3c4d oder cableplanner://doc/…')}
+          aria-label={t('analysis.sheet.placeholder', '1a2b3c4d oder cableplanner://doc/…')}
+          className="min-w-[16rem] flex-1 rounded border border-cp-border bg-cp-surface-3 p-1.5"
+        />
+        <button
+          type="button"
+          onClick={pruefen}
+          disabled={!draft.trim()}
+          className="rounded border border-cp-border px-2.5 py-1 text-cp-text-secondary hover:text-cp-text disabled:opacity-40"
+        >
+          {t('analysis.sheet.check', 'Prüfen')}
+        </button>
+      </div>
+
+      {treffer && <div className={`text-cp-sm ${ton(treffer)}`}>{text(treffer)}</div>}
+    </div>
+  )
+}
+
 const TABS: { id: Tab; labelKey: string; fallback: string }[] = [
   { id: 'weight', labelKey: 'analysis.tab.weight', fallback: 'Gewicht & Wärme' },
   { id: 'network', labelKey: 'analysis.tab.network', fallback: 'Netzwerk' },
   { id: 'redundancy', labelKey: 'analysis.tab.redundancy', fallback: 'Redundanz' },
   { id: 'rf', labelKey: 'analysis.tab.rf', fallback: 'RF / Funk' },
   { id: 'runs', labelKey: 'analysis.tab.runs', fallback: 'Kabelwege' },
+  { id: 'sheet', labelKey: 'analysis.tab.sheet', fallback: 'Blatt prüfen' },
 ]
 
 export const AnalysisDialog = () => {
@@ -1277,6 +1385,7 @@ export const AnalysisDialog = () => {
       {active === 'redundancy' && <RedundancyTab projectName={projectName} />}
       {active === 'rf' && <RfTab projectName={projectName} />}
       {active === 'runs' && <RunsTab projectName={projectName} />}
+      {active === 'sheet' && <SheetTab />}
     </ModalShell>
   )
 }

--- a/src/renderer/components/Export/ExportDialog.tsx
+++ b/src/renderer/components/Export/ExportDialog.tsx
@@ -1430,7 +1430,13 @@ const DeviceBomSection = () => {
   // Drum-Mikrofonierung (Stative, Clamps, XLR) kommt ueber den Namen mit.
   const drumKit = useProjectStore((s) => s.project.drumKit)
   const wirelessRig = useProjectStore((s) => s.project.wirelessRig)
-  const zusatz = useMemo(() => zusatzBedarf({ drumKit, wirelessRig }), [drumKit, wirelessRig])
+  // Bedarf 17 — die Kabel und die vom Plan verlangten Adapter gehoeren in
+  // DIESELBE Liste. Das Lager kommissioniert aus einer, nicht aus dreien.
+  const cables = useProjectStore((s) => s.project.cables)
+  const zusatz = useMemo(
+    () => zusatzBedarf({ drumKit, wirelessRig, cables, equipment }),
+    [drumKit, wirelessRig, cables, equipment],
+  )
   const bom = useMemo(
     () => buildPlanBom(equipment, items, nodes, units, zusatz),
     [equipment, items, nodes, units, zusatz],

--- a/src/renderer/components/Inventory/InventoryDialog.tsx
+++ b/src/renderer/components/Inventory/InventoryDialog.tsx
@@ -48,12 +48,15 @@ import type {
   SetComponent,
 } from '../../types/inventory'
 import { useCheckoutStore } from '../../store/checkoutStore'
+import type { CheckoutRecord } from '../../types/checkout'
 import {
   containerContents,
   checkoutSheet,
   discrepancyTable,
   openCheckoutsTable,
   overdueCheckouts,
+  scanBackIntoCheckout,
+  unlabelledLines,
   type CheckoutRefusal,
 } from '../../lib/containerCheckout'
 import { toCsv } from '../../lib/csv'
@@ -1534,6 +1537,11 @@ const CheckoutTab = () => {
   const [projectName, setProjectName] = useState('')
   const [dueBack, setDueBack] = useState('')
   const [refusal, setRefusal] = useState<CheckoutRefusal | null>(null)
+  // Bedarf 16 — der Papierweg zurueck. Der Code vom Blatt wird gegen die
+  // Ausgabeliste gehalten; das Abhaken auf Papier wird damit zur EINGABE fuer
+  // den Datensatz statt zu einem zweiten, der ihm widerspricht.
+  const [scanDraft, setScanDraft] = useState<Record<string, string>>({})
+  const [scanEcho, setScanEcho] = useState<Record<string, { text: string; ok: boolean }>>({})
 
   const snap = useMemo(() => ({ items, nodes, units }), [items, nodes, units])
   const container = useMemo(() => nodes.filter((n) => isContainerKind(n.kind)), [nodes])
@@ -1565,6 +1573,33 @@ const CheckoutTab = () => {
       setProjectName('')
       setDueBack('')
     }
+  }
+
+  const scanBack = (r: CheckoutRecord) => {
+    const roh = (scanDraft[r.id] ?? '').trim()
+    if (!roh) return
+    const treffer = scanBackIntoCheckout(r, roh)
+    setScanEcho((s) => ({
+      ...s,
+      [r.id]:
+        treffer.kind === 'line'
+          ? {
+              text: format(t('inventory.checkout.scanHit', '{code} → {label}'), {
+                code: roh,
+                label: treffer.line.label,
+              }),
+              ok: true,
+            }
+          : {
+              // Die nuetzlichste Auskunft dieses Scans. Sie faengt das Packen
+              // ins falsche Case, und zwar bevor es faehrt.
+              text: format(t('inventory.checkout.scanMiss', '{code} gehört nicht zu diesem Vorgang'), {
+                code: roh,
+              }),
+              ok: false,
+            },
+    }))
+    setScanDraft((s) => ({ ...s, [r.id]: '' }))
   }
 
   const refusalLabel = (r: CheckoutRefusal): string => {
@@ -1729,6 +1764,61 @@ const CheckoutTab = () => {
               ))}
             </tbody>
           </table>
+        )}
+
+        {/* Bedarf 16 — der Papierweg zurueck. Der Schein traegt die
+            Etiketten-Codes; hier kommen sie wieder herein, per Lesegeraet
+            oder getippt. Ein Code, der nicht zum Vorgang gehoert, wird als
+            solcher gemeldet — das ist der eigentliche Fang. */}
+        {offen.length > 0 && (
+          <div className="border-t border-cp-border-muted px-2 py-1.5">
+            <div className="mb-1 text-cp-text-secondary">
+              {t(
+                'inventory.checkout.scanIntro',
+                'Code vom Ausgabeschein einlesen — das Abhaken auf Papier wird damit zur Eingabe statt zu einer zweiten Liste.',
+              )}
+            </div>
+            {offen.map((r) => {
+              const ohneEtikett = unlabelledLines(r)
+              return (
+                <div key={r.id} className="mb-1 flex flex-wrap items-center gap-1.5">
+                  <span className="text-cp-text-muted">{r.nodeLabel}</span>
+                  <input
+                    value={scanDraft[r.id] ?? ''}
+                    onChange={(e) => setScanDraft((s) => ({ ...s, [r.id]: e.target.value }))}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') scanBack(r)
+                    }}
+                    placeholder={t('inventory.checkout.scanPlaceholder', 'Etiketten-Code')}
+                    aria-label={format(t('inventory.checkout.scanFor', 'Code für {node}'), { node: r.nodeLabel })}
+                    className="w-40 rounded border border-cp-border bg-cp-surface-3 p-1"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => scanBack(r)}
+                    className="rounded border border-cp-border px-2 py-0.5 text-cp-text-secondary hover:text-cp-text"
+                  >
+                    {t('inventory.checkout.scanCheck', 'Prüfen')}
+                  </button>
+                  {scanEcho[r.id] && (
+                    <span className={scanEcho[r.id].ok ? 'text-cp-text-secondary' : 'text-cp-danger'}>
+                      {scanEcho[r.id].text}
+                    </span>
+                  )}
+                  {ohneEtikett.length > 0 && (
+                    // Kein Fehler, sondern eine Arbeitsliste: diese Positionen
+                    // muessen von Hand abgeglichen werden, bis sie ein Etikett
+                    // haben.
+                    <span className="text-cp-text-faint">
+                      {format(t('inventory.checkout.unlabelled', '{n} ohne Etikett — nur von Hand abgleichbar'), {
+                        n: ohneEtikett.length,
+                      })}
+                    </span>
+                  )}
+                </div>
+              )
+            })}
+          </div>
         )}
       </div>
 

--- a/src/renderer/components/Rentman/RentmanImportDialog.tsx
+++ b/src/renderer/components/Rentman/RentmanImportDialog.tsx
@@ -30,6 +30,11 @@ import { NewRentmanDeviceWizard, type UnknownCandidate } from './NewRentmanDevic
 import { ProjectSelector } from './ProjectSelector'
 import { TemplateMergeDialog } from '../Library/TemplateMergeDialog'
 
+import { reconcileErp, erpReconcileTable } from '../../lib/erpReconcile'
+import { deriveDemand } from '../../lib/inventoryCoverage'
+import { zusatzBedarf } from '../../lib/planDemandExtras'
+import { csvFromTable } from '../../lib/documentStamp'
+import { downloadBlob } from '../../lib/downloadBlob'
 import {
   mapProjects, mapEquipment, isRentmanPhysicalFlag,
   autoDetectCategory, loadRentmanCatMap, saveRentmanCatMap, detectCableRows,
@@ -79,6 +84,25 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
   const [pickerOpen, setPickerOpen] = useState(false)
   const [selectedProjectId, setSelectedProjectId] = useState('')
   const [items, setItems] = useState<RentmanEquipment[]>([])
+
+  // Bedarf 28 — Plan gegen Reservierung. Der Plan-Bedarf ist derselbe, den
+  // die Stueckliste benutzt (samt Kabeln und Adaptern aus Bedarf 17): zwei
+  // Bedarfsbegriffe nebeneinander waeren zwei Wahrheiten.
+  const drumKit = useProjectStore((s) => s.project.drumKit)
+  const wirelessRig = useProjectStore((s) => s.project.wirelessRig)
+  const planCables = useProjectStore((s) => s.project.cables)
+  const erpReport = useMemo(
+    () =>
+      reconcileErp(
+        deriveDemand(
+          projectEquipment,
+          zusatzBedarf({ drumKit, wirelessRig, cables: planCables, equipment: projectEquipment }),
+        ),
+        projectEquipment,
+        items,
+      ),
+    [projectEquipment, drumKit, wirelessRig, planCables, items],
+  )
   // #335 — Kombinationen (Sets), die als Rack importiert werden sollen.
   const [rackSetIds, setRackSetIds] = useState<Set<string>>(new Set())
   const [selectedCategories, setSelectedCategories] = useState<Set<string>>(new Set())
@@ -1476,6 +1500,53 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
         {loading && <div className="mb-2 text-cp-base text-cp-text-secondary">{t('rentman.import.loading', 'Loading…')}</div>}
         {error && <div className="mb-2 rounded bg-red-900/50 p-2 text-cp-base text-red-100">{error}</div>}
         {warning && <div className="mb-2 rounded bg-amber-900/40 p-2 text-cp-base text-amber-100">{warning}</div>}
+
+        {/* Bedarf 28 — der Abgleich in BEIDE Richtungen. Ein reiner Import
+            zeigt nur, was die Reservierung hat; die Frage des Projektleiters
+            ist aber „was steht in meinem Plan, das die Reservierung NICHT
+            hat" — und die Gegenrichtung: was ist reserviert und wird nicht
+            gebraucht. */}
+        {items.length > 0 && erpReport.rows.length > 0 && (
+          <div className="mb-2 rounded border border-cp-border bg-cp-surface-2 p-2 text-cp-xs">
+            <div className="mb-1 flex items-center justify-between">
+              <span className="font-medium text-cp-text">
+                {t('rentman.diff.title', 'Plan gegen Reservierung')}
+              </span>
+              <button
+                type="button"
+                onClick={() =>
+                  downloadBlob(
+                    'plan-gegen-reservierung.csv',
+                    csvFromTable(erpReconcileTable(erpReport)),
+                    'text/csv',
+                  )
+                }
+                className="rounded border border-cp-border px-2 py-0.5 text-cp-text-secondary hover:text-cp-text"
+              >
+                CSV
+              </button>
+            </div>
+            <div className="text-cp-text-secondary">
+              {format(
+                t(
+                  'rentman.diff.summary',
+                  '{plan} nur im Plan · {erp} nur reserviert · {qty} Mengen weichen ab',
+                ),
+                { plan: erpReport.onlyInPlan, erp: erpReport.onlyInErp, qty: erpReport.differing },
+              )}
+            </div>
+            {erpReport.ignored.length > 0 && (
+              // Die weggelassenen Zeilen werden GENANNT. Eine Reservierung mit
+              // vierzig Zeilen, von denen zwoelf stillschweigend fehlen,
+              // laesst niemanden nachvollziehen, warum die Summe nicht stimmt.
+              <div className="mt-0.5 text-cp-text-faint">
+                {format(t('rentman.diff.ignored', '{n} Zeilen nicht gezählt (Kommentare, Set-Inhalte, gestrichene)'), {
+                  n: erpReport.ignored.length,
+                })}
+              </div>
+            )}
+          </div>
+        )}
 
         {items.length > 0 && (
           <>

--- a/src/renderer/lib/containerCheckout.ts
+++ b/src/renderer/lib/containerCheckout.ts
@@ -52,7 +52,7 @@ export const containerContents = (
 
   for (const n of snap.nodes) {
     if (!inner.has(n.id)) continue
-    lines.push({ kind: 'node', refId: n.id, label: n.name, quantity: 1 })
+    lines.push({ kind: 'node', refId: n.id, label: n.name, quantity: 1, ...(n.code ? { code: n.code } : {}) })
   }
   for (const u of snap.units) {
     if (!u.locationId || !scope.has(u.locationId)) continue
@@ -60,11 +60,27 @@ export const containerContents = (
     // gibt, sonst der Code. Ein blosses „1 x Modell" beantwortet die Frage
     // „welche fehlt?" nicht.
     const kennung = u.serial ?? u.code ?? u.id
-    lines.push({ kind: 'unit', refId: u.id, label: kennung, quantity: 1 })
+    // Der Code ist das, was der Scanner findet; die Seriennummer ist das, was
+    // der Mensch liest. Beide werden mitgeschrieben -- sie sind nicht
+    // dasselbe, und die eine durch die andere zu ersetzen macht genau eine
+    // der beiden Rollen kaputt.
+    lines.push({
+      kind: 'unit',
+      refId: u.id,
+      label: kennung,
+      quantity: 1,
+      ...(u.code ? { code: u.code } : {}),
+    })
   }
   for (const it of snap.items) {
     if (!it.locationId || !scope.has(it.locationId)) continue
-    lines.push({ kind: 'item', refId: it.id, label: it.model, quantity: it.quantity })
+    lines.push({
+      kind: 'item',
+      refId: it.id,
+      label: it.model,
+      quantity: it.quantity,
+      ...(it.code ? { code: it.code } : {}),
+    })
   }
 
   // Stabil sortiert: Container, dann Einheiten, dann Mengen-Artikel; innerhalb
@@ -206,9 +222,59 @@ const ART: Record<CheckoutLine['kind'], string> = {
  * Kanonisches Deutsch -- er wandert als CSV und wird in Excel geoeffnet.
  */
 export const checkoutSheet = (record: CheckoutRecord): CsvTable => ({
-  headers: ['Art', 'Bezeichnung', 'Menge', 'Kennung'],
-  rows: record.contents.map((l): CsvCell[] => [ART[l.kind], l.label, l.quantity, l.refId]),
+  headers: ['Art', 'Bezeichnung', 'Menge', 'Etiketten-Code', 'Abgehakt'],
+  rows: record.contents.map((l): CsvCell[] => [
+    ART[l.kind],
+    l.label,
+    l.quantity,
+    // Bedarf 16 — der Code, den der Scanner am Objekt findet. Wo keiner
+    // klebt, steht das da: die interne Id einzusetzen ergaebe eine Spalte,
+    // die scannbar AUSSIEHT und es nicht ist.
+    l.code ?? 'kein Etikett',
+    // Die leere Spalte fuer den Stift. Sie ist der Grund, warum das Blatt
+    // ueberhaupt gedruckt wird: „works with gloves, in the dark, never logs
+    // out". Ohne sie wird daneben auf dem Rand abgehakt.
+    '',
+  ]),
 })
+
+/**
+ * Bedarf 16 — der Rueckweg des Papiers.
+ *
+ * Ein gescannter Code wird gegen die Ausgabeliste gehalten: gehoert er zu
+ * diesem Vorgang, und welche Zeile ist es? So wird das Abhaken auf Papier zur
+ * EINGABE fuer den digitalen Datensatz statt zu einem zweiten, der ihm
+ * widerspricht.
+ *
+ * `unknown-code` ist ein eigenes Ergebnis und kein `null`: „der Code gehoert
+ * nicht in dieses Case" ist die nuetzlichste Auskunft, die dieser Scan geben
+ * kann -- sie faengt das Packen ins falsche Case, und zwar bevor es faehrt.
+ */
+export type ScanBackResult =
+  | { kind: 'line'; line: CheckoutLine }
+  | { kind: 'unknown-code' }
+
+/** Normalisierung wie beim Lager-Scan: Etiketten kommen mit Leerzeichen und
+ *  in wechselnder Schreibweise aus dem Lesegeraet. */
+const normCode = (v: string | undefined): string => (v ?? '').trim().toLowerCase()
+
+export const scanBackIntoCheckout = (record: CheckoutRecord, raw: string): ScanBackResult => {
+  const needle = normCode(raw)
+  if (!needle) return { kind: 'unknown-code' }
+  const line = record.contents.find((l) => normCode(l.code) === needle)
+  return line ? { kind: 'line', line } : { kind: 'unknown-code' }
+}
+
+/**
+ * Was auf dem Blatt steht, aber kein Etikett traegt.
+ *
+ * Nicht als Fehler, sondern als ARBEITSLISTE: diese Positionen lassen sich
+ * beim Rueckweg nicht scannen, also muessen sie von Hand abgeglichen werden.
+ * Wer den Anteil kennt, weiss, wieviel des Bedarfs-Gewinns er heute schon
+ * hat -- und welche Kisten ein Etikett brauchen.
+ */
+export const unlabelledLines = (record: CheckoutRecord): CheckoutLine[] =>
+  record.contents.filter((l) => !l.code)
 
 /**
  * Die Uebersicht: was ist draussen, bei wem, seit wann, bis wann.

--- a/src/renderer/lib/documentRegistry.ts
+++ b/src/renderer/lib/documentRegistry.ts
@@ -21,6 +21,7 @@ import { assetRegisterTable } from './assetRegister'
 import { handoverTable } from './handoverPackage'
 import { deliveryTableForProject } from './deliveryParity'
 import { runOfShowSheetForProject } from './encoderFeasibility'
+import { tallyMapTableForProject } from './tallyMap'
 import type { CsvTable } from './csv'
 
 const ofTable =
@@ -57,6 +58,13 @@ export const DOCUMENT_STANDS: Record<string, (project: CablePlannerProject) => s
   // kanonisches Deutsch. Der Stream-Key steht darauf als Verweis, nicht als
   // Wert -- der Fingerabdruck misst also nichts Geheimes.
   ablaufblatt: ofTable(runOfShowSheetForProject),
+  // Bedarf 26 — die Tally-Karte. Der Bedarf nennt sie als erstes unter den
+  // Blaettern, die bei einer spaeten Aenderung vergessen werden („multiviewer
+  // window, comms position, TALLY, truck plan, check-in list"), und sie war
+  // fuer die Impact-Liste unsichtbar. Reproduzierbar, weil `buildTallyMap`
+  // allein aus `equipment`, `cables` und `sourceIdentities` ableitet: keine
+  // Nutzer-Einstellung, keine Sprache.
+  'tally-karte': ofTable(tallyMapTableForProject),
 }
 
 /**
@@ -78,6 +86,33 @@ export const UNJUDGEABLE_DOCUMENTS: Record<string, string> = {
   'kabel-bom':
     'Der Inhalt hängt am Reserve-Aufschlag, den der Nutzer beim Export einstellt; ' +
     'dieser Prozentsatz steht nicht im Stempel.',
+  // Bedarf 26 — was der Plan zwar erzeugt, aber nicht als EIN Dokument.
+  //
+  // Diese drei gibt es je GERAET: eine Label-Datei je Videohub, ein
+  // Multiviewer-Layout je Mischer, eine Port-Karte je Switch. Das Register
+  // fuehrt EINEN Stand je Bezeichner; ein gemeinsamer ergaebe einen Stand,
+  // der beim zweiten Geraet nicht passt — schlimmer als keiner.
+  //
+  // Sie hier zu nennen ist der Punkt: bis hierher fehlten sie ganz, und
+  // Verschweigen sieht in einer Impact-Liste aus wie „unberuehrt". Als
+  // `unknown` sagen sie, was wahr ist — nachsehen muss ein Mensch. Wer sie
+  // reproduzierbar machen will, braucht einen Bezeichner JE GERAET; das ist
+  // ein eigener Schritt.
+  'videohub-labels':
+    'Es gibt eine Label-Datei je Videohub; das Register führt einen Stand je ' +
+    'Bezeichner. Ein gemeinsamer Stand wäre beim zweiten Gerät falsch.',
+  'atem-mv-layout':
+    'Es gibt ein Multiviewer-Layout je Mischer, und die Fensterzahl ist eine ' +
+    'Einstellung am Gerät, die nicht im Plan steht.',
+  'switch-port-karte':
+    'Es gibt eine Port-Karte je Switch; dieselbe Begründung wie bei den ' +
+    'Videohub-Labels.',
+  // Die Deckung haengt am LAGERBESTAND, und der steht nicht im Projekt: er
+  // lebt projektuebergreifend im Lager-Store. Dieselbe Liste ergibt morgen
+  // ein anderes Ergebnis, ohne dass sich am Plan etwas geaendert hat.
+  stueckliste:
+    'Der Inhalt hängt am Lagerbestand, der projektübergreifend lebt und nicht ' +
+    'im Plan steht — dieselbe Liste ergibt morgen ein anderes Ergebnis.',
 }
 
 /** Lesbarer Name eines Dokument-Bezeichners für Meldungen. */
@@ -91,6 +126,11 @@ export const DOCUMENT_LABELS: Record<string, string> = {
   'kabel-bom': 'Kabel-Stückliste',
   ausspielung: 'Ausspielung',
   ablaufblatt: 'Ablaufblatt',
+  'tally-karte': 'Tally-Karte',
+  'videohub-labels': 'Videohub-Labels',
+  'atem-mv-layout': 'Multiviewer-Layout',
+  'switch-port-karte': 'Switch-Port-Karte',
+  stueckliste: 'Stückliste',
 }
 
 /**

--- a/src/renderer/lib/erpReconcile.ts
+++ b/src/renderer/lib/erpReconcile.ts
@@ -1,0 +1,269 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Bedarf 28 — der Abgleich gegen die ERP-Reservierung, in BEIDE Richtungen.
+//
+// DER BEFUND benennt die Frage, die tatsaechlich gestellt wird:
+//
+//   > Equipment gets typed into the quote, the technical plan, the ERP
+//   > reservation, the pick list, the truck list, the sub-hire PO, the
+//   > check-in list and the invoice. The PM's real question is never „what
+//   > does my plan contain" but „WHAT DOES MY PLAN CONTAIN THAT THE ERP
+//   > PROJECT DOES NOT, and which side changed since we last agreed?"
+//
+// Und die Bedarfs-Datenbank sagt, was daraus folgt: „The valuable increment
+// is the DIFF, not more export." Der Cable-Planner konnte bis hierher
+// exportieren und importieren — beides in eine Richtung. Was fehlte, war die
+// Gegenueberstellung.
+//
+// ─── DIE DREI ZEILEN, DIE NICHT ZAEHLEN ────────────────────────────────────
+//
+// Eine Rentman-Reservierung enthaelt mehr als Geraete, und jede dieser Zeilen
+// mitzuzaehlen macht JEDEN Abgleich falsch:
+//
+//   `comment`      Eine Textzeile („Aufbau ab 8 Uhr"). Kein Geraet.
+//   `isSetChild`   Der Inhalt einer Kombination — im Elternteil schon gezaehlt.
+//                  Beides zu zaehlen verdoppelt das halbe Projekt.
+//   Menge 0        Eine Zeile, die auf null gesetzt wurde, ist gestrichen.
+//
+// ─── WIE ZUGEORDNET WIRD ───────────────────────────────────────────────────
+//
+// Dieselbe Ordnung wie beim Lager-Resolver (`inventoryCoverage`) und beim
+// Netz-Abgleich (`networkReconcile`): erst die Tatsache, dann der Vorschlag,
+// und sonst gar nichts.
+//
+//   1. Ueber `rentmanId` am Plan-Geraet — das ist die Bruecke, die der Import
+//      gesetzt hat, und damit eine TATSACHE.
+//   2. Ueber den normalisierten Namen — ein VORSCHLAG, und er wird als solcher
+//      ausgewiesen.
+//
+// EIN NAME, DER ZWEIMAL VORKOMMT, ORDNET NICHTS ZU. Dieselbe Regel wie bei
+// `reconcileNetwork`: wo beide Seiten nicht eindeutig sind, ist die Zuordnung
+// geraten, und eine geratene Zuordnung im Handelsabgleich kostet echtes Geld
+// — sie erklaert eine Position fuer vorhanden, die es nicht ist.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+import type { DemandLine } from './inventoryCoverage'
+import { normaliseName } from './inventoryCoverage'
+import type { EquipmentItem } from '../types/equipment'
+import type { CsvCell, CsvTable } from './csv'
+
+/**
+ * Was dieser Abgleich von einer ERP-Zeile braucht.
+ *
+ * Strukturell und nicht als Import aus `components/Rentman/`: eine Bibliothek
+ * darf nicht von einer Komponente abhaengen. `RentmanEquipment` passt darauf,
+ * ohne dass eine der beiden Seiten die andere kennt.
+ */
+export interface ErpLine {
+  /** Rentman-Geraete-Id (nicht die Zeilen-Id). */
+  equipmentId: string
+  name: string
+  qty: number
+  kind: 'device' | 'virtual' | 'physical' | 'comment'
+  isSetChild: boolean
+}
+
+export type ErpVerdict =
+  /** Beide Seiten haben es, in gleicher Menge. */
+  | 'matched'
+  /** Beide haben es, die Mengen weichen ab. */
+  | 'quantity-differs'
+  /** Der Plan verlangt es, die Reservierung kennt es nicht. */
+  | 'only-in-plan'
+  /** Reserviert, aber im Plan nicht verlangt. */
+  | 'only-in-erp'
+
+export type ErpBasis =
+  /** Ueber `rentmanId` — eine Tatsache. */
+  | 'rentman-id'
+  /** Ueber den Namen — ein Vorschlag. */
+  | 'name'
+  /** Kein Gegenstueck. */
+  | 'none'
+  /** Der Name kommt mehrfach vor; zuordnen hiesse raten. */
+  | 'ambiguous'
+
+export interface ErpRow {
+  verdict: ErpVerdict
+  basis: ErpBasis
+  label: string
+  /** Menge laut Plan. `undefined`, wenn der Plan die Position nicht kennt. */
+  planQty?: number
+  /** Menge laut Reservierung. `undefined`, wenn sie sie nicht kennt. */
+  erpQty?: number
+}
+
+export interface ErpReport {
+  rows: ErpRow[]
+  onlyInPlan: number
+  onlyInErp: number
+  differing: number
+  /** Zeilen der Reservierung, die bewusst nicht gezaehlt wurden, mit Grund. */
+  ignored: { label: string; reason: string }[]
+}
+
+/**
+ * Zeilen der Reservierung, die ein Geraet sind — und die Begruendung fuer
+ * jede, die es nicht ist. Die Begruendung wird MITGELIEFERT und nicht
+ * verworfen: eine Reservierung mit vierzig Zeilen, von denen der Abgleich
+ * zwoelf stillschweigend weglaesst, laesst niemanden nachvollziehen, warum
+ * die Summe nicht stimmt.
+ */
+const teilen = (erp: ErpLine[]): { geraete: ErpLine[]; ignored: ErpReport['ignored'] } => {
+  const geraete: ErpLine[] = []
+  const ignored: ErpReport['ignored'] = []
+  for (const l of erp) {
+    if (l.kind === 'comment') {
+      ignored.push({ label: l.name, reason: 'Kommentarzeile, kein Geraet' })
+      continue
+    }
+    if (l.isSetChild) {
+      ignored.push({ label: l.name, reason: 'Inhalt einer Kombination, im Elternteil gezaehlt' })
+      continue
+    }
+    if (!(l.qty > 0)) {
+      ignored.push({ label: l.name, reason: 'Menge 0 — gestrichene Zeile' })
+      continue
+    }
+    geraete.push(l)
+  }
+  return { geraete, ignored }
+}
+
+/**
+ * Wie oft ein Name vorkommt. Gezaehlt und nicht bloss gefiltert: „kommt
+ * zweimal vor" und „kommt gar nicht vor" sind zwei verschiedene Auskuenfte,
+ * und wer die Doppelten vorher wegwirft, kann sie nicht mehr auseinander
+ * halten. Genau daran ist die erste Fassung dieser Datei gescheitert — sie
+ * meldete den mehrdeutigen Namen als „kein Gegenstueck".
+ */
+const nameCount = <T>(items: T[], key: (t: T) => string): Map<string, number> => {
+  const zaehler = new Map<string, number>()
+  for (const it of items) zaehler.set(key(it), (zaehler.get(key(it)) ?? 0) + 1)
+  return zaehler
+}
+
+/**
+ * Plan gegen Reservierung.
+ *
+ * `equipment` wird gebraucht, um von einer Bedarfszeile auf die
+ * `rentmanId` ihrer Plan-Geraete zu kommen — das ist die Bruecke, die der
+ * Import gesetzt hat.
+ */
+export const reconcileErp = (
+  demand: DemandLine[],
+  equipment: EquipmentItem[],
+  erp: ErpLine[],
+): ErpReport => {
+  const { geraete, ignored } = teilen(erp)
+
+  const erpById = new Map(geraete.map((l) => [l.equipmentId, l]))
+  const erpNamen = nameCount(geraete, (l) => normaliseName(l.name))
+  const planNamen = nameCount(demand, (d) => normaliseName(d.label))
+  const eqById = new Map(equipment.map((e) => [e.id, e]))
+
+  const rows: ErpRow[] = []
+  const getroffen = new Set<string>()
+
+  for (const d of demand) {
+    // (1) Die Tatsache: eine `rentmanId` an einem der Plan-Geraete dieser
+    //     Zeile. Sie stammt aus dem Import und ist keine Vermutung.
+    const ids = new Set(
+      d.equipmentIds.map((id) => eqById.get(id)?.rentmanId).filter((v): v is string => !!v),
+    )
+    let treffer: ErpLine | undefined
+    let basis: ErpBasis = 'none'
+    for (const id of ids) {
+      const l = erpById.get(id)
+      if (l) {
+        treffer = l
+        basis = 'rentman-id'
+        break
+      }
+    }
+
+    // (2) Der Vorschlag: der Name, aber nur wenn er auf BEIDEN Seiten
+    //     eindeutig ist. Sonst ist die Zuordnung geraten.
+    if (!treffer) {
+      const name = normaliseName(d.label)
+      const imErp = erpNamen.get(name) ?? 0
+      const imPlan = planNamen.get(name) ?? 0
+      if (imErp === 1 && imPlan === 1) {
+        treffer = geraete.find((l) => normaliseName(l.name) === name)
+        basis = 'name'
+      } else if (imErp > 1 || (imErp === 1 && imPlan > 1)) {
+        // Es GIBT ein Gegenstueck, nur nicht eindeutig. Das ist eine andere
+        // Auskunft als „gibt es nicht" -- und die brauchbarere: sie sagt, wo
+        // ein Mensch hinschauen muss.
+        basis = 'ambiguous'
+      }
+    }
+
+    if (!treffer) {
+      rows.push({ verdict: 'only-in-plan', basis, label: d.label, planQty: d.quantity })
+      continue
+    }
+    getroffen.add(treffer.equipmentId)
+    rows.push({
+      verdict: treffer.qty === d.quantity ? 'matched' : 'quantity-differs',
+      basis,
+      label: d.label,
+      planQty: d.quantity,
+      erpQty: treffer.qty,
+    })
+  }
+
+  // Die andere Richtung — der halbe Bedarf, den ein reiner Export nie zeigt:
+  // reserviert und bezahlt, aber im Plan nicht verlangt.
+  for (const l of geraete) {
+    if (getroffen.has(l.equipmentId)) continue
+    rows.push({ verdict: 'only-in-erp', basis: 'none', label: l.name, erpQty: l.qty })
+  }
+
+  rows.sort(
+    (a, b) => RANG[a.verdict] - RANG[b.verdict] || a.label.localeCompare(b.label, 'de'),
+  )
+
+  return {
+    rows,
+    onlyInPlan: rows.filter((r) => r.verdict === 'only-in-plan').length,
+    onlyInErp: rows.filter((r) => r.verdict === 'only-in-erp').length,
+    differing: rows.filter((r) => r.verdict === 'quantity-differs').length,
+    ignored,
+  }
+}
+
+/** Was zuerst zu klaeren ist, steht oben: fehlendes Material vor
+ *  Mengenabweichung vor Ueberzaehligem vor dem, was stimmt. */
+const RANG: Record<ErpVerdict, number> = {
+  'only-in-plan': 0,
+  'quantity-differs': 1,
+  'only-in-erp': 2,
+  matched: 3,
+}
+
+const URTEIL: Record<ErpVerdict, string> = {
+  'only-in-plan': 'nur im Plan',
+  'quantity-differs': 'Menge weicht ab',
+  'only-in-erp': 'nur in der Reservierung',
+  matched: 'stimmt',
+}
+
+const BASIS: Record<ErpBasis, string> = {
+  'rentman-id': 'ueber Rentman-Id (Tatsache)',
+  name: 'ueber den Namen (Vorschlag)',
+  none: '',
+  ambiguous: 'Name mehrfach — nicht zugeordnet',
+}
+
+/** Der Abgleich als Blatt. Kanonisches Deutsch — er wandert als CSV. */
+export const erpReconcileTable = (report: ErpReport): CsvTable => ({
+  headers: ['Befund', 'Position', 'Plan', 'Reservierung', 'Zuordnung'],
+  rows: report.rows.map((r): CsvCell[] => [
+    URTEIL[r.verdict],
+    r.label,
+    r.planQty ?? '',
+    r.erpQty ?? '',
+    BASIS[r.basis],
+  ]),
+})

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -4151,6 +4151,24 @@ export const en: Dict = {
   'analysis.redundancy.none': 'No obvious single power feeds found.',
   'analysis.tab.rf': 'RF / wireless',
   'analysis.tab.runs': 'Cable runs',
+  'analysis.tab.sheet': 'Check a sheet',
+
+  /* Bedarf 27 — der Rueckweg vom Papier. */
+  'analysis.sheet.intro':
+    'A sheet in your hand: type the eight-character state from its foot, or read the whole document code. The answer says which document it is and whether the plan has moved on since.',
+  'analysis.sheet.placeholder': '1a2b3c4d or cableplanner://doc/\u2026',
+  'analysis.sheet.check': 'Check',
+  // {label} und {stand} werden vom Aufrufer ersetzt.
+  'analysis.sheet.current': '{label}: state {stand} \u2014 current',
+  'analysis.sheet.stale': '{label}: state {stand} \u2014 SUPERSEDED, the plan has moved on',
+  // {label}, {stand} und {grund} werden vom Aufrufer ersetzt.
+  'analysis.sheet.unknown': '{label}: state {stand} \u2014 not judgeable ({grund})',
+  'analysis.sheet.matched': '{label}: current (state {stand})',
+  // {stand} wird vom Aufrufer ersetzt.
+  'analysis.sheet.foreign':
+    'State {stand} belongs to no document of this plan \u2014 most likely a superseded printout',
+  'analysis.sheet.unreadable':
+    'Neither a document code nor a state \u2014 eight characters from the foot of the sheet, or the whole code',
 
   /* Bedarf 13 — die Kabelwege: was die Laenge behauptet, und ob sie noch gilt. */
   'analysis.runs.intro':

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -1926,6 +1926,13 @@ export const en: Dict = {
   'rentman.import.loadingShort': 'Loading…',
   'rentman.import.reloadSync': '↻ Reload & sync',
   'rentman.import.categories': 'Categories:',
+
+  /* Bedarf 28 — der Abgleich in beide Richtungen. */
+  'rentman.diff.title': 'Plan vs. reservation',
+  // {plan}, {erp} und {qty} werden vom Aufrufer ersetzt.
+  'rentman.diff.summary': '{plan} only in the plan \u00b7 {erp} only reserved \u00b7 {qty} quantities differ',
+  // {n} wird vom Aufrufer ersetzt.
+  'rentman.diff.ignored': '{n} lines not counted (comments, set contents, cancelled)',
   'rentman.import.categoriesAll': 'All',
   'rentman.import.status.linkedTitle':
     'Items with identical Rentman equipment ID in the local library — silent re-import, ports + custom data are preserved.',

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3695,6 +3695,20 @@ export const en: Dict = {
   'inventory.checkout.alreadyOut': 'Already checked out',
   'inventory.checkout.insideOut': 'Sits inside a container that is already checked out',
   'inventory.checkout.unknownNode': 'Unknown storage node',
+
+  /* Bedarf 16 — der Papierweg zurueck. */
+  'inventory.checkout.scanIntro':
+    'Read a code off the run sheet \u2014 ticking on paper becomes the input, not a second list.',
+  'inventory.checkout.scanPlaceholder': 'Label code',
+  'inventory.checkout.scanCheck': 'Check',
+  // {node} wird vom Aufrufer ersetzt.
+  'inventory.checkout.scanFor': 'Code for {node}',
+  // {code} und {label} werden vom Aufrufer ersetzt.
+  'inventory.checkout.scanHit': '{code} \u2192 {label}',
+  // {code} wird vom Aufrufer ersetzt.
+  'inventory.checkout.scanMiss': '{code} does not belong to this check-out',
+  // {n} wird vom Aufrufer ersetzt.
+  'inventory.checkout.unlabelled': '{n} without a label \u2014 hand reconciliation only',
   'inventory.location': 'Location / case',
   'inventory.noLocation': '— no location —',
   'inventory.locationsHint': 'Storage locations and cases — every node scannable, nestable at will (case in case in transport case).',

--- a/src/renderer/lib/planDemandExtras.ts
+++ b/src/renderer/lib/planDemandExtras.ts
@@ -26,9 +26,37 @@
 // Ebene tiefer: wer sechs Mikrofone kommissioniert und keine Stative, steht am
 // Aufbautag genauso da. Sie kommen deshalb als NAMENS-Zeilen mit, wie alles
 // andere ohne Katalog-Zuordnung, und tragen ihre Herkunft im Text.
+//
+// ─── BEDARF 17: DIE KABEL UND DIE ADAPTER (2026-09-06) ─────────────────────
+//
+// Derselbe blinde Fleck, eine Ebene groesser. Der Bedarf sagt:
+//
+//   > The pick list is generated from the commercial reservation, never from
+//   > the cable/camera/lighting plan. The plan's BOM (INCLUDING ADAPTERS AND
+//   > SPARES) is re-typed by a human; warehouse substitutions made at pack
+//   > time never reach the plan and surface at load-in.
+//
+// Der Cable-Planner hatte die Kabel-Stueckliste (`cableBomTable`) — aber als
+// EIGENES Blatt. Der Deckungs-Abgleich gegen das Lager las nur `deriveDemand`,
+// also die Geraete. Das Lager kommissioniert damit die Kameras und nicht die
+// Kabel: genau die Trennung, die der Bedarf beklagt.
+//
+// Und die ADAPTER standen ueberhaupt nirgends. Der Plan WEISS, dass er welche
+// braucht — `cable.needsConverter` und der LWL-Steckertyp-Mismatch aus
+// `drawingChecks` (Check 17b) sagen es beide — aber diese Erkenntnis blieb im
+// Zeichnungs-Befund stehen und wurde nie zu Material. Ein Adapter, den
+// niemand einpackt, ist am Aufbautag dasselbe wie ein fehlendes Kabel.
+//
+// WAS HIER NICHT PASSIERT: der Reserve-Aufschlag. `cableBomTable` kennt einen,
+// und er ist eine EXPORT-Einstellung des Nutzers — deshalb steht `kabel-bom`
+// in `UNJUDGEABLE_DOCUMENTS`. Ihn in den Deckungs-Abgleich zu ziehen hiesse,
+// die Antwort „reicht der Bestand?" von einem Prozentsatz abhaengig zu machen,
+// den an dieser Stelle niemand sieht. Die Zeilen zaehlen, was der Plan
+// verlangt; der Aufschlag bleibt, wo er sichtbar eingestellt wird.
 // ───────────────────────────────────────────────────────────────────────────
 
 import type { CablePlannerProject } from '../types/project'
+import type { Port } from '../types/equipment'
 import { resolveDeviceType } from './deviceTypeRegistry'
 import { deriveDrumBom } from './drumMicing'
 
@@ -50,6 +78,8 @@ export interface ZusatzBedarf {
 
 const DRUM = 'Drum-Mikrofonierung'
 const FUNK = 'Funkstrecken-Plan'
+const KABEL = 'Kabelplan'
+const ADAPTER = 'Adapter (vom Plan verlangt)'
 
 /** Zaehlt gleiche Positionen zusammen, deterministisch sortiert. */
 const zusammen = (roh: ZusatzBedarf[]): ZusatzBedarf[] => {
@@ -74,7 +104,7 @@ const zusammen = (roh: ZusatzBedarf[]): ZusatzBedarf[] => {
  * Signatur statt im Rumpf.
  */
 export const zusatzBedarf = (
-  plan: Pick<CablePlannerProject, 'drumKit' | 'wirelessRig'>,
+  plan: Pick<CablePlannerProject, 'drumKit' | 'wirelessRig' | 'cables' | 'equipment'>,
 ): ZusatzBedarf[] => {
   const roh: ZusatzBedarf[] = []
 
@@ -119,6 +149,72 @@ export const zusatzBedarf = (
         ...(type?.template.category ? { category: type.template.category } : {}),
         quantity: 1,
         herkunft: FUNK,
+      })
+    }
+  }
+
+  // ── Kabel ─────────────────────────────────────────────────────────────────
+  // Gebuendelt wie in `buildCableBomRows`: nach Typ UND Laenge, denn ein
+  // 5-m-SDI und ein 50-m-SDI sind im Lager zwei Artikel. Ein Multicore zaehlt
+  // je Buendel einmal — sonst kommissioniert das Lager sechzehn Kabel fuer
+  // eine Trommel.
+  const gezaehlteBuendel = new Set<string>()
+  for (const c of plan.cables ?? []) {
+    // Funkstrecken sind keine Kabel. Sie stehen als Geraete im Plan.
+    if (c.wireless) continue
+    if (c.multicoreName) {
+      if (gezaehlteBuendel.has(c.multicoreName)) continue
+      gezaehlteBuendel.add(c.multicoreName)
+    }
+    const laenge = c.length ?? 0
+    roh.push({
+      label: laenge > 0 ? `${c.type} ${laenge} m` : c.type,
+      quantity: 1,
+      herkunft: KABEL,
+    })
+  }
+
+  // ── Adapter ───────────────────────────────────────────────────────────────
+  // Der Plan WEISS, dass er welche braucht -- er sagt es an zwei Stellen --
+  // und bis hierher blieb diese Erkenntnis im Zeichnungs-Befund stehen, statt
+  // Material zu werden. Ein Adapter, den niemand einpackt, ist am Aufbautag
+  // dasselbe wie ein fehlendes Kabel.
+  const portById = new Map<string, Port>()
+  for (const e of plan.equipment ?? []) {
+    for (const p of [...(e.inputs ?? []), ...(e.outputs ?? [])]) portById.set(p.id, p)
+  }
+  for (const c of plan.cables ?? []) {
+    if (c.wireless) continue
+    const von = portById.get(c.fromPortId)
+    const nach = portById.get(c.toPortId)
+
+    // (1) Optischer Steckertyp ungleich -- dieselbe Bedingung wie Check 17b in
+    //     `drawingChecks`. Der Adapter wird BENANNT: „LWL-Adapter LC ↔ SC" ist
+    //     kommissionierbar, „Adapter" ist es nicht.
+    const a = von?.fiberConnector
+    const b = nach?.fiberConnector
+    if (a && b && a !== b) {
+      roh.push({ label: `LWL-Adapter ${a} ↔ ${b}`, quantity: 1, herkunft: ADAPTER })
+      continue
+    }
+
+    // (2) Das ausdrueckliche Haekchen am Kabel. Es kommt NACH der optischen
+    //     Pruefung, damit ein Link nicht zweimal zaehlt: dasselbe Kabel traegt
+    //     beides oft gleichzeitig.
+    if (c.needsConverter) {
+      const vonTyp = von?.connectorType
+      const nachTyp = nach?.connectorType
+      roh.push({
+        // Wo die Stecker bekannt sind, steht der Adapter mit ihnen da. Wo
+        // nicht, bleibt die Zeile allgemein -- eine erfundene Steckerpaarung
+        // waere schlimmer als eine unbestimmte Zeile, weil sie bestellbar
+        // aussieht.
+        label:
+          vonTyp && nachTyp && vonTyp !== nachTyp
+            ? `Adapter ${vonTyp} ↔ ${nachTyp}`
+            : `Adapter für „${c.name || c.type}"`,
+        quantity: 1,
+        herkunft: ADAPTER,
       })
     }
   }

--- a/src/renderer/lib/sheetLookup.ts
+++ b/src/renderer/lib/sheetLookup.ts
@@ -1,0 +1,133 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Bedarf 27 — der Rueckweg vom Papier. „Gilt dieses Blatt noch?"
+//
+// DER BEFUND ist keine Klage ueber Papier, sondern ueber die Einbahnstrasse:
+//
+//   > Pick lists, call sheets, running orders, load-out lists and damage
+//   > forms stay paper because paper needs no battery, works in a basement
+//   > and can be signed. But NOTHING CROSSES BACK: changes are made in pen on
+//   > the printed plan and the plan never learns.
+//
+// Und die Frist steht daneben: „Must complete in under ten seconds or it will
+// not be used in the last two hours before doors."
+//
+// ─── WAS SCHON DA WAR UND NIEMAND ERREICHEN KONNTE ─────────────────────────
+//
+// ADR-004 hat den Stempel auf jedes Blatt gesetzt — Dokument-Bezeichner,
+// Stand, Datum — und `documentRegistry` kann den Stand von heute ausrechnen.
+// `docStandStatus` und `findByStand` sind gebaut, getestet und BEANTWORTEN
+// GENAU DIESE FRAGE. Nur rief sie nichts auf: kein Knopf, kein Feld, kein
+// Dialog. Gemessen 2026-09-06 — die einzige Fundstelle ausserhalb ihrer
+// eigenen Dateien war ein KOMMENTAR in `changeImpact.ts`.
+//
+// Diese Datei ist die Engstelle, durch die der Rueckweg geht: EINE Funktion,
+// die alles annimmt, was von einem Blatt kommen kann.
+//
+// ─── DREI EINGABEN, EIN ERGEBNIS ───────────────────────────────────────────
+//
+// Vom Blatt kommt je nach Weg etwas anderes zurueck, und alle drei Formen
+// muessen gehen — sonst scheitert der Rueckweg an der Eingabe statt an der
+// Sache:
+//
+//   1. der ganze Code   `cableplanner://doc/pull-liste?s=1a2b3c4d`
+//   2. nur der Stand    `#1a2b3c4d`  (das, was auf dem CSV-Fuss steht)
+//   3. abgetippt        `1a2b3c4d`   (mit Leerzeichen, in Grossbuchstaben)
+//
+// Der ganze Code ist die beste Eingabe: er nennt das Dokument SELBST. Der
+// blosse Stand muss geraten werden — `findByStand` haelt ihn gegen alle
+// bekannten Dokumente — und findet nichts, wenn das Blatt inzwischen ueberholt
+// ist. Genau dieser Fall ist der wichtigste, und er wird deshalb BENANNT:
+// „Stand gehoert zu keinem Dokument von jetzt" heisst fast immer „das Blatt
+// ist alt", und die Auskunft ist brauchbar, auch wenn sie nicht sagt, welches.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+import type { CablePlannerProject } from '../types/project'
+import { DOCUMENT_LABELS, UNJUDGEABLE_DOCUMENTS, currentStand, findByStand } from './documentRegistry'
+import { docStandStatus, parseDocQrPayload, type DocStandStatus } from './qrPayload'
+
+export type SheetLookupKind =
+  /** Der Code nennt das Dokument, und der Stand liess sich vergleichen. */
+  | 'identified'
+  /** Nur ein Stand, und er passt zu einem Dokument von jetzt. */
+  | 'matched-by-stand'
+  /** Ein gueltiger Stand, der zu keinem aktuellen Dokument passt. */
+  | 'stale-or-foreign'
+  /** Weder Code noch acht Hex-Zeichen. */
+  | 'unreadable'
+
+export interface SheetLookup {
+  kind: SheetLookupKind
+  /** Dokument-Bezeichner, wo er bekannt ist. */
+  docId?: string
+  /** Lesbarer Name dazu. */
+  label?: string
+  /** Der Stand vom Blatt, normalisiert (klein, ohne `#`). */
+  stand?: string
+  /** Urteil ueber den Stand — nur wo ein Dokument benannt ist. */
+  status?: DocStandStatus
+  /** Warum ein Dokument nicht beurteilbar ist. Aus dem Register, nicht neu
+   *  formuliert: zwei Formulierungen derselben Regel laufen auseinander. */
+  reason?: string
+  /** Revisions-Label vom Blatt, wo der Code eines trug. */
+  revision?: string
+}
+
+/** Acht Hex-Zeichen, wie sie unter jedem Blatt stehen. Leerzeichen und
+ *  Grossbuchstaben kommen vom Abtippen und sind kein Fehler. */
+const STAND = /^[0-9a-f]{8}$/
+
+const normStand = (raw: string): string => raw.trim().replace(/^#/, '').replace(/\s+/g, '').toLowerCase()
+
+/**
+ * Was ein Blatt sagt — aus allem, was von ihm zurueckkommen kann.
+ *
+ * Liefert IMMER ein Ergebnis. `unreadable` ist eines davon: „das ist kein
+ * Dokument-Code" ist eine Auskunft und kein Fehlerfall, und wer sie als
+ * Ausnahme wirft, zwingt jeden Aufrufer zu einem try/catch fuer den
+ * Normalfall des Vertippens.
+ */
+export const lookUpSheet = (raw: string, project: CablePlannerProject): SheetLookup => {
+  const text = (raw ?? '').trim()
+  if (!text) return { kind: 'unreadable' }
+
+  // (1) Der ganze Code. Er nennt das Dokument selbst — die beste Eingabe.
+  const ref = parseDocQrPayload(text)
+  if (ref) {
+    const stand = normStand(ref.stand)
+    const heute = currentStand(ref.docId, project)
+    return {
+      kind: 'identified',
+      docId: ref.docId,
+      label: DOCUMENT_LABELS[ref.docId] ?? ref.docId,
+      stand,
+      status: docStandStatus({ ...ref, stand }, heute),
+      ...(UNJUDGEABLE_DOCUMENTS[ref.docId] ? { reason: UNJUDGEABLE_DOCUMENTS[ref.docId] } : {}),
+      ...(ref.revision ? { revision: ref.revision } : {}),
+    }
+  }
+
+  // (2)/(3) Nur ein Stand — abgetippt oder aus dem CSV-Fuss.
+  const stand = normStand(text)
+  if (!STAND.test(stand)) return { kind: 'unreadable' }
+
+  const treffer = findByStand(stand, project)
+  if (treffer) {
+    // Er passt zu einem Dokument von JETZT, also ist das Blatt aktuell. Ein
+    // `status` waere hier eine zweite Rechnung ueber dieselbe Tatsache.
+    return {
+      kind: 'matched-by-stand',
+      docId: treffer.docId,
+      label: treffer.label,
+      stand,
+      status: 'current',
+    }
+  }
+
+  // Der wichtigste Fall, und der Grund, warum er einen eigenen Namen hat:
+  // „passt zu keinem Dokument von jetzt" heisst fast immer „das Blatt ist
+  // alt". Ein `null` an dieser Stelle waere dieselbe Tatsache, aber
+  // unbenannt — und der Aufrufer machte daraus „nicht gefunden", was nach
+  // einem Tippfehler klingt statt nach einem ueberholten Ausdruck.
+  return { kind: 'stale-or-foreign', stand }
+}

--- a/src/renderer/lib/tallyMap.ts
+++ b/src/renderer/lib/tallyMap.ts
@@ -28,7 +28,7 @@ import type { SourceIdentity } from '../types/sourceIdentity'
 import { deriveLabels, routerLinkFor, switcherLinkFor } from './labelDerivation'
 import { detectDeviceKind } from './deviceKind'
 import { umdAddressClashes } from './sourceIdentity'
-import { toCsv } from './csv'
+import { toCsv, type CsvTable } from './csv'
 
 export interface TallyMapDevice {
   id: string
@@ -215,6 +215,31 @@ export const buildTallyMap = (project: TallyProject): TallyMap => {
 }
 
 /** Die Karte als reviewbare Tabelle — was auf Papier oder in Excel landet. */
+/**
+ * Die Tally-Karte als Tabelle, getrennt vom Serialisieren.
+ *
+ * Bedarf 26 braucht sie in dieser Form: `documentRegistry` rechnet den Stand
+ * eines Dokuments aus seiner TABELLE aus, nicht aus dem fertigen CSV. Vorher
+ * gab es nur `tallyMapCsv`, und die Tally-Karte war damit fuer die
+ * Impact-Liste unsichtbar -- ausgerechnet das Blatt, das der Bedarf als
+ * erstes unter den vergessenen nennt.
+ */
+export const tallyMapTable = (map: TallyMap): CsvTable => ({
+  headers: ['Nr.', 'Rolle', 'Geraet(e)', 'Mischer', 'Eingang', 'UMD-Adresse'],
+  rows: map.rows.map((r) => [
+    r.number ?? '',
+    r.name,
+    r.devices.map((d) => d.name).join(' + '),
+    r.switcher?.name ?? '',
+    r.switcher?.input ?? '',
+    r.umdAddress ?? '',
+  ]),
+})
+
+/** Fuer das Register: dieselbe Tabelle aus einem Projekt. */
+export const tallyMapTableForProject = (project: TallyProject): CsvTable =>
+  tallyMapTable(buildTallyMap(project))
+
 export const tallyMapCsv = (map: TallyMap): string =>
   toCsv(
     ['Nr.', 'Rolle', 'Geraet(e)', 'Mischer', 'Eingang', 'UMD-Adresse'],

--- a/src/renderer/store/checkoutStore.ts
+++ b/src/renderer/store/checkoutStore.ts
@@ -36,7 +36,11 @@ const istZeile = (v: unknown): v is CheckoutLine => {
     typeof l.refId === 'string' &&
     typeof l.label === 'string' &&
     typeof l.quantity === 'number' &&
-    Number.isFinite(l.quantity)
+    Number.isFinite(l.quantity) &&
+    // Bedarf 16 — der Etiketten-Code ist optional, aber wenn er da ist, ist er
+    // ein String. Ein `code: 42` aus einer fremden Datei wuerde beim Scannen
+    // nie treffen und die Zeile stumm unscannbar machen.
+    (l.code === undefined || typeof l.code === 'string')
   )
 }
 

--- a/src/renderer/types/checkout.ts
+++ b/src/renderer/types/checkout.ts
@@ -52,6 +52,24 @@ export interface CheckoutLine {
   label: string
   /** Stueckzahl. Bei `unit` und `node` immer 1 -- sie sind einzeln. */
   quantity: number
+  /**
+   * Bedarf 16 -- der ETIKETTEN-CODE, so wie er auf dem Objekt klebt.
+   *
+   * Der Befund verlangt „the printed artefact scannable back in": das
+   * Abhaken auf Papier soll die EINGABE fuer den digitalen Datensatz werden
+   * statt eines zweiten, widerspruechlichen. Dafuer muss auf dem Blatt die
+   * Kennung stehen, die der Scanner am Objekt findet.
+   *
+   * Der erste Wurf dieses Blatts druckte `refId` -- die interne UUID. Sie
+   * sieht auf Papier aus wie eine Kennung und ist keine: sie klebt auf
+   * keinem Case, und kein Scanner findet sie. Ein Blatt, das eine
+   * unscannbare Zeichenkette in die Spalte „Kennung" setzt, ist schlimmer
+   * als eines ohne Spalte -- es sieht benutzbar aus.
+   *
+   * Undefined = das Objekt traegt kein Etikett. Das wird auf dem Blatt
+   * BENANNT, nicht durch die UUID ersetzt.
+   */
+  code?: string
 }
 
 /** Der Vorgang der Ausgabe. */

--- a/tests/changeImpact.test.ts
+++ b/tests/changeImpact.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { changeImpact, changeImpactSummary } from '../src/renderer/lib/changeImpact'
 import {
-  DOCUMENT_STANDS,
   DOCUMENT_LABELS,
+  DOCUMENT_STANDS,
   UNJUDGEABLE_DOCUMENTS,
 } from '../src/renderer/lib/documentRegistry'
 import registrySrc from '../src/renderer/lib/documentRegistry.ts?raw'
@@ -67,7 +67,12 @@ describe('changeImpact — die Vorwärts-Frage', () => {
       Object.keys(DOCUMENT_STANDS).length,
     )
     expect(impact.unknown).toBe(Object.keys(UNJUDGEABLE_DOCUMENTS).length)
-    expect(changeImpactSummary(impact)).toBe('1 nicht beurteilbar')
+    // Aus dem Register abgeleitet und nicht als Zahl getippt: die Liste der
+    // unbeurteilbaren Dokumente WAECHST (Bedarf 26 hat vier dazugelegt), und
+    // eine feste Zahl haette hier nur gesagt, dass jemand sie nachtippt.
+    expect(changeImpactSummary(impact)).toBe(
+      `${Object.keys(UNJUDGEABLE_DOCUMENTS).length} nicht beurteilbar`,
+    )
   })
 
   it('erkennt, dass ein geänderter Kabel-Typ die Pull-Liste überholt', () => {
@@ -133,12 +138,16 @@ describe('changeImpact — die Vorwärts-Frage', () => {
     expect(
       impact.documents.some((d) => d.verdict === 'unaffected' && !ohneGeraetebezug.has(d.docId)),
     ).toBe(false)
-    // Zwei verschiedene Gruende fuer dasselbe Urteil — die Meldung darf sie
-    // nicht vermischen.
+    // JEDER unbeurteilbare Grund steht fuer sich, und die gescheiterte
+    // Ableitung ist noch einer dazu — die Meldung darf sie nicht vermischen.
+    // Fruehe Fassung: `toBe(2)`, als es genau ein unbeurteilbares Dokument
+    // gab. Das war dieselbe Aussage, nur nachgetippt; sie wird jetzt
+    // gerechnet, damit ein neuer Eintrag im Register sie nicht falsch macht,
+    // sondern mitnimmt.
     const reasons = new Set(
       impact.documents.filter((d) => d.verdict === 'unknown').map((d) => d.reason),
     )
-    expect(reasons.size).toBe(2)
+    expect(reasons.size).toBe(Object.keys(UNJUDGEABLE_DOCUMENTS).length + 1)
   })
 
   it('die Zusammenfassung verschweigt das Unbeurteilbare nicht', () => {
@@ -238,6 +247,72 @@ describe('der Guard: das Register ist die einzige Liste', () => {
     for (const [id, reason] of Object.entries(UNJUDGEABLE_DOCUMENTS)) {
       expect(reason, `Grund fehlt fuer ${id}`).toBeTruthy()
       expect(DOCUMENT_LABELS[id], `Label fehlt fuer ${id}`).toBeTruthy()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Bedarf 26 -- die Blaetter, die bei einer spaeten Aenderung vergessen werden.
+//
+//   > One late change (e.g. a fifth camera 48h out) touches roughly 30
+//   > artefacts ... The ones that get missed are OMISSIONS, not errors:
+//   > multiviewer window, comms position, tally, truck plan, check-in list.
+//   > Nothing links them.
+//
+// `changeImpact` gab es schon -- aber es kannte nur die Dokumente im Register,
+// und die vom Bedarf genannten standen NICHT darin. Ein Blatt, das die Liste
+// gar nicht nennt, ist in ihr nicht „unberuehrt", sondern unsichtbar; und
+// genau das nennt der Bedarf: Auslassungen, keine Fehler.
+// ---------------------------------------------------------------------------
+describe('Bedarf 26 — die vergessenen Blaetter stehen jetzt in der Liste', () => {
+  it('die Tally-Karte ist reproduzierbar und wird beurteilt', () => {
+    // Sie leitet allein aus `equipment`, `cables` und `sourceIdentities` ab —
+    // keine Nutzer-Einstellung, keine Sprache. Also gehoert sie nicht unter
+    // „weiss ich nicht", sondern unter die beurteilbaren.
+    expect(Object.keys(DOCUMENT_STANDS)).toContain('tally-karte')
+    expect(DOCUMENT_LABELS['tally-karte']).toBeTruthy()
+  })
+
+  it('die Tally-Karte reagiert auf eine Aenderung am Plan', () => {
+    // Der eigentliche Punkt: nicht dass sie im Register STEHT, sondern dass
+    // ihr Stand sich bewegt, wenn sich der Plan bewegt.
+    //
+    // Der erste Anlauf benannte einfach ein Geraet des Standard-Projekts um --
+    // und blieb gleich. Zu Recht: `buildTallyMap` laeuft ueber
+    // `sourceIdentities`, und das Fixture hat keine, die Karte ist also leer.
+    // Ein Test, der eine leere Karte gegen eine leere Karte haelt, prueft
+    // nichts. Hier steht deshalb eine Rolle mit einem Geraet daran.
+    const mitRolle = (name: string): CablePlannerProject =>
+      project({
+        equipment: [{ ...eq('A', name), sourceIdentityId: 'src1' } as EquipmentItem, eq('B', 'Switcher')],
+        sourceIdentities: [{ id: 'src1', name: 'CAM 1', number: 1 }],
+      } as Partial<CablePlannerProject>)
+
+    const before = mitRolle('Kamera 1')
+    const after = mitRolle('Kamera 1 NEU')
+    expect(DOCUMENT_STANDS['tally-karte'](before)).not.toBe(DOCUMENT_STANDS['tally-karte'](after))
+    // Und sie bleibt gleich, wenn sich nichts bewegt -- sonst waere der
+    // Stempel Rauschen und der Vergleich wertlos.
+    expect(DOCUMENT_STANDS['tally-karte'](before)).toBe(DOCUMENT_STANDS['tally-karte'](mitRolle('Kamera 1')))
+  })
+
+  it('die Blaetter je Geraet sind BENANNT statt weggelassen', () => {
+    // Videohub-Labels, MV-Layout und Port-Karte gibt es je GERAET; das
+    // Register fuehrt einen Stand je Bezeichner. Sie sind deshalb nicht
+    // beurteilbar — aber sie zu verschweigen sieht in einer Impact-Liste aus
+    // wie „unberuehrt", und das ist die schlechtere Antwort.
+    for (const id of ['videohub-labels', 'atem-mv-layout', 'switch-port-karte', 'stueckliste']) {
+      expect(Object.keys(UNJUDGEABLE_DOCUMENTS)).toContain(id)
+      expect(UNJUDGEABLE_DOCUMENTS[id].length).toBeGreaterThan(30)
+      expect(DOCUMENT_LABELS[id]).toBeTruthy()
+    }
+  })
+
+  it('kein Bezeichner steht in BEIDEN Registern', () => {
+    // Beurteilbar UND unbeurteilbar zugleich waere eine Aussage, die sich
+    // selbst widerspricht.
+    for (const id of Object.keys(UNJUDGEABLE_DOCUMENTS)) {
+      expect(Object.keys(DOCUMENT_STANDS)).not.toContain(id)
     }
   })
 })

--- a/tests/containerCheckout.test.ts
+++ b/tests/containerCheckout.test.ts
@@ -21,6 +21,7 @@ import storeQuelle from '../src/renderer/store/checkoutStore.ts?raw'
 import inventoryStoreQuelle from '../src/renderer/store/inventoryStore.ts?raw'
 import keysQuelle from '../src/renderer/lib/storageKeys.ts?raw'
 import { stripComments } from './support/stripComments'
+import { scanBackIntoCheckout, unlabelledLines } from '../src/renderer/lib/containerCheckout'
 
 // ---------------------------------------------------------------------------
 // Bedarf 15 -- den Container ein- und auschecken, nicht den Artikel.
@@ -38,16 +39,16 @@ import { stripComments } from './support/stripComments'
 
 const zeit = '2026-09-06T10:00:00.000Z'
 
-const node = (id: string, name: string, kind: StorageNode['kind'], parentId?: string): StorageNode => ({
-  id, name, kind, parentId, createdAt: zeit, updatedAt: zeit,
+const node = (id: string, name: string, kind: StorageNode['kind'], parentId?: string, code?: string): StorageNode => ({
+  id, name, kind, parentId, code, createdAt: zeit, updatedAt: zeit,
 })
 
-const item = (id: string, model: string, quantity: number, locationId?: string): InventoryItem => ({
-  id, model, quantity, locationId, createdAt: zeit, updatedAt: zeit,
+const item = (id: string, model: string, quantity: number, locationId?: string, code?: string): InventoryItem => ({
+  id, model, quantity, locationId, code, createdAt: zeit, updatedAt: zeit,
 })
 
-const unit = (id: string, itemId: string, serial: string, locationId?: string): InventoryUnit => ({
-  id, itemId, serial, locationId, condition: 'ok', history: [], createdAt: zeit, updatedAt: zeit,
+const unit = (id: string, itemId: string, serial: string, locationId?: string, code?: string): InventoryUnit => ({
+  id, itemId, serial, locationId, code, condition: 'ok', history: [], createdAt: zeit, updatedAt: zeit,
 })
 
 /**
@@ -70,14 +71,14 @@ const lager = (): InventorySnapshotIn => ({
     node('a3', 'Regal A3', 'shelf', 'depot'),
     node('b1', 'Regal B1', 'shelf', 'depot'),
     node('tc1', 'Transport-Case 1', 'transportCase', 'a3'),
-    node('c2', 'Case 2', 'case', 'tc1'),
+    node('c2', 'Case 2', 'case', 'tc1', 'CASE-002'),
   ],
   items: [
-    item('klett', 'Klettband', 5, 'c2'),
+    item('klett', 'Klettband', 5, 'c2'),  // bewusst OHNE Etikett
     item('stativ', 'Stativ', 2, 'b1'),
   ],
   units: [
-    unit('u1', 'obj', 'S-1', 'c2'),
+    unit('u1', 'obj', 'S-1', 'c2', 'UNIT-0001'),
     unit('u2', 'cam', 'S-2', 'tc1'),
   ],
 })
@@ -256,11 +257,24 @@ describe('die Blaetter', () => {
       record: CheckoutRecord
     }).record
 
-  it('der Ausgabeschein zaehlt jede Position mit Kennung auf', () => {
+  it('der Ausgabeschein traegt den ETIKETTEN-CODE, nicht die interne Id', () => {
+    // Bedarf 16: „the printed artefact scannable back in". Der erste Wurf
+    // druckte `refId` -- eine UUID, die auf keinem Case klebt und die kein
+    // Scanner findet. Eine Spalte, die scannbar AUSSIEHT und es nicht ist,
+    // ist schlimmer als keine.
     const t = checkoutSheet(rec())
-    expect(t.headers).toEqual(['Art', 'Bezeichnung', 'Menge', 'Kennung'])
+    expect(t.headers).toEqual(['Art', 'Bezeichnung', 'Menge', 'Etiketten-Code', 'Abgehakt'])
     expect(t.rows).toHaveLength(4)
-    expect(t.rows.every((r) => String(r[3] ?? '').length > 0)).toBe(true)
+    const codes = t.rows.map((r) => String(r[3]))
+    expect(codes).not.toContain('id-Case 2')
+    expect(codes.some((c) => c === 'kein Etikett')).toBe(true)
+  })
+
+  it('haelt eine leere Spalte fuer den Stift frei', () => {
+    // Der Grund, warum das Blatt ueberhaupt gedruckt wird: „works with
+    // gloves, in the dark, never logs out". Ohne die Spalte wird auf dem Rand
+    // abgehakt, und der Rand kommt nicht zurueck in den Datensatz.
+    expect(checkoutSheet(rec()).rows.every((r) => r[4] === '')).toBe(true)
   })
 
   it('die Uebersicht nennt den Lagerort als PFAD', () => {
@@ -377,5 +391,100 @@ describe('die Belege bleiben aus dem portablen Lager-Format heraus', () => {
   it('benutzt einen eigenen localStorage-Key aus der Registry', () => {
     expect(storeQuelle).toContain('STORAGE_KEYS.checkouts')
     expect(keysQuelle).toContain("checkouts: 'cable-planner:checkouts'")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Bedarf 16 -- den Papierweg schliessen.
+//
+//   > Picking is ticked on paper with a pen (works with gloves, in the dark,
+//   > never logs out), then typed into the ERP hours later; the warehouse runs
+//   > permanently a few hours behind reality.
+//
+// Die Zahlen daneben: ~1 Fehler je 300 getippte Zeichen gegen ~1 je 3 Mio.
+// Scans. Der Bedarf verlangt deshalb nicht, das Papier abzuschaffen, sondern
+// es SCANNBAR ZURUECK zu machen.
+// ---------------------------------------------------------------------------
+describe('der Etiketten-Code faehrt mit', () => {
+  const rec = (): CheckoutRecord =>
+    (buildCheckout(lager(), [], 'tc1', ausgabe(), 'r1') as { record: CheckoutRecord }).record
+
+  it('friert den Code des Containers ein', () => {
+    expect(rec().contents.find((l) => l.refId === 'c2')?.code).toBe('CASE-002')
+  })
+
+  it('friert den Code der Einheit ein -- getrennt von der Seriennummer', () => {
+    // Der Code ist, was der Scanner findet; die Seriennummer, was der Mensch
+    // liest. Die eine durch die andere zu ersetzen macht eine der beiden
+    // Rollen kaputt.
+    const l = rec().contents.find((x) => x.refId === 'u1')!
+    expect(l.code).toBe('UNIT-0001')
+    expect(l.label).toBe('S-1')
+  })
+
+  it('erfindet keinen Code, wo keiner klebt', () => {
+    expect(rec().contents.find((l) => l.refId === 'klett')?.code).toBeUndefined()
+  })
+
+  it('nennt die Positionen ohne Etikett als Arbeitsliste', () => {
+    // Nicht als Fehler: wer den Anteil kennt, weiss, welche Kisten ein
+    // Etikett brauchen -- und wieviel des Gewinns er heute schon hat.
+    expect(unlabelledLines(rec()).map((l) => l.refId)).toEqual(['u2', 'klett'])
+  })
+})
+
+describe('der Scan zurueck ins Blatt', () => {
+  const rec = (): CheckoutRecord =>
+    (buildCheckout(lager(), [], 'tc1', ausgabe(), 'r1') as { record: CheckoutRecord }).record
+
+  it('findet die Zeile zum Code', () => {
+    const r = scanBackIntoCheckout(rec(), 'CASE-002')
+    expect(r.kind).toBe('line')
+    expect(r.kind === 'line' && r.line.refId).toBe('c2')
+  })
+
+  it('liest Leerzeichen und Schreibweise weg', () => {
+    // Etiketten kommen mit Leerzeichen und in wechselnder Schreibweise aus
+    // dem Lesegeraet.
+    expect(scanBackIntoCheckout(rec(), '  case-002 ').kind).toBe('line')
+  })
+
+  it('meldet einen fremden Code ALS SOLCHEN', () => {
+    // Die nuetzlichste Auskunft dieses Scans: „gehoert nicht in dieses Case"
+    // faengt das Packen ins falsche Case, und zwar bevor es faehrt.
+    expect(scanBackIntoCheckout(rec(), 'CASE-999').kind).toBe('unknown-code')
+    expect(scanBackIntoCheckout(rec(), '').kind).toBe('unknown-code')
+  })
+
+  it('trifft NICHT ueber die interne Id', () => {
+    // Sie steht auf keinem Etikett. Ein Treffer darauf waere ein Zufall, der
+    // im Betrieb nie eintritt und im Test Sicherheit vortaeuscht.
+    expect(scanBackIntoCheckout(rec(), 'c2').kind).toBe('unknown-code')
+  })
+})
+
+describe('der Scan-Rueckweg ist erreichbar', () => {
+  it('steht im Lager-Dialog und TREIBT die Anzeige', () => {
+    // Der erste Wurf dieses Tests suchte nur den NAMEN im Quelltext. Die
+    // Gegenprobe liess ihn als `void scanBackIntoCheckout` stehen und
+    // verdrahtete daneben eine feste Antwort -- der Test blieb gruen. Ein
+    // Guard auf einen Bezeichner prueft, dass er vorkommt, nicht dass er
+    // etwas tut.
+    expect(dialogQuelle).toMatch(/const treffer = scanBackIntoCheckout\(r, roh\)/)
+    expect(dialogQuelle).toMatch(/treffer\.kind === 'line'/)
+    expect(dialogQuelle).toMatch(/treffer\.line\.label/)
+    expect(dialogQuelle).toMatch(/onKeyDown=\{\(e\) => \{\s*\n\s*if \(e\.key === 'Enter'\) scanBack\(r\)/)
+  })
+
+  it('nennt die Positionen ohne Etikett auf dem Schirm', () => {
+    expect(dialogQuelle).toContain('unlabelledLines(r)')
+    expect(dialogQuelle).toContain("'inventory.checkout.unlabelled'")
+  })
+
+  it('meldet den fremden Code, statt ihn zu verschlucken', () => {
+    for (const key of ['inventory.checkout.scanHit', 'inventory.checkout.scanMiss']) {
+      expect(dialogQuelle).toContain(`'${key}'`)
+      expect(dictsQuelle).toContain(`'${key}'`)
+    }
   })
 })

--- a/tests/erpReconcile.test.ts
+++ b/tests/erpReconcile.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest'
+import { erpReconcileTable, reconcileErp, type ErpLine } from '../src/renderer/lib/erpReconcile'
+import type { DemandLine } from '../src/renderer/lib/inventoryCoverage'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+import quelle from '../src/renderer/lib/erpReconcile.ts?raw'
+import dialogQuelle from '../src/renderer/components/Rentman/RentmanImportDialog.tsx?raw'
+import dictsQuelle from '../src/renderer/lib/i18n/dicts.ts?raw'
+
+// ---------------------------------------------------------------------------
+// Bedarf 28 -- der Abgleich gegen die ERP-Reservierung, in BEIDE Richtungen.
+//
+//   > The PM's real question is never „what does my plan contain" but „WHAT
+//   > DOES MY PLAN CONTAIN THAT THE ERP PROJECT DOES NOT, and which side
+//   > changed since we last agreed?"
+//
+// Und: „The valuable increment is the DIFF, not more export."
+//
+// Der teuerste Fehler waere eine geratene Zuordnung: sie erklaert eine
+// Position fuer vorhanden, die es nicht ist, und das kostet am Aufbautag ein
+// Geraet. Der zweitteuerste ist das Mitzaehlen der Zeilen, die keine Geraete
+// sind -- dann stimmt keine Summe.
+// ---------------------------------------------------------------------------
+
+const eq = (id: string, rentmanId?: string): EquipmentItem =>
+  ({ id, name: id, category: 'Sonstiges', inputs: [], outputs: [], x: 0, y: 0, width: 1, height: 1, rentmanId }) as unknown as EquipmentItem
+
+const demand = (label: string, quantity: number, equipmentIds: string[] = []): DemandLine => ({
+  key: label,
+  label,
+  quantity,
+  equipmentIds,
+  labelIsDeviceName: false,
+})
+
+const erp = (over: Partial<ErpLine> = {}): ErpLine => ({
+  equipmentId: 'r1',
+  name: 'Sony PMW-F55',
+  qty: 1,
+  kind: 'device',
+  isSetChild: false,
+  ...over,
+})
+
+describe('die Zeilen, die nicht zaehlen', () => {
+  it('ignoriert Kommentarzeilen und sagt WARUM', () => {
+    // „Aufbau ab 8 Uhr" ist kein Geraet. Sie mitzuzaehlen macht jeden
+    // Abgleich falsch.
+    const r = reconcileErp([], [], [erp({ kind: 'comment', name: 'Aufbau ab 8 Uhr' })])
+    expect(r.rows).toEqual([])
+    expect(r.ignored).toEqual([{ label: 'Aufbau ab 8 Uhr', reason: 'Kommentarzeile, kein Geraet' }])
+  })
+
+  it('ignoriert den Inhalt einer Kombination', () => {
+    // Er ist im Elternteil schon gezaehlt; beides zu zaehlen verdoppelt das
+    // halbe Projekt.
+    const r = reconcileErp([], [], [erp({ isSetChild: true })])
+    expect(r.rows).toEqual([])
+    expect(r.ignored[0].reason).toContain('Kombination')
+  })
+
+  it('ignoriert eine gestrichene Zeile (Menge 0)', () => {
+    const r = reconcileErp([], [], [erp({ qty: 0 })])
+    expect(r.rows).toEqual([])
+    expect(r.ignored[0].reason).toContain('Menge 0')
+  })
+
+  it('liefert die Begruendung MIT, statt still wegzulassen', () => {
+    // Eine Reservierung mit vierzig Zeilen, von denen zwoelf stillschweigend
+    // fehlen, laesst niemanden nachvollziehen, warum die Summe nicht stimmt.
+    const r = reconcileErp([], [], [erp({ kind: 'comment' }), erp({ isSetChild: true }), erp({ qty: 0 })])
+    expect(r.ignored).toHaveLength(3)
+    expect(r.ignored.every((i) => i.reason.length > 10)).toBe(true)
+  })
+})
+
+describe('die Zuordnung: erst die Tatsache, dann der Vorschlag', () => {
+  it('ordnet ueber die rentmanId zu und nennt das als Tatsache', () => {
+    const r = reconcileErp([demand('Kamera', 1, ['e1'])], [eq('e1', 'r1')], [erp()])
+    expect(r.rows[0].basis).toBe('rentman-id')
+    expect(r.rows[0].verdict).toBe('matched')
+  })
+
+  it('ordnet ueber den Namen zu und nennt das als Vorschlag', () => {
+    const r = reconcileErp([demand('Sony PMW-F55', 1)], [], [erp()])
+    expect(r.rows[0].basis).toBe('name')
+    expect(r.rows[0].verdict).toBe('matched')
+  })
+
+  it('zieht die rentmanId dem Namen vor', () => {
+    // Die Bruecke aus dem Import ist eine Tatsache; der Name ist es nie.
+    const zeilen = [erp({ equipmentId: 'r1', name: 'Ganz anders' }), erp({ equipmentId: 'r2', name: 'Kamera' })]
+    const r = reconcileErp([demand('Kamera', 1, ['e1'])], [eq('e1', 'r1')], zeilen)
+    expect(r.rows.find((x) => x.basis === 'rentman-id')?.label).toBe('Kamera')
+  })
+
+  it('ordnet NICHT zu, wenn der Name auf der ERP-Seite mehrfach vorkommt', () => {
+    // Eine geratene Zuordnung erklaert eine Position fuer vorhanden, die es
+    // nicht ist — und das kostet am Aufbautag ein Geraet.
+    const zwei = [erp({ equipmentId: 'r1' }), erp({ equipmentId: 'r2' })]
+    const r = reconcileErp([demand('Sony PMW-F55', 1)], [], zwei)
+    const planZeile = r.rows.find((x) => x.verdict === 'only-in-plan')
+    expect(planZeile?.basis).toBe('ambiguous')
+  })
+
+  it('ordnet NICHT zu, wenn der Name auf der PLAN-Seite mehrfach vorkommt', () => {
+    // Die andere Haelfte derselben Regel. Sie fehlt gern.
+    const zweimal = [demand('Sony PMW-F55', 1, ['e1']), demand('Sony PMW-F55', 2, ['e2'])]
+    const r = reconcileErp(zweimal, [], [erp()])
+    expect(r.rows.filter((x) => x.basis === 'ambiguous')).toHaveLength(2)
+  })
+})
+
+describe('die vier Befunde', () => {
+  it('nennt, was nur im Plan steht', () => {
+    const r = reconcileErp([demand('Fehlt im ERP', 2)], [], [])
+    expect(r.rows[0]).toEqual({ verdict: 'only-in-plan', basis: 'none', label: 'Fehlt im ERP', planQty: 2 })
+    expect(r.onlyInPlan).toBe(1)
+  })
+
+  it('nennt, was nur in der Reservierung steht', () => {
+    // Der halbe Bedarf, den ein reiner Export nie zeigt: reserviert und
+    // bezahlt, aber im Plan nicht verlangt.
+    const r = reconcileErp([], [], [erp({ name: 'Zuviel bestellt', qty: 3 })])
+    expect(r.rows[0].verdict).toBe('only-in-erp')
+    expect(r.rows[0].erpQty).toBe(3)
+    expect(r.onlyInErp).toBe(1)
+  })
+
+  it('nennt eine Mengenabweichung MIT beiden Zahlen', () => {
+    const r = reconcileErp([demand('Sony PMW-F55', 5)], [], [erp({ qty: 3 })])
+    expect(r.rows[0].verdict).toBe('quantity-differs')
+    expect(r.rows[0].planQty).toBe(5)
+    expect(r.rows[0].erpQty).toBe(3)
+    expect(r.differing).toBe(1)
+  })
+
+  it('sortiert das zu Klaerende nach oben', () => {
+    // Fehlendes Material zuerst, dann Mengen, dann Ueberzaehliges, dann was
+    // stimmt.
+    const d = [demand('Nur Plan', 1), demand('Menge', 5, ['e1']), demand('Stimmt', 1, ['e2'])]
+    const e = [eq('e1', 'rM'), eq('e2', 'rS')]
+    const lines = [
+      erp({ equipmentId: 'rM', name: 'Menge', qty: 2 }),
+      erp({ equipmentId: 'rS', name: 'Stimmt', qty: 1 }),
+      erp({ equipmentId: 'rX', name: 'Nur ERP' }),
+    ]
+    expect(reconcileErp(d, e, lines).rows.map((r) => r.verdict)).toEqual([
+      'only-in-plan',
+      'quantity-differs',
+      'only-in-erp',
+      'matched',
+    ])
+  })
+})
+
+describe('das Blatt', () => {
+  it('fuehrt beide Mengen und die Art der Zuordnung', () => {
+    const r = reconcileErp([demand('Sony PMW-F55', 5)], [], [erp({ qty: 3 })])
+    const t = erpReconcileTable(r)
+    expect(t.headers).toEqual(['Befund', 'Position', 'Plan', 'Reservierung', 'Zuordnung'])
+    expect(t.rows[0]).toEqual(['Menge weicht ab', 'Sony PMW-F55', 5, 3, 'ueber den Namen (Vorschlag)'])
+  })
+
+  it('laesst die Mengenspalte LEER, wo eine Seite die Position nicht kennt', () => {
+    // Eine 0 waere eine Behauptung („null Stueck reserviert"); leer ist die
+    // Wahrheit („kommt dort nicht vor").
+    const t = erpReconcileTable(reconcileErp([demand('Nur Plan', 2)], [], []))
+    expect(t.rows[0][3]).toBe('')
+  })
+})
+
+describe('was die Datei NICHT tut', () => {
+  it('holt sich weder Zeit noch Store noch Netz', () => {
+    expect(quelle).not.toMatch(/new Date\(\)|Date\.now\(\)|useProjectStore|fetch\(|axios/)
+  })
+
+  it('haengt nicht von einer Komponente ab', () => {
+    // Eine Bibliothek, die aus `components/` importiert, dreht die
+    // Abhaengigkeit um — und `RentmanEquipment` passt strukturell ohnehin.
+    expect(quelle).not.toMatch(/from '\.\.\/components\//)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ERREICHBARKEIT. Der Abgleich gehoert dorthin, wo die Reservierung schon auf
+// dem Schirm ist -- ein eigener Dialog waere ein zweiter Ort fuer dieselbe
+// Frage.
+// ---------------------------------------------------------------------------
+describe('Erreichbarkeit im Rentman-Dialog', () => {
+  it('rechnet den Abgleich und zeigt ihn an', () => {
+    expect(dialogQuelle).toMatch(/const erpReport = useMemo\(/)
+    expect(dialogQuelle).toMatch(/reconcileErp\(/)
+    expect(dialogQuelle).toMatch(/erpReport\.onlyInPlan/)
+    expect(dialogQuelle).toMatch(/erpReport\.onlyInErp/)
+    // Und die BEDINGUNG, unter der der Block erscheint. Ohne sie blieb die
+    // Gegenprobe gruen, die `items.length > 0` durch `false` ersetzte: alle
+    // gesuchten Zeichenketten standen weiter da, gerendert wurde nichts.
+    expect(dialogQuelle).toContain('{items.length > 0 && erpReport.rows.length > 0 && (')
+  })
+
+  it('benutzt DENSELBEN Bedarfsbegriff wie die Stueckliste', () => {
+    // Zwei Bedarfsbegriffe nebeneinander waeren zwei Wahrheiten. Der Aufruf
+    // reicht Kabel und Geraete herein, wie in Bedarf 17 festgelegt.
+    expect(dialogQuelle).toMatch(/deriveDemand\(\s*\n?\s*projectEquipment,/)
+    expect(dialogQuelle).toMatch(/zusatzBedarf\(\{ drumKit, wirelessRig, cables: planCables, equipment: projectEquipment \}\)/)
+  })
+
+  it('nennt die nicht gezaehlten Zeilen', () => {
+    expect(dialogQuelle).toContain('erpReport.ignored.length')
+    expect(dictsQuelle).toContain("'rentman.diff.ignored'")
+  })
+
+  it('gibt das Blatt aus', () => {
+    expect(dialogQuelle).toMatch(/csvFromTable\(erpReconcileTable\(erpReport\)\)/)
+  })
+})

--- a/tests/planteileAusserhalbEquipment.test.ts
+++ b/tests/planteileAusserhalbEquipment.test.ts
@@ -20,6 +20,7 @@ import type { EquipmentItem } from '../src/renderer/types/equipment'
 import type { InventoryItem, StorageNode } from '../src/renderer/types/inventory'
 import type { DrumKitPlan } from '../src/renderer/types/drumKit'
 import type { WirelessRigPlan } from '../src/renderer/types/wirelessRig'
+import exportDialogQuelle from '../src/renderer/components/Export/ExportDialog.tsx?raw'
 
 const SM57 = '8a940e24-1c9c-4571-a820-50cd7ce55ed1'
 const SM58 = '4e75a4d0-7490-431f-8230-fef93fa265ef'
@@ -177,5 +178,154 @@ describe('die beiden Zaehlungen der Drum-Mics widersprechen sich nicht', () => {
       (x) => x.label === 'XLR-Kabel (Mic → Stagebox)',
     )
     expect(xlr?.quantity).toBe(plan.mics.length)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Bedarf 17 -- die Kabel und die Adapter in DIESELBE Liste.
+//
+//   > The pick list is generated from the commercial reservation, never from
+//   > the cable/camera/lighting plan. The plan's BOM (INCLUDING ADAPTERS AND
+//   > SPARES) is re-typed by a human.
+//
+// Der Cable-Planner hatte die Kabel-Stueckliste als EIGENES Blatt, und der
+// Deckungs-Abgleich gegen das Lager las nur die Geraete. Die Adapter standen
+// nirgends -- obwohl der Plan an zwei Stellen sagt, dass er welche braucht.
+// ---------------------------------------------------------------------------
+const kabel = (over: Partial<import('../src/renderer/types/cable').Cable> = {}) =>
+  ({
+    id: 'c1',
+    name: 'K1',
+    type: 'SDI',
+    length: 5,
+    color: '#fff',
+    fromEquipmentId: 'A',
+    fromPortId: 'A-out',
+    toEquipmentId: 'B',
+    toPortId: 'B-in',
+    notes: '',
+    ...over,
+  }) as import('../src/renderer/types/cable').Cable
+
+const mitPorts = (id: string, portId: string, over: Record<string, unknown> = {}): EquipmentItem =>
+  eq({
+    id,
+    outputs: [{ id: portId, name: portId, type: 'port', connectorType: 'BNC', ...over }],
+  } as Partial<EquipmentItem>)
+
+describe('Bedarf 17 — die Kabel kommen in die Bedarfsliste', () => {
+  it('zaehlt Kabel nach Typ UND Laenge', () => {
+    // Ein 5-m-SDI und ein 50-m-SDI sind im Lager zwei Artikel.
+    const z = zusatzBedarf({
+      cables: [kabel(), kabel({ id: 'c2' }), kabel({ id: 'c3', length: 50 })],
+      equipment: [],
+    })
+    const kabelZeilen = z.filter((x) => x.herkunft === 'Kabelplan')
+    expect(kabelZeilen.map((x) => `${x.label} x${x.quantity}`).sort()).toEqual([
+      'SDI 5 m x2',
+      'SDI 50 m x1',
+    ])
+  })
+
+  it('zaehlt ein Multicore je Buendel EINMAL', () => {
+    // Sonst kommissioniert das Lager sechzehn Kabel fuer eine Trommel.
+    //
+    // Der erste Anlauf dieses Tests prueft die ZEILENZAHL -- und blieb gruen,
+    // als die Buendel-Sperre entfernt wurde: drei gleiche Adern tragen
+    // dieselbe Beschriftung, `zusammen()` legt sie ohnehin zu EINER Zeile
+    // zusammen. Was sich aendert, ist die MENGE.
+    const adern = [1, 2, 3].map((n) => kabel({ id: `m${n}`, multicoreName: 'MC-1' }))
+    const z = zusatzBedarf({ cables: adern, equipment: [] })
+    const zeilen = z.filter((x) => x.herkunft === 'Kabelplan')
+    expect(zeilen).toHaveLength(1)
+    expect(zeilen[0].quantity).toBe(1)
+  })
+
+  it('zaehlt ZWEI Buendel als zwei', () => {
+    // Die Gegenrichtung derselben Regel: die Sperre darf nicht so weit gehen,
+    // dass sie ein zweites Multicore verschluckt.
+    const adern = [
+      kabel({ id: 'a1', multicoreName: 'MC-1' }),
+      kabel({ id: 'a2', multicoreName: 'MC-1' }),
+      kabel({ id: 'b1', multicoreName: 'MC-2' }),
+    ]
+    const zeilen = zusatzBedarf({ cables: adern, equipment: [] }).filter(
+      (x) => x.herkunft === 'Kabelplan',
+    )
+    expect(zeilen[0].quantity).toBe(2)
+  })
+
+  it('laesst Funkstrecken weg -- die sind keine Kabel', () => {
+    const z = zusatzBedarf({ cables: [kabel({ wireless: true })], equipment: [] })
+    expect(z.filter((x) => x.herkunft === 'Kabelplan')).toEqual([])
+  })
+
+  it('rechnet KEINEN Reserve-Aufschlag ein', () => {
+    // Der Aufschlag ist eine Export-Einstellung des Nutzers -- deshalb steht
+    // `kabel-bom` in `UNJUDGEABLE_DOCUMENTS`. Ihn hier einzurechnen hiesse,
+    // die Antwort „reicht der Bestand?" von einem Prozentsatz abhaengig zu
+    // machen, den an dieser Stelle niemand sieht.
+    const z = zusatzBedarf({ cables: [kabel()], equipment: [] })
+    expect(z.find((x) => x.herkunft === 'Kabelplan')?.quantity).toBe(1)
+  })
+})
+
+describe('Bedarf 17 — die Adapter, die der Plan selbst verlangt', () => {
+  it('macht aus einem LWL-Steckertyp-Mismatch einen benannten Adapter', () => {
+    // Dieselbe Bedingung wie Check 17b in `drawingChecks`. Bis hierher blieb
+    // die Erkenntnis im Zeichnungs-Befund stehen und wurde nie zu Material.
+    const von = eq({ id: 'A', outputs: [{ id: 'A-out', name: 'OUT', type: 'port', connectorType: 'LC', fiberConnector: 'LC' }] } as Partial<EquipmentItem>)
+    const nach = eq({ id: 'B', inputs: [{ id: 'B-in', name: 'IN', type: 'port', connectorType: 'SC', fiberConnector: 'SC' }] } as Partial<EquipmentItem>)
+    const z = zusatzBedarf({ cables: [kabel()], equipment: [von, nach] })
+    const ad = z.filter((x) => x.herkunft === 'Adapter (vom Plan verlangt)')
+    expect(ad).toHaveLength(1)
+    // BENANNT: „LWL-Adapter LC ↔ SC" ist kommissionierbar, „Adapter" nicht.
+    expect(ad[0].label).toBe('LWL-Adapter LC ↔ SC')
+  })
+
+  it('macht aus dem Haekchen `needsConverter` einen Adapter mit Steckern', () => {
+    const von = eq({ id: 'A', outputs: [{ id: 'A-out', name: 'OUT', type: 'port', connectorType: 'BNC' }] } as Partial<EquipmentItem>)
+    const nach = eq({ id: 'B', inputs: [{ id: 'B-in', name: 'IN', type: 'port', connectorType: 'HDMI' }] } as Partial<EquipmentItem>)
+    const z = zusatzBedarf({ cables: [kabel({ needsConverter: true })], equipment: [von, nach] })
+    expect(z.find((x) => x.herkunft === 'Adapter (vom Plan verlangt)')?.label).toBe('Adapter BNC ↔ HDMI')
+  })
+
+  it('erfindet keine Steckerpaarung, wo die Ports unbekannt sind', () => {
+    // Eine erfundene Paarung waere schlimmer als eine unbestimmte Zeile: sie
+    // sieht bestellbar aus.
+    const z = zusatzBedarf({ cables: [kabel({ needsConverter: true, name: 'K7' })], equipment: [] })
+    expect(z.find((x) => x.herkunft === 'Adapter (vom Plan verlangt)')?.label).toBe('Adapter für „K7"')
+  })
+
+  it('zaehlt EINEN Link nicht zweimal', () => {
+    // Dasselbe Kabel traegt oft beides gleichzeitig.
+    const von = eq({ id: 'A', outputs: [{ id: 'A-out', name: 'OUT', type: 'port', connectorType: 'LC', fiberConnector: 'LC' }] } as Partial<EquipmentItem>)
+    const nach = eq({ id: 'B', inputs: [{ id: 'B-in', name: 'IN', type: 'port', connectorType: 'SC', fiberConnector: 'SC' }] } as Partial<EquipmentItem>)
+    const z = zusatzBedarf({ cables: [kabel({ needsConverter: true })], equipment: [von, nach] })
+    expect(z.filter((x) => x.herkunft === 'Adapter (vom Plan verlangt)')).toHaveLength(1)
+  })
+
+  it('meldet keinen Adapter, wo der Plan keinen verlangt', () => {
+    const von = eq({ id: 'A', outputs: [{ id: 'A-out', name: 'OUT', type: 'port', connectorType: 'BNC' }] } as Partial<EquipmentItem>)
+    const nach = eq({ id: 'B', inputs: [{ id: 'B-in', name: 'IN', type: 'port', connectorType: 'BNC' }] } as Partial<EquipmentItem>)
+    expect(
+      zusatzBedarf({ cables: [kabel()], equipment: [von, nach] }).filter(
+        (x) => x.herkunft === 'Adapter (vom Plan verlangt)',
+      ),
+    ).toEqual([])
+  })
+})
+
+describe('Bedarf 17 — die Erreichbarkeit im Deckungs-Abgleich', () => {
+  it('die Kabel-Zeilen erreichen deriveDemand', () => {
+    // Der eigentliche Punkt: nicht ein weiteres Blatt, sondern DIESELBE
+    // Liste, gegen die der Lagerbestand gehalten wird.
+    const z = zusatzBedarf({ cables: [kabel()], equipment: [] })
+    const demand = deriveDemand([], z)
+    expect(demand.some((d) => d.label === 'SDI 5 m')).toBe(true)
+  })
+
+  it('der Export-Dialog reicht Kabel UND Geraete herein', () => {
+    expect(exportDialogQuelle).toMatch(/zusatzBedarf\(\{ drumKit, wirelessRig, cables, equipment \}\)/)
   })
 })

--- a/tests/sheetLookup.test.ts
+++ b/tests/sheetLookup.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest'
+import { lookUpSheet } from '../src/renderer/lib/sheetLookup'
+import { DOCUMENT_STANDS, UNJUDGEABLE_DOCUMENTS } from '../src/renderer/lib/documentRegistry'
+import { buildDocQrPayload } from '../src/renderer/lib/qrPayload'
+import type { CablePlannerProject } from '../src/renderer/types/project'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+import quelle from '../src/renderer/lib/sheetLookup.ts?raw'
+import analyseQuelle from '../src/renderer/components/Analysis/AnalysisDialog.tsx?raw'
+import dictsQuelle from '../src/renderer/lib/i18n/dicts.ts?raw'
+
+// ---------------------------------------------------------------------------
+// Bedarf 27 -- der Rueckweg vom Papier.
+//
+//   > Pick lists, call sheets ... stay paper because paper needs no battery,
+//   > works in a basement and can be signed. But NOTHING CROSSES BACK.
+//
+// ADR-004 hat den Stempel auf jedes Blatt gesetzt, und `docStandStatus` /
+// `findByStand` beantworten genau die Frage „gilt dieses Blatt noch?". Nur
+// rief sie NICHTS auf: gemessen war die einzige Fundstelle ausserhalb ihrer
+// eigenen Dateien ein Kommentar.
+// ---------------------------------------------------------------------------
+
+const eq = (id: string, name: string): EquipmentItem =>
+  ({
+    id,
+    name,
+    category: 'Sonstiges',
+    inputs: [{ id: `${id}-in`, name: 'IN 1', type: 'port', connectorType: 'BNC' }],
+    outputs: [{ id: `${id}-out`, name: 'OUT 1', type: 'port', connectorType: 'BNC' }],
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 100,
+  }) as unknown as EquipmentItem
+
+const cable = (id: string, over: Partial<Cable> = {}): Cable =>
+  ({
+    id,
+    name: `Kabel ${id}`,
+    type: 'SDI',
+    length: 10,
+    color: '#fff',
+    fromEquipmentId: 'A',
+    fromPortId: 'A-out',
+    toEquipmentId: 'B',
+    toPortId: 'B-in',
+    notes: '',
+    ...over,
+  }) as Cable
+
+const project = (over: Partial<CablePlannerProject> = {}): CablePlannerProject =>
+  ({
+    metadata: { name: 'Testanlage', description: '', createdAt: '', updatedAt: '' },
+    equipment: [eq('A', 'Kamera 1'), eq('B', 'Switcher')],
+    cables: [cable('c1')],
+    canvasState: { x: 0, y: 0, zoom: 1 },
+    ...over,
+  }) as CablePlannerProject
+
+const standVon = (docId: string, p: CablePlannerProject) => DOCUMENT_STANDS[docId](p)
+
+describe('der ganze Code — die beste Eingabe', () => {
+  it('nennt das Dokument und sagt, dass es aktuell ist', () => {
+    const p = project()
+    const code = buildDocQrPayload('pull-liste', standVon('pull-liste', p))
+    const r = lookUpSheet(code, p)
+    expect(r.kind).toBe('identified')
+    expect(r.docId).toBe('pull-liste')
+    expect(r.status).toBe('current')
+  })
+
+  it('sagt UEBERHOLT, wenn der Plan seither weiter ist', () => {
+    // Der eigentliche Zweck. Ein Blatt in der Hand, zwei Stunden vor Doors.
+    const alt = project()
+    const code = buildDocQrPayload('pull-liste', standVon('pull-liste', alt))
+    const neu = project({ cables: [cable('c1', { type: 'Cat6' })] })
+    const r = lookUpSheet(code, neu)
+    expect(r.status).toBe('stale')
+    expect(r.docId).toBe('pull-liste')
+  })
+
+  it('sagt „nicht beurteilbar" MIT dem Grund aus dem Register', () => {
+    // Zwei Formulierungen derselben Regel laufen auseinander; der Grund wird
+    // deshalb geholt und nicht neu geschrieben.
+    const p = project()
+    const code = buildDocQrPayload('kabel-bom', 'aaaaaaaa')
+    const r = lookUpSheet(code, p)
+    expect(r.status).toBe('unknown')
+    expect(r.reason).toBe(UNJUDGEABLE_DOCUMENTS['kabel-bom'])
+  })
+
+  it('reicht das Revisions-Label vom Blatt durch', () => {
+    const p = project()
+    const code = buildDocQrPayload('pull-liste', standVon('pull-liste', p), 'Rev C')
+    expect(lookUpSheet(code, p).revision).toBe('Rev C')
+  })
+})
+
+describe('nur der Stand — abgetippt vom Fuss des Blatts', () => {
+  it('findet das Dokument ueber den Stand allein', () => {
+    const p = project()
+    const r = lookUpSheet(standVon('pull-liste', p), p)
+    expect(r.kind).toBe('matched-by-stand')
+    expect(r.docId).toBe('pull-liste')
+    expect(r.status).toBe('current')
+  })
+
+  it('nimmt die Raute, Leerzeichen und Grossbuchstaben an', () => {
+    // Sie kommen vom Abtippen und sind kein Fehler. Wer daran scheitert,
+    // scheitert an der Eingabe statt an der Sache.
+    const p = project()
+    const s = standVon('pull-liste', p)
+    for (const eingabe of [`#${s}`, ` ${s} `, s.toUpperCase(), `# ${s.toUpperCase()} `]) {
+      expect(lookUpSheet(eingabe, p).kind).toBe('matched-by-stand')
+    }
+  })
+
+  it('BENENNT den ueberholten Ausdruck, statt „nicht gefunden" zu sagen', () => {
+    // Der wichtigste Fall. „Passt zu keinem Dokument von jetzt" heisst fast
+    // immer „das Blatt ist alt" -- ein blosses `null` klaenge nach Tippfehler.
+    const r = lookUpSheet('deadbeef', project())
+    expect(r.kind).toBe('stale-or-foreign')
+    expect(r.stand).toBe('deadbeef')
+    // Kein Dokument benannt -- und das ist die Aussage, nicht eine Luecke.
+    expect(r.docId).toBeUndefined()
+  })
+})
+
+describe('was keine Ausnahme wirft', () => {
+  it('leere und unsinnige Eingabe liefert ein Ergebnis', () => {
+    // „Das ist kein Dokument-Code" ist eine Auskunft und kein Fehlerfall. Wer
+    // sie wirft, zwingt jeden Aufrufer zu einem try/catch fuer das Vertippen.
+    for (const raw of ['', '   ', 'Guten Morgen', '123', 'xyzxyzxy']) {
+      expect(lookUpSheet(raw, project()).kind).toBe('unreadable')
+    }
+  })
+
+  it('liefert fuer jede Eingabeform eine benannte Art', () => {
+    // Vier Wege, vier Arten -- keine faellt in einen Sammeltopf.
+    const p = project()
+    expect(lookUpSheet('', p).kind).toBe('unreadable')
+    expect(lookUpSheet('deadbeef', p).kind).toBe('stale-or-foreign')
+    expect(lookUpSheet(standVon('pull-liste', p), p).kind).toBe('matched-by-stand')
+    expect(lookUpSheet(buildDocQrPayload('pull-liste', standVon('pull-liste', p)), p).kind).toBe(
+      'identified',
+    )
+  })
+})
+
+describe('was die Datei NICHT tut', () => {
+  it('holt sich weder Zeit noch Store', () => {
+    expect(quelle).not.toMatch(/new Date\(\)|Date\.now\(\)|useProjectStore|useUiStore/)
+  })
+
+  it('schreibt den Unbeurteilbar-Grund nicht neu', () => {
+    // Er kommt aus `UNJUDGEABLE_DOCUMENTS`. Zwei Formulierungen derselben
+    // Regel laufen auseinander, und die zweite merkt es niemand.
+    expect(quelle).toContain('UNJUDGEABLE_DOCUMENTS[ref.docId]')
+  })
+})
+
+describe('Erreichbarkeit — der Grund, warum es diese Datei gibt', () => {
+  it('wird im Analyse-Dialog aufgerufen und TREIBT die Anzeige', () => {
+    // Der Aufruf UND seine Wirkung: ein Guard auf den blossen Bezeichner
+    // prueft nur, dass er vorkommt (gemessen an Bedarf 16, wo genau das eine
+    // Gegenprobe gruen liess).
+    expect(analyseQuelle).toMatch(/setTreffer\(lookUpSheet\(draft, project\)\)/)
+    expect(analyseQuelle).toMatch(/\{treffer && <div className=\{`text-cp-sm \$\{ton\(treffer\)\}`\}>\{text\(treffer\)\}/)
+  })
+
+  it('hat einen eigenen Reiter', () => {
+    expect(analyseQuelle).toContain("id: 'sheet'")
+    expect(analyseQuelle).toContain('<SheetTab />')
+  })
+
+  it('nennt die Eingabeform, statt sie raten zu lassen', () => {
+    for (const key of ['analysis.sheet.intro', 'analysis.sheet.placeholder']) {
+      expect(analyseQuelle).toContain(`'${key}'`)
+      expect(dictsQuelle).toContain(`'${key}'`)
+    }
+  })
+})


### PR DESCRIPTION
Fünf P1-Bedarfe. Der erste berichtigt einen Fehler aus `#707`; der vierte macht etwas erreichbar, das seit ADR-004 gebaut ist und nie jemand aufrufen konnte.

---

## Bedarf 16 — der Ausgabeschein trug interne IDs

> Picking is ticked on paper with a pen … then typed into the ERP hours later; the warehouse runs **permanently a few hours behind reality.**

Rund **ein Fehler je 300 getippte Zeichen** gegen **einen je drei Millionen Scans**.

Das Blatt aus `#707` druckte in der Spalte „Kennung" die interne `refId` — eine UUID, die auf keinem Case klebt. *Ein Blatt, das eine unscannbare Zeichenkette in eine Spalte namens „Kennung" setzt, ist schlimmer als eines ohne die Spalte.* Jetzt: **Etiketten-Code** eingefroren und gedruckt (wo keiner klebt: „kein Etikett"), Code und Seriennummer **beide** geführt, eine leere Spalte für den Stift, und `scanBackIntoCheckout` trifft **nur** über den Code.

## Bedarf 17 — Kabel und Adapter fehlten in der einen Liste

Die Kabel waren ein eigenes Blatt; der Deckungs-Abgleich las nur die Geräte. Die **Adapter standen nirgends**, obwohl der Plan an zwei Stellen sagt, dass er welche braucht. *Ein Adapter, den niemand einpackt, ist am Aufbautag dasselbe wie ein fehlendes Kabel.* Sie werden benannt; wo die Ports keine Stecker führen, bleibt die Zeile unbestimmt — *eine erfundene Steckerpaarung sieht bestellbar aus.*

## Bedarf 26 — die vergessenen Blätter stehen jetzt in der Liste

> The ones that get missed are **omissions, not errors**: multiviewer window, comms position, **tally**, truck plan, check-in list.

`changeImpact` kannte nur die Dokumente im Register, und die vom Bedarf genannten standen nicht darin. Die **Tally-Karte** ist jetzt beurteilbar; die Blätter je *Gerät* und die Stückliste werden als **nicht beurteilbar mit Grund** geführt — sie zu verschweigen sieht aus wie eine Freigabe.

## Bedarf 27 — der Rückweg vom Papier

> Nothing crosses back … **Must complete in under ten seconds** or it will not be used in the last two hours before doors.

**Die Antwort war seit ADR-004 gebaut und unerreichbar:** `docStandStatus` und `findByStand` beantworten „gilt dieses Blatt noch?", und die einzige Fundstelle ausserhalb ihrer eigenen Dateien war ein **Kommentar**. Jetzt: **Analyse → Blatt prüfen**, ein Feld. Ganzer Code, blosser Stand oder abgetippt mit Raute und Grossbuchstaben. Der wichtigste Fall hat einen eigenen Namen: ein gültiger Stand ohne Gegenstück heisst „vermutlich ein überholter Ausdruck", nicht „nicht gefunden".

## Bedarf 28 — Plan gegen Reservierung, in beide Richtungen

> The PM's real question is never „what does my plan contain" but **„what does my plan contain that the ERP project does not"**. … The valuable increment is the **diff**, not more export.

Reserviert und nicht geplant fällt bei einem reinen Import nie auf, und es ist Geld.

| Regel | Warum |
| --- | --- |
| `comment`, `isSetChild`, Menge 0 zählen **nicht** | Eine Textzeile ist kein Gerät; ein Set-Inhalt ist im Elternteil schon gezählt — beides zu zählen verdoppelt das halbe Projekt |
| Die weggelassenen Zeilen werden **mit Grund** ausgewiesen | Vierzig Zeilen, von denen zwölf stillschweigend fehlen, lassen niemanden nachvollziehen, warum die Summe nicht stimmt |
| `rentmanId` ist eine **Tatsache**, der Name ein **Vorschlag** | Dieselbe Ordnung wie im Lager-Resolver und im Netz-Abgleich |
| Ein Name, der auf **einer der beiden** Seiten doppelt vorkommt, ordnet nichts zu | Eine geratene Zuordnung erklärt eine Position für vorhanden, die es nicht ist |
| Die Mengenspalte bleibt **leer**, nicht 0 | Eine 0 wäre eine Behauptung; leer ist die Wahrheit |

Die erste Fassung konnte „kommt zweimal vor" und „kommt gar nicht vor" nicht auseinanderhalten — sie warf die Doppelten weg, *bevor* sie zählte. `ErpLine` ist strukturell beschrieben und nicht aus `components/` importiert; `RentmanEquipment` passt darauf, und es ist eine bereits defensiv geparste Form statt eines geratenen API-Schemas.

---

## Fünf Tests waren zu schwach — alle durch Gegenproben aufgefallen

| Test | Was er wirklich prüfte |
| --- | --- |
| Erreichbarkeit (16) | Nur den **Namen** `scanBackIntoCheckout` |
| Multicore-Regel (17) | Die **Zeilenzahl** statt der Menge |
| Tally-Reaktion (26) | Eine **leere Karte gegen eine leere Karte** |
| Zwei Impact-Zahlen (26) | Getippte Konstanten, die falsch werden, sobald das Register wächst |
| Erreichbarkeit (28) | Die Felder des Berichts, aber **nicht die Render-Bedingung** — die Probe ersetzte sie durch `false`, alle gesuchten Zeichenketten blieben stehen |

Dazu zwei Funktionen, die vor der Auslieferung wieder entfielen: `refusalText` (15) und `sheetLookupText` (27) — kanonisches Deutsch für etwas, das kein Dokument je trägt, ist Code ohne Leser.

## Gegenproben

Neununddreissig Fehler eingespritzt, jeder hat Tests umgeworfen:

| Bereich | Anzahl |
| --- | --- |
| Ausgabeschein (16) | 9 |
| Bedarfsliste (17) | 8 |
| Impact-Register (26) | 4 |
| Blatt prüfen (27) | 8 |
| ERP-Abgleich (28) | 10 |

## Geprüft

`tsc -p tsconfig.app.json --noEmit` (0 Fehler) · `eslint` (0 Fehler, 10 vorbestehende Warnungen) · `vitest` **1326/1328** (2 skipped), davon 63 neu · `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT