### PR TITLE
network: Segmente — welche VLAN wofür da ist, und wer darin falsch liegt (#116)

### DIFF
--- a/src/renderer/components/Analysis/AnalysisDialog.tsx
+++ b/src/renderer/components/Analysis/AnalysisDialog.tsx
@@ -86,6 +86,7 @@ import {
 import type { VenueAnswerStatus } from '../../types/venueAnswer'
 import { RF_BANDS, bandsForFrequency, bandLabel } from '../../lib/rfBands'
 import { PTP_FINDING_LABEL, buildPtpPlan, ptpTable } from '../../lib/ptpPlan'
+import { SegmentsPanel } from '../Network/SegmentsPanel'
 import { CREW_SECTION_LABEL, buildCrewSheet, crewSheetTable } from '../../lib/crewNetworkSheet'
 import {
   MULTICAST_ESSENCE_LABEL,
@@ -725,6 +726,11 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
           {vlanCounts.map((v) => `VLAN ${v.id} (${v.count})`).join(' · ')}
         </p>
       )}
+      {/* BEDARF 116 — die Segmente. Sie stehen ZWISCHEN der VLAN-Zeile
+          darueber (welche Ids kommen vor) und den Subnetzen darunter: erst
+          die Zahl, dann ihre Bedeutung, dann die Adressen. */}
+      <SegmentsPanel projectName={projectName} />
+
       {/* #346 — IPAM: Subnetz-Übersicht. */}
       {subnets.length > 0 && (
         <div className="rounded border border-[var(--cp-border-muted)] bg-[var(--cp-surface-3)] p-2 text-cp-xs">

--- a/src/renderer/components/Network/SegmentsPanel.tsx
+++ b/src/renderer/components/Network/SegmentsPanel.tsx
@@ -1,0 +1,240 @@
+import { useMemo } from 'react'
+import { AlertTriangle, Download, Plus, Trash2 } from 'lucide-react'
+import { useProjectStore } from '../../store/projectStore'
+import { useTranslation, format } from '../../lib/i18n'
+import { Icon } from '../shared/Icon'
+import { downloadBlob } from '../../lib/downloadBlob'
+import { toCsv } from '../../lib/csv'
+import { buildExportFilenameWithSuffix } from '../../lib/exportFilename'
+import {
+  ROLE_TEXT,
+  segmentFindings,
+  segmentReachTable,
+  segmentTable,
+  segmentViews,
+  vlansInUse,
+} from '../../lib/networkSegments'
+import { NETWORK_INTERFACE_ROLES, type NetworkInterfaceRole } from '../../types/network'
+import type { NetworkSegment } from '../../types/networkSegment'
+
+/**
+ * BEDARF 116 — die Segmente als Gegenstand des Plans.
+ *
+ *   > A systems tech must reach VuNET, the mixer app, Dante Controller, Lake
+ *   > Controller and Shure WWB ON SEPARATE VLANs FROM ONE MACHINE, while
+ *   > keeping amp control off Dante PTP […]
+ *
+ * Die VLAN-Id steht seit Bedarf 19/24 an jeder Schnittstelle. Hier bekommt sie
+ * einen Namen, einen Zweck und eine geplante Zeit — und erst damit lässt sich
+ * fragen, ob eine Schnittstelle im richtigen Segment liegt.
+ *
+ * Der Knopf „VLANs aus dem Plan übernehmen" legt Datensätze für die Ids an,
+ * die schon benutzt werden. Er füllt NICHT den Zweck: den kennt nur der
+ * Mensch, und geraten wäre er die stille Zusage, gegen die dieser Bedarf
+ * überhaupt gebaut ist.
+ */
+export const SegmentsPanel = ({ projectName }: { projectName: string }) => {
+  const t = useTranslation()
+  const equipment = useProjectStore((s) => s.project.equipment)
+  const gespeichert = useProjectStore((s) => s.project.networkSegments)
+  const segments = useMemo(() => gespeichert ?? [], [gespeichert])
+  const setNetworkSegments = useProjectStore((s) => s.setNetworkSegments)
+
+  const views = useMemo(() => segmentViews(equipment, segments), [equipment, segments])
+  const findings = useMemo(() => segmentFindings(equipment, segments), [equipment, segments])
+  const fehlend = useMemo(
+    () => vlansInUse(equipment).filter((v) => !segments.some((s) => s.vlanId === v)),
+    [equipment, segments],
+  )
+
+  const patch = (vlanId: number, p: Partial<NetworkSegment>) =>
+    setNetworkSegments(segments.map((s) => (s.vlanId === vlanId ? { ...s, ...p } : s)))
+
+  const uebernehmen = () =>
+    setNetworkSegments(
+      [...segments, ...fehlend.map((vlanId) => ({ vlanId, name: '', purpose: 'unspecified' as const }))]
+        .sort((a, b) => a.vlanId - b.vlanId),
+    )
+
+  const entfernen = (vlanId: number) =>
+    setNetworkSegments(segments.filter((s) => s.vlanId !== vlanId))
+
+  const laden = (suffix: string, table: { headers: string[]; rows: unknown[][] }) =>
+    downloadBlob(
+      buildExportFilenameWithSuffix(projectName, suffix, 'csv'),
+      toCsv(table.headers, table.rows as never),
+      'text/csv;charset=utf-8',
+    )
+
+  const inputCls = 'rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-cp-xs'
+
+  return (
+    <div className="rounded border border-cp-border bg-cp-surface-2 p-2 text-cp-xs">
+      <div className="mb-1 flex flex-wrap items-center gap-2">
+        <span className="font-semibold text-cp-text-secondary">
+          {t('segment.title', 'Segmente (VLAN, Zweck, Zeit, Weg hinein)')}
+        </span>
+        {fehlend.length > 0 && (
+          <button
+            type="button"
+            onClick={uebernehmen}
+            className="inline-flex items-center gap-1 rounded border border-cp-border px-2 py-0.5 hover:bg-cp-surface-3"
+          >
+            <Icon icon={Plus} size="xs" />
+            {format(
+              t('segment.adopt', '{n} VLAN(s) aus dem Plan übernehmen'),
+              { n: fehlend.length },
+            )}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => laden('segmente', segmentTable(equipment, segments))}
+          className="ml-auto inline-flex items-center gap-1 rounded border border-cp-border px-2 py-0.5 hover:bg-cp-surface-3"
+        >
+          <Icon icon={Download} size="xs" />
+          {t('segment.export', 'Segmente')}
+        </button>
+        <button
+          type="button"
+          onClick={() => laden('segment-zugang', segmentReachTable(equipment, segments))}
+          className="inline-flex items-center gap-1 rounded border border-cp-border px-2 py-0.5 hover:bg-cp-surface-3"
+        >
+          <Icon icon={Download} size="xs" />
+          {t('segment.exportReach', 'Wer steht wo')}
+        </button>
+      </div>
+
+      <p className="mb-2 text-cp-text-muted">
+        {t(
+          'segment.hint',
+          'Eine VLAN-Nummer allein sagt niemandem, ob Dante dort hin darf. Der Zweck wird nicht geraten — er entscheidet, welche Schnittstelle hier falsch liegt.',
+        )}
+      </p>
+
+      {views.length === 0 ? (
+        <p className="text-cp-text-muted">
+          {t('segment.empty', 'Noch keine VLAN-Id an einer Schnittstelle vergeben.')}
+        </p>
+      ) : (
+        <table className="w-full border-collapse">
+          <thead>
+            <tr className="text-left text-cp-text-secondary">
+              <th className="px-1 py-1">{t('segment.col.vlan', 'VLAN')}</th>
+              <th className="px-1 py-1">{t('segment.col.name', 'Segment')}</th>
+              <th className="px-1 py-1">{t('segment.col.purpose', 'Zweck')}</th>
+              <th className="px-1 py-1">{t('segment.col.ptp', 'PTP-Domäne')}</th>
+              <th className="px-1 py-1">{t('segment.col.gateway', 'Weg hinein')}</th>
+              <th className="px-1 py-1">{t('segment.col.members', 'Schnittstellen')}</th>
+              <th className="px-1 py-1" />
+            </tr>
+          </thead>
+          <tbody>
+            {views.map((v) => (
+              <tr key={v.vlanId} className="border-t border-cp-border-muted">
+                <td className="px-1 py-1 font-mono">{v.vlanId}</td>
+                <td className="px-1 py-1">
+                  {v.segment ? (
+                    <input
+                      value={v.segment.name}
+                      onChange={(e) => patch(v.vlanId, { name: e.target.value })}
+                      placeholder={t('segment.namePh', 'Dante Prim')}
+                      className={`w-28 ${inputCls}`}
+                    />
+                  ) : (
+                    <span className="text-cp-warn">{t('segment.notKept', 'nicht hinterlegt')}</span>
+                  )}
+                </td>
+                <td className="px-1 py-1">
+                  {v.segment && (
+                    <select
+                      value={v.segment.purpose}
+                      onChange={(e) =>
+                        patch(v.vlanId, { purpose: e.target.value as NetworkInterfaceRole })
+                      }
+                      className={inputCls}
+                    >
+                      {NETWORK_INTERFACE_ROLES.map((r) => (
+                        <option key={r} value={r}>
+                          {t(`nic.role.${r}`, ROLE_TEXT[r])}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                </td>
+                <td className="px-1 py-1">
+                  {v.segment && (
+                    <input
+                      type="number"
+                      min={0}
+                      max={127}
+                      value={v.segment.ptpDomain ?? ''}
+                      onChange={(e) => {
+                        const roh = e.target.value.trim()
+                        const zahl = roh === '' ? undefined : Number(roh)
+                        patch(v.vlanId, {
+                          ptpDomain:
+                            zahl !== undefined && Number.isInteger(zahl) && zahl >= 0 && zahl <= 127
+                              ? zahl
+                              : undefined,
+                        })
+                      }}
+                      className={`w-16 ${inputCls} font-mono`}
+                    />
+                  )}
+                </td>
+                <td className="px-1 py-1">
+                  {v.segment && (
+                    <select
+                      value={v.segment.gatewayEquipmentId ?? ''}
+                      onChange={(e) =>
+                        patch(v.vlanId, { gatewayEquipmentId: e.target.value || undefined })
+                      }
+                      className={inputCls}
+                    >
+                      <option value="">{t('segment.noGateway', 'nur direkt am Segment')}</option>
+                      {equipment.map((e) => (
+                        <option key={e.id} value={e.id}>
+                          {e.name}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                </td>
+                <td className="px-1 py-1 font-mono">{v.members.length}</td>
+                <td className="px-1 py-1">
+                  {v.segment && (
+                    <button
+                      type="button"
+                      onClick={() => entfernen(v.vlanId)}
+                      title={t('segment.remove', 'Segment-Datensatz entfernen')}
+                      className="rounded border border-cp-border px-1 py-0.5 hover:bg-cp-surface-3"
+                    >
+                      <Icon icon={Trash2} size="xs" />
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {findings.length > 0 && (
+        <ul className="mt-2 flex max-h-40 flex-col gap-0.5 overflow-auto">
+          {findings.map((f, idx) => (
+            <li
+              key={`${f.kind}:${f.vlanId}:${idx}`}
+              className={`flex items-start gap-1 ${
+                f.severity === 'error' ? 'text-cp-danger' : 'text-cp-warn'
+              }`}
+            >
+              <Icon icon={AlertTriangle} size="xs" />
+              <span>{f.message}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/lib/dataDictionary.ts
+++ b/src/renderer/lib/dataDictionary.ts
@@ -51,6 +51,18 @@ export const UNDESCRIBED = 'nicht beschrieben'
  * Datei, ohne dass sich am Plan etwas geaendert haette.
  */
 export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
+  // Bedarf 116 — die Segmente (`lib/networkSegments.ts`).
+  Segment:
+    'Der Name des VLAN im Haus („Dante Prim“, „Steuerung“). „ohne Namen“ heißt: die Id ist in Gebrauch, aber niemand hat gesagt, wofür.',
+  Zweck:
+    'Wofür das Segment da ist — dieselbe Vokabel wie die Rolle an der Schnittstelle (Medien primär/sekundär, Steuerung, Management). „nicht angegeben“ ist kein Fehler, sondern eine offene Entscheidung.',
+  'PTP-Domäne (geplant)':
+    'Die Zeit, die in diesem Segment laufen SOLL — der Entwurf, nicht die Messung am Gerät. Weicht ein Gerät davon ab, ist das ein Befund.',
+  'Weg hinein':
+    'Das Gerät, das in dieses Segment routet (das Mgmt-Gateway). „nur direkt am Segment“ ist eine Auskunft und keine Lücke: nicht jedes Segment soll von außen erreichbar sein.',
+  Schnittstellen: 'Wie viele Netz-Schnittstellen aus dem Plan in diesem Segment liegen.',
+  'Gerät':
+    'Das Gerät, dem die Zeile gehört — mit seinem Namen aus dem Plan, nicht mit einer Kurzform.',
   // Bedarf 101 — die Vorschau auf eine Umbenennung (`lib/renameImpact.ts`).
   Zielsystem:
     'Das System, das den Namen speichert (ATEM, Videohub, TSL-UMD, Dante) — samt Feld, weil derselbe Name dort in mehreren Feldern mit verschiedenen Budgets landet.',

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3490,6 +3490,24 @@ export const en: Dict = {
   'channelList.view.stage': 'Stage (position)',
   'channelList.view.console': 'Console (names)',
   'channelList.view.monitor': 'Monitor paths',
+  // Bedarf 116 — die Segmente: welche VLAN wofuer da ist.
+  'segment.title': 'Segments (VLAN, purpose, timing, way in)',
+  'segment.hint':
+    'A VLAN number alone tells nobody whether Dante may go there. The purpose is not guessed \u2014 it decides which interface is in the wrong place.',
+  'segment.adopt': 'Adopt {n} VLAN(s) from the plan',
+  'segment.export': 'Segments',
+  'segment.exportReach': 'Who sits where',
+  'segment.empty': 'No VLAN id assigned to an interface yet.',
+  'segment.notKept': 'not recorded',
+  'segment.namePh': 'Dante Prim',
+  'segment.noGateway': 'reachable only from inside',
+  'segment.remove': 'Remove segment record',
+  'segment.col.vlan': 'VLAN',
+  'segment.col.name': 'Segment',
+  'segment.col.purpose': 'Purpose',
+  'segment.col.ptp': 'PTP domain',
+  'segment.col.gateway': 'Way in',
+  'segment.col.members': 'Interfaces',
   // Bedarf 105 — das Tally je Position: Weg, Lampe, und was zu sehen war.
   'tallyPos.title': 'Pre-show check: path, lamp, and what was seen',
   'tallyPos.hint':

--- a/src/renderer/lib/networkSegments.ts
+++ b/src/renderer/lib/networkSegments.ts
@@ -1,0 +1,365 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Segmente: welche VLAN wofür da ist, und wer darin nichts zu suchen hat
+// (Bedarf 116, P3).
+//
+//   > A systems tech must reach VuNET, the mixer app, Dante Controller, Lake
+//   > Controller and Shure WWB ON SEPARATE VLANs FROM ONE MACHINE, while
+//   > keeping amp control off Dante PTP and stopping Waves SoundGrid
+//   > attaching to the wrong segment.
+//
+// Belegt an `misnow1/vunet-dante-combiner-2000` (2026-08-13, sieben offene
+// Punkte): ein tragbares Mgmt-VLAN-Gateway, gebaut, damit EIN Steuer-Rechner
+// alle fünf Anwendungen erreicht — ohne zweite Netzkarte, mit dokumentiertem
+// „break-glass"-Rückfall.
+//
+// ─── DIE FRAGE, DIE DER PLAN BEANTWORTEN KANN ──────────────────────────────
+//
+// Nicht: „läuft das Netz?" Der Plan misst nichts. Sondern: STEHT DER ENTWURF
+// DA, BEVOR DER LAPTOP VOR ORT IST — welche Segmente gibt es, wofür sind sie,
+// welche Zeit läuft darin, und kommt man hinein. Genau das ist die Massnahme
+// aus der Bedarfs-Datenbank: „so the network design is documented before the
+// laptop is on site."
+//
+// ─── DIE VIER BEFUNDE, UND WOHER SIE KOMMEN ────────────────────────────────
+//
+//   1. `unnamed-segment`   — eine VLAN-Id ist in Gebrauch, aber niemand hat
+//      gesagt, wofür. „VLAN 30" ist keine Auskunft.
+//   2. `mixed-segment`     — Medien UND Steuerung im selben Segment. Das ist
+//      der Satz „on separate VLANs" aus dem Beleg, verneint.
+//   3. `role-mismatch`     — die Rolle der Schnittstelle passt nicht zum Zweck
+//      des Segments. Das sind die beiden übrigen Sätze: „amp control off
+//      Dante PTP" und „SoundGrid attaching to the wrong segment".
+//   4. `ptp-mismatch`      — das Segment plant Domäne X, ein Gerät darin sagt
+//      Y. `ptpPlan.ts` kann das NICHT sehen: es kennt Domänen und Profile,
+//      aber keine Segmente. Der Widerspruch zwischen Entwurf und Gerät
+//      entsteht erst hier.
+//
+// Ein leeres Segment ist KEIN Befund: die Planung fängt oft mit den Segmenten
+// an und füllt die Geräte später. Ein Befund darauf meckerte bei jedem
+// halbfertigen Plan, und ein Check, der immer meckert, wird weggeklickt.
+// Gemeldet wird nur der Datensatz, dessen VLAN NIEMAND benutzt und der auch
+// keinen Namen trägt — der ist ein Rest, kein Entwurf.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { EquipmentItem } from '../types/equipment'
+import type { NetworkInterface, NetworkInterfaceRole } from '../types/network'
+import {
+  NO_GATEWAY,
+  NO_PTP_IN_SEGMENT,
+  NO_SEGMENT_NAME,
+  type NetworkSegment,
+} from '../types/networkSegment'
+import { allDeviceInterfaces, interfaceLabel } from './networkInterfaces'
+import type { CsvTable } from './csv'
+
+/**
+ * Rollen-Namen in kanonischem Deutsch.
+ *
+ * Kanonisch und nicht übersetzt, weil sie in EXPORTIERTE Tabellen gehen:
+ * ein Blatt, dessen Inhalt sich mit dem Sprachschalter ändert, meldet jedes
+ * gedruckte Exemplar als veraltet (dieselbe Regel wie bei `deliveryIssueText`).
+ */
+export const ROLE_TEXT: Readonly<Record<NetworkInterfaceRole, string>> = {
+  'media-primary': 'Medien primär',
+  'media-secondary': 'Medien sekundär',
+  control: 'Steuerung',
+  management: 'Management',
+  unspecified: 'nicht angegeben',
+}
+
+const isMedia = (r: NetworkInterfaceRole): boolean =>
+  r === 'media-primary' || r === 'media-secondary'
+
+/**
+ * Passt eine Rolle in ein Segment dieses Zwecks?
+ *
+ * Grosszügig, wo der Plan nichts weiss, und streng nur dort, wo der Beleg
+ * einen Schaden nennt:
+ *
+ *   * `unspecified` auf einer der beiden Seiten passt IMMER. Wer nichts
+ *     gesagt hat, hat nichts Falsches gesagt.
+ *   * Medien primär und sekundär dürfen sich NICHT mischen — ein
+ *     2022-7-Aufbau, dessen beide Beine im selben VLAN liegen, ist kein
+ *     redundanter Aufbau mehr, sondern ein doppelter.
+ *   * `management` in einem Steuer-Segment ist erlaubt: das Mgmt-VLAN aus
+ *     dem Beleg IST der Weg, über den die Steuerung hineinkommt.
+ */
+export function roleFitsPurpose(
+  role: NetworkInterfaceRole,
+  purpose: NetworkInterfaceRole,
+): boolean {
+  if (role === 'unspecified' || purpose === 'unspecified') return true
+  if (role === purpose) return true
+  if (isMedia(role) && isMedia(purpose)) return false
+  if (role === 'management' && purpose === 'control') return true
+  if (role === 'control' && purpose === 'management') return true
+  return false
+}
+
+export interface SegmentMember {
+  equipmentId: string
+  /** „Kamera 1 · Dante Sec" — die vorhandene Vokabel, nicht eine zweite. */
+  where: string
+  role: NetworkInterfaceRole
+  ptpDomain?: number
+}
+
+export interface SegmentView {
+  vlanId: number
+  /** Der hinterlegte Datensatz. Fehlt er, ist das Segment unbenannt. */
+  segment?: NetworkSegment
+  members: SegmentMember[]
+}
+
+/** Welche VLAN-Ids im Plan wirklich vorkommen, aufsteigend. */
+export function vlansInUse(equipment: readonly EquipmentItem[]): number[] {
+  const s = new Set<number>()
+  for (const { nic } of allDeviceInterfaces([...equipment])) {
+    if (typeof nic.vlanId === 'number' && Number.isFinite(nic.vlanId)) s.add(nic.vlanId)
+  }
+  return [...s].sort((a, b) => a - b)
+}
+
+/**
+ * Segmente mit ihren Mitgliedern.
+ *
+ * Führt die Vereinigung aus BEIDEN Richtungen: jede benutzte VLAN-Id und
+ * jeden hinterlegten Datensatz. Nur die eine Richtung zu nehmen verlöre
+ * entweder den Entwurf, den noch niemand bestückt hat, oder das VLAN, in dem
+ * jemand ohne Entwurf ein Gerät angemeldet hat — und das zweite ist genau der
+ * Zustand, den der Beleg beschreibt.
+ */
+export function segmentViews(
+  equipment: readonly EquipmentItem[],
+  segments: readonly NetworkSegment[],
+): SegmentView[] {
+  const byVlan = new Map<number, SegmentView>()
+  const nimm = (vlanId: number): SegmentView => {
+    let v = byVlan.get(vlanId)
+    if (!v) {
+      v = { vlanId, members: [] }
+      byVlan.set(vlanId, v)
+    }
+    return v
+  }
+  for (const s of segments) nimm(s.vlanId).segment = s
+  for (const { equipment: e, nic } of allDeviceInterfaces([...equipment])) {
+    if (typeof nic.vlanId !== 'number' || !Number.isFinite(nic.vlanId)) continue
+    const eintrag: SegmentMember = {
+      equipmentId: e.id,
+      where: interfaceLabel(e, nic as NetworkInterface),
+      role: nic.role,
+    }
+    if (typeof nic.ptpDomain === 'number') eintrag.ptpDomain = nic.ptpDomain
+    nimm(nic.vlanId).members.push(eintrag)
+  }
+  return [...byVlan.values()].sort((a, b) => a.vlanId - b.vlanId)
+}
+
+export type SegmentFindingKind =
+  | 'unnamed-segment'
+  | 'mixed-segment'
+  | 'role-mismatch'
+  | 'ptp-mismatch'
+  | 'orphan-segment'
+
+export interface SegmentFinding {
+  kind: SegmentFindingKind
+  severity: 'error' | 'warning'
+  /** VLAN-Id als Klick-/Sortierschlüssel. */
+  vlanId: number
+  message: string
+}
+
+const segmentName = (v: SegmentView): string =>
+  v.segment?.name?.trim() || `VLAN ${v.vlanId}`
+
+export function segmentFindings(
+  equipment: readonly EquipmentItem[],
+  segments: readonly NetworkSegment[],
+): SegmentFinding[] {
+  const views = segmentViews(equipment, segments)
+  const out: SegmentFinding[] = []
+
+  for (const v of views) {
+    const name = segmentName(v)
+
+    if (!v.segment || !v.segment.name?.trim()) {
+      if (v.members.length > 0) {
+        out.push({
+          kind: 'unnamed-segment',
+          severity: 'warning',
+          vlanId: v.vlanId,
+          message:
+            `VLAN ${v.vlanId} trägt ${v.members.length} Schnittstelle(n), aber keinen Namen — ` +
+            'eine Zahl allein sagt niemandem, ob Dante dort hin darf.',
+        })
+      } else if (v.segment) {
+        // Ein Datensatz ohne Namen UND ohne Mitglieder ist ein Rest.
+        out.push({
+          kind: 'orphan-segment',
+          severity: 'warning',
+          vlanId: v.vlanId,
+          message: `VLAN ${v.vlanId} ist hinterlegt, aber weder benannt noch benutzt.`,
+        })
+      }
+    }
+
+    // „on separate VLANs": Medien und Steuerung im selben Segment.
+    const hatMedien = v.members.some((m) => isMedia(m.role))
+    const hatSteuerung = v.members.some((m) => m.role === 'control')
+    if (hatMedien && hatSteuerung) {
+      out.push({
+        kind: 'mixed-segment',
+        severity: 'error',
+        vlanId: v.vlanId,
+        message:
+          `${name} führt Medien UND Steuerung. Der Beleg verlangt getrennte Segmente: ` +
+          'Steuerverkehr im Medien-VLAN sitzt auf demselben PTP wie die Audio-Uhr.',
+      })
+    }
+
+    // „attaching to the wrong segment": Rolle gegen Zweck.
+    const zweck = v.segment?.purpose ?? 'unspecified'
+    for (const m of v.members) {
+      if (roleFitsPurpose(m.role, zweck)) continue
+      out.push({
+        kind: 'role-mismatch',
+        severity: 'error',
+        vlanId: v.vlanId,
+        message:
+          `${m.where} ist "${ROLE_TEXT[m.role]}", liegt aber in ${name} ` +
+          `("${ROLE_TEXT[zweck]}").`,
+      })
+    }
+
+    // Entwurf gegen Gerät — das, was `ptpPlan.ts` nicht sehen kann.
+    const geplant = v.segment?.ptpDomain
+    if (typeof geplant === 'number') {
+      for (const m of v.members) {
+        if (m.ptpDomain === undefined || m.ptpDomain === geplant) continue
+        out.push({
+          kind: 'ptp-mismatch',
+          severity: 'error',
+          vlanId: v.vlanId,
+          message:
+            `${name} ist auf PTP-Domäne ${geplant} geplant, ${m.where} steht auf ` +
+            `${m.ptpDomain}.`,
+        })
+      }
+    }
+  }
+  return out
+}
+
+export const SEGMENT_HEADERS = [
+  'VLAN',
+  'Segment',
+  'Zweck',
+  'PTP-Domäne (geplant)',
+  'Weg hinein',
+  'Schnittstellen',
+] as const
+
+/** Der Entwurf als Blatt — das Dokument, das der Bedarf verlangt. */
+export function segmentTable(
+  equipment: readonly EquipmentItem[],
+  segments: readonly NetworkSegment[],
+): CsvTable {
+  const namen = new Map(equipment.map((e) => [e.id, e.name]))
+  return {
+    headers: [...SEGMENT_HEADERS],
+    rows: segmentViews(equipment, segments).map((v) => [
+      v.vlanId,
+      v.segment?.name?.trim() || NO_SEGMENT_NAME,
+      ROLE_TEXT[v.segment?.purpose ?? 'unspecified'],
+      v.segment?.ptpDomain ?? NO_PTP_IN_SEGMENT,
+      v.segment?.gatewayEquipmentId
+        ? (namen.get(v.segment.gatewayEquipmentId) ?? NO_GATEWAY)
+        : NO_GATEWAY,
+      v.members.length,
+    ]),
+  }
+}
+
+export const REACH_HEADERS = ['Gerät', 'Segment', 'VLAN', 'Rolle', 'Schnittstelle'] as const
+
+/**
+ * Welches Gerät in welchen Segmenten steht.
+ *
+ * Die Antwort auf „from one machine": ein Steuer-Rechner, der fünf
+ * Anwendungen erreichen soll, steht hier mit fünf Zeilen — oder eben mit
+ * einer, und dann weiss man es VOR dem Aufbau statt währenddessen.
+ *
+ * Der Plan behauptet dabei NICHT, dass die Verbindung steht. Er sagt, was
+ * geplant ist; ob das Paket ankommt, entscheidet der Switch.
+ */
+export function segmentReachTable(
+  equipment: readonly EquipmentItem[],
+  segments: readonly NetworkSegment[],
+): CsvTable {
+  const nameOf = new Map(segments.map((s) => [s.vlanId, s.name?.trim() || NO_SEGMENT_NAME]))
+  const rows: CsvTable['rows'] = []
+  for (const { equipment: e, nic } of allDeviceInterfaces([...equipment])) {
+    if (typeof nic.vlanId !== 'number' || !Number.isFinite(nic.vlanId)) continue
+    rows.push([
+      e.name,
+      nameOf.get(nic.vlanId) ?? NO_SEGMENT_NAME,
+      nic.vlanId,
+      ROLE_TEXT[nic.role],
+      nic.label?.trim() || 'ohne Beschriftung',
+    ])
+  }
+  rows.sort(
+    (a, b) => String(a[0]).localeCompare(String(b[0])) || Number(a[2]) - Number(b[2]),
+  )
+  return { headers: [...REACH_HEADERS], rows }
+}
+
+/** Normalisiert geladene Segmente — die Schema-Migrationsschicht. */
+export function normaliseNetworkSegments(raw: unknown): NetworkSegment[] {
+  if (!Array.isArray(raw)) return []
+  const rollen: readonly NetworkInterfaceRole[] = [
+    'media-primary',
+    'media-secondary',
+    'control',
+    'management',
+    'unspecified',
+  ]
+  const out: NetworkSegment[] = []
+  const gesehen = new Set<number>()
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue
+    const r = entry as Record<string, unknown>
+    const vlanId = typeof r.vlanId === 'number' ? r.vlanId : NaN
+    // 1..4094 ist der nutzbare Bereich; 0 und 4095 sind reserviert. Ein
+    // Datensatz ausserhalb zeigt auf kein VLAN, das jemand einrichten kann.
+    //
+    // GANZZAHLIG, und nicht abgeschnitten: `1.5` auf `1` zu runden erfaende
+    // eine Antwort auf eine kaputte Eingabe. Eine gebrochene VLAN-Id heisst,
+    // dass die Quelle falsch war — und dann ist der Datensatz weg besser als
+    // im falschen Segment.
+    if (!Number.isInteger(vlanId) || vlanId < 1 || vlanId > 4094) continue
+    if (gesehen.has(vlanId)) continue
+    gesehen.add(vlanId)
+    const seg: NetworkSegment = {
+      vlanId,
+      name: typeof r.name === 'string' ? r.name.trim() : '',
+      purpose: rollen.includes(r.purpose as NetworkInterfaceRole)
+        ? (r.purpose as NetworkInterfaceRole)
+        : 'unspecified',
+    }
+    if (typeof r.ptpDomain === 'number' && Number.isInteger(r.ptpDomain) &&
+        r.ptpDomain >= 0 && r.ptpDomain <= 127) {
+      seg.ptpDomain = r.ptpDomain
+    }
+    if (typeof r.gatewayEquipmentId === 'string' && r.gatewayEquipmentId.trim()) {
+      seg.gatewayEquipmentId = r.gatewayEquipmentId.trim()
+    }
+    if (typeof r.note === 'string' && r.note.trim()) seg.note = r.note.trim()
+    out.push(seg)
+  }
+  return out.sort((a, b) => a.vlanId - b.vlanId)
+}

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -79,6 +79,7 @@ import { normaliseCostPlan } from '../lib/costComparison'
 import { normaliseNamingScheme } from '../lib/namingScheme'
 import { normaliseMicPlot } from '../lib/micAssignment'
 import { normaliseTallyPositions } from '../lib/tallyPosition'
+import { normaliseNetworkSegments } from '../lib/networkSegments'
 import { normaliseVenueAnswers } from '../lib/venueAnswers'
 import { isNetworkInterfaceRole, normaliseNetworkInterface } from '../lib/networkInterfaces'
 import type { NetworkInterface } from '../types/network'
@@ -515,6 +516,11 @@ export interface ProjectState {
    * ausgefuehrt wurde, statt still nichts zu tun: fuer den Bedienenden ist
    * ein wortloses Nichts von einem kaputten Programm nicht zu unterscheiden.
    */
+  /** Bedarf 116 — die Segmente setzen. Ein Setter fuer die ganze Liste:
+   *  die Befunde lesen alle Segmente gegeneinander. */
+  setNetworkSegments: (
+    segments: import('../types/networkSegment').NetworkSegment[],
+  ) => void
   /** Bedarf 105 — Tally-Weg/Lampe einer Position setzen (Upsert). Liefert
    *  `'unknown-role'`, wenn es die Rolle nicht gibt. */
   setTallyPosition: (
@@ -666,6 +672,16 @@ const healProjectPositions = (
   // bei `clearDanglingIdentity` eine Zeile weiter unten.
   const tallyPositions = normaliseTallyPositions(project.tallyPositions).filter((p) =>
     identityIds.has(p.identityId),
+  )
+  // Bedarf 116 — die Segmente. Der Gateway-Zeiger wird gegen die Geraete
+  // gehalten: ein Zeiger ins Leere saehe auf dem Blatt aus wie ein Weg in das
+  // Segment hinein, und genau danach sucht jemand vor Ort. Das SEGMENT selbst
+  // ueberlebt — es ist der Entwurf, und der gilt auch ohne Gateway.
+  const geraeteIds = new Set(project.equipment.map((e) => e.id))
+  const networkSegments = normaliseNetworkSegments(project.networkSegments).map((s) =>
+    s.gatewayEquipmentId && !geraeteIds.has(s.gatewayEquipmentId)
+      ? (({ gatewayEquipmentId: _weg, ...rest }) => rest)(s)
+      : s,
   )
   // Initiative 9 — Ausspielziele. Dieselbe Bauform wie die Rollen darueber:
   // normalisieren, Verworfenes melden, Backup-Zeiger ins Leere entfernen.
@@ -873,6 +889,8 @@ const healProjectPositions = (
     // hinterlegt" und „Liste leer" sind hier dasselbe, und ein `undefined`
     // zwaenge jeden Leser zu einer zweiten Fallunterscheidung.
     tallyPositions,
+    // Bedarf 116 — dito.
+    networkSegments,
     deliveryDestinations,
     // Bedarf 72 — `undefined` heisst „kein Adressplan", nicht „leerer".
     multicast,

--- a/src/renderer/store/slices/metaSlice.ts
+++ b/src/renderer/store/slices/metaSlice.ts
@@ -41,6 +41,7 @@ export type MetaSlice = Pick<
   | 'setMicPlot'
   | 'setTallyPosition'
   | 'recordTallyCheck'
+  | 'setNetworkSegments'
   | 'applyNaming'
 >
 
@@ -127,6 +128,20 @@ export const createMetaSlice: StateCreator<ProjectState, [], [], MetaSlice> = (s
   setMicPlot: (plot) =>
     set((state) => {
       const updated = { ...state.project, micPlot: plot }
+      scheduleProjectAutosave(updated)
+      return { project: updated }
+    }),
+  // BEDARF 116 — die Segmente.
+  //
+  // EIN Setter fuer die ganze Liste und keiner je Segment: die Befunde
+  // ("Medien und Steuerung im selben Segment", "Rolle passt nicht zum Zweck")
+  // lesen ALLE Segmente gegeneinander. Ein Einzel-Setter verfuehrte dazu, in
+  // einer Schleife zu schreiben, und jede Zwischenstufe waere ein Zustand, in
+  // dem die Pruefung die eigenen frisch gesetzten Zwecke noch nicht kennt --
+  // dieselbe Begruendung wie bei `setMulticastConfig` und `setMicPlot`.
+  setNetworkSegments: (segments) =>
+    set((state) => {
+      const updated = { ...state.project, networkSegments: segments }
       scheduleProjectAutosave(updated)
       return { project: updated }
     }),

--- a/src/renderer/types/networkSegment.ts
+++ b/src/renderer/types/networkSegment.ts
@@ -1,0 +1,81 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Das Segment als Gegenstand des Plans (Bedarf 116, P3).
+//
+//   > A systems tech must reach VuNET, the mixer app, Dante Controller, Lake
+//   > Controller and Shure WWB ON SEPARATE VLANs FROM ONE MACHINE, while
+//   > keeping amp control off Dante PTP and stopping Waves SoundGrid
+//   > attaching to the wrong segment.
+//
+// Belegt an `misnow1/vunet-dante-combiner-2000` (angelegt 2026-08-13, sieben
+// offene Punkte): ein tragbares Linux-Gateway im Mgmt-VLAN, gebaut, damit EIN
+// Steuer-Rechner alle fünf Anwendungen erreicht — ohne zweite Netzkarte, mit
+// einem dokumentierten „break-glass"-Rückfall.
+//
+// ─── WAS ES SCHON GAB, UND WAS FEHLTE ──────────────────────────────────────
+//
+// Die VLAN-ID steht seit Bedarf 19/24 an jeder Schnittstelle, die Rolle
+// (`media-primary`, `control`, `management` …) auch, und die PTP-Domäne seit
+// Bedarf 73. Was fehlte, ist das SEGMENT als Gegenstand: eine Zahl ohne Namen
+// ist keine Auskunft. „VLAN 30" beantwortet nicht, ob Dante dort hin darf.
+//
+// Erst mit einem benannten Segment lassen sich die drei Sätze aus dem Beleg
+// überhaupt prüfen:
+//
+//   * „on separate VLANs" — liegen Medien und Steuerung getrennt, oder teilen
+//     sie ein Segment?
+//   * „keeping amp control off Dante PTP" — steht eine Steuer-Schnittstelle
+//     in einem Segment, dessen Zweck Medien ist?
+//   * „stopping SoundGrid attaching to the wrong segment" — passt die Rolle
+//     der Schnittstelle zum Zweck des Segments, in dem sie liegt?
+//
+// ─── EINE VOKABEL, NICHT ZWEI ──────────────────────────────────────────────
+//
+// Der Zweck eines Segments ist eine `NetworkInterfaceRole` und KEIN eigener
+// Aufzählungstyp. Ein zweiter Satz Wörter für dieselbe Sache („media" hier,
+// „media-primary" dort) wäre genau die Krankheit, die das Spaltenlexikon
+// (Bedarf 81) bei Spaltennamen abgestellt hat: dann dürfte „control" im
+// Segment etwas anderes heissen als an der Schnittstelle, und niemand hätte
+// einen Ort, an dem der Widerspruch auffiele.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { NetworkInterfaceRole } from './network'
+
+export interface NetworkSegment {
+  /** VLAN-Id. Der Schlüssel — ein Segment IST eine VLAN-Id mit Bedeutung. */
+  vlanId: number
+  /** Wie es im Haus heisst („Dante Prim", „Steuerung", „Mgmt"). */
+  name: string
+  /**
+   * Wofür es da ist — dieselbe Vokabel wie an der Schnittstelle.
+   *
+   * `unspecified` heisst „noch nicht entschieden" und ist kein Fehler: ein
+   * Segment, das der Veranstalter stellt und über das niemand Auskunft gibt,
+   * ist genau das. Es zu raten wäre teurer als die Lücke.
+   */
+  purpose: NetworkInterfaceRole
+  /**
+   * Die PTP-Domäne, die in diesem Segment gefahren wird — als ENTWURF des
+   * Segments, nicht als Messung am Gerät.
+   *
+   * Sie steht hier NEBEN `NetworkInterface.ptpDomain` und ersetzt sie nicht:
+   * die eine ist der Plan für das Segment, die andere die Angabe am Gerät.
+   * Genau die Differenz zwischen beiden ist der Befund, den `segmentFindings`
+   * meldet — und den `ptpPlan.ts` nicht sehen kann, weil es die Segmente
+   * nicht kennt.
+   */
+  ptpDomain?: number
+  /**
+   * Wie man von aussen hineinkommt: das Gerät, das in dieses Segment routet
+   * (der „Mgmt-VLAN gateway" aus dem Beleg), als Geräte-Id im selben Plan.
+   *
+   * Fehlt es, sagt das Blatt „nur direkt am Segment" — und das ist eine
+   * Auskunft und keine Lücke: nicht jedes Segment SOLL erreichbar sein.
+   */
+  gatewayEquipmentId?: string
+  note?: string
+}
+
+/** Was auf dem Blatt steht, wo nichts festgehalten wurde. */
+export const NO_SEGMENT_NAME = 'ohne Namen'
+export const NO_GATEWAY = 'nur direkt am Segment'
+export const NO_PTP_IN_SEGMENT = 'keine Zeit geplant'

--- a/src/renderer/types/project.ts
+++ b/src/renderer/types/project.ts
@@ -259,6 +259,13 @@ export interface CablePlannerProject {
    *  Rolle wird beim Laden verworfen: er zeigte ins Leere und saehe auf dem
    *  Blatt aus wie eine gepruefte Position. */
   tallyPositions?: import('./tallyPosition').TallyPosition[]
+  /** Bedarf 116 — die Segmente: welche VLAN wofuer da ist, welche Zeit darin
+   *  laeuft und wie man hineinkommt. Die VLAN-Id steht seit Bedarf 19/24 an
+   *  jeder Schnittstelle; hier bekommt sie eine Bedeutung. Optional -> alte
+   *  Projekte heilen zu []. Ein Segment mit einem Gateway-Zeiger ins Leere
+   *  verliert den Zeiger beim Laden: er saehe auf dem Blatt aus wie ein Weg
+   *  hinein. */
+  networkSegments?: import('./networkSegment').NetworkSegment[]
   /** Initiative 9 — die Ausspielung: wohin gesendet wird, mit welchen
    *  Parametern, und welcher Weg der Ausweichweg ist. Optional → alte
    *  Projekte heilen zu []. **Ohne Stream-Keys** — die liegen im

--- a/tests/networkSegments.test.ts
+++ b/tests/networkSegments.test.ts
@@ -1,0 +1,431 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  REACH_HEADERS,
+  ROLE_TEXT,
+  SEGMENT_HEADERS,
+  normaliseNetworkSegments,
+  roleFitsPurpose,
+  segmentFindings,
+  segmentReachTable,
+  segmentTable,
+  segmentViews,
+  vlansInUse,
+} from '../src/renderer/lib/networkSegments'
+import {
+  NO_GATEWAY,
+  NO_PTP_IN_SEGMENT,
+  NO_SEGMENT_NAME,
+  type NetworkSegment,
+} from '../src/renderer/types/networkSegment'
+import { useProjectStore } from '../src/renderer/store/projectStore'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+import type { NetworkInterface, NetworkInterfaceRole } from '../src/renderer/types/network'
+import libQuelle from '../src/renderer/lib/networkSegments.ts?raw'
+import typenQuelle from '../src/renderer/types/networkSegment.ts?raw'
+import panelQuelle from '../src/renderer/components/Network/SegmentsPanel.tsx?raw'
+import dialogQuelle from '../src/renderer/components/Analysis/AnalysisDialog.tsx?raw'
+import storeQuelle from '../src/renderer/store/projectStore.ts?raw'
+
+// ---------------------------------------------------------------------------
+// Segmente: welche VLAN wofuer da ist (Bedarf 116, P3).
+//
+//   > A systems tech must reach VuNET, the mixer app, Dante Controller, Lake
+//   > Controller and Shure WWB ON SEPARATE VLANs FROM ONE MACHINE, while
+//   > keeping amp control off Dante PTP and stopping Waves SoundGrid
+//   > attaching to the wrong segment.
+//
+// Belegt an `misnow1/vunet-dante-combiner-2000` (2026-08-13, sieben offene
+// Punkte): ein tragbares Mgmt-VLAN-Gateway, gebaut, damit EIN Steuer-Rechner
+// alle fuenf Anwendungen erreicht — ohne zweite Netzkarte.
+//
+// Die Massnahme der Bedarfs-Datenbank ist woertlich: „model VLANs, PTP domain
+// and control-vs-media segregation as part of the plan, SO THE NETWORK DESIGN
+// IS DOCUMENTED BEFORE THE LAPTOP IS ON SITE."
+// ---------------------------------------------------------------------------
+
+const nic = (over: Partial<NetworkInterface> & { id: string }): NetworkInterface => ({
+  role: 'unspecified',
+  ...over,
+})
+
+const eq = (id: string, name: string, nics: NetworkInterface[]): EquipmentItem =>
+  ({
+    id,
+    name,
+    category: 'Netzwerk',
+    inputs: [],
+    outputs: [],
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 160,
+    networkInterfaces: nics,
+  }) as unknown as EquipmentItem
+
+const seg = (over: Partial<NetworkSegment> & { vlanId: number }): NetworkSegment => ({
+  name: 'Segment',
+  purpose: 'unspecified',
+  ...over,
+})
+
+// ── 1. Rolle gegen Zweck ───────────────────────────────────────────────────
+
+describe('roleFitsPurpose — „attaching to the wrong segment"', () => {
+  it('laesst durch, wo niemand etwas gesagt hat', () => {
+    // Wer nichts gesagt hat, hat nichts Falsches gesagt. Sonst meldete jeder
+    // halbfertige Plan einen Fehler, und ein Check, der immer meckert, wird
+    // weggeklickt statt gelesen.
+    expect(roleFitsPurpose('unspecified', 'media-primary')).toBe(true)
+    expect(roleFitsPurpose('control', 'unspecified')).toBe(true)
+  })
+
+  it('laesst die gleiche Rolle durch', () => {
+    for (const r of ['media-primary', 'control', 'management'] as NetworkInterfaceRole[]) {
+      expect(roleFitsPurpose(r, r)).toBe(true)
+    }
+  })
+
+  it('trennt Medien von Steuerung — der Satz aus dem Beleg', () => {
+    expect(roleFitsPurpose('control', 'media-primary')).toBe(false)
+    expect(roleFitsPurpose('media-primary', 'control')).toBe(false)
+  })
+
+  it('trennt die beiden Medien-Beine voneinander', () => {
+    // Ein 2022-7-Aufbau, dessen beide Beine im selben VLAN liegen, ist kein
+    // redundanter Aufbau mehr, sondern ein doppelter.
+    expect(roleFitsPurpose('media-primary', 'media-secondary')).toBe(false)
+    expect(roleFitsPurpose('media-secondary', 'media-primary')).toBe(false)
+  })
+
+  it('laesst Management und Steuerung zusammen — das Mgmt-VLAN IST der Weg', () => {
+    expect(roleFitsPurpose('management', 'control')).toBe(true)
+    expect(roleFitsPurpose('control', 'management')).toBe(true)
+  })
+
+  it('haelt Management aus dem Medien-Segment heraus', () => {
+    expect(roleFitsPurpose('management', 'media-primary')).toBe(false)
+  })
+})
+
+// ── 2. Die Sicht ───────────────────────────────────────────────────────────
+
+describe('segmentViews', () => {
+  const welt = [
+    eq('sw', 'Switch', [nic({ id: 'sw#nic1', role: 'management', vlanId: 99 })]),
+    eq('cam', 'Kamera 1', [nic({ id: 'cam#nic1', role: 'media-primary', vlanId: 10 })]),
+  ]
+
+  it('nennt die benutzten VLANs aufsteigend', () => {
+    expect(vlansInUse(welt)).toEqual([10, 99])
+  })
+
+  it('vereinigt benutzte Ids UND hinterlegte Datensaetze', () => {
+    // Nur die eine Richtung zu nehmen verloere entweder den Entwurf, den noch
+    // niemand bestueckt hat, oder das VLAN, in dem jemand ohne Entwurf ein
+    // Geraet angemeldet hat — und das zweite ist genau der Zustand aus dem
+    // Beleg.
+    const v = segmentViews(welt, [seg({ vlanId: 20, name: 'Steuerung' })])
+    expect(v.map((x) => x.vlanId)).toEqual([10, 20, 99])
+    expect(v.find((x) => x.vlanId === 20)?.members).toEqual([])
+    expect(v.find((x) => x.vlanId === 10)?.segment).toBeUndefined()
+  })
+
+  it('nennt das Mitglied mit der vorhandenen Vokabel', () => {
+    const welt2 = [
+      eq('cam', 'Kamera 1', [
+        nic({ id: 'cam#nic1', role: 'media-primary', vlanId: 10, label: 'Dante Prim' }),
+      ]),
+    ]
+    expect(segmentViews(welt2, [])[0].members[0].where).toBe('Kamera 1 · Dante Prim')
+  })
+
+  it('ignoriert Schnittstellen ohne VLAN', () => {
+    const ohne = [eq('x', 'X', [nic({ id: 'x#nic1', role: 'control', ipAddress: '10.0.0.1' })])]
+    expect(segmentViews(ohne, [])).toEqual([])
+  })
+})
+
+// ── 3. Die Befunde ─────────────────────────────────────────────────────────
+
+describe('segmentFindings', () => {
+  it('meldet die benutzte VLAN ohne Namen', () => {
+    // „VLAN 30" beantwortet nicht, ob Dante dort hin darf.
+    const welt = [eq('cam', 'Kamera 1', [nic({ id: 'cam#nic1', role: 'media-primary', vlanId: 30 })])]
+    const f = segmentFindings(welt, [])
+    expect(f.find((x) => x.kind === 'unnamed-segment')?.vlanId).toBe(30)
+  })
+
+  it('meldet KEIN leeres Segment als Fehler', () => {
+    // Die Planung faengt oft mit den Segmenten an und fuellt die Geraete
+    // spaeter.
+    const f = segmentFindings([], [seg({ vlanId: 10, name: 'Dante Prim', purpose: 'media-primary' })])
+    expect(f).toEqual([])
+  })
+
+  it('meldet den namenlosen UND unbenutzten Datensatz als Rest', () => {
+    const f = segmentFindings([], [seg({ vlanId: 10, name: '  ' })])
+    expect(f.map((x) => x.kind)).toEqual(['orphan-segment'])
+  })
+
+  it('meldet Medien UND Steuerung im selben Segment als FEHLER', () => {
+    // Der Satz „on separate VLANs" aus dem Beleg, verneint.
+    const welt = [
+      eq('cam', 'Kamera 1', [nic({ id: 'cam#nic1', role: 'media-primary', vlanId: 10 })]),
+      eq('pc', 'Regie-PC', [nic({ id: 'pc#nic1', role: 'control', vlanId: 10 })]),
+    ]
+    const f = segmentFindings(welt, [seg({ vlanId: 10, name: 'Dante Prim' })])
+    const gemischt = f.find((x) => x.kind === 'mixed-segment')
+    expect(gemischt?.severity).toBe('error')
+    expect(gemischt?.message).toContain('PTP')
+  })
+
+  it('meldet die Schnittstelle im falschen Segment und NENNT beide Seiten', () => {
+    // „Tally kaputt" schickt niemanden zum richtigen Geraet — hier gilt
+    // dasselbe: der Befund muss sagen, was wo liegt.
+    const welt = [eq('amp', 'Endstufe', [nic({ id: 'amp#nic1', role: 'control', vlanId: 10 })])]
+    const f = segmentFindings(welt, [
+      seg({ vlanId: 10, name: 'Dante Prim', purpose: 'media-primary' }),
+    ])
+    const treffer = f.find((x) => x.kind === 'role-mismatch')
+    expect(treffer?.severity).toBe('error')
+    expect(treffer?.message).toContain('Endstufe')
+    expect(treffer?.message).toContain(ROLE_TEXT.control)
+    expect(treffer?.message).toContain(ROLE_TEXT['media-primary'])
+  })
+
+  it('meldet den Widerspruch zwischen geplanter und eingetragener PTP-Domaene', () => {
+    // Genau das kann `ptpPlan.ts` NICHT sehen: es kennt Domaenen und Profile,
+    // aber keine Segmente.
+    const welt = [
+      eq('cam', 'Kamera 1', [
+        nic({ id: 'cam#nic1', role: 'media-primary', vlanId: 10, ptpDomain: 127 }),
+      ]),
+    ]
+    const f = segmentFindings(welt, [
+      seg({ vlanId: 10, name: 'Dante Prim', purpose: 'media-primary', ptpDomain: 0 }),
+    ])
+    const treffer = f.find((x) => x.kind === 'ptp-mismatch')
+    expect(treffer?.severity).toBe('error')
+    expect(treffer?.message).toContain('0')
+    expect(treffer?.message).toContain('127')
+  })
+
+  it('meldet KEINEN PTP-Widerspruch, wo das Geraet nichts sagt', () => {
+    const welt = [eq('cam', 'Kamera 1', [nic({ id: 'cam#nic1', role: 'media-primary', vlanId: 10 })])]
+    const f = segmentFindings(welt, [
+      seg({ vlanId: 10, name: 'Dante Prim', purpose: 'media-primary', ptpDomain: 0 }),
+    ])
+    expect(f.some((x) => x.kind === 'ptp-mismatch')).toBe(false)
+  })
+
+  it('meldet KEINEN PTP-Widerspruch, wo das Segment nichts plant', () => {
+    const welt = [
+      eq('cam', 'Kamera 1', [
+        nic({ id: 'cam#nic1', role: 'media-primary', vlanId: 10, ptpDomain: 127 }),
+      ]),
+    ]
+    const f = segmentFindings(welt, [seg({ vlanId: 10, name: 'D', purpose: 'media-primary' })])
+    expect(f.some((x) => x.kind === 'ptp-mismatch')).toBe(false)
+  })
+
+  it('meldet nichts bei einem sauber entworfenen Segment', () => {
+    const welt = [
+      eq('cam', 'Kamera 1', [
+        nic({ id: 'cam#nic1', role: 'media-primary', vlanId: 10, ptpDomain: 0 }),
+      ]),
+    ]
+    expect(
+      segmentFindings(welt, [
+        seg({ vlanId: 10, name: 'Dante Prim', purpose: 'media-primary', ptpDomain: 0 }),
+      ]),
+    ).toEqual([])
+  })
+})
+
+// ── 4. Die Blaetter ────────────────────────────────────────────────────────
+
+describe('segmentTable', () => {
+  it('haelt den Spaltenkopf fest', () => {
+    expect(segmentTable([], []).headers).toEqual([...SEGMENT_HEADERS])
+  })
+
+  it('schreibt einen NAMEN statt einer leeren Zelle', () => {
+    const welt = [eq('cam', 'Kamera 1', [nic({ id: 'cam#nic1', role: 'media-primary', vlanId: 10 })])]
+    const [zeile] = segmentTable(welt, []).rows
+    expect(zeile[1]).toBe(NO_SEGMENT_NAME)
+    expect(zeile[2]).toBe(ROLE_TEXT.unspecified)
+    expect(zeile[3]).toBe(NO_PTP_IN_SEGMENT)
+    expect(zeile[4]).toBe(NO_GATEWAY)
+  })
+
+  it('setzt den Gateway-NAMEN ein, nicht die Id', () => {
+    // Eine Id auf dem Blatt schickt niemanden irgendwohin.
+    const welt = [
+      eq('gw', 'Mgmt-Gateway', [nic({ id: 'gw#nic1', role: 'management', vlanId: 99 })]),
+    ]
+    const [zeile] = segmentTable(welt, [
+      seg({ vlanId: 99, name: 'Mgmt', purpose: 'management', gatewayEquipmentId: 'gw' }),
+    ]).rows
+    expect(zeile[4]).toBe('Mgmt-Gateway')
+  })
+})
+
+describe('segmentReachTable — „from one machine"', () => {
+  it('haelt den Spaltenkopf fest', () => {
+    expect(segmentReachTable([], []).headers).toEqual([...REACH_HEADERS])
+  })
+
+  it('fuehrt ein Geraet mit fuenf Segmenten in fuenf Zeilen', () => {
+    // Das ist die Antwort auf den Beleg: ein Steuer-Rechner, der fuenf
+    // Anwendungen erreichen soll, steht hier mit fuenf Zeilen — oder eben mit
+    // einer, und dann weiss man es VOR dem Aufbau.
+    const pc = eq(
+      'pc',
+      'Systemtechnik-Laptop',
+      [10, 20, 30, 40, 99].map((v, i) =>
+        nic({ id: `pc#nic${i}`, role: 'control', vlanId: v, label: `VLAN ${v}` }),
+      ),
+    )
+    expect(segmentReachTable([pc], []).rows).toHaveLength(5)
+  })
+
+  it('laesst Schnittstellen OHNE VLAN weg', () => {
+    // Das Blatt beantwortet „wer steht in welchem Segment". Eine
+    // Schnittstelle ohne VLAN stuende dort mit einer leeren Zelle in der
+    // Spalte, um die es geht — und eine leere Zelle liest sich wie eine
+    // Antwort.
+    const welt = [
+      eq('pc', 'Regie-PC', [
+        nic({ id: 'pc#nic1', role: 'control', vlanId: 20 }),
+        nic({ id: 'pc#nic2', role: 'control', ipAddress: '10.0.0.9' }),
+      ]),
+    ]
+    const rows = segmentReachTable(welt, []).rows
+    expect(rows).toHaveLength(1)
+    expect(rows[0][2]).toBe(20)
+  })
+
+  it('sortiert nach Geraet und dann nach VLAN', () => {
+    const welt = [
+      eq('z', 'Zebra', [nic({ id: 'z#nic1', role: 'control', vlanId: 20 })]),
+      eq('a', 'Anton', [
+        nic({ id: 'a#nic1', role: 'control', vlanId: 30 }),
+        nic({ id: 'a#nic2', role: 'control', vlanId: 10 }),
+      ]),
+    ]
+    expect(segmentReachTable(welt, []).rows.map((r) => [r[0], r[2]])).toEqual([
+      ['Anton', 10],
+      ['Anton', 30],
+      ['Zebra', 20],
+    ])
+  })
+})
+
+// ── 5. Was beim Laden ueberlebt ────────────────────────────────────────────
+
+describe('normaliseNetworkSegments', () => {
+  it('wirft eine VLAN-Id ausserhalb des nutzbaren Bereichs weg', () => {
+    // 0 und 4095 sind reserviert. Ein Datensatz darauf zeigt auf kein VLAN,
+    // das jemand einrichten kann.
+    for (const v of [0, 4095, -1, 1.5, 'zehn']) {
+      expect(normaliseNetworkSegments([{ vlanId: v, name: 'x' }])).toEqual([])
+    }
+    expect(normaliseNetworkSegments([{ vlanId: 1 }])).toHaveLength(1)
+    expect(normaliseNetworkSegments([{ vlanId: 4094 }])).toHaveLength(1)
+  })
+
+  it('nimmt bei zwei Datensaetzen fuer dieselbe VLAN den ersten', () => {
+    const out = normaliseNetworkSegments([
+      { vlanId: 10, name: 'erst' },
+      { vlanId: 10, name: 'dann' },
+    ])
+    expect(out).toHaveLength(1)
+    expect(out[0].name).toBe('erst')
+  })
+
+  it('macht aus einem erfundenen Zweck „unspecified"', () => {
+    expect(normaliseNetworkSegments([{ vlanId: 10, purpose: 'zauberei' }])[0].purpose).toBe(
+      'unspecified',
+    )
+  })
+
+  it('wirft eine PTP-Domaene ausserhalb 0..127 weg', () => {
+    expect('ptpDomain' in normaliseNetworkSegments([{ vlanId: 10, ptpDomain: 128 }])[0]).toBe(false)
+    expect(normaliseNetworkSegments([{ vlanId: 10, ptpDomain: 127 }])[0].ptpDomain).toBe(127)
+    expect(normaliseNetworkSegments([{ vlanId: 10, ptpDomain: 0 }])[0].ptpDomain).toBe(0)
+  })
+
+  it('laesst leere Felder weg statt sie leer zu fuehren', () => {
+    const [s] = normaliseNetworkSegments([{ vlanId: 10, gatewayEquipmentId: '  ', note: '' }])
+    expect('gatewayEquipmentId' in s).toBe(false)
+    expect('note' in s).toBe(false)
+  })
+
+  it('sortiert aufsteigend', () => {
+    expect(normaliseNetworkSegments([{ vlanId: 99 }, { vlanId: 10 }]).map((s) => s.vlanId)).toEqual(
+      [10, 99],
+    )
+  })
+})
+
+// ── 6. Der Store ───────────────────────────────────────────────────────────
+
+describe('der Store', () => {
+  beforeEach(() => {
+    useProjectStore.setState((s) => ({ project: { ...s.project, networkSegments: [] } }))
+  })
+
+  it('setzt die ganze Liste auf einmal', () => {
+    useProjectStore.getState().setNetworkSegments([seg({ vlanId: 10, name: 'Dante' })])
+    expect(useProjectStore.getState().project.networkSegments).toHaveLength(1)
+  })
+
+  it('raeumt beim Laden den Gateway-Zeiger ins Leere weg — das Segment bleibt', () => {
+    // Ein Zeiger ins Leere saehe auf dem Blatt aus wie ein Weg in das Segment
+    // hinein, und genau danach sucht jemand vor Ort. Der ENTWURF gilt auch
+    // ohne Gateway.
+    expect(storeQuelle).toContain('gatewayEquipmentId && !geraeteIds.has(s.gatewayEquipmentId)')
+    expect(storeQuelle).toContain('normaliseNetworkSegments(project.networkSegments)')
+  })
+})
+
+// ── 7. Reinheit und Erreichbarkeit ─────────────────────────────────────────
+
+describe('das Modul und die Oberflaeche', () => {
+  it('nimmt keine Uhr und keinen Store', () => {
+    expect(libQuelle).not.toContain('new Date(')
+    expect(libQuelle).not.toContain('useProjectStore')
+  })
+
+  it('fuehrt EINE Vokabel fuer die Rolle, nicht zwei', () => {
+    // Ein zweiter Satz Woerter fuer dieselbe Sache waere genau die Krankheit,
+    // die das Spaltenlexikon bei Spaltennamen abgestellt hat.
+    expect(typenQuelle).toContain("purpose: NetworkInterfaceRole")
+    expect(typenQuelle).not.toContain('SegmentPurpose')
+  })
+
+  it('traegt kanonisches Deutsch in den Tabellen, nicht die Oberflaechensprache', () => {
+    // Ein Blatt, dessen Inhalt sich mit dem Sprachschalter aendert, meldet
+    // jedes gedruckte Exemplar als veraltet.
+    expect(libQuelle).not.toContain("useTranslation")
+    expect(libQuelle).toContain('ROLE_TEXT')
+  })
+
+  it('ist im Netz-Reiter erreichbar', () => {
+    expect(dialogQuelle).toContain('<SegmentsPanel projectName={projectName} />')
+  })
+
+  it('raet den Zweck NICHT beim Uebernehmen', () => {
+    // Geraten waere er die stille Zusage, gegen die dieser Bedarf gebaut ist.
+    const block = panelQuelle.slice(
+      panelQuelle.indexOf('const uebernehmen'),
+      panelQuelle.indexOf('const entfernen'),
+    )
+    expect(block).toContain("purpose: 'unspecified' as const")
+    expect(block).toContain("name: ''")
+  })
+
+  it('haelt die Befunde in der Oberflaeche, statt sie zu verschweigen', () => {
+    expect(panelQuelle).toContain('segmentFindings(equipment, segments)')
+  })
+})


### PR DESCRIPTION
Bedarf 116 (P3) aus dem Recherche-Korpus.

> A systems tech must reach VuNET, the mixer app, Dante Controller, Lake Controller and Shure WWB **on separate VLANs from one machine**, while keeping amp control off Dante PTP and stopping Waves SoundGrid attaching to the wrong segment.

Belegt an `misnow1/vunet-dante-combiner-2000` (2026-08-13, sieben offene Punkte): ein tragbares Mgmt-VLAN-Gateway, gebaut, damit **ein** Steuer-Rechner alle fünf Anwendungen erreicht — ohne zweite Netzkarte. Die Maßnahme der Bedarfs-Datenbank ist wörtlich: „model VLANs, PTP domain and control-vs-media segregation as part of the plan, **so the network design is documented before the laptop is on site**."

## Was es schon gab, und was fehlte

VLAN-Id, Rolle und PTP-Domäne stehen seit Bedarf 19/24/73 an jeder Schnittstelle. Was fehlte, ist das **Segment als Gegenstand**: eine Zahl ohne Namen ist keine Auskunft. „VLAN 30" beantwortet nicht, ob Dante dort hin darf.

## Vier Befunde, jeder aus einem Satz des Belegs

| Befund | Woher |
|---|---|
| `unnamed-segment` | eine benutzte VLAN-Id ohne Namen |
| `mixed-segment` (Fehler) | „on separate VLANs", verneint — Steuerverkehr im Medien-VLAN sitzt auf derselben PTP wie die Audio-Uhr |
| `role-mismatch` (Fehler) | „amp control off Dante PTP" und „SoundGrid attaching to the wrong segment" |
| `ptp-mismatch` (Fehler) | Segment plant Domäne X, Gerät sagt Y — das kann `ptpPlan.ts` nicht sehen, es kennt keine Segmente |

`roleFitsPurpose` ist großzügig, wo der Plan nichts weiß, und streng nur, wo der Beleg einen Schaden nennt: `unspecified` passt immer, Management und Steuerung passen zusammen (das Mgmt-VLAN *ist* der Weg hinein), die beiden Medien-Beine passen nicht (beide im selben VLAN ist kein redundanter Aufbau, sondern ein doppelter). Ein **leeres** Segment ist kein Befund — die Planung fängt oft mit den Segmenten an.

## Eine Vokabel, nicht zwei

`purpose` ist eine `NetworkInterfaceRole` und kein eigener Aufzählungstyp. Sonst dürfte „control" im Segment etwas anderes heißen als an der Schnittstelle, und niemand hätte einen Ort, an dem der Widerspruch auffiele.

## Zwei Blätter

`segmentTable` ist der Entwurf. `segmentReachTable` beantwortet „from one machine": ein Steuer-Rechner mit fünf Anwendungen steht dort mit fünf Zeilen — oder mit einer, und dann weiß man es *vor* dem Aufbau. Der Knopf „VLANs aus dem Plan übernehmen" lässt den Zweck **leer**: geraten wäre er die stille Zusage, gegen die dieser Bedarf gebaut ist.

## Beim Bauen entschieden

- Eine gebrochene VLAN-Id (`1.5`) wird **verworfen**, nicht auf 1 gerundet — Runden erfände eine Antwort auf eine kaputte Eingabe. (Die Gegenprobe hat das aufgedeckt.)
- Der Gateway-Zeiger wird beim Laden gegen die Geräte gehalten und weggeräumt, wenn er ins Leere zeigt. Das Segment überlebt: der Entwurf gilt auch ohne Gateway.

## Prüfung

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — 162 Test-Dateien grün (40 neue Fälle)
- `npm run lint` — 0 Errors
- Gegenprobe: 31 injizierte Defekte, alle rot. Eine Lücke fand sie selbst: das Zugangsblatt ließ Schnittstellen ohne VLAN mitlaufen — eine leere Zelle in genau der Spalte, um die es geht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_