### PR TITLE
rf: der Scan vor Ort, gegen den Plan gehalten (Bedarf 112)

### DIFF
--- a/src/renderer/components/Analysis/AnalysisDialog.tsx
+++ b/src/renderer/components/Analysis/AnalysisDialog.tsx
@@ -111,6 +111,15 @@ import {
   parseFreqMhz,
   spectrumTable,
 } from '../../lib/spectrumPlan'
+import {
+  carrierCheckTable,
+  checkCarriers,
+  parseScanCsv,
+  SCAN_FINDING_LABEL,
+  scanFindings,
+  scannedRange,
+} from '../../lib/spectrumScan'
+import { DEFAULT_OCCUPIED_DBM, VERDICT_LABEL, type SpectrumScan } from '../../types/spectrumScan'
 
 type Tab =
   | 'weight'
@@ -1502,6 +1511,23 @@ const RfTab = ({ projectName }: { projectName: string }) => {
   // ALLES, was funkt, und `computeRfConflicts` laeuft genau einmal darueber.
   const spectrum = useMemo(() => buildSpectrumPlan(project), [project])
 
+  // BEDARF 112 — der Scan vor Ort. Ein Scan ist KEIN Sender und geht deshalb
+  // nicht in `collectTransmitters` ein: was dort steht, sind Traeger, aus
+  // denen Intermodulation gerechnet wird, und eine Messung ist ein
+  // Pegelverlauf, dessen Spitzen auch eine Reflexion sein koennen. Er wird
+  // GEGEN den Plan gehalten, nicht in ihn hinein.
+  const [scan, setScan] = useState<SpectrumScan | null>(null)
+  const [schwelle, setSchwelle] = useState(DEFAULT_OCCUPIED_DBM)
+  const carrierChecks = useMemo(
+    () => (scan ? checkCarriers(scan, spectrum.entries, schwelle) : []),
+    [scan, spectrum, schwelle],
+  )
+  const scanBefunde = useMemo(
+    () => (scan ? scanFindings(scan, carrierChecks, schwelle) : []),
+    [scan, carrierChecks, schwelle],
+  )
+  const scanSpanne = useMemo(() => (scan ? scannedRange(scan) : null), [scan])
+
   const links = useMemo(() => {
     const nameOf = new Map(project.equipment.map((e) => [e.id, e.name]))
     return project.cables
@@ -1778,6 +1804,105 @@ const RfTab = ({ projectName }: { projectName: string }) => {
           </p>
         </div>
       </details>
+
+      {/* BEDARF 112 — die Messung gegen den Plan. „Nicht gemessen" ist ein
+          eigenes Urteil und keine Entwarnung: ein Scan von 470–608 MHz sagt
+          ueber 614 MHz gar nichts. */}
+      <div className="rounded border border-[var(--cp-border)] p-2">
+        <div className="mb-2 flex flex-wrap items-center gap-2 text-cp-xs">
+          <span className="font-medium">
+            {t('scan.title', 'Spektrum-Scan vom Analyser')}
+          </span>
+          <label className="cursor-pointer rounded border border-[var(--cp-border)] px-2 py-1 hover:bg-[var(--cp-surface-2)]">
+            {t('scan.import', '📈 Scan einlesen')}
+            <input
+              type="file"
+              accept=".csv,.txt"
+              className="hidden"
+              onChange={(e) => {
+                const f = e.target.files?.[0]
+                // Das Feld wird geleert, damit dieselbe Datei zweimal gewaehlt
+                // werden kann — nach einem zweiten Scan heisst sie oft gleich.
+                e.target.value = ''
+                if (!f) return
+                void f.text().then((text) => setScan(parseScanCsv(text, f.name)))
+              }}
+            />
+          </label>
+          {scan && (
+            <>
+              <span className="text-[var(--cp-text-secondary)]">
+                {scan.fileName ? `${scan.fileName} · ` : ''}
+                {format(t('scan.points', '{n} Messpunkte'), { n: String(scan.points.length) })}
+                {scanSpanne ? ` · ${scanSpanne.fromMhz}–${scanSpanne.toMhz} MHz` : ''}
+              </span>
+              <label className="flex items-center gap-1">
+                {t('scan.threshold', 'belegt ab (dBm)')}
+                <input
+                  type="number"
+                  value={schwelle}
+                  onChange={(e) => setSchwelle(Number(e.target.value))}
+                  title={t(
+                    'scan.thresholdHint',
+                    'Was „belegt" heißt, hängt an Antenne, Vorverstärker und Abstand — keine dieser Angaben steht in der Datei. Deshalb ist die Schwelle ein Feld und kein Festwert.',
+                  )}
+                  className="w-20 rounded border border-[var(--cp-border)] bg-[var(--cp-surface-1)] px-1 py-0.5"
+                />
+              </label>
+              <button
+                type="button"
+                onClick={() =>
+                  downloadBlob(
+                    buildExportFilenameWithSuffix(projectName || 'cable-planner', 'scan-abgleich', 'csv'),
+                    csvFromTable(carrierCheckTable(carrierChecks)),
+                    'text/csv;charset=utf-8',
+                  )
+                }
+                className="rounded border border-[var(--cp-border)] px-2 py-1 hover:bg-[var(--cp-surface-2)]"
+              >
+                {t('scan.exportCheck', 'Abgleich')}
+              </button>
+            </>
+          )}
+        </div>
+        {scanBefunde.length > 0 && (
+          <ul className="flex flex-col gap-1 text-cp-xs">
+            {scanBefunde.map((f, i) => (
+              <li key={`${f.kind}-${i}`} className="text-amber-300/90">
+                <strong>{SCAN_FINDING_LABEL[f.kind]}</strong> — {f.text}
+              </li>
+            ))}
+          </ul>
+        )}
+        {scan && carrierChecks.length > 0 && (
+          <table className="mt-2 w-full text-cp-xs">
+            <thead className="text-[var(--cp-text-secondary)]">
+              <tr>
+                <th className="px-2 py-1 text-left">{t('scan.what', 'Was funkt')}</th>
+                <th className="px-2 py-1 text-left">{t('scan.freq', 'MHz')}</th>
+                <th className="px-2 py-1 text-left">{t('scan.verdict', 'Urteil')}</th>
+                <th className="px-2 py-1 text-left">{t('scan.peak', 'Spitze (dBm)')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {carrierChecks.map((c) => (
+                <tr key={c.entry.id} className="border-t border-[var(--cp-border-muted)]">
+                  <td className="px-2 py-1">{c.entry.label}</td>
+                  <td className="px-2 py-1">{c.entry.mhz}</td>
+                  <td
+                    className={`px-2 py-1 ${c.verdict === 'occupied' ? 'text-cp-danger' : c.verdict === 'not-scanned' ? 'text-[var(--cp-text-muted)]' : ''}`}
+                  >
+                    {VERDICT_LABEL[c.verdict]}
+                  </td>
+                  <td className="px-2 py-1">
+                    {c.peakDbm === undefined ? VERDICT_LABEL['not-scanned'] : c.peakDbm}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
 
       <div className="flex justify-end gap-2">
         <button

--- a/src/renderer/lib/dataDictionary.ts
+++ b/src/renderer/lib/dataDictionary.ts
@@ -156,6 +156,13 @@ export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
   Grundlage:
     'Woraus dieses Blatt spricht: aus dem festgeschriebenen As-Built, aus einem veralteten As-Built oder aus dem Plan (also im Zweifel dem Angebot).',
   Gruppe: 'Die vergebene Multicast-Gruppenadresse.',
+  // Bedarf 112 — der Scan vor Ort.
+  'Was funkt': 'Der geplante Träger — ein Rig-Kanal oder eine drahtlose Strecke aus dem Kabelgraph.',
+  'Pegel (dBm)': 'Der gemessene Pegel an diesem Punkt.',
+  Urteil:
+    'Was die Messung über diesen Träger sagt: frei gemessen, belegt gemessen — oder „nicht gemessen“, wenn er außerhalb des gescannten Bereichs liegt. Das dritte ist keine Entwarnung.',
+  'Spitzenpegel (dBm)':
+    'Der höchste gemessene Pegel im Fenster um diese Frequenz. „nicht gemessen“ heißt: der Scan reicht dort nicht hin.',
   // Bedarf 114 — die Spalten des Session-Blatts.
   Akku:
     'Wie lange der Akku schon eingelegt ist. Keine Restlaufzeit — die hängt an Typ, Alter, Sendeleistung und Temperatur und steht nirgends im Plan.',

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3490,6 +3490,18 @@ export const en: Dict = {
   'channelList.view.stage': 'Stage (position)',
   'channelList.view.console': 'Console (names)',
   'channelList.view.monitor': 'Monitor paths',
+  // Bedarf 112 — der Scan vor Ort, gegen den Plan gehalten.
+  'scan.title': 'Spectrum scan from the analyser',
+  'scan.import': '📈 Read scan',
+  'scan.points': '{n} measurement points',
+  'scan.threshold': 'occupied from (dBm)',
+  'scan.thresholdHint':
+    'What \u201Coccupied\u201D means depends on antenna, preamp and distance \u2014 none of which is in the file. That is why the threshold is a field, not a fixed value.',
+  'scan.exportCheck': 'Comparison',
+  'scan.what': 'What transmits',
+  'scan.freq': 'MHz',
+  'scan.verdict': 'Verdict',
+  'scan.peak': 'Peak (dBm)',
   // Bedarf 114 — wer traegt in welcher Vorstellung welche Strecke.
   'micPlot.title': 'Mic plot — who wears which channel',
   'micPlot.session': 'Session',

--- a/src/renderer/lib/spectrumScan.ts
+++ b/src/renderer/lib/spectrumScan.ts
@@ -1,0 +1,318 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Der Scan vor Ort, gegen den Plan gehalten (Bedarf 112, P3).
+//
+// Die Begründung und die Grenze stehen in `types/spectrumScan.ts`. Hier steht
+// die Mechanik, und sie ist rein: keine Uhr, kein Store, kein IO.
+//
+// ─── DIE EINE REGEL, DIE DIESES MODUL TRÄGT ────────────────────────────────
+//
+// „Nicht gemessen" ist NICHT „frei". Ein Scan von 470–608 MHz sagt über
+// 614 MHz gar nichts, und die Antwort darauf ist ein drittes Urteil und keine
+// Beruhigung. Genau dieselbe Regel wie beim Spektrum-Plan selbst (Bedarf 95):
+// eine Rechnung, die drei von acht Sendern nicht kennt, sagt „frei" und meint
+// „ich habe nicht nachgesehen".
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { CarrierVerdict, ScanPoint, SpectrumScan } from '../types/spectrumScan'
+import { DEFAULT_OCCUPIED_DBM, VERDICT_LABEL } from '../types/spectrumScan'
+import type { SpectrumEntry } from './spectrumPlan'
+import { SPECTRUM_SOURCE_LABEL } from './spectrumPlan'
+import type { CsvCell, CsvTable } from './csv'
+
+// Klammern gehören mit weg: Analyser schreiben ihre Einheit als „Frequency
+// (Hz)", und eine Normalisierung, die die Klammern stehen lässt, findet die
+// Spalte nicht — die Datei gilt dann als unlesbar, obwohl sie mustergültig
+// ist.
+const norm = (s: string): string => s.trim().toLowerCase().replace(/[\s_\-.()[\]]/g, '')
+
+/**
+ * Überschriften, die als Frequenz- bzw. Pegel-Spalte gelten.
+ *
+ * Verglichen wird mit ANFANG und nicht auf Gleichheit: die Einheit hängt
+ * hinten dran („frequencykhz", „leveldbm"), und jede Schreibweise einzeln
+ * aufzuzählen hiesse, bei der nächsten Analyser-Firmware wieder eine zu
+ * vergessen.
+ */
+export const FREQ_ALIASES = ['frequency', 'freq', 'frequenz', 'mhz', 'khz', 'ghz', 'hz']
+export const LEVEL_ALIASES = ['level', 'dbm', 'pegel', 'amplitude', 'power', 'value']
+
+const matchesAlias = (header: string, aliases: readonly string[]): boolean =>
+  aliases.some((a) => header === a || header.startsWith(a))
+
+const splitLine = (line: string, delim: string): string[] =>
+  line.split(delim).map((c) => c.trim().replace(/^"(.*)"$/s, '$1'))
+
+const detectDelimiter = (text: string): string => {
+  const kopf = text.split(/\r?\n/, 1)[0] ?? ''
+  const semi = kopf.match(/;/g)?.length ?? 0
+  const komma = kopf.match(/,/g)?.length ?? 0
+  const tab = kopf.match(/\t/g)?.length ?? 0
+  if (tab >= semi && tab >= komma && tab > 0) return '\t'
+  return semi >= komma ? ';' : ','
+}
+
+/**
+ * Eine Zahl aus einer Zelle — mit deutschem ODER englischem Dezimaltrennzeichen.
+ *
+ * `null` heisst „keine Zahl". Ein `NaN` durchzureichen wäre schlimmer: es
+ * rechnet in jedem Vergleich falsch, ohne je aufzufallen.
+ */
+export function parseNumber(cell: string | undefined): number | null {
+  if (cell === undefined) return null
+  const t = cell.trim()
+  if (!t) return null
+  // Der ZULETZT stehende Trenner ist der Dezimaltrenner: „1.234,5" ist
+  // deutsch (Punkt gruppiert), „1,234.5" englisch (Komma gruppiert), und
+  // „1,5" ist deutsch. Die frühere Regel „Komma nur ohne Punkt daneben" las
+  // „1.234,5" als 1,2345 — eine Frequenz um drei Zehnerpotenzen daneben, die
+  // in keiner Prüfung auffällt, weil sie eine gültige Zahl ist.
+  const letzterPunkt = t.lastIndexOf('.')
+  const letztesKomma = t.lastIndexOf(',')
+  const bereinigt =
+    letztesKomma > letzterPunkt
+      ? t.replace(/\./g, '').replace(',', '.')
+      : t.replace(/,/g, '')
+  const n = Number(bereinigt)
+  return Number.isFinite(n) ? n : null
+}
+
+/**
+ * Frequenz einer Zelle in MHz, gemessen an der Spalten-Überschrift.
+ *
+ * Analyser schreiben ihre Frequenzspalte mal in Hz (tinySA-Voreinstellung),
+ * mal in MHz. Welche Einheit gilt, steht in der ÜBERSCHRIFT und wird nicht
+ * an der Grössenordnung geraten: eine Datei mit „500000000" wäre in MHz
+ * gelesen eine halbe Milliarde MHz, und eine Datei mit „500" in Hz gelesen
+ * eine halbe Millisekunde Funk. Beides fiele auf. Der gefährliche Fall ist
+ * ein Scan im GHz-Bereich, dessen Zahlen in beiden Einheiten plausibel
+ * aussehen — deshalb: die Überschrift entscheidet, sonst MHz.
+ */
+export function toMhz(value: number, headerNorm: string): number {
+  if (headerNorm.includes('khz')) return value / 1000
+  if (headerNorm.includes('ghz')) return value * 1000
+  if (headerNorm.includes('mhz')) return value
+  // „hz" ohne Präfix — aber erst prüfen, ob nicht doch „mhz"/„khz"/„ghz"
+  // gemeint war; die drei sind oben schon weg.
+  if (headerNorm.includes('hz')) return value / 1_000_000
+  return value
+}
+
+/**
+ * Liest eine Analyser-CSV.
+ *
+ * Tolerant wie die Dante-Matrix (Bedarf 94): Spalten über die Überschrift,
+ * Trenner erkannt, unlesbare Zeilen GEZÄHLT statt verschwiegen. Zusätzlich
+ * kommt hier eine Datei ganz OHNE Überschrift vor — tinySA schreibt in seiner
+ * schlanken Einstellung nur Zahlenpaare. Dann gilt: erste Spalte Frequenz,
+ * zweite Pegel, Einheit MHz. Das ist eine Annahme, und sie steht deshalb im
+ * Ergebnis nicht als Gewissheit, sondern als das, was `unreadable` und die
+ * gemessene Spanne dem Leser zeigen.
+ */
+export function parseScanCsv(text: string, fileName?: string): SpectrumScan {
+  const delim = detectDelimiter(text)
+  const zeilen = text.split(/\r?\n/).filter((z) => z.trim() !== '')
+  if (zeilen.length === 0) return { points: [], unreadable: 0, ...(fileName ? { fileName } : {}) }
+
+  const kopf = splitLine(zeilen[0], delim).map(norm)
+  let iFreq = kopf.findIndex((h) => matchesAlias(h, FREQ_ALIASES))
+  // Kein Schutz gegen „beide Spalten sind dieselbe": die beiden Alias-Listen
+  // sind disjunkt, und keine ist Praefix einer der anderen — geprueft in
+  // `tests/spectrumScan.test.ts`. Ein Schutz, der nie greifen kann, behauptet
+  // eine Gefahr, die es nicht gibt, und verdeckt die Bedingung, die ihn
+  // ueberfluessig macht.
+  let iLevel = kopf.findIndex((h) => matchesAlias(h, LEVEL_ALIASES))
+  let freqHeader = iFreq >= 0 ? kopf[iFreq] : 'mhz'
+  let datenAb = 1
+
+  // Keine Überschrift erkannt: Zahlenpaare, erste Spalte Frequenz in MHz.
+  if (iFreq < 0 || iLevel < 0) {
+    const ersteIstZahl = parseNumber(splitLine(zeilen[0], delim)[0]) !== null
+    if (!ersteIstZahl) {
+      // Es GIBT eine Überschrift, sie nennt aber keine der beiden Spalten.
+      // Dann ist die Datei nicht lesbar — und jede Datenzeile wird gezählt,
+      // damit „0 Punkte" nicht wie ein leeres Band aussieht.
+      return {
+        points: [],
+        unreadable: zeilen.length - 1,
+        ...(fileName ? { fileName } : {}),
+      }
+    }
+    iFreq = 0
+    iLevel = 1
+    freqHeader = 'mhz'
+    datenAb = 0
+  }
+
+  const points: ScanPoint[] = []
+  let unreadable = 0
+  for (let i = datenAb; i < zeilen.length; i++) {
+    const z = splitLine(zeilen[i], delim)
+    const f = parseNumber(z[iFreq])
+    const l = parseNumber(z[iLevel])
+    if (f === null || l === null) {
+      unreadable++
+      continue
+    }
+    points.push({ mhz: toMhz(f, freqHeader), dbm: l })
+  }
+  points.sort((a, b) => a.mhz - b.mhz)
+  return { points, unreadable, ...(fileName ? { fileName } : {}) }
+}
+
+/** Die gemessene Spanne. `null` bei leerem Scan — kein „0 bis 0". */
+export function scannedRange(scan: SpectrumScan): { fromMhz: number; toMhz: number } | null {
+  if (scan.points.length === 0) return null
+  return { fromMhz: scan.points[0].mhz, toMhz: scan.points[scan.points.length - 1].mhz }
+}
+
+/**
+ * Der höchste gemessene Pegel im Fenster um eine Frequenz.
+ *
+ * Das Fenster ist nötig, weil ein Scan diskret ist: er hat einen Punkt bei
+ * 502,3 und einen bei 502,4, aber keinen bei genau 502,375. Ohne Fenster
+ * fände eine Trägerprüfung nie einen Messpunkt und meldete jede Frequenz als
+ * ungemessen.
+ *
+ * `null` heisst: ausserhalb des gemessenen Bereichs.
+ */
+export function peakNear(
+  scan: SpectrumScan,
+  mhz: number,
+  windowMhz: number,
+): number | null {
+  // Kein eigener Bereichs-Check: die Schleife darunter liefert fuer eine
+  // Frequenz ausserhalb ohnehin `null`, weil kein Punkt ins Fenster faellt.
+  // Der Check waere eine zweite Stelle, an der „ausserhalb" definiert ist —
+  // und zwei Definitionen desselben Begriffs gehen irgendwann auseinander.
+  let max: number | null = null
+  for (const p of scan.points) {
+    if (Math.abs(p.mhz - mhz) > windowMhz) continue
+    if (max === null || p.dbm > max) max = p.dbm
+  }
+  return max
+}
+
+/** Was ein geplanter Träger gegenüber der Messung ist. */
+export interface CarrierCheck {
+  entry: SpectrumEntry
+  verdict: CarrierVerdict
+  /** Höchster gemessener Pegel im Fenster; fehlt bei `not-scanned`. */
+  peakDbm?: number
+}
+
+/**
+ * Jeden geplanten Träger gegen die Messung halten.
+ *
+ * Drei Urteile, und das dritte ist der Grund für dieses Modul: „nicht
+ * gemessen" ist keine Entwarnung. Ein Scan von 470–608 MHz sagt über 614 MHz
+ * gar nichts.
+ */
+export function checkCarriers(
+  scan: SpectrumScan,
+  entries: readonly SpectrumEntry[],
+  occupiedDbm: number = DEFAULT_OCCUPIED_DBM,
+  windowMhz = 0.1,
+): CarrierCheck[] {
+  return entries.map((entry) => {
+    const peak = peakNear(scan, entry.mhz, windowMhz)
+    if (peak === null) return { entry, verdict: 'not-scanned' as const }
+    return {
+      entry,
+      verdict: peak >= occupiedDbm ? ('occupied' as const) : ('clear' as const),
+      peakDbm: peak,
+    }
+  })
+}
+
+// ── Befunde ────────────────────────────────────────────────────────────────
+
+export type ScanFindingKind = 'carrier-occupied' | 'outside-scan' | 'nothing-readable' | 'partial-read'
+
+export const SCAN_FINDING_LABEL: Readonly<Record<ScanFindingKind, string>> = {
+  'carrier-occupied': 'Geplanter Träger sitzt auf gemessener Energie',
+  'outside-scan': 'Träger ausserhalb des gemessenen Bereichs',
+  'nothing-readable': 'Keine Zeile der Datei war lesbar',
+  'partial-read': 'Ein Teil der Datei war nicht lesbar',
+}
+
+export interface ScanFinding {
+  kind: ScanFindingKind
+  text: string
+  entryIds: string[]
+}
+
+export function scanFindings(
+  scan: SpectrumScan,
+  checks: readonly CarrierCheck[],
+  occupiedDbm: number = DEFAULT_OCCUPIED_DBM,
+): ScanFinding[] {
+  const out: ScanFinding[] = []
+
+  if (scan.points.length === 0) {
+    out.push({
+      kind: 'nothing-readable',
+      entryIds: [],
+      text: `Aus dieser Datei liess sich kein Messpunkt lesen (${scan.unreadable} Zeile(n) verworfen). Ohne Messung steht bei jedem Träger „${VERDICT_LABEL['not-scanned']}" — und das ist die ehrliche Antwort, nicht „frei".`,
+    })
+    return out
+  }
+
+  if (scan.unreadable > 0) {
+    out.push({
+      kind: 'partial-read',
+      entryIds: [],
+      text: `${scan.unreadable} Zeile(n) der Datei waren nicht lesbar. Die Messung ist damit lückenhaft; eine Lücke sieht im Verlauf aus wie ein freies Band.`,
+    })
+  }
+
+  const belegt = checks.filter((c) => c.verdict === 'occupied')
+  if (belegt.length > 0) {
+    out.push({
+      kind: 'carrier-occupied',
+      entryIds: belegt.map((c) => c.entry.id),
+      text: `${belegt.length} geplante(r) Träger liegen auf gemessener Energie über ${occupiedDbm} dBm: ${belegt.map((c) => `${c.entry.label} (${c.entry.mhz} MHz)`).join(', ')}. Was dort sitzt, sagt die Messung nicht — nur, dass etwas sitzt.`,
+    })
+  }
+
+  const draussen = checks.filter((c) => c.verdict === 'not-scanned')
+  if (draussen.length > 0) {
+    const spanne = scannedRange(scan)
+    out.push({
+      kind: 'outside-scan',
+      entryIds: draussen.map((c) => c.entry.id),
+      text: `${draussen.length} Träger liegen ausserhalb des gemessenen Bereichs${spanne ? ` (${spanne.fromMhz}–${spanne.toMhz} MHz)` : ''}. Für sie sagt dieser Scan nichts — „${VERDICT_LABEL['not-scanned']}" ist kein „frei".`,
+    })
+  }
+
+  return out
+}
+
+// ── Blätter ────────────────────────────────────────────────────────────────
+
+/**
+ * Der Abgleich als Tabelle.
+ *
+ * Das ist die Ausgabe, die der Beleg als Hersteller-Format wünscht — und die
+ * hier bewusst eine dokumentierte Tabelle ist. Warum, steht in
+ * `types/spectrumScan.ts`.
+ */
+export function carrierCheckTable(checks: readonly CarrierCheck[]): CsvTable {
+  return {
+    headers: ['Was funkt', 'Quelle', 'Frequenz (MHz)', 'Urteil', 'Spitzenpegel (dBm)'],
+    rows: checks.map((c): CsvCell[] => [
+      c.entry.label,
+      SPECTRUM_SOURCE_LABEL[c.entry.source],
+      c.entry.mhz,
+      VERDICT_LABEL[c.verdict],
+      c.peakDbm === undefined ? VERDICT_LABEL['not-scanned'] : c.peakDbm,
+    ]),
+  }
+}
+
+/** Die Messpunkte selbst — für das Archiv und für fremde Werkzeuge. */
+export function scanTable(scan: SpectrumScan): CsvTable {
+  return {
+    headers: ['Frequenz (MHz)', 'Pegel (dBm)'],
+    rows: scan.points.map((p): CsvCell[] => [p.mhz, p.dbm]),
+  }
+}

--- a/src/renderer/types/spectrumScan.ts
+++ b/src/renderer/types/spectrumScan.ts
@@ -1,0 +1,85 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Der Scan vor Ort, gegen den Plan gehalten (Bedarf 112, P3).
+//
+//   > Cheap analysers (tinySA, RF Explorer) are widely used for site scans,
+//   > but their CSV is not readable by any coordination software, so engineers
+//   > run CONVERSION SCRIPTS ON THE CRITICAL PATH OF LOAD-IN.
+//
+// Belegt an `erikkaashoek/tinySA#88`: dort wird um Export nach Shure WWB,
+// Sennheiser WSM, Audio-Technica Wireless Manager und Professional Wireless
+// IAS gebeten, weil „the supplied default .csv format is not recognized by any
+// of these industry standard softwares".
+//
+// ─── WAS GEBAUT IST, UND WAS NICHT ─────────────────────────────────────────
+//
+// GEBAUT ist die LESE-Seite und der Abgleich: die Analyser-CSV einlesen und
+// die geplanten Träger dagegen halten. Das ist die Frage, die im Saal
+// gestellt wird — „ist meine Frequenz hier frei?" — und sie lässt sich mit
+// dem beantworten, was der Plan und die Datei wissen.
+//
+// NICHT gebaut sind die vier Hersteller-Formate. Für keines liegt in diesem
+// Korpus ein Schema vor. Das ist dieselbe Entscheidung wie beim
+// Dante-Preset-XML (Bedarf 94), und sie fällt hier zum dritten Mal — was sie
+// nicht schwächer macht, sondern zeigt, wo die Grenze dieses Korpus liegt:
+// ein Exporter nach Vermutung sähe aus, als könnte er es, und bei einer halb
+// verstandenen Frequenzliste fällt das erst auf, wenn im Saal etwas rauscht.
+// Ausgegeben wird stattdessen eine Tabelle mit Spaltenlexikon — lesbar für
+// den Menschen, importierbar in jedes Tabellenprogramm.
+//
+// ─── EIN SCAN IST KEIN SENDER ──────────────────────────────────────────────
+//
+// Der Scan geht bewusst NICHT als Quelle in `spectrumPlan.collectTransmitters`
+// ein. Was dort steht, sind Sender mit einer Trägerfrequenz, aus denen die
+// Intermodulation gerechnet wird. Eine Messung ist etwas anderes: ein
+// Pegelverlauf über ein Band, dessen Spitzen fremde Sender sein können — oder
+// eine Reflexion, ein Nachbarkanal, der Analyser selbst. Sie als Sender
+// einzuspeisen erzeugte IM3-Produkte aus Rauschen.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Ein Messpunkt: Pegel bei einer Frequenz. */
+export interface ScanPoint {
+  mhz: number
+  /** Pegel in dBm, wie die Datei ihn nennt. */
+  dbm: number
+}
+
+/** Was gelesen wurde. */
+export interface SpectrumScan {
+  /** Punkte, aufsteigend nach Frequenz. */
+  points: ScanPoint[]
+  /**
+   * Zeilen, die nicht lesbar waren.
+   *
+   * Als Zahl und nicht verschwiegen: eine Messung, von der die Hälfte
+   * stillschweigend wegfiel, sieht aus wie ein leeres Band.
+   */
+  unreadable: number
+  /** Dateiname, wie ihn der Nutzer gewählt hat — für den Stempel. */
+  fileName?: string
+}
+
+/**
+ * Ab welchem Pegel eine Frequenz als belegt gilt.
+ *
+ * Vorgabewert und KEINE Wahrheit: was „belegt" heisst, hängt an Antenne,
+ * Vorverstärker und Abstand, und keine dieser Angaben steht in der Datei.
+ * Deshalb ist die Schwelle ein Eingabefeld und der Wert hier nur der
+ * Startpunkt — er liegt bewusst grob in der Mitte zwischen dem Grundrauschen
+ * eines tinySA (etwa −100 dBm) und einem nahen Sender (−30 dBm).
+ */
+export const DEFAULT_OCCUPIED_DBM = -70
+
+/** Was ein geplanter Träger gegenüber der Messung ist. */
+export type CarrierVerdict =
+  /** Gemessen und unter der Schwelle. */
+  | 'clear'
+  /** Gemessen und über der Schwelle — da sitzt etwas. */
+  | 'occupied'
+  /** Ausserhalb des gemessenen Bereichs. Kein Urteil, und das ist der Punkt. */
+  | 'not-scanned'
+
+export const VERDICT_LABEL: Readonly<Record<CarrierVerdict, string>> = {
+  clear: 'frei gemessen',
+  occupied: 'belegt gemessen',
+  'not-scanned': 'nicht gemessen',
+}

--- a/tests/spectrumScan.test.ts
+++ b/tests/spectrumScan.test.ts
@@ -1,0 +1,411 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SCAN_FINDING_LABEL,
+  carrierCheckTable,
+  checkCarriers,
+  parseNumber,
+  FREQ_ALIASES,
+  LEVEL_ALIASES,
+  parseScanCsv,
+  peakNear,
+  scanFindings,
+  scanTable,
+  scannedRange,
+  toMhz,
+} from '../src/renderer/lib/spectrumScan'
+import { DEFAULT_OCCUPIED_DBM, VERDICT_LABEL } from '../src/renderer/types/spectrumScan'
+import type { SpectrumEntry } from '../src/renderer/lib/spectrumPlan'
+import { undescribedColumns } from '../src/renderer/lib/dataDictionary'
+import typenQuelle from '../src/renderer/types/spectrumScan.ts?raw'
+import libQuelle from '../src/renderer/lib/spectrumScan.ts?raw'
+import planQuelle from '../src/renderer/lib/spectrumPlan.ts?raw'
+import dialogQuelle from '../src/renderer/components/Analysis/AnalysisDialog.tsx?raw'
+
+// ---------------------------------------------------------------------------
+// Der Scan vor Ort, gegen den Plan gehalten (Bedarf 112, P3).
+//
+//   > Cheap analysers (tinySA, RF Explorer) are widely used for site scans,
+//   > but their CSV is not readable by any coordination software, so engineers
+//   > run CONVERSION SCRIPTS ON THE CRITICAL PATH OF LOAD-IN.
+//
+// Belegt an `erikkaashoek/tinySA#88`. Gebaut ist die LESE-Seite und der
+// Abgleich; die vier Hersteller-Formate sind NICHT gebaut, weil fuer keines
+// ein Schema im Korpus vorliegt — dieselbe Entscheidung wie beim
+// Dante-Preset-XML (Bedarf 94).
+// ---------------------------------------------------------------------------
+
+const entry = (id: string, mhz: number, label = `Kanal ${id}`): SpectrumEntry => ({
+  id,
+  label,
+  mhz,
+  source: 'rig',
+})
+
+// ── 1. Die Datei lesen ─────────────────────────────────────────────────────
+
+describe('parseScanCsv', () => {
+  it('liest eine Datei mit Ueberschrift und Komma', () => {
+    const s = parseScanCsv('Frequency,Level\n500.0,-95\n500.1,-42\n')
+    expect(s.points).toEqual([
+      { mhz: 500.0, dbm: -95 },
+      { mhz: 500.1, dbm: -42 },
+    ])
+    expect(s.unreadable).toBe(0)
+  })
+
+  it('liest Semikolon und Tabulator genauso', () => {
+    expect(parseScanCsv('Frequenz;Pegel\n500,0;-95\n').points).toEqual([{ mhz: 500, dbm: -95 }])
+    expect(parseScanCsv('Frequency\tLevel\n500\t-95\n').points).toEqual([{ mhz: 500, dbm: -95 }])
+  })
+
+  it('nimmt die EINHEIT aus der Ueberschrift und raet sie nicht an der Groesse', () => {
+    // Eine Datei mit „500000000" in MHz gelesen waere eine halbe Milliarde
+    // MHz. Der gefaehrliche Fall ist aber der GHz-Scan, dessen Zahlen in
+    // beiden Einheiten plausibel aussehen — deshalb entscheidet die
+    // Ueberschrift.
+    expect(parseScanCsv('Frequency (Hz),Level\n500000000,-95\n').points[0].mhz).toBe(500)
+    expect(parseScanCsv('Frequency (kHz),Level\n500000,-95\n').points[0].mhz).toBe(500)
+    expect(parseScanCsv('Frequency (GHz),Level\n0.5,-95\n').points[0].mhz).toBe(500)
+    expect(parseScanCsv('Frequency (MHz),Level\n500,-95\n').points[0].mhz).toBe(500)
+    // Der Fall, an dem sich Ueberschrift und Groessen-Raterei trennen: eine
+    // Hz-Datei mit einem KLEINEN Wert. Wer an der Groesse raet, liest 500 MHz;
+    // die Ueberschrift sagt 500 Hz.
+    expect(parseScanCsv('Frequency (Hz),Level\n500,-95\n').points[0].mhz).toBe(0.0005)
+    // Und andersherum: ein 2-GHz-Scan mit kHz-Ueberschrift. Wer an der Groesse
+    // raet, macht daraus 2 MHz statt 2000 — beides gueltige Zahlen, und die
+    // falsche faellt erst auf, wenn der Abgleich jeden Traeger als
+    // „nicht gemessen“ meldet.
+    expect(parseScanCsv('Frequency (kHz),Level\n2000000,-95\n').points[0].mhz).toBe(2000)
+  })
+
+  it('liest eine Datei ganz OHNE Ueberschrift als Zahlenpaare in MHz', () => {
+    // tinySA schreibt in der schlanken Einstellung nur Paare.
+    const s = parseScanCsv('500.0,-95\n500.1,-42\n')
+    expect(s.points).toHaveLength(2)
+    expect(s.points[0].mhz).toBe(500)
+  })
+
+  it('zaehlt unlesbare Zeilen, statt sie zu verschweigen', () => {
+    // Eine Messung, von der die Haelfte stillschweigend wegfiel, sieht aus
+    // wie ein leeres Band.
+    const s = parseScanCsv('Frequency,Level\n500,-95\nkaputt,-42\n500.2,\n')
+    expect(s.points).toHaveLength(1)
+    expect(s.unreadable).toBe(2)
+  })
+
+  it('gibt bei einer Ueberschrift ohne die beiden Spalten NICHTS aus', () => {
+    // Und zaehlt jede Datenzeile als unlesbar: „0 Punkte, 0 verworfen" saehe
+    // aus wie ein leeres Band.
+    const s = parseScanCsv('Zeit;Temperatur\n10:00;21\n10:01;22\n')
+    expect(s.points).toEqual([])
+    expect(s.unreadable).toBe(2)
+  })
+
+  it('findet die Spalten auch mit Einheit in Klammern', () => {
+    // Analyser schreiben „Frequency (Hz)". Eine Normalisierung, die die
+    // Klammern stehen laesst, findet die Spalte nicht — und die Datei gilt
+    // als unlesbar, obwohl sie mustergueltig ist.
+    const s = parseScanCsv('Frequency (kHz);Level (dBm)\n500000;-95\n')
+    expect(s.points).toEqual([{ mhz: 500, dbm: -95 }])
+    expect(s.unreadable).toBe(0)
+  })
+
+  it('findet auch eine Ueberschrift, die NUR aus der Einheit besteht', () => {
+    // Analyser schreiben ihre Spalten auch als „(MHz)" und „(dBm)". Ohne
+    // Klammer-Normalisierung faende der Leser sie nicht — und die Datei
+    // gaelte als unlesbar, obwohl sie mustergueltig ist.
+    const s = parseScanCsv('(MHz);(dBm)\n500;-95\n')
+    expect(s.points).toEqual([{ mhz: 500, dbm: -95 }])
+  })
+
+  it('findet die Spalten ueber die UEBERSCHRIFT, nicht ueber die Position', () => {
+    // Eine Datei mit vertauschten Spalten ist dieselbe Datei. Positionsfest
+    // gelesen waere daraus ein Scan bei -95 MHz mit 500 dBm geworden — beides
+    // gueltige Zahlen, die in keiner Pruefung auffallen.
+    const s = parseScanCsv('Level;Frequency\n-95;500\n')
+    expect(s.points).toEqual([{ mhz: 500, dbm: -95 }])
+  })
+
+  it('gibt bei nur EINER erkannten Spalte nichts aus', () => {
+    const s = parseScanCsv('MHz\n500\n')
+    expect(s.points).toEqual([])
+    expect(s.unreadable).toBe(1)
+  })
+
+  it('haelt die beiden Alias-Listen disjunkt', () => {
+    // DIE Bedingung, die den Schutz „nicht dieselbe Spalte" ueberfluessig
+    // macht: keine Ueberschrift kann beide Listen treffen, weil keine der
+    // einen Praefix einer der anderen ist. Faellt das, muss der Schutz zurueck
+    // — und dieser Test sagt es dann.
+    const treffer = (h: string, list: readonly string[]) =>
+      list.some((a) => h === a || h.startsWith(a))
+    for (const f of FREQ_ALIASES) {
+      expect(treffer(f, LEVEL_ALIASES), `${f} trifft auch die Pegel-Liste`).toBe(false)
+    }
+    for (const l of LEVEL_ALIASES) {
+      expect(treffer(l, FREQ_ALIASES), `${l} trifft auch die Frequenz-Liste`).toBe(false)
+    }
+  })
+
+  it('sortiert die Punkte aufsteigend', () => {
+    const s = parseScanCsv('Frequency,Level\n500.2,-95\n500.0,-42\n')
+    expect(s.points.map((p) => p.mhz)).toEqual([500.0, 500.2])
+  })
+
+  it('haelt den Dateinamen fest, wenn es einen gibt', () => {
+    expect(parseScanCsv('Frequency,Level\n500,-95\n', 'scan.csv').fileName).toBe('scan.csv')
+    expect('fileName' in parseScanCsv('Frequency,Level\n500,-95\n')).toBe(false)
+  })
+})
+
+describe('parseNumber', () => {
+  it('liest deutsches und englisches Dezimaltrennzeichen', () => {
+    expect(parseNumber('500,5')).toBe(500.5)
+    expect(parseNumber('500.5')).toBe(500.5)
+    expect(parseNumber('1.234,5')).toBe(1234.5)
+    expect(parseNumber('1,234.5')).toBe(1234.5)
+  })
+
+  it('liefert null statt NaN', () => {
+    // Ein NaN rechnet in jedem Vergleich falsch, ohne je aufzufallen.
+    expect(parseNumber('kaputt')).toBeNull()
+    expect(parseNumber('')).toBeNull()
+    expect(parseNumber(undefined)).toBeNull()
+  })
+})
+
+describe('toMhz', () => {
+  it('rechnet nach der Ueberschrift', () => {
+    expect(toMhz(500_000_000, 'frequencyhz')).toBe(500)
+    expect(toMhz(500_000, 'freqkhz')).toBe(500)
+    expect(toMhz(0.5, 'fghz')).toBe(500)
+    expect(toMhz(500, 'mhz')).toBe(500)
+    expect(toMhz(500, 'frequency')).toBe(500)
+  })
+
+  it('verwechselt mhz/khz/ghz nicht mit dem blossen „hz"', () => {
+    // „mhz" enthaelt „hz" — eine Pruefung in der falschen Reihenfolge machte
+    // aus 500 MHz 0,0005 MHz.
+    expect(toMhz(500, 'mhz')).toBe(500)
+    expect(toMhz(500, 'khz')).toBe(0.5)
+  })
+})
+
+// ── 2. Die gemessene Spanne ────────────────────────────────────────────────
+
+describe('scannedRange', () => {
+  it('nennt Anfang und Ende', () => {
+    const s = parseScanCsv('Frequency,Level\n470,-95\n608,-90\n')
+    expect(scannedRange(s)).toEqual({ fromMhz: 470, toMhz: 608 })
+  })
+
+  it('sagt null bei leerem Scan statt „0 bis 0"', () => {
+    expect(scannedRange({ points: [], unreadable: 0 })).toBeNull()
+  })
+})
+
+describe('peakNear', () => {
+  const s = parseScanCsv('Frequency,Level\n502.3,-95\n502.4,-40\n502.5,-88\n')
+
+  it('findet die Spitze im Fenster', () => {
+    // Ein Scan ist diskret: er hat keinen Punkt bei genau 502,375. Ohne
+    // Fenster faende eine Traegerpruefung nie einen Messpunkt.
+    expect(peakNear(s, 502.375, 0.1)).toBe(-40)
+  })
+
+  it('sagt null ausserhalb des gemessenen Bereichs', () => {
+    expect(peakNear(s, 614, 0.1)).toBeNull()
+    // Und genauso in einer LUECKE innerhalb des Bereichs: beides heisst „hier
+    // ist nicht gemessen worden", und beides ergibt sich aus derselben
+    // Schleife. Ein eigener Bereichs-Check waere eine zweite Definition
+    // desselben Begriffs.
+    const mitLuecke = parseScanCsv('Frequency,Level\n500,-95\n560,-90\n')
+    expect(peakNear(mitLuecke, 530, 0.1)).toBeNull()
+  })
+
+  it('laesst das Fenster ueber den Rand hinausreichen', () => {
+    // Ein Traeger 0,05 MHz neben dem letzten Messpunkt ist gemessen — der
+    // Scan endet nicht mitten in der Luft.
+    expect(peakNear(s, 502.55, 0.1)).toBe(-88)
+  })
+})
+
+// ── 3. Drei Urteile, und das dritte ist der Punkt ──────────────────────────
+
+describe('checkCarriers', () => {
+  const s = parseScanCsv('Frequency,Level\n500,-95\n502.4,-40\n505,-92\n')
+
+  it('nennt einen gemessenen freien Traeger frei', () => {
+    expect(checkCarriers(s, [entry('a', 500)])[0].verdict).toBe('clear')
+  })
+
+  it('nennt einen Traeger auf gemessener Energie belegt', () => {
+    const c = checkCarriers(s, [entry('b', 502.4)])[0]
+    expect(c.verdict).toBe('occupied')
+    expect(c.peakDbm).toBe(-40)
+  })
+
+  it('sagt „nicht gemessen" statt „frei", wo der Scan nicht hinreicht', () => {
+    // DIE Regel dieses Moduls. Ein Scan von 500–505 MHz sagt ueber 614 MHz
+    // gar nichts, und das ist keine Entwarnung.
+    const c = checkCarriers(s, [entry('c', 614)])[0]
+    expect(c.verdict).toBe('not-scanned')
+    expect(c.peakDbm).toBeUndefined()
+    expect(VERDICT_LABEL['not-scanned']).not.toContain('frei')
+  })
+
+  it('folgt der eingestellten Schwelle', () => {
+    // Was „belegt" heisst, haengt an Antenne, Vorverstaerker und Abstand —
+    // keine dieser Angaben steht in der Datei.
+    expect(checkCarriers(s, [entry('a', 500)], -100)[0].verdict).toBe('occupied')
+    expect(checkCarriers(s, [entry('b', 502.4)], -20)[0].verdict).toBe('clear')
+  })
+
+  it('nimmt die Voreinstellung, wenn keine Schwelle kommt', () => {
+    expect(DEFAULT_OCCUPIED_DBM).toBe(-70)
+    expect(checkCarriers(s, [entry('b', 502.4)])[0].verdict).toBe('occupied')
+  })
+})
+
+// ── 4. Befunde ─────────────────────────────────────────────────────────────
+
+describe('scanFindings', () => {
+  const s = parseScanCsv('Frequency,Level\n500,-95\n502.4,-40\n505,-92\n')
+
+  it('meldet Traeger auf gemessener Energie mit Namen und Frequenz', () => {
+    const c = checkCarriers(s, [entry('b', 502.4, 'Lead Vox')])
+    const f = scanFindings(s, c).find((x) => x.kind === 'carrier-occupied')
+    expect(f?.text).toContain('Lead Vox')
+    expect(f?.text).toContain('502.4')
+    expect(f?.entryIds).toEqual(['b'])
+  })
+
+  it('meldet Traeger ausserhalb der Messung MIT der Spanne', () => {
+    const c = checkCarriers(s, [entry('c', 614)])
+    const f = scanFindings(s, c).find((x) => x.kind === 'outside-scan')
+    expect(f?.text).toContain('500')
+    expect(f?.text).toContain('505')
+    expect(f?.text).toContain(VERDICT_LABEL['not-scanned'])
+  })
+
+  it('meldet eine Datei, aus der nichts lesbar war — und nichts sonst', () => {
+    const leer = parseScanCsv('Zeit;Temperatur\n10:00;21\n')
+    const f = scanFindings(leer, checkCarriers(leer, [entry('a', 500)]))
+    expect(f.map((x) => x.kind)).toEqual(['nothing-readable'])
+    expect(f[0].text).toContain(VERDICT_LABEL['not-scanned'])
+  })
+
+  it('meldet eine halb gelesene Datei', () => {
+    const halb = parseScanCsv('Frequency,Level\n500,-95\nkaputt,-42\n')
+    expect(scanFindings(halb, []).map((x) => x.kind)).toContain('partial-read')
+  })
+
+  it('schweigt bei sauberer Datei und freien Traegern', () => {
+    expect(scanFindings(s, checkCarriers(s, [entry('a', 500)]))).toEqual([])
+  })
+
+  it('haelt fuer jede Befundart eine lesbare Ueberschrift bereit', () => {
+    for (const k of ['carrier-occupied', 'outside-scan', 'nothing-readable', 'partial-read'] as const) {
+      expect(SCAN_FINDING_LABEL[k].length).toBeGreaterThan(10)
+    }
+  })
+})
+
+// ── 5. Die Blätter ─────────────────────────────────────────────────────────
+
+describe('die Blaetter', () => {
+  const s = parseScanCsv('Frequency,Level\n502.4,-40\n')
+
+  it('nennt Urteil und Spitzenpegel', () => {
+    const t = carrierCheckTable(checkCarriers(s, [entry('b', 502.4, 'Lead Vox')]))
+    expect(t.headers).toEqual([
+      'Was funkt',
+      'Quelle',
+      'Frequenz (MHz)',
+      'Urteil',
+      'Spitzenpegel (dBm)',
+    ])
+    expect(t.rows[0][3]).toBe(VERDICT_LABEL.occupied)
+    expect(t.rows[0][4]).toBe(-40)
+  })
+
+  it('schreibt „nicht gemessen" in die Pegel-Spalte statt einer leeren Zelle', () => {
+    const t = carrierCheckTable(checkCarriers(s, [entry('c', 614)]))
+    expect(t.rows[0][4]).toBe(VERDICT_LABEL['not-scanned'])
+  })
+
+  it('gibt die Messpunkte selbst aus', () => {
+    const t = scanTable(s)
+    expect(t.headers).toEqual(['Frequenz (MHz)', 'Pegel (dBm)'])
+    expect(t.rows[0]).toEqual([502.4, -40])
+  })
+
+  it('hat fuer jede Spalte einen Lexikon-Eintrag', () => {
+    expect(undescribedColumns(carrierCheckTable([]).headers)).toEqual([])
+    expect(undescribedColumns(scanTable(s).headers)).toEqual([])
+  })
+})
+
+// ── 6. Ein Scan ist kein Sender ────────────────────────────────────────────
+
+describe('die Grenze', () => {
+  it('geht NICHT als Quelle in den Spektrum-Plan ein', () => {
+    // Was dort steht, sind Traeger, aus denen Intermodulation gerechnet wird.
+    // Eine Messung ist ein Pegelverlauf, dessen Spitzen auch eine Reflexion
+    // sein koennen — sie als Sender einzuspeisen erzeugte IM3 aus Rauschen.
+    expect(planQuelle).not.toContain('spectrumScan')
+    expect(planQuelle).not.toContain("'scan'")
+    expect(typenQuelle).toContain('IM3-Produkte aus Rauschen')
+  })
+
+  it('baut KEIN Hersteller-Format nach', () => {
+    // Fuer keines der vier liegt ein Schema im Korpus vor. Ein Exporter nach
+    // Vermutung saehe aus, als koennte er es.
+    for (const name of ['wwb', 'wsm', 'ias', 'wirelessmanager']) {
+      expect(libQuelle.toLowerCase()).not.toContain(`export function ${name}`)
+    }
+    expect(typenQuelle).toContain('Korpus ein Schema vor')
+  })
+
+  it('bleibt rein', () => {
+    expect(libQuelle).not.toContain('Date.now')
+    expect(libQuelle).not.toContain('new Date(')
+    expect(libQuelle).not.toContain('useProjectStore')
+    expect(libQuelle).not.toContain('fetch(')
+  })
+})
+
+// ── 7. Erreichbar ──────────────────────────────────────────────────────────
+
+describe('der RF-Reiter', () => {
+  it('liest den Scan ein und leert das Dateifeld', () => {
+    // Sonst laesst sich dieselbe Datei nicht zweimal waehlen — und nach einem
+    // zweiten Scan heisst sie oft gleich.
+    expect(dialogQuelle).toContain('parseScanCsv(text, f.name)')
+    // Verankert am Scan-Leser und NICHT an `accept="…"`: der Dante-Import
+    // (Bedarf 94) steht im selben Dialog mit demselben `accept`, und eine
+    // Suche darauf fand seine Zeile noch, nachdem diese hier weg war.
+    const scanBlock = dialogQuelle.slice(
+      dialogQuelle.indexOf("t('scan.import'"),
+      dialogQuelle.indexOf('parseScanCsv(text, f.name)'),
+    )
+    expect(scanBlock).toContain("e.target.value = ''")
+  })
+
+  it('macht die Schwelle einstellbar statt sie festzuschreiben', () => {
+    expect(dialogQuelle).toContain('setSchwelle(Number(e.target.value))')
+    expect(dialogQuelle).toContain('scan.thresholdHint')
+  })
+
+  it('zeigt die gemessene Spanne neben der Punktzahl', () => {
+    // Ohne sie liest jemand „nicht gemessen" und weiss nicht, wo die Messung
+    // aufhoert.
+    expect(dialogQuelle).toContain('scanSpanne.fromMhz')
+    expect(dialogQuelle).toContain('scanSpanne.toMhz')
+  })
+
+  it('speist den Scan nicht in den Spektrum-Plan ein', () => {
+    expect(dialogQuelle).toContain('checkCarriers(scan, spectrum.entries, schwelle)')
+    expect(dialogQuelle).not.toMatch(/buildSpectrumPlan\([^)]*scan/)
+  })
+})


### PR DESCRIPTION
> Cheap analysers (tinySA, RF Explorer) are widely used for site scans, but their CSV is not readable by any coordination software, so engineers run **conversion scripts on the critical path of load-in**.

Belegt an `erikkaashoek/tinySA#88`: dort wird um Export nach Shure WWB, Sennheiser WSM, Audio-Technica Wireless Manager und Professional Wireless IAS gebeten, weil *„the supplied default .csv format is not recognized by any of these industry standard softwares"*.

## Was gebaut ist

Die **Lese-Seite und der Abgleich** — die Frage, die im Saal gestellt wird: „ist meine Frequenz hier frei?"

- **`parseScanCsv`** liest tolerant wie die Dante-Matrix (#94): Spalten über die *Überschrift* statt über die Position, Trenner erkannt (`;`/`,`/Tab), unlesbare Zeilen **gezählt** statt verschwiegen. Dazu der Fall, den es dort nicht gab: eine Datei ganz ohne Überschrift, wie tinySA sie schlank schreibt.
- **Die Einheit kommt aus der Überschrift** und wird nicht an der Größe geraten. Der gefährliche Fall ist ein 2-GHz-Scan mit kHz-Überschrift: wer rät, macht daraus 2 MHz statt 2000 — beides gültige Zahlen, und die falsche fällt erst auf, wenn der Abgleich jeden Träger als „nicht gemessen" meldet.
- **`checkCarriers` gibt drei Urteile, und das dritte ist der Punkt:** „nicht gemessen" ist *nicht* „frei". Ein Scan von 470–608 MHz sagt über 614 MHz gar nichts. Dieselbe Regel wie beim Spektrum-Plan selbst (#95).
- **Die Schwelle ist ein Feld, kein Festwert:** was „belegt" heisst, hängt an Antenne, Vorverstärker und Abstand — keine dieser Angaben steht in der Datei.
- Vier Befunde, dazu zwei Tabellen mit Lexikon-Einträgen. Erreichbar im RF-Reiter der Analyse.

## Was nicht gebaut ist

Die vier Hersteller-Formate. Für keines liegt in diesem Korpus ein Schema vor — dieselbe Entscheidung wie beim Dante-Preset-XML (#94), und sie fällt hier **zum dritten Mal**. Das macht sie nicht schwächer, sondern zeigt, wo die Grenze dieses Korpus liegt: ein Exporter nach Vermutung sähe aus, als könnte er es.

Und ein Scan geht ausdrücklich **nicht** als Quelle in `collectTransmitters` ein. Dort stehen Träger, aus denen Intermodulation gerechnet wird; eine Messung ist ein Pegelverlauf, dessen Spitzen auch eine Reflexion sein können — sie als Sender einzuspeisen erzeugte IM3-Produkte aus Rauschen.

## Geprüft

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 158 Dateien grün
- `npm run lint` — 0 Fehler (10 Warnungen, unverändert)
- **28 Injektionen**, alle rot. **Fünf überlebten die erste Runde** und haben Code und Tests geschärft:
  - Ein echter Fehler: „1.234,5" wurde als **1,2345** gelesen — eine Frequenz um drei Zehnerpotenzen daneben, die in keiner Prüfung auffällt, weil sie eine gültige Zahl ist. Regel jetzt: der *zuletzt* stehende Trenner ist der Dezimaltrenner.
  - Zwei Schutz-Zweige waren beweisbar wirkungslos und sind **entfernt** (der Bereichs-Check in `peakNear`, den die Schleife ohnehin liefert; der Schutz gegen „Pegel- und Frequenzspalte sind dieselbe", der bei disjunkten Alias-Listen nie greifen kann). Statt ihrer hält jetzt je ein Test die Bedingung fest, die sie überflüssig macht.
  - Zwei Tests waren zu locker (Klammer-Normalisierung, Überschrift-vor-Größe) und haben jetzt einen Fall, an dem sich richtige von falscher Lesung trennt.
  - Und einmal wieder die falsche Fundstelle: die Prüfung „Dateifeld wird geleert" hing am `accept="…"`, und der Dante-Import im selben Dialog hat dasselbe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_