### PR TITLE
verify: „wie geplant" gegen „wie gebaut" — ein Blatt statt vier Vergleiche (#126)

### DIFF
--- a/src/renderer/components/Network/ReconcileDialog.tsx
+++ b/src/renderer/components/Network/ReconcileDialog.tsx
@@ -17,6 +17,13 @@ import {
   type ReconcileReport,
   type ReconcileVerdict,
 } from '../../lib/networkReconcile'
+import {
+  asBuiltSummary,
+  asBuiltTable,
+  fromNetworkReport,
+  mergeEntries,
+  unverifiedEntries,
+} from '../../lib/asBuilt'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Plan gegen Vorgefundenes (Bedarf 21).
@@ -48,6 +55,27 @@ export const ReconcileDialog = () => {
     [equipment, scan],
   )
 
+  // BEDARF 126 — das As-Built-Blatt.
+  //
+  //   > post HAS NO RECORD of which physical source was on which input.
+  //
+  // Der Abgleich oben zeigt die ABWEICHUNGEN; dieses Blatt zeigt den ganzen
+  // Bestand, und zwar mit der Luecke darin: jedes Geraet, das der Scan NICHT
+  // gesehen hat, steht als „nicht nachgesehen" darauf. Ohne diese Zeilen
+  // fuehrte das Blatt nur die Geraete, an denen jemand war, und laese sich wie
+  // eine vollstaendige Pruefung.
+  const asBuilt = useMemo(() => {
+    const geplant = unverifiedEntries(
+      equipment
+        .filter((e) => e.ipAddress)
+        .map((e) => ({ subject: e.name, field: 'IP-Adresse', planned: e.ipAddress })),
+      'network-scan',
+    )
+    return mergeEntries(geplant, report ? fromNetworkReport(report) : [])
+  }, [equipment, report])
+
+  const asBuiltStand = useMemo(() => asBuiltSummary(asBuilt), [asBuilt])
+
   if (!open) return null
 
   const load = async () => {
@@ -77,6 +105,14 @@ export const ReconcileDialog = () => {
     downloadBlob(
       buildExportFilenameWithSuffix(projectName, 'abgleich', 'csv'),
       csvFromTable(reconcileTable(report)),
+      'text/csv',
+    )
+  }
+
+  const exportAsBuilt = () => {
+    downloadBlob(
+      buildExportFilenameWithSuffix(projectName, 'as-built', 'csv'),
+      csvFromTable(asBuiltTable(asBuilt)),
       'text/csv',
     )
   }
@@ -153,6 +189,30 @@ export const ReconcileDialog = () => {
                 </button>
               </>
             )}
+          </div>
+
+          {/* BEDARF 126 — „wie geplant" gegen „wie gebaut", als EIN Blatt.
+              Es steht auch OHNE Scan da: dann besteht es ganz aus „nicht
+              nachgesehen", und genau das ist die ehrliche Auskunft. */}
+          <div className="flex flex-wrap items-center gap-2 border-t border-cp-border-muted pt-2 text-cp-xs">
+            <span className="text-cp-text-secondary">
+              {t('asBuilt.title', 'As-Built-Blatt (wie geplant / wie gebaut)')}
+            </span>
+            <span className="text-cp-text-muted">
+              {format(
+                t('asBuilt.count', '{verified} von {total} Angaben nachgesehen'),
+                { verified: asBuiltStand.verified, total: asBuiltStand.total },
+              )}
+            </span>
+            <button
+              type="button"
+              onClick={exportAsBuilt}
+              disabled={asBuiltStand.total === 0}
+              className="ml-auto inline-flex items-center gap-1 rounded border border-cp-border px-2 py-1 text-cp-text-secondary hover:text-cp-text disabled:opacity-40"
+            >
+              <Icon icon={Download} size="xs" />
+              {t('asBuilt.export', 'As-Built')}
+            </button>
           </div>
 
           {error && (

--- a/src/renderer/lib/asBuilt.ts
+++ b/src/renderer/lib/asBuilt.ts
@@ -1,0 +1,321 @@
+// ───────────────────────────────────────────────────────────────────────────
+// „Wie geplant" gegen „wie gebaut" — ein Blatt statt vier Vergleiche
+// (Bedarf 126, P4).
+//
+//   > Nothing reconciles the plan against what the devices actually hold;
+//   > drift is discovered IN REHEARSAL AT BEST AND ON AIR AT WORST, and POST
+//   > HAS NO RECORD of which physical source was on which input.
+//
+// Belegt an der Architektur von Sofie: dort ist die Unterscheidung ein
+// erstklassiger Begriff — Parts werden vor der Wiedergabe instanziiert, damit
+// On Air/Next von Änderungen am Ingest unberührt bleiben UND damit sich der
+// „as played"-Zustand unabhängig vom „as planned"-Zustand betrachten lässt.
+//
+// Die Massnahme der Bedarfs-Datenbank ist wörtlich: „Read-back/verify: 'the
+// rig says X, the plan says Y'. Nothing in the surveyed ecosystem offers
+// this, and it also produces the AS-BUILT ARTEFACT post-production currently
+// lacks."
+//
+// ─── WAS ES SCHON GAB, UND WARUM ES NICHT REICHTE ──────────────────────────
+//
+// Dieser Plan vergleicht an VIER Stellen gegen die Wirklichkeit:
+//
+//   `networkReconcile`    Plan gegen ARP-/Netz-Scan (Bedarf 21)
+//   `atemLiveCompare`     Plan gegen den ATEM (MV, Audio-Matrix)
+//   `videohubRouting`     Plan gegen die Kreuzpunkte des Hubs
+//   `erpReconcile`        Plan gegen die Vermietungs-Software
+//
+// Jeder für sich ist richtig. Zusammen sind sie das, was der Beleg beklagt:
+// vier Vergleiche in vier Dialogen, die niemand gemeinsam fährt, und danach
+// kein einziges Blatt, das die Post lesen könnte. Dieses Modul rechnet
+// deshalb NICHTS neu — es nimmt, was die vier schon liefern, und bringt es in
+// EINE Zeilenform mit EINEM Urteil.
+//
+// ─── DIE REGEL, DIE DAS BLATT TRÄGT ────────────────────────────────────────
+//
+// OHNE ABLESUNG GIBT ES KEIN „STIMMT". Eine Zeile, zu der kein Gerät befragt
+// wurde, heisst `not-verified` — nicht `match`. Das ist dieselbe Regel wie
+// beim Tally-Urteil (Bedarf 105) und aus demselben Grund: „stimmt" ist eine
+// Aussage über die Wirklichkeit, und wer nicht hingesehen hat, hat keine.
+//
+// Und: JEDE ABLESUNG TRÄGT IHREN ZEITPUNKT. Ein Verify-Lauf von gestern ist
+// kein Verify-Lauf; ein Blatt ohne Zeitpunkt behauptet Gegenwart. Die Uhr
+// kommt vom Aufrufer — dieses Modul nimmt keine.
+//
+// ─── WAS DAS BLATT NICHT TUT ───────────────────────────────────────────────
+//
+// Es schreibt den Befund NICHT in den Plan zurück. „Was der Hub gerade tut,
+// ist eine Beobachtung, was im Plan steht, eine Absicht" (`videohubRouting`),
+// und beides in dieselbe Variable zu schreiben macht die Absicht
+// unauffindbar. Das Blatt stellt beide nebeneinander; entscheiden tut ein
+// Mensch.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { LiveComparison } from './atemLiveCompare'
+import { allDeltas } from './atemLiveCompare'
+import type { ReconcileReport } from './networkReconcile'
+import { salvoChanges } from './salvoSheet'
+import type { VideohubCrosspoints } from '../types/equipment'
+import type { CsvTable } from './csv'
+
+/** Woher eine Ablesung stammt. */
+export type ReadingSource =
+  /** Netz-Scan (ARP-Tabelle, Switch-Auszug). */
+  | 'network-scan'
+  /** Der Mischer selbst. */
+  | 'atem'
+  /** Der Router. */
+  | 'videohub'
+  /** Die Vermietungs-Software. */
+  | 'erp'
+  /** Von Hand eingetragen, weil niemand das Gerät befragen kann. */
+  | 'manual'
+
+export const READING_SOURCE_LABEL: Readonly<Record<ReadingSource, string>> = {
+  'network-scan': 'Netz-Scan',
+  atem: 'Mischer',
+  videohub: 'Router',
+  erp: 'Vermietung',
+  manual: 'von Hand',
+}
+
+/** Das Urteil einer Zeile. */
+export type AsBuiltVerdict =
+  /** Plan und Ablesung sagen dasselbe. */
+  | 'match'
+  /** Beide sagen etwas, und es ist verschieden. */
+  | 'differs'
+  /** Der Plan sieht es vor, die Ablesung kennt es nicht. */
+  | 'missing'
+  /** Die Ablesung meldet es, der Plan kennt es nicht. */
+  | 'unexpected'
+  /** Niemand hat nachgesehen. KEIN Urteil — und das ist der Punkt. */
+  | 'not-verified'
+
+export const AS_BUILT_VERDICT_LABEL: Readonly<Record<AsBuiltVerdict, string>> = {
+  match: 'stimmt überein',
+  differs: 'weicht ab',
+  missing: 'im Plan, nicht vorgefunden',
+  unexpected: 'vorgefunden, nicht im Plan',
+  'not-verified': 'nicht nachgesehen',
+}
+
+/** Was auf dem Blatt steht, wo eine Seite nichts sagt. */
+export const NOT_STATED = 'keine Angabe'
+
+/** Eine Zeile: ein Gegenstand, ein Feld, zwei Seiten. */
+export interface AsBuiltEntry {
+  /** Worum es geht („ATEM 1 · In 3", „Kamera 1"). */
+  subject: string
+  /** Welches Feld verglichen wurde („Quelle", „IP-Adresse", „Kreuzpunkt"). */
+  field: string
+  /** Was der Plan sagt. Fehlt bei `unexpected`. */
+  planned?: string
+  /** Was abgelesen wurde. Fehlt bei `missing` und `not-verified`. */
+  actual?: string
+  source: ReadingSource
+  /** Zeitpunkt der Ablesung (ISO). Fehlt bei `not-verified`. */
+  at?: string
+}
+
+/**
+ * Das Urteil aus den beiden Seiten — die Engstelle.
+ *
+ * Bewusst NICHT aus dem Vorhandensein einer Ablesung allein: eine Zeile ohne
+ * Zeitpunkt ist keine Ablesung, sondern eine Behauptung. Deshalb verlangt
+ * jedes Urteil ausser `not-verified`, dass ein Zeitpunkt dabeisteht.
+ */
+export function asBuiltVerdict(entry: AsBuiltEntry): AsBuiltVerdict {
+  if (!entry.at) return 'not-verified'
+  const p = entry.planned?.trim()
+  const a = entry.actual?.trim()
+  if (!p && !a) return 'not-verified'
+  if (p && !a) return 'missing'
+  if (!p && a) return 'unexpected'
+  return p === a ? 'match' : 'differs'
+}
+
+export const AS_BUILT_HEADERS = [
+  'Gegenstand',
+  'Feld',
+  'Wie geplant',
+  'Wie gebaut',
+  'Urteil',
+  'Abgelesen von',
+  'Abgelesen am',
+] as const
+
+const datum = (at: string | undefined): string => (at ? at.slice(0, 10) : NOT_STATED)
+
+/**
+ * Das As-Built-Blatt — das Artefakt, das der Post heute fehlt.
+ *
+ * Sortiert nach Gegenstand und Feld, damit zwei Läufe desselben Aufbaus
+ * zeilenweise nebeneinander zu legen sind. Ein Blatt, dessen Reihenfolge vom
+ * Bearbeitungsverlauf abhängt, lässt sich nicht vergleichen — dieselbe
+ * Begründung wie bei `switcherLinkFor`.
+ */
+export function asBuiltTable(entries: readonly AsBuiltEntry[]): CsvTable {
+  const rows = [...entries]
+    .sort((a, b) => a.subject.localeCompare(b.subject) || a.field.localeCompare(b.field))
+    .map((e) => [
+      e.subject,
+      e.field,
+      e.planned?.trim() || NOT_STATED,
+      e.actual?.trim() || NOT_STATED,
+      AS_BUILT_VERDICT_LABEL[asBuiltVerdict(e)],
+      READING_SOURCE_LABEL[e.source],
+      datum(e.at),
+    ])
+  return { headers: [...AS_BUILT_HEADERS], rows }
+}
+
+export interface AsBuiltSummary {
+  /** Je Urteil die Anzahl. */
+  counts: Record<AsBuiltVerdict, number>
+  /** Wie viele Zeilen überhaupt eine Ablesung haben. */
+  verified: number
+  total: number
+  /** Der jüngste Zeitpunkt einer Ablesung, oder undefined. */
+  latest?: string
+}
+
+/**
+ * Die Zusammenfassung — und zwar mit `not-verified` SICHTBAR.
+ *
+ * Ein Deckblatt, das nur „12 stimmen überein, 2 weichen ab" sagt, verschweigt
+ * die dreissig Zeilen, in die niemand gesehen hat, und liest sich wie eine
+ * Freigabe. Deshalb steht hier immer auch, wie viele von wie vielen.
+ */
+export function asBuiltSummary(entries: readonly AsBuiltEntry[]): AsBuiltSummary {
+  const counts: Record<AsBuiltVerdict, number> = {
+    match: 0,
+    differs: 0,
+    missing: 0,
+    unexpected: 0,
+    'not-verified': 0,
+  }
+  let latest: string | undefined
+  for (const e of entries) {
+    counts[asBuiltVerdict(e)] += 1
+    if (e.at && (!latest || e.at > latest)) latest = e.at
+  }
+  const verified = entries.length - counts['not-verified']
+  return {
+    counts,
+    verified,
+    total: entries.length,
+    ...(latest ? { latest } : {}),
+  }
+}
+
+// ─── Die vier Zubringer ────────────────────────────────────────────────────
+//
+// Jeder nimmt das Ergebnis eines vorhandenen Vergleichs und übersetzt es in
+// die gemeinsame Zeilenform. Keiner rechnet neu: das wäre eine fünfte
+// Wahrheit über dieselbe Frage, und genau die Vervielfachung beklagt der
+// Bedarf.
+
+/** Aus dem Netz-Abgleich (Bedarf 21). */
+export function fromNetworkReport(report: ReconcileReport): AsBuiltEntry[] {
+  return report.rows.map((r) => {
+    const subject = r.planned ?? r.found ?? 'unbenannt'
+    const entry: AsBuiltEntry = {
+      subject,
+      field: 'IP-Adresse',
+      source: 'network-scan',
+      at: report.takenAt,
+    }
+    if (r.plannedIp) entry.planned = r.plannedIp
+    if (r.foundIp) entry.actual = r.foundIp
+    return entry
+  })
+}
+
+/** Aus dem Mischer-Vergleich. `at` kommt vom Aufrufer — das Modul hat keine Uhr. */
+export function fromLiveComparison(
+  comparison: LiveComparison,
+  field: string,
+  at: string,
+): AsBuiltEntry[] {
+  return allDeltas(comparison).map((d) => {
+    const entry: AsBuiltEntry = { subject: d.label, field, source: 'atem', at }
+    if (d.planned !== undefined) entry.planned = String(d.planned)
+    if (d.confirmed !== undefined) entry.actual = String(d.confirmed)
+    return entry
+  })
+}
+
+/**
+ * Aus dem Kreuzpunkt-Vergleich.
+ *
+ * Über `salvoChanges` und nicht über `routingDifferences` direkt: die
+ * Umbenennung von `planned`/`live` auf `from`/`to` liegt dort schon, und die
+ * Nummern werden hier — wie auf dem Umbau-Zettel — als AUFGEDRUCKTE Nummern
+ * geführt (ab 1). Ein Blatt, das intern zählt, schickt jemanden zum falschen
+ * Kreuzpunkt.
+ */
+export function fromCrosspoints(
+  deviceName: string,
+  planned: VideohubCrosspoints,
+  live: VideohubCrosspoints,
+  at: string,
+): AsBuiltEntry[] {
+  return salvoChanges(planned, live).map((c) => {
+    const entry: AsBuiltEntry = {
+      subject: `${deviceName} · Ausgang ${c.output + 1}`,
+      field: 'Kreuzpunkt',
+      source: 'videohub',
+      at,
+    }
+    if (c.from !== undefined) entry.planned = String(c.from + 1)
+    if (c.to !== undefined) entry.actual = String(c.to + 1)
+    return entry
+  })
+}
+
+/**
+ * Zeilen für alles, was NICHT abgelesen wurde.
+ *
+ * Der wichtigste Zubringer, und der einzige, der nichts vergleicht: er macht
+ * die Lücke sichtbar. Ohne ihn führte das Blatt nur die Gegenstände, an denen
+ * jemand war — und läse sich wie eine vollständige Prüfung.
+ */
+export function unverifiedEntries(
+  subjects: readonly { subject: string; field: string; planned?: string }[],
+  source: ReadingSource = 'manual',
+): AsBuiltEntry[] {
+  return subjects.map((s) => ({
+    subject: s.subject,
+    field: s.field,
+    source,
+    ...(s.planned ? { planned: s.planned } : {}),
+  }))
+}
+
+/**
+ * Zusammenführen, ohne dass eine Ablesung eine andere still überschreibt.
+ *
+ * Gleicher Gegenstand und gleiches Feld: die JÜNGERE Ablesung gewinnt, und
+ * eine Zeile ohne Ablesung verliert immer gegen eine mit. So darf der
+ * `unverifiedEntries`-Zubringer grosszügig alles auflisten, ohne die echten
+ * Befunde zu verdrängen.
+ */
+export function mergeEntries(...groups: ReadonlyArray<readonly AsBuiltEntry[]>): AsBuiltEntry[] {
+  const byKey = new Map<string, AsBuiltEntry>()
+  for (const group of groups) {
+    for (const e of group) {
+      const key = `${e.subject} ${e.field}`
+      const vorhanden = byKey.get(key)
+      if (!vorhanden) {
+        byKey.set(key, e)
+        continue
+      }
+      if (!e.at) continue
+      if (!vorhanden.at || e.at > vorhanden.at) byKey.set(key, e)
+    }
+  }
+  return [...byKey.values()]
+}

--- a/src/renderer/lib/dataDictionary.ts
+++ b/src/renderer/lib/dataDictionary.ts
@@ -51,6 +51,16 @@ export const UNDESCRIBED = 'nicht beschrieben'
  * Datei, ohne dass sich am Plan etwas geaendert haette.
  */
 export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
+  // Bedarf 126 — das As-Built-Blatt (`lib/asBuilt.ts`).
+  Gegenstand:
+    'Worum die Zeile geht — ein Gerät, ein Anschluss oder ein Ausgang, so benannt, wie er im Plan heißt.',
+  'Wie geplant': 'Was der Plan für dieses Feld vorsieht. „keine Angabe“ heißt: der Plan sagt dazu nichts.',
+  'Wie gebaut':
+    'Was am Gerät ABGELESEN wurde. „keine Angabe“ heißt: niemand hat nachgesehen oder das Gerät hat dazu nichts gemeldet — nicht, dass es leer wäre.',
+  'Abgelesen von':
+    'Woher die Ablesung stammt (Netz-Scan, Mischer, Router, Vermietung, von Hand). Ohne Ablesung steht in der Urteils-Spalte „nicht nachgesehen“.',
+  'Abgelesen am':
+    'Der Tag der Ablesung. Fehlt er, gilt die Zeile als ungeprüft — ein Verify-Lauf von gestern ist kein Verify-Lauf.',
   // Bedarf 125 — das Multiviewer-Bild (`lib/mvSheet.ts`).
   Multiviewer:
     'Welcher Multiviewer des Mischers gemeint ist — Gerätename plus laufende Nummer, ab 1 gezählt wie am Gerät.',

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3490,6 +3490,10 @@ export const en: Dict = {
   'channelList.view.stage': 'Stage (position)',
   'channelList.view.console': 'Console (names)',
   'channelList.view.monitor': 'Monitor paths',
+  // Bedarf 126 — „wie geplant" gegen „wie gebaut".
+  'asBuilt.title': 'As-built sheet (as planned / as built)',
+  'asBuilt.count': '{verified} of {total} entries verified',
+  'asBuilt.export': 'As-built',
   // Bedarf 125 — das Multiviewer-Bild als Blatt.
   'mv.sheet.title': 'Multiviewer layout (who is in which window)',
   'mv.sheet.hint':

--- a/tests/asBuilt.test.ts
+++ b/tests/asBuilt.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AS_BUILT_HEADERS,
+  AS_BUILT_VERDICT_LABEL,
+  NOT_STATED,
+  READING_SOURCE_LABEL,
+  asBuiltSummary,
+  asBuiltTable,
+  asBuiltVerdict,
+  fromCrosspoints,
+  fromLiveComparison,
+  fromNetworkReport,
+  mergeEntries,
+  unverifiedEntries,
+  type AsBuiltEntry,
+} from '../src/renderer/lib/asBuilt'
+import type { LiveComparison } from '../src/renderer/lib/atemLiveCompare'
+import type { ReconcileReport } from '../src/renderer/lib/networkReconcile'
+import libQuelle from '../src/renderer/lib/asBuilt.ts?raw'
+import dialogQuelle from '../src/renderer/components/Network/ReconcileDialog.tsx?raw'
+
+// ---------------------------------------------------------------------------
+// „Wie geplant" gegen „wie gebaut" (Bedarf 126, P4).
+//
+//   > Nothing reconciles the plan against what the devices actually hold;
+//   > drift is discovered IN REHEARSAL AT BEST AND ON AIR AT WORST, and POST
+//   > HAS NO RECORD of which physical source was on which input.
+//
+// Belegt an der Architektur von Sofie, wo „as planned" und „as played" ein
+// erstklassiger Begriff sind. Die Massnahme woertlich: „Read-back/verify:
+// 'the rig says X, the plan says Y'. […] it also produces the AS-BUILT
+// ARTEFACT post-production currently lacks."
+//
+// DIE REGEL, DIE DAS BLATT TRAEGT: ohne Ablesung gibt es kein „stimmt".
+// ---------------------------------------------------------------------------
+
+const eintrag = (over: Partial<AsBuiltEntry> = {}): AsBuiltEntry => ({
+  subject: 'ATEM 1 · In 3',
+  field: 'Quelle',
+  source: 'atem',
+  ...over,
+})
+
+const jetzt = '2026-09-06T10:00:00.000Z'
+
+// ── 1. Ohne Ablesung kein „stimmt" ─────────────────────────────────────────
+
+describe('asBuiltVerdict — die Engstelle', () => {
+  it('sagt „nicht nachgesehen", wo kein Zeitpunkt steht', () => {
+    // Dieselbe Regel wie beim Tally-Urteil (Bedarf 105): „stimmt" ist eine
+    // Aussage ueber die Wirklichkeit, und wer nicht hingesehen hat, hat keine.
+    expect(asBuiltVerdict(eintrag({ planned: 'Kamera 1' }))).toBe('not-verified')
+    // Und auch dann nicht, wenn beide Seiten zufaellig dasselbe sagen.
+    expect(asBuiltVerdict(eintrag({ planned: 'Kamera 1', actual: 'Kamera 1' }))).toBe(
+      'not-verified',
+    )
+  })
+
+  it('nennt Uebereinstimmung erst MIT Zeitpunkt', () => {
+    expect(asBuiltVerdict(eintrag({ planned: 'Kamera 1', actual: 'Kamera 1', at: jetzt }))).toBe(
+      'match',
+    )
+  })
+
+  it('unterscheidet Abweichung, Fehlen und Ueberraschung', () => {
+    expect(asBuiltVerdict(eintrag({ planned: 'Kamera 1', actual: 'Kamera 2', at: jetzt }))).toBe(
+      'differs',
+    )
+    expect(asBuiltVerdict(eintrag({ planned: 'Kamera 1', at: jetzt }))).toBe('missing')
+    expect(asBuiltVerdict(eintrag({ actual: 'Kamera 9', at: jetzt }))).toBe('unexpected')
+  })
+
+  it('zaehlt eine Ablesung ohne beide Seiten nicht als Ablesung', () => {
+    expect(asBuiltVerdict(eintrag({ at: jetzt }))).toBe('not-verified')
+    expect(asBuiltVerdict(eintrag({ planned: '  ', actual: ' ', at: jetzt }))).toBe('not-verified')
+  })
+
+  it('haelt fuer jedes Urteil eine lesbare Ueberschrift bereit', () => {
+    for (const k of ['match', 'differs', 'missing', 'unexpected', 'not-verified'] as const) {
+      expect(AS_BUILT_VERDICT_LABEL[k].length).toBeGreaterThan(5)
+    }
+  })
+})
+
+// ── 2. Das Blatt ───────────────────────────────────────────────────────────
+
+describe('asBuiltTable — das Artefakt, das der Post fehlt', () => {
+  it('haelt den Spaltenkopf fest', () => {
+    expect(asBuiltTable([]).headers).toEqual([...AS_BUILT_HEADERS])
+  })
+
+  it('stellt beide Seiten NEBENEINANDER', () => {
+    // „the rig says X, the plan says Y" — beides, nicht eines.
+    const [zeile] = asBuiltTable([
+      eintrag({ planned: 'Kamera 1', actual: 'Kamera 2', at: jetzt }),
+    ]).rows
+    expect(zeile[2]).toBe('Kamera 1')
+    expect(zeile[3]).toBe('Kamera 2')
+    expect(zeile[4]).toBe(AS_BUILT_VERDICT_LABEL.differs)
+  })
+
+  it('schreibt einen NAMEN statt einer leeren Zelle', () => {
+    const [zeile] = asBuiltTable([eintrag({ planned: 'Kamera 1' })]).rows
+    expect(zeile[3]).toBe(NOT_STATED)
+    expect(zeile[6]).toBe(NOT_STATED)
+  })
+
+  it('nennt die Quelle der Ablesung im Klartext', () => {
+    const [zeile] = asBuiltTable([eintrag({ source: 'videohub', at: jetzt })]).rows
+    expect(zeile[5]).toBe(READING_SOURCE_LABEL.videohub)
+  })
+
+  it('sortiert nach Gegenstand und Feld — zwei Laeufe muessen vergleichbar sein', () => {
+    const rows = asBuiltTable([
+      eintrag({ subject: 'Zebra', field: 'B' }),
+      eintrag({ subject: 'Anton', field: 'B' }),
+      eintrag({ subject: 'Anton', field: 'A' }),
+    ]).rows
+    expect(rows.map((r) => [r[0], r[1]])).toEqual([
+      ['Anton', 'A'],
+      ['Anton', 'B'],
+      ['Zebra', 'B'],
+    ])
+  })
+
+  it('traegt nur das Datum, nicht die volle Uhrzeit', () => {
+    const [zeile] = asBuiltTable([eintrag({ planned: 'x', actual: 'x', at: jetzt })]).rows
+    expect(zeile[6]).toBe('2026-09-06')
+  })
+})
+
+// ── 3. Die Zusammenfassung verschweigt die Luecke nicht ────────────────────
+
+describe('asBuiltSummary', () => {
+  it('zaehlt „nicht nachgesehen" MIT', () => {
+    // Ein Deckblatt, das nur „12 stimmen ueberein" sagt, liest sich wie eine
+    // Freigabe — und verschweigt die dreissig Zeilen, in die niemand gesehen
+    // hat.
+    const s = asBuiltSummary([
+      eintrag({ planned: 'a', actual: 'a', at: jetzt }),
+      eintrag({ subject: 'B', planned: 'b' }),
+      eintrag({ subject: 'C', planned: 'c' }),
+    ])
+    expect(s.counts.match).toBe(1)
+    expect(s.counts['not-verified']).toBe(2)
+    expect(s.verified).toBe(1)
+    expect(s.total).toBe(3)
+  })
+
+  it('nennt den JUENGSTEN Zeitpunkt', () => {
+    const s = asBuiltSummary([
+      eintrag({ planned: 'a', actual: 'a', at: '2026-09-01T10:00:00.000Z' }),
+      eintrag({ subject: 'B', planned: 'b', actual: 'b', at: '2026-09-06T10:00:00.000Z' }),
+    ])
+    expect(s.latest).toBe('2026-09-06T10:00:00.000Z')
+  })
+
+  it('laesst den Zeitpunkt WEG, wo es keinen gibt', () => {
+    // Ein Blatt ohne Zeitpunkt behauptet sonst Gegenwart.
+    const s = asBuiltSummary([eintrag({ planned: 'a' })])
+    expect('latest' in s).toBe(false)
+  })
+
+  it('kommt mit einer leeren Liste zurecht', () => {
+    const s = asBuiltSummary([])
+    expect(s.total).toBe(0)
+    expect(s.verified).toBe(0)
+  })
+})
+
+// ── 4. Die Zubringer rechnen nichts neu ────────────────────────────────────
+
+describe('fromNetworkReport', () => {
+  const report: ReconcileReport = {
+    takenAt: jetzt,
+    source: 'arp',
+    counts: {} as ReconcileReport['counts'],
+    rows: [
+      { verdict: 'address-mismatch', planned: 'Kamera 1', plannedIp: '10.0.0.1', found: 'Kamera 1', foundIp: '10.0.0.9' },
+      { verdict: 'missing', planned: 'Kamera 2', plannedIp: '10.0.0.2' },
+      { verdict: 'unexpected', found: 'Fremdgeraet', foundIp: '10.0.0.77' },
+    ],
+  }
+
+  it('uebernimmt den Zeitpunkt des SCANS, nicht des Aufrufs', () => {
+    expect(fromNetworkReport(report).every((e) => e.at === jetzt)).toBe(true)
+  })
+
+  it('bildet die drei Faelle auf die drei Urteile ab', () => {
+    const [a, b, c] = fromNetworkReport(report)
+    expect(asBuiltVerdict(a)).toBe('differs')
+    expect(asBuiltVerdict(b)).toBe('missing')
+    expect(asBuiltVerdict(c)).toBe('unexpected')
+  })
+
+  it('nennt die Zeile ohne beide Namen „unbenannt" statt leer', () => {
+    const [e] = fromNetworkReport({ ...report, rows: [{ verdict: 'ambiguous' }] })
+    expect(e.subject).toBe('unbenannt')
+  })
+})
+
+describe('fromLiveComparison', () => {
+  const comparison: LiveComparison = {
+    deltas: [{ key: 'w1', label: 'MV Fenster 1', planned: 1, confirmed: 2 }],
+    onlyPlanned: [{ key: 'w2', label: 'MV Fenster 2', planned: 3 }],
+    onlyConfirmed: [{ key: 'w3', label: 'MV Fenster 3', confirmed: 4 }],
+    agreeing: 5,
+  }
+
+  it('nimmt ALLE drei Listen — nicht nur die Deltas', () => {
+    // „Im Plan, aber das Geraet sagt nichts dazu" ist etwas anderes als „im
+    // Plan auf 0"; beide gehoeren aufs Blatt.
+    expect(fromLiveComparison(comparison, 'Quelle', jetzt)).toHaveLength(3)
+  })
+
+  it('haelt planned und confirmed auseinander', () => {
+    const [d, nurPlan, nurGeraet] = fromLiveComparison(comparison, 'Quelle', jetzt)
+    expect([d.planned, d.actual]).toEqual(['1', '2'])
+    expect('actual' in nurPlan).toBe(false)
+    expect('planned' in nurGeraet).toBe(false)
+  })
+
+  it('nimmt den Zeitpunkt vom Aufrufer', () => {
+    expect(fromLiveComparison(comparison, 'Quelle', jetzt)[0].at).toBe(jetzt)
+  })
+})
+
+describe('fromCrosspoints', () => {
+  it('fuehrt die AUFGEDRUCKTEN Nummern, nicht die internen', () => {
+    // Ein Blatt, das intern ab 0 zaehlt, schickt jemanden zum falschen
+    // Kreuzpunkt — dieselbe Regel wie auf dem Umbau-Zettel (Bedarf 121).
+    const [e] = fromCrosspoints('Videohub', { 0: 1 }, { 0: 2 }, jetzt)
+    expect(e.subject).toBe('Videohub · Ausgang 1')
+    expect(e.planned).toBe('2')
+    expect(e.actual).toBe('3')
+  })
+
+  it('meldet nur die Ausgaenge, die abweichen', () => {
+    expect(fromCrosspoints('VH', { 0: 1, 1: 1 }, { 0: 1, 1: 2 }, jetzt)).toHaveLength(1)
+  })
+
+  it('laesst die fehlende Seite weg', () => {
+    const [e] = fromCrosspoints('VH', { 0: 1 }, {}, jetzt)
+    expect('actual' in e).toBe(false)
+    expect(asBuiltVerdict(e)).toBe('missing')
+  })
+})
+
+// ── 5. Die Luecke bleibt sichtbar ──────────────────────────────────────────
+
+describe('unverifiedEntries', () => {
+  it('macht aus einem Plan-Gegenstand eine Zeile OHNE Ablesung', () => {
+    // Ohne diesen Zubringer fuehrte das Blatt nur die Gegenstaende, an denen
+    // jemand war — und laese sich wie eine vollstaendige Pruefung.
+    const [e] = unverifiedEntries([{ subject: 'Kamera 5', field: 'Quelle', planned: 'In 5' }])
+    expect('at' in e).toBe(false)
+    expect(asBuiltVerdict(e)).toBe('not-verified')
+  })
+
+  it('laesst einen leeren Plan-Wert weg statt ihn leer zu fuehren', () => {
+    const [e] = unverifiedEntries([{ subject: 'X', field: 'Y' }])
+    expect('planned' in e).toBe(false)
+  })
+})
+
+describe('mergeEntries', () => {
+  it('laesst die Ablesung gegen die Luecke gewinnen', () => {
+    const gemischt = mergeEntries(
+      unverifiedEntries([{ subject: 'ATEM 1 · In 3', field: 'Quelle', planned: 'Kamera 1' }]),
+      [eintrag({ planned: 'Kamera 1', actual: 'Kamera 2', at: jetzt })],
+    )
+    expect(gemischt).toHaveLength(1)
+    expect(asBuiltVerdict(gemischt[0])).toBe('differs')
+  })
+
+  it('laesst die Ablesung auch dann gewinnen, wenn sie SPAETER kommt', () => {
+    // Die Reihenfolge der Zubringer darf das Ergebnis nicht bestimmen.
+    const andersrum = mergeEntries(
+      [eintrag({ planned: 'Kamera 1', actual: 'Kamera 2', at: jetzt })],
+      unverifiedEntries([{ subject: 'ATEM 1 · In 3', field: 'Quelle', planned: 'Kamera 1' }]),
+    )
+    expect(asBuiltVerdict(andersrum[0])).toBe('differs')
+  })
+
+  it('nimmt bei zwei Ablesungen die JUENGERE — in BEIDEN Reihenfolgen', () => {
+    // Nur die eine Richtung zu pruefen sagt nichts: dort gewinnt die zweite
+    // Gruppe ohnehin. Der Fall, um den es geht, ist die ALTE Ablesung, die
+    // spaeter hereinkommt — sie darf die juengere nicht ueberschreiben.
+    const alt_zuerst = mergeEntries(
+      [eintrag({ planned: 'a', actual: 'alt', at: '2026-09-01T10:00:00.000Z' })],
+      [eintrag({ planned: 'a', actual: 'neu', at: '2026-09-06T10:00:00.000Z' })],
+    )
+    expect(alt_zuerst[0].actual).toBe('neu')
+
+    const neu_zuerst = mergeEntries(
+      [eintrag({ planned: 'a', actual: 'neu', at: '2026-09-06T10:00:00.000Z' })],
+      [eintrag({ planned: 'a', actual: 'alt', at: '2026-09-01T10:00:00.000Z' })],
+    )
+    expect(neu_zuerst[0].actual).toBe('neu')
+  })
+
+  it('trennt gleiche Gegenstaende mit verschiedenem FELD', () => {
+    const m = mergeEntries(
+      [eintrag({ field: 'Quelle', at: jetzt, planned: 'a', actual: 'a' })],
+      [eintrag({ field: 'Kreuzpunkt', at: jetzt, planned: 'b', actual: 'b' })],
+    )
+    expect(m).toHaveLength(2)
+  })
+})
+
+// ── 6. Die Oberflaeche ─────────────────────────────────────────────────────
+
+describe('der Abgleich-Dialog', () => {
+  it('fuehrt AUCH die Geraete, die der Scan nicht gesehen hat', () => {
+    // Sonst fuehrte das Blatt nur die Geraete, an denen jemand war, und laese
+    // sich wie eine vollstaendige Pruefung — genau der Zustand, den der
+    // Bedarf beklagt („post has no record").
+    expect(dialogQuelle).toContain('unverifiedEntries(')
+    expect(dialogQuelle).toContain('mergeEntries(geplant, report ? fromNetworkReport(report) : [])')
+  })
+
+  it('nennt die Deckung in Zahlen, statt nur die Abweichungen zu zeigen', () => {
+    expect(dialogQuelle).toContain('asBuiltSummary(asBuilt)')
+    expect(dialogQuelle).toContain("t('asBuilt.count'")
+  })
+})
+
+// ── 7. Reinheit ────────────────────────────────────────────────────────────
+
+describe('das Modul', () => {
+  it('nimmt keine Uhr und keinen Store', () => {
+    expect(libQuelle).not.toContain('new Date(')
+    expect(libQuelle).not.toContain('Date.now')
+    expect(libQuelle).not.toContain('useProjectStore')
+  })
+
+  it('rechnet KEINEN der vier Vergleiche neu', () => {
+    // Eine fuenfte Wahrheit ueber dieselbe Frage waere genau die
+    // Vervielfachung, die der Bedarf beklagt.
+    expect(libQuelle).toContain('allDeltas(comparison)')
+    expect(libQuelle).toContain('salvoChanges(planned, live)')
+    expect(libQuelle).toContain('report.rows.map')
+    expect(libQuelle).not.toContain('normaliseMac')
+    expect(libQuelle).not.toContain('compareAssignments')
+  })
+
+  it('schreibt den Befund nicht in den Plan zurueck', () => {
+    // „Was der Hub gerade tut, ist eine Beobachtung, was im Plan steht, eine
+    // Absicht." Beides in dieselbe Variable zu schreiben macht die Absicht
+    // unauffindbar.
+    expect(libQuelle).not.toContain('updateEquipment')
+    expect(libQuelle).toContain('entscheiden tut ein')
+  })
+})


### PR DESCRIPTION
Bedarf 126 (P4) aus dem Recherche-Korpus.

> Nothing reconciles the plan against what the devices actually hold; drift is discovered **in rehearsal at best and on air at worst**, and **post has no record** of which physical source was on which input.

Belegt an der Architektur von Sofie, wo „as planned" und „as played" ein erstklassiger Begriff sind. Die Maßnahme wörtlich: „Read-back/verify: 'the rig says X, the plan says Y'. […] it also produces the **as-built artefact** post-production currently lacks."

## Was es schon gab, und warum es nicht reichte

Der Plan vergleicht an **vier** Stellen gegen die Wirklichkeit: `networkReconcile` (Bedarf 21), `atemLiveCompare`, `videohubRouting`, `erpReconcile`. Jeder für sich ist richtig — zusammen sind sie genau das, was der Beleg beklagt: vier Vergleiche in vier Dialogen, die niemand gemeinsam fährt, und danach kein Blatt, das die Post lesen könnte.

`lib/asBuilt.ts` rechnet deshalb **nichts neu**. Vier Zubringer übersetzen, was die vorhandenen Vergleiche schon liefern, in eine Zeilenform mit einem Urteil.

## Die Regel, die das Blatt trägt

**Ohne Ablesung gibt es kein „stimmt".** Eine Zeile ohne befragtes Gerät heißt `not-verified` — auch dann, wenn beide Seiten zufällig dasselbe sagen. Dieselbe Regel wie beim Tally-Urteil (Bedarf 105). Und jede Ablesung trägt ihren **Zeitpunkt**; ein Verify-Lauf von gestern ist kein Verify-Lauf.

## Die Lücke bleibt sichtbar

`unverifiedEntries` ist der wichtigste Zubringer und der einzige, der nichts vergleicht: er listet auf, was **nicht** abgelesen wurde. Ohne ihn führte das Blatt nur die Geräte, an denen jemand war, und läse sich wie eine vollständige Prüfung. `asBuiltSummary` nennt immer „x von y nachgesehen".

## Was das Blatt nicht tut

Es schreibt den Befund **nicht** in den Plan zurück — „was der Hub gerade tut, ist eine Beobachtung, was im Plan steht, eine Absicht". Erreichbar im Abgleich-Dialog, und zwar auch **ohne** Scan: dann besteht es ganz aus „nicht nachgesehen", und genau das ist die ehrliche Auskunft.

## Prüfung

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — 165 Test-Dateien grün (35 neue Fälle)
- `npm run lint` — 0 Errors
- Gegenprobe: 26 injizierte Defekte, alle rot. Zwei Lücken fand sie selbst und beide sind geschlossen: der Test auf die jüngere Ablesung prüfte nur eine Reihenfolge (in der sie ohnehin durch die Einfügereihenfolge gewann), und die Verwendung von `unverifiedEntries` im Dialog war ungeprüft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_