### PR TITLE
import: kein stiller Verlust beim CSV-Import (Bedarf 29)

### DIFF
--- a/src/renderer/components/Import/CsvImportDialog.tsx
+++ b/src/renderer/components/Import/CsvImportDialog.tsx
@@ -5,9 +5,16 @@
 // der Kopfzeile automatisch zugeordnet (DE/EN-Aliase); der User sieht eine
 // Vorschau bevor importiert wird. Deckt Rental-Systeme ab, die kein
 // dediziertes Plugin haben (Current RMS / HireHop / Flex / Excel-Export).
+//
+// BEDARF 29 (P1) — „silent data loss on import must be impossible". Die
+// Zuordnung, die Vorschau und die Zaehlung liegen seither in
+// `lib/csvImportPlan.ts`: was NICHT uebernommen wird, hat dort einen Namen,
+// eine Liste und eine Zahl, und dieser Dialog zeigt sie. Drei stille Verluste
+// waren es vorher — unbekannte Spalten, namenlose Zeilen, und eine
+// Erfolgsmeldung, die uebersprungene Namen als „hinzugefuegt" zaehlte.
 
 import { useMemo, useState } from 'react'
-import { FileUp } from 'lucide-react'
+import { FileUp, AlertTriangle } from 'lucide-react'
 import { useUiStore } from '../../store/uiStore'
 import { useProjectStore } from '../../store/projectStore'
 import { ModalShell } from '../shared/ModalShell'
@@ -16,90 +23,27 @@ import { Button } from '../shared/Button'
 import { infoDialog } from '../../lib/infoDialog'
 import { useTranslation, format } from '../../lib/i18n'
 import { parseCsv } from '../../lib/csvParse'
