### PR TITLE
ausspielung: das Sicherheitsnetz einmal erklärt, mit Namensabgleich (Bedarf 89)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1487,7 +1487,9 @@ export default function App() {
                     ? t('app.loadReport.venueAnswer', 'Antwort der Haus-IT')
                     : d.kind === 'multicast-assignment'
                       ? t('app.loadReport.multicastAssignment', 'Multicast-Vergabe')
-                      : t('app.loadReport.sourceIdentity', 'Signalquelle')}
+                      : d.kind === 'fallback-rule'
+                        ? t('app.loadReport.fallbackRule', 'Ausweich-Regel')
+                        : t('app.loadReport.sourceIdentity', 'Signalquelle')}
                 {d.label ? ` „${d.label}"` : ''}
                 {' — '}
                 {d.reason === 'duplicate-id'

--- a/src/renderer/components/Delivery/DeliveryDialog.tsx
+++ b/src/renderer/components/Delivery/DeliveryDialog.tsx
@@ -29,6 +29,13 @@ import {
   assessArchive,
 } from '../../lib/archiveIsolation'
 import {
+  FALLBACK_FINDING_LABEL,
+  assessFallback,
+  fallbackSkeleton,
+  fallbackTable,
+} from '../../lib/fallbackPlan'
+import type { FallbackRule } from '../../types/fallback'
+import {
   DELIVERY_PLATFORMS,
   DEFAULT_ENCODING,
   platformByKey,
@@ -109,6 +116,11 @@ export const DeliveryDialog = () => {
   // mitreissen koennte, und sie wird an derselben Stelle beantwortet, an der
   // die Encoder benannt werden.
   const archive = useMemo(() => assessArchive(project), [project])
+  // BEDARF 89 — das Sicherheitsnetz. Auch hier: die Frage entsteht erst, wenn
+  // es eine Ausspielung gibt, die geschuetzt werden koennte.
+  const setFallbackPlan = useProjectStore((s) => s.setFallbackPlan)
+  const fallback = useMemo(() => assessFallback(project), [project])
+  const [sceneDraft, setSceneDraft] = useState('')
   const chainById = useMemo(
     () => new Map<string, DeliveryChain>(chains.map((c) => [c.destinationId, c])),
     [chains],
@@ -310,6 +322,55 @@ export const DeliveryDialog = () => {
     )
   }
 
+  // Ein Setter fuer den ganzen Plan (siehe metaSlice): Szenenliste, Waechter
+  // und Regeln haengen aneinander.
+  const patchFallback = (patch: Partial<typeof fallback.plan>) =>
+    setFallbackPlan({ ...fallback.plan, ...patch })
+
+  const addRule = (destinationId: string) => {
+    const id = `fb-${destinationId}`
+    if (fallback.plan.rules.some((r) => r.id === id)) return
+    patchFallback({ rules: [...fallback.plan.rules, { id, destinationId }] })
+  }
+  const patchRule = (id: string, patch: Partial<FallbackRule>) =>
+    patchFallback({
+      rules: fallback.plan.rules.map((r) => (r.id === id ? { ...r, ...patch } : r)),
+    })
+  const removeRule = (id: string) =>
+    patchFallback({ rules: fallback.plan.rules.filter((r) => r.id !== id) })
+
+  // Die Szenenliste wird EINGEFUEGT, nicht gelesen: der Planer oeffnet keine
+  // Szenensammlung. Zeilen- oder kommagetrennt, weil beides aus einem
+  // Encoder-Fenster kommt.
+  const applyScenes = () => {
+    const namen = [
+      ...new Set(
+        sceneDraft
+          .split(/[\n,;]+/)
+          .map((x) => x.trim())
+          .filter(Boolean),
+      ),
+    ]
+    if (!namen.length) return
+    patchFallback({ scenes: namen })
+    setSceneDraft('')
+  }
+
+  const exportFallback = () => {
+    downloadBlob(
+      buildExportFilenameWithSuffix(projectName, 'ausweich-plan', 'csv'),
+      csvFromTable(fallbackTable(project)),
+      'text/csv',
+    )
+  }
+  const exportSkeleton = () => {
+    downloadBlob(
+      buildExportFilenameWithSuffix(projectName, 'ausweich-geruest', 'json'),
+      fallbackSkeleton(project),
+      'application/json',
+    )
+  }
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
       <div className="flex max-h-[88vh] w-full max-w-5xl flex-col overflow-hidden rounded-lg border border-cp-border bg-cp-surface-1 shadow-xl">
@@ -447,6 +508,210 @@ export const DeliveryDialog = () => {
                   {archive.findings.map((f, i) => (
                     <li key={`${f.kind}-${i}`} className="text-amber-300/90">
                       <strong>{ARCHIVE_FINDING_LABEL[f.kind]}</strong> — {archiveFindingText(f)}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+
+          {/* BEDARF 89 — das Sicherheitsnetz. Nur sichtbar, wenn es ein Ziel
+              gibt: ohne Ausspielung gibt es nichts zu schützen, und der
+              Abschnitt wäre eine Frage ohne Anlass. */}
+          {list.length > 0 && (
+            <div className="mb-4 rounded border border-cp-border-muted bg-cp-surface-2 p-2.5">
+              <div className="mb-1.5 flex flex-wrap items-center gap-2 text-cp-sm">
+                <span className="font-medium text-cp-text">
+                  {t('delivery.fb.title', 'Ausweichverhalten (Sicherheitsnetz)')}
+                </span>
+                <button
+                  type="button"
+                  onClick={exportFallback}
+                  className="ml-auto flex items-center gap-1 rounded border border-cp-border px-2 py-1 text-cp-sm text-cp-text-secondary hover:text-cp-text"
+                >
+                  <FileText size={13} /> {t('delivery.fb.export', 'Blatt')}
+                </button>
+                <button
+                  type="button"
+                  onClick={exportSkeleton}
+                  title={t(
+                    'delivery.fb.skeletonHint',
+                    'Gerüst zum Abtippen, keine einspielbare Konfiguration — das NOALBS-Schema hängt an deiner Version',
+                  )}
+                  className="flex items-center gap-1 rounded border border-cp-border px-2 py-1 text-cp-sm text-cp-text-secondary hover:text-cp-text"
+                >
+                  <Download size={13} /> {t('delivery.fb.skeleton', 'Gerüst')}
+                </button>
+              </div>
+
+              <p className="mb-2 text-cp-xs text-cp-text-muted">
+                {t(
+                  'delivery.fb.intro',
+                  'Der teure Fehler ist nicht das Netz, das nicht auslöst — es ist das Netz, das grundlos auslöst und die Show auf eine Tafel parkt, während die Strecke läuft. Szenennamen stehen im Encoder, im Wächter und im Kopf des Operators; hier stehen sie einmal, und der Abgleich kostet nichts.',
+                )}
+              </p>
+
+              <div className="mb-2 flex flex-wrap items-end gap-2 text-cp-sm">
+                <label className="flex flex-col gap-0.5">
+                  <span className="text-cp-xs text-cp-text-muted">
+                    {t('delivery.fb.watcher', 'Wächter läuft auf')}
+                  </span>
+                  <select
+                    value={fallback.plan.watcherEquipmentId ?? ''}
+                    onChange={(e) =>
+                      patchFallback({ watcherEquipmentId: e.target.value || undefined })
+                    }
+                    aria-label={t('delivery.fb.watcher', 'Wächter läuft auf')}
+                    className={inputCls}
+                  >
+                    <option value="">{t('delivery.fb.watcherNone', '— nicht benannt —')}</option>
+                    {encoderChoices.map((e) => (
+                      <option key={e.id} value={e.id}>
+                        {e.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="flex flex-1 flex-col gap-0.5">
+                  <span className="text-cp-xs text-cp-text-muted">
+                    {t('delivery.fb.stats', 'Statistik-Quelle, wie der Wächter sie sieht')}
+                  </span>
+                  <input
+                    value={fallback.plan.statsUrl ?? ''}
+                    onChange={(e) => patchFallback({ statsUrl: e.target.value || undefined })}
+                    placeholder="http://10.0.0.20/stat"
+                    aria-label={t('delivery.fb.stats', 'Statistik-Quelle, wie der Wächter sie sieht')}
+                    className={`${inputCls} w-full`}
+                  />
+                </label>
+              </div>
+
+              <div className="mb-2 flex flex-wrap items-end gap-2 text-cp-sm">
+                <label className="flex flex-1 flex-col gap-0.5">
+                  <span className="text-cp-xs text-cp-text-muted">
+                    {format(
+                      t('delivery.fb.scenes', 'Szenen im Encoder ({n} hinterlegt)'),
+                      { n: String(fallback.plan.scenes.length) },
+                    )}
+                  </span>
+                  <input
+                    value={sceneDraft}
+                    onChange={(e) => setSceneDraft(e.target.value)}
+                    placeholder={t(
+                      'delivery.fb.scenesPh',
+                      'Namen einfügen, durch Komma oder Zeilenumbruch getrennt',
+                    )}
+                    aria-label={t('delivery.fb.scenes', 'Szenen im Encoder')}
+                    className={`${inputCls} w-full`}
+                  />
+                </label>
+                <button
+                  type="button"
+                  onClick={applyScenes}
+                  className="rounded border border-cp-border px-2 py-1.5 text-cp-sm text-cp-text-secondary hover:text-cp-text"
+                >
+                  {t('delivery.fb.scenesApply', 'Übernehmen')}
+                </button>
+              </div>
+              {fallback.plan.scenes.length > 0 && (
+                <div className="mb-2 text-cp-xs text-cp-text-faint">
+                  {fallback.plan.scenes.join(' · ')}
+                </div>
+              )}
+
+              <ul className="flex flex-col gap-1.5">
+                {list.map((d) => {
+                  const rule = fallback.plan.rules.find((r) => r.destinationId === d.id)
+                  if (!rule) {
+                    return (
+                      <li key={d.id} className="flex items-center gap-2 text-cp-xs">
+                        <span className="flex-1 text-cp-text-muted">{d.name}</span>
+                        <button
+                          type="button"
+                          onClick={() => addRule(d.id)}
+                          className="rounded border border-cp-border px-2 py-0.5 text-cp-text-secondary hover:text-cp-text"
+                        >
+                          <Plus size={11} className="inline" />{' '}
+                          {t('delivery.fb.protect', 'Absichern')}
+                        </button>
+                      </li>
+                    )
+                  }
+                  return (
+                    <li
+                      key={d.id}
+                      className="rounded border border-cp-border-muted bg-cp-surface-3 p-2"
+                    >
+                      <div className="mb-1 flex items-center gap-2 text-cp-sm">
+                        <span className="flex-1 font-medium text-cp-text">{d.name}</span>
+                        <button
+                          type="button"
+                          onClick={() => removeRule(rule.id)}
+                          aria-label={t('delivery.fb.remove', 'Regel entfernen')}
+                          className="text-cp-text-muted hover:text-cp-danger"
+                        >
+                          <Trash2 size={13} />
+                        </button>
+                      </div>
+                      <div className="flex flex-wrap gap-2 text-cp-xs">
+                        {(
+                          [
+                            ['sceneNormal', t('delivery.fb.sceneNormal', 'Normalbetrieb')],
+                            ['sceneLow', t('delivery.fb.sceneLow', 'Niedrige Bitrate')],
+                            ['sceneOffline', t('delivery.fb.sceneOffline', 'Offline')],
+                          ] as const
+                        ).map(([feld, label]) => (
+                          <label key={feld} className="flex flex-col gap-0.5">
+                            <span className="text-cp-text-muted">{label}</span>
+                            <input
+                              value={rule[feld] ?? ''}
+                              onChange={(e) => patchRule(rule.id, { [feld]: e.target.value || undefined })}
+                              aria-label={`${d.name} — ${label}`}
+                              className={`${inputCls} w-36`}
+                            />
+                          </label>
+                        ))}
+                        <label className="flex flex-col gap-0.5">
+                          <span className="text-cp-text-muted">
+                            {t('delivery.fb.low', 'Schwelle niedrig')}
+                          </span>
+                          <input
+                            type="number"
+                            min={0}
+                            value={rule.lowKbps ?? ''}
+                            onChange={(e) =>
+                              patchRule(rule.id, { lowKbps: Number(e.target.value) || undefined })
+                            }
+                            aria-label={`${d.name} — ${t('delivery.fb.low', 'Schwelle niedrig')}`}
+                            className={`${inputCls} w-24`}
+                          />
+                        </label>
+                        <label className="flex flex-col gap-0.5">
+                          <span className="text-cp-text-muted">
+                            {t('delivery.fb.offline', 'Schwelle offline')}
+                          </span>
+                          <input
+                            type="number"
+                            min={0}
+                            value={rule.offlineKbps ?? ''}
+                            onChange={(e) =>
+                              patchRule(rule.id, { offlineKbps: Number(e.target.value) || undefined })
+                            }
+                            aria-label={`${d.name} — ${t('delivery.fb.offline', 'Schwelle offline')}`}
+                            className={`${inputCls} w-24`}
+                          />
+                        </label>
+                      </div>
+                    </li>
+                  )
+                })}
+              </ul>
+
+              {fallback.findings.length > 0 && (
+                <ul className="mt-2 flex flex-col gap-1 text-cp-xs">
+                  {fallback.findings.map((f, i) => (
+                    <li key={`${f.kind}-${i}`} className="text-amber-300/90">
+                      <strong>{FALLBACK_FINDING_LABEL[f.kind]}</strong> — {f.text}
                     </li>
                   ))}
                 </ul>

--- a/src/renderer/lib/documentRegistry.ts
+++ b/src/renderer/lib/documentRegistry.ts
@@ -27,6 +27,7 @@ import { buildPtpPlan, ptpTable } from './ptpPlan'
 import { crewSheetTableForProject } from './crewNetworkSheet'
 import { spectrumTableForProject } from './spectrumPlan'
 import { multicastTableForProject } from './multicastPlan'
+import { fallbackTable } from './fallbackPlan'
 import type { CsvTable } from './csv'
 
 const ofTable =
@@ -98,6 +99,10 @@ export const DOCUMENT_STANDS: Record<string, (project: CablePlannerProject) => s
   // sich mit jeder Umformulierung aendert, meldete jedes gedruckte Exemplar
   // als veraltet.
   'multicast-plan': ofTable(multicastTableForProject),
+  // Bedarf 89 — das Sicherheitsnetz als Blatt mit Stand. Reproduzierbar: der
+  // Inhalt folgt allein aus den Regeln und den Zielen. Die BEFUNDE stehen
+  // nicht drin -- sie tragen Fliesstext.
+  'ausweich-plan': ofTable(fallbackTable),
 }
 
 /**
@@ -165,6 +170,7 @@ export const DOCUMENT_LABELS: Record<string, string> = {
   'crew-netz': 'Netz-Merkblatt (Crew)',
   'spektrum-plan': 'Spektrum-Plan',
   'multicast-plan': 'Multicast-Adressplan',
+  'ausweich-plan': 'Ausweich-Plan (Sicherheitsnetz)',
   'videohub-labels': 'Videohub-Labels',
   'atem-mv-layout': 'Multiviewer-Layout',
   'switch-port-karte': 'Switch-Port-Karte',

--- a/src/renderer/lib/fallbackPlan.ts
+++ b/src/renderer/lib/fallbackPlan.ts
@@ -1,0 +1,360 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Das Sicherheitsnetz (Bedarf 89, P2). Was passieren SOLL, wenn ein Ziel
+// schwaechelt — und die Pruefung, ob das ueberhaupt passieren KANN.
+//
+//   > Scene names exist in the OBS scene collection, again in hand-edited
+//   > NOALBS JSON, and again in the operator's memory during the show; the
+//   > safety net's characteristic failure is parking the show on a slate while
+//   > the stream is fine.
+//
+// Die Bedarfs-Datenbank sagt auch, wie: „Record the intended fallback
+// behaviour (thresholds, scene names, which destination it protects) as part
+// of the plan and emit it as a NOALBS skeleton; name-consistency checking
+// between plan and exported config is a cheap win."
+//
+// ─── DIE BILLIGE PRUEFUNG, DIE NIEMAND MACHT ───────────────────────────────
+//
+// Ein Szenenname ist eine Zeichenkette, die an drei Stellen steht und an genau
+// einer stimmt. Der Waechter schaltet auf „BRB", der Encoder kennt „Be Right
+// Back", und niemand merkt es — bis zu dem Moment, in dem es darauf ankommt.
+// Der Vergleich kostet nichts und faellt trotzdem aus, weil die Szenenliste
+// nirgends neben der Regel steht. Hier steht sie.
+//
+// Solange die Szenenliste LEER ist, laeuft die Pruefung nicht — und genau das
+// wird gesagt (`scenes-unknown`). Ein stiller Durchlauf saehe aus wie
+// „geprueft", und das ist der teuerste Zustand von allen.
+//
+// ─── `localhost` IST KEINE ADRESSE, SONDERN EINE ANNAHME ───────────────────
+//
+// NOALBS #178: der Waechter erreicht `http://localhost/stat` nicht, obwohl
+// dieselbe URL im Browser antwortet — der Browser lief auf einer anderen
+// Maschine. Folge: dauerhaftes Umschalten auf die Offline-Szene bei laufendem
+// RTMP. Der Plan weiss, auf welchem Geraet der Waechter laeuft und auf welchem
+// der Encoder steht; er kann die Annahme also benennen. Ob die URL antwortet,
+// weiss er nicht — das ist eine Messung an der Maschine, und eine geratene
+// Antwort saehe wie eine aus.
+//
+// ─── WAS DER EXPORT IST UND WAS NICHT ──────────────────────────────────────
+//
+// `fallbackSkeleton` ist ein GERUEST zum Abtippen, keine Datei zum Einspielen.
+// Das exakte NOALBS-Schema haengt an der Version, die jemand faehrt, und diese
+// Anwendung hat sie nie gesehen. Eine JSON-Datei auszugeben, die aussieht wie
+// eine Konfiguration und keine ist, waere schlimmer als gar keine: jemand
+// spielt sie in ein laufendes Sicherheitsnetz. Der Hinweis steht deshalb IN
+// der Datei, nicht nur daneben.
+//
+// Und: KEIN Stream-Key. Der liegt im Schluesselbund (`credentialKeys.ts`), und
+// eine exportierte Konfiguration ist eine Datei, die per Mail geht.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { CablePlannerProject } from '../types/project'
+import type { DeliveryDestination } from '../types/delivery'
+import type { FallbackPlan, FallbackRule } from '../types/fallback'
+import type { CsvTable } from './csv'
+
+export type FallbackFindingKind =
+  | 'scene-unknown'
+  | 'scenes-unknown'
+  | 'stats-loopback'
+  | 'threshold-above-bitrate'
+  | 'threshold-order'
+  | 'no-return-path'
+
+export const FALLBACK_FINDING_LABEL: Readonly<Record<FallbackFindingKind, string>> = {
+  'scene-unknown': 'Szene gibt es im Encoder nicht',
+  'scenes-unknown': 'Szenenliste fehlt — der Namensabgleich läuft nicht',
+  'stats-loopback': 'localhost ist eine Annahme über die Maschine',
+  'threshold-above-bitrate': 'Schwelle über der geplanten Bitrate',
+  'threshold-order': 'Schwellen stehen verkehrt herum',
+  'no-return-path': 'Kein Rückweg aus der Ausweichszene',
+}
+
+export interface FallbackFinding {
+  kind: FallbackFindingKind
+  text: string
+  /** Die betroffene Regel, fuer den Sprung. Leer bei planweiten Befunden. */
+  ruleId?: string
+}
+
+export interface FallbackAssessment {
+  plan: FallbackPlan
+  findings: FallbackFinding[]
+  /**
+   * Ziele ohne Regel. KEIN Befund: ein Plan ohne Sicherheitsnetz ist eine
+   * Entscheidung, und je Ziel eine Warnung zu setzen wuerde die sechs echten
+   * Befunde darunter begraben (dieselbe Haltung wie `withoutDomain` beim
+   * Zeit-Plan und `open` beim Multicast-Adressplan).
+   */
+  unprotected: string[]
+  /** Traegt das Projekt ueberhaupt eine Ausspielung? */
+  hasDestinations: boolean
+}
+
+const LOOPBACK = /^(https?:\/\/)?(localhost|127\.0\.0\.1|\[::1\]|::1)(:|\/|$)/i
+
+/** Ist diese Statistik-URL auf „dieselbe Maschine" gestellt? */
+export const isLoopback = (url: string | undefined): boolean => !!url && LOOPBACK.test(url.trim())
+
+/** Die geplante Gesamtbitrate eines Ziels — Video plus Audio, in kbit/s. */
+export const plannedKbps = (d: DeliveryDestination): number =>
+  (d.encoding?.videoBitrateKbps ?? 0) + (d.encoding?.audioBitrateKbps ?? 0)
+
+const EMPTY: FallbackPlan = { scenes: [], rules: [] }
+
+/**
+ * Die Pruefung. Sie liest nur — sie setzt keine Szene und keine Schwelle.
+ *
+ * Alles, was sie sagt, folgt aus dem Plan: die Szenenliste, die Regeln, die
+ * geplanten Bitraten der Ziele und die Geraete, auf denen Waechter und Encoder
+ * stehen. Keine Messung, keine Vorgabe.
+ */
+export function assessFallback(project: CablePlannerProject): FallbackAssessment {
+  const plan = project.fallback ?? EMPTY
+  const dests = project.deliveryDestinations ?? []
+  const destById = new Map(dests.map((d) => [d.id, d]))
+  const equipById = new Map(project.equipment.map((e) => [e.id, e]))
+  const findings: FallbackFinding[] = []
+
+  const scenes = plan.scenes.map((s) => s.trim()).filter(Boolean)
+  const bekannt = new Set(scenes)
+  const named = (id: string) => destById.get(id)?.name ?? id
+  const geraet = (id: string | undefined) => (id ? (equipById.get(id)?.name ?? id) : undefined)
+
+  // 1) Die Szenenliste selbst. Zuerst, weil sie die naechste Pruefung traegt.
+  if (plan.rules.length > 0 && scenes.length === 0) {
+    findings.push({
+      kind: 'scenes-unknown',
+      text: 'Es sind Regeln hinterlegt, aber keine Szene des Encoders steht im Plan. Der Namensabgleich — die billigste Prüfung von allen — läuft damit nicht, und das Ergebnis „keine Beanstandung" wäre keins.',
+    })
+  }
+
+  for (const r of plan.rules) {
+    const ziel = destById.get(r.destinationId)
+
+    // 2) Der Namensabgleich. Der Kern des Bedarfs.
+    if (scenes.length > 0) {
+      for (const [feld, name] of [
+        ['Normalbetrieb', r.sceneNormal],
+        ['niedrige Bitrate', r.sceneLow],
+        ['offline', r.sceneOffline],
+      ] as const) {
+        const wert = name?.trim()
+        if (!wert || bekannt.has(wert)) continue
+        findings.push({
+          kind: 'scene-unknown',
+          ruleId: r.id,
+          text: `${named(r.destinationId)}, ${feld}: „${wert}" steht in keiner Szene des Encoders. Der Wächter schaltet auf einen Namen, den es nicht gibt — die Show bleibt stehen, wo sie gerade war, und niemand sieht einen Fehler.`,
+        })
+      }
+    }
+
+    // 3) Der Rueckweg. NOALBS #119: eine klebende Offline-Szene.
+    if (r.sceneOffline?.trim() && !r.sceneNormal?.trim()) {
+      findings.push({
+        kind: 'no-return-path',
+        ruleId: r.id,
+        text: `${named(r.destinationId)}: eine Ausweichszene ist benannt, eine für den Normalbetrieb nicht. Wer einmal umschaltet, schaltet nie zurück — die Show läuft auf der Tafel weiter, während die Strecke längst wieder steht.`,
+      })
+    }
+
+    // 4) Die Schwellen gegeneinander.
+    if (
+      typeof r.lowKbps === 'number' &&
+      typeof r.offlineKbps === 'number' &&
+      r.offlineKbps >= r.lowKbps
+    ) {
+      findings.push({
+        kind: 'threshold-order',
+        ruleId: r.id,
+        text: `${named(r.destinationId)}: „offline" liegt bei ${r.offlineKbps} kbit/s und „niedrig" bei ${r.lowKbps} kbit/s. Offline muss UNTER niedrig liegen, sonst ist der Zwischenzustand nicht erreichbar und es gibt nur an oder aus.`,
+      })
+    }
+
+    // 5) Die Schwelle gegen die geplante Bitrate.
+    if (ziel && typeof r.lowKbps === 'number') {
+      const geplant = plannedKbps(ziel)
+      if (geplant > 0 && r.lowKbps >= geplant) {
+        findings.push({
+          kind: 'threshold-above-bitrate',
+          ruleId: r.id,
+          text: `${named(r.destinationId)}: die Schwelle „niedrig" liegt bei ${r.lowKbps} kbit/s, geplant sind ${geplant} kbit/s (Video ${ziel.encoding.videoBitrateKbps} + Audio ${ziel.encoding.audioBitrateKbps}). Der Zustand liegt damit vom ersten Moment an vor und geht nie weg.`,
+        })
+      }
+    }
+  }
+
+  // 6) `localhost`. NOALBS #178.
+  if (plan.rules.length > 0 && isLoopback(plan.statsUrl)) {
+    const waechter = geraet(plan.watcherEquipmentId)
+    const encoderNamen = [
+      ...new Set(
+        plan.rules
+          .map((r) => geraet(destById.get(r.destinationId)?.encoderEquipmentId))
+          .filter((n): n is string => !!n),
+      ),
+    ]
+    const fremde = waechter ? encoderNamen.filter((n) => n !== waechter) : []
+    findings.push({
+      kind: 'stats-loopback',
+      text: waechter
+        ? fremde.length
+          ? `Die Statistik-Quelle ist „${plan.statsUrl}". Der Wächter läuft auf ${waechter}, die Statistik kommt aber von ${fremde.join(', ')} — localhost zeigt dann auf ${waechter} und nicht dorthin. Genau das schaltet dauerhaft auf die Offline-Szene, während die Strecke läuft (NOALBS #178).`
+          : `Die Statistik-Quelle ist „${plan.statsUrl}". Wächter und Encoder stehen im Plan auf ${waechter} — das passt, solange es dabei bleibt. Ob die URL dort antwortet, sagt der Plan nicht; das ist eine Messung an der Maschine.`
+        : `Die Statistik-Quelle ist „${plan.statsUrl}". „localhost" heißt „dieselbe Maschine" — welche das ist, steht nicht im Plan. Im Beleg antwortete dieselbe URL im Browser und nicht im Wächter, und die Show lief auf der Offline-Szene weiter (NOALBS #178).`,
+    })
+  }
+
+  const geschuetzt = new Set(plan.rules.map((r) => r.destinationId))
+  return {
+    plan,
+    findings,
+    unprotected: dests.filter((d) => !geschuetzt.has(d.id)).map((d) => d.id),
+    hasDestinations: dests.length > 0,
+  }
+}
+
+/** Das Blatt: eine Zeile je Regel, mit den drei Szenen und beiden Schwellen. */
+export function fallbackTable(project: CablePlannerProject): CsvTable {
+  const a = assessFallback(project)
+  const dests = project.deliveryDestinations ?? []
+  const name = (id: string) => dests.find((d) => d.id === id)?.name ?? id
+  return {
+    headers: [
+      'Ziel',
+      'Normalbetrieb',
+      'Niedrige Bitrate',
+      'Offline',
+      'Schwelle niedrig (kbit/s)',
+      'Schwelle offline (kbit/s)',
+      'Geplant (kbit/s)',
+      'Anmerkung',
+    ],
+    rows: a.plan.rules.map((r) => {
+      const d = dests.find((x) => x.id === r.destinationId)
+      return [
+        name(r.destinationId),
+        r.sceneNormal ?? '',
+        r.sceneLow ?? '',
+        r.sceneOffline ?? '',
+        r.lowKbps ?? '',
+        r.offlineKbps ?? '',
+        d ? plannedKbps(d) : '',
+        r.note ?? '',
+      ]
+    }),
+  }
+}
+
+/**
+ * Das Geruest zum Abtippen.
+ *
+ * Bewusst KEINE NOALBS-Datei: das Schema haengt an der Version, und diese
+ * Anwendung hat sie nie gesehen. Der Hinweis steht IN der Ausgabe, damit er
+ * die Datei nicht verlaesst — jemand schickt sie weiter, und der Satz daneben
+ * bleibt im Chat zurueck.
+ *
+ * Ohne Stream-Key, ohne Ingest-Key: die Datei geht per Mail.
+ */
+export function fallbackSkeleton(project: CablePlannerProject): string {
+  const a = assessFallback(project)
+  const dests = project.deliveryDestinations ?? []
+  const equip = new Map(project.equipment.map((e) => [e.id, e.name]))
+  return JSON.stringify(
+    {
+      _hinweis:
+        'Gerüst zum Abtippen, KEINE einspielbare Konfiguration. Das genaue NOALBS-Schema hängt an der Version, die du fährst; dieser Plan kennt sie nicht. Stream-Keys stehen hier nicht und dürfen hier nicht stehen.',
+      waechter: {
+        geraet: a.plan.watcherEquipmentId ? (equip.get(a.plan.watcherEquipmentId) ?? null) : null,
+        statistikUrl: a.plan.statsUrl ?? null,
+      },
+      szenenImEncoder: a.plan.scenes,
+      regeln: a.plan.rules.map((r) => {
+        const d = dests.find((x) => x.id === r.destinationId)
+        return {
+          ziel: d?.name ?? r.destinationId,
+          plattform: d?.platform ?? null,
+          encoder: d?.encoderEquipmentId ? (equip.get(d.encoderEquipmentId) ?? null) : null,
+          geplantKbps: d ? plannedKbps(d) : null,
+          szenen: {
+            normal: r.sceneNormal ?? null,
+            niedrig: r.sceneLow ?? null,
+            offline: r.sceneOffline ?? null,
+          },
+          schwellenKbps: { niedrig: r.lowKbps ?? null, offline: r.offlineKbps ?? null },
+          anmerkung: r.note ?? null,
+        }
+      }),
+      befunde: a.findings.map((f) => ({ art: f.kind, text: f.text })),
+    },
+    null,
+    2,
+  )
+}
+
+/**
+ * Normalisiert den gespeicherten Plan beim Laden.
+ *
+ * Verworfen wird nur, was unlesbar ist: eine Regel ohne Ziel kann nichts
+ * schuetzen. Eine Regel mit einem Szenennamen, den es nicht gibt, BLEIBT —
+ * dafuer gibt es einen Befund, und sie hier wegzuwerfen hiesse, den Fehler zu
+ * verstecken statt ihn zu zeigen.
+ */
+export function normaliseFallbackPlan(
+  raw: unknown,
+  onDrop?: (d: { reason: 'missing-required' | 'duplicate-id'; label: string }) => void,
+): FallbackPlan | undefined {
+  if (!raw || typeof raw !== 'object') return undefined
+  const o = raw as Partial<FallbackPlan>
+  const str = (v: unknown): string | undefined =>
+    typeof v === 'string' && v.trim() ? v.trim() : undefined
+  const num = (v: unknown): number | undefined =>
+    typeof v === 'number' && Number.isFinite(v) && v >= 0 ? v : undefined
+
+  const scenes = [
+    ...new Set((Array.isArray(o.scenes) ? o.scenes : []).map((s) => str(s)).filter((s): s is string => !!s)),
+  ]
+  const seen = new Set<string>()
+  const rules: FallbackRule[] = []
+  for (const raw2 of Array.isArray(o.rules) ? o.rules : []) {
+    const r = raw2 as Partial<FallbackRule>
+    const id = str(r.id)
+    const destinationId = str(r.destinationId)
+    if (!id || !destinationId) {
+      onDrop?.({ reason: 'missing-required', label: id ?? destinationId ?? '' })
+      continue
+    }
+    if (seen.has(id)) {
+      onDrop?.({ reason: 'duplicate-id', label: id })
+      continue
+    }
+    seen.add(id)
+    const rule: FallbackRule = { id, destinationId }
+    const sceneNormal = str(r.sceneNormal)
+    if (sceneNormal) rule.sceneNormal = sceneNormal
+    const sceneLow = str(r.sceneLow)
+    if (sceneLow) rule.sceneLow = sceneLow
+    const sceneOffline = str(r.sceneOffline)
+    if (sceneOffline) rule.sceneOffline = sceneOffline
+    const lowKbps = num(r.lowKbps)
+    if (lowKbps !== undefined) rule.lowKbps = lowKbps
+    const offlineKbps = num(r.offlineKbps)
+    if (offlineKbps !== undefined) rule.offlineKbps = offlineKbps
+    const note = str(r.note)
+    if (note) rule.note = note
+    rules.push(rule)
+  }
+
+  const watcherEquipmentId = str(o.watcherEquipmentId)
+  const statsUrl = str(o.statsUrl)
+  // Ein Objekt ohne alles traegt nichts — Ballast in jedem Projektfile, das
+  // den Dialog einmal geoeffnet hat.
+  if (!watcherEquipmentId && !statsUrl && scenes.length === 0 && rules.length === 0) return undefined
+  return {
+    ...(watcherEquipmentId ? { watcherEquipmentId } : {}),
+    ...(statsUrl ? { statsUrl } : {}),
+    scenes,
+    rules,
+  }
+}

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3211,6 +3211,7 @@ export const en: Dict = {
   'app.loadReport.deliveryDestination': 'Delivery destination',
   'app.loadReport.venueAnswer': 'Venue IT answer',
   'app.loadReport.multicastAssignment': 'Multicast assignment',
+  'app.loadReport.fallbackRule': 'Fallback rule',
   'app.loadReport.duplicateId': 'duplicate id, the first entry wins',
   'app.loadReport.missingRequired': 'required field missing (name)',
   'app.loadReport.hint': 'Devices that pointed at these roles lost their assignment — including the TSL address used for tally. Saving overwrites the file with this state.',
@@ -4254,6 +4255,27 @@ export const en: Dict = {
   'analysis.crew.title': 'Network briefing sheet for the crew',
   'analysis.crew.ask': '{n} points to settle on site',
   'analysis.crew.export': 'Crew network sheet',
+  // Bedarf 89 — das Sicherheitsnetz.
+  'delivery.fb.title': 'Fallback behaviour (safety net)',
+  'delivery.fb.intro':
+    'The expensive failure is not the net that never fires \u2014 it is the net that fires for no reason and parks the show on a slate while the stream is fine. Scene names live in the encoder, in the watchdog and in the operator\u2019s head; here they live once, and comparing them costs nothing.',
+  'delivery.fb.export': 'Sheet',
+  'delivery.fb.skeleton': 'Skeleton',
+  'delivery.fb.skeletonHint':
+    'A skeleton to copy by hand, not a config to load \u2014 the NOALBS schema depends on the version you run',
+  'delivery.fb.watcher': 'Watchdog runs on',
+  'delivery.fb.watcherNone': '\u2014 not stated \u2014',
+  'delivery.fb.stats': 'Stats source, as the watchdog sees it',
+  'delivery.fb.scenes': 'Scenes in the encoder ({n} on file)',
+  'delivery.fb.scenesPh': 'Paste names, separated by comma or newline',
+  'delivery.fb.scenesApply': 'Apply',
+  'delivery.fb.protect': 'Protect',
+  'delivery.fb.remove': 'Remove rule',
+  'delivery.fb.sceneNormal': 'Normal',
+  'delivery.fb.sceneLow': 'Low bitrate',
+  'delivery.fb.sceneOffline': 'Offline',
+  'delivery.fb.low': 'Low threshold',
+  'delivery.fb.offline': 'Offline threshold',
   // Bedarf 72 — der Multicast-Adressplan.
   'analysis.mc.title': 'Multicast address plan',
   'analysis.mc.intro':

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -72,6 +72,7 @@ import {
 } from '../lib/sourceIdentity'
 import { normaliseDeliveryDestinations } from '../lib/deliveryNormalise'
 import { normaliseMulticastConfig } from '../lib/multicastPlan'
+import { normaliseFallbackPlan } from '../lib/fallbackPlan'
 import { normaliseVenueAnswers } from '../lib/venueAnswers'
 import { isNetworkInterfaceRole, normaliseNetworkInterface } from '../lib/networkInterfaces'
 import type { NetworkInterface } from '../types/network'
@@ -442,6 +443,7 @@ export interface ProjectState {
   setDrumKit: (plan: import('../types/drumKit').DrumKitPlan | undefined) => void
   setWirelessRig: (plan: import('../types/wirelessRig').WirelessRigPlan | undefined) => void
   setMulticastConfig: (config: import('../types/multicast').MulticastConfig | undefined) => void
+  setFallbackPlan: (plan: import('../types/fallback').FallbackPlan | undefined) => void
   /** v7.9.3 — Mobile-Viewer Check-State setzen (vom POST /checks-IPC).
    *  Komplettes Objekt-Replace damit gelöschte Checks (false → kein
    *  key) auch übernommen werden. */
@@ -629,6 +631,12 @@ const healProjectPositions = (
   const multicast = normaliseMulticastConfig(project.multicast, (d) =>
     onDrop?.({ kind: 'multicast-assignment', reason: d.reason, label: d.label }),
   )
+  // Bedarf 89 — das Sicherheitsnetz. Eine Regel ohne Ziel kann nichts
+  // schuetzen und fliegt raus; eine Regel mit einem Szenennamen, den es nicht
+  // gibt, BLEIBT — dafuer gibt es einen Befund.
+  const fallback = normaliseFallbackPlan(project.fallback, (d) =>
+    onDrop?.({ kind: 'fallback-rule', reason: d.reason, label: d.label }),
+  )
   return {
     ...project,
     equipment: project.equipment.map((item) => {
@@ -776,6 +784,8 @@ const healProjectPositions = (
     deliveryDestinations,
     // Bedarf 72 — `undefined` heisst „kein Adressplan", nicht „leerer".
     multicast,
+    // Bedarf 89 — dito: `undefined` heisst „kein Sicherheitsnetz erklaert".
+    fallback,
     // ADR-003 — Rentman-Zaehler: gesendet ist nicht bestaetigt.
     metadata: {
       ...healRentmanCableMap(project.metadata),

--- a/src/renderer/store/slices/metaSlice.ts
+++ b/src/renderer/store/slices/metaSlice.ts
@@ -32,6 +32,7 @@ export type MetaSlice = Pick<
   | 'setDrumKit'
   | 'setWirelessRig'
   | 'setMulticastConfig'
+  | 'setFallbackPlan'
 >
 
 export const createMetaSlice: StateCreator<ProjectState, [], [], MetaSlice> = (set) => ({
@@ -117,6 +118,17 @@ export const createMetaSlice: StateCreator<ProjectState, [], [], MetaSlice> = (s
   setMulticastConfig: (config) =>
     set((state) => {
       const updated = { ...state.project, multicast: config }
+      scheduleProjectAutosave(updated)
+      return { project: updated }
+    }),
+  // BEDARF 89 — das Sicherheitsnetz. Wieder ein Setter fuer das ganze Objekt:
+  // Szenenliste, Waechter und Regeln haengen aneinander, und ein Einzel-Setter
+  // je Regel liesse einen Zustand zu, in dem eine Regel auf eine Szene zeigt,
+  // die die Liste noch nicht kennt — genau der Zustand, den die Pruefung
+  // meldet, nur diesmal von der Oberflaeche selbst erzeugt.
+  setFallbackPlan: (plan) =>
+    set((state) => {
+      const updated = { ...state.project, fallback: plan }
       scheduleProjectAutosave(updated)
       return { project: updated }
     }),

--- a/src/renderer/types/fallback.ts
+++ b/src/renderer/types/fallback.ts
@@ -1,0 +1,77 @@
+// ───────────────────────────────────────────────────────────────────────────
+// BEDARF 89 (P2) — das Sicherheitsnetz, einmal erklaert.
+//
+//   > Scene names exist in the OBS scene collection, again in hand-edited
+//   > NOALBS JSON, and again in the operator's memory during the show; the
+//   > safety net's characteristic failure is parking the show on a slate while
+//   > the stream is fine.
+//
+// Belege, beide in voller Laenge gelesen:
+//   NOALBS #178 (2024-10-23, offen) — der Waechter erreicht `http://localhost/
+//   stat` NICHT, obwohl dieselbe URL im Browser antwortet. Also schaltet er
+//   dauerhaft auf die Offline-Szene, waehrend RTMP laeuft, und `!bitrate`
+//   antwortet „No connection :(".
+//   NOALBS #119 (2022-09-14) — eine klebende Offline-Szene, die sich immer
+//   wieder durchsetzt.
+//
+// ─── DER FEHLER IST EIN FALSCH-POSITIV, NICHT EIN VERPASSTER AUSFALL ───────
+//
+// Das ist der Grund, warum dieses Objekt ueberhaupt existiert. Ein
+// Sicherheitsnetz, das nicht ausloest, kostet eine Show. Ein Sicherheitsnetz,
+// das GRUNDLOS ausloest, kostet auch eine Show — und niemand sucht den Fehler
+// beim Netz, weil das Netz ja „funktioniert". Beide Belege sind von dieser
+// zweiten Sorte.
+//
+// Die drei Angaben, die der Bedarf nennt (Schwellen, Szenennamen, welches Ziel
+// geschuetzt wird), stehen deshalb HIER und nicht in drei Koepfen. Dazu die
+// eine, die aus #178 folgt: WO der Waechter laeuft. `localhost` ist keine
+// Adresse, sondern eine Annahme ueber die Maschine.
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Was der Waechter tun soll, wenn ein Ziel schwaechelt.
+ *
+ * Alle Szenen sind optional, und keine wird geraten. Eine erfundene
+ * „Offline"-Szene waere genau der Fehler aus dem Bedarf: der Waechter schaltet
+ * auf einen Namen, den der Encoder nicht kennt, und die Show steht.
+ */
+export interface FallbackRule {
+  id: string
+  /** Das Ziel, das diese Regel schuetzt — eine `DeliveryDestination.id`. */
+  destinationId: string
+  /** Szene fuer den Normalbetrieb — der Rueckweg. */
+  sceneNormal?: string
+  /** Szene bei niedriger Bitrate. */
+  sceneLow?: string
+  /** Szene, wenn nichts mehr ankommt. */
+  sceneOffline?: string
+  /** Schwelle „niedrig" in kbit/s. */
+  lowKbps?: number
+  /** Schwelle „offline" in kbit/s. */
+  offlineKbps?: number
+  /** Notiz — was am Showtag jemand wissen muss. */
+  note?: string
+}
+
+/** Das Sicherheitsnetz des ganzen Projekts. */
+export interface FallbackPlan {
+  /**
+   * Das Geraet, auf dem der Waechter LAEUFT.
+   *
+   * Aus NOALBS #178. Ohne dieses Feld ist `localhost` in der Statistik-URL
+   * nicht pruefbar — und genau diese Annahme hat dort die Show auf die
+   * Offline-Szene geparkt.
+   */
+  watcherEquipmentId?: string
+  /** Die Statistik-Quelle, WIE SIE DER WAECHTER SIEHT (nicht wie der Browser). */
+  statsUrl?: string
+  /**
+   * Die Szenen, die der Encoder wirklich hat.
+   *
+   * Abgetippt oder eingefuegt — der Planer liest keine Szenensammlung. Solange
+   * diese Liste leer ist, kann die Namenspruefung nicht laufen, und DAS wird
+   * gesagt: ein stiller Durchlauf saehe aus wie „geprueft".
+   */
+  scenes: string[]
+  rules: FallbackRule[]
+}

--- a/src/renderer/types/loadReport.ts
+++ b/src/renderer/types/loadReport.ts
@@ -41,6 +41,10 @@ export type LoadDropKind =
    *  bei jeder anderen Sorte: die Vergabe steht im Blatt, das jemand mit ins
    *  Rack nimmt, und eine unlesbare Zeile fiele erst dort auf. */
   | 'multicast-assignment'
+  /** Bedarf 89 — eine Ausweich-Regel ohne Ziel. Sie schuetzt nichts, und sie
+   *  stehenzulassen waere schlimmer als sie zu verwerfen: im Blatt saehe sie
+   *  aus wie ein Sicherheitsnetz. */
+  | 'fallback-rule'
 
 export interface LoadDrop {
   kind: LoadDropKind

--- a/src/renderer/types/project.ts
+++ b/src/renderer/types/project.ts
@@ -263,6 +263,16 @@ export interface CablePlannerProject {
    * neu berechnet, sieht aus wie die alte und ist es nicht.
    */
   multicast?: import('./multicast').MulticastConfig
+  /**
+   * Bedarf 89 — das Sicherheitsnetz: Schwellen, Szenennamen, welches Ziel
+   * geschützt wird, und wo der Wächter läuft.
+   *
+   * Am Projekt und nicht am Ziel: die Szenenliste des Encoders und die
+   * Maschine, auf der der Wächter steht, gelten für die ganze Show. Ein Feld
+   * je Ziel müsste sie vervielfachen — und der Namensabgleich verglich dann
+   * gegen die falsche Kopie.
+   */
+  fallback?: import('./fallback').FallbackPlan
 }
 
 /** #412 — Ein festgeschriebener Projekt-Stand. */

--- a/tests/fallbackPlan.test.ts
+++ b/tests/fallbackPlan.test.ts
@@ -1,0 +1,583 @@
+import { describe, expect, it } from 'vitest'
+import {
+  FALLBACK_FINDING_LABEL,
+  assessFallback,
+  fallbackSkeleton,
+  fallbackTable,
+  isLoopback,
+  normaliseFallbackPlan,
+  plannedKbps,
+} from '../src/renderer/lib/fallbackPlan'
+import type { CablePlannerProject } from '../src/renderer/types/project'
+import type { DeliveryDestination } from '../src/renderer/types/delivery'
+import type { FallbackPlan } from '../src/renderer/types/fallback'
+import dialogQuelle from '../src/renderer/components/Delivery/DeliveryDialog.tsx?raw'
+import registerQuelle from '../src/renderer/lib/documentRegistry.ts?raw'
+import storeQuelle from '../src/renderer/store/projectStore.ts?raw'
+import metaQuelle from '../src/renderer/store/slices/metaSlice.ts?raw'
+import dictsQuelle from '../src/renderer/lib/i18n/dicts.ts?raw'
+
+// ---------------------------------------------------------------------------
+// Das Sicherheitsnetz, einmal erklaert (Bedarf 89, P2).
+//
+//   > Scene names exist in the OBS scene collection, again in hand-edited
+//   > NOALBS JSON, and again in the operator's memory during the show; the
+//   > safety net's characteristic failure is parking the show on a slate while
+//   > the stream is fine.
+//
+// Belege: NOALBS #178 (2024-10-23, offen) — der Waechter erreicht
+// `http://localhost/stat` nicht, obwohl dieselbe URL im Browser antwortet, und
+// schaltet dauerhaft auf offline, waehrend RTMP laeuft. NOALBS #119
+// (2022-09-14) — eine klebende Offline-Szene.
+//
+// Der Bedarf sagt auch, wie: „Record the intended fallback behaviour
+// (thresholds, scene names, which destination it protects) as part of the plan
+// […]; name-consistency checking between plan and exported config is a cheap
+// win."
+// ---------------------------------------------------------------------------
+
+const geraet = (id: string, name: string) =>
+  ({ id, name, x: 0, y: 0, width: 10, height: 10, category: 'Video', inputs: [], outputs: [] }) as never
+
+const ziel = (
+  id: string,
+  name: string,
+  over: Partial<DeliveryDestination> = {},
+): DeliveryDestination =>
+  ({
+    id,
+    name,
+    platform: 'custom',
+    transport: 'RTMP',
+    encoding: {
+      width: 1920,
+      height: 1080,
+      fps: 50,
+      videoCodec: 'H.264',
+      videoBitrateKbps: 6000,
+      keyframeSec: 2,
+      audioCodec: 'AAC',
+      audioSampleRate: 48000,
+      audioBitrateKbps: 160,
+    },
+    ...over,
+  }) as never
+
+const projekt = (over: Partial<CablePlannerProject> = {}): CablePlannerProject =>
+  ({
+    metadata: { name: 'Show' },
+    equipment: [],
+    cables: [],
+    locations: [],
+    ...over,
+  }) as never
+
+const plan = (over: Partial<FallbackPlan> = {}): FallbackPlan => ({
+  scenes: [],
+  rules: [],
+  ...over,
+})
+
+// ---------------------------------------------------------------------------
+describe('ohne Ausspielung gibt es nichts zu schuetzen', () => {
+  it('meldet nichts und sagt, dass es keine Ziele gibt', () => {
+    const a = assessFallback(projekt())
+    expect(a.findings).toEqual([])
+    expect(a.hasDestinations).toBe(false)
+    expect(a.unprotected).toEqual([])
+  })
+
+  it('haelt ein ungeschuetztes Ziel AUS den Befunden heraus', () => {
+    // Ein Plan ohne Sicherheitsnetz ist eine Entscheidung. Je Ziel eine
+    // Warnung wuerde die sechs echten Befunde darunter begraben — dieselbe
+    // Haltung wie `withoutDomain` beim Zeit-Plan.
+    const a = assessFallback(projekt({ deliveryDestinations: [ziel('d1', 'YouTube')] }))
+    expect(a.findings).toEqual([])
+    expect(a.unprotected).toEqual(['d1'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('der Namensabgleich — die billige Pruefung, die niemand macht', () => {
+  it('meldet eine Szene, die der Encoder nicht kennt', () => {
+    const a = assessFallback(
+      projekt({
+        deliveryDestinations: [ziel('d1', 'YouTube')],
+        fallback: plan({
+          scenes: ['Programm', 'Be Right Back'],
+          rules: [{ id: 'r1', destinationId: 'd1', sceneOffline: 'BRB', sceneNormal: 'Programm' }],
+        }),
+      }),
+    )
+    const f = a.findings.find((x) => x.kind === 'scene-unknown')!
+    expect(f).toBeDefined()
+    expect(f.text).toContain('BRB')
+    expect(f.ruleId).toBe('r1')
+  })
+
+  it('prueft ALLE DREI Szenen, nicht nur die Offline-Szene', () => {
+    const a = assessFallback(
+      projekt({
+        deliveryDestinations: [ziel('d1', 'YouTube')],
+        fallback: plan({
+          scenes: ['Programm'],
+          rules: [
+            {
+              id: 'r1',
+              destinationId: 'd1',
+              sceneNormal: 'Programm',
+              sceneLow: 'Sparsam',
+              sceneOffline: 'Tafel',
+            },
+          ],
+        }),
+      }),
+    )
+    const unbekannt = a.findings.filter((f) => f.kind === 'scene-unknown')
+    expect(unbekannt).toHaveLength(2)
+    expect(unbekannt.map((f) => f.text.includes('Sparsam')).some(Boolean)).toBe(true)
+    expect(unbekannt.map((f) => f.text.includes('Tafel')).some(Boolean)).toBe(true)
+  })
+
+  it('SAGT, wenn die Szenenliste fehlt, statt still durchzulaufen', () => {
+    // Ein stiller Durchlauf saehe aus wie „geprueft", und das ist der
+    // teuerste Zustand von allen.
+    const a = assessFallback(
+      projekt({
+        deliveryDestinations: [ziel('d1', 'YouTube')],
+        fallback: plan({ rules: [{ id: 'r1', destinationId: 'd1', sceneOffline: 'BRB' }] }),
+      }),
+    )
+    expect(a.findings.some((f) => f.kind === 'scenes-unknown')).toBe(true)
+    // Und der Namensabgleich behauptet dann NICHTS.
+    expect(a.findings.some((f) => f.kind === 'scene-unknown')).toBe(false)
+  })
+
+  it('meldet die fehlende Liste NICHT, solange es keine Regel gibt', () => {
+    const a = assessFallback(
+      projekt({ deliveryDestinations: [ziel('d1', 'YouTube')], fallback: plan() }),
+    )
+    expect(a.findings).toEqual([])
+  })
+
+  it('nennt die FOLGE, nicht nur den Namen', () => {
+    const a = assessFallback(
+      projekt({
+        deliveryDestinations: [ziel('d1', 'YouTube')],
+        fallback: plan({
+          scenes: ['Programm'],
+          rules: [{ id: 'r1', destinationId: 'd1', sceneNormal: 'Programm', sceneOffline: 'BRB' }],
+        }),
+      }),
+    )
+    const f = a.findings.find((x) => x.kind === 'scene-unknown')!
+    expect(f.text).toMatch(/Show bleibt stehen|niemand sieht/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('der Rueckweg — NOALBS #119', () => {
+  it('meldet eine Ausweichszene ohne Normalbetrieb', () => {
+    const a = assessFallback(
+      projekt({
+        deliveryDestinations: [ziel('d1', 'YouTube')],
+        fallback: plan({ scenes: ['Tafel'], rules: [{ id: 'r1', destinationId: 'd1', sceneOffline: 'Tafel' }] }),
+      }),
+    )
+    const f = a.findings.find((x) => x.kind === 'no-return-path')!
+    expect(f).toBeDefined()
+    expect(f.text).toMatch(/nie zurück/)
+  })
+
+  it('meldet nichts, wenn der Rueckweg benannt ist', () => {
+    const a = assessFallback(
+      projekt({
+        deliveryDestinations: [ziel('d1', 'YouTube')],
+        fallback: plan({
+          scenes: ['Tafel', 'Programm'],
+          rules: [{ id: 'r1', destinationId: 'd1', sceneOffline: 'Tafel', sceneNormal: 'Programm' }],
+        }),
+      }),
+    )
+    expect(a.findings.filter((f) => f.kind === 'no-return-path')).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('die Schwellen', () => {
+  it('meldet offline UEBER niedrig als verkehrt herum', () => {
+    const a = assessFallback(
+      projekt({
+        deliveryDestinations: [ziel('d1', 'YouTube')],
+        fallback: plan({
+          scenes: ['P'],
+          rules: [{ id: 'r1', destinationId: 'd1', lowKbps: 1000, offlineKbps: 2000 }],
+        }),
+      }),
+    )
+    const f = a.findings.find((x) => x.kind === 'threshold-order')!
+    expect(f).toBeDefined()
+    expect(f.text).toContain('2000')
+    expect(f.text).toContain('1000')
+  })
+
+  it('meldet gleiche Schwellen ebenfalls — der Zwischenzustand faellt weg', () => {
+    const a = assessFallback(
+      projekt({
+        deliveryDestinations: [ziel('d1', 'YouTube')],
+        fallback: plan({
+          scenes: ['P'],
+          rules: [{ id: 'r1', destinationId: 'd1', lowKbps: 1000, offlineKbps: 1000 }],
+        }),
+      }),
+    )
+    expect(a.findings.some((f) => f.kind === 'threshold-order')).toBe(true)
+  })
+
+  it('MISST DIE SCHWELLE AN DER GEPLANTEN BITRATE', () => {
+    // 6000 Video + 160 Audio. Eine Schwelle „niedrig" bei 6500 liegt vom
+    // ersten Moment an vor und geht nie weg — das Netz haengt in der
+    // Ausweichszene fest, waehrend nichts fehlt.
+    const a = assessFallback(
+      projekt({
+        deliveryDestinations: [ziel('d1', 'YouTube')],
+        fallback: plan({ scenes: ['P'], rules: [{ id: 'r1', destinationId: 'd1', lowKbps: 6500 }] }),
+      }),
+    )
+    const f = a.findings.find((x) => x.kind === 'threshold-above-bitrate')!
+    expect(f).toBeDefined()
+    expect(f.text).toContain('6160')
+    expect(f.text).toContain('6500')
+  })
+
+  it('rechnet Video UND Audio, nicht nur Video', () => {
+    expect(plannedKbps(ziel('d1', 'Y'))).toBe(6160)
+    // Genau zwischen Video und Video+Audio: eine reine Video-Rechnung meldete
+    // hier faelschlich.
+    const a = assessFallback(
+      projekt({
+        deliveryDestinations: [ziel('d1', 'YouTube')],
+        fallback: plan({ scenes: ['P'], rules: [{ id: 'r1', destinationId: 'd1', lowKbps: 6100 }] }),
+      }),
+    )
+    expect(a.findings.filter((f) => f.kind === 'threshold-above-bitrate')).toEqual([])
+  })
+
+  it('meldet eine sinnvolle Schwelle nicht', () => {
+    const a = assessFallback(
+      projekt({
+        deliveryDestinations: [ziel('d1', 'YouTube')],
+        fallback: plan({
+          scenes: ['P'],
+          rules: [{ id: 'r1', destinationId: 'd1', lowKbps: 3000, offlineKbps: 200 }],
+        }),
+      }),
+    )
+    expect(a.findings).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('`localhost` ist eine Annahme — NOALBS #178', () => {
+  it('erkennt jede Schreibweise der Rueckschleife', () => {
+    for (const url of ['http://localhost/stat', 'https://127.0.0.1:8080/x', 'localhost:9999', '::1/stat']) {
+      expect(isLoopback(url), url).toBe(true)
+    }
+    for (const url of ['http://10.0.0.20/stat', 'http://encoder.local/stat', undefined]) {
+      expect(isLoopback(url), String(url)).toBe(false)
+    }
+  })
+
+  it('NENNT DIE BEIDEN MASCHINEN, wenn Waechter und Encoder verschieden sind', () => {
+    const a = assessFallback(
+      projekt({
+        equipment: [geraet('pc', 'Streaming-PC'), geraet('enc', 'Encoder im Rack')],
+        deliveryDestinations: [ziel('d1', 'YouTube', { encoderEquipmentId: 'enc' })],
+        fallback: plan({
+          scenes: ['P'],
+          statsUrl: 'http://localhost/stat',
+          watcherEquipmentId: 'pc',
+          rules: [{ id: 'r1', destinationId: 'd1' }],
+        }),
+      }),
+    )
+    const f = a.findings.find((x) => x.kind === 'stats-loopback')!
+    expect(f).toBeDefined()
+    expect(f.text).toContain('Streaming-PC')
+    expect(f.text).toContain('Encoder im Rack')
+    expect(f.text).toContain('#178')
+  })
+
+  it('sagt bei unbenanntem Waechter, dass die Maschine NICHT IM PLAN STEHT', () => {
+    const a = assessFallback(
+      projekt({
+        deliveryDestinations: [ziel('d1', 'YouTube')],
+        fallback: plan({
+          scenes: ['P'],
+          statsUrl: 'http://localhost/stat',
+          rules: [{ id: 'r1', destinationId: 'd1' }],
+        }),
+      }),
+    )
+    const f = a.findings.find((x) => x.kind === 'stats-loopback')!
+    expect(f.text).toMatch(/steht nicht im Plan/)
+  })
+
+  it('BEHAUPTET NICHT, dass die URL antwortet — auch nicht im guten Fall', () => {
+    // Ob der Waechter die Statistik erreicht, ist eine Messung an der
+    // Maschine. Eine geratene Antwort saehe wie eine aus.
+    const a = assessFallback(
+      projekt({
+        equipment: [geraet('pc', 'Streaming-PC')],
+        deliveryDestinations: [ziel('d1', 'YouTube', { encoderEquipmentId: 'pc' })],
+        fallback: plan({
+          scenes: ['P'],
+          statsUrl: 'http://localhost/stat',
+          watcherEquipmentId: 'pc',
+          rules: [{ id: 'r1', destinationId: 'd1' }],
+        }),
+      }),
+    )
+    const f = a.findings.find((x) => x.kind === 'stats-loopback')!
+    expect(f.text).toMatch(/Messung an der Maschine/)
+  })
+
+  it('meldet eine echte Adresse nicht', () => {
+    const a = assessFallback(
+      projekt({
+        deliveryDestinations: [ziel('d1', 'YouTube')],
+        fallback: plan({
+          scenes: ['P'],
+          statsUrl: 'http://10.0.0.20/stat',
+          rules: [{ id: 'r1', destinationId: 'd1' }],
+        }),
+      }),
+    )
+    expect(a.findings).toEqual([])
+  })
+
+  it('meldet die Rueckschleife nicht, solange es keine Regel gibt', () => {
+    const a = assessFallback(
+      projekt({
+        deliveryDestinations: [ziel('d1', 'YouTube')],
+        fallback: plan({ statsUrl: 'http://localhost/stat' }),
+      }),
+    )
+    expect(a.findings).toEqual([])
+  })
+
+  it('haelt die Etiketten kanonisch deutsch', () => {
+    expect(FALLBACK_FINDING_LABEL['stats-loopback']).toBe(
+      'localhost ist eine Annahme über die Maschine',
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('das Blatt und das Geruest', () => {
+  const voll = () =>
+    projekt({
+      equipment: [geraet('pc', 'Streaming-PC')],
+      deliveryDestinations: [ziel('d1', 'YouTube', { encoderEquipmentId: 'pc' })],
+      fallback: plan({
+        scenes: ['Programm', 'Tafel'],
+        statsUrl: 'http://10.0.0.20/stat',
+        watcherEquipmentId: 'pc',
+        rules: [
+          {
+            id: 'r1',
+            destinationId: 'd1',
+            sceneNormal: 'Programm',
+            sceneOffline: 'Tafel',
+            lowKbps: 3000,
+            offlineKbps: 200,
+            note: 'Regie fragen',
+          },
+        ],
+      }),
+    })
+
+  it('traegt alles, was der Bedarf nennt — plus die geplante Bitrate', () => {
+    const t = fallbackTable(voll())
+    expect(t.headers).toEqual([
+      'Ziel',
+      'Normalbetrieb',
+      'Niedrige Bitrate',
+      'Offline',
+      'Schwelle niedrig (kbit/s)',
+      'Schwelle offline (kbit/s)',
+      'Geplant (kbit/s)',
+      'Anmerkung',
+    ])
+    expect(t.rows[0]).toEqual(['YouTube', 'Programm', '', 'Tafel', 3000, 200, 6160, 'Regie fragen'])
+  })
+
+  it('SAGT IN DER DATEI, dass es kein einspielbares Geruest ist', () => {
+    // Der Satz muss IN der Ausgabe stehen: jemand schickt sie weiter, und der
+    // Hinweis daneben bleibt im Chat zurueck.
+    const j = JSON.parse(fallbackSkeleton(voll()))
+    expect(j._hinweis).toMatch(/KEINE einspielbare Konfiguration/)
+    expect(j._hinweis).toMatch(/Stream-Keys/)
+  })
+
+  it('TRAEGT KEINEN STREAM-KEY UND KEINE INGEST-URL', () => {
+    // Eine exportierte Konfiguration ist eine Datei, die per Mail geht.
+    const p = voll()
+    p.deliveryDestinations![0] = {
+      ...p.deliveryDestinations![0],
+      ingestUrl: 'rtmp://a.rtmp.youtube.com/live2',
+      hasStreamKey: true,
+    }
+    const roh = fallbackSkeleton(p)
+    expect(roh).not.toContain('rtmp://')
+    expect(roh.toLowerCase()).not.toContain('streamkey')
+    expect(roh).not.toContain('hasStreamKey')
+  })
+
+  it('nennt Geraete beim NAMEN, nicht bei der Id', () => {
+    const j = JSON.parse(fallbackSkeleton(voll()))
+    expect(j.waechter.geraet).toBe('Streaming-PC')
+    expect(j.regeln[0].encoder).toBe('Streaming-PC')
+    expect(j.regeln[0].geplantKbps).toBe(6160)
+  })
+
+  it('legt die Befunde MIT in die Datei', () => {
+    const p = voll()
+    p.fallback = plan({ scenes: [], rules: [{ id: 'r1', destinationId: 'd1' }] })
+    const j = JSON.parse(fallbackSkeleton(p))
+    expect(j.befunde.map((b: { art: string }) => b.art)).toContain('scenes-unknown')
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('der Lade-Pfad', () => {
+  it('verwirft eine Regel ohne Ziel und meldet sie', () => {
+    const drops: { reason: string }[] = []
+    const p = normaliseFallbackPlan(
+      { scenes: ['A'], rules: [{ id: 'r1' }, { id: 'r2', destinationId: 'd1' }] },
+      (d) => drops.push(d),
+    )
+    expect(p?.rules).toHaveLength(1)
+    expect(drops[0].reason).toBe('missing-required')
+  })
+
+  it('BEHAELT eine Regel mit einem Szenennamen, den es nicht gibt', () => {
+    // Sie hier wegzuwerfen hiesse, den Fehler zu verstecken statt ihn zu
+    // zeigen — dafuer gibt es `scene-unknown`.
+    const p = normaliseFallbackPlan({
+      scenes: ['A'],
+      rules: [{ id: 'r1', destinationId: 'd1', sceneOffline: 'gibt-es-nicht' }],
+    })
+    expect(p?.rules[0].sceneOffline).toBe('gibt-es-nicht')
+  })
+
+  it('meldet eine doppelte Regel-Id, der erste Eintrag gilt', () => {
+    const drops: { reason: string }[] = []
+    const p = normaliseFallbackPlan(
+      {
+        scenes: [],
+        rules: [
+          { id: 'r1', destinationId: 'd1', sceneOffline: 'A' },
+          { id: 'r1', destinationId: 'd2', sceneOffline: 'B' },
+        ],
+      },
+      (d) => drops.push(d),
+    )
+    expect(p?.rules).toHaveLength(1)
+    expect(p?.rules[0].destinationId).toBe('d1')
+    expect(drops[0].reason).toBe('duplicate-id')
+  })
+
+  it('entdoppelt und trimmt die Szenenliste', () => {
+    const p = normaliseFallbackPlan({ scenes: [' A ', 'A', '', 'B'], rules: [] })
+    expect(p?.scenes).toEqual(['A', 'B'])
+  })
+
+  it('nimmt keine negative Schwelle', () => {
+    const p = normaliseFallbackPlan({
+      scenes: [],
+      rules: [{ id: 'r1', destinationId: 'd1', lowKbps: -5, offlineKbps: 200 }],
+    })
+    expect(p?.rules[0].lowKbps).toBeUndefined()
+    expect(p?.rules[0].offlineKbps).toBe(200)
+  })
+
+  it('heilt ein Objekt ohne alles zu `undefined`', () => {
+    expect(normaliseFallbackPlan({ scenes: [], rules: [] })).toBeUndefined()
+    expect(normaliseFallbackPlan(undefined)).toBeUndefined()
+    expect(normaliseFallbackPlan('nein')).toBeUndefined()
+  })
+
+  it('haengt in `healProjectPositions`', () => {
+    expect(storeQuelle).toContain('normaliseFallbackPlan(project.fallback')
+    expect(storeQuelle).toMatch(/kind: 'fallback-rule', reason: d\.reason, label: d\.label/)
+    expect(storeQuelle).toMatch(/^\s*fallback,$/m)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('Erreichbarkeit', () => {
+  it('steht im Ausspiel-Dialog, dort wo die Ziele stehen', () => {
+    expect(dialogQuelle).toContain('assessFallback(project)')
+    expect(dialogQuelle).toMatch(/\{list\.length > 0 && \(/)
+    expect(dialogQuelle).toContain("t('delivery.fb.title'")
+  })
+
+  it('bietet BEIDE Ausgaben an — Blatt und Geruest', () => {
+    expect(dialogQuelle).toContain('onClick={exportFallback}')
+    expect(dialogQuelle).toContain('onClick={exportSkeleton}')
+    expect(dialogQuelle).toContain('fallbackSkeleton(project)')
+  })
+
+  it('warnt am Geruest-Knopf, dass es nicht einspielbar ist', () => {
+    // Als AUFRUFFORM, nicht als Teilzeichenkette: der Schluessel steht im
+    // Quelltext auf einer eigenen Zeile hinter `t(`.
+    expect(dialogQuelle).toMatch(/title=\{t\(\s*'delivery\.fb\.skeletonHint',/)
+  })
+
+  it('nimmt die Szenenliste per EINFUEGEN entgegen, zeilen- oder kommagetrennt', () => {
+    // Der Planer liest keine Szenensammlung. Ein Feld je Szene waere bei
+    // zwanzig Szenen unbenutzbar.
+    expect(dialogQuelle).toMatch(/\.split\(\/\[\\n,;\]\+\/\)/)
+    expect(dialogQuelle).toContain('patchFallback({ scenes: namen })')
+  })
+
+  it('setzt den Store ueber einen Setter, der den GANZEN Plan nimmt', () => {
+    // Der ganze Rumpf am Stueck: ein `toContain` auf `scheduleProjectAutosave`
+    // traefe jeden anderen Setter derselben Datei mit.
+    expect(metaQuelle).toMatch(
+      /setFallbackPlan: \(plan\) =>\n\s*set\(\(state\) => \{\n\s*const updated = \{ \.\.\.state\.project, fallback: plan \}\n\s*scheduleProjectAutosave\(updated\)\n\s*return \{ project: updated \}\n\s*\}\),/,
+    )
+  })
+
+  it('ist ein Dokument mit Stand', () => {
+    expect(registerQuelle).toContain("'ausweich-plan': ofTable(fallbackTable)")
+    expect(registerQuelle).toContain("'ausweich-plan': 'Ausweich-Plan (Sicherheitsnetz)'")
+  })
+
+  it('hat fuer jeden neuen Text einen EN-Eintrag', () => {
+    for (const key of [
+      'delivery.fb.title',
+      'delivery.fb.intro',
+      'delivery.fb.export',
+      'delivery.fb.skeleton',
+      'delivery.fb.skeletonHint',
+      'delivery.fb.watcher',
+      'delivery.fb.watcherNone',
+      'delivery.fb.stats',
+      'delivery.fb.scenes',
+      'delivery.fb.scenesPh',
+      'delivery.fb.scenesApply',
+      'delivery.fb.protect',
+      'delivery.fb.remove',
+      'delivery.fb.sceneNormal',
+      'delivery.fb.sceneLow',
+      'delivery.fb.sceneOffline',
+      'delivery.fb.low',
+      'delivery.fb.offline',
+      'app.loadReport.fallbackRule',
+    ]) {
+      expect(dictsQuelle).toContain(`'${key}'`)
+    }
+  })
+})


### PR DESCRIPTION
**Bedarf 89 (P2)** — „Fallback and scene-switch logic declared once, consistent with the scene names the encoder actually has."

> Scene names exist in the OBS scene collection, again in hand-edited NOALBS JSON, and again in the operator's memory during the show; the safety net's characteristic failure is **parking the show on a slate while the stream is fine**.

Belege, beide in voller Länge gelesen:

- **NOALBS #178** (2024-10-23, offen) — der Wächter erreicht `http://localhost/stat` *nicht*, obwohl dieselbe URL im Browser antwortet, und schaltet deshalb dauerhaft auf die Offline-Szene, während RTMP läuft; `!bitrate` antwortet „No connection :(".
- **NOALBS #119** (2022-09-14) — eine klebende Offline-Szene, die sich immer wieder durchsetzt.

## Der Fehler ist ein Falsch-Positiv

Das ist der Grund, warum es dieses Objekt gibt. Ein Sicherheitsnetz, das nicht auslöst, kostet eine Show. Eines, das **grundlos** auslöst, kostet auch eine — und niemand sucht den Fehler beim Netz, weil das Netz ja „funktioniert". Beide Belege sind von dieser zweiten Sorte.

## Sechs benannte Befunde

| | |
|---|---|
| `scene-unknown` | der Namensabgleich — die Bedarfs-Datenbank nennt ihn selbst „a cheap win". Geprüft werden **alle drei** Szenen, nicht nur die Ausweichszene |
| `scenes-unknown` | die Szenenliste fehlt, der Abgleich läuft nicht — und **genau das wird gesagt** |
| `no-return-path` | #119: eine Ausweichszene ohne Normalbetrieb schaltet einmal um und nie zurück |
| `stats-loopback` | #178: `localhost` ist keine Adresse, sondern eine Annahme über die Maschine |
| `threshold-above-bitrate` | die Schwelle liegt über der geplanten Bitrate (Video **plus** Audio) — der Zustand liegt vom ersten Moment an vor |
| `threshold-order` | offline muss unter niedrig liegen, sonst gibt es nur an oder aus |

Ein stiller Durchlauf bei fehlender Szenenliste sähe aus wie „geprüft", und das ist der teuerste Zustand von allen — deshalb `scenes-unknown`.

Bei `stats-loopback` kennt der Plan **beide Maschinen**: den Wächter und den Encoder des geschützten Ziels. Steht der Wächter nicht im Plan, sagt der Befund genau das, statt zu schweigen. **Ob die URL antwortet, sagt der Plan nicht** — das ist eine Messung an der Maschine, und eine geratene Antwort sähe wie eine aus.

Ziele **ohne** Regel sind kein Befund, sondern die Liste `unprotected`: ein Plan ohne Sicherheitsnetz ist eine Entscheidung, und je Ziel eine Warnung begrübe die sechs echten Befunde (wie `withoutDomain` bei Bedarf 73 und `open` bei Bedarf 72).

## Zwei Ausgaben, und was das Gerüst nicht ist

Das Blatt ist ein Dokument mit Stand (`ausweich-plan`, ADR-004). Das JSON-Gerüst ist **ausdrücklich keine einspielbare NOALBS-Datei**: das Schema hängt an der Version, die jemand fährt, und diese Anwendung hat sie nie gesehen. Eine Datei auszugeben, die aussieht wie eine Konfiguration und keine ist, wäre schlimmer als gar keine — jemand spielt sie in ein laufendes Sicherheitsnetz. Der Hinweis steht **in** der Datei, nicht nur daneben: sie wird weitergeschickt, der Satz daneben bleibt im Chat zurück.

Kein Stream-Key und keine Ingest-URL im Gerüst. Es ist eine Datei, die per Mail geht.

## Erreichbarkeit

Im Ausspiel-Dialog, dort wo die Ziele und die Encoder ohnehin stehen. Die Szenenliste wird **eingefügt** (zeilen-, komma- oder semikolongetrennt): der Planer liest keine Szenensammlung, und ein Feld je Szene wäre bei zwanzig Szenen unbenutzbar.

## Geprüft

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 139 Testdateien, 1740 Tests grün (2 skipped); 40 neue
- `npx eslint .` — 0 Fehler
- **37 Gegenproben, alle rot**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_