### PR TITLE
lager: „Bestand" ist nicht „verfügbar" (Bedarf 80)

### DIFF
--- a/src/renderer/components/Export/ExportDialog.tsx
+++ b/src/renderer/components/Export/ExportDialog.tsx
@@ -42,6 +42,7 @@ import { sanitizeForPdf } from '../../lib/sanitizeForPdf'
 import { downloadBlob } from '../../lib/downloadBlob'
 import { buildTallyMap, tallyMapCsv, toTallyPiDevices } from '../../lib/tallyMap'
 import { buildPlanBom, outcomeLabel, pickListCsv, planBomCsv } from '../../lib/planBom'
+import { useCheckoutStore } from '../../store/checkoutStore'
 import { zusatzBedarf } from '../../lib/planDemandExtras'
 import { useInventoryStore } from '../../store/inventoryStore'
 import { exportGroupAsPatchPdf, buildGroupPatchPdfBlob } from '../../lib/exportGroupPdf'
@@ -1437,9 +1438,13 @@ const DeviceBomSection = () => {
     () => zusatzBedarf({ drumKit, wirelessRig, cables, equipment }),
     [drumKit, wirelessRig, cables, equipment],
   )
+  // Bedarf 80: die offenen Ausgaben gehoeren in die Rechnung. Ohne sie sagt
+  // die Stueckliste „Bestand 5" fuer ein Case, das auf einer anderen Show
+  // steht — „the PM promises gear they do not have".
+  const checkoutRecords = useCheckoutStore((s) => s.records)
   const bom = useMemo(
-    () => buildPlanBom(equipment, items, nodes, units, zusatz),
-    [equipment, items, nodes, units, zusatz],
+    () => buildPlanBom(equipment, items, nodes, units, zusatz, checkoutRecords),
+    [equipment, items, nodes, units, zusatz, checkoutRecords],
   )
 
   const download = (suffix: string, content: string) =>
@@ -1525,7 +1530,22 @@ const DeviceBomSection = () => {
                         </button>
                       )}
                     </td>