-import type { EquipmentTemplate } from '../../types/equipment'
-
-type FieldKey = 'name' | 'category' | 'watts' | 'weight' | 'serial' | 'ip' | 'rackUnits' | 'subtitle'
-
-const ALIASES: Record<FieldKey, string[]> = {
-  name: ['name', 'gerät', 'geraet', 'device', 'bezeichnung', 'artikel'],
-  category: ['kategorie', 'category', 'typ', 'type', 'gruppe'],
-  watts: ['watt', 'watts', 'leistung', 'power', 'w'],
-  weight: ['gewicht', 'weight', 'kg'],
-  serial: ['seriennummer', 'serial', 's/n', 'sn'],
-  ip: ['ip', 'ip-adresse', 'ipaddress', 'ip address', 'ip adresse'],
-  rackUnits: ['he', 'rackunits', 'ru', 'höheneinheiten', 'hoeheneinheiten'],
-  subtitle: ['untertitel', 'subtitle', 'hersteller', 'manufacturer', 'marke', 'brand'],
-}
-
-const mapHeader = (header: string[]): Partial<Record<FieldKey, number>> => {
-  const map: Partial<Record<FieldKey, number>> = {}
-  header.forEach((h, i) => {
-    const key = h.trim().toLowerCase()
-    for (const [field, aliases] of Object.entries(ALIASES) as [FieldKey, string[]][]) {
-      if (map[field] == null && aliases.includes(key)) map[field] = i
-    }
-  })
-  return map
-}
-
-const toNum = (s?: string): number | undefined => {
-  const n = parseFloat((s ?? '').replace(',', '.').replace(/[^\d.-]/g, ''))
-  return Number.isFinite(n) ? n : undefined
-}
-
-const buildTemplates = (
-  rows: string[][],
-  map: Partial<Record<FieldKey, number>>,
-  fallbackCategory: string,
-): EquipmentTemplate[] => {
-  const at = (r: string[], key: FieldKey): string | undefined =>
-    map[key] != null ? r[map[key] as number]?.trim() : undefined
-  const [, ...body] = rows
-  const out: EquipmentTemplate[] = []
-  for (const r of body) {
-    const name = (map.name != null ? r[map.name] : r[0])?.trim()
-    if (!name) continue
-    const tpl: EquipmentTemplate = {
-      name,
-      category: at(r, 'category') || fallbackCategory,
-      inputs: [],
-      outputs: [],
-      width: 220,
-      height: 60,
-    }
-    const w = toNum(at(r, 'watts'))
-    if (w != null) tpl.powerConsumptionWatts = w
-    const kg = toNum(at(r, 'weight'))
-    if (kg != null) tpl.weightKg = kg
-    const sn = at(r, 'serial')
-    if (sn) tpl.serialNumber = sn
-    const ip = at(r, 'ip')
-    if (ip) tpl.ipAddress = ip
-    const ru = toNum(at(r, 'rackUnits'))
-    if (ru != null) {
-      tpl.rackUnits = Math.max(1, Math.round(ru))
-      tpl.isRackDevice = true
-    }
-    const sub = at(r, 'subtitle')
-    if (sub) tpl.subtitle = sub
-    out.push(tpl)
-  }
-  return out
-}
+import { ALIASES, planCsvImport, type FieldKey } from '../../lib/csvImportPlan'
 
 export const CsvImportDialog = () => {
   const t = useTranslation()
   const open = useUiStore((s) => s.csvImport.open)
   const close = useUiStore((s) => s.closeCsvImport)
   const addCustomTemplates = useProjectStore((s) => s.addCustomTemplates)
+  const customLibrary = useProjectStore((s) => s.customLibrary)
   const [text, setText] = useState('')
 
   const parsed = useMemo(() => parseCsv(text), [text])
-  const map = useMemo(() => mapHeader(parsed[0] ?? []), [parsed])
-  const templates = useMemo(
-    () => buildTemplates(parsed, map, t('csvImport.fallbackCategory', 'Importiert')),
-    [parsed, map, t],
+  const plan = useMemo(
+    () =>
+      planCsvImport(
+        parsed,
+        customLibrary.map((tpl) => tpl.name),
+        t('csvImport.fallbackCategory', 'Importiert'),
+      ),
+    [parsed, customLibrary, t],
   )
+  const templates = plan.fresh
 
   if (!open) return null
 
@@ -114,18 +58,27 @@ export const CsvImportDialog = () => {
     addCustomTemplates(templates)
     close()
     setText('')
-    void infoDialog(
-      t('csvImport.doneTitle', 'CSV importiert'),
-      {
-        body: format(t('csvImport.doneBody', '{n} Gerät(e) als Library-Templates hinzugefügt (bestehende Namen unverändert).'), {
-          n: templates.length,
-        }),
-        tone: 'success',
-      },
-    )
+    // Die Zahl im Erfolgsfenster ist jetzt die, die wirklich angelegt wurde —
+    // und was NICHT angelegt wurde, steht daneben statt nirgends.
+    void infoDialog(t('csvImport.doneTitle', 'CSV importiert'), {
+      body: format(
+        t(
+          'csvImport.doneBody',
+          '{n} Gerät(e) neu angelegt. Unverändert geblieben: {vorhanden} bereits vorhandene(r) Name(n). Übersprungen: {ohneName} Zeile(n) ohne Namen.',
+        ),
+        {
+          n: plan.fresh.length,
+          vorhanden: plan.existing.length,
+          ohneName: plan.rowsWithoutName.length,
+        },
+      ),
+      tone: 'success',
+    })
   }
 
-  const mappedFields = (Object.keys(ALIASES) as FieldKey[]).filter((k) => map[k] != null)
+  const mappedFields = (Object.keys(ALIASES) as FieldKey[]).filter((k) => plan.mapping[k] != null)
+  const etwasFaelltAuf =
+    plan.unmapped.length > 0 || plan.duplicates.length > 0 || plan.rowsWithoutName.length > 0 || plan.existing.length > 0
 
   return (
     <ModalShell
@@ -139,7 +92,7 @@ export const CsvImportDialog = () => {
         <p className="text-cp-xs text-[var(--cp-text-muted)]">
           {t(
             'csvImport.intro',
-            'CSV einfügen oder Datei wählen. Erste Zeile = Spaltenüberschriften. Erkannte Spalten: Name, Kategorie, Leistung (W), Gewicht (kg), Seriennummer, IP, HE, Untertitel/Hersteller. Import legt Library-Templates an (kein Überschreiben).',
+            'CSV einfügen oder Datei wählen. Erste Zeile = Spaltenüberschriften. Erkannte Spalten: Name, Kategorie, Leistung (W), Gewicht (kg), Seriennummer, IP, HE, Untertitel/Hersteller. Jede andere Spalte wandert in die Notizen — nichts fällt still weg. Import legt Library-Templates an (kein Überschreiben).',
           )}
         </p>
         <label className="inline-flex cursor-pointer items-center gap-1 rounded bg-[var(--cp-surface-2)] px-2 py-1 text-cp-xs hover:bg-[var(--cp-surface-3)]">
@@ -166,6 +119,73 @@ export const CsvImportDialog = () => {
                 fields: mappedFields.join(', ') || '—',
               })}
             </div>
+
+            {/* BEDARF 29 — was NICHT ankommt, steht hier. Der Bedarf verlangt
+                „a preview that names exactly what will be dropped"; eine
+                Vorschau, die nur die erkannten Spalten nennt, sagt ueber die
+                nicht erkannten nichts — und Verschweigen sieht aus wie
+                „vollstaendig uebernommen". */}
+            {etwasFaelltAuf && (
+              <div className="rounded border border-[var(--cp-warn)]/40 bg-[var(--cp-surface-2)] p-2 text-cp-xs">
+                <div className="mb-1 flex items-center gap-1 font-medium text-[var(--cp-text)]">
+                  <Icon icon={AlertTriangle} size="xs" />
+                  {t('csvImport.whatHappens', 'Was mit dem Rest passiert')}
+                </div>
+                <ul className="flex list-disc flex-col gap-0.5 pl-4 text-[var(--cp-text-secondary)]">
+                  {plan.unmapped.length > 0 && (
+                    <li>
+                      {format(
+                        t(
+                          'csvImport.unmapped',
+                          'Nicht als Feld erkannt, wandert in die Notizen: {cols}',
+                        ),
+                        { cols: plan.unmapped.map((c) => c.header || `#${c.index + 1}`).join(', ') },
+                      )}
+                    </li>
+                  )}
+                  {plan.duplicates.length > 0 && (
+                    <li>
+                      {format(
+                        t(
+                          'csvImport.duplicateCols',
+                          'Zweite Spalte auf dasselbe Feld — die erste gewinnt, diese wird zur Notiz: {cols}',
+                        ),
+                        {
+                          cols: plan.duplicates
+                            .map((c) => `${c.header || `#${c.index + 1}`} (${c.field})`)
+                            .join(', '),
+                        },
+                      )}
+                    </li>
+                  )}
+                  {plan.rowsWithoutName.length > 0 && (
+                    <li>
+                      {format(
+                        t('csvImport.noName', '{n} Zeile(n) ohne Namen werden übersprungen: {rows}'),
+                        {
+                          n: plan.rowsWithoutName.length,
+                          rows: plan.rowsWithoutName.slice(0, 12).join(', '),
+                        },
+                      )}
+                    </li>
+                  )}
+                  {plan.existing.length > 0 && (
+                    <li>
+                      {format(
+                        t(
+                          'csvImport.existing',
+                          '{n} Name(n) gibt es schon — sie bleiben unverändert, es wird nichts überschrieben: {names}',
+                        ),
+                        {
+                          n: plan.existing.length,
+                          names: plan.existing.slice(0, 12).join(', '),
+                        },
+                      )}
+                    </li>
+                  )}
+                </ul>
+              </div>
+            )}
             <div className="max-h-48 overflow-auto rounded border border-[var(--cp-border-muted)]">
               <table className="w-full text-cp-xs">
                 <thead className="sticky top-0 bg-[var(--cp-surface-2)] text-left text-[var(--cp-text-muted)]">

--- a/src/renderer/lib/csvImportPlan.ts
+++ b/src/renderer/lib/csvImportPlan.ts
@@ -1,0 +1,234 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Der CSV-Import als PLAN, bevor er passiert (Bedarf 29, P1).
+//
+// WAS DER BEDARF SAGT:
+//
+//   > Silent data loss on import/export must be impossible — the columns the
+//   > production office added are the ones that vanish. […] The lost columns
+//   > are the production-office ones: notes, responsible person,
+//   > client-facing description. Loss is discovered by whoever needed the
+//   > column, when they needed it.
+//
+// Und der Weg, den er vorgibt: „Any import/export the suite ships needs a
+// preview that names exactly what will be dropped, and a sync that refuses to
+// overwrite non-empty values with empty ones."
+//
+// WAS VORHER PASSIERTE — drei stille Verluste in einem einzigen Dialog:
+//
+//   1. Der Kopfzeilen-Abgleich traf acht bekannte Felder. Jede andere Spalte
+//      fiel weg, und die Vorschau nannte nur die ZUGEORDNETEN Spalten. Wer
+//      „Verantwortlich" und „Kundennotiz" mitgeschickt hatte, sah eine
+//      Erfolgsmeldung und merkte den Verlust, wenn er die Spalte brauchte.
+//   2. Zeilen ohne Namen wurden uebersprungen (`if (!name) continue`) und
+//      nirgends gezaehlt.
+//   3. `addCustomTemplates` ueberschreibt bestehende Namen nicht — richtig so,
+//      das ist die zweite Regel des Bedarfs. Die Erfolgsmeldung zaehlte aber
+//      ALLE gebauten Vorlagen als „hinzugefuegt". Wer vierzig Zeilen einlas,
+//      von denen zwoelf schon in der Library standen, las „40 hinzugefuegt".
+//
+// WAS JETZT GILT. Diese Datei rechnet den Import DURCH, bevor er ausgefuehrt
+// wird, und beantwortet dabei jede der drei Fragen mit einer Zahl und einer
+// Liste. Der Dialog zeigt sie; der Knopf traegt die richtige Zahl.
+//
+// UND: die unbekannten Spalten fallen nicht mehr weg, sie wandern nach
+// `notes`, mit ihrer Ueberschrift davor. Das ist mehr, als der Bedarf
+// verlangt — er will nur, dass der Verlust GENANNT wird. Der Grund fuer das
+// Mehr: eine genannte Spalte ist immer noch eine verlorene, und `notes` ist
+// Freitext, den jeder loeschen kann. Umgekehrt geht es nicht.
+//
+// REIN: keine Uhr, kein Store, kein IO, keine Uebersetzung.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { EquipmentTemplate } from '../types/equipment'
+
+export type FieldKey =
+  | 'name'
+  | 'category'
+  | 'watts'
+  | 'weight'
+  | 'serial'
+  | 'ip'
+  | 'rackUnits'
+  | 'subtitle'
+
+/**
+ * Ueberschriften, die auf ein Feld zeigen. Exakter Vergleich in Kleinschrift —
+ * ein Teilstring-Vergleich haette „Name des Kunden" auf `name` gezogen.
+ */
+export const ALIASES: Record<FieldKey, string[]> = {
+  name: ['name', 'gerät', 'geraet', 'device', 'bezeichnung', 'artikel'],
+  category: ['kategorie', 'category', 'typ', 'type', 'gruppe'],
+  watts: ['watt', 'watts', 'leistung', 'power', 'w'],
+  weight: ['gewicht', 'weight', 'kg'],
+  serial: ['seriennummer', 'serial', 's/n', 'sn'],
+  ip: ['ip', 'ip-adresse', 'ipaddress', 'ip address', 'ip adresse'],
+  rackUnits: ['he', 'rackunits', 'ru', 'höheneinheiten', 'hoeheneinheiten'],
+  subtitle: ['untertitel', 'subtitle', 'hersteller', 'manufacturer', 'marke', 'brand'],
+}
+
+export interface ColumnRef {
+  /** Spaltenindex in der Datei, 0-basiert. */
+  index: number
+  /** Die Ueberschrift, wie sie in der Datei steht. Leer, wenn die Spalte keine hat. */
+  header: string
+}
+
+export interface DuplicateColumn extends ColumnRef {
+  /** Das Feld, das schon von einer frueheren Spalte belegt war. */
+  field: FieldKey
+}
+
+export interface CsvImportPlan {
+  /** Feld → Spaltenindex. */
+  mapping: Partial<Record<FieldKey, number>>
+  /** Spalten, die auf kein Feld zeigen. */
+  unmapped: ColumnRef[]
+  /** Zweite Spalte auf ein schon belegtes Feld. Die erste gewinnt — hier steht,
+   *  welche dabei nicht gewonnen hat. */
+  duplicates: DuplicateColumn[]
+  /**
+   * Die Spalten, deren Inhalt nach `notes` wandert: `unmapped` UND
+   * `duplicates`, in Dateireihenfolge.
+   *
+   * Die zweite Haelfte ist der Punkt. Eine zweite „Name"-Spalte verliert die
+   * Zuordnung, aber ihr INHALT ist trotzdem etwas, das jemand mitgeschickt
+   * hat — sie wegzuwerfen waere derselbe stille Verlust, nur mit einem
+   * Hinweis daneben. Und die Oberflaeche sagt genau das; sie darf es nur
+   * sagen, weil es hier auch passiert.
+   */
+  carried: ColumnRef[]
+  /** Zeilennummern (1-basiert, wie in der Tabelle) ohne Namen. */
+  rowsWithoutName: number[]
+  /** Vorlagen, die neu angelegt werden. */
+  fresh: EquipmentTemplate[]
+  /** Namen, die es schon gibt: sie werden NICHT ueberschrieben. */
+  existing: string[]
+}
+
+/**
+ * Kopfzeile → Feldzuordnung, plus alles, was dabei liegen bleibt.
+ *
+ * Die zweite Haelfte des Rueckgabewerts ist der eigentliche Punkt: bis hierher
+ * gab es nur `mapping`, und was NICHT darin stand, war unsichtbar.
+ */
+export const mapHeader = (
+  header: string[],
+): {
+  mapping: Partial<Record<FieldKey, number>>
+  unmapped: ColumnRef[]
+  duplicates: DuplicateColumn[]
+} => {
+  const mapping: Partial<Record<FieldKey, number>> = {}
+  const unmapped: ColumnRef[] = []
+  const duplicates: DuplicateColumn[] = []
+  header.forEach((h, i) => {
+    const key = h.trim().toLowerCase()
+    let hit: FieldKey | null = null
+    for (const [field, aliases] of Object.entries(ALIASES) as [FieldKey, string[]][]) {
+      if (!aliases.includes(key)) continue
+      hit = field
+      if (mapping[field] == null) mapping[field] = i
+      else duplicates.push({ index: i, header: h.trim(), field })
+      break
+    }
+    if (!hit) unmapped.push({ index: i, header: h.trim() })
+  })
+  return { mapping, unmapped, duplicates }
+}
+
+const toNum = (s?: string): number | undefined => {
+  const n = parseFloat((s ?? '').replace(',', '.').replace(/[^\d.-]/g, ''))
+  return Number.isFinite(n) ? n : undefined
+}
+
+/**
+ * Die unbekannten Spalten einer Zeile als Notiz-Text.
+ *
+ * Form: `Ueberschrift: Wert`, eine je Zeile. Leere Zellen fallen weg — eine
+ * Notiz „Verantwortlich:" ohne Wert ist kein bewahrter Inhalt, sondern
+ * Rauschen. Eine Spalte ohne Ueberschrift bekommt ihre Nummer, damit sie
+ * ueberhaupt wiederfindbar bleibt.
+ */
+export const carriedNotes = (row: string[], carried: ColumnRef[]): string => {
+  const teile: string[] = []
+  for (const c of carried) {
+    const wert = (row[c.index] ?? '').trim()
+    if (!wert) continue
+    teile.push(`${c.header || `Spalte ${c.index + 1}`}: ${wert}`)
+  }
+  return teile.join('\n')
+}
+
+/**
+ * Den ganzen Import durchrechnen, ohne ihn auszufuehren.
+ *
+ * `existingNames` kommt von aussen (die Library lebt im Store, diese Datei
+ * kennt keinen Store). Ohne sie liesse sich die dritte Frage nicht
+ * beantworten — und genau die stand vorher falsch in der Erfolgsmeldung.
+ */
+export function planCsvImport(
+  rows: string[][],
+  existingNames: Iterable<string>,
+  fallbackCategory: string,
+): CsvImportPlan {
+  const [header = [], ...body] = rows
+  const { mapping, unmapped, duplicates } = mapHeader(header)
+  const carried: ColumnRef[] = [...unmapped, ...duplicates].sort((a, b) => a.index - b.index)
+  const vorhanden = new Set(existingNames)
+
+  const at = (r: string[], key: FieldKey): string | undefined =>
+    mapping[key] != null ? r[mapping[key] as number]?.trim() : undefined
+
+  const rowsWithoutName: number[] = []
+  const fresh: EquipmentTemplate[] = []
+  const existing: string[] = []
+  // Namen, die INNERHALB der Datei doppelt vorkommen, duerfen nicht zweimal
+  // als „neu" gezaehlt werden: `addCustomTemplates` legt sie einmal an.
+  const schonGeplant = new Set<string>()
+
+  body.forEach((r, i) => {
+    const name = (mapping.name != null ? r[mapping.name] : r[0])?.trim()
+    if (!name) {
+      // +2: eins fuer die Kopfzeile, eins fuer die 1-basierte Zaehlung.
+      rowsWithoutName.push(i + 2)
+      return
+    }
+    if (vorhanden.has(name) || schonGeplant.has(name)) {
+      if (!existing.includes(name)) existing.push(name)
+      return
+    }
+    schonGeplant.add(name)
+
+    const tpl: EquipmentTemplate = {
+      name,
+      category: at(r, 'category') || fallbackCategory,
+      inputs: [],
+      outputs: [],
+      width: 220,
+      height: 60,
+    }
+    const w = toNum(at(r, 'watts'))
+    if (w != null) tpl.powerConsumptionWatts = w
+    const kg = toNum(at(r, 'weight'))
+    if (kg != null) tpl.weightKg = kg
+    const sn = at(r, 'serial')
+    if (sn) tpl.serialNumber = sn
+    const ip = at(r, 'ip')
+    if (ip) tpl.ipAddress = ip
+    const ru = toNum(at(r, 'rackUnits'))
+    if (ru != null) {
+      tpl.rackUnits = Math.max(1, Math.round(ru))
+      tpl.isRackDevice = true
+    }
+    const sub = at(r, 'subtitle')
+    if (sub) tpl.subtitle = sub
+    // Leere Zellen setzen NICHTS — das ist die zweite Regel des Bedarfs
+    // („refuses to overwrite non-empty values with empty ones"), hier in ihrer
+    // milderen Form: ein leeres Feld gar nicht erst anzulegen.
+    const notiz = carriedNotes(r, carried)
+    if (notiz) tpl.notes = notiz
+    fresh.push(tpl)
+  })
+
+  return { mapping, unmapped, duplicates, carried, rowsWithoutName, fresh, existing }
+}

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -4231,7 +4231,11 @@ export const en: Dict = {
   'analysis.rf.conflictChannel': '{a} ↔ {b}: same channel {ch}',
   // CSV-Import (#354)
   'csvImport.title': 'Import equipment from CSV',
-  'csvImport.intro': 'Paste CSV or pick a file. First row = column headers. Recognized columns: name, category, power (W), weight (kg), serial number, IP, RU, subtitle/manufacturer. Import creates library templates (no overwrite).',
+  'csvImport.intro':
+    'Paste CSV or pick a file. First row = column headers. Recognized columns: name, category, ' +
+    'power (W), weight (kg), serial number, IP, RU, subtitle/manufacturer. Every other column is ' +
+    'carried into the notes — nothing is dropped silently. Import creates library templates ' +
+    '(no overwrite).',
   'csvImport.pickFile': 'Choose CSV file…',
   'csvImport.detected': 'Detected: {rows} row(s), mapped columns: {fields}',
   'csvImport.fallbackCategory': 'Imported',
@@ -4239,7 +4243,17 @@ export const en: Dict = {
   'csvImport.col.category': 'Category',
   'csvImport.importBtn': 'Import {n}',
   'csvImport.doneTitle': 'CSV imported',
-  'csvImport.doneBody': 'Added {n} device(s) as library templates (existing names unchanged).',
+  'csvImport.doneBody':
+    'Created {n} new device(s). Left unchanged: {vorhanden} name(s) that already existed. ' +
+    'Skipped: {ohneName} row(s) without a name.',
+  // Bedarf 29 — was NICHT ankommt, hat einen Namen.
+  'csvImport.whatHappens': 'What happens to the rest',
+  'csvImport.unmapped': 'Not recognised as a field, carried into the notes: {cols}',
+  'csvImport.duplicateCols':
+    'Second column on the same field — the first one wins, this one becomes a note: {cols}',
+  'csvImport.noName': '{n} row(s) without a name will be skipped: {rows}',
+  'csvImport.existing':
+    '{n} name(s) already exist — they stay unchanged, nothing is overwritten: {names}',
   'app.mobileShare.title': 'Phone access: a small LAN server + QR code so a phone can open the mobile viewer.',
   'app.mobileShare.ariaLabel': 'Phone access',
   'app.redo': 'Redo (Ctrl+Y)',

--- a/tests/csvImportPlan.test.ts
+++ b/tests/csvImportPlan.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest'
+import { carriedNotes, mapHeader, planCsvImport } from '../src/renderer/lib/csvImportPlan'
+import { parseCsv } from '../src/renderer/lib/csvParse'
+import dialogQuelle from '../src/renderer/components/Import/CsvImportDialog.tsx?raw'
+import dictsQuelle from '../src/renderer/lib/i18n/dicts.ts?raw'
+
+// ---------------------------------------------------------------------------
+// Kein stiller Verlust beim Import (Bedarf 29, P1).
+//
+//   > Silent data loss on import/export must be impossible -- the columns the
+//   > production office added are the ones that vanish. […] Loss is discovered
+//   > by whoever needed the column, when they needed it.
+//
+// Der CSV-Import hatte drei stille Verluste: unbekannte Spalten fielen weg,
+// namenlose Zeilen wurden ungezaehlt uebersprungen, und die Erfolgsmeldung
+// zaehlte uebersprungene (weil vorhandene) Namen als „hinzugefuegt".
+//
+// Geprueft wird deshalb nicht, dass der Import funktioniert -- das tat er --,
+// sondern dass er SAGT, was er nicht mitnimmt, und dass die Zahlen stimmen.
+// ---------------------------------------------------------------------------
+
+const csv = (text: string) => parseCsv(text)
+
+describe('was nicht erkannt wird, hat einen Namen', () => {
+  it('nennt jede Spalte, die auf kein Feld zeigt', () => {
+    const { unmapped } = mapHeader(['Name', 'Kategorie', 'Verantwortlich', 'Kundennotiz'])
+    expect(unmapped.map((c) => c.header)).toEqual(['Verantwortlich', 'Kundennotiz'])
+  })
+
+  it('nennt die zweite Spalte auf dasselbe Feld, statt sie zu verschlucken', () => {
+    // Zwei „Name"-Spalten sind ein echter Fall (Export aus zwei Systemen
+    // zusammengeklebt). Die erste gewinnt -- aber die zweite darf nicht
+    // wortlos verschwinden.
+    const { mapping, duplicates } = mapHeader(['Name', 'Bezeichnung'])
+    expect(mapping.name).toBe(0)
+    expect(duplicates).toEqual([{ index: 1, header: 'Bezeichnung', field: 'name' }])
+  })
+
+  it('gibt einer Spalte ohne Ueberschrift ihre Nummer', () => {
+    // Sonst stuende in der Notiz „: Wert" und niemand faende die Spalte wieder.
+    expect(carriedNotes(['x'], [{ index: 0, header: '' }])).toBe('Spalte 1: x')
+  })
+})
+
+describe('was nicht erkannt wird, geht trotzdem nicht verloren', () => {
+  it('traegt unbekannte Spalten mit ihrer Ueberschrift in die Notizen', () => {
+    const plan = planCsvImport(
+      csv('Name;Verantwortlich;Kundennotiz\nATEM;Lars;bitte vorher testen'),
+      [],
+      'Importiert',
+    )
+    expect(plan.fresh[0].notes).toBe('Verantwortlich: Lars\nKundennotiz: bitte vorher testen')
+  })
+
+  it('traegt AUCH die verlorene Doppelspalte in die Notizen', () => {
+    // Die Oberflaeche sagt „wird zur Notiz". Sie darf das nur sagen, wenn es
+    // hier auch passiert -- sonst waere der Hinweis schlimmer als keiner.
+    const plan = planCsvImport(csv('Name;Bezeichnung\nATEM;ATEM Mini Extreme'), [], 'Importiert')
+    expect(plan.carried.map((c) => c.header)).toEqual(['Bezeichnung'])
+    expect(plan.fresh[0].notes).toBe('Bezeichnung: ATEM Mini Extreme')
+  })
+
+  it('haelt die Notiz-Zeilen in DATEIREIHENFOLGE', () => {
+    // `[...unmapped, ...duplicates]` unsortiert saehe fuer den Leser wie eine
+    // andere Datei aus als die, die er geschickt hat.
+    const plan = planCsvImport(
+      csv('Bezeichnung;Name;Verantwortlich\nATEM Mini;ATEM;Lars'),
+      [],
+      'Importiert',
+    )
+    // „Bezeichnung" ist selbst ein Name-Alias und steht VORNE, gewinnt also
+    // das Feld; die spaetere Spalte „Name" wird zur Notiz. Genau daran haengt
+    // die Reihenfolge-Zusage: Notiz-Zeile 1 kommt aus Spalte 2, nicht aus der
+    // Reihenfolge „erst unmapped, dann duplicates".
+    expect(plan.fresh[0].name).toBe('ATEM Mini')
+    expect(plan.fresh[0].notes).toBe('Name: ATEM\nVerantwortlich: Lars')
+  })
+
+  it('schreibt keine leeren Notiz-Zeilen', () => {
+    // „Verantwortlich:" ohne Wert ist kein bewahrter Inhalt, sondern Rauschen.
+    const plan = planCsvImport(csv('Name;Verantwortlich\nATEM;'), [], 'Importiert')
+    expect(plan.fresh[0].notes).toBeUndefined()
+  })
+
+  it('legt gar keine Notiz an, wenn jede Spalte erkannt wurde', () => {
+    const plan = planCsvImport(csv('Name;Kategorie\nATEM;Mischer'), [], 'Importiert')
+    expect(plan.fresh[0].notes).toBeUndefined()
+  })
+})
+
+describe('die Zahlen im Erfolgsfenster stimmen', () => {
+  it('zaehlt bestehende Namen NICHT als neu angelegt', () => {
+    // Der eigentliche Fehler: `addCustomTemplates` ueberspringt bestehende
+    // Namen (richtig so), und die Meldung zaehlte sie trotzdem mit. Wer
+    // vierzig Zeilen einlas, von denen zwoelf schon dastanden, las „40".
+    const plan = planCsvImport(
+      csv('Name\nATEM\nHyperDeck\nATEM Mini'),
+      ['ATEM', 'HyperDeck'],
+      'Importiert',
+    )
+    expect(plan.fresh.map((t) => t.name)).toEqual(['ATEM Mini'])
+    expect(plan.existing).toEqual(['ATEM', 'HyperDeck'])
+  })
+
+  it('zaehlt einen INNERHALB der Datei doppelten Namen nur einmal als neu', () => {
+    const plan = planCsvImport(csv('Name\nATEM\nATEM'), [], 'Importiert')
+    expect(plan.fresh).toHaveLength(1)
+    expect(plan.existing).toEqual(['ATEM'])
+  })
+
+  it('nennt die Zeilennummern der namenlosen Zeilen so, wie sie in der Tabelle stehen', () => {
+    // 1-basiert und mit Kopfzeile: die zweite Datenzeile ist Zeile 3.
+    const plan = planCsvImport(csv('Name;Kategorie\nATEM;Mischer\n;Mischer'), [], 'Importiert')
+    expect(plan.rowsWithoutName).toEqual([3])
+  })
+})
+
+describe('leere Zellen ueberschreiben nichts', () => {
+  it('legt kein Feld an, dessen Zelle leer ist', () => {
+    // Die zweite Regel des Bedarfs („refuses to overwrite non-empty values
+    // with empty ones") in ihrer milderen Form: gar nicht erst schreiben.
+    const plan = planCsvImport(
+      csv('Name;Seriennummer;IP;Leistung\nATEM;;;'),
+      [],
+      'Importiert',
+    )
+    const tpl = plan.fresh[0]
+    expect(tpl.serialNumber).toBeUndefined()
+    expect(tpl.ipAddress).toBeUndefined()
+    expect(tpl.powerConsumptionWatts).toBeUndefined()
+  })
+
+  it('laesst einen bestehenden Namen unangetastet, statt ihn leer zu ueberschreiben', () => {
+    const plan = planCsvImport(csv('Name;Leistung\nATEM;'), ['ATEM'], 'Importiert')
+    expect(plan.fresh).toEqual([])
+    expect(plan.existing).toEqual(['ATEM'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ERREICHBARKEIT. Ein Plan, den der Dialog nicht zeigt, ist kein Hinweis.
+// ---------------------------------------------------------------------------
+describe('Erreichbarkeit im Import-Dialog', () => {
+  it('rechnet den Import gegen die BESTEHENDE Library durch', () => {
+    // Ohne die Library kann die dritte Frage nicht beantwortet werden -- und
+    // genau die stand vorher falsch in der Erfolgsmeldung.
+    expect(dialogQuelle).toContain("from '../../lib/csvImportPlan'")
+    expect(dialogQuelle).toContain('planCsvImport(')
+    expect(dialogQuelle).toContain('customLibrary.map((tpl) => tpl.name)')
+  })
+
+  it('zeigt jeden der vier Befunde', () => {
+    // Geprueft wird die RENDER-Bedingung (`… > 0 && (`), nicht das blosse
+    // Vorkommen des Ausdrucks: derselbe Text steht auch in `etwasFaelltAuf`,
+    // und eine Gegenprobe, die nur das Rendern abschaltet, blieb damit gruen.
+    // Genau dieser Fehler ist schon einmal in einem Erreichbarkeits-Guard
+    // passiert.
+    expect(dialogQuelle).toContain('{plan.unmapped.length > 0 && (')
+    expect(dialogQuelle).toContain('{plan.duplicates.length > 0 && (')
+    expect(dialogQuelle).toContain('{plan.rowsWithoutName.length > 0 && (')
+    expect(dialogQuelle).toContain('{plan.existing.length > 0 && (')
+    // Und der Kasten selbst haengt am Sammel-Flag.
+    expect(dialogQuelle).toContain('{etwasFaelltAuf && (')
+  })
+
+  it('meldet am Ende die WIRKLICH angelegte Zahl', () => {
+    expect(dialogQuelle).toContain('n: plan.fresh.length')
+    expect(dialogQuelle).toContain('vorhanden: plan.existing.length')
+    expect(dialogQuelle).toContain('ohneName: plan.rowsWithoutName.length')
+  })
+
+  it('hat fuer jeden neuen Text einen EN-Eintrag', () => {
+    for (const key of [
+      'csvImport.whatHappens',
+      'csvImport.unmapped',
+      'csvImport.duplicateCols',
+      'csvImport.noName',
+      'csvImport.existing',
+    ]) {
+      expect(dialogQuelle).toContain(`'${key}'`)
+      expect(dictsQuelle).toContain(`'${key}'`)
+    }
+  })
+})


### PR DESCRIPTION
## Worum es geht

Bedarf 29 (P1), belegt mit neun Issues aus einem Produkt über zwei Jahre:

> Silent data loss on import/export must be impossible — **the columns the production office added are the ones that vanish**. […] Loss is discovered by whoever needed the column, when they needed it.

Der vorgegebene Weg: *„a preview that names exactly what will be dropped, and a sync that refuses to overwrite non-empty values with empty ones."*

## Drei stille Verluste in einem Dialog

Der CSV-Import (#354) hatte alle drei:

1. **Unbekannte Spalten fielen weg.** Der Kopfzeilen-Abgleich traf acht Felder; die Vorschau nannte nur die **zugeordneten** Spalten. Wer „Verantwortlich" und „Kundennotiz" mitschickte, sah eine Erfolgsmeldung und merkte den Verlust, wenn er die Spalte brauchte. Genau der Satz aus dem Bedarf.
2. **Zeilen ohne Namen** wurden übersprungen (`if (!name) continue`) und nirgends gezählt.
3. **Die Erfolgsmeldung log.** `addCustomTemplates` überschreibt bestehende Namen nicht — richtig so, das *ist* die zweite Regel des Bedarfs. Gezählt wurden aber alle gebauten Vorlagen: wer vierzig Zeilen einlas, von denen zwölf schon in der Library standen, las *„40 hinzugefügt"*.

## Was jetzt gilt

| Datei | Was |
| --- | --- |
| `lib/csvImportPlan.ts` (neu) | Rechnet den Import **durch, bevor er passiert**. Zuordnung, unbekannte Spalten, Doppelspalten, namenlose Zeilen und bestehende Namen sind Rückgabewerte statt Nebenwirkung. Rein: kein Store, kein IO, keine Übersetzung. |
| `components/Import/CsvImportDialog.tsx` | Kasten „Was mit dem Rest passiert" — vier Zeilen, jede mit den betroffenen Spalten bzw. Zeilennummern im Klartext. Die Zahl im Erfolgsfenster ist die **wirklich** angelegte, daneben die unverändert gebliebenen und die übersprungenen. |

**Und die unbekannten Spalten fallen nicht mehr weg:** sie wandern nach `notes`, mit ihrer Überschrift davor, in Dateireihenfolge.

Das ist mehr, als der Bedarf verlangt — er will nur, dass der Verlust *genannt* wird. Der Grund für das Mehr: eine genannte Spalte ist immer noch eine verlorene, und `notes` ist Freitext, den jeder löschen kann; umgekehrt geht es nicht. Die verlorene **Doppelspalte** wandert mit, sonst wäre der Hinweis „wird zur Notiz" eine Unwahrheit.

Leere Zellen setzen weiterhin **nichts** — die zweite Regel des Bedarfs in ihrer milderen Form, jetzt mit Test statt nur als Verhalten.

## Gegenproben

Zwölf. Elf sofort rot — und **eine blieb grün und hat einen echten schwachen Guard aufgedeckt:**

Die Erreichbarkeitsprüfung suchte `plan.unmapped.length > 0` als Zeichenkette. Die steht aber auch in der Sammel-Bedingung `etwasFaelltAuf`, und eine Gegenprobe, die nur das *Rendern* abschaltete, lief durch. Der Guard prüft jetzt die JSX-Bedingung mitsamt `&& (`; beide Gegenproben dazu (einzelne Zeile weg, ganzer Kasten weg) sind rot.

## Prüfstand

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — 1373 passed, 2 skipped (124 Dateien)
- `npm run lint` — 0 Errors (10 Alt-Warnungen)

Closes Bedarf 29 aus `docs/research/synthesis/USER-NEED-DATABASE.md` für den CSV-Weg. Die übrigen Import-Wege (NetBox, Rentman, Greengo) haben feste Schemata statt beliebiger Nutzerspalten — sie tragen dasselbe Risiko nicht in derselben Form und sind ein eigener Schritt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_