### PR TITLE
scan: der Bildschirm bleibt an, solange gescannt wird (Bedarf 69)

### DIFF
--- a/src/mobile/MobileApp.tsx
+++ b/src/mobile/MobileApp.tsx
@@ -40,6 +40,7 @@ import { cableLabelId } from '../renderer/lib/docIds'
 // Export "PGM" zeigten. Der Guard dagegen globte nur `src/renderer/**` und
 // konnte es nicht sehen.
 import { portDisplayLabel } from '../renderer/lib/portLabel'
+import { keepScreenAwake } from '../renderer/lib/wakeLock'
 import type { CablePlannerProject } from '../renderer/types/project'
 
 /** Deep-Link beim Laden: `?lookup=cable/C-0001` oder `#cable/C-0001` /
@@ -873,6 +874,15 @@ const QrFindOverlay = ({
   const [text, setText] = useState('')
   const [camError, setCamError] = useState<string | null>(null)
   const canScan = cameraScanSupported()
+
+  // Bedarf 69 — „the phone locks mid-scan and has to be double-tapped"
+  // (inventree-app#492). Die Sperre haengt am OVERLAY und nicht an der
+  // Kamera: wer im Lager einen Code abtippt, weil der Kamera-Scan im
+  // unsicheren LAN-Kontext gesperrt ist, hat dasselbe Problem.
+  useEffect(() => {
+    const awake = keepScreenAwake()
+    return () => awake.release()
+  }, [])
 
   useEffect(() => {
     if (!canScan) return

--- a/src/renderer/lib/barcodeScanner.ts
+++ b/src/renderer/lib/barcodeScanner.ts
@@ -10,6 +10,8 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { keepScreenAwake } from './wakeLock'
+
 /** Ist Kamera-Scannen in dieser Umgebung möglich? */
 export const isBarcodeScannerSupported = (): boolean =>
   typeof window !== 'undefined' &&
@@ -40,6 +42,11 @@ export const startCameraScan = async (
   video.setAttribute('playsinline', 'true')
   await video.play().catch(() => {})
 
+  // Bedarf 69: das Telefon darf nicht mitten im Scan zugehen. Die Sperre
+  // haengt am SCAN, nicht an einem Knopf — sie beginnt mit der Kamera und
+  // endet mit ihr, also kann sie nicht versehentlich stehenbleiben.
+  const awake = keepScreenAwake()
+
   const Detector = (window as any).BarcodeDetector
   const supported: string[] = (await Detector.getSupportedFormats?.().catch(() => FORMATS)) ?? FORMATS
   const detector = new Detector({ formats: FORMATS.filter((f) => supported.includes(f)) })
@@ -67,6 +74,7 @@ export const startCameraScan = async (
       cancelAnimationFrame(raf)
       stream.getTracks().forEach((t) => t.stop())
       video.srcObject = null
+      awake.release()
     },
   }
 }

