### PR TITLE
viewer: der geteilte Plan sagt, welcher Stand er ist (Bedarf 1)

### DIFF
--- a/src/viewer/ViewerApp.tsx
+++ b/src/viewer/ViewerApp.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { CablePlannerProject, ProjectAnnotation } from '../renderer/types/project'
 import { styleForLayer } from '../renderer/lib/cableLayers'
+import { stampForPlan } from '../renderer/lib/documentStamp'
 
 // #143 — Zero-Install-Web-Viewer (Stage 1). Lädt eine .cpviewer/.json und
 // rendert den Plan read-only als SVG plus die Anmerkungen. Der Reviewer kann
@@ -10,6 +11,26 @@ import { styleForLayer } from '../renderer/lib/cableLayers'
 //
 // Bewusst self-contained — kein ReactFlow/Store/Electron, damit das Bundle
 // klein bleibt und in jedem Browser ohne Backend offline läuft.
+//
+// BEDARF 1 (P1) — „the technical plan on the freelancer's phone before they
+// leave home, and offline once on site". Der Bedarf nennt zwei Inkremente:
+// „share to a person with no account, and make it the live document rather
+// than a PDF fork". Das ERSTE ist genau diese Datei: sie braucht kein Konto,
+// keine Installation und kein Backend.
+//
+// Das ZWEITE fehlte, und zwar an der einzigen Stelle, an der es zählt. Was
+// hier ankommt, ist eine Momentaufnahme — und sie sagte nicht, WELCHE. Der
+// Kopf zeigte den Projektnamen und der Fuß drei Zahlen; der STAND stand
+// nirgends. Damit war das Geteilte funktional die PDF-Gabelung, die der
+// Bedarf beklagt: der Empfänger hält etwas in der Hand und kann nicht
+// feststellen, ob es noch gilt.
+//
+// Der Stempel steht seit ADR-004 im Planer, auf jedem Blatt und in jeder
+// Liste, und die Rückfrage ist seit `cable#709` beantwortbar
+// (`docStandStatus` / `findByStand`, Bedarf 27). Von den acht Hex-Zeichen
+// heisst es dort ausdrücklich, ein Mensch könne sie „am Telefon vorlesen und
+// mit dem Bildschirm vergleichen" — genau der Rückweg, den ein Freelancer
+// ohne Konto braucht. Er stand nur nicht auf dem, was er bekommt.
 
 const REVIEWER_KEY = 'cable-planner.viewer.reviewer'
 const annKey = (p: CablePlannerProject): string =>
@@ -262,20 +283,40 @@ export const ViewerApp = () => {
   const removeAnnotation = (id: string): void =>
     setAnnotations((prev) => prev.filter((a) => a.id !== id))
 
+  // Der Stempel des GETEILTEN Plans (Bedarf 1). Berechnet aus der Datei, nicht
+  // aus einer Uhr: `fingerprint`, `revision` und `drifted` haengen allein am
+  // Inhalt. `printedAt` waere hier der Moment des Oeffnens und damit eine
+  // Aussage ueber den Leser statt ueber das Dokument — es wird deshalb NICHT
+  // angezeigt. Ueber `stampForPlan` und nicht ueber einen eigenen Nachbau,
+  // damit im Viewer dieselbe Zahl steht wie auf dem Ausdruck.
+  const stamp = useMemo(
+    () => (project ? stampForPlan(project, new Date()) : null),
+    [project],
+  )
+  const standHinweis =
+    'Diese Ansicht ist eine Momentaufnahme. Ob sie noch gilt, beantwortet der ' +
+    'Planer: dort „Analyse → Blatt prüfen" mit dieser Zeichenfolge.'
+
   const downloadAnnotated = (): void => {
-    if (!project) return
+    // `stamp` statt einer zweiten Berechnung: eine zweite Ableitung derselben
+    // Zahl im selben Bauteil ist die zweite Wahrheit, die irgendwann abweicht.
+    if (!project || !stamp) return
     const out: CablePlannerProject = { ...project, annotations }
     const blob = new Blob([JSON.stringify(out, null, 2)], { type: 'application/json' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
     const base = (project.metadata?.name ?? 'plan').replace(/[^\w.-]+/g, '_')
-    a.download = `${base}.cpviewer`
+    // Der Stand IM DATEINAMEN (Bedarf 1). Wer drei Ruecklaeufer im
+    // Download-Ordner hat, sieht sonst dreimal denselben Namen und muss jede
+    // oeffnen, um zu wissen, auf welchem Plan sie sitzt. Kein `#`: das ist in
+    // URLs ein Fragment-Trenner und faellt beim Verschicken ueber Weblinks ab.
+    a.download = `${base}_${stamp.fingerprint}.cpviewer`
     document.body.appendChild(a); a.click(); document.body.removeChild(a)
     URL.revokeObjectURL(url)
   }
 
-  if (!project) {
+  if (!project || !stamp) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-cp-bg p-4 text-cp-text">
         <div className="w-full max-w-md rounded-lg border border-cp-border bg-cp-surface-1 p-6 shadow-2xl" onDragOver={(e) => e.preventDefault()} onDrop={onDrop}>
@@ -324,6 +365,12 @@ export const ViewerApp = () => {
         <div className="min-w-0">
           <h1 className="truncate text-sm font-semibold">{project.metadata?.name ?? 'Plan'}</h1>
           {project.metadata?.description && <p className="truncate text-xs text-cp-text-muted">{project.metadata.description}</p>}
+          {/* Bedarf 1: der Stand des Geteilten. Ohne ihn ist diese Ansicht
+              eine Momentaufnahme, die nicht sagt, welche. */}
+          <p className="truncate text-[11px] text-cp-text-faint" title={standHinweis}>
+            Stand <span className="font-mono">#{stamp.fingerprint}</span>
+            {stamp.revision && <> · {stamp.revision}{stamp.drifted && ' + Änderungen'}</>}
+          </p>
         </div>
         <div className="flex shrink-0 items-center gap-2 text-xs text-cp-text-muted">
           <span className="rounded bg-cp-surface-3 px-2 py-1">Plan read-only</span>

--- a/tests/viewerStand.test.ts
+++ b/tests/viewerStand.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import viewerQuelle from '../src/viewer/ViewerApp.tsx?raw'
+import { planFingerprint, stampForPlan } from '../src/renderer/lib/documentStamp'
+import type { CablePlannerProject, ProjectAnnotation } from '../src/renderer/types/project'
+
+// ---------------------------------------------------------------------------
+// Der geteilte Plan sagt, welcher Stand er ist (Bedarf 1, P1).
+//
+//   > The technical plan on the freelancer's phone before they leave home, and
+//   > offline once on site. […] Two increments: share to a person with no
+//   > account, and MAKE IT THE LIVE DOCUMENT RATHER THAN A PDF FORK.
+//
+// Das erste Inkrement war gebaut: der Web-Viewer braucht kein Konto, keine
+// Installation und kein Backend. Das zweite fehlte an der einzigen Stelle, an
+// der es zaehlt — die Ansicht sagte NICHT, welche Momentaufnahme sie ist.
+// Damit war das Geteilte funktional die PDF-Gabelung, die der Bedarf beklagt.
+//
+// Der Rueckweg dazu ist seit `cable#709` gebaut (`findByStand`, Bedarf 27).
+// Geprueft wird hier deshalb nicht der Rueckweg, sondern dass die Zahl, die
+// ihn ausloest, auf dem Geteilten UEBERHAUPT steht — und dass sie den Weg
+// hin und zurueck ueberlebt.
+// ---------------------------------------------------------------------------
+
+const projekt = (over: Partial<CablePlannerProject> = {}): CablePlannerProject =>
+  ({
+    metadata: { name: 'Sendung Freitag', createdAt: 1, updatedAt: 1 },
+    equipment: [
+      { id: 'e1', name: 'ATEM', category: 'Video', inputs: [], outputs: [], x: 0, y: 0, width: 200, height: 80 },
+    ],
+    cables: [],
+    locations: [],
+    ...over,
+  }) as unknown as CablePlannerProject
+
+const anmerkung = (id: string): ProjectAnnotation =>
+  ({
+    id,
+    text: 'Bitte pruefen',
+    status: 'open',
+    author: 'Jan',
+    createdAt: 1,
+    anchor: { type: 'free', x: 10, y: 10 },
+  }) as unknown as ProjectAnnotation
+
+describe('der Stand steht auf dem, was geteilt wird', () => {
+  it('der Kopf zeigt den Fingerabdruck', () => {
+    expect(viewerQuelle).toContain('stampForPlan')
+    expect(viewerQuelle).toContain('#{stamp.fingerprint}')
+  })
+
+  it('der Kopf zeigt die Revision und sagt, wenn der Plan davon abweicht', () => {
+    // „Rev 2" allein liest sich als *dieser Stand ist Rev 2*. Weicht der Plan
+    // ab, muss es dabeistehen — sonst behauptet die Ansicht einen Stand, den
+    // sie nicht hat. Dieselbe Regel wie in `stampLine`.
+    expect(viewerQuelle).toContain('{stamp.revision}')
+    expect(viewerQuelle).toContain("stamp.drifted && ' + Änderungen'")
+  })
+
+  it('zeigt KEIN Druckdatum', () => {
+    // `printedAt` waere im Viewer der Moment des Oeffnens: eine Aussage ueber
+    // den Leser, nicht ueber das Dokument. Ein Datum, das sich bei jedem
+    // Oeffnen aendert, sieht aus wie eine Aktualisierung, die es nicht gab.
+    expect(viewerQuelle).not.toContain('stamp.printedAt')
+    expect(viewerQuelle).not.toContain('stampLine(')
+  })
+
+  it('leitet den Stand EINMAL ab, nicht zweimal', () => {
+    // Zwei Ableitungen derselben Zahl im selben Bauteil sind die zweite
+    // Wahrheit, die irgendwann abweicht.
+    expect((viewerQuelle.match(/stampForPlan\(/g) ?? []).length).toBe(1)
+  })
+
+  it('nennt den Rueckweg, statt nur eine Zahl hinzuschreiben', () => {
+    // Acht Hex-Zeichen ohne Hinweis sind ein Rätsel. Der Bedarf will, dass
+    // jemand OHNE Konto feststellen kann, ob sein Plan noch gilt.
+    expect(viewerQuelle).toContain('standHinweis')
+    expect(viewerQuelle).toMatch(/Blatt prüfen/)
+  })
+})
+
+describe('die Zahl ueberlebt den Weg hin und zurueck', () => {
+  it('Anmerkungen aendern den Stand des PLANS nicht', () => {
+    // Der Reviewer darf annotieren — das ist der einzige Schreibpfad. Wuerde
+    // das den Fingerabdruck aendern, meldete der zurueckgelesene Plan sich als
+    // anderer Stand, und die Rueckfrage „gilt #a1b2c3d4 noch?" liefe ins Leere.
+    const p = projekt()
+    const mitAnmerkung = { ...p, annotations: [anmerkung('a1')] }
+    expect(planFingerprint(mitAnmerkung)).toBe(planFingerprint(p))
+  })
+
+  it('eine echte Plan-Aenderung aendert ihn sehr wohl', () => {
+    const p = projekt()
+    const verschoben = {
+      ...p,
+      equipment: [{ ...p.equipment[0], x: 400 }],
+    } as CablePlannerProject
+    expect(planFingerprint(verschoben)).not.toBe(planFingerprint(p))
+  })
+
+  it('der Ruecklaeufer traegt den Stand im Dateinamen', () => {
+    // Drei Ruecklaeufer im Download-Ordner hiessen sonst dreimal gleich.
+    expect(viewerQuelle).toContain('${base}_${stamp.fingerprint}.cpviewer')
+    // Kein `#`: in URLs ist das der Fragment-Trenner und faellt beim
+    // Verschicken ueber Weblinks ab.
+    expect(viewerQuelle).not.toContain('${base}_#${stamp.fingerprint}')
+  })
+})
+
+describe('der Stempel haengt am Inhalt, nicht an der Uhr', () => {
+  it('zweimal geoeffnet ergibt denselben Fingerabdruck', () => {
+    const p = projekt()
+    const a = stampForPlan(p, new Date('2026-01-01T00:00:00Z'))
+    const b = stampForPlan(p, new Date('2026-09-06T12:00:00Z'))
+    expect(a.fingerprint).toBe(b.fingerprint)
+    expect(a.printedAt).not.toBe(b.printedAt)
+  })
+
+  it('ohne festgeschriebene Revision behauptet er keine Abweichung', () => {
+    expect(stampForPlan(projekt(), new Date()).drifted).toBe(false)
+  })
+})


### PR DESCRIPTION
## Worum es geht

Bedarf 1 (P1) nennt zwei Inkremente: *„share to a person with no account, and **make it the live document rather than a PDF fork**."*

**Das erste war gebaut:** der Web-Viewer (#143) braucht kein Konto, keine Installation und kein Backend, läuft in jedem Browser und offline.

**Das zweite fehlte an der einzigen Stelle, an der es zählt.** Was dort ankommt, ist eine Momentaufnahme — und sie sagte nicht, *welche*. Der Kopf zeigte den Projektnamen, der Fuß drei Zahlen; der Stand stand nirgends. Damit war das Geteilte funktional genau die PDF-Gabelung, die der Bedarf beklagt: der Empfänger hält etwas in der Hand und kann nicht feststellen, ob es noch gilt.

Bemerkenswert daran ist, dass **beide Enden schon standen**. Der Stempel ist seit ADR-004 auf jedem Blatt und in jeder Liste; die Rückfrage ist seit #709 beantwortbar (`docStandStatus` / `findByStand`, Bedarf 27). Von den acht Hex-Zeichen sagt `documentStamp.ts` wörtlich, ein Mensch könne sie *„am Telefon vorlesen und mit dem Bildschirm vergleichen"* — genau der Rückweg, den ein Freelancer ohne Konto braucht. Er stand nur nicht auf dem, was er bekommt.

## Was sich ändert

- **Der Kopf zeigt `Stand #xxxxxxxx`**, dazu die Revision und, wenn der Plan davon abweicht, „+ Änderungen". „Rev 2" allein liest sich als *dieser Stand ist Rev 2* — dieselbe Regel wie in `stampLine`.
- **Kein Druckdatum.** `printedAt` wäre hier der Moment des Öffnens: eine Aussage über den Leser statt über das Dokument. Ein Datum, das sich bei jedem Öffnen ändert, sieht aus wie eine Aktualisierung, die es nicht gab.
- **Ein Satz daneben sagt, was man mit der Zahl macht.** Acht Hex-Zeichen ohne Hinweis sind ein Rätsel; der Bedarf will, dass jemand *ohne Konto* feststellen kann, ob sein Plan noch gilt.
- **Der Rückläufer trägt den Stand im Dateinamen.** Drei annotierte Dateien im Download-Ordner hießen sonst dreimal gleich. Kein `#` — in URLs ist das der Fragment-Trenner.
- **Über `stampForPlan` und genau einmal.** Eine zweite Ableitung derselben Zahl im selben Bauteil ist die zweite Wahrheit, die irgendwann abweicht.

## Die Zahl überlebt den Weg hin und zurück

Anmerkungen gehen nicht in `planFingerprint` ein — der einzige Schreibpfad des Reviewers ändert den Stand des Plans also nicht. Sonst liefe die Rückfrage *„gilt #a1b2c3d4 noch?"* nach jeder Anmerkung ins Leere. Beide Richtungen sind festgehalten (Anmerkung ändert nichts, verschobenes Gerät sehr wohl).

## Gegenproben

Acht, alle rot: Fingerabdruck nicht im Kopf · Revision ohne Abweichungs-Hinweis · Druckdatum im Kopf · zweite Ableitung derselben Zahl · kein Hinweis auf den Rückweg · Rückläufer ohne Stand im Namen · Anmerkungen ändern den Stand · Stempel hängt an der Uhr

## Prüfstand

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — 1383 passed, 2 skipped
- `npm run lint` — 0 Errors (10 Alt-Warnungen) · `npm run build` OK

Closes Bedarf 1 aus `docs/research/synthesis/USER-NEED-DATABASE.md`, zweites Inkrement. Das erste (kein Konto) war mit #143 erledigt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_