### PR TITLE
import: jede Mengen-Operation sagt, was sie ausgelassen hat (Bedarf 65)

### DIFF
--- a/src/renderer/components/Import/CsvImportDialog.tsx
+++ b/src/renderer/components/Import/CsvImportDialog.tsx
@@ -55,11 +55,14 @@ export const CsvImportDialog = () => {
   }
 
   const doImport = () => {
-    addCustomTemplates(templates)
+    // Die Zahlen kommen aus dem BERICHT des Stores, nicht aus dem Plan
+    // (Bedarf 65). Der Plan ist die Vorschau VOR dem Klick; was danach
+    // gemeldet wird, muss das Ergebnis sein. Zwei parallel gefuehrte
+    // Zaehlungen ueber dieselbe Operation weichen irgendwann ab, und dann
+    // stimmt die falsche.
+    const bericht = addCustomTemplates(templates)
     close()
     setText('')
-    // Die Zahl im Erfolgsfenster ist jetzt die, die wirklich angelegt wurde —
-    // und was NICHT angelegt wurde, steht daneben statt nirgends.
     void infoDialog(t('csvImport.doneTitle', 'CSV importiert'), {
       body: format(
         t(
@@ -67,9 +70,14 @@ export const CsvImportDialog = () => {
           '{n} Gerät(e) neu angelegt. Unverändert geblieben: {vorhanden} bereits vorhandene(r) Name(n). Übersprungen: {ohneName} Zeile(n) ohne Namen.',
         ),
         {
-          n: plan.fresh.length,
-          vorhanden: plan.existing.length,
-          ohneName: plan.rowsWithoutName.length,
+          n: bericht.added.length,
+          // Der Plan kennt die Namen, die schon in der Library standen; der
+          // Bericht die, die es ERST BEIM ANLEGEN waren — also die, die
+          // zwischen Vorschau und Klick dazugekommen sind (zweites Fenster,
+          // Ordner-Sync). Beide zaehlen, und der zweite Fall ist genau der
+          // stille Sprung, den Bedarf 65 meint.
+          vorhanden: plan.existing.length + bericht.skipped.length,
+          ohneName: plan.rowsWithoutName.length + bericht.unnamed,
         },
       ),
       tone: 'success',

--- a/src/renderer/components/Import/GraphmlImportDialog.tsx
+++ b/src/renderer/components/Import/GraphmlImportDialog.tsx
@@ -29,6 +29,8 @@ import {
 import { useProjectStore } from '../../store/projectStore'
 import { projectHistory } from '../../store/projectHistory'
 import { useTranslation, format } from '../../lib/i18n'
+import { infoDialog } from '../../lib/infoDialog'
+import { hasOmissions } from '../../lib/templateAddReport'
 
 export interface GraphmlImportDialogProps {
   open: boolean
@@ -236,7 +238,29 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
         void _gid
         return rest
       })
-      addCustomTemplates(templates)
+      // Bedarf 65: bis hierher schloss dieser Zweig den Dialog KOMMENTARLOS.
+      // Wer zwanzig Geraete aus einem yEd-Diagramm in die Library schickte,
+      // von denen achtzehn schon dastanden, sah zwei neue Eintraege und keinen
+      // Hinweis darauf, warum.
+      const bericht = addCustomTemplates(templates)
+      void infoDialog(t('graphml.dialog.libDoneTitle', 'In die Library übernommen'), {
+        body: format(
+          t(
+            'graphml.dialog.libDoneBody',
+            '{n} Gerät(e) neu angelegt. Nicht angelegt: {vorhanden} bereits vorhandene(r) Name(n){namen}{ohneName}',
+          ),
+          {
+            n: bericht.added.length,
+            vorhanden: bericht.skipped.length,
+            namen: bericht.skipped.length > 0 ? ` — ${bericht.skipped.slice(0, 12).join(', ')}` : '',
+            ohneName:
+              bericht.unnamed > 0
+                ? format(t('graphml.dialog.libUnnamed', ' · {n} ohne Namen'), { n: bericht.unnamed })
+                : '',
+          },
+        ),
+        tone: hasOmissions(bericht) ? 'info' : 'success',
+      })
       reset()
       onClose()
       return

--- a/src/renderer/components/Settings/tabs/ProjectTab.tsx
+++ b/src/renderer/components/Settings/tabs/ProjectTab.tsx
@@ -5,6 +5,7 @@ import { Icon } from '../../shared/Icon'
 import { useProjectStore } from '../../../store/projectStore'
 import { useTranslation, format } from '../../../lib/i18n'
 import { infoDialog } from '../../../lib/infoDialog'
+import { EMPTY_TEMPLATE_ADD_REPORT, hasOmissions } from '../../../lib/templateAddReport'
 import { pickImageAsDataUri } from '../../../lib/readImageAsDataUri'
 import { SettingsCard } from '../SettingsCard'
 import { DEFAULT_CABLE_NUMBERING, cableNumberExample } from '../../../lib/cableNumbering'
@@ -88,8 +89,12 @@ const LibraryExportSection = () => {
       // Merge-by-name: addCustomTemplates only adds entries whose name
       // doesn't exist yet. Damit überschreibt der Import nie eigene
       // Edits am gleichen Template.
+      // Bedarf 65: der Bericht sagt, was WIRKLICH angelegt wurde. Bis hierher
+      // meldete das Fenster `data.customLibrary.length` — die Zahl aus der
+      // DATEI. Zweihundert importiert, drei angelegt, gemeldet: „200".
+      let bericht = EMPTY_TEMPLATE_ADD_REPORT
       if (Array.isArray(data.customLibrary)) {
-        addCustomTemplates(data.customLibrary)
+        bericht = addCustomTemplates(data.customLibrary)
       }
       if (Array.isArray(data.knownCategories)) {
         addKnownCategories(data.knownCategories)
@@ -105,9 +110,31 @@ const LibraryExportSection = () => {
       }
       await infoDialog(t('settings.project.libImport.okTitle', 'Library importiert'), {
         body:
-          `${data.customLibrary?.length ?? 0} ${t('settings.project.libImport.templatesWord', 'Geräte-Templates')} · ` +
+          `${bericht.added.length} ${t('settings.project.libImport.templatesWord', 'Geräte-Templates')} · ` +
           `${data.groupPresets?.length ?? 0} ${t('settings.project.libImport.presetsWord', 'Gruppen-Presets')}\n\n` +
-          t('settings.project.libImport.okBody', 'Nur neue Einträge wurden hinzugefügt — vorhandene Templates bleiben unverändert.'),
+          t('settings.project.libImport.okBody', 'Nur neue Einträge wurden hinzugefügt — vorhandene Templates bleiben unverändert.') +
+          // Was NICHT angelegt wurde, mit Namen. „Vorhandene bleiben
+          // unveraendert" allein sagt nicht, WELCHE und WIE VIELE — und wer
+          // die Datei geschickt hat, will genau das wissen.
+          (hasOmissions(bericht)
+            ? '\n\n' +
+              format(
+                t(
+                  'settings.project.libImport.skipped',
+                  'Nicht angelegt: {n} bereits vorhandene(r) Name(n){namen}{ohneName}',
+                ),
+                {
+                  n: bericht.skipped.length,
+                  namen: bericht.skipped.length > 0 ? ` — ${bericht.skipped.slice(0, 12).join(', ')}` : '',
+                  ohneName:
+                    bericht.unnamed > 0
+                      ? format(t('settings.project.libImport.unnamed', ' · {n} ohne Namen'), {
+                          n: bericht.unnamed,
+                        })
+                      : '',
+                },
+              )
+            : ''),
         tone: 'success',
       })
     } catch (err) {

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -268,6 +268,10 @@ export const en: Dict = {
   'settings.project.libImport.okTitle': 'Library imported',
   'settings.project.libImport.okBody':
     'Only new entries were added — existing templates remain unchanged.',
+  // Bedarf 65 — was NICHT angelegt wurde, mit Namen.
+  'settings.project.libImport.skipped':
+    'Not created: {n} name(s) that already existed{namen}{ohneName}',
+  'settings.project.libImport.unnamed': ' · {n} without a name',
   'settings.project.libImport.templatesWord': 'device templates',
   'settings.project.libImport.presetsWord': 'group presets',
   'settings.project.libImport.failTitle': 'Import failed',
@@ -1530,6 +1534,11 @@ export const en: Dict = {
   'graphml.dialog.pickOther': 'Pick another file',
   'graphml.dialog.file': 'File',
   'graphml.dialog.nodes': 'nodes',
+  // Bedarf 65 — der Library-Zweig meldete gar nichts.
+  'graphml.dialog.libDoneTitle': 'Added to the library',
+  'graphml.dialog.libDoneBody':
+    'Created {n} device(s). Not created: {vorhanden} name(s) that already existed{namen}{ohneName}',
+  'graphml.dialog.libUnnamed': ' · {n} without a name',
   'graphml.dialog.edges': 'edges',
   'graphml.dialog.otherFile': '↻ Another file',
   'graphml.dialog.devices': 'Devices',

--- a/src/renderer/lib/templateAddReport.ts
+++ b/src/renderer/lib/templateAddReport.ts
@@ -1,0 +1,64 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Was eine Mengen-Operation getan hat — und was nicht (Bedarf 65, P2).
+//
+// WAS DER BEDARF SAGT:
+//
+//   > Scanning a batch, an item that is already checked out elsewhere is
+//   > silently dropped from the list with no alert. The case leaves the
+//   > building short and nobody knows until the crew opens it on site.
+//
+//   > Any set operation in the suite (scan a case, import a list, mark a rack
+//   > packed) must end with an explicit success/skipped/why account that is
+//   > actionable on the spot. **Cheapest reliability win in the whole dossier.**
+//
+// Beleg: grokability/snipe-it#18106 (offen, auf dem Aug-2026-Meilenstein der
+// Betreuer) — „bulk checkout does not display any Alerts. Also the Asset is
+// excluded from the list… Especially if scanning multiple items."
+//
+// WO ES IN DIESER ANWENDUNG PASSIERT. `addCustomTemplates` ueberspringt
+// Namen, die es schon gibt. Das ist RICHTIG — ein Import darf eigene Edits
+// nicht ueberschreiben (dieselbe Regel wie Bedarf 96). Falsch war, dass es
+// niemand erfaehrt:
+//
+//   * Library-Import (Einstellungen): meldete die Zahl aus der DATEI, nicht
+//     die angelegte. Zweihundert Vorlagen importiert, drei angelegt, gemeldet:
+//     „200 Geraete-Templates".
+//   * GraphML-Import in die Library: meldete GAR NICHTS und schloss den
+//     Dialog.
+//   * CSV-Import: seit `cable#711` richtig — aber mit einer eigenen,
+//     danebengerechneten Zahl.
+//
+// Drei Meldungen ueber dieselbe Mengen-Operation, von denen zwei falsch waren
+// und die dritte parallel gefuehrt wurde. Deshalb steht die Auskunft jetzt am
+// ENGPASS: `addCustomTemplates` gibt zurueck, was es getan hat, und jeder
+// Aufrufer sagt dasselbe.
+//
+// REIN: keine Uhr, kein Store, kein IO, keine Uebersetzung.
+// ───────────────────────────────────────────────────────────────────────────
+
+export interface TemplateAddReport {
+  /** Namen, die neu angelegt wurden. */
+  added: string[]
+  /**
+   * Namen, die es schon gab. Sie bleiben UNVERAENDERT — der Import
+   * ueberschreibt keine Handarbeit (Bedarf 96). Aber er sagt es.
+   */
+  skipped: string[]
+  /**
+   * Eintraege ohne Namen. Sie lassen sich nicht per Namen zusammenfuehren:
+   * zwei davon haetten denselben leeren Schluessel, und der zweite
+   * ueberschriebe den ersten. Sie werden deshalb NICHT angelegt — und das
+   * ist genau die Art Verlust, die der Bedarf meint, wenn sie niemand nennt.
+   */
+  unnamed: number
+}
+
+export const EMPTY_TEMPLATE_ADD_REPORT: TemplateAddReport = {
+  added: [],
+  skipped: [],
+  unnamed: 0,
+}
+
+/** Hat die Operation etwas ausgelassen? Dann muss die Meldung es sagen. */
+export const hasOmissions = (r: TemplateAddReport): boolean =>
+  r.skipped.length > 0 || r.unnamed > 0

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -360,7 +360,12 @@ export interface ProjectState {
   ) => string
   clear: () => void
   addCustomTemplate: (template: EquipmentTemplate) => void
-  addCustomTemplates: (templates: EquipmentTemplate[]) => void
+  /** Ergaenzt die Library und BERICHTET, was dabei uebersprungen wurde
+   *  (Bedarf 65). Der Rueckgabewert ist die einzige Wahrheit darueber; wer
+   *  ihn ignoriert, meldet zwangslaeufig etwas anderes als das Ergebnis. */
+  addCustomTemplates: (
+    templates: EquipmentTemplate[],
+  ) => import('../lib/templateAddReport').TemplateAddReport
   /** v7.9.70 / #171 — Rebuild library entries for every Rentman-tagged
    *  canvas equipment whose template was lost. Returns the count of
    *  templates that were added/patched. */

--- a/src/renderer/store/slices/templateSlice.ts
+++ b/src/renderer/store/slices/templateSlice.ts
@@ -28,6 +28,8 @@ import type { ProjectState } from '../projectStore'
  * resyncRentmanLibraryFromCanvas (haengt an healRentmanLibraryFromProject,
  * dem Project-Healing-Helper).
  */
+import type { TemplateAddReport } from '../../lib/templateAddReport'
+
 export type TemplateSlice = Pick<
   ProjectState,
   | 'addCustomTemplate'
@@ -104,20 +106,43 @@ export const createTemplateSlice: StateCreator<ProjectState, [], [], TemplateSli
       if (template.rentmanId) upsertCachedRentmanTemplate(template)
       return { customLibrary: next }
     }),
-  addCustomTemplates: (templates) =>
+  /**
+   * Vorlagen ergaenzen — und SAGEN, was dabei nicht passiert ist (Bedarf 65).
+   *
+   * Uebersprungen wird weiterhin, was es schon gibt: ein Import darf eigene
+   * Edits nicht ueberschreiben. Neu ist nur, dass es niemand mehr erraten
+   * muss. Die Auskunft steht hier und nicht bei den drei Aufrufern, weil sie
+   * dort dreimal danebengerechnet wurde — einmal aus der Datei statt aus dem
+   * Ergebnis, einmal gar nicht, einmal parallel.
+   */
+  addCustomTemplates: (templates) => {
+    const report: TemplateAddReport = { added: [], skipped: [], unnamed: 0 }
     set((state) => {
       const byName = new Map(state.customLibrary.map((t) => [t.name, t]))
-      // Only add templates that don't already exist (don't overwrite user edits).
-      templates.forEach((t) => {
-        if (!byName.has(t.name)) byName.set(t.name, t)
-      })
+      for (const t of templates) {
+        const name = t.name?.trim() ?? ''
+        if (!name) {
+          // Zwei namenlose Vorlagen haetten denselben leeren Schluessel; die
+          // zweite ueberschriebe die erste. Sie werden deshalb nicht angelegt.
+          report.unnamed += 1
+          continue
+        }
+        if (byName.has(t.name)) {
+          if (!report.skipped.includes(t.name)) report.skipped.push(t.name)
+          continue
+        }
+        byName.set(t.name, t)
+        report.added.push(t.name)
+      }
       const next = Array.from(byName.values())
       persistCustomLibrary(next)
       templates.forEach((template) => {
         if (template.rentmanId) upsertCachedRentmanTemplate(template)
       })
       return { customLibrary: next }
-    }),
+    })
+    return report
+  },
   removeCustomTemplate: (name) =>
     set((state) => {
       const next = state.customLibrary.filter((t) => t.name !== name)

--- a/tests/csvImportPlan.test.ts
+++ b/tests/csvImportPlan.test.ts
@@ -164,7 +164,15 @@ describe('Erreichbarkeit im Import-Dialog', () => {
   })
 
   it('meldet am Ende die WIRKLICH angelegte Zahl', () => {
-    expect(dialogQuelle).toContain('n: plan.fresh.length')
+    // Seit Bedarf 65 kommt sie aus dem BERICHT des Stores, nicht mehr aus dem
+    // Plan. Der Plan ist die Vorschau VOR dem Klick; gemeldet werden muss das
+    // Ergebnis. Vorher stand hier `n: plan.fresh.length` -- dieselbe Zahl,
+    // aber aus der falschen Quelle: zwei parallel gefuehrte Zaehlungen ueber
+    // dieselbe Operation weichen irgendwann ab, und dann stimmt die falsche.
+    expect(dialogQuelle).toContain('n: bericht.added.length')
+    expect(dialogQuelle).not.toContain('n: plan.fresh.length')
+    // Was nur der Plan weiss, kommt weiter von ihm — die namenlosen Zeilen
+    // der DATEI sieht der Store nie.
     expect(dialogQuelle).toContain('vorhanden: plan.existing.length')
     expect(dialogQuelle).toContain('ohneName: plan.rowsWithoutName.length')
   })

--- a/tests/templateAddReport.test.ts
+++ b/tests/templateAddReport.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { useProjectStore } from '../src/renderer/store/projectStore'
+import { hasOmissions } from '../src/renderer/lib/templateAddReport'
+import type { EquipmentTemplate } from '../src/renderer/types/equipment'
+import csvQuelle from '../src/renderer/components/Import/CsvImportDialog.tsx?raw'
+import graphmlQuelle from '../src/renderer/components/Import/GraphmlImportDialog.tsx?raw'
+import projectTabQuelle from '../src/renderer/components/Settings/tabs/ProjectTab.tsx?raw'
+import dictsQuelle from '../src/renderer/lib/i18n/dicts.ts?raw'
+
+// ---------------------------------------------------------------------------
+// Keine Mengen-Operation endet stumm (Bedarf 65, P2).
+//
+//   > Any set operation in the suite (scan a case, import a list, mark a rack
+//   > packed) must end with an explicit success/skipped/why account that is
+//   > actionable on the spot. CHEAPEST RELIABILITY WIN IN THE WHOLE DOSSIER.
+//
+// Beleg: grokability/snipe-it#18106 — „bulk checkout does not display any
+// Alerts. Also the Asset is excluded from the list… Especially if scanning
+// multiple items." Der Fall dort: das Case faehrt unvollstaendig los.
+//
+// In dieser Anwendung ueberspringt `addCustomTemplates` bestehende Namen. Das
+// ist RICHTIG (Bedarf 96: ein Import darf Handarbeit nicht ueberschreiben).
+// Falsch war, dass es niemand erfuhr -- an drei Stellen auf drei Arten.
+// ---------------------------------------------------------------------------
+
+const tpl = (name: string): EquipmentTemplate =>
+  ({ name, category: 'Test', inputs: [], outputs: [], width: 220, height: 60 }) as EquipmentTemplate
+
+beforeEach(() => {
+  useProjectStore.setState({ customLibrary: [] })
+})
+
+describe('der Bericht sagt, was passiert ist', () => {
+  it('nennt die neu angelegten Namen', () => {
+    const r = useProjectStore.getState().addCustomTemplates([tpl('ATEM'), tpl('HyperDeck')])
+    expect(r.added).toEqual(['ATEM', 'HyperDeck'])
+    expect(r.skipped).toEqual([])
+    expect(hasOmissions(r)).toBe(false)
+  })
+
+  it('nennt die uebersprungenen Namen — und ueberschreibt sie NICHT', () => {
+    const eigen = { ...tpl('ATEM'), category: 'Von Hand gepflegt' }
+    useProjectStore.setState({ customLibrary: [eigen] })
+    const r = useProjectStore.getState().addCustomTemplates([tpl('ATEM'), tpl('Neu')])
+    expect(r.added).toEqual(['Neu'])
+    expect(r.skipped).toEqual(['ATEM'])
+    expect(hasOmissions(r)).toBe(true)
+    // Bedarf 96: die Handarbeit steht noch da.
+    expect(
+      useProjectStore.getState().customLibrary.find((t) => t.name === 'ATEM')?.category,
+    ).toBe('Von Hand gepflegt')
+  })
+
+  it('zaehlt namenlose Eintraege, statt sie sich gegenseitig ueberschreiben zu lassen', () => {
+    // Zwei namenlose haetten denselben leeren Schluessel; die zweite
+    // ueberschriebe die erste. Ein yEd-Knoten ohne Beschriftung ist genau
+    // dieser Fall.
+    const r = useProjectStore.getState().addCustomTemplates([tpl(''), tpl('  '), tpl('Echt')])
+    expect(r.unnamed).toBe(2)
+    expect(r.added).toEqual(['Echt'])
+    expect(useProjectStore.getState().customLibrary).toHaveLength(1)
+  })
+
+  it('nennt einen INNERHALB der Menge doppelten Namen nur einmal als uebersprungen', () => {
+    const r = useProjectStore.getState().addCustomTemplates([tpl('ATEM'), tpl('ATEM')])
+    expect(r.added).toEqual(['ATEM'])
+    expect(r.skipped).toEqual(['ATEM'])
+  })
+
+  it('meldet bei leerer Eingabe nichts und aendert nichts', () => {
+    const r = useProjectStore.getState().addCustomTemplates([])
+    expect(hasOmissions(r)).toBe(false)
+    expect(r.added).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ERREICHBARKEIT. Ein Bericht, den kein Aufrufer liest, ist keine Auskunft.
+// Genau das war der Zustand: die Zahl kam aus der Datei, aus dem Plan, oder
+// gar nicht -- nur nicht aus dem Ergebnis.
+// ---------------------------------------------------------------------------
+describe('alle drei Aufrufer melden das Ergebnis', () => {
+  it('CSV-Import nimmt die Zahl aus dem BERICHT, nicht aus dem Plan', () => {
+    expect(csvQuelle).toContain('const bericht = addCustomTemplates(templates)')
+    expect(csvQuelle).toContain('n: bericht.added.length')
+    // Der Plan bleibt die Vorschau VOR dem Klick — aber er liefert die
+    // Erfolgszahl nicht mehr.
+    expect(csvQuelle).not.toContain('n: plan.fresh.length')
+  })
+
+  it('Library-Import meldet die ANGELEGTE Zahl, nicht die aus der Datei', () => {
+    expect(projectTabQuelle).toContain('bericht = addCustomTemplates(data.customLibrary)')
+    expect(projectTabQuelle).toContain('${bericht.added.length}')
+    // Die Datei-Zahl war der Fehler: 200 importiert, 3 angelegt, „200" gemeldet.
+    expect(projectTabQuelle).not.toContain('${data.customLibrary?.length ?? 0}')
+    expect(projectTabQuelle).toContain('hasOmissions(bericht)')
+  })
+
+  it('GraphML-Import meldet ueberhaupt etwas', () => {
+    // Dieser Zweig schloss den Dialog kommentarlos.
+    expect(graphmlQuelle).toContain('const bericht = addCustomTemplates(templates)')
+    expect(graphmlQuelle).toContain("t('graphml.dialog.libDoneTitle'")
+    expect(graphmlQuelle).toContain('bericht.added.length')
+  })
+
+  it('hat fuer jeden neuen Text einen EN-Eintrag', () => {
+    for (const key of [
+      'settings.project.libImport.skipped',
+      'settings.project.libImport.unnamed',
+      'graphml.dialog.libDoneTitle',
+      'graphml.dialog.libDoneBody',
+      'graphml.dialog.libUnnamed',
+    ]) {
+      expect(dictsQuelle).toContain(`'${key}'`)
+    }
+  })
+
+  it('die Auskunft steht am ENGPASS, nicht dreimal daneben', () => {
+    // Drei Aufrufer, eine Wahrheit. Wer die Zahl selbst nachrechnet, rechnet
+    // sie irgendwann anders — genau das war der Zustand vorher.
+    for (const quelle of [csvQuelle, graphmlQuelle, projectTabQuelle]) {
+      expect(quelle).toMatch(/bericht(\s*)=(\s*)addCustomTemplates\(/)
+    }
+  })
+})


### PR DESCRIPTION
## Worum es geht

Bedarf 65 (P2) nennt sich selbst *„the cheapest reliability win in the whole dossier"*:

> Any set operation in the suite (scan a case, import a list, mark a rack packed) must end with an **explicit success/skipped/why account that is actionable on the spot**.

Der Beleg ist ein offener Fehler bei snipe-it (grokability/snipe-it#18106, auf dem Aug-2026-Meilenstein der Betreuer): beim Stapel-Scan fällt ein bereits ausgegebener Artikel wortlos aus der Liste. *„The case leaves the building short and nobody knows until the crew opens it on site."*

## Wo das hier passierte

`addCustomTemplates` überspringt Namen, die es schon gibt. Das ist **richtig** — ein Import darf eigene Edits nicht überschreiben; das ist Bedarf 96 wörtlich. Falsch war, dass es niemand erfuhr, an drei Stellen auf drei verschiedene Arten:

| Stelle | Was gemeldet wurde |
| --- | --- |
| Library-Import (Einstellungen) | `data.customLibrary.length` — die Zahl **aus der Datei**. Zweihundert importiert, drei angelegt, gemeldet: „200 Geräte-Templates". Der Satz „vorhandene bleiben unverändert" stand daneben und nannte weder wie viele noch welche. |
| GraphML-Import in die Library | **Gar nichts.** Der Dialog schloss sich. Wer zwanzig Geräte aus einem yEd-Diagramm schickte, von denen achtzehn schon dastanden, sah zwei neue Einträge und keinen Hinweis darauf, warum. |
| CSV-Import (seit #711) | Richtig — aber mit einer eigenen, daneben gerechneten Zahl. |

Drei Meldungen über dieselbe Mengen-Operation, zwei davon falsch, die dritte parallel geführt.

## Die Auskunft steht jetzt am Engpass

- **`addCustomTemplates` gibt einen `TemplateAddReport` zurück**: welche Namen neu angelegt wurden, welche schon da waren (und deshalb unverändert bleiben), und wie viele Einträge keinen Namen hatten.
- **Namenlose Einträge werden ausdrücklich gezählt** statt still verrechnet. Vorher landeten zwei davon unter demselben leeren Schlüssel, und der zweite überschrieb den ersten — ein yEd-Knoten ohne Beschriftung ist genau dieser Fall.
- **Alle drei Aufrufer melden aus dem Bericht.** Der CSV-Plan bleibt die Vorschau *vor* dem Klick und liefert weiter, was nur er weiß (die namenlosen **Zeilen der Datei**); die Erfolgszahl kommt aus dem Ergebnis.

## Ein Guard hat angeschlagen — zu Recht

Der Bedarfs-29-Guard hielt `n: plan.fresh.length` fest. Dieselbe Zahl, aber aus der falschen Quelle: zwei parallel geführte Zählungen über dieselbe Operation weichen irgendwann ab, und dann stimmt die falsche. Er ist mit der Begründung nachgezogen, warum die Quelle gewechselt hat — nicht stillschweigend gelöscht.

## Gegenproben

Acht, alle rot: übersprungene nicht gemeldet · namenlose still verschluckt · namenlose überschreiben einander · bestehende werden überschrieben · CSV meldet wieder den Plan · Library meldet die Datei-Zahl · Library verschweigt das Ausgelassene · GraphML meldet wieder nichts

## Prüfstand

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — 1393 passed, 2 skipped (126 Dateien)
- `npm run lint` — 0 Errors (10 Alt-Warnungen) · `npm run build` OK

Closes Bedarf 65 aus `docs/research/synthesis/USER-NEED-DATABASE.md` für die Library-Mengen-Operationen. Der Container-Ausgabe-Weg erfüllte die Regel schon (#707: `checkoutRefusal` ist ein sichtbarer Rückgabewert, kein stiller Sprung).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_