### PR TITLE
kanalliste + dante + bestand: Szenendatei, Subscription-Matrix, zwei Identitäten je Einheit (Bedarfe 92, 94, 107)

### DIFF
--- a/src/renderer/components/Analysis/AnalysisDialog.tsx
+++ b/src/renderer/components/Analysis/AnalysisDialog.tsx
@@ -56,6 +56,16 @@ import {
   type NamingRefusal,
 } from '../../lib/namingScheme'
 import type { NamingScheme } from '../../types/namingScheme'
+import {
+  DANTE_DIFF_LABEL,
+  DANTE_FINDING_LABEL,
+  assessDantePatch,
+  danteDiffTable,
+  dantePatchTable,
+  diffDantePatches,
+  parseDanteMatrix,
+} from '../../lib/dantePatch'
+import type { DantePatch } from '../../types/dantePatch'
 import { cableRunFindings, cableRunTable, type RunFinding } from '../../lib/cableRunChecks'
 import { lookUpSheet, type SheetLookup } from '../../lib/sheetLookup'
 import {
@@ -112,6 +122,7 @@ type Tab =
   | 'client'
   | 'cost'
   | 'naming'
+  | 'dante'
 
 const WATT_TO_BTU = 3.412
 
@@ -2397,10 +2408,140 @@ const NamingTab = ({ projectName }: { projectName: string }) => {
   )
 }
 
