### PR TITLE
delivery: der Ausspielweg als Signalfluss (Bedarf 32)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -245,6 +245,20 @@ CablePlannerProject
   Projekt, weil eine `.avplan` per Mail wandert, in Dropbox liegt und in den
   Mobile-/Web-Viewer geht. Beim Laden wird das Häkchen nachgefragt, nicht
   geglaubt.
+- `encoderEquipmentId?` (Bedarf 32) — **die einzige Naht zwischen Ziel-Register
+  und Plan.** Zeigt auf das `EquipmentItem`, das dieses Ziel beliefert. Alles
+  Weitere ist abgeleitet und wird nicht gespeichert: der Programm-Eingang des
+  Encoders kommt aus seinen Anschlüssen, die Quelle aus der Rückwärtssuche im
+  Kabelgraph (`labelDerivation.resolveSignalSource`, ADR-001). Die Ableitung
+  steht in `lib/deliveryPath.ts` und erzeugt das Blatt `ausspielweg`.
+  - **Optional, und das bleibt es.** Ohne Angabe meldet die Kette `no-encoder`
+    statt sich einen Encoder auszusuchen. Ein Zeiger auf ein gelöschtes Gerät
+    wird beim Laden **nicht** stillschweigend geleert — `encoder-gone` ist die
+    ehrlichere Antwort als ein Feld, das kommentarlos leer wird.
+  - Die Encoder-Machbarkeit (`lib/encoderFeasibility.ts`) zählt seither **je
+    Gerät** statt über den ganzen Plan. Vier Ziele auf zwei Maschinen sind je
+    Maschine zwei; die frühere Summe meldete „vier gleichzeitige Ziele, vMix
+    führt drei" auf einem korrekten Aufbau.
 
 **NetworkInterface** (Bedarf 19, `types/network.ts`):
 - `role` (`media-primary` | `media-secondary` | `control` | `management` |

--- a/src/renderer/components/Delivery/DeliveryDialog.tsx
+++ b/src/renderer/components/Delivery/DeliveryDialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { X, Plus, Trash2, AlertTriangle, Radio, Eye, EyeOff, Download, Cpu, FileText } from 'lucide-react'
+import { X, Plus, Trash2, AlertTriangle, Radio, Eye, EyeOff, Download, Cpu, FileText, Route } from 'lucide-react'
 import { useProjectStore } from '../../store/projectStore'
 import { useUiStore } from '../../store/uiStore'
 import { useTranslation, format } from '../../lib/i18n'
@@ -16,6 +16,12 @@ import {
   runOfShowSheetForProject,
   type FeasibilityFinding,
 } from '../../lib/encoderFeasibility'
+import {
+  buildDeliveryChains,
+  deliveryPathTable,
+  type ChainFinding,
+  type DeliveryChain,
+} from '../../lib/deliveryPath'
 import {
   DELIVERY_PLATFORMS,
   DEFAULT_ENCODING,
@@ -86,6 +92,24 @@ export const DeliveryDialog = () => {
     () => ENCODERS.map((e) => ({ encoder: e, findings: checkEncoderFeasibility(list, e) })),
     [list],
   )
+  // Bedarf 32: der Weg vom Programm-Signal bis zur Plattform, abgeleitet aus
+  // demselben Kabelgraph wie die Label-Ableitung. Nichts davon wird
+  // gespeichert ausser dem einen Zeiger auf das Geraet.
+  const chains = useMemo(() => buildDeliveryChains(project), [project])
+  const chainById = useMemo(
+    () => new Map<string, DeliveryChain>(chains.map((c) => [c.destinationId, c])),
+    [chains],
+  )
+  // Die Auswahl zeigt ALLE Geraete des Plans, nicht nur die, die nach einem
+  // Encoder aussehen. Es gibt keine Encoder-Kategorie im Katalog, und eine
+  // geratene Filterung liesse genau das Geraet verschwinden, das jemand als
+  // „Streaming-PC" oder „Sonstiges" angelegt hat.
+  const encoderChoices = useMemo(
+    () => [...project.equipment].sort((a, b) => a.name.localeCompare(b.name)),
+    [project.equipment],
+  )
+  const deviceName = (id?: string): string =>
+    id ? (project.equipment.find((e) => e.id === id)?.name ?? id) : ''
 
   if (!open) return null
 
@@ -151,6 +175,53 @@ export const DeliveryDialog = () => {
     }
   }
 
+  // Ausgeschriebener switch, aus demselben Grund wie bei `feasibilityText`:
+  // ein zusammengesetzter Schluessel ist fuer den i18n-Deckungs-Guard
+  // unsichtbar und faellt im EN-Betrieb still auf den nackten Slug zurueck.
+  const chainFindingLabel = (f: ChainFinding): string => {
+    switch (f.kind) {
+      case 'no-encoder':
+        return t('delivery.chain.noEncoder', 'Kein Encoder im Plan benannt')
+      case 'encoder-gone':
+        return t('delivery.chain.encoderGone', 'Benanntes Gerät steht nicht mehr im Plan')
+      case 'encoder-unfed':
+        return format(
+          t('delivery.chain.encoderUnfed', '{device} hat an keinem Programm-Eingang ein Kabel'),
+          { device: f.values?.[0] ?? '' },
+        )
+      case 'feed-ambiguous':
+        return format(
+          t('delivery.chain.feedAmbiguous', 'Mehrere verkabelte Programm-Eingänge: {ports}'),
+          { ports: (f.values ?? []).join(' / ') },
+        )
+      case 'backup-shares-encoder':
+        return format(
+          t(
+            'delivery.chain.backupSharesEncoder',
+            'Backup läuft über dasselbe Gerät wie der Primärweg ({device})',
+          ),
+          { device: f.values?.[0] ?? '' },
+        )
+    }
+  }
+
+  /** Die Kette als eine Zeile. Nur was bekannt ist — kein Platzhalter, der
+   *  wie eine Antwort aussieht. */
+  const chainLine = (c: DeliveryChain): string => {
+    const parts: string[] = []
+    if (c.source) {
+      parts.push(
+        c.source.hops > 0
+          ? `${c.source.name} ${format(t('delivery.path.hops', '(über {n})'), { n: c.source.hops })}`
+          : c.source.name,
+      )
+    }
+    if (c.encoder) parts.push(c.encoder.name)
+    parts.push(c.transport)
+    parts.push(c.destinationName)
+    return parts.join(' → ')
+  }
+
   const addDestination = () => {
     add({ name: t('delivery.newName', 'Neues Ziel'), platform: 'custom', encoding: { ...DEFAULT_ENCODING } })
   }
@@ -205,6 +276,17 @@ export const DeliveryDialog = () => {
     downloadBlob(buildExportFilenameWithSuffix(projectName, 'ablaufblatt', 'csv'), csv, 'text/csv')
   }
 
+  // Bedarf 32: das Blatt, das der Bedarf vermisst — „no artefact shows the
+  // delivery path". Mit Stempel wie jede andere Liste.
+  const exportPath = () => {
+    const csv = csvFromTable(
+      deliveryPathTable(project),
+      stampForRows(project, deliveryPathTable, new Date()),
+      'ausspielweg',
+    )
+    downloadBlob(buildExportFilenameWithSuffix(projectName, 'ausspielweg', 'csv'), csv, 'text/csv')
+  }
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
       <div className="flex max-h-[88vh] w-full max-w-5xl flex-col overflow-hidden rounded-lg border border-cp-border bg-cp-surface-1 shadow-xl">
@@ -223,6 +305,17 @@ export const DeliveryDialog = () => {
               className="flex items-center gap-1 rounded border border-cp-border px-2 py-1 text-cp-sm text-cp-text-secondary hover:text-cp-text"
             >
               <FileText size={13} /> {t('delivery.runOfShow', 'Ablaufblatt')}
+            </button>
+            <button
+              type="button"
+              onClick={exportPath}
+              title={t(
+                'delivery.path.hint',
+                'Der Weg vom Programm-Signal bis zur Plattform — Quelle, Encoder, Transport, Ziel',
+              )}
+              className="flex items-center gap-1 rounded border border-cp-border px-2 py-1 text-cp-sm text-cp-text-secondary hover:text-cp-text"
+            >
+              <Route size={13} /> {t('delivery.path.title', 'Ausspielweg')}
             </button>
             <button type="button" onClick={() => setOpen(false)} aria-label={t('common.close', 'Schließen')} className="text-cp-text-muted hover:text-cp-text">
               <X size={18} />
@@ -288,6 +381,17 @@ export const DeliveryDialog = () => {
                             <AlertTriangle size={12} className="mt-0.5 flex-none" />
                             <span>
                               {feasibilityText(f)}
+                              {/* Seit Bedarf 32 zaehlt die Pruefung je Geraet.
+                                  Ohne diesen Zusatz saehen zwei Gruppen gleich
+                                  aus und niemand wuesste, welche Maschine
+                                  gemeint ist. */}
+                              {f.deviceId && (
+                                <span className="ml-1 text-cp-text-secondary">
+                                  {format(t('delivery.encoder.onDevice', 'auf {device}'), {
+                                    device: deviceName(f.deviceId),
+                                  })}
+                                </span>
+                              )}
                               {/* Die Fundstelle steht dabei: ein Befund ueber
                                   fremde Software ohne Beleg ist eine Behauptung. */}
                               <span className="ml-1 text-cp-text-faint">({f.source})</span>
@@ -309,6 +413,7 @@ export const DeliveryDialog = () => {
             <ul className="flex flex-col gap-3">
               {list.map((d) => {
                 const issues = issuesFor(d.id)
+                const chain = chainById.get(d.id)
                 const advice = d.transport === 'SRT' ? srtLatencyAdvice(d.srt?.measuredRttMs) : null
                 return (
                   <li key={d.id} className="rounded border border-cp-border bg-cp-surface-2 p-2.5">
@@ -345,6 +450,30 @@ export const DeliveryDialog = () => {
                         <option value="RTMP">RTMP</option>
                         <option value="SRT">SRT</option>
                         <option value="HLS">HLS</option>
+                      </select>
+                      <select
+                        value={d.encoderEquipmentId ?? ''}
+                        onChange={(e) => update(d.id, { encoderEquipmentId: e.target.value || undefined })}
+                        aria-label={t('delivery.path.encoder', 'Encoder im Plan')}
+                        title={t(
+                          'delivery.path.encoderHint',
+                          'Welches Gerät des Plans dieses Ziel beliefert — daraus leitet sich der Ausspielweg ab',
+                        )}
+                        className={inputCls}
+                      >
+                        <option value="">{t('delivery.path.noEncoder', '— kein Encoder benannt —')}</option>
+                        {encoderChoices.map((e) => (
+                          <option key={e.id} value={e.id}>{e.name}</option>
+                        ))}
+                        {/* Ein Zeiger auf ein geloeschtes Geraet bleibt sichtbar,
+                            statt still auf „kein Encoder" zu springen — sonst
+                            sieht der Nutzer nie, dass da mal etwas stand. */}
+                        {d.encoderEquipmentId &&
+                          !encoderChoices.some((e) => e.id === d.encoderEquipmentId) && (
+                            <option value={d.encoderEquipmentId}>
+                              {t('delivery.path.encoderGoneOption', '(Gerät nicht mehr im Plan)')}
+                            </option>
+                          )}
                       </select>
                       <select
                         value={d.backupOfId ?? ''}
@@ -526,6 +655,28 @@ export const DeliveryDialog = () => {
                           </li>
                         ))}
                       </ul>
+                    )}
+
+                    {/* Bedarf 32 — der Weg als eine Zeile, direkt an dem Ziel,
+                        um das es geht. Ein eigener Kasten weiter oben waere
+                        weiter weg von der Auswahl, die ihn bestimmt. */}
+                    {chain && (
+                      <div className="mt-1.5 border-t border-cp-border-muted pt-1.5">
+                        <div className="flex items-start gap-1 text-cp-xs text-cp-text-muted">
+                          <Route size={12} className="mt-0.5 flex-none" />
+                          <span>{chainLine(chain)}</span>
+                        </div>
+                        {chain.findings.length > 0 && (
+                          <ul className="mt-0.5 flex flex-col gap-0.5">
+                            {chain.findings.map((f) => (
+                              <li key={f.kind} className="flex items-start gap-1 text-cp-xs text-cp-warn">
+                                <AlertTriangle size={12} className="mt-0.5 flex-none" />
+                                <span>{chainFindingLabel(f)}</span>
+                              </li>
+                            ))}
+                          </ul>
+                        )}
+                      </div>
                     )}
                   </li>
                 )

--- a/src/renderer/lib/deliveryPath.ts
+++ b/src/renderer/lib/deliveryPath.ts
@@ -1,0 +1,239 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Der Ausspielweg (Bedarf 32, P1) — die Uebertragungskette als Signalfluss.
+//
+// WAS DER BEDARF SAGT:
+//
+//   > The transmission chain modelled as first-class signal flow (encoder,
+//   > transport, destination, backup) rather than a note on the last node.
+//   > Signal-flow diagrams stop at the encoder input; everything downstream
+//   > lives in encoder web UIs, platform consoles and someone's head, so no
+//   > artefact shows the delivery path.
+//
+// Und der Grund, warum das teuer ist, steht im Rollen-Bericht als Zitat von
+// Alistair Horne: „REMI punishes sloppiness. If the timing's off, the links
+// are fragile, the comms is messy or nobody's thought about what happens when
+// something fails, remote production will find that weakness and expose it."
+//
+// WAS SEIT `cable#703` SCHON DASTAND — und was fehlte. Das Ziel-Register
+// (Plattform, Ingest, Encoding, Backup), die Paritaetspruefung und der
+// Transport-Rechner sind gebaut. Sie beschreiben aber alle nur das ENDE der
+// Kette. `DeliveryDestination` hatte keinen einzigen Zeiger in den Plan: kein
+// Geraet, kein Anschluss, kein Kabel. Das Register war damit genau das zweite
+// Dokument, das der Bedarf beklagt — nur eben in unserer eigenen Anwendung.
+//
+// DIE NAHT IST EIN FELD. `encoderEquipmentId` zeigt auf das Geraet, das
+// sendet. Alles andere ist ABGELEITET und wird nicht gespeichert: der
+// Programm-Eingang des Encoders kommt aus seinen Anschluessen, die Quelle aus
+// der Rueckwaertssuche im Kabelgraph (`resolveSignalSource`, ADR-001). Damit
+// gibt es keine zweite Wahrheit ueber den Weg — es gibt nur den Plan.
+//
+// WAS HIER NICHT PASSIERT: geraten. Ein Encoder mit zwei verkabelten
+// Programm-Eingaengen bekommt `feed-ambiguous` und keine Antwort. Welcher der
+// beiden das Programm fuehrt, ist eine Einsatz-Entscheidung; die falsche
+// Antwort waere schlimmer als keine, weil sie auf einem Blatt landet, das am
+// Showtag geglaubt wird. Dieselbe Regel wie beim Router ohne gesetzten
+// Kreuzpunkt.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { Cable } from '../types/cable'
+import type { EquipmentItem } from '../types/equipment'
+import type { DeliveryDestination, DeliveryTransport } from '../types/delivery'
+import { buildGraphContext, isReferencePort, resolveSignalSource } from './labelDerivation'
+import type { CsvCell, CsvTable } from './csv'
+
+export type ChainFindingKind =
+  /** Das Ziel benennt kein Geraet — der Plan sagt nicht, was sendet. */
+  | 'no-encoder'
+  /** Das benannte Geraet steht nicht (mehr) im Plan. */
+  | 'encoder-gone'
+  /** Der Encoder hat an keinem Programm-Eingang ein Kabel. */
+  | 'encoder-unfed'
+  /** Mehrere Programm-Eingaenge sind verkabelt; welcher zaehlt, sagt der Plan nicht. */
+  | 'feed-ambiguous'
+  /** Backup und Primaerweg haengen am selben Geraet. */
+  | 'backup-shares-encoder'
+
+export interface ChainFinding {
+  kind: ChainFindingKind
+  /** Klartext-Werte zum Befund, in fester Reihenfolge (z. B. die Anschlussnamen). */
+  values?: string[]
+}
+
+export interface ChainNode {
+  equipmentId: string
+  name: string
+}
+
+export interface DeliveryChain {
+  destinationId: string
+  destinationName: string
+  role: 'primary' | 'backup'
+  /** Bei einem Backup: der Name des Primaerwegs, sofern er existiert. */
+  backupOfName?: string
+  transport: DeliveryTransport
+  /** Das sendende Geraet, sofern benannt UND im Plan vorhanden. */
+  encoder?: ChainNode
+  /** Der Programm-Eingang des Encoders — nur bei genau einem verkabelten. */
+  feedPort?: { id: string; name: string }
+  /** Was am anderen Ende der Rueckwaertssuche steht. `hops` = Zwischenstationen. */
+  source?: ChainNode & { hops: number }
+  findings: ChainFinding[]
+}
+
+type ChainInput = {
+  deliveryDestinations?: DeliveryDestination[]
+  equipment: EquipmentItem[]
+  cables: Cable[]
+}
+
+/**
+ * Die Programm-Eingaenge eines Geraets, an denen ein Kabel haengt.
+ *
+ * „Programm" heisst: kein Referenz-, Rueckweg- oder Steuer-Anschluss. Die
+ * Abgrenzung kommt aus `labelDerivation.isReferencePort` und nicht aus einer
+ * eigenen Liste — sonst zaehlte hier morgen der Intercom-Anschluss als
+ * Speisung, waehrend die Label-Ableitung ihn ueberspringt.
+ */
+const fedProgramInputs = (
+  device: EquipmentItem,
+  links: Map<string, unknown>,
+): EquipmentItem['inputs'] =>
+  device.inputs.filter((p) => !isReferencePort(p) && links.has(p.id))
+
+/**
+ * Die Ketten aller Ausspielziele.
+ *
+ * Reihenfolge: wie im Register. Ein Ziel ohne Befund ist eine vollstaendige
+ * Kette; ein Ziel mit Befunden traegt sie einzeln, damit die Liste nicht
+ * „irgendwas stimmt nicht" sagt, sondern was.
+ */
+export function buildDeliveryChains(project: ChainInput): DeliveryChain[] {
+  const destinations = project.deliveryDestinations ?? []
+  if (destinations.length === 0) return []
+
+  const ctx = buildGraphContext(project.equipment, project.cables)
+  const byId = new Map(destinations.map((d) => [d.id, d]))
+
+  return destinations.map((d): DeliveryChain => {
+    const primary = d.backupOfId ? byId.get(d.backupOfId) : undefined
+    const chain: DeliveryChain = {
+      destinationId: d.id,
+      destinationName: d.name,
+      role: d.backupOfId ? 'backup' : 'primary',
+      transport: d.transport,
+      findings: [],
+    }
+    if (primary) chain.backupOfName = primary.name
+
+    if (!d.encoderEquipmentId) {
+      chain.findings.push({ kind: 'no-encoder' })
+      return chain
+    }
+
+    const device = ctx.eqById.get(d.encoderEquipmentId)
+    if (!device) {
+      // Der Zeiger bleibt im Projekt stehen (siehe `normaliseDeliveryDestination`);
+      // hier wird er zur Auskunft statt zum stillen Loch.
+      chain.findings.push({ kind: 'encoder-gone', values: [d.encoderEquipmentId] })
+      return chain
+    }
+    chain.encoder = { equipmentId: device.id, name: device.name }
+
+    // Ein Backup, das am selben Blech haengt wie sein Primaerweg, ist kein
+    // Ausweichweg — es ist derselbe Weg mit zwei Zielen. Genau die Schwaeche,
+    // die der Bedarf zitiert: „nobody's thought about what happens when
+    // something fails".
+    if (primary?.encoderEquipmentId && primary.encoderEquipmentId === d.encoderEquipmentId) {
+      chain.findings.push({ kind: 'backup-shares-encoder', values: [device.name] })
+    }
+
+    const fed = fedProgramInputs(device, ctx.links)
+    if (fed.length === 0) {
+      chain.findings.push({ kind: 'encoder-unfed', values: [device.name] })
+      return chain
+    }
+    if (fed.length > 1) {
+      chain.findings.push({
+        kind: 'feed-ambiguous',
+        values: fed.map((p) => p.name ?? p.id),
+      })
+      return chain
+    }
+
+    const port = fed[0]
+    chain.feedPort = { id: port.id, name: port.name ?? port.id }
+    const found = resolveSignalSource(port.id, ctx)
+    if (found) {
+      const src = ctx.eqById.get(found.equipmentId)
+      if (src) chain.source = { equipmentId: src.id, name: src.name, hops: found.hops }
+    }
+    return chain
+  })
+}
+
+/**
+ * Der Befund in kanonischem Deutsch.
+ *
+ * Warum kanonisch und nicht uebersetzt: dieselbe Regel wie bei
+ * `deliveryIssueText`. Dieser Text landet auf einem BLATT, und der Stand des
+ * Blattes wird aus seinem Inhalt gerechnet (`documentRegistry`). Waere er
+ * uebersetzt, haette dasselbe Projekt in zwei Sprachen zwei Staende — und
+ * jeder Abgleich meldete das Blatt als veraltet. Auf dem BILDSCHIRM steht die
+ * uebersetzte Form; die baut der Dialog.
+ */
+export const chainFindingText = (f: ChainFinding): string => {
+  switch (f.kind) {
+    case 'no-encoder':
+      return 'Kein Encoder im Plan benannt'
+    case 'encoder-gone':
+      return 'Benanntes Gerät steht nicht mehr im Plan'
+    case 'encoder-unfed':
+      return `${f.values?.[0] ?? 'Der Encoder'} hat an keinem Programm-Eingang ein Kabel`
+    case 'feed-ambiguous':
+      return `Mehrere verkabelte Programm-Eingänge: ${(f.values ?? []).join(' / ')}`
+    case 'backup-shares-encoder':
+      return `Backup läuft über dasselbe Gerät wie der Primärweg (${f.values?.[0] ?? ''})`
+  }
+}
+
+/**
+ * Das Blatt: von der Quelle bis zur Plattform, eine Zeile je Ziel.
+ *
+ * Das ist das Artefakt, das der Bedarf vermisst („no artefact shows the
+ * delivery path"). Es steht bewusst NEBEN dem Ablaufblatt und ersetzt es
+ * nicht: dieses hier sagt, WOHER das Signal kommt, jenes, WOHIN es geht und
+ * mit welchen Parametern.
+ *
+ * Kein Stream-Key, keine Ingest-URL — die stehen auf dem Ablaufblatt. Ein
+ * Blatt ueber den Signalweg braucht kein Geheimnis.
+ */
+export function deliveryPathTable(project: ChainInput): CsvTable {
+  const chains = buildDeliveryChains(project)
+  return {
+    headers: [
+      'Ziel',
+      'Rolle',
+      'Quelle',
+      'Zwischenstationen',
+      'Encoder',
+      'Programm-Eingang',
+      'Transport',
+      'Befund',
+    ],
+    rows: chains.map((c): CsvCell[] => [
+      c.destinationName,
+      c.role === 'backup' ? `Backup von ${c.backupOfName ?? '?'}` : 'Primaerweg',
+      c.source?.name ?? '',
+      // Leer statt 0, wenn es keine Quelle gibt: eine 0 laese sich als
+      // „direkt verkabelt" lesen, und das waere eine Aussage, die niemand
+      // geprueft hat.
+      c.source ? String(c.source.hops) : '',
+      c.encoder?.name ?? '',
+      c.feedPort?.name ?? '',
+      c.transport,
+      c.findings.map(chainFindingText).join(' · '),
+    ]),
+  }
+}

--- a/src/renderer/lib/documentRegistry.ts
+++ b/src/renderer/lib/documentRegistry.ts
@@ -22,6 +22,7 @@ import { handoverTable } from './handoverPackage'
 import { deliveryTableForProject } from './deliveryParity'
 import { runOfShowSheetForProject } from './encoderFeasibility'
 import { tallyMapTableForProject } from './tallyMap'
+import { deliveryPathTable } from './deliveryPath'
 import type { CsvTable } from './csv'
 
 const ofTable =
@@ -65,6 +66,11 @@ export const DOCUMENT_STANDS: Record<string, (project: CablePlannerProject) => s
   // allein aus `equipment`, `cables` und `sourceIdentities` ableitet: keine
   // Nutzer-Einstellung, keine Sprache.
   'tally-karte': ofTable(tallyMapTableForProject),
+  // Bedarf 32 — der Ausspielweg. Reproduzierbar, weil `buildDeliveryChains`
+  // allein aus `deliveryDestinations`, `equipment` und `cables` ableitet:
+  // keine Nutzer-Einstellung beim Export, keine Sprache (die Befundtexte sind
+  // kanonisches Deutsch, siehe `chainFindingText`) und kein Zufall.
+  ausspielweg: ofTable(deliveryPathTable),
 }
 
 /**
@@ -127,6 +133,7 @@ export const DOCUMENT_LABELS: Record<string, string> = {
   ausspielung: 'Ausspielung',
   ablaufblatt: 'Ablaufblatt',
   'tally-karte': 'Tally-Karte',
+  ausspielweg: 'Ausspielweg',
   'videohub-labels': 'Videohub-Labels',
   'atem-mv-layout': 'Multiviewer-Layout',
   'switch-port-karte': 'Switch-Port-Karte',

--- a/src/renderer/lib/encoderFeasibility.ts
+++ b/src/renderer/lib/encoderFeasibility.ts
@@ -107,6 +107,14 @@ export type FeasibilityKind =
 export interface FeasibilityFinding {
   kind: FeasibilityKind
   encoder: EncoderId
+  /**
+   * Das Geraet im Plan, dessen Ziele diesen Befund ausgeloest haben
+   * (`DeliveryDestination.encoderEquipmentId`, Bedarf 32).
+   *
+   * `undefined` heisst: die Ziele dieser Gruppe benennen kein Geraet. Dann
+   * gilt der Befund fuer sie gemeinsam — mehr weiss der Plan nicht.
+   */
+  deviceId?: string
   /** Bei `must-match-differs`: welches Feld. */
   field?: keyof EncodingProfile
   /** Die abweichenden Werte im Klartext, in Zielreihenfolge. */
@@ -116,17 +124,64 @@ export interface FeasibilityFinding {
 }
 
 /**
+ * Die Primaerwege, gruppiert nach dem GERAET, das sie beliefert (Bedarf 32).
+ *
+ * WARUM DAS NOETIG WURDE. Bis `encoderEquipmentId` existierte, zaehlte diese
+ * Datei alle Primaerwege in einen Topf und hielt die Summe gegen die
+ * Zielgrenze eines Werkzeugs. Das setzt stillschweigend voraus, dass alle
+ * Ziele auf DEMSELBEN Encoder liegen — bei zwei Maschinen mit je zwei Zielen
+ * meldete sie „vier gleichzeitige Ziele, vMix fuehrt drei", obwohl keine der
+ * beiden Maschinen mehr als zwei zu tragen hat. Ein falscher Befund auf einem
+ * korrekten Aufbau, und laut dem Kommentar oben ist genau das der Weg, auf
+ * dem auch die richtigen Befunde ignoriert werden.
+ *
+ * Ziele ohne benanntes Geraet bilden EINE Gruppe. Das ist die vorsichtigere
+ * Annahme (der uebliche Fall ist eine Maschine, die niemand aufgeschrieben
+ * hat) und zugleich das bisherige Verhalten — wer kein Geraet benennt,
+ * bekommt genau die Pruefung von vorher.
+ */
+export interface EncoderGroup {
+  /** Das benannte Geraet, oder `undefined` fuer die Ziele ohne Angabe. */
+  deviceId?: string
+  destinations: DeliveryDestination[]
+}
+
+export function groupByEncoder(destinations: DeliveryDestination[]): EncoderGroup[] {
+  const groups = new Map<string, EncoderGroup>()
+  for (const d of destinations) {
+    // Der leere Schluessel ist die Gruppe „kein Geraet benannt". Ein Geraet
+    // kann nie so heissen, weil `encoderEquipmentId` beim Laden getrimmt und
+    // leer verworfen wird.
+    const key = d.encoderEquipmentId ?? ''
+    const existing = groups.get(key)
+    if (existing) existing.destinations.push(d)
+    else groups.set(key, { ...(key ? { deviceId: key } : {}), destinations: [d] })
+  }
+  return [...groups.values()]
+}
+
+/**
  * Den Plan gegen einen Encoder halten.
  *
  * Gezählt werden die PRIMÄRWEGE — ein Backup läuft im Havariefall und nicht
  * daneben; es als viertes gleichzeitiges Ziel zu zählen ergäbe einen Befund,
  * den es nicht gibt. Dieselbe Regel wie im Uplink-Budget.
+ *
+ * Und gezählt wird JE GERAET, nicht ueber den ganzen Plan (siehe
+ * `groupByEncoder`). Die Gruppierung sitzt hier und nicht beim Aufrufer:
+ * damit bekommt jede Stelle, die diese Funktion ruft, dieselbe Rechnung.
  */
 export function checkEncoderFeasibility(
   destinations: DeliveryDestination[],
   encoder: EncoderSpec,
 ): FeasibilityFinding[] {
   const primaries = checkDelivery(destinations).primaries
+  return groupByEncoder(primaries).flatMap((g) => findingsForGroup(g, encoder))
+}
+
+function findingsForGroup(group: EncoderGroup, encoder: EncoderSpec): FeasibilityFinding[] {
+  const primaries = group.destinations
+  const deviceId = group.deviceId
   const out: FeasibilityFinding[] = []
   if (primaries.length < 2) return out
 
@@ -134,6 +189,7 @@ export function checkEncoderFeasibility(
     out.push({
       kind: 'too-many-destinations',
       encoder: encoder.id,
+      deviceId,
       values: [String(primaries.length), String(encoder.maxDestinations)],
       source: encoder.source,
     })
@@ -162,6 +218,7 @@ export function checkEncoderFeasibility(
           ? 'per-destination-quality-unsupported'
           : 'per-destination-quality-unknown',
       encoder: encoder.id,
+      deviceId,
       source: encoder.source,
     })
   }
@@ -171,6 +228,7 @@ export function checkEncoderFeasibility(
     out.push({
       kind: 'must-match-differs',
       encoder: encoder.id,
+      deviceId,
       field: f,
       values: primaries.map((d) => String(d.encoding[f])),
       source: encoder.source,

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3914,6 +3914,23 @@ export const en: Dict = {
     'The plan asks for per-destination quality \u2014 whether this tool can do that is unresolved',
   // {field} und {values} werden vom Aufrufer ersetzt.
   'delivery.encoder.mustMatch': '{field} must match across all destinations, but is {values}',
+  // Bedarf 32 — der Ausspielweg.
+  'delivery.encoder.onDevice': 'on {device}',
+  'delivery.path.title': 'Delivery path',
+  'delivery.path.hint':
+    'The path from the programme feed to the platform — source, encoder, transport, destination',
+  'delivery.path.encoder': 'Encoder in the plan',
+  'delivery.path.encoderHint':
+    'Which device of the plan feeds this destination — the delivery path is derived from it',
+  'delivery.path.noEncoder': '— no encoder named —',
+  'delivery.path.encoderGoneOption': '(device no longer in the plan)',
+  'delivery.path.hops': '(via {n})',
+  'delivery.chain.noEncoder': 'No encoder named in the plan',
+  'delivery.chain.encoderGone': 'The named device is no longer in the plan',
+  'delivery.chain.encoderUnfed': '{device} has no cable on any programme input',
+  'delivery.chain.feedAmbiguous': 'Several cabled programme inputs: {ports}',
+  'delivery.chain.backupSharesEncoder':
+    'Backup runs through the same device as the primary path ({device})',
   'wireless.title': 'Wireless / vocals',
   'wireless.channel': 'Channel',
   'wireless.addChannel': 'Channel',

--- a/src/renderer/lib/labelDerivation.ts
+++ b/src/renderer/lib/labelDerivation.ts
@@ -307,7 +307,14 @@ export const buildGraphContext = (
 const REFERENCE_PORT =
   /genlock|\bref\b|reference|sync|return|tally|timecode|\bltc\b|talkback|intercom|comms|control|\bctrl\b|\brcp\b|\bgpi\b|prompter/i
 
-const isReferencePort = (port: Port): boolean =>
+/**
+ * Exportiert, weil `deliveryPath.ts` (Bedarf 32) dieselbe Frage stellt: welcher
+ * Eingang eines Geraets fuehrt das PROGRAMM und welcher nur Referenz, Rueckweg
+ * oder Steuerung? Eine zweite Kopie derselben Liste waere die zweite Wahrheit,
+ * die morgen auseinanderlaeuft — dann meldete die Kette einen Encoder als
+ * „gespeist", weil an seinem Intercom-Anschluss ein Kabel haengt.
+ */
+export const isReferencePort = (port: Port): boolean =>
   REFERENCE_PORT.test(`${port.name ?? ''} ${port.contentLabel ?? ''}`)
 
 /**

--- a/src/renderer/types/delivery.ts
+++ b/src/renderer/types/delivery.ts
@@ -118,6 +118,28 @@ export interface DeliveryDestination {
    * verschwindet die Beziehung mit dem Backup, das sie behauptet.
    */
   backupOfId?: string
+  /**
+   * Das GERAET im Plan, das dieses Ziel beliefert (Bedarf 32).
+   *
+   * Bis hierher endete der Signalfluss am Encoder-Eingang: das Ziel-Register
+   * war ein zweites Dokument neben dem Plan, und der Bedarf sagt genau das —
+   * „signal-flow diagrams stop at the encoder input; everything downstream
+   * lives in encoder web UIs, platform consoles and someone's head, so no
+   * artefact shows the delivery path".
+   *
+   * Dieses eine Feld schliesst die Naht. Es ist eine `EquipmentItem.id`, also
+   * ein Zeiger in denselben Plan, aus dem Kabel und Anschluesse kommen —
+   * damit ist der Weg vom Programm-Signal bis zur Plattform ableitbar
+   * (`lib/deliveryPath.ts`) statt erzaehlt.
+   *
+   * OPTIONAL, und das bleibt es. Ein Ziel ohne benanntes Geraet ist ein
+   * gueltiges Ziel — der Weg dahin ist dann eben unbekannt, und die Kette
+   * sagt das als Befund (`no-encoder`), statt sich einen Encoder auszusuchen.
+   * Ein Zeiger auf ein geloeschtes Geraet wird beim Laden NICHT stillschweigend
+   * entfernt: `encoder-gone` ist die ehrlichere Antwort als ein Feld, das
+   * kommentarlos leer wird.
+   */
+  encoderEquipmentId?: string
   /** Notiz — was am Showtag jemand wissen muss. */
   note?: string
 }
@@ -248,6 +270,14 @@ export const normaliseDeliveryDestination = (
   if (typeof r.ingestUrl === 'string' && r.ingestUrl.trim()) out.ingestUrl = r.ingestUrl.trim()
   if (typeof r.account === 'string' && r.account.trim()) out.account = r.account.trim()
   if (typeof r.note === 'string' && r.note.trim()) out.note = r.note.trim()
+  // Bedarf 32: der Zeiger auf den Encoder im Plan. Ob das Geraet noch
+  // existiert, weiss diese Funktion nicht — sie sieht nur den Rohsatz. Genau
+  // deshalb wird hier nichts verworfen: `buildDeliveryChains` sagt spaeter
+  // `encoder-gone`, und das ist eine Auskunft. Ein hier still geleertes Feld
+  // waere keine.
+  if (typeof r.encoderEquipmentId === 'string' && r.encoderEquipmentId.trim()) {
+    out.encoderEquipmentId = r.encoderEquipmentId.trim()
+  }
   if (typeof r.backupOfId === 'string' && r.backupOfId.trim() && r.backupOfId.trim() !== id) {
     out.backupOfId = r.backupOfId.trim()
   }

--- a/tests/changeImpact.test.ts
+++ b/tests/changeImpact.test.ts
@@ -134,7 +134,15 @@ describe('changeImpact — die Vorwärts-Frage', () => {
     // Die Liste ist bewusst benannt und nicht „alles, was durchkommt": waechst
     // sie um einen Bezeichner, der doch an `equipment` haengt, faellt das beim
     // Eintragen auf statt still.
-    const ohneGeraetebezug = new Set(['plan', 'ausspielung', 'ablaufblatt'])
+    //
+    // `ausspielweg` (Bedarf 32) steht hier mit einem ANDEREN Grund als die
+    // beiden davor, und der ist wichtig genug, um ihn nicht zu verwischen: er
+    // haengt sehr wohl an `equipment` — nur nicht, solange es kein einziges
+    // Ausspielziel gibt. Dann ist das leere Blatt die wahre Antwort und kein
+    // Ausweichen. Sobald ein Ziel existiert, ist er ohne Geraete unbeurteilbar;
+    // genau das haelt der Test unter diesem hier fest, damit die Zeile nicht
+    // als „haengt nie an Geraeten" missverstanden wird.
+    const ohneGeraetebezug = new Set(['plan', 'ausspielung', 'ablaufblatt', 'ausspielweg'])
     expect(
       impact.documents.some((d) => d.verdict === 'unaffected' && !ohneGeraetebezug.has(d.docId)),
     ).toBe(false)
@@ -148,6 +156,21 @@ describe('changeImpact — die Vorwärts-Frage', () => {
       impact.documents.filter((d) => d.verdict === 'unknown').map((d) => d.reason),
     )
     expect(reasons.size).toBe(Object.keys(UNJUDGEABLE_DOCUMENTS).length + 1)
+  })
+
+  it('der Ausspielweg ist ohne Geraete unbeurteilbar, SOBALD es ein Ziel gibt', () => {
+    // Die Ausnahme oben gilt nur dem leeren Register. Ein Torso MIT Ziel darf
+    // nicht „unberuehrt" melden: ohne Geraete und Kabel gibt es keinen Weg zu
+    // pruefen, und „unberuehrt" laese sich als Freigabe lesen.
+    const mitZiel = {
+      metadata: { name: 'x' },
+      deliveryDestinations: [
+        { id: 'd1', name: 'YouTube', platform: 'custom', transport: 'RTMP', encoding: {} },
+      ],
+    } as unknown as CablePlannerProject
+    const impact = changeImpact(mitZiel, mitZiel)
+    const weg = impact.documents.find((d) => d.docId === 'ausspielweg')
+    expect(weg?.verdict).toBe('unknown')
   })
 
   it('die Zusammenfassung verschweigt das Unbeurteilbare nicht', () => {

--- a/tests/deliveryPath.test.ts
+++ b/tests/deliveryPath.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildDeliveryChains,
+  chainFindingText,
+  deliveryPathTable,
+} from '../src/renderer/lib/deliveryPath'
+import { DEFAULT_ENCODING, type DeliveryDestination } from '../src/renderer/types/delivery'
+import { DOCUMENT_STANDS, DOCUMENT_LABELS } from '../src/renderer/lib/documentRegistry'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem, Port } from '../src/renderer/types/equipment'
+import dialogQuelle from '../src/renderer/components/Delivery/DeliveryDialog.tsx?raw'
+import dictsQuelle from '../src/renderer/lib/i18n/dicts.ts?raw'
+import pfadQuelle from '../src/renderer/lib/deliveryPath.ts?raw'
+
+// ---------------------------------------------------------------------------
+// Der Ausspielweg (Bedarf 32).
+//
+//   > The transmission chain modelled as first-class signal flow (encoder,
+//   > transport, destination, backup) rather than a note on the last node.
+//   > Signal-flow diagrams stop at the encoder input.
+//
+// Bis hierher hatte `DeliveryDestination` keinen einzigen Zeiger in den Plan:
+// das Ziel-Register war das zweite Dokument, das der Bedarf beklagt -- nur in
+// unserer eigenen Anwendung. Geprueft wird deshalb, dass der Weg ABGELEITET
+// wird (aus Kabeln, nicht aus einem zweiten Feld), dass er anhaelt statt zu
+// raten, und dass „weiss ich nicht" als Befund herauskommt und nicht als
+// leere Zelle, die wie „in Ordnung" aussieht.
+// ---------------------------------------------------------------------------
+
+const port = (id: string, name: string, over: Partial<Port> = {}): Port => ({
+  id,
+  name,
+  type: 'BNC',
+  connectorType: 'BNC',
+  ...over,
+})
+
+const eq = (over: Partial<EquipmentItem>): EquipmentItem => ({
+  id: 'e1',
+  name: 'Gerät',
+  category: 'Video',
+  inputs: [],
+  outputs: [],
+  x: 0,
+  y: 0,
+  width: 200,
+  height: 160,
+  ...over,
+})
+
+const cable = (from: [string, string], to: [string, string], id = `${from[1]}->${to[1]}`): Cable => ({
+  id,
+  name: id,
+  type: 'BNC',
+  length: 10,
+  color: '#fff',
+  fromEquipmentId: from[0],
+  fromPortId: from[1],
+  toEquipmentId: to[0],
+  toPortId: to[1],
+  notes: '',
+})
+
+const ziel = (name: string, over: Partial<DeliveryDestination> = {}): DeliveryDestination => ({
+  id: `id-${name}`,
+  name,
+  platform: 'custom',
+  transport: 'RTMP',
+  ingestUrl: 'rtmp://example.test/live',
+  hasStreamKey: true,
+  encoding: { ...DEFAULT_ENCODING },
+  ...over,
+})
+
+/** Mischer -> Encoder, der uebliche Aufbau. */
+const aufbau = () => {
+  const mischer = eq({
+    id: 'atem',
+    name: 'ATEM Mini Extreme',
+    outputs: [port('atem-pgm', 'Programm SDI')],
+  })
+  const encoder = eq({
+    id: 'enc',
+    name: 'Streaming-PC',
+    category: 'Sonstiges',
+    inputs: [port('enc-in', 'SDI In')],
+  })
+  return {
+    equipment: [mischer, encoder],
+    cables: [cable(['atem', 'atem-pgm'], ['enc', 'enc-in'])],
+  }
+}
+
+describe('die Kette entsteht aus dem Plan, nicht aus einem zweiten Feld', () => {
+  it('nennt Quelle, Encoder, Transport und Ziel', () => {
+    const [c] = buildDeliveryChains({
+      ...aufbau(),
+      deliveryDestinations: [ziel('YouTube', { encoderEquipmentId: 'enc' })],
+    })
+    expect(c.encoder?.name).toBe('Streaming-PC')
+    expect(c.feedPort?.name).toBe('SDI In')
+    expect(c.source?.name).toBe('ATEM Mini Extreme')
+    expect(c.findings).toEqual([])
+  })
+
+  it('laeuft durch einen Konverter hindurch bis zur echten Quelle', () => {
+    // Dieselbe Rueckwaertssuche wie die Label-Ableitung (ADR-001): ein
+    // Durchleiter mit genau EINEM passenden Eingang ist keine Quelle.
+    const mischer = eq({ id: 'atem', name: 'Mischer', outputs: [port('atem-pgm', 'Programm')] })
+    const konverter = eq({
+      id: 'conv',
+      name: 'SDI/HDMI-Konverter',
+      inputs: [port('conv-in', 'SDI In')],
+      outputs: [port('conv-out', 'SDI Out')],
+    })
+    const encoder = eq({ id: 'enc', name: 'Encoder', inputs: [port('enc-in', 'SDI In')] })
+    const chains = buildDeliveryChains({
+      equipment: [mischer, konverter, encoder],
+      cables: [
+        cable(['atem', 'atem-pgm'], ['conv', 'conv-in']),
+        cable(['conv', 'conv-out'], ['enc', 'enc-in']),
+      ],
+      deliveryDestinations: [ziel('YouTube', { encoderEquipmentId: 'enc' })],
+    })
+    expect(chains[0].source?.name).toBe('Mischer')
+    expect(chains[0].source?.hops).toBeGreaterThan(0)
+  })
+
+  it('ohne Ziele gibt es keine Ketten', () => {
+    expect(buildDeliveryChains({ ...aufbau(), deliveryDestinations: [] })).toEqual([])
+  })
+})
+
+describe('was der Plan nicht sagt, wird nicht erfunden', () => {
+  it('meldet ein Ziel ohne benanntes Geraet als Befund, nicht als leere Zelle', () => {
+    const [c] = buildDeliveryChains({
+      ...aufbau(),
+      deliveryDestinations: [ziel('YouTube')],
+    })
+    expect(c.findings.map((f) => f.kind)).toEqual(['no-encoder'])
+    expect(c.encoder).toBeUndefined()
+  })
+
+  it('meldet einen Zeiger auf ein geloeschtes Geraet, statt ihn still zu leeren', () => {
+    // Ein stillschweigend geleertes Feld sieht aus wie „nie ausgefuellt".
+    // Dann sucht niemand nach dem Geraet, das jemand geloescht hat.
+    const [c] = buildDeliveryChains({
+      ...aufbau(),
+      deliveryDestinations: [ziel('YouTube', { encoderEquipmentId: 'weg' })],
+    })
+    expect(c.findings.map((f) => f.kind)).toEqual(['encoder-gone'])
+  })
+
+  it('haelt bei mehreren verkabelten Programm-Eingaengen an und nennt sie', () => {
+    // Welcher der beiden das Programm fuehrt, ist eine Einsatz-Entscheidung.
+    // Die falsche Antwort landet auf einem Blatt und wird am Showtag geglaubt.
+    const mischer = eq({
+      id: 'atem',
+      name: 'Mischer',
+      outputs: [port('atem-a', 'Programm'), port('atem-b', 'Aux')],
+    })
+    const encoder = eq({
+      id: 'enc',
+      name: 'Encoder',
+      inputs: [port('enc-1', 'SDI 1'), port('enc-2', 'SDI 2')],
+    })
+    const [c] = buildDeliveryChains({
+      equipment: [mischer, encoder],
+      cables: [
+        cable(['atem', 'atem-a'], ['enc', 'enc-1']),
+        cable(['atem', 'atem-b'], ['enc', 'enc-2']),
+      ],
+      deliveryDestinations: [ziel('YouTube', { encoderEquipmentId: 'enc' })],
+    })
+    const f = c.findings.find((x) => x.kind === 'feed-ambiguous')
+    expect(f?.values).toEqual(['SDI 1', 'SDI 2'])
+    expect(c.source).toBeUndefined()
+  })
+
+  it('meldet einen Encoder ohne Kabel am Programm-Eingang', () => {
+    const encoder = eq({ id: 'enc', name: 'Encoder', inputs: [port('enc-in', 'SDI In')] })
+    const [c] = buildDeliveryChains({
+      equipment: [encoder],
+      cables: [],
+      deliveryDestinations: [ziel('YouTube', { encoderEquipmentId: 'enc' })],
+    })
+    expect(c.findings.map((f) => f.kind)).toEqual(['encoder-unfed'])
+  })
+
+  it('zaehlt einen Referenz-/Steuer-Anschluss NICHT als Speisung', () => {
+    // Ein Kabel am Intercom-Anschluss macht den Encoder nicht gespeist. Die
+    // Abgrenzung kommt aus `labelDerivation.isReferencePort` -- eine zweite
+    // Liste liefe auseinander, und dann meldete diese Kette „alles gut", weil
+    // am Talkback ein Kabel haengt.
+    const pult = eq({ id: 'pult', name: 'Sprechstelle', outputs: [port('pult-out', 'Intercom')] })
+    const encoder = eq({
+      id: 'enc',
+      name: 'Encoder',
+      inputs: [port('enc-in', 'SDI In'), port('enc-com', 'Intercom In')],
+    })
+    const [c] = buildDeliveryChains({
+      equipment: [pult, encoder],
+      cables: [cable(['pult', 'pult-out'], ['enc', 'enc-com'])],
+      deliveryDestinations: [ziel('YouTube', { encoderEquipmentId: 'enc' })],
+    })
+    expect(c.findings.map((f) => f.kind)).toEqual(['encoder-unfed'])
+  })
+})
+
+describe('der Ausweichweg, der keiner ist', () => {
+  it('meldet ein Backup auf demselben Geraet wie sein Primaerweg', () => {
+    // „nobody's thought about what happens when something fails" -- ein
+    // Backup auf demselben Blech ist derselbe Weg mit zwei Zielen.
+    const chains = buildDeliveryChains({
+      ...aufbau(),
+      deliveryDestinations: [
+        ziel('Haupt', { encoderEquipmentId: 'enc' }),
+        ziel('Backup', { backupOfId: 'id-Haupt', encoderEquipmentId: 'enc' }),
+      ],
+    })
+    expect(chains[0].findings.map((f) => f.kind)).toEqual([])
+    const b = chains[1]
+    expect(b.role).toBe('backup')
+    expect(b.backupOfName).toBe('Haupt')
+    expect(b.findings.map((f) => f.kind)).toContain('backup-shares-encoder')
+  })
+
+  it('schweigt, wenn das Backup auf einem zweiten Geraet laeuft', () => {
+    const basis = aufbau()
+    const zweiter = eq({ id: 'enc2', name: 'Encoder 2', inputs: [port('enc2-in', 'SDI In')] })
+    const chains = buildDeliveryChains({
+      equipment: [...basis.equipment, zweiter],
+      cables: [...basis.cables, cable(['atem', 'atem-pgm'], ['enc2', 'enc2-in'], 'zweit')],
+      deliveryDestinations: [
+        ziel('Haupt', { encoderEquipmentId: 'enc' }),
+        ziel('Backup', { backupOfId: 'id-Haupt', encoderEquipmentId: 'enc2' }),
+      ],
+    })
+    expect(chains[1].findings.map((f) => f.kind)).not.toContain('backup-shares-encoder')
+  })
+})
+
+describe('das Blatt', () => {
+  it('traegt den Befund im Klartext statt einer leeren Spalte', () => {
+    const t = deliveryPathTable({
+      ...aufbau(),
+      deliveryDestinations: [ziel('YouTube')],
+    })
+    const befundSpalte = t.headers.indexOf('Befund')
+    expect(String(t.rows[0][befundSpalte])).toContain('Kein Encoder')
+  })
+
+  it('laesst die Zwischenstationen LEER statt 0, wenn es keine Quelle gibt', () => {
+    // Eine 0 laese sich als „direkt verkabelt" lesen. Das waere eine Aussage,
+    // die niemand geprueft hat.
+    const t = deliveryPathTable({
+      ...aufbau(),
+      deliveryDestinations: [ziel('YouTube')],
+    })
+    expect(t.rows[0][t.headers.indexOf('Zwischenstationen')]).toBe('')
+  })
+
+  it('traegt weder Stream-Key noch Ingest-URL', () => {
+    // Ein Blatt ueber den Signalweg braucht kein Geheimnis. Die Ingest-URL
+    // steht auf dem Ablaufblatt; hier waere sie nur eine zweite Kopie.
+    const t = deliveryPathTable({
+      ...aufbau(),
+      deliveryDestinations: [ziel('YouTube', { encoderEquipmentId: 'enc' })],
+    })
+    const alles = JSON.stringify(t)
+    expect(alles).not.toContain('rtmp://')
+    expect(alles).not.toContain('stream-key')
+  })
+
+  it('nennt die Rolle, damit klar ist, was der Ausweichweg ist', () => {
+    const t = deliveryPathTable({
+      ...aufbau(),
+      deliveryDestinations: [
+        ziel('Haupt', { encoderEquipmentId: 'enc' }),
+        ziel('Backup', { backupOfId: 'id-Haupt' }),
+      ],
+    })
+    const rolle = t.headers.indexOf('Rolle')
+    expect(t.rows[0][rolle]).toBe('Primaerweg')
+    expect(String(t.rows[1][rolle])).toContain('Backup von Haupt')
+  })
+})
+
+describe('der Befundtext auf dem Blatt bleibt kanonisch deutsch', () => {
+  it('haengt an keiner Uebersetzung', () => {
+    // Dieselbe Regel wie bei `deliveryIssueText`: der Stand des Blattes wird
+    // aus seinem Inhalt gerechnet. Uebersetzt haette dasselbe Projekt in zwei
+    // Sprachen zwei Staende, und jeder Abgleich meldete es als veraltet.
+    expect(pfadQuelle).not.toContain("from './i18n")
+    expect(chainFindingText({ kind: 'no-encoder' })).toBe('Kein Encoder im Plan benannt')
+  })
+})
+
+describe('das Blatt hat einen Stand', () => {
+  it('ist im Register gefuehrt und wird aus dem Plan gerechnet', () => {
+    expect(DOCUMENT_STANDS.ausspielweg).toBeTypeOf('function')
+    expect(DOCUMENT_LABELS.ausspielweg).toBeTruthy()
+  })
+
+  it('aendert sich, wenn sich der Weg aendert', () => {
+    // Ein Stand, der einen Encoder-Wechsel nicht bemerkt, meldet ein
+    // ueberholtes Blatt als aktuell.
+    const basis = { metadata: { name: 'P' }, ...aufbau() } as never
+    const ohne = DOCUMENT_STANDS.ausspielweg({
+      ...(basis as object),
+      deliveryDestinations: [ziel('YouTube')],
+    } as never)
+    const mit = DOCUMENT_STANDS.ausspielweg({
+      ...(basis as object),
+      deliveryDestinations: [ziel('YouTube', { encoderEquipmentId: 'enc' })],
+    } as never)
+    expect(ohne).not.toBe(mit)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ERREICHBARKEIT. Der wiederkehrende Fehler in diesem Projekt ist nicht der
+// falsche Rechenweg, sondern das gebaute Modul, das kein Knopf aufruft.
+// ---------------------------------------------------------------------------
+describe('Erreichbarkeit im Ausspiel-Dialog', () => {
+  it('laesst den Encoder im Plan benennen', () => {
+    expect(dialogQuelle).toContain('encoderEquipmentId: e.target.value || undefined')
+    expect(dialogQuelle).toContain('encoderChoices.map(')
+  })
+
+  it('zeigt die Kette und ihre Befunde', () => {
+    expect(dialogQuelle).toContain("from '../../lib/deliveryPath'")
+    expect(dialogQuelle).toContain('buildDeliveryChains(project)')
+    expect(dialogQuelle).toMatch(/chain\.findings\.map\(/)
+    expect(dialogQuelle).toContain('chainLine(chain)')
+  })
+
+  it('bietet das Blatt mit Stempel zum Ausgeben an', () => {
+    expect(dialogQuelle).toMatch(/onClick=\{exportPath\}/)
+    expect(dialogQuelle).toContain('stampForRows(project, deliveryPathTable')
+  })
+
+  it('setzt die Befundtexte NICHT dynamisch zusammen', () => {
+    // Ein zusammengesetzter Schluessel ist fuer den i18n-Deckungs-Guard
+    // unsichtbar und faellt im EN-Betrieb still auf den nackten Slug zurueck.
+    expect(dialogQuelle).not.toMatch(/t\(`delivery\.chain\./)
+    for (const key of [
+      'delivery.chain.noEncoder',
+      'delivery.chain.encoderGone',
+      'delivery.chain.encoderUnfed',
+      'delivery.chain.feedAmbiguous',
+      'delivery.chain.backupSharesEncoder',
+      'delivery.path.title',
+      'delivery.path.encoder',
+      'delivery.path.noEncoder',
+      'delivery.encoder.onDevice',
+    ]) {
+      expect(dialogQuelle).toContain(`'${key}'`)
+      expect(dictsQuelle).toContain(`'${key}'`)
+    }
+  })
+})

--- a/tests/deliveryPersistenz.test.ts
+++ b/tests/deliveryPersistenz.test.ts
@@ -124,6 +124,35 @@ describe('Normalisierung', () => {
 // Key des Kunden das Projekt, und zwar unbemerkt: die Oberflaeche sieht danach
 // genauso aus.
 // ---------------------------------------------------------------------------
+describe('der Zeiger auf den Encoder (Bedarf 32)', () => {
+  it('ueberlebt das Laden', () => {
+    const d = normaliseDeliveryDestination(
+      { name: 'YouTube', encoderEquipmentId: '  enc-1  ' },
+      'x',
+    )
+    expect(d?.encoderEquipmentId).toBe('enc-1')
+  })
+
+  it('wird NICHT geprueft und NICHT still geleert', () => {
+    // Diese Funktion sieht nur den Rohsatz, nicht den Geraetebestand. Ein
+    // hier geleertes Feld saehe spaeter aus wie „nie ausgefuellt" -- dann
+    // sucht niemand nach dem Geraet, das jemand geloescht hat. Die Auskunft
+    // gibt `buildDeliveryChains` mit `encoder-gone`.
+    const d = normaliseDeliveryDestination({ name: 'YouTube', encoderEquipmentId: 'weg' }, 'x')
+    expect(d?.encoderEquipmentId).toBe('weg')
+  })
+
+  it('laesst leere und falsch getypte Werte weg', () => {
+    expect(
+      normaliseDeliveryDestination({ name: 'X', encoderEquipmentId: '   ' }, 'x')
+        ?.encoderEquipmentId,
+    ).toBeUndefined()
+    expect(
+      normaliseDeliveryDestination({ name: 'X', encoderEquipmentId: 42 }, 'x')?.encoderEquipmentId,
+    ).toBeUndefined()
+  })
+})
+
 describe('der Weg vom Loeschen zum Schluesselbund', () => {
   it('ist in App.tsx verdrahtet', async () => {
     const src = await import('../src/renderer/App.tsx?raw').then((m) => m.default as string)

--- a/tests/encoderFeasibility.test.ts
+++ b/tests/encoderFeasibility.test.ts
@@ -3,6 +3,7 @@ import {
   checkAllEncoders,
   checkEncoderFeasibility,
   ENCODERS,
+  groupByEncoder,
   runOfShowSheet,
 } from '../src/renderer/lib/encoderFeasibility'
 import { DEFAULT_ENCODING, type DeliveryDestination } from '../src/renderer/types/delivery'
@@ -111,6 +112,79 @@ describe('vMix — belegte Grenzen', () => {
     expect(felder).toContain('keyframeSec')
     const fpsBefund = f.find((x) => x.field === 'fps')
     expect(fpsBefund?.values).toEqual(['25', '30'])
+  })
+})
+
+describe('gezaehlt wird je GERAET, nicht ueber den ganzen Plan (Bedarf 32)', () => {
+  it('meldet NICHT zu viele Ziele, wenn sie auf zwei Maschinen liegen', () => {
+    // Vier Ziele auf zwei Encodern sind je Maschine zwei. Bis
+    // `encoderEquipmentId` existierte, warf diese Datei alles in einen Topf
+    // und meldete „4 gleichzeitige Ziele, vMix fuehrt 3" -- ein falscher
+    // Befund auf einem korrekten Aufbau, und genau so werden auch die
+    // richtigen Befunde daneben ignoriert.
+    const f = checkEncoderFeasibility(
+      [
+        ziel('A', { encoderEquipmentId: 'enc-1' }),
+        ziel('B', { encoderEquipmentId: 'enc-1' }),
+        ziel('C', { encoderEquipmentId: 'enc-2' }),
+        ziel('D', { encoderEquipmentId: 'enc-2' }),
+      ],
+      vmix,
+    )
+    expect(f.map((x) => x.kind)).not.toContain('too-many-destinations')
+  })
+
+  it('meldet die Grenze weiterhin, wenn alle vier auf DERSELBEN Maschine liegen', () => {
+    const f = checkEncoderFeasibility(
+      ['A', 'B', 'C', 'D'].map((n) => ziel(n, { encoderEquipmentId: 'enc-1' })),
+      vmix,
+    )
+    const zuViele = f.find((x) => x.kind === 'too-many-destinations')
+    expect(zuViele?.values).toEqual(['4', '3'])
+    expect(zuViele?.deviceId).toBe('enc-1')
+  })
+
+  it('vergleicht die Qualitaet nur INNERHALB einer Maschine', () => {
+    // Twitch auf Maschine 1 mit 6.000 und YouTube auf Maschine 2 mit 12.000
+    // ist kein Widerspruch -- es sind zwei Encoder mit je einem Ziel.
+    const f = checkEncoderFeasibility(
+      [
+        ziel('Twitch', {
+          encoderEquipmentId: 'enc-1',
+          encoding: { ...DEFAULT_ENCODING, videoBitrateKbps: 6000 },
+        }),
+        ziel('YouTube', {
+          encoderEquipmentId: 'enc-2',
+          encoding: { ...DEFAULT_ENCODING, videoBitrateKbps: 12000 },
+        }),
+      ],
+      vmix,
+    )
+    expect(f).toEqual([])
+  })
+
+  it('haelt die Ziele OHNE benanntes Geraet zusammen — und sagt das per leerem deviceId', () => {
+    // Der uebliche Fall ist eine Maschine, die niemand aufgeschrieben hat.
+    // Sie einzeln zu zaehlen liesse die Grenze nie greifen.
+    const f = checkEncoderFeasibility(['A', 'B', 'C', 'D'].map((n) => ziel(n)), vmix)
+    const zuViele = f.find((x) => x.kind === 'too-many-destinations')
+    expect(zuViele?.values).toEqual(['4', '3'])
+    expect(zuViele?.deviceId).toBeUndefined()
+  })
+
+  it('gruppiert nach dem Geraet, nicht nach der Reihenfolge', () => {
+    // Abwechselnd eingetragen: eine Gruppierung, die nur benachbarte Ziele
+    // zusammenfasst, liefe hier auseinander.
+    const gruppen = groupByEncoder([
+      ziel('A', { encoderEquipmentId: 'enc-1' }),
+      ziel('B', { encoderEquipmentId: 'enc-2' }),
+      ziel('C', { encoderEquipmentId: 'enc-1' }),
+    ])
+    expect(gruppen).toHaveLength(2)
+    expect(gruppen.find((g) => g.deviceId === 'enc-1')?.destinations.map((d) => d.name)).toEqual([
+      'A',
+      'C',
+    ])
   })
 })
 


### PR DESCRIPTION
## Worum es geht

Bedarf 32 (P1, Rolle Streaming) verlangt die Übertragungskette als **erstklassigen Signalfluss** statt als Notiz am letzten Knoten:

> Signal-flow diagrams stop at the encoder input; everything downstream lives in encoder web UIs, platform consoles and someone's head, so **no artefact shows the delivery path**.

Seit `cable#703` gab es das Ziel-Register, die Paritätsprüfung und den Transport-Rechner — aber `DeliveryDestination` hatte **keinen einzigen Zeiger in den Plan**. Kein Gerät, kein Anschluss, kein Kabel. Das Register war damit genau das zweite Dokument, das der Bedarf beklagt, nur eben in unserer eigenen Anwendung.

## Die Naht ist ein Feld

`DeliveryDestination.encoderEquipmentId?` zeigt auf das `EquipmentItem`, das sendet. **Alles Weitere ist abgeleitet und wird nicht gespeichert:**

- der Programm-Eingang aus den Anschlüssen des Encoders,
- die Quelle aus der Rückwärtssuche im Kabelgraph (`labelDerivation.resolveSignalSource`, ADR-001).

Damit gibt es keine zweite Wahrheit über den Weg — es gibt nur den Plan.

## Was dazukommt

| Datei | Was |
| --- | --- |
| `types/delivery.ts` | `encoderEquipmentId?` + Normalisierung. Der Zeiger wird beim Laden **nicht** gegen den Gerätebestand geprüft und **nicht** still geleert. |
| `lib/deliveryPath.ts` (neu) | `buildDeliveryChains` + `deliveryPathTable` — das Blatt `ausspielweg`: Ziel, Rolle, Quelle, Zwischenstationen, Encoder, Programm-Eingang, Transport, Befund. |
| `lib/documentRegistry.ts` | `ausspielweg` mit Stand, reproduzierbar aus dem Plan. |
| `lib/labelDerivation.ts` | `isReferencePort` exportiert — dieselbe Vokabel für „was ist ein Programm-Eingang". |
| `components/Delivery/DeliveryDialog.tsx` | Encoder-Auswahl je Ziel, die Kette als eine Zeile darunter, Befunde, CSV-Ausgabe mit Stempel. |

**Fünf Befunde, jeder ein benanntes Ergebnis statt einer leeren Zelle:** `no-encoder`, `encoder-gone`, `encoder-unfed`, `feed-ambiguous`, `backup-shares-encoder`.

Der letzte ist der, den der Bedarf zitiert — *„nobody's thought about what happens when something fails"*: ein Backup auf demselben Blech ist derselbe Weg mit zwei Zielen, kein Ausweichweg.

**Geraten wird nichts.** Zwei verkabelte Programm-Eingänge ergeben `feed-ambiguous` und keine Antwort. Welcher das Programm führt, ist eine Einsatz-Entscheidung; die falsche landet auf einem Blatt, das am Showtag geglaubt wird. Dieselbe Regel wie beim Router ohne gesetzten Kreuzpunkt.

Kein Stream-Key, keine Ingest-URL auf dem Wegblatt — die stehen auf dem Ablaufblatt. Ein Blatt über den Signalweg braucht kein Geheimnis (Test hält das fest).

## Mitgefunden und behoben

`checkEncoderFeasibility` zählte **alle** Primärwege in einen Topf und hielt die Summe gegen die Zielgrenze eines Werkzeugs. Das setzt stillschweigend voraus, dass alle Ziele auf **demselben** Encoder liegen — bei zwei Maschinen mit je zwei Zielen meldete es *„vier gleichzeitige Ziele, vMix führt drei"* auf einem korrekten Aufbau. Ein falscher Befund auf einem richtigen Plan, und genau so werden auch die richtigen Befunde daneben ignoriert.

Seit Bedarf 32 gibt es die Gruppierung: `groupByEncoder` teilt je Gerät, Ziele ohne Angabe bilden eine Gruppe (das bisherige Verhalten, und die vorsichtigere Annahme), und jeder Befund trägt `deviceId`.

## Gegenproben

Elf, alle rot — keine blieb grün:

Referenz-Anschluss zählt als Speisung · mehrdeutige Speisung wird geraten · Backup auf demselben Gerät bleibt stumm · Zwischenstationen als 0 statt leer · gelöschtes Gerät verschwiegen · alle Ziele in eine Gruppe · Blatt nicht im Register · Kette im Dialog nicht gerendert · Befundtext leer · Encoder-Auswahl ohne Schreibweg · Ingest-URL landet auf dem Wegblatt

## Prüfstand

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — 1356 passed, 2 skipped (123 Dateien)
- `npm run lint` — 0 Errors (10 Alt-Warnungen)
- `npm run build` OK · `npm run ui:smoke` grün

`tests/changeImpact.test.ts` bekam eine zusätzliche Zeile in der benannten Ausnahmeliste — mit dem anderen Grund im Klartext und einem eigenen Test darunter, der festhält, dass `ausspielweg` **sobald es ein Ziel gibt** ohne Geräte `unknown` meldet und nicht „unberührt".

Closes Bedarf 32 aus `docs/research/synthesis/USER-NEED-DATABASE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_