### PR TITLE
netz: ein Multicast-Adressplan mit beiden unsichtbaren Regeln (Bedarf 72)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1485,7 +1485,9 @@ export default function App() {
                   ? t('app.loadReport.deliveryDestination', 'Ausspielziel')
                   : d.kind === 'venue-answer'
                     ? t('app.loadReport.venueAnswer', 'Antwort der Haus-IT')
-                    : t('app.loadReport.sourceIdentity', 'Signalquelle')}
+                    : d.kind === 'multicast-assignment'
+                      ? t('app.loadReport.multicastAssignment', 'Multicast-Vergabe')
+                      : t('app.loadReport.sourceIdentity', 'Signalquelle')}
                 {d.label ? ` „${d.label}"` : ''}
                 {' — '}
                 {d.reason === 'duplicate-id'

--- a/src/renderer/components/Analysis/AnalysisDialog.tsx
+++ b/src/renderer/components/Analysis/AnalysisDialog.tsx
@@ -52,6 +52,15 @@ import { RF_BANDS, bandsForFrequency, bandLabel } from '../../lib/rfBands'
 import { PTP_FINDING_LABEL, buildPtpPlan, ptpTable } from '../../lib/ptpPlan'
 import { CREW_SECTION_LABEL, buildCrewSheet, crewSheetTable } from '../../lib/crewNetworkSheet'
 import {
+  MULTICAST_ESSENCE_LABEL,
+  MULTICAST_FINDING_LABEL,
+  allocateMulticast,
+  buildMulticastPlan,
+  multicastMac,
+  multicastTable,
+} from '../../lib/multicastPlan'
+import { MULTICAST_LEG_LABEL } from '../../types/multicast'
+import {
   SPECTRUM_SOURCE_LABEL,
   buildSpectrumPlan,
   conflictParticipants,
@@ -383,6 +392,54 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
   // aus vier Quellen schoepft (Geraete, Kabel, Kontakte, Antworten des Hauses).
   const projekt = useProjectStore((s) => s.project)
   const crew = useMemo(() => buildCrewSheet(projekt), [projekt])
+
+  // BEDARF 72 — der Multicast-Adressplan. Die Fluesse kommen aus dem
+  // Kabelgraph, die Adressen aus dem Projekt.
+  const setMulticastConfig = useProjectStore((s) => s.setMulticastConfig)
+  const multicast = useMemo(() => buildMulticastPlan(projekt), [projekt])
+  // Der Entwurf liegt lokal, damit das Tippen im Pool-Feld nicht bei jedem
+  // Zeichen eine Vergabe-Rechnung ueber mehrere hundert Fluesse ausloest.
+  const [poolDraft, setPoolDraft] = useState(projekt.multicast?.pool ?? '')
+  const [portDraft, setPortDraft] = useState(String(projekt.multicast?.basePort ?? 20000))
+
+  const rahmenUebernehmen = () => {
+    const port = Number(portDraft)
+    setMulticastConfig({
+      pool: poolDraft.trim(),
+      basePort: Number.isInteger(port) && port > 0 && port <= 65535 ? port : 20000,
+      assignments: projekt.multicast?.assignments ?? [],
+    })
+  }
+
+  // Vergeben heisst NACHVERGEBEN. `allocateMulticast` bewegt keine bestehende
+  // Adresse — eine verteilte Adresse umzunummerieren waere der stille Verlust
+  // aus Bedarf 96. Deshalb braucht dieser Knopf auch keine Rueckfrage.
+  const vergeben = () => {
+    const cfg = projekt.multicast
+    if (!cfg) return
+    const res = allocateMulticast(multicast.flows, cfg)
+    setMulticastConfig({ ...cfg, assignments: res.assignments })
+  }
+
+  // Verwaiste Vergaben wegzuraeumen ist eine eigene, sichtbare Handlung: sie
+  // LOESCHT etwas, und was sie loescht, steht darueber namentlich da.
+  const verwaisteEntfernen = () => {
+    const cfg = projekt.multicast
+    if (!cfg) return
+    const weg = new Set(multicast.stale.map((a) => `${a.flowKey}|${a.leg}`))
+    setMulticastConfig({
+      ...cfg,
+      assignments: cfg.assignments.filter((a) => !weg.has(`${a.flowKey}|${a.leg}`)),
+    })
+  }
+
+  const exportMulticast = () => {
+    downloadBlob(
+      buildExportFilenameWithSuffix(projectName, 'multicast-adressplan', 'csv'),
+      csvFromTable(multicastTable(multicast)),
+      'text/csv',
+    )
+  }
 
   // Ausgeschriebene Beschriftungen statt `t(`...${key}`)`: ein zusammengesetzter
   // Schluessel ist fuer den i18n-Abdeckungs-Test unsichtbar, und der deutsche
@@ -917,6 +974,143 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
         </div>
       )}
 
+      {/* BEDARF 72 — der Multicast-Adressplan. Nur sichtbar, wenn der Plan
+          ueberhaupt Multicast-Essenz traegt: ein reiner SDI-Aufbau hat keine
+          Gruppen, und ein leerer Abschnitt waere Rauschen. */}
+      {multicast.needsMulticast && (
+        <div className="rounded-cp-panel border border-[var(--cp-border)] bg-[var(--cp-surface-1)] p-cp-3">
+          <div className="mb-2 text-cp-sm font-semibold text-[var(--cp-text)]">
+            {t('analysis.mc.title', 'Multicast-Adressplan')}
+          </div>
+          <div className="mb-2 text-cp-xs text-[var(--cp-text-muted)]">
+            {t(
+              'analysis.mc.intro',
+              'Jede Essenz ist eine eigene Gruppe, und die Gruppe gehört dem Sender — fünf Empfänger an einer Kamera abonnieren eine, nicht fünf. Zwei Regeln sieht man einer Tabelle nicht an: Adresse und Port müssen zusammen eindeutig sein, und 32 Gruppen fallen auf dieselbe L2-Adresse. Die MAC steht deshalb im Blatt.',
+            )}
+          </div>
+
+          <div className="mb-2 flex flex-wrap items-end gap-2">
+            <label className="flex flex-col gap-0.5">
+              <span className="text-cp-xs text-[var(--cp-text-muted)]">
+                {t('analysis.mc.pool', 'Pool (CIDR)')}
+              </span>
+              <input
+                value={poolDraft}
+                onChange={(e) => setPoolDraft(e.target.value)}
+                onBlur={rahmenUebernehmen}
+                placeholder="239.100.0.0/16"
+                className="w-44 rounded border border-[var(--cp-border)] bg-[var(--cp-surface-2)] px-2 py-1 font-mono text-cp-xs text-[var(--cp-text)]"
+              />
+            </label>
+            <label className="flex flex-col gap-0.5">
+              <span className="text-cp-xs text-[var(--cp-text-muted)]">
+                {t('analysis.mc.port', 'UDP-Port')}
+              </span>
+              <input
+                value={portDraft}
+                onChange={(e) => setPortDraft(e.target.value)}
+                onBlur={rahmenUebernehmen}
+                inputMode="numeric"
+                className="w-24 rounded border border-[var(--cp-border)] bg-[var(--cp-surface-2)] px-2 py-1 font-mono text-cp-xs text-[var(--cp-text)]"
+              />
+            </label>
+            <button
+              type="button"
+              onClick={vergeben}
+              disabled={!multicast.pool || multicast.open.length === 0}
+              className="rounded border border-[var(--cp-border)] px-2 py-1 text-cp-xs font-medium text-[var(--cp-text)] hover:bg-[var(--cp-surface-2)] disabled:opacity-40"
+            >
+              {format(t('analysis.mc.allocate', '{n} offene Beine vergeben'), {
+                n: String(multicast.open.length),
+              })}
+            </button>
+          </div>
+
+          {multicast.poolError && (
+            <div className="mb-2 text-cp-xs text-amber-300/90">{multicast.poolError}</div>
+          )}
+          {!multicast.pool && !multicast.poolError && (
+            <div className="mb-2 text-cp-xs text-[var(--cp-text-faint)]">
+              {t(
+                'analysis.mc.noPool',
+                'Kein Pool erklärt — es wird nichts vergeben. Ein Pool mit /9 oder enger kann mit sich selbst nicht kollidieren; erst ein weiterer lässt das Bit los, das die 32 Gruppen auf eine MAC fallen lässt.',
+              )}
+            </div>
+          )}
+
+          <ul className="flex flex-col gap-0.5 text-cp-xs">
+            {multicast.flows.map((f) =>
+              f.legs.map((leg) => {
+                const a = multicast.assignments.find((x) => x.flowKey === f.key && x.leg === leg)
+                return (
+                  <li key={`${f.key}-${leg}`} className="flex flex-wrap items-baseline gap-2">
+                    <span className="flex-1 text-[var(--cp-text)]">{f.label}</span>
+                    <span className="w-20 shrink-0 text-[var(--cp-text-muted)]">
+                      {MULTICAST_ESSENCE_LABEL[f.essence]}
+                    </span>
+                    <span className="w-24 shrink-0 text-[var(--cp-text-faint)]">
+                      {MULTICAST_LEG_LABEL[leg]}
+                    </span>
+                    <span
+                      className={`w-32 shrink-0 font-mono ${
+                        a ? 'text-[var(--cp-text)]' : 'text-amber-300/90'
+                      }`}
+                    >
+                      {a ? a.address : t('analysis.mc.open', 'offen')}
+                    </span>
+                    <span className="w-40 shrink-0 font-mono text-[var(--cp-text-faint)]">
+                      {a ? (multicastMac(a.address) ?? '') : ''}
+                    </span>
+                  </li>
+                )
+              }),
+            )}
+          </ul>
+
+          {multicast.stale.length > 0 && (
+            <div className="mt-2 flex flex-wrap items-baseline gap-2">
+              <span className="text-cp-xs text-[var(--cp-text-faint)]">
+                {format(
+                  t(
+                    'analysis.mc.stale',
+                    '{n} Vergabe(n) gehören zu Flüssen, die es nicht mehr gibt: {liste}',
+                  ),
+                  {
+                    n: String(multicast.stale.length),
+                    liste: multicast.stale.map((a) => a.address).join(', '),
+                  },
+                )}
+              </span>
+              <button
+                type="button"
+                onClick={verwaisteEntfernen}
+                className="rounded border border-[var(--cp-border)] px-2 py-0.5 text-cp-xs text-[var(--cp-text)] hover:bg-[var(--cp-surface-2)]"
+              >
+                {t('analysis.mc.dropStale', 'Verwaiste entfernen')}
+              </button>
+            </div>
+          )}
+
+          {multicast.findings.length > 0 && (
+            <ul className="mt-2 flex flex-col gap-1">
+              {multicast.findings.map((f, i) => (
+                <li key={`${f.kind}-${i}`} className="text-cp-xs">
+                  <span
+                    className={
+                      f.kind === 'outside-pool'
+                        ? 'text-[var(--cp-text-muted)]'
+                        : 'text-amber-300/90'
+                    }
+                  >
+                    <strong>{MULTICAST_FINDING_LABEL[f.kind]}</strong> — {f.text}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
       {/* BEDARF 77 — das Merkblatt. Kurz gehalten: es soll auf eine Seite
           passen und von jemandem gelesen werden, der gerade ein Kabel in der
           Hand hat. Was der Plan nicht weiss, steht als Frage drauf statt als
@@ -988,6 +1182,14 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
           className="inline-flex items-center gap-1 rounded border border-[var(--cp-border)] px-2 py-1 text-cp-xs font-medium text-[var(--cp-text)] hover:bg-[var(--cp-surface-2)] disabled:opacity-40"
         >
           <Icon icon={Download} size="xs" /> {t('analysis.ptp.export', 'Zeit-Plan (PTP)')}
+        </button>
+        <button
+          type="button"
+          onClick={exportMulticast}
+          disabled={!multicast.needsMulticast}
+          className="inline-flex items-center gap-1 rounded border border-[var(--cp-border)] px-2 py-1 text-cp-xs font-medium text-[var(--cp-text)] hover:bg-[var(--cp-surface-2)] disabled:opacity-40"
+        >
+          <Icon icon={Download} size="xs" /> {t('analysis.mc.export', 'Multicast-Adressplan')}
         </button>
         <button
           type="button"

--- a/src/renderer/lib/documentRegistry.ts
+++ b/src/renderer/lib/documentRegistry.ts
@@ -26,6 +26,7 @@ import { deliveryPathTable } from './deliveryPath'
 import { buildPtpPlan, ptpTable } from './ptpPlan'
 import { crewSheetTableForProject } from './crewNetworkSheet'
 import { spectrumTableForProject } from './spectrumPlan'
+import { multicastTableForProject } from './multicastPlan'
 import type { CsvTable } from './csv'
 
 const ofTable =
@@ -91,6 +92,12 @@ export const DOCUMENT_STANDS: Record<string, (project: CablePlannerProject) => s
   // Intercom-Zuordnungen. Die BEFUNDE stehen nicht drin -- sie tragen
   // Fliesstext aus `computeRfConflicts`.
   'spektrum-plan': ofTable(spectrumTableForProject),
+  // Bedarf 72 — der Multicast-Adressplan. Reproduzierbar: die Fluesse folgen
+  // aus dem Kabelgraph, die Adressen stehen im Projekt. Die BEFUNDE stehen
+  // nicht in der Tabelle -- sie tragen Fliesstext, und ein Blatt, dessen Stand
+  // sich mit jeder Umformulierung aendert, meldete jedes gedruckte Exemplar
+  // als veraltet.
+  'multicast-plan': ofTable(multicastTableForProject),
 }
 
 /**
@@ -157,6 +164,7 @@ export const DOCUMENT_LABELS: Record<string, string> = {
   'ptp-plan': 'Zeit-Plan (PTP)',
   'crew-netz': 'Netz-Merkblatt (Crew)',
   'spektrum-plan': 'Spektrum-Plan',
+  'multicast-plan': 'Multicast-Adressplan',
   'videohub-labels': 'Videohub-Labels',
   'atem-mv-layout': 'Multiviewer-Layout',
   'switch-port-karte': 'Switch-Port-Karte',

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3210,6 +3210,7 @@ export const en: Dict = {
   'app.loadReport.sourceIdentity': 'Source',
   'app.loadReport.deliveryDestination': 'Delivery destination',
   'app.loadReport.venueAnswer': 'Venue IT answer',
+  'app.loadReport.multicastAssignment': 'Multicast assignment',
   'app.loadReport.duplicateId': 'duplicate id, the first entry wins',
   'app.loadReport.missingRequired': 'required field missing (name)',
   'app.loadReport.hint': 'Devices that pointed at these roles lost their assignment — including the TSL address used for tally. Saving overwrites the file with this state.',
@@ -4253,6 +4254,19 @@ export const en: Dict = {
   'analysis.crew.title': 'Network briefing sheet for the crew',
   'analysis.crew.ask': '{n} points to settle on site',
   'analysis.crew.export': 'Crew network sheet',
+  // Bedarf 72 — der Multicast-Adressplan.
+  'analysis.mc.title': 'Multicast address plan',
+  'analysis.mc.intro':
+    'Every essence is its own group, and the group belongs to the sender \u2014 five receivers on one camera subscribe to one, not five. Two rules a table never shows: address and port must be unique together, and 32 groups collapse onto the same L2 address. That is why the MAC is on the sheet.',
+  'analysis.mc.pool': 'Pool (CIDR)',
+  'analysis.mc.port': 'UDP port',
+  'analysis.mc.allocate': 'Allocate {n} open legs',
+  'analysis.mc.noPool':
+    'No pool declared \u2014 nothing is allocated. A pool of /9 or narrower cannot collide with itself; only a wider one frees the bit that drops 32 groups onto one MAC.',
+  'analysis.mc.open': 'open',
+  'analysis.mc.stale': '{n} assignment(s) belong to flows that no longer exist: {liste}',
+  'analysis.mc.dropStale': 'Remove orphaned',
+  'analysis.mc.export': 'Multicast address plan',
   // Bedarf 95 — ein Spektrum-Plan.
   'analysis.rf.scope': '{n} transmitters in the plan: {rig} from the wireless mic rig, {link} as radio links.',
   'analysis.rf.noFreq': '{n} without a frequency \u2014 they are in NO calculation: {liste}',

--- a/src/renderer/lib/multicastPlan.ts
+++ b/src/renderer/lib/multicastPlan.ts
@@ -1,0 +1,694 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Der Multicast-Adressplan (Bedarf 72, P2). Welche Gruppe welcher Sender
+// belegt, unter welchem UDP-Port, auf welcher L2-Adresse — und welche zwei
+// Zeilen sich dabei ins Gehege kommen, ohne dass man es ihnen ansieht.
+//
+//   > Every essence (2110-20/-30/-40) is its own multicast group, doubled for
+//   > 2022-7. A mid-size truck is several hundred rows allocated by hand in
+//   > Excel. Two invisible rules get violated: (address, UDP port) must be
+//   > unique per sender, and 32 L3 multicast addresses alias onto one L2 MAC,
+//   > so a naive scheme collides.
+//
+// Belege: Arista, „M&E Multicast Addressing" (der 2^5-Kollaps); Dataton
+// WATCHOUT, ST-2110-Netzwerkeinrichtung (Adresse und Port zusammen eindeutig).
+//
+// ─── DIE ZWEITE REGEL, UND WARUM SIE UNSICHTBAR IST ────────────────────────
+//
+// Eine IPv4-Multicast-Adresse wird auf die MAC `01:00:5e:` + die UNTEREN 23
+// BITS der Adresse abgebildet. Die Adresse hat unterhalb von 224.0.0.0/4
+// achtundzwanzig freie Bits. 28 - 23 = 5, also fallen 2^5 = 32 verschiedene
+// Gruppen auf DIESELBE MAC.
+//
+// Was daran teuer ist: die beiden Adressen sehen im Plan verschieden aus, und
+// sie SIND verschieden — der Switch trennt sie sauber, wenn er IGMP-Snooping
+// auf L3 macht. Die Netzwerkkarte des Empfaengers filtert aber auf L2. Sie
+// nimmt beide Stroeme an, das Betriebssystem verwirft den falschen, und der
+// Empfaenger traegt die doppelte Last. Bei einem unkomprimierten 1080p59.94-
+// Fluss nach 2110-20 sind das rund 1,5 Gbit/s, die niemand eingeplant hat.
+//
+// Ob es tatsaechlich weh tut, haengt an der Karte und am Switch. Deshalb sagt
+// der Befund, WAS aliasiert und was es kostet — nicht, dass es ausfaellt. Der
+// Plan misst nicht (dieselbe Haltung wie bei „is it flowing", Bedarf 76, und
+// beim Encoder-Ueberlauf, Bedarf 90).
+//
+// ─── WELCHER POOL MIT SICH SELBST KOLLIDIEREN KANN ─────────────────────────
+//
+// Die fuenf verlorenen Bits sind Bit 23 (das oberste Bit im zweiten Oktett)
+// und die Bits 24..27 (das untere Halbbyte des ersten Oktetts). Ein Pool mit
+// Praefix /9 oder enger haelt alle fuenf fest — er kann mit sich selbst gar
+// nicht aliasieren. Erst ein Pool ueber /8 laesst Bit 23 los.
+//
+// Genau das ist das „naive scheme" aus dem Beleg: `239.<dienst>.<x>.<y>` mit
+// dem Dienst im zweiten Oktett. 239.1.1.1 (Video) und 239.129.1.1 (Audio)
+// tragen dieselbe MAC — Paar fuer Paar, ueber den ganzen Plan.
+//
+// Der Alias-Test bleibt trotzdem drin, auch bei einem /16-Pool: eine von Hand
+// gepflegte Vergabe kann AUSSERHALB des Pools liegen, und genau die ist der
+// haeufige Fall — ein halb gefuellter Plan, in den jemand aus dem Gedaechtnis
+// nachgetragen hat.
+//
+// ─── WAS DIESE DATEI NICHT TUT ─────────────────────────────────────────────
+//
+// Sie verschiebt keine bestehende Vergabe und loescht keine. `allocateMulticast`
+// VERGIBT NUR NACH — eine verteilte Adresse umzunummerieren waere genau der
+// stille Datenverlust, den Bedarf 96 verbietet (Cryde/musicall#798). Vergaben
+// zu Fluessen, die es nicht mehr gibt, werden als `stale` GEMELDET; sie
+// wegzuraeumen ist eine eigene, sichtbare Handlung.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { EquipmentItem, Port } from '../types/equipment'
+import type { Cable } from '../types/cable'
+import type { CablePlannerProject } from '../types/project'
+import type { SignalStandard } from '../types/cableSpec'
+import type { MulticastAssignment, MulticastConfig, MulticastLeg } from '../types/multicast'
+import { MULTICAST_LEG_LABEL } from '../types/multicast'
+import type { CsvTable } from './csv'
+import { deviceInterfaces } from './networkInterfaces'
+import { portDisplayLabel } from './portLabel'
+
+// ───────────────────────────────────────────────────────────────────────────
+// Essenz
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Die Essenz, die ueber eine Gruppe laeuft.
+ *
+ * Bewusst FEINER als `EssenceFamily` in `ptpPlan.ts`. Dort geht es um den
+ * Medientakt, und dafuer stehen -20 und -40 auf derselben Seite. Hier geht es
+ * um Gruppen, und der Bedarf sagt ausdruecklich „every essence (2110-20/-30/
+ * -40) is its own multicast group": ANC ist eine eigene Gruppe, kein Anhaengsel
+ * des Videos. Licht ueber IP kommt dazu — sACN und Art-Net sind Multicast und
+ * belegen denselben Adressraum, auch wenn PTP sie nicht interessiert.
+ */
+export type MulticastEssence = 'video' | 'audio' | 'anc' | 'lighting'
+
+export const MULTICAST_ESSENCE_LABEL: Readonly<Record<MulticastEssence, string>> = {
+  video: 'Video',
+  audio: 'Audio',
+  anc: 'ANC / Daten',
+  lighting: 'Licht',
+}
+
+/**
+ * Welcher Standard welche Essenz ist.
+ *
+ * Diese Zuordnung ist die einzige Stelle, die es weiss. `tests/multicastPlan
+ * .test.ts` prueft, dass jeder Standard aus den drei Multicast-Mengen in
+ * `venueNetworkRequest` hier einen Eintrag hat — sonst faellt ein spaeter
+ * hinzugefuegter Standard still aus dem Adressplan heraus, und der Plan
+ * meldete eine vollstaendige Vergabe fuer eine Gruppe, die er nie gesehen hat.
+ */
+export const MULTICAST_ESSENCE: Readonly<Partial<Record<SignalStandard, MulticastEssence>>> = {
+  'ST2110-20': 'video',
+  'ST2110-30': 'audio',
+  'ST2110-40': 'anc',
+  AES67: 'audio',
+  Dante: 'audio',
+  sACN: 'lighting',
+  'Art-Net': 'lighting',
+}
+
+export const essenceOf = (std: SignalStandard | undefined): MulticastEssence | null =>
+  (std && MULTICAST_ESSENCE[std]) || null
+
+// ───────────────────────────────────────────────────────────────────────────
+// Adress-Arithmetik
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Punktierte IPv4 als vorzeichenlose Zahl, oder `null` bei Unsinn. */
+export function ipToInt(addr: string): number | null {
+  const parts = addr.trim().split('.')
+  if (parts.length !== 4) return null
+  let out = 0
+  for (const p of parts) {
+    if (!/^\d{1,3}$/.test(p)) return null
+    const n = Number(p)
+    if (n > 255) return null
+    out = out * 256 + n
+  }
+  return out
+}
+
+export const intToIp = (n: number): string =>
+  [(n >>> 24) & 255, (n >>> 16) & 255, (n >>> 8) & 255, n & 255].join('.')
+
+/** Liegt die Adresse in 224.0.0.0/4? */
+export const isMulticastAddress = (addr: string): boolean => {
+  const n = ipToInt(addr)
+  return n !== null && n >= 0xe0000000 && n <= 0xefffffff
+}
+
+/**
+ * Die L2-Adresse, auf die eine Gruppe abgebildet wird.
+ *
+ * `01:00:5e:` plus die unteren 23 Bit — das oberste Bit des vierten Bytes wird
+ * dabei zwangsweise 0. Genau dieses eine Bit ist der Grund fuer den Kollaps.
+ */
+export function multicastMac(addr: string): string | null {
+  const n = ipToInt(addr)
+  if (n === null) return null
+  const b2 = (n >>> 16) & 0x7f
+  const b3 = (n >>> 8) & 0xff
+  const b4 = n & 0xff
+  const hex = (v: number) => v.toString(16).padStart(2, '0')
+  return `01:00:5e:${hex(b2)}:${hex(b3)}:${hex(b4)}`
+}
+
+/** Die unteren 23 Bit. Zwei Adressen mit gleichem Wert teilen sich eine MAC. */
+export function aliasKey(addr: string): number | null {
+  const n = ipToInt(addr)
+  return n === null ? null : n & 0x007fffff
+}
+
+/** Bereiche, die keine Medien tragen duerfen — mit dem Grund im Klartext. */
+export const RESERVED_RANGES: ReadonlyArray<{
+  cidr: string
+  from: number
+  to: number
+  reason: string
+}> = [
+  {
+    cidr: '224.0.0.0/24',
+    from: 0xe0000000,
+    to: 0xe00000ff,
+    reason: 'Local Network Control Block — TTL 1, wird von keinem Router weitergegeben',
+  },
+  {
+    cidr: '224.0.1.0/24',
+    from: 0xe0000100,
+    to: 0xe00001ff,
+    reason: 'Internetwork Control Block — hier liegen NTP und PTP selbst (224.0.1.129 ff.)',
+  },
+  {
+    cidr: '232.0.0.0/8',
+    from: 0xe8000000,
+    to: 0xe8ffffff,
+    reason: 'Source-Specific Multicast — verlangt (S,G)-Joins, ein ASM-Plan greift hier ins Leere',
+  },
+  {
+    cidr: '239.255.255.250/32',
+    from: 0xeffffffa,
+    to: 0xeffffffa,
+    reason: 'SSDP/UPnP — jede Windows-Maschine im Netz spricht diese Gruppe an',
+  },
+]
+
+export const reservedReason = (addr: string): string | null => {
+  const n = ipToInt(addr)
+  if (n === null) return null
+  for (const r of RESERVED_RANGES) if (n >= r.from && n <= r.to) return `${r.cidr}: ${r.reason}`
+  return null
+}
+
+export interface ParsedPool {
+  base: number
+  count: number
+  prefix: number
+}
+
+/**
+ * `239.100.0.0/16` → Basis und Groesse. `null`, wenn es kein brauchbarer
+ * Multicast-Pool ist — kein Wegwerfen des Fehlers: `buildMulticastPlan`
+ * traegt ihn als `poolError` weiter, damit die Oberflaeche sagen kann, WAS
+ * an der Eingabe nicht stimmt.
+ */
+export function parsePool(cidr: string): ParsedPool | null {
+  const m = /^\s*(\d{1,3}(?:\.\d{1,3}){3})\s*\/\s*(\d{1,2})\s*$/.exec(cidr)
+  if (!m) return null
+  const base = ipToInt(m[1])
+  const prefix = Number(m[2])
+  if (base === null || prefix < 4 || prefix > 32) return null
+  const size = 2 ** (32 - prefix)
+  // Auf die eigene Groesse ausgerichtet — sonst meint „239.100.0.5/16" etwas
+  // anderes, als der Leser sieht.
+  const aligned = base - (base % size)
+  if (aligned < 0xe0000000 || aligned + size - 1 > 0xefffffff) return null
+  return { base: aligned, count: size, prefix }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Die Fluesse — abgeleitet
+// ───────────────────────────────────────────────────────────────────────────
+
+export const flowKey = (equipmentId: string, portId: string): string =>
+  `${equipmentId}:${portId}`
+
+export interface MulticastFlow {
+  key: string
+  equipmentId: string
+  portId: string
+  /** „Kamera 1 · SDI OUT 1". */
+  label: string
+  standard: SignalStandard
+  essence: MulticastEssence
+  /** Geraete-Namen der Empfaenger — der Grund, warum es EINE Gruppe ist. */
+  receivers: string[]
+  /**
+   * Die Beine, die dieser Fluss braucht. Aus den Medien-Schnittstellen des
+   * SENDERS abgeleitet: wer `media-primary` UND `media-secondary` fuehrt,
+   * sendet nach 2022-7 doppelt. Abgeleitet und nicht gespeichert, damit ein
+   * nachgetragenes Sekundaernetz das Bein B sofort als offen zeigt.
+   */
+  legs: MulticastLeg[]
+}
+
+/**
+ * Die Fluss-Tabelle aus dem gezeichneten Signalfluss — die Engstelle.
+ *
+ * Ein Fluss je SENDE-PORT, nicht je Kabel: fuenf Empfaenger an einer Kamera
+ * sind eine Gruppe. Der Standard kommt vom Kabel, sonst vom Port; ein Kabel
+ * ohne Standard an einem Port mit Standard ist der Normalfall im Bestand.
+ */
+export function collectFlows(
+  equipment: readonly EquipmentItem[],
+  cables: readonly Cable[],
+): MulticastFlow[] {
+  const byId = new Map(equipment.map((e) => [e.id, e]))
+  const portOf = (e: EquipmentItem, portId: string): Port | undefined =>
+    [...(e.outputs ?? []), ...(e.inputs ?? [])].find((p) => p.id === portId)
+
+  const flows = new Map<string, MulticastFlow>()
+  for (const c of cables) {
+    const sender = byId.get(c.fromEquipmentId)
+    if (!sender) continue
+    const port = portOf(sender, c.fromPortId)
+    const std = c.standard ?? port?.standard
+    const essence = essenceOf(std)
+    if (!std || !essence) continue
+
+    const key = flowKey(sender.id, c.fromPortId)
+    const existing = flows.get(key)
+    const receiver = byId.get(c.toEquipmentId)?.name
+    if (existing) {
+      if (receiver && !existing.receivers.includes(receiver)) existing.receivers.push(receiver)
+      continue
+    }
+    const nics = deviceInterfaces(sender)
+    const doppelt =
+      nics.some((n) => n.role === 'media-primary') && nics.some((n) => n.role === 'media-secondary')
+    flows.set(key, {
+      key,
+      equipmentId: sender.id,
+      portId: c.fromPortId,
+      label: `${sender.name} · ${port ? portDisplayLabel(port) : c.fromPortId}`,
+      standard: std,
+      essence,
+      receivers: receiver ? [receiver] : [],
+      legs: doppelt ? ['a', 'b'] : ['a'],
+    })
+  }
+  for (const f of flows.values()) f.receivers.sort((a, b) => a.localeCompare(b, 'de'))
+  return [...flows.values()].sort((a, b) => a.label.localeCompare(b.label, 'de'))
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Die Befunde
+// ───────────────────────────────────────────────────────────────────────────
+
+export type MulticastFindingKind =
+  | 'pair-collision'
+  | 'mac-alias'
+  | 'leg-shared'
+  | 'reserved-range'
+  | 'outside-pool'
+
+export const MULTICAST_FINDING_LABEL: Readonly<Record<MulticastFindingKind, string>> = {
+  'pair-collision': 'Adresse und Port doppelt vergeben',
+  'mac-alias': 'Zwei Gruppen auf einer L2-Adresse',
+  'leg-shared': 'Beide Beine auf derselben Gruppe',
+  'reserved-range': 'Adresse aus einem gesperrten Bereich',
+  'outside-pool': 'Vergabe außerhalb des Pools',
+}
+
+export interface MulticastFinding {
+  kind: MulticastFindingKind
+  text: string
+  /** Die betroffenen Fluss-Schluessel, fuer den Sprung in den Plan. */
+  flowKeys: string[]
+}
+
+/** Ein offenes Bein: ein Fluss, dem fuer dieses Bein die Adresse fehlt. */
+export interface MulticastOpenLeg {
+  flowKey: string
+  label: string
+  leg: MulticastLeg
+}
+
+export interface MulticastPlan {
+  flows: MulticastFlow[]
+  assignments: MulticastAssignment[]
+  findings: MulticastFinding[]
+  /** Beine ohne Adresse — die Liste, die man abarbeitet. Kein Befund. */
+  open: MulticastOpenLeg[]
+  /** Vergaben zu Fluessen, die es im Plan nicht mehr gibt. Nur gemeldet. */
+  stale: MulticastAssignment[]
+  /** Der geparste Pool — `null`, wenn keiner erklaert ist oder er unbrauchbar ist. */
+  pool: ParsedPool | null
+  /** Was an der Pool-Eingabe nicht stimmt, im Klartext. */
+  poolError: string | null
+  /** Traegt der Plan ueberhaupt Multicast-Essenz? */
+  needsMulticast: boolean
+}
+
+const legLabel = (leg: MulticastLeg) => MULTICAST_LEG_LABEL[leg]
+
+/**
+ * Die Pruefung. Sie liest nur — sie repariert nichts und vergibt nichts.
+ *
+ * `open` ist absichtlich KEIN Befund: ein Plan, in dem noch nie vergeben
+ * wurde, haette sonst je Fluss eine Warnung und begrübe die vier echten
+ * darunter. Dieselbe Entscheidung wie bei `withoutDomain` im Zeit-Plan.
+ */
+export function assessMulticast(
+  flows: readonly MulticastFlow[],
+  assignments: readonly MulticastAssignment[],
+  pool: ParsedPool | null,
+): { findings: MulticastFinding[]; open: MulticastOpenLeg[]; stale: MulticastAssignment[] } {
+  const byKey = new Map(flows.map((f) => [f.key, f]))
+  const nameOf = (key: string) => byKey.get(key)?.label ?? key
+  const findings: MulticastFinding[] = []
+
+  const lebendig = assignments.filter((a) => byKey.has(a.flowKey))
+  const stale = assignments.filter((a) => !byKey.has(a.flowKey))
+
+  // 1) Adresse + Port doppelt. Die WATCHOUT-Regel.
+  const paare = new Map<string, MulticastAssignment[]>()
+  for (const a of lebendig) {
+    const k = `${a.address}:${a.port}`
+    paare.set(k, [...(paare.get(k) ?? []), a])
+  }
+  for (const [k, liste] of paare) {
+    if (liste.length < 2) continue
+    findings.push({
+      kind: 'pair-collision',
+      text: `${k} ist ${liste.length}-mal vergeben: ${liste
+        .map((a) => `${nameOf(a.flowKey)} (Bein ${legLabel(a.leg)})`)
+        .join(', ')}. Adresse und Port zusammen müssen je Sender eindeutig sein.`,
+      flowKeys: [...new Set(liste.map((a) => a.flowKey))],
+    })
+  }
+
+  // 2) Der L2-Alias. Verschiedene Adressen, eine MAC.
+  const macs = new Map<number, MulticastAssignment[]>()
+  for (const a of lebendig) {
+    const k = aliasKey(a.address)
+    if (k === null) continue
+    macs.set(k, [...(macs.get(k) ?? []), a])
+  }
+  for (const liste of macs.values()) {
+    const adressen = [...new Set(liste.map((a) => a.address))]
+    if (adressen.length < 2) continue
+    findings.push({
+      kind: 'mac-alias',
+      text: `${adressen.join(' und ')} tragen dieselbe L2-Adresse ${multicastMac(
+        adressen[0],
+      )} — 32 Gruppen fallen auf eine MAC. Die Karte des Empfängers filtert auf L2 und nimmt beide Ströme an; verworfen wird erst im Betriebssystem, die Last liegt vorher an. Betroffen: ${[
+        ...new Set(liste.map((a) => nameOf(a.flowKey))),
+      ].join(', ')}.`,
+      flowKeys: [...new Set(liste.map((a) => a.flowKey))],
+    })
+  }
+
+  // 3) Beide Beine auf einer Gruppe — Redundanz, die keine ist.
+  const proFluss = new Map<string, MulticastAssignment[]>()
+  for (const a of lebendig) proFluss.set(a.flowKey, [...(proFluss.get(a.flowKey) ?? []), a])
+  for (const [key, liste] of proFluss) {
+    if (liste.length < 2) continue
+    const adressen = new Set(liste.map((a) => a.address))
+    if (adressen.size > 1) continue
+    findings.push({
+      kind: 'leg-shared',
+      text: `${nameOf(key)} führt beide Beine auf ${
+        liste[0].address
+      }. Ein 2022-7-Paar auf einer Gruppe überlebt keinen Ausfall des Netzes, in dem die Gruppe liegt — es kostet die doppelte Bandbreite und liefert keine Redundanz.`,
+      flowKeys: [key],
+    })
+  }
+
+  // 4) Gesperrte Bereiche.
+  for (const a of lebendig) {
+    if (!isMulticastAddress(a.address)) {
+      findings.push({
+        kind: 'reserved-range',
+        text: `${nameOf(a.flowKey)} (Bein ${legLabel(a.leg)}) trägt ${
+          a.address
+        } — das ist keine Multicast-Adresse (224.0.0.0/4).`,
+        flowKeys: [a.flowKey],
+      })
+      continue
+    }
+    const grund = reservedReason(a.address)
+    if (grund) {
+      findings.push({
+        kind: 'reserved-range',
+        text: `${nameOf(a.flowKey)} (Bein ${legLabel(a.leg)}) trägt ${a.address} aus ${grund}.`,
+        flowKeys: [a.flowKey],
+      })
+    }
+  }
+
+  // 5) Ausserhalb des erklaerten Pools. KEIN Fehler — aber der Grund, warum
+  //    die naechste Vergabe jemanden ueberrascht.
+  if (pool) {
+    const draussen = lebendig.filter((a) => {
+      const n = ipToInt(a.address)
+      return n === null || n < pool.base || n > pool.base + pool.count - 1
+    })
+    if (draussen.length) {
+      findings.push({
+        kind: 'outside-pool',
+        text: `${draussen.length} Vergabe(n) liegen außerhalb von ${intToIp(pool.base)}/${
+          pool.prefix
+        }: ${draussen.map((a) => `${nameOf(a.flowKey)} → ${a.address}`).join(', ')}.`,
+        flowKeys: [...new Set(draussen.map((a) => a.flowKey))],
+      })
+    }
+  }
+
+  const belegt = new Set(lebendig.map((a) => `${a.flowKey}|${a.leg}`))
+  const open: MulticastOpenLeg[] = []
+  for (const f of flows) {
+    for (const leg of f.legs) {
+      if (!belegt.has(`${f.key}|${leg}`)) open.push({ flowKey: f.key, label: f.label, leg })
+    }
+  }
+
+  return { findings, open, stale }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Die Vergabe
+// ───────────────────────────────────────────────────────────────────────────
+
+export interface AllocationResult {
+  /** Die bestehenden Vergaben PLUS die neuen. Keine bestehende ist bewegt. */
+  assignments: MulticastAssignment[]
+  /** Was neu dazugekommen ist. */
+  issued: MulticastAssignment[]
+  /** Beine, fuer die im Pool nichts mehr frei war — benannt statt still. */
+  exhausted: MulticastOpenLeg[]
+}
+
+/**
+ * Vergibt Adressen fuer alle offenen Beine — und nur fuer die.
+ *
+ * Bestehende Vergaben bleiben unangetastet, auch wenn sie ausserhalb des
+ * Pools liegen oder gegen eine Regel verstossen: eine verteilte Adresse
+ * umzunummerieren waere der stille Verlust, den Bedarf 96 verbietet. Was an
+ * ihnen falsch ist, sagt `assessMulticast`; korrigieren tut es ein Mensch.
+ *
+ * Ueberspringt beim Suchen jede Adresse, die gesperrt ist, deren (Adresse,
+ * Port) schon vergeben ist ODER die mit einer bereits vergebenen dieselbe
+ * L2-Adresse traegt. Der letzte Punkt ist der ganze Sinn der Uebung.
+ */
+export function allocateMulticast(
+  flows: readonly MulticastFlow[],
+  config: MulticastConfig,
+): AllocationResult {
+  const pool = parsePool(config.pool)
+  const bestehend = config.assignments.filter((a) => flows.some((f) => f.key === a.flowKey))
+  const { open } = assessMulticast(flows, config.assignments, pool)
+  if (!pool) return { assignments: [...config.assignments], issued: [], exhausted: [...open] }
+
+  const port = config.basePort
+  const paare = new Set(config.assignments.map((a) => `${a.address}:${a.port}`))
+  const aliase = new Set(
+    config.assignments.map((a) => aliasKey(a.address)).filter((k): k is number => k !== null),
+  )
+
+  const issued: MulticastAssignment[] = []
+  const exhausted: MulticastOpenLeg[] = []
+  let cursor = 0
+
+  for (const bein of open) {
+    let gefunden: string | null = null
+    while (cursor < pool.count) {
+      const kandidat = intToIp(pool.base + cursor)
+      cursor += 1
+      if (reservedReason(kandidat)) continue
+      if (paare.has(`${kandidat}:${port}`)) continue
+      const alias = aliasKey(kandidat)
+      if (alias !== null && aliase.has(alias)) continue
+      gefunden = kandidat
+      break
+    }
+    if (!gefunden) {
+      exhausted.push(bein)
+      continue
+    }
+    paare.add(`${gefunden}:${port}`)
+    const alias = aliasKey(gefunden)
+    if (alias !== null) aliase.add(alias)
+    issued.push({ flowKey: bein.flowKey, leg: bein.leg, address: gefunden, port })
+  }
+
+  // Verwaiste Vergaben bleiben in der Liste. Sie zu entfernen ist eine eigene
+  // Handlung mit einem eigenen Knopf; hier weggeraeumt waeren sie weg, sobald
+  // jemand versehentlich ein Kabel loescht und neu vergibt.
+  const verwaist = config.assignments.filter((a) => !bestehend.includes(a))
+  return { assignments: [...bestehend, ...issued, ...verwaist], issued, exhausted }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Plan und Blatt
+// ───────────────────────────────────────────────────────────────────────────
+
+export function buildMulticastPlan(project: {
+  equipment: readonly EquipmentItem[]
+  cables: readonly Cable[]
+  multicast?: MulticastConfig
+}): MulticastPlan {
+  const flows = collectFlows(project.equipment, project.cables)
+  const cfg = project.multicast
+  const roh = cfg?.pool?.trim() ?? ''
+  const pool = roh ? parsePool(roh) : null
+  const poolError = !roh
+    ? null
+    : pool
+      ? null
+      : `„${roh}" ist kein brauchbarer Pool. Erwartet wird ein CIDR innerhalb von 224.0.0.0/4, z. B. 239.100.0.0/16.`
+  const assignments = cfg?.assignments ?? []
+  const { findings, open, stale } = assessMulticast(flows, assignments, pool)
+  return {
+    flows,
+    assignments: [...assignments],
+    findings,
+    open,
+    stale,
+    pool,
+    poolError,
+    needsMulticast: flows.length > 0,
+  }
+}
+
+/**
+ * Das Blatt. Die MAC-Spalte steht mit Absicht drauf: die Regel, gegen die man
+ * blind verstoesst, wird erst sichtbar, wenn zwei Zeilen dieselbe MAC tragen.
+ */
+export function multicastTable(plan: MulticastPlan): CsvTable {
+  const byKey = new Map(plan.flows.map((f) => [f.key, f]))
+  const rows: (string | number)[][] = []
+  for (const f of plan.flows) {
+    for (const leg of f.legs) {
+      const a = plan.assignments.find((x) => x.flowKey === f.key && x.leg === leg)
+      rows.push([
+        f.label,
+        MULTICAST_ESSENCE_LABEL[f.essence],
+        f.standard,
+        MULTICAST_LEG_LABEL[leg],
+        a?.address ?? 'offen',
+        a ? a.port : '',
+        a ? (multicastMac(a.address) ?? '') : '',
+        f.receivers.join(', '),
+      ])
+    }
+  }
+  for (const s of plan.stale) {
+    rows.push([
+      byKey.get(s.flowKey)?.label ?? s.flowKey,
+      'verwaist',
+      '',
+      MULTICAST_LEG_LABEL[s.leg],
+      s.address,
+      s.port,
+      multicastMac(s.address) ?? '',
+      '',
+    ])
+  }
+  return {
+    headers: [
+      'Fluss',
+      'Essenz',
+      'Standard',
+      'Bein',
+      'Gruppe',
+      'UDP-Port',
+      'L2-MAC',
+      'Empfänger',
+    ],
+    rows,
+  }
+}
+
+export const multicastTableForProject = (project: CablePlannerProject): CsvTable =>
+  multicastTable(buildMulticastPlan(project))
+
+// ───────────────────────────────────────────────────────────────────────────
+// Lade-Pfad
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Normalisiert die gespeicherte Konfiguration beim Laden.
+ *
+ * Diese Funktion gibt es, weil bei Bedarf 73 genau hier zwei Fehler lagen:
+ * `interfaceIsEmpty` kannte die neuen Felder nicht und `normaliseNetworkInterface`
+ * uebernahm sie nicht — eine Schnittstelle mit NUR einer PTP-Domaene wurde beim
+ * Laden still weggeworfen. Eine Vergabe, die dasselbe Schicksal traefe, faellt
+ * noch spaeter auf: sie steht im ausgedruckten Blatt und im Geraet, nur nicht
+ * mehr im Plan.
+ *
+ * Verworfen wird deshalb NUR, was unlesbar ist — und das wird gemeldet.
+ * Eine Adresse ausserhalb des Pools, in einem gesperrten Bereich oder mit
+ * einem Alias bleibt: sie ist LESBAR und falsch, und dafuer gibt es Befunde.
+ */
+export function normaliseMulticastConfig(
+  raw: unknown,
+  onDrop?: (d: { reason: 'missing-required' | 'duplicate-id'; label: string }) => void,
+): MulticastConfig | undefined {
+  if (!raw || typeof raw !== 'object') return undefined
+  const o = raw as Partial<MulticastConfig>
+  const pool = typeof o.pool === 'string' ? o.pool.trim() : ''
+  const basePort =
+    typeof o.basePort === 'number' && Number.isInteger(o.basePort) && o.basePort > 0 && o.basePort <= 65535
+      ? o.basePort
+      : 20000
+  const seen = new Set<string>()
+  const assignments: MulticastAssignment[] = []
+  for (const a of Array.isArray(o.assignments) ? o.assignments : []) {
+    const x = a as Partial<MulticastAssignment>
+    const key = typeof x.flowKey === 'string' ? x.flowKey.trim() : ''
+    const leg: MulticastLeg | null = x.leg === 'a' || x.leg === 'b' ? x.leg : null
+    const address = typeof x.address === 'string' ? x.address.trim() : ''
+    if (!key || !leg || !address || ipToInt(address) === null) {
+      onDrop?.({ reason: 'missing-required', label: address || key })
+      continue
+    }
+    const id = `${key}|${leg}`
+    if (seen.has(id)) {
+      onDrop?.({ reason: 'duplicate-id', label: `${address} (${key})` })
+      continue
+    }
+    seen.add(id)
+    const port =
+      typeof x.port === 'number' && Number.isInteger(x.port) && x.port > 0 && x.port <= 65535
+        ? x.port
+        : basePort
+    assignments.push({ flowKey: key, leg, address, port })
+  }
+  // Ein Objekt ohne Pool UND ohne Vergabe traegt nichts — es waere Ballast in
+  // jedem Projektfile, das den Dialog einmal geoeffnet hat.
+  if (!pool && assignments.length === 0) return undefined
+  return { pool, basePort, assignments }
+}

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -71,6 +71,7 @@ import {
   sourceIdentityIdSet,
 } from '../lib/sourceIdentity'
 import { normaliseDeliveryDestinations } from '../lib/deliveryNormalise'
+import { normaliseMulticastConfig } from '../lib/multicastPlan'
 import { normaliseVenueAnswers } from '../lib/venueAnswers'
 import { isNetworkInterfaceRole, normaliseNetworkInterface } from '../lib/networkInterfaces'
 import type { NetworkInterface } from '../types/network'
@@ -440,6 +441,7 @@ export interface ProjectState {
   /** Drum-Mikrofonierung — den Drum-Kit-Plan setzen (undefined = entfernen). */
   setDrumKit: (plan: import('../types/drumKit').DrumKitPlan | undefined) => void
   setWirelessRig: (plan: import('../types/wirelessRig').WirelessRigPlan | undefined) => void
+  setMulticastConfig: (config: import('../types/multicast').MulticastConfig | undefined) => void
   /** v7.9.3 — Mobile-Viewer Check-State setzen (vom POST /checks-IPC).
    *  Komplettes Objekt-Replace damit gelöschte Checks (false → kein
    *  key) auch übernommen werden. */
@@ -620,6 +622,13 @@ const healProjectPositions = (
   const venueAnswers = normaliseVenueAnswers(project.metadata?.venueAnswers, (d) =>
     onDrop?.({ kind: 'venue-answer', reason: d.reason, label: d.label }),
   )
+  // Bedarf 72 — die Multicast-Vergaben. Verworfen wird nur, was UNLESBAR ist;
+  // eine lesbare Adresse mit einem Problem (gesperrter Bereich, L2-Alias,
+  // ausserhalb des Pools) bleibt stehen und bekommt einen Befund. Sie hier
+  // wegzuwerfen hiesse, den Fehler zu verstecken, statt ihn zu zeigen.
+  const multicast = normaliseMulticastConfig(project.multicast, (d) =>
+    onDrop?.({ kind: 'multicast-assignment', reason: d.reason, label: d.label }),
+  )
   return {
     ...project,
     equipment: project.equipment.map((item) => {
@@ -765,6 +774,8 @@ const healProjectPositions = (
     // ADR-001 — Rollen sind optional; alte Projekte heilen zu [].
     sourceIdentities,
     deliveryDestinations,
+    // Bedarf 72 — `undefined` heisst „kein Adressplan", nicht „leerer".
+    multicast,
     // ADR-003 — Rentman-Zaehler: gesendet ist nicht bestaetigt.
     metadata: {
       ...healRentmanCableMap(project.metadata),

--- a/src/renderer/store/slices/metaSlice.ts
+++ b/src/renderer/store/slices/metaSlice.ts
@@ -31,6 +31,7 @@ export type MetaSlice = Pick<
   | 'updateGreenGoConfig'
   | 'setDrumKit'
   | 'setWirelessRig'
+  | 'setMulticastConfig'
 >
 
 export const createMetaSlice: StateCreator<ProjectState, [], [], MetaSlice> = (set) => ({
@@ -103,6 +104,19 @@ export const createMetaSlice: StateCreator<ProjectState, [], [], MetaSlice> = (s
   setWirelessRig: (plan) =>
     set((state) => {
       const updated = { ...state.project, wirelessRig: plan }
+      scheduleProjectAutosave(updated)
+      return { project: updated }
+    }),
+  // BEDARF 72 — Pool, Port und die vergebenen Gruppen.
+  //
+  // Ein Setter fuer das ganze Objekt und keiner je Vergabe: der Aufrufer ist
+  // `allocateMulticast`, das die vollstaendige Liste zurueckgibt. Ein
+  // Einzel-Setter verfuehrte dazu, in einer Schleife zu vergeben — und jede
+  // Zwischenstufe waere ein Zustand, in dem die Alias-Pruefung die eigenen
+  // frisch vergebenen Adressen noch nicht kennt.
+  setMulticastConfig: (config) =>
+    set((state) => {
+      const updated = { ...state.project, multicast: config }
       scheduleProjectAutosave(updated)
       return { project: updated }
     }),

--- a/src/renderer/types/loadReport.ts
+++ b/src/renderer/types/loadReport.ts
@@ -36,6 +36,11 @@ export type LoadDropKind =
    *  aus wie „nie gefragt", und dann fragt jemand ein zweites Mal — oder gar
    *  nicht mehr, weil er die Genehmigung von letztem Jahr im Kopf hat. */
   | 'venue-answer'
+  /** Bedarf 72 — eine Multicast-Vergabe, die keine Adresse traegt oder deren
+   *  Bein/Fluss unlesbar ist. Sie still zu behalten waere hier schlimmer als
+   *  bei jeder anderen Sorte: die Vergabe steht im Blatt, das jemand mit ins
+   *  Rack nimmt, und eine unlesbare Zeile fiele erst dort auf. */
+  | 'multicast-assignment'
 
 export interface LoadDrop {
   kind: LoadDropKind

--- a/src/renderer/types/multicast.ts
+++ b/src/renderer/types/multicast.ts
@@ -1,0 +1,76 @@
+// ───────────────────────────────────────────────────────────────────────────
+// BEDARF 72 (P2) — der Multicast-Adressplan fuer ST 2110.
+//
+//   > Every essence (2110-20/-30/-40) is its own multicast group, doubled for
+//   > 2022-7. A mid-size truck is several hundred rows allocated by hand in
+//   > Excel. Two invisible rules get violated: (address, UDP port) must be
+//   > unique per sender, and 32 L3 multicast addresses alias onto one L2 MAC,
+//   > so a naive scheme collides.
+//
+// Belege: Arista, „M&E Multicast Addressing" (L3/L2-Alias, 2^5-Kollaps);
+// Dataton WATCHOUT, ST-2110-Netzwerkeinrichtung (Adresse+Port eindeutig).
+//
+// ─── WAS HIER GESPEICHERT WIRD, UND WARUM NICHT MEHR ───────────────────────
+//
+// Der FLUSS wird abgeleitet: welcher Sender welche Essenz ausgibt, steht im
+// Kabelgraph, und ein zweites Feld dafuer waere ab dem ersten umgesteckten
+// Kabel falsch (dieselbe Begruendung wie bei `familiesByDevice`, Bedarf 73).
+//
+// Die ADRESSE dagegen muss stehen bleiben. Sie ist verteilt worden: sie steht
+// im Sender, im Empfaenger, im Switch-Filter und auf dem Blatt, das jemand
+// ausgedruckt mit ins Rack genommen hat. Eine Adresse, die sich beim naechsten
+// Oeffnen des Plans neu berechnet, ist schlimmer als keine — sie sieht aus wie
+// die alte und ist es nicht. Deshalb: Fluesse abgeleitet, Vergaben gespeichert.
+//
+// ─── DER SCHLUESSEL IST DER SENDE-PORT, NICHT DAS KABEL ────────────────────
+//
+// Eine Multicast-Gruppe gehoert dem SENDER. Fuenf Empfaenger derselben Kamera
+// abonnieren eine Gruppe, nicht fuenf. Genau das ist der Punkt, an dem eine
+// Excel-Tabelle mit einer Zeile je Kabel auseinanderfaellt. Der Schluessel ist
+// deshalb `<equipmentId>:<portId>` — er ueberlebt jedes Umstecken auf der
+// Empfaengerseite und jedes hinzugekommene Ziel.
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Das Bein eines 2022-7-Paars.
+ *
+ * `a` ist das Primaernetz (rot), `b` das Sekundaernetz (blau). Ein Fluss ohne
+ * zweite Medien-Schnittstelle am Sender hat nur `a` — und dass er nur eines
+ * hat, steht damit IM PLAN und nicht in der Erinnerung.
+ */
+export type MulticastLeg = 'a' | 'b'
+
+export const MULTICAST_LEGS: ReadonlyArray<MulticastLeg> = ['a', 'b']
+
+export const MULTICAST_LEG_LABEL: Readonly<Record<MulticastLeg, string>> = {
+  a: 'A (primär)',
+  b: 'B (sekundär)',
+}
+
+/** Eine vergebene Gruppe: ein Bein eines Flusses. */
+export interface MulticastAssignment {
+  /** `<equipmentId>:<portId>` — siehe Kopf. */
+  flowKey: string
+  leg: MulticastLeg
+  /** Gruppen-Adresse, punktiert („239.100.0.12"). */
+  address: string
+  /** Ziel-UDP-Port. */
+  port: number
+}
+
+/**
+ * Der Rahmen, in dem vergeben wird.
+ *
+ * Optional am Projekt: ohne erklaerten Pool vergibt niemand etwas, und ein
+ * still gesetzter Vorgabe-Pool waere eine Behauptung ueber ein Netz, das
+ * diese Anwendung nie gesehen hat. Der Plan zeigt dann die Fluss-Tabelle und
+ * sagt, dass kein Pool erklaert ist — ein benanntes Ergebnis statt einer
+ * leeren Liste.
+ */
+export interface MulticastConfig {
+  /** CIDR, z. B. „239.100.0.0/16". */
+  pool: string
+  /** UDP-Port, den jede Vergabe traegt. */
+  basePort: number
+  assignments: MulticastAssignment[]
+}

--- a/src/renderer/types/network.ts
+++ b/src/renderer/types/network.ts
@@ -191,4 +191,17 @@ export const interfaceIsEmpty = (n: NetworkInterface): boolean =>
   // an der jemand NUR die Domaene eingetragen hat, „leer" — und `deviceInterfaces`
   // wirft leere Schnittstellen weg. Die Eingabe waere beim naechsten Laden
   // verschwunden, ohne dass irgendwo etwas steht.
-  n.ptpDomain === undefined && !n.ptpProfile && !n.ptpRole
+  n.ptpDomain === undefined && !n.ptpProfile && !n.ptpRole &&
+  // BEDARF 72: die ROLLE zaehlt genauso mit, und aus demselben Grund.
+  // Aufgefallen beim Multicast-Adressplan, der das zweite 2022-7-Bein aus
+  // `media-primary` PLUS `media-secondary` ableitet: waehrend der Planung hat
+  // noch keine der beiden Karten eine Adresse — es steht nur die Rolle da.
+  // Ohne diese Zeile war so eine Schnittstelle „leer", `deviceInterfaces`
+  // warf sie weg und `normaliseNetworkInterface` gab `null` zurueck. Das
+  // Sekundaernetz war beim naechsten Laden verschwunden, und der Adressplan
+  // haette anschliessend behauptet, dieser Fluss brauche nur EIN Bein.
+  //
+  // `unspecified` zaehlt NICHT mit: das ist die Abwesenheit einer Angabe, und
+  // Schnittstelle 0 traegt sie immer. Wuerde sie mitzaehlen, waere nie eine
+  // Schnittstelle leer und jedes Geraet bekaeme eine erfundene NIC 0.
+  (!n.role || n.role === 'unspecified')

--- a/src/renderer/types/project.ts
+++ b/src/renderer/types/project.ts
@@ -252,6 +252,17 @@ export interface CablePlannerProject {
    * einer einzelnen Ausspielung. Zwei Ziele teilen sich dieselbe Aufzeichnung.
    */
   archiveRecording?: import('./delivery').ArchiveRecording
+  /**
+   * Bedarf 72 — der Multicast-Adressplan: aus welchem Pool vergeben wird und
+   * welche Gruppe welcher Sende-Port belegt.
+   *
+   * Nur die VERGABEN stehen hier. Welche Flüsse es gibt, leitet
+   * `collectFlows` aus dem Kabelgraph ab — ein zweites Feld dafür wäre ab dem
+   * ersten umgesteckten Kabel falsch. Die Adresse dagegen muss stehen
+   * bleiben: sie ist verteilt worden, und eine, die sich beim nächsten Öffnen
+   * neu berechnet, sieht aus wie die alte und ist es nicht.
+   */
+  multicast?: import('./multicast').MulticastConfig
 }
 
 /** #412 — Ein festgeschriebener Projekt-Stand. */

--- a/tests/multicastPlan.test.ts
+++ b/tests/multicastPlan.test.ts
@@ -1,0 +1,665 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MULTICAST_ESSENCE,
+  MULTICAST_FINDING_LABEL,
+  aliasKey,
+  allocateMulticast,
+  assessMulticast,
+  buildMulticastPlan,
+  collectFlows,
+  intToIp,
+  ipToInt,
+  isMulticastAddress,
+  multicastMac,
+  multicastTable,
+  normaliseMulticastConfig,
+  parsePool,
+  reservedReason,
+} from '../src/renderer/lib/multicastPlan'
+import {
+  AUDIO_MULTICAST,
+  LIGHTING_MULTICAST,
+  VIDEO_MULTICAST,
+} from '../src/renderer/lib/venueNetworkRequest'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+import type { Cable } from '../src/renderer/types/cable'
+import type { MulticastAssignment, MulticastConfig } from '../src/renderer/types/multicast'
+import analyseQuelle from '../src/renderer/components/Analysis/AnalysisDialog.tsx?raw'
+import registerQuelle from '../src/renderer/lib/documentRegistry.ts?raw'
+import storeQuelle from '../src/renderer/store/projectStore.ts?raw'
+import metaQuelle from '../src/renderer/store/slices/metaSlice.ts?raw'
+import dictsQuelle from '../src/renderer/lib/i18n/dicts.ts?raw'
+
+// ---------------------------------------------------------------------------
+// Der Multicast-Adressplan (Bedarf 72, P2).
+//
+//   > Every essence (2110-20/-30/-40) is its own multicast group, doubled for
+//   > 2022-7. … Two invisible rules get violated: (address, UDP port) must be
+//   > unique per sender, and 32 L3 multicast addresses alias onto one L2 MAC,
+//   > so a naive scheme collides.
+//
+// Belege: Arista „M&E Multicast Addressing" (2^5-Kollaps); Dataton WATCHOUT
+// (Adresse und Port zusammen eindeutig).
+// ---------------------------------------------------------------------------
+
+const geraet = (id: string, name: string, extra: Partial<EquipmentItem> = {}): EquipmentItem =>
+  ({
+    id,
+    name,
+    type: 'camera',
+    x: 0,
+    y: 0,
+    inputs: [],
+    outputs: [],
+    ...extra,
+  }) as unknown as EquipmentItem
+
+const kabel = (id: string, from: string, fromPort: string, to: string, std?: string): Cable =>
+  ({
+    id,
+    fromEquipmentId: from,
+    fromPortId: fromPort,
+    toEquipmentId: to,
+    toPortId: `${to}-in`,
+    ...(std ? { standard: std } : {}),
+  }) as unknown as Cable
+
+const nic = (id: string, role: string) => ({ id, role }) as never
+
+/** Kamera mit rot/blau, Kamera ohne, ein Switch als Empfaenger. */
+const aufbau = () => {
+  const cam = geraet('cam1', 'Kamera 1', {
+    outputs: [{ id: 'p1', name: '2110 OUT', type: 'video', connectorType: 'RJ45' }],
+    networkInterfaces: [nic('cam1#nic1', 'media-primary'), nic('cam1#nic2', 'media-secondary')],
+  } as never)
+  const mic = geraet('sb1', 'Stagebox 1', {
+    outputs: [{ id: 'p1', name: 'Dante OUT', type: 'audio', connectorType: 'RJ45' }],
+  } as never)
+  const rec = geraet('rec', 'Recorder')
+  const mv = geraet('mv', 'Multiviewer')
+  return {
+    equipment: [cam, mic, rec, mv],
+    cables: [
+      kabel('c1', 'cam1', 'p1', 'rec', 'ST2110-20'),
+      kabel('c2', 'cam1', 'p1', 'mv', 'ST2110-20'),
+      kabel('c3', 'sb1', 'p1', 'rec', 'Dante'),
+    ],
+  }
+}
+
+// ---------------------------------------------------------------------------
+describe('die Adress-Arithmetik, auf der beide Regeln stehen', () => {
+  it('rechnet punktiert und ganzzahlig ineinander', () => {
+    expect(ipToInt('239.100.0.1')).toBe(0xef640001)
+    expect(intToIp(0xef640001)).toBe('239.100.0.1')
+    expect(ipToInt('239.100.0')).toBeNull()
+    expect(ipToInt('239.100.0.256')).toBeNull()
+    expect(ipToInt('a.b.c.d')).toBeNull()
+  })
+
+  it('kennt die Grenzen von 224.0.0.0/4', () => {
+    expect(isMulticastAddress('224.0.0.0')).toBe(true)
+    expect(isMulticastAddress('239.255.255.255')).toBe(true)
+    expect(isMulticastAddress('223.255.255.255')).toBe(false)
+    expect(isMulticastAddress('240.0.0.0')).toBe(false)
+  })
+
+  it('bildet auf 01:00:5e plus die UNTEREN 23 BIT ab', () => {
+    expect(multicastMac('239.100.0.1')).toBe('01:00:5e:64:00:01')
+    // Das oberste Bit des zweiten Oktetts faellt weg — genau das ist der
+    // Kollaps. 228 = 100 + 128.
+    expect(multicastMac('239.228.0.1')).toBe('01:00:5e:64:00:01')
+  })
+
+  it('LEGT DAS NAIVE SCHEMA AUS DEM BELEG OFFEN', () => {
+    // „239.<dienst>.<x>.<y>" mit dem Dienst im zweiten Oktett: Video auf
+    // 239.1.*, Audio auf 239.129.* — Paar fuer Paar dieselbe MAC.
+    expect(aliasKey('239.1.1.1')).toBe(aliasKey('239.129.1.1'))
+    expect(multicastMac('239.1.1.1')).toBe(multicastMac('239.129.1.1'))
+    // Und quer ueber das erste Oktett, weil dessen unteres Halbbyte auch faellt.
+    expect(aliasKey('239.1.1.1')).toBe(aliasKey('224.1.1.1'))
+    // Zwei Adressen im selben /16 kollidieren dagegen NIE.
+    expect(aliasKey('239.100.0.1')).not.toBe(aliasKey('239.100.0.2'))
+  })
+
+  it('nennt fuer jeden gesperrten Bereich den Grund', () => {
+    expect(reservedReason('224.0.0.5')).toContain('224.0.0.0/24')
+    expect(reservedReason('224.0.1.129')).toContain('PTP')
+    expect(reservedReason('232.0.0.9')).toContain('Source-Specific')
+    expect(reservedReason('239.255.255.250')).toContain('SSDP')
+    expect(reservedReason('239.100.0.1')).toBeNull()
+  })
+
+  it('parst den Pool und richtet ihn auf seine eigene Groesse aus', () => {
+    expect(parsePool('239.100.0.0/16')).toEqual({ base: 0xef640000, count: 65536, prefix: 16 })
+    // „239.100.0.5/16" meint dasselbe Netz wie „239.100.0.0/16" — sonst
+    // laege der Pool woanders als der Leser denkt.
+    expect(parsePool('239.100.0.5/16')?.base).toBe(0xef640000)
+    // Ausserhalb von 224.0.0.0/4 ist kein Multicast-Pool.
+    expect(parsePool('10.0.0.0/8')).toBeNull()
+    expect(parsePool('239.100.0.0')).toBeNull()
+    expect(parsePool('239.100.0.0/33')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('die Fluesse kommen aus dem gezeichneten Signalfluss', () => {
+  it('macht aus DREI Kabeln an einem Sende-Port EINE Gruppe', () => {
+    // Das ist der Punkt, an dem eine Excel-Tabelle mit einer Zeile je Kabel
+    // auseinanderfaellt: fuenf Empfaenger abonnieren eine Gruppe, nicht fuenf.
+    const a = aufbau()
+    const flows = collectFlows(a.equipment, a.cables)
+    expect(flows).toHaveLength(2)
+    const cam = flows.find((f) => f.equipmentId === 'cam1')!
+    expect(cam.receivers).toEqual(['Multiviewer', 'Recorder'])
+  })
+
+  it('trennt die Essenzen, und ANC ist eine eigene', () => {
+    // Der Bedarf sagt es woertlich: „every essence (2110-20/-30/-40) is its
+    // own multicast group". -40 als Anhaengsel des Videos zu fuehren waere
+    // eine Gruppe zu wenig.
+    const cam = geraet('cam1', 'Kamera 1', {
+      outputs: [
+        { id: 'v', name: 'VID', type: 'video', connectorType: 'RJ45' },
+        { id: 'a', name: 'ANC', type: 'data', connectorType: 'RJ45' },
+      ],
+    } as never)
+    const flows = collectFlows(
+      [cam, geraet('rec', 'Recorder')],
+      [kabel('c1', 'cam1', 'v', 'rec', 'ST2110-20'), kabel('c2', 'cam1', 'a', 'rec', 'ST2110-40')],
+    )
+    expect(flows.map((f) => f.essence).sort()).toEqual(['anc', 'video'])
+  })
+
+  it('leitet das zweite Bein aus den MEDIEN-Schnittstellen des Senders ab', () => {
+    const a = aufbau()
+    const flows = collectFlows(a.equipment, a.cables)
+    expect(flows.find((f) => f.equipmentId === 'cam1')!.legs).toEqual(['a', 'b'])
+    // Die Stagebox hat kein Sekundaernetz — sie bekommt EIN Bein, und dass es
+    // eines ist, steht damit im Plan statt in der Erinnerung.
+    expect(flows.find((f) => f.equipmentId === 'sb1')!.legs).toEqual(['a'])
+  })
+
+  it('nimmt den Standard vom Port, wenn das Kabel keinen traegt', () => {
+    // Der Normalfall im Bestand.
+    const cam = geraet('cam1', 'Kamera 1', {
+      outputs: [{ id: 'p1', name: 'OUT', type: 'video', connectorType: 'RJ45', standard: 'ST2110-20' }],
+    } as never)
+    const flows = collectFlows([cam, geraet('rec', 'R')], [kabel('c1', 'cam1', 'p1', 'rec')])
+    expect(flows).toHaveLength(1)
+    expect(flows[0].standard).toBe('ST2110-20')
+  })
+
+  it('laesst Unicast-Standards draussen', () => {
+    const flows = collectFlows(
+      [
+        geraet('cam1', 'K', {
+          outputs: [{ id: 'p1', name: 'SDI', type: 'video', connectorType: 'BNC' }],
+        } as never),
+        geraet('rec', 'R'),
+      ],
+      [kabel('c1', 'cam1', 'p1', 'rec', 'SDI-12G')],
+    )
+    expect(flows).toEqual([])
+  })
+
+  it('haelt jeden Multicast-Standard aus `venueNetworkRequest` in der Essenz-Karte', () => {
+    // Ohne diesen Guard fiele ein spaeter hinzugefuegter Standard still aus
+    // dem Adressplan heraus — und der Plan meldete eine vollstaendige Vergabe
+    // fuer eine Gruppe, die er nie gesehen hat.
+    for (const std of [...AUDIO_MULTICAST, ...VIDEO_MULTICAST, ...LIGHTING_MULTICAST]) {
+      expect(MULTICAST_ESSENCE[std], `${std} fehlt in MULTICAST_ESSENCE`).toBeDefined()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+const flowsOf = () => collectFlows(aufbau().equipment, aufbau().cables)
+const zu = (label: string) => flowsOf().find((f) => f.label.startsWith(label))!.key
+
+describe('die Befunde — beide unsichtbaren Regeln, benannt', () => {
+  const pool = parsePool('239.100.0.0/16')
+
+  it('meldet Adresse UND Port doppelt (WATCHOUT-Regel)', () => {
+    const flows = flowsOf()
+    const a: MulticastAssignment[] = [
+      { flowKey: zu('Kamera 1'), leg: 'a', address: '239.100.0.1', port: 20000 },
+      { flowKey: zu('Stagebox 1'), leg: 'a', address: '239.100.0.1', port: 20000 },
+    ]
+    const { findings } = assessMulticast(flows, a, pool)
+    const f = findings.find((x) => x.kind === 'pair-collision')!
+    expect(f).toBeDefined()
+    expect(f.text).toContain('239.100.0.1:20000')
+    expect(f.flowKeys).toHaveLength(2)
+  })
+
+  it('sagt NICHTS, wenn nur der Port geteilt wird', () => {
+    // Ein fester UDP-Port ueber alle Gruppen ist gaengige Praxis; die Regel
+    // verlangt das PAAR eindeutig, nicht den Port.
+    const flows = flowsOf()
+    const a: MulticastAssignment[] = [
+      { flowKey: zu('Kamera 1'), leg: 'a', address: '239.100.0.1', port: 20000 },
+      { flowKey: zu('Stagebox 1'), leg: 'a', address: '239.100.0.2', port: 20000 },
+    ]
+    expect(assessMulticast(flows, a, pool).findings).toEqual([])
+  })
+
+  it('MELDET DEN L2-ALIAS mit beiden Adressen und der geteilten MAC', () => {
+    // Der Befund muss beide Adressen und die MAC nennen. Sonst liest er sich
+    // wie ein Fehlalarm: „das sind doch verschiedene Adressen".
+    const flows = flowsOf()
+    const a: MulticastAssignment[] = [
+      { flowKey: zu('Kamera 1'), leg: 'a', address: '239.1.0.1', port: 20000 },
+      { flowKey: zu('Stagebox 1'), leg: 'a', address: '239.129.0.1', port: 20000 },
+    ]
+    const f = assessMulticast(flows, a, pool).findings.find((x) => x.kind === 'mac-alias')!
+    expect(f).toBeDefined()
+    expect(f.text).toContain('239.1.0.1')
+    expect(f.text).toContain('239.129.0.1')
+    expect(f.text).toContain('01:00:5e:01:00:01')
+  })
+
+  it('nennt beim Alias die FOLGE und behauptet keinen Ausfall', () => {
+    // Ob es weh tut, haengt an Karte und Switch. Der Befund sagt, was es
+    // kostet — nicht, dass es ausfaellt (dieselbe Haltung wie bei „is it
+    // flowing", Bedarf 76).
+    const flows = flowsOf()
+    const f = assessMulticast(
+      flows,
+      [
+        { flowKey: zu('Kamera 1'), leg: 'a', address: '239.1.0.1', port: 20000 },
+        { flowKey: zu('Stagebox 1'), leg: 'a', address: '239.129.0.1', port: 20000 },
+      ],
+      pool,
+    ).findings.find((x) => x.kind === 'mac-alias')!
+    expect(f.text).toMatch(/L2/)
+    expect(f.text).toMatch(/Last/)
+    expect(f.text).not.toMatch(/fällt aus|Ausfall/)
+  })
+
+  it('meldet zwei Beine auf einer Gruppe als Redundanz, die keine ist', () => {
+    const flows = flowsOf()
+    const key = zu('Kamera 1')
+    const f = assessMulticast(
+      flows,
+      [
+        { flowKey: key, leg: 'a', address: '239.100.0.1', port: 20000 },
+        { flowKey: key, leg: 'b', address: '239.100.0.1', port: 20000 },
+      ],
+      pool,
+    ).findings.find((x) => x.kind === 'leg-shared')!
+    expect(f).toBeDefined()
+    expect(f.flowKeys).toEqual([key])
+  })
+
+  it('meldet zwei Beine auf VERSCHIEDENEN Gruppen NICHT', () => {
+    const flows = flowsOf()
+    const key = zu('Kamera 1')
+    const findings = assessMulticast(
+      flows,
+      [
+        { flowKey: key, leg: 'a', address: '239.100.0.1', port: 20000 },
+        { flowKey: key, leg: 'b', address: '239.101.0.1', port: 20000 },
+      ],
+      pool,
+    ).findings
+    expect(findings.filter((f) => f.kind === 'leg-shared')).toEqual([])
+  })
+
+  it('meldet gesperrte Bereiche und Nicht-Multicast getrennt begruendet', () => {
+    const flows = flowsOf()
+    const findings = assessMulticast(
+      flows,
+      [
+        { flowKey: zu('Kamera 1'), leg: 'a', address: '224.0.1.129', port: 20000 },
+        { flowKey: zu('Stagebox 1'), leg: 'a', address: '10.0.0.1', port: 20000 },
+      ],
+      pool,
+    ).findings.filter((f) => f.kind === 'reserved-range')
+    expect(findings).toHaveLength(2)
+    expect(findings.some((f) => f.text.includes('PTP'))).toBe(true)
+    expect(findings.some((f) => f.text.includes('224.0.0.0/4'))).toBe(true)
+  })
+
+  it('meldet eine Vergabe ausserhalb des Pools — nur, wenn einer erklaert ist', () => {
+    const flows = flowsOf()
+    const a: MulticastAssignment[] = [
+      { flowKey: zu('Kamera 1'), leg: 'a', address: '239.200.0.1', port: 20000 },
+    ]
+    expect(assessMulticast(flows, a, pool).findings.some((f) => f.kind === 'outside-pool')).toBe(true)
+    // Ohne Pool gibt es kein „ausserhalb".
+    expect(assessMulticast(flows, a, null).findings.some((f) => f.kind === 'outside-pool')).toBe(false)
+  })
+
+  it('haelt „noch nicht vergeben" AUS den Befunden heraus', () => {
+    // Ein Plan, in dem nie vergeben wurde, haette sonst je Fluss eine Warnung
+    // und begruebe die echten darunter — dieselbe Entscheidung wie bei
+    // `withoutDomain` im Zeit-Plan (Bedarf 73).
+    const flows = flowsOf()
+    const r = assessMulticast(flows, [], pool)
+    expect(r.findings).toEqual([])
+    // Drei Beine: Kamera a+b, Stagebox a.
+    expect(r.open).toHaveLength(3)
+    expect(r.open.map((o) => o.leg).sort()).toEqual(['a', 'a', 'b'])
+  })
+
+  it('meldet Vergaben zu verschwundenen Fluessen als `stale`, nicht als Befund', () => {
+    const flows = flowsOf()
+    const r = assessMulticast(
+      flows,
+      [{ flowKey: 'weg:weg', leg: 'a', address: '239.100.0.9', port: 20000 }],
+      pool,
+    )
+    expect(r.stale).toHaveLength(1)
+    expect(r.findings).toEqual([])
+  })
+
+  it('haelt die Etiketten kanonisch deutsch', () => {
+    expect(MULTICAST_FINDING_LABEL['mac-alias']).toBe('Zwei Gruppen auf einer L2-Adresse')
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('die Vergabe vergibt NACH und bewegt nichts', () => {
+  const cfg = (over: Partial<MulticastConfig> = {}): MulticastConfig => ({
+    pool: '239.100.0.0/16',
+    basePort: 20000,
+    assignments: [],
+    ...over,
+  })
+
+  it('vergibt jedes offene Bein genau einmal', () => {
+    const flows = flowsOf()
+    const r = allocateMulticast(flows, cfg())
+    expect(r.issued).toHaveLength(3)
+    expect(new Set(r.issued.map((a) => a.address)).size).toBe(3)
+    expect(r.exhausted).toEqual([])
+    expect(r.issued.every((a) => a.port === 20000)).toBe(true)
+  })
+
+  it('LAESST EINE BESTEHENDE ADRESSE STEHEN — auch eine unpassende', () => {
+    // Eine verteilte Adresse umzunummerieren waere der stille Verlust, den
+    // Bedarf 96 verbietet (Cryde/musicall#798). Sie steht im Sender, im
+    // Empfaenger, im Switch-Filter und auf einem ausgedruckten Blatt.
+    const flows = flowsOf()
+    const alt: MulticastAssignment = {
+      flowKey: zu('Kamera 1'),
+      leg: 'a',
+      address: '239.200.7.7',
+      port: 20000,
+    }
+    const r = allocateMulticast(flows, cfg({ assignments: [alt] }))
+    expect(r.assignments).toContainEqual(alt)
+    expect(r.issued.map((a) => a.address)).not.toContain('239.200.7.7')
+    expect(r.issued).toHaveLength(2)
+  })
+
+  it('WEICHT EINEM L2-ALIAS AUS, den eine bestehende Vergabe aufspannt', () => {
+    // Der ganze Sinn der Uebung. Die Bestandsadresse liegt ausserhalb des
+    // Pools; die neue Vergabe darf trotzdem nicht auf ihre MAC fallen.
+    const flows = flowsOf()
+    const alt: MulticastAssignment = {
+      flowKey: zu('Kamera 1'),
+      leg: 'a',
+      address: '239.228.0.0',
+      port: 20000,
+    }
+    const r = allocateMulticast(flows, cfg({ assignments: [alt] }))
+    // 239.100.0.0 traegt dieselbe MAC wie 239.228.0.0 und muss uebersprungen
+    // worden sein.
+    expect(r.issued.map((a) => a.address)).not.toContain('239.100.0.0')
+    for (const a of r.issued) expect(aliasKey(a.address)).not.toBe(aliasKey('239.228.0.0'))
+  })
+
+  it('ueberspringt gesperrte Bereiche', () => {
+    const flows = flowsOf()
+    // Ein Pool, der auf dem Local Network Control Block beginnt.
+    const r = allocateMulticast(flows, cfg({ pool: '224.0.0.0/16' }))
+    expect(r.issued).toHaveLength(3)
+    for (const a of r.issued) expect(reservedReason(a.address)).toBeNull()
+  })
+
+  it('BENENNT einen erschoepften Pool, statt still weniger zu vergeben', () => {
+    const flows = flowsOf()
+    // /30 = vier Adressen, davon liegen alle vier in 224.0.0.0/24 und sind
+    // gesperrt: es bleibt nichts uebrig.
+    const r = allocateMulticast(flows, cfg({ pool: '224.0.0.0/30' }))
+    expect(r.issued).toEqual([])
+    expect(r.exhausted).toHaveLength(3)
+    expect(r.exhausted[0]).toHaveProperty('label')
+  })
+
+  it('vergibt ohne brauchbaren Pool GAR NICHTS und meldet alles als offen', () => {
+    const flows = flowsOf()
+    const r = allocateMulticast(flows, cfg({ pool: 'Unsinn' }))
+    expect(r.issued).toEqual([])
+    expect(r.exhausted).toHaveLength(3)
+  })
+
+  it('ist idempotent: ein zweiter Lauf vergibt nichts mehr', () => {
+    const flows = flowsOf()
+    const erst = allocateMulticast(flows, cfg())
+    const zweit = allocateMulticast(flows, cfg({ assignments: erst.assignments }))
+    expect(zweit.issued).toEqual([])
+    expect(zweit.assignments).toEqual(erst.assignments)
+  })
+
+  it('BEHAELT eine verwaiste Vergabe, statt sie beim Vergeben mitzuloeschen', () => {
+    // Sonst waere sie weg, sobald jemand versehentlich ein Kabel loescht und
+    // neu vergibt.
+    const flows = flowsOf()
+    const verwaist: MulticastAssignment = {
+      flowKey: 'weg:weg',
+      leg: 'a',
+      address: '239.100.9.9',
+      port: 20000,
+    }
+    const r = allocateMulticast(flows, cfg({ assignments: [verwaist] }))
+    expect(r.assignments).toContainEqual(verwaist)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('das Blatt macht die unsichtbare Regel sichtbar', () => {
+  it('traegt eine MAC-Spalte, und sie ist gefuellt', () => {
+    const a = aufbau()
+    const flows = collectFlows(a.equipment, a.cables)
+    const res = allocateMulticast(flows, {
+      pool: '239.100.0.0/16',
+      basePort: 20000,
+      assignments: [],
+    })
+    const plan = buildMulticastPlan({
+      ...a,
+      multicast: { pool: '239.100.0.0/16', basePort: 20000, assignments: res.assignments },
+    })
+    const t = multicastTable(plan)
+    expect(t.headers).toEqual([
+      'Fluss',
+      'Essenz',
+      'Standard',
+      'Bein',
+      'Gruppe',
+      'UDP-Port',
+      'L2-MAC',
+      'Empfänger',
+    ])
+    expect(t.rows).toHaveLength(3)
+    const mac = t.headers.indexOf('L2-MAC')
+    expect(t.rows.every((r) => String(r[mac]).startsWith('01:00:5e:'))).toBe(true)
+  })
+
+  it('schreibt „offen" statt einer leeren Zelle', () => {
+    // Eine leere Zelle liest sich wie „gibt es nicht"; offen ist ein Zustand.
+    const a = aufbau()
+    const t = multicastTable(buildMulticastPlan(a))
+    expect(t.rows.some((r) => r[4] === 'offen')).toBe(true)
+  })
+
+  it('fuehrt die Empfaenger in EINER Zeile, weil es EINE Gruppe ist', () => {
+    const a = aufbau()
+    const t = multicastTable(buildMulticastPlan(a))
+    const cam = t.rows.find((r) => String(r[0]).startsWith('Kamera 1'))!
+    expect(cam[7]).toBe('Multiviewer, Recorder')
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('der Lade-Pfad wirft nur weg, was unlesbar ist', () => {
+  it('behaelt eine lesbare, aber falsche Adresse', () => {
+    // Sie hier wegzuwerfen hiesse, den Fehler zu verstecken statt ihn zu
+    // zeigen — es gibt Befunde dafuer.
+    const cfg = normaliseMulticastConfig({
+      pool: '239.100.0.0/16',
+      basePort: 20000,
+      assignments: [{ flowKey: 'a:b', leg: 'a', address: '10.0.0.1', port: 20000 }],
+    })
+    expect(cfg?.assignments).toHaveLength(1)
+  })
+
+  it('verwirft und MELDET, was keine Adresse oder kein Bein hat', () => {
+    const drops: { reason: string; label: string }[] = []
+    const cfg = normaliseMulticastConfig(
+      {
+        pool: '239.100.0.0/16',
+        basePort: 20000,
+        assignments: [
+          { flowKey: 'a:b', leg: 'a', address: '239.100.0.1', port: 20000 },
+          { flowKey: 'a:b', leg: 'z', address: '239.100.0.2', port: 20000 },
+          { flowKey: '', leg: 'a', address: '239.100.0.3', port: 20000 },
+          { flowKey: 'c:d', leg: 'a', address: 'Unsinn', port: 20000 },
+        ],
+      },
+      (d) => drops.push(d),
+    )
+    expect(cfg?.assignments).toHaveLength(1)
+    expect(drops).toHaveLength(3)
+    expect(drops.every((d) => d.reason === 'missing-required')).toBe(true)
+  })
+
+  it('meldet ein doppeltes Bein als `duplicate-id`', () => {
+    const drops: { reason: string }[] = []
+    const cfg = normaliseMulticastConfig(
+      {
+        pool: '239.100.0.0/16',
+        basePort: 20000,
+        assignments: [
+          { flowKey: 'a:b', leg: 'a', address: '239.100.0.1', port: 20000 },
+          { flowKey: 'a:b', leg: 'a', address: '239.100.0.2', port: 20000 },
+        ],
+      },
+      (d) => drops.push(d),
+    )
+    expect(cfg?.assignments).toHaveLength(1)
+    expect(cfg?.assignments[0].address).toBe('239.100.0.1')
+    expect(drops[0].reason).toBe('duplicate-id')
+  })
+
+  it('heilt ein Objekt ohne Pool und ohne Vergabe zu `undefined`', () => {
+    // Sonst traegt jedes Projektfile, das den Dialog einmal geoeffnet hat,
+    // einen leeren Block.
+    expect(normaliseMulticastConfig({ pool: '  ', basePort: 20000, assignments: [] })).toBeUndefined()
+    expect(normaliseMulticastConfig(undefined)).toBeUndefined()
+    expect(normaliseMulticastConfig('nein')).toBeUndefined()
+  })
+
+  it('faellt bei unsinnigem Port auf 20000 zurueck, statt ihn zu uebernehmen', () => {
+    const cfg = normaliseMulticastConfig({
+      pool: '239.100.0.0/16',
+      basePort: 999999,
+      assignments: [{ flowKey: 'a:b', leg: 'a', address: '239.100.0.1' }],
+    })
+    expect(cfg?.basePort).toBe(20000)
+    expect(cfg?.assignments[0].port).toBe(20000)
+  })
+
+  it('haengt in `healProjectPositions`, nicht nur im Modul', () => {
+    // Sonst laeuft die Normalisierung nie: der Lade-Pfad ist die einzige
+    // Stelle, an der eine fremde Datei ankommt.
+    expect(storeQuelle).toContain('normaliseMulticastConfig(project.multicast')
+    expect(storeQuelle).toMatch(/kind: 'multicast-assignment', reason: d\.reason, label: d\.label/)
+    expect(storeQuelle).toMatch(/^\s*multicast,$/m)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('der Plan als Ganzes', () => {
+  it('nennt einen unbrauchbaren Pool im Klartext, statt ihn zu schlucken', () => {
+    const plan = buildMulticastPlan({
+      ...aufbau(),
+      multicast: { pool: '10.0.0.0/8', basePort: 20000, assignments: [] },
+    })
+    expect(plan.pool).toBeNull()
+    expect(plan.poolError).toContain('10.0.0.0/8')
+  })
+
+  it('unterscheidet „kein Pool" von „kaputter Pool"', () => {
+    const plan = buildMulticastPlan(aufbau())
+    expect(plan.pool).toBeNull()
+    expect(plan.poolError).toBeNull()
+  })
+
+  it('meldet einen reinen SDI-Aufbau als „braucht kein Multicast"', () => {
+    const plan = buildMulticastPlan({ equipment: [], cables: [] })
+    expect(plan.needsMulticast).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('Erreichbarkeit', () => {
+  it('steht im Netzwerk-Reiter der Analyse', () => {
+    expect(analyseQuelle).toContain('buildMulticastPlan(projekt)')
+    expect(analyseQuelle).toContain('{multicast.needsMulticast && (')
+  })
+
+  it('vergibt ueber `allocateMulticast` und schreibt die GANZE Liste zurueck', () => {
+    // Ein Einzel-Setter verfuehrte zur Schleife — und jede Zwischenstufe waere
+    // ein Zustand, in dem die Alias-Pruefung die eigenen frisch vergebenen
+    // Adressen noch nicht kennt.
+    expect(analyseQuelle).toContain('const res = allocateMulticast(multicast.flows, cfg)')
+    expect(analyseQuelle).toContain('setMulticastConfig({ ...cfg, assignments: res.assignments })')
+  })
+
+  it('zeigt die MAC neben der Adresse, nicht nur im CSV', () => {
+    expect(analyseQuelle).toMatch(/\{a \? \(multicastMac\(a\.address\) \?\? ''\) : ''\}/)
+  })
+
+  it('bietet das Entfernen verwaister Vergaben als EIGENE Handlung an', () => {
+    expect(analyseQuelle).toContain('onClick={verwaisteEntfernen}')
+    expect(analyseQuelle).toMatch(/cfg\.assignments\.filter\(\(a\) => !weg\.has\(`\$\{a\.flowKey\}\|\$\{a\.leg\}`\)\)/)
+  })
+
+  it('setzt den Store ueber einen Setter, der das ganze Objekt nimmt', () => {
+    // Der GANZE Rumpf am Stueck, nicht drei einzelne `toContain`. Ein
+    // `toContain('scheduleProjectAutosave(updated)')` traf jeden anderen
+    // Setter in derselben Datei mit — das Autosave konnte aus DIESEM
+    // verschwinden, ohne dass irgendetwas rot wurde. Genau das hat die
+    // Gegenprobe gezeigt.
+    expect(metaQuelle).toMatch(
+      /setMulticastConfig: \(config\) =>\n\s*set\(\(state\) => \{\n\s*const updated = \{ \.\.\.state\.project, multicast: config \}\n\s*scheduleProjectAutosave\(updated\)\n\s*return \{ project: updated \}\n\s*\}\),/,
+    )
+  })
+
+  it('ist ein Dokument mit Stand', () => {
+    expect(registerQuelle).toContain("'multicast-plan': ofTable(multicastTableForProject)")
+    expect(registerQuelle).toContain("'multicast-plan': 'Multicast-Adressplan'")
+  })
+
+  it('hat fuer jeden neuen Text einen EN-Eintrag', () => {
+    for (const key of [
+      'analysis.mc.title',
+      'analysis.mc.intro',
+      'analysis.mc.pool',
+      'analysis.mc.port',
+      'analysis.mc.allocate',
+      'analysis.mc.noPool',
+      'analysis.mc.open',
+      'analysis.mc.stale',
+      'analysis.mc.dropStale',
+      'analysis.mc.export',
+      'app.loadReport.multicastAssignment',
+    ]) {
+      expect(dictsQuelle).toContain(`'${key}'`)
+    }
+  })
+})

--- a/tests/networkInterfaces.test.ts
+++ b/tests/networkInterfaces.test.ts
@@ -130,9 +130,23 @@ describe('mehrere Schnittstellen', () => {
   it('ueberspringt leere Zusatz-Schnittstellen', () => {
     const e = geraet('X', {
       ipAddress: '10.0.0.5',
-      networkInterfaces: [{ id: 'n2', role: 'control' }],
+      networkInterfaces: [{ id: 'n2', role: 'unspecified' }],
     })
     expect(deviceInterfaces(e)).toHaveLength(1)
+  })
+
+  it('BEHAELT eine Schnittstelle, an der nur die ROLLE steht (Bedarf 72)', () => {
+    // Aufgefallen beim Multicast-Adressplan: waehrend der Planung hat noch
+    // keine der beiden Medien-Karten eine Adresse — es steht nur die Rolle da.
+    // Bis Bedarf 72 galt so eine Schnittstelle als leer und flog raus, und der
+    // Adressplan haette anschliessend behauptet, dieser Fluss brauche nur EIN
+    // 2022-7-Bein. Dieselbe Begruendung wie beim Etikett eine Zeile weiter
+    // unten: eine ausgesprochene Rolle IST eine Aussage.
+    const e = geraet('X', {
+      ipAddress: '10.0.0.5',
+      networkInterfaces: [{ id: 'n2', role: 'media-secondary' }],
+    })
+    expect(deviceInterfaces(e)).toHaveLength(2)
   })
 
   it('sammelt sie ueber den ganzen Plan mit ihrem Geraet', () => {
@@ -159,9 +173,17 @@ describe('Normalisierung beim Laden', () => {
 
   it('wirft eine voellig leere Schnittstelle weg', () => {
     // Ballast in jedem Projektfile, und in der Port-Karte eine Zeile ohne Inhalt.
-    expect(normaliseNetworkInterface({ id: 'n2', role: 'control' }, 'x', roleOk)).toBeNull()
+    // „Voellig leer" heisst: auch OHNE ausgesprochene Rolle — `unspecified` ist
+    // die Abwesenheit einer Angabe und traegt nichts bei.
+    expect(normaliseNetworkInterface({ id: 'n2', role: 'unspecified' }, 'x', roleOk)).toBeNull()
+    expect(normaliseNetworkInterface({ id: 'n2' }, 'x', roleOk)).toBeNull()
     // Eine nur beschriftete bleibt: „SFP+ 2" ohne Adresse ist eine Aussage.
     expect(normaliseNetworkInterface({ id: 'n2', label: 'SFP+ 2' }, 'x', roleOk)).not.toBeNull()
+    // Und eine nur mit Rolle genauso — Bedarf 72. Sie hier zu verwerfen liesse
+    // das Sekundaernetz beim naechsten Laden verschwinden.
+    expect(normaliseNetworkInterface({ id: 'n2', role: 'media-secondary' }, 'x', roleOk)?.role).toBe(
+      'media-secondary',
+    )
   })
 
   it('nimmt nur VLAN-Ids, die es geben kann', () => {


### PR DESCRIPTION
**Bedarf 72 (P2)** — „Generate the ST 2110 multicast address plan with the standard's and the fabric's rules built in."

> Every essence (2110-20/-30/-40) is its own multicast group, doubled for 2022-7. A mid-size truck is several hundred rows allocated by hand in Excel. Two invisible rules get violated: (address, UDP port) must be unique per sender, and 32 L3 multicast addresses alias onto one L2 MAC, so a naive scheme collides.

Belege: Arista, „M&E Multicast Addressing" (der 2⁵-Kollaps); Dataton WATCHOUT, ST-2110-Netzwerkeinrichtung (Adresse und Port zusammen eindeutig). Der Bedarf nennt das Ziel wörtlich: *„Derive the flow table from the signal flow the user already drew, then allocate addresses under enforced constraints. A rule a human violates blind and a tool enforces for free."*

## Die Engstelle

`lib/multicastPlan.ts` (neu). `collectFlows` leitet die Fluss-Tabelle aus dem Kabelgraph ab — **ein Fluss je Sende-Port, nicht je Kabel.** Genau da fällt eine Excel-Tabelle auseinander: fünf Empfänger an einer Kamera abonnieren eine Gruppe, nicht fünf.

Vier Essenzen statt zwei, bewusst feiner als `EssenceFamily` im Zeit-Plan (Bedarf 73): dort geht es um den Medientakt, und dafür stehen -20 und -40 auf derselben Seite. Hier geht es um Gruppen, und der Bedarf sagt „every essence (2110-20/-30/-40) is its own multicast group" — ANC ist eine eigene Gruppe, kein Anhängsel des Videos. Licht über IP (sACN, Art-Net) kommt dazu.

## Die zweite Regel, sichtbar gemacht

Eine IPv4-Multicast-Adresse wird auf `01:00:5e:` + die **unteren 23 Bit** abgebildet. Unterhalb von 224.0.0.0/4 sind 28 Bit frei, also fallen 2⁵ = 32 Gruppen auf dieselbe MAC. Das naive Schema aus dem Beleg — `239.<dienst>.<x>.<y>` mit dem Dienst im zweiten Oktett — kollidiert damit Paar für Paar: 239.1.1.1 (Video) und 239.129.1.1 (Audio) tragen dieselbe MAC.

Der Befund nennt **beide Adressen und die geteilte MAC**; ohne die MAC liest er sich wie ein Fehlalarm („das sind doch verschiedene Adressen"). Und er nennt die **Folge**: die Karte des Empfängers filtert auf L2, nimmt beide Ströme an, verworfen wird erst im Betriebssystem — bei 2110-20 sind das rund 1,5 Gbit/s, die niemand eingeplant hat. Einen Ausfall behauptet er nicht: ob es weh tut, hängt an Karte und Switch, und der Plan misst nicht (dieselbe Haltung wie bei „is it flowing", Bedarf 76).

## Fünf benannte Befunde

| | |
|---|---|
| `pair-collision` | Adresse und Port doppelt — die WATCHOUT-Regel |
| `mac-alias` | zwei Gruppen auf einer L2-Adresse — die Arista-Regel |
| `leg-shared` | 2022-7 auf einer Gruppe: doppelte Bandbreite, keine Redundanz |
| `reserved-range` | 224.0.0.0/24, 224.0.1.0/24 (dort liegt PTP selbst), 232/8 SSM, SSDP |
| `outside-pool` | kein Fehler, aber der Grund, warum die nächste Vergabe überrascht |

„Noch nicht vergeben" ist **kein** Befund, sondern die Liste `open` — sonst hätte ein frischer Plan je Fluss eine Warnung und begrübe die echten darunter (dieselbe Entscheidung wie `withoutDomain` bei Bedarf 73).

## Die Vergabe vergibt nur nach

`allocateMulticast` bewegt keine bestehende Adresse und löscht keine. Eine verteilte Adresse steht im Sender, im Empfänger, im Switch-Filter und auf einem ausgedruckten Blatt; sie umzunummerieren wäre der stille Verlust, den Bedarf 96 verbietet. Beim Suchen übersprungen wird alles, was gesperrt ist, dessen (Adresse, Port) schon vergeben ist **oder das mit einer bestehenden dieselbe MAC trägt** — das ist der ganze Sinn der Übung. Ein erschöpfter Pool wird benannt (`exhausted`), nicht still gekürzt. Verwaiste Vergaben bleiben stehen und werden gemeldet; sie zu entfernen ist eine eigene, sichtbare Handlung.

Das zweite 2022-7-Bein wird aus den Medien-Schnittstellen des Senders abgeleitet (`media-primary` **plus** `media-secondary`), nicht gespeichert. Ein Fluss mit nur einem Bein sagt damit im Plan, dass er nur eines hat.

## Zwei Lade-Pfad-Fehler mitrepariert

Beide aus derselben Familie wie die bei Bedarf 73:

- **`interfaceIsEmpty` zählte die Rolle nicht mit.** Während der Planung hat noch keine der beiden Medien-Karten eine Adresse — es steht nur die Rolle da. So eine Schnittstelle galt als leer: `deviceInterfaces` warf sie weg, `normaliseNetworkInterface` gab `null` zurück. Das Sekundärnetz war beim nächsten Laden verschwunden, und der Adressplan hätte anschließend behauptet, dieser Fluss brauche nur ein Bein. `unspecified` zählt weiterhin nicht mit — sonst wäre nie eine Schnittstelle leer.
- Die beiden Tests, die das alte Verhalten festhielten, widersprachen ihrer eigenen Begründung: „eine nur beschriftete bleibt, ‚SFP+ 2' ohne Adresse ist eine Aussage". Eine ausgesprochene Rolle ist genauso eine.

`normaliseMulticastConfig` wirft nur weg, was **unlesbar** ist, und meldet es über `LoadDrop`. Eine lesbare, aber falsche Adresse bleibt: sie zu verwerfen hieße, den Fehler zu verstecken statt ihn zu zeigen.

## Was bewusst fehlt

Eine Vorbelegung des Pools. Ohne erklärten Pool wird nichts vergeben, und der Abschnitt sagt das — ein still gesetzter Vorgabe-Pool wäre eine Behauptung über ein Netz, das diese Anwendung nie gesehen hat.

## Geprüft

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 138 Testdateien, 1700 Tests grün (2 skipped); 51 neue
- `npx eslint .` — 0 Fehler
- **37 Gegenproben, alle rot.** Eine echte Lücke dabei gefunden: der metaSlice-Guard prüfte `scheduleProjectAutosave(updated)` per `toContain` und traf damit jeden anderen Setter derselben Datei mit — das Autosave konnte aus *diesem* verschwinden, ohne dass etwas rot wurde. Jetzt der ganze Rumpf am Stück.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_