+/* ------------------------------------------------------ Dante-Patch -- */
+
+/**
+ * BEDARF 94 — der Dante-Patch als lesbares, vergleichbares Dokument.
+ *
+ * Eingelesen wird die MATRIX, nicht das Preset-XML: dessen Schema liegt nicht
+ * vor, und ein Parser nach Vermutung sähe aus, als könnte er es. Die
+ * Begründung steht ausführlich im Kopf von `types/dantePatch.ts`.
+ *
+ * Der zweite Import ist wie bei der Szenendatei (Bedarf 92) der eigentliche
+ * Nutzen — und der erste bleibt der Bezugsstand.
+ */
+const DanteTab = ({ projectName }: { projectName: string }) => {
+  const t = useTranslation()
+  const project = useProjectStore((s) => s.project)
+  const [patchA, setPatchA] = useState<DantePatch | null>(null)
+  const [patchB, setPatchB] = useState<DantePatch | null>(null)
+
+  const aktuell = patchB ?? patchA
+  const befunde = useMemo(
+    () => (aktuell ? assessDantePatch(aktuell, project) : []),
+    [aktuell, project],
+  )
+  const unterschiede = useMemo(
+    () => (patchA && patchB ? diffDantePatches(patchA, patchB) : []),
+    [patchA, patchB],
+  )
+
+  const laden = async (f: File) => {
+    const gelesen = parseDanteMatrix(await f.text())
+    if (!patchA) setPatchA(gelesen)
+    else setPatchB(gelesen)
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-cp-xs leading-snug text-[var(--cp-text-muted)]">
+        {t(
+          'analysis.dante.intro',
+          'Die Subscription-Matrix als Blatt und als Vergleich. Diese Anwendung geht nicht ins Netz, abonniert nichts und benennt nichts um — sie liest die Tabelle, in die das Preset ohnehin konvertiert wird.',
+        )}
+      </p>
+      <div className="flex flex-wrap items-center gap-2">
+        <label className="cursor-pointer rounded border border-[var(--cp-border)] px-2 py-1 text-cp-xs">
+          {t('analysis.dante.import', 'Matrix einlesen')}
+          <input
+            type="file"
+            accept=".csv,.txt"
+            className="hidden"
+            onChange={(e) => {
+              const f = e.target.files?.[0]
+              // Geleert, damit dieselbe Datei zweimal gewählt werden kann.
+              e.target.value = ''
+              if (f) void laden(f)
+            }}
+          />
+        </label>
+        {aktuell && (
+          <>
+            <span className="text-cp-xs text-[var(--cp-text-secondary)]">
+              {t('analysis.dante.count', '{n} Empfangskanäle')
+                .replace('{n}', String(aktuell.subscriptions.length))}
+            </span>
+            {aktuell.unreadable > 0 && (
+              <span className="text-cp-xs text-amber-300/90">
+                {t('analysis.dante.unreadable', '{n} Zeilen nicht lesbar').replace(
+                  '{n}',
+                  String(aktuell.unreadable),
+                )}
+              </span>
+            )}
+            <CsvButton
+              onClick={() =>
+                downloadBlob(
+                  buildExportFilenameWithSuffix(projectName, 'dante-patch', 'csv'),
+                  csvFromTable(dantePatchTable(aktuell)),
+                  'text/csv',
+                )
+              }
+            />
+            {unterschiede.length > 0 && (
+              <button
+                type="button"
+                onClick={() =>
+                  downloadBlob(
+                    buildExportFilenameWithSuffix(projectName, 'dante-aenderungen', 'csv'),
+                    csvFromTable(danteDiffTable(unterschiede)),
+                    'text/csv',
+                  )
+                }
+                className="rounded border border-[var(--cp-border)] px-2 py-1 text-cp-xs"
+              >
+                {t('analysis.dante.exportDiff', 'Änderungen')}
+              </button>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Zwei Stände, keine Änderung: das ist eine Aussage und wird gesagt. */}
+      {patchB && unterschiede.length === 0 && (
+        <p className="text-cp-xs text-[var(--cp-text-secondary)]">
+          {t('analysis.dante.noChange', 'Zwischen den beiden Ständen hat sich am Patch nichts geändert.')}
+        </p>
+      )}
+      {unterschiede.length > 0 && (
+        <ul className="flex flex-col gap-0.5 text-cp-xs">
+          {unterschiede.map((d) => (
+            <li key={`${d.rx}-${d.kind}`}>
+              <span className="text-[var(--cp-text-faint)]">{d.rx}</span>{' '}
+              <span className="text-amber-300/90">{DANTE_DIFF_LABEL[d.kind]}</span>{' '}
+              {d.before} → {d.after}
+            </li>
+          ))}
+        </ul>
+      )}
+      {befunde.length > 0 && (
+        <ul className="flex flex-col gap-1 text-cp-xs">
+          {befunde.map((f, i) => (
+            <li key={`${f.kind}-${i}`} className="text-amber-300/90">
+              <strong>{DANTE_FINDING_LABEL[f.kind]}</strong> — {f.text}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
 const TABS: { id: Tab; labelKey: string; fallback: string }[] = [
   { id: 'client', labelKey: 'analysis.tab.client', fallback: 'Kunden-Übersicht' },
   { id: 'cost', labelKey: 'analysis.tab.cost', fallback: 'Kosten: Plan gegen Ist' },
   { id: 'naming', labelKey: 'analysis.tab.naming', fallback: 'Namensregel' },
+  { id: 'dante', labelKey: 'analysis.tab.dante', fallback: 'Dante-Patch' },
   { id: 'weight', labelKey: 'analysis.tab.weight', fallback: 'Gewicht & Wärme' },
   { id: 'network', labelKey: 'analysis.tab.network', fallback: 'Netzwerk' },
   { id: 'redundancy', labelKey: 'analysis.tab.redundancy', fallback: 'Redundanz' },
@@ -2451,6 +2592,7 @@ export const AnalysisDialog = () => {
       {active === 'client' && <ClientTab projectName={projectName} />}
       {active === 'cost' && <CostTab projectName={projectName} />}
       {active === 'naming' && <NamingTab projectName={projectName} />}
+      {active === 'dante' && <DanteTab projectName={projectName} />}
     </ModalShell>
   )
 }

--- a/src/renderer/components/Inventory/InventoryDialog.tsx
+++ b/src/renderer/components/Inventory/InventoryDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { IDENTITY_FINDING_LABEL, identityFindings, unitLabel } from '../../lib/unitIdentity'
 import {
   Plus,
   Pencil,
@@ -269,7 +270,7 @@ export const InventoryDialog = ({ open, onClose }: InventoryDialogProps) => {
     } else {
       const model = items.find((it) => it.id === match.unit.itemId)?.model ?? '?'
       setTab('units')
-      setScanResult(format(t('inventory.scanUnit', 'Einheit: {model} · {serial}'), { model, serial: match.unit.serial || match.unit.code || match.unit.id.slice(0, 6) }))
+      setScanResult(format(t('inventory.scanUnit', 'Einheit: {model} · {serial}'), { model, serial: unitLabel(match.unit, 'house') }))
     }
     setScan('')
   }
@@ -1407,6 +1408,7 @@ const UnitsTab = ({ codeCell }: UnitsTabProps) => {
   const [faultFor, setFaultFor] = useState<string | null>(null)
   const [faultText, setFaultText] = useState('')
   const [faultServices, setFaultServices] = useState<FaultService[]>([])
+  const identitaetsBefunde = useMemo(() => identityFindings(units), [units])
   const [form, setForm] = useState<UnitFormState | null>(null)
   const [openHistory, setOpenHistory] = useState<string | null>(null)
 
@@ -1424,13 +1426,14 @@ const UnitsTab = ({ codeCell }: UnitsTabProps) => {
     const payload: InventoryUnitInput = {
       itemId: form.itemId,
       serial: form.serial?.trim() || undefined,
+      houseRef: form.houseRef?.trim() || undefined,
       code: form.code?.trim() || undefined,
       codeType: form.code?.trim() ? form.codeType ?? 'qr' : undefined,
       locationId: form.locationId || undefined,
       condition: form.condition ?? 'ok',
       notes: form.notes?.trim() || undefined,
     }
-    if (form.id) updateUnit(form.id, { serial: payload.serial, code: payload.code, codeType: payload.codeType, notes: payload.notes })
+    if (form.id) updateUnit(form.id, { serial: payload.serial, houseRef: payload.houseRef, code: payload.code, codeType: payload.codeType, notes: payload.notes })
     else addUnit(payload)
     setForm(null)
   }
@@ -1476,8 +1479,22 @@ const UnitsTab = ({ codeCell }: UnitsTabProps) => {
               </select>
             </label>
             <label className="block">
-              {t('inventory.serial', 'Seriennummer')}
+              {t('inventory.serial', 'Seriennummer (Hersteller)')}
               <input value={form.serial ?? ''} onChange={(e) => setForm({ ...form, serial: e.target.value })} className={inputCls} />
+            </label>
+            {/* BEDARF 107 — zwei Identitäten, zwei Felder. Die Herstellernummer
+                braucht die Versicherung, die Sub-Vermietung und die Wartung;
+                die Hausreferenz braucht alles Interne. Ein Feld für beide
+                zwingt das Lager zur Wahl, und die andere landet mit Filzstift
+                auf dem Case. */}
+            <label className="block">
+              {t('inventory.houseRef', 'Hausreferenz')}
+              <input
+                value={form.houseRef ?? ''}
+                onChange={(e) => setForm({ ...form, houseRef: e.target.value })}
+                placeholder={t('inventory.houseRefPh', 'z. B. AV-0421')}
+                className={inputCls}
+              />
             </label>
             <label className="block">
               {t('inventory.code', 'Code (QR/Barcode)')}
@@ -1506,6 +1523,18 @@ const UnitsTab = ({ codeCell }: UnitsTabProps) => {
         </div>
       )}
 
+      {/* BEDARF 107 — was an den Nummern nicht stimmt. Beide Doppelungen sind
+          unmöglich und deshalb aussagekräftig: eine Herstellernummer gibt es
+          genau einmal auf der Welt, eine Hausreferenz genau einmal im Haus. */}
+      {identitaetsBefunde.length > 0 && (
+        <ul className="mb-2 flex flex-col gap-1 text-cp-xs">
+          {identitaetsBefunde.map((f, i) => (
+            <li key={`${f.kind}-${i}`} className="text-amber-300/90">
+              <strong>{IDENTITY_FINDING_LABEL[f.kind]}</strong> — {f.text}
+            </li>
+          ))}
+        </ul>
+      )}
       {units.length === 0 ? (
         <div className="rounded border border-dashed border-cp-border py-10 text-center text-cp-text-muted">
           {items.length === 0
@@ -1520,6 +1549,7 @@ const UnitsTab = ({ codeCell }: UnitsTabProps) => {
                 <Tags size={13} className="shrink-0 text-cp-text-muted" />
                 <span className="font-medium">{itemById.get(u.itemId)?.model ?? t('inventory.unknownItem', '(gelöschter Artikel)')}</span>
                 {u.serial && <span className="text-cp-text-secondary">SN {u.serial}</span>}
+                {u.houseRef && <span className="text-cp-text-secondary">#{u.houseRef}</span>}
                 {u.code && codeCell(u.code, u.codeType)}
                 <span className={`rounded px-1.5 py-0.5 text-[10px] ${CONDITION_TONE[u.condition]}`}>{conditionLabel(u.condition)}</span>
                 {/* BEDARF 52 — der Verdacht steht NEBEN dem Zustand, nicht

--- a/src/renderer/components/Patch/PatchListDialog.tsx
+++ b/src/renderer/components/Patch/PatchListDialog.tsx
@@ -31,6 +31,17 @@ import {
   venueView,
   type ChannelViewId,
 } from '../../lib/channelList'
+import {
+  diffScenes,
+  matchToPlan,
+  matchTable,
+  parseSceneFile,
+  sceneDiffTable,
+  sceneTable,
+  SCENE_DIFF_LABEL,
+  type MatchMode,
+} from '../../lib/sceneImport'
+import { SCENE_FORMAT_LABEL, type SceneImport } from '../../types/sceneImport'
 import type { Cable } from '../../types/cable'
 import type { EquipmentItem, Port } from '../../types/equipment'
 
@@ -257,6 +268,40 @@ export const PatchListDialog = () => {
   // und React beschwert sich zu Recht.
   const channels = useMemo(() => buildChannelList(equipment, cables), [equipment, cables])
   const monitors = useMemo(() => monitorPaths(equipment, cables), [equipment, cables])
+
+  // BEDARF 92 — zwei Stände: der erste Import und der letzte. Mehr braucht
+  // der Vergleich nicht, und eine Historie aller Uploads wäre eine zweite
+  // Revisionsliste neben der, die das Projekt schon hat.
+  const [szeneA, setSzeneA] = useState<SceneImport | null>(null)
+  const [szeneB, setSzeneB] = useState<SceneImport | null>(null)
+  const [szeneMode, setSzeneMode] = useState<MatchMode>('by-name')
+
+  const ladeSzene = async (f: File) => {
+    const text = await f.text()
+    const gelesen = parseSceneFile(text)
+    // Der erste Import wird der Bezugsstand, jeder weitere der aktuelle. So
+    // vergleicht der zweite Upload gegen den ersten, der dritte gegen den
+    // ersten — der Bezugspunkt bleibt die Probe, nicht der letzte Klick.
+    if (!szeneA) setSzeneA(gelesen)
+    else setSzeneB(gelesen)
+  }
+
+  const szeneAktuell = szeneB ?? szeneA
+  const szeneDiff = useMemo(
+    () => (szeneA && szeneB ? diffScenes(szeneA, szeneB) : []),
+    [szeneA, szeneB],
+  )
+  const szeneMatches = useMemo(
+    () =>
+      szeneAktuell
+        ? matchToPlan(
+            szeneAktuell,
+            channels.map((c) => ({ ch: c.ch, source: c.source })),
+            szeneMode,
+          )
+        : [],
+    [szeneAktuell, channels, szeneMode],
+  )
 
   if (!open) return null
 
@@ -580,6 +625,34 @@ export const PatchListDialog = () => {
                 >
                   {t('channelList.export', '🎚 Kanalliste')}
                 </button>
+                {/* BEDARF 92 — die Kanalliste aus der Datei lesen, die das
+                    Pult ohnehin schreibt. Ein LESER, kein Schreiber: hier
+                    geht nichts ans Pult zurück. Der zweite Import ist der
+                    eigentliche Nutzen — er ist die Änderungsliste aus der
+                    Probe, die heute nur im Kopf von jemandem existiert. */}
+                <label
+                  className="cursor-pointer rounded border border-cp-border px-3 py-1 text-cp-xs text-cp-text-secondary hover:text-cp-text"
+                  title={t(
+                    'scene.importHint',
+                    'Szenendatei des Pults (X32/M32/WING) einlesen. Diese Anwendung schreibt nichts zurück ans Pult.',
+                  )}
+                >
+                  {t('scene.import', '🎛 Szene einlesen')}
+                  <input
+                    type="file"
+                    accept=".scn,.txt,.snap,.shw"
+                    className="hidden"
+                    onChange={(e) => {
+                      const f = e.target.files?.[0]
+                      // Das Feld wird geleert, damit dieselbe Datei zweimal
+                      // gewählt werden kann — genau das braucht der Vergleich,
+                      // wenn jemand nach der Probe neu exportiert und die Datei
+                      // gleich heisst.
+                      e.target.value = ''
+                      if (f) void ladeSzene(f)
+                    }}
+                  />
+                </label>
               </>
             )}
           </div>
@@ -587,6 +660,113 @@ export const PatchListDialog = () => {
       }
     >
       <div className="flex h-full flex-col">
+        {/* BEDARF 92 — was aus der Szenendatei gelesen wurde, und was sich
+            seit dem ersten Import geändert hat. Steht ÜBER der Kabelliste und
+            nicht in einem eigenen Dialog: der Vergleich beantwortet die Frage
+            „was hat sich in der Probe geändert", und die stellt sich genau
+            hier, mit der Liste daneben. */}
+        {szeneAktuell && (
+          <div className="mb-2 rounded border border-cp-border-muted bg-cp-surface-2 p-2 text-cp-xs">
+            <div className="mb-1.5 flex flex-wrap items-center gap-2">
+              <span className="font-medium text-cp-text">
+                {t('scene.title', 'Szenendatei des Pults')}
+              </span>
+              <span className="text-cp-text-secondary">
+                {SCENE_FORMAT_LABEL[szeneAktuell.format]} ·{' '}
+                {t('scene.channelCount', '{n} Kanäle').replace(
+                  '{n}',
+                  String(szeneAktuell.channels.length),
+                )}
+              </span>
+              {/* Eine Datei, aus der die Hälfte nicht gelesen wurde, sieht
+                  sonst aus wie ein Pult mit wenigen Kanälen. */}
+              {szeneAktuell.unreadable > 0 && (
+                <span className="text-amber-300/90">
+                  {t('scene.unreadable', '{n} Zeilen nicht lesbar').replace(
+                    '{n}',
+                    String(szeneAktuell.unreadable),
+                  )}
+                </span>
+              )}
+              <select
+                value={szeneMode}
+                onChange={(e) => setSzeneMode(e.target.value as MatchMode)}
+                aria-label={t('scene.matchMode', 'Zuordnung zum Plan')}
+                className="rounded border border-cp-border bg-cp-surface-3 px-1 py-0.5"
+              >
+                <option value="by-name">{t('scene.byName', 'über den Namen')}</option>
+                <option value="by-number">
+                  {t('scene.byNumber', 'über die Kanalnummer (nur wenn sie stimmt)')}
+                </option>
+              </select>
+              <button
+                type="button"
+                onClick={() =>
+                  downloadBlob(
+                    buildExportFilenameWithSuffix(projectName, 'pult-kanaele', 'csv'),
+                    csvFromTable(sceneTable(szeneAktuell)),
+                    'text/csv',
+                  )
+                }
+                className="rounded border border-cp-border px-2 py-0.5 text-cp-text-secondary hover:text-cp-text"
+              >
+                {t('scene.exportList', 'Kanäle')}
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  downloadBlob(
+                    buildExportFilenameWithSuffix(projectName, 'pult-zuordnung', 'csv'),
+                    csvFromTable(matchTable(szeneMatches)),
+                    'text/csv',
+                  )
+                }
+                className="rounded border border-cp-border px-2 py-0.5 text-cp-text-secondary hover:text-cp-text"
+              >
+                {t('scene.exportMatch', 'Zuordnung')}
+              </button>
+              {szeneDiff.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() =>
+                    downloadBlob(
+                      buildExportFilenameWithSuffix(projectName, 'pult-aenderungen', 'csv'),
+                      csvFromTable(sceneDiffTable(szeneDiff)),
+                      'text/csv',
+                    )
+                  }
+                  className="rounded border border-cp-border px-2 py-0.5 text-cp-text-secondary hover:text-cp-text"
+                >
+                  {t('scene.exportDiff', 'Änderungen')}
+                </button>
+              )}
+            </div>
+            {/* Zwei Stände liegen vor, aber nichts hat sich geändert: das ist
+                eine Aussage und wird gesagt. Ein leerer Block läse sich als
+                „noch nicht verglichen". */}
+            {szeneB && szeneDiff.length === 0 && (
+              <p className="text-cp-text-secondary">
+                {t(
+                  'scene.noChange',
+                  'Zwischen den beiden Ständen hat sich an den Kanalnamen nichts geändert.',
+                )}
+              </p>
+            )}
+            {szeneDiff.length > 0 && (
+              <ul className="flex flex-col gap-0.5">
+                {szeneDiff.map((d) => (
+                  <li key={`${d.ch}-${d.kind}`}>
+                    <span className="tabular-nums text-cp-text-faint">Ch {d.ch}</span>{' '}
+                    <span className="text-amber-300/90">{SCENE_DIFF_LABEL[d.kind]}</span>{' '}
+                    {d.kind === 'recolored'
+                      ? `${d.beforeColor ?? '—'} → ${d.afterColor ?? '—'}`
+                      : `${d.before || '—'} → ${d.after || '—'}`}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
         <div className="flex items-center gap-2 border-b border-cp-border-muted py-2">
           <input
             value={filter}

--- a/src/renderer/components/Properties/sections/NetworkAccessSection.tsx
+++ b/src/renderer/components/Properties/sections/NetworkAccessSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { unitLabel } from '../../../lib/unitIdentity'
 import { Eye, EyeOff } from 'lucide-react'
 import { useCanvasProjectStore as useProjectStore } from '../../../store/projectStoreContext'
 import { useTranslation } from '../../../lib/i18n'
@@ -33,9 +34,12 @@ export const NetworkAccessSection = ({ equipment }: { equipment: EquipmentItem }
   // handelt vom eingebrannten Geraete-Namen, und wo keiner ist, waere das Feld
   // Ballast in jeder Seitenleiste.
   const anchors = identityAnchors(equipment)
-  const unitLabel = (u: (typeof units)[number]) => {
+  // Bedarf 107 — im Plan zaehlt die Hausreferenz: das Geraet steht hier im
+  // eigenen Aufbau, nicht auf einem Versicherungsblatt. Die Regel dafuer steht
+  // in `unitLabel` und nicht hier: sie war bis dahin an vier Stellen kopiert.
+  const einheitZeile = (u: (typeof units)[number]): string => {
     const modell = items.find((i) => i.id === u.itemId)?.model
-    return [modell, u.serial ?? u.code ?? u.id].filter(Boolean).join(' · ')
+    return [modell, unitLabel(u, 'house')].filter(Boolean).join(' · ')
   }
 
   return (
@@ -89,7 +93,7 @@ export const NetworkAccessSection = ({ equipment }: { equipment: EquipmentItem }
               <option value="">{t('eq.field.unitNone', '— nicht benannt —')}</option>
               {units.map((u) => (
                 <option key={u.id} value={u.id}>
-                  {unitLabel(u)}
+                  {einheitZeile(u)}
                 </option>
               ))}
             </select>

--- a/src/renderer/lib/dantePatch.ts
+++ b/src/renderer/lib/dantePatch.ts
@@ -1,0 +1,304 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Der Dante-Patch als Dokument (Bedarf 94, P2).
+//
+// Warum die Matrix gelesen wird und nicht das Preset-XML, steht im Kopf von
+// `types/dantePatch.ts`. Hier steht, was aus der gelesenen Liste wird.
+//
+// ─── DREI FRAGEN, DIE DER BELEG STELLT ─────────────────────────────────────
+//
+// 1. „welcher Empfangskanal haengt an nichts" — die freien Eingaenge.
+// 2. „was hat sich seit dem letzten Stand geaendert" — der Vergleich.
+// 3. „stimmt das ueberhaupt mit dem Plan ueberein" — die Geraetenamen.
+//
+// Die dritte ist die, die dieser Planer als einziger beantworten kann: er
+// kennt die Geraete, die im Plan eine Dante-Schnittstelle fuehren. Ein
+// Sendegeraet im Patch, das im Plan nicht existiert, ist entweder ein Tippfehler
+// im Namen oder ein Geraet, das niemand eingeplant hat — beides faellt sonst
+// erst im Saal auf.
+//
+// ─── DIE UMBENENNUNGS-FALLE ────────────────────────────────────────────────
+//
+//   > renaming machines or channels LOSES THE EXISTING PATCH
+//
+// Dieser Planer benennt nichts um (das tut Bedarf 74, und auch dort nur mit
+// einer Warnung). Was er hier tut, ist den Schaden SICHTBAR machen: nach einer
+// Umbenennung steht der alte Name im Patch und der neue im Plan, und genau das
+// meldet `device-not-in-plan`.
+//
+// REIN: keine Uhr, kein Store, kein IO, kein Netz.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { CablePlannerProject } from '../types/project'
+import type { DantePatch, DanteSubscription } from '../types/dantePatch'
+import { hasDanteInterface } from './namingScheme'
+import type { CsvTable } from './csv'
+
+/** Spalten-Ueberschriften, die als die vier Felder gelten. Kleingeschrieben
+ *  verglichen; Umlaute und Leerzeichen egal. */
+const HEADER_ALIASES: Readonly<Record<keyof DanteSubscription, readonly string[]>> = {
+  rxDevice: ['rxdevice', 'rxgerät', 'rxgeraet', 'empfänger', 'empfaenger', 'receiver', 'receivedevice'],
+  rxChannel: ['rxchannel', 'rxkanal', 'empfangskanal', 'receivechannel', 'destination'],
+  txDevice: ['txdevice', 'txgerät', 'txgeraet', 'sender', 'transmitter', 'transmitdevice'],
+  txChannel: ['txchannel', 'txkanal', 'sendekanal', 'transmitchannel', 'source'],
+}
+
+const norm = (s: string): string => s.trim().toLowerCase().replace(/[\s_\-.]/g, '')
+
+/** Trennt eine CSV-Zeile an `;` oder `,` — je nachdem, was haeufiger vorkommt.
+ *  Deutsches Excel schreibt Semikolon, angelsaechsisches Komma. */
+const splitLine = (line: string, delim: string): string[] =>
+  line.split(delim).map((c) => c.trim().replace(/^"(.*)"$/s, '$1'))
+
+const detectDelimiter = (text: string): string => {
+  const kopf = text.split(/\r?\n/, 1)[0] ?? ''
+  return (kopf.match(/;/g)?.length ?? 0) >= (kopf.match(/,/g)?.length ?? 0) ? ';' : ','
+}
+
+/**
+ * Liest eine Subscription-Matrix als flache Liste.
+ *
+ * Die Spalten werden ueber ihre UEBERSCHRIFT gefunden, nicht ueber ihre
+ * Position: eine Datei, deren Spalten jemand umsortiert hat, ist dieselbe
+ * Datei, und eine positionsfeste Lesung machte daraus stillschweigend einen
+ * anderen Patch — Sender und Empfaenger vertauscht.
+ *
+ * Fehlt eine der beiden Rx-Spalten, kommt NICHTS heraus und jede Datenzeile
+ * wird als unlesbar gezaehlt: ohne Empfaenger ist eine Subscription keine.
+ * Die Tx-Spalten duerfen fehlen — dann ist jede Zeile ein freier Eingang, und
+ * auch das ist eine Auskunft.
+ */
+export function parseDanteMatrix(text: string): DantePatch {
+  const delim = detectDelimiter(text)
+  const zeilen = text.split(/\r?\n/).filter((z) => z.trim() !== '')
+  if (zeilen.length === 0) return { subscriptions: [], unreadable: 0 }
+
+  const kopf = splitLine(zeilen[0], delim).map(norm)
+  const spalte = (feld: keyof DanteSubscription): number =>
+    kopf.findIndex((h) => HEADER_ALIASES[feld].includes(h))
+
+  const iRxD = spalte('rxDevice')
+  const iRxC = spalte('rxChannel')
+  const iTxD = spalte('txDevice')
+  const iTxC = spalte('txChannel')
+  // Fehlt eine der Rx-Spalten, faellt jede Zeile ohnehin durch die
+  // Empfaenger-Pruefung in der Schleife und wird dort als unlesbar gezaehlt.
+  // Eine Sonderbehandlung davor waere dieselbe Aussage ein zweites Mal — und
+  // eine zweite Stelle, an der sich die Zaehlung aendern koennte.
+
+  const subs: DanteSubscription[] = []
+  let unreadable = 0
+  const gesehen = new Set<string>()
+  for (const z of zeilen.slice(1)) {
+    const c = splitLine(z, delim)
+    const rxDevice = (c[iRxD] ?? '').trim()
+    const rxChannel = (c[iRxC] ?? '').trim()
+    if (!rxDevice || !rxChannel) {
+      unreadable += 1
+      continue
+    }
+    // Ein Empfangskanal kommt genau einmal vor — er kann nur EIN Abo haben.
+    // Die zweite Zeile ist deshalb nicht „auch noch", sondern ein Widerspruch;
+    // sie wird als Befund gemeldet, nicht hier still zusammengefasst.
+    const key = `${norm(rxDevice)}|${norm(rxChannel)}`
+    gesehen.add(key)
+    const eintrag: DanteSubscription = { rxDevice, rxChannel }
+    const txDevice = iTxD >= 0 ? (c[iTxD] ?? '').trim() : ''
+    const txChannel = iTxC >= 0 ? (c[iTxC] ?? '').trim() : ''
+    if (txDevice) eintrag.txDevice = txDevice
+    if (txChannel) eintrag.txChannel = txChannel
+    subs.push(eintrag)
+  }
+  return { subscriptions: subs, unreadable }
+}
+
+// ─── Befunde ───────────────────────────────────────────────────────────────
+
+export type DanteFindingKind =
+  | 'rx-duplicate'
+  | 'half-subscription'
+  | 'device-not-in-plan'
+  | 'plan-device-unpatched'
+  | 'nothing-subscribed'
+
+export const DANTE_FINDING_LABEL: Readonly<Record<DanteFindingKind, string>> = {
+  'rx-duplicate': 'Ein Empfangskanal steht zweimal',
+  'half-subscription': 'Halbes Abo — Gerät ohne Kanal oder Kanal ohne Gerät',
+  'device-not-in-plan': 'Gerät im Patch, das der Plan nicht kennt',
+  'plan-device-unpatched': 'Dante-Gerät im Plan, das im Patch nicht vorkommt',
+  'nothing-subscribed': 'Kein einziger Empfangskanal ist abonniert',
+}
+
+export interface DanteFinding {
+  kind: DanteFindingKind
+  text: string
+}
+
+/**
+ * Was an diesem Patch auffällt — auch im Vergleich mit dem Plan.
+ *
+ * `plan` ist optional: ein Patch laesst sich auch ohne Projekt lesen, dann
+ * fallen die beiden Abgleich-Befunde weg. Sie zu erfinden, weil kein Plan da
+ * ist, waere schlimmer als sie wegzulassen.
+ */
+export function assessDantePatch(
+  patch: DantePatch,
+  plan?: CablePlannerProject,
+): DanteFinding[] {
+  const out: DanteFinding[] = []
+
+  const zaehler = new Map<string, number>()
+  for (const s of patch.subscriptions) {
+    const k = `${norm(s.rxDevice)}|${norm(s.rxChannel)}`
+    zaehler.set(k, (zaehler.get(k) ?? 0) + 1)
+  }
+  for (const [k, n] of zaehler) {
+    if (n < 2) continue
+    out.push({
+      kind: 'rx-duplicate',
+      text: `„${k.replace('|', ' / ')}" steht ${n}× in der Liste. Ein Empfangskanal kann nur ein Abo haben — eine der Zeilen ist falsch, und welche, weiss nur der Controller.`,
+    })
+  }
+
+  for (const s of patch.subscriptions) {
+    const hatGeraet = !!s.txDevice
+    const hatKanal = !!s.txChannel
+    if (hatGeraet !== hatKanal) {
+      out.push({
+        kind: 'half-subscription',
+        text: `„${s.rxDevice} / ${s.rxChannel}" trägt ${
+          hatGeraet ? 'ein Sendegerät ohne Kanal' : 'einen Sendekanal ohne Gerät'
+        }. Als Abo ist das unvollständig; als freier Eingang gelesen wäre die halbe Angabe verloren.`,
+      })
+    }
+  }
+
+  const abonniert = patch.subscriptions.filter((s) => s.txDevice && s.txChannel)
+  if (patch.subscriptions.length > 0 && abonniert.length === 0) {
+    out.push({
+      kind: 'nothing-subscribed',
+      text: `Keiner der ${patch.subscriptions.length} Empfangskanäle ist abonniert. Entweder ist der Patch leer, oder die Sendespalten der Datei wurden nicht gefunden.`,
+    })
+  }
+
+  // Ohne Plan gibt es die beiden Abgleich-Befunde nicht. Das ist KEINE
+  // Sonderbehandlung, sondern derselbe Fall wie ein Plan ohne Dante-Geraete:
+  // beide sagen „es gibt nichts zu vergleichen", und beide muessen dasselbe
+  // Ergebnis liefern. Der frueh zurueckkehrende Zweig spart nur die Arbeit.
+  if (!plan) return out
+
+  const planGeraete = new Map(
+    plan.equipment.filter(hasDanteInterface).map((e) => [norm(e.name), e.name]),
+  )
+  const imPatch = new Set<string>()
+  for (const s of patch.subscriptions) {
+    imPatch.add(norm(s.rxDevice))
+    if (s.txDevice) imPatch.add(norm(s.txDevice))
+  }
+
+  // Nur melden, wenn der Plan ueberhaupt Dante-Geraete fuehrt. Ein Projekt, in
+  // dem niemand eine Dante-Schnittstelle gepflegt hat, wuerde sonst jeden
+  // Geraetenamen des Patches als unbekannt melden — und ein Befund, der bei
+  // jedem Namen anschlaegt, wird nach der dritten Zeile weggeklickt.
+  if (planGeraete.size > 0) {
+    const fremd = [...imPatch].filter((n) => !planGeraete.has(n))
+    if (fremd.length > 0) {
+      out.push({
+        kind: 'device-not-in-plan',
+        text: `${fremd.length} Gerät(e) im Patch führt der Plan nicht als Dante-Gerät: ${fremd.slice(0, 6).join(', ')}${fremd.length > 6 ? ' …' : ''}. Nach einer Umbenennung steht genau so der alte Name im Patch und der neue im Plan.`,
+      })
+    }
+    const fehlend = [...planGeraete].filter(([n]) => !imPatch.has(n)).map(([, name]) => name)
+    if (fehlend.length > 0) {
+      out.push({
+        kind: 'plan-device-unpatched',
+        text: `${fehlend.length} Dante-Gerät(e) aus dem Plan kommen im Patch nicht vor: ${fehlend.slice(0, 6).join(', ')}${fehlend.length > 6 ? ' …' : ''}.`,
+      })
+    }
+  }
+
+  return out
+}
+
+// ─── Der Vergleich ─────────────────────────────────────────────────────────
+
+export type DanteDiffKind = 'subscribed' | 'unsubscribed' | 'changed' | 'rx-added' | 'rx-removed'
+
+export const DANTE_DIFF_LABEL: Readonly<Record<DanteDiffKind, string>> = {
+  subscribed: 'neu abonniert',
+  unsubscribed: 'Abo entfernt',
+  changed: 'auf andere Quelle gelegt',
+  'rx-added': 'Empfangskanal neu',
+  'rx-removed': 'Empfangskanal weg',
+}
+
+export interface DanteDiffRow {
+  rx: string
+  kind: DanteDiffKind
+  before: string
+  after: string
+}
+
+const NO_SOURCE = 'nichts'
+const quelle = (s: DanteSubscription | undefined): string =>
+  s?.txDevice && s.txChannel ? `${s.txDevice} / ${s.txChannel}` : NO_SOURCE
+
+/**
+ * Was sich zwischen zwei Ständen geändert hat.
+ *
+ * Beidseitig unabonnierte Kanaele stehen NICHT drin: in einem 64-Kanal-Patch
+ * waeren das die meisten Zeilen, und eine Aenderungsliste, in der fast nichts
+ * eine Aenderung ist, wird nicht gelesen. Dieselbe Regel wie beim
+ * Szenen-Vergleich (Bedarf 92).
+ */
+export function diffDantePatches(vorher: DantePatch, nachher: DantePatch): DanteDiffRow[] {
+  const key = (s: DanteSubscription): string => `${s.rxDevice} / ${s.rxChannel}`
+  const a = new Map(vorher.subscriptions.map((s) => [norm(key(s)), s]))
+  const b = new Map(nachher.subscriptions.map((s) => [norm(key(s)), s]))
+  const alle = [...new Set([...a.keys(), ...b.keys()])].sort()
+  const out: DanteDiffRow[] = []
+
+  for (const k of alle) {
+    const va = a.get(k)
+    const vb = b.get(k)
+    const rx = key(vb ?? (va as DanteSubscription))
+    if (!va) {
+      out.push({ rx, kind: 'rx-added', before: NO_SOURCE, after: quelle(vb) })
+      continue
+    }
+    if (!vb) {
+      out.push({ rx, kind: 'rx-removed', before: quelle(va), after: NO_SOURCE })
+      continue
+    }
+    const qa = quelle(va)
+    const qb = quelle(vb)
+    if (qa === qb) continue
+    const kind: DanteDiffKind =
+      qa === NO_SOURCE ? 'subscribed' : qb === NO_SOURCE ? 'unsubscribed' : 'changed'
+    out.push({ rx, kind, before: qa, after: qb })
+  }
+  return out
+}
+
+// Kanonisches Deutsch — dieselbe Regel wie bei allen Blaettern.
+const NO_CHANNEL = 'kein Kanal'
+
+/** Der Patch als Blatt: eine Zeile je Empfangskanal, Quelle daneben. */
+export function dantePatchTable(patch: DantePatch): CsvTable {
+  return {
+    headers: ['Empfänger', 'Empfangskanal', 'Sender', 'Sendekanal'],
+    rows: patch.subscriptions.map((s) => [
+      s.rxDevice,
+      s.rxChannel,
+      s.txDevice ?? NO_SOURCE,
+      s.txChannel ?? NO_CHANNEL,
+    ]),
+  }
+}
+
+/** Der Vergleich als Blatt — die Änderungsliste. */
+export function danteDiffTable(rows: readonly DanteDiffRow[]): CsvTable {
+  return {
+    headers: ['Empfangskanal', 'Was', 'Vorher', 'Nachher'],
+    rows: rows.map((r) => [r.rx, DANTE_DIFF_LABEL[r.kind], r.before, r.after]),
+  }
+}

--- a/src/renderer/lib/dataDictionary.ts
+++ b/src/renderer/lib/dataDictionary.ts
@@ -98,6 +98,9 @@ export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
   'Bezug im Plan':
     'Woran die Kostenposition im Plan hängt — ein Gerät, ein Ausspielziel, oder ausdrücklich nichts (Fahrt, Personal).',
   Ch: 'Die Kanalnummer am Pult.',
+  'Ch (Pult)': 'Die Kanalnummer, die in der Szenendatei des Pults steht.',
+  'Ch (Plan)':
+    'Die Kanalnummer der Kanalliste aus dem Plan. „nicht zugeordnet" heißt: dieser Pult-Kanal findet im Plan keine Entsprechung.',
   Code: 'Der Etiketten- oder Barcode, mit dem die Einheit gescannt wird.',
   Container: 'Der Container (Case, Kiste), zu dem diese Zeile gehört.',
   Dienste:
@@ -115,6 +118,8 @@ export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
   'Etiketten-Code': 'Der aufgeklebte Code, unter dem die Einheit gescannt wird.',
   'Fehler gesamt':
     'Alle je gemeldeten Fehler an dieser Einheit, auch die behobenen. Die Zahl daneben zählt nur die offenen.',
+  Farbe:
+    'Die Farbe des Kanals am Pult. Sie ist dort die Gruppierung — Drums rot, Vocals gelb.',
   Feld: 'Das benannte Feld des Übergabe-Dokuments.',
   Fluss: 'Ein einzelner Sende-Strom, aus dem Kabelgraph abgeleitet (Gerät und Port).',
   'Frage an das Haus':
@@ -158,8 +163,10 @@ export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
   Menge: 'Die Stückzahl dieser Position.',
   Mischer: 'Der Bildmischer, auf den sich die Eingangsnummer bezieht.',
   Modell: 'Der Gerätetyp — nicht die einzelne Einheit.',
+  Nachher: 'Der Stand nach dem zweiten Import.',
   Name: 'Der Name, unter dem der Datensatz im Plan geführt wird.',
   'Neuer Name': 'Der Name, den die Regel für dieses Gerät ergibt.',
+  'Name (Pult)': 'Der Name, den jemand am Pult eingetippt hat.',
   'Niedrige Bitrate': 'Die Szene, auf die bei niedriger Bitrate geschaltet werden soll.',
   Normalbetrieb: 'Die Szene für den Normalbetrieb — der Rückweg aus der Ausweichszene.',
   Notiz: 'Freitext zu diesem Ziel.',
@@ -181,6 +188,7 @@ export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
   Punkt: 'Der Punkt des Anforderungsblatts, auf den sich die Zeile bezieht.',
   Quelle:
     'Woher das Signal oder die Angabe kommt — je nach Blatt das speisende Gerät, der Kanal oder die Fundstelle.',
+  'Quelle (Plan)': 'Die Quelle, die der Plan für den zugeordneten Kanal führt.',
   Reservierung: 'Die Menge, die im Warenwirtschaftssystem reserviert ist.',
   Rolle: 'Wofür das Gerät oder die Schnittstelle in diesem Zusammenhang steht.',
   'Schätzung': 'Der geschätzte Betrag dieser Position.',
@@ -199,6 +207,7 @@ export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
   Stecker: 'Der Steckertyp an diesem Ende.',
   'Stream-Key':
     'Nur der VERWEIS auf den Schlüsselbund-Eintrag, nie der Wert. Ein Blatt geht per Mail.',
+  Stumm: 'Ob der Kanal stummgeschaltet gespeichert wurde.',
   Text: 'Der Klartext dieser Zeile.',
   Thumbnail: 'Der Dateiname des Vorschaubilds — das Bild selbst steckt nicht im Projekt.',
   Titel: 'Der Titel, unter dem die Veranstaltung läuft.',
@@ -208,6 +217,7 @@ export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
   'UMD-Adresse': 'Die TSL-Adresse, unter der der Multiviewer diese Quelle beschriftet.',
   Video: 'Die geplanten Video-Parameter des Ziels.',
   VLAN: 'Das VLAN, in dem die Schnittstelle liegt.',
+  Vorher: 'Der Stand beim ersten Import.',
   Vorgefunden: 'Was vor Ort tatsächlich angetroffen wurde — die Ist-Seite des Abgleichs.',
   Wann: 'Wann die Angabe gemacht oder die Antwort gegeben wurde.',
   Was: 'Worum es in dieser Zeile geht.',

--- a/src/renderer/lib/dataDictionary.ts
+++ b/src/renderer/lib/dataDictionary.ts
@@ -145,6 +145,10 @@ export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
     'Woher der Ist-Wert stammt — aus dem ERP, von der Rechnung oder von Hand geschätzt.',
   'Im Klartext im Plan':
     'Wie oft der alte Name in Notizen oder Antworten als Text vorkommt. Diese Stellen bricht ein Umbenennen still.',
+  Herstellernummer:
+    'Die Seriennummer des Herstellers. Sie zählt außerhalb des Hauses — Versicherung, Sub-Vermietung, Wartung.',
+  Hausreferenz:
+    'Die Nummer, unter der dieses Haus die Einheit führt. Sie klebt auf dem Case und ist die, die der Lagerist ruft.',
   'Im Plan': 'Was der Plan an dieser Stelle vorsieht — die Soll-Seite des Abgleichs.',
   'Ingest-URL': 'Die Adresse, an die gesendet wird. Ohne Stream-Key — der steht nie in einer Datei.',
   IP: 'Die IP-Adresse der Schnittstelle.',

--- a/src/renderer/lib/dataDictionary.ts
+++ b/src/renderer/lib/dataDictionary.ts
@@ -111,6 +111,8 @@ export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
   Eingang: 'Der physische Eingang am Gerät oder Mischer.',
   Einheit: 'Die einzelne, mit Seriennummer unterscheidbare Kiste — nicht das Modell.',
   Empfänger: 'Wer den Multicast-Fluss empfängt.',
+  Empfangskanal:
+    'Der Eingang am empfangenden Dante-Gerät. Jeder kann genau ein Abo haben — steht er zweimal, ist eine der Zeilen falsch.',
   Encoder: 'Das Gerät im Plan, das dieses Ziel beliefert.',
   Ergebnis: 'Wie die Inventur-Prüfung dieser Position ausgegangen ist.',
   'Erwartet in': 'Wo die Position laut Plan liegen müsste.',
@@ -197,6 +199,9 @@ export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
   Schnittstelle: 'Die Netzwerk-Schnittstelle des Geräts (erste, Dante-Sekundär, ST 2110 blau …).',
   'Schwelle niedrig (kbit/s)': 'Ab welcher Bitrate der Wächter „niedrig" annehmen soll.',
   'Schwelle offline (kbit/s)': 'Ab welcher Bitrate der Wächter „offline" annehmen soll.',
+  Sender:
+    'Das sendende Dante-Gerät. „nichts“ heißt: dieser Empfangskanal ist nicht abonniert — ein gültiger Zustand, kein Fehler.',
+  Sendekanal: 'Der Ausgang am sendenden Dante-Gerät.',
   'Serie (Einheit)': 'Die Seriennummer, die an der Lager-Einheit steht.',
   'Serie (Platz)': 'Die Seriennummer, die am Platz im Plan hinterlegt ist.',
   Show: 'Das Projekt oder die Show, zu der die Zeile gehört.',

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -4481,6 +4481,15 @@ export const en: Dict = {
   'analysis.naming.before': 'Old name',
   'analysis.naming.after': 'New name',
   'analysis.naming.chars': 'Characters',
+  // Bedarf 94 — der Dante-Patch als Dokument.
+  'analysis.tab.dante': 'Dante patch',
+  'analysis.dante.intro':
+    'The subscription matrix as a sheet and as a comparison. This application does not go on the network, subscribes to nothing and renames nothing \u2014 it reads the table the preset is converted into anyway.',
+  'analysis.dante.import': 'Read matrix',
+  'analysis.dante.count': '{n} receive channels',
+  'analysis.dante.unreadable': '{n} lines not readable',
+  'analysis.dante.exportDiff': 'Changes',
+  'analysis.dante.noChange': 'Nothing changed in the patch between the two states.',
 
   /* Bedarf 27 — der Rueckweg vom Papier. */
   'analysis.sheet.intro':

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3491,6 +3491,20 @@ export const en: Dict = {
   'channelList.view.console': 'Console (names)',
   'channelList.view.monitor': 'Monitor paths',
   'channelList.export': '🎚 Channel list',
+  // Bedarf 92 — die Szenendatei des Pults lesen und zwei Staende vergleichen.
+  'scene.import': '\u{1F39B} Read scene file',
+  'scene.importHint':
+    'Read the console scene file (X32/M32/WING). This application writes nothing back to the console.',
+  'scene.title': 'Console scene file',
+  'scene.channelCount': '{n} channels',
+  'scene.unreadable': '{n} lines not readable',
+  'scene.matchMode': 'Match to the plan',
+  'scene.byName': 'by name',
+  'scene.byNumber': 'by channel number (only if it holds)',
+  'scene.exportList': 'Channels',
+  'scene.exportMatch': 'Match',
+  'scene.exportDiff': 'Changes',
+  'scene.noChange': 'Nothing changed in the channel names between the two states.',
   'channelList.exportHint':
     'The same channel list, cut for this reader. The monitor view shows paths, not mix contents \u2014 the plan does not know those.',
   // #314 Replace device section

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3838,7 +3838,10 @@ export const en: Dict = {
   'inventory.editUnit': 'Edit unit',
   'inventory.newUnit': 'New unit',
   'inventory.unitItem': 'Item model',
-  'inventory.serial': 'Serial number',
+  'inventory.serial': 'Serial number (manufacturer)',
+  // Bedarf 107 — zwei Identitaeten, zwei Felder.
+  'inventory.houseRef': 'House reference',
+  'inventory.houseRefPh': 'e.g. AV-0421',
   'inventory.unitDeleteTitle': 'Delete unit?',
   'inventory.unitsNoItems': 'Create items first, then you can serialize individual units.',
   'inventory.unitsEmpty': 'No units yet. Serialize individual copies of an item.',

--- a/src/renderer/lib/inventoryAudit.ts
+++ b/src/renderer/lib/inventoryAudit.ts
@@ -40,6 +40,7 @@
 // ───────────────────────────────────────────────────────────────────────────
 
 import type { InventoryItem, StorageNode, InventoryUnit } from '../types/inventory'
+import { unitLabel } from './unitIdentity'
 import { resolveInventoryCode, type ScanSources } from './inventoryScan'
 import { descendantNodeIds, nodePathLabel } from './storageTree'
 import type { CsvCell, CsvTable } from './csv'
@@ -103,7 +104,8 @@ export function auditScan(
   if (treffer.kind === 'unit') {
     const u: InventoryUnit = treffer.unit
     const model = sources.items.find((i) => i.id === u.itemId)?.model
-    const label = u.serial || u.code || u.id.slice(0, 6)
+    // Bedarf 107 — die Inventur zaehlt im eigenen Haus.
+    const label = unitLabel(u, 'house')
     if (!u.locationId) {
       return { outcome: 'no-location', code: roh, label, ...(model ? { model } : {}), unitId: u.id }
     }

--- a/src/renderer/lib/inventoryPortable.ts
+++ b/src/renderer/lib/inventoryPortable.ts
@@ -23,7 +23,16 @@ export const INVENTORY_FORMAT = 'avplan-inventory'
 // loeschte also die bestaetigte deviceTypeId. Dafuer ist jetzt
 // `lib/inventoryMerge.ts` da; die Version kann das nicht leisten, weil eine
 // alte Datei zu lesen ausdruecklich erlaubt bleibt.
-export const INVENTORY_FORMAT_VERSION = 2
+//
+// Version 3 (Bedarf 107): `InventoryUnit.houseRef` — die haus-eigene Referenz
+// neben der Hersteller-Seriennummer. Dieselbe Begruendung wie bei Version 2,
+// eine Ebene tiefer: `inventoryStore.healUnit` baut jede Einheit Feld fuer
+// Feld neu auf. Ein Planer, der `houseRef` nicht kennt, wuerde eine Datei mit
+// Hausreferenzen still ohne sie zurueckschreiben — und die Nummer, die auf dem
+// Case klebt, waere weg. Mit der erhoehten Version weigert er sich stattdessen
+// zu lesen, und das ist die ehrlichere Antwort. Aeltere Dateien (v1/v2) lesen
+// wir unveraendert weiter; ihre Einheiten haben schlicht keine Hausreferenz.
+export const INVENTORY_FORMAT_VERSION = 3
 
 export interface InventorySnapshot {
   items: InventoryItem[]

--- a/src/renderer/lib/inventoryScan.ts
+++ b/src/renderer/lib/inventoryScan.ts
@@ -22,9 +22,16 @@ export interface ScanSources {
 }
 
 /**
- * Löst einen gescannten/eingegebenen Code auf. Reihenfolge: Einheit (Code oder
- * Seriennr.) → Lager-Knoten (Code) → Artikel (Code). Einheiten zuerst, weil ihr
- * Code am spezifischsten ist. Liefert den ersten Treffer oder null.
+ * Löst einen gescannten/eingegebenen Code auf. Reihenfolge: Einheit (Code,
+ * Hausreferenz oder Seriennr.) → Lager-Knoten (Code) → Artikel (Code).
+ * Einheiten zuerst, weil ihr Code am spezifischsten ist. Liefert den ersten
+ * Treffer oder null.
+ *
+ * Bedarf 107 — die HAUSREFERENZ gehört hier ausdrücklich dazu, und zwar als
+ * die wahrscheinlichste Eingabe von allen: sie ist die Nummer, die auf dem
+ * Case klebt und die jemand abtippt, wenn der Aufkleber unlesbar geworden
+ * ist. Ein neues Identitäts-Feld, das die Suche nicht kennt, wäre für den
+ * Lageristen unsichtbar.
  */
 export const resolveInventoryCode = (
   raw: string,
@@ -33,7 +40,9 @@ export const resolveInventoryCode = (
   const needle = norm(raw)
   if (!needle) return null
 
-  const unit = units.find((u) => norm(u.code) === needle || norm(u.serial) === needle)
+  const unit = units.find(
+    (u) => norm(u.code) === needle || norm(u.houseRef) === needle || norm(u.serial) === needle,
+  )
   if (unit) return { kind: 'unit', unit }
 
   const node = nodes.find((n) => norm(n.code) === needle)

--- a/src/renderer/lib/packList.ts
+++ b/src/renderer/lib/packList.ts
@@ -7,6 +7,7 @@
 // (nichts erfinden).
 // ───────────────────────────────────────────────────────────────────────────
 import type { InventoryItem, StorageNode, InventoryUnit } from '../types/inventory'
+import { unitLabel } from './unitIdentity'
 import { isContainerKind } from './storageTree'
 import { ownershipNote } from './ownership'
 
@@ -103,7 +104,9 @@ export const derivePackList = (
       .map((u) => {
         const item = itemById.get(u.itemId)
         const model = item?.model ?? '?'
-        const serial = u.serial || u.code || u.id.slice(0, 6)
+        // Bedarf 107 — die Packliste ist ein HAUS-Blatt: der Lagerist ruft
+        // die Hausreferenz, nicht die Herstellernummer.
+        const serial = unitLabel(u, 'house')
         // Die Einheit erbt die Herkunft ihres Artikels: sie hat keine eigene,
         // und eine erfundene waere schlimmer als keine.
         const ownership = item ? ownershipNote(item, heute) : ''

--- a/src/renderer/lib/sceneImport.ts
+++ b/src/renderer/lib/sceneImport.ts
@@ -1,0 +1,303 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Die Szenendatei des Pults lesen und zwei Stände vergleichen (Bedarf 92, P2).
+//
+// Warum es das gibt und wo die Grenze liegt, steht in `types/sceneImport.ts`.
+// Hier steht, wie gelesen und wie verglichen wird.
+//
+// ─── DAS FORMAT, ZEILE FUER ZEILE ──────────────────────────────────────────
+//
+// Eine X32/M32-Szenendatei ist Text. Die Kanaele stehen als:
+//
+//   /ch/01/config "Kick" 1 RD 1
+//    │    │       │      │ │  └ Icon-/Quellindex
+//    │    │       │      │ └─── Farbe (RD, GN, YE …), teils mit „i" fuer invers
+//    │    │       │      └───── Icon-Nummer
+//    │    │       └──────────── Name in Anfuehrungszeichen
+//    │    └──────────────────── Unterknoten
+//    └───────────────────────── Kanal, zweistellig, 1-basiert
+//
+// Ein leerer Name steht als `""`. Genau der ist der interessante Fall: er
+// heisst „dieser Kanal ist am Pult unbeschriftet", NICHT „diesen Kanal gibt es
+// nicht" — und ein Import, der ihn wegliesse, machte aus einem Loch im
+// Beschriftungsstreifen ein Loch in der Liste.
+//
+// ─── WAS BEIM VERGLEICH GEZAEHLT WIRD ──────────────────────────────────────
+//
+// Vier Faelle, und der vierte ist der, um den es geht:
+//   `added`     Kanal war leer, ist jetzt beschriftet.
+//   `removed`   Kanal war beschriftet, ist jetzt leer.
+//   `renamed`   Beide beschriftet, anderer Name.
+//   `recolored` Gleicher Name, andere Farbe.
+//
+// Der letzte sieht harmlos aus und ist es nicht: die Farbe ist am Pult die
+// Gruppierung. Ein Kanal, der von Rot nach Gelb gewandert ist, ist in der
+// Probe von den Drums zu den Vocals umgezogen — auf einem Blatt, das nur
+// Namen vergleicht, ist das unsichtbar.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import {
+  type SceneChannel,
+  type SceneFormat,
+  type SceneImport,
+} from '../types/sceneImport'
+import type { CsvTable } from './csv'
+
+/**
+ * Die Kanal-Zeile.
+ *
+ * `/ch/01/config "Kick" 1 RD 1` — Nummer, Name in Anfuehrungszeichen, danach
+ * bis zu drei Felder. Name und Folgefelder sind optional, weil aeltere
+ * Exporte kuerzere Zeilen schreiben; fehlt der Name ganz, ist die Zeile
+ * unlesbar und wird gezaehlt statt still verworfen.
+ */
+const CHANNEL_LINE = /^\/ch\/(\d{1,2})\/config\s+"((?:[^"\\]|\\.)*)"(?:\s+(\S+))?(?:\s+(\S+))?/
+
+/** Die `/mute`-Zeile desselben Kanals, wo eine Datei sie fuehrt. */
+const MUTE_LINE = /^\/ch\/(\d{1,2})\/mix\s+(\S+)/
+
+/**
+ * Woran das Format erkannt wird.
+ *
+ * Es wird NICHT geraten: erkennt keine Marke, steht `unknown` da, und die
+ * Kanaele werden trotzdem gelesen — die Zeilen sind laut Beleg dieselben. Eine
+ * erfundene Marke auf dem Blatt waere schlechter als ein ehrliches „nicht
+ * erkannt": jemand suchte den Fehler dann beim falschen Pult.
+ */
+const detectFormat = (text: string): SceneFormat => {
+  if (/^#\d+\.\d+#\s*"?WING/im.test(text) || /\/\$syswing/i.test(text)) return 'wing'
+  if (/^#\d+\.\d+#/m.test(text) || /^\/ch\/\d{1,2}\/config/m.test(text)) return 'x32'
+  return 'unknown'
+}
+
+const unescape = (s: string): string => s.replace(/\\"/g, '"').replace(/\\\\/g, '\\')
+
+/**
+ * Liest eine Szenendatei.
+ *
+ * Doppelte Kanalzeilen: die ERSTE gewinnt. Dieselbe Regel wie ueberall sonst
+ * beim Laden — und hier zusaetzlich, weil eine Szenendatei ihre Kanaele in
+ * einem Block schreibt und ein zweiter Block meist aus einem angehaengten
+ * zweiten Export stammt.
+ */
+export function parseSceneFile(text: string): SceneImport {
+  const format = detectFormat(text)
+  const byCh = new Map<number, SceneChannel>()
+  const mutes = new Map<number, boolean>()
+  let unreadable = 0
+
+  for (const roh of text.split(/\r?\n/)) {
+    const line = roh.trim()
+    if (!line.startsWith('/ch/')) continue
+
+    const m = CHANNEL_LINE.exec(line)
+    if (m) {
+      const ch = Number(m[1])
+      // Kanal 0 gibt es nicht; eine Zeile, die einen behauptet, ist unlesbar.
+      if (!Number.isInteger(ch) || ch < 1) {
+        unreadable += 1
+        continue
+      }
+      if (byCh.has(ch)) continue
+      const eintrag: SceneChannel = { ch, name: unescape(m[2]) }
+      // Feld 3 ist das Icon, Feld 4 die Farbe. Nur Buchstabenkuerzel wie „RD"
+      // oder „RDi" gelten als Farbe — eine Zahl an der Stelle ist keine.
+      //
+      // `OFF` ist die Farbe „keine": das X32 schreibt sie fuer einen Streifen
+      // ohne Farbe, und sie als Farbe zu fuehren waere ein Unterschied, den es
+      // am Pult nicht gibt — der Vergleich meldete dann eine Farbaenderung, wo
+      // jemand nur eine Farbe entfernt hat.
+      const farbe = m[4]
+      if (farbe && farbe !== 'OFF' && /^[A-Za-z]{2,3}$/.test(farbe)) eintrag.color = farbe
+      byCh.set(ch, eintrag)
+      continue
+    }
+
+    const mm = MUTE_LINE.exec(line)
+    if (mm) {
+      const ch = Number(mm[1])
+      if (Number.isInteger(ch) && ch >= 1) mutes.set(ch, mm[2] === 'OFF')
+      continue
+    }
+
+    // Sieht aus wie eine Kanalzeile, ist aber keine — z. B. ein abgeschnittener
+    // Export. Wird gezaehlt, damit die Zahl auf dem Blatt stehen kann.
+    if (/^\/ch\/\d{1,2}\/config/.test(line)) unreadable += 1
+  }
+
+  const channels = [...byCh.values()]
+    .map((c) => (mutes.has(c.ch) ? { ...c, muted: mutes.get(c.ch) } : c))
+    .sort((a, b) => a.ch - b.ch)
+
+  return { format, channels, unreadable }
+}
+
+// ─── Der Vergleich zweier Uploads ──────────────────────────────────────────
+
+export type SceneDiffKind = 'added' | 'removed' | 'renamed' | 'recolored'
+
+export const SCENE_DIFF_LABEL: Readonly<Record<SceneDiffKind, string>> = {
+  added: 'neu beschriftet',
+  removed: 'Beschriftung entfernt',
+  renamed: 'umbenannt',
+  recolored: 'Farbe geändert',
+}
+
+export interface SceneDiffRow {
+  ch: number
+  kind: SceneDiffKind
+  before: string
+  after: string
+  /** Nur bei `recolored` gesetzt. */
+  beforeColor?: string
+  afterColor?: string
+}
+
+const named = (c: SceneChannel | undefined): boolean => !!c && c.name.trim() !== ''
+
+/**
+ * Was sich zwischen zwei Ständen geändert hat.
+ *
+ * Kanaele, die in beiden Staenden unbeschriftet sind, stehen NICHT in der
+ * Liste: bei 32 oder 48 Kanaelen waeren das die meisten Zeilen, und eine
+ * Aenderungsliste, in der fast nichts eine Aenderung ist, wird nicht gelesen.
+ */
+export function diffScenes(vorher: SceneImport, nachher: SceneImport): SceneDiffRow[] {
+  const a = new Map(vorher.channels.map((c) => [c.ch, c]))
+  const b = new Map(nachher.channels.map((c) => [c.ch, c]))
+  const alle = [...new Set([...a.keys(), ...b.keys()])].sort((x, y) => x - y)
+  const out: SceneDiffRow[] = []
+
+  for (const ch of alle) {
+    const va = a.get(ch)
+    const vb = b.get(ch)
+    const nameA = va?.name.trim() ?? ''
+    const nameB = vb?.name.trim() ?? ''
+
+    if (!named(va) && !named(vb)) continue
+    if (!named(va)) {
+      out.push({ ch, kind: 'added', before: nameA, after: nameB })
+      continue
+    }
+    if (!named(vb)) {
+      out.push({ ch, kind: 'removed', before: nameA, after: nameB })
+      continue
+    }
+    if (nameA !== nameB) {
+      out.push({ ch, kind: 'renamed', before: nameA, after: nameB })
+      continue
+    }
+    // Gleicher Name, andere Farbe: am Pult ist die Farbe die Gruppierung.
+    if ((va?.color ?? '') !== (vb?.color ?? '')) {
+      out.push({
+        ch,
+        kind: 'recolored',
+        before: nameA,
+        after: nameB,
+        ...(va?.color ? { beforeColor: va.color } : {}),
+        ...(vb?.color ? { afterColor: vb.color } : {}),
+      })
+    }
+  }
+  return out
+}
+
+// Kanonisches Deutsch — dieselbe Regel wie bei allen Blaettern: ein Text, der
+// mit der eingestellten Sprache wechselt, aendert den Stand des Dokuments.
+const NO_NAME = 'unbeschriftet'
+const NO_COLOR = 'keine Farbe'
+
+/** Die eingelesene Liste als Blatt. */
+export function sceneTable(scene: SceneImport): CsvTable {
+  return {
+    headers: ['Ch', 'Name', 'Farbe', 'Stumm'],
+    rows: scene.channels.map((c) => [
+      c.ch,
+      c.name.trim() || NO_NAME,
+      c.color ?? NO_COLOR,
+      c.muted === undefined ? 'nicht angegeben' : c.muted ? 'ja' : 'nein',
+    ]),
+  }
+}
+
+/** Der Vergleich als Blatt — die Änderungsliste aus der Probe. */
+export function sceneDiffTable(rows: readonly SceneDiffRow[]): CsvTable {
+  return {
+    headers: ['Ch', 'Was', 'Vorher', 'Nachher'],
+    rows: rows.map((r) => [
+      r.ch,
+      SCENE_DIFF_LABEL[r.kind],
+      r.kind === 'recolored' ? (r.beforeColor ?? NO_COLOR) : r.before || NO_NAME,
+      r.kind === 'recolored' ? (r.afterColor ?? NO_COLOR) : r.after || NO_NAME,
+    ]),
+  }
+}
+
+// ─── Die Zuordnung zum Plan ────────────────────────────────────────────────
+
+export type MatchMode =
+  /** Ueber den Namen — der Normalfall. */
+  | 'by-name'
+  /** Ueber die Kanalnummer. NUR wenn der Nutzer sagt, dass sie stimmt. */
+  | 'by-number'
+
+export interface SceneMatch {
+  sceneCh: number
+  sceneName: string
+  /** Die Kanalnummer im Plan, oder `undefined` fuer „nicht zugeordnet". */
+  planCh?: number
+  planSource?: string
+}
+
+/**
+ * Ordnet die Pult-Kanäle den Plan-Kanälen zu.
+ *
+ * ÜBER DIE NUMMER NUR AUF ANSAGE. Ein Pult zaehlt seine Eingaenge, der Plan
+ * zaehlt seine Kabel, und beide beginnen bei 1 — daraus eine Gleichung zu
+ * machen waere die naheliegendste und teuerste Annahme dieses Moduls. Ueber
+ * den Namen ist die Zuordnung eine Beobachtung („beide heissen Kick"), ueber
+ * die Nummer eine Behauptung ueber die Verkabelung.
+ *
+ * Was sich nicht findet, bleibt ohne `planCh`. Das ist die Auskunft: dieser
+ * Kanal steht am Pult und nirgends im Plan.
+ */
+export function matchToPlan(
+  scene: SceneImport,
+  plan: ReadonlyArray<{ ch: number; source: string }>,
+  mode: MatchMode,
+): SceneMatch[] {
+  const norm = (s: string): string => s.trim().toLowerCase().replace(/\s+/g, ' ')
+  const byName = new Map<string, { ch: number; source: string }>()
+  for (const p of plan) {
+    const k = norm(p.source)
+    // Erster gewinnt: zwei Plan-Kanaele mit demselben Quellnamen sind moeglich
+    // (zwei Mikros „SM58"), und den zweiten stillschweigend zu bevorzugen
+    // waere Zufall statt Regel.
+    if (k && !byName.has(k)) byName.set(k, p)
+  }
+  const byNumber = new Map(plan.map((p) => [p.ch, p]))
+
+  return scene.channels.map((c) => {
+    const treffer =
+      mode === 'by-number' ? byNumber.get(c.ch) : byName.get(norm(c.name))
+    return {
+      sceneCh: c.ch,
+      sceneName: c.name.trim(),
+      ...(treffer ? { planCh: treffer.ch, planSource: treffer.source } : {}),
+    }
+  })
+}
+
+/** Die Zuordnung als Blatt. Nicht Zugeordnetes trägt einen NAMEN. */
+export function matchTable(matches: readonly SceneMatch[]): CsvTable {
+  return {
+    headers: ['Ch (Pult)', 'Name (Pult)', 'Ch (Plan)', 'Quelle (Plan)'],
+    rows: matches.map((m) => [
+      m.sceneCh,
+      m.sceneName || NO_NAME,
+      m.planCh ?? 'nicht zugeordnet',
+      m.planSource ?? 'nicht im Plan',
+    ]),
+  }
+}

--- a/src/renderer/lib/unitIdentity.ts
+++ b/src/renderer/lib/unitIdentity.ts
@@ -1,0 +1,164 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Zwei Identitäten je Einheit, und wer welche liest (Bedarf 107, P3).
+//
+//   > Systems with a single code field force the warehouse to choose which
+//   > identity to store; the other one is then needed for insurance, sub-hire
+//   > to third parties and maintenance history, and gets kept in a spreadsheet
+//   > or ON THE CASE WITH A MARKER.
+//
+// Beleg zweiter Hand aus dem Schwester-Dossier: Rentman trennt „Internal
+// Reference" von „Manufacturer Serial Number" ausdruecklich, und zwar weil die
+// zweite fuer Versicherung, Fremdvermietung und das Wartungsmodul gebraucht
+// wird. Die Bedarfs-Datenbank zieht daraus die Konsequenz fuer den Zeitpunkt:
+// „Cheap today, expensive after the first real deployment."
+//
+// ─── EINE ENGSTELLE FUER „WIE HEISST DIESE KISTE AUF DEM BLATT" ────────────
+//
+// Vor diesem Modul stand an drei Stellen dieselbe Zeile:
+//   `u.serial || u.code || u.id.slice(0, 6)`
+// Drei Kopien einer Regel, die sich mit zwei Identitaeten aendern MUSS — und
+// die dritte haette man beim Aendern uebersehen. Sie steht jetzt einmal hier.
+//
+// ─── UND DIE REGEL SELBST ──────────────────────────────────────────────────
+//
+// Wer liest, entscheidet, was vorne steht:
+//
+//   `house`     Kommissionierliste, Inventur, Packliste. Die Hausreferenz
+//               ist die Nummer, die auf dem Case klebt und die der Lagerist
+//               ruft.
+//   `external`  Versicherung, Sub-Vermietung, Wartung. Dort zaehlt die
+//               HERSTELLERNUMMER; eine Hausnummer bedeutet ausserhalb des
+//               Hauses nichts, und auf einem Versicherungsblatt ist sie
+//               schlimmer als eine leere Zelle: sie sieht aus wie eine
+//               Seriennummer.
+//
+// Fehlt die gewuenschte, wird die andere genommen — aber BENANNT. „AV-0421
+// (Hausreferenz)" auf einem Versicherungsblatt ist eine Auskunft; „AV-0421"
+// allein ist eine Verwechslung.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { InventoryUnit } from '../types/inventory'
+import type { CsvTable } from './csv'
+
+export type IdentityAudience = 'house' | 'external'
+
+/** Wie eine fremde Nummer beschriftet wird, wenn die gewuenschte fehlt. */
+export const HOUSE_REF_NOTE = 'Hausreferenz'
+export const SERIAL_NOTE = 'Herstellernummer'
+/** Was dasteht, wenn die Einheit gar keine Nummer traegt. */
+export const NO_IDENTITY = 'ohne Nummer'
+
+/**
+ * Die eine Beschriftung einer Einheit auf einem Blatt.
+ *
+ * Der Etiketten-Code (`code`) kommt als DRITTE Wahl: er ist eine
+ * Scan-Kennung und keine Identitaet — zwei Einheiten koennen nacheinander
+ * denselben aufgeklebt bekommen, wenn eine ausgemustert wurde.
+ */
+export function unitLabel(unit: InventoryUnit, audience: IdentityAudience): string {
+  const serial = unit.serial?.trim()
+  const house = unit.houseRef?.trim()
+  const code = unit.code?.trim()
+  const bevorzugt = audience === 'external' ? serial : house
+  if (bevorzugt) return bevorzugt
+  const ersatz = audience === 'external' ? house : serial
+  if (ersatz) {
+    return `${ersatz} (${audience === 'external' ? HOUSE_REF_NOTE : SERIAL_NOTE})`
+  }
+  if (code) return code
+  return NO_IDENTITY
+}
+
+export type IdentityFindingKind = 'serial-duplicate' | 'houseref-duplicate' | 'no-identity'
+
+export const IDENTITY_FINDING_LABEL: Readonly<Record<IdentityFindingKind, string>> = {
+  'serial-duplicate': 'Zwei Einheiten mit derselben Herstellernummer',
+  'houseref-duplicate': 'Zwei Einheiten mit derselben Hausreferenz',
+  'no-identity': 'Einheit ganz ohne Nummer',
+}
+
+export interface IdentityFinding {
+  kind: IdentityFindingKind
+  text: string
+  unitIds: string[]
+}
+
+const gruppiere = (
+  units: readonly InventoryUnit[],
+  feld: (u: InventoryUnit) => string | undefined,
+): Map<string, InventoryUnit[]> => {
+  const m = new Map<string, InventoryUnit[]>()
+  for (const u of units) {
+    // Gross-/Kleinschreibung und Bindestriche zaehlen nicht: „av-0421" und
+    // „AV0421" sind dieselbe Nummer, zweimal getippt. Dieselbe Normalisierung
+    // wie bei `sameSerial` in `assetIdentity.ts` (Bedarf 78).
+    const k = (feld(u) ?? '').trim().replace(/[\s-]/g, '').toLowerCase()
+    if (!k) continue
+    m.set(k, [...(m.get(k) ?? []), u])
+  }
+  return m
+}
+
+/**
+ * Was an den Nummern nicht stimmt.
+ *
+ * Beide Doppelungen sind unmoeglich und deshalb aussagekraeftig: eine
+ * Herstellernummer gibt es genau einmal auf der Welt, eine Hausreferenz genau
+ * einmal im Haus. Eine doppelte heisst entweder Tippfehler oder doppelt
+ * angelegte Einheit — und im zweiten Fall zaehlt die Inventur eine Kiste zu
+ * viel.
+ */
+export function identityFindings(units: readonly InventoryUnit[]): IdentityFinding[] {
+  const out: IdentityFinding[] = []
+  for (const [k, gruppe] of gruppiere(units, (u) => u.serial)) {
+    if (gruppe.length < 2) continue
+    out.push({
+      kind: 'serial-duplicate',
+      unitIds: gruppe.map((u) => u.id),
+      text: `${gruppe.length} Einheiten tragen die Herstellernummer „${k}". Eine Seriennummer gibt es genau einmal — entweder ist eine falsch getippt, oder dieselbe Kiste steht zweimal im Bestand und die Inventur zählt eine zu viel.`,
+    })
+  }
+  for (const [k, gruppe] of gruppiere(units, (u) => u.houseRef)) {
+    if (gruppe.length < 2) continue
+    out.push({
+      kind: 'houseref-duplicate',
+      unitIds: gruppe.map((u) => u.id),
+      text: `${gruppe.length} Einheiten tragen die Hausreferenz „${k}". Im eigenen Haus ist das die Nummer, die der Lagerist ruft — sie zweimal zu vergeben heißt, dass er die falsche Kiste holt.`,
+    })
+  }
+  const ohne = units.filter(
+    (u) => !u.serial?.trim() && !u.houseRef?.trim() && !u.code?.trim(),
+  )
+  if (ohne.length > 0) {
+    out.push({
+      kind: 'no-identity',
+      unitIds: ohne.map((u) => u.id),
+      text: `${ohne.length} Einheit(en) tragen weder Herstellernummer noch Hausreferenz noch Etiketten-Code. Auf jedem Blatt stehen sie als „${NO_IDENTITY}" — unterscheidbar sind sie dann nur über ihren Platz im Regal.`,
+    })
+  }
+  return out
+}
+
+/**
+ * Beide Identitäten nebeneinander — das Blatt für die Versicherung und für
+ * die Sub-Vermietung.
+ *
+ * Genau das ist der Zweck der Trennung: eine Liste, die BEIDE Nummern trägt,
+ * musste bisher von Hand aus zwei Quellen zusammengeschrieben werden.
+ */
+export function identityTable(
+  units: readonly InventoryUnit[],
+  modelOf: (unit: InventoryUnit) => string,
+): CsvTable {
+  return {
+    headers: ['Modell', 'Herstellernummer', 'Hausreferenz', 'Etiketten-Code'],
+    rows: units.map((u) => [
+      modelOf(u),
+      u.serial?.trim() || NO_IDENTITY,
+      u.houseRef?.trim() || NO_IDENTITY,
+      u.code?.trim() || NO_IDENTITY,
+    ]),
+  }
+}

--- a/src/renderer/store/inventoryStore.ts
+++ b/src/renderer/store/inventoryStore.ts
@@ -270,6 +270,12 @@ const healUnit = (raw: unknown): InventoryUnit | null => {
     id: typeof r.id === 'string' && r.id ? r.id : uuidv4(),
     itemId: r.itemId,
     serial: typeof r.serial === 'string' && r.serial.trim() ? r.serial.trim() : undefined,
+    // Bedarf 107 — die Hausreferenz kommt NEU dazu und wird NICHT aus `serial`
+    // abgeleitet. Welche der beiden Identitaeten in einem Altbestand im
+    // `serial`-Feld steht, weiss dieser Planer nicht; eine geratene Umbuchung
+    // machte aus einer Herstellernummer eine Hausnummer, die die Versicherung
+    // nicht kennt. Neues Feld, Vorgabewert leer, nie ueberschreiben.
+    houseRef: typeof r.houseRef === 'string' && r.houseRef.trim() ? r.houseRef.trim() : undefined,
     code: typeof r.code === 'string' && r.code.trim() ? r.code.trim() : undefined,
     codeType: healCodeType(r.codeType),
     locationId: typeof r.locationId === 'string' && r.locationId ? r.locationId : undefined,
@@ -389,7 +395,7 @@ interface InventoryState {
   /** Legt eine serialisierte Einheit an (mit „created"-Historieneintrag). */
   addUnit: (input: InventoryUnitInput) => string
   /** Aktualisiert Stammfelder einer Einheit (Ort/Zustand via move/condition). */
-  updateUnit: (id: string, patch: Partial<Pick<InventoryUnit, 'serial' | 'code' | 'codeType' | 'notes'>>) => void
+  updateUnit: (id: string, patch: Partial<Pick<InventoryUnit, 'serial' | 'houseRef' | 'code' | 'codeType' | 'notes'>>) => void
   /** Entfernt eine Einheit. */
   removeUnit: (id: string) => void
   /** Verschiebt eine Einheit an einen Lagerort (hängt „moved" an die Historie). */

--- a/src/renderer/types/dantePatch.ts
+++ b/src/renderer/types/dantePatch.ts
@@ -1,0 +1,62 @@
+// ───────────────────────────────────────────────────────────────────────────
+// BEDARF 94 (P2) — der Dante-Patch als LESBARES, VERGLEICHBARES Dokument.
+//
+//   > Repetitive changes require opening many pages in Dante Controller;
+//   > renaming machines or channels loses the existing patch; THE ONLY WAY TO
+//   > MAKE A PATCH READABLE OFF THE NETWORK IS TO EXPORT XML AND CONVERT IT TO
+//   > AN EXCEL MATRIX.
+//
+// Beleg: Mamat79/Dante-Config-Editor (README, 2026-08-24).
+//
+// ─── WAS HIER GEBAUT WIRD — UND WAS DER BEDARF WOERTLICH VERLANGT ──────────
+//
+// Die Bedarfs-Datenbank sagt: „Import a Dante Controller XML preset and render
+// it as a documented, diffable patch inside the plan — DOCUMENTATION HALF
+// ONLY, no network access."
+//
+// Gebaut wird die Dokumentations-Haelfte. NICHT gebaut wird der XML-Leser, und
+// zwar aus einem Grund, der hier ausdruecklich stehen soll: das Schema des
+// Dante-Preset-XML liegt in diesem Korpus NICHT vor. Es haengt an der
+// Controller-Version, diese Anwendung hat nie eines gesehen, und ein Parser
+// nach Vermutung haette genau die Eigenschaft, die in dieser Codebasis nirgends
+// erlaubt ist: er saehe aus, als koennte er es. Bei einer halb gelesenen
+// Subscription-Liste faellt das erst auf, wenn im Saal etwas fehlt.
+//
+// Gelesen wird stattdessen die MATRIX, die der Beleg selbst als heutigen Weg
+// nennt — die Tabelle, in die das XML ohnehin konvertiert wird. Vier Spalten,
+// selbsterklaerend, und jede Zeile eine Subscription. Wer eines Tages ein
+// echtes Preset-XML in der Hand hat, setzt den Leser davor; alles dahinter —
+// Vergleich, Befunde, Matrix — bleibt wie es ist.
+//
+// UND KEIN NETZ. Der Bedarf sagt „no network access", und die Anwendung ist
+// offline-first: hier wird nichts abonniert, nichts umbenannt und nichts an
+// ein Geraet geschickt.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Eine Subscription: welcher Empfangskanal hört auf welchen Sendekanal. */
+export interface DanteSubscription {
+  /** Geraet, das empfaengt. */
+  rxDevice: string
+  /** Empfangskanal an diesem Geraet. */
+  rxChannel: string
+  /**
+   * Geraet, das sendet. Leer heisst: dieser Empfangskanal ist NICHT abonniert.
+   *
+   * Das ist ein gueltiger Zustand und keine Luecke — eine Matrix zeigt auch die
+   * freien Eingaenge, und die Frage „welcher Kanal haengt an nichts" ist eine
+   * der beiden, um die es hier geht.
+   */
+  txDevice?: string
+  txChannel?: string
+}
+
+export interface DantePatch {
+  subscriptions: DanteSubscription[]
+  /**
+   * Wie viele Zeilen wie eine Subscription aussahen, aber nicht lesbar waren.
+   *
+   * Eine Zahl und keine stille Null: eine Datei, aus der die Haelfte nicht
+   * gelesen wurde, sieht sonst aus wie ein kleiner Patch.
+   */
+  unreadable: number
+}

--- a/src/renderer/types/inventory.ts
+++ b/src/renderer/types/inventory.ts
@@ -277,8 +277,35 @@ export interface InventoryUnit {
   id: string
   /** Referenz auf das Artikel-Modell (`InventoryItem.id`). */
   itemId: string
-  /** Seriennummer (Hersteller oder intern). */
+  /**
+   * Die HERSTELLER-Seriennummer.
+   *
+   * Bedarf 107 — bis hierher hiess das Feld „Hersteller ODER intern", und
+   * genau das ist der Defekt: ein Feld fuer zwei Identitaeten zwingt das
+   * Lager, sich fuer eine zu entscheiden, und die andere landet auf dem Case
+   * mit Filzstift oder in einer Tabelle daneben. Gebraucht werden aber beide,
+   * und zwar von verschiedenen Leuten: die Herstellernummer fuer Versicherung,
+   * Sub-Vermietung an Dritte und Wartungshistorie, die Hausnummer fuer alles
+   * Interne.
+   *
+   * Die Trennung passiert JETZT, weil sie jetzt nichts kostet: es gibt noch
+   * keine Bestandsdaten zu migrieren. Die Bedarfs-Datenbank sagt genau das —
+   * „Cheap today, expensive after the first real deployment."
+   */
   serial?: string
+  /**
+   * Die HAUS-EIGENE Referenz — die Nummer, unter der dieses Haus die Einheit
+   * fuehrt („AV-0421").
+   *
+   * Steht NEBEN `serial` und nicht statt ihr. Ein Altbestand, in dem die
+   * Hausnummer im `serial`-Feld steht, wird NICHT automatisch umgeraeumt:
+   * welche der beiden dort gemeint war, weiss der Planer nicht, und eine
+   * geratene Umbuchung machte aus einer Herstellernummer eine Hausnummer, die
+   * die Versicherung nicht kennt. Welche gemeint war, weiss nur der Mensch;
+   * die App zeigt stattdessen beide Felder nebeneinander (`identityTable`),
+   * damit die Verwechslung sichtbar wird statt weiterzuwandern.
+   */
+  houseRef?: string
   /** Fester Etiketten-Code der Einheit. */
   code?: string
   codeType?: InventoryCodeType

--- a/src/renderer/types/sceneImport.ts
+++ b/src/renderer/types/sceneImport.ts
@@ -1,0 +1,84 @@
+// ───────────────────────────────────────────────────────────────────────────
+// BEDARF 92 (P2) — die Kanalliste aus der Datei lesen, die das Pult ohnehin
+// schreibt.
+//
+//   > The authoritative channel names live in the console show file; the
+//   > paperwork is typed by hand from memory or from an older PDF. NOTHING
+//   > FLOWS BACK FROM THE DESK after rehearsal changes.
+//
+// Der Beleg (computi71/bandregie#11) nennt das Format ausdruecklich: im
+// X32/M32-Szenenformat stehen die Kanalnamen als
+//
+//   /ch/01/config "Kick" 1 RD 1
+//
+// und lassen sich „reliably" parsen; WING schreibt dieselben Zeilen. Genau
+// deshalb ist dieser Bedarf baubar und die Nachbarn 93 und 94 nicht: hier
+// liegt das Format im Korpus, dort nicht.
+//
+// ─── WAS DAS HIER IST UND WAS NICHT ────────────────────────────────────────
+//
+// Ein LESER, kein Schreiber. Diese Anwendung erzeugt keine Szenendatei und
+// schickt nichts an ein Pult. Sie liest eine Datei, die jemand vom Pult
+// exportiert hat, und macht daraus eine Liste — und beim zweiten Mal einen
+// Vergleich mit dem ersten.
+//
+// Der Vergleich ist die eigentliche Auskunft. Der Bedarf sagt es so:
+//
+//   > offer a diff between uploads
+//
+// und die Bedarfs-Datenbank folgert: „The upload diff is the
+// rehearsal-to-show change log that today exists only in someone's head."
+//
+// ─── WAS NICHT GERATEN WIRD ────────────────────────────────────────────────
+//
+// Die Zuordnung Pult-Kanal → Plan-Kanal. Ein Pult zaehlt seine Eingaenge, der
+// Plan zaehlt seine Kabel, und beide beginnen bei 1 — daraus eine Gleichung zu
+// machen waere die naheliegendste und teuerste Annahme dieser Datei. Zugeordnet
+// wird ueber die Kanalnummer NUR, wenn der Nutzer es sagt; sonst ueber den
+// Namen, und was sich nicht findet, bleibt ausdruecklich unzugeordnet.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Welche Sorte Datei gelesen wurde. */
+export type SceneFormat =
+  /** Behringer X32 / Midas M32 — `/ch/NN/config "Name" …`. */
+  | 'x32'
+  /** Behringer WING — dieselben Zeilen (laut Beleg). */
+  | 'wing'
+  /** Erkannt wurde nichts; die Datei wird nicht geraten. */
+  | 'unknown'
+
+export const SCENE_FORMAT_LABEL: Readonly<Record<SceneFormat, string>> = {
+  x32: 'X32 / M32',
+  wing: 'WING',
+  unknown: 'nicht erkannt',
+}
+
+/** Ein Kanal, wie er in der Szenendatei steht. */
+export interface SceneChannel {
+  /** Kanalnummer am Pult, wie in der Zeile — 1-basiert. */
+  ch: number
+  /** Der Name, den jemand am Pult eingetippt hat. */
+  name: string
+  /**
+   * Die Farbe, soweit die Zeile eine traegt (z. B. `RD`).
+   *
+   * Sie steht mit drin, weil sie am Pult die Gruppierung IST — Drums rot,
+   * Vocals gelb. Auf dem Blatt ist das die einzige Information darueber, wie
+   * der Kollege am Pult die Liste gedacht hat.
+   */
+  color?: string
+  /** Ob der Kanal stummgeschaltet gespeichert wurde. */
+  muted?: boolean
+}
+
+export interface SceneImport {
+  format: SceneFormat
+  channels: SceneChannel[]
+  /**
+   * Wie viele Zeilen wie ein Kanal aussahen, aber nicht lesbar waren.
+   *
+   * Eine Zahl und keine stille Null: eine Datei, aus der die Haelfte nicht
+   * gelesen wurde, sieht sonst aus wie ein Pult mit wenigen Kanaelen.
+   */
+  unreadable: number
+}

--- a/tests/dantePatch.test.ts
+++ b/tests/dantePatch.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DANTE_DIFF_LABEL,
+  DANTE_FINDING_LABEL,
+  assessDantePatch,
+  danteDiffTable,
+  dantePatchTable,
+  diffDantePatches,
+  parseDanteMatrix,
+} from '../src/renderer/lib/dantePatch'
+import type { CablePlannerProject } from '../src/renderer/types/project'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+import libQuelle from '../src/renderer/lib/dantePatch.ts?raw'
+import typenQuelle from '../src/renderer/types/dantePatch.ts?raw'
+import dialogQuelle from '../src/renderer/components/Analysis/AnalysisDialog.tsx?raw'
+
+// ---------------------------------------------------------------------------
+// Der Dante-Patch als lesbares, vergleichbares Dokument (Bedarf 94, P2).
+//
+//   > Repetitive changes require opening many pages in Dante Controller;
+//   > renaming machines or channels LOSES THE EXISTING PATCH; the only way to
+//   > make a patch readable off the network is to export XML and convert it to
+//   > an Excel matrix.                (Mamat79/Dante-Config-Editor, 2026-08-24)
+//
+// Gebaut wird die Dokumentations-Haelfte, die die Bedarfs-Datenbank verlangt.
+// NICHT gebaut wird der XML-Leser: das Schema liegt in diesem Korpus nicht vor.
+// ---------------------------------------------------------------------------
+
+const CSV = `Rx Device;Rx Channel;Tx Device;Tx Channel
+Stagebox A;01;Pult;Out 1
+Stagebox A;02;Pult;Out 2
+Stagebox A;03;;
+Amp Rack;01;Pult;Out 5
+`
+
+const eq = (name: string, dante = true): EquipmentItem =>
+  ({
+    id: name,
+    name,
+    x: 0,
+    y: 0,
+    width: 10,
+    height: 10,
+    category: 'Audio',
+    inputs: [],
+    outputs: [],
+    ...(dante
+      ? { networkInterfaces: [{ id: 'n', label: 'Dante', role: 'dante-primary' }] }
+      : {}),
+  }) as never
+
+const projekt = (namen: string[]): CablePlannerProject =>
+  ({
+    metadata: { name: 'Show', description: '', createdAt: '', updatedAt: '' },
+    equipment: namen.map((n) => eq(n)),
+    cables: [],
+    canvasState: { x: 0, y: 0, zoom: 1 },
+  }) as CablePlannerProject
+
+const arten = (p: Parameters<typeof assessDantePatch>[0], plan?: CablePlannerProject): string[] =>
+  assessDantePatch(p, plan).map((f) => f.kind)
+
+// ── 1. Die Grenze: kein XML, kein Netz ─────────────────────────────────────
+
+describe('die Grenze', () => {
+  it('liest kein Preset-XML und tut nicht so', () => {
+    // Das Schema haengt an der Controller-Version, diese Anwendung hat nie
+    // eines gesehen. Ein Parser nach Vermutung saehe aus, als koennte er es.
+    expect(libQuelle).not.toMatch(/DOMParser|parseFromString|<\?xml|querySelector/)
+    expect(typenQuelle).toMatch(/das Schema des\s*\n?\/\/ Dante-Preset-XML liegt in diesem Korpus NICHT vor/)
+  })
+
+  it('geht nicht ins Netz und benennt nichts um', () => {
+    expect(libQuelle).not.toMatch(/fetch\(|WebSocket|mdns|bonjour|subscribe\(/i)
+  })
+})
+
+// ── 2. Die Matrix lesen ────────────────────────────────────────────────────
+
+describe('parseDanteMatrix', () => {
+  it('liest die vier Spalten über ihre ÜBERSCHRIFT', () => {
+    const p = parseDanteMatrix(CSV)
+    expect(p.subscriptions).toHaveLength(4)
+    expect(p.subscriptions[0]).toEqual({
+      rxDevice: 'Stagebox A',
+      rxChannel: '01',
+      txDevice: 'Pult',
+      txChannel: 'Out 1',
+    })
+  })
+
+  it('findet die Spalten auch umsortiert', () => {
+    // Eine Datei, deren Spalten jemand umsortiert hat, ist dieselbe Datei —
+    // eine positionsfeste Lesung machte daraus stillschweigend einen anderen
+    // Patch, Sender und Empfänger vertauscht.
+    const p = parseDanteMatrix('Tx Device;Rx Device;Tx Channel;Rx Channel\nPult;Box;Out 1;01\n')
+    expect(p.subscriptions[0]).toEqual({
+      rxDevice: 'Box',
+      rxChannel: '01',
+      txDevice: 'Pult',
+      txChannel: 'Out 1',
+    })
+  })
+
+  it('BEHÄLT einen unabonnierten Empfangskanal', () => {
+    // „Welcher Kanal hängt an nichts" ist eine der beiden Fragen, um die es
+    // hier geht.
+    const frei = parseDanteMatrix(CSV).subscriptions.find((s) => s.rxChannel === '03')
+    expect(frei).toEqual({ rxDevice: 'Stagebox A', rxChannel: '03' })
+  })
+
+  it('liest ohne Rx-Spalten GAR NICHTS und zählt JEDE Datenzeile als unlesbar', () => {
+    // Die Zahl ist die Aussage: eine Datei ohne Empfänger-Spalte ist nicht
+    // „leer", sondern unbrauchbar, und wie viele Zeilen dabei verloren gehen,
+    // steht daneben.
+    const p = parseDanteMatrix('Tx Device;Tx Channel\nPult;Out 1\nPult;Out 2\nPult;Out 3\n')
+    expect(p.subscriptions).toHaveLength(0)
+    expect(p.unreadable).toBe(3)
+  })
+
+  it('zählt Zeilen ohne Empfänger als unlesbar', () => {
+    const p = parseDanteMatrix('Rx Device;Rx Channel\nBox;01\n;02\n')
+    expect(p.subscriptions).toHaveLength(1)
+    expect(p.unreadable).toBe(1)
+  })
+
+  it('erkennt Komma UND Semikolon', () => {
+    expect(parseDanteMatrix('Rx Device,Rx Channel\nBox,01\n').subscriptions).toHaveLength(1)
+    expect(parseDanteMatrix('Rx Device;Rx Channel\nBox;01\n').subscriptions).toHaveLength(1)
+  })
+
+  it('nimmt deutsche und englische Überschriften', () => {
+    expect(parseDanteMatrix('Empfänger;Empfangskanal\nBox;01\n').subscriptions).toHaveLength(1)
+    expect(parseDanteMatrix('Receiver;Destination\nBox;01\n').subscriptions).toHaveLength(1)
+  })
+
+  it('nimmt eine leere Datei ohne zu stolpern', () => {
+    expect(parseDanteMatrix('')).toEqual({ subscriptions: [], unreadable: 0 })
+  })
+})
+
+// ── 3. Die Befunde ─────────────────────────────────────────────────────────
+
+describe('assessDantePatch', () => {
+  it('meldet einen doppelt belegten Empfangskanal', () => {
+    // Ein Empfangskanal kann nur ein Abo haben.
+    const p = parseDanteMatrix('Rx Device;Rx Channel;Tx Device;Tx Channel\nBox;01;A;1\nBox;01;B;2\n')
+    expect(arten(p)).toContain('rx-duplicate')
+  })
+
+  it('meldet ein halbes Abo', () => {
+    const p = parseDanteMatrix('Rx Device;Rx Channel;Tx Device;Tx Channel\nBox;01;Pult;\n')
+    expect(arten(p)).toContain('half-subscription')
+  })
+
+  it('meldet einen Patch, in dem gar nichts abonniert ist', () => {
+    const p = parseDanteMatrix('Rx Device;Rx Channel\nBox;01\nBox;02\n')
+    expect(arten(p)).toContain('nothing-subscribed')
+  })
+
+  it('meldet ein Gerät, das der Plan nicht kennt', () => {
+    // Nach einer Umbenennung steht genau so der alte Name im Patch und der
+    // neue im Plan.
+    const p = parseDanteMatrix(CSV)
+    expect(arten(p, projekt(['Stagebox A', 'Pult']))).toContain('device-not-in-plan')
+  })
+
+  it('meldet ein Dante-Gerät des Plans, das im Patch fehlt', () => {
+    const p = parseDanteMatrix(CSV)
+    expect(arten(p, projekt(['Stagebox A', 'Amp Rack', 'Pult', 'Monitorpult']))).toContain(
+      'plan-device-unpatched',
+    )
+  })
+
+  it('schweigt beim Abgleich, wenn der Plan KEIN Dante-Gerät führt', () => {
+    // Sonst schlüge der Befund bei jedem Namen an, und ein Befund, der immer
+    // anschlägt, wird nach der dritten Zeile weggeklickt.
+    const ohne = {
+      ...projekt([]),
+      equipment: [eq('Irgendwas', false)],
+    } as CablePlannerProject
+    expect(arten(parseDanteMatrix(CSV), ohne)).not.toContain('device-not-in-plan')
+  })
+
+  it('gibt ohne Plan dasselbe wie mit einem Plan OHNE Dante-Geräte', () => {
+    // Beide sagen „es gibt nichts zu vergleichen". Der früh zurückkehrende
+    // Zweig für `!plan` spart nur Arbeit — er darf keine andere Antwort geben.
+    const p = parseDanteMatrix(CSV)
+    const ohneDante = {
+      ...projekt([]),
+      equipment: [eq('Irgendwas', false)],
+    } as CablePlannerProject
+    expect(arten(p)).toEqual(arten(p, ohneDante))
+    expect(arten(p)).not.toContain('device-not-in-plan')
+    expect(arten(p)).not.toContain('plan-device-unpatched')
+  })
+
+  it('gibt jeder Befundart eine Beschriftung', () => {
+    for (const k of Object.keys(DANTE_FINDING_LABEL)) {
+      expect(DANTE_FINDING_LABEL[k as never]).toBeTruthy()
+    }
+  })
+})
+
+// ── 4. Der Vergleich ───────────────────────────────────────────────────────
+
+describe('diffDantePatches', () => {
+  const a = parseDanteMatrix(CSV)
+
+  it('meldet eine neu abonnierte Quelle', () => {
+    const b = parseDanteMatrix(CSV.replace('Stagebox A;03;;', 'Stagebox A;03;Pult;Out 3'))
+    expect(diffDantePatches(a, b)).toEqual([
+      {
+        rx: 'Stagebox A / 03',
+        kind: 'subscribed',
+        before: 'nichts',
+        after: 'Pult / Out 3',
+      },
+    ])
+  })
+
+  it('meldet ein entferntes Abo', () => {
+    const b = parseDanteMatrix(CSV.replace('Stagebox A;01;Pult;Out 1', 'Stagebox A;01;;'))
+    expect(diffDantePatches(a, b)[0]).toMatchObject({ kind: 'unsubscribed' })
+  })
+
+  it('meldet eine andere Quelle am gleichen Kanal', () => {
+    const b = parseDanteMatrix(CSV.replace('Pult;Out 1', 'Pult;Out 9'))
+    expect(diffDantePatches(a, b)[0]).toMatchObject({
+      kind: 'changed',
+      before: 'Pult / Out 1',
+      after: 'Pult / Out 9',
+    })
+  })
+
+  it('meldet einen weggefallenen Empfangskanal', () => {
+    const b = parseDanteMatrix(CSV.replace('Amp Rack;01;Pult;Out 5\n', ''))
+    expect(diffDantePatches(a, b)[0]).toMatchObject({ kind: 'rx-removed' })
+  })
+
+  it('lässt beidseitig unabonnierte Kanäle WEG', () => {
+    // In einem 64-Kanal-Patch wären das die meisten Zeilen.
+    expect(diffDantePatches(a, a)).toEqual([])
+  })
+
+  it('gibt jeder Änderungsart eine Beschriftung', () => {
+    for (const k of Object.keys(DANTE_DIFF_LABEL)) {
+      expect(DANTE_DIFF_LABEL[k as never]).toBeTruthy()
+    }
+  })
+})
+
+// ── 5. Die Blätter und die Oberfläche ──────────────────────────────────────
+
+describe('die Blätter', () => {
+  it('geben jeder leeren Zelle einen NAMEN', () => {
+    const zeile = dantePatchTable(parseDanteMatrix(CSV)).rows[2].map(String)
+    expect(zeile).toContain('nichts')
+    expect(zeile).toContain('kein Kanal')
+    expect(zeile.every((z) => z.trim() !== '')).toBe(true)
+  })
+
+  it('nennen die Änderung beim Namen', () => {
+    const b = parseDanteMatrix(CSV.replace('Pult;Out 1', 'Pult;Out 9'))
+    const t = danteDiffTable(diffDantePatches(parseDanteMatrix(CSV), b))
+    expect(t.rows[0].map(String)).toContain('auf andere Quelle gelegt')
+  })
+
+  it('tragen kanonisches Deutsch', () => {
+    expect(libQuelle).not.toContain("t('")
+  })
+})
+
+describe('die Oberfläche', () => {
+  it('vergleicht erst, wenn zwei Stände vorliegen', () => {
+    expect(dialogQuelle).toMatch(/patchA && patchB \? diffDantePatches\(patchA, patchB\) : \[\]/)
+  })
+
+  it('behält den ERSTEN Import als Bezugsstand', () => {
+    expect(dialogQuelle).toMatch(/if \(!patchA\) setPatchA\(gelesen\)\s*\n?\s*else setPatchB\(gelesen\)/)
+  })
+
+  it('sagt ausdrücklich, wenn sich nichts geändert hat', () => {
+    expect(dialogQuelle).toMatch(/patchB && unterschiede\.length === 0 && \(/)
+  })
+
+  it('zeigt die Zahl der unlesbaren Zeilen', () => {
+    expect(dialogQuelle).toMatch(/aktuell\.unreadable > 0 && \(/)
+  })
+
+  it('zeigt jeden Befund mit seiner Beschriftung', () => {
+    expect(dialogQuelle).toMatch(
+      /befunde\.length > 0 && \([\s\S]*DANTE_FINDING_LABEL\[f\.kind\][\s\S]*f\.text/,
+    )
+  })
+})

--- a/tests/inventoryContract.test.ts
+++ b/tests/inventoryContract.test.ts
@@ -28,12 +28,12 @@ import type { InventoryItem, StorageNode, InventorySet, InventoryUnit } from '..
 // Eingefrorener Contract — MUSS in allen drei Repos identisch sein.
 const CONTRACT = {
   format: 'avplan-inventory',
-  version: 2,
+  version: 3,
   envelopeKeys: ['app', 'exportedAt', 'format', 'items', 'nodes', 'sets', 'units', 'version'],
   itemKeys: ['category', 'code', 'codeType', 'createdAt', 'deviceTypeId', 'dimensions', 'id', 'locationId', 'manufacturer', 'materialKinds', 'model', 'notes', 'ownership', 'quantity', 'rentPricePerDay', 'returnDue', 'stockLocation', 'supplier', 'updatedAt'],
   nodeKeys: ['code', 'codeType', 'createdAt', 'dimensions', 'id', 'kind', 'name', 'notes', 'parentId', 'updatedAt'],
   setKeys: ['components', 'createdAt', 'id', 'name', 'notes', 'updatedAt'],
-  unitKeys: ['code', 'codeType', 'condition', 'createdAt', 'history', 'id', 'itemId', 'locationId', 'notes', 'serial', 'updatedAt'],
+  unitKeys: ['code', 'codeType', 'condition', 'createdAt', 'history', 'houseRef', 'id', 'itemId', 'locationId', 'notes', 'serial', 'updatedAt'],
 } as const
 
 // Voll besetzte Muster-Entitaeten (jedes Feld gesetzt). Sie halten die
@@ -63,7 +63,7 @@ const set: InventorySet = {
   notes: 'x', createdAt: 't', updatedAt: 't',
 }
 const unit: InventoryUnit = {
-  id: 'u1', itemId: 'i1', serial: 'SN-1', code: 'UNI-1', codeType: 'qr', locationId: 'n1',
+  id: 'u1', itemId: 'i1', serial: 'SN-1', houseRef: 'AV-0421', code: 'UNI-1', codeType: 'qr', locationId: 'n1',
   condition: 'ok', notes: 'x', history: [{ at: 't', kind: 'created', detail: 'x' }],
   createdAt: 't', updatedAt: 't',
 }

--- a/tests/sceneImport.test.ts
+++ b/tests/sceneImport.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SCENE_DIFF_LABEL,
+  diffScenes,
+  matchTable,
+  matchToPlan,
+  parseSceneFile,
+  sceneDiffTable,
+  sceneTable,
+} from '../src/renderer/lib/sceneImport'
+import { SCENE_FORMAT_LABEL } from '../src/renderer/types/sceneImport'
+import libQuelle from '../src/renderer/lib/sceneImport.ts?raw'
+import typenQuelle from '../src/renderer/types/sceneImport.ts?raw'
+import dialogQuelle from '../src/renderer/components/Patch/PatchListDialog.tsx?raw'
+
+// ---------------------------------------------------------------------------
+// Die Kanalliste aus der Datei lesen, die das Pult ohnehin schreibt
+// (Bedarf 92, P2).
+//
+//   > The authoritative channel names live in the console show file; the
+//   > paperwork is typed by hand from memory or from an older PDF. NOTHING
+//   > FLOWS BACK FROM THE DESK after rehearsal changes.
+//
+// Der Beleg (computi71/bandregie#11) nennt das Format: `/ch/NN/config "Name"`,
+// „can be parsed reliably", WING schreibt dieselben Zeilen. Und er nennt den
+// zweiten Teil: „offer a diff between uploads".
+// ---------------------------------------------------------------------------
+
+const SZENE = `#4.0# "Probe" "" %000000000 1
+/ch/01/config "Kick" 1 RD 1
+/ch/02/config "Snare" 2 RD 2
+/ch/03/config "Bass DI" 3 BL 3
+/ch/04/config "" 1 OFF 4
+/ch/05/config "Vox Lead" 5 YE 5
+`
+
+describe('parseSceneFile — das Format aus dem Beleg', () => {
+  it('liest Nummer, Name und Farbe', () => {
+    const s = parseSceneFile(SZENE)
+    expect(s.channels).toHaveLength(5)
+    expect(s.channels[0]).toEqual({ ch: 1, name: 'Kick', color: 'RD' })
+    expect(s.channels[4]).toEqual({ ch: 5, name: 'Vox Lead', color: 'YE' })
+  })
+
+  it('BEHÄLT einen unbeschrifteten Kanal', () => {
+    // Ein leerer Name heisst „am Pult unbeschriftet", NICHT „gibt es nicht".
+    // Ein Import, der ihn wegliesse, machte aus einem Loch im
+    // Beschriftungsstreifen ein Loch in der Liste.
+    const s = parseSceneFile(SZENE)
+    // Ohne Farbe: das X32 schreibt `OFF` fuer einen Streifen ohne Farbe, und
+    // die wird nicht als Farbe gefuehrt.
+    expect(s.channels.find((c) => c.ch === 4)).toEqual({ ch: 4, name: '' })
+  })
+
+  it('erkennt X32 und WING', () => {
+    expect(parseSceneFile(SZENE).format).toBe('x32')
+    expect(parseSceneFile('#2.0# "WING Show"\n/ch/01/config "Kick" 1 RD 1\n').format).toBe('wing')
+  })
+
+  it('rät das Format NICHT, liest die Kanäle aber trotzdem', () => {
+    // Eine erfundene Marke auf dem Blatt waere schlechter als ein ehrliches
+    // „nicht erkannt": jemand suchte den Fehler beim falschen Pult.
+    const s = parseSceneFile('irgendwas\n')
+    expect(s.format).toBe('unknown')
+    expect(SCENE_FORMAT_LABEL.unknown).toBe('nicht erkannt')
+  })
+
+  it('zählt unlesbare Kanalzeilen, statt sie still zu schlucken', () => {
+    // Eine Datei, aus der die Haelfte nicht gelesen wurde, saehe sonst aus wie
+    // ein Pult mit wenigen Kanaelen.
+    const s = parseSceneFile('/ch/01/config "Kick" 1 RD 1\n/ch/02/config abgeschnitten\n')
+    expect(s.channels).toHaveLength(1)
+    expect(s.unreadable).toBe(1)
+  })
+
+  it('lässt bei doppelter Kanalzeile die ERSTE gewinnen', () => {
+    const s = parseSceneFile('/ch/01/config "Erst" 1 RD 1\n/ch/01/config "Dann" 1 GN 1\n')
+    expect(s.channels[0].name).toBe('Erst')
+  })
+
+  it('nimmt eine Zahl an der Farbstelle NICHT als Farbe', () => {
+    expect(parseSceneFile('/ch/01/config "Kick" 1 7 1\n').channels[0].color).toBeUndefined()
+  })
+
+  it('führt `OFF` NICHT als Farbe', () => {
+    // Das X32 schreibt `OFF` fuer einen Streifen ohne Farbe. Als Farbe geführt
+    // meldete der Vergleich eine Farbänderung, wo jemand nur eine Farbe
+    // entfernt hat.
+    expect(parseSceneFile('/ch/01/config "Kick" 1 OFF 1\n').channels[0].color).toBeUndefined()
+    const a = parseSceneFile('/ch/01/config "Kick" 1 RD 1\n')
+    const b = parseSceneFile('/ch/01/config "Kick" 1 OFF 1\n')
+    const d = diffScenes(a, b)[0]
+    expect(d.kind).toBe('recolored')
+    expect(d.beforeColor).toBe('RD')
+    // Kein `afterColor`: die Farbe wurde entfernt, nicht gewechselt.
+    expect(d.afterColor).toBeUndefined()
+  })
+
+  it('liest Anführungszeichen im Namen', () => {
+    expect(parseSceneFile('/ch/01/config "Gt \\"Amp\\"" 1 RD 1\n').channels[0].name).toBe('Gt "Amp"')
+  })
+
+  it('verwirft Kanal 0', () => {
+    const s = parseSceneFile('/ch/00/config "Nichts" 1 RD 1\n')
+    expect(s.channels).toHaveLength(0)
+    expect(s.unreadable).toBe(1)
+  })
+
+  it('nimmt den Mute-Zustand mit, wo die Datei ihn führt', () => {
+    const s = parseSceneFile('/ch/01/config "Kick" 1 RD 1\n/ch/01/mix OFF -oo OFF +0 OFF\n')
+    expect(s.channels[0].muted).toBe(true)
+  })
+
+  it('sortiert nach Kanalnummer, nicht nach Dateireihenfolge', () => {
+    const s = parseSceneFile('/ch/03/config "C" 1 RD 1\n/ch/01/config "A" 1 RD 1\n')
+    expect(s.channels.map((c) => c.ch)).toEqual([1, 3])
+  })
+})
+
+// ── Der Vergleich zweier Uploads ───────────────────────────────────────────
+
+describe('diffScenes — die Änderungsliste aus der Probe', () => {
+  const a = parseSceneFile(SZENE)
+
+  it('meldet einen umbenannten Kanal', () => {
+    const b = parseSceneFile(SZENE.replace('"Bass DI"', '"Bass Amp"'))
+    const d = diffScenes(a, b)
+    expect(d).toEqual([{ ch: 3, kind: 'renamed', before: 'Bass DI', after: 'Bass Amp' }])
+  })
+
+  it('meldet einen neu beschrifteten Kanal', () => {
+    const b = parseSceneFile(SZENE.replace('/ch/04/config ""', '/ch/04/config "Toms"'))
+    expect(diffScenes(a, b)[0]).toMatchObject({ ch: 4, kind: 'added', after: 'Toms' })
+  })
+
+  it('meldet eine entfernte Beschriftung', () => {
+    const b = parseSceneFile(SZENE.replace('"Vox Lead"', '""'))
+    expect(diffScenes(a, b)[0]).toMatchObject({ ch: 5, kind: 'removed', before: 'Vox Lead' })
+  })
+
+  it('meldet eine Farbänderung bei gleichem Namen', () => {
+    // Die Farbe ist am Pult die Gruppierung. Ein Kanal, der von Rot nach Gelb
+    // gewandert ist, ist von den Drums zu den Vocals umgezogen — auf einem
+    // Blatt, das nur Namen vergleicht, ist das unsichtbar.
+    const b = parseSceneFile(SZENE.replace('"Snare" 2 RD 2', '"Snare" 2 YE 2'))
+    expect(diffScenes(a, b)).toEqual([
+      { ch: 2, kind: 'recolored', before: 'Snare', after: 'Snare', beforeColor: 'RD', afterColor: 'YE' },
+    ])
+  })
+
+  it('lässt beidseitig unbeschriftete Kanäle WEG', () => {
+    // Bei 32 oder 48 Kanaelen waeren das die meisten Zeilen, und eine
+    // Aenderungsliste, in der fast nichts eine Aenderung ist, wird nicht
+    // gelesen.
+    expect(diffScenes(a, a)).toEqual([])
+  })
+
+  it('gibt jeder Änderungsart eine Beschriftung', () => {
+    for (const k of Object.keys(SCENE_DIFF_LABEL)) {
+      expect(SCENE_DIFF_LABEL[k as never]).toBeTruthy()
+    }
+  })
+})
+
+// ── Die Zuordnung zum Plan ─────────────────────────────────────────────────
+
+describe('matchToPlan — die Nummer ist keine Gleichung', () => {
+  const scene = parseSceneFile(SZENE)
+  const plan = [
+    { ch: 1, source: 'Bass DI' },
+    { ch: 2, source: 'Kick' },
+  ]
+
+  it('ordnet über den Namen zu — eine Beobachtung', () => {
+    const m = matchToPlan(scene, plan, 'by-name')
+    expect(m.find((x) => x.sceneCh === 1)?.planCh).toBe(2)
+    expect(m.find((x) => x.sceneCh === 3)?.planCh).toBe(1)
+  })
+
+  it('ordnet über die Nummer NUR auf Ansage zu', () => {
+    // Ein Pult zaehlt seine Eingaenge, der Plan zaehlt seine Kabel, und beide
+    // beginnen bei 1. Ueber die Nummer ist die Zuordnung eine Behauptung ueber
+    // die Verkabelung.
+    const m = matchToPlan(scene, plan, 'by-number')
+    expect(m.find((x) => x.sceneCh === 1)?.planCh).toBe(1)
+    expect(m.find((x) => x.sceneCh === 1)?.planSource).toBe('Bass DI')
+  })
+
+  it('lässt unzugeordnet, was sich nicht findet', () => {
+    const m = matchToPlan(scene, plan, 'by-name')
+    const vox = m.find((x) => x.sceneCh === 5)
+    expect(vox?.planCh).toBeUndefined()
+    expect(vox?.planSource).toBeUndefined()
+  })
+
+  it('ignoriert Gross-/Kleinschreibung und Mehrfach-Leerzeichen', () => {
+    const s = parseSceneFile('/ch/01/config "  bass   di " 1 RD 1\n')
+    expect(matchToPlan(s, plan, 'by-name')[0].planCh).toBe(1)
+  })
+
+  it('lässt bei zwei gleichnamigen Plan-Kanälen den ERSTEN gewinnen', () => {
+    const doppelt = [
+      { ch: 7, source: 'SM58' },
+      { ch: 9, source: 'SM58' },
+    ]
+    const s = parseSceneFile('/ch/01/config "SM58" 1 RD 1\n')
+    expect(matchToPlan(s, doppelt, 'by-name')[0].planCh).toBe(7)
+  })
+})
+
+// ── Die Blätter ────────────────────────────────────────────────────────────
+
+describe('die Blätter', () => {
+  it('geben jeder leeren Zelle einen NAMEN', () => {
+    const t = sceneTable(parseSceneFile('/ch/04/config "" 1 OFF 4\n'))
+    const zeile = t.rows[0].map(String)
+    expect(zeile).toContain('unbeschriftet')
+    expect(zeile).toContain('keine Farbe')
+    expect(zeile).toContain('nicht angegeben')
+    expect(zeile.every((z) => z.trim() !== '')).toBe(true)
+  })
+
+  it('nennen eine fehlende Zuordnung beim Namen', () => {
+    const m = matchToPlan(parseSceneFile('/ch/01/config "Kick" 1 RD 1\n'), [], 'by-name')
+    const zeile = matchTable(m).rows[0].map(String)
+    expect(zeile).toContain('nicht zugeordnet')
+    expect(zeile).toContain('nicht im Plan')
+  })
+
+  it('zeigen bei einer Farbänderung die FARBEN, nicht zweimal denselben Namen', () => {
+    const a = parseSceneFile('/ch/01/config "Kick" 1 RD 1\n')
+    const b = parseSceneFile('/ch/01/config "Kick" 1 YE 1\n')
+    const zeile = sceneDiffTable(diffScenes(a, b)).rows[0].map(String)
+    expect(zeile).toContain('RD')
+    expect(zeile).toContain('YE')
+  })
+
+  it('tragen kanonisches Deutsch', () => {
+    expect(libQuelle).not.toContain("t('")
+  })
+})
+
+// ── Die Grenzen ────────────────────────────────────────────────────────────
+
+describe('ein Leser, kein Schreiber', () => {
+  it('erzeugt keine Szenendatei und schickt nichts ans Pult', () => {
+    expect(libQuelle).not.toMatch(/fetch\(|WebSocket|osc|udp|\/ch\/\$\{/i)
+    expect(typenQuelle).toMatch(/Ein LESER, kein Schreiber/)
+  })
+
+  it('bietet den Vergleich erst an, wenn zwei Stände vorliegen', () => {
+    expect(dialogQuelle).toMatch(/szeneA && szeneB \? diffScenes\(szeneA, szeneB\) : \[\]/)
+  })
+
+  it('sagt ausdrücklich, wenn sich nichts geändert hat', () => {
+    // Ein leerer Block läse sich als „noch nicht verglichen".
+    expect(dialogQuelle).toMatch(/szeneB && szeneDiff\.length === 0 && \(/)
+    expect(dialogQuelle).toMatch(/scene\.noChange/)
+  })
+
+  it('behält den ERSTEN Import als Bezugsstand', () => {
+    expect(dialogQuelle).toMatch(/if \(!szeneA\) setSzeneA\(gelesen\)\s*\n?\s*else setSzeneB\(gelesen\)/)
+  })
+
+  it('leert das Dateifeld, damit dieselbe Datei zweimal gewählt werden kann', () => {
+    expect(dialogQuelle).toMatch(/e\.target\.value = ''/)
+  })
+
+  it('zeigt die Zahl der unlesbaren Zeilen an', () => {
+    expect(dialogQuelle).toMatch(/szeneAktuell\.unreadable > 0 && \(/)
+  })
+})

--- a/tests/unitIdentity.test.ts
+++ b/tests/unitIdentity.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it } from 'vitest'
+import {
+  HOUSE_REF_NOTE,
+  IDENTITY_FINDING_LABEL,
+  NO_IDENTITY,
+  SERIAL_NOTE,
+  identityFindings,
+  identityTable,
+  unitLabel,
+} from '../src/renderer/lib/unitIdentity'
+import type { InventoryItem, InventoryUnit } from '../src/renderer/types/inventory'
+import { derivePackList } from '../src/renderer/lib/packList'
+import { auditScan } from '../src/renderer/lib/inventoryAudit'
+import { resolveInventoryCode } from '../src/renderer/lib/inventoryScan'
+import typenQuelle from '../src/renderer/types/inventory.ts?raw'
+import libQuelle from '../src/renderer/lib/unitIdentity.ts?raw'
+import storeQuelle from '../src/renderer/store/inventoryStore.ts?raw'
+import packQuelle from '../src/renderer/lib/packList.ts?raw'
+import auditQuelle from '../src/renderer/lib/inventoryAudit.ts?raw'
+import dialogQuelle from '../src/renderer/components/Inventory/InventoryDialog.tsx?raw'
+import netzQuelle from '../src/renderer/components/Properties/sections/NetworkAccessSection.tsx?raw'
+import lexikonQuelle from '../src/renderer/lib/dataDictionary.ts?raw'
+
+// ---------------------------------------------------------------------------
+// Zwei Identitaeten je Einheit (Bedarf 107, P3).
+//
+//   > Systems with a single code field force the warehouse to choose which
+//   > identity to store; the other one is then needed for insurance, sub-hire
+//   > to third parties and maintenance history, and gets kept in a spreadsheet
+//   > or ON THE CASE WITH A MARKER.
+//
+// Der Beleg ist zweiter Hand (Rentman trennt „Internal Reference" von
+// „Manufacturer Serial Number", und die Bedarfs-Datenbank zieht daraus den
+// Zeitpunkt: „Cheap today, expensive after the first real deployment.").
+// Gebaut wird deshalb genau das, was aus dem Mechanismus folgt — zwei Felder,
+// eine Regel wer welches liest — und nichts, was eine Herkunft raten wuerde.
+// ---------------------------------------------------------------------------
+
+const unit = (over: Partial<InventoryUnit> = {}): InventoryUnit =>
+  ({
+    id: over.id ?? 'u1',
+    itemId: over.itemId ?? 'm1',
+    condition: over.condition ?? 'ok',
+    history: [],
+    createdAt: '',
+    updatedAt: '',
+    ...over,
+  }) as InventoryUnit
+
+const item = (id = 'm1', model = 'Sony PXW-Z750'): InventoryItem =>
+  ({ id, model, quantity: 1, createdAt: '', updatedAt: '' }) as unknown as InventoryItem
+
+// ── 1. Zwei Felder, nicht eines ────────────────────────────────────────────
+
+describe('das Lager muss sich nicht fuer eine Identitaet entscheiden', () => {
+  it('traegt Herstellernummer und Hausreferenz nebeneinander', () => {
+    const u = unit({ serial: 'S0134-77', houseRef: 'AV-0421' })
+    expect(u.serial).toBe('S0134-77')
+    expect(u.houseRef).toBe('AV-0421')
+  })
+
+  it('nennt `serial` im Typ ausdruecklich die HERSTELLER-Nummer', () => {
+    // Das Feld hiess „Hersteller ODER intern" — genau die Formulierung, die
+    // das Lager zur Wahl zwang. Wer sie zurueckschreibt, hebt den Bedarf auf.
+    const start = typenQuelle.indexOf('Bedarf 107')
+    expect(start).toBeGreaterThan(0)
+    const block = typenQuelle.slice(start, typenQuelle.indexOf('code?: string', start))
+    expect(block).toContain('serial?: string')
+    expect(block).toContain('houseRef?: string')
+    expect(typenQuelle).not.toContain('Seriennummer (Hersteller oder intern)')
+  })
+
+  it('laesst die Hausreferenz durch die Bearbeitung durch', () => {
+    // `updateUnit` ist der einzige Weg, Stammfelder einer bestehenden Einheit
+    // zu aendern. Fehlt `houseRef` in seiner Signatur, laesst sich das Feld
+    // zwar anlegen, aber nie korrigieren.
+    expect(storeQuelle).toMatch(/updateUnit:[^\n]*'serial' \| 'houseRef'/)
+  })
+})
+
+// ── 2. Die Heilung raet nicht ──────────────────────────────────────────────
+
+describe('ein Altbestand wird nicht umgebucht', () => {
+  it('heilt `houseRef` als eigenes Feld', () => {
+    expect(storeQuelle).toContain(
+      "houseRef: typeof r.houseRef === 'string' && r.houseRef.trim() ? r.houseRef.trim() : undefined",
+    )
+  })
+
+  it('leitet die Hausreferenz NIE aus der Seriennummer ab', () => {
+    // Der teuerste denkbare Fehler dieses Bedarfs: eine Migration, die
+    // `serial` nach `houseRef` kopiert. Aus einer Herstellernummer wuerde
+    // eine Hausnummer, die die Versicherung nicht kennt — und niemand saehe
+    // es, weil beide Felder danach gefuellt sind.
+    const start = storeQuelle.indexOf('const healUnit')
+    expect(start).toBeGreaterThan(0)
+    const heilung = storeQuelle.slice(start, storeQuelle.indexOf('const load', start))
+    expect(heilung).toContain('houseRef')
+    expect(heilung).not.toMatch(/houseRef[^\n]*r\.serial/)
+    expect(heilung).not.toMatch(/serial[^\n]*\?\?[^\n]*r\.houseRef/)
+  })
+})
+
+// ── 3. Wer liest, entscheidet ──────────────────────────────────────────────
+
+describe('unitLabel — wer liest, entscheidet was vorne steht', () => {
+  const beide = unit({ serial: 'S0134-77', houseRef: 'AV-0421', code: 'QR-9' })
+
+  it('zeigt dem Haus die Hausreferenz', () => {
+    expect(unitLabel(beide, 'house')).toBe('AV-0421')
+  })
+
+  it('zeigt der Versicherung die Herstellernummer', () => {
+    expect(unitLabel(beide, 'external')).toBe('S0134-77')
+  })
+
+  it('benennt die Ersatz-Nummer, statt sie als die andere auszugeben', () => {
+    // „AV-0421" allein auf einem Versicherungsblatt ist eine Verwechslung,
+    // „AV-0421 (Hausreferenz)" eine Auskunft.
+    const nurHaus = unit({ houseRef: 'AV-0421' })
+    expect(unitLabel(nurHaus, 'external')).toBe(`AV-0421 (${HOUSE_REF_NOTE})`)
+    const nurSerie = unit({ serial: 'S0134-77' })
+    expect(unitLabel(nurSerie, 'house')).toBe(`S0134-77 (${SERIAL_NOTE})`)
+  })
+
+  it('nimmt den Etiketten-Code erst an dritter Stelle', () => {
+    // Der Code ist eine Scan-Kennung, keine Identitaet: nach einer
+    // Ausmusterung kann derselbe Aufkleber an einer anderen Kiste haengen.
+    expect(unitLabel(unit({ code: 'QR-9' }), 'house')).toBe('QR-9')
+    expect(unitLabel(unit({ code: 'QR-9' }), 'external')).toBe('QR-9')
+    expect(unitLabel(unit({ houseRef: 'AV-0421', code: 'QR-9' }), 'house')).toBe('AV-0421')
+  })
+
+  it('sagt „ohne Nummer" statt eine id-Haelfte zu zeigen', () => {
+    // Vorher stand hier `u.id.slice(0, 6)` — ein uuid-Fragment, das aussieht
+    // wie eine Nummer und keine ist. Ein benanntes Ergebnis ist ehrlicher.
+    const nackt = unit({ id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479' })
+    expect(unitLabel(nackt, 'house')).toBe(NO_IDENTITY)
+    expect(unitLabel(nackt, 'external')).toBe(NO_IDENTITY)
+    expect(unitLabel(nackt, 'house')).not.toContain('f47ac1')
+  })
+
+  it('behandelt reine Leerzeichen wie ein leeres Feld', () => {
+    expect(unitLabel(unit({ houseRef: '   ', serial: 'S1' }), 'house')).toBe(
+      `S1 (${SERIAL_NOTE})`,
+    )
+    expect(unitLabel(unit({ houseRef: ' AV-1 ' }), 'house')).toBe('AV-1')
+  })
+})
+
+// ── 4. Die Engstelle ───────────────────────────────────────────────────────
+
+describe('die Regel steht an genau einer Stelle', () => {
+  it('hat kein Modul mehr eine eigene Kopie der Reihenfolge', () => {
+    // Die Zeile `u.serial || u.code || u.id.slice(0, 6)` stand an vier
+    // Stellen. Vier Kopien einer Regel, die sich mit zwei Identitaeten
+    // aendern MUSS — beim Aendern haette man eine uebersehen.
+    for (const quelle of [packQuelle, auditQuelle, dialogQuelle, netzQuelle]) {
+      expect(quelle).not.toMatch(/id\.slice\(0, ?6\)/)
+      expect(quelle).toContain("unitLabel(")
+    }
+  })
+
+  it('liest die Packliste als HAUS-Blatt', () => {
+    const u = unit({ id: 'u1', serial: 'S0134-77', houseRef: 'AV-0421', locationId: 'n1' })
+    const zeilen = derivePackList(
+      'n1',
+      { items: [item()], nodes: [{ id: 'n1', kind: 'case', name: 'Case 1' } as never], units: [u] },
+      '2026-09-06',
+    )
+    const flach = JSON.stringify(zeilen)
+    expect(flach).toContain('AV-0421')
+    expect(flach).not.toContain('S0134-77')
+  })
+
+  it('findet eine Einheit auch ueber die abgetippte Hausreferenz', () => {
+    // Die Hausreferenz ist die wahrscheinlichste Eingabe von allen: sie klebt
+    // auf dem Case, und sie wird abgetippt, wenn der Aufkleber unlesbar ist.
+    // Ein Identitaets-Feld, das die Suche nicht kennt, ist fuer den Lageristen
+    // nicht vorhanden.
+    const u = unit({ id: 'u1', serial: 'S0134-77', houseRef: 'AV-0421' })
+    const treffer = resolveInventoryCode('av-0421', { items: [item()], nodes: [], units: [u] })
+    expect(treffer).toEqual({ kind: 'unit', unit: u })
+    expect(resolveInventoryCode('S0134-77', { items: [item()], nodes: [], units: [u] })).toEqual({
+      kind: 'unit',
+      unit: u,
+    })
+  })
+
+  it('liest die Inventur als HAUS-Blatt', () => {
+    const u = unit({ id: 'u1', serial: 'S0134-77', houseRef: 'AV-0421', code: 'QR-9' })
+    const treffer = auditScan('QR-9', 'n1', { items: [item()], nodes: [], units: [u], sets: [] })
+    expect(treffer.label).toBe('AV-0421')
+  })
+})
+
+// ── 5. Was an den Nummern nicht stimmt ─────────────────────────────────────
+
+describe('identityFindings', () => {
+  it('meldet zwei Einheiten mit derselben Herstellernummer', () => {
+    const f = identityFindings([
+      unit({ id: 'a', serial: 'S0134-77' }),
+      unit({ id: 'b', serial: 'S0134-77' }),
+      unit({ id: 'c', serial: 'S0134-78' }),
+    ])
+    const dopp = f.filter((x) => x.kind === 'serial-duplicate')
+    expect(dopp).toHaveLength(1)
+    expect(dopp[0].unitIds).toEqual(['a', 'b'])
+    expect(dopp[0].text).toContain('Inventur')
+  })
+
+  it('zaehlt „av-0421" und „AV0421" als dieselbe Nummer', () => {
+    // Zweimal getippt, einmal mit Bindestrich: derselbe Aufkleber. Wer hier
+    // buchstabengenau vergleicht, meldet den haeufigsten Fall nicht.
+    const f = identityFindings([
+      unit({ id: 'a', houseRef: 'av-0421' }),
+      unit({ id: 'b', houseRef: 'AV0421' }),
+    ])
+    expect(f.map((x) => x.kind)).toEqual(['houseref-duplicate'])
+    expect(f[0].unitIds).toEqual(['a', 'b'])
+  })
+
+  it('trennt die beiden Doppelungen', () => {
+    // Dieselbe Zeichenfolge einmal als Herstellernummer, einmal als
+    // Hausreferenz ist KEINE Doppelung: die beiden leben in verschiedenen
+    // Namensräumen.
+    const f = identityFindings([
+      unit({ id: 'a', serial: 'X-1' }),
+      unit({ id: 'b', houseRef: 'X-1' }),
+    ])
+    expect(f).toEqual([])
+  })
+
+  it('schweigt bei leeren Feldern statt sie als Doppelung zu zaehlen', () => {
+    const f = identityFindings([
+      unit({ id: 'a', serial: '', houseRef: '  ', code: 'QR-1' }),
+      unit({ id: 'b', serial: undefined, houseRef: undefined, code: 'QR-2' }),
+    ])
+    expect(f).toEqual([])
+  })
+
+  it('meldet Einheiten ganz ohne Nummer gesammelt', () => {
+    const f = identityFindings([
+      unit({ id: 'a' }),
+      unit({ id: 'b' }),
+      unit({ id: 'c', code: 'QR-1' }),
+    ])
+    const ohne = f.filter((x) => x.kind === 'no-identity')
+    expect(ohne).toHaveLength(1)
+    expect(ohne[0].unitIds).toEqual(['a', 'b'])
+    expect(ohne[0].text).toContain(NO_IDENTITY)
+  })
+
+  it('haelt fuer jede Befundart eine lesbare Ueberschrift bereit', () => {
+    for (const kind of ['serial-duplicate', 'houseref-duplicate', 'no-identity'] as const) {
+      expect(IDENTITY_FINDING_LABEL[kind].length).toBeGreaterThan(10)
+    }
+  })
+})
+
+// ── 6. Das Blatt mit beiden Nummern ────────────────────────────────────────
+
+describe('identityTable', () => {
+  it('stellt beide Identitaeten nebeneinander', () => {
+    const t = identityTable([unit({ serial: 'S0134-77', houseRef: 'AV-0421', code: 'QR-9' })], () =>
+      'Sony PXW-Z750',
+    )
+    expect(t.headers).toEqual(['Modell', 'Herstellernummer', 'Hausreferenz', 'Etiketten-Code'])
+    expect(t.rows[0]).toEqual(['Sony PXW-Z750', 'S0134-77', 'AV-0421', 'QR-9'])
+  })
+
+  it('schreibt „ohne Nummer" statt einer leeren Zelle', () => {
+    const t = identityTable([unit({ serial: 'S1' })], () => 'Modell')
+    expect(t.rows[0]).toEqual(['Modell', 'S1', NO_IDENTITY, NO_IDENTITY])
+  })
+
+  it('hat fuer jede Spalte einen Lexikon-Eintrag', () => {
+    // Ein Blatt, das die Versicherung liest, braucht die Erklaerung, WELCHE
+    // der beiden Nummern in welcher Spalte steht — sonst hat die Trennung
+    // auf dem Papier wieder nur eine Bedeutung.
+    for (const spalte of ['Herstellernummer', 'Hausreferenz']) {
+      expect(lexikonQuelle).toContain(`${spalte}:`)
+    }
+  })
+})
+
+// ── 7. Beides ist im Dialog erreichbar ─────────────────────────────────────
+
+describe('der Bestandsdialog', () => {
+  const marker = dialogQuelle.indexOf('BEDARF 107 — zwei Identitäten')
+  const formular = dialogQuelle.slice(marker, dialogQuelle.indexOf("t('inventory.code'", marker))
+
+  it('hat ein eigenes Eingabefeld fuer die Hausreferenz', () => {
+    expect(marker).toBeGreaterThan(0)
+    expect(formular.length).toBeGreaterThan(200)
+    expect(formular).toContain("t('inventory.houseRef'")
+    expect(formular).toContain('form.houseRef')
+    expect(formular).toContain('houseRef: e.target.value')
+  })
+
+  it('speichert die Hausreferenz beim Anlegen UND beim Bearbeiten', () => {
+    expect(dialogQuelle).toContain("houseRef: form.houseRef?.trim() || undefined")
+    expect(dialogQuelle).toMatch(/updateUnit\(form\.id, \{[^}]*houseRef: payload\.houseRef/)
+  })
+
+  it('zeigt beide Nummern in der Liste, unterscheidbar', () => {
+    expect(dialogQuelle).toContain('{u.serial && <span')
+    expect(dialogQuelle).toContain('{u.houseRef && <span')
+    expect(dialogQuelle).toContain('#{u.houseRef}')
+  })
+
+  it('stellt die Befunde ueber die Liste', () => {
+    const befundBlock = dialogQuelle.indexOf('identitaetsBefunde.length > 0')
+    const liste = dialogQuelle.indexOf('units.length === 0')
+    expect(befundBlock).toBeGreaterThan(0)
+    expect(befundBlock).toBeLessThan(liste)
+  })
+})
+
+// ── 8. Rein ────────────────────────────────────────────────────────────────
+
+describe('das Modul bleibt rein', () => {
+  it('hat weder Uhr noch Store noch IO', () => {
+    expect(libQuelle).not.toContain('Date.now')
+    expect(libQuelle).not.toContain('new Date(')
+    expect(libQuelle).not.toContain('useInventoryStore')
+    expect(libQuelle).not.toContain('window.')
+  })
+})


### PR DESCRIPTION
Drei Bedarfe. Zwei galten bisher als „blockiert durch fremde Schemata" — bei genauerem Lesen liegt für den einen das Format im Korpus, und für den anderen der heutige Ausweichweg. Der dritte ist eine Trennung, die jetzt nichts kostet und nach dem ersten echten Einsatz teuer wäre.

## Bedarf 92 — die Szenendatei des Pults lesen

> The authoritative channel names live in the console show file; the paperwork is typed by hand from memory or from an older PDF. **Nothing flows back from the desk** after rehearsal changes.

Der Beleg (computi71/bandregie#11) nennt das Format ausdrücklich: `/ch/01/config "Kick" 1 RD 1`, „can be parsed reliably", WING schreibt dieselben Zeilen.

- **Ein Leser, kein Schreiber** — hier geht nichts ans Pult zurück.
- **Der unbeschriftete Kanal bleibt** — ein leerer Name heisst „am Pult unbeschriftet", nicht „gibt es nicht".
- **Die Farbe zählt als Änderung** — am Pult ist sie die Gruppierung. `OFF` ist dabei keine Farbe, sondern deren Abwesenheit.
- **Die Kanalnummer ist keine Gleichung** — zugeordnet wird über den Namen; über die Nummer nur auf ausdrückliche Ansage.
- **Der erste Import ist der Bezugsstand** — und wenn sich nichts geändert hat, steht das da.

## Bedarf 94 — der Dante-Patch als Dokument

> renaming machines or channels **loses the existing patch**; the only way to make a patch readable off the network is to export XML and convert it to an Excel matrix.

Die Bedarfs-Datenbank verlangt „import a Dante Controller XML preset […] documentation half only". Gebaut ist die Dokumentations-Hälfte; **nicht gebaut ist der XML-Leser**, und das ist eine bewusste Abweichung vom Wortlaut: das Schema liegt in diesem Korpus nicht vor, es hängt an der Controller-Version, und ein Parser nach Vermutung sähe aus, als könnte er es — bei einer halb gelesenen Subscription-Liste fällt das erst auf, wenn im Saal etwas fehlt. Gelesen wird die Matrix, die der Beleg selbst als heutigen Weg nennt.

- **Spalten über die Überschrift, nicht über die Position** — sonst wären bei umsortierten Spalten Sender und Empfänger vertauscht.
- **Der unabonnierte Empfangskanal bleibt.**
- **Die Umbenennungs-Falle wird sichtbar gemacht, nicht gelöst** — `device-not-in-plan` ist genau der Fall „alter Name im Patch, neuer im Plan".
- **Kein Netz.**

## Bedarf 107 — zwei Identitäten je Einheit, getrennt geführt

> Systems with a single code field force the warehouse to choose which identity to store; the other one is then needed for insurance, sub-hire to third parties and maintenance history, and gets kept in a spreadsheet or **on the case with a marker**.

Das Feld `InventoryUnit.serial` hiess bis hierher „Seriennummer (Hersteller **oder** intern)" — und genau das ist der Defekt. Gebraucht werden beide, von verschiedenen Leuten. Die Trennung passiert jetzt, weil sie jetzt nichts kostet: es gibt noch keine Bestandsdaten zu migrieren.

- **`houseRef` neben `serial`, kein Umräumen.** Welche der beiden Identitäten in einem Altbestand im `serial`-Feld steht, weiß dieser Planer nicht; eine geratene Umbuchung machte aus einer Herstellernummer eine Hausnummer, die die Versicherung nicht kennt. `healUnit` legt das Feld leer an und leitet nichts ab.
- **Eine Engstelle statt vier Kopien.** `u.serial || u.code || u.id.slice(0, 6)` stand an vier Stellen — vier Kopien einer Regel, die sich mit zwei Identitäten ändern *muss*. Jetzt entscheidet `unitLabel(unit, audience)` nach Leser: `house` (Kommissionierliste, Inventur, Packliste, Seitenleiste) zeigt die Hausreferenz, `external` (Versicherung, Sub-Vermietung, Wartung) die Herstellernummer.
- **Die Ersatz-Nummer wird benannt.** „AV-0421 (Hausreferenz)" auf einem Versicherungsblatt ist eine Auskunft; „AV-0421" allein eine Verwechslung. Ohne jede Nummer steht „ohne Nummer" da statt einer uuid-Hälfte.
- **Befunde:** doppelte Herstellernummer, doppelte Hausreferenz (beide unmöglich und deshalb aussagekräftig — eine doppelte heisst Tippfehler oder doppelt angelegte Einheit, und dann zählt die Inventur eine Kiste zu viel), Einheit ganz ohne Nummer.
- **`identityTable`** stellt beide Nummern nebeneinander — das Blatt für Versicherung und Sub-Vermietung, das bisher von Hand aus zwei Quellen zusammengeschrieben werden musste.
- **Der Scan findet die Hausreferenz.** Sie ist die wahrscheinlichste Eingabe von allen: sie klebt auf dem Case und wird abgetippt, wenn der Aufkleber unlesbar ist.
- **Portables Format auf Version 3.** Dieselbe Begründung wie bei Version 2, eine Ebene tiefer: `healUnit` baut jede Einheit Feld für Feld neu auf, ein Planer ohne `houseRef` würde eine Datei mit Hausreferenzen still ohne sie zurückschreiben. Die identische Änderung liegt als larszu/multicam-planner#95 und larszu/light-planner#73 vor — ohne sie wiesen die beiden anderen Planer jede Datei ab, die dieser ab jetzt schreibt.

## Geprüft

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 154 Dateien, 2161 Tests grün
- `npm run lint` — 0 Fehler (10 Warnungen, unverändert)
- Gegengeprüft mit **87 Injektionen**. Eine deckte einen echten Fehler auf (`OFF` als Farbe gelesen → Farbänderung bei jedem farblosen Kanal). Zwei blieben grün und waren beweisbar wirkungslos — eine redundante Sonderbehandlung wurde entfernt, für die andere hält jetzt ein Test die Gleichheit fest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT