### PR TITLE
bestand: welche Kiste den Plan-Platz füllt (Bedarf 78)

### DIFF
--- a/src/renderer/components/Analysis/AnalysisDialog.tsx
+++ b/src/renderer/components/Analysis/AnalysisDialog.tsx
@@ -61,6 +61,14 @@ import {
 } from '../../lib/multicastPlan'
 import { MULTICAST_LEG_LABEL } from '../../types/multicast'
 import {
+  ASSET_FINDING_LABEL,
+  IDENTITY_ANCHOR_LABEL,
+  assessAssetIdentity,
+  assetIdentityTable,
+} from '../../lib/assetIdentity'
+import { useInventoryStore } from '../../store/inventoryStore'
+import { useCheckoutStore } from '../../store/checkoutStore'
+import {
   SPECTRUM_SOURCE_LABEL,
   buildSpectrumPlan,
   conflictParticipants,
@@ -399,6 +407,29 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
   const multicast = useMemo(() => buildMulticastPlan(projekt), [projekt])
   // Der Entwurf liegt lokal, damit das Tippen im Pool-Feld nicht bei jedem
   // Zeichen eine Vergabe-Rechnung ueber mehrere hundert Fluesse ausloest.
+  // BEDARF 78 — welche Kiste welchen Platz fuellt. Der Bestand und die
+  // Ausgabescheine liegen in eigenen Stores; hier werden sie NUR GELESEN.
+  const invUnits = useInventoryStore((st) => st.units)
+  const invItems = useInventoryStore((st) => st.items)
+  const checkouts = useCheckoutStore((st) => st.records)
+  const asset = useMemo(
+    () =>
+      assessAssetIdentity({
+        equipment,
+        units: invUnits,
+        items: invItems,
+        checkouts,
+      }),
+    [equipment, invUnits, invItems, checkouts],
+  )
+  const exportAsset = () => {
+    downloadBlob(
+      buildExportFilenameWithSuffix(projectName, 'geraete-identitaet', 'csv'),
+      csvFromTable(assetIdentityTable(asset)),
+      'text/csv',
+    )
+  }
+
   const [poolDraft, setPoolDraft] = useState(projekt.multicast?.pool ?? '')
   const [portDraft, setPortDraft] = useState(String(projekt.multicast?.basePort ?? 20000))
 
@@ -967,6 +998,59 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
                   >
                     <strong>{PTP_FINDING_LABEL[f.kind]}</strong> — {f.text}
                   </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {/* BEDARF 78 — welche Kiste den Platz füllt. Nur sichtbar, wenn der
+          Plan überhaupt Plätze mit Netz-Identität trägt: an einem reinen
+          SDI-Aufbau gibt es keinen eingebrannten Geräte-Namen, der beim
+          Tausch mitwandern könnte. */}
+      {asset.hasAnchored && (
+        <div className="rounded-cp-panel border border-[var(--cp-border)] bg-[var(--cp-surface-1)] p-cp-3">
+          <div className="mb-2 flex items-baseline justify-between gap-2">
+            <div className="text-cp-sm font-semibold text-[var(--cp-text)]">
+              {t('analysis.asset.title', 'Welche Kiste füllt welchen Platz')}
+            </div>
+            <button
+              type="button"
+              onClick={exportAsset}
+              className="inline-flex items-center gap-1 rounded border border-[var(--cp-border)] px-2 py-0.5 text-cp-xs text-[var(--cp-text)] hover:bg-[var(--cp-surface-2)]"
+            >
+              <Icon icon={Download} size="xs" /> {t('analysis.asset.export', 'Blatt')}
+            </button>
+          </div>
+          <div className="mb-2 text-cp-xs text-[var(--cp-text-muted)]">
+            {t(
+              'analysis.asset.intro',
+              'Zwei baugleiche Stageboxen sind im Plan dasselbe Kästchen, im Lager zwei Einheiten und im Netz zwei verschiedene Geräte — jede mit eigenem eingebranntem Namen und eigener MAC. Ein Tausch am Ladetag fällt erst in der Probe auf. Hier werden nur Aufzeichnungen verglichen; was im Rack steht, weiß der Plan nicht.',
+            )}
+          </div>
+          <ul className="flex flex-col gap-0.5 text-cp-xs">
+            {asset.rows.map((r) => (
+              <li key={r.equipmentId} className="flex flex-wrap items-baseline gap-2">
+                <span className="flex-1 text-[var(--cp-text)]">{r.name}</span>
+                <span className="w-48 shrink-0 text-[var(--cp-text-faint)]">
+                  {r.anchors.map((x) => IDENTITY_ANCHOR_LABEL[x]).join(', ')}
+                </span>
+                <span
+                  className={`w-40 shrink-0 font-mono ${
+                    r.unitId ? 'text-[var(--cp-text)]' : 'text-amber-300/90'
+                  }`}
+                >
+                  {r.unitSerial ?? (r.unitId ? r.unitId : t('analysis.asset.none', 'nicht benannt'))}
+                </span>
+              </li>
+            ))}
+          </ul>
+          {asset.findings.length > 0 && (
+            <ul className="mt-2 flex flex-col gap-1">
+              {asset.findings.map((f, i) => (
+                <li key={`${f.kind}-${f.equipmentId}-${i}`} className="text-cp-xs text-amber-300/90">
+                  <strong>{ASSET_FINDING_LABEL[f.kind]}</strong> — {f.text}
                 </li>
               ))}
             </ul>

--- a/src/renderer/components/Properties/sections/NetworkAccessSection.tsx
+++ b/src/renderer/components/Properties/sections/NetworkAccessSection.tsx
@@ -6,6 +6,8 @@ import { SortableSection } from '../SortableSection'
 import { Icon } from '../../shared/Icon'
 import { ExtraInterfacesPanel } from './ExtraInterfacesPanel'
 import type { EquipmentItem } from '../../../types/equipment'
+import { useInventoryStore } from '../../../store/inventoryStore'
+import { identityAnchors } from '../../../lib/assetIdentity'
 
 /**
  * #306 — "Network & Access"-SortableSection aus EquipmentProperties
@@ -20,6 +22,21 @@ export const NetworkAccessSection = ({ equipment }: { equipment: EquipmentItem }
   const t = useTranslation()
   const updateEquipment = useProjectStore((state) => state.updateEquipment)
   const [showPassword, setShowPassword] = useState(false)
+  // BEDARF 78 — welche KISTE diesen Platz fuellt. Der Bestand liegt in einem
+  // eigenen Store (localStorage), nicht am Projekt: dieselbe Kiste faehrt auf
+  // mehreren Shows, und sie ins Projektfile zu kopieren waere eine zweite
+  // Wahrheit ueber den Lagerbestand.
+  const units = useInventoryStore((state) => state.units)
+  const items = useInventoryStore((state) => state.items)
+  // Die Auswahl erscheint nur an Plaetzen MIT Netz-Identitaet. An einem Stativ
+  // ist die Frage „welche Kiste" richtig und hier trotzdem falsch: der Bedarf
+  // handelt vom eingebrannten Geraete-Namen, und wo keiner ist, waere das Feld
+  // Ballast in jeder Seitenleiste.
+  const anchors = identityAnchors(equipment)
+  const unitLabel = (u: (typeof units)[number]) => {
+    const modell = items.find((i) => i.id === u.itemId)?.model
+    return [modell, u.serial ?? u.code ?? u.id].filter(Boolean).join(' · ')
+  }
 
   return (
     <SortableSection
@@ -51,6 +68,41 @@ export const NetworkAccessSection = ({ equipment }: { equipment: EquipmentItem }
             className="w-full rounded border border-cp-border bg-cp-surface-1 p-2 font-mono"
           />
         </label>
+        {/* BEDARF 78 — WELCHE Kiste. Direkt neben der Seriennummer, weil die
+            beiden gegeneinander gehalten werden: der Freitext ist abgetippt,
+            die Einheit kommt aus dem Bestand, und wo sie auseinandergehen, ist
+            ein Tausch uebrig geblieben. */}
+        {anchors.length > 0 && (
+          <label className="block">
+            <span className="mb-1 block text-cp-text-secondary">
+              {t('eq.field.unit', 'Einheit aus dem Bestand')}
+            </span>
+            <select
+              value={equipment.inventoryUnitId ?? ''}
+              onChange={(event) =>
+                updateEquipment(equipment.id, {
+                  inventoryUnitId: event.target.value || undefined,
+                })
+              }
+              className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
+            >
+              <option value="">{t('eq.field.unitNone', '— nicht benannt —')}</option>
+              {units.map((u) => (
+                <option key={u.id} value={u.id}>
+                  {unitLabel(u)}
+                </option>
+              ))}
+            </select>
+            {!equipment.inventoryUnitId && (
+              <span className="mt-1 block text-cp-xs text-cp-text-muted">
+                {t(
+                  'eq.field.unitHint',
+                  'Dieser Platz trägt eine Netz-Identität. Ohne benannte Einheit ist ein Tausch gegen eine baugleiche Kiste unsichtbar — der eingebrannte Geräte-Name wandert mit.',
+                )}
+              </span>
+            )}
+          </label>
+        )}
         <label className="block">
           <span className="mb-1 block text-cp-text-secondary">{t('eq.field.subnet', 'Subnet Mask')}</span>
           <input

--- a/src/renderer/lib/assetIdentity.ts
+++ b/src/renderer/lib/assetIdentity.ts
@@ -1,0 +1,279 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Welche KISTE steht im Plan-Platz (Bedarf 78, P2).
+//
+//   > The rental system knows serial numbers and barcodes; the IP plan knows
+//   > hostnames and addresses. A last-minute substitution of one identical
+//   > stagebox for another is invisible to both the IP plan and the Dante
+//   > subscription set, and only surfaces as a fault during rehearsal.
+//
+// ─── WARUM DER TAUSCH UNSICHTBAR IST ───────────────────────────────────────
+//
+// Zwei baugleiche Stageboxen sind im Plan dasselbe Kaestchen. Im Lager sind
+// sie zwei Einheiten mit zwei Seriennummern. Und im NETZ sind sie zwei
+// verschiedene Geraete: jede traegt ihren eigenen eingebrannten Dante-Namen
+// und ihre eigene MAC.
+//
+// Wer am Ladetag die eine gegen die andere tauscht, tauscht damit auch:
+//   - den Dante-Namen, auf den jedes Abonnement zeigt,
+//   - die MAC, auf die die DHCP-Reservierung und der Switch-Port-Filter
+//     ausgestellt sind,
+//   - und, wenn statisch adressiert wurde, die IP, die in der Kiste steht.
+//
+// Nichts davon faellt beim Aufbau auf. Es faellt in der Probe auf, wenn ein
+// Kanal stumm bleibt.
+//
+// ─── WAS DIESE DATEI TUT UND WAS SIE NICHT WEISS ───────────────────────────
+//
+// Sie vergleicht AUFZEICHNUNGEN: was der Plan-Platz ueber seine Netz-Identitaet
+// sagt, welche Einheit ihm zugeordnet ist, was das Lager ueber diese Einheit
+// weiss, und was auf dem Ausgabeschein steht. Wo diese Aufzeichnungen
+// EINANDER widersprechen, sagt sie es.
+//
+// Sie weiss NICHT, welche Kiste tatsaechlich im Rack steht. Kein Befund
+// behauptet, dass getauscht wurde — jeder sagt, dass die Aufzeichnungen
+// auseinandergehen. Der Unterschied ist wichtig: eine Behauptung ueber die
+// Wirklichkeit muesste jemand pruefen gehen, ein Widerspruch zwischen zwei
+// Listen laesst sich am Schreibtisch aufloesen.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { EquipmentItem } from '../types/equipment'
+import type { InventoryUnit, InventoryItem } from '../types/inventory'
+import type { CheckoutRecord } from '../types/checkout'
+import type { CsvTable } from './csv'
+import { deviceInterfaces } from './networkInterfaces'
+
+/**
+ * Woran haengt an diesem Platz eine Netz-Identitaet?
+ *
+ * Nur diese Plaetze sind ueberhaupt betroffen. Ein Stativ hat keinen
+ * Dante-Namen, und es in die Liste zu nehmen hiesse, den halben Plan zu
+ * melden.
+ */
+export type IdentityAnchor = 'ip' | 'mac' | 'dante' | 'ptp'
+
+export const IDENTITY_ANCHOR_LABEL: Readonly<Record<IdentityAnchor, string>> = {
+  ip: 'IP-Adresse',
+  mac: 'MAC-Adresse',
+  dante: 'Dante-/Geräte-Name',
+  ptp: 'PTP-Domäne',
+}
+
+/**
+ * Welche Anker dieser Platz traegt.
+ *
+ * Der Dante-Name ist der GERAETE-Name: bei Dante und AES67 ist er die
+ * Adresse, unter der Abonnements den Sender finden. Er zaehlt deshalb nur,
+ * wenn am Platz ueberhaupt eine Netz-Schnittstelle haengt — sonst waere jedes
+ * benannte Geraet im Plan ein Anker.
+ */
+export function identityAnchors(e: EquipmentItem): IdentityAnchor[] {
+  const nics = deviceInterfaces(e)
+  const out: IdentityAnchor[] = []
+  if (nics.some((n) => n.ipAddress)) out.push('ip')
+  if (nics.some((n) => n.macAddress)) out.push('mac')
+  if (nics.length > 0 && e.name?.trim()) out.push('dante')
+  if (nics.some((n) => typeof n.ptpDomain === 'number')) out.push('ptp')
+  return out
+}
+
+export type AssetFindingKind =
+  | 'unit-unnamed'
+  | 'unit-double'
+  | 'unit-missing'
+  | 'serial-mismatch'
+  | 'unit-not-issued'
+  | 'unit-blocked'
+
+export const ASSET_FINDING_LABEL: Readonly<Record<AssetFindingKind, string>> = {
+  'unit-unnamed': 'Platz mit Netz-Identität, aber ohne benannte Einheit',
+  'unit-double': 'Eine Einheit steht in zwei Plätzen',
+  'unit-missing': 'Benannte Einheit steht nicht im Bestand',
+  'serial-mismatch': 'Seriennummer am Platz und an der Einheit gehen auseinander',
+  'unit-not-issued': 'Benannte Einheit steht auf keinem offenen Ausgabeschein',
+  'unit-blocked': 'Benannte Einheit ist nicht einsatzbereit',
+}
+
+export interface AssetFinding {
+  kind: AssetFindingKind
+  text: string
+  /** Der betroffene Plan-Platz, fuer den Sprung. */
+  equipmentId: string
+  /** Die betroffene Einheit, wenn eine benannt ist. */
+  unitId?: string
+}
+
+export interface AssetIdentityInput {
+  equipment: readonly EquipmentItem[]
+  units?: readonly InventoryUnit[]
+  items?: readonly InventoryItem[]
+  /** Offene und geschlossene Vorgaenge — die Pruefung nimmt nur die offenen. */
+  checkouts?: readonly CheckoutRecord[]
+}
+
+export interface AssetIdentityRow {
+  equipmentId: string
+  name: string
+  anchors: IdentityAnchor[]
+  unitId?: string
+  /** Seriennummer der benannten Einheit. */
+  unitSerial?: string
+  /** Seriennummer, die am Platz steht. */
+  plannedSerial?: string
+}
+
+export interface AssetIdentityAssessment {
+  rows: AssetIdentityRow[]
+  findings: AssetFinding[]
+  /** Traegt der Plan ueberhaupt Plaetze mit Netz-Identitaet? */
+  hasAnchored: boolean
+}
+
+const trimmed = (v: string | undefined): string | undefined => v?.trim() || undefined
+
+/** Seriennummern vergleichen, wie ein Mensch sie tippt: ohne Leerraum, ohne Fall. */
+const sameSerial = (a: string | undefined, b: string | undefined): boolean =>
+  (a ?? '').replace(/[\s-]/g, '').toLowerCase() === (b ?? '').replace(/[\s-]/g, '').toLowerCase()
+
+/**
+ * Der Abgleich. Er liest nur — er ordnet keine Einheit zu und aendert nichts.
+ */
+export function assessAssetIdentity(input: AssetIdentityInput): AssetIdentityAssessment {
+  const units = input.units ?? []
+  const unitById = new Map(units.map((u) => [u.id, u]))
+  const itemById = new Map((input.items ?? []).map((i) => [i.id, i]))
+  const findings: AssetFinding[] = []
+
+  // Nur Plaetze MIT Anker. Alles andere ist nicht betroffen.
+  const anchored = input.equipment
+    .map((e) => ({ e, anchors: identityAnchors(e) }))
+    .filter((x) => x.anchors.length > 0)
+
+  // Welche Einheiten stehen auf einem OFFENEN Ausgabeschein?
+  const ausgegeben = new Set<string>()
+  for (const r of input.checkouts ?? []) {
+    if (r.in) continue
+    for (const l of r.contents) if (l.kind === 'unit') ausgegeben.add(l.refId)
+  }
+  const hatOffene = (input.checkouts ?? []).some((r) => !r.in)
+
+  // Doppelbelegung zuerst: sie betrifft zwei Plaetze und gehoert nicht je
+  // Platz gemeldet.
+  const proEinheit = new Map<string, EquipmentItem[]>()
+  for (const { e } of anchored) {
+    const uid = trimmed(e.inventoryUnitId)
+    if (!uid) continue
+    proEinheit.set(uid, [...(proEinheit.get(uid) ?? []), e])
+  }
+  for (const [uid, plaetze] of proEinheit) {
+    if (plaetze.length < 2) continue
+    const u = unitById.get(uid)
+    findings.push({
+      kind: 'unit-double',
+      equipmentId: plaetze[0].id,
+      unitId: uid,
+      text: `${u?.serial ? `Einheit ${u.serial}` : 'Eine Einheit'} steht in ${plaetze.length} Plätzen: ${plaetze
+        .map((p) => p.name)
+        .join(', ')}. Eine Kiste steht an einem Ort — einer der Plätze führt einen Rest von gestern.`,
+    })
+  }
+
+  const rows: AssetIdentityRow[] = []
+  for (const { e, anchors } of anchored) {
+    const uid = trimmed(e.inventoryUnitId)
+    const unit = uid ? unitById.get(uid) : undefined
+    const plannedSerial = trimmed(e.serialNumber)
+    rows.push({
+      equipmentId: e.id,
+      name: e.name,
+      anchors,
+      ...(uid ? { unitId: uid } : {}),
+      ...(unit?.serial ? { unitSerial: unit.serial } : {}),
+      ...(plannedSerial ? { plannedSerial } : {}),
+    })
+
+    if (!uid) {
+      findings.push({
+        kind: 'unit-unnamed',
+        equipmentId: e.id,
+        text: `${e.name} trägt ${anchors
+          .map((a) => IDENTITY_ANCHOR_LABEL[a])
+          .join(' und ')}, aber es steht nicht, WELCHE Kiste das ist. Wird sie am Ladetag gegen eine baugleiche getauscht, wandert der eingebrannte Geräte-Name mit — und die Abonnements zeigen ins Leere, ohne dass etwas rot wird.`,
+      })
+      continue
+    }
+
+    if (!unit) {
+      // Nicht still leeren: ein Zeiger ins Nichts ist eine Auskunft darueber,
+      // dass hier einmal eine Einheit stand.
+      findings.push({
+        kind: 'unit-missing',
+        equipmentId: e.id,
+        unitId: uid,
+        text: `${e.name} nennt eine Einheit, die im Bestand nicht steht. Entweder ist sie gelöscht worden, oder der Plan kommt aus einer anderen Lagerdatenbank.`,
+      })
+      continue
+    }
+
+    if (plannedSerial && unit.serial && !sameSerial(plannedSerial, unit.serial)) {
+      findings.push({
+        kind: 'serial-mismatch',
+        equipmentId: e.id,
+        unitId: uid,
+        text: `${e.name}: am Platz steht Seriennummer ${plannedSerial}, die zugeordnete Einheit trägt ${unit.serial}. Zwei Aufzeichnungen über dieselbe Kiste widersprechen sich — welche stimmt, sagt der Plan nicht, aber eine von beiden ist von einem Tausch übrig.`,
+      })
+    }
+
+    if (unit.condition && unit.condition !== 'ok') {
+      const modell = itemById.get(unit.itemId)?.model
+      findings.push({
+        kind: 'unit-blocked',
+        equipmentId: e.id,
+        unitId: uid,
+        text: `${e.name} ist mit ${modell ? `${modell} ` : ''}${
+          unit.serial ?? uid
+        } belegt, und die Einheit steht auf „${unit.condition}". Sie geht so nicht raus.`,
+      })
+    }
+
+    // Nur pruefen, wenn es ueberhaupt Ausgabescheine gibt: ohne Lagerbetrieb
+    // waere das eine Warnung fuer jeden Platz.
+    if (hatOffene && !ausgegeben.has(uid)) {
+      findings.push({
+        kind: 'unit-not-issued',
+        equipmentId: e.id,
+        unitId: uid,
+        text: `${e.name} nennt Einheit ${
+          unit.serial ?? uid
+        }, die auf keinem offenen Ausgabeschein steht. Entweder fährt eine andere Kiste mit, oder der Schein ist unvollständig.`,
+      })
+    }
+  }
+
+  return { rows, findings, hasAnchored: anchored.length > 0 }
+}
+
+/**
+ * Das Blatt: welcher Platz von welcher Kiste gefuellt wird.
+ *
+ * Es ist das Blatt, mit dem jemand vor dem Rack steht und die Seriennummer
+ * abliest. Deshalb stehen BEIDE Seriennummern drauf — die geplante und die
+ * der zugeordneten Einheit; steht nur eine da, kann man nicht vergleichen.
+ */
+export function assetIdentityTable(a: AssetIdentityAssessment): CsvTable {
+  return {
+    headers: ['Platz', 'Anker', 'Einheit', 'Serie (Einheit)', 'Serie (Platz)', 'Befund'],
+    rows: a.rows.map((r) => [
+      r.name,
+      r.anchors.map((x) => IDENTITY_ANCHOR_LABEL[x]).join(', '),
+      r.unitId ?? 'nicht benannt',
+      r.unitSerial ?? '',
+      r.plannedSerial ?? '',
+      a.findings
+        .filter((f) => f.equipmentId === r.equipmentId)
+        .map((f) => ASSET_FINDING_LABEL[f.kind])
+        .join('; '),
+    ]),
+  }
+}

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -4255,6 +4255,16 @@ export const en: Dict = {
   'analysis.crew.title': 'Network briefing sheet for the crew',
   'analysis.crew.ask': '{n} points to settle on site',
   'analysis.crew.export': 'Crew network sheet',
+  // Bedarf 78 — welche Kiste welchen Platz fuellt.
+  'analysis.asset.title': 'Which box fills which slot',
+  'analysis.asset.intro':
+    'Two identical stageboxes are one box on the plan, two units in the warehouse and two different devices on the network \u2014 each with its own burned-in name and its own MAC. A swap on load-in day only surfaces during rehearsal. Only records are compared here; what is actually in the rack, the plan does not know.',
+  'analysis.asset.export': 'Sheet',
+  'analysis.asset.none': 'not stated',
+  'eq.field.unit': 'Unit from stock',
+  'eq.field.unitNone': '\u2014 not stated \u2014',
+  'eq.field.unitHint':
+    'This slot carries a network identity. Without a named unit a swap for an identical box is invisible \u2014 the burned-in device name travels with it.',
   // Bedarf 91 — Vorlagen, die wissen, aus welchem Haus sie kommen.
   'tplScope.title': 'Bind this template to the venue?',
   'tplScope.body':

--- a/src/renderer/lib/modelFields.ts
+++ b/src/renderer/lib/modelFields.ts
@@ -128,6 +128,11 @@ export const INSTANCE_FIELDS = [
   // Wer dieses Exemplar ist
   'assetTag',
   'serialNumber',
+  // BEDARF 78 — die Einheit aus dem Bestand. Instanz, und zwar besonders
+  // deutlich: sie IST das eine Exemplar. In einem Template getragen wuerde sie
+  // beim zweiten Herausziehen zwei Plaetze auf dieselbe Kiste zeigen lassen --
+  // genau der Befund `unit-double`, nur diesmal vom Werkzeug erzeugt.
+  'inventoryUnitId',
   'qrId',
   'sourceIdentityId',
   'installStatus',

--- a/src/renderer/lib/planDiff.ts
+++ b/src/renderer/lib/planDiff.ts
@@ -238,6 +238,11 @@ export const EQUIPMENT_FIELD_CLASS: Record<string, FieldClass> = {
   installStatus: 'substantive',
   assetTag: 'substantive',
   serialNumber: 'substantive',
+  // BEDARF 78 — welche Kiste. Substantiell und nicht kosmetisch: wer sie
+  // aendert, hat getauscht, und mit der Kiste wandern der eingebrannte
+  // Geraete-Name und die MAC. Ein Diff, der das schluckt, verschweigt genau
+  // die Aenderung, deretwegen das Feld existiert.
+  inventoryUnitId: 'substantive',
   ownership: 'substantive',
   stockLocation: 'substantive',
   packed: 'substantive',

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -555,6 +555,25 @@ export interface EquipmentItem {
   /** Issue #39: physical serial number, surfaces in location/frame BOM exports. */
   serialNumber?: string
   /**
+   * BEDARF 78 — WELCHE Kiste diesen Platz füllt (`InventoryUnit.id`).
+   *
+   * Zwei baugleiche Stageboxen sind im Plan dasselbe Kästchen, im Lager zwei
+   * Einheiten und im Netz zwei verschiedene Geräte: jede trägt ihren eigenen
+   * eingebrannten Dante-Namen und ihre eigene MAC. Ohne dieses Feld ist ein
+   * Tausch am Ladetag für beide Seiten unsichtbar und fällt erst in der Probe
+   * auf, wenn ein Kanal stumm bleibt.
+   *
+   * OPTIONAL, und das bleibt es. Die meisten Plätze im Plan sind kein
+   * Netz-Gerät und brauchen keine Einheit; ein Pflichtfeld würde den halben
+   * Plan mit Warnungen füllen. `assessAssetIdentity` meldet nur die Plätze,
+   * an denen überhaupt eine Netz-Identität hängt.
+   *
+   * `serialNumber` daneben bleibt, wo es ist: es ist FREITEXT, den jemand
+   * abgetippt hat, und die beiden gegeneinander zu halten ist genau der
+   * Befund, den der Bedarf will (`serial-mismatch`).
+   */
+  inventoryUnitId?: string
+  /**
    * When true, render the equipment node as a compact label-only badge
    * (icon + name only, ports as dots on the edges) instead of the full
    * port-list card. Issue #37 — useful for converters and other devices

--- a/tests/assetIdentity.test.ts
+++ b/tests/assetIdentity.test.ts
@@ -1,0 +1,375 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ASSET_FINDING_LABEL,
+  IDENTITY_ANCHOR_LABEL,
+  assessAssetIdentity,
+  assetIdentityTable,
+  identityAnchors,
+  type AssetIdentityInput,
+} from '../src/renderer/lib/assetIdentity'
+import { INSTANCE_FIELDS } from '../src/renderer/lib/modelFields'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+import type { InventoryUnit, InventoryItem } from '../src/renderer/types/inventory'
+import type { CheckoutRecord } from '../src/renderer/types/checkout'
+import sectionQuelle from '../src/renderer/components/Properties/sections/NetworkAccessSection.tsx?raw'
+import analyseQuelle from '../src/renderer/components/Analysis/AnalysisDialog.tsx?raw'
+import diffQuelle from '../src/renderer/lib/planDiff.ts?raw'
+import dictsQuelle from '../src/renderer/lib/i18n/dicts.ts?raw'
+
+// ---------------------------------------------------------------------------
+// Welche KISTE steht im Plan-Platz (Bedarf 78, P2).
+//
+//   > The rental system knows serial numbers and barcodes; the IP plan knows
+//   > hostnames and addresses. A last-minute substitution of one identical
+//   > stagebox for another is invisible to both the IP plan and the Dante
+//   > subscription set, and only surfaces as a fault during rehearsal.
+//
+// Zwei baugleiche Stageboxen sind im Plan dasselbe Kaestchen, im Lager zwei
+// Einheiten und im NETZ zwei verschiedene Geraete — jede mit eigenem
+// eingebranntem Namen und eigener MAC.
+// ---------------------------------------------------------------------------
+
+const zeit = '2026-09-06T10:00:00.000Z'
+
+const geraet = (id: string, name: string, over: Partial<EquipmentItem> = {}): EquipmentItem =>
+  ({ id, name, x: 0, y: 0, inputs: [], outputs: [], ...over }) as never
+
+const netz = (id: string, name: string, over: Partial<EquipmentItem> = {}) =>
+  geraet(id, name, { ipAddress: '10.0.0.5', ...over })
+
+const einheit = (id: string, serial: string, over: Partial<InventoryUnit> = {}): InventoryUnit =>
+  ({
+    id,
+    itemId: 'sb',
+    serial,
+    condition: 'ok',
+    history: [],
+    createdAt: zeit,
+    updatedAt: zeit,
+    ...over,
+  }) as never
+
+const artikel: InventoryItem = { id: 'sb', model: 'Stagebox 32', quantity: 4 } as never
+
+const schein = (unitIds: string[], geschlossen = false): CheckoutRecord =>
+  ({
+    id: 'co1',
+    nodeId: 'case1',
+    nodeLabel: 'Case 1',
+    out: { at: zeit, by: 'Lars' },
+    contents: unitIds.map((refId) => ({ kind: 'unit', refId, label: refId, quantity: 1 })),
+    ...(geschlossen ? { in: { at: zeit, by: 'Lars' } } : {}),
+  }) as never
+
+const eingabe = (over: Partial<AssetIdentityInput> = {}): AssetIdentityInput => ({
+  equipment: [],
+  ...over,
+})
+
+// ---------------------------------------------------------------------------
+describe('betroffen ist nur, wo eine NETZ-Identitaet haengt', () => {
+  it('erkennt IP, MAC, Namen und PTP als Anker', () => {
+    expect(identityAnchors(netz('a', 'Stagebox 1'))).toEqual(['ip', 'dante'])
+    expect(identityAnchors(geraet('b', 'X', { macAddress: 'aa:bb' }))).toEqual(['mac', 'dante'])
+    expect(
+      identityAnchors(
+        geraet('c', 'X', { networkInterfaces: [{ id: 'n1', role: 'media-primary', ptpDomain: 127 }] } as never),
+      ),
+    ).toEqual(['dante', 'ptp'])
+  })
+
+  it('sieht ein STATIV nicht als betroffen an', () => {
+    // Ein Stativ hat keinen eingebrannten Geraete-Namen. Es in die Liste zu
+    // nehmen hiesse, den halben Plan zu melden — und die echten Faelle
+    // darunter zu begraben.
+    expect(identityAnchors(geraet('s', 'Stativ'))).toEqual([])
+    const a = assessAssetIdentity(eingabe({ equipment: [geraet('s', 'Stativ')] }))
+    expect(a.hasAnchored).toBe(false)
+    expect(a.findings).toEqual([])
+  })
+
+  it('zaehlt den GERAETE-Namen nur, wenn ueberhaupt eine Schnittstelle da ist', () => {
+    // Sonst waere jedes benannte Objekt im Plan ein Anker.
+    expect(identityAnchors(geraet('x', 'Kiste ohne Netz'))).toEqual([])
+  })
+
+  it('haelt die Etiketten kanonisch deutsch', () => {
+    expect(IDENTITY_ANCHOR_LABEL.dante).toBe('Dante-/Geräte-Name')
+    expect(ASSET_FINDING_LABEL['serial-mismatch']).toBe(
+      'Seriennummer am Platz und an der Einheit gehen auseinander',
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('der Fall aus dem Bedarf: niemand weiss, WELCHE Kiste', () => {
+  it('meldet einen Platz mit Netz-Identitaet ohne benannte Einheit', () => {
+    const a = assessAssetIdentity(eingabe({ equipment: [netz('e1', 'Stagebox 1')] }))
+    const f = a.findings.find((x) => x.kind === 'unit-unnamed')!
+    expect(f).toBeDefined()
+    expect(f.equipmentId).toBe('e1')
+  })
+
+  it('NENNT DIE FOLGE, nicht nur die Luecke', () => {
+    // „Feld leer" bewegt niemanden. „Der eingebrannte Name wandert mit, und
+    // die Abonnements zeigen ins Leere" schon.
+    const a = assessAssetIdentity(eingabe({ equipment: [netz('e1', 'Stagebox 1')] }))
+    const f = a.findings.find((x) => x.kind === 'unit-unnamed')!
+    expect(f.text).toMatch(/eingebrannte/)
+    expect(f.text).toMatch(/Abonnements/)
+  })
+
+  it('schweigt, sobald eine Einheit benannt ist', () => {
+    const a = assessAssetIdentity(
+      eingabe({
+        equipment: [netz('e1', 'Stagebox 1', { inventoryUnitId: 'u1' })],
+        units: [einheit('u1', 'SN-1')],
+      }),
+    )
+    expect(a.findings).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('wo zwei Aufzeichnungen einander widersprechen', () => {
+  it('FAENGT DEN TAUSCH an den beiden Seriennummern', () => {
+    // Jemand hat die neue Nummer am Platz eingetragen und den Zeiger auf die
+    // alte Einheit stehen lassen (oder umgekehrt). Eine von beiden ist von
+    // einem Tausch uebrig.
+    const a = assessAssetIdentity(
+      eingabe({
+        equipment: [netz('e1', 'Stagebox 1', { inventoryUnitId: 'u1', serialNumber: 'SN-2' })],
+        units: [einheit('u1', 'SN-1')],
+      }),
+    )
+    const f = a.findings.find((x) => x.kind === 'serial-mismatch')!
+    expect(f).toBeDefined()
+    expect(f.text).toContain('SN-1')
+    expect(f.text).toContain('SN-2')
+  })
+
+  it('BEHAUPTET NICHT, welche der beiden stimmt', () => {
+    // Der Plan weiss nicht, was im Rack steht. Ein Widerspruch zwischen zwei
+    // Listen laesst sich am Schreibtisch aufloesen; eine Behauptung ueber die
+    // Wirklichkeit muesste jemand pruefen gehen.
+    const a = assessAssetIdentity(
+      eingabe({
+        equipment: [netz('e1', 'Stagebox 1', { inventoryUnitId: 'u1', serialNumber: 'SN-2' })],
+        units: [einheit('u1', 'SN-1')],
+      }),
+    )
+    const f = a.findings.find((x) => x.kind === 'serial-mismatch')!
+    expect(f.text).toMatch(/welche stimmt, sagt der Plan nicht/)
+  })
+
+  it('vergleicht Seriennummern, wie ein Mensch sie tippt', () => {
+    // Bindestrich und Leerzeichen sind Tippgewohnheit, kein Unterschied.
+    const a = assessAssetIdentity(
+      eingabe({
+        equipment: [netz('e1', 'S', { inventoryUnitId: 'u1', serialNumber: ' sn 1 ' })],
+        units: [einheit('u1', 'SN-1')],
+      }),
+    )
+    expect(a.findings.filter((f) => f.kind === 'serial-mismatch')).toEqual([])
+  })
+
+  it('meldet nichts, solange nur EINE der beiden Nummern da ist', () => {
+    // Nichts zu vergleichen ist kein Widerspruch.
+    const a = assessAssetIdentity(
+      eingabe({
+        equipment: [netz('e1', 'S', { inventoryUnitId: 'u1' })],
+        units: [einheit('u1', 'SN-1')],
+      }),
+    )
+    expect(a.findings).toEqual([])
+  })
+
+  it('meldet EINE Einheit in ZWEI Plaetzen — einmal, nicht zweimal', () => {
+    const a = assessAssetIdentity(
+      eingabe({
+        equipment: [
+          netz('e1', 'Stagebox 1', { inventoryUnitId: 'u1' }),
+          netz('e2', 'Stagebox 2', { inventoryUnitId: 'u1' }),
+        ],
+        units: [einheit('u1', 'SN-1')],
+      }),
+    )
+    const doppelt = a.findings.filter((f) => f.kind === 'unit-double')
+    expect(doppelt).toHaveLength(1)
+    expect(doppelt[0].text).toContain('Stagebox 1')
+    expect(doppelt[0].text).toContain('Stagebox 2')
+  })
+
+  it('leert einen Zeiger ins Nichts NICHT still, sondern meldet ihn', () => {
+    const a = assessAssetIdentity(
+      eingabe({ equipment: [netz('e1', 'S', { inventoryUnitId: 'weg' })], units: [] }),
+    )
+    const f = a.findings.find((x) => x.kind === 'unit-missing')!
+    expect(f).toBeDefined()
+    expect(f.text).toMatch(/anderen Lagerdatenbank/)
+    // Und die Zeile traegt die Einheit weiter — sie ist eine Auskunft.
+    expect(a.rows[0].unitId).toBe('weg')
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('was das Lager dazu sagt', () => {
+  it('meldet eine Einheit, die nicht einsatzbereit ist — mit Modell', () => {
+    const a = assessAssetIdentity(
+      eingabe({
+        equipment: [netz('e1', 'Stagebox 1', { inventoryUnitId: 'u1' })],
+        units: [einheit('u1', 'SN-1', { condition: 'inRepair' })],
+        items: [artikel],
+      }),
+    )
+    const f = a.findings.find((x) => x.kind === 'unit-blocked')!
+    expect(f).toBeDefined()
+    expect(f.text).toContain('Stagebox 32')
+    expect(f.text).toContain('inRepair')
+  })
+
+  it('meldet eine Einheit, die auf keinem offenen Schein steht', () => {
+    const a = assessAssetIdentity(
+      eingabe({
+        equipment: [netz('e1', 'Stagebox 1', { inventoryUnitId: 'u1' })],
+        units: [einheit('u1', 'SN-1')],
+        checkouts: [schein(['u2'])],
+      }),
+    )
+    expect(a.findings.some((f) => f.kind === 'unit-not-issued')).toBe(true)
+  })
+
+  it('schweigt, wenn die Einheit auf dem offenen Schein steht', () => {
+    const a = assessAssetIdentity(
+      eingabe({
+        equipment: [netz('e1', 'Stagebox 1', { inventoryUnitId: 'u1' })],
+        units: [einheit('u1', 'SN-1')],
+        checkouts: [schein(['u1'])],
+      }),
+    )
+    expect(a.findings).toEqual([])
+  })
+
+  it('zaehlt einen GESCHLOSSENEN Vorgang nicht als Ausgabe', () => {
+    // Was zurueck ist, faehrt nicht mit.
+    const a = assessAssetIdentity(
+      eingabe({
+        equipment: [netz('e1', 'Stagebox 1', { inventoryUnitId: 'u1' })],
+        units: [einheit('u1', 'SN-1')],
+        checkouts: [schein(['u1'], true), schein(['u2'])],
+      }),
+    )
+    expect(a.findings.some((f) => f.kind === 'unit-not-issued')).toBe(true)
+  })
+
+  it('prueft die Ausgabe GAR NICHT, wenn es keinen offenen Vorgang gibt', () => {
+    // Ohne Lagerbetrieb waere das eine Warnung fuer jeden Platz — und damit
+    // eine Warnung fuer niemanden.
+    const a = assessAssetIdentity(
+      eingabe({
+        equipment: [netz('e1', 'Stagebox 1', { inventoryUnitId: 'u1' })],
+        units: [einheit('u1', 'SN-1')],
+        checkouts: [schein(['u2'], true)],
+      }),
+    )
+    expect(a.findings).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('das Blatt, mit dem jemand vor dem Rack steht', () => {
+  it('traegt BEIDE Seriennummern — sonst kann man nicht vergleichen', () => {
+    const a = assessAssetIdentity(
+      eingabe({
+        equipment: [netz('e1', 'Stagebox 1', { inventoryUnitId: 'u1', serialNumber: 'SN-2' })],
+        units: [einheit('u1', 'SN-1')],
+      }),
+    )
+    const t = assetIdentityTable(a)
+    expect(t.headers).toEqual([
+      'Platz',
+      'Anker',
+      'Einheit',
+      'Serie (Einheit)',
+      'Serie (Platz)',
+      'Befund',
+    ])
+    expect(t.rows[0][3]).toBe('SN-1')
+    expect(t.rows[0][4]).toBe('SN-2')
+    expect(t.rows[0][5]).toContain('Seriennummer')
+  })
+
+  it('schreibt „nicht benannt" statt einer leeren Zelle', () => {
+    const t = assetIdentityTable(assessAssetIdentity(eingabe({ equipment: [netz('e1', 'S')] })))
+    expect(t.rows[0][2]).toBe('nicht benannt')
+  })
+
+  it('fuehrt keine Zeile fuer Plaetze ohne Anker', () => {
+    const t = assetIdentityTable(
+      assessAssetIdentity(eingabe({ equipment: [netz('e1', 'S'), geraet('s', 'Stativ')] })),
+    )
+    expect(t.rows).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('Erreichbarkeit und Einordnung des neuen Feldes', () => {
+  it('ist eine INSTANZ-Eigenschaft, nicht eine des Modells', () => {
+    // In einem Template getragen zeigten zwei Plaetze auf dieselbe Kiste --
+    // genau der Befund `unit-double`, nur diesmal vom Werkzeug erzeugt.
+    expect(INSTANCE_FIELDS as readonly string[]).toContain('inventoryUnitId')
+  })
+
+  it('ist im Plan-Diff SUBSTANTIELL, nicht kosmetisch', () => {
+    // Wer sie aendert, hat getauscht. Ein Diff, der das schluckt, verschweigt
+    // genau die Aenderung, deretwegen das Feld existiert.
+    expect(diffQuelle).toContain("inventoryUnitId: 'substantive'")
+  })
+
+  it('steht als Auswahl neben der Seriennummer — und nur bei Anker', () => {
+    expect(sectionQuelle).toContain('const anchors = identityAnchors(equipment)')
+    expect(sectionQuelle).toMatch(/\{anchors\.length > 0 && \(/)
+    expect(sectionQuelle).toMatch(
+      /updateEquipment\(equipment\.id, \{\n\s*inventoryUnitId: event\.target\.value \|\| undefined,\n\s*\}\)/,
+    )
+  })
+
+  it('sagt an der leeren Auswahl, warum sie zaehlt', () => {
+    expect(sectionQuelle).toMatch(/\{!equipment\.inventoryUnitId && \(/)
+    expect(sectionQuelle).toContain("t(\n                  'eq.field.unitHint',")
+  })
+
+  it('steht als Befundliste im Netzwerk-Reiter der Analyse', () => {
+    expect(analyseQuelle).toContain('assessAssetIdentity({')
+    expect(analyseQuelle).toContain('{asset.hasAnchored && (')
+    // Die BEDINGUNG und das Etikett zusammen, nicht das Etikett allein: eine
+    // Gegenprobe, die nur den Wahrheitswert des `&&` umlegt, liess das
+    // Etikett im Quelltext stehen — die Liste wurde nie gerendert und nichts
+    // wurde rot.
+    expect(analyseQuelle).toMatch(
+      /\{asset\.findings\.length > 0 && \([\s\S]{0,400}ASSET_FINDING_LABEL\[f\.kind\]/,
+    )
+  })
+
+  it('LIEST Bestand und Scheine nur, statt sie ins Projekt zu kopieren', () => {
+    // Dieselbe Kiste faehrt auf mehreren Shows; sie ins Projektfile zu
+    // kopieren waere eine zweite Wahrheit ueber den Lagerbestand.
+    expect(analyseQuelle).toContain('const invUnits = useInventoryStore((st) => st.units)')
+    expect(analyseQuelle).toContain('const checkouts = useCheckoutStore((st) => st.records)')
+    expect(analyseQuelle).not.toContain('setInventory')
+  })
+
+  it('hat fuer jeden neuen Text einen EN-Eintrag', () => {
+    for (const key of [
+      'analysis.asset.title',
+      'analysis.asset.intro',
+      'analysis.asset.export',
+      'analysis.asset.none',
+      'eq.field.unit',
+      'eq.field.unitNone',
+      'eq.field.unitHint',
+    ]) {
+      expect(dictsQuelle).toContain(`'${key}'`)
+    }
+  })
+})


### PR DESCRIPTION
**Bedarf 78 (P2)** — „Link the rental/inventory asset to its network identity."

> The rental system knows serial numbers and barcodes; the IP plan knows hostnames and addresses. A last-minute substitution of one identical stagebox for another is **invisible to both** the IP plan and the Dante subscription set, and only surfaces as a fault during rehearsal.

## Warum der Tausch unsichtbar ist

Zwei baugleiche Stageboxen sind **im Plan** dasselbe Kästchen. **Im Lager** sind sie zwei Einheiten mit zwei Seriennummern. **Im Netz** sind sie zwei verschiedene Geräte: jede trägt ihren eigenen eingebrannten Dante-Namen und ihre eigene MAC.

Wer am Ladetag die eine gegen die andere tauscht, tauscht damit auch den Namen, auf den jedes Abonnement zeigt, und die MAC, auf die DHCP-Reservierung und Switch-Port-Filter ausgestellt sind. Nichts davon fällt beim Aufbau auf — es fällt in der Probe auf, wenn ein Kanal stumm bleibt.

## Gebaut

- **`EquipmentItem.inventoryUnitId`** (neu) — welche Einheit diesen Platz füllt. Optional und das bleibt es: die meisten Plätze sind kein Netz-Gerät. `serialNumber` daneben bleibt, wo es ist — es ist Freitext, den jemand abgetippt hat, und die beiden gegeneinander zu halten ist genau der Befund, den der Bedarf will.
- **`lib/assetIdentity.ts`** (neu) mit `identityAnchors` und sechs Befunden. Betroffen ist **nur**, wo eine Netz-Identität hängt (IP, MAC, Geräte-Name bei vorhandener Schnittstelle, PTP-Domäne). Ein Stativ hat keinen eingebrannten Namen; es mitzumelden hieße, den halben Plan zu melden und die echten Fälle darunter zu begraben.

| Befund | |
|---|---|
| `unit-unnamed` | der Fall aus dem Bedarf — und der Text nennt die **Folge**, nicht nur die Lücke |
| `serial-mismatch` | der Tausch, gefangen an den beiden Seriennummern |
| `unit-double` | eine Kiste steht an einem Ort; einer der Plätze führt einen Rest von gestern |
| `unit-missing` | Zeiger ins Nichts — gemeldet, nicht still geleert |
| `unit-blocked` | die Einheit steht in der Werkstatt |
| `unit-not-issued` | steht auf keinem offenen Ausgabeschein (geprüft nur, wenn es überhaupt einen gibt) |

## Was der Plan nicht weiß

**Welche Kiste im Rack steht.** Kein Befund behauptet, dass getauscht wurde — jeder sagt, dass zwei *Aufzeichnungen* auseinandergehen. Der Unterschied ist praktisch: eine Behauptung über die Wirklichkeit müsste jemand prüfen gehen, ein Widerspruch zwischen zwei Listen lässt sich am Schreibtisch auflösen.

Bestand und Ausgabescheine werden nur **gelesen** (`inventoryStore`, `checkoutStore`). Sie ins Projektfile zu kopieren wäre eine zweite Wahrheit über den Lagerbestand — dieselbe Kiste fährt auf mehreren Shows.

## Zwei bestehende Guards haben das neue Feld sofort eingefordert

Und beide hatten recht:

- **`modelFields`** → Instanz. In einem Template getragen zeigten zwei Plätze auf dieselbe Kiste — genau der Befund `unit-double`, nur diesmal vom Werkzeug erzeugt.
- **`planDiff`** → substantiell. Wer es ändert, hat getauscht; ein Diff, der das schluckt, verschweigt genau die Änderung, deretwegen das Feld existiert.

## Geprüft

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 141 Testdateien, 1794 Tests grün (2 skipped); 28 neue
- `npx eslint .` — 0 Fehler
- **31 Gegenproben, alle rot.** Eine echte Lücke dabei gefunden: der Analyse-Guard prüfte `ASSET_FINDING_LABEL[f.kind]` allein und blieb grün, als die Befundliste nie gerendert wurde. Jetzt Bedingung und Etikett zusammen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_