-                    <td className="px-2 py-1 font-mono">{row.available ?? '—'}</td>
+                    {/* Bedarf 80: die Qualifizierung steht IN DEMSELBEN
+                        Zug wie die Zahl („5 im Lager · 3 verfügbar"), nicht
+                        in einer Fussnote und nicht in einem Tooltip. Und die
+                        Bindung steht am Objekt, das sie hat — nicht als
+                        ausgegrauter Knopf irgendwo anders. */}
+                    <td className="px-2 py-1 font-mono">
+                      {row.available ?? '—'}
+                      {row.committed !== undefined && row.committed > 0 && (
+                        <span className="ml-1 font-sans text-cp-warn" title={row.commitmentNote}>
+                          {format(
+                            t('export.devicebom.committed', '(von {stock} · {n} auf Ausgabe)'),
+                            { stock: row.stock ?? '?', n: row.committed },
+                          )}
+                        </span>
+                      )}
+                    </td>
                     <td className="px-2 py-1 text-cp-text-secondary">{row.location || '—'}</td>
                   </tr>
                 ))}

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -2298,6 +2298,8 @@ export const en: Dict = {
   'export.devicebom.noTypeTitle':
     'No catalogue type — the model name here is only the device name. Assigning a catalogue type turns the coverage into a fact.',
   'export.devicebom.short': '— {n} missing',
+  // Bedarf 80 — die Zahl traegt ihre Qualifizierung mit.
+  'export.devicebom.committed': '(of {stock} · {n} checked out)',
   'export.devicebom.confirm': 'Confirm',
   'export.devicebom.confirmTitle':
     'Writes the catalogue identity permanently onto this inventory position. The coverage is then a fact and never has to be guessed from the name again.',

--- a/src/renderer/lib/inventoryCommitment.ts
+++ b/src/renderer/lib/inventoryCommitment.ts
@@ -1,0 +1,121 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Was gerade auf einem anderen Job ist (Bedarf 80, P2).
+//
+// WAS DER BEDARF SAGT:
+//
+//   > A number meaning 'stock' is read as a number meaning 'available'.
+//   > Index shows '5 pcs' while detail shows '0 available'; index says
+//   > 'Partial custody' (on site) while detail says 'Partially checked out'
+//   > (gone on a booking). THE PM PROMISES GEAR THEY DO NOT HAVE.
+//
+// Belegt mit sechs unabhaengigen Fehlern von vier Meldern ueber fuenfzehn
+// Monate (shelf.nu#1761, #1817, #2724 u. a.).
+//
+// Und die Entwurfsregel dazu, woertlich: „every quantity carries its
+// availability qualifier in the same glyph run ('5 pcs · 0 available'), and
+// conflicts are labelled ON THE OBJECT THAT HAS THEM, never announced as a
+// disabled button."
+//
+// ─── WARUM DAS HIER ENTSTEHEN KANN ─────────────────────────────────────────
+//
+// Seit `cable#707` gibt es das Ausgabe-Register: welcher Container ist raus,
+// an wen, fuer welche Show, und WAS TATSAECHLICH DRIN WAR (eingefroren, nicht
+// aus der Kit-Vorlage). Damit ist „wie viele Stueck dieses Artikels sind
+// gerade draussen" eine ableitbare Zahl.
+//
+// `resolveCoverage` wusste davon nichts. Sein `available` war der LAGERBESTAND
+// abzueglich defekter Einheiten — und zaehlte damit Geraete mit, die
+// physisch auf einer anderen Show stehen. Genau der Satz aus dem Befund: die
+// Produktionsleitung sagt Technik zu, die sie nicht hat.
+//
+// ─── ZWEI FALLSTRICKE, DIE HIER BEWUSST BEHANDELT SIND ─────────────────────
+//
+// 1. VERSCHACHTELTE CONTAINER NICHT DOPPELT ZAEHLEN. Eine Ausgabe fuehrt ein
+//    Case IM Case als eigene Zeile UND seinen Inhalt einzeln (Bedarf 15).
+//    Wer die `node`-Zeilen mitzaehlt, zaehlt denselben Inhalt zweimal.
+//
+// 2. EINE EINHEIT GEHOERT ZU EINEM ARTIKEL. Die Ausgabe-Zeile einer
+//    serialisierten Einheit traegt ihre eigene Id, nicht die des Artikels —
+//    das ist Absicht („children keep their own ERP identities"). Fuer die
+//    Bestandsrechnung muss sie ueber `units` aufgeloest werden, sonst
+//    reduziert eine ausgegebene Funkstrecke den Bestand ihres Modells nicht.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { CheckoutRecord } from '../types/checkout'
+import type { InventoryUnit } from '../types/inventory'
+
+export interface Commitment {
+  /** Stueckzahl dieses Artikels auf offenen Ausgaben. */
+  quantity: number
+  /**
+   * Woher die Bindung kommt — je offener Vorgang eine Zeile.
+   *
+   * Der Bedarf verlangt, dass ein Konflikt AN DEM OBJEKT steht, das ihn hat,
+   * „never announced as a disabled button". Eine blosse Zahl sagt „zwei sind
+   * weg"; erst der Vorgang sagt, WOHIN — und nur damit kann jemand
+   * entscheiden, ob er sie zurueckholt oder umplant.
+   */
+  on: Array<{ recordId: string; nodeLabel: string; projectName?: string; quantity: number }>
+}
+
+/**
+ * Wie viele Stueck je Artikel gerade auf einer offenen Ausgabe stehen.
+ *
+ * `units` wird gebraucht, um die Zeile einer serialisierten Einheit ihrem
+ * Artikel zuzuordnen. Fehlt die Einheit im heutigen Bestand (geloescht,
+ * seither umgebucht), zaehlt sie nichts — sie ist dann auch im Bestand nicht
+ * mehr drin, den sie mindern wuerde.
+ */
+export const committedByItem = (
+  records: CheckoutRecord[],
+  units: InventoryUnit[] = [],
+): Map<string, Commitment> => {
+  const itemOfUnit = new Map(units.map((u) => [u.id, u.itemId]))
+  const out = new Map<string, Commitment>()
+
+  for (const r of records) {
+    if (r.in) continue // zurueck = nicht mehr gebunden
+    for (const line of r.contents) {
+      // Fallstrick 1: der Inhalt des verschachtelten Cases steht schon
+      // einzeln in derselben Liste.
+      if (line.kind === 'node') continue
+      const itemId = line.kind === 'unit' ? itemOfUnit.get(line.refId) : line.refId
+      if (!itemId) continue
+      const menge = Number.isFinite(line.quantity) && line.quantity > 0 ? line.quantity : 0
+      if (menge === 0) continue
+      const vorhanden = out.get(itemId)
+      const eintrag = {
+        recordId: r.id,
+        nodeLabel: r.nodeLabel,
+        ...(r.out.projectName ? { projectName: r.out.projectName } : {}),
+        quantity: menge,
+      }
+      if (vorhanden) {
+        vorhanden.quantity += menge
+        const gleicherVorgang = vorhanden.on.find((o) => o.recordId === r.id)
+        if (gleicherVorgang) gleicherVorgang.quantity += menge
+        else vorhanden.on.push(eintrag)
+      } else {
+        out.set(itemId, { quantity: menge, on: [eintrag] })
+      }
+    }
+  }
+  return out
+}
+
+/**
+ * Die Zusatz-Angabe fuer eine Zeile, in kanonischem Deutsch.
+ *
+ * Der Bedarf will die Qualifizierung „in the same glyph run" — nicht in einer
+ * Fussnote, nicht in einem Tooltip. Deshalb ist das ein Textstueck und keine
+ * eigene Spalte: es steht da, wo die Zahl steht.
+ */
+export const commitmentNote = (c: Commitment | undefined): string => {
+  if (!c || c.quantity === 0) return ''
+  const wohin = c.on
+    .map((o) => `${o.quantity}× ${o.projectName ?? o.nodeLabel}`)
+    .join(', ')
+  return `${c.quantity} auf offener Ausgabe (${wohin})`
+}

--- a/src/renderer/lib/inventoryCoverage.ts
+++ b/src/renderer/lib/inventoryCoverage.ts
@@ -29,6 +29,8 @@
 
 import type { EquipmentItem } from '../types/equipment'
 import type { InventoryItem, InventoryUnit } from '../types/inventory'
+import type { CheckoutRecord } from '../types/checkout'
+import { commitmentNote, committedByItem } from './inventoryCommitment'
 import type { ZusatzBedarf } from './planDemandExtras'
 import { resolveDeviceType } from './deviceTypeRegistry'
 import { isWithinDistance } from './levenshtein'
@@ -63,8 +65,16 @@ export interface CoverageLine {
   /** Deckende bzw. VORGESCHLAGENE Lager-Position. */
   itemId?: string
   itemModel?: string
-  /** Bestand dieser Position. */
+  /** VERFUEGBAR ueber alle deckenden Positionen: Bestand abzueglich
+   *  unbrauchbarer Einheiten und abzueglich offener Ausgaben (Bedarf 80). */
   available?: number
+  /** Bestand IM LAGER, ohne Ruecksicht auf offene Ausgaben. */
+  stock?: number
+  /** Davon gerade auf einer offenen Ausgabe. 0 wird weggelassen. */
+  committed?: number
+  /** Auf welchen Vorgaengen — der Konflikt steht am Objekt, nicht als
+   *  ausgegrauter Knopf. */
+  commitmentNote?: string
   /** Fehlmenge, wenn der Bestand nicht reicht. Nur bei matched aussagekraeftig:
    *  bei einem Vorschlag ist noch gar nicht sicher, dass es die Position ist. */
   short?: number
@@ -95,8 +105,25 @@ export interface CoverageLine {
 /** Eine einzelne Lager-Position, die zu einer Bedarfszeile beitraegt. */
 export interface CoverageSource {
   itemId: string
-  /** Nutzbarer Bestand: Menge abzueglich bekannt unbrauchbarer Einheiten. */
+  /**
+   * VERFUEGBAR: Bestand abzueglich unbrauchbarer Einheiten UND abzueglich
+   * dessen, was gerade auf einer offenen Ausgabe steht (Bedarf 80).
+   *
+   * Der Name bleibt `available`, und das ist Absicht: er bedeutet jetzt, was
+   * er sagt. Bis `cable#714` war es der Lagerbestand — und jede Stelle, die
+   * ihn las, versprach damit Technik, die auf einer anderen Show stand
+   * („the PM promises gear they do not have"). Wer den Bestand braucht,
+   * nimmt `stock`.
+   */
   available: number
+  /** Nutzbarer Bestand IM LAGER: Menge abzueglich unbrauchbarer Einheiten,
+   *  ohne Ruecksicht auf offene Ausgaben. */
+  stock: number
+  /** Davon gerade auf einer offenen Ausgabe. 0 wird weggelassen. */
+  committed?: number
+  /** Auf WELCHEN Vorgaengen — der Bedarf verlangt den Konflikt am Objekt,
+   *  nicht als blosse Zahl. Leer, wenn nichts gebunden ist. */
+  commitmentNote?: string
   model: string
   /** Lagerort-Id der Position — der Aufrufer loest den Pfad auf. */
   locationId?: string
@@ -296,6 +323,13 @@ export const resolveCoverage = (
   items: InventoryItem[],
   units: InventoryUnit[] = [],
   zusatz: ZusatzBedarf[] = [],
+  /**
+   * Offene Ausgaben (Bedarf 80). Fehlt der Parameter, rechnet die Deckung wie
+   * bisher gegen den blossen Lagerbestand — das ist der ehrliche Rueckfall
+   * fuer Aufrufer, die kein Ausgabe-Register haben (Mobile, Viewer), und
+   * NICHT der Normalfall. Wer eins hat, reicht es durch.
+   */
+  checkouts: CheckoutRecord[] = [],
 ): CoverageResult => {
   const demands = deriveDemand(equipment, zusatz)
 
@@ -313,20 +347,54 @@ export const resolveCoverage = (
     .slice()
     .sort((a, b) => a.model.localeCompare(b.model, 'de') || a.id.localeCompare(b.id))
 
+  // Bedarf 80: was gerade auf einer offenen Ausgabe steht. Aus demselben
+  // Register, das `cable#707` angelegt hat — kein zweiter Zustand.
+  const gebunden = committedByItem(checkouts, units)
+
   const quelle = (item: InventoryItem): CoverageSource => {
     // Nicht unter null: mehr unbrauchbare Einheiten als Bestand waere ein
     // widerspruechlicher Datenstand, und eine negative Menge in einer
     // Kommissionier-Liste ist schlimmer als eine zu kleine.
     const unusable = Math.min(item.quantity, unbrauchbarProItem.get(item.id) ?? 0)
+    const stock = item.quantity - unusable
+    const c = gebunden.get(item.id)
+    // Dieselbe Regel wie oben: nicht unter null. Mehr ausgegeben als im
+    // Bestand ist ein widerspruechlicher Datenstand (jemand hat den Artikel
+    // nach der Ausgabe reduziert) — dann ist „nichts verfuegbar" die
+    // richtige Antwort, keine negative Zahl.
+    const committed = Math.min(stock, c?.quantity ?? 0)
+    const note = commitmentNote(c)
     return {
       itemId: item.id,
       model: item.model,
-      available: item.quantity - unusable,
+      available: stock - committed,
+      stock,
+      ...(committed > 0 ? { committed } : {}),
+      ...(note ? { commitmentNote: note } : {}),
       ...(item.locationId ? { locationId: item.locationId } : {}),
       ...(unusable > 0 ? { unusable } : {}),
     }
   }
   const summe = (q: CoverageSource[]): number => q.reduce((n, x) => n + x.available, 0)
+  const summeStock = (q: CoverageSource[]): number => q.reduce((n, x) => n + x.stock, 0)
+  const summeGebunden = (q: CoverageSource[]): number =>
+    q.reduce((n, x) => n + (x.committed ?? 0), 0)
+  /** Die Bindungen aller Positionen einer Zeile, mit „ · " verbunden. Wer nur
+   *  die erste liest, ruft beim falschen Job an. */
+  const notizen = (q: CoverageSource[]): string =>
+    q.map((x) => x.commitmentNote).filter(Boolean).join(' · ')
+  /** Die drei Zahlen einer Zeile in einem Zug — der Bedarf verlangt die
+   *  Qualifizierung neben der Zahl, nicht in einer Fussnote. */
+  const mengen = (q: CoverageSource[]) => {
+    const gebundenSumme = summeGebunden(q)
+    const note = notizen(q)
+    return {
+      available: summe(q),
+      stock: summeStock(q),
+      ...(gebundenSumme > 0 ? { committed: gebundenSumme } : {}),
+      ...(note ? { commitmentNote: note } : {}),
+    }
+  }
 
   // ALLE Positionen je Typ, nicht die erste. Siehe CoverageLine.sources.
   const byType = new Map<string, CoverageSource[]>()
@@ -349,14 +417,17 @@ export const resolveCoverage = (
   const lines: CoverageLine[] = demands.map((demand) => {
     const exactType = demand.deviceTypeId ? byType.get(demand.deviceTypeId) : undefined
     if (exactType && exactType.length > 0) {
-      const bestand = summe(exactType)
-      const short = Math.max(0, demand.quantity - bestand)
+      // Die Fehlmenge zaehlt gegen das VERFUEGBARE, nicht gegen den Bestand
+      // (Bedarf 80). Sonst meldet die Liste „gedeckt" fuer Technik, die auf
+      // einer anderen Show steht.
+      const verfuegbar = summe(exactType)
+      const short = Math.max(0, demand.quantity - verfuegbar)
       return {
         demand,
         outcome: 'matched-by-type',
         itemId: exactType[0].itemId,
         itemModel: exactType[0].model,
-        available: bestand,
+        ...mengen(exactType),
         sources: exactType,
         ...(short > 0 ? { short } : {}),
       }
@@ -370,7 +441,7 @@ export const resolveCoverage = (
         outcome: 'proposed-by-name',
         itemId: exactName[0].itemId,
         itemModel: exactName[0].model,
-        available: summe(exactName),
+        ...mengen(exactName),
         sources: exactName,
         reason: `Modellname stimmt ueberein ("${exactName[0].model}"), aber die Lager-Position traegt keine Typ-Identitaet.`,
       }
@@ -393,7 +464,7 @@ export const resolveCoverage = (
           outcome: 'proposed-by-name',
           itemId: gleiche[0].itemId,
           itemModel: gleiche[0].model,
-          available: summe(gleiche),
+          ...mengen(gleiche),
           sources: gleiche,
           reason: `Modellname weicht um hoechstens ${MAX_EDIT_DISTANCE} Zeichen ab ("${near.model}") — bitte pruefen.`,
         }

--- a/src/renderer/lib/planBom.ts
+++ b/src/renderer/lib/planBom.ts
@@ -22,6 +22,7 @@
 import type { EquipmentItem } from '../types/equipment'
 import type { InventoryItem, InventoryUnit, StorageNode } from '../types/inventory'
 import { resolveCoverage, type CoverageLine, type CoverageOutcome } from './inventoryCoverage'
+import type { CheckoutRecord } from '../types/checkout'
 import type { ZusatzBedarf } from './planDemandExtras'
 import { nodePathLabel } from './storageTree'
 import { toCsv } from './csv'
@@ -33,8 +34,15 @@ export interface PlanBomRow {
   model: string
   category?: string
   outcome: CoverageOutcome
-  /** Bestand der deckenden bzw. vorgeschlagenen Position. */
+  /** VERFUEGBAR: Bestand abzueglich unbrauchbarer Einheiten und abzueglich
+   *  offener Ausgaben (Bedarf 80). */
   available?: number
+  /** Bestand IM LAGER, ohne Ruecksicht auf offene Ausgaben. */
+  stock?: number
+  /** Davon gerade auf einer offenen Ausgabe. */
+  committed?: number
+  /** Auf welchen Vorgaengen, im Klartext. */
+  commitmentNote?: string
   /** Fehlmenge — nur bei einer echten Deckung aussagekräftig. */
   short?: number
   /** Serialisierte Einheiten, die nicht einsatzbereit sind (defekt, in
@@ -101,6 +109,13 @@ const rowOf = (
     ...(line.demand.category ? { category: line.demand.category } : {}),
     outcome: line.outcome,
     ...(line.available !== undefined ? { available: line.available } : {}),
+    // Bedarf 80: die Zahl traegt ihre Qualifizierung MIT. Ein blosser Bestand
+    // ohne den Hinweis, dass die Haelfte davon auf einer anderen Show steht,
+    // ist genau die Zahl, an der die Produktionsleitung Technik zusagt, die
+    // sie nicht hat.
+    ...(line.stock !== undefined ? { stock: line.stock } : {}),
+    ...(line.committed !== undefined ? { committed: line.committed } : {}),
+    ...(line.commitmentNote ? { commitmentNote: line.commitmentNote } : {}),
     ...(line.short !== undefined ? { short: line.short } : {}),
     // Nicht einsatzbereite Einheiten werden BENANNT, nicht bloss abgezogen.
     // Ein stiller Abzug sieht aus wie ein zu kleiner Bestand, und der naechste
@@ -133,8 +148,12 @@ export const buildPlanBom = (
   nodes: StorageNode[],
   units: InventoryUnit[] = [],
   zusatz: ZusatzBedarf[] = [],
+  /** Offene Ausgaben (Bedarf 80). Ohne sie rechnet die Liste gegen den
+   *  blossen Lagerbestand und verspricht Technik, die auf einer anderen Show
+   *  steht. */
+  checkouts: CheckoutRecord[] = [],
 ): PlanBom => {
-  const coverage = resolveCoverage(equipment, items, units, zusatz)
+  const coverage = resolveCoverage(equipment, items, units, zusatz, checkouts)
   const rows = coverage.lines.map((line) => rowOf(line, items, nodes))
   return {
     rows,
@@ -153,13 +172,29 @@ export const buildPlanBom = (
 /** Die kaufmännische Sicht: was der Plan braucht, mit Deckungsstand. */
 export const planBomCsv = (bom: PlanBom): string =>
   toCsv(
-    ['Menge', 'Modell', 'Kategorie', 'Deckung', 'Bestand', 'Fehlmenge', 'Nicht einsatzbereit', 'Hinweis'],
+    // Bedarf 80: „Bestand" und „Verfuegbar" stehen NEBENEINANDER, und dazu
+    // die Bindung im Klartext. Eine einzige Spalte „Bestand" liest jeder als
+    // „so viel kann ich einplanen" — und genau daran haengt der Befund.
+    [
+      'Menge',
+      'Modell',
+      'Kategorie',
+      'Deckung',
+      'Bestand',
+      'Verfuegbar',
+      'Auf offener Ausgabe',
+      'Fehlmenge',
+      'Nicht einsatzbereit',
+      'Hinweis',
+    ],
     bom.rows.map((r) => [
       r.quantity,
       r.model,
       r.category ?? '',
       outcomeLabel(r.outcome),
+      r.stock ?? '',
       r.available ?? '',
+      r.commitmentNote ?? '',
       r.short ?? '',
       r.unusable ?? '',
       r.reason ?? (r.modelIsDeviceName ? 'Ohne Katalog-Typ — Modellname ist der Gerätename.' : ''),

--- a/tests/lagerdeckungMehrereOrte.test.ts
+++ b/tests/lagerdeckungMehrereOrte.test.ts
@@ -73,9 +73,13 @@ describe('der Bestand wird ueber Lagerpositionen summiert', () => {
 
   it('beide Positionen stehen als Quelle drin', () => {
     const res = resolveCoverage(plan(5), zweiOrte(3, 3))
+    // `stock` kam mit Bedarf 80 dazu: ohne offene Ausgabe ist es dasselbe wie
+    // `available`, und genau das haelt die Zeile hier fest. Auseinander gehen
+    // die beiden erst, wenn ein Case draussen ist — das prueft
+    // `tests/verfuegbarkeitGegenAusgaben.test.ts`.
     expect(res.lines[0].sources).toEqual([
-      { itemId: 'i1', model: MODELL, available: 3, locationId: 'c1' },
-      { itemId: 'i2', model: MODELL, available: 3, locationId: 'c2' },
+      { itemId: 'i1', model: MODELL, available: 3, stock: 3, locationId: 'c1' },
+      { itemId: 'i2', model: MODELL, available: 3, stock: 3, locationId: 'c2' },
     ])
   })
 

--- a/tests/verfuegbarkeitGegenAusgaben.test.ts
+++ b/tests/verfuegbarkeitGegenAusgaben.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest'
+import { committedByItem, commitmentNote } from '../src/renderer/lib/inventoryCommitment'
+import { resolveCoverage } from '../src/renderer/lib/inventoryCoverage'
+import { buildPlanBom, planBomCsv } from '../src/renderer/lib/planBom'
+import type { CheckoutRecord } from '../src/renderer/types/checkout'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+import type { InventoryItem, InventoryUnit, StorageNode } from '../src/renderer/types/inventory'
+import exportQuelle from '../src/renderer/components/Export/ExportDialog.tsx?raw'
+import dictsQuelle from '../src/renderer/lib/i18n/dicts.ts?raw'
+
+// ---------------------------------------------------------------------------
+// „Bestand" ist nicht „verfuegbar" (Bedarf 80, P2).
+//
+//   > A number meaning 'stock' is read as a number meaning 'available'. […]
+//   > THE PM PROMISES GEAR THEY DO NOT HAVE.
+//
+// Belegt mit sechs unabhaengigen Fehlern von vier Meldern ueber fuenfzehn
+// Monate. Die Entwurfsregel dazu, woertlich: „every quantity carries its
+// availability qualifier in the same glyph run […] and conflicts are labelled
+// ON THE OBJECT THAT HAS THEM, never announced as a disabled button."
+//
+// Seit `cable#707` weiss diese Anwendung, welcher Container gerade draussen
+// ist und was drin war. `resolveCoverage` wusste davon nichts: sein
+// `available` war der Lagerbestand und zaehlte Technik mit, die physisch auf
+// einer anderen Show stand.
+// ---------------------------------------------------------------------------
+
+const TYP = 'eb02ca7e-856c-40ab-9a73-d1e98110f003'
+const MODELL = 'Sony PMW-F55'
+
+const eq = (over: Partial<EquipmentItem>): EquipmentItem => ({
+  id: 'e1',
+  name: 'Gerät',
+  category: 'Kameras',
+  inputs: [],
+  outputs: [],
+  x: 0,
+  y: 0,
+  width: 200,
+  height: 160,
+  ...over,
+})
+
+const item = (over: Partial<InventoryItem>): InventoryItem => ({
+  id: 'i1',
+  model: MODELL,
+  quantity: 1,
+  createdAt: 't',
+  updatedAt: 't',
+  ...over,
+})
+
+const unit = (id: string, itemId: string) =>
+  ({ id, itemId, condition: 'ok', history: [], createdAt: 't', updatedAt: 't' }) as unknown as InventoryUnit
+
+const NODES: StorageNode[] = [
+  { id: 'depot', name: 'Depot', kind: 'depot', createdAt: 't', updatedAt: 't' } as StorageNode,
+  { id: 'c1', name: 'Case 1', kind: 'case', parentId: 'depot', createdAt: 't', updatedAt: 't' } as StorageNode,
+]
+
+const plan = (n: number) => Array.from({ length: n }, (_, i) => eq({ id: `e${i}`, deviceTypeId: TYP }))
+const lager = (n: number) => [item({ id: 'i1', quantity: n, deviceTypeId: TYP, locationId: 'c1' })]
+
+const ausgabe = (over: Partial<CheckoutRecord> = {}): CheckoutRecord => ({
+  id: 'r1',
+  nodeId: 'c1',
+  nodeLabel: 'Case 1',
+  out: { at: '2026-09-01T08:00:00Z', to: 'Truck 2', projectName: 'Show B' },
+  contents: [{ kind: 'item', refId: 'i1', label: MODELL, quantity: 2 }],
+  ...over,
+})
+
+describe('was draussen ist, zaehlt nicht zum Verfuegbaren', () => {
+  it('fuenf im Lager, zwei auf einer offenen Ausgabe: drei verfuegbar', () => {
+    const res = resolveCoverage(plan(5), lager(5), [], [], [ausgabe()])
+    expect(res.lines[0]).toMatchObject({ stock: 5, committed: 2, available: 3 })
+  })
+
+  it('die Fehlmenge zaehlt gegen das VERFUEGBARE, nicht gegen den Bestand', () => {
+    // Genau der Satz aus dem Befund: sonst meldet die Liste „gedeckt" fuer
+    // Technik, die auf einer anderen Show steht.
+    const res = resolveCoverage(plan(5), lager(5), [], [], [ausgabe()])
+    expect(res.lines[0].short).toBe(2)
+  })
+
+  it('ein zurueckgebuchter Vorgang bindet nichts mehr', () => {
+    const zurueck = ausgabe({ in: { at: '2026-09-02T08:00:00Z', missing: [], extra: [] } })
+    const res = resolveCoverage(plan(5), lager(5), [], [], [zurueck])
+    expect(res.lines[0]).toMatchObject({ stock: 5, available: 5 })
+    expect(res.lines[0].committed).toBeUndefined()
+  })
+
+  it('ohne Ausgabe-Register bleibt alles wie vorher', () => {
+    // Der ehrliche Rueckfall fuer Aufrufer ohne Register (Mobile, Viewer).
+    const res = resolveCoverage(plan(5), lager(5))
+    expect(res.lines[0]).toMatchObject({ stock: 5, available: 5 })
+  })
+})
+
+describe('die drei Fallstricke des Zaehlens', () => {
+  it('zaehlt den Inhalt eines verschachtelten Cases NICHT doppelt', () => {
+    // Eine Ausgabe fuehrt das Case im Case als eigene Zeile UND seinen Inhalt
+    // einzeln (Bedarf 15). Wer die `node`-Zeile mitzaehlt, zaehlt zweimal.
+    const m = committedByItem([
+      ausgabe({
+        contents: [
+          { kind: 'node', refId: 'c2', label: 'Case 2', quantity: 1 },
+          { kind: 'item', refId: 'i1', label: MODELL, quantity: 2 },
+        ],
+      }),
+    ])
+    expect(m.get('i1')?.quantity).toBe(2)
+    expect(m.get('c2')).toBeUndefined()
+  })
+
+  it('loest eine ausgegebene EINHEIT auf ihren Artikel auf', () => {
+    // Die Zeile traegt die Id der Einheit, nicht die des Artikels — das ist
+    // Absicht („children keep their own ERP identities"). Ohne die Aufloesung
+    // mindert eine ausgegebene Funkstrecke den Bestand ihres Modells nicht.
+    const m = committedByItem(
+      [ausgabe({ contents: [{ kind: 'unit', refId: 'u1', label: 'SN-1', quantity: 1 }] })],
+      [unit('u1', 'i1')],
+    )
+    expect(m.get('i1')?.quantity).toBe(1)
+  })
+
+  it('geht nicht unter null, wenn mehr draussen ist als im Bestand', () => {
+    // Widerspruechlicher Datenstand (jemand hat den Artikel nach der Ausgabe
+    // reduziert). „Nichts verfuegbar" ist die richtige Antwort.
+    const res = resolveCoverage(plan(1), lager(1), [], [], [
+      ausgabe({ contents: [{ kind: 'item', refId: 'i1', label: MODELL, quantity: 9 }] }),
+    ])
+    expect(res.lines[0].available).toBe(0)
+    expect(res.lines[0].committed).toBe(1)
+  })
+})
+
+describe('der Konflikt steht am Objekt, das ihn hat', () => {
+  it('nennt Menge und Ziel, nicht nur eine Zahl', () => {
+    // „never announced as a disabled button": erst der Vorgang sagt, WOHIN —
+    // und nur damit kann jemand entscheiden, ob er zurueckholt oder umplant.
+    const res = resolveCoverage(plan(5), lager(5), [], [], [ausgabe()])
+    expect(res.lines[0].commitmentNote).toBe('2 auf offener Ausgabe (2× Show B)')
+  })
+
+  it('faellt auf den Container zurueck, wenn keine Show benannt ist', () => {
+    const ohneShow = ausgabe({ out: { at: 't', to: 'Truck 2' } })
+    expect(commitmentNote(committedByItem([ohneShow]).get('i1'))).toBe(
+      '2 auf offener Ausgabe (2× Case 1)',
+    )
+  })
+
+  it('fasst mehrere Vorgaenge zusammen, ohne einen zu verschweigen', () => {
+    const m = committedByItem([
+      ausgabe(),
+      ausgabe({ id: 'r2', out: { at: 't', to: 'Truck 3', projectName: 'Show C' } }),
+    ])
+    expect(m.get('i1')?.quantity).toBe(4)
+    expect(commitmentNote(m.get('i1'))).toBe('4 auf offener Ausgabe (2× Show B, 2× Show C)')
+  })
+
+  it('ohne Bindung gibt es keinen Text', () => {
+    expect(commitmentNote(undefined)).toBe('')
+  })
+})
+
+describe('das Blatt zeigt beide Zahlen', () => {
+  it('die CSV hat Bestand UND Verfuegbar nebeneinander', () => {
+    // Eine einzige Spalte „Bestand" liest jeder als „so viel kann ich
+    // einplanen" — daran haengt der ganze Befund.
+    const bom = buildPlanBom(plan(5), lager(5), NODES, [], [], [ausgabe()])
+    const zeilen = planBomCsv(bom).split('\r\n')
+    expect(zeilen[0]).toContain('Bestand;Verfuegbar;Auf offener Ausgabe')
+    expect(zeilen[1]).toContain('5;3;2 auf offener Ausgabe')
+  })
+
+  it('die Zeile gilt als fehlend, obwohl der Bestand reicht', () => {
+    const bom = buildPlanBom(plan(5), lager(5), NODES, [], [], [ausgabe()])
+    expect(bom.missing).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ERREICHBARKEIT. Eine ehrliche Zahl, die kein Fenster zeigt, ist keine.
+// ---------------------------------------------------------------------------
+describe('Erreichbarkeit im Export-Dialog', () => {
+  it('reicht die offenen Ausgaben in die Rechnung durch', () => {
+    expect(exportQuelle).toContain("from '../../store/checkoutStore'")
+    expect(exportQuelle).toContain('buildPlanBom(equipment, items, nodes, units, zusatz, checkoutRecords)')
+    // Ohne die Abhaengigkeit rechnet das Memo nach einer Ausgabe nicht neu.
+    expect(exportQuelle).toContain('[equipment, items, nodes, units, zusatz, checkoutRecords]')
+  })
+
+  it('zeigt die Qualifizierung NEBEN der Zahl', () => {
+    // „in the same glyph run", nicht in einer Fussnote und nicht nur im
+    // Tooltip: der Tooltip traegt zusaetzlich die Vorgaenge.
+    expect(exportQuelle).toContain("t('export.devicebom.committed'")
+    expect(exportQuelle).toContain('title={row.commitmentNote}')
+    expect(dictsQuelle).toContain("'export.devicebom.committed'")
+  })
+})


### PR DESCRIPTION
## Worum es geht

Bedarf 80 (P2), belegt mit **sechs unabhängigen Fehlern von vier Meldern über fünfzehn Monate**:

> A number meaning 'stock' is read as a number meaning 'available'. […] **The PM promises gear they do not have.**

Die Entwurfsregel dazu, wörtlich: *„every quantity carries its availability qualifier in the same glyph run ('5 pcs · 0 available'), and conflicts are labelled **on the object that has them**, never announced as a disabled button."*

## Der Fehler war hier, nicht nur im Markt

Seit #707 weiß diese Anwendung, welcher Container gerade draußen ist, an wen, für welche Show und **was tatsächlich drin war**. `resolveCoverage` wusste davon nichts: sein `available` war der Lagerbestand abzüglich defekter Einheiten — und zählte damit Technik mit, die physisch auf einer anderen Show steht. Die Stückliste meldete „gedeckt", die Kommissionier-Liste schickte jemanden ins Regal, und dort stand nichts.

## Was sich ändert

| | |
| --- | --- |
| `lib/inventoryCommitment.ts` (neu, rein) | Leitet aus dem Register ab, wie viele Stück je Artikel auf offenen Ausgaben stehen — **und auf welchen**. Der Bedarf verlangt den Konflikt am Objekt; eine bloße Zahl sagt „zwei sind weg", erst der Vorgang sagt wohin. |
| `CoverageSource` / `CoverageLine` | Drei Zahlen statt einer: `stock` (im Lager), `committed` (auf Ausgabe), `available` (die ehrliche). Der Name `available` bleibt und bedeutet ab jetzt, was er sagt — jede Stelle, die ihn liest, bekommt damit die richtige Zahl, ohne angefasst zu werden. |
| Fehlmenge | Zählt gegen das **Verfügbare**. Sonst meldet die Liste weiter „gedeckt" für Technik auf einer anderen Show. |
| CSV + Tabelle | „Bestand" und „Verfügbar" nebeneinander, plus die Bindung im Klartext — in **demselben Zug** wie die Zahl, mit den Vorgängen im Titel. |

## Zwei Fallstricke, bewusst behandelt und einzeln geprüft

1. **Ein verschachteltes Case** steht in der Ausgabe als eigene Zeile **und** mit seinem Inhalt einzeln (Bedarf 15). Wer die `node`-Zeilen mitzählt, zählt denselben Inhalt zweimal.
2. **Die Zeile einer serialisierten Einheit** trägt ihre eigene Id, nicht die des Artikels (*„children keep their own ERP identities"*). Ohne Auflösung über `units` mindert eine ausgegebene Funkstrecke den Bestand ihres Modells nicht.

Und: **mehr draußen als im Bestand geht nicht unter null.** Das ist ein widersprüchlicher Datenstand, und „nichts verfügbar" ist die richtige Antwort — eine negative Menge in einer Kommissionier-Liste ist schlimmer als eine zu kleine, dieselbe Regel wie bei den unbrauchbaren Einheiten.

Ohne Ausgabe-Register rechnet alles wie bisher: der ehrliche Rückfall für Aufrufer, die keins haben (Mobile, Viewer).

## Gegenproben

Zehn, alle rot: Ausgaben mindern nichts · Fehlmenge gegen den Bestand · zurückgebuchte binden weiter · verschachteltes Case doppelt · Einheit nicht aufgelöst · geht unter null · Notiz nennt kein Ziel · CSV ohne Verfügbar-Spalte · Dialog reicht nichts durch · Qualifizierung nicht neben der Zahl

## Prüfstand

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — 1421 passed, 2 skipped (128 Dateien)
- `npm run lint` — 0 Errors (10 Alt-Warnungen) · `npm run build` OK

`tests/lagerdeckungMehrereOrte.test.ts` bekam das neue `stock`-Feld in seine Quellen-Zusicherung eingetragen, mit dem Hinweis, dass die beiden Zahlen ohne offene Ausgabe gleich sind.

Closes Bedarf 80 aus `docs/research/synthesis/USER-NEED-DATABASE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_