--- a/src/renderer/lib/wakeLock.ts
+++ b/src/renderer/lib/wakeLock.ts
@@ -1,0 +1,114 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Der Bildschirm bleibt an, solange gescannt wird (Bedarf 69, P2).
+//
+// WAS DER BEDARF SAGT — sechs unabhaengige Reibungen aus drei Trackern:
+//
+//   > Scanner input submits the whole form instead of tabbing to the next
+//   > field; THE PHONE LOCKS MID-SCAN AND HAS TO BE DOUBLE-TAPPED; the scan
+//   > resolves to the company default warehouse rather than where the stock
+//   > is; scanning on receipt adds duplicate rows instead of incrementing.
+//
+//   > If the suite ever exposes a scan surface: location-context-first,
+//   > continuous scan without form submission, WAKE-LOCK WHILE SCANNING, and
+//   > idempotent quantity handling. These are six independent frictions across
+//   > three trackers — cheap to get right, very visible when wrong.
+//
+// Beleg fuer genau diesen Punkt: inventree/inventree-app#492 (2024-05) — das
+// Telefon sperrt, waehrend der Scanner offen ist.
+//
+// Diese Anwendung hat zwei Kamera-Scan-Flaechen (`lib/barcodeScanner.ts` fuer
+// den Desktop, das Overlay in `src/mobile/MobileApp.tsx` fuer das Telefon).
+// KEINE davon hielt den Bildschirm wach. Auf dem Telefon ist das die Flaeche,
+// die im Lager wirklich benutzt wird.
+//
+// ─── DER TEIL, DEN MAN VERGISST ────────────────────────────────────────────
+//
+// Die Wake-Lock-API gibt die Sperre AUTOMATISCH FREI, sobald die Seite in den
+// Hintergrund geht — und holt sie beim Zurueckkommen NICHT von allein zurueck.
+// Wer sie einmal anfordert und sich darauf verlaesst, hat nach dem ersten
+// Wechsel in eine andere App wieder genau das Problem aus dem Befund, ohne
+// dass irgendetwas eine Fehlermeldung wirft. Deshalb haengt hier ein
+// `visibilitychange`-Horcher daran, der sie neu anfordert.
+//
+// EHRLICH DEGRADIEREND, wie `barcodeScanner.ts`: wo es die API nicht gibt
+// (aelteres iOS-Safari, unsicherer Kontext), passiert nichts, es wirft nichts,
+// und die Oberflaeche behauptet nichts. Ein Hinweis „Bildschirm bleibt an",
+// der auf dem halben Geraetepark nicht stimmt, waere schlimmer als keiner.
+// ───────────────────────────────────────────────────────────────────────────
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/** Ist die Wake-Lock-API hier verfuegbar? */
+export const isWakeLockSupported = (): boolean =>
+  typeof navigator !== 'undefined' && 'wakeLock' in (navigator as any)
+
+export interface WakeLockHandle {
+  /** Sperre freigeben und den Horcher abmelden. Mehrfach aufrufbar. */
+  release: () => void
+}
+
+/**
+ * Haelt den Bildschirm wach, bis `release()` gerufen wird.
+ *
+ * Gibt IMMER ein Handle zurueck — auch ohne API-Unterstuetzung. Der Aufrufer
+ * soll `release()` bedenkenlos rufen koennen, ohne vorher zu pruefen; ein
+ * `null` hier zwaenge jede Aufrufstelle zu einer Fallunterscheidung, und die
+ * wird irgendwo vergessen.
+ */
+export const keepScreenAwake = (): WakeLockHandle => {
+  let sentinel: any = null
+  let freigegeben = false
+
+  const anfordern = async (): Promise<void> => {
+    if (freigegeben || !isWakeLockSupported()) return
+    try {
+      const neu = await (navigator as any).wakeLock.request('screen')
+      // DAS WETTRENNEN. `release()` kann waehrend dieses `await` gelaufen sein
+      // — dann ist der Horcher schon abgemeldet und `sentinel` geleert, und
+      // die eben erhaltene Sperre haette niemand mehr in der Hand. Der
+      // Bildschirm bliebe fuer den Rest der Sitzung an, ohne dass irgendwo
+      // etwas darauf zeigt. Die Pruefung VOR dem `await` faengt das nicht.
+      if (freigegeben) {
+        void neu?.release?.()
+        return
+      }
+      sentinel = neu
+    } catch {
+      // Kein Grund zur Aufregung: der Browser darf ablehnen (Akku niedrig,
+      // Richtlinie). Der Scan laeuft weiter, der Bildschirm eben nicht.
+      // Wichtig ist, dass hier NICHTS weiterfliegt: `anfordern` wird mit
+      // `void` gerufen, eine durchgelassene Ablehnung waere eine unbehandelte
+      // Promise-Ablehnung mitten im Scan.
+      sentinel = null
+    }
+  }
+
+  const beiSichtbarkeit = (): void => {
+    // Die Sperre ist beim Wechsel in den Hintergrund gefallen. Zurueck im
+    // Vordergrund muss sie neu angefordert werden — von allein kommt sie nicht.
+    if (typeof document !== 'undefined' && document.visibilityState === 'visible') {
+      void anfordern()
+    }
+  }
+
+  void anfordern()
+  if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', beiSichtbarkeit)
+  }
+
+  return {
+    release: () => {
+      if (freigegeben) return
+      freigegeben = true
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', beiSichtbarkeit)
+      }
+      try {
+        void sentinel?.release?.()
+      } catch {
+        /* Schon freigegeben oder nie gehalten — beides in Ordnung. */
+      }
+      sentinel = null
+    },
+  }
+}

