### PR TITLE
lager: die Kommissionier-Liste nennt den Grund der Fehlmenge (Bedarf 64)

### DIFF
--- a/src/renderer/lib/planBom.ts
+++ b/src/renderer/lib/planBom.ts
@@ -227,7 +227,7 @@ export const planBomCsv = (bom: PlanBom): string =>
  * lesbar bleiben, nicht verschwinden und nicht sicher aussehen.
  */
 export const pickListCsv = (bom: PlanBom): string => {
-  const zeilen: Array<[string, number, string, number, number | string]> = []
+  const zeilen: Array<[string, number, string, number, number | string, string]> = []
   for (const r of bom.rows) {
     if (r.outcome !== 'matched-by-type') continue
     const orte = r.locations ?? []
@@ -237,14 +237,19 @@ export const pickListCsv = (bom: PlanBom): string => {
       const nehmen = Math.min(offen, o.available)
       if (nehmen <= 0) continue
       offen -= nehmen
-      zeilen.push([o.location, nehmen, r.model, o.available, ''])
+      zeilen.push([o.location, nehmen, r.model, o.available, '', ''])
     }
     // Fehlmenge: eine eigene Zeile ohne Lagerort — es gibt keinen Ort, an dem
     // sie läge. Auch dann, wenn gar keine Position einen Lagerort trug.
-    if (offen > 0) zeilen.push(['', 0, r.model, 0, offen])
+    //
+    // BEDARF 64: mit dem GRUND, soweit er bekannt ist. Der Bedarf verlangt
+    // ausdruecklich „which job holds it" — und ohne diesen Hinweis sucht der
+    // Kommissionierer das fuenfte Stueck im Regal, obwohl es auf einem Truck
+    // steht. Seit Bedarf 80 weiss die Zeile das; sie hat es nur nicht gesagt.
+    if (offen > 0) zeilen.push(['', 0, r.model, 0, offen, r.commitmentNote ?? ''])
   }
   return toCsv(
-    ['Lagerort', 'Menge', 'Modell', 'Bestand', 'Fehlmenge'],
+    ['Lagerort', 'Menge', 'Modell', 'Bestand', 'Fehlmenge', 'Grund'],
     zeilen
       .slice()
       .sort((a, b) => a[0].localeCompare(b[0], 'de') || a[2].localeCompare(b[2], 'de')),

--- a/tests/lagerdeckungMehrereOrte.test.ts
+++ b/tests/lagerdeckungMehrereOrte.test.ts
@@ -97,9 +97,11 @@ describe('der Bestand wird ueber Lagerpositionen summiert', () => {
 describe('die Kommissionier-Liste teilt auf die Lagerorte auf', () => {
   it('eine Zeile je Ort, mit der dort zu entnehmenden Menge', () => {
     const bom = buildPlanBom(plan(5), zweiOrte(3, 3), NODES)
+    // Die Spalte „Grund" kam mit Bedarf 64 dazu und ist hier leer: es fehlt
+    // nichts, also gibt es nichts zu begruenden.
     expect(pickListCsv(bom).split('\r\n').slice(1)).toEqual([
-      'Depot › Case 1;3;Sony PMW-F55;3;',
-      'Depot › Case 2;2;Sony PMW-F55;3;',
+      'Depot › Case 1;3;Sony PMW-F55;3;;',
+      'Depot › Case 2;2;Sony PMW-F55;3;;',
     ])
   })
 
@@ -116,8 +118,8 @@ describe('die Kommissionier-Liste teilt auf die Lagerorte auf', () => {
       item({ id: 'i1', model: MODELL, quantity: 3, deviceTypeId: TYP, locationId: 'c1' }),
     ], NODES)
     expect(pickListCsv(bom).split('\r\n').slice(1)).toEqual([
-      ';0;Sony PMW-F55;0;2',
-      'Depot › Case 1;3;Sony PMW-F55;3;',
+      ';0;Sony PMW-F55;0;2;',
+      'Depot › Case 1;3;Sony PMW-F55;3;;',
     ])
   })
 

--- a/tests/verfuegbarkeitGegenAusgaben.test.ts
+++ b/tests/verfuegbarkeitGegenAusgaben.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { committedByItem, commitmentNote } from '../src/renderer/lib/inventoryCommitment'
 import { resolveCoverage } from '../src/renderer/lib/inventoryCoverage'
-import { buildPlanBom, planBomCsv } from '../src/renderer/lib/planBom'
+import { buildPlanBom, pickListCsv, planBomCsv } from '../src/renderer/lib/planBom'
 import type { CheckoutRecord } from '../src/renderer/types/checkout'
 import type { EquipmentItem } from '../src/renderer/types/equipment'
 import type { InventoryItem, InventoryUnit, StorageNode } from '../src/renderer/types/inventory'
@@ -177,6 +177,35 @@ describe('das Blatt zeigt beide Zahlen', () => {
   it('die Zeile gilt als fehlend, obwohl der Bestand reicht', () => {
     const bom = buildPlanBom(plan(5), lager(5), NODES, [], [], [ausgabe()])
     expect(bom.missing).toHaveLength(1)
+  })
+
+  it('die Kommissionier-Liste nennt den GRUND der Fehlmenge (Bedarf 64)', () => {
+    // „which job holds it": ohne diesen Hinweis sucht der Kommissionierer das
+    // fehlende Stueck im Regal, obwohl es auf einem Truck steht. Seit
+    // Bedarf 80 weiss die Zeile es -- sie hat es nur nicht gesagt.
+    const bom = buildPlanBom(plan(5), lager(5), NODES, [], [], [ausgabe()])
+    const zeilen = pickListCsv(bom).split('\r\n')
+    expect(zeilen[0]).toContain('Fehlmenge;Grund')
+    const fehl = zeilen.find((z) => z.startsWith(';0;'))
+    expect(fehl).toContain('2 auf offener Ausgabe (2× Show B)')
+  })
+
+  it('laesst die Spalte leer, wenn nichts gebunden ist', () => {
+    // Ein Grund, der immer dasteht, ist keiner.
+    const bom = buildPlanBom(plan(9), lager(5), NODES)
+    const fehl = pickListCsv(bom).split('\r\n').find((z) => z.startsWith(';0;'))
+    expect(fehl?.endsWith(';')).toBe(true)
+  })
+
+  it('setzt den Grund NUR auf die Fehlmengen-Zeile', () => {
+    // Auf einer Entnahme-Zeile waere er falsch: was dort steht, ist DA. Die
+    // erste Fassung dieser Pruefung sah nur den Fall ohne Bindung -- eine
+    // Gegenprobe, die den Grund auf jede Zeile schrieb, blieb gruen.
+    const bom = buildPlanBom(plan(5), lager(5), NODES, [], [], [ausgabe()])
+    const zeilen = pickListCsv(bom).split('\r\n').slice(1).filter(Boolean)
+    const entnahme = zeilen.filter((z) => !z.startsWith(';0;'))
+    expect(entnahme.length).toBeGreaterThan(0)
+    for (const z of entnahme) expect(z.endsWith(';')).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Worum es geht

Bedarf 64 (P2) verlangt eine ortsbewusste Kommissionier-Liste:

> A plan-derived BOM should emit location-aware, case-aware pick data (which case is it already in, **which rack, which job holds it**), not just item+quantity.

**Der größte Teil steht seit #676:** die Liste teilt die Menge auf alle Lagerpositionen auf, nennt den vollen Lagerort-Pfad (also auch das Case, in dem etwas schon steckt) und führt die Fehlmenge als eigene Zeile, statt sie verschwinden zu lassen.

**Was fehlte, ist das dritte Stück: welcher Job.** Seit #715 *weiß* die Zeile es — `commitmentNote` steht auf der BOM-Zeile und nennt Menge und Ziel jeder offenen Ausgabe. Auf der Kommissionier-Liste stand es nicht. Der Kommissionierer las „Fehlmenge 2" ohne Grund und suchte die beiden Stücke im Regal, obwohl sie auf einem Truck standen.

## Nur auf der Fehlmengen-Zeile

Auf einer Entnahme-Zeile wäre der Grund falsch: was dort steht, **ist da**.

Genau daran hing eine Gegenprobe, die zunächst grün blieb — die Prüfung sah nur den Fall *ohne* Bindung, und der Grund auf jeder Zeile lief durch. Sie prüft jetzt beide Seiten.

## Gegenproben

Drei; zwei sofort rot, die dritte nach der Verschärfung: Grund fällt weg · Spalte fehlt in der Kopfzeile · Grund steht auf jeder Zeile.

## Prüfstand

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — **1490 passed, 2 skipped** (131 Dateien)
- `npm run lint` — 0 Errors (10 Alt-Warnungen)

Closes Bedarf 64 aus `docs/research/synthesis/USER-NEED-DATABASE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_