### PR TITLE
übergabe: woraus nächstes Jahr geplant wird (Bedarf 84)

### DIFF
--- a/src/renderer/components/Export/InstallationDocsDialog.tsx
+++ b/src/renderer/components/Export/InstallationDocsDialog.tsx
@@ -46,6 +46,11 @@ import {
 import { assetRegisterCsv, assetRegisterTable } from '../../lib/assetRegister'
 import { stampForRows } from '../../lib/documentStamp'
 import { buildHandoverManifest, handoverTable } from '../../lib/handoverPackage'
+import {
+  JOB_BASIS_LABEL,
+  JOB_FINDING_LABEL,
+  assessJobHandover,
+} from '../../lib/jobHandover'
 import { cableLabelId, equipmentAssetTag, qrPayload } from '../../lib/docIds'
 
 type ExportRow = {
@@ -73,6 +78,11 @@ export const InstallationDocsDialog = () => {
   const [busy, setBusy] = useState(false)
   const [info, setInfo] = useState('')
   const [overwriteLabels, setOverwriteLabels] = useState(false)
+
+  // BEDARF 84 — woraus naechstes Jahr geplant wuerde. Steht GANZ OBEN in
+  // diesem Dialog: hier wird die Uebergabe gebaut, und wer sie baut, muss
+  // wissen, ob sie den Bauzustand oder das Angebot traegt.
+  const job = useMemo(() => assessJobHandover(project), [project])
 
   const baseName = project.metadata.name || 'anlage'
 
@@ -284,6 +294,47 @@ export const InstallationDocsDialog = () => {
       draggableKey="cable-planner:modal-pos:install-docs"
     >
       <div className="space-y-4 text-cp-sm">
+        {/* BEDARF 84 — die Grundlage. „Next year the same event is re-planned
+            from the QUOTE, not from what was actually built." Der Zustand
+            steht vor allem anderen, weil er über den Wert des ganzen Pakets
+            entscheidet. */}
+        <section
+          className={`rounded border p-3 ${
+            job.basis === 'as-built'
+              ? 'border-cp-border bg-cp-surface-2/40'
+              : 'border-amber-500/40 bg-amber-500/5'
+          }`}
+        >
+          <div className="mb-1 flex flex-wrap items-baseline gap-2">
+            <span className="font-medium text-cp-text">
+              {t('docs.job.title', 'Grundlage dieser Übergabe')}
+            </span>
+            <span
+              className={
+                job.basis === 'as-built' ? 'text-cp-text-secondary' : 'text-amber-300/90'
+              }
+            >
+              {JOB_BASIS_LABEL[job.basis]}
+              {job.asBuilt ? ` — ${job.asBuilt.label}` : ''}
+            </span>
+          </div>
+          <p className="text-cp-xs text-cp-text-muted">
+            {t(
+              'docs.job.intro',
+              'Nächstes Jahr wird dieselbe Veranstaltung aus dieser Datei geplant. Trägt sie den Plan von vor dem Aufbau, wird jede Änderung vor Ort ein zweites Mal gefunden.',
+            )}
+          </p>
+          {job.findings.length > 0 && (
+            <ul className="mt-2 flex flex-col gap-1">
+              {job.findings.map((f) => (
+                <li key={f.kind} className="text-cp-xs text-amber-300/90">
+                  <strong>{JOB_FINDING_LABEL[f.kind]}</strong> — {f.text}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
         {/* Bearbeiter-Identität */}
         <section className="rounded border border-cp-border bg-cp-surface-2/40 p-3">
           <label className="block">

--- a/src/renderer/components/Project/TemplatesDialog.tsx
+++ b/src/renderer/components/Project/TemplatesDialog.tsx
@@ -32,6 +32,7 @@ import {
   type TemplateScope,
 } from '../../lib/templateScope'
 import { venueScopeDialog } from '../../lib/venueScopeDialog'
+import { JOB_BASIS_LABEL } from '../../lib/jobHandover'
 
 export const TemplatesDialog = () => {
   const t = useTranslation()
@@ -161,6 +162,23 @@ export const TemplatesDialog = () => {
           {format(t('templates.venue', 'Haus-Vorlage: {venue} · {n} Antworten'), {
             venue: tpl.venue,
             n: tpl.project.metadata?.venueAnswers?.length ?? 0,
+          })}
+        </div>
+      )}
+      {/* BEDARF 84 — woraus die Vorlage gemacht wurde. Steht auf der Karte,
+          weil es hier über ihren Wert entscheidet: eine aus dem Angebot
+          gemachte Vorlage bringt nächstes Jahr genau die Fixes NICHT mit, um
+          derentwillen jemand sie aufmacht. */}
+      {tpl.basis && (
+        <div
+          className={`text-[10px] ${
+            tpl.basis === 'as-built'
+              ? 'text-[var(--cp-text-muted)]'
+              : 'text-amber-300/90'
+          }`}
+        >
+          {format(t('templates.basis', 'Grundlage: {basis}'), {
+            basis: JOB_BASIS_LABEL[tpl.basis],
           })}
         </div>
       )}

--- a/src/renderer/lib/documentRegistry.ts
+++ b/src/renderer/lib/documentRegistry.ts
@@ -151,6 +151,18 @@ export const UNJUDGEABLE_DOCUMENTS: Record<string, string> = {
   stueckliste:
     'Der Inhalt hängt am Lagerbestand, der projektübergreifend lebt und nicht ' +
     'im Plan steht — dieselbe Liste ergibt morgen ein anderes Ergebnis.',
+  // Bedarf 84 — die Grundlage der Übergabe. Der erste Wurf trug sie in
+  // `DOCUMENT_STANDS`, und der Guard „keine Dokument-Ableitung hängt an der
+  // Revisionsliste" hat das sofort gefangen — zu Recht: der Revisions-Vergleich
+  // spannt einen Snapshot mit `revisions: []` auf, und ein revisions-abhängiger
+  // Stand meldete danach JEDES Blatt als überholt, nur weil die Liste leer ist.
+  // Eine erfundene Abweichung ist derselbe Schaden wie ein erfundener Zustand
+  // (ADR-003). Dieselbe Begründung, aus der `buildHandoverManifest` seit jeher
+  // draußen steht.
+  'job-grundlage':
+    'Der Zustand hängt an der Revisionsliste (As-Built). Der Revisions-Vergleich ' +
+    'spannt Snapshots ohne diese Liste auf — ein Stand daraus meldete jedes Blatt ' +
+    'als überholt, obwohl sich nichts geändert hat.',
 }
 
 /** Lesbarer Name eines Dokument-Bezeichners für Meldungen. */
@@ -171,6 +183,7 @@ export const DOCUMENT_LABELS: Record<string, string> = {
   'spektrum-plan': 'Spektrum-Plan',
   'multicast-plan': 'Multicast-Adressplan',
   'ausweich-plan': 'Ausweich-Plan (Sicherheitsnetz)',
+  'job-grundlage': 'Grundlage der Übergabe',
   'videohub-labels': 'Videohub-Labels',
   'atem-mv-layout': 'Multiviewer-Layout',
   'switch-port-karte': 'Switch-Port-Karte',

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -4255,6 +4255,11 @@ export const en: Dict = {
   'analysis.crew.title': 'Network briefing sheet for the crew',
   'analysis.crew.ask': '{n} points to settle on site',
   'analysis.crew.export': 'Crew network sheet',
+  // Bedarf 84 — woraus naechstes Jahr geplant wuerde.
+  'docs.job.title': 'Basis of this handover',
+  'docs.job.intro':
+    'Next year the same event will be planned from this file. If it carries the plan from before load-in, every on-site change gets rediscovered.',
+  'templates.basis': 'Basis: {basis}',
   // Bedarf 78 — welche Kiste welchen Platz fuellt.
   'analysis.asset.title': 'Which box fills which slot',
   'analysis.asset.intro':

--- a/src/renderer/lib/jobHandover.ts
+++ b/src/renderer/lib/jobHandover.ts
@@ -1,0 +1,173 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Woraus naechstes Jahr geplant wird (Bedarf 84, P2).
+//
+//   > Show files on USB sticks, photos in WhatsApp, marked-up plans in a skip.
+//   > Next year the same event is re-planned from the QUOTE, not from what was
+//   > actually built, and every on-site fix is rediscovered. For freelance PMs
+//   > the whole job lives in one head.
+//
+// ─── DIE DATEI GAB ES SCHON. IHR STAND WAR DIE FRAGE ───────────────────────
+//
+// Der Planer hat die Uebergabe-Datei laengst: die `.avplan` ist verlustfrei
+// (ADR-005), und `handoverPackage.ts` baut daraus ein Closeout-Paket fuer den
+// Betreiber einer Festinstallation. Was fehlte, ist der Satz, den der Bedarf
+// woertlich sagt: das Naechste-Jahr-Problem ist nicht, dass keine Datei da
+// waere — es ist, dass die Datei den ANGEBOTSSTAND traegt und aussieht wie der
+// Bauzustand.
+//
+// Der Planer kennt beide: `ProjectRevision.asBuilt` ist die Festschreibung
+// „so wurde es gebaut", und `planDiff` sagt, was sich seither geaendert hat.
+// Aus beidem folgt ein Zustand mit drei Namen, und der ist die ganze Auskunft.
+//
+// ─── DIE DREI ZUSTAENDE ────────────────────────────────────────────────────
+//
+// `as-quoted`  Kein As-Built festgeschrieben. Was hier steht, ist der Plan --
+//              also im Zweifel das Angebot. Genau der Ausgangspunkt, den der
+//              Bedarf beklagt.
+// `drifted`    Ein As-Built liegt vor, aber der Plan ist seither
+//              SUBSTANTIELL weitergezogen. Das ist der teuerste Zustand: das
+//              Blatt traegt das Wort „As-Built" und stimmt nicht mehr.
+// `as-built`   Ein As-Built liegt vor, und seither hat sich nichts
+//              Substantielles geaendert.
+//
+// „Substantiell" ist nicht selbst gerechnet, sondern kommt aus `planDiff`
+// (ADR-005, Design-Frage 2): eine verschobene Position ist kein Bauzustand,
+// ein umgestecktes Kabel schon. Zwei Vorstellungen davon, was zaehlt, waeren
+// hier besonders teuer — die eine faerbte das Blatt, die andere den Diff.
+//
+// ─── WAS DIESE DATEI NICHT TUT ─────────────────────────────────────────────
+//
+// Sie schreibt kein As-Built fest. Das ist eine Aussage ueber die Wirklichkeit
+// und gehoert einem Menschen, der vor dem Aufbau gestanden hat. Sie sagt nur,
+// ob eine da ist und ob sie noch gilt.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { CablePlannerProject, ProjectRevision } from '../types/project'
+import type { CsvTable } from './csv'
+import { planDiff } from './planDiff'
+
+export type JobBasis = 'as-built' | 'drifted' | 'as-quoted'
+
+export const JOB_BASIS_LABEL: Readonly<Record<JobBasis, string>> = {
+  'as-built': 'Wie gebaut',
+  drifted: 'As-Built veraltet',
+  'as-quoted': 'Wie geplant (kein As-Built)',
+}
+
+export type JobHandoverFindingKind =
+  | 'no-as-built'
+  | 'as-built-stale'
+  | 'open-questions'
+  | 'unbuilt-notes'
+  | 'no-venue'
+
+export const JOB_FINDING_LABEL: Readonly<Record<JobHandoverFindingKind, string>> = {
+  'no-as-built': 'Kein As-Built festgeschrieben',
+  'as-built-stale': 'Das As-Built ist überholt',
+  'open-questions': 'Fragen ans Haus stehen offen',
+  'unbuilt-notes': 'Offene Anmerkungen im Plan',
+  'no-venue': 'Kein Ort genannt',
+}
+
+export interface JobHandoverFinding {
+  kind: JobHandoverFindingKind
+  text: string
+}
+
+export interface JobHandover {
+  basis: JobBasis
+  /** Die juengste As-Built-Revision, wenn es eine gibt. */
+  asBuilt?: ProjectRevision
+  /** Wie viele substantielle Aenderungen seit dem As-Built. 0 bei `as-built`. */
+  changedSince: number
+  findings: JobHandoverFinding[]
+}
+
+/** Die juengste As-Built-Revision — nach `createdAt`, sonst nach Reihenfolge. */
+export function latestAsBuilt(project: CablePlannerProject): ProjectRevision | undefined {
+  const alle = (project.revisions ?? []).filter((r) => r.asBuilt)
+  if (alle.length === 0) return undefined
+  return [...alle].sort((a, b) => (a.createdAt ?? '').localeCompare(b.createdAt ?? '')).at(-1)
+}
+
+/**
+ * Woraus naechstes Jahr geplant wuerde, wenn jemand DIESE Datei aufmacht.
+ */
+export function assessJobHandover(project: CablePlannerProject): JobHandover {
+  const asBuilt = latestAsBuilt(project)
+  const findings: JobHandoverFinding[] = []
+
+  let basis: JobBasis = 'as-quoted'
+  let changedSince = 0
+  if (asBuilt) {
+    // Die Revision haelt den Plan OHNE `revisions`. Beide Seiten werden auf
+    // dieselbe Form gebracht, damit der Vergleich nicht an der Liste selbst
+    // haengt -- sie ist kein Bauzustand.
+    //
+    // EHRLICH GESAGT ist das heute wirkungslos, und die Gegenprobe hat es
+    // gezeigt: `planDiff.substantive` zaehlt nur Entitaets-Aenderungen und
+    // Zu-/Abgaenge, nicht die `sections`, in denen ein abweichendes
+    // `revisions` landen wuerde. Die Zeile bleibt trotzdem stehen: sie kostet
+    // nichts und haelt die Absicht fest, falls `substantive` je die Sektionen
+    // mitzaehlt. Was sie NICHT tut, ist ein Test behaupten.
+    const vorher = { ...asBuilt.snapshot, revisions: [] } as CablePlannerProject
+    const nachher = { ...project, revisions: [] } as CablePlannerProject
+    changedSince = planDiff(vorher, nachher).substantive
+    basis = changedSince > 0 ? 'drifted' : 'as-built'
+  }
+
+  if (!asBuilt) {
+    findings.push({
+      kind: 'no-as-built',
+      text: 'Es ist nichts als „wie gebaut" festgeschrieben. Wer diese Datei nächstes Jahr öffnet, plant aus dem Stand, der vor dem Aufbau da war — also aus dem Angebot, und jede Änderung vor Ort wird ein zweites Mal gefunden.',
+    })
+  } else if (changedSince > 0) {
+    findings.push({
+      kind: 'as-built-stale',
+      text: `Seit „${asBuilt.label}" haben sich ${changedSince} Dinge substantiell geändert. Das Blatt trägt das Wort „As-Built" und stimmt nicht mehr — das ist teurer als gar keines, weil niemand nachfragt.`,
+    })
+  }
+
+  const offen = (project.metadata?.venueAnswers ?? []).filter((a) => a.status === 'pending')
+  if (offen.length > 0) {
+    findings.push({
+      kind: 'open-questions',
+      text: `${offen.length} Frage(n) ans Haus sind ohne Antwort geblieben. Genau die werden nächstes Jahr ein zweites Mal gestellt — an dieselbe IT-Abteilung.`,
+    })
+  }
+
+  const notizen = (project.annotations ?? []).filter((a) => a.status === 'open')
+  if (notizen.length > 0) {
+    findings.push({
+      kind: 'unbuilt-notes',
+      text: `${notizen.length} Anmerkung(en) stehen noch auf „offen". Solange sie das tun, ist unklar, ob der Punkt gebaut, verworfen oder vergessen wurde.`,
+    })
+  }
+
+  if (!project.metadata?.siteAddress?.trim()) {
+    findings.push({
+      kind: 'no-venue',
+      text: 'Der Plan nennt keinen Ort. Ohne ihn lässt sich diese Datei nächstes Jahr nicht dem Haus zuordnen, und die Antworten der Haus-IT gelten nirgends (Bedarf 85, 91).',
+    })
+  }
+
+  return { basis, ...(asBuilt ? { asBuilt } : {}), changedSince, findings }
+}
+
+/** Das Blatt: der Zustand in einer Zeile, die Befunde darunter. */
+export function jobHandoverTable(project: CablePlannerProject): CsvTable {
+  const a = assessJobHandover(project)
+  return {
+    headers: ['Grundlage', 'As-Built', 'Änderungen seither', 'Befund'],
+    rows: [
+      [
+        JOB_BASIS_LABEL[a.basis],
+        a.asBuilt ? `${a.asBuilt.label} (${a.asBuilt.createdAt})` : 'keins',
+        a.changedSince,
+        a.findings.map((f) => JOB_FINDING_LABEL[f.kind]).join('; '),
+      ],
+    ],
+  }
+}

--- a/src/renderer/lib/projectTemplates.ts
+++ b/src/renderer/lib/projectTemplates.ts
@@ -11,6 +11,7 @@ import { v4 as uuidv4 } from 'uuid'
 import type { CablePlannerProject } from '../types/project'
 import type { LocationFrame } from '../types/location'
 import { stripForTemplate, projectVenue, type TemplateScope } from './templateScope'
+import { assessJobHandover, type JobBasis } from './jobHandover'
 
 export interface ProjectTemplate {
   id: string
@@ -32,6 +33,20 @@ export interface ProjectTemplate {
    * können, aus welchem Haus die Antworten kommen.
    */
   venue?: string
+  /**
+   * BEDARF 84 — woraus diese Vorlage gemacht wurde: aus dem Bauzustand oder
+   * aus dem Plan von vorher.
+   *
+   * **Beim Schreiben eingefroren**, wie `VenueAnswer.venue` (Bedarf 85). Das
+   * Quell-Projekt zieht weiter; die Vorlage nicht. Sie später aus dem
+   * mitkopierten Stand zu berechnen ergäbe eine Auskunft über einen Plan, den
+   * niemand mehr aufmacht.
+   *
+   * Der Bedarf sagt es wörtlich: „next year the same event is re-planned from
+   * the QUOTE, not from what was actually built". Wenn das passiert, soll es
+   * wenigstens draufstehen.
+   */
+  basis?: JobBasis
   project: CablePlannerProject
 }
 
@@ -213,12 +228,17 @@ export const saveUserTemplate = (
   delete clone.metadata.rentmanCableMap
 
   const venue = scope === 'venue' ? projectVenue(project) : undefined
+  // Bedarf 84 — aus dem QUELL-Projekt gelesen, nicht aus der Kopie: `clone`
+  // hat die Revisionen bereits verloren (sie sind die Geschichte einer
+  // anderen Show), und ohne sie waere jede Vorlage „wie geplant".
+  const basis = assessJobHandover(project).basis
   const tpl: ProjectTemplate = {
     id: `user-${uuidv4()}`,
     name,
     description,
     builtin: false,
     ...(venue ? { venue } : {}),
+    basis,
     project: clone,
   }
   const next = [...loadUserTemplates(), tpl]

--- a/tests/jobHandover.test.ts
+++ b/tests/jobHandover.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import {
+  JOB_BASIS_LABEL,
+  JOB_FINDING_LABEL,
+  assessJobHandover,
+  jobHandoverTable,
+  latestAsBuilt,
+} from '../src/renderer/lib/jobHandover'
+import {
+  DOCUMENT_STANDS,
+  UNJUDGEABLE_DOCUMENTS,
+} from '../src/renderer/lib/documentRegistry'
+import { saveUserTemplate } from '../src/renderer/lib/projectTemplates'
+import type { CablePlannerProject, ProjectRevision } from '../src/renderer/types/project'
+import docsQuelle from '../src/renderer/components/Export/InstallationDocsDialog.tsx?raw'
+import tplDialogQuelle from '../src/renderer/components/Project/TemplatesDialog.tsx?raw'
+import tplQuelle from '../src/renderer/lib/projectTemplates.ts?raw'
+import dictsQuelle from '../src/renderer/lib/i18n/dicts.ts?raw'
+
+// ---------------------------------------------------------------------------
+// Woraus naechstes Jahr geplant wird (Bedarf 84, P2).
+//
+//   > Show files on USB sticks, photos in WhatsApp, marked-up plans in a skip.
+//   > Next year the same event is re-planned from the QUOTE, not from what was
+//   > actually built, and every on-site fix is rediscovered.
+//
+// Die Datei gab es schon — die `.avplan` ist verlustfrei (ADR-005). Was
+// fehlte, ist der Satz, den der Bedarf woertlich sagt: sie traegt den
+// ANGEBOTSSTAND und sieht aus wie der Bauzustand.
+// ---------------------------------------------------------------------------
+
+const geraet = (id: string, name: string, over: Record<string, unknown> = {}) =>
+  ({ id, name, x: 0, y: 0, inputs: [], outputs: [], ...over }) as never
+
+const projekt = (over: Partial<CablePlannerProject> = {}): CablePlannerProject =>
+  ({
+    metadata: { name: 'Show', description: '', siteAddress: 'Halle A' },
+    equipment: [],
+    cables: [],
+    locations: [],
+    ...over,
+  }) as never
+
+const revision = (
+  label: string,
+  asBuilt: boolean,
+  snapshot: CablePlannerProject,
+  createdAt = '2026-01-01T00:00:00.000Z',
+): ProjectRevision =>
+  ({ id: `rev-${label}`, label, note: '', createdAt, asBuilt, snapshot }) as never
+
+// ---------------------------------------------------------------------------
+describe('die drei Zustaende', () => {
+  it('meldet ohne As-Built „wie geplant" — der Fall aus dem Bedarf', () => {
+    const a = assessJobHandover(projekt())
+    expect(a.basis).toBe('as-quoted')
+    expect(a.asBuilt).toBeUndefined()
+    expect(a.findings.some((f) => f.kind === 'no-as-built')).toBe(true)
+  })
+
+  it('NENNT DIE FOLGE: jede Aenderung vor Ort wird ein zweites Mal gefunden', () => {
+    const f = assessJobHandover(projekt()).findings.find((x) => x.kind === 'no-as-built')!
+    expect(f.text).toMatch(/Angebot/)
+    expect(f.text).toMatch(/zweites Mal/)
+  })
+
+  it('meldet ein unveraendertes As-Built als „wie gebaut"', () => {
+    const stand = projekt({ equipment: [geraet('e1', 'Kamera 1')] })
+    const p = { ...stand, revisions: [revision('As-Built', true, stand)] } as CablePlannerProject
+    const a = assessJobHandover(p)
+    expect(a.basis).toBe('as-built')
+    expect(a.changedSince).toBe(0)
+    expect(a.findings.some((f) => f.kind === 'as-built-stale')).toBe(false)
+  })
+
+  it('MELDET EIN UEBERHOLTES As-Built — der teuerste Zustand', () => {
+    // Das Blatt traegt das Wort „As-Built" und stimmt nicht mehr. Teurer als
+    // gar keines, weil niemand nachfragt.
+    const stand = projekt({ equipment: [geraet('e1', 'Kamera 1')] })
+    const p = {
+      ...stand,
+      equipment: [geraet('e1', 'Kamera 1'), geraet('e2', 'Kamera 2')],
+      revisions: [revision('As-Built', true, stand)],
+    } as CablePlannerProject
+    const a = assessJobHandover(p)
+    expect(a.basis).toBe('drifted')
+    expect(a.changedSince).toBeGreaterThan(0)
+    const f = a.findings.find((x) => x.kind === 'as-built-stale')!
+    expect(f.text).toContain('As-Built')
+    expect(f.text).toMatch(/niemand nachfragt/)
+  })
+
+  it('nimmt NUR substantielle Aenderungen — eine verschobene Position ist kein Bauzustand', () => {
+    // „Substantiell" kommt aus `planDiff` (ADR-005, Design-Frage 2). Zwei
+    // Vorstellungen davon, was zaehlt, waeren hier besonders teuer.
+    const stand = projekt({ equipment: [geraet('e1', 'Kamera 1', { x: 0, y: 0 })] })
+    const p = {
+      ...stand,
+      equipment: [geraet('e1', 'Kamera 1', { x: 500, y: 300 })],
+      revisions: [revision('As-Built', true, stand)],
+    } as CablePlannerProject
+    expect(assessJobHandover(p).basis).toBe('as-built')
+  })
+
+  it('ignoriert eine Revision, die KEIN As-Built ist', () => {
+    const stand = projekt()
+    const p = { ...stand, revisions: [revision('Rev A', false, stand)] } as CablePlannerProject
+    expect(assessJobHandover(p).basis).toBe('as-quoted')
+  })
+
+  it('nimmt die JUENGSTE As-Built-Revision', () => {
+    const alt = projekt({ equipment: [geraet('e1', 'A')] })
+    const neu = projekt({ equipment: [geraet('e1', 'A'), geraet('e2', 'B')] })
+    const p = {
+      ...neu,
+      revisions: [
+        revision('Alt', true, alt, '2026-01-01T00:00:00.000Z'),
+        revision('Neu', true, neu, '2026-06-01T00:00:00.000Z'),
+      ],
+    } as CablePlannerProject
+    expect(latestAsBuilt(p)?.label).toBe('Neu')
+    // Gegen die juengste gemessen ist nichts offen.
+    expect(assessJobHandover(p).basis).toBe('as-built')
+  })
+
+  it('meldet ein Projekt mit As-Built nicht allein wegen der Revisionsliste als ueberholt', () => {
+    // Der Snapshot fuehrt `revisions` per Typ nicht; das Projekt schon. Waere
+    // dieser Unterschied ein Bauzustand, meldete JEDES Projekt mit As-Built
+    // sofort „ueberholt".
+    //
+    // Diese Zusicherung haelt heute auch ohne die Normalisierung in
+    // `assessJobHandover`, weil `planDiff.substantive` die `sections` gar
+    // nicht mitzaehlt (Gegenprobe `drift-includes-revisions` blieb gruen).
+    // Der Test steht trotzdem hier: er sichert das ERGEBNIS, nicht den Weg.
+    const stand = projekt({ equipment: [geraet('e1', 'Kamera 1')] })
+    const p = { ...stand, revisions: [revision('As-Built', true, stand)] } as CablePlannerProject
+    expect(assessJobHandover(p).changedSince).toBe(0)
+  })
+
+  it('haelt die Etiketten kanonisch deutsch', () => {
+    expect(JOB_BASIS_LABEL['as-quoted']).toBe('Wie geplant (kein As-Built)')
+    expect(JOB_FINDING_LABEL['as-built-stale']).toBe('Das As-Built ist überholt')
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('was sonst naechstes Jahr fehlt', () => {
+  it('meldet offene Fragen ans Haus — die werden ein zweites Mal gestellt', () => {
+    const p = projekt({
+      metadata: {
+        name: 'x',
+        siteAddress: 'Halle A',
+        venueAnswers: [
+          { key: 'ports', status: 'pending' },
+          { key: 'vlan', status: 'granted' },
+        ],
+      },
+    } as never)
+    const f = assessJobHandover(p).findings.find((x) => x.kind === 'open-questions')!
+    expect(f).toBeDefined()
+    expect(f.text).toContain('1 Frage')
+    expect(f.text).toMatch(/zweites Mal/)
+  })
+
+  it('zaehlt eine beantwortete Frage NICHT als offen', () => {
+    const p = projekt({
+      metadata: { name: 'x', siteAddress: 'H', venueAnswers: [{ key: 'a', status: 'refused' }] },
+    } as never)
+    expect(assessJobHandover(p).findings.some((f) => f.kind === 'open-questions')).toBe(false)
+  })
+
+  it('meldet offene Anmerkungen — gebaut, verworfen oder vergessen ist unklar', () => {
+    const p = projekt({
+      annotations: [
+        { id: 'a1', author: 'x', createdAt: 'y', text: 'Kabel umlegen', status: 'open', anchor: { type: 'free', x: 0, y: 0 } },
+        { id: 'a2', author: 'x', createdAt: 'y', text: 'ok', status: 'built', anchor: { type: 'free', x: 0, y: 0 } },
+      ],
+    } as never)
+    const f = assessJobHandover(p).findings.find((x) => x.kind === 'unbuilt-notes')!
+    expect(f).toBeDefined()
+    expect(f.text).toContain('1 Anmerkung')
+  })
+
+  it('meldet einen fehlenden Ort und verweist auf die Haus-Antworten', () => {
+    const p = projekt({ metadata: { name: 'x' } } as never)
+    const f = assessJobHandover(p).findings.find((x) => x.kind === 'no-venue')!
+    expect(f).toBeDefined()
+    expect(f.text).toMatch(/85|91/)
+  })
+
+  it('meldet einen vorhandenen Ort nicht', () => {
+    expect(assessJobHandover(projekt()).findings.some((f) => f.kind === 'no-venue')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('das Blatt', () => {
+  it('nennt Grundlage, As-Built und die Zahl der Aenderungen', () => {
+    const stand = projekt({ equipment: [geraet('e1', 'A')] })
+    const p = {
+      ...stand,
+      equipment: [geraet('e1', 'A'), geraet('e2', 'B')],
+      revisions: [revision('As-Built', true, stand)],
+    } as CablePlannerProject
+    const t = jobHandoverTable(p)
+    expect(t.headers).toEqual(['Grundlage', 'As-Built', 'Änderungen seither', 'Befund'])
+    expect(t.rows[0][0]).toBe('As-Built veraltet')
+    expect(String(t.rows[0][1])).toContain('As-Built')
+    expect(Number(t.rows[0][2])).toBeGreaterThan(0)
+  })
+
+  it('schreibt „keins" statt einer leeren Zelle', () => {
+    expect(jobHandoverTable(projekt()).rows[0][1]).toBe('keins')
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('das Register: NICHT reproduzierbar, und das steht da', () => {
+  it('steht in UNJUDGEABLE_DOCUMENTS und NICHT in DOCUMENT_STANDS', () => {
+    // Der erste Wurf trug es in DOCUMENT_STANDS, und der Guard „keine
+    // Dokument-Ableitung haengt an der Revisionsliste" hat es gefangen: der
+    // Revisions-Vergleich spannt Snapshots ohne diese Liste auf, und ein
+    // revisions-abhaengiger Stand meldete danach JEDES Blatt als ueberholt.
+    expect(DOCUMENT_STANDS['job-grundlage']).toBeUndefined()
+    expect(UNJUDGEABLE_DOCUMENTS['job-grundlage']).toBeDefined()
+  })
+
+  it('nennt den Grund und nicht nur die Tatsache', () => {
+    expect(UNJUDGEABLE_DOCUMENTS['job-grundlage']).toMatch(/Revisionsliste/)
+    expect(UNJUDGEABLE_DOCUMENTS['job-grundlage']).toMatch(/als überholt/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('die Vorlage friert die Grundlage EIN', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('schreibt „wie geplant" an eine Vorlage ohne As-Built', () => {
+    const tpl = saveUserTemplate('Zweikamera', '', projekt(), 'neutral')
+    expect(tpl.basis).toBe('as-quoted')
+  })
+
+  it('schreibt „wie gebaut", wenn eines vorliegt', () => {
+    const stand = projekt({ equipment: [geraet('e1', 'A')] })
+    const p = { ...stand, revisions: [revision('As-Built', true, stand)] } as CablePlannerProject
+    expect(saveUserTemplate('Halle A', '', p, 'venue').basis).toBe('as-built')
+  })
+
+  it('LIEST AUS DEM QUELL-PROJEKT, nicht aus der gestrippten Kopie', () => {
+    // Die Kopie hat die Revisionen verloren (Geschichte einer anderen Show).
+    // Aus ihr gelesen waere JEDE Vorlage „wie geplant" — die Auskunft waere
+    // immer dieselbe und damit keine.
+    const stand = projekt({ equipment: [geraet('e1', 'A')] })
+    const p = { ...stand, revisions: [revision('As-Built', true, stand)] } as CablePlannerProject
+    const tpl = saveUserTemplate('X', '', p, 'venue')
+    expect(tpl.basis).toBe('as-built')
+    expect(tpl.project.revisions).toBeUndefined()
+    expect(tplQuelle).toContain('const basis = assessJobHandover(project).basis')
+  })
+
+  it('friert ein: das Quell-Projekt zieht weiter, die Vorlage nicht', () => {
+    const stand = projekt({ equipment: [geraet('e1', 'A')] })
+    const p = { ...stand, revisions: [revision('As-Built', true, stand)] } as CablePlannerProject
+    const tpl = saveUserTemplate('X', '', p, 'venue')
+    // Das Projekt zieht weiter — die gespeicherte Vorlage bleibt, was sie war.
+    p.equipment = [geraet('e1', 'A'), geraet('e2', 'B')]
+    expect(assessJobHandover(p).basis).toBe('drifted')
+    expect(tpl.basis).toBe('as-built')
+  })
+})
+
+// ---------------------------------------------------------------------------
+describe('Erreichbarkeit', () => {
+  it('steht GANZ OBEN im Uebergabe-Dialog, vor allem anderen', () => {
+    // Wer die Uebergabe baut, muss wissen, ob sie den Bauzustand traegt.
+    //
+    // Als REIHENFOLGE gepruefet, nicht als Nachbarschaft: eine Regex mit
+    // Abstandsfenster blieb gruen, als der Abschnitt nur verschoben wurde
+    // (Gegenprobe `ui-docs-section-moved`). Positionen vergleichen faengt das.
+    expect(docsQuelle).toContain('assessJobHandover(project)')
+    const grundlage = docsQuelle.indexOf("t('docs.job.title'")
+    const bearbeiter = docsQuelle.indexOf('{/* Bearbeiter-Identität */}')
+    const exporte = docsQuelle.indexOf('{/* Listen / Exporte */}')
+    expect(grundlage).toBeGreaterThan(-1)
+    expect(bearbeiter).toBeGreaterThan(-1)
+    expect(exporte).toBeGreaterThan(-1)
+    expect(grundlage).toBeLessThan(bearbeiter)
+    expect(grundlage).toBeLessThan(exporte)
+  })
+
+  it('faerbt den Kasten, wenn die Grundlage NICHT der Bauzustand ist', () => {
+    expect(docsQuelle).toMatch(/job\.basis === 'as-built'\n\s*\? 'border-cp-border/)
+  })
+
+  it('zeigt die Befunde und nicht nur das Etikett', () => {
+    expect(docsQuelle).toMatch(
+      /\{job\.findings\.length > 0 && \([\s\S]{0,600}JOB_FINDING_LABEL\[f\.kind\]/,
+    )
+  })
+
+  it('zeigt die Grundlage auf der Vorlagen-Karte', () => {
+    expect(tplDialogQuelle).toMatch(/\{tpl\.basis && \(/)
+    expect(tplDialogQuelle).toContain("t('templates.basis'")
+    expect(tplDialogQuelle).toContain('JOB_BASIS_LABEL[tpl.basis]')
+  })
+
+  it('hat fuer jeden neuen Text einen EN-Eintrag', () => {
+    for (const key of ['docs.job.title', 'docs.job.intro', 'templates.basis']) {
+      expect(dictsQuelle).toContain(`'${key}'`)
+    }
+  })
+})


### PR DESCRIPTION
**Bedarf 84 (P2)** — „A handover artefact: one file that carries the whole job to the next person."

> Show files on USB sticks, photos in WhatsApp, marked-up plans in a skip. **Next year the same event is re-planned from the QUOTE, not from what was actually built**, and every on-site fix is rediscovered.

## Die Datei gab es schon

Die `.avplan` ist verlustfrei (ADR-005), und `handoverPackage.ts` baut daraus ein Closeout-Paket. Was fehlte, ist der Satz, den der Bedarf wörtlich sagt: das Nächste-Jahr-Problem ist nicht die fehlende Datei, sondern dass die vorhandene den **Angebotsstand** trägt und aussieht wie der Bauzustand.

## Drei benannte Zustände

| | |
|---|---|
| `as-quoted` | nichts als „wie gebaut" festgeschrieben — der Ausgangspunkt, den der Bedarf beklagt |
| `drifted` | ein As-Built liegt vor, der Plan ist seither **substantiell** weitergezogen — der teuerste Fall, weil das Blatt das Wort trägt und nicht mehr stimmt |
| `as-built` | ein As-Built liegt vor, und seither hat sich nichts Substantielles geändert |

„Substantiell" ist **nicht selbst gerechnet**, sondern kommt aus `planDiff` (ADR-005, Design-Frage 2): eine verschobene Position ist kein Bauzustand, ein umgestecktes Kabel schon. Zwei Vorstellungen davon wären hier besonders teuer — die eine färbte das Blatt, die andere den Diff.

Vier weitere Befunde, alle mit derselben Frage: *was wird nächstes Jahr ein zweites Mal gemacht?* Offene Fragen ans Haus, offene Anmerkungen, ein fehlender Ort (ohne ihn gelten die Haus-Antworten nirgends — Bedarfe 85, 91).

## Eingefroren, wo es reisen muss

`ProjectTemplate.basis` wird **beim Schreiben eingefroren**, wie `VenueAnswer.venue`: das Quell-Projekt zieht weiter, die Vorlage nicht. Gelesen wird aus dem **Quell**-Projekt, nicht aus der gestrippten Kopie — die hat die Revisionen bereits verloren (Bedarf 91), und aus ihr wäre jede Vorlage „wie geplant" und die Auskunft damit keine.

Der Zustand steht **ganz oben** im Übergabe-Dialog, vor allem anderen: wer die Übergabe baut, muss wissen, ob sie den Bauzustand trägt. Und auf der Vorlagen-Karte, weil dort über ihren Wert entschieden wird.

## Das Register sagt nein, und das ist richtig

Der erste Wurf trug `job-grundlage` in `DOCUMENT_STANDS`. Der bestehende Guard *„keine Dokument-Ableitung hängt an der Revisionsliste"* hat es sofort gefangen: der Revisions-Vergleich spannt Snapshots mit `revisions: []` auf — ein revisions-abhängiger Stand meldete danach **jedes** Blatt als überholt, obwohl sich nichts geändert hat. Eine erfundene Abweichung ist derselbe Schaden wie ein erfundener Zustand (ADR-003).

Es steht jetzt in `UNJUDGEABLE_DOCUMENTS`, mit dem Grund — aus dem `buildHandoverManifest` seit jeher dort steht.

## Geprüft

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 142 Testdateien, 1821 Tests grün (2 skipped); 27 neue
- `npx eslint .` — 0 Fehler
- **27 Gegenproben.** Zwei blieben zunächst grün: die Ordnungs-Zusicherung im Dialog war eine Regex mit Abstandsfenster und überlebte ein Verschieben — sie vergleicht jetzt Positionen. Die zweite (`revisions` im Diff) ist **nachweislich inert**: `planDiff.substantive` zählt die `sections` gar nicht mit. Die Normalisierung bleibt als Absichtserklärung stehen, und der Kommentar sagt jetzt, dass sie heute nichts verhindert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_