--- a/tests/wakeLock.test.ts
+++ b/tests/wakeLock.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { isWakeLockSupported, keepScreenAwake } from '../src/renderer/lib/wakeLock'
+import scannerQuelle from '../src/renderer/lib/barcodeScanner.ts?raw'
+import mobileQuelle from '../src/mobile/MobileApp.tsx?raw'
+
+// ---------------------------------------------------------------------------
+// Der Bildschirm bleibt an, solange gescannt wird (Bedarf 69, P2).
+//
+//   > Scanner input submits the whole form instead of tabbing to the next
+//   > field; THE PHONE LOCKS MID-SCAN and has to be double-tapped; […]
+//   > If the suite ever exposes a scan surface: location-context-first,
+//   > continuous scan without form submission, WAKE-LOCK WHILE SCANNING, and
+//   > idempotent quantity handling. Cheap to get right, very visible when
+//   > wrong.
+//
+// Beleg fuer diesen Punkt: inventree/inventree-app#492 (2024-05).
+//
+// Der Teil, den man vergisst, ist nicht das Anfordern, sondern das ERNEUTE
+// Anfordern: die API gibt die Sperre beim Wechsel in den Hintergrund von
+// selbst frei und holt sie NICHT zurueck. Genau darauf zielt der groesste
+// Teil dieser Datei.
+// ---------------------------------------------------------------------------
+
+interface FakeSentinel {
+  released: boolean
+  release: () => Promise<void>
+}
+
+const anfragen: FakeSentinel[] = []
+let ablehnen = false
+
+const fakeWakeLock = {
+  request: vi.fn(async (typ: string) => {
+    expect(typ).toBe('screen')
+    if (ablehnen) throw new Error('policy')
+    const s: FakeSentinel = {
+      released: false,
+      release: async () => {
+        s.released = true
+      },
+    }
+    anfragen.push(s)
+    return s
+  }),
+}
+
+const setzeSichtbarkeit = (v: 'visible' | 'hidden'): void => {
+  Object.defineProperty(document, 'visibilityState', { value: v, configurable: true })
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
+beforeEach(() => {
+  anfragen.length = 0
+  ablehnen = false
+  fakeWakeLock.request.mockClear()
+  Object.defineProperty(navigator, 'wakeLock', { value: fakeWakeLock, configurable: true })
+  Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
+})
+
+afterEach(() => {
+  Reflect.deleteProperty(navigator as unknown as Record<string, unknown>, 'wakeLock')
+})
+
+const flush = () => new Promise((r) => setTimeout(r, 0))
+
+describe('die Sperre wird gehalten und wieder freigegeben', () => {
+  it('fordert sie beim Start an', async () => {
+    const h = keepScreenAwake()
+    await flush()
+    expect(fakeWakeLock.request).toHaveBeenCalledTimes(1)
+    h.release()
+  })
+
+  it('gibt sie beim Freigeben zurueck', async () => {
+    const h = keepScreenAwake()
+    await flush()
+    h.release()
+    await flush()
+    expect(anfragen[0].released).toBe(true)
+  })
+
+  it('vertraegt doppeltes Freigeben', async () => {
+    const h = keepScreenAwake()
+    await flush()
+    h.release()
+    h.release()
+    expect(anfragen).toHaveLength(1)
+  })
+})
+
+describe('der Teil, den man vergisst', () => {
+  it('fordert sie NEU an, wenn die Seite zurueckkommt', async () => {
+    // Die API gibt die Sperre im Hintergrund von selbst frei und holt sie
+    // nicht zurueck. Ohne diesen Horcher waere die Sperre nach dem ersten
+    // App-Wechsel weg -- lautlos, ohne Fehler, und das Telefon geht wieder
+    // mitten im Scan zu.
+    const h = keepScreenAwake()
+    await flush()
+    expect(fakeWakeLock.request).toHaveBeenCalledTimes(1)
+
+    setzeSichtbarkeit('hidden')
+    await flush()
+    setzeSichtbarkeit('visible')
+    await flush()
+
+    expect(fakeWakeLock.request).toHaveBeenCalledTimes(2)
+    h.release()
+  })
+
+  it('fordert NICHT neu an, nachdem freigegeben wurde', async () => {
+    // Sonst haelt ein geschlossenes Overlay den Bildschirm weiter wach, und
+    // zwar fuer immer.
+    const h = keepScreenAwake()
+    await flush()
+    h.release()
+    setzeSichtbarkeit('hidden')
+    setzeSichtbarkeit('visible')
+    await flush()
+    expect(fakeWakeLock.request).toHaveBeenCalledTimes(1)
+  })
+
+  it('meldet sich beim Freigeben vom Horcher ab', async () => {
+    const ab = vi.spyOn(document, 'removeEventListener')
+    const h = keepScreenAwake()
+    await flush()
+    h.release()
+    expect(ab).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+    ab.mockRestore()
+  })
+})
+
+describe('ehrlich degradierend', () => {
+  it('ohne API passiert nichts und es wirft nichts', async () => {
+    Reflect.deleteProperty(navigator as unknown as Record<string, unknown>, 'wakeLock')
+    expect(isWakeLockSupported()).toBe(false)
+    const h = keepScreenAwake()
+    await flush()
+    expect(() => h.release()).not.toThrow()
+  })
+
+  it('eine Ablehnung des Browsers erzeugt KEINE unbehandelte Ablehnung', async () => {
+    // Akku niedrig, Richtlinie -- der Scan laeuft weiter, der Bildschirm eben
+    // nicht. `anfordern` wird mit `void` gerufen; wuerde die Ablehnung
+    // durchgelassen, waere sie eine unbehandelte Promise-Ablehnung mitten im
+    // Scan. Ein blosses `expect(release).not.toThrow()` sieht das NICHT --
+    // die erste Fassung dieser Pruefung blieb deshalb gruen, als die
+    // Gegenprobe ein `throw` in den catch-Block setzte.
+    const unhandled: unknown[] = []
+    const horcher = (e: unknown) => unhandled.push(e)
+    process.on('unhandledRejection', horcher)
+    ablehnen = true
+    const h = keepScreenAwake()
+    await flush()
+    await flush()
+    process.off('unhandledRejection', horcher)
+    expect(unhandled).toEqual([])
+    expect(() => h.release()).not.toThrow()
+  })
+
+  it('gibt eine Sperre frei, die WAEHREND des Freigebens ankommt', async () => {
+    // Das Wettrennen: `release()` laeuft, waehrend die Anfrage noch offen ist.
+    // Die Pruefung vor dem `await` faengt das nicht -- danach haelt niemand
+    // mehr die eben erhaltene Sperre, und der Bildschirm bleibt fuer den Rest
+    // der Sitzung an, ohne dass irgendwo etwas darauf zeigt.
+    const h = keepScreenAwake()
+    h.release() // noch bevor die Anfrage zurueck ist
+    await flush()
+    await flush()
+    expect(anfragen[0]?.released).toBe(true)
+  })
+
+  it('gibt IMMER ein Handle zurueck, auch ohne API', () => {
+    Reflect.deleteProperty(navigator as unknown as Record<string, unknown>, 'wakeLock')
+    // Ein `null` zwaenge jede Aufrufstelle zu einer Fallunterscheidung, und
+    // die wird irgendwo vergessen.
+    expect(typeof keepScreenAwake().release).toBe('function')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ERREICHBARKEIT. Beide Scan-Flaechen muessen sie halten -- die auf dem
+// Telefon ist die, die im Lager wirklich benutzt wird.
+// ---------------------------------------------------------------------------
+describe('beide Scan-Flaechen halten sie', () => {
+  it('der Kamera-Scanner haengt sie an den Scan, nicht an einen Knopf', () => {
+    expect(scannerQuelle).toContain("from './wakeLock'")
+    expect(scannerQuelle).toContain('const awake = keepScreenAwake()')
+    // Sie endet mit der Kamera -- also kann sie nicht stehenbleiben.
+    expect(scannerQuelle).toContain('awake.release()')
+  })
+
+  it('das Telefon-Overlay haelt sie, auch wenn die Kamera gesperrt ist', () => {
+    // Wer im unsicheren LAN-Kontext den Code abtippt, hat dasselbe Problem.
+    expect(mobileQuelle).toContain("from '../renderer/lib/wakeLock'")
+    expect(mobileQuelle).toMatch(/const awake = keepScreenAwake\(\)\n\s*return \(\) => awake\.release\(\)/)
+  })
+
+  it('die Code-Eingabe schickt KEIN Formular ab', () => {
+    // Die erste der sechs Reibungen (snipe-it#17057): ein Hardware-Scanner
+    // schickt ein Enter, und ein Formular darunter macht daraus ein Absenden.
+    // Hier ruft Enter `submitText()` -- es gibt gar kein Formular.
+    expect(mobileQuelle).toContain("if (e.key === 'Enter') submitText()")
+    expect(mobileQuelle).not.toMatch(/<form[\s>]/)
+  })
+})


### PR DESCRIPTION
## Worum es geht

Bedarf 69 (P2) zählt sechs unabhängige Reibungen aus drei Trackern auf und nennt sie *„cheap to get right, very visible when wrong"*. Eine davon trifft diese Anwendung direkt:

> the phone locks mid-scan and has to be double-tapped

Beleg: inventree/inventree-app#492 (2024-05).

Diese Anwendung hat **zwei** Kamera-Scan-Flächen — `lib/barcodeScanner.ts` für den Desktop und das Overlay in `src/mobile/MobileApp.tsx` für das Telefon. **Keine davon hielt den Bildschirm wach**, und die auf dem Telefon ist die, die im Lager wirklich benutzt wird.

## Was dazukommt

`lib/wakeLock.ts` (neu), mit derselben Bauform wie `barcodeScanner.ts`: **ehrlich degradierend.** Wo es die API nicht gibt (älteres iOS-Safari, unsicherer Kontext), passiert nichts, es wirft nichts, und die Oberfläche behauptet nichts — ein Hinweis „Bildschirm bleibt an", der auf dem halben Gerätepark nicht stimmt, wäre schlimmer als keiner.

**Der Teil, den man vergisst, ist nicht das Anfordern.** Die Wake-Lock-API gibt die Sperre automatisch frei, sobald die Seite in den Hintergrund geht, und holt sie beim Zurückkommen **nicht** von allein zurück. Wer sie einmal anfordert, hat nach dem ersten App-Wechsel wieder genau das Problem aus dem Befund — lautlos, ohne Fehlermeldung. Deshalb hängt ein `visibilitychange`-Horcher daran.

Die Sperre hängt am **Scan**, nicht an einem Knopf: sie beginnt mit der Kamera und endet mit ihr, also kann sie nicht stehenbleiben. Im Telefon-Overlay hängt sie am **Overlay**, weil dort im unsicheren LAN-Kontext oft von Hand getippt wird — dasselbe Problem, ohne Kamera.

Die erste der sechs Reibungen (snipe-it#17057, *„form submits on scan"*) war hier schon in Ordnung: das Eingabefeld steht in keinem Formular, Enter ruft `submitText()`. Neu ist nur der Guard, der das festhält.

## Zwei Gegenproben blieben zunächst grün — beide haben etwas Echtes aufgedeckt

**1. Ein Wettrennen beim Freigeben.** `release()` kann während des `await` der Anfrage laufen. Dann ist der Horcher abgemeldet und `sentinel` geleert — und die eben erhaltene Sperre hält niemand mehr in der Hand: der Bildschirm bliebe für den Rest der Sitzung an, ohne dass irgendwo etwas darauf zeigt. Die Prüfung *vor* dem `await` fängt das nicht. Eine während des Freigebens ankommende Sperre wird jetzt sofort zurückgegeben.

**2. Eine Zusicherung, die ihre eigene Behauptung nicht prüfen konnte.** „Eine Ablehnung des Browsers ist kein Fehler" prüfte nur `expect(release).not.toThrow()`. Die Ablehnung fällt aber in einem mit `void` gerufenen Promise an, nicht synchron — die Gegenprobe mit einem `throw` im catch-Block lief durch. Der Test horcht jetzt auf `unhandledRejection`.

Elf Gegenproben insgesamt, nach der Verschärfung alle rot.

## Prüfstand

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — 1406 passed, 2 skipped (127 Dateien)
- `npm run lint` — 0 Errors (10 Alt-Warnungen) · `npm run build` OK

Closes Bedarf 69 aus `docs/research/synthesis/USER-NEED-DATABASE.md` für die beiden Reibungen, die auf die vorhandenen Scan-Flächen zutreffen (Wake-Lock, kein Formular-Absenden). Die übrigen vier setzen einen Wareneingangs- bzw. Mengen-Scan voraus, den es hier nicht gibt — „location-context-first" und „idempotent quantity handling" hätten ohne diese Fläche kein Zuhause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_