### PR TITLE
mv: das Multiviewer-Bild als Blatt, aus denselben Rollen wie Tally und UMD (#125)

### DIFF
--- a/src/renderer/components/Export/ExportDialog.tsx
+++ b/src/renderer/components/Export/ExportDialog.tsx
@@ -18,7 +18,7 @@ import jsPDF from 'jspdf'
 import { useUiStore } from '../../store/uiStore'
 import { PacketSection } from './PacketSection'
 import { useProjectStore } from '../../store/projectStore'
-import { AlertTriangle, Check, Lightbulb, Package as PackageIcon } from 'lucide-react'
+import { AlertTriangle, Check, Download, Lightbulb, Package as PackageIcon } from 'lucide-react'
 import { useTranslation, format } from '../../lib/i18n'
 import { detectLayerForConnector, type StandardLayer } from '../../lib/cableLayers'
 
@@ -43,6 +43,13 @@ import { sanitizeForPdf } from '../../lib/sanitizeForPdf'
 import { downloadBlob } from '../../lib/downloadBlob'
 import { buildTallyMap, tallyMapCsv, toTallyPiDevices } from '../../lib/tallyMap'
 import { TallyPreShowPanel } from '../Tally/TallyPreShowPanel'
+import { toCsv } from '../../lib/csv'
+import {
+  mvFindings,
+  mvSheetTable,
+  multiViewersOf,
+  sourceNamesFromTallyRows,
+} from '../../lib/mvSheet'
 import { buildPlanBom, outcomeLabel, pickListCsv, planBomCsv } from '../../lib/planBom'
 import { useCheckoutStore } from '../../store/checkoutStore'
 import { zusatzBedarf } from '../../lib/planDemandExtras'
@@ -1279,6 +1286,84 @@ const BomSection = () => {
 // beantwortet der Plan; das vierte, die Lampe, gehoert der Hardware und wird
 // ausdruecklich NICHT erfunden.
 
+/**
+ * BEDARF 125 — das Multiviewer-Bild als Blatt.
+ *
+ *   > MV window assignment is configured by hand per show; remote recall is
+ *   > unreliable, so THE TRUSTED STORE IS THE SWITCHER'S OWN BINARY SAVE
+ *   > FILE, WHICH NO OTHER DEPARTMENT CAN READ.
+ *
+ * Der Plan macht den Recall nicht zuverlaessiger — das ist Sache des
+ * Mischers. Er liefert das Blatt, das heute fehlt: welche Rolle steht in
+ * welchem Fenster, lesbar fuer Regie, Bildtechnik und Kameraleute, aus
+ * derselben Aufloesung wie Tally und UMD.
+ */
+const MvSheetPanel = ({ map }: { map: ReturnType<typeof buildTallyMap> }) => {
+  const t = useTranslation()
+  const equipment = useProjectStore((s) => s.project.equipment)
+  const projectName = useProjectStore((s) => s.project.metadata?.name)
+
+  const namen = useMemo(() => sourceNamesFromTallyRows(map.rows), [map.rows])
+  const geraete = useMemo(
+    () => equipment.filter((e) => multiViewersOf(e).length > 0),
+    [equipment],
+  )
+  const befunde = useMemo(
+    () => geraete.flatMap((e) => mvFindings(multiViewersOf(e), namen)),
+    [geraete, namen],
+  )
+
+  if (geraete.length === 0) return null
+
+  const laden = (device: (typeof geraete)[number]) => {
+    const table = mvSheetTable(device.name, multiViewersOf(device), namen)
+    downloadBlob(
+      buildExportFilenameWithSuffix(projectName, `mv-${device.name}`, 'csv'),
+      toCsv(table.headers, table.rows),
+      'text/csv;charset=utf-8',
+    )
+  }
+
+  return (
+    <div className="shrink-0 rounded border border-cp-border bg-cp-surface-2 p-2">
+      <div className="mb-1 flex flex-wrap items-center gap-2">
+        <span className="text-cp-xs font-semibold text-cp-text-secondary">
+          {t('mv.sheet.title', 'Multiviewer-Bild (wer steht in welchem Fenster)')}
+        </span>
+        {geraete.map((e) => (
+          <button
+            key={e.id}
+            type="button"
+            onClick={() => laden(e)}
+            className="inline-flex items-center gap-1 rounded border border-cp-border px-2 py-0.5 text-cp-xs hover:bg-cp-surface-3"
+          >
+            <Icon icon={Download} size="xs" />
+            {e.name}
+          </button>
+        ))}
+      </div>
+      <p className="text-cp-xs text-cp-text-muted">
+        {t(
+          'mv.sheet.hint',
+          'Die Namen kommen aus denselben Rollen wie Tally und UMD — nicht aus einer zweiten, von Hand geführten Liste. Der Mischer speichert sein Bild binär; dieses Blatt kann auch die Kamera-Crew lesen.',
+        )}
+      </p>
+      {befunde.length > 0 && (
+        <ul className="mt-1 flex max-h-32 flex-col gap-0.5 overflow-auto text-cp-xs">
+          {befunde.map((b, idx) => (
+            <li
+              key={`${b.kind}:${b.mvIndex}:${idx}`}
+              className={b.severity === 'error' ? 'text-cp-danger' : 'text-cp-warn'}
+            >
+              {b.message}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
 const TallySection = () => {
   const t = useTranslation()
   const project = useProjectStore((s) => s.project)
@@ -1355,6 +1440,14 @@ const TallySection = () => {
           </table>
         </div>
       )}
+
+      {/* BEDARF 125 — das Multiviewer-Bild. Es steht HIER und nicht in einem
+          eigenen Abschnitt, weil es an derselben Aufloesung haengt wie die
+          Tally-Karte darueber: „labels come from the source records". Ein
+          eigener Abschnitt verfuehrte dazu, die Namen ein zweites Mal
+          aufzuloesen — genau die dritte handgefuehrte Kopie, die der Bedarf
+          beklagt. */}
+      <MvSheetPanel map={map} />
 
       {/* BEDARF 105 — die zweite Haelfte. Die Karte darueber sagt, was der Plan
           ABLEITET; hier steht, was niemand ableiten kann: der Weg zur Lampe

--- a/src/renderer/lib/dataDictionary.ts
+++ b/src/renderer/lib/dataDictionary.ts
@@ -51,6 +51,14 @@ export const UNDESCRIBED = 'nicht beschrieben'
  * Datei, ohne dass sich am Plan etwas geaendert haette.
  */
 export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
+  // Bedarf 125 — das Multiviewer-Bild (`lib/mvSheet.ts`).
+  Multiviewer:
+    'Welcher Multiviewer des Mischers gemeint ist — Gerätename plus laufende Nummer, ab 1 gezählt wie am Gerät.',
+  Fenster:
+    'Der interne Fenster-Index im Bild (große Fenster 0–3, kleine Zellen 10–43). Er steht auf dem Blatt, damit sich eine Zeile eindeutig einem Fenster zuordnen lässt — die POSITION ist die Angabe, nach der man auf dem Schirm sucht.',
+  'Größe': 'Ob das Fenster groß oder klein ist — im Multiviewer der Unterschied zwischen Haupt- und Neben-Bild.',
+  'Quelle (ATEM)':
+    'Die Quell-Nummer, wie der Mischer sie führt. Steht daneben „keine Rolle im Plan“, kennt der Plan zu dieser Nummer keine Signalquelle — meist eine interne Quelle des Mischers (Farbfläche, Media Player).',
   // Bedarf 121 — der Umbau-Zettel (`lib/salvoSheet.ts`).
   'Ziel (Beschriftung)':
     'Wie der Ausgang beschriftet ist — derselbe Text, den auch der Videohub bekommt (Rolle vor Port-Inhalt vor Portname). „ohne Beschriftung“ heißt: am Port steht nichts.',
@@ -258,7 +266,12 @@ export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
   Plattform: 'Die Zielplattform (YouTube, Twitch, eigenes Ziel …).',
   Platz: 'Der Platz im Rack oder Case, an dem die Einheit sitzt.',
   Port: 'Der Port am Switch oder am Gerät.',
-  Position: 'Die einzelne Zeile einer Liste oder Buchung.',
+  // Drei Lesarten. Die zweite kam mit Bedarf 105 (die Vor-Show-Liste fuehrt
+  // die KAMERA-Position), die dritte mit Bedarf 125 (das MV-Blatt fuehrt den
+  // Ort auf dem SCHIRM) — und der Eintrag beschrieb bis dahin weiter nur die
+  // Listenzeile. Genau die Art Erklaerung, die geglaubt wird und falsch ist.
+  Position:
+    'Je nach Blatt dreierlei: die Listenzeile einer Liste oder Buchung; die Kamera-Position (die Rolle, an der die Tally-Lampe haengt); oder der Ort auf dem Schirm („oben links, Zelle 2“).',
   Positionen: 'Wie viele Positionen der Container enthält.',
   Profil: 'Das PTP-Profil (ST 2059-2, AES67 …).',
   'Programm-Eingang': 'Der Eingang, an dem das Programm-Signal in den Ausspielweg eintritt.',

--- a/src/renderer/lib/documentRegistry.ts
+++ b/src/renderer/lib/documentRegistry.ts
@@ -23,6 +23,8 @@ import { deliveryTableForProject } from './deliveryParity'
 import { runOfShowSheetForProject } from './encoderFeasibility'
 import { tallyMapTableForProject } from './tallyMap'
 import { preShowTallyTable } from './tallyPosition'
+import { mvSheetTable, multiViewersOf, sourceNamesFromTallyRows } from './mvSheet'
+import { buildTallyMap } from './tallyMap'
 import { deliveryPathTable } from './deliveryPath'
 import { buildPtpPlan, ptpTable } from './ptpPlan'
 import { crewSheetTableForProject } from './crewNetworkSheet'
@@ -84,6 +86,27 @@ export const DOCUMENT_STANDS: Record<string, (project: CablePlannerProject) => s
   // keine Sprache (die Zellen tragen kanonisches Deutsch aus
   // `TALLY_*_LABEL`), kein Zufall — die Zeitstempel stehen in den Daten und
   // werden nicht beim Bauen genommen.
+  // Bedarf 125 — das Multiviewer-Bild als Blatt. Reproduzierbar, weil es
+  // allein aus `atemMvConfig` und derselben Tally-Aufloesung folgt: keine
+  // Nutzer-Einstellung beim Export, keine Sprache, kein Live-Zustand des
+  // Mischers (der waere eine Beobachtung und wuerde jeden Vergleich brechen).
+  'mv-bild': (project) => {
+    const namen = sourceNamesFromTallyRows(
+      buildTallyMap({
+        equipment: project.equipment,
+        cables: project.cables,
+        sourceIdentities: project.sourceIdentities,
+      }).rows,
+    )
+    const rows: string[] = []
+    for (const device of project.equipment) {
+      const mvs = multiViewersOf(device)
+      if (mvs.length === 0) continue
+      const table = mvSheetTable(device.name, mvs, namen)
+      rows.push(documentFingerprint(table.headers, table.rows))
+    }
+    return documentFingerprint(['mv'], rows.map((r) => [r]))
+  },
   'tally-vorshow': (project) =>
     ofTable(() => preShowTallyTable(project.sourceIdentities ?? [], project.tallyPositions ?? []))(
       project,
@@ -230,6 +253,7 @@ export const DOCUMENT_LABELS: Record<string, string> = {
   ablaufblatt: 'Ablaufblatt',
   'tally-karte': 'Tally-Karte',
   'tally-vorshow': 'Tally-Vor-Show-Liste',
+  'mv-bild': 'Multiviewer-Bild',
   ausspielweg: 'Ausspielweg',
   'ptp-plan': 'Zeit-Plan (PTP)',
   'crew-netz': 'Netz-Merkblatt (Crew)',

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3490,6 +3490,10 @@ export const en: Dict = {
   'channelList.view.stage': 'Stage (position)',
   'channelList.view.console': 'Console (names)',
   'channelList.view.monitor': 'Monitor paths',
+  // Bedarf 125 — das Multiviewer-Bild als Blatt.
+  'mv.sheet.title': 'Multiviewer layout (who is in which window)',
+  'mv.sheet.hint':
+    'The names come from the same roles as tally and UMD \u2014 not from a second, hand-kept list. The switcher stores its layout as a binary file; this sheet can be read by the camera crew too.',
   // Bedarf 121 — der Umbau-Zettel: nur was sich aendert.
   'salvo.changeover': 'Changeover from',
   'salvo.to': 'to',

--- a/src/renderer/lib/mvSheet.ts
+++ b/src/renderer/lib/mvSheet.ts
@@ -1,0 +1,252 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Das Multiviewer-Bild als Blatt (Bedarf 125, P4).
+//
+//   > MV window assignment is configured by hand per show; remote recall is
+//   > unreliable, so THE TRUSTED STORE IS THE SWITCHER'S OWN BINARY SAVE FILE,
+//   > WHICH NO OTHER DEPARTMENT CAN READ.
+//
+// Belegt an `bitfocus/companion-module-bmd-atem#480` (2026, offen): dort
+// rufen die MV-Fenster 2 und 3 dieselbe Quelle ab, und der Melder hält fest,
+// dass nur das Sichern und Zurückspielen des KOMPLETTEN Mischer-Zustands über
+// ATEM Software Control zuverlässig funktioniert.
+//
+// ─── DER SCHADEN IST NICHT DER RECALL, SONDERN DIE LESBARKEIT ──────────────
+//
+// Dass ein Zustand nur als Binärdatei des Mischers existiert, heisst: die
+// Kameraleute wissen nicht, in welchem Fenster sie stehen, der Regisseur hat
+// keinen Plan zum Gegenlesen, und beim nächsten Aufbau tippt jemand die
+// Belegung erneut ein. Der Plan kann den Recall nicht zuverlässiger machen —
+// das ist Sache des Mischers. Er kann aber das BLATT liefern, das heute fehlt,
+// und zwar aus denselben Rollen, aus denen Tally, UMD und die Videohub-Labels
+// kommen (`labelDerivation`).
+//
+// ─── WAS DIESES MODUL NICHT TUT ────────────────────────────────────────────
+//
+// Es schreibt NICHTS an den Mischer und liest keinen Live-Zustand. Die
+// Belegung kommt aus `equipment.atemMvConfig` — dem geplanten Bild, das der
+// MV-Dialog führt (cable-planner#288) — und die Rollen aus dem Kabelgraph. Was der
+// Mischer gerade wirklich tut, ist eine Beobachtung; sie hier einzumischen
+// erzeugte genau die zweite Wahrheit, die ADR-001 überall sonst verbietet.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { AtemMvDefinition, EquipmentItem } from '../types/equipment'
+import { getMvGridSpec, getMvQuadrants, mvWindowIndex } from './atemMvLayout'
+import type { CsvTable } from './csv'
+
+/** Was auf dem Blatt steht, wo nichts belegt ist. */
+export const NO_SOURCE = 'nicht belegt'
+/** Was dort steht, wo die Quelle keiner Rolle im Plan entspricht. */
+export const NO_ROLE = 'keine Rolle im Plan'
+
+/** Ein Fenster im Bild. */
+export interface MvWindow {
+  /** Fenster-Index im internen Schema (0-3 gross, 10-43 klein). */
+  windowIndex: number
+  /** Wo es auf dem Schirm sitzt, im Klartext („oben links", „unten rechts, Zelle 2"). */
+  position: string
+  /** true: eines der grossen Fenster. */
+  big: boolean
+  /** ATEM-Quell-Id, wie sie im Profil steht. */
+  sourceId?: number
+}
+
+const QUADRANT_NAME = ['oben links', 'oben rechts', 'unten links', 'unten rechts'] as const
+
+/**
+ * Die Fenster eines Multiviewers, in Lese-Reihenfolge.
+ *
+ * Aus dem QUADRANTEN-Modell und nicht aus `layout`: `getMvQuadrants` ist die
+ * vorhandene Engstelle dafür (sie fällt für Alt-Daten selbst auf das Layout
+ * zurück). Ein zweiter Weg von `layout` zu den Fenstern liefe auseinander,
+ * sobald jemand einen Quadranten umstellt.
+ */
+export function mvWindows(mv: AtemMvDefinition): MvWindow[] {
+  const quadrants = getMvQuadrants(mv)
+  const belegt = new Map(mv.windows.map((w) => [w.windowIndex, w.sourceId]))
+  const out: MvWindow[] = []
+  for (let q = 0; q < 4; q++) {
+    const quadIdx = q as 0 | 1 | 2 | 3
+    if (quadrants[quadIdx] === 'big') {
+      const idx = mvWindowIndex(quadIdx)
+      out.push({
+        windowIndex: idx,
+        position: QUADRANT_NAME[q],
+        big: true,
+        ...(belegt.has(idx) ? { sourceId: belegt.get(idx) } : {}),
+      })
+      continue
+    }
+    for (let c = 0; c < 4; c++) {
+      const idx = mvWindowIndex(quadIdx, c as 0 | 1 | 2 | 3)
+      out.push({
+        windowIndex: idx,
+        // Die Zelle wird 1-basiert genannt: auf dem Papier zählt niemand ab 0.
+        position: `${QUADRANT_NAME[q]}, Zelle ${c + 1}`,
+        big: false,
+        ...(belegt.has(idx) ? { sourceId: belegt.get(idx) } : {}),
+      })
+    }
+  }
+  return out
+}
+
+/**
+ * Wie viele Fenster das gewählte Layout überhaupt hat.
+ *
+ * Aus derselben Gitter-Tabelle, aus der die Oberfläche zeichnet — sonst
+ * behauptete das Blatt eine andere Fensterzahl als der Bildschirm zeigt.
+ */
+export const mvWindowCount = (layout: number): number => {
+  const spec = getMvGridSpec(layout)
+  return spec.big.length + spec.small.length
+}
+
+/**
+ * Quell-Id → Klartext.
+ *
+ * Kommt FERTIG herein. Die Auflösung „welche Rolle speist ATEM-Eingang N"
+ * liegt in `labelDerivation`/`tallyMap` und hängt am Kabelgraph; sie hier ein
+ * zweites Mal zu bauen wäre die zweite Wahrheit — und genau daran krankt der
+ * Bedarf schon auf der Marktseite (drei handgeführte Kopien derselben
+ * Eingangs-Karte).
+ */
+export type SourceNames = ReadonlyMap<number, string>
+
+export const MV_SHEET_HEADERS = [
+  'Multiviewer',
+  'Fenster',
+  'Position',
+  'Größe',
+  'Quelle (ATEM)',
+  'Rolle',
+] as const
+
+const groesse = (big: boolean) => (big ? 'groß' : 'klein')
+
+/** Das Blatt: ein Multiviewer, eine Zeile je Fenster. */
+export function mvSheetTable(
+  deviceName: string,
+  multiViewers: ReadonlyArray<AtemMvDefinition>,
+  names: SourceNames,
+): CsvTable {
+  const rows: CsvTable['rows'] = []
+  for (const mv of [...multiViewers].sort((a, b) => a.index - b.index)) {
+    for (const w of mvWindows(mv)) {
+      rows.push([
+        `${deviceName} · MV ${mv.index + 1}`,
+        w.windowIndex,
+        w.position,
+        groesse(w.big),
+        w.sourceId ?? NO_SOURCE,
+        w.sourceId === undefined ? NO_SOURCE : (names.get(w.sourceId) ?? NO_ROLE),
+      ])
+    }
+  }
+  return { headers: [...MV_SHEET_HEADERS], rows }
+}
+
+export type MvFindingKind =
+  /** Zwei Fenster zeigen dieselbe Quelle — der Fall aus dem Beleg. */
+  | 'duplicate-source'
+  /** Ein Fenster ist unbelegt. */
+  | 'empty-window'
+  /** Die Quelle entspricht keiner Rolle im Plan. */
+  | 'unknown-source'
+
+export interface MvFinding {
+  kind: MvFindingKind
+  severity: 'error' | 'warning'
+  /** Multiviewer-Index (0-basiert) als Sortierschlüssel. */
+  mvIndex: number
+  message: string
+}
+
+/**
+ * Befunde über die Belegung.
+ *
+ * `duplicate-source` ist der belegte Fall (`#480`: „MV windows 2 and 3 recall
+ * the same source") — und er ist ein FEHLER und keine Warnung: zwei gleiche
+ * Bilder nebeneinander heissen, dass eine Kamera auf dem Multiviewer gar nicht
+ * vorkommt, und das merkt der Regisseur in dem Moment, in dem er sie braucht.
+ *
+ * Ein unbelegtes Fenster ist dagegen nur ein Hinweis: ein Aufbau mit weniger
+ * Kameras als Fenstern ist der Normalfall, kein Mangel.
+ */
+export function mvFindings(
+  multiViewers: ReadonlyArray<AtemMvDefinition>,
+  names: SourceNames,
+): MvFinding[] {
+  const out: MvFinding[] = []
+  for (const mv of [...multiViewers].sort((a, b) => a.index - b.index)) {
+    const fenster = mvWindows(mv)
+    const nachQuelle = new Map<number, MvWindow[]>()
+    for (const w of fenster) {
+      if (w.sourceId === undefined) {
+        out.push({
+          kind: 'empty-window',
+          severity: 'warning',
+          mvIndex: mv.index,
+          message: `MV ${mv.index + 1}: Fenster ${w.position} ist ${NO_SOURCE}.`,
+        })
+        continue
+      }
+      nachQuelle.set(w.sourceId, [...(nachQuelle.get(w.sourceId) ?? []), w])
+      if (!names.has(w.sourceId)) {
+        out.push({
+          kind: 'unknown-source',
+          severity: 'warning',
+          mvIndex: mv.index,
+          message:
+            `MV ${mv.index + 1}: Fenster ${w.position} zeigt Quelle ${w.sourceId}, ` +
+            `zu der der Plan keine Rolle kennt.`,
+        })
+      }
+    }
+    for (const [sourceId, ws] of nachQuelle) {
+      if (ws.length < 2) continue
+      const name = names.get(sourceId) ?? `Quelle ${sourceId}`
+      out.push({
+        kind: 'duplicate-source',
+        severity: 'error',
+        mvIndex: mv.index,
+        message:
+          `MV ${mv.index + 1}: ${ws.length} Fenster zeigen "${name}" ` +
+          `(${ws.map((w) => w.position).join(', ')}). Dann fehlt eine andere Quelle im Bild.`,
+      })
+    }
+  }
+  return out
+}
+
+/**
+ * Die Quell-Namen aus einer Tally-Karte.
+ *
+ * Der Brückenkopf zwischen diesem Blatt und den Rollen: `buildTallyMap` löst
+ * bereits „welche Rolle kommt an welchem Mischer-Eingang an" auf, und die
+ * ATEM-Quell-Id eines Kamera-Eingangs IST diese Eingangsnummer. Damit hängt
+ * das MV-Blatt an derselben Auflösung wie Tally und UMD — was der Bedarf
+ * wörtlich verlangt („labels come from the source records").
+ *
+ * NUR Kamera-Eingänge: interne Quellen des Mischers (Farbflächen, Media
+ * Player, SuperSource) tragen im ATEM eigene Id-Bereiche und haben im Plan
+ * keine Rolle. Sie hier zu raten hiesse, dem Blatt einen Namen zu geben, den
+ * niemand nachprüfen kann.
+ */
+export function sourceNamesFromTallyRows(
+  rows: ReadonlyArray<{ name: string; switcher?: { input: number } }>,
+): SourceNames {
+  const out = new Map<number, string>()
+  for (const r of rows) {
+    if (!r.switcher) continue
+    // Erster gewinnt: zwei Rollen auf demselben Eingang sind ein Befund der
+    // Tally-Karte und nicht dieses Blatts.
+    if (!out.has(r.switcher.input)) out.set(r.switcher.input, r.name)
+  }
+  return out
+}
+
+/** Alle Multiviewer eines Geräts — leer, wenn keine MV-Konfiguration da ist. */
+export const multiViewersOf = (device: EquipmentItem): AtemMvDefinition[] =>
+  device.atemMvConfig?.multiViewers ?? []

--- a/tests/dataDictionary.test.ts
+++ b/tests/dataDictionary.test.ts
@@ -85,6 +85,9 @@ describe('COLUMN_GLOSSARY — ein Lexikon nach NAMEN, nicht nach Blatt', () => {
       ['Vorher', ['Import', 'Zielsystem', 'Ausgang']],
       ['Nachher', ['Import', 'Umbenennung', 'Ausgang']],
       ['Ausgang', ['Pult', 'Router']],
+      // Bedarf 125: `Position` heisst auf drei Blaettern drei verschiedene
+      // Dinge, und der Eintrag beschrieb lange nur das erste.
+      ['Position', ['Listenzeile', 'Kamera-Position', 'Schirm']],
     ] as const) {
       for (const lesart of lesarten) {
         expect(COLUMN_GLOSSARY[spalte], `${spalte} nennt "${lesart}" nicht`).toContain(lesart)

--- a/tests/mvSheet.test.ts
+++ b/tests/mvSheet.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MV_SHEET_HEADERS,
+  NO_ROLE,
+  NO_SOURCE,
+  multiViewersOf,
+  mvFindings,
+  mvSheetTable,
+  mvWindowCount,
+  mvWindows,
+  sourceNamesFromTallyRows,
+} from '../src/renderer/lib/mvSheet'
+import { MV_LAYOUT } from '../src/renderer/lib/atemMvLayout'
+import { DOCUMENT_STANDS } from '../src/renderer/lib/documentRegistry'
+import type { AtemMvDefinition, EquipmentItem } from '../src/renderer/types/equipment'
+import libQuelle from '../src/renderer/lib/mvSheet.ts?raw'
+import dialogQuelle from '../src/renderer/components/Export/ExportDialog.tsx?raw'
+
+// ---------------------------------------------------------------------------
+// Das Multiviewer-Bild als Blatt (Bedarf 125, P4).
+//
+//   > MV window assignment is configured by hand per show; remote recall is
+//   > unreliable, so THE TRUSTED STORE IS THE SWITCHER'S OWN BINARY SAVE
+//   > FILE, WHICH NO OTHER DEPARTMENT CAN READ.
+//
+// Belegt an `bitfocus/companion-module-bmd-atem#480` (2026, offen): dort rufen
+// die MV-Fenster 2 und 3 dieselbe Quelle ab.
+//
+// Der Plan macht den Recall nicht zuverlaessiger — das ist Sache des Mischers.
+// Er liefert das Blatt, das heute fehlt.
+// ---------------------------------------------------------------------------
+
+const mv = (over: Partial<AtemMvDefinition> = {}): AtemMvDefinition => ({
+  index: 0,
+  layout: MV_LAYOUT.Default,
+  windows: [],
+  ...over,
+})
+
+/** Ein Bild mit zwei grossen Fenstern oben und acht kleinen unten. */
+const standard = (windows: AtemMvDefinition['windows']): AtemMvDefinition =>
+  mv({ quadrants: ['big', 'big', 'small', 'small'], windows })
+
+const namen = new Map([
+  [1, 'Kamera 1'],
+  [2, 'Kamera 2'],
+  [3, 'Kamera 3'],
+])
+
+// ── 1. Die Fenster ─────────────────────────────────────────────────────────
+
+describe('mvWindows', () => {
+  it('nennt jede Position im Klartext', () => {
+    // Auf dem Papier sucht niemand nach „windowIndex 32".
+    const w = mvWindows(standard([]))
+    expect(w[0].position).toBe('oben links')
+    expect(w[1].position).toBe('oben rechts')
+    expect(w[2].position).toBe('unten links, Zelle 1')
+  })
+
+  it('zaehlt die Zellen ab 1 und nicht ab 0', () => {
+    const zellen = mvWindows(standard([])).filter((w) => !w.big)
+    expect(zellen.map((w) => w.position)).toContain('unten rechts, Zelle 4')
+    expect(zellen.some((w) => w.position.includes('Zelle 0'))).toBe(false)
+  })
+
+  it('unterscheidet gross und klein', () => {
+    const w = mvWindows(standard([]))
+    expect(w.filter((x) => x.big)).toHaveLength(2)
+    expect(w.filter((x) => !x.big)).toHaveLength(8)
+  })
+
+  it('traegt die belegte Quelle und laesst die unbelegte WEG', () => {
+    // `undefined` als Feld zu fuehren hiesse, dass ein JSON-Roundtrip aus
+    // „nicht belegt" eine leere Zelle macht — und die liest sich wie eine
+    // Antwort.
+    const w = mvWindows(standard([{ windowIndex: 0, sourceId: 1 }]))
+    expect(w[0].sourceId).toBe(1)
+    expect('sourceId' in w[1]).toBe(false)
+  })
+
+  it('folgt den QUADRANTEN und nicht dem Layout-Feld', () => {
+    // `getMvQuadrants` ist die vorhandene Engstelle; ein zweiter Weg von
+    // `layout` zu den Fenstern liefe auseinander, sobald jemand einen
+    // Quadranten umstellt.
+    const alle_gross = mvWindows(mv({ quadrants: ['big', 'big', 'big', 'big'], windows: [] }))
+    expect(alle_gross).toHaveLength(4)
+    expect(alle_gross.every((w) => w.big)).toBe(true)
+  })
+})
+
+describe('mvWindowCount', () => {
+  it('rechnet aus derselben Gitter-Tabelle wie die Oberflaeche', () => {
+    // Sonst behauptete das Blatt eine andere Fensterzahl, als der Bildschirm
+    // zeigt.
+    expect(mvWindowCount(MV_LAYOUT.Default)).toBe(10)
+    expect(mvWindowCount(MV_LAYOUT.Grid16Small)).toBe(16)
+    expect(mvWindowCount(MV_LAYOUT.Quad4Big)).toBe(4)
+  })
+})
+
+// ── 2. Das Blatt ───────────────────────────────────────────────────────────
+
+describe('mvSheetTable', () => {
+  it('haelt den Spaltenkopf fest', () => {
+    expect(mvSheetTable('ATEM', [], namen).headers).toEqual([...MV_SHEET_HEADERS])
+  })
+
+  it('nennt den Multiviewer ab 1, wie am Geraet', () => {
+    const [zeile] = mvSheetTable('ATEM 1', [standard([{ windowIndex: 0, sourceId: 1 }])], namen).rows
+    expect(zeile[0]).toBe('ATEM 1 · MV 1')
+  })
+
+  it('setzt die ROLLE ein, nicht die Quell-Nummer allein', () => {
+    // „labels come from the source records" — das ist die Massnahme aus dem
+    // Bedarf, woertlich.
+    const [zeile] = mvSheetTable('ATEM', [standard([{ windowIndex: 0, sourceId: 2 }])], namen).rows
+    expect(zeile[4]).toBe(2)
+    expect(zeile[5]).toBe('Kamera 2')
+  })
+
+  it('sagt „keine Rolle im Plan" statt eine zu erfinden', () => {
+    const [zeile] = mvSheetTable('ATEM', [standard([{ windowIndex: 0, sourceId: 99 }])], namen).rows
+    expect(zeile[5]).toBe(NO_ROLE)
+  })
+
+  it('sagt „nicht belegt" in BEIDEN Spalten', () => {
+    const [zeile] = mvSheetTable('ATEM', [standard([])], namen).rows
+    expect(zeile[4]).toBe(NO_SOURCE)
+    expect(zeile[5]).toBe(NO_SOURCE)
+  })
+
+  it('sortiert nach Multiviewer-Index', () => {
+    const rows = mvSheetTable(
+      'ATEM',
+      [mv({ index: 1, quadrants: ['big', 'big', 'big', 'big'] }), mv({ index: 0, quadrants: ['big', 'big', 'big', 'big'] })],
+      namen,
+    ).rows
+    expect(rows[0][0]).toBe('ATEM · MV 1')
+    expect(rows[4][0]).toBe('ATEM · MV 2')
+  })
+
+  it('hat einen eintragbaren Stand', () => {
+    expect(typeof DOCUMENT_STANDS['mv-bild']).toBe('function')
+  })
+})
+
+// ── 3. Der belegte Fehler ──────────────────────────────────────────────────
+
+describe('mvFindings', () => {
+  it('meldet zwei Fenster mit derselben Quelle als FEHLER', () => {
+    // DER Fall aus `#480`: „MV windows 2 and 3 recall the same source".
+    // Fehler und nicht Warnung: zwei gleiche Bilder nebeneinander heissen,
+    // dass eine Kamera auf dem Multiviewer gar nicht vorkommt.
+    const f = mvFindings(
+      [standard([
+        { windowIndex: 30, sourceId: 1 },
+        { windowIndex: 31, sourceId: 1 },
+      ])],
+      namen,
+    )
+    const doppelt = f.find((x) => x.kind === 'duplicate-source')
+    expect(doppelt?.severity).toBe('error')
+    expect(doppelt?.message).toContain('Kamera 1')
+    expect(doppelt?.message).toContain('fehlt')
+  })
+
+  it('nennt in der Doppelbelegung BEIDE Positionen', () => {
+    // „Zwei Fenster doppelt" schickt niemanden zum richtigen Fenster.
+    const f = mvFindings(
+      [standard([
+        { windowIndex: 30, sourceId: 1 },
+        { windowIndex: 31, sourceId: 1 },
+      ])],
+      namen,
+    )
+    const m = f.find((x) => x.kind === 'duplicate-source')?.message ?? ''
+    expect(m).toContain('Zelle 1')
+    expect(m).toContain('Zelle 2')
+  })
+
+  it('macht aus dem leeren Fenster nur einen HINWEIS', () => {
+    // Ein Aufbau mit weniger Kameras als Fenstern ist der Normalfall.
+    const f = mvFindings([standard([])], namen)
+    expect(f.every((x) => x.kind === 'empty-window' && x.severity === 'warning')).toBe(true)
+  })
+
+  it('ignoriert eine Belegung, die im aktuellen Layout kein Fenster hat', () => {
+    // `windowIndex 20` gehoert zum Quadranten oben rechts als KLEINE Zelle.
+    // Steht der Quadrant auf „gross", gibt es diese Zelle nicht — und ein
+    // Blatt, das sie trotzdem fuehrte, schickte jemanden vor einen Bildteil,
+    // den er nicht findet. (Die Zellen-Nummern folgen `mvWindowIndex`:
+    // Quadrant 0 -> 10-13, 1 -> 20-23, 2 -> 30-33, 3 -> 40-43.)
+    const w = mvWindows(standard([{ windowIndex: 20, sourceId: 1 }]))
+    expect(w.every((x) => x.sourceId === undefined)).toBe(true)
+  })
+
+  it('meldet die Quelle ohne Rolle', () => {
+    const f = mvFindings([standard([{ windowIndex: 0, sourceId: 99 }])], namen)
+    expect(f.find((x) => x.kind === 'unknown-source')?.message).toContain('99')
+  })
+
+  it('meldet nichts bei einem sauber belegten Bild', () => {
+    const voll = mv({
+      index: 0,
+      quadrants: ['big', 'big', 'big', 'big'],
+      windows: [
+        { windowIndex: 0, sourceId: 1 },
+        { windowIndex: 1, sourceId: 2 },
+        { windowIndex: 2, sourceId: 3 },
+        { windowIndex: 3, sourceId: 4 },
+      ],
+    })
+    expect(mvFindings([voll], new Map([...namen, [4, 'Kamera 4']]))).toEqual([])
+  })
+})
+
+// ── 4. Die Bruecke zu den Rollen ───────────────────────────────────────────
+
+describe('sourceNamesFromTallyRows', () => {
+  it('nimmt Eingangsnummer -> Rollenname aus der Tally-Karte', () => {
+    const m = sourceNamesFromTallyRows([
+      { name: 'Kamera 1', switcher: { input: 1 } },
+      { name: 'Kamera 2', switcher: { input: 3 } },
+    ])
+    expect(m.get(1)).toBe('Kamera 1')
+    expect(m.get(3)).toBe('Kamera 2')
+  })
+
+  it('ueberspringt Rollen ohne Mischer-Eingang', () => {
+    // Eine Rolle, die nirgends am Mischer ankommt, hat keine Quell-Nummer —
+    // sie zu raten hiesse, dem Blatt einen unpruefbaren Namen zu geben.
+    const m = sourceNamesFromTallyRows([{ name: 'Kamera ohne Kabel' }])
+    expect(m.size).toBe(0)
+  })
+
+  it('laesst bei zwei Rollen auf einem Eingang die erste stehen', () => {
+    // Das ist ein Befund der TALLY-Karte und nicht dieses Blatts.
+    const m = sourceNamesFromTallyRows([
+      { name: 'Erste', switcher: { input: 1 } },
+      { name: 'Zweite', switcher: { input: 1 } },
+    ])
+    expect(m.get(1)).toBe('Erste')
+  })
+})
+
+describe('multiViewersOf', () => {
+  it('liefert eine leere Liste, wo keine Konfiguration steht', () => {
+    expect(multiViewersOf({ id: 'x', name: 'X' } as EquipmentItem)).toEqual([])
+  })
+})
+
+// ── 5. Reinheit und Erreichbarkeit ─────────────────────────────────────────
+
+describe('das Modul und die Oberflaeche', () => {
+  it('nimmt keine Uhr, keinen Store und keinen Live-Zustand', () => {
+    // Was der Mischer GERADE tut, ist eine Beobachtung. Sie hier einzumischen
+    // erzeugte genau die zweite Wahrheit, die ADR-001 sonst verbietet.
+    expect(libQuelle).not.toContain('new Date(')
+    expect(libQuelle).not.toContain('useProjectStore')
+    expect(libQuelle).not.toContain('cablePlannerApi')
+  })
+
+  it('loest die Namen NICHT selbst auf', () => {
+    // Drei handgefuehrte Kopien derselben Eingangs-Karte sind der Kern des
+    // Bedarfs. Eine vierte hier waere dieselbe Krankheit.
+    expect(libQuelle).not.toContain('roleLabelsByPort')
+    expect(libQuelle).not.toContain('deriveLabels')
+    expect(libQuelle).toContain('Kommt FERTIG herein')
+  })
+
+  it('geht ueber die vorhandene Quadranten-Engstelle', () => {
+    expect(libQuelle).toContain('getMvQuadrants(mv)')
+  })
+
+  it('ist im Tally-Abschnitt erreichbar — an DERSELBEN Aufloesung', () => {
+    expect(dialogQuelle).toMatch(/<MvSheetPanel map=\{map\} \/>/)
+    expect(dialogQuelle).toContain('sourceNamesFromTallyRows(map.rows)')
+  })
+})


### PR DESCRIPTION
Bedarf 125 (P4) aus dem Recherche-Korpus.

> MV window assignment is configured by hand per show; remote recall is unreliable, so **the trusted store is the switcher's own binary save file, which no other department can read**.

Belegt an `bitfocus/companion-module-bmd-atem#480` (2026, offen): dort rufen die MV-Fenster 2 und 3 dieselbe Quelle ab.

## Der Schaden ist nicht der Recall, sondern die Lesbarkeit

Der Plan macht den Recall nicht zuverlässiger — das ist Sache des Mischers, und dieses Modul schreibt nichts an ihn und liest keinen Live-Zustand. Der Schaden, den der Plan beheben kann: der Zustand existiert **nur** binär. Die Kameraleute wissen dann nicht, in welchem Fenster sie stehen, der Regisseur hat nichts zum Gegenlesen, und beim nächsten Aufbau tippt jemand die Belegung erneut ein.

`lib/mvSheet.ts` liefert das fehlende Blatt: eine Zeile je Fenster, mit der **Position im Klartext** („unten rechts, Zelle 2") statt eines internen Index, und mit der **Rolle** statt der nackten Quell-Nummer.

## Die Namen kommen aus den Rollen — nicht aus einer vierten Liste

Die Maßnahme lautet wörtlich „labels come from the source records", und der Kern des Marktproblems sind **drei handgeführte Kopien** derselben Eingangs-Karte. Eine vierte hier wäre dieselbe Krankheit. Das Modul löst deshalb nichts selbst auf: `SourceNames` kommt fertig herein, im Dialog aus `map.rows` — derselben Tally-Karte. Das Panel hängt aus demselben Grund **im** Tally-Abschnitt; ein eigener Abschnitt verführte dazu, die Namen ein zweites Mal aufzulösen.

Ebenso: Fenster aus `getMvQuadrants`, Fensterzahl aus `getMvGridSpec` — den vorhandenen Engstellen, aus denen auch die Oberfläche zeichnet.

## Der belegte Fehler wird zum Befund

`duplicate-source` ist der Fall aus #480 und ein **Fehler**, keine Warnung: zwei gleiche Bilder nebeneinander heißen, dass eine Kamera auf dem Multiviewer gar nicht vorkommt. Der Befund nennt **beide** Positionen. Ein unbelegtes Fenster ist dagegen nur ein Hinweis — weniger Kameras als Fenster ist der Normalfall.

## Ein Lexikon-Eintrag, der zwei Blätter falsch beschrieb

`Position` erklärte weiterhin nur „die einzelne Zeile einer Liste" — während die Vor-Show-Liste (Bedarf 105) darunter die **Kamera**-Position führt und dieses Blatt den Ort auf dem **Schirm**. Dritter Fall derselben Art in dieser Reihe (nach `Abnahme` und `Vorher`/`Nachher`); der Eintrag nennt jetzt alle drei Lesarten, und ein Guard hält es fest.

## Prüfung

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — 164 Test-Dateien grün (27 neue Fälle)
- `npm run lint` — 0 Errors
- Gegenprobe: 24 injizierte Defekte, alle rot — darunter „Doppelbelegung wird verschwiegen", „Modul löst die Namen selbst auf", „Fenster kommen aus dem Layout statt den Quadranten", „Dialog löst die Namen zweitmalig auf".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_