### PR TITLE
vorlagen: den As-Built zur Vorlage der nächsten Show (Bedarf 75)

### DIFF
--- a/src/renderer/components/Project/TemplatesDialog.tsx
+++ b/src/renderer/components/Project/TemplatesDialog.tsx
@@ -22,6 +22,7 @@ import {
   deleteUserTemplate,
   instantiateTemplate,
   loadUserTemplates,
+  promoteAsBuiltToTemplate,
   saveUserTemplate,
   type ProjectTemplate,
 } from '../../lib/projectTemplates'
@@ -32,7 +33,7 @@ import {
   type TemplateScope,
 } from '../../lib/templateScope'
 import { venueScopeDialog } from '../../lib/venueScopeDialog'
-import { JOB_BASIS_LABEL } from '../../lib/jobHandover'
+import { JOB_BASIS_LABEL, latestAsBuilt } from '../../lib/jobHandover'
 
 export const TemplatesDialog = () => {
   const t = useTranslation()
@@ -103,6 +104,11 @@ export const TemplatesDialog = () => {
     })
   }
 
+  // Bedarf 75 — nur fuer den Hinweistext am Knopf. Der Knopf bleibt aktiv:
+  // wer ihn drueckt, bekommt den GRUND zu sehen, statt vor einem grauen Knopf
+  // zu stehen.
+  const hasAsBuilt = !!latestAsBuilt(useProjectStore.getState().project)
+
   const saveCurrent = async () => {
     const current = useProjectStore.getState().project
     const name = await promptDialog(
@@ -127,6 +133,50 @@ export const TemplatesDialog = () => {
     setUserTemplates(loadUserTemplates())
     void infoDialog(t('templates.savedTitle', 'Als Vorlage gespeichert'), {
       body: format(t('templates.savedBody', 'Vorlage „{name}“ gespeichert.'), { name }),
+      tone: 'success',
+    })
+  }
+
+  // BEDARF 75 — den festgeschriebenen Bauzustand zur Vorlage machen.
+  //
+  // Ein eigener Weg neben „Aktuelles als Vorlage": der speichert den Plan, wie
+  // er GERADE ist — nach dem Abbau also den Stand nach dem letzten Klick.
+  // Was die naechste Show braucht, ist der Stand, den jemand ausdruecklich als
+  // gebaut festgeschrieben hat.
+  const promoteCurrent = async () => {
+    const current = useProjectStore.getState().project
+    const name = await promptDialog(
+      t('templates.promoteNamePrompt', 'Name der Vorlage (aus dem As-Built)'),
+      current.metadata.name && current.metadata.name !== 'Untitled Project' ? current.metadata.name : '',
+    )
+    if (name === null) return
+    const gebunden = venueBoundCount(current)
+    let scope: TemplateScope = 'neutral'
+    if (gebunden > 0) {
+      const antwort = await venueScopeDialog(gebunden, projectVenue(current) ?? '')
+      if (antwort === null) return
+      scope = antwort
+    }
+    const res = promoteAsBuiltToTemplate(name, current.metadata.description ?? '', current, scope)
+    if (res.refused) {
+      // Die Ablehnung ist der Punkt: auf den Live-Plan auszuweichen ergaebe
+      // eine Vorlage mit dem Wort „wie gebaut" darauf, die den Angebotsstand
+      // traegt (Bedarf 84).
+      void infoDialog(t('templates.promoteNoneTitle', 'Kein As-Built festgeschrieben'), {
+        body: t(
+          'templates.promoteNoneBody',
+          'Es ist nichts als „wie gebaut" festgeschrieben. Schreibe zuerst eine As-Built-Revision fest — sonst wäre die Vorlage der Plan von vor dem Aufbau, nur mit einem anderen Namen.',
+        ),
+        tone: 'warning',
+      })
+      return
+    }
+    setUserTemplates(loadUserTemplates())
+    void infoDialog(t('templates.savedTitle', 'Als Vorlage gespeichert'), {
+      body: format(
+        t('templates.promotedBody', 'Vorlage „{name}“ aus dem As-Built „{from}“ erstellt.'),
+        { name, from: res.from ?? '' },
+      ),
       tone: 'success',
     })
   }
@@ -225,6 +275,23 @@ export const TemplatesDialog = () => {
             className="shrink-0"
           >
             {t('templates.saveCurrent', 'Aktuelles Projekt als Vorlage')}
+          </Button>
+          {/* BEDARF 75 — der Bauzustand als Startpunkt der nächsten Show.
+              Immer sichtbar, auch ohne As-Built: ein Knopf, der verschwindet,
+              erklärt nicht, warum. Der Hinweis dahinter tut es. */}
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => void promoteCurrent()}
+            leftIcon={Save}
+            className="shrink-0"
+            title={
+              hasAsBuilt
+                ? t('templates.promoteHint', 'Nimmt den festgeschriebenen As-Built-Stand, nicht den aktuellen Plan')
+                : t('templates.promoteNoneTitle', 'Kein As-Built festgeschrieben')
+            }
+          >
+            {t('templates.promote', 'As-Built als Vorlage')}
           </Button>
         </div>
 

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -4255,6 +4255,14 @@ export const en: Dict = {
   'analysis.crew.title': 'Network briefing sheet for the crew',
   'analysis.crew.ask': '{n} points to settle on site',
   'analysis.crew.export': 'Crew network sheet',
+  // Bedarf 75 — den As-Built zur Vorlage der naechsten Show machen.
+  'templates.promote': 'As-built as template',
+  'templates.promoteHint': 'Takes the committed as-built state, not the current plan',
+  'templates.promoteNamePrompt': 'Template name (from the as-built)',
+  'templates.promoteNoneTitle': 'No as-built committed',
+  'templates.promoteNoneBody':
+    'Nothing is committed as \u201cas built\u201d. Commit an as-built revision first \u2014 otherwise the template would be the plan from before load-in, only under another name.',
+  'templates.promotedBody': 'Template \u201c{name}\u201d created from the as-built \u201c{from}\u201d.',
   // Bedarf 84 — woraus naechstes Jahr geplant wuerde.
   'docs.job.title': 'Basis of this handover',
   'docs.job.intro':

--- a/src/renderer/lib/projectTemplates.ts
+++ b/src/renderer/lib/projectTemplates.ts
@@ -11,7 +11,7 @@ import { v4 as uuidv4 } from 'uuid'
 import type { CablePlannerProject } from '../types/project'
 import type { LocationFrame } from '../types/location'
 import { stripForTemplate, projectVenue, type TemplateScope } from './templateScope'
-import { assessJobHandover, type JobBasis } from './jobHandover'
+import { assessJobHandover, latestAsBuilt, type JobBasis } from './jobHandover'
 
 export interface ProjectTemplate {
   id: string
@@ -244,6 +244,63 @@ export const saveUserTemplate = (
   const next = [...loadUserTemplates(), tpl]
   persist(next)
   return tpl
+}
+
+/**
+ * BEDARF 75 — „promote as-built to template".
+ *
+ *   > Trucks historically 'would need to be completely reconfigured to meet
+ *   > the requirements of the new job' when moving between event types. Switch
+ *   > configs are typically not saved back after load-out, so the next show
+ *   > starts from the plan rather than from the as-built.
+ *
+ * Der Bedarf nennt den Weg selbst: „a 'promote as-built to template' action
+ * after load-out so the reconciliation import feeds back into the next show's
+ * starting point."
+ *
+ * WARUM DAS NICHT DASSELBE IST WIE `saveUserTemplate`. Der schreibt den
+ * Plan, wie er GERADE ist. Nach dem Abbau ist das der Stand nach dem letzten
+ * Klick — und der kann alles Moegliche sein: halb aufgeraeumt, mit
+ * Testgeraeten, mit einer Ruecknahme, die nur im Kopf stattgefunden hat. Was
+ * die naechste Show braucht, ist der Stand, den jemand ausdruecklich als
+ * gebaut festgeschrieben hat.
+ *
+ * DIE ABLEHNUNG IST DER PUNKT. Ohne As-Built gibt es nichts zu befoerdern,
+ * und auf den Live-Plan auszuweichen waere der Fehler, gegen den Bedarf 84
+ * geschrieben ist: eine Vorlage mit dem Wort „wie gebaut" darauf, die den
+ * Angebotsstand traegt. `promoteAsBuiltToTemplate` gibt dann `null` und einen
+ * Grund zurueck; die Oberflaeche sagt ihn, statt still etwas anderes zu tun.
+ */
+export type PromoteRefusal = 'no-as-built'
+
+export interface PromoteResult {
+  template?: ProjectTemplate
+  /** Gesetzt, wenn nichts befoerdert wurde — mit dem Grund. */
+  refused?: PromoteRefusal
+  /** Das Etikett der befoerderten Revision, fuer die Rueckmeldung. */
+  from?: string
+}
+
+export const promoteAsBuiltToTemplate = (
+  name: string,
+  description: string,
+  project: CablePlannerProject,
+  scope: TemplateScope,
+): PromoteResult => {
+  const asBuilt = latestAsBuilt(project)
+  if (!asBuilt) return { refused: 'no-as-built' }
+  // Der Schnappschuss ist ein Projekt OHNE `revisions` (per Typ). Genau das
+  // ist hier richtig: die Geschichte der alten Show gehoert nicht in die
+  // Vorlage, und `stripForTemplate` wuerde sie ohnehin entfernen.
+  const stand = { ...asBuilt.snapshot, revisions: [] } as CablePlannerProject
+  const tpl = saveUserTemplate(name, description, stand, scope)
+  // `saveUserTemplate` liest die Grundlage aus dem uebergebenen Projekt, und
+  // das ist hier der Schnappschuss OHNE Revisionen — also „wie geplant".
+  // Das waere die falsche Auskunft: der Inhalt IST der Bauzustand. Die
+  // Vorlage wird deshalb nachtraeglich richtiggestellt und neu abgelegt.
+  const korrigiert: ProjectTemplate = { ...tpl, basis: 'as-built' }
+  persist(loadUserTemplates().map((t) => (t.id === tpl.id ? korrigiert : t)))
+  return { template: korrigiert, from: asBuilt.label }
 }
 
 /** Löscht eine User-Vorlage. Built-ins sind nicht löschbar. */

--- a/tests/promoteAsBuilt.test.ts
+++ b/tests/promoteAsBuilt.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import {
+  loadUserTemplates,
+  promoteAsBuiltToTemplate,
+  saveUserTemplate,
+} from '../src/renderer/lib/projectTemplates'
+import type { CablePlannerProject, ProjectRevision } from '../src/renderer/types/project'
+import dialogQuelle from '../src/renderer/components/Project/TemplatesDialog.tsx?raw'
+import tplQuelle from '../src/renderer/lib/projectTemplates.ts?raw'
+import dictsQuelle from '../src/renderer/lib/i18n/dicts.ts?raw'
+
+// ---------------------------------------------------------------------------
+// „Promote as-built to template" (Bedarf 75, P2).
+//
+//   > Trucks historically 'would need to be completely reconfigured to meet
+//   > the requirements of the new job' when moving between event types. Switch
+//   > configs are typically not saved back after load-out, so the next show
+//   > starts from the plan rather than from the as-built.
+//
+// Der Bedarf nennt den Weg woertlich: „a 'promote as-built to template' action
+// after load-out so the reconciliation import feeds back into the next show's
+// starting point."
+// ---------------------------------------------------------------------------
+
+const geraet = (id: string, name: string) =>
+  ({ id, name, x: 0, y: 0, inputs: [], outputs: [] }) as never
+
+const projekt = (over: Partial<CablePlannerProject> = {}): CablePlannerProject =>
+  ({
+    metadata: { name: 'Show', description: '', siteAddress: 'Halle A' },
+    equipment: [],
+    cables: [],
+    locations: [],
+    ...over,
+  }) as never
+
+const revision = (label: string, asBuilt: boolean, snapshot: CablePlannerProject, at = '2026-01-01T00:00:00.000Z'): ProjectRevision =>
+  ({ id: `rev-${label}`, label, note: '', createdAt: at, asBuilt, snapshot }) as never
+
+describe('die Ablehnung ist der Punkt', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('befoerdert NICHTS, wenn kein As-Built festgeschrieben ist', () => {
+    // Auf den Live-Plan auszuweichen ergaebe eine Vorlage mit dem Wort „wie
+    // gebaut" darauf, die den Angebotsstand traegt — genau der Fehler, gegen
+    // den Bedarf 84 geschrieben ist.
+    const res = promoteAsBuiltToTemplate('X', '', projekt(), 'neutral')
+    expect(res.refused).toBe('no-as-built')
+    expect(res.template).toBeUndefined()
+    expect(loadUserTemplates()).toEqual([])
+  })
+
+  it('ignoriert eine Revision, die kein As-Built ist', () => {
+    const stand = projekt()
+    const p = { ...stand, revisions: [revision('Rev A', false, stand)] } as CablePlannerProject
+    expect(promoteAsBuiltToTemplate('X', '', p, 'neutral').refused).toBe('no-as-built')
+  })
+})
+
+describe('befoerdert den festgeschriebenen Stand, nicht den aktuellen Plan', () => {
+  beforeEach(() => localStorage.clear())
+
+  const aufbau = () => {
+    const gebaut = projekt({ equipment: [geraet('e1', 'Kamera 1')] })
+    return {
+      gebaut,
+      jetzt: {
+        ...gebaut,
+        // Nach dem Abbau am Plan weitergeklickt — genau der Stand, den
+        // `saveUserTemplate` naehme.
+        equipment: [geraet('e1', 'Kamera 1'), geraet('e9', 'Testgerät')],
+        revisions: [revision('As-Built', true, gebaut)],
+      } as CablePlannerProject,
+    }
+  }
+
+  it('NIMMT DEN SCHNAPPSCHUSS, nicht den Live-Plan', () => {
+    const { jetzt } = aufbau()
+    const res = promoteAsBuiltToTemplate('Halle A Standard', '', jetzt, 'venue')
+    expect(res.refused).toBeUndefined()
+    expect(res.template!.project.equipment.map((e) => e.id)).toEqual(['e1'])
+    expect(res.from).toBe('As-Built')
+  })
+
+  it('unterscheidet sich damit sichtbar von `saveUserTemplate`', () => {
+    const { jetzt } = aufbau()
+    const normal = saveUserTemplate('Normal', '', jetzt, 'venue')
+    expect(normal.project.equipment.map((e) => e.id)).toEqual(['e1', 'e9'])
+  })
+
+  it('schreibt „wie gebaut" an die Vorlage — und zwar RICHTIG', () => {
+    // Der Schnappschuss traegt selbst keine Revisionen; aus ihm gelesen waere
+    // die Grundlage „wie geplant". Der Inhalt IST aber der Bauzustand.
+    const { jetzt } = aufbau()
+    const res = promoteAsBuiltToTemplate('X', '', jetzt, 'venue')
+    expect(res.template!.basis).toBe('as-built')
+    // Und der abgelegte Stand traegt es auch — nicht nur der Rueckgabewert.
+    expect(loadUserTemplates()[0].basis).toBe('as-built')
+  })
+
+  it('legt GENAU EINE Vorlage ab, nicht zwei', () => {
+    const { jetzt } = aufbau()
+    promoteAsBuiltToTemplate('X', '', jetzt, 'venue')
+    expect(loadUserTemplates()).toHaveLength(1)
+  })
+
+  it('nimmt die juengste As-Built-Revision', () => {
+    const alt = projekt({ equipment: [geraet('e1', 'A')] })
+    const neu = projekt({ equipment: [geraet('e1', 'A'), geraet('e2', 'B')] })
+    const p = {
+      ...neu,
+      revisions: [
+        revision('Alt', true, alt, '2026-01-01T00:00:00.000Z'),
+        revision('Neu', true, neu, '2026-06-01T00:00:00.000Z'),
+      ],
+    } as CablePlannerProject
+    const res = promoteAsBuiltToTemplate('X', '', p, 'neutral')
+    expect(res.from).toBe('Neu')
+    expect(res.template!.project.equipment).toHaveLength(2)
+  })
+
+  it('gehorcht dem Umfang aus Bedarf 91', () => {
+    const { jetzt } = aufbau()
+    expect(promoteAsBuiltToTemplate('A', '', jetzt, 'venue').template!.venue).toBe('Halle A')
+    localStorage.clear()
+    const neutral = promoteAsBuiltToTemplate('B', '', jetzt, 'neutral').template!
+    expect(neutral.venue).toBeUndefined()
+    expect(neutral.project.metadata.siteAddress).toBeUndefined()
+  })
+
+  it('traegt die Revisionsliste NICHT in die Vorlage', () => {
+    const { jetzt } = aufbau()
+    expect(promoteAsBuiltToTemplate('X', '', jetzt, 'venue').template!.project.revisions).toBeUndefined()
+  })
+})
+
+describe('Erreichbarkeit', () => {
+  it('ist ein eigener Knopf neben „Aktuelles als Vorlage"', () => {
+    expect(dialogQuelle).toContain('onClick={() => void promoteCurrent()}')
+    expect(dialogQuelle).toContain("t('templates.promote'")
+    expect(dialogQuelle).toContain('promoteAsBuiltToTemplate(name, current.metadata.description')
+  })
+
+  it('SAGT den Grund, statt still etwas anderes zu tun', () => {
+    expect(dialogQuelle).toMatch(/if \(res\.refused\) \{[\s\S]{0,600}templates\.promoteNoneBody/)
+    // Und danach wird nichts gespeichert.
+    expect(dialogQuelle).toMatch(/tone: 'warning',\n\s*\}\)\n\s*return/)
+  })
+
+  it('bleibt ANKLICKBAR ohne As-Built — ein grauer Knopf erklaert nichts', () => {
+    expect(dialogQuelle).toContain('const hasAsBuilt = !!latestAsBuilt(')
+    expect(dialogQuelle).toMatch(/title=\{\n\s*hasAsBuilt/)
+    // Kein `disabled` an diesem Knopf.
+    const block = dialogQuelle.slice(
+      dialogQuelle.indexOf('onClick={() => void promoteCurrent()}'),
+      dialogQuelle.indexOf("t('templates.promote'"),
+    )
+    expect(block).not.toContain('disabled')
+  })
+
+  it('fragt denselben Umfang wie beim normalen Speichern', () => {
+    const block = dialogQuelle.slice(
+      dialogQuelle.indexOf('const promoteCurrent = async'),
+      dialogQuelle.indexOf('const removeTemplate ='),
+    )
+    expect(block.length).toBeGreaterThan(0)
+    expect(block).toContain('venueBoundCount(current)')
+    expect(block).toContain('await venueScopeDialog(')
+    expect(block).toMatch(/if \(antwort === null\) return/)
+  })
+
+  it('korrigiert die Grundlage im Modul, nicht in der Oberflaeche', () => {
+    // Sonst haette eine zweite Oberflaeche denselben Fehler wieder.
+    expect(tplQuelle).toContain("const korrigiert: ProjectTemplate = { ...tpl, basis: 'as-built' }")
+  })
+
+  it('hat fuer jeden neuen Text einen EN-Eintrag', () => {
+    for (const key of [
+      'templates.promote',
+      'templates.promoteHint',
+      'templates.promoteNamePrompt',
+      'templates.promoteNoneTitle',
+      'templates.promoteNoneBody',
+      'templates.promotedBody',
+    ]) {
+      expect(dictsQuelle).toContain(`'${key}'`)
+    }
+  })
+})


### PR DESCRIPTION
**Bedarf 75 (P2)** — „Reusable per-truck / per-show templates and presets rather than rebuilding each event."

> Trucks historically 'would need to be completely reconfigured to meet the requirements of the new job' when moving between event types. Switch configs are typically not saved back after load-out, so **the next show starts from the plan rather than from the as-built**.

Der Bedarf nennt den Weg wörtlich: *„a **'promote as-built to template' action** after load-out so the reconciliation import feeds back into the next show's starting point."*

## Warum das nicht `saveUserTemplate` ist

Der speichert den Plan, wie er **gerade** ist. Nach dem Abbau ist das der Stand nach dem letzten Klick — halb aufgeräumt, mit Testgeräten, mit einer Rücknahme, die nur im Kopf stattgefunden hat. Was die nächste Show braucht, ist der Stand, den jemand ausdrücklich als gebaut festgeschrieben hat.

`promoteAsBuiltToTemplate` nimmt den Schnappschuss der **jüngsten** As-Built-Revision und gibt deren Etikett zurück.

## Die Ablehnung ist der Punkt

Ohne As-Built gibt es nichts zu befördern, und auf den Live-Plan auszuweichen ergäbe eine Vorlage mit dem Wort „wie gebaut" darauf, die den Angebotsstand trägt — genau der Fehler, gegen den Bedarf 84 geschrieben ist. Die Funktion gibt `refused: 'no-as-built'` zurück, und die Oberfläche **sagt** den Grund.

Der Knopf bleibt dabei **anklickbar**, auch ohne As-Built: ein grauer Knopf erklärt nicht, warum er grau ist; wer ihn drückt, bekommt den Grund zu sehen.

## Zwei Details, die leicht falsch geworden wären

- **Die Grundlage wird richtiggestellt** — der Schnappschuss trägt selbst keine Revisionen, also läse `assessJobHandover` daraus „wie geplant", obwohl der Inhalt der Bauzustand *ist*. Korrigiert wird im **Modul**, nicht in der Oberfläche; sonst hätte eine zweite Oberfläche denselben Fehler wieder.
- **Derselbe Umfang wie beim normalen Speichern** (Bedarf 91): gefragt wird nur, wenn etwas Ortsgebundenes dranhängt, und Abbruch speichert nichts.

## Was bewusst fehlt

Die „per-event deltas" aus dem Bedarf als eigenes Objekt. Der Unterschied zwischen Basis und Show ist bereits berechenbar (`planDiff`, Vergleichs-Dialog); ihn zusätzlich zu speichern erzeugte eine zweite Wahrheit, die beim ersten Umstecken veraltet.

## Geprüft

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 143 Testdateien, 1836 Tests grün (2 skipped); 15 neue
- `npx eslint .` — 0 Fehler
- **14 Gegenproben, alle rot**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_