### PR TITLE
export: Unterlagen-Stapel — druckbares Packet mit wiederholtem Kopf und lesbarer Farbe (#115)

### DIFF
--- a/src/renderer/components/Export/ExportDialog.tsx
+++ b/src/renderer/components/Export/ExportDialog.tsx
@@ -16,6 +16,7 @@ import {
 import { useDialogA11y } from '../../hooks/useDialogA11y'
 import jsPDF from 'jspdf'
 import { useUiStore } from '../../store/uiStore'
+import { PacketSection } from './PacketSection'
 import { useProjectStore } from '../../store/projectStore'
 import { AlertTriangle, Check, Lightbulb, Package as PackageIcon } from 'lucide-react'
 import { useTranslation, format } from '../../lib/i18n'
@@ -51,7 +52,7 @@ import { LayerVisibilityChips } from '../Canvas/LayerVisibilityChips'
 import type { Cable } from '../../types/cable'
 
 export type ExportFormat = 'pdf' | 'png' | 'jpeg' | 'svg' | 'dxf'
-type Section = 'plan' | 'patch' | 'bom' | 'devicebom' | 'rack' | 'tally'
+type Section = 'plan' | 'patch' | 'bom' | 'devicebom' | 'rack' | 'tally' | 'packet'
 
 /** v7.9.103 — Page-Size-Optionen fuer den Vektor-PDF-Pfad. */
 export type PdfPageSizeOpt =
@@ -88,6 +89,7 @@ const SECTION_LABEL: Record<Section, string> = {
   devicebom: 'Geräte-Stückliste',
   rack: 'Racks & Gruppen',
   tally: 'Tally-Karte',
+  packet: 'Unterlagen-Stapel',
 }
 
 const SECTION_ICON: Record<Section, LucideIcon> = {
@@ -97,6 +99,7 @@ const SECTION_ICON: Record<Section, LucideIcon> = {
   devicebom: PackageIcon,
   rack: Server,
   tally: Lightbulb,
+  packet: Printer,
 }
 
 const SECTION_DESC: Record<Section, string> = {
@@ -105,6 +108,8 @@ const SECTION_DESC: Record<Section, string> = {
   bom: 'Stückliste aller Kabel im Projekt (Typ + Länge zusammengefasst). Editierbare Rentman-Planung daneben. Export als CSV oder PDF.',
   devicebom: 'Was der Plan an Geräten braucht, gezählt nach Modell und gegen das Lager gedeckt. Drei Zustände, die unterscheidbar bleiben: gedeckt (über die Katalog-Identität), VORSCHLAG (Namenstreffer, wartet auf Bestätigung) und nicht im Lager. Dazu die Kommissionier-Liste — nur sicher Gedecktes, nach Lagerort sortiert.',
   rack: 'Gespeicherte Racks und Gruppen einzeln als PDF exportieren oder drucken — eine Patch-Seite pro enthaltenem Gerät mit interner Verkabelung.',
+  packet:
+    'Mehrere Blätter als EIN druckbarer Stapel: eine Seite je Blatt, Spaltenkopf auf jeder Folgeseite wiederholt, Papierformat und Farbmodus wählbar. Für den Ordner, der mit auf die Show fährt. Jedes Blatt trägt seinen Stempel — ein Stapel aus gestempelten Blättern lässt sich morgen gegen den Plan halten.',
   tally: 'Die Kette Rolle → Gerät → Mischer-Eingang → UMD-Adresse, aus dem Plan abgeleitet und geprüft. Als CSV zum Gegenlesen, als JSON für die tally-pi-Konfiguration. Die Lampe selbst — welcher GPIO-Pin welcher Box — gehört der Hardware und steht bewusst nicht drin.',
 }
 
@@ -190,6 +195,7 @@ export const ExportDialog = ({
               {section === 'bom' && <BomSection />}
               {section === 'devicebom' && <DeviceBomSection />}
               {section === 'rack' && <RackGroupSection onClose={onClose} />}
+              {section === 'packet' && <PacketSection />}
               {section === 'tally' && <TallySection />}
             </div>
           </div>

--- a/src/renderer/components/Export/PacketSection.tsx
+++ b/src/renderer/components/Export/PacketSection.tsx
@@ -1,0 +1,176 @@
+import { useMemo, useState } from 'react'
+import { Printer, AlertTriangle } from 'lucide-react'
+import { useProjectStore } from '../../store/projectStore'
+import { useTranslation } from '../../lib/i18n'
+import { Icon } from '../shared/Icon'
+import { printHtmlDocument } from '../../lib/printHtml'
+import {
+  DEFAULT_PACKET_OPTIONS,
+  buildPacketHtml,
+  sheetFromTable,
+  sheetsWithUndescribedColumns,
+  type ColourMode,
+  type PacketSheet,
+  type PaperSize,
+} from '../../lib/documentPacket'
+import { stampForRows } from '../../lib/documentStamp'
+import { DOCUMENT_STANDS } from '../../lib/documentRegistry'
+import { pullListTable, terminationListTable, cableScheduleTable } from '../../lib/installerLists'
+import { assetRegisterTable } from '../../lib/assetRegister'
+import { crewSheetTableForProject } from '../../lib/crewNetworkSheet'
+import { spectrumTableForProject } from '../../lib/spectrumPlan'
+import { deliveryTableForProject } from '../../lib/deliveryParity'
+import { tallyMapTableForProject } from '../../lib/tallyMap'
+import type { CsvTable } from '../../lib/csv'
+import type { CablePlannerProject } from '../../types/project'
+
+/**
+ * BEDARF 115 — ein Papierstapel, den man zusammenheften kann.
+ *
+ *   > Stage plot print offers only two modes […] neither of which fits a
+ *   > packet; a 44-row patch list SPANS PAGES AND LOSES ITS REPEATING HEADER
+ *   > and colour chips.
+ *
+ * Diese Ansicht stellt den Stapel zusammen; das Papier selbst baut
+ * `lib/documentPacket.ts`. Die Trennung ist Absicht: die Regel „der Kopf
+ * wiederholt sich auf jeder Seite" gehört nicht in eine Oberfläche, sonst
+ * gilt sie nur für den einen Stapel, den jemand hier zusammenklickt.
+ *
+ * Angeboten werden die Blätter, die einen eintragbaren STAND haben
+ * (`DOCUMENT_STANDS`) — jedes trägt seinen Stempel, und ein Stapel aus
+ * gestempelten Blättern lässt sich morgen gegen den Plan halten. Ein Blatt
+ * ohne Stand käme ohne Datum aus dem Drucker, und genau das ist der Zustand,
+ * den ADR-004 abgeschafft hat.
+ */
+
+interface Kandidat {
+  id: string
+  label: string
+  table: (p: CablePlannerProject) => CsvTable
+}
+
+const KANDIDATEN: ReadonlyArray<Kandidat> = [
+  { id: 'pull-liste', label: 'Zug-Liste', table: pullListTable },
+  { id: 'termination-liste', label: 'Auflege-Liste', table: terminationListTable },
+  { id: 'kabel-schedule', label: 'Kabel-Schedule', table: cableScheduleTable },
+  { id: 'asset-register', label: 'Geräte-Register', table: assetRegisterTable },
+  { id: 'crew-netz', label: 'Netz-Merkblatt', table: crewSheetTableForProject },
+  { id: 'spektrum-plan', label: 'Spektrum-Plan', table: spectrumTableForProject },
+  { id: 'ausspielung', label: 'Ausspielung', table: deliveryTableForProject },
+  { id: 'tally-karte', label: 'Tally-Karte', table: tallyMapTableForProject },
+]
+
+export const PacketSection = () => {
+  const t = useTranslation()
+  const project = useProjectStore((s) => s.project)
+  const [gewaehlt, setGewaehlt] = useState<string[]>(['pull-liste', 'kabel-schedule'])
+  const [paper, setPaper] = useState<PaperSize>(DEFAULT_PACKET_OPTIONS.paper)
+  const [colour, setColour] = useState<ColourMode>(DEFAULT_PACKET_OPTIONS.colour)
+  const [glossary, setGlossary] = useState(DEFAULT_PACKET_OPTIONS.glossary)
+
+  // Der Zeitpunkt kommt EINMAL aus der Uhr und geht in jeden Stempel — sonst
+  // trägt Blatt 1 eine andere Minute als Blatt 7, und der Stapel sieht aus,
+  // als wäre er über eine Stunde zusammengesucht worden.
+  const blaetter: PacketSheet[] = useMemo(() => {
+    const jetzt = new Date()
+    return KANDIDATEN.filter((k) => gewaehlt.includes(k.id)).map((k) => {
+      const table = k.table(project)
+      // Der Stempel kommt aus derselben Ableitung, aus der das Blatt kommt —
+      // sonst stempelt er etwas anderes, als gedruckt wird.
+      const stempel = DOCUMENT_STANDS[k.id] ? stampForRows(project, k.table, jetzt) : undefined
+      return sheetFromTable(k.label, table, stempel)
+    })
+  }, [project, gewaehlt])
+
+  const unerklaert = useMemo(() => sheetsWithUndescribedColumns(blaetter), [blaetter])
+
+  const drucken = () => {
+    if (blaetter.length === 0) return
+    printHtmlDocument(
+      buildPacketHtml(
+        project.metadata.name || 'AV-Planer',
+        blaetter,
+        { paper, colour, glossary },
+      ),
+    )
+  }
+
+  const toggle = (id: string) =>
+    setGewaehlt((v) => (v.includes(id) ? v.filter((x) => x !== id) : [...v, id]))
+
+  const selectCls =
+    'rounded border border-cp-border bg-cp-surface-1 px-2 py-1 text-cp-xs text-cp-text'
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-2 gap-1 sm:grid-cols-3">
+        {KANDIDATEN.map((k) => (
+          <label key={k.id} className="flex items-center gap-1.5 text-cp-xs">
+            <input type="checkbox" checked={gewaehlt.includes(k.id)} onChange={() => toggle(k.id)} />
+            <span>{t(`packet.sheet.${k.id}`, k.label)}</span>
+          </label>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3 text-cp-xs">
+        <label className="flex items-center gap-1.5">
+          {t('packet.paper', 'Papier')}
+          <select value={paper} onChange={(e) => setPaper(e.target.value as PaperSize)} className={selectCls}>
+            <option value="A4">A4</option>
+            <option value="Letter">Letter</option>
+            <option value="A3">A3</option>
+          </select>
+        </label>
+        {/* BEDARF 115 — der Farbmodus. „Mono" ist nicht „grau": eine Farbfläche,
+            die im Graustufendruck zu einem grauen Kästchen wird, ist keine
+            Information mehr. Der NAME steht in beiden Modi da. */}
+        <label className="flex items-center gap-1.5">
+          {t('packet.colour', 'Farbe')}
+          <select
+            value={colour}
+            onChange={(e) => setColour(e.target.value as ColourMode)}
+            title={t(
+              'packet.colourHint',
+              'Farbfelder werden nur im Farbmodus gedruckt. Der Name der Gruppe steht in BEIDEN Modi da — ein graues Kästchen auf der Fotokopie unterscheidet zwei Gruppen nicht mehr.',
+            )}
+            className={selectCls}
+          >
+            <option value="colour">{t('packet.colour.colour', 'farbig')}</option>
+            <option value="mono">{t('packet.colour.mono', 'schwarzweiß')}</option>
+          </select>
+        </label>
+        <label className="flex items-center gap-1.5">
+          <input type="checkbox" checked={glossary} onChange={(e) => setGlossary(e.target.checked)} />
+          {t('packet.glossary', 'Spaltenlexikon mitdrucken')}
+        </label>
+        <button
+          type="button"
+          onClick={drucken}
+          disabled={blaetter.length === 0}
+          className="ml-auto inline-flex items-center gap-1.5 rounded bg-emerald-700 px-3 py-1 text-cp-xs hover:bg-emerald-600 disabled:opacity-40"
+        >
+          <Icon icon={Printer} size="xs" />
+          {t('packet.print', 'Stapel drucken')}
+        </button>
+      </div>
+
+      {/* Ein Packet geht an jemanden, der die Spalten nicht kennt — das ist der
+          ganze Grund für das Lexikon. Ein Blatt mit unerklärten Spalten ist
+          deshalb ein Befund und keine Kleinigkeit. */}
+      {unerklaert.length > 0 && (
+        <ul className="flex flex-col gap-1 text-cp-xs text-amber-300/90">
+          {unerklaert.map((u) => (
+            <li key={u.title} className="flex items-start gap-1.5">
+              <Icon icon={AlertTriangle} size="xs" />
+              <span>
+                {t('packet.undescribed', '„{sheet}“: {cols} ohne Erklärung im Lexikon.')
+                  .replace('{sheet}', u.title)
+                  .replace('{cols}', u.columns.join(', '))}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/lib/documentPacket.ts
+++ b/src/renderer/lib/documentPacket.ts
@@ -1,0 +1,241 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Ein Papierstapel, den man zusammenheften kann (Bedarf 115, P3).
+//
+//   > Stage plot print offers only two modes (grayscale text-only on white, or
+//   > full colour with icons on dark), neither of which fits a packet; a
+//   > 44-row patch list SPANS PAGES AND LOSES ITS REPEATING HEADER and colour
+//   > chips.
+//
+// Belegt an `SoundDocs/sounddocs#121` (2026-04-23): gewünscht sind
+// browser-nativer Druck mit Vorschau, Papiergröße, Farbmodus und
+// Icon-Schalter, ausdrücklich „for users assembling documentation packets".
+// `Cryde/musicall#803` verlangt zusätzlich, dass der PDF-Export die Farbe
+// behält.
+//
+// ─── DREI FEHLER, DIE DER BELEG BENENNT, UND WAS DAGEGEN STEHT ─────────────
+//
+//   1. **Der Kopf verschwindet auf Seite 2.** Eine 44-zeilige Patchliste
+//      reisst um, und ab der zweiten Seite steht dort eine Zahlenkolonne ohne
+//      Spaltennamen. `thead { display: table-header-group }` ist die
+//      Browser-Antwort darauf, und sie steht hier einmal statt in jedem
+//      Aufrufer.
+//
+//   2. **Zwei Modi, von denen keiner passt.** Weder „grau auf weiss, ohne
+//      Icons" noch „farbig auf dunkel". Ein Packet braucht Papier: weiss,
+//      Text schwarz, und die Farbe als ZUSATZ statt als Träger.
+//
+//   3. **Die Farbcodierung überlebt den Druck nicht.** Und das ist der
+//      heikelste Punkt, denn er wird meist falsch gelöst: ein Farbfeld, das
+//      im Graustufendruck zu einem grauen Kästchen wird, ist keine
+//      Information mehr — zwei verschiedene Gruppen sehen gleich aus. Deshalb
+//      trägt eine Farbzelle hier IMMER auch ihren NAMEN. Im Farbmodus steht
+//      der Name neben dem Feld, im Monochrom-Modus steht er allein. Was
+//      gedruckt wird, ist dann in beiden Fällen lesbar — und auf einer
+//      Fotokopie ebenfalls.
+//
+// ─── EINE SEITE JE ARTEFAKT ────────────────────────────────────────────────
+//
+// „Packet-assemblable" heisst: jedes Blatt fängt oben auf einer neuen Seite
+// an, damit man den Stapel lochen und in einen Ordner heften kann, ohne dass
+// die Kabelliste auf der Rückseite der Kanalliste endet. Das ist ein
+// `page-break-before` und keine Meinung.
+//
+// REIN: keine Uhr, kein Store, kein IO. Der Stempel kommt fertig herein —
+// gebaut wird er in `documentStamp.ts`, mit der Uhr des Aufrufers.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { CsvCell, CsvTable } from './csv'
+import type { DocumentStamp } from './documentStamp'
+import { stampLine } from './documentStamp'
+import { dictionaryRows, undescribedColumns } from './dataDictionary'
+
+/** Papierformat. Mehr als diese drei kommen im Korpus nicht vor. */
+export type PaperSize = 'A4' | 'Letter' | 'A3'
+
+/**
+ * Farbmodus.
+ *
+ * `colour` Farbfelder werden gedruckt — plus Name.
+ * `mono`   Nur der Name. Für Schwarzweiss-Drucker und Fotokopien.
+ */
+export type ColourMode = 'colour' | 'mono'
+
+export interface PacketOptions {
+  paper: PaperSize
+  colour: ColourMode
+  /**
+   * Ob das Spaltenlexikon mitgedruckt wird.
+   *
+   * Vorgabe an: der Beleg zu Bedarf 88 nennt ausdrücklich einen Empfänger,
+   * „who might not know what each field is". Wer den Stapel für sich selbst
+   * druckt, schaltet es ab.
+   */
+  glossary: boolean
+}
+
+export const DEFAULT_PACKET_OPTIONS: PacketOptions = {
+  paper: 'A4',
+  colour: 'colour',
+  glossary: true,
+}
+
+/**
+ * Eine Farbzelle: Wert plus Farbe.
+ *
+ * Der Wert ist der NAME der Gruppe/Kategorie und nicht die Farbe selbst —
+ * genau das ist der Punkt aus dem Kopfkommentar. Wer hier `#ff0000` als Wert
+ * übergibt, bekommt im Monochrom-Druck „#ff0000" zu lesen, und das ist
+ * ehrlich, aber nutzlos.
+ */
+export interface ColourCell {
+  value: string
+  /** CSS-Farbe. Fehlt sie, ist es eine gewöhnliche Zelle. */
+  colour?: string
+}
+
+export type PacketCell = CsvCell | ColourCell
+
+export interface PacketSheet {
+  title: string
+  /** Untertitel/Kontext (Ort, Stichtag). Optional. */
+  subtitle?: string
+  headers: string[]
+  rows: PacketCell[][]
+  /** Der Stempel dieses Blatts. Ohne ihn steht kein Stand darauf. */
+  stamp?: DocumentStamp
+}
+
+const isColourCell = (c: PacketCell): c is ColourCell =>
+  typeof c === 'object' && c !== null && 'value' in c
+
+export const esc = (s: unknown): string =>
+  String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+
+/**
+ * Eine Zelle als HTML.
+ *
+ * Die Regel aus dem Kopfkommentar in einer Zeile: eine Farbzelle trägt
+ * IMMER ihren Namen. Im Farbmodus kommt das Feld dazu; im Monochrom-Modus
+ * bleibt der Name allein.
+ */
+export function cellHtml(cell: PacketCell, colour: ColourMode): string {
+  if (!isColourCell(cell)) return esc(cell)
+  const name = esc(cell.value)
+  if (colour === 'mono' || !cell.colour) return name
+  return `<span class="chip" style="background:${esc(cell.colour)}"></span>${name}`
+}
+
+/** Eine Tabelle aus dem übrigen Code als Packet-Blatt. */
+export function sheetFromTable(
+  title: string,
+  table: CsvTable,
+  stamp?: DocumentStamp,
+  subtitle?: string,
+): PacketSheet {
+  return {
+    title,
+    ...(subtitle ? { subtitle } : {}),
+    headers: [...table.headers],
+    rows: table.rows.map((r) => [...r]),
+    ...(stamp ? { stamp } : {}),
+  }
+}
+
+/**
+ * Blätter, deren Spalten im Lexikon fehlen.
+ *
+ * Ein Packet geht an jemanden, der die Spalten nicht kennt — das ist der
+ * ganze Grund für das Lexikon. Ein Blatt mit unerklärten Spalten ist deshalb
+ * ein Befund und keine Kleinigkeit.
+ */
+export function sheetsWithUndescribedColumns(
+  sheets: readonly PacketSheet[],
+): Array<{ title: string; columns: string[] }> {
+  return sheets
+    .map((s) => ({ title: s.title, columns: undescribedColumns(s.headers) }))
+    .filter((x) => x.columns.length > 0)
+}
+
+const PAPER_CSS: Readonly<Record<PaperSize, string>> = {
+  A4: 'A4',
+  Letter: 'Letter',
+  A3: 'A3',
+}
+
+/**
+ * Der ganze Stapel als ein druckbares HTML-Dokument.
+ *
+ * Ein Dokument und nicht eines je Blatt: der Nutzer druckt einmal, und der
+ * Stapel kommt in der Reihenfolge heraus, in der er ihn zusammengestellt hat.
+ * Mehrere Dokumente hiessen mehrere Druckdialoge und eine Reihenfolge, die
+ * vom Zufall abhängt.
+ */
+export function buildPacketHtml(
+  documentTitle: string,
+  sheets: readonly PacketSheet[],
+  opts: PacketOptions = DEFAULT_PACKET_OPTIONS,
+): string {
+  const seiten = sheets
+    .map((sheet, i) => {
+      const kopf = sheet.headers.map((h) => `<th>${esc(h)}</th>`).join('')
+      const zeilen = sheet.rows
+        .map((r) => `<tr>${r.map((c) => `<td>${cellHtml(c, opts.colour)}</td>`).join('')}</tr>`)
+        .join('\n')
+      const lexikon =
+        opts.glossary && sheet.headers.length > 0
+          ? `<table class="glossary"><tbody>${dictionaryRows(sheet.headers)
+              .map(
+                (row) =>
+                  `<tr><th>${esc(row[0])}</th><td>${esc(row[1])}</td></tr>`,
+              )
+              .join('')}</tbody></table>`
+          : ''
+      // `page-break-before` auf jedem Blatt AUSSER dem ersten: sonst beginnt
+      // der Stapel mit einer leeren Seite.
+      return `<section class="sheet"${i > 0 ? ' style="page-break-before:always"' : ''}>
+  <h1>${esc(sheet.title)}</h1>
+  ${sheet.subtitle ? `<div class="sub">${esc(sheet.subtitle)}</div>` : ''}
+  <table class="data">
+    <thead><tr>${kopf}</tr></thead>
+    <tbody>
+${zeilen}
+    </tbody>
+  </table>
+  ${lexikon}
+  ${sheet.stamp ? `<div class="stamp">${esc(stampLine(sheet.stamp))}</div>` : ''}
+</section>`
+    })
+    .join('\n')
+
+  return `<!doctype html><html><head><meta charset="utf-8"><title>${esc(documentTitle)}</title>
+<style>
+  @page { size: ${PAPER_CSS[opts.paper]}; margin: 14mm; }
+  /* Papier ist weiss. Der dunkle Modus der Oberflaeche hat auf Papier nichts
+     zu suchen: er kostet Toner und macht die Kopie unlesbar. */
+  body { font-family: Arial, sans-serif; color: #111; background: #fff; font-size: 10pt; }
+  h1 { font-size: 14pt; margin: 0 0 1mm; }
+  .sub { color: #555; font-size: 9pt; margin-bottom: 3mm; }
+  table.data { width: 100%; border-collapse: collapse; font-size: 9pt; }
+  /* DER FEHLER AUS DEM BELEG: „a 44-row patch list spans pages and loses its
+     repeating header". Genau dagegen steht diese eine Zeile. */
+  table.data thead { display: table-header-group; }
+  table.data tfoot { display: table-footer-group; }
+  table.data th, table.data td { border: 0.2mm solid #999; padding: 1mm 1.5mm; text-align: left; }
+  table.data th { background: #eee; }
+  /* Eine Zeile wird nicht mitten im Umbruch zerrissen. */
+  table.data tr { page-break-inside: avoid; }
+  .chip { display: inline-block; width: 3mm; height: 3mm; margin-right: 1.5mm;
+          border: 0.2mm solid #333; vertical-align: middle; }
+  table.glossary { margin-top: 4mm; font-size: 8pt; border-collapse: collapse; }
+  table.glossary th { text-align: left; padding: 0.5mm 2mm 0.5mm 0; color: #333; white-space: nowrap; vertical-align: top; }
+  table.glossary td { padding: 0.5mm 0; color: #555; }
+  .stamp { margin-top: 4mm; font-family: 'Courier New', monospace; font-size: 8pt; color: #555; }
+  .sheet { page-break-inside: auto; }
+</style></head><body>
+${seiten}
+</body></html>`
+}

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3490,6 +3490,16 @@ export const en: Dict = {
   'channelList.view.stage': 'Stage (position)',
   'channelList.view.console': 'Console (names)',
   'channelList.view.monitor': 'Monitor paths',
+  // Bedarf 115 — der Unterlagen-Stapel.
+  'packet.paper': 'Paper',
+  'packet.colour': 'Colour',
+  'packet.colour.colour': 'colour',
+  'packet.colour.mono': 'black and white',
+  'packet.colourHint':
+    'Colour swatches are printed in colour mode only. The name of the group is shown in BOTH modes \u2014 a grey box on a photocopy no longer tells two groups apart.',
+  'packet.glossary': 'Print column glossary',
+  'packet.print': 'Print packet',
+  'packet.undescribed': '\u201C{sheet}\u201D: {cols} not explained in the glossary.',
   // Bedarf 112 — der Scan vor Ort, gegen den Plan gehalten.
   'scan.title': 'Spectrum scan from the analyser',
   'scan.import': '📈 Read scan',

--- a/tests/documentPacket.test.ts
+++ b/tests/documentPacket.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_PACKET_OPTIONS,
+  buildPacketHtml,
+  cellHtml,
+  sheetFromTable,
+  sheetsWithUndescribedColumns,
+  type PacketSheet,
+} from '../src/renderer/lib/documentPacket'
+import { buildDocumentStamp } from '../src/renderer/lib/documentStamp'
+import libQuelle from '../src/renderer/lib/documentPacket.ts?raw'
+import panelQuelle from '../src/renderer/components/Export/PacketSection.tsx?raw'
+import dialogQuelle from '../src/renderer/components/Export/ExportDialog.tsx?raw'
+
+// ---------------------------------------------------------------------------
+// Ein Papierstapel, den man zusammenheften kann (Bedarf 115, P3).
+//
+//   > Stage plot print offers only two modes (grayscale text-only on white, or
+//   > full colour with icons on dark), neither of which fits a packet; a
+//   > 44-row patch list SPANS PAGES AND LOSES ITS REPEATING HEADER and colour
+//   > chips.
+//
+// Belegt an `SoundDocs/sounddocs#121` (2026-04-23), „for users assembling
+// documentation packets"; `Cryde/musicall#803` verlangt zusaetzlich, dass der
+// Export die Farbe behaelt.
+// ---------------------------------------------------------------------------
+
+const sheet = (over: Partial<PacketSheet> = {}): PacketSheet => ({
+  title: over.title ?? 'Zug-Liste',
+  headers: over.headers ?? ['Von', 'Nach'],
+  rows: over.rows ?? [['A', 'B']],
+  ...(over.subtitle ? { subtitle: over.subtitle } : {}),
+  ...(over.stamp ? { stamp: over.stamp } : {}),
+})
+
+// ── 1. Der Fehler aus dem Beleg ────────────────────────────────────────────
+
+describe('der Spaltenkopf ueberlebt den Seitenumbruch', () => {
+  it('setzt `display: table-header-group` auf den Tabellenkopf', () => {
+    // DER gemeldete Fehler: „a 44-row patch list spans pages and loses its
+    // repeating header". Ab Seite 2 stuende dort eine Zahlenkolonne ohne
+    // Spaltennamen.
+    const html = buildPacketHtml('Stapel', [sheet()])
+    expect(html).toContain('table.data thead { display: table-header-group; }')
+  })
+
+  it('legt den Kopf in ein echtes <thead>', () => {
+    // Ohne das greift die CSS-Regel nicht: sie beschreibt eine
+    // Tabellenkopf-Gruppe, und die gibt es nur, wenn eine da ist.
+    const html = buildPacketHtml('Stapel', [sheet({ headers: ['Von', 'Nach'] })])
+    expect(html).toMatch(/<thead><tr><th>Von<\/th><th>Nach<\/th><\/tr><\/thead>/)
+  })
+
+  it('zerreisst keine Zeile im Umbruch', () => {
+    expect(buildPacketHtml('Stapel', [sheet()])).toContain('page-break-inside: avoid')
+  })
+})
+
+// ── 2. Eine Seite je Artefakt ──────────────────────────────────────────────
+
+describe('der Stapel ist zusammenheftbar', () => {
+  it('faengt jedes Blatt AUSSER dem ersten auf einer neuen Seite an', () => {
+    const html = buildPacketHtml('Stapel', [sheet({ title: 'Eins' }), sheet({ title: 'Zwei' })])
+    // Genau ein Umbruch bei zwei Blaettern: ein Umbruch vor dem ersten
+    // erzeugte eine leere erste Seite.
+    expect(html.match(/page-break-before:always/g) ?? []).toHaveLength(1)
+    expect(html.indexOf('Eins')).toBeLessThan(html.indexOf('page-break-before:always'))
+  })
+
+  it('baut EIN Dokument und nicht eines je Blatt', () => {
+    const html = buildPacketHtml('Stapel', [sheet({ title: 'Eins' }), sheet({ title: 'Zwei' })])
+    expect(html.match(/<!doctype html>/gi) ?? []).toHaveLength(1)
+    expect(html).toContain('Eins')
+    expect(html).toContain('Zwei')
+  })
+})
+
+// ── 3. Der Farbmodus ───────────────────────────────────────────────────────
+
+describe('die Farbcodierung ueberlebt den Druck', () => {
+  it('traegt eine Farbzelle IMMER ihren Namen', () => {
+    // Der heikelste Punkt: ein Farbfeld, das im Graustufendruck zu einem
+    // grauen Kaestchen wird, ist keine Information mehr — zwei Gruppen sehen
+    // dann gleich aus.
+    expect(cellHtml({ value: 'Bühne links', colour: '#c00' }, 'colour')).toContain('Bühne links')
+    expect(cellHtml({ value: 'Bühne links', colour: '#c00' }, 'mono')).toBe('Bühne links')
+  })
+
+  it('druckt das Farbfeld nur im Farbmodus', () => {
+    expect(cellHtml({ value: 'X', colour: '#c00' }, 'colour')).toContain('class="chip"')
+    expect(cellHtml({ value: 'X', colour: '#c00' }, 'mono')).not.toContain('chip')
+  })
+
+  it('kommt ohne Farbe aus', () => {
+    expect(cellHtml({ value: 'X' }, 'colour')).toBe('X')
+  })
+
+  it('behandelt gewoehnliche Zellen unveraendert', () => {
+    expect(cellHtml('Text', 'colour')).toBe('Text')
+    expect(cellHtml(42, 'mono')).toBe('42')
+  })
+
+  it('maskiert HTML in Werten und Farben', () => {
+    // Ein Geraetename mit `<` ist erlaubt; er darf das Dokument nicht
+    // aufbrechen.
+    expect(cellHtml('<b>x</b>', 'colour')).toBe('&lt;b&gt;x&lt;/b&gt;')
+    expect(cellHtml({ value: 'a', colour: '"><script>' }, 'colour')).not.toContain('<script>')
+  })
+})
+
+// ── 4. Papier ist weiss ────────────────────────────────────────────────────
+
+describe('das Papier', () => {
+  it('folgt dem gewaehlten Format', () => {
+    expect(buildPacketHtml('S', [sheet()], { ...DEFAULT_PACKET_OPTIONS, paper: 'A3' })).toContain(
+      '@page { size: A3;',
+    )
+    expect(buildPacketHtml('S', [sheet()], { ...DEFAULT_PACKET_OPTIONS, paper: 'Letter' })).toContain(
+      '@page { size: Letter;',
+    )
+  })
+
+  it('druckt schwarz auf weiss und nicht den dunklen Modus', () => {
+    // „full colour with icons on dark" ist einer der beiden Modi, die der
+    // Beleg als unbrauchbar nennt: er kostet Toner und macht die Kopie
+    // unlesbar.
+    const html = buildPacketHtml('S', [sheet()])
+    expect(html).toContain('background: #fff')
+    expect(html).toContain('color: #111')
+  })
+})
+
+// ── 5. Das Lexikon ─────────────────────────────────────────────────────────
+
+describe('das Spaltenlexikon', () => {
+  it('faehrt vorgabegemaess mit', () => {
+    // Ein Packet geht an jemanden, der die Spalten nicht kennt.
+    expect(DEFAULT_PACKET_OPTIONS.glossary).toBe(true)
+    expect(buildPacketHtml('S', [sheet({ headers: ['Von'] })])).toContain('class="glossary"')
+  })
+
+  it('laesst sich abschalten', () => {
+    const html = buildPacketHtml('S', [sheet()], { ...DEFAULT_PACKET_OPTIONS, glossary: false })
+    expect(html).not.toContain('class="glossary"')
+  })
+
+  it('nennt Blaetter mit unerklaerten Spalten', () => {
+    const offen = sheetsWithUndescribedColumns([
+      sheet({ title: 'Fremd', headers: ['Von', 'Erfundene Spalte'] }),
+      sheet({ title: 'Sauber', headers: ['Von'] }),
+    ])
+    expect(offen).toEqual([{ title: 'Fremd', columns: ['Erfundene Spalte'] }])
+  })
+})
+
+// ── 6. Der Stempel ─────────────────────────────────────────────────────────
+
+describe('der Stempel', () => {
+  // Der Stempel kommt fertig herein — gebaut wird er im Aufrufer, mit dessen
+  // Uhr. Hier reicht ein Projekt-Rumpf.
+  const projekt = { metadata: { name: 'Testshow' }, revisions: [] } as unknown as Parameters<
+    typeof buildDocumentStamp
+  >[0]
+  const stamp = buildDocumentStamp(projekt, 'abc123', undefined, new Date('2026-09-06T10:00:00Z'))
+
+  it('steht auf dem Blatt, wenn es einen gibt', () => {
+    const html = buildPacketHtml('S', [sheet({ stamp })])
+    expect(html).toContain('class="stamp"')
+    expect(html).toContain('Testshow')
+  })
+
+  it('faellt weg, wo keiner uebergeben wurde — statt einen zu erfinden', () => {
+    expect(buildPacketHtml('S', [sheet()])).not.toContain('class="stamp"')
+  })
+
+  it('wird nicht in diesem Modul gebaut', () => {
+    // Die Uhr gehoert dem Aufrufer. Ein Modul, das seine eigene Zeit nimmt,
+    // stempelt bei jedem Aufruf anders und macht den Vergleich unmoeglich.
+    expect(libQuelle).not.toContain('new Date(')
+    expect(libQuelle).not.toContain('Date.now')
+  })
+})
+
+// ── 7. Ein Blatt aus einer Tabelle ─────────────────────────────────────────
+
+describe('sheetFromTable', () => {
+  it('uebernimmt Kopf und Zeilen', () => {
+    const s = sheetFromTable('Titel', { headers: ['A'], rows: [['1']] })
+    expect(s.title).toBe('Titel')
+    expect(s.headers).toEqual(['A'])
+    expect(s.rows).toEqual([['1']])
+  })
+
+  it('kopiert, statt die Quelle zu teilen', () => {
+    // Sonst aendert ein spaeteres Sortieren im Stapel die Tabelle, aus der er
+    // gebaut wurde.
+    const table = { headers: ['A'], rows: [['1']] }
+    const s = sheetFromTable('Titel', table)
+    s.headers.push('B')
+    expect(table.headers).toEqual(['A'])
+  })
+
+  it('laesst Stempel und Untertitel weg, wenn keine da sind', () => {
+    const s = sheetFromTable('Titel', { headers: [], rows: [] })
+    expect('stamp' in s).toBe(false)
+    expect('subtitle' in s).toBe(false)
+  })
+})
+
+// ── 8. Erreichbar ──────────────────────────────────────────────────────────
+
+describe('der Stapel im Export-Dialog', () => {
+  it('ist ein eigener Abschnitt', () => {
+    expect(dialogQuelle).toContain("{section === 'packet' && <PacketSection />}")
+    expect(dialogQuelle).toContain("packet: 'Unterlagen-Stapel',")
+  })
+
+  it('nimmt die Uhr EINMAL fuer den ganzen Stapel', () => {
+    // Sonst traegt Blatt 1 eine andere Minute als Blatt 7, und der Stapel
+    // sieht aus, als waere er ueber eine Stunde zusammengesucht worden.
+    const block = panelQuelle.slice(panelQuelle.indexOf('const blaetter'), panelQuelle.indexOf('const unerklaert'))
+    expect(block.match(/new Date\(\)/g) ?? []).toHaveLength(1)
+  })
+
+  it('stempelt aus DERSELBEN Ableitung, aus der es druckt', () => {
+    expect(panelQuelle).toContain('stampForRows(project, k.table, jetzt)')
+  })
+
+  it('bietet nur Blaetter mit eintragbarem Stand an', () => {
+    // Ein Blatt ohne Stand kaeme ohne Datum aus dem Drucker.
+    expect(panelQuelle).toContain('DOCUMENT_STANDS[k.id]')
+  })
+
+  it('meldet unerklaerte Spalten, statt sie stumm zu drucken', () => {
+    expect(panelQuelle).toContain('sheetsWithUndescribedColumns(blaetter)')
+    expect(panelQuelle).toContain("t('packet.undescribed'")
+  })
+})


### PR DESCRIPTION
Bedarf 115 (P3) aus dem Recherche-Korpus.

> Stage plot print offers only two modes (grayscale text-only on white, or full colour with icons on dark), neither of which fits a packet; a 44-row patch list **spans pages and loses its repeating header** and colour chips.

Belegt an `SoundDocs/sounddocs#121` (2026-04-23) — dort ausdrücklich „for users assembling documentation packets"; `Cryde/musicall#803` verlangt zusätzlich, dass der Export die Farbe behält.

## Die drei Fehler, die der Beleg benennt

**1. Der Kopf verschwindet ab Seite 2.** `table.data thead { display: table-header-group }` steht einmal in `lib/documentPacket.ts` statt in jedem Aufrufer, und der Kopf liegt dafür in einem echten `<thead>` — ohne das greift die Regel nicht, denn sie beschreibt eine Tabellenkopf-Gruppe, und die gibt es nur, wenn eine da ist. Dazu `page-break-inside: avoid` je Zeile.

**2. Zwei Modi, von denen keiner passt.** Gedruckt wird Papier: weiß, Text schwarz. Der dunkle Modus der Oberfläche kostet Toner und macht die Fotokopie unlesbar.

**3. Die Farbcodierung überlebt den Druck nicht.** Der heikelste Punkt, weil er meist falsch gelöst wird: ein Farbfeld, das im Graustufendruck zu einem grauen Kästchen wird, ist keine Information mehr — zwei verschiedene Gruppen sehen dann gleich aus. Eine `ColourCell` trägt deshalb **immer** ihren Namen; im Farbmodus kommt das Feld dazu, im Monochrom-Modus bleibt der Name allein.

## Zusammenheftbar

Jedes Blatt fängt oben auf einer neuen Seite an — `page-break-before` auf jedem **außer** dem ersten, sonst beginnt der Stapel mit einer leeren Seite. Und alles ist EIN Dokument statt eines je Blatt: sonst mehrere Druckdialoge und eine Reihenfolge, die vom Zufall abhängt.

## Änderungen

- `src/renderer/lib/documentPacket.ts` — rein: keine Uhr, kein Store, kein IO. Der Stempel kommt fertig herein; ein Modul, das seine eigene Zeit nähme, stempelte bei jedem Aufruf anders. `cellHtml`, `sheetFromTable` (kopiert Kopf und Zeilen, statt die Quelltabelle zu teilen), `sheetsWithUndescribedColumns`, `buildPacketHtml`.
- `src/renderer/components/Export/PacketSection.tsx` — stellt den Stapel zusammen. Angeboten werden nur Blätter mit eintragbarem **Stand** (`DOCUMENT_STANDS`); eines ohne Stand käme ohne Datum aus dem Drucker, und genau diesen Zustand hat ADR-004 abgeschafft. Die Uhr wird EINMAL für den ganzen Stapel genommen; gestempelt wird aus DERSELBEN Ableitung, aus der gedruckt wird.
- `ExportDialog.tsx` — neuer Abschnitt „Unterlagen-Stapel".
- Spaltenlexikon fährt vorgabegemäß mit (Beleg zu Bedarf 88: ein Empfänger, „who might not know what each field is"); Blätter mit unerklärten Spalten werden als Befund gemeldet statt stumm gedruckt.
- `tests/documentPacket.test.ts` — 26 Fälle.

## Prüfung

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — 159 Test-Dateien grün
- `npm run lint` — 0 Errors
- Gegenprobe: 22 injizierte Defekte (Kopf-Wiederholung fällt weg, Umbruch auch vor dem ersten Blatt, Farbzelle verliert ihren Namen, dunkler Modus aufs Papier, `sheetFromTable` teilt die Quelle, Uhr je Blatt statt einmal, Abschnitt fällt aus dem Dialog …) kommen alle rot zurück.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_