### PR TITLE
ausspielung: die Archiv-Aufzeichnung teilt kein Schicksal mit der Uebertragung (Bedarf 90)

### DIFF
--- a/src/renderer/components/Delivery/DeliveryDialog.tsx
+++ b/src/renderer/components/Delivery/DeliveryDialog.tsx
@@ -23,9 +23,16 @@ import {
   type DeliveryChain,
 } from '../../lib/deliveryPath'
 import {
+  ARCHIVE_FINDING_LABEL,
+  archiveFindingText,
+  archiveTable,
+  assessArchive,
+} from '../../lib/archiveIsolation'
+import {
   DELIVERY_PLATFORMS,
   DEFAULT_ENCODING,
   platformByKey,
+  type ArchiveAnswer,
   type DeliveryDestination,
 } from '../../types/delivery'
 
@@ -51,6 +58,7 @@ export const DeliveryDialog = () => {
   const add = useProjectStore((s) => s.addDeliveryDestination)
   const update = useProjectStore((s) => s.updateDeliveryDestination)
   const remove = useProjectStore((s) => s.removeDeliveryDestination)
+  const setArchive = useProjectStore((s) => s.setArchiveRecording)
   const project = useProjectStore((s) => s.project)
   const projectName = project.metadata.name
 
@@ -96,6 +104,11 @@ export const DeliveryDialog = () => {
   // demselben Kabelgraph wie die Label-Ableitung. Nichts davon wird
   // gespeichert ausser dem einen Zeiger auf das Geraet.
   const chains = useMemo(() => buildDeliveryChains(project), [project])
+  // BEDARF 90 — die Archiv-Aufzeichnung. Sie gehoert hierher und nicht in die
+  // Analyse: die Frage entsteht erst, wenn es eine Ausspielung gibt, die sie
+  // mitreissen koennte, und sie wird an derselben Stelle beantwortet, an der
+  // die Encoder benannt werden.
+  const archive = useMemo(() => assessArchive(project), [project])
   const chainById = useMemo(
     () => new Map<string, DeliveryChain>(chains.map((c) => [c.destinationId, c])),
     [chains],
@@ -287,6 +300,16 @@ export const DeliveryDialog = () => {
     downloadBlob(buildExportFilenameWithSuffix(projectName, 'ausspielweg', 'csv'), csv, 'text/csv')
   }
 
+  // BEDARF 90 — das Archiv-Blatt. Klein, aber ein Beleg: „wir haben gefragt,
+  // und das war die Antwort" ist genau das, was nach dem Abbau fehlt.
+  const exportArchive = () => {
+    downloadBlob(
+      buildExportFilenameWithSuffix(projectName, 'archiv-aufzeichnung', 'csv'),
+      csvFromTable(archiveTable(archive)),
+      'text/csv',
+    )
+  }
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
       <div className="flex max-h-[88vh] w-full max-w-5xl flex-col overflow-hidden rounded-lg border border-cp-border bg-cp-surface-1 shadow-xl">
@@ -330,6 +353,106 @@ export const DeliveryDialog = () => {
               'Wohin gesendet wird, mit welchen Parametern, und welcher Weg der Ausweichweg ist. Der Stream-Key liegt im Schlüsselbund des Rechners, nie in der Projektdatei — eine .avplan geht per Mail.',
             )}
           </p>
+
+          {/* BEDARF 90 — die Archiv-Aufzeichnung. Nur sichtbar, wenn es
+              überhaupt ein Ausspielziel gibt: ohne Übertragung gibt es nichts,
+              was die Aufzeichnung mitreißen könnte, und die Frage dort zu
+              stellen wäre eine Warnung ohne Anlass. */}
+          {list.length > 0 && (
+            <div className="mb-4 rounded border border-cp-border-muted bg-cp-surface-2 p-2.5">
+              <div className="mb-1.5 flex flex-wrap items-center gap-2 text-cp-sm">
+                <span className="font-medium text-cp-text">
+                  {t('delivery.archive.title', 'Unabhängige Archiv-Aufzeichnung')}
+                </span>
+                <select
+                  value={archive.answer}
+                  onChange={(e) => {
+                    const answer = e.target.value as ArchiveAnswer
+                    if (answer === 'not-stated') return setArchive(undefined)
+                    setArchive({
+                      answer,
+                      ...(answer === 'device' && project.archiveRecording?.equipmentId
+                        ? { equipmentId: project.archiveRecording.equipmentId }
+                        : {}),
+                      ...(project.archiveRecording?.note
+                        ? { note: project.archiveRecording.note }
+                        : {}),
+                    })
+                  }}
+                  aria-label={t('delivery.archive.answer', 'Antwort')}
+                  className={inputCls}
+                >
+                  <option value="not-stated">
+                    {t('delivery.archive.notStated', '— noch nicht beantwortet —')}
+                  </option>
+                  <option value="device">{t('delivery.archive.onDevice', 'auf diesem Gerät')}</option>
+                  <option value="none-by-choice">
+                    {t('delivery.archive.none', 'bewusst keine')}
+                  </option>
+                </select>
+                {archive.answer === 'device' && (
+                  <select
+                    value={project.archiveRecording?.equipmentId ?? ''}
+                    onChange={(e) =>
+                      setArchive({
+                        answer: 'device',
+                        ...(e.target.value ? { equipmentId: e.target.value } : {}),
+                        ...(project.archiveRecording?.note
+                          ? { note: project.archiveRecording.note }
+                          : {}),
+                      })
+                    }
+                    aria-label={t('delivery.archive.device', 'Aufzeichnendes Gerät')}
+                    className={inputCls}
+                  >
+                    <option value="">{t('delivery.archive.pick', '— Gerät wählen —')}</option>
+                    {encoderChoices.map((e) => (
+                      <option key={e.id} value={e.id}>
+                        {e.name}
+                      </option>
+                    ))}
+                  </select>
+                )}
+                {archive.answer !== 'not-stated' && (
+                  <input
+                    value={project.archiveRecording?.note ?? ''}
+                    onChange={(e) =>
+                      setArchive({
+                        answer: archive.answer,
+                        ...(project.archiveRecording?.equipmentId
+                          ? { equipmentId: project.archiveRecording.equipmentId }
+                          : {}),
+                        ...(e.target.value ? { note: e.target.value } : {}),
+                      })
+                    }
+                    placeholder={
+                      archive.answer === 'none-by-choice'
+                        ? t('delivery.archive.whyPh', 'Warum keine? (Webinar ohne Nachverwertung …)')
+                        : t('delivery.archive.notePh', 'Anmerkung (Medium, Kartenwechsel …)')
+                    }
+                    aria-label={t('delivery.archive.note', 'Anmerkung')}
+                    className={`${inputCls} min-w-0 flex-1`}
+                  />
+                )}
+                <button
+                  type="button"
+                  onClick={exportArchive}
+                  className="flex items-center gap-1 rounded border border-cp-border px-2 py-1 text-cp-sm text-cp-text-secondary hover:text-cp-text"
+                >
+                  <FileText size={13} /> {t('delivery.archive.export', 'Blatt')}
+                </button>
+              </div>
+              {archive.findings.length > 0 && (
+                <ul className="flex flex-col gap-1 text-cp-xs">
+                  {archive.findings.map((f, i) => (
+                    <li key={`${f.kind}-${i}`} className="text-amber-300/90">
+                      <strong>{ARCHIVE_FINDING_LABEL[f.kind]}</strong> — {archiveFindingText(f)}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
 
           {/* Uplink-Budget: die 40-%-Kopfraum-Regel, mit Rechnung daneben. */}
           <div className="mb-4 rounded border border-cp-border-muted bg-cp-surface-2 p-2.5">

--- a/src/renderer/lib/archiveIsolation.ts
+++ b/src/renderer/lib/archiveIsolation.ts
@@ -1,0 +1,258 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Teilt die Archiv-Aufzeichnung ihr Schicksal mit der Ausspielung?
+// (Bedarf 90, P2.)
+//
+// DER BELEG ist ein geschlossener, nicht behobener Fehlerbericht:
+//
+//   > with obs-multi-rtmp, „OBS encoder will overload if (any) stream upload
+//   > will stall/lag", degrading the recording's frame rate to the point the
+//   > material must be discarded
+//
+// obsproject/obs-studio#13147, „closed as not planned". Die UNABHAENGIG
+// konfigurierte Aufzeichnung wird von einer stockenden Ausspielung
+// mitgerissen, und es faellt erst nach dem Abbau auf — da ist die Show vorbei
+// und die Kamera-Karten sind formatiert.
+//
+// ─── DIE GRENZE, DIE DER BEDARF SELBST ZIEHT ───────────────────────────────
+//
+//   > Not a Cable Planner feature but a PLANNING FACT: the plan should force
+//   > an explicit answer to „where does the independent archive recording
+//   > live and what is it isolated from", and flag a delivery path where the
+//   > only recording shares fate with the transmission.
+//
+// Also keine Telemetrie. Ob ein Encoder gerade ueberlastet ist, weiss ein
+// offline-Planer nicht; eine geratene Antwort saehe wie eine Messung aus.
+// Dieselbe Grenze wie „is it flowing" in Bedarf 76.
+//
+// ─── WAS ABGELEITET WIRD UND WAS GEFRAGT ───────────────────────────────────
+//
+// GEFRAGT wird genau eine Sache: WELCHES Geraet aufzeichnet (oder dass es
+// bewusst keines gibt). Das kann der Plan nicht wissen — ein Mischer mit
+// SSD-Schacht zeichnet auf, wenn jemand auf Aufnahme drueckt, und das steht
+// in keinem Kabel.
+//
+// ABGELEITET wird alles andere, aus dem Kabelgraph und dem Ziel-Register:
+//
+//   `shares-encoder`   Das aufzeichnende Geraet IST der Encoder eines Ziels.
+//                      Genau der Fall aus dem Fehlerbericht.
+//   `fed-by-encoder`   Der Recorder haengt HINTER dem Encoder. Stockt der
+//                      Encoder, stockt auch, was er ausgibt — dieselbe
+//                      Abhaengigkeit, nur eine Kabellaenge weiter.
+//   `recorder-gone`    Das benannte Geraet steht nicht (mehr) im Plan.
+//   `not-stated`       Es gibt Ausspielziele und keine Antwort.
+//
+// `none-by-choice` ist KEIN Befund. „Wir haben bewusst keine Archiv-Kopie"
+// ist eine gueltige Entscheidung (ein Webinar ohne Nachverwertung), und sie
+// als Fehler zu melden hiesse, den Nutzer fuer seine eigene Entscheidung zu
+// ruegen. Sie steht auf dem Blatt, damit sie nachlesbar ist — mehr nicht.
+//
+// Und ausdruecklich KEIN Befund ist die gemeinsame QUELLE: dass Recorder und
+// Encoder vom selben Mischer-Ausgang gespeist werden, ist der NORMALFALL und
+// genau richtig. Wer das meldete, wuerde die Warnung entwerten, auf die es
+// ankommt.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { Cable } from '../types/cable'
+import type { EquipmentItem } from '../types/equipment'
+import type { ArchiveRecording, DeliveryDestination } from '../types/delivery'
+import type { CsvCell, CsvTable } from './csv'
+
+export type ArchiveFindingKind =
+  | 'not-stated'
+  | 'recorder-gone'
+  | 'shares-encoder'
+  | 'fed-by-encoder'
+
+export interface ArchiveFinding {
+  kind: ArchiveFindingKind
+  /** Klartext-Werte zum Befund, in fester Reihenfolge. */
+  values?: string[]
+}
+
+export interface ArchiveAssessment {
+  /** Die Antwort, wie sie im Projekt steht — `not-stated`, wenn keine da ist. */
+  answer: ArchiveRecording['answer']
+  /** Der Recorder, sofern benannt UND im Plan vorhanden. */
+  recorder?: { equipmentId: string; name: string }
+  /** Die Begruendung bei `none-by-choice`, sonst die Anmerkung. */
+  note?: string
+  findings: ArchiveFinding[]
+  /**
+   * Die Ziele, deren Encoder das aufzeichnende Geraet IST — die Namen fuer
+   * den Befundtext, damit er nicht nur „ein Ziel" sagt.
+   */
+  sharedWith: string[]
+}
+
+export interface ArchiveInput {
+  equipment: readonly EquipmentItem[]
+  cables: readonly Cable[]
+  deliveryDestinations?: readonly DeliveryDestination[]
+  archiveRecording?: ArchiveRecording
+}
+
+/**
+ * Liegt `to` im Kabelgraph HINTER `from`? Breitensuche vorwaerts, mit einer
+ * Tiefengrenze.
+ *
+ * Die Grenze ist kein Geschmack: ein Signalweg mit acht Zwischenstationen ist
+ * moeglich, aber die Aussage „stockt der Encoder, stockt auch das" wird mit
+ * jedem Konverter dazwischen schwaecher — und eine unbegrenzte Suche findet
+ * in einem grossen Plan am Ende immer irgendeinen Weg.
+ */
+function reachesForward(
+  cables: readonly Cable[],
+  from: string,
+  to: string,
+  maxHops = 4,
+): boolean {
+  if (from === to) return false
+  let front = new Set([from])
+  const gesehen = new Set([from])
+  for (let hop = 0; hop < maxHops; hop++) {
+    const next = new Set<string>()
+    for (const c of cables) {
+      if (!front.has(c.fromEquipmentId)) continue
+      if (c.toEquipmentId === to) return true
+      if (!gesehen.has(c.toEquipmentId)) {
+        gesehen.add(c.toEquipmentId)
+        next.add(c.toEquipmentId)
+      }
+    }
+    if (next.size === 0) return false
+    front = next
+  }
+  return false
+}
+
+/** Die ganze Beurteilung. */
+export function assessArchive(input: ArchiveInput): ArchiveAssessment {
+  const { equipment, cables } = input
+  const destinations = input.deliveryDestinations ?? []
+  const rec = input.archiveRecording
+  const answer = rec?.answer ?? 'not-stated'
+  const note = rec?.note?.trim() || undefined
+  const findings: ArchiveFinding[] = []
+  const sharedWith: string[] = []
+
+  // Ohne ein einziges Ausspielziel gibt es die Frage nicht: eine Show ohne
+  // Uebertragung hat keine Uebertragung, die die Aufzeichnung mitreissen
+  // koennte. Sie hier trotzdem zu stellen waere eine Warnung ohne Anlass.
+  if (destinations.length === 0) {
+    return { answer, ...(note ? { note } : {}), findings, sharedWith }
+  }
+
+  if (answer === 'not-stated') {
+    findings.push({ kind: 'not-stated' })
+    return { answer, ...(note ? { note } : {}), findings, sharedWith }
+  }
+
+  if (answer === 'none-by-choice') {
+    // Kein Befund. Die Entscheidung steht auf dem Blatt, das genuegt.
+    return { answer, ...(note ? { note } : {}), findings, sharedWith }
+  }
+
+  const byId = new Map(equipment.map((e) => [e.id, e]))
+  const recorderId = rec?.equipmentId
+  const recorder = recorderId ? byId.get(recorderId) : undefined
+  if (!recorder) {
+    findings.push({ kind: 'recorder-gone', values: recorderId ? [recorderId] : [] })
+    return { answer, ...(note ? { note } : {}), findings, sharedWith }
+  }
+
+  const encoderIds = new Set(
+    destinations.map((d) => d.encoderEquipmentId).filter(Boolean) as string[],
+  )
+
+  for (const d of destinations) {
+    if (d.encoderEquipmentId && d.encoderEquipmentId === recorder.id) sharedWith.push(d.name)
+  }
+  if (sharedWith.length) {
+    findings.push({ kind: 'shares-encoder', values: [recorder.name, ...sharedWith] })
+  }
+
+  // Hinter dem Encoder: dieselbe Abhaengigkeit, nur eine Kabellaenge weiter.
+  // Nur pruefen, wenn der Recorder nicht ohnehin schon DER Encoder ist —
+  // sonst stuenden zwei Befunde fuer dieselbe Sache.
+  if (!sharedWith.length) {
+    for (const encId of encoderIds) {
+      if (reachesForward(cables, encId, recorder.id)) {
+        findings.push({
+          kind: 'fed-by-encoder',
+          values: [recorder.name, byId.get(encId)?.name ?? encId],
+        })
+        break
+      }
+    }
+  }
+
+  return {
+    answer,
+    recorder: { equipmentId: recorder.id, name: recorder.name },
+    ...(note ? { note } : {}),
+    findings,
+    sharedWith,
+  }
+}
+
+/**
+ * Der Befundtext — kanonisches Deutsch, wie jeder Text, der auf einem
+ * Dokument landen kann (ADR-004: der Stand haengt am Inhalt).
+ */
+export function archiveFindingText(f: ArchiveFinding): string {
+  const v = f.values ?? []
+  switch (f.kind) {
+    case 'not-stated':
+      return (
+        'Der Plan hat Ausspielziele, sagt aber nicht, wo die unabhaengige ' +
+        'Archiv-Aufzeichnung liegt. Das ist keine Warnung ueber ein Geraet, sondern ' +
+        'eine offene Frage: entweder ein Geraet benennen oder ausdruecklich sagen, ' +
+        'dass es bewusst keine gibt.'
+      )
+    case 'recorder-gone':
+      return (
+        `Das als Recorder benannte Geraet steht nicht mehr im Plan${v[0] ? ` (${v[0]})` : ''}. ` +
+        'Die Antwort auf die Archiv-Frage zeigt damit ins Leere.'
+      )
+    case 'shares-encoder':
+      return (
+        `${v[0]} zeichnet auf UND sendet (${v.slice(1).join(', ')}). Eine stockende ` +
+        'Ausspielung ueberlastet denselben Encoder und zieht die Aufzeichnung mit ' +
+        'herunter — belegt an obs-studio#13147, wo die Bildrate der Aufnahme so weit ' +
+        'einbrach, dass das Material verworfen werden musste. Auffallen wird es erst ' +
+        'nach dem Abbau.'
+      )
+    case 'fed-by-encoder':
+      return (
+        `${v[0]} haengt hinter ${v[1]}, also hinter dem sendenden Geraet. Stockt der ` +
+        'Encoder, stockt auch, was er ausgibt: dieselbe Abhaengigkeit, nur eine ' +
+        'Kabellaenge weiter.'
+      )
+  }
+}
+
+export const ARCHIVE_FINDING_LABEL: Record<ArchiveFindingKind, string> = {
+  'not-stated': 'Archiv-Frage unbeantwortet',
+  'recorder-gone': 'Benannter Recorder fehlt im Plan',
+  'shares-encoder': 'Aufzeichnung und Ausspielung auf einem Geraet',
+  'fed-by-encoder': 'Aufzeichnung haengt hinter dem Encoder',
+}
+
+export const ARCHIVE_ANSWER_LABEL: Record<ArchiveRecording['answer'], string> = {
+  device: 'auf einem Geraet',
+  'none-by-choice': 'bewusst keine',
+  'not-stated': 'nicht beantwortet',
+}
+
+/** Das Blatt: die Antwort und, falls es welche gibt, die Befunde. */
+export function archiveTable(a: ArchiveAssessment): CsvTable {
+  const rows: CsvCell[][] = [
+    ['Antwort', ARCHIVE_ANSWER_LABEL[a.answer], a.recorder?.name ?? '', a.note ?? ''],
+  ]
+  for (const f of a.findings) {
+    rows.push(['Befund', ARCHIVE_FINDING_LABEL[f.kind], '', archiveFindingText(f)])
+  }
+  return { headers: ['Art', 'Was', 'Geraet', 'Text'], rows }
+}

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3969,6 +3969,18 @@ export const en: Dict = {
   // Bedarf 32 — der Ausspielweg.
   'delivery.encoder.onDevice': 'on {device}',
   'delivery.path.title': 'Delivery path',
+  // Bedarf 90 — die unabhaengige Archiv-Aufzeichnung.
+  'delivery.archive.title': 'Independent archive recording',
+  'delivery.archive.answer': 'Answer',
+  'delivery.archive.notStated': '\u2014 not answered yet \u2014',
+  'delivery.archive.onDevice': 'on this device',
+  'delivery.archive.none': 'deliberately none',
+  'delivery.archive.device': 'Recording device',
+  'delivery.archive.pick': '\u2014 pick a device \u2014',
+  'delivery.archive.whyPh': 'Why none? (webinar with no re-use \u2026)',
+  'delivery.archive.notePh': 'Note (medium, card swap \u2026)',
+  'delivery.archive.note': 'Note',
+  'delivery.archive.export': 'Sheet',
   'delivery.path.hint':
     'The path from the programme feed to the platform — source, encoder, transport, destination',
   'delivery.path.encoder': 'Encoder in the plan',

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -496,6 +496,8 @@ export interface ProjectState {
   ) => void
   /** Loescht das Ziel UND seinen Stream-Key aus dem OS-Schluesselbund. */
   removeDeliveryDestination: (id: string) => void
+  /** Bedarf 90 — die Antwort auf „wo liegt die unabhaengige Aufzeichnung". */
+  setArchiveRecording: (rec: import('../types/delivery').ArchiveRecording | undefined) => void
   /** #143 — Annotationen aus einer zurückgelesenen Viewer-Datei mergen
    *  (by id: neue hinzufügen, geänderte aktualisieren, vorhandene behalten).
    *  Gibt die Anzahl hinzugefügter/aktualisierter Annotationen zurück. */

--- a/src/renderer/store/slices/deliverySlice.ts
+++ b/src/renderer/store/slices/deliverySlice.ts
@@ -25,7 +25,10 @@ import {
  */
 export type DeliverySlice = Pick<
   ProjectState,
-  'addDeliveryDestination' | 'updateDeliveryDestination' | 'removeDeliveryDestination'
+  | 'addDeliveryDestination'
+  | 'updateDeliveryDestination'
+  | 'removeDeliveryDestination'
+  | 'setArchiveRecording'
 >
 
 /**
@@ -113,6 +116,19 @@ export const createDeliverySlice: StateCreator<ProjectState, [], [], DeliverySli
       } catch {
         /* Der Schluesselbund kann fehlen (Browser, Linux ohne libsecret). */
       }
+      return { project: updated }
+    }),
+
+  // BEDARF 90 — die Antwort auf „wo liegt die unabhaengige Aufzeichnung".
+  //
+  // `undefined` loescht die Antwort und ist damit etwas anderes als
+  // `none-by-choice`: das eine heisst „niemand hat geantwortet", das andere
+  // „wir haben bewusst keine". Genau diese Unterscheidung verlangt der
+  // Bedarf, also darf der Setter sie nicht einebnen.
+  setArchiveRecording: (rec) =>
+    set((state) => {
+      const updated = { ...state.project, archiveRecording: rec }
+      scheduleProjectAutosave(updated)
       return { project: updated }
     }),
 })

--- a/src/renderer/types/delivery.ts
+++ b/src/renderer/types/delivery.ts
@@ -294,3 +294,60 @@ export const normaliseDeliveryDestination = (
   }
   return out
 }
+
+// ───────────────────────────────────────────────────────────────────────────
+// BEDARF 90 — die Archiv-Aufzeichnung. „The insurance copy needs isolation."
+//
+// DER BELEG ist ein geschlossener, nicht behobener Fehlerbericht:
+//
+//   > with obs-multi-rtmp, „OBS encoder will overload if (any) stream upload
+//   > will stall/lag", degrading the recording's frame rate to the point the
+//   > material must be discarded
+//
+// obsproject/obs-studio#13147 (2026-02-20, „closed as not planned"). Der
+// Melder nennt das Prinzip, um das es geht: die Ausspielung darf die
+// Aufzeichnung nicht anfassen duerfen. Und der Schaden faellt erst NACH dem
+// Abbau auf — da ist die Show vorbei und die Kamera-Karten sind gelöscht.
+//
+// ─── WAS HIER NICHT GEBAUT WIRD ────────────────────────────────────────────
+//
+// Telemetrie. Der Bedarf sagt es selbst: „Not a Cable Planner feature but a
+// PLANNING FACT." Ob ein Encoder gerade ueberlastet ist, weiss ein
+// offline-Planer nicht, und eine geratene Antwort saehe wie eine Messung aus
+// — dieselbe Grenze wie bei „is it flowing" in Bedarf 76.
+//
+// ─── WAS GEBAUT WIRD ───────────────────────────────────────────────────────
+//
+// Eine ausdrueckliche Antwort auf „wo liegt die unabhaengige Aufzeichnung",
+// und die Pruefung, ob sie ihr Schicksal mit der Ausspielung teilt.
+//
+// `none-by-choice` ist der Grund, warum das ein eigener Typ ist und kein
+// optionales Feld: „wir haben bewusst keine Archiv-Kopie" ist eine gueltige
+// Entscheidung (ein Webinar ohne Nachverwertung), und sie ist etwas ANDERES
+// als „niemand hat es gesagt". Ein fehlendes Feld koennte beides heissen,
+// und der Bedarf verlangt ausdruecklich, dass der Plan die Antwort ERZWINGT.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Die drei Antworten auf „wo liegt die unabhaengige Aufzeichnung". */
+export type ArchiveAnswer =
+  /** Auf diesem Geraet. */
+  | 'device'
+  /** Es gibt bewusst keine — mit Begruendung. */
+  | 'none-by-choice'
+  /** Niemand hat geantwortet. Kein Fehler, aber auch keine Antwort. */
+  | 'not-stated'
+
+export interface ArchiveRecording {
+  answer: ArchiveAnswer
+  /**
+   * Das aufzeichnende Geraet — nur bei `answer === 'device'`.
+   *
+   * Wie `encoderEquipmentId` in Bedarf 32 die einzige Naht zwischen
+   * Ziel-Register und Plan ist, ist dies die einzige zwischen der
+   * Archiv-Frage und dem Plan. Alles Weitere — ob das Geraet auch sendet, ob
+   * es hinter dem Encoder haengt — wird aus dem Kabelgraph ABGELEITET.
+   */
+  equipmentId?: string
+  /** Bei `none-by-choice` die Begruendung; sonst eine Anmerkung. */
+  note?: string
+}

--- a/src/renderer/types/project.ts
+++ b/src/renderer/types/project.ts
@@ -244,6 +244,14 @@ export interface CablePlannerProject {
    *  Projekte heilen zu []. **Ohne Stream-Keys** — die liegen im
    *  OS-Schluesselbund, siehe `types/delivery.ts`. */
   deliveryDestinations?: import('./delivery').DeliveryDestination[]
+  /**
+   * Bedarf 90 — die Antwort auf „wo liegt die unabhängige Archiv-Aufzeichnung
+   * und wovon ist sie getrennt".
+   *
+   * Am Projekt und nicht am Ziel: die Archiv-Kopie gehört der Show, nicht
+   * einer einzelnen Ausspielung. Zwei Ziele teilen sich dieselbe Aufzeichnung.
+   */
+  archiveRecording?: import('./delivery').ArchiveRecording
 }
 
 /** #412 — Ein festgeschriebener Projekt-Stand. */

--- a/tests/archiveIsolation.test.ts
+++ b/tests/archiveIsolation.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ARCHIVE_ANSWER_LABEL,
+  ARCHIVE_FINDING_LABEL,
+  archiveFindingText,
+  archiveTable,
+  assessArchive,
+  type ArchiveInput,
+} from '../src/renderer/lib/archiveIsolation'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+import type { Cable } from '../src/renderer/types/cable'
+import type { DeliveryDestination } from '../src/renderer/types/delivery'
+import dialogQuelle from '../src/renderer/components/Delivery/DeliveryDialog.tsx?raw'
+import sliceQuelle from '../src/renderer/store/slices/deliverySlice.ts?raw'
+
+// ---------------------------------------------------------------------------
+// Die Archiv-Aufzeichnung teilt nicht das Schicksal der Ausspielung
+// (Bedarf 90, P2).
+//
+//   > with obs-multi-rtmp, „OBS encoder will overload if (any) stream upload
+//   > will stall/lag", degrading the recording's frame rate to the point the
+//   > material must be discarded
+//
+// obsproject/obs-studio#13147, „closed as not planned". Der Schaden faellt
+// erst NACH dem Abbau auf.
+//
+// Der Bedarf zieht die Grenze selbst: „Not a Cable Planner feature but a
+// PLANNING FACT: the plan should force an explicit answer […] and flag a
+// delivery path where the only recording shares fate with the transmission."
+// Also keine Telemetrie — eine Antwort und eine Ableitung.
+// ---------------------------------------------------------------------------
+
+const geraet = (id: string, name: string): EquipmentItem =>
+  ({ id, name, x: 0, y: 0, width: 10, height: 10, category: 'Video', inputs: [], outputs: [] }) as never
+
+const kabel = (id: string, from: string, to: string): Cable =>
+  ({
+    id,
+    name: id,
+    type: 'sdi',
+    length: 1,
+    color: '#fff',
+    fromEquipmentId: from,
+    fromPortId: 'a',
+    toEquipmentId: to,
+    toPortId: 'b',
+    notes: '',
+  }) as never
+
+const ziel = (id: string, name: string, encoderEquipmentId?: string): DeliveryDestination =>
+  ({
+    id,
+    name,
+    platform: 'custom',
+    transport: 'rtmp',
+    encoding: {},
+    ...(encoderEquipmentId ? { encoderEquipmentId } : {}),
+  }) as never
+
+const eingabe = (over: Partial<ArchiveInput> = {}): ArchiveInput => ({
+  equipment: [],
+  cables: [],
+  ...over,
+})
+
+describe('Bedarf 90 — ohne Ausspielung gibt es die Frage nicht', () => {
+  it('meldet nichts, wenn kein Ziel im Plan steht', () => {
+    // Eine Show ohne Uebertragung hat keine Uebertragung, die die
+    // Aufzeichnung mitreissen koennte. Die Frage dort zu stellen waere eine
+    // Warnung ohne Anlass.
+    const a = assessArchive(eingabe({ equipment: [geraet('rec', 'HyperDeck')] }))
+    expect(a.findings).toHaveLength(0)
+    expect(a.answer).toBe('not-stated')
+  })
+})
+
+describe('Bedarf 90 — der Plan erzwingt eine ausdrueckliche Antwort', () => {
+  it('meldet die unbeantwortete Frage, sobald es ein Ziel gibt', () => {
+    const a = assessArchive(eingabe({ deliveryDestinations: [ziel('d1', 'YouTube')] }))
+    expect(a.findings.map((f) => f.kind)).toEqual(['not-stated'])
+    expect(archiveFindingText(a.findings[0])).toContain('bewusst keine')
+  })
+
+  it('„bewusst keine" ist eine ANTWORT und kein Befund', () => {
+    // Ein Webinar ohne Nachverwertung braucht keine Archiv-Kopie. Das als
+    // Fehler zu melden hiesse, den Nutzer fuer seine eigene Entscheidung zu
+    // ruegen.
+    const a = assessArchive(
+      eingabe({
+        deliveryDestinations: [ziel('d1', 'YouTube')],
+        archiveRecording: { answer: 'none-by-choice', note: 'Webinar, keine Nachverwertung' },
+      }),
+    )
+    expect(a.findings).toHaveLength(0)
+    expect(a.answer).toBe('none-by-choice')
+    expect(a.note).toBe('Webinar, keine Nachverwertung')
+  })
+
+  it('unterscheidet „bewusst keine" von „nicht beantwortet"', () => {
+    const ohne = assessArchive(eingabe({ deliveryDestinations: [ziel('d1', 'Y')] }))
+    const bewusst = assessArchive(
+      eingabe({
+        deliveryDestinations: [ziel('d1', 'Y')],
+        archiveRecording: { answer: 'none-by-choice' },
+      }),
+    )
+    expect(ohne.answer).not.toBe(bewusst.answer)
+    expect(ohne.findings.length).toBeGreaterThan(0)
+    expect(bewusst.findings).toHaveLength(0)
+  })
+})
+
+describe('Bedarf 90 — der belegte Fehler: ein Geraet, zwei Aufgaben', () => {
+  it('meldet, wenn der Recorder DER Encoder ist — mit dem Ziel im Text', () => {
+    const a = assessArchive(
+      eingabe({
+        equipment: [geraet('obs', 'Streaming-PC')],
+        deliveryDestinations: [ziel('d1', 'YouTube', 'obs')],
+        archiveRecording: { answer: 'device', equipmentId: 'obs' },
+      }),
+    )
+    const f = a.findings.find((x) => x.kind === 'shares-encoder')
+    expect(f).toBeDefined()
+    expect(a.sharedWith).toEqual(['YouTube'])
+    const text = archiveFindingText(f!)
+    expect(text).toContain('Streaming-PC')
+    expect(text).toContain('YouTube')
+    // Der Beleg gehoert in den Text: ohne ihn ist es eine Meinung. Und die
+    // FOLGE gehoert dazu — „die Bildrate brach ein" laesst sich achselzuckend
+    // lesen, „das Material musste verworfen werden" nicht.
+    expect(text).toContain('obs-studio#13147')
+    expect(text).toContain('verworfen')
+  })
+
+  it('nennt ALLE betroffenen Ziele', () => {
+    const a = assessArchive(
+      eingabe({
+        equipment: [geraet('obs', 'PC')],
+        deliveryDestinations: [ziel('d1', 'YouTube', 'obs'), ziel('d2', 'Twitch', 'obs')],
+        archiveRecording: { answer: 'device', equipmentId: 'obs' },
+      }),
+    )
+    expect(a.sharedWith).toEqual(['YouTube', 'Twitch'])
+  })
+
+  it('meldet NICHT, wenn der Recorder ein eigenes Geraet ist', () => {
+    const a = assessArchive(
+      eingabe({
+        equipment: [geraet('obs', 'PC'), geraet('hd', 'HyperDeck')],
+        cables: [kabel('k1', 'mix', 'hd')],
+        deliveryDestinations: [ziel('d1', 'YouTube', 'obs')],
+        archiveRecording: { answer: 'device', equipmentId: 'hd' },
+      }),
+    )
+    expect(a.findings).toHaveLength(0)
+    expect(a.recorder).toEqual({ equipmentId: 'hd', name: 'HyperDeck' })
+  })
+})
+
+describe('Bedarf 90 — hinter dem Encoder ist dieselbe Abhaengigkeit', () => {
+  it('meldet einen Recorder, der vom Encoder gespeist wird', () => {
+    const a = assessArchive(
+      eingabe({
+        equipment: [geraet('obs', 'Streaming-PC'), geraet('hd', 'HyperDeck')],
+        cables: [kabel('k1', 'obs', 'hd')],
+        deliveryDestinations: [ziel('d1', 'YouTube', 'obs')],
+        archiveRecording: { answer: 'device', equipmentId: 'hd' },
+      }),
+    )
+    const f = a.findings.find((x) => x.kind === 'fed-by-encoder')
+    expect(f).toBeDefined()
+    expect(archiveFindingText(f!)).toContain('Streaming-PC')
+  })
+
+  it('findet den Weg auch ueber eine Zwischenstation', () => {
+    const a = assessArchive(
+      eingabe({
+        equipment: [geraet('obs', 'PC'), geraet('conv', 'Konverter'), geraet('hd', 'HyperDeck')],
+        cables: [kabel('k1', 'obs', 'conv'), kabel('k2', 'conv', 'hd')],
+        deliveryDestinations: [ziel('d1', 'Y', 'obs')],
+        archiveRecording: { answer: 'device', equipmentId: 'hd' },
+      }),
+    )
+    expect(a.findings.some((f) => f.kind === 'fed-by-encoder')).toBe(true)
+  })
+
+  it('meldet NICHT, wenn beide vom selben Mischer gespeist werden', () => {
+    // Der Normalfall und genau richtig: ein geteilter Ausgang. Wer das
+    // meldete, wuerde die Warnung entwerten, auf die es ankommt.
+    const a = assessArchive(
+      eingabe({
+        equipment: [geraet('mix', 'Mischer'), geraet('obs', 'PC'), geraet('hd', 'HyperDeck')],
+        cables: [kabel('k1', 'mix', 'obs'), kabel('k2', 'mix', 'hd')],
+        deliveryDestinations: [ziel('d1', 'Y', 'obs')],
+        archiveRecording: { answer: 'device', equipmentId: 'hd' },
+      }),
+    )
+    expect(a.findings).toHaveLength(0)
+  })
+
+  it('meldet nicht ZWEIMAL dasselbe, wenn der Recorder der Encoder ist', () => {
+    // Zwei Ziele: das eine sendet VOM Recorder, das andere speist ihn. Ohne
+    // die Schutzklausel stuenden `shares-encoder` und `fed-by-encoder`
+    // nebeneinander und meinten dieselbe Abhaengigkeit. Eine erste Fassung
+    // dieses Tests nutzte eine Selbst-Schleife (`obs -> obs`) und konnte den
+    // Fall gar nicht erzeugen.
+    const a = assessArchive(
+      eingabe({
+        equipment: [geraet('obs', 'PC'), geraet('zweit', 'Zweit-Encoder')],
+        cables: [kabel('k1', 'zweit', 'obs')],
+        deliveryDestinations: [ziel('d1', 'Y', 'obs'), ziel('d2', 'Z', 'zweit')],
+        archiveRecording: { answer: 'device', equipmentId: 'obs' },
+      }),
+    )
+    expect(a.findings.map((f) => f.kind)).toEqual(['shares-encoder'])
+  })
+
+  it('sucht nicht unbegrenzt weit', () => {
+    // Eine unbegrenzte Suche findet in einem grossen Plan am Ende immer
+    // irgendeinen Weg, und die Aussage „stockt der Encoder, stockt auch das"
+    // wird mit jedem Konverter dazwischen schwaecher.
+    const kette = ['obs', 'a', 'b', 'c', 'd', 'e', 'hd']
+    const a = assessArchive(
+      eingabe({
+        equipment: kette.map((id) => geraet(id, id)),
+        cables: kette.slice(0, -1).map((id, i) => kabel(`k${i}`, id, kette[i + 1])),
+        deliveryDestinations: [ziel('d1', 'Y', 'obs')],
+        archiveRecording: { answer: 'device', equipmentId: 'hd' },
+      }),
+    )
+    expect(a.findings).toHaveLength(0)
+  })
+})
+
+describe('Bedarf 90 — ein Zeiger ins Leere heisst so', () => {
+  it('meldet einen Recorder, den es im Plan nicht gibt', () => {
+    const a = assessArchive(
+      eingabe({
+        deliveryDestinations: [ziel('d1', 'Y', 'obs')],
+        archiveRecording: { answer: 'device', equipmentId: 'weg' },
+      }),
+    )
+    expect(a.findings.map((f) => f.kind)).toEqual(['recorder-gone'])
+    expect(a.recorder).toBeUndefined()
+  })
+
+  it('meldet auch die Antwort „Geraet" ohne Geraet', () => {
+    const a = assessArchive(
+      eingabe({
+        deliveryDestinations: [ziel('d1', 'Y')],
+        archiveRecording: { answer: 'device' },
+      }),
+    )
+    expect(a.findings.map((f) => f.kind)).toEqual(['recorder-gone'])
+  })
+})
+
+describe('Bedarf 90 — das Blatt', () => {
+  it('traegt Antwort, Geraet und die Befunde im Klartext', () => {
+    const a = assessArchive(
+      eingabe({
+        equipment: [geraet('obs', 'PC')],
+        deliveryDestinations: [ziel('d1', 'YouTube', 'obs')],
+        archiveRecording: { answer: 'device', equipmentId: 'obs', note: 'SSD im Schacht' },
+      }),
+    )
+    const tab = archiveTable(a)
+    expect(tab.headers).toEqual(['Art', 'Was', 'Geraet', 'Text'])
+    expect(tab.rows[0]).toContain(ARCHIVE_ANSWER_LABEL.device)
+    expect(tab.rows[0]).toContain('SSD im Schacht')
+    expect(tab.rows[1]).toContain(ARCHIVE_FINDING_LABEL['shares-encoder'])
+  })
+
+  it('setzt keinen Platzhalter, wo nichts steht', () => {
+    const tab = archiveTable(assessArchive(eingabe({ deliveryDestinations: [ziel('d1', 'Y')] })))
+    expect(tab.rows.every((r) => r.every((c) => String(c) !== 'undefined'))).toBe(true)
+  })
+
+  it('jeder Befund hat eine Beschriftung und einen Text', () => {
+    for (const k of Object.keys(ARCHIVE_FINDING_LABEL)) {
+      const kind = k as keyof typeof ARCHIVE_FINDING_LABEL
+      expect(ARCHIVE_FINDING_LABEL[kind].length).toBeGreaterThan(0)
+      expect(archiveFindingText({ kind, values: ['A', 'B'] }).length).toBeGreaterThan(20)
+    }
+  })
+})
+
+describe('Bedarf 90 — verdrahtet', () => {
+  it('der Ausspiel-Dialog beurteilt und zeigt die Befunde', () => {
+    expect(dialogQuelle).toMatch(/assessArchive\(project\)/)
+    expect(dialogQuelle).toContain('ARCHIVE_FINDING_LABEL[f.kind]')
+  })
+
+  it('der Abschnitt erscheint nur mit mindestens einem Ziel', () => {
+    expect(dialogQuelle).toMatch(/\{list\.length > 0 && \(/)
+  })
+
+  it('„noch nicht beantwortet" loescht die Antwort, statt sie zu setzen', () => {
+    // Sonst waere „nicht beantwortet" ein gespeicherter Wert und damit selbst
+    // eine Aussage — und die Unterscheidung zu `none-by-choice` fiele in sich
+    // zusammen.
+    expect(dialogQuelle).toContain("if (answer === 'not-stated') return setArchive(undefined)")
+  })
+
+  it('der Setter ebnet die Unterscheidung nicht ein', () => {
+    // Auf die FORM pruefen: eine Gegenprobe setzte
+    // `archiveRecording: rec ?? { answer: 'not-stated' }` und blieb gruen,
+    // weil `toContain` den Teilstring fand. Ein gespeichertes
+    // „nicht beantwortet" waere selbst eine Aussage, und die Unterscheidung
+    // zu `none-by-choice` fiele in sich zusammen.
+    expect(sliceQuelle).toMatch(/setArchiveRecording: \(rec\) =>/)
+    expect(sliceQuelle).toMatch(/archiveRecording: rec\s*\}/)
+  })
+})


### PR DESCRIPTION
Bedarf 90 (P2) steht auf einem geschlossenen, nicht behobenen Fehlerbericht:

> with obs-multi-rtmp, „OBS encoder will overload if (any) stream upload will stall/lag", **degrading the recording's frame rate to the point the material must be discarded**

obsproject/obs-studio#13147, „closed as not planned". Die *unabhaengig
konfigurierte* Aufzeichnung wird von einer stockenden Ausspielung mitgerissen
— und es faellt erst nach dem Abbau auf, wenn die Show vorbei und die
Kamera-Karten formatiert sind.

## Die Grenze zieht der Bedarf selbst

> **Not a Cable Planner feature but a planning fact:** the plan should force an explicit answer to „where does the independent archive recording live and what is it isolated from", and flag a delivery path where the only recording shares fate with the transmission.

Also **keine Telemetrie**. Ob ein Encoder gerade ueberlastet ist, weiss ein
offline-Planer nicht; eine geratene Antwort saehe wie eine Messung aus —
dieselbe Grenze wie „is it flowing" in Bedarf 76.

## Was gebaut ist

- **`types/delivery.ts`** — `ArchiveRecording` mit **drei** Antworten.
- **`project.archiveRecording`** plus `setArchiveRecording`.
- **`lib/archiveIsolation.ts` (neu)** — `assessArchive` mit vier Befunden,
  `archiveFindingText`, `archiveTable`.
- **Ausspiel-Dialog** — die Frage steht dort, wo die Encoder benannt werden,
  mit Befunden und einem Blatt zum Mitnehmen.

**Gefragt wird genau eine Sache:** welches Geraet aufzeichnet. Das kann der
Plan nicht wissen — ein Mischer mit SSD-Schacht zeichnet auf, wenn jemand auf
Aufnahme drueckt, und das steht in keinem Kabel. **Alles andere ist
abgeleitet:**

| Befund | |
|---|---|
| `shares-encoder` | Der Recorder **ist** der Encoder eines Ziels — der belegte Fall. Der Text nennt die Fundstelle *und* die Folge: „die Bildrate brach ein" liest man achselzuckend, „das Material musste verworfen werden" nicht. |
| `fed-by-encoder` | Der Recorder haengt hinter dem Encoder. Dieselbe Abhaengigkeit, eine Kabellaenge weiter. Vorwaertssuche mit Tiefengrenze — unbegrenzt faende sie in einem grossen Plan am Ende immer irgendeinen Weg. |
| `recorder-gone` | Der Zeiger geht ins Leere. |
| `not-stated` | Es gibt Ziele und keine Antwort. |

`none-by-choice` ist **kein** Befund und genau deshalb ein eigener Zustand:
„wir haben bewusst keine Archiv-Kopie" ist eine gueltige Entscheidung (ein
Webinar ohne Nachverwertung) und etwas *anderes* als „niemand hat es gesagt".
Ein fehlendes Feld koennte beides heissen; der Bedarf verlangt aber, dass der
Plan die Antwort **erzwingt** — deshalb *loescht* „noch nicht beantwortet" die
Antwort, statt sie zu speichern.

Und ausdruecklich kein Befund ist die gemeinsame **Quelle**: dass Recorder und
Encoder vom selben Mischer-Ausgang gespeist werden, ist der Normalfall und
genau richtig. Wer das meldete, entwertete die Warnung, auf die es ankommt.

Ohne ein einziges Ausspielziel wird gar nicht gefragt.

## Gegenproben

Vierzehn. **Zwei blieben gruen** und deckten je einen echten Mangel auf —
beide nachgebessert und erneut rot bekommen:

- „doppelter Befund bei Encoder = Recorder" liess sich mit der alten
  Vorrichtung (Selbst-Schleife `obs → obs`) gar nicht erzeugen.
- „der Setter ebnet die Unterscheidung nicht ein" suchte den **Teilstring**
  `archiveRecording: rec`, und `rec ?? { answer: 'not-stated' }` enthaelt ihn
  noch.

Zwei weitere blieben gruen, **ohne eine Luecke zu zeigen**: eine Mutation an
der Erreichbarkeitssuche war in beiden Richtungen bedeutungslos (die
Zusicherung prueft jetzt gegen ein bedingungsloses `true`), und eine Textprobe
traf einen anderen Satzteil als den, den ihr Name versprach — die Fundstelle
war die ganze Zeit gesichert; die **Folge** ist es jetzt zusaetzlich.

## Geprueft

- `npx tsc -p tsconfig.app.json --noEmit`: 0 Fehler
- `npm test`: 1649 Tests gruen, 2 skipped (137 Dateien)
- `npm run lint`: 0 Fehler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_