### PR TITLE
lager: Schaden mit Zuordnung beim Einchecken (Bedarf 68)

### DIFF
--- a/src/renderer/components/Inventory/InventoryDialog.tsx
+++ b/src/renderer/components/Inventory/InventoryDialog.tsx
@@ -49,7 +49,8 @@ import type {
 } from '../../types/inventory'
 import { useCheckoutStore } from '../../store/checkoutStore'
 import { ownershipNote, overdueSubhire, subhireStatus } from '../../lib/ownership'
-import type { CheckoutRecord } from '../../types/checkout'
+import type { CheckoutDamage, CheckoutRecord } from '../../types/checkout'
+import { damageEntries, damageTable, damageTally } from '../../lib/damageRegister'
 import {
   containerContents,
   checkoutSheet,
@@ -1658,6 +1659,10 @@ const CheckoutTab = () => {
   // Bedarf 16 — der Papierweg zurueck. Der Code vom Blatt wird gegen die
   // Ausgabeliste gehalten; das Abhaken auf Papier wird damit zur EINGABE fuer
   // den Datensatz statt zu einem zweiten, der ihm widerspricht.
+  // Bedarf 68 — Schaeden, aufgenommen in dem Moment, in dem das Objekt in der
+  // Hand ist. Schluessel: `recordId` → `kind:refId` → Text.
+  const [damageDraft, setDamageDraft] = useState<Record<string, Record<string, string>>>({})
+  const [damageOpen, setDamageOpen] = useState<Record<string, boolean>>({})
   const [scanDraft, setScanDraft] = useState<Record<string, string>>({})
   const [scanEcho, setScanEcho] = useState<Record<string, { text: string; ok: boolean }>>({})
 
@@ -1665,6 +1670,9 @@ const CheckoutTab = () => {
   const container = useMemo(() => nodes.filter((n) => isContainerKind(n.kind)), [nodes])
   const offen = useMemo(() => records.filter((r) => !r.in), [records])
   const zurueck = useMemo(() => records.filter((r) => r.in), [records])
+  // Bedarf 68 — die aufgenommenen Schaeden mit ihrer abgeleiteten Zuordnung.
+  const schaeden = useMemo(() => damageEntries(records), [records])
+  const haeufung = useMemo(() => damageTally(records, 'person'), [records])
   // Der Stichtag kommt EINMAL aus der Uhr und wird durchgereicht — sonst
   // beantwortet dieselbe Zeile in zwei Zellen zwei verschiedene Tage.
   const heute = new Date().toISOString().slice(0, 10)
@@ -1691,6 +1699,22 @@ const CheckoutTab = () => {
       setProjectName('')
       setDueBack('')
     }
+  }
+
+  /** Die aufgenommenen Schaeden eines Vorgangs, als Belegzeilen. */
+  const damageOf = (r: CheckoutRecord): CheckoutDamage[] => {
+    const entwurf = damageDraft[r.id] ?? {}
+    return r.contents
+      .map((line) => ({ line, note: (entwurf[`${line.kind}:${line.refId}`] ?? '').trim() }))
+      .filter((d) => d.note.length > 0)
+  }
+
+  const bucheZurueck = (r: CheckoutRecord) => {
+    checkIn(snap, r.id, undefined, damageOf(r))
+    // Der Entwurf ist verbraucht: er steht jetzt im Beleg, und ein
+    // stehengebliebener Text landete beim naechsten Vorgang im falschen.
+    setDamageDraft((d) => ({ ...d, [r.id]: {} }))
+    setDamageOpen((o) => ({ ...o, [r.id]: false }))
   }
 
   const scanBack = (r: CheckoutRecord) => {
@@ -1862,9 +1886,21 @@ const CheckoutTab = () => {
                     >
                       {t('inventory.checkout.sheet', 'Schein')}
                     </button>
+                    {/* Bedarf 68: der Schaden wird aufgenommen, BEVOR
+                        zurueckgebucht wird — danach ist der Beleg zu, und ein
+                        Beleg darf nicht nachtraeglich anders lauten. */}
                     <button
                       type="button"
-                      onClick={() => checkIn(snap, r.id)}
+                      onClick={() => setDamageOpen((o) => ({ ...o, [r.id]: !o[r.id] }))}
+                      className="mr-2 text-cp-text-secondary hover:text-cp-text"
+                    >
+                      {format(t('inventory.checkout.damageBtn', 'Schaden ({n})'), {
+                        n: damageOf(r).length,
+                      })}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => bucheZurueck(r)}
                       className="mr-2 text-cp-text-secondary hover:text-cp-text"
                     >
                       {t('inventory.checkout.doIn', 'Zurückbuchen')}
@@ -1880,6 +1916,46 @@ const CheckoutTab = () => {
                   </td>
                 </tr>
               ))}
+              {/* Bedarf 68 — die Aufnahme selbst. Eine Zeile je Position des
+                  Vorgangs; wer nichts eintraegt, hat keinen Schaden gemeldet.
+                  KEIN Ankreuzfeld: „beschaedigt" ohne Angabe hilft weder der
+                  Werkstatt noch der Rechnung. */}
+              {offen
+                .filter((r) => damageOpen[r.id])
+                .map((r) => (
+                  <tr key={`${r.id}-damage`} className="border-t border-cp-border-muted">
+                    <td colSpan={3} className="bg-cp-surface-2 px-2 py-1.5">
+                      <div className="mb-1 text-cp-text-secondary">
+                        {format(t('inventory.checkout.damageTitle', 'Schaden aufnehmen — {name}'), {
+                          name: r.nodeLabel,
+                        })}
+                      </div>
+                      <ul className="flex max-h-48 flex-col gap-1 overflow-y-auto">
+                        {r.contents.map((line) => {
+                          const key = `${line.kind}:${line.refId}`
+                          return (
+                            <li key={key} className="flex items-center gap-2">
+                              <span className="min-w-[9rem] flex-none truncate text-cp-text-muted">
+                                {line.label}
+                              </span>
+                              <input
+                                value={damageDraft[r.id]?.[key] ?? ''}
+                                onChange={(e) =>
+                                  setDamageDraft((d) => ({
+                                    ...d,
+                                    [r.id]: { ...(d[r.id] ?? {}), [key]: e.target.value },
+                                  }))
+                                }
+                                placeholder={t('inventory.checkout.damagePh', 'Was ist kaputt?')}
+                                className="flex-1 rounded border border-cp-border bg-cp-surface-3 px-1.5 py-1"
+                              />
+                            </li>
+                          )
+                        })}
+                      </ul>
+                    </td>
+                  </tr>
+                ))}
             </tbody>
           </table>
         )}
@@ -1970,6 +2046,59 @@ const CheckoutTab = () => {
                 </li>
               ))}
           </ul>
+        </div>
+      )}
+
+      {/* BEDARF 68 — Schaden MIT ZUORDNUNG. Der Bedarf nennt sie „the valuable
+          field" (job, person, time, container) und das Foto ausdruecklich
+          nicht. Die Zuordnung steht nicht am Schaden, sondern wird aus dem
+          Vorgang abgeleitet — vier gespeicherte Felder waeren von der ersten
+          Korrektur am Vorgang an falsch.
+
+          Die Haeufungs-Zeile ist der Wunsch aus dem Beleg (snipe-it#13153):
+          „to see whether particular people/locations tend to break devices
+          more often". Sie ZAEHLT und urteilt nicht — ein Werkzeug, das aus
+          drei Vorfaellen eine Schuld macht, wird beim vierten nicht mehr
+          gefuettert. */}
+      {schaeden.length > 0 && (
+        <div className="rounded border border-cp-danger/40">
+          <div className="flex items-center justify-between border-b border-cp-border-muted bg-cp-surface-2 px-2 py-1">
+            <span className="flex items-center gap-1.5 font-medium">
+              <AlertTriangle size={13} />
+              {format(t('inventory.checkout.damageTitleList', 'Schäden ({n})'), { n: schaeden.length })}
+            </span>
+            <button
+              type="button"
+              onClick={() => csv('schaeden.csv', damageTable(records))}
+              className="flex items-center gap-1 text-cp-text-secondary hover:text-cp-text"
+            >
+              <Download size={12} /> CSV
+            </button>
+          </div>
+          <ul className="flex flex-col gap-0.5 px-2 py-1.5">
+            {schaeden.slice(0, 12).map((e, i) => (
+              <li key={`${e.recordId}-${e.label}-${i}`} className="text-cp-text-secondary">
+                {format(
+                  t('inventory.checkout.damageLine', '{at} · {label}: {note} — {job}, an {person} ({container})'),
+                  {
+                    at: e.at.slice(0, 10),
+                    label: e.label,
+                    note: e.note,
+                    job: e.job,
+                    person: e.person,
+                    container: e.container,
+                  },
+                )}
+              </li>
+            ))}
+          </ul>
+          {haeufung.length > 1 && (
+            <div className="border-t border-cp-border-muted px-2 py-1.5 text-cp-text-muted">
+              {format(t('inventory.checkout.damageTally', 'Häufung nach Ausgabe an: {list}'), {
+                list: haeufung.map((h) => `${h.key} (${h.count})`).join(', '),
+              })}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/renderer/lib/containerCheckout.ts
+++ b/src/renderer/lib/containerCheckout.ts
@@ -20,7 +20,7 @@ import type {
   InventoryUnit,
   StorageNode,
 } from '../types/inventory'
-import type { CheckoutLine, CheckoutRecord } from '../types/checkout'
+import type { CheckoutDamage, CheckoutLine, CheckoutRecord } from '../types/checkout'
 import { descendantNodeIds, isContainerKind, nodePathLabel } from './storageTree'
 import type { CsvCell, CsvTable } from './csv'
 import { ownershipNote } from './ownership'
@@ -211,9 +211,25 @@ export const closeCheckout = (
   jetzt: CheckoutLine[],
   at: string,
   note?: string,
+  /** Schaeden, die beim Einchecken aufgenommen wurden (Bedarf 68). Getrennt
+   *  von den Fehlmengen: ein beschaedigtes Objekt IST da. */
+  damaged?: CheckoutDamage[],
 ): CheckoutRecord => {
   const { missing, extra } = checkinDifference(record, jetzt)
-  return { ...record, in: { at, missing, extra, ...(note ? { note } : {}) } }
+  // Ohne Text kein Eintrag: „beschaedigt" ohne Angabe hilft weder der
+  // Werkstatt noch der Rechnung, und eine leere Zeile im Beleg sieht aus wie
+  // eine Aussage.
+  const echte = (damaged ?? []).filter((d) => d.note.trim().length > 0)
+  return {
+    ...record,
+    in: {
+      at,
+      missing,
+      extra,
+      ...(echte.length > 0 ? { damaged: echte.map((d) => ({ ...d, note: d.note.trim() })) } : {}),
+      ...(note ? { note } : {}),
+    },
+  }
 }
 
 /** Offene Vorgaenge (noch nicht zurueck). */

--- a/src/renderer/lib/damageRegister.ts
+++ b/src/renderer/lib/damageRegister.ts
@@ -1,0 +1,141 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Schaden mit Zuordnung (Bedarf 68, P2).
+//
+// WAS DER BEDARF SAGT:
+//
+//   > Damage evidence is photos in a WhatsApp thread plus a paper condition
+//   > form; the load-out list was ticked in the dark or does not exist. With
+//   > 24-hour reporting windows commonly cited, an undocumented load-out
+//   > becomes an UNCHARGED, UNATTRIBUTABLE loss.
+//
+//   > Damage capture belongs on the device already in their hand AT CHECK-IN,
+//   > and the valuable field is THE ATTRIBUTION (job, person, time,
+//   > container), not the photo. Feeds the invoice-or-absorb decision
+//   > directly.
+//
+// Beleg: grokability/snipe-it#13153 (2023-06, offen, zuletzt 2025-10) — der
+// Wunsch, dass ein Reparatur-Datensatz festhaelt, WEM das Geraet zugeordnet
+// war und WO es stand, ausdruecklich „to see whether particular
+// people/locations tend to break devices more often".
+//
+// ─── WARUM DIE ZUORDNUNG NICHT AM SCHADEN HAENGT ───────────────────────────
+//
+// `CheckoutDamage` traegt nur die Zeile und den Text. Job, Person, Zeit und
+// Container stehen im VORGANG, an dem der Schaden haengt. Sie dort noch einmal
+// zu speichern ergaebe vier Felder, die von der ersten Korrektur am Vorgang an
+// falsch waeren — und ein Beleg, der sich selbst widerspricht, ist keiner.
+//
+// Diese Datei leitet sie deshalb ab. Das ist der ganze Trick: der Bedarf nennt
+// die Zuordnung „the valuable field", und sie kostet kein einziges
+// gespeichertes Byte.
+//
+// ─── WAS HIER NICHT ENTSTEHT ───────────────────────────────────────────────
+//
+// Keine Schuldzuweisung. Die Auswertung nach Person und Ort ist das, was der
+// Beleg woertlich verlangt, und sie sagt „hier haeuft es sich" — nicht „der
+// war es". Ein Werkzeug, das aus drei Vorfaellen ein Urteil macht, wird beim
+// vierten nicht mehr gefuettert, und dann ist die Datenlage schlechter als
+// vorher.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { CheckoutRecord } from '../types/checkout'
+import type { CsvCell, CsvTable } from './csv'
+
+export interface DamageEntry {
+  recordId: string
+  /** Was beschaedigt ist. */
+  label: string
+  /** Etiketten-Code, wenn das Objekt einen traegt. */
+  code?: string
+  note: string
+  // ── Die Zuordnung, abgeleitet aus dem Vorgang ────────────────────────────
+  /** Die Show, wenn sie benannt war. Leer, wenn nicht — und das steht dann da. */
+  job: string
+  /** An wen ausgegeben war (Person, Truck, Kunde). */
+  person: string
+  /** Der Container, in dem es unterwegs war. */
+  container: string
+  /** Zeitpunkt der Rueckgabe (ISO), also wann der Schaden aufgenommen wurde. */
+  at: string
+}
+
+const UNBEKANNT = 'nicht benannt'
+
+/**
+ * Alle Schaeden aller abgeschlossenen Vorgaenge, mit ihrer Zuordnung.
+ *
+ * Neueste zuerst: wer das Fenster oeffnet, will wissen, was gerade
+ * zurueckkam — die Rechnung dafuer geht diese Woche raus.
+ */
+export const damageEntries = (records: CheckoutRecord[]): DamageEntry[] => {
+  const out: DamageEntry[] = []
+  for (const r of records) {
+    for (const d of r.in?.damaged ?? []) {
+      out.push({
+        recordId: r.id,
+        label: d.line.label,
+        ...(d.line.code ? { code: d.line.code } : {}),
+        note: d.note,
+        // Fehlt eine Angabe, steht das DA statt wegzufallen. „Wir wissen nicht,
+        // auf welcher Show" ist die Auskunft, die den naechsten Vorgang
+        // besser macht; eine leere Zelle ist keine.
+        job: r.out.projectName?.trim() || UNBEKANNT,
+        person: r.out.to.trim() || UNBEKANNT,
+        container: r.nodeLabel,
+        at: r.in?.at ?? '',
+      })
+    }
+  }
+  return out.sort((a, b) => b.at.localeCompare(a.at) || a.label.localeCompare(b.label, 'de'))
+}
+
+export interface DamageTally {
+  key: string
+  count: number
+}
+
+/**
+ * Wo es sich haeuft — nach Person oder nach Container.
+ *
+ * Genau die Frage aus dem Beleg: „to see whether particular people/locations
+ * tend to break devices more often". Die Antwort ist eine ZAEHLUNG, kein
+ * Urteil; wer daraus eine Schuld macht, hat die Zahl missverstanden.
+ *
+ * Ohne Vorfaelle eine leere Liste — und der Aufrufer zeigt dann nichts, statt
+ * „0 Schaeden" zu melden.
+ */
+export const damageTally = (
+  records: CheckoutRecord[],
+  nach: 'person' | 'container' | 'job',
+): DamageTally[] => {
+  const zaehler = new Map<string, number>()
+  for (const e of damageEntries(records)) {
+    const k = nach === 'person' ? e.person : nach === 'container' ? e.container : e.job
+    zaehler.set(k, (zaehler.get(k) ?? 0) + 1)
+  }
+  return [...zaehler.entries()]
+    .map(([key, count]) => ({ key, count }))
+    .sort((a, b) => b.count - a.count || a.key.localeCompare(b.key, 'de'))
+}
+
+/**
+ * Das Blatt fuer die Entscheidung „berechnen oder tragen".
+ *
+ * Der Bedarf nennt sie beim Namen („feeds the invoice-or-absorb decision
+ * directly"), und dafuer braucht sie genau diese Spalten: was, woran, wem,
+ * wann. Kanonisches Deutsch, weil das Blatt einen Stand traegt.
+ */
+export const damageTable = (records: CheckoutRecord[]): CsvTable => ({
+  headers: ['Zurueck am', 'Objekt', 'Etiketten-Code', 'Schaden', 'Show', 'Ausgegeben an', 'Container'],
+  rows: damageEntries(records).map((e): CsvCell[] => [
+    e.at.slice(0, 10),
+    e.label,
+    e.code ?? 'kein Etikett',
+    e.note,
+    e.job,
+    e.person,
+    e.container,
+  ]),
+})

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3659,6 +3659,13 @@ export const en: Dict = {
   'inventory.returnNoDate': '{qty}× {model} → {supplier} · no return date',
   'inventory.returnsMore': '… and {n} more',
   'inventory.supplierUnknown': 'supplier unknown',
+  // Bedarf 68 — Schaden mit Zuordnung.
+  'inventory.checkout.damageBtn': 'Damage ({n})',
+  'inventory.checkout.damageTitle': 'Record damage — {name}',
+  'inventory.checkout.damagePh': 'What is broken?',
+  'inventory.checkout.damageTitleList': 'Damage ({n})',
+  'inventory.checkout.damageLine': '{at} · {label}: {note} — {job}, out to {person} ({container})',
+  'inventory.checkout.damageTally': 'Concentration by who it went out to: {list}',
   'inventory.notes': 'Note',
   'inventory.empty': 'No inventory items yet. Add some or import them from the plan.',
   'inventory.noMatch': 'No items match the search.',

--- a/src/renderer/store/checkoutStore.ts
+++ b/src/renderer/store/checkoutStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { v4 as uuidv4 } from 'uuid'
 import { STORAGE_KEYS } from '../lib/storageKeys'
-import type { CheckoutLine, CheckoutRecord } from '../types/checkout'
+import type { CheckoutDamage, CheckoutLine, CheckoutRecord } from '../types/checkout'
 import {
   buildCheckout,
   closeCheckout,
@@ -112,7 +112,13 @@ interface CheckoutState {
    * ABGELEITET und gegen die Ausgabeliste gehalten; der Unterschied landet im
    * Beleg, statt still verrechnet zu werden.
    */
-  checkIn: (snap: InventorySnapshotIn, recordId: string, note?: string) => void
+  checkIn: (
+    snap: InventorySnapshotIn,
+    recordId: string,
+    note?: string,
+    /** Schaeden, beim Einchecken aufgenommen (Bedarf 68). */
+    damaged?: CheckoutDamage[],
+  ) => void
   /** Einen Beleg loeschen (Fehleingabe). Die Historie hat sonst kein Ventil. */
   removeRecord: (recordId: string) => void
 }
@@ -137,7 +143,7 @@ export const useCheckoutStore = create<CheckoutState>((set, get) => ({
     return undefined
   },
 
-  checkIn: (snap, recordId, note) =>
+  checkIn: (snap, recordId, note, damaged) =>
     set((state) => {
       const at = new Date().toISOString()
       const records = state.records.map((r) =>
@@ -145,7 +151,7 @@ export const useCheckoutStore = create<CheckoutState>((set, get) => ({
         // Rueckgabe-Liste soll sagen, ob etwas heute schon ueberfaellig ist,
         // nicht ob es das am Ausgabetag war.
         r.id === recordId && !r.in
-          ? closeCheckout(r, containerContents(snap, r.nodeId, at.slice(0, 10)), at, note)
+          ? closeCheckout(r, containerContents(snap, r.nodeId, at.slice(0, 10)), at, note, damaged)
           : r,
       )
       persist(records)

--- a/src/renderer/types/checkout.ts
+++ b/src/renderer/types/checkout.ts
@@ -99,6 +99,40 @@ export interface CheckoutOut {
   note?: string
 }
 
+/**
+ * Ein Schaden, festgehalten in dem Moment, in dem das Objekt in der Hand ist
+ * (Bedarf 68, P2).
+ *
+ * Der Bedarf sagt, WO das hingehoert und WAS daran wertvoll ist:
+ *
+ *   > Damage capture belongs on the device already in their hand AT CHECK-IN,
+ *   > and the valuable field is THE ATTRIBUTION (job, person, time,
+ *   > container), not the photo. Feeds the invoice-or-absorb decision
+ *   > directly.
+ *
+ * Und was heute stattdessen passiert: „Damage evidence is photos in a WhatsApp
+ * thread plus a paper condition form; the load-out list was ticked in the dark
+ * or does not exist. With 24-hour reporting windows commonly cited, an
+ * undocumented load-out becomes an UNCHARGED, UNATTRIBUTABLE loss."
+ *
+ * Die Zuordnung steht NICHT in diesem Objekt. Sie steht im Vorgang, an dem es
+ * haengt -- Job (`out.projectName`), Person (`out.to`), Zeit (`in.at`),
+ * Container (`nodeLabel`) -- und wird von `lib/damageRegister.ts` daraus
+ * abgeleitet. Sie hier zu wiederholen ergaebe vier Felder, die von der
+ * ersten Korrektur am Vorgang an falsch waeren.
+ *
+ * KEIN FOTO. Der Bedarf sagt ausdruecklich, dass es nicht das Wertvolle ist,
+ * und ein Bild im Projekt-Zustand waere ein Anhang-Verwaltungsproblem, das
+ * hier nichts zu suchen hat.
+ */
+export interface CheckoutDamage {
+  /** Die betroffene Zeile der Ausgabeliste — eingefroren wie sie ausging. */
+  line: CheckoutLine
+  /** Was kaputt ist, im Klartext. Ohne Text kein Eintrag: „beschaedigt" ohne
+   *  Angabe hilft weder der Werkstatt noch der Rechnung. */
+  note: string
+}
+
 /** Der Vorgang der Rueckgabe, mit dem Unterschied zur Ausgabe. */
 export interface CheckoutIn {
   at: string
@@ -106,6 +140,14 @@ export interface CheckoutIn {
   missing: CheckoutLine[]
   /** Was zurueckkam, ohne auf der Ausgabeliste zu stehen. */
   extra: CheckoutLine[]
+  /**
+   * Was zurueckkam und beschaedigt war (Bedarf 68).
+   *
+   * Getrennt von `missing`: ein beschaedigtes Objekt IST da. Es unter die
+   * Fehlmengen zu schreiben waere zweimal falsch — die Rueckgabe saehe
+   * unvollstaendig aus, und der Schaden waere als Verlust verbucht.
+   */
+  damaged?: CheckoutDamage[]
   note?: string
 }
 

--- a/tests/containerCheckout.test.ts
+++ b/tests/containerCheckout.test.ts
@@ -349,7 +349,12 @@ describe('Erreichbarkeit im Lager-Dialog', () => {
   it('gibt aus und bucht zurueck ueber den Store', () => {
     expect(dialogQuelle).toContain("from '../../store/checkoutStore'")
     expect(dialogQuelle).toMatch(/checkOut\(snap, nodeId,/)
-    expect(dialogQuelle).toMatch(/checkIn\(snap, r\.id\)/)
+    // Seit Bedarf 68 laeuft die Rueckbuchung ueber `bucheZurueck`, weil sie
+    // die aufgenommenen Schaeden mitgeben muss. Der Weg IN DEN STORE bleibt
+    // derselbe -- das ist es, was diese Zeile zusichert, und deshalb prueft
+    // sie den Aufruf und nicht mehr den Knopf.
+    expect(dialogQuelle).toMatch(/checkIn\(snap, r\.id, undefined, damageOf\(r\)\)/)
+    expect(dialogQuelle).toMatch(/onClick=\{\(\) => bucheZurueck\(r\)\}/)
   })
 
   it('zeigt VOR dem Klick, was mitginge', () => {

--- a/tests/damageRegister.test.ts
+++ b/tests/damageRegister.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from 'vitest'
+import { damageEntries, damageTable, damageTally } from '../src/renderer/lib/damageRegister'
+import { closeCheckout } from '../src/renderer/lib/containerCheckout'
+import type { CheckoutLine, CheckoutRecord } from '../src/renderer/types/checkout'
+import inventarQuelle from '../src/renderer/components/Inventory/InventoryDialog.tsx?raw'
+import storeQuelle from '../src/renderer/store/checkoutStore.ts?raw'
+import dictsQuelle from '../src/renderer/lib/i18n/dicts.ts?raw'
+
+// ---------------------------------------------------------------------------
+// Schaden mit Zuordnung (Bedarf 68, P2).
+//
+//   > Damage evidence is photos in a WhatsApp thread plus a paper condition
+//   > form […] an undocumented load-out becomes an UNCHARGED, UNATTRIBUTABLE
+//   > loss.
+//
+//   > Damage capture belongs on the device already in their hand AT CHECK-IN,
+//   > and the valuable field is THE ATTRIBUTION (job, person, time,
+//   > container), not the photo. Feeds the invoice-or-absorb decision
+//   > directly.
+//
+// Beleg: grokability/snipe-it#13153 — ein Reparatur-Datensatz soll festhalten,
+// WEM das Geraet zugeordnet war und WO es stand, „to see whether particular
+// people/locations tend to break devices more often".
+// ---------------------------------------------------------------------------
+
+const line = (label: string, over: Partial<CheckoutLine> = {}): CheckoutLine => ({
+  kind: 'item',
+  refId: `id-${label}`,
+  label,
+  quantity: 1,
+  ...over,
+})
+
+const record = (over: Partial<CheckoutRecord> = {}): CheckoutRecord => ({
+  id: 'r1',
+  nodeId: 'c1',
+  nodeLabel: 'Case 1',
+  out: { at: '2026-09-01T08:00:00Z', to: 'Jan', projectName: 'Show B' },
+  contents: [line('Objektiv'), line('Stativ')],
+  ...over,
+})
+
+describe('der Schaden landet im Beleg, nicht in den Fehlmengen', () => {
+  it('schreibt den aufgenommenen Schaden in die Rueckgabe', () => {
+    const r = closeCheckout(record(), record().contents, '2026-09-10T17:00:00Z', undefined, [
+      { line: line('Objektiv'), note: 'Frontlinse zerkratzt' },
+    ])
+    expect(r.in?.damaged).toHaveLength(1)
+    expect(r.in?.damaged?.[0].note).toBe('Frontlinse zerkratzt')
+  })
+
+  it('zaehlt ein beschaedigtes Objekt NICHT als fehlend', () => {
+    // Es unter die Fehlmengen zu schreiben waere zweimal falsch: die Rueckgabe
+    // saehe unvollstaendig aus, und der Schaden waere als Verlust verbucht.
+    const r = closeCheckout(record(), record().contents, '2026-09-10T17:00:00Z', undefined, [
+      { line: line('Objektiv'), note: 'kaputt' },
+    ])
+    expect(r.in?.missing).toEqual([])
+  })
+
+  it('verwirft einen Eintrag ohne Text', () => {
+    // „beschaedigt" ohne Angabe hilft weder der Werkstatt noch der Rechnung,
+    // und eine leere Zeile im Beleg sieht aus wie eine Aussage.
+    const r = closeCheckout(record(), record().contents, '2026-09-10T17:00:00Z', undefined, [
+      { line: line('Objektiv'), note: '   ' },
+    ])
+    expect(r.in?.damaged).toBeUndefined()
+  })
+
+  it('trimmt den Text, statt ihn roh zu speichern', () => {
+    const r = closeCheckout(record(), record().contents, '2026-09-10T17:00:00Z', undefined, [
+      { line: line('Objektiv'), note: '  Bajonett locker  ' },
+    ])
+    expect(r.in?.damaged?.[0].note).toBe('Bajonett locker')
+  })
+
+  it('ohne Schaeden bleibt das Feld ganz weg', () => {
+    const r = closeCheckout(record(), record().contents, '2026-09-10T17:00:00Z')
+    expect(r.in?.damaged).toBeUndefined()
+  })
+})
+
+describe('die Zuordnung wird abgeleitet, nicht gespeichert', () => {
+  const geschlossen = (over: Partial<CheckoutRecord> = {}): CheckoutRecord =>
+    closeCheckout(record(over), record(over).contents, '2026-09-10T17:00:00Z', undefined, [
+      { line: line('Objektiv'), note: 'Frontlinse zerkratzt' },
+    ])
+
+  it('nennt Show, Person, Container und Zeit', () => {
+    // Genau die vier Felder, die der Bedarf „the valuable field" nennt — und
+    // kein einziges davon ist gespeichert.
+    const e = damageEntries([geschlossen()])[0]
+    expect(e).toMatchObject({
+      label: 'Objektiv',
+      job: 'Show B',
+      person: 'Jan',
+      container: 'Case 1',
+      at: '2026-09-10T17:00:00Z',
+    })
+  })
+
+  it('folgt einer Korrektur am Vorgang, statt sie zu ueberleben', () => {
+    // Der Punkt der Ableitung: vier gespeicherte Felder waeren ab der ersten
+    // Korrektur falsch.
+    const e = damageEntries([geschlossen({ nodeLabel: 'Case 7', out: { at: 't', to: 'Mira', projectName: 'Show C' } })])[0]
+    expect(e.person).toBe('Mira')
+    expect(e.job).toBe('Show C')
+    expect(e.container).toBe('Case 7')
+  })
+
+  it('nennt JEDE fehlende Angabe, statt sie leer zu lassen', () => {
+    // „Wir wissen nicht, auf welcher Show" ist die Auskunft, die den naechsten
+    // Vorgang besser macht; eine leere Zelle ist keine. Das gilt fuer BEIDE
+    // Freitext-Felder -- die erste Fassung dieser Pruefung sah nur die Show,
+    // und eine Gegenprobe, die den Rueckfall bei der Person entfernte, blieb
+    // gruen.
+    const ohneShow = damageEntries([geschlossen({ out: { at: 't', to: 'Jan' } })])[0]
+    expect(ohneShow.job).toBe('nicht benannt')
+    const ohnePerson = damageEntries([geschlossen({ out: { at: 't', to: '  ', projectName: 'S' } })])[0]
+    expect(ohnePerson.person).toBe('nicht benannt')
+  })
+
+  it('ignoriert offene Vorgaenge — dort gibt es noch keine Rueckgabe', () => {
+    // Strukturell garantiert: ein offener Vorgang hat kein `in`, und die
+    // Schaeden haengen daran. Diese Zeile haelt die FORM fest, damit ein
+    // zweiter Speicherort dafuer auffaellt statt sich einzuschleichen.
+    expect(damageEntries([record()])).toEqual([])
+    expect(record().in).toBeUndefined()
+  })
+
+  it('setzt die juengste Rueckgabe nach oben', () => {
+    const alt = closeCheckout(record({ id: 'alt' }), record().contents, '2026-09-01T10:00:00Z', undefined, [
+      { line: line('Stativ'), note: 'Bein verbogen' },
+    ])
+    const neu = closeCheckout(record({ id: 'neu' }), record().contents, '2026-09-12T10:00:00Z', undefined, [
+      { line: line('Objektiv'), note: 'zerkratzt' },
+    ])
+    expect(damageEntries([alt, neu]).map((e) => e.recordId)).toEqual(['neu', 'alt'])
+  })
+})
+
+describe('die Haeufung zaehlt und urteilt nicht', () => {
+  const mit = (id: string, to: string, note: string) =>
+    closeCheckout(record({ id, out: { at: 't', to, projectName: 'S' } }), record().contents, `2026-09-1${id}T10:00:00Z`, undefined, [
+      { line: line('Objektiv'), note },
+    ])
+
+  it('sortiert nach Anzahl, die groesste zuerst', () => {
+    const r = [mit('1', 'Jan', 'a'), mit('2', 'Jan', 'b'), mit('3', 'Mira', 'c')]
+    expect(damageTally(r, 'person')).toEqual([
+      { key: 'Jan', count: 2 },
+      { key: 'Mira', count: 1 },
+    ])
+  })
+
+  it('kann auch nach Container und Show zaehlen', () => {
+    const r = [mit('1', 'Jan', 'a')]
+    expect(damageTally(r, 'container')[0].key).toBe('Case 1')
+    expect(damageTally(r, 'job')[0].key).toBe('S')
+  })
+
+  it('gibt ohne Vorfaelle eine LEERE Liste, keine Null-Zeile', () => {
+    // Der Aufrufer zeigt dann nichts, statt „0 Schaeden" zu melden.
+    expect(damageTally([record()], 'person')).toEqual([])
+  })
+})
+
+describe('das Blatt fuer „berechnen oder tragen"', () => {
+  it('traegt alle vier Zuordnungs-Spalten', () => {
+    const r = closeCheckout(record(), record().contents, '2026-09-10T17:00:00Z', undefined, [
+      { line: line('Objektiv', { code: 'INV-7' }), note: 'zerkratzt' },
+    ])
+    const t = damageTable([r])
+    expect(t.headers).toEqual([
+      'Zurueck am',
+      'Objekt',
+      'Etiketten-Code',
+      'Schaden',
+      'Show',
+      'Ausgegeben an',
+      'Container',
+    ])
+    expect(t.rows[0]).toEqual([
+      '2026-09-10',
+      'Objektiv',
+      'INV-7',
+      'zerkratzt',
+      'Show B',
+      'Jan',
+      'Case 1',
+    ])
+  })
+
+  it('sagt „kein Etikett", statt die interne Id zu drucken', () => {
+    // Dieselbe Regel wie beim Ausgabeschein (Bedarf 16): eine unscannbare
+    // Zeichenkette in einer Spalte namens „Etiketten-Code" sieht benutzbar aus.
+    const r = closeCheckout(record(), record().contents, '2026-09-10T17:00:00Z', undefined, [
+      { line: line('Objektiv'), note: 'x' },
+    ])
+    expect(damageTable([r]).rows[0][2]).toBe('kein Etikett')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ERREICHBARKEIT. Eine Aufnahme, die es nur in der Bibliothek gibt, nimmt
+// nichts auf.
+// ---------------------------------------------------------------------------
+describe('Erreichbarkeit im Lager-Dialog', () => {
+  it('nimmt den Schaden VOR dem Zurueckbuchen auf', () => {
+    // Danach ist der Beleg zu, und ein Beleg darf nicht nachtraeglich anders
+    // lauten.
+    expect(inventarQuelle).toContain('checkIn(snap, r.id, undefined, damageOf(r))')
+    expect(inventarQuelle).toContain("t('inventory.checkout.damagePh'")
+  })
+
+  it('reicht die Schaeden durch den Store bis in den Beleg', () => {
+    expect(storeQuelle).toContain('damaged?: CheckoutDamage[]')
+    // Nicht per Regex ueber die Argumentliste: der Aufruf enthaelt ein
+    // verschachteltes `containerContents(...)`, und `[^)]*` bricht an dessen
+    // Klammer ab. Die letzten drei Argumente reichen als Zusicherung.
+    expect(storeQuelle).toContain('at, note, damaged)')
+  })
+
+  it('leert den Entwurf nach dem Zurueckbuchen', () => {
+    // Ein stehengebliebener Text landete beim naechsten Vorgang im falschen
+    // Beleg.
+    expect(inventarQuelle).toContain('setDamageDraft((d) => ({ ...d, [r.id]: {} }))')
+  })
+
+  it('zeigt die Schaeden mit ihrer Zuordnung und die Haeufung', () => {
+    expect(inventarQuelle).toContain('damageEntries(records)')
+    expect(inventarQuelle).toContain("damageTally(records, 'person')")
+    expect(inventarQuelle).toContain('{schaeden.length > 0 && (')
+    expect(inventarQuelle).toContain('damageTable(records)')
+  })
+
+  it('hat fuer jeden neuen Text einen EN-Eintrag', () => {
+    for (const key of [
+      'inventory.checkout.damageBtn',
+      'inventory.checkout.damageTitle',
+      'inventory.checkout.damagePh',
+      'inventory.checkout.damageTitleList',
+      'inventory.checkout.damageLine',
+      'inventory.checkout.damageTally',
+    ]) {
+      expect(inventarQuelle).toContain(`'${key}'`)
+      expect(dictsQuelle).toContain(`'${key}'`)
+    }
+  })
+})


### PR DESCRIPTION
## Worum es geht

Bedarf 68 (P2) sagt, **wo** das hingehört und **was** daran wertvoll ist:

> Damage capture belongs on the device already in their hand **at check-in**, and the valuable field is **the attribution** (job, person, time, container), **not the photo**. Feeds the invoice-or-absorb decision directly.

Und was heute stattdessen passiert:

> Damage evidence is photos in a WhatsApp thread plus a paper condition form; the load-out list was ticked in the dark or does not exist. With 24-hour reporting windows commonly cited, an undocumented load-out becomes an **uncharged, unattributable** loss.

Beleg: grokability/snipe-it#13153 (2023-06, offen, zuletzt 2025-10) — der Wunsch, dass ein Reparatur-Datensatz festhält, *wem* das Gerät zugeordnet war und *wo* es stand, ausdrücklich *„to see whether particular people/locations tend to break devices more often"*.

## Was dazukommt

- **`CheckoutIn.damaged`** hält den Schaden fest, **getrennt** von den Fehlmengen. Ein beschädigtes Objekt *ist* da; es unter `missing` zu schreiben wäre zweimal falsch — die Rückgabe sähe unvollständig aus, und der Schaden wäre als Verlust verbucht.
- **Die Zuordnung wird abgeleitet, nicht gespeichert.** Job, Person, Zeit und Container stehen im Vorgang, an dem der Schaden hängt; sie am Schaden zu wiederholen ergäbe vier Felder, die ab der ersten Korrektur am Vorgang falsch wären. Der Bedarf nennt sie *„the valuable field"* — und sie kostet kein gespeichertes Byte.
- **Kein Foto.** Der Bedarf sagt ausdrücklich, dass es nicht das Wertvolle ist; ein Bild im Projekt-Zustand wäre ein Anhang-Verwaltungsproblem, das hier nichts zu suchen hat.
- **Kein Ankreuzfeld: ohne Text kein Eintrag.** „Beschädigt" ohne Angabe hilft weder der Werkstatt noch der Rechnung, und eine leere Zeile im Beleg sieht aus wie eine Aussage.
- **Aufgenommen wird vor dem Zurückbuchen** — danach ist der Beleg zu, und ein Beleg darf nicht nachträglich anders lauten. Der Entwurf wird danach geleert, sonst landet er beim nächsten Vorgang im falschen.
- **`damageTally`** beantwortet die Frage aus dem Beleg. Sie **zählt und urteilt nicht**: ein Werkzeug, das aus drei Vorfällen eine Schuld macht, wird beim vierten nicht mehr gefüttert — und dann ist die Datenlage schlechter als vorher.

Wo eine Angabe fehlt, steht das da („nicht benannt") statt wegzufallen — für **beide** Freitext-Felder.

## Gegenproben

Dreizehn; zwölf sofort rot, die dreizehnte nach einer Verschärfung:

**Eine blieb grün und deckte eine echte Lücke auf:** die Prüfung „nennt eine fehlende Angabe" sah nur die *Show*. Der Rückfall bei der *Person* war ungeschützt — eine Gegenprobe, die ihn entfernte, lief durch. Beide sind jetzt gepinnt.

**Eine weitere blieb grün und war die falsche Frage:** dass offene Vorgänge keine Schäden führen, ist *strukturell* garantiert (sie haben kein `in`), nicht durch eine Bedingung, die man umdrehen kann. Der Test hält jetzt die **Form** fest, statt eine erfundene Regel zu behaupten.

## Ein Guard hat angeschlagen

Der Erreichbarkeits-Guard aus Bedarf 15 prüfte `checkIn(snap, r.id)` wörtlich. Die Rückbuchung läuft jetzt über `bucheZurueck`, weil sie die aufgenommenen Schäden mitgeben muss. Er prüft nun den **Store-Aufruf** statt des Knopfes — der Weg in den Store ist, was er zusichern soll.

## Prüfstand

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — **1469 passed, 2 skipped** (130 Dateien)
- `npm run lint` — 0 Errors (10 Alt-Warnungen) · `npm run build` OK

Closes Bedarf 68 aus `docs/research/synthesis/USER-NEED-DATABASE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_