### PR TITLE
lager: Inventur mit „am falschen Ort" als eigenem Ergebnis (Bedarf 66)

### DIFF
--- a/src/renderer/components/Inventory/InventoryDialog.tsx
+++ b/src/renderer/components/Inventory/InventoryDialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   Plus,
   Pencil,
@@ -51,6 +51,8 @@ import { useCheckoutStore } from '../../store/checkoutStore'
 import { ownershipNote, overdueSubhire, subhireStatus } from '../../lib/ownership'
 import type { CheckoutDamage, CheckoutRecord } from '../../types/checkout'
 import { damageEntries, damageTable, damageTally } from '../../lib/damageRegister'
+import { AUDIT_LABEL, auditRelocations, auditScan, auditTable, type AuditHit } from '../../lib/inventoryAudit'
+import { keepScreenAwake } from '../../lib/wakeLock'
 import {
   containerContents,
   checkoutSheet,
@@ -812,8 +814,63 @@ const LocationsTab = ({ dimsEditor, formatDims, codeCell }: LocationsTabProps) =
   const updateNode = useInventoryStore((s) => s.updateNode)
   const moveNode = useInventoryStore((s) => s.moveNode)
   const removeNode = useInventoryStore((s) => s.removeNode)
+  const updateItem = useInventoryStore((s) => s.updateItem)
+  // `moveUnit` statt `updateUnit`: ein Ortswechsel gehoert in die Historie der
+  // Einheit. Ein stilles Feld-Schreiben liesse die Frage „wann kam die
+  // hierher?" unbeantwortet — und genau die stellt jemand drei Wochen spaeter.
+  const moveUnit = useInventoryStore((s) => s.moveUnit)
   // Der Stichtag kommt EINMAL aus der Uhr und wird durchgereicht.
   const heuteIso = new Date().toISOString().slice(0, 10)
+
+  // ── BEDARF 66 + die Restreibung aus Bedarf 69 ────────────────────────────
+  //
+  // Der Ort steht FEST, bevor der erste Artikel gescannt wird -- „the scan
+  // resolves to the company default warehouse rather than where the stock is"
+  // ist genau der Fehler, den das verhindert.
+  const [auditNode, setAuditNode] = useState('')
+  const [auditDraft, setAuditDraft] = useState('')
+  const [auditHits, setAuditHits] = useState<AuditHit[]>([])
+
+  // Bedarf 69: waehrend inventiert wird, bleibt der Bildschirm an. Die Sperre
+  // haengt am geoeffneten Panel und endet mit ihm.
+  useEffect(() => {
+    if (!auditNode) return
+    const awake = keepScreenAwake()
+    return () => awake.release()
+  }, [auditNode])
+
+  const auditScanNow = () => {
+    const roh = auditDraft.trim()
+    if (!roh || !auditNode) return
+    const hit = auditScan(roh, auditNode, { items, nodes, units })
+    // Ein Lagerort-Etikett wechselt den KONTEXT, statt als Fehltreffer zu
+    // gelten: wer das Case-Etikett scannt, meint fast immer „ich stehe jetzt
+    // hier". Das ist die location-context-first-Regel im Betrieb.
+    if (hit.outcome === 'is-a-location') {
+      const ziel = nodes.find((n) => (n.code ?? '').trim().toLowerCase() === roh.toLowerCase())
+      if (ziel) {
+        setAuditNode(ziel.id)
+        setAuditHits([])
+        setAuditDraft('')
+        return
+      }
+    }
+    // Neueste oben: wer scannt, schaut auf die letzte Zeile.
+    setAuditHits((h) => [hit, ...h])
+    setAuditDraft('')
+  }
+
+  /** Den TATSAECHLICHEN Ort uebernehmen — der Beleg verlangt genau das.
+   *  Schreibend, deshalb ein eigener Klick und nicht automatisch. */
+  const auditAdopt = () => {
+    for (const r of auditRelocations(auditHits)) {
+      if (r.itemId) updateItem(r.itemId, { locationId: auditNode })
+      if (r.unitId) moveUnit(r.unitId, auditNode, nodePathLabel(nodes, auditNode))
+    }
+    // Nach dem Uebernehmen stimmt die Liste nicht mehr: sie behauptete einen
+    // Widerspruch, den es nicht mehr gibt.
+    setAuditHits([])
+  }
 
   const handlePackList = async (node: StorageNode) => {
     const list = derivePackList(node.id, { items, nodes, units }, heuteIso)
@@ -935,6 +992,17 @@ const LocationsTab = ({ dimsEditor, formatDims, codeCell }: LocationsTabProps) =
                 </button>
               </>
             )}
+            {/* BEDARF 66 — „verify this rack". Der Knopf sitzt an JEDER
+                Lagerstelle, nicht nur an Containern: ein Regal wird genauso
+                inventiert wie ein Case, und die Frage ist dieselbe. */}
+            <button
+              type="button"
+              onClick={() => setAuditNode(auditNode === node.id ? '' : node.id)}
+              className="rounded p-1 text-cp-text-muted hover:bg-cp-surface-4 hover:text-cp-text"
+              title={t('inventory.auditStart', 'Inventur an diesem Ort')}
+            >
+              <ScanLine size={13} />
+            </button>
             <button
               type="button"
               onClick={() => setForm({ name: '', kind: container ? 'case' : 'shelf', parentId: node.id })}
@@ -951,6 +1019,89 @@ const LocationsTab = ({ dimsEditor, formatDims, codeCell }: LocationsTabProps) =
             </button>
           </div>
         </div>
+
+        {/* BEDARF 66 — die Inventur an DIESEM Ort. Zwei Farben („im Bestand /
+            nicht im Bestand") beantworten die Frage nicht, die im Lager
+            gestellt wird: fast alles ist im Bestand, und „am falschen Ort" ist
+            nach jedem Load-out der Normalfall, nicht die Ausnahme. */}
+        {auditNode === node.id && (
+          <div
+            style={{ marginLeft: depth * 16 + 22 }}
+            className="mb-1 mt-1 rounded border border-cp-accent/40 bg-cp-surface-2 p-2"
+          >
+            <div className="mb-1.5 flex flex-wrap items-center gap-2">
+              <span className="font-medium text-cp-text">
+                {format(t('inventory.auditTitle', 'Inventur: {name}'), { name: node.name })}
+              </span>
+              <input
+                value={auditDraft}
+                onChange={(e) => setAuditDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  // Enter scannt weiter, statt ein Formular abzuschicken
+                  // (Bedarf 69, snipe-it#17057). Das Feld leert sich selbst —
+                  // der naechste Code kann sofort kommen.
+                  if (e.key === 'Enter') auditScanNow()
+                }}
+                autoFocus
+                placeholder={t('inventory.auditPh', 'Code scannen — Lagerort-Etikett wechselt den Ort')}
+                className="min-w-[14rem] flex-1 rounded border border-cp-border bg-cp-surface-3 px-2 py-1"
+              />
+              <button
+                type="button"
+                disabled={auditHits.length === 0}
+                onClick={() => {
+                  const t2 = auditTable(auditHits, nodes, node.id)
+                  downloadBlob(`inventur-${node.name}.csv`, toCsv(t2.headers, t2.rows), 'text/csv')
+                }}
+                className="flex items-center gap-1 text-cp-text-secondary hover:text-cp-text disabled:opacity-40"
+              >
+                <Download size={12} /> CSV
+              </button>
+              <button
+                type="button"
+                disabled={auditRelocations(auditHits).length === 0}
+                onClick={auditAdopt}
+                title={t(
+                  'inventory.auditAdoptHint',
+                  'Schreibt diesen Ort auf alle am falschen Ort gefundenen Objekte — der Bestand folgt damit dem, was tatsächlich hier liegt',
+                )}
+                className="rounded border border-cp-border px-2 py-1 text-cp-text-secondary hover:text-cp-text disabled:opacity-40"
+              >
+                {format(t('inventory.auditAdopt', 'Ort übernehmen ({n})'), {
+                  n: auditRelocations(auditHits).length,
+                })}
+              </button>
+            </div>
+            {auditHits.length === 0 ? (
+              <div className="text-cp-text-muted">
+                {t('inventory.auditEmpty', 'Noch nichts gescannt.')}
+              </div>
+            ) : (
+              <ul className="flex max-h-56 flex-col gap-0.5 overflow-y-auto">
+                {auditHits.map((h, i) => (
+                  <li
+                    key={`${h.code}-${i}`}
+                    className={
+                      h.outcome === 'expected-here'
+                        ? 'text-cp-text-secondary'
+                        : h.outcome === 'wrong-place'
+                          ? 'text-cp-warn'
+                          : 'text-cp-danger'
+                    }
+                  >
+                    {/* Modell UND Ort in jeder Zeile — beides verlangt der
+                        Beleg ausdruecklich, und ohne beides „finds nothing
+                        actionable". */}
+                    {AUDIT_LABEL[h.outcome]} · {h.label || h.code}
+                    {h.model && h.model !== h.label ? ` (${h.model})` : ''}
+                    {h.expected ? ` — ${format(t('inventory.auditExpected', 'erwartet in {ort}'), { ort: h.expected })}` : ''}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+
         {directItems.length > 0 && (
           <div style={{ marginLeft: depth * 16 + 22 }} className="mt-0.5 mb-0.5 flex flex-wrap gap-1">
             {directItems.map((it) => (

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3666,6 +3666,15 @@ export const en: Dict = {
   'inventory.checkout.damageTitleList': 'Damage ({n})',
   'inventory.checkout.damageLine': '{at} · {label}: {note} — {job}, out to {person} ({container})',
   'inventory.checkout.damageTally': 'Concentration by who it went out to: {list}',
+  // Bedarf 66 — Inventur mit „am falschen Ort" als eigenem Ergebnis.
+  'inventory.auditStart': 'Stock-take at this location',
+  'inventory.auditTitle': 'Stock-take: {name}',
+  'inventory.auditPh': 'Scan a code — a location label switches the location',
+  'inventory.auditEmpty': 'Nothing scanned yet.',
+  'inventory.auditExpected': 'expected in {ort}',
+  'inventory.auditAdopt': 'Adopt location ({n})',
+  'inventory.auditAdoptHint':
+    'Writes this location onto every object found in the wrong place — the records then follow what is actually here',
   'inventory.notes': 'Note',
   'inventory.empty': 'No inventory items yet. Add some or import them from the plan.',
   'inventory.noMatch': 'No items match the search.',

--- a/src/renderer/lib/inventoryAudit.ts
+++ b/src/renderer/lib/inventoryAudit.ts
@@ -1,0 +1,179 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Inventur: „ist das hier, wo es hingehoert?" (Bedarf 66, P2 — und die
+// Restreibung aus Bedarf 69).
+//
+// WAS BEDARF 66 SAGT:
+//
+//   > Bulk audit by scanning shows only green (in database) / red (not in
+//   > database). No model, no location, no wrong-place flag — so the audit
+//   > finds nothing actionable, and IN AN AV WAREHOUSE WRONG-PLACE IS THE
+//   > NORMAL OUTCOME OF EVERY LOAD-OUT.
+//
+//   > If the suite ever offers a stock-taking or 'verify this rack' mode, the
+//   > result row must carry EXPECTED-VS-ACTUAL LOCATION and RECORD THE ACTUAL
+//   > ONE. This is also the cheapest path to keeping the plan's as-built
+//   > container tree honest.
+//
+// Beleg: grokability/snipe-it#8095 (2020-05, offen, zuletzt 2025-06,
+// 9 Kommentare) — verlangt Modell und Lagerort in der Ergebniszeile, eine
+// DRITTE Farbe fuer den falschen Ort, und dass solche Objekte trotzdem als
+// „am gepruefen Ort gefunden" verbucht werden.
+//
+// ─── ZWEI FARBEN SIND EINE ZU WENIG ────────────────────────────────────────
+//
+// „Im Bestand / nicht im Bestand" beantwortet die Frage nicht, die im Lager
+// gestellt wird. Fast alles ist im Bestand; die Frage ist, ob es DA ist, wo
+// der Datensatz es vermutet. Deshalb gibt es hier vier benannte Ergebnisse,
+// und `wrong-place` ist das haeufigste — nicht das Ausnahmefall.
+//
+// ─── DIE REIBUNG AUS BEDARF 69, DIE HIER IHR ZUHAUSE FINDET ────────────────
+//
+//   > the scan resolves to the company default warehouse rather than where the
+//   > stock is […] location-context-first
+//
+// `auditScan` verlangt den Ort ALS ERSTES ARGUMENT. Ohne ihn gibt es kein
+// Ergebnis — nicht weil das streng waere, sondern weil „gefunden" ohne „wo"
+// keine Auskunft ist. Das ist derselbe Grund, aus dem der Befund den
+// Standard-Lagerort beklagt.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { InventoryItem, StorageNode, InventoryUnit } from '../types/inventory'
+import { resolveInventoryCode, type ScanSources } from './inventoryScan'
+import { descendantNodeIds, nodePathLabel } from './storageTree'
+import type { CsvCell, CsvTable } from './csv'
+
+export type AuditOutcome =
+  /** Der Datensatz sagt: liegt hier (oder in einem Behaelter hier drin). */
+  | 'expected-here'
+  /** Es gibt das Objekt, aber der Datensatz verortet es woanders. */
+  | 'wrong-place'
+  /** Der Datensatz kennt keinen Lagerort dafuer. Nicht dasselbe wie „falscher
+   *  Ort": hier gibt es nichts zu widerlegen, nur etwas nachzutragen. */
+  | 'no-location'
+  /** Der Code gehoert zu keinem Objekt im Bestand. */
+  | 'not-in-inventory'
+  /** Der Code gehoert zu einem LAGERORT. Beim Inventieren ist das fast immer
+   *  ein Griff daneben — jemand scannt das Case-Etikett statt des Inhalts —,
+   *  und es als „nicht im Bestand" zu melden waere schlicht falsch. */
+  | 'is-a-location'
+
+export interface AuditHit {
+  outcome: AuditOutcome
+  /** Der gescannte Code, wie er eingegeben wurde. */
+  code: string
+  /** Menschenlesbare Bezeichnung des Getroffenen. Leer bei `not-in-inventory`. */
+  label: string
+  /** Modell — der Bedarf verlangt es ausdruecklich in der Ergebniszeile. */
+  model?: string
+  /** Wo der Datensatz es vermutet, als Pfad. Leer bei `no-location`. */
+  expected?: string
+  /** Was verschoben wuerde, wenn jemand den Ort uebernimmt. */
+  itemId?: string
+  unitId?: string
+}
+
+/**
+ * Einen gescannten Code am geprueften Ort einordnen.
+ *
+ * `atNodeId` ist der Ort, an dem der Mensch STEHT — nicht der, an dem der
+ * Datensatz das Objekt vermutet. Genau diese Unterscheidung fehlt in dem
+ * Befund, den Bedarf 66 zitiert.
+ *
+ * „Hier" schliesst Behaelter ein: wer vor Regal A3 steht und ein Objekt aus
+ * Case 1 in Regal A3 scannt, hat es am richtigen Ort. Eine Inventur, die den
+ * Teilbaum nicht mitzaehlt, meldete jedes eingepackte Objekt als verstellt.
+ */
+export function auditScan(
+  code: string,
+  atNodeId: string,
+  sources: ScanSources,
+): AuditHit {
+  const roh = code.trim()
+  const treffer = resolveInventoryCode(roh, sources)
+  if (!treffer) return { outcome: 'not-in-inventory', code: roh, label: '' }
+
+  if (treffer.kind === 'node') {
+    return { outcome: 'is-a-location', code: roh, label: treffer.node.name }
+  }
+
+  const hier = new Set([atNodeId, ...descendantNodeIds(sources.nodes, atNodeId)])
+
+  if (treffer.kind === 'unit') {
+    const u: InventoryUnit = treffer.unit
+    const model = sources.items.find((i) => i.id === u.itemId)?.model
+    const label = u.serial || u.code || u.id.slice(0, 6)
+    if (!u.locationId) {
+      return { outcome: 'no-location', code: roh, label, ...(model ? { model } : {}), unitId: u.id }
+    }
+    return {
+      outcome: hier.has(u.locationId) ? 'expected-here' : 'wrong-place',
+      code: roh,
+      label,
+      ...(model ? { model } : {}),
+      expected: nodePathLabel(sources.nodes, u.locationId),
+      unitId: u.id,
+    }
+  }
+
+  const it: InventoryItem = treffer.item
+  if (!it.locationId) {
+    return { outcome: 'no-location', code: roh, label: it.model, model: it.model, itemId: it.id }
+  }
+  return {
+    outcome: hier.has(it.locationId) ? 'expected-here' : 'wrong-place',
+    code: roh,
+    label: it.model,
+    model: it.model,
+    expected: nodePathLabel(sources.nodes, it.locationId),
+    itemId: it.id,
+  }
+}
+
+/**
+ * Das Inventur-Blatt.
+ *
+ * Modell UND Ort in jeder Zeile — beides verlangt der Beleg ausdruecklich,
+ * und ohne beides „finds nothing actionable". Der geprueften Ort steht als
+ * eigene Spalte daneben: erst der Vergleich der beiden macht die Zeile
+ * verwertbar.
+ */
+export function auditTable(hits: AuditHit[], nodes: StorageNode[], atNodeId: string): CsvTable {
+  const geprueft = nodePathLabel(nodes, atNodeId)
+  return {
+    headers: ['Ergebnis', 'Code', 'Objekt', 'Modell', 'Erwartet in', 'Geprueft an'],
+    rows: hits.map((h): CsvCell[] => [
+      AUDIT_LABEL[h.outcome],
+      h.code,
+      h.label,
+      h.model ?? '',
+      // Leer heisst hier „kein Lagerort im Datensatz" und ist selbst die
+      // Aussage — nicht dasselbe wie ein falscher Ort.
+      h.expected ?? '',
+      geprueft,
+    ]),
+  }
+}
+
+/** Kanonisches Deutsch fuer das Blatt — der Stand haengt am Inhalt. */
+export const AUDIT_LABEL: Record<AuditOutcome, string> = {
+  'expected-here': 'Am erwarteten Ort',
+  'wrong-place': 'Am falschen Ort',
+  'no-location': 'Ohne Lagerort im Datensatz',
+  'not-in-inventory': 'Nicht im Bestand',
+  'is-a-location': 'Das ist ein Lagerort, kein Objekt',
+}
+
+/**
+ * Was eine Uebernahme des tatsaechlichen Ortes aendern wuerde.
+ *
+ * Der Beleg verlangt, dass ein am falschen Ort gefundenes Objekt trotzdem
+ * „als am gepruefen Ort gefunden" verbucht wird. Das ist eine SCHREIBENDE
+ * Handlung, und sie gehoert dem Menschen: diese Funktion sagt nur, was
+ * passieren wuerde, und aendert nichts.
+ */
+export const auditRelocations = (hits: AuditHit[]): Array<{ itemId?: string; unitId?: string }> =>
+  hits
+    .filter((h) => h.outcome === 'wrong-place' || h.outcome === 'no-location')
+    .map((h) => ({ ...(h.itemId ? { itemId: h.itemId } : {}), ...(h.unitId ? { unitId: h.unitId } : {}) }))

--- a/tests/inventoryAudit.test.ts
+++ b/tests/inventoryAudit.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest'
+import { AUDIT_LABEL, auditRelocations, auditScan, auditTable } from '../src/renderer/lib/inventoryAudit'
+import type { InventoryItem, InventoryUnit, StorageNode } from '../src/renderer/types/inventory'
+import inventarQuelle from '../src/renderer/components/Inventory/InventoryDialog.tsx?raw'
+import dictsQuelle from '../src/renderer/lib/i18n/dicts.ts?raw'
+
+// ---------------------------------------------------------------------------
+// Inventur mit „am falschen Ort" als eigenem Ergebnis (Bedarf 66, P2 — plus
+// die Restreibung aus Bedarf 69).
+//
+//   > Bulk audit by scanning shows only green (in database) / red (not in
+//   > database). No model, no location, no wrong-place flag — so the audit
+//   > finds nothing actionable, and IN AN AV WAREHOUSE WRONG-PLACE IS THE
+//   > NORMAL OUTCOME OF EVERY LOAD-OUT.
+//
+//   > the result row must carry expected-vs-actual location and RECORD THE
+//   > ACTUAL ONE.
+//
+// Beleg: grokability/snipe-it#8095 (2020-05, offen, zuletzt 2025-06).
+//
+// Zwei Farben beantworten die Frage nicht, die im Lager gestellt wird: fast
+// alles ist im Bestand. Die Frage ist, ob es DA ist.
+// ---------------------------------------------------------------------------
+
+const zeit = '2026-09-06T10:00:00.000Z'
+const node = (id: string, name: string, parentId?: string, code?: string): StorageNode =>
+  ({ id, name, kind: 'shelf', parentId, code, createdAt: zeit, updatedAt: zeit }) as StorageNode
+const item = (id: string, model: string, locationId?: string, code?: string): InventoryItem =>
+  ({ id, model, quantity: 1, locationId, code, createdAt: zeit, updatedAt: zeit }) as InventoryItem
+const unit = (id: string, itemId: string, locationId?: string, code?: string): InventoryUnit =>
+  ({ id, itemId, serial: `SN-${id}`, locationId, code, condition: 'ok', history: [], createdAt: zeit, updatedAt: zeit }) as unknown as InventoryUnit
+
+const lager = () => ({
+  nodes: [
+    node('a3', 'Regal A3'),
+    node('c1', 'Case 1', 'a3', 'CASE-1'),
+    node('b1', 'Regal B1'),
+  ],
+  items: [
+    item('hier', 'Klettband', 'a3', 'ITM-HIER'),
+    item('imcase', 'Gaffa', 'c1', 'ITM-CASE'),
+    item('woanders', 'Stativ', 'b1', 'ITM-WEG'),
+    item('ohneort', 'Adapter', undefined, 'ITM-LOS'),
+  ],
+  units: [unit('u1', 'hier', 'b1', 'UNIT-1')],
+})
+
+describe('vier benannte Ergebnisse statt zwei Farben', () => {
+  it('erkennt, was am erwarteten Ort liegt', () => {
+    expect(auditScan('ITM-HIER', 'a3', lager()).outcome).toBe('expected-here')
+  })
+
+  it('zaehlt den Inhalt eines Behaelters am Ort MIT', () => {
+    // Wer vor Regal A3 steht und etwas aus Case 1 in A3 scannt, hat es am
+    // richtigen Ort. Eine Inventur ohne Teilbaum meldete jedes eingepackte
+    // Objekt als verstellt — und waere damit nach dem ersten Case wertlos.
+    expect(auditScan('ITM-CASE', 'a3', lager()).outcome).toBe('expected-here')
+  })
+
+  it('meldet den falschen Ort UND wo es erwartet wurde', () => {
+    const h = auditScan('ITM-WEG', 'a3', lager())
+    expect(h.outcome).toBe('wrong-place')
+    expect(h.expected).toBe('Regal B1')
+    // Der Beleg verlangt das Modell ausdruecklich in der Ergebniszeile.
+    expect(h.model).toBe('Stativ')
+  })
+
+  it('unterscheidet „ohne Lagerort" von „falscher Ort"', () => {
+    // Hier gibt es nichts zu widerlegen, nur etwas nachzutragen.
+    const h = auditScan('ITM-LOS', 'a3', lager())
+    expect(h.outcome).toBe('no-location')
+    expect(h.expected).toBeUndefined()
+  })
+
+  it('meldet einen unbekannten Code als nicht im Bestand', () => {
+    expect(auditScan('XXX', 'a3', lager()).outcome).toBe('not-in-inventory')
+  })
+
+  it('erkennt ein LAGERORT-Etikett als solches', () => {
+    // Beim Inventieren ist das fast immer der Griff zum Case-Etikett. Es als
+    // „nicht im Bestand" zu melden waere schlicht falsch.
+    const h = auditScan('CASE-1', 'a3', lager())
+    expect(h.outcome).toBe('is-a-location')
+    expect(h.label).toBe('Case 1')
+  })
+
+  it('loest eine Einheit ueber ihren Artikel auf und nennt dessen Modell', () => {
+    const h = auditScan('UNIT-1', 'a3', lager())
+    expect(h.outcome).toBe('wrong-place')
+    expect(h.model).toBe('Klettband')
+    expect(h.unitId).toBe('u1')
+  })
+})
+
+describe('das Blatt traegt Modell UND Ort', () => {
+  it('nennt beides plus den gepruefen Ort', () => {
+    const hits = [auditScan('ITM-WEG', 'a3', lager())]
+    const t = auditTable(hits, lager().nodes, 'a3')
+    expect(t.headers).toEqual(['Ergebnis', 'Code', 'Objekt', 'Modell', 'Erwartet in', 'Geprueft an'])
+    expect(t.rows[0]).toEqual(['Am falschen Ort', 'ITM-WEG', 'Stativ', 'Stativ', 'Regal B1', 'Regal A3'])
+  })
+
+  it('haelt die Etiketten kanonisch deutsch', () => {
+    expect(AUDIT_LABEL['wrong-place']).toBe('Am falschen Ort')
+  })
+})
+
+describe('was eine Uebernahme aendern wuerde', () => {
+  it('nennt nur das Verstellte und das Ortlose', () => {
+    const hits = ['ITM-HIER', 'ITM-WEG', 'ITM-LOS', 'XXX'].map((c) => auditScan(c, 'a3', lager()))
+    expect(auditRelocations(hits)).toEqual([{ itemId: 'woanders' }, { itemId: 'ohneort' }])
+  })
+
+  it('aendert selbst NICHTS', () => {
+    // Schreiben gehoert dem Menschen. Diese Funktion sagt nur, was passieren
+    // wuerde — sonst verschoebe ein Scan Bestand, bevor jemand hinsieht.
+    const bestand = lager()
+    const vorher = JSON.stringify(bestand)
+    auditRelocations([auditScan('ITM-WEG', 'a3', bestand)])
+    expect(JSON.stringify(bestand)).toBe(vorher)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ERREICHBARKEIT — und die Restreibung aus Bedarf 69, die hier ihr Zuhause
+// findet: der Ort steht fest, BEVOR der erste Artikel gescannt wird.
+// ---------------------------------------------------------------------------
+describe('Erreichbarkeit im Lager-Dialog', () => {
+  it('scannt gegen den gewaehlten Ort, nicht gegen einen Standard', () => {
+    // „the scan resolves to the company default warehouse rather than where
+    // the stock is" (Bedarf 69) — genau das verhindert der Pflicht-Ort.
+    expect(inventarQuelle).toContain("auditScan(roh, auditNode, { items, nodes, units })")
+    expect(inventarQuelle).toContain('if (!roh || !auditNode) return')
+  })
+
+  it('laesst ein Lagerort-Etikett den Ort WECHSELN', () => {
+    // Wer das Case-Etikett scannt, meint „ich stehe jetzt hier".
+    expect(inventarQuelle).toContain("if (hit.outcome === 'is-a-location')")
+    expect(inventarQuelle).toContain('setAuditNode(ziel.id)')
+  })
+
+  it('haelt den Bildschirm waehrend der Inventur wach', () => {
+    // Bedarf 69, die zweite Reibung — hier mit einem Panel, an dem sie haengen
+    // kann.
+    expect(inventarQuelle).toMatch(/if \(!auditNode\) return\n\s*const awake = keepScreenAwake\(\)/)
+  })
+
+  it('schickt Enter NICHT als Formular ab', () => {
+    expect(inventarQuelle).toContain("if (e.key === 'Enter') auditScanNow()")
+  })
+
+  it('uebernimmt den Ort ueber `moveUnit`, nicht als stilles Feld', () => {
+    // Ein Ortswechsel gehoert in die Historie der Einheit; sonst bleibt „wann
+    // kam die hierher?" unbeantwortet.
+    expect(inventarQuelle).toContain('moveUnit(r.unitId, auditNode, nodePathLabel(nodes, auditNode))')
+    expect(inventarQuelle).toContain("updateItem(r.itemId, { locationId: auditNode })")
+  })
+
+  it('zeigt das Ergebnis mit Modell und erwartetem Ort', () => {
+    expect(inventarQuelle).toContain('AUDIT_LABEL[h.outcome]')
+    expect(inventarQuelle).toContain("t('inventory.auditExpected'")
+    expect(inventarQuelle).toContain('auditTable(auditHits, nodes, node.id)')
+  })
+
+  it('hat fuer jeden neuen Text einen EN-Eintrag', () => {
+    for (const key of [
+      'inventory.auditStart',
+      'inventory.auditTitle',
+      'inventory.auditPh',
+      'inventory.auditEmpty',
+      'inventory.auditExpected',
+      'inventory.auditAdopt',
+      'inventory.auditAdoptHint',
+    ]) {
+      expect(inventarQuelle).toContain(`'${key}'`)
+      expect(dictsQuelle).toContain(`'${key}'`)
+    }
+  })
+})


### PR DESCRIPTION
## Worum es geht

Bedarf 66 (P2) beschreibt, warum eine Scan-Inventur mit zwei Farben nichts bringt:

> Bulk audit by scanning shows only green (in database) / red (not in database). No model, no location, no wrong-place flag — so the audit **finds nothing actionable**, and in an AV warehouse **wrong-place is the normal outcome of every load-out**.

> If the suite ever offers a stock-taking or 'verify this rack' mode, the result row must carry **expected-vs-actual location and record the actual one**.

Beleg: grokability/snipe-it#8095 (2020-05, offen, zuletzt 2025-06, neun Kommentare) — verlangt Modell und Lagerort in der Ergebniszeile, eine **dritte** Farbe für den falschen Ort, und dass solche Objekte trotzdem als am geprüften Ort gefunden verbucht werden.

## Fünf benannte Ergebnisse statt zwei Farben

Der Punkt ist: fast alles **ist** im Bestand. Die Frage im Lager lautet nicht „kennen wir das?", sondern „liegt es da, wo der Datensatz es vermutet?".

- **„Ohne Lagerort" ist von „falscher Ort" getrennt** — dort gibt es nichts zu widerlegen, nur etwas nachzutragen.
- **Ein Lagerort-Etikett ist ein eigenes Ergebnis, kein Fehltreffer.** Beim Inventieren ist das fast immer der Griff zum Case-Etikett — und im Betrieb wechselt es den Ort, statt einen Fehler zu melden.
- **„Hier" schließt den Teilbaum ein.** Wer vor Regal A3 steht und etwas aus Case 1 in A3 scannt, hat es am richtigen Ort; ohne diese Regel meldete die Inventur jedes eingepackte Objekt als verstellt und wäre nach dem ersten Case wertlos.
- **Die Übernahme des tatsächlichen Ortes ist ein eigener Klick**, kein Nebeneffekt des Scannens. Bei Einheiten läuft sie über `moveUnit`, damit der Wechsel in der **Historie** steht — ein stilles Feld-Schreiben ließe „wann kam die hierher?" unbeantwortet.

## Hier findet auch die Restreibung aus Bedarf 69 ihr Zuhause

Bei #714 blieben zwei der sechs Reibungen ohne Ort, weil es keine Fläche gab, an der sie hängen konnten. Die Inventur ist diese Fläche:

> the scan resolves to the company default warehouse rather than where the stock is […] **location-context-first**

`auditScan` verlangt den Ort als **erstes Argument** — ohne ihn gibt es kein Ergebnis, weil „gefunden" ohne „wo" keine Auskunft ist. Dazu hält das geöffnete Panel den Bildschirm wach, und Enter scannt weiter statt ein Formular abzuschicken.

## Gegenproben

Zwölf, alle rot: Teilbaum zählt nicht mit · falscher Ort ohne „erwartet in" · Modell fehlt in der Zeile · ohne Ort gilt als falscher Ort · Lagerort gilt als Fehltreffer · Einheit ohne Modell · Übernahme nimmt auch Richtiges mit · Blatt ohne Modell-Spalte · Ort ist nicht Pflicht · Lagerort wechselt den Ort nicht · kein Wake-Lock bei der Inventur · Einheit ohne Historie verschoben

## Prüfstand

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — **1487 passed, 2 skipped** (131 Dateien)
- `npm run lint` — 0 Errors (10 Alt-Warnungen) · `npm run build` OK

Closes Bedarf 66 und den Rest von Bedarf 69 aus `docs/research/synthesis/USER-NEED-DATABASE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_