### PR TITLE
videohub: der Umbau-Zettel — nur was sich ändert (#121)

### DIFF
--- a/src/renderer/components/Export/VideohubExportDialog.tsx
+++ b/src/renderer/components/Export/VideohubExportDialog.tsx
@@ -32,6 +32,15 @@ import { portDisplayLabel } from '../../lib/portLabel'
 import { roleLabelsByPort } from '../../lib/labelDerivation'
 import { isWithinDistance } from '../../lib/levenshtein'
 import { promptDialog } from '../../lib/promptDialog'
+import {
+  changeoverTable,
+  salvoById,
+  salvoChanges,
+  salvoFindings,
+  salvoTable,
+  type PortLabels,
+} from '../../lib/salvoSheet'
+import { toCsv } from '../../lib/csv'
 
 // #237 — Stop-Words die im Smart-Routing nicht zum Score beitragen.
 // "out"/"in" matched sonst auf praktisch jeden Port-Namen weil beide
@@ -79,6 +88,136 @@ const buildDefaultRouting = (totalIn: number, totalOut: number): Record<number, 
 const downloadTextFile = (filename: string, content: string) =>
   downloadBlob(filename, content, 'text/plain;charset=utf-8')
 
+/**
+ * BEDARF 121 — der Umbau-Zettel.
+ *
+ *   > A printed paper sheet of routes is RE-KEYED INTO A 40x40 VIDEOHUB
+ *   > BEFORE EVERY CHANGEOVER.
+ *
+ * Belegt an `bitfocus/companion-module-bmd-videohub#9` (2020-10, weiterhin
+ * offen): „I have a paper sheet of routes for our BMD 40x40 that I need to
+ * manually enter before each change over" — eine Halle, die zwischen Baseball
+ * und Softball wechselt.
+ *
+ * Der volle Zustand steht als eigenes Blatt daneben; er ist der Zettel, den
+ * es heute schon gibt. Der NEUE Zettel ist der Unterschied: wer vierzig
+ * Zeilen abtippt, tippt achtunddreissig davon unveraendert ab.
+ */
+const ChangeoverSheet = ({
+  salvos,
+  labels,
+  deviceName,
+  onLog,
+}: {
+  salvos: VideohubSalvo[]
+  labels: PortLabels
+  deviceName: string
+  onLog: (text: string, ok?: boolean) => void
+}) => {
+  const t = useTranslation()
+  const [vonId, setVonId] = useState<string>('')
+  const [nachId, setNachId] = useState<string>('')
+
+  const von = salvoById(salvos, vonId)
+  const nach = salvoById(salvos, nachId)
+  const aenderungen = useMemo(
+    () => (von && nach ? salvoChanges(von.routing, nach.routing) : []),
+    [von, nach],
+  )
+  const befunde = useMemo(() => salvoFindings(salvos), [salvos])
+
+  const ladeCsv = (suffix: string, table: { headers: string[]; rows: unknown[][] }) => {
+    downloadBlob(
+      buildExportFilenameWithSuffix(deviceName, suffix, 'csv'),
+      toCsv(table.headers, table.rows as never),
+      'text/csv;charset=utf-8',
+    )
+    onLog(`${suffix} als CSV geladen`)
+  }
+
+  const selCls =
+    'rounded border border-cyan-800/60 bg-cyan-950/40 px-1 py-0.5 text-[11px] text-cyan-100'
+
+  return (
+    <div className="mb-2 rounded border border-cyan-800/40 bg-cp-surface-2/40 p-2">
+      <div className="mb-1 flex flex-wrap items-center gap-1 text-[11px]">
+        <span className="text-cyan-300">{t('salvo.changeover', 'Umbau von')}</span>
+        <select value={vonId} onChange={(e) => setVonId(e.target.value)} className={selCls}>
+          <option value="">{t('salvo.pick', '— Satz wählen —')}</option>
+          {salvos.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))}
+        </select>
+        <span className="text-cyan-300">{t('salvo.to', 'nach')}</span>
+        <select value={nachId} onChange={(e) => setNachId(e.target.value)} className={selCls}>
+          <option value="">{t('salvo.pick', '— Satz wählen —')}</option>
+          {salvos.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))}
+        </select>
+        {von && nach && (
+          <button
+            type="button"
+            onClick={() =>
+              ladeCsv('umbau', changeoverTable(von.routing, nach.routing, labels))
+            }
+            className="ml-auto rounded bg-cyan-700 px-2 py-0.5 text-white hover:bg-cyan-600"
+          >
+            <Icon icon={Download} size="xs" className="mr-1 inline-block align-text-bottom" />
+            {t('salvo.exportChangeover', 'Umbau-Zettel')}
+          </button>
+        )}
+        {nach && (
+          <button
+            type="button"
+            onClick={() => ladeCsv('satz', salvoTable(nach.routing, labels))}
+            className="rounded border border-cyan-800/60 px-2 py-0.5 text-cyan-100 hover:bg-cyan-900/40"
+          >
+            <Icon icon={Download} size="xs" className="mr-1 inline-block align-text-bottom" />
+            {t('salvo.exportFull', 'Voller Satz')}
+          </button>
+        )}
+      </div>
+
+      {von && nach && (
+        <div className="text-[11px]">
+          {aenderungen.length === 0 ? (
+            /* Ein leeres Blatt ist hier eine ANTWORT und kein Fehler: die
+               beiden Saetze sind gleich, es ist nichts umzustecken. */
+            <span className="text-emerald-300">
+              {t('salvo.noChange', 'Kein Unterschied — beim Umbau ist nichts umzustecken.')}
+            </span>
+          ) : (
+            <span className="text-cyan-200">
+              {fmt(
+                t('salvo.changeCount', '{n} von {total} Kreuzpunkten ändern sich.'),
+                { n: aenderungen.length, total: Object.keys(nach.routing).length },
+              )}
+            </span>
+          )}
+        </div>
+      )}
+
+      {befunde.length > 0 && (
+        <ul className="mt-1 flex flex-col gap-0.5 text-[11px]">
+          {befunde.map((b, idx) => (
+            <li
+              key={`${b.kind}:${b.subject}:${idx}`}
+              className={b.severity === 'error' ? 'text-red-400' : 'text-amber-300/90'}
+            >
+              {b.message}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
 export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShowMatrix }: Props) => {
   const t = useTranslation()
   const equipment = useProjectStore((s) => s.project.equipment)
@@ -110,6 +249,18 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
   // Datei nutzt. Frueher doppelt weiter unten definiert — was verhinderte, dass
   // Code oberhalb davon auf das Geraet zugreifen kann.
   const device = initialDevice
+  // BEDARF 121 — die Beschriftungen fuer den Umbau-Zettel kommen aus
+  // DERSELBEN Aufloesung wie Vorschau, .txt, Label-PDF und TCP-Push
+  // (`labelOf`). Ein eigener `portDisplayLabel`-Aufruf waere der fuenfte Weg,
+  // und genau so entsteht einer, der die Rolle nicht kennt.
+  const portLabels: PortLabels = useMemo(
+    () => ({
+      inputs: (initialDevice?.inputs ?? []).map((p) => labelOf(p, '')),
+      outputs: (initialDevice?.outputs ?? []).map((p) => labelOf(p, '')),
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [initialDevice, roleLabels],
+  )
   // Kein Raten: Geraetetyp-ID → expliziter Katalog-Preset-Key; sonst 'custom'
   // mit den echten BNC-Port-Zahlen des Geraets (siehe videohubPresetForDevice).
   const initialPreset = initialDevice
@@ -1138,6 +1289,20 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
               + {t('export.saveCurrentRouting', 'Aktuelles Routing speichern')}
             </button>
           </div>
+          {/* BEDARF 121 — der Umbau-Zettel.
+              „I have a paper sheet of routes for our BMD 40x40 that I need to
+              MANUALLY ENTER BEFORE EACH CHANGE OVER" (bmd-videohub#9). Wer
+              vor dem Umbau alle vierzig Zeilen abtippt, tippt achtunddreissig
+              davon unveraendert ab. Der Zettel, der die Arbeit spart, ist
+              nicht der Zustand, sondern der UNTERSCHIED. */}
+          {salvos.length > 0 && (
+            <ChangeoverSheet
+              salvos={salvos}
+              labels={portLabels}
+              deviceName={device?.name || 'Videohub'}
+              onLog={logEvent}
+            />
+          )}
           {salvos.length === 0 ? (
             <div className="text-[11px] text-cp-text-muted">
               {t('export.noSalvos', 'Noch keine Salvos. Speichere die aktuelle Crosspoint-Verteilung und ruf sie spaeter mit einem Klick zurueck.')}

--- a/src/renderer/lib/dataDictionary.ts
+++ b/src/renderer/lib/dataDictionary.ts
@@ -51,6 +51,11 @@ export const UNDESCRIBED = 'nicht beschrieben'
  * Datei, ohne dass sich am Plan etwas geaendert haette.
  */
 export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
+  // Bedarf 121 — der Umbau-Zettel (`lib/salvoSheet.ts`).
+  'Ziel (Beschriftung)':
+    'Wie der Ausgang beschriftet ist — derselbe Text, den auch der Videohub bekommt (Rolle vor Port-Inhalt vor Portname). „ohne Beschriftung“ heißt: am Port steht nichts.',
+  'Neue Quelle':
+    'Die Beschriftung des Eingangs, der nach dem Umbau auf diesem Ausgang liegt. Steht hier „nicht gesetzt“, sagt der Ziel-Satz zu diesem Ausgang nichts — dann ist beim Umbau ungeklärt, ob er bleiben oder sich ändern soll.',
   // Bedarf 116 — die Segmente (`lib/networkSegments.ts`).
   Segment:
     'Der Name des VLAN im Haus („Dante Prim“, „Steuerung“). „ohne Namen“ heißt: die Id ist in Gebrauch, aber niemand hat gesagt, wofür.',
@@ -131,7 +136,8 @@ export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
     'Unter welcher Bedingung das Haus zugestimmt hat, oder welcher Umweg vereinbart wurde.',
   'Aus dem Plan':
     'Der Wert, den der Plan für diesen Punkt vorsieht — die Frage- oder Vergleichsseite.',
-  Ausgang: 'Der Ausgang am Pult, auf den dieser Kanal geht.',
+  Ausgang:
+    'Der Ausgang, auf den etwas geht — je nach Blatt der Pult-Ausgang eines Kanals oder der Router-Ausgang eines Kreuzpunkts. Auf dem Umbau-Zettel steht die Nummer, wie sie am Geraet aufgedruckt ist (ab 1), nicht die interne ab 0.',
   Ausgegeben: 'Wann der Container ausgegeben wurde.',
   'Ausgegeben an': 'An wen die beschädigte Einheit zuletzt ausgegeben war.',
   'Backup von': 'Für welches Ziel dieses Ziel der Ausweichweg ist.',
@@ -234,7 +240,8 @@ export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
   Menge: 'Die Stückzahl dieser Position.',
   Mischer: 'Der Bildmischer, auf den sich die Eingangsnummer bezieht.',
   Modell: 'Der Gerätetyp — nicht die einzelne Einheit.',
-  Nachher: 'Der Stand nach dem zweiten Import.',
+  Nachher:
+    'Der Stand NACH der Aenderung: beim Vergleich zweier Importe der zweite Stand, auf dem Umbenennungs-Blatt der Text nach der Umbenennung, auf dem Umbau-Zettel der Eingang, der auf diesen Ausgang kommt.',
   Name: 'Der Name, unter dem der Datensatz im Plan geführt wird.',
   'Neuer Name': 'Der Name, den die Regel für dieses Gerät ergibt.',
   'Name (Pult)': 'Der Name, den jemand am Pult eingetippt hat.',
@@ -293,7 +300,13 @@ export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
   'UMD-Adresse': 'Die TSL-Adresse, unter der der Multiviewer diese Quelle beschriftet.',
   Video: 'Die geplanten Video-Parameter des Ziels.',
   VLAN: 'Das VLAN, in dem die Schnittstelle liegt.',
-  Vorher: 'Der Stand beim ersten Import.',
+  // Drei Lesarten, und der Eintrag nennt alle drei — genau dafuer geht das
+  // Lexikon nach NAMEN und nicht nach Blatt. Bis zum Bedarf 121 stand hier
+  // nur der Import, waehrend die Spalte laengst auch auf dem
+  // Umbenennungs-Blatt (Bedarf 101) stand: eine Erklaerung, die etwas anderes
+  // beschreibt als die Spalte, ist schlimmer als keine — sie wird geglaubt.
+  Vorher:
+    'Der Stand VOR der Aenderung: beim Vergleich zweier Importe der erste Stand, auf dem Umbenennungs-Blatt der Text, den das Zielsystem heute speichert, auf dem Umbau-Zettel der Eingang, der jetzt auf diesem Ausgang liegt.',
   Vorgefunden: 'Was vor Ort tatsächlich angetroffen wurde — die Ist-Seite des Abgleichs.',
   Wann: 'Wann die Angabe gemacht oder die Antwort gegeben wurde.',
   Was: 'Worum es in dieser Zeile geht.',

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3490,6 +3490,14 @@ export const en: Dict = {
   'channelList.view.stage': 'Stage (position)',
   'channelList.view.console': 'Console (names)',
   'channelList.view.monitor': 'Monitor paths',
+  // Bedarf 121 — der Umbau-Zettel: nur was sich aendert.
+  'salvo.changeover': 'Changeover from',
+  'salvo.to': 'to',
+  'salvo.pick': '\u2014 pick a set \u2014',
+  'salvo.exportChangeover': 'Changeover sheet',
+  'salvo.exportFull': 'Full set',
+  'salvo.noChange': 'No difference \u2014 nothing to re-patch for this changeover.',
+  'salvo.changeCount': '{n} of {total} crosspoints change.',
   // Bedarf 116 — die Segmente: welche VLAN wofuer da ist.
   'segment.title': 'Segments (VLAN, purpose, timing, way in)',
   'segment.hint':

--- a/src/renderer/lib/salvoSheet.ts
+++ b/src/renderer/lib/salvoSheet.ts
@@ -1,0 +1,264 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Der Umbau-Zettel: nur was sich ändert (Bedarf 121, P4).
+//
+//   > A printed paper sheet of routes is RE-KEYED INTO A 40x40 VIDEOHUB
+//   > BEFORE EVERY CHANGEOVER.
+//
+// Belegt an `bitfocus/companion-module-bmd-videohub#9` (2020-10, weiterhin
+// offen), wörtlich: „I have a paper sheet of routes for our BMD 40x40 that I
+// need to manually enter before each change over" — eine Halle, die zwischen
+// Baseball und Softball wechselt.
+//
+// ─── WAS SCHON DA WAR ──────────────────────────────────────────────────────
+//
+// Benannte Kreuzpunkt-Sätze („Salvos") gibt es seit Initiative 10, und
+// `routingDifferences` vergleicht den Plan mit dem, was das Gerät meldet.
+// Was fehlte, ist genau das Blatt, das der Beleg beschreibt — und die
+// Einsicht, dass es das FALSCHE Blatt ist:
+//
+//   Wer vor dem Umbau alle vierzig Zeilen abtippt, tippt achtunddreissig
+//   davon unverändert ab. Der Zettel, der die Arbeit wirklich spart, ist
+//   nicht der Zustand, sondern der UNTERSCHIED.
+//
+// Deshalb gibt es hier zwei Blätter und nicht eines:
+//
+//   `salvoTable`      der volle Zustand — für den Ordner, für die Übergabe,
+//                     und für den Fall, dass jemand bei Null anfängt.
+//   `changeoverTable` NUR die Kreuzpunkte, die sich ändern, mit Vorher und
+//                     Nachher. Das ist der Zettel für den Umbau.
+//
+// ─── NUMMERN, WIE SIE AUF DEM GERÄT STEHEN ─────────────────────────────────
+//
+// Intern sind Ein- und Ausgänge 0-basiert (so kommen sie über das
+// Videohub-Protokoll). Auf dem PAPIER steht die Nummer, die am Gerät
+// aufgedruckt ist, und die fängt bei 1 an. Diese Umrechnung passiert HIER,
+// einmal, und nicht in jedem Aufrufer — eine Liste, die um eins verschoben
+// ist, führt beim Umbau zum falschen Kreuzpunkt, und das merkt man erst,
+// wenn das Bild falsch ist.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { EquipmentItem, VideohubCrosspoints, VideohubSalvo } from '../types/equipment'
+import { routingDifferences } from './videohubRouting'
+import { portDisplayLabel } from './portLabel'
+import type { CsvTable } from './csv'
+
+/** Was auf dem Blatt steht, wo keine Beschriftung hinterlegt ist. */
+export const NO_PORT_LABEL = 'ohne Beschriftung'
+/** Was in der Vorher-/Nachher-Spalte steht, wo der Satz nichts sagt. */
+export const NOT_SET = 'nicht gesetzt'
+
+/**
+ * Beschriftungen je Ein-/Ausgang, 0-basiert.
+ *
+ * Kommt fertig herein: die Auflösung „welcher Text gehört zu diesem Port"
+ * liegt in `exportVideohub.displayFor` und hängt an Rollen und Kabelgraph.
+ * Sie hier ein zweites Mal zu bauen wäre die zweite Wahrheit, die ADR-001
+ * überall sonst verbietet — und sie liefe sofort auseinander, weil die
+ * Rollen-Auflösung sich weiterentwickelt.
+ */
+export interface PortLabels {
+  inputs: ReadonlyArray<string>
+  outputs: ReadonlyArray<string>
+}
+
+/**
+ * Beschriftungen aus einem Gerät, ohne Rollen-Auflösung.
+ *
+ * Der einfache Fall für Aufrufer, die den Kabelgraphen nicht haben (Druck,
+ * Export). Wer ihn hat, reicht `roleLabels`-aufgelöste Texte herein und
+ * bekommt dieselben Namen, die auch im Videohub landen.
+ */
+export const portLabelsOf = (device: Pick<EquipmentItem, 'inputs' | 'outputs'>): PortLabels => ({
+  inputs: device.inputs.map((p) => portDisplayLabel(p) || ''),
+  outputs: device.outputs.map((p) => portDisplayLabel(p) || ''),
+})
+
+const label = (labels: ReadonlyArray<string>, index: number | undefined): string => {
+  if (index === undefined) return NOT_SET
+  return labels[index]?.trim() || NO_PORT_LABEL
+}
+
+/** Die Nummer, wie sie am Gerät aufgedruckt ist (1-basiert). */
+export const printedNumber = (index: number): number => index + 1
+
+export const SALVO_HEADERS = ['Ausgang', 'Ziel (Beschriftung)', 'Eingang', 'Quelle'] as const
+
+/**
+ * Der volle Zustand eines Satzes — die Papierseite, die es heute schon gibt.
+ *
+ * Sortiert nach Ausgang, weil so umgesteckt wird: man geht die Ausgänge
+ * durch und stellt für jeden die Quelle ein.
+ */
+export function salvoTable(routing: VideohubCrosspoints, labels: PortLabels): CsvTable {
+  // Das `sort` ist HEUTE redundant — nicht-negative Ganzzahl-Schluessel
+  // liefert `Object.keys` von sich aus aufsteigend, und der Filter darueber
+  // laesst nur solche durch. Die Gegenprobe hat das aufgedeckt: die Zeile
+  // wegzunehmen aendert nichts.
+  //
+  // Sie bleibt trotzdem, und das ist der Unterschied zu einer wirkungslosen
+  // ABFRAGE (die gehoert heraus): hier haengt die Redundanz am Filter
+  // darueber. Wer den Filter lockert — etwa um negative Schluessel zu melden
+  // statt sie wegzuwerfen —, faellt sonst still auf Einfuegereihenfolge
+  // zurueck, und eine falsch sortierte Liste fuehrt beim Umbau zum falschen
+  // Kreuzpunkt. Der Test haelt die REIHENFOLGE fest, nicht diese Zeile.
+  const outputs = Object.keys(routing)
+    .map(Number)
+    .filter((n) => Number.isInteger(n) && n >= 0)
+    .sort((a, b) => a - b)
+  return {
+    headers: [...SALVO_HEADERS],
+    rows: outputs.map((o) => [
+      printedNumber(o),
+      label(labels.outputs, o),
+      printedNumber(routing[o]),
+      label(labels.inputs, routing[o]),
+    ]),
+  }
+}
+
+export interface CrosspointChange {
+  /** 0-basierter Ausgang. */
+  output: number
+  /** Eingang im Ausgangs-Satz, oder undefined wenn dieser nichts sagt. */
+  from?: number
+  /** Eingang im Ziel-Satz, oder undefined wenn dieser nichts sagt. */
+  to?: number
+}
+
+/**
+ * Was sich zwischen zwei Sätzen ändert.
+ *
+ * Rechnet NICHT selbst, sondern schreibt `routingDifferences` um: dort
+ * heissen die beiden Seiten `planned` und `live`, weil die Funktion für den
+ * Abgleich Plan-gegen-Gerät gebaut wurde (Initiative 10). Die Rechnung ist
+ * dieselbe — „was sagt Seite A, was sagt Seite B, wo sind sie ungleich" —,
+ * und sie zweimal zu haben hiesse, sie zweimal zu pflegen. Umbenannt wird
+ * trotzdem: `planned`/`live` auf einem Umbau-Zettel wäre schlicht falsch, es
+ * ist zweimal ein Plan.
+ */
+export function salvoChanges(
+  from: VideohubCrosspoints,
+  to: VideohubCrosspoints,
+): CrosspointChange[] {
+  return routingDifferences(from, to).map((d) => ({
+    output: d.output,
+    ...(d.planned !== undefined ? { from: d.planned } : {}),
+    ...(d.live !== undefined ? { to: d.live } : {}),
+  }))
+}
+
+export const CHANGEOVER_HEADERS = [
+  'Ausgang',
+  'Ziel (Beschriftung)',
+  'Vorher',
+  'Nachher',
+  'Neue Quelle',
+] as const
+
+/**
+ * Der Umbau-Zettel: nur die Kreuzpunkte, die sich ändern.
+ *
+ * DAS ist die Antwort auf den Beleg. Wer zwischen Baseball und Softball
+ * wechselt, steckt nicht vierzig Kreuzpunkte, sondern die vier, die anders
+ * sind — und tippt die übrigen sechsunddreissig nicht ab, nur um zu sehen,
+ * dass sie gleich bleiben.
+ *
+ * Ein leeres Blatt ist hier eine ANTWORT und kein Fehler: die beiden Sätze
+ * sind gleich, es ist nichts umzustecken.
+ */
+export function changeoverTable(
+  from: VideohubCrosspoints,
+  to: VideohubCrosspoints,
+  labels: PortLabels,
+): CsvTable {
+  return {
+    headers: [...CHANGEOVER_HEADERS],
+    rows: salvoChanges(from, to).map((c) => [
+      printedNumber(c.output),
+      label(labels.outputs, c.output),
+      c.from === undefined ? NOT_SET : printedNumber(c.from),
+      c.to === undefined ? NOT_SET : printedNumber(c.to),
+      label(labels.inputs, c.to),
+    ]),
+  }
+}
+
+/** Salvo nach Id — ohne `find` beim Aufrufer, damit „gibt es nicht" EIN Fall ist. */
+export const salvoById = (
+  salvos: ReadonlyArray<VideohubSalvo>,
+  id: string | undefined,
+): VideohubSalvo | undefined => (id ? salvos.find((s) => s.id === id) : undefined)
+
+export type SalvoFindingKind =
+  /** Zwei Sätze mit demselben Namen. */
+  | 'duplicate-name'
+  /** Ein Satz, der zu keinem Ausgang etwas sagt. */
+  | 'empty-salvo'
+  /** Ein Satz sagt zu Ausgängen etwas, die ein anderer nicht kennt. */
+  | 'partial-coverage'
+
+export interface SalvoFinding {
+  kind: SalvoFindingKind
+  severity: 'error' | 'warning'
+  subject: string
+  message: string
+}
+
+/**
+ * Befunde über die Satz-Sammlung.
+ *
+ * `partial-coverage` ist der unangenehme: zwei Sätze, die verschiedene
+ * Ausgänge abdecken, ergeben einen Umbau-Zettel mit „nicht gesetzt" — und
+ * beim Umbau steht dann jemand vor einem Ausgang und weiss nicht, ob er ihn
+ * lassen oder ändern soll. Der Befund sagt das VOR dem Druck.
+ */
+export function salvoFindings(salvos: ReadonlyArray<VideohubSalvo>): SalvoFinding[] {
+  const out: SalvoFinding[] = []
+  const gesehen = new Map<string, number>()
+  for (const s of salvos) {
+    const key = s.name.trim().toLowerCase()
+    if (key) gesehen.set(key, (gesehen.get(key) ?? 0) + 1)
+    if (Object.keys(s.routing).length === 0) {
+      out.push({
+        kind: 'empty-salvo',
+        severity: 'warning',
+        subject: s.name,
+        message: `"${s.name}" sagt zu keinem Ausgang etwas — er stellt beim Aufruf nichts um.`,
+      })
+    }
+  }
+  for (const [key, anzahl] of gesehen) {
+    if (anzahl < 2) continue
+    const name = salvos.find((s) => s.name.trim().toLowerCase() === key)?.name ?? key
+    out.push({
+      kind: 'duplicate-name',
+      severity: 'error',
+      subject: name,
+      message:
+        `${anzahl} Sätze heissen "${name}". Wer am Telefon „fahr Satz X" sagt, meint dann zwei ` +
+        'verschiedene Zustände.',
+    })
+  }
+  // Deckungslücken paarweise, aber nur EINMAL je Paar.
+  for (let i = 0; i < salvos.length; i++) {
+    for (let j = i + 1; j < salvos.length; j++) {
+      const a = salvos[i]
+      const b = salvos[j]
+      const nurA = Object.keys(a.routing).filter((o) => b.routing[Number(o)] === undefined)
+      const nurB = Object.keys(b.routing).filter((o) => a.routing[Number(o)] === undefined)
+      if (nurA.length === 0 && nurB.length === 0) continue
+      out.push({
+        kind: 'partial-coverage',
+        severity: 'warning',
+        subject: `${a.name} / ${b.name}`,
+        message:
+          `"${a.name}" und "${b.name}" decken verschiedene Ausgänge ab ` +
+          `(${nurA.length} nur hier, ${nurB.length} nur dort). Auf dem Umbau-Zettel steht dort ` +
+          `"${NOT_SET}", und davor steht beim Umbau jemand ratlos.`,
+      })
+    }
+  }
+  return out
+}

--- a/tests/dataDictionary.test.ts
+++ b/tests/dataDictionary.test.ts
@@ -74,6 +74,22 @@ describe('COLUMN_GLOSSARY — ein Lexikon nach NAMEN, nicht nach Blatt', () => {
     for (const spalte of ['Ziel', 'Quelle', 'Art', 'Herkunft']) {
       expect(COLUMN_GLOSSARY[spalte], spalte).toMatch(/je nach|sonst|Auf anderen|Im /)
     }
+    // `Vorher`/`Nachher`/`Ausgang` sind erst mit Bedarf 101 und 121
+    // mehrdeutig geworden — und die Erklaerung blieb dabei stehen: sie
+    // beschrieb weiter NUR den Import-Vergleich, waehrend die Spalte laengst
+    // auch auf dem Umbenennungs-Blatt und dem Umbau-Zettel stand. Eine
+    // Erklaerung, die etwas anderes beschreibt als die Spalte, ist schlimmer
+    // als keine — sie wird geglaubt. Der Guard haelt jetzt fest, dass jede
+    // dieser drei Spalten ALLE ihre Lesarten nennt.
+    for (const [spalte, lesarten] of [
+      ['Vorher', ['Import', 'Zielsystem', 'Ausgang']],
+      ['Nachher', ['Import', 'Umbenennung', 'Ausgang']],
+      ['Ausgang', ['Pult', 'Router']],
+    ] as const) {
+      for (const lesart of lesarten) {
+        expect(COLUMN_GLOSSARY[spalte], `${spalte} nennt "${lesart}" nicht`).toContain(lesart)
+      }
+    }
   })
 
   it('verspricht bei „Stream-Key" ausdruecklich, dass kein Wert darin steht', () => {

--- a/tests/salvoSheet.test.ts
+++ b/tests/salvoSheet.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CHANGEOVER_HEADERS,
+  NOT_SET,
+  NO_PORT_LABEL,
+  SALVO_HEADERS,
+  changeoverTable,
+  portLabelsOf,
+  printedNumber,
+  salvoById,
+  salvoChanges,
+  salvoFindings,
+  salvoTable,
+  type PortLabels,
+} from '../src/renderer/lib/salvoSheet'
+import type { Port, VideohubCrosspoints, VideohubSalvo } from '../src/renderer/types/equipment'
+import libQuelle from '../src/renderer/lib/salvoSheet.ts?raw'
+import dialogQuelle from '../src/renderer/components/Export/VideohubExportDialog.tsx?raw'
+
+// ---------------------------------------------------------------------------
+// Der Umbau-Zettel: nur was sich aendert (Bedarf 121, P4).
+//
+//   > A printed paper sheet of routes is RE-KEYED INTO A 40x40 VIDEOHUB
+//   > BEFORE EVERY CHANGEOVER.
+//
+// Belegt an `bitfocus/companion-module-bmd-videohub#9` (2020-10, weiterhin
+// offen), woertlich: „I have a paper sheet of routes for our BMD 40x40 that I
+// need to manually enter before each change over" — eine Halle, die zwischen
+// Baseball und Softball wechselt.
+//
+// Die Einsicht dieses Inkrements: der Zettel, den es heute gibt, ist der
+// FALSCHE. Wer vierzig Zeilen abtippt, tippt achtunddreissig davon
+// unveraendert ab.
+// ---------------------------------------------------------------------------
+
+const labels: PortLabels = {
+  inputs: ['Kamera 1', 'Kamera 2', 'Kamera 3', ''],
+  outputs: ['Regie', 'Anzeigetafel', 'Aufzeichnung', ''],
+}
+
+const salvo = (id: string, name: string, routing: VideohubCrosspoints): VideohubSalvo => ({
+  id,
+  name,
+  routing,
+  createdAt: '2026-09-06T10:00:00.000Z',
+})
+
+// ── 1. Die Nummer auf dem Papier ───────────────────────────────────────────
+
+describe('die aufgedruckte Nummer', () => {
+  it('faengt bei 1 an, nicht bei 0', () => {
+    // Intern sind Ein- und Ausgaenge 0-basiert (so kommen sie ueber das
+    // Videohub-Protokoll). Eine Liste, die um eins verschoben ist, fuehrt beim
+    // Umbau zum falschen Kreuzpunkt — und das merkt man erst, wenn das Bild
+    // falsch ist.
+    expect(printedNumber(0)).toBe(1)
+    expect(printedNumber(39)).toBe(40)
+  })
+
+  it('rechnet die Nummer im BLATT um, nicht erst im Aufrufer', () => {
+    const [zeile] = salvoTable({ 0: 2 }, labels).rows
+    expect(zeile[0]).toBe(1)
+    expect(zeile[2]).toBe(3)
+  })
+})
+
+// ── 2. Der volle Satz ──────────────────────────────────────────────────────
+
+describe('salvoTable — der Zettel, den es heute gibt', () => {
+  it('haelt den Spaltenkopf fest', () => {
+    expect(salvoTable({}, labels).headers).toEqual([...SALVO_HEADERS])
+  })
+
+  it('sortiert nach Ausgang — so wird umgesteckt', () => {
+    const rows = salvoTable({ 2: 0, 0: 1, 1: 2 }, labels).rows
+    expect(rows.map((r) => r[0])).toEqual([1, 2, 3])
+  })
+
+  it('setzt die Beschriftungen beider Seiten ein', () => {
+    const [zeile] = salvoTable({ 1: 0 }, labels).rows
+    expect(zeile[1]).toBe('Anzeigetafel')
+    expect(zeile[3]).toBe('Kamera 1')
+  })
+
+  it('nennt den unbeschrifteten Port beim Namen', () => {
+    const [zeile] = salvoTable({ 3: 3 }, labels).rows
+    expect(zeile[1]).toBe(NO_PORT_LABEL)
+    expect(zeile[3]).toBe(NO_PORT_LABEL)
+  })
+
+  it('ignoriert kaputte Ausgangs-Schluessel', () => {
+    expect(salvoTable({ '-1': 0, x: 1 } as unknown as VideohubCrosspoints, labels).rows).toEqual([])
+  })
+})
+
+// ── 3. Der Umbau-Zettel ────────────────────────────────────────────────────
+
+describe('changeoverTable — der Zettel, um den es geht', () => {
+  const baseball = { 0: 0, 1: 1, 2: 2 }
+  const softball = { 0: 0, 1: 2, 2: 2 }
+
+  it('haelt den Spaltenkopf fest', () => {
+    expect(changeoverTable({}, {}, labels).headers).toEqual([...CHANGEOVER_HEADERS])
+  })
+
+  it('fuehrt NUR die Kreuzpunkte, die sich aendern', () => {
+    // DAS ist die Antwort auf den Beleg: nicht vierzig Zeilen abtippen,
+    // sondern die vier, die anders sind.
+    const rows = changeoverTable(baseball, softball, labels).rows
+    expect(rows).toHaveLength(1)
+    expect(rows[0][0]).toBe(2)
+  })
+
+  it('schreibt Vorher UND Nachher, damit man es gegenlesen kann', () => {
+    const [zeile] = changeoverTable(baseball, softball, labels).rows
+    expect(zeile[2]).toBe(2)
+    expect(zeile[3]).toBe(3)
+    expect(zeile[4]).toBe('Kamera 3')
+  })
+
+  it('ist bei gleichen Saetzen LEER — und das ist eine Antwort', () => {
+    expect(changeoverTable(baseball, baseball, labels).rows).toEqual([])
+  })
+
+  it('nennt einen Ausgang, den nur EINE Seite kennt, statt ihn zu verschweigen', () => {
+    // Fehlen ist ein Unterschied, kein Gleichstand: wer vor dem Ausgang steht
+    // und nicht weiss, ob er ihn lassen soll, hat ein Problem.
+    const nur_a = changeoverTable({ 0: 0, 1: 1 }, { 0: 0 }, labels).rows
+    expect(nur_a).toHaveLength(1)
+    expect(nur_a[0][2]).toBe(2)
+    expect(nur_a[0][3]).toBe(NOT_SET)
+    expect(nur_a[0][4]).toBe(NOT_SET)
+
+    const nur_b = changeoverTable({ 0: 0 }, { 0: 0, 1: 1 }, labels).rows
+    expect(nur_b[0][2]).toBe(NOT_SET)
+    expect(nur_b[0][3]).toBe(2)
+  })
+})
+
+describe('salvoChanges', () => {
+  it('benennt die beiden Seiten „from" und „to", nicht „planned" und „live"', () => {
+    // Dieselbe Rechnung wie `routingDifferences`, aber ein Umbau vergleicht
+    // zweimal einen PLAN. „planned"/„live" waere auf diesem Blatt schlicht
+    // falsch.
+    const [c] = salvoChanges({ 0: 1 }, { 0: 2 })
+    expect(c).toEqual({ output: 0, from: 1, to: 2 })
+  })
+
+  it('laesst die fehlende Seite weg, statt sie als undefined zu fuehren', () => {
+    const [c] = salvoChanges({ 0: 1 }, {})
+    expect('to' in c).toBe(false)
+    expect(c.from).toBe(1)
+  })
+})
+
+// ── 4. Die Befunde ueber die Sammlung ──────────────────────────────────────
+
+describe('salvoFindings', () => {
+  it('meldet zwei Saetze mit demselben Namen als FEHLER', () => {
+    // Wer am Telefon „fahr Satz A" sagt, meint dann zwei verschiedene
+    // Zustaende.
+    const f = salvoFindings([salvo('1', 'Show A', { 0: 0 }), salvo('2', 'show a', { 0: 1 })])
+    const doppelt = f.find((x) => x.kind === 'duplicate-name')
+    expect(doppelt?.severity).toBe('error')
+  })
+
+  it('meldet den leeren Satz', () => {
+    const f = salvoFindings([salvo('1', 'Leer', {})])
+    expect(f.find((x) => x.kind === 'empty-salvo')?.severity).toBe('warning')
+  })
+
+  it('meldet die Deckungsluecke zwischen zwei Saetzen', () => {
+    // Auf dem Umbau-Zettel stuende dort „nicht gesetzt", und davor steht beim
+    // Umbau jemand ratlos.
+    const f = salvoFindings([
+      salvo('1', 'Baseball', { 0: 0, 1: 1 }),
+      salvo('2', 'Softball', { 0: 0, 2: 2 }),
+    ])
+    const luecke = f.find((x) => x.kind === 'partial-coverage')
+    expect(luecke).toBeDefined()
+    expect(luecke?.message).toContain(NOT_SET)
+  })
+
+  it('meldet dieselbe Luecke nur EINMAL je Paar', () => {
+    const f = salvoFindings([
+      salvo('1', 'A', { 0: 0, 1: 1 }),
+      salvo('2', 'B', { 0: 0, 2: 2 }),
+    ])
+    expect(f.filter((x) => x.kind === 'partial-coverage')).toHaveLength(1)
+  })
+
+  it('meldet nichts bei zwei sauberen, deckungsgleichen Saetzen', () => {
+    expect(
+      salvoFindings([salvo('1', 'Baseball', { 0: 0, 1: 1 }), salvo('2', 'Softball', { 0: 1, 1: 0 })]),
+    ).toEqual([])
+  })
+})
+
+// ── 5. Kleinkram, der trotzdem beisst ──────────────────────────────────────
+
+describe('salvoById', () => {
+  const liste = [salvo('a', 'A', {}), salvo('b', 'B', {})]
+
+  it('findet den Satz', () => {
+    expect(salvoById(liste, 'b')?.name).toBe('B')
+  })
+
+  it('macht „keine Auswahl" und „gibt es nicht" zu EINEM Fall', () => {
+    expect(salvoById(liste, '')).toBeUndefined()
+    expect(salvoById(liste, undefined)).toBeUndefined()
+    expect(salvoById(liste, 'weg')).toBeUndefined()
+  })
+})
+
+describe('portLabelsOf', () => {
+  const port = (id: string, name: string): Port =>
+    ({ id, name, type: 'BNC', connectorType: 'BNC' }) as Port
+
+  it('nimmt die vorhandene Port-Vokabel', () => {
+    const l = portLabelsOf({ inputs: [port('i1', 'CAM 1')], outputs: [port('o1', 'PGM')] })
+    expect(l.inputs[0]).toBe('CAM 1')
+    expect(l.outputs[0]).toBe('PGM')
+  })
+})
+
+// ── 6. Reinheit und Erreichbarkeit ─────────────────────────────────────────
+
+describe('das Modul und die Oberflaeche', () => {
+  it('nimmt keine Uhr und keinen Store', () => {
+    expect(libQuelle).not.toContain('new Date(')
+    expect(libQuelle).not.toContain('useProjectStore')
+  })
+
+  it('rechnet den Unterschied NICHT ein zweites Mal', () => {
+    // `routingDifferences` macht dieselbe Rechnung fuer Plan-gegen-Geraet.
+    // Sie zweimal zu haben hiesse, sie zweimal zu pflegen.
+    expect(libQuelle).toContain('routingDifferences(from, to)')
+    expect(libQuelle).not.toMatch(/for \(const output of \[\.\.\.outputs\]/)
+  })
+
+  it('baut die Beschriftungen NICHT selbst aus Rollen und Kabeln', () => {
+    // Die Aufloesung liegt in `exportVideohub.displayFor` und haengt am
+    // Kabelgraphen. Sie hier ein zweites Mal zu bauen waere die zweite
+    // Wahrheit — und sie liefe sofort auseinander.
+    expect(libQuelle).not.toContain('roleLabelsByPort')
+    expect(libQuelle).toContain('Kommt fertig herein')
+  })
+
+  it('ist im Videohub-Dialog erreichbar', () => {
+    // Auf die FORM und nicht auf den blossen Namen: `{false && <Changeover…}`
+    // enthielte den Namen auch und zeigte nichts. Die Gegenprobe hat genau
+    // das durchgelassen.
+    expect(dialogQuelle).toMatch(
+      /\{salvos\.length > 0 && \(\s*<ChangeoverSheet\b/,
+    )
+    expect(dialogQuelle).toContain('deviceName={device?.name')
+    expect(dialogQuelle).toContain('labels={portLabels}')
+  })
+
+  it('nimmt im Dialog DIESELBE Beschriftung wie die uebrigen Ausgabewege', () => {
+    // Vier Wege standen dort vorher mit eigenem `portDisplayLabel`; genau so
+    // entsteht einer, der die Rolle nicht kennt.
+    const block = dialogQuelle.slice(
+      dialogQuelle.indexOf('const portLabels: PortLabels'),
+      dialogQuelle.indexOf('// Kein Raten: Geraetetyp-ID'),
+    )
+    expect(block).toContain('labelOf(p, ')
+    expect(block).not.toContain('portDisplayLabel')
+  })
+})


### PR DESCRIPTION
Bedarf 121 (P4) aus dem Recherche-Korpus.

> A printed paper sheet of routes is **re-keyed into a 40x40 Videohub before every changeover**.

Belegt an `bitfocus/companion-module-bmd-videohub#9` (2020-10, weiterhin offen), wörtlich: „I have a paper sheet of routes for our BMD 40x40 that I need to manually enter before each change over" — eine Halle, die zwischen Baseball und Softball wechselt.

## Die Einsicht: der Zettel, den es gibt, ist der falsche

Salvos gibt es seit Initiative 10, `routingDifferences` vergleicht Plan gegen Gerät. Was fehlte, ist das Blatt aus dem Beleg — und die Einsicht, dass es das falsche Blatt ist:

> Wer vor dem Umbau alle vierzig Zeilen abtippt, tippt achtunddreißig davon **unverändert** ab.

Deshalb zwei Blätter: `salvoTable` (der volle Zustand, für den Ordner) und `changeoverTable` (**nur** die Kreuzpunkte, die sich ändern, mit Vorher und Nachher). Ein leeres Umbau-Blatt ist eine Antwort, kein Fehler.

## Nummern, wie sie auf dem Gerät stehen

Intern 0-basiert, auf dem Papier ab 1. Die Umrechnung passiert im Blatt, einmal — eine um eins verschobene Liste führt beim Umbau zum falschen Kreuzpunkt, und das merkt man erst, wenn das Bild falsch ist.

## Keine zweite Wahrheit

- Die Beschriftungen kommen **fertig herein**; die Auflösung liegt in `exportVideohub.displayFor`. Im Dialog speist `portLabels` sich aus demselben `labelOf`, das Vorschau, .txt, Label-PDF und TCP-Push benutzen.
- `salvoChanges` rechnet nicht selbst, sondern schreibt `routingDifferences` um: dieselbe Rechnung, andere Vokabel. `planned`/`live` wäre auf einem Umbau-Zettel falsch — es ist zweimal ein Plan.

## Befunde über die Sammlung

`duplicate-name` (Fehler — wer am Telefon „fahr Satz A" sagt, meint dann zwei Zustände), `empty-salvo`, und `partial-coverage`: zwei Sätze mit verschiedenen Ausgängen ergeben ein „nicht gesetzt" auf dem Zettel, und davor steht beim Umbau jemand ratlos.

## Ein Lexikon-Eintrag, der etwas anderes beschrieb als die Spalte

Der erweiterte Spalten-Guard (aus Bedarf 105) hat es aufgedeckt: `Vorher`/`Nachher` erklärten weiterhin **nur** den Import-Vergleich, obwohl die Spalten längst auch auf dem Umbenennungs-Blatt (Bedarf 101) standen — und jetzt zusätzlich auf dem Umbau-Zettel. Dasselbe bei `Ausgang` (Pult gegen Router). Alle drei nennen jetzt jede Lesart, und ein Guard hält das fest.

## Prüfung

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — 163 Test-Dateien grün (27 neue Fälle)
- `npm run lint` — 0 Errors
- Gegenprobe: 22 injizierte Defekte, 21 rot. Zwei Lücken fand sie selbst und beide sind geschlossen: die Erreichbarkeits-Zusicherung ließ sich mit `{false && <ChangeoverSheet…}` aushebeln, und die Mehrdeutigkeit von `Vorher` war ungeprüft.
- Der eine grüne Fall ist bewusst so: das `sort` in `salvoTable` ist heute redundant (nicht-negative Ganzzahl-Schlüssel liefert `Object.keys` aufsteigend). Es bleibt, und der Kommentar sagt warum — die Redundanz hängt am Filter darüber, und wer den lockert, fällt sonst still auf Einfügereihenfolge zurück. Der Test hält die Reihenfolge fest, nicht die Zeile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_