### PR TITLE
identity: Umbenennen kostet eine Änderung — und man sieht vorher, wo sie ankommt (#101)

### DIFF
--- a/src/renderer/components/Properties/sections/SourceIdentitySection.tsx
+++ b/src/renderer/components/Properties/sections/SourceIdentitySection.tsx
@@ -8,6 +8,11 @@ import {
   parseUmdAddress,
   umdAddressClashes,
 } from '../../../lib/sourceIdentity'
+import {
+  RENAME_REFUSAL_LABEL,
+  renameImpact,
+  swallowedLandings,
+} from '../../../lib/renameImpact'
 import type { EquipmentItem } from '../../../types/equipment'
 
 const NEW_ROLE = '__new__'
@@ -31,6 +36,8 @@ export const SourceIdentitySection = ({ equipment }: { equipment: EquipmentItem 
   const allEquipment = useProjectStore((s) => s.project.equipment)
   const addSourceIdentity = useProjectStore((s) => s.addSourceIdentity)
   const updateSourceIdentity = useProjectStore((s) => s.updateSourceIdentity)
+  const renameSourceIdentity = useProjectStore((s) => s.renameSourceIdentity)
+  const cables = useProjectStore((s) => s.project.cables)
   const removeSourceIdentity = useProjectStore((s) => s.removeSourceIdentity)
   const bindEquipment = useProjectStore((s) => s.bindEquipmentToSourceIdentity)
 
@@ -68,6 +75,35 @@ export const SourceIdentitySection = ({ equipment }: { equipment: EquipmentItem 
         : ''
   const umdRejected =
     umdText.trim() !== '' && parseUmdAddress(umdText.trim()) === undefined
+
+  // BEDARF 101 — der Namens-Entwurf.
+  //
+  // Bis hierher schrieb jeder Anschlag direkt in den Store. Das ist bei einem
+  // Namen, an dem der ganze Plan haengt, die falsche Zusage: „Kam" ist ein
+  // gueltiger Zwischenstand des Tippens und ein ungueltiger Rollenname, und
+  // die Vorschau haette fuer jeden davon eine andere Antwort. Der Entwurf
+  // steht, bis jemand „Umbenennen" drueckt — und bis dahin zeigt die Vorschau,
+  // WO die eine Aenderung ankommt.
+  const [nameDraft, setNameDraft] = useState<{ id: string; text: string } | null>(null)
+  const nameText = bound && nameDraft?.id === bound.id ? nameDraft.text : (bound?.name ?? '')
+  const nameDirty = Boolean(bound && nameText.trim() !== bound.name.trim())
+
+  const impact = useMemo(() => {
+    if (!bound || !nameDirty) return null
+    return renameImpact(
+      { equipment: allEquipment, cables, sourceIdentities: list },
+      bound.id,
+      nameText,
+    )
+  }, [allEquipment, bound, cables, list, nameDirty, nameText])
+
+  const verschluckt = useMemo(() => (impact ? swallowedLandings(impact) : []), [impact])
+
+  const applyRename = () => {
+    if (!bound) return
+    const absage = renameSourceIdentity(bound.id, nameText)
+    if (!absage) setNameDraft(null)
+  }
 
   const onPickRole = (value: string) => {
     if (value === '') {
@@ -131,10 +167,12 @@ export const SourceIdentitySection = ({ equipment }: { equipment: EquipmentItem 
                   {t('sourceIdentity.name', 'Redaktioneller Name')}
                 </span>
                 <input
-                  value={bound.name}
-                  onChange={(event) =>
-                    updateSourceIdentity(bound.id, { name: event.target.value })
-                  }
+                  value={nameText}
+                  onChange={(event) => setNameDraft({ id: bound.id, text: event.target.value })}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') applyRename()
+                    if (event.key === 'Escape') setNameDraft(null)
+                  }}
                   placeholder="Kamera 1"
                   className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
                 />
@@ -161,6 +199,93 @@ export const SourceIdentitySection = ({ equipment }: { equipment: EquipmentItem 
                 />
               </label>
             </div>
+
+            {/* BEDARF 101 — die Vorschau auf die eine Änderung.
+                Sie steht ZWISCHEN Eingabefeld und Knopf, weil sie dort gelesen
+                wird: erst sehen, wo es ankommt, dann drücken. */}
+            {impact && (
+              <div className="flex flex-col gap-1.5 rounded border border-cp-border-muted bg-cp-surface-2 p-2">
+                {impact.refusal ? (
+                  <p className="text-cp-danger">
+                    {t(`rename.refusal.${impact.refusal}`, RENAME_REFUSAL_LABEL[impact.refusal])}
+                  </p>
+                ) : (
+                  <>
+                    <p className="text-cp-text-secondary">
+                      {format(
+                        t(
+                          'rename.lands',
+                          '„{old}“ → „{new}“ ändert {n} Stellen in den abgeleiteten Blättern — eine Änderung, kein Nachtippen.',
+                        ),
+                        { old: impact.oldName, new: impact.newName, n: impact.landings.length },
+                      )}
+                    </p>
+                    {impact.landings.length > 0 && (
+                      <ul className="flex flex-col gap-0.5 font-mono text-cp-xs">
+                        {impact.landings.slice(0, 8).map((l) => (
+                          <li key={l.key} className="text-cp-text-muted">
+                            {l.target} · {l.where}: {l.before || '—'} →{' '}
+                            <span className={l.unchangedAtTarget ? 'text-cp-warn' : 'text-cp-text'}>
+                              {l.after || '—'}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                    {/* Der unangenehme Befund: das Blatt ändert sich, das
+                        Gerät nicht — weil das Budget die Unterscheidung
+                        wegschneidet. */}
+                    {verschluckt.length > 0 && (
+                      <p className="text-cp-warn">
+                        {format(
+                          t(
+                            'rename.swallowed',
+                            '{n} Ziel(e) speichern danach denselben Text wie vorher — dort kommt die Umbenennung nicht an.',
+                          ),
+                          { n: verschluckt.length },
+                        )}
+                      </p>
+                    )}
+                    {/* Und der Rest des Marktproblems im eigenen Modell: was
+                        abgetippt dasteht, folgt nicht mit. */}
+                    {impact.stragglers.length > 0 && (
+                      <p className="text-cp-warn">
+                        {format(
+                          t(
+                            'rename.stragglers',
+                            'Der alte Name steht abgetippt in {n} Feld(ern) ({where}) — die folgen NICHT mit.',
+                          ),
+                          {
+                            n: impact.stragglers.length,
+                            where: impact.stragglers
+                              .slice(0, 3)
+                              .map((s) => `${s.where} · ${s.field}`)
+                              .join(', '),
+                          },
+                        )}
+                      </p>
+                    )}
+                  </>
+                )}
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={applyRename}
+                    disabled={Boolean(impact.refusal)}
+                    className="rounded bg-emerald-700 px-2 py-1 hover:bg-emerald-600 disabled:opacity-40"
+                  >
+                    {t('rename.apply', 'Umbenennen')}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setNameDraft(null)}
+                    className="rounded border border-cp-border px-2 py-1 hover:bg-cp-surface-3"
+                  >
+                    {t('rename.discard', 'Verwerfen')}
+                  </button>
+                </div>
+              </div>
+            )}
 
             <label className="block">
               <span className="mb-1 block text-cp-text-secondary">

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3490,6 +3490,20 @@ export const en: Dict = {
   'channelList.view.stage': 'Stage (position)',
   'channelList.view.console': 'Console (names)',
   'channelList.view.monitor': 'Monitor paths',
+  // Bedarf 101 — Umbenennen kostet eine Aenderung, und man sieht wo sie ankommt.
+  'rename.apply': 'Rename',
+  'rename.discard': 'Discard',
+  'rename.lands':
+    '\u201C{old}\u201D \u2192 \u201C{new}\u201D changes {n} places in the derived sheets \u2014 one edit, no re-typing.',
+  'rename.swallowed':
+    '{n} target(s) will store the same text as before \u2014 the rename does not arrive there.',
+  'rename.stragglers':
+    'The old name is typed out in {n} field(s) ({where}) \u2014 those do NOT follow.',
+  'rename.refusal.unknown-role': 'This role no longer exists.',
+  'rename.refusal.empty-name': 'Without a name the role cannot be assigned to anyone.',
+  'rename.refusal.same-name': 'That is already the name.',
+  'rename.refusal.name-taken':
+    'Another role is already called that \u2014 two roles with one name cannot be told apart on the multiviewer.',
   // Bedarf 115 — der Unterlagen-Stapel.
   'packet.paper': 'Paper',
   'packet.colour': 'Colour',

--- a/src/renderer/lib/renameImpact.ts
+++ b/src/renderer/lib/renameImpact.ts
@@ -1,0 +1,318 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Umbenennen kostet EINE Änderung — und man sieht vorher, wo sie ankommt
+// (Bedarf 101, P3).
+//
+//   > A renamed preset or source has to be re-typed on every button that
+//   > references it, on every page; label editing happens several times a day
+//   > during show weeks.
+//
+// Belegt an `bitfocus/companion#1266` (2022) — dort für PTZ-Presets auf drei
+// Seiten: „if I want to change the name of a preset … I have to change the
+// names of all three buttons one by one" — und an `bitfocus/companion#4324`
+// (2026, offen): die zusätzlichen Klicks „add up very quickly … when changing
+// labels several times a day".
+//
+// ─── WAS HIER SCHON GELÖST WAR, UND WAS NICHT ──────────────────────────────
+//
+// Die eine Änderung gibt es in diesem Plan seit ADR-001: eine `SourceIdentity`
+// ist eine ROLLE, Geräte binden sich an ihre `id`, und jedes abgeleitete
+// Artefakt liest den Namen über `deriveLabels` nach. Wer die Rolle umbenennt,
+// hat damit ALLE Blätter umbenannt — ohne dieses Modul.
+//
+// Was fehlte, ist die andere Hälfte des Belegs: die Gewissheit. Wer in
+// Companion drei Knöpfe von Hand nachzieht, SIEHT wenigstens, was er anfasst.
+// Wer hier ein Feld ändert, sieht nichts — und muss darauf vertrauen, dass es
+// überall angekommen ist. Dieses Modul beantwortet das, bevor die Änderung
+// passiert, und es beantwortet es mit derselben Ableitung, aus der die
+// Exporter ihre Texte ziehen: `deriveLabels` einmal mit dem alten und einmal
+// mit dem neuen Namen, und die Differenz IST die Liste der Blätter. Eine von
+// Hand gepflegte Aufzählung wäre schon beim nächsten Zielsystem falsch.
+//
+// ─── DIE ZWEI UNANGENEHMEN BEFUNDE ─────────────────────────────────────────
+//
+//   1. **Die Umbenennung kommt beim Ziel gar nicht an.** Der ATEM-Kurzname
+//      hat 4 Byte. „Kamera 1" und „Kamera 1 (Havarie)" landen dort auf
+//      demselben Text. Das Blatt ändert sich, der Multiviewer nicht — und das
+//      ist genau die Sorte Überraschung, die man in der Sendung entdeckt.
+//      `unchangedAtTarget` sagt es vorher.
+//
+//   2. **Irgendwo steht der alte Name abgetippt.** Ein Portlabel „Cam1", ein
+//      Kabelname, eine Notiz. Diese Stellen folgen der Rolle NICHT — sie sind
+//      der Rest des Marktproblems innerhalb des eigenen Modells, und sie
+//      stumm stehen zu lassen hiesse, die Zusage „eine Änderung" zu brechen.
+//      Sie werden benannt, nicht automatisch mitgeändert: ob „Cam1" in einer
+//      Notiz diese Rolle meint, weiss nur der Mensch.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { Cable } from '../types/cable'
+import type { EquipmentItem } from '../types/equipment'
+import type { SourceIdentity } from '../types/sourceIdentity'
+import { deriveLabels, type LabelCandidate } from './labelDerivation'
+import {
+  LABEL_TARGETS,
+  fitToTarget,
+  type FittedLabel,
+  type LabelTargetId,
+} from './labelTargets'
+import type { CsvTable } from './csv'
+
+/** Warum eine Umbenennung nicht ausgeführt wird. */
+export type RenameRefusal =
+  /** Die Rolle gibt es nicht (mehr). */
+  | 'unknown-role'
+  /** Leerer Name — eine namenlose Rolle kann niemand zuweisen. */
+  | 'empty-name'
+  /** Der Name ist schon der aktuelle. */
+  | 'same-name'
+  /** Eine ANDERE Rolle heisst bereits so. */
+  | 'name-taken'
+
+export const RENAME_REFUSAL_LABEL: Readonly<Record<RenameRefusal, string>> = {
+  'unknown-role': 'Diese Rolle gibt es nicht mehr.',
+  'empty-name': 'Ohne Namen lässt sich die Rolle niemandem zuweisen.',
+  'same-name': 'Der Name steht schon so da.',
+  'name-taken':
+    'Eine andere Rolle heisst bereits so — zwei gleichnamige Rollen sind auf ' +
+    'dem Multiviewer nicht mehr auseinanderzuhalten.',
+}
+
+/** Ein Ort, an dem der Name des Ziels wirklich ankommt. */
+export interface RenameLanding {
+  /** Stabiler Schlüssel aus der Ableitung — als React-key nutzbar. */
+  key: string
+  targetId: LabelTargetId
+  /** Zielsystem und Feld im Klartext („ATEM · Kurzname"). */
+  target: string
+  /** Menschliche Verortung („ATEM 1 · In 3"). */
+  where: string
+  /** Was das Zielsystem HEUTE speichert. */
+  before: string
+  /** Was es nach der Umbenennung speichert. */
+  after: string
+  /** true: der neue Text wird beim Ziel gekürzt. */
+  truncated: boolean
+  /**
+   * true: vorher und nachher sind beim Ziel identisch.
+   *
+   * Der unangenehme Fall. Das Blatt ändert sich, das Gerät nicht — weil das
+   * Budget die Unterscheidung wegschneidet.
+   */
+  unchangedAtTarget: boolean
+  /** Zeichen aus dem neuen Namen, die das Ziel nicht transportieren kann. */
+  invalidChars: string[]
+}
+
+/** Ein Feld, in dem der alte Name ABGETIPPT steht und deshalb stehen bleibt. */
+export interface RenameStraggler {
+  /** Verortung („Kamera links" / „Kabel Cam1 → ATEM"). */
+  where: string
+  /** Welches Feld — im Klartext, nicht als Pfad. */
+  field: string
+  /** Der Text, wie er dort steht. */
+  text: string
+}
+
+export interface RenameImpact {
+  refusal?: RenameRefusal
+  oldName: string
+  newName: string
+  /** Orte, an denen die eine Änderung ankommt. */
+  landings: RenameLanding[]
+  /** Felder mit abgetipptem alten Namen. Folgen NICHT. */
+  stragglers: RenameStraggler[]
+}
+
+export interface RenameInput {
+  equipment: EquipmentItem[]
+  cables: Cable[]
+  sourceIdentities: SourceIdentity[]
+}
+
+const norm = (s: string) => s.trim().toLowerCase()
+
+/**
+ * Prüft die Umbenennung, ohne sie auszuführen.
+ *
+ * Getrennt von `renameImpact`, weil der Store die Absage braucht und die
+ * Auswirkung nicht: eine Ablehnung ist eine Ja/Nein-Frage, die Vorschau ist
+ * eine Rechnung über den ganzen Graphen.
+ */
+export function renameRefusal(
+  identities: readonly SourceIdentity[],
+  id: string,
+  newName: string,
+): RenameRefusal | null {
+  const role = identities.find((s) => s.id === id)
+  if (!role) return 'unknown-role'
+  const next = newName.trim()
+  if (!next) return 'empty-name'
+  if (next === role.name.trim()) return 'same-name'
+  if (identities.some((s) => s.id !== id && norm(s.name) === norm(next))) return 'name-taken'
+  return null
+}
+
+/**
+ * Ein Wort und kein Wortteil.
+ *
+ * Ohne die Grenze meldet eine Rolle namens „A" jedes Gerät im Plan. Die
+ * Nachbarn dürfen keine Buchstaben oder Ziffern sein; Bindestrich, Punkt,
+ * Schrägstrich und Leerzeichen zählen als Grenze — „Cam1-Backup" enthält
+ * „Cam1", und genau das soll gemeldet werden.
+ */
+const containsWord = (haystack: string, needle: string): boolean => {
+  const h = haystack.toLowerCase()
+  const n = needle.toLowerCase()
+  if (!n) return false
+  let from = 0
+  for (;;) {
+    const i = h.indexOf(n, from)
+    if (i < 0) return false
+    const vor = i > 0 ? h[i - 1] : ''
+    const nach = i + n.length < h.length ? h[i + n.length] : ''
+    const wort = /[\p{L}\p{N}]/u
+    if (!wort.test(vor) && !wort.test(nach)) return true
+    from = i + 1
+  }
+}
+
+/**
+ * Felder, in denen ein Mensch den Rollennamen abtippen kann und die auf einem
+ * Blatt landen. Bewusst kurz und einzeln begründet — eine Volltextsuche über
+ * das ganze Projekt meldete jede Zufalls-Übereinstimmung und wäre nach dem
+ * dritten Fehlalarm abgeschaltet.
+ */
+const stragglersIn = (
+  { equipment, cables }: RenameInput,
+  oldName: string,
+  identityId: string,
+): RenameStraggler[] => {
+  const out: RenameStraggler[] = []
+  const treffer = (where: string, field: string, text: string | undefined) => {
+    if (text && containsWord(text, oldName)) out.push({ where, field, text })
+  }
+
+  for (const device of equipment) {
+    // Der Gerätename steht auf dem Canvas, in der Stückliste und auf jedem
+    // Label-Bogen. Er folgt der Rolle NICHT — das ist Absicht (das Blech
+    // heisst, wie es heisst), aber wer „Kamera 1" als Gerätenamen getippt
+    // hat, meint meistens die Rolle.
+    treffer(device.name, 'Gerätename', device.name)
+    treffer(device.name, 'Kurzname', device.shortName)
+    treffer(device.name, 'Untertitel', device.subtitle)
+    treffer(device.name, 'Notiz', device.notes)
+    for (const port of [...device.inputs, ...device.outputs]) {
+      // `contentLabel` ist der Text, den die Exporter nehmen, wo KEINE Rolle
+      // gebunden ist. Steht dort der alte Name, zeigt das Zielsystem ihn
+      // nach der Umbenennung weiter.
+      treffer(`${device.name} · ${port.name || 'Port'}`, 'Port-Inhalt', port.contentLabel)
+      treffer(`${device.name} · ${port.name || 'Port'}`, 'Portname', port.name)
+    }
+  }
+  for (const cable of cables) {
+    // Der Kabelname steht auf dem Etikett, das im Saal am Kabel klebt. Er
+    // wird nicht nachgedruckt, wenn eine Rolle umbenannt wird.
+    treffer(cable.name || 'Kabel', 'Kabelname', cable.name)
+    treffer(cable.name || 'Kabel', 'Kabelnotiz', cable.notes)
+  }
+
+  // Geräte, die die Rolle TRAGEN, tragen ihren Namen oft doppelt — einmal als
+  // Bindung, einmal abgetippt. Das ist kein zweiter Befund, sondern derselbe.
+  const gebunden = new Set(
+    equipment.filter((e) => e.sourceIdentityId === identityId).map((e) => e.name),
+  )
+  return out.filter((s) => !(s.field === 'Gerätename' && gebunden.has(s.text)))
+}
+
+const targetLabel = (id: LabelTargetId): string =>
+  `${LABEL_TARGETS[id].system} · ${LABEL_TARGETS[id].field}`
+
+const fittedByKey = (candidates: LabelCandidate[]): Map<string, FittedLabel & { where: string }> => {
+  const out = new Map<string, FittedLabel & { where: string }>()
+  for (const c of candidates) {
+    out.set(c.key, { ...fitToTarget(c.raw, LABEL_TARGETS[c.targetId], c.sourceText), where: c.where })
+  }
+  return out
+}
+
+/**
+ * Was die eine Änderung bewirkt — berechnet, nicht behauptet.
+ *
+ * Die Ableitung läuft zweimal: einmal wie sie heute ist, einmal mit der
+ * umbenannten Rolle. Was sich dazwischen unterscheidet, IST die Liste der
+ * Blätter. Deshalb kann sie nicht veralten, wenn ein sechstes Zielsystem
+ * dazukommt.
+ */
+export function renameImpact(input: RenameInput, id: string, newName: string): RenameImpact {
+  const role = input.sourceIdentities.find((s) => s.id === id)
+  const oldName = role?.name ?? ''
+  const next = newName.trim()
+  const refusal = renameRefusal(input.sourceIdentities, id, newName)
+  if (refusal) return { refusal, oldName, newName: next, landings: [], stragglers: [] }
+
+  const vorher = fittedByKey(
+    deriveLabels({
+      equipment: input.equipment,
+      cables: input.cables,
+      sourceIdentities: input.sourceIdentities,
+    }).candidates,
+  )
+  const nachher = fittedByKey(
+    deriveLabels({
+      equipment: input.equipment,
+      cables: input.cables,
+      sourceIdentities: input.sourceIdentities.map((s) =>
+        s.id === id ? { ...s, name: next } : s,
+      ),
+    }).candidates,
+  )
+
+  const landings: RenameLanding[] = []
+  for (const [key, neu] of nachher) {
+    const alt = vorher.get(key)
+    // Nur was sich im WUNSCHTEXT unterscheidet, ist eine Landung. Ein
+    // Kandidat, dessen Text die Rolle gar nicht speist, bliebe sonst als
+    // „unverändert" in der Liste und machte sie unlesbar.
+    if (!alt || alt.raw === neu.raw) continue
+    landings.push({
+      key,
+      targetId: neu.targetId,
+      target: targetLabel(neu.targetId),
+      where: neu.where,
+      before: alt.value,
+      after: neu.value,
+      truncated: neu.truncated,
+      unchangedAtTarget: alt.value === neu.value,
+      invalidChars: neu.invalidChars,
+    })
+  }
+  landings.sort((a, b) => a.target.localeCompare(b.target) || a.where.localeCompare(b.where))
+
+  return {
+    oldName,
+    newName: next,
+    landings,
+    stragglers: stragglersIn(input, oldName, id),
+  }
+}
+
+/** Landungen, bei denen die Umbenennung beim Ziel NICHT ankommt. */
+export const swallowedLandings = (impact: RenameImpact): RenameLanding[] =>
+  impact.landings.filter((l) => l.unchangedAtTarget)
+
+export const RENAME_TABLE_HEADERS = ['Zielsystem', 'Ort', 'Vorher', 'Nachher', 'Hinweis'] as const
+
+const hinweis = (l: RenameLanding): string => {
+  const teile: string[] = []
+  if (l.unchangedAtTarget) teile.push('kommt hier NICHT an (Budget)')
+  else if (l.truncated) teile.push('gekürzt')
+  if (l.invalidChars.length) teile.push(`nicht darstellbar: ${l.invalidChars.join(' ')}`)
+  return teile.join('; ')
+}
+
+/** Die Vorschau als Tabelle — für den Unterlagen-Stapel und den CSV-Export. */
+export const renameTable = (impact: RenameImpact): CsvTable => ({
+  headers: [...RENAME_TABLE_HEADERS],
+  rows: impact.landings.map((l) => [l.target, l.where, l.before, l.after, hinweis(l)]),
+})

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -498,10 +498,26 @@ export interface ProjectState {
   addSourceIdentity: (
     identity: Omit<import('../types/sourceIdentity').SourceIdentity, 'id'> & { id?: string },
   ) => string | undefined
+  /**
+   * Alles AUSSER dem Namen. Umbenannt wird ueber `renameSourceIdentity`
+   * (Bedarf 101): nur dort wird geprueft, ob schon eine andere Rolle so
+   * heisst, und zwei gleichnamige Rollen sind auf dem Multiviewer nicht mehr
+   * auseinanderzuhalten. Ein zweiter Weg an dieser Pruefung vorbei waere
+   * genau der Zustand, den die Pruefung verhindern soll.
+   */
   updateSourceIdentity: (
     id: string,
-    patch: Partial<Omit<import('../types/sourceIdentity').SourceIdentity, 'id'>>,
+    patch: Partial<Omit<import('../types/sourceIdentity').SourceIdentity, 'id' | 'name'>>,
   ) => void
+  /**
+   * Bedarf 101 — die EINE Aenderung. Liefert den Grund, wenn sie nicht
+   * ausgefuehrt wurde, statt still nichts zu tun: fuer den Bedienenden ist
+   * ein wortloses Nichts von einem kaputten Programm nicht zu unterscheiden.
+   */
+  renameSourceIdentity: (
+    id: string,
+    newName: string,
+  ) => import('../lib/renameImpact').RenameRefusal | undefined
   removeSourceIdentity: (id: string) => void
   /** Geraet an eine Rolle binden; `undefined` loest die Bindung. */
   bindEquipmentToSourceIdentity: (equipmentId: string, identityId: string | undefined) => void

--- a/src/renderer/store/slices/sourceIdentitySlice.ts
+++ b/src/renderer/store/slices/sourceIdentitySlice.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { scheduleProjectAutosave } from '../projectAutosave'
 import type { ProjectState } from '../projectStore'
 import type { SourceIdentity } from '../../types/sourceIdentity'
+import { renameRefusal } from '../../lib/renameImpact'
 
 /**
  * ADR-001, Inkrement 2 — Signalquellen-Rollen.
@@ -20,6 +21,7 @@ export type SourceIdentitySlice = Pick<
   ProjectState,
   | 'addSourceIdentity'
   | 'updateSourceIdentity'
+  | 'renameSourceIdentity'
   | 'removeSourceIdentity'
   | 'bindEquipmentToSourceIdentity'
 >
@@ -58,17 +60,43 @@ export const createSourceIdentitySlice: StateCreator<
     set((state) => {
       const existing = state.project.sourceIdentities ?? []
       if (!existing.some((s) => s.id === id)) return {}
-      const next = existing.map((s) => {
-        if (s.id !== id) return s
-        const merged = { ...s, ...patch, id: s.id }
-        // Ein leerer Name macht die Rolle unzuweisbar — der alte bleibt.
-        if (typeof merged.name === 'string' && merged.name.trim() === '') merged.name = s.name
-        return merged
-      })
+      // `name` steht nicht im Typ des Patches — umbenannt wird ueber
+      // `renameSourceIdentity`. Sollte ein ungetypter Aufrufer ihn doch
+      // mitschicken, faellt er hier weg, statt an der Pruefung vorbeizukommen.
+      const { name: _verworfen, ...rest } = patch as Partial<SourceIdentity>
+      const next = existing.map((s) => (s.id === id ? { ...s, ...rest, id: s.id } : s))
       const updated = { ...state.project, sourceIdentities: next }
       scheduleProjectAutosave(updated)
       return { project: updated }
     }),
+  /**
+   * BEDARF 101 — die eine Aenderung, mit einem Grund statt eines Schweigens.
+   *
+   * Der Beleg (`bitfocus/companion#1266`, `#4324`) beschreibt das Nachtippen
+   * auf jedem Knopf. Hier folgt jedes abgeleitete Blatt der Rolle von selbst,
+   * weil es ihren Namen ueber `deriveLabels` nachliest — diese Funktion ist
+   * die einzige Stelle, an der er sich aendert.
+   *
+   * Abgelehnt wird mit `RenameRefusal` und nicht mit `false`: „name-taken"
+   * und „empty-name" verlangen verschiedene Antworten des Bedienenden, und
+   * ein Boolean zwaenge die Oberflaeche, den Grund zu erraten.
+   */
+  renameSourceIdentity: (id, newName) => {
+    let absage: ReturnType<typeof renameRefusal> = null
+    set((state) => {
+      const existing = state.project.sourceIdentities ?? []
+      absage = renameRefusal(existing, id, newName)
+      if (absage) return {}
+      const trimmed = newName.trim()
+      const updated = {
+        ...state.project,
+        sourceIdentities: existing.map((s) => (s.id === id ? { ...s, name: trimmed } : s)),
+      }
+      scheduleProjectAutosave(updated)
+      return { project: updated }
+    })
+    return absage ?? undefined
+  },
   removeSourceIdentity: (id) =>
     set((state) => {
       const existing = state.project.sourceIdentities ?? []

--- a/tests/renameImpact.test.ts
+++ b/tests/renameImpact.test.ts
@@ -1,0 +1,414 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  RENAME_REFUSAL_LABEL,
+  RENAME_TABLE_HEADERS,
+  renameImpact,
+  renameRefusal,
+  renameTable,
+  swallowedLandings,
+} from '../src/renderer/lib/renameImpact'
+import { useProjectStore } from '../src/renderer/store/projectStore'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem, Port } from '../src/renderer/types/equipment'
+import type { SourceIdentity } from '../src/renderer/types/sourceIdentity'
+import libQuelle from '../src/renderer/lib/renameImpact.ts?raw'
+import sliceQuelle from '../src/renderer/store/slices/sourceIdentitySlice.ts?raw'
+import storeQuelle from '../src/renderer/store/projectStore.ts?raw'
+import panelQuelle from '../src/renderer/components/Properties/sections/SourceIdentitySection.tsx?raw'
+
+// ---------------------------------------------------------------------------
+// Umbenennen kostet EINE Aenderung — und man sieht vorher, wo sie ankommt
+// (Bedarf 101, P3).
+//
+//   > A renamed preset or source has to be re-typed on every button that
+//   > references it, on every page; label editing happens several times a day
+//   > during show weeks.
+//
+// Belegt an `bitfocus/companion#1266` (2022, PTZ-Presets auf drei Seiten) und
+// `bitfocus/companion#4324` (2026, offen): die Klicks „add up very quickly …
+// when changing labels several times a day".
+// ---------------------------------------------------------------------------
+
+const port = (id: string, name: string, over: Partial<Port> = {}): Port => ({
+  id,
+  name,
+  type: 'BNC',
+  connectorType: 'BNC',
+  ...over,
+})
+
+const eq = (over: Partial<EquipmentItem>): EquipmentItem => ({
+  id: 'e1',
+  name: 'Gerät',
+  category: 'Video',
+  inputs: [],
+  outputs: [],
+  x: 0,
+  y: 0,
+  width: 200,
+  height: 160,
+  ...over,
+})
+
+const cable = (from: [string, string], to: [string, string]): Cable => ({
+  id: `${from[1]}->${to[1]}`,
+  name: `${from[1]}->${to[1]}`,
+  type: 'BNC',
+  length: 10,
+  color: '#fff',
+  fromEquipmentId: from[0],
+  fromPortId: from[1],
+  toEquipmentId: to[0],
+  toPortId: to[1],
+  notes: '',
+})
+
+const rolle = (id: string, name: string, over: Partial<SourceIdentity> = {}): SourceIdentity => ({
+  id,
+  name,
+  ...over,
+})
+
+/** Eine Kamera auf ATEM-Eingang 1, mit gebundener Rolle. */
+const welt = (rollenName: string, over: Partial<EquipmentItem> = {}) => {
+  const kamera = eq({
+    id: 'cam1',
+    name: 'Kamera links',
+    category: 'Kameras',
+    outputs: [port('cam1-out', 'SDI Out')],
+    sourceIdentityId: 'r1',
+    ...over,
+  })
+  const mischer = eq({
+    id: 'atem',
+    name: 'ATEM Mini Extreme',
+    inputs: [port('atem-in1', 'In 1')],
+  })
+  return {
+    equipment: [kamera, mischer],
+    cables: [cable(['cam1', 'cam1-out'], ['atem', 'atem-in1'])],
+    sourceIdentities: [rolle('r1', rollenName)],
+  }
+}
+
+// ── 1. Die Absage hat einen Namen ──────────────────────────────────────────
+
+describe('renameRefusal — warum es nicht geht, statt still nichts zu tun', () => {
+  const list = [rolle('r1', 'Kamera 1'), rolle('r2', 'Kamera 2')]
+
+  it('laesst die gewoehnliche Umbenennung zu', () => {
+    expect(renameRefusal(list, 'r1', 'Kamera Bühne')).toBeNull()
+  })
+
+  it('meldet die verschwundene Rolle', () => {
+    expect(renameRefusal(list, 'weg', 'Egal')).toBe('unknown-role')
+  })
+
+  it('lehnt den leeren Namen ab', () => {
+    // Eine namenlose Rolle kann niemand zuweisen — und ein leeres UMD-Display
+    // sieht aus wie ein defektes.
+    expect(renameRefusal(list, 'r1', '   ')).toBe('empty-name')
+  })
+
+  it('lehnt den unveraenderten Namen ab', () => {
+    expect(renameRefusal(list, 'r1', 'Kamera 1')).toBe('same-name')
+    expect(renameRefusal(list, 'r1', '  Kamera 1  ')).toBe('same-name')
+  })
+
+  it('lehnt den Namen einer ANDEREN Rolle ab — auch in anderer Schreibweise', () => {
+    // Zwei Rollen mit einem Namen sind auf dem Multiviewer nicht mehr
+    // auseinanderzuhalten, und das Tally zeigt dann auf beide.
+    expect(renameRefusal(list, 'r1', 'Kamera 2')).toBe('name-taken')
+    expect(renameRefusal(list, 'r1', 'kamera 2')).toBe('name-taken')
+  })
+
+  it('haelt fuer jede Absage eine lesbare Ueberschrift bereit', () => {
+    for (const k of ['unknown-role', 'empty-name', 'same-name', 'name-taken'] as const) {
+      expect(RENAME_REFUSAL_LABEL[k].length).toBeGreaterThan(10)
+    }
+  })
+})
+
+// ── 2. Die eine Aenderung kommt an ─────────────────────────────────────────
+
+describe('renameImpact — wo die eine Aenderung landet', () => {
+  it('nennt die abgeleiteten Blaetter, statt sie zu behaupten', () => {
+    // DER Beleg: „I have to change the names of all three buttons one by one".
+    // Hier aendert EIN Feld den Text bei jedem Ziel, das ihn ableitet.
+    const i = renameImpact(welt('Kamera 1'), 'r1', 'Bühne links')
+    expect(i.refusal).toBeUndefined()
+    expect(i.landings.length).toBeGreaterThan(0)
+    for (const l of i.landings) expect(l.after).not.toBe(l.before)
+  })
+
+  it('traegt das UMD-Display die Rolle, nicht den Geraetenamen', () => {
+    const i = renameImpact(welt('Kamera 1'), 'r1', 'Bühne links')
+    const umd = i.landings.find((l) => l.targetId === 'tsl-umd-v31')
+    expect(umd).toBeDefined()
+    expect(umd?.before).toBe('Kamera 1')
+    expect(umd?.after).toBe('Bühne links')
+  })
+
+  it('laesst Ziele weg, die diese Rolle gar nicht speisen', () => {
+    // Sonst stuende die halbe Anlage in der Liste, und niemand faende darin
+    // die drei Stellen, um die es geht. Hier haengt eine zweite Kamera OHNE
+    // Rolle am selben Mischer: ihre Label-Kandidaten existieren, aendern sich
+    // aber nicht — und duerfen deshalb nicht als Landung erscheinen.
+    const w = welt('Kamera 1')
+    w.equipment.push(
+      eq({
+        id: 'cam2',
+        name: 'Kamera rechts',
+        category: 'Kameras',
+        outputs: [port('cam2-out', 'SDI Out')],
+      }),
+    )
+    w.equipment[1].inputs.push(port('atem-in2', 'In 2'))
+    w.cables.push(cable(['cam2', 'cam2-out'], ['atem', 'atem-in2']))
+
+    const i = renameImpact(w, 'r1', 'Bühne links')
+    expect(i.landings.length).toBeGreaterThan(0)
+    // Kein Kandidat der rollenlosen Kamera — weder ueber ihren Port noch
+    // ueber ihr UMD.
+    expect(i.landings.some((l) => l.key.includes('cam2') || l.where.includes('In 2'))).toBe(false)
+    expect(i.landings.every((l) => l.before !== l.after || l.unchangedAtTarget)).toBe(true)
+  })
+
+  it('rechnet die Absage, statt eine Vorschau auf Unmoegliches zu bauen', () => {
+    const w = welt('Kamera 1')
+    w.sourceIdentities.push(rolle('r2', 'Kamera 2'))
+    const i = renameImpact(w, 'r1', 'Kamera 2')
+    expect(i.refusal).toBe('name-taken')
+    expect(i.landings).toEqual([])
+    expect(i.stragglers).toEqual([])
+  })
+})
+
+// ── 3. Der unangenehme Befund: sie kommt NICHT an ──────────────────────────
+
+describe('die Umbenennung, die beim Ziel verschluckt wird', () => {
+  it('meldet, wenn das Zielbudget den Unterschied wegschneidet', () => {
+    // DER Fall, um den es geht: der ATEM-Kurzname hat 4 Byte. „Kamera 1" und
+    // „Kamera 2" landen dort BEIDE auf „KAME". Das Blatt aendert sich, der
+    // Multiviewer nicht — und diese Ueberraschung entdeckt man sonst in der
+    // Sendung.
+    const i = renameImpact(welt('Kamera 1'), 'r1', 'Kamera 2')
+    const kurz = i.landings.find((l) => l.targetId === 'atem-input-short')
+    expect(kurz).toBeDefined()
+    expect(kurz?.before).toBe('KAME')
+    expect(kurz?.after).toBe('KAME')
+    expect(kurz?.unchangedAtTarget).toBe(true)
+
+    // Und die uebrigen Ziele kommen sehr wohl an — sonst waere der Befund
+    // „die Umbenennung wirkt nirgends", und das waere etwas anderes.
+    const lang = i.landings.find((l) => l.targetId === 'atem-input-long')
+    expect(lang?.after).toBe('Kamera 2')
+    expect(lang?.unchangedAtTarget).toBe(false)
+
+    expect(swallowedLandings(i).map((l) => l.targetId)).toEqual(['atem-input-short'])
+  })
+
+  it('zaehlt das Byte-Budget und nicht die Zeichen', () => {
+    // Ein Umlaut kostet im 4-Byte-Kurznamen zwei — „BÜH" statt „BÜHN". Wer
+    // hier Zeichen zaehlte, versprochenes Platzangebot, das der ATEM nicht
+    // hat, und der vierte Buchstabe fiele erst auf dem Geraet weg.
+    const i = renameImpact(welt('Kamera 1'), 'r1', 'Bühne links')
+    const kurz = i.landings.find((l) => l.targetId === 'atem-input-short')
+    expect(kurz?.after).toBe('BÜH')
+    expect(kurz?.truncated).toBe(true)
+  })
+
+  it('zaehlt eine echte Aenderung NICHT als verschluckt', () => {
+    const i = renameImpact(welt('Kamera 1'), 'r1', 'Bühne links')
+    const umd = i.landings.find((l) => l.targetId === 'tsl-umd-v31')
+    expect(umd?.unchangedAtTarget).toBe(false)
+  })
+
+  it('meldet Zeichen, die das Ziel nicht transportiert', () => {
+    // TSL UMD v3.1 traegt 7-Bit-ASCII. Ein Umlaut im Rollennamen kommt dort
+    // nicht an — und das erfaehrt man besser vor der Umbenennung.
+    const i = renameImpact(welt('Kamera 1'), 'r1', 'Bühne links')
+    const umd = i.landings.find((l) => l.targetId === 'tsl-umd-v31')
+    expect(umd?.invalidChars).toContain('ü')
+  })
+})
+
+// ── 4. Was NICHT mitfolgt ──────────────────────────────────────────────────
+
+describe('die abgetippten Namen', () => {
+  it('nennt das Portlabel, in dem der alte Name abgetippt steht', () => {
+    // Der Rest des Marktproblems im eigenen Modell: was jemand getippt hat,
+    // folgt der Rolle nicht — und es stumm stehen zu lassen braeche die
+    // Zusage „eine Aenderung".
+    const w = welt('Cam1')
+    w.equipment[1].inputs[0].contentLabel = 'Cam1'
+    const i = renameImpact(w, 'r1', 'Bühne links')
+    expect(i.stragglers.some((s) => s.field === 'Port-Inhalt' && s.text === 'Cam1')).toBe(true)
+  })
+
+  it('nennt Kabelname und Kabelnotiz', () => {
+    const w = welt('Cam1')
+    w.cables[0].name = 'Cam1 → ATEM'
+    w.cables[0].notes = 'Ersatzweg für Cam1'
+    const i = renameImpact(w, 'r1', 'Bühne links')
+    expect(i.stragglers.filter((s) => s.field.startsWith('Kabel'))).toHaveLength(2)
+  })
+
+  it('meldet den Namen NICHT als Wortteil', () => {
+    // Ohne Wortgrenze meldete eine Rolle namens „A" jedes Geraet im Plan,
+    // und nach dem dritten Fehlalarm schaltet das jemand ab.
+    const w = welt('Cam1')
+    w.cables[0].name = 'Cam12 → ATEM'
+    const i = renameImpact(w, 'r1', 'Bühne links')
+    expect(i.stragglers.some((s) => s.text === 'Cam12 → ATEM')).toBe(false)
+  })
+
+  it('erkennt den Namen am Bindestrich als eigenes Wort', () => {
+    const w = welt('Cam1')
+    w.cables[0].name = 'Cam1-Backup'
+    const i = renameImpact(w, 'r1', 'Bühne links')
+    expect(i.stragglers.some((s) => s.text === 'Cam1-Backup')).toBe(true)
+  })
+
+  it('meldet den Geraetenamen des TRAEGERS nicht doppelt', () => {
+    // Eine Kamera, die „Kamera 1" heisst und die Rolle „Kamera 1" traegt,
+    // ist EIN Sachverhalt. Ihn zweimal zu melden macht die Liste unlesbar.
+    const w = welt('Kamera 1', { name: 'Kamera 1' })
+    const i = renameImpact(w, 'r1', 'Bühne links')
+    expect(i.stragglers.filter((s) => s.field === 'Gerätename')).toHaveLength(0)
+  })
+
+  it('meldet den Geraetenamen eines FREMDEN Geraets sehr wohl', () => {
+    const w = welt('Kamera 1')
+    w.equipment.push(eq({ id: 'mon', name: 'Monitor Kamera 1', category: 'Monitore' }))
+    const i = renameImpact(w, 'r1', 'Bühne links')
+    expect(i.stragglers.some((s) => s.text === 'Monitor Kamera 1')).toBe(true)
+  })
+})
+
+// ── 5. Die Tabelle ─────────────────────────────────────────────────────────
+
+describe('renameTable', () => {
+  it('haelt den Spaltenkopf fest', () => {
+    expect(renameTable(renameImpact(welt('Kamera 1'), 'r1', 'Bühne links')).headers).toEqual([
+      ...RENAME_TABLE_HEADERS,
+    ])
+  })
+
+  it('schreibt den Hinweis, statt ihn dem Leser zu ueberlassen', () => {
+    const i = renameImpact(welt('Kamera 1'), 'r1', 'Bühne links')
+    const zeilen = renameTable(i).rows
+    expect(zeilen.length).toBe(i.landings.length)
+    const umdZeile = zeilen.find((r) => String(r[0]).includes('TSL'))
+    expect(String(umdZeile?.[4])).toContain('nicht darstellbar')
+  })
+})
+
+// ── 6. Die eine Engstelle im Store ─────────────────────────────────────────
+
+describe('renameSourceIdentity — der einzige Weg', () => {
+  beforeEach(() => {
+    useProjectStore.setState((s) => ({ project: { ...s.project, sourceIdentities: [] } }))
+  })
+
+  const anlegen = () => {
+    const id = useProjectStore.getState().addSourceIdentity({ name: 'Kamera 1' })
+    if (!id) throw new Error('Rolle nicht angelegt')
+    return id
+  }
+
+  it('benennt um und liefert keine Absage', () => {
+    const id = anlegen()
+    expect(useProjectStore.getState().renameSourceIdentity(id, 'Bühne links')).toBeUndefined()
+    expect(
+      useProjectStore.getState().project.sourceIdentities?.find((s) => s.id === id)?.name,
+    ).toBe('Bühne links')
+  })
+
+  it('gibt den Grund zurueck, statt still nichts zu tun', () => {
+    const id = anlegen()
+    useProjectStore.getState().addSourceIdentity({ name: 'Kamera 2' })
+    expect(useProjectStore.getState().renameSourceIdentity(id, 'Kamera 2')).toBe('name-taken')
+    expect(useProjectStore.getState().renameSourceIdentity(id, '  ')).toBe('empty-name')
+    expect(useProjectStore.getState().renameSourceIdentity('weg', 'Egal')).toBe('unknown-role')
+    // Und der Name steht unveraendert da.
+    expect(
+      useProjectStore.getState().project.sourceIdentities?.find((s) => s.id === id)?.name,
+    ).toBe('Kamera 1')
+  })
+
+  it('schneidet Leerraum ab', () => {
+    const id = anlegen()
+    useProjectStore.getState().renameSourceIdentity(id, '  Bühne links  ')
+    expect(
+      useProjectStore.getState().project.sourceIdentities?.find((s) => s.id === id)?.name,
+    ).toBe('Bühne links')
+  })
+
+  it('laesst `updateSourceIdentity` den Namen NICHT mehr aendern', () => {
+    // Der zweite Weg an der Kollisionspruefung vorbei ist genau der Zustand,
+    // den die Pruefung verhindern soll. Der Typ verbietet ihn; hier wird
+    // geprueft, dass auch ein ungetypter Aufrufer nicht durchkommt.
+    const id = anlegen()
+    ;(
+      useProjectStore.getState().updateSourceIdentity as unknown as (
+        id: string,
+        patch: Record<string, unknown>,
+      ) => void
+    )(id, { name: 'Heimlich', umdAddress: 5 })
+    const rolleNachher = useProjectStore.getState().project.sourceIdentities?.find((s) => s.id === id)
+    expect(rolleNachher?.name).toBe('Kamera 1')
+    // Das uebrige Patchen funktioniert weiter.
+    expect(rolleNachher?.umdAddress).toBe(5)
+  })
+})
+
+// ── 7. Reinheit und Erreichbarkeit ─────────────────────────────────────────
+
+describe('das Modul und die Oberflaeche', () => {
+  it('nimmt keine Uhr und keinen Store', () => {
+    expect(libQuelle).not.toContain('new Date(')
+    expect(libQuelle).not.toContain('useProjectStore')
+  })
+
+  it('rechnet die Landungen aus der ABLEITUNG, nicht aus einer Aufzaehlung', () => {
+    // Eine von Hand gepflegte Liste der Zielsysteme waere beim sechsten
+    // Zielsystem falsch — und zwar unbemerkt.
+    expect(libQuelle).toContain('deriveLabels')
+    expect((libQuelle.match(/deriveLabels\(/g) ?? []).length).toBe(2)
+  })
+
+  it('haelt die Umbenennung als eigenes Verb im Store', () => {
+    expect(sliceQuelle).toContain('renameSourceIdentity: (id, newName)')
+    expect(sliceQuelle).toContain('renameRefusal(existing, id, newName)')
+  })
+
+  it('verbietet den Namen im Patch-Typ', () => {
+    expect(storeQuelle).toContain("Omit<import('../types/sourceIdentity').SourceIdentity, 'id' | 'name'>")
+  })
+
+  it('zeigt die Vorschau, bevor umbenannt wird', () => {
+    expect(panelQuelle).toContain("t('rename.apply'")
+    expect(panelQuelle).toContain('swallowedLandings')
+    // Der Block, der die Vorschau rechnet, darf GENAU EINEN Rueckgabewert mit
+    // Inhalt haben: `renameImpact`. Eine zweite Rueckgabe waere ein zweiter
+    // Zustand, und der stille davon („keine Vorschau") ist der, den der
+    // Bedarf abschafft.
+    const block = panelQuelle.slice(
+      panelQuelle.indexOf('const impact = useMemo'),
+      panelQuelle.indexOf('const verschluckt'),
+    )
+    expect(block.length).toBeGreaterThan(0)
+    expect(block.match(/return /g) ?? []).toHaveLength(2)
+    expect(block).toContain('if (!bound || !nameDirty) return null')
+    expect(block).toContain('return renameImpact(')
+  })
+
+  it('schreibt nicht mehr bei jedem Anschlag in den Store', () => {
+    // „Kam" ist ein gueltiger Zwischenstand des Tippens und ein ungueltiger
+    // Rollenname; jeden davon zu speichern hiesse, den Plan waehrend des
+    // Tippens dreimal umzubenennen.
+    expect(panelQuelle).not.toContain('updateSourceIdentity(bound.id, { name:')
+    expect(panelQuelle).toContain('setNameDraft({ id: bound.id, text: event.target.value })')
+  })
+})


### PR DESCRIPTION
Bedarf 101 (P3) aus dem Recherche-Korpus.

> A renamed preset or source has to be **re-typed on every button that references it**, on every page; label editing happens several times a day during show weeks.

Belegt an `bitfocus/companion#1266` (2022, PTZ-Presets auf drei Seiten: „if I want to change the name of a preset… I have to change the names of all three buttons one by one") und `bitfocus/companion#4324` (2026, offen): die Klicks „add up very quickly… when changing labels several times a day".

## Was schon gelöst war, und was nicht

Die eine Änderung gibt es hier seit ADR-001: eine `SourceIdentity` ist eine **Rolle**, Geräte binden sich an ihre `id`, und jedes abgeleitete Artefakt liest den Namen über `deriveLabels` nach.

Was fehlte, ist die andere Hälfte des Belegs: die **Gewissheit**. Wer in Companion drei Knöpfe von Hand nachzieht, sieht wenigstens, was er anfasst. Wer hier ein Feld ändert, sah nichts.

## `lib/renameImpact.ts` (neu)

`renameImpact` lässt `deriveLabels` **zweimal** laufen — einmal wie heute, einmal mit der umbenannten Rolle. Die Differenz *ist* die Liste der Blätter; eine von Hand gepflegte Aufzählung der Zielsysteme wäre schon beim sechsten falsch, und zwar unbemerkt.

Zwei Befunde fallen dabei ab, die sonst niemand sieht:

- **Die Umbenennung kommt beim Ziel gar nicht an.** Der ATEM-Kurzname hat 4 Byte; „Kamera 1" und „Kamera 2" landen dort beide auf `KAME`. Das Blatt ändert sich, der Multiviewer nicht. Gezählt werden **Bytes**, nicht Zeichen — „Bühne links" wird zu `BÜH`.
- **Irgendwo steht der alte Name abgetippt.** Portlabel, Kabelname, Notiz, Untertitel. Die folgen der Rolle nicht. Sie werden **benannt**, nicht automatisch mitgeändert: ob „Cam1" in einer Notiz diese Rolle meint, weiß nur der Mensch. Gesucht wird auf Wortgrenze — ohne sie meldete eine Rolle namens „A" jedes Gerät im Plan.

## Die Engstelle im Store

`renameSourceIdentity(id, name)` liefert `RenameRefusal | undefined` statt still nichts zu tun: `unknown-role`, `empty-name`, `same-name`, `name-taken`. `updateSourceIdentity` nimmt den Namen nicht mehr an (Typ auf `Omit<…, 'id' | 'name'>` verengt, ungetypter Aufrufer verliert das Feld beim Zerlegen) — ein zweiter Weg an der Kollisionsprüfung vorbei wäre genau der Zustand, den sie verhindert.

## Oberfläche

`SourceIdentitySection` schreibt nicht mehr bei jedem Anschlag in den Store — „Kam" ist ein gültiger Zwischenstand des Tippens und ein ungültiger Rollenname. Der Entwurf steht, bis jemand „Umbenennen" drückt; bis dahin zeigt die Vorschau, wo die Änderung ankommt, wo sie verschluckt wird und was abgetippt stehen bleibt.

## Prüfung

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — 160 Test-Dateien grün (32 neue Fälle)
- `npm run lint` — 0 Errors
- Gegenprobe: 23 injizierte Defekte kommen alle rot zurück. **Zwei Lücken fand die Gegenprobe selbst**, beide geschlossen: der Test auf „unveränderte Kandidaten" war tautologisch (jetzt hängt eine zweite, rollenlose Kamera am selben Mischer und darf nicht in der Liste auftauchen), und die Vorschau-Zusicherung ließ sich mit einem Null-Rückgabewert aushebeln (jetzt Block-Slice mit Rückgabe-Zählung).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_