### PR TITLE
vorlagen: eine Vorlage weiß, aus welchem Haus sie kommt (Bedarf 91)

### DIFF
--- a/src/renderer/components/Project/TemplatesDialog.tsx
+++ b/src/renderer/components/Project/TemplatesDialog.tsx
@@ -25,6 +25,13 @@ import {
   saveUserTemplate,
   type ProjectTemplate,
 } from '../../lib/projectTemplates'
+import {
+  projectVenue,
+  templateCarryReport,
+  venueBoundCount,
+  type TemplateScope,
+} from '../../lib/templateScope'
+import { venueScopeDialog } from '../../lib/venueScopeDialog'
 
 export const TemplatesDialog = () => {
   const t = useTranslation()
@@ -66,6 +73,21 @@ export const TemplatesDialog = () => {
       )
       if (!ok) return
     }
+    // BEDARF 91 — was die Vorlage an Haus-Antworten mitbringt, und ob es hier
+    // gilt. VOR dem Laden gesagt: danach steht es im Blatt und sieht aus wie
+    // Auskunft.
+    const bericht = templateCarryReport(
+      tpl.venue,
+      tpl.project.metadata?.venueAnswers?.length ?? 0,
+      projectVenue(useProjectStore.getState().project),
+    )
+    if (bericht.state === 'elsewhere') {
+      const weiter = await confirmDialog(t('templates.carryTitle', 'Antworten aus einem anderen Haus'), {
+        body: bericht.text,
+        okLabel: t('templates.carryOk', 'Trotzdem laden'),
+      })
+      if (!weiter) return
+    }
     const name = await promptDialog(
       t('templates.namePrompt', 'Name des neuen Projekts'),
       label(tpl),
@@ -89,7 +111,18 @@ export const TemplatesDialog = () => {
         : '',
     )
     if (name === null) return
-    saveUserTemplate(name, current.metadata.description ?? '', current)
+    // BEDARF 91 — gefragt wird NUR, wenn etwas Ortsgebundenes dranhaengt.
+    // Ohne Haus-Antworten und ohne Adresse gibt es nichts zu entscheiden, und
+    // eine Rueckfrage, die meistens „nichts dabei" bedeutet, wird zur
+    // Klickgewohnheit.
+    const gebunden = venueBoundCount(current)
+    let scope: TemplateScope = 'neutral'
+    if (gebunden > 0) {
+      const antwort = await venueScopeDialog(gebunden, projectVenue(current) ?? '')
+      if (antwort === null) return
+      scope = antwort
+    }
+    saveUserTemplate(name, current.metadata.description ?? '', current, scope)
     setUserTemplates(loadUserTemplates())
     void infoDialog(t('templates.savedTitle', 'Als Vorlage gespeichert'), {
       body: format(t('templates.savedBody', 'Vorlage „{name}“ gespeichert.'), { name }),
@@ -120,6 +153,17 @@ export const TemplatesDialog = () => {
         </div>
       </div>
       <div className="text-[10px] text-[var(--cp-text-faint)]">{stats(tpl)}</div>
+      {/* BEDARF 91 — aus welchem Haus. Steht auf der Karte, weil die
+          Entscheidung „diese Vorlage oder die neutrale" hier faellt und nicht
+          erst nach dem Laden. */}
+      {tpl.venue && (
+        <div className="text-[10px] text-[var(--cp-text-muted)]">
+          {format(t('templates.venue', 'Haus-Vorlage: {venue} · {n} Antworten'), {
+            venue: tpl.venue,
+            n: tpl.project.metadata?.venueAnswers?.length ?? 0,
+          })}
+        </div>
+      )}
       <div className="mt-auto flex items-center justify-between gap-2 pt-1">
         <Button variant="success" size="sm" onClick={() => void applyTemplate(tpl)}>
           {t('templates.use', 'Verwenden')}

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -4255,6 +4255,15 @@ export const en: Dict = {
   'analysis.crew.title': 'Network briefing sheet for the crew',
   'analysis.crew.ask': '{n} points to settle on site',
   'analysis.crew.export': 'Crew network sheet',
+  // Bedarf 91 — Vorlagen, die wissen, aus welchem Haus sie kommen.
+  'tplScope.title': 'Bind this template to the venue?',
+  'tplScope.body':
+    '{n} venue-bound entries hang on this project \u2014 the venue IT answers and the address{venue}. A neutral template leaves them out; a venue template takes them along and remembers which venue they apply to.',
+  'tplScope.venue': 'For this venue',
+  'tplScope.neutral': 'Neutral (shape only)',
+  'templates.venue': 'Venue template: {venue} \u00b7 {n} answers',
+  'templates.carryTitle': 'Answers from a different venue',
+  'templates.carryOk': 'Load anyway',
   // Bedarf 89 — das Sicherheitsnetz.
   'delivery.fb.title': 'Fallback behaviour (safety net)',
   'delivery.fb.intro':

--- a/src/renderer/lib/projectTemplates.ts
+++ b/src/renderer/lib/projectTemplates.ts
@@ -10,6 +10,7 @@
 import { v4 as uuidv4 } from 'uuid'
 import type { CablePlannerProject } from '../types/project'
 import type { LocationFrame } from '../types/location'
+import { stripForTemplate, projectVenue, type TemplateScope } from './templateScope'
 
 export interface ProjectTemplate {
   id: string
@@ -22,6 +23,15 @@ export interface ProjectTemplate {
   descKey?: string
   /** i18n-Key für den Namen (nur Built-ins). */
   nameKey?: string
+  /**
+   * Bedarf 91 — das Haus, aus dem diese Vorlage stammt.
+   *
+   * Nur bei `scope: 'venue'` gesetzt. Es steht HIER und nicht nur in
+   * `project.metadata.siteAddress`, weil es beim Verwenden gebraucht wird,
+   * BEVOR das Projekt geladen ist: die Karte in der Galerie muss sagen
+   * können, aus welchem Haus die Antworten kommen.
+   */
+  venue?: string
   project: CablePlannerProject
 }
 
@@ -163,8 +173,22 @@ export const saveUserTemplate = (
   name: string,
   description: string,
   project: CablePlannerProject,
+  /**
+   * BEDARF 91 — ein Pflicht-Parameter OHNE Default, und das mit Absicht.
+   *
+   * Dieselbe Bauform wie `credentials` bei `syncSharedLibrary` (Design-Frage
+   * 5): der alte Zustand war „geht stillschweigend mit", und ein Default
+   * hätte genau den wiederhergestellt, sobald ein Aufrufer ihn weglässt. Wer
+   * eine Vorlage schreibt, muss beantwortet haben, ob sie an ein Haus
+   * gebunden ist.
+   */
+  scope: TemplateScope,
 ): ProjectTemplate => {
-  const clone: CablePlannerProject = cloneProject(project)
+  // Bedarf 91 — erst das Ortsgebundene, dann die Auftrags-Identität. Zwei
+  // Schritte, weil die Fragen verschieden sind: das eine hängt am HAUS, das
+  // andere am KUNDEN, und eine Vorlage für dasselbe Haus behält das eine und
+  // nie das andere.
+  const clone: CablePlannerProject = stripForTemplate(cloneProject(project), scope)
   // projektspezifische Identität entfernen
   delete clone.annotations
   delete clone.checkState
@@ -188,11 +212,13 @@ export const saveUserTemplate = (
   delete clone.metadata.rentmanCablePlan
   delete clone.metadata.rentmanCableMap
 
+  const venue = scope === 'venue' ? projectVenue(project) : undefined
   const tpl: ProjectTemplate = {
     id: `user-${uuidv4()}`,
     name,
     description,
     builtin: false,
+    ...(venue ? { venue } : {}),
     project: clone,
   }
   const next = [...loadUserTemplates(), tpl]

--- a/src/renderer/lib/templateScope.ts
+++ b/src/renderer/lib/templateScope.ts
@@ -1,0 +1,189 @@
+// ───────────────────────────────────────────────────────────────────────────
+// BEDARF 91 (P2) — was von einer Show in die naechste mitgeht, und was nicht.
+//
+//   > SRT latency, port negotiations, which SIM worked, which uplink was real,
+//   > the mix-minus arrangement and the fallback thresholds are re-derived per
+//   > event and live nowhere shared; the most valuable document in the role is
+//   > the one least likely to exist.
+//
+// Und der Weg dahin steht in derselben Zeile: „Venue and template reuse in the
+// project model, with the as-built network answer and transport parameters
+// attached."
+//
+// ─── DIE VORLAGE GAB ES SCHON. SIE TRUG DAS FALSCHE MIT ────────────────────
+//
+// `saveUserTemplate` strippte bisher die AUFTRAGS-Identitaet (Kunde, Logos,
+// Rentman-Bezug) und liess alles andere stehen. Das war richtig, solange eine
+// Vorlage nur Geraete und Kabel trug. Inzwischen traegt ein Projekt Dinge, die
+// an EINEM Haus oder an EINEM Rechner haengen:
+//
+//   `metadata.venueAnswers` (Bedarf 85)  Was DIESES Haus genehmigt hat.
+//   `metadata.siteAddress`               Welches Haus das war.
+//   `multicast.assignments` (Bedarf 72)  Adressen, die fuer DIESE Show
+//                                        vergeben wurden — und anderswo laufen.
+//   `hasStreamKey` (Initiative 9)        Ob auf DIESEM Rechner ein Schluessel
+//                                        liegt.
+//   `revisions`, `pendingChanges`        Die Geschichte einer anderen Show.
+//
+// Eine neutrale Vorlage, die die Genehmigungen der Halle A mitbringt, ist
+// schlimmer als eine ohne: die Zeilen sehen aus wie Auskunft, und niemand
+// fragt nach. Genau davor warnt Bedarf 85 mit `elsewhere`.
+//
+// ─── ZWEI SORTEN VORLAGE, UND DIE FRAGE WIRD GESTELLT ──────────────────────
+//
+// `neutral`  Die Form: Raeume, Geraete, Verkabelung, das Ausspiel-Schema.
+//            Alles Ortsgebundene faellt weg.
+// `venue`    Das Haus: dieselbe Form PLUS die Antworten dieses Hauses und
+//            seine Adresse. Die Vorlage merkt sich, WELCHES Haus — und beim
+//            Verwenden sagt `templateCarryReport`, ob es dasselbe ist.
+//
+// Gefragt wird wie bei den Zugangsdaten (`credentialChoiceDialog`, Design-
+// Frage 5): am einzelnen Vorgang, nicht pauschal — und NUR, wenn ueberhaupt
+// etwas Ortsgebundenes dranhaengt. Eine Rueckfrage, die meistens „nichts
+// dabei" bedeutet, wird zur Klickgewohnheit.
+//
+// ─── WAS IMMER FAELLT, UNABHAENGIG VON DER FRAGE ───────────────────────────
+//
+// Die Multicast-Vergaben und das Schluessel-Haekchen. Beide sind keine
+// Ortsangabe, sondern eine Behauptung, die im neuen Projekt schlicht falsch
+// ist: die Adressen laufen anderswo, und der Schluessel liegt im
+// Schluesselbund eines anderen Rechners. Der POOL bleibt — das ist das
+// Schema, und das ist genau das Wiederverwendbare.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { CablePlannerProject } from '../types/project'
+import { sameVenue } from './venueAnswers'
+
+export type TemplateScope = 'venue' | 'neutral'
+
+export const TEMPLATE_SCOPE_LABEL: Readonly<Record<TemplateScope, string>> = {
+  venue: 'Für dieses Haus',
+  neutral: 'Neutral (nur die Form)',
+}
+
+/**
+ * Wie viel Ortsgebundenes an diesem Projekt haengt.
+ *
+ * Der Aufrufer fragt nur, wenn das groesser als 0 ist — siehe Kopf.
+ */
+export function venueBoundCount(project: CablePlannerProject): number {
+  const answers = project.metadata?.venueAnswers?.length ?? 0
+  const address = project.metadata?.siteAddress?.trim() ? 1 : 0
+  return answers + address
+}
+
+/** Der Ort dieses Projekts, getrimmt — oder `undefined`. */
+export const projectVenue = (project: CablePlannerProject): string | undefined =>
+  project.metadata?.siteAddress?.trim() || undefined
+
+/**
+ * Macht aus einem Projekt den Vorlagen-Inhalt. Die Engstelle.
+ *
+ * Arbeitet auf einer KOPIE und gibt eine neue zurueck; der Aufrufer haelt
+ * weiter sein Projekt. Was hier nicht steht, geht mit — das ist Absicht: ein
+ * neues Feld soll im Zweifel MITGEHEN und nicht still verschwinden. Wer ein
+ * ortsgebundenes Feld hinzufuegt, traegt es hier ein, und `tests/templateScope
+ * .test.ts` haelt die Liste fest.
+ */
+export function stripForTemplate(
+  project: CablePlannerProject,
+  scope: TemplateScope,
+): CablePlannerProject {
+  const clone = JSON.parse(JSON.stringify(project)) as CablePlannerProject
+
+  // Die Geschichte einer anderen Show. Sie sagt ueber die Form nichts und
+  // laesst die Vorlage mit jedem Speichern wachsen.
+  delete clone.revisions
+  delete clone.pendingChanges
+
+  // Immer weg: Behauptungen, die im neuen Projekt falsch WAEREN.
+  if (clone.multicast) {
+    // Der Pool bleibt — das Schema ist das Wiederverwendbare. Die Vergaben
+    // gehen; sie laufen in der Show, aus der die Vorlage stammt.
+    clone.multicast = { ...clone.multicast, assignments: [] }
+  }
+  if (clone.deliveryDestinations) {
+    clone.deliveryDestinations = clone.deliveryDestinations.map((d) => {
+      const { hasStreamKey: _weg, ...rest } = d
+      return rest
+    })
+  }
+
+  if (scope === 'neutral') {
+    clone.metadata = { ...clone.metadata }
+    delete clone.metadata.siteAddress
+    delete clone.metadata.venueAnswers
+  }
+
+  return clone
+}
+
+export type CarryState = 'carries' | 'elsewhere' | 'none'
+
+export const CARRY_LABEL: Readonly<Record<CarryState, string>> = {
+  carries: 'Gilt hier',
+  elsewhere: 'Aus einem anderen Haus',
+  none: 'Keine Haus-Antworten dabei',
+}
+
+export interface CarryReport {
+  state: CarryState
+  /** Das Haus, aus dem die Vorlage stammt. */
+  from?: string
+  /** Das Haus, in das sie gehen soll. */
+  to?: string
+  /** Wie viele Antworten betroffen sind. */
+  answers: number
+  text: string
+}
+
+/**
+ * Was beim Verwenden einer Vorlage mit den Haus-Antworten passiert.
+ *
+ * Der Vergleich ist STRENG und benutzt dieselbe Funktion wie Bedarf 85:
+ * „Halle A" und „Halle A, Eingang Nord" koennen dasselbe Haus sein, und sie
+ * als gleich zu behandeln hiesse, eine Genehmigung zu uebertragen, die
+ * vielleicht nie fuer diesen Bereich galt. Im Zweifel `elsewhere` — das
+ * kostet einen Anruf, der andere Fehler kostet den Aufbau.
+ *
+ * Zwei Wahrheiten darueber, was „dasselbe Haus" heisst, waeren hier besonders
+ * teuer: die eine entscheidet, was die Vorlage mitbringt, die andere, wie es
+ * im Blatt markiert wird.
+ */
+export function templateCarryReport(
+  templateVenue: string | undefined,
+  answers: number,
+  targetVenue: string | undefined,
+): CarryReport {
+  const from = templateVenue?.trim() || undefined
+  const to = targetVenue?.trim() || undefined
+  if (!answers || !from) {
+    return {
+      state: 'none',
+      ...(from ? { from } : {}),
+      ...(to ? { to } : {}),
+      answers,
+      text: 'Die Vorlage bringt keine Antworten eines Hauses mit — nur die Form.',
+    }
+  }
+  if (to && sameVenue(from, to)) {
+    return {
+      state: 'carries',
+      from,
+      to,
+      answers,
+      text: `${answers} Antwort(en) aus „${from}" gelten hier weiter — dasselbe Haus.`,
+    }
+  }
+  return {
+    state: 'elsewhere',
+    from,
+    ...(to ? { to } : {}),
+    answers,
+    text: to
+      ? `${answers} Antwort(en) stammen aus „${from}", das Projekt steht in „${to}". Sie werden als „aus einem anderen Haus" geführt und gelten hier nicht.`
+      : `${answers} Antwort(en) stammen aus „${from}". Solange das Projekt keinen Ort nennt, bleibt offen, ob sie hier gelten.`,
+  }
+}

--- a/src/renderer/lib/venueAnswers.ts
+++ b/src/renderer/lib/venueAnswers.ts
@@ -87,7 +87,11 @@ const trimmed = (v: string | undefined): string | undefined => {
  * Bereich galt. Im Zweifel `elsewhere` — das kostet einen Anruf, der andere
  * Fehler kostet den Aufbau.
  */
-const sameVenue = (a: string | undefined, b: string | undefined): boolean =>
+// Exportiert seit Bedarf 91: die Vorlage muss dieselbe Frage stellen wie das
+// Blatt („ist das dasselbe Haus?"), und zwei Antworten darauf waeren besonders
+// teuer -- die eine entscheidet, was eine Vorlage mitbringt, die andere, wie
+// es markiert wird.
+export const sameVenue = (a: string | undefined, b: string | undefined): boolean =>
   (a ?? '').trim().toLowerCase() === (b ?? '').trim().toLowerCase()
 
 export interface MergeInput {

--- a/src/renderer/lib/venueScopeDialog.tsx
+++ b/src/renderer/lib/venueScopeDialog.tsx
@@ -1,0 +1,89 @@
+import { useTranslation } from './i18n'
+import {
+  MODAL_BACKDROP,
+  MODAL_BUTTON_SECONDARY,
+  MODAL_CARD,
+  backdropMouseDown,
+  modalButtonPrimary,
+  mountModal,
+  useModalKeyboard,
+} from './modalRoot'
+import type { TemplateScope } from './templateScope'
+
+/**
+ * BEDARF 91 — die Frage, die beim Speichern einer Vorlage gestellt wird.
+ *
+ * Dieselbe Bauform und dieselbe Begruendung wie `credentialChoiceDialog`
+ * (Design-Frage 5): am einzelnen Vorgang fragen statt pauschal entscheiden,
+ * weil beide Pauschalen einen echten Preis haben.
+ *
+ * Immer strippen kostet genau das, was der Bedarf will — „the most valuable
+ * document in the role is the one least likely to exist": die Antworten des
+ * Hauses waeren beim naechsten Mal wieder weg, und jemand fragt zum zweiten
+ * Mal dieselbe IT-Abteilung.
+ *
+ * Immer mitgeben bringt die Genehmigungen der Halle A in eine Vorlage, mit
+ * der jemand im Kongresszentrum arbeitet. Die Zeilen sehen dort aus wie
+ * Auskunft, und niemand fragt nach.
+ *
+ * GEFRAGT WIRD NUR, WENN ETWAS DRANHAENGT. `venueBoundCount` entscheidet das
+ * beim Aufrufer. Eine Rueckfrage, die meistens „nichts dabei" bedeutet, wird
+ * zur Klickgewohnheit — und dann liest sie niemand mehr an dem einen Tag, an
+ * dem sie zaehlt.
+ */
+export function venueScopeDialog(
+  /** Wie viele ortsgebundene Angaben dranhaengen — steht im Text. */
+  count: number,
+  /** Der Ort, um den es geht. Leer, wenn das Projekt keinen nennt. */
+  venue: string,
+): Promise<TemplateScope | null> {
+  return mountModal<TemplateScope | null>((done) => (
+    <VenueScopeDialog count={count} venue={venue} onDone={done} />
+  ))
+}
+
+interface Props {
+  count: number
+  venue: string
+  onDone: (value: TemplateScope | null) => void
+}
+
+const VenueScopeDialog = ({ count, venue, onDone }: Props) => {
+  const t = useTranslation()
+  // Escape bricht ab und speichert gar nichts. „Ich habe nicht geantwortet"
+  // ist kein Grund, die Antworten eines Hauses weiterzureichen.
+  useModalKeyboard(() => onDone(null))
+
+  return (
+    <div style={MODAL_BACKDROP} onMouseDown={backdropMouseDown(() => onDone(null))}>
+      <div style={{ ...MODAL_CARD, maxWidth: 560 }} role="dialog" aria-modal="true">
+        <div style={{ marginBottom: 8, fontSize: 14, fontWeight: 600 }}>
+          {t('tplScope.title', 'Vorlage an dieses Haus binden?')}
+        </div>
+        <div style={{ marginBottom: 16, fontSize: 13, color: '#cbd5e1' }}>
+          {t(
+            'tplScope.body',
+            '{n} ortsgebundene Angaben hängen an diesem Projekt — die Antworten der Haus-IT und die Adresse{venue}. Eine neutrale Vorlage lässt sie weg; eine Haus-Vorlage nimmt sie mit und merkt sich, für welches Haus sie gelten.',
+          )
+            .replace('{n}', String(count))
+            .replace('{venue}', venue ? ` (${venue})` : '')}
+        </div>
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', flexWrap: 'wrap' }}>
+          <button type="button" onClick={() => onDone(null)} style={MODAL_BUTTON_SECONDARY}>
+            {t('common.cancel', 'Abbrechen')}
+          </button>
+          <button type="button" onClick={() => onDone('venue')} style={MODAL_BUTTON_SECONDARY}>
+            {t('tplScope.venue', 'Für dieses Haus')}
+          </button>
+          <button
+            type="button"
+            onClick={() => onDone('neutral')}
+            style={modalButtonPrimary('#10b981')}
+          >
+            {t('tplScope.neutral', 'Neutral (nur die Form)')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/tests/templateScope.test.ts
+++ b/tests/templateScope.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import {
+  CARRY_LABEL,
+  TEMPLATE_SCOPE_LABEL,
+  projectVenue,
+  stripForTemplate,
+  templateCarryReport,
+  venueBoundCount,
+} from '../src/renderer/lib/templateScope'
+import { sameVenue } from '../src/renderer/lib/venueAnswers'
+import { loadUserTemplates, saveUserTemplate } from '../src/renderer/lib/projectTemplates'
+import type { CablePlannerProject } from '../src/renderer/types/project'
+import dialogQuelle from '../src/renderer/components/Project/TemplatesDialog.tsx?raw'
+import tplQuelle from '../src/renderer/lib/projectTemplates.ts?raw'
+import scopeDialogQuelle from '../src/renderer/lib/venueScopeDialog.tsx?raw'
+import dictsQuelle from '../src/renderer/lib/i18n/dicts.ts?raw'
+
+// ---------------------------------------------------------------------------
+// Was von einer Show in die naechste mitgeht (Bedarf 91, P2).
+//
+//   > SRT latency, port negotiations, which SIM worked, which uplink was real,
+//   > the mix-minus arrangement and the fallback thresholds are re-derived per
+//   > event and live nowhere shared; the most valuable document in the role is
+//   > the one least likely to exist.
+//
+// Und der Weg: „Venue and template reuse in the project model, with the
+// as-built network answer and transport parameters attached."
+//
+// Die Vorlage gab es schon. Sie trug das Falsche mit: die Genehmigungen EINES
+// Hauses, die Multicast-Adressen EINER Show und das Schluessel-Haekchen EINES
+// Rechners.
+// ---------------------------------------------------------------------------
+
+const projekt = (over: Partial<CablePlannerProject> = {}): CablePlannerProject =>
+  ({
+    metadata: { name: 'Show', description: '' },
+    equipment: [],
+    cables: [],
+    locations: [],
+    ...over,
+  }) as never
+
+const mitAllem = () =>
+  projekt({
+    metadata: {
+      name: 'Show',
+      description: '',
+      siteAddress: 'Halle A',
+      venueAnswers: [
+        { key: 'ports', status: 'granted', venue: 'Halle A' },
+        { key: 'vlan', status: 'refused', venue: 'Halle A' },
+      ],
+    },
+    multicast: {
+      pool: '239.100.0.0/16',
+      basePort: 20000,
+      assignments: [{ flowKey: 'cam:p1', leg: 'a', address: '239.100.0.1', port: 20000 }],
+    },
+    deliveryDestinations: [
+      {
+        id: 'd1',
+        name: 'YouTube',
+        platform: 'youtube',
+        transport: 'RTMP',
+        hasStreamKey: true,
+        encoding: { videoBitrateKbps: 6000, audioBitrateKbps: 160 },
+      },
+    ],
+    revisions: [{ id: 'r1', label: 'A', note: '', createdAt: 'x', asBuilt: false, snapshot: {} }],
+    pendingChanges: [{ id: 'p1' }],
+  } as never)
+
+// ---------------------------------------------------------------------------
+describe('was IMMER faellt — Behauptungen, die im neuen Projekt falsch waeren', () => {
+  it('nimmt die Multicast-VERGABEN weg und laesst den POOL stehen', () => {
+    // Die Adressen laufen in der Show, aus der die Vorlage stammt. Der Pool
+    // ist das Schema — und genau das ist das Wiederverwendbare.
+    for (const scope of ['venue', 'neutral'] as const) {
+      const c = stripForTemplate(mitAllem(), scope)
+      expect(c.multicast?.assignments, scope).toEqual([])
+      expect(c.multicast?.pool, scope).toBe('239.100.0.0/16')
+      expect(c.multicast?.basePort, scope).toBe(20000)
+    }
+  })
+
+  it('nimmt das Schluessel-Haekchen weg — es gilt fuer EINEN Rechner', () => {
+    for (const scope of ['venue', 'neutral'] as const) {
+      const c = stripForTemplate(mitAllem(), scope)
+      expect(c.deliveryDestinations?.[0], scope).not.toHaveProperty('hasStreamKey')
+      // Das Ziel selbst bleibt: die Plattform ist Teil der Form.
+      expect(c.deliveryDestinations?.[0].name, scope).toBe('YouTube')
+    }
+  })
+
+  it('nimmt die Geschichte einer anderen Show weg', () => {
+    const c = stripForTemplate(mitAllem(), 'venue')
+    expect(c.revisions).toBeUndefined()
+    expect(c.pendingChanges).toBeUndefined()
+  })
+
+  it('fasst das UEBERGEBENE Projekt nicht an', () => {
+    const p = mitAllem()
+    const vorher = JSON.stringify(p)
+    stripForTemplate(p, 'neutral')
+    expect(JSON.stringify(p)).toBe(vorher)
+  })
+})
+
+describe('was nur bei `neutral` faellt — das Ortsgebundene', () => {
+  it('nimmt Adresse und Haus-Antworten weg', () => {
+    const c = stripForTemplate(mitAllem(), 'neutral')
+    expect(c.metadata.siteAddress).toBeUndefined()
+    expect(c.metadata.venueAnswers).toBeUndefined()
+  })
+
+  it('BEHAELT sie bei `venue` — sonst gibt es den Bedarf gar nicht', () => {
+    const c = stripForTemplate(mitAllem(), 'venue')
+    expect(c.metadata.siteAddress).toBe('Halle A')
+    expect(c.metadata.venueAnswers).toHaveLength(2)
+  })
+
+  it('zaehlt, wie viel dranhaengt — Antworten PLUS Adresse', () => {
+    expect(venueBoundCount(mitAllem())).toBe(3)
+    expect(venueBoundCount(projekt())).toBe(0)
+    // Eine Adresse aus Leerzeichen ist keine.
+    expect(venueBoundCount(projekt({ metadata: { name: 'x', siteAddress: '   ' } } as never))).toBe(0)
+  })
+
+  it('haelt die Etiketten kanonisch deutsch', () => {
+    expect(TEMPLATE_SCOPE_LABEL.neutral).toBe('Neutral (nur die Form)')
+    expect(CARRY_LABEL.elsewhere).toBe('Aus einem anderen Haus')
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('der Vorlagen-Schreiber verlangt die Entscheidung', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('schreibt das Haus AN DIE VORLAGE, nicht nur ins Projekt', () => {
+    // Die Karte in der Galerie muss es sagen koennen, BEVOR das Projekt
+    // geladen ist.
+    const tpl = saveUserTemplate('Halle A Standard', '', mitAllem(), 'venue')
+    expect(tpl.venue).toBe('Halle A')
+    expect(loadUserTemplates()[0].venue).toBe('Halle A')
+  })
+
+  it('setzt kein Haus bei einer neutralen Vorlage', () => {
+    const tpl = saveUserTemplate('Zweikamera', '', mitAllem(), 'neutral')
+    expect(tpl.venue).toBeUndefined()
+    expect(tpl.project.metadata.venueAnswers).toBeUndefined()
+  })
+
+  it('setzt kein Haus, wenn das Projekt keines nennt', () => {
+    const p = projekt({
+      metadata: { name: 'x', venueAnswers: [{ key: 'ports', status: 'granted' }] },
+    } as never)
+    expect(saveUserTemplate('X', '', p, 'venue').venue).toBeUndefined()
+  })
+
+  it('strippt weiterhin die AUFTRAGS-Identitaet — beide Fragen, nicht eine', () => {
+    // Das eine haengt am HAUS, das andere am KUNDEN. Eine Vorlage fuer
+    // dasselbe Haus behaelt das eine und nie das andere.
+    const p = mitAllem()
+    p.metadata = { ...p.metadata, client: 'Kunde GmbH', projectNumber: '4711' } as never
+    const tpl = saveUserTemplate('Halle A', '', p, 'venue')
+    expect(tpl.project.metadata.client).toBeUndefined()
+    expect(tpl.project.metadata.projectNumber).toBeUndefined()
+    expect(tpl.project.metadata.siteAddress).toBe('Halle A')
+  })
+
+  it('nimmt den Umfang als PFLICHT-PARAMETER ohne Default', () => {
+    // Dieselbe Bauform wie `credentials` bei `syncSharedLibrary`: ein Default
+    // haette den alten Zustand („geht stillschweigend mit") wiederhergestellt,
+    // sobald ein Aufrufer ihn weglaesst.
+    expect(tplQuelle).toMatch(/scope: TemplateScope,\n\): ProjectTemplate => \{/)
+    expect(tplQuelle).not.toMatch(/scope: TemplateScope = /)
+    expect(tplQuelle).toContain('stripForTemplate(cloneProject(project), scope)')
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('was beim Verwenden mit den Antworten passiert', () => {
+  it('nennt dasselbe Haus als geltend', () => {
+    const r = templateCarryReport('Halle A', 2, 'halle a')
+    expect(r.state).toBe('carries')
+    expect(r.text).toContain('dasselbe Haus')
+  })
+
+  it('BENUTZT DIESELBE STRENGE als das Blatt', () => {
+    // „Halle A" und „Halle A, Eingang Nord" koennen dasselbe Haus sein — und
+    // sie als gleich zu behandeln hiesse, eine Genehmigung zu uebertragen,
+    // die vielleicht nie fuer diesen Bereich galt. Zwei Wahrheiten darueber
+    // waeren hier besonders teuer.
+    expect(sameVenue('Halle A', 'Halle A, Eingang Nord')).toBe(false)
+    expect(templateCarryReport('Halle A', 2, 'Halle A, Eingang Nord').state).toBe('elsewhere')
+  })
+
+  it('nennt beide Haeuser im Text', () => {
+    const r = templateCarryReport('Halle A', 3, 'Kongresszentrum')
+    expect(r.state).toBe('elsewhere')
+    expect(r.text).toContain('Halle A')
+    expect(r.text).toContain('Kongresszentrum')
+    expect(r.answers).toBe(3)
+  })
+
+  it('laesst offen statt zu behaupten, wenn das Ziel keinen Ort nennt', () => {
+    const r = templateCarryReport('Halle A', 2, undefined)
+    expect(r.state).toBe('elsewhere')
+    expect(r.text).toMatch(/bleibt offen/)
+  })
+
+  it('meldet „keine Antworten dabei" als eigenen Zustand, nicht als Fehler', () => {
+    expect(templateCarryReport(undefined, 0, 'Halle A').state).toBe('none')
+    // Auch mit Haus, aber ohne Antworten.
+    expect(templateCarryReport('Halle A', 0, 'Halle A').state).toBe('none')
+  })
+
+  it('liest den Ort aus dem Projekt getrimmt', () => {
+    expect(projectVenue(projekt({ metadata: { name: 'x', siteAddress: '  Halle A ' } } as never))).toBe(
+      'Halle A',
+    )
+    expect(projectVenue(projekt())).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('Erreichbarkeit', () => {
+  it('fragt beim Speichern — aber NUR, wenn etwas dranhaengt', () => {
+    // Eine Rueckfrage, die meistens „nichts dabei" bedeutet, wird zur
+    // Klickgewohnheit; dieselbe Ueberlegung wie bei `credentialChoiceDialog`.
+    expect(dialogQuelle).toContain('const gebunden = venueBoundCount(current)')
+    expect(dialogQuelle).toMatch(/if \(gebunden > 0\) \{\n\s*const antwort = await venueScopeDialog\(/)
+  })
+
+  it('bricht bei Abbruch ab, statt neutral zu speichern', () => {
+    expect(dialogQuelle).toMatch(/if \(antwort === null\) return/)
+  })
+
+  it('reicht den Umfang an den Schreiber durch', () => {
+    expect(dialogQuelle).toContain(
+      "saveUserTemplate(name, current.metadata.description ?? '', current, scope)",
+    )
+  })
+
+  it('warnt VOR dem Laden, wenn die Antworten aus einem anderen Haus kommen', () => {
+    // Danach stehen sie im Blatt und sehen aus wie Auskunft.
+    expect(dialogQuelle).toMatch(/if \(bericht\.state === 'elsewhere'\) \{/)
+    expect(dialogQuelle).toContain('body: bericht.text')
+    expect(dialogQuelle).toMatch(/if \(!weiter\) return/)
+  })
+
+  it('zeigt das Haus auf der Karte', () => {
+    expect(dialogQuelle).toContain("t('templates.venue'")
+    expect(dialogQuelle).toMatch(/\{tpl\.venue && \(/)
+  })
+
+  it('bricht der Frage-Dialog bei Escape ab, statt etwas mitzugeben', () => {
+    expect(scopeDialogQuelle).toContain('useModalKeyboard(() => onDone(null))')
+  })
+
+  it('hat fuer jeden neuen Text einen EN-Eintrag', () => {
+    for (const key of [
+      'tplScope.title',
+      'tplScope.body',
+      'tplScope.venue',
+      'tplScope.neutral',
+      'templates.venue',
+      'templates.carryTitle',
+      'templates.carryOk',
+    ]) {
+      expect(dictsQuelle).toContain(`'${key}'`)
+    }
+  })
+})


### PR DESCRIPTION
**Bedarf 91 (P2)** — „Reusable per-venue and per-show knowledge so the same problems are not re-solved every time."

> SRT latency, port negotiations, which SIM worked, which uplink was real, the mix-minus arrangement and the fallback thresholds are re-derived per event and live nowhere shared; **the most valuable document in the role is the one least likely to exist.**

Der Weg steht in derselben Zeile: *„Venue and template reuse in the project model, with the as-built network answer and transport parameters attached."*

## Die Vorlage gab es schon — sie trug das Falsche mit

`saveUserTemplate` strippte die **Auftrags**-Identität (Kunde, Logos, Rentman-Bezug) und ließ alles andere stehen. Das war richtig, solange eine Vorlage nur Geräte und Kabel trug. Inzwischen trägt ein Projekt Dinge, die an *einem* Haus oder an *einem* Rechner hängen — und die gingen stillschweigend mit:

| Feld | woran es hängt |
|---|---|
| `metadata.venueAnswers` (Bedarf 85) | was **dieses** Haus genehmigt hat |
| `metadata.siteAddress` | welches Haus das war |
| `multicast.assignments` (Bedarf 72) | Adressen, die für **diese** Show vergeben wurden und dort laufen |
| `hasStreamKey` (Initiative 9) | ob auf **diesem** Rechner ein Schlüssel liegt |
| `revisions`, `pendingChanges` | die Geschichte einer anderen Show |

Eine neutrale Vorlage, die die Genehmigungen der Halle A mitbringt, ist schlimmer als eine ohne: die Zeilen sehen aus wie Auskunft, und niemand fragt nach. Genau davor warnt Bedarf 85 mit `elsewhere`.

## Zwei Sorten Vorlage, und die Frage wird gestellt

`lib/templateScope.ts` (neu) ist die Engstelle. `stripForTemplate` kennt zwei Umfänge:

- **`neutral`** — die Form: Räume, Geräte, Verkabelung, das Ausspiel-Schema.
- **`venue`** — dieselbe Form *plus* die Antworten dieses Hauses und seine Adresse.

Vergaben und Schlüssel-Häkchen fallen **immer**: sie sind keine Ortsangabe, sondern eine Behauptung, die im neuen Projekt schlicht falsch ist. Der Multicast-**Pool** bleibt — das ist das Schema, und das ist genau das Wiederverwendbare.

`saveUserTemplate` nimmt den Umfang als **Pflicht-Parameter ohne Default** — dieselbe Bauform wie `credentials` bei `syncSharedLibrary` (Design-Frage 5). Ein Default hätte den alten Zustand („geht stillschweigend mit") wiederhergestellt, sobald ein Aufrufer ihn wegläss; der Compiler hat prompt den einen bestehenden Aufrufer gefunden.

Gefragt wird **nur, wenn etwas Ortsgebundenes dranhängt** (`venueBoundCount`). Eine Rückfrage, die meistens „nichts dabei" bedeutet, wird zur Klickgewohnheit — dieselbe Überlegung wie bei `credentialChoiceDialog`. Escape bricht ab und speichert nichts.

## Beim Verwenden

`ProjectTemplate.venue` steht **an der Vorlage** und nicht nur im Projekt: die Karte in der Galerie muss das Haus nennen können, *bevor* geladen wird.

`templateCarryReport` sagt vor dem Laden, ob die Antworten hier gelten — und benutzt dafür `sameVenue` aus `venueAnswers.ts`, jetzt exportiert. Zwei Wahrheiten darüber, was „dasselbe Haus" heißt, wären hier besonders teuer: die eine entscheidet, was die Vorlage mitbringt, die andere, wie es im Blatt markiert wird. Streng bleibt streng — „Halle A" ist nicht „Halle A, Eingang Nord".

## Was bewusst fehlt

**Der geteilte Ordner.** Der Bedarf sagt „live nowhere *shared*", und Vorlagen liegen weiterhin im `localStorage` dieses Rechners. `syncSharedLibrary` (#434) deckt Geräte und Gruppen ab, nicht Vorlagen; das dort zu ergänzen ist ein eigenes Inkrement mit eigenem Sperr- und Merge-Verhalten und gehört nicht als Anhängsel in diesen PR.

## Geprüft

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 140 Testdateien, 1766 Tests grün (2 skipped); 26 neue
- `npx eslint .` — 0 Fehler
- **32 Gegenproben, alle rot**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_