### PR TITLE
handover: eine Quittung je Container — auch für den Rückweg (#136)

### DIFF
--- a/src/renderer/components/Inventory/InventoryDialog.tsx
+++ b/src/renderer/components/Inventory/InventoryDialog.tsx
@@ -51,7 +51,15 @@ import type {
 } from '../../types/inventory'
 import { FAULT_SERVICE_LABEL } from '../../types/inventory'
 import { affectedServices, openFaultsOf } from '../../lib/faultHistory'
+import { promptDialog } from '../../lib/promptDialog'
 import { useCheckoutStore } from '../../store/checkoutStore'
+import {
+  SIGNATURE_REFUSAL_LABEL,
+  SIGNATURE_STATE_LABEL,
+  handoverSignatureTable,
+  signatureState,
+  type HandoverLeg,
+} from '../../lib/handoverSignature'
 import { ownershipNote, overdueSubhire, subhireStatus } from '../../lib/ownership'
 import type { CheckoutDamage, CheckoutRecord } from '../../types/checkout'
 import { damageEntries, damageTable, damageTally } from '../../lib/damageRegister'
@@ -2000,6 +2008,9 @@ const CheckoutTab = () => {
   const checkOut = useCheckoutStore((s) => s.checkOut)
   const checkIn = useCheckoutStore((s) => s.checkIn)
   const removeRecord = useCheckoutStore((s) => s.removeRecord)
+  // BEDARF 136 — quittieren, beide Beine.
+  const sign = useCheckoutStore((s) => s.sign)
+  const [signRefusal, setSignRefusal] = useState<string | null>(null)
 
   const [nodeId, setNodeId] = useState('')
   const [to, setTo] = useState('')
@@ -2236,6 +2247,62 @@ const CheckoutTab = () => {
                     >
                       {t('inventory.checkout.sheet', 'Schein')}
                     </button>
+                    {/* BEDARF 136 — die Quittung, und zwar auf BEIDEN Beinen.
+                        „check-in has no signature at all, so the return leg
+                        has no counter-signed evidence when a dispute arises
+                        weeks later" (snipe-it#19070/#19114). Das Blatt traegt
+                        beide Zeilen; hier wird festgehalten, WER und WANN. */}
+                    <button
+                      type="button"
+                      onClick={() =>
+                        csv(`quittung-${r.nodeLabel}.csv`, handoverSignatureTable(r))
+                      }
+                      className="mr-2 text-cp-text-secondary hover:text-cp-text"
+                      title={t(
+                        'inventory.checkout.signState',
+                        'Quittungs-Block zum Ausdrucken (beide Beine)',
+                      )}
+                    >
+                      {t(`handover.state.${signatureState(r)}`, SIGNATURE_STATE_LABEL[signatureState(r)])}
+                    </button>
+                    {signRefusal && (
+                      <span className="mr-2 text-cp-danger">{signRefusal}</span>
+                    )}
+                    {(['out', 'in'] as HandoverLeg[]).map((leg) => {
+                      const schon = leg === 'out' ? r.out.signature : r.in?.signature
+                      if (schon) return null
+                      // Die Rueckgabe laesst sich erst gegenzeichnen, wenn sie
+                      // stattgefunden hat — sonst quittierte jemand etwas, das
+                      // noch im Truck liegt.
+                      if (leg === 'in' && !r.in) return null
+                      return (
+                        <button
+                          key={leg}
+                          type="button"
+                          onClick={async () => {
+                            const name = (
+                              await promptDialog(
+                                leg === 'out'
+                                  ? t('handover.askOut', 'Ausgabe quittiert von:')
+                                  : t('handover.askIn', 'Rückgabe gegengezeichnet von:'),
+                              )
+                            )?.trim()
+                            if (!name) return
+                            const absage = sign(r.id, leg, name)
+                            setSignRefusal(
+                              absage && absage !== 'unknown-record'
+                                ? SIGNATURE_REFUSAL_LABEL[absage]
+                                : null,
+                            )
+                          }}
+                          className="mr-2 text-cp-text-secondary hover:text-cp-text"
+                        >
+                          {leg === 'out'
+                            ? t('handover.signOut', 'Ausgabe quittieren')
+                            : t('handover.signIn', 'Rückgabe gegenzeichnen')}
+                        </button>
+                      )
+                    })}
                     {/* Bedarf 68: der Schaden wird aufgenommen, BEVOR
                         zurueckgebucht wird — danach ist der Beleg zu, und ein
                         Beleg darf nicht nachtraeglich anders lauten. */}

--- a/src/renderer/lib/dataDictionary.ts
+++ b/src/renderer/lib/dataDictionary.ts
@@ -51,6 +51,13 @@ export const UNDESCRIBED = 'nicht beschrieben'
  * Datei, ohne dass sich am Plan etwas geaendert haette.
  */
 export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
+  // Bedarf 136 — der Quittungs-Block (`lib/handoverSignature.ts`).
+  Vorgang: 'Welches Bein des Ausgabe-Vorgangs quittiert wird: die Ausgabe oder die Rückgabe.',
+  Datum:
+    'Der Tag, auf den sich die Zeile bezieht — bei einer geleisteten Unterschrift ihr Datum, sonst der Tag der Ausgabe bzw. der Rückgabe.',
+  Bemerkung: 'Was beim Unterschreiben gesagt wurde („unter Vorbehalt“, „Deckel fehlt“).',
+  Unterschrift:
+    'Die Strichlinie für den Stift. Sie steht nur da, wo NICHT unterschrieben ist — wo jemand quittiert hat, steht sein Name in der Spalte „Name“, und die Anwendung führt KEIN Bild der Unterschrift.',
   // Bedarf 126 — das As-Built-Blatt (`lib/asBuilt.ts`).
   Gegenstand:
     'Worum die Zeile geht — ein Gerät, ein Anschluss oder ein Ausgang, so benannt, wie er im Plan heißt.',

--- a/src/renderer/lib/handoverSignature.ts
+++ b/src/renderer/lib/handoverSignature.ts
@@ -1,0 +1,239 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Eine Unterschrift für den ganzen Container — und eine für den Rückweg
+// (Bedarf 136, P4).
+//
+//   > Each asset in a bulk handover has to be signed for separately;
+//   > CHECK-IN HAS NO SIGNATURE AT ALL, so the return leg has no
+//   > counter-signed evidence when a dispute arises weeks later.
+//
+// Belegt an `grokability/snipe-it#19070` (2026-05-26, offen: „they have to
+// sign for each one separately… possible to have multiple assets on one sign
+// out document?") und `#19114` (2026-05-29, offen, zwei Zustimmungen): die
+// Unterschrift existiert bei der Abholung und fehlt bei der Rückgabe.
+//
+// ─── DIE ERSTE HÄLFTE WAR SCHON DA ─────────────────────────────────────────
+//
+// „One signature for a whole batch" ist in diesem Lager seit Bedarf 15
+// erfüllt, ohne dass es jemand so genannt hätte: ein `CheckoutRecord` ist EIN
+// Container mit eingefrorenem Inhalt. Wer ihn quittiert, quittiert alles
+// darin. Der Container IST die unterschreibbare Einheit.
+//
+// Was fehlte, ist die zweite Hälfte, und sie ist die teurere: der RÜCKWEG.
+// Ohne Gegenzeichnung steht drei Wochen später Aussage gegen Aussage — und
+// genau dieser Moment ist der, für den der Beleg überhaupt geschrieben wurde.
+//
+// ─── WAS HIER NICHT GEBAUT WIRD ────────────────────────────────────────────
+//
+// KEINE Bild-Unterschrift. Der Beleg verlangt eine gegengezeichnete Spur,
+// keine Grafik; ein gemaltes Feld auf einem Tablet, dessen Echtheit niemand
+// prüfen kann, wäre eine Zusage über Beweiskraft, die diese Anwendung nicht
+// halten kann. Festgehalten wird, WER unterschrieben hat und WANN — das
+// Papier daneben trägt den Stift.
+//
+// ─── APPEND-ONLY, WIE DER VORGANG SELBST ───────────────────────────────────
+//
+// Eine gesetzte Unterschrift wird NICHT überschrieben. `CheckoutRecord` ist
+// append-only, „weil ein Beleg nicht nachträglich anders lauten darf"
+// (`types/checkout.ts`) — eine Unterschrift, die sich stillschweigend
+// austauschen lässt, ist keine. Wer sich vertan hat, bekommt eine Absage mit
+// Namen und nicht ein wortloses Nichts.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type {
+  CheckoutRecord,
+  CheckoutSignature,
+} from '../types/checkout'
+import type { CsvTable } from './csv'
+
+/** Welches Bein des Vorgangs unterschrieben wird. */
+export type HandoverLeg = 'out' | 'in'
+
+export const LEG_LABEL: Readonly<Record<HandoverLeg, string>> = {
+  out: 'Ausgabe',
+  in: 'Rückgabe',
+}
+
+/** Warum eine Unterschrift nicht angenommen wird. */
+export type SignatureRefusal =
+  /** Kein Name — ohne Namen keine Unterschrift. */
+  | 'no-name'
+  /** Auf diesem Bein steht schon eine, und sie wird nicht überschrieben. */
+  | 'already-signed'
+  /** Die Rückgabe ist noch nicht erfolgt; es gibt nichts gegenzuzeichnen. */
+  | 'not-returned'
+
+export const SIGNATURE_REFUSAL_LABEL: Readonly<Record<SignatureRefusal, string>> = {
+  'no-name': 'Ohne Namen ist es keine Unterschrift.',
+  'already-signed':
+    'Hier steht schon eine Unterschrift. Ein Beleg, der sich austauschen lässt, ist keiner — ' +
+    'eine Korrektur gehört als Notiz daneben.',
+  'not-returned':
+    'Der Container ist noch nicht zurück. Gegengezeichnet wird, was zurückgekommen ist.',
+}
+
+/**
+ * Die Engstelle: darf hier unterschrieben werden?
+ *
+ * Getrennt vom Setzen, weil der Store die Absage braucht und der Aufrufer
+ * den Grund — „schon unterschrieben" und „noch nicht zurück" verlangen
+ * verschiedene Antworten des Bedienenden.
+ */
+export function signatureRefusal(
+  record: CheckoutRecord,
+  leg: HandoverLeg,
+  name: string,
+): SignatureRefusal | null {
+  if (!name.trim()) return 'no-name'
+  if (leg === 'in' && !record.in) return 'not-returned'
+  const vorhanden = leg === 'out' ? record.out.signature : record.in?.signature
+  if (vorhanden) return 'already-signed'
+  return null
+}
+
+/**
+ * Setzt die Unterschrift und liefert einen NEUEN Datensatz.
+ *
+ * Der alte bleibt unberührt — dieselbe Regel wie bei `closeCheckout`. Bei
+ * einer Absage kommt der Datensatz unverändert zurück, zusammen mit dem
+ * Grund: ein Aufrufer, der nur den Datensatz bekäme, könnte „nichts passiert"
+ * nicht von „passiert" unterscheiden.
+ */
+export function signHandover(
+  record: CheckoutRecord,
+  leg: HandoverLeg,
+  signature: CheckoutSignature,
+): { record: CheckoutRecord } | { refusal: SignatureRefusal } {
+  const refusal = signatureRefusal(record, leg, signature.name)
+  if (refusal) return { refusal }
+  const sauber: CheckoutSignature = {
+    name: signature.name.trim(),
+    at: signature.at,
+    ...(signature.note?.trim() ? { note: signature.note.trim() } : {}),
+  }
+  if (leg === 'out') {
+    return { record: { ...record, out: { ...record.out, signature: sauber } } }
+  }
+  // `record.in` ist hier gesetzt: `signatureRefusal` hat das geprüft.
+  return { record: { ...record, in: { ...record.in!, signature: sauber } } }
+}
+
+/** Wie weit der Vorgang gegengezeichnet ist. */
+export type SignatureState =
+  /** Beide Beine unterschrieben. */
+  | 'both'
+  /** Nur die Ausgabe — der Fall aus dem Beleg. */
+  | 'out-only'
+  /** Nur die Rückgabe (kommt vor: nachgetragene Altdaten). */
+  | 'in-only'
+  /** Keine Unterschrift. */
+  | 'none'
+
+export const SIGNATURE_STATE_LABEL: Readonly<Record<SignatureState, string>> = {
+  both: 'beidseitig quittiert',
+  'out-only': 'nur Ausgabe quittiert',
+  'in-only': 'nur Rückgabe quittiert',
+  none: 'nicht quittiert',
+}
+
+export function signatureState(record: CheckoutRecord): SignatureState {
+  const aus = Boolean(record.out.signature)
+  const ein = Boolean(record.in?.signature)
+  if (aus && ein) return 'both'
+  if (aus) return 'out-only'
+  if (ein) return 'in-only'
+  return 'none'
+}
+
+export type HandoverFindingKind =
+  /** Container ist draussen und niemand hat die Ausgabe quittiert. */
+  | 'unsigned-out'
+  /** Container ist zurück und niemand hat die Rückgabe gegengezeichnet. */
+  | 'unsigned-in'
+
+export interface HandoverFinding {
+  kind: HandoverFindingKind
+  severity: 'error' | 'warning'
+  /** Vorgangs-Id als Klick-/Sortierschlüssel. */
+  recordId: string
+  message: string
+}
+
+/**
+ * Befunde über die Quittierung.
+ *
+ * `unsigned-in` ist ein FEHLER und nicht nur ein Hinweis: der Beleg beschreibt
+ * genau diesen Zustand als den, der wochenlang folgenlos aussieht und dann
+ * den Streit entscheidet. `unsigned-out` bleibt ein Hinweis — der Container
+ * ist noch unterwegs, die Unterschrift kann nachkommen, und ein Fehler auf
+ * jedem laufenden Vorgang wäre Lärm.
+ */
+export function handoverFindings(records: readonly CheckoutRecord[]): HandoverFinding[] {
+  const out: HandoverFinding[] = []
+  for (const r of records) {
+    if (!r.out.signature) {
+      out.push({
+        kind: 'unsigned-out',
+        severity: 'warning',
+        recordId: r.id,
+        message: `"${r.nodeLabel}" ist ausgegeben, aber die Ausgabe ist nicht quittiert.`,
+      })
+    }
+    if (r.in && !r.in.signature) {
+      out.push({
+        kind: 'unsigned-in',
+        severity: 'error',
+        recordId: r.id,
+        message:
+          `"${r.nodeLabel}" ist zurück, aber die Rückgabe ist NICHT gegengezeichnet. ` +
+          'Bei einer Nachfrage in drei Wochen steht Aussage gegen Aussage.',
+      })
+    }
+  }
+  return out
+}
+
+/** Was auf dem Blatt steht, wo niemand unterschrieben hat. */
+export const NOT_SIGNED = 'nicht unterschrieben'
+/** Die Zeile, auf der jemand mit dem Stift unterschreibt. */
+export const SIGNATURE_RULE = '____________________'
+
+export const HANDOVER_SIGNATURE_HEADERS = [
+  'Container',
+  'Vorgang',
+  'Name',
+  'Datum',
+  'Bemerkung',
+  'Unterschrift',
+] as const
+
+const datum = (at: string | undefined): string => (at ? at.slice(0, 10) : '')
+
+/**
+ * Der Quittungs-Block unter der Ausgabeliste.
+ *
+ * IMMER BEIDE ZEILEN, auch die für ein Bein, das es noch nicht gibt: das
+ * Blatt fährt mit dem Case mit, und die Rückgabe-Zeile muss schon darauf
+ * stehen, wenn das Case zurückkommt. Ein Blatt, das die zweite Zeile erst
+ * druckt, wenn die Rückgabe eingetragen ist, kommt genau einen Vorgang zu
+ * spät — und dann unterschreibt wieder niemand.
+ *
+ * Wo niemand unterschrieben hat, steht die STRICHLINIE für den Stift und
+ * nicht eine leere Zelle: eine leere Zelle liest sich, als sei nichts
+ * vorgesehen.
+ */
+export function handoverSignatureTable(record: CheckoutRecord): CsvTable {
+  const zeile = (leg: HandoverLeg): (string | number)[] => {
+    const sig = leg === 'out' ? record.out.signature : record.in?.signature
+    return [
+      record.nodeLabel,
+      LEG_LABEL[leg],
+      sig?.name ?? NOT_SIGNED,
+      sig ? datum(sig.at) : datum(leg === 'out' ? record.out.at : record.in?.at),
+      sig?.note ?? '',
+      sig ? '' : SIGNATURE_RULE,
+    ]
+  }
+  return { headers: [...HANDOVER_SIGNATURE_HEADERS], rows: [zeile('out'), zeile('in')] }
+}

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3490,6 +3490,16 @@ export const en: Dict = {
   'channelList.view.stage': 'Stage (position)',
   'channelList.view.console': 'Console (names)',
   'channelList.view.monitor': 'Monitor paths',
+  // Bedarf 136 — eine Unterschrift je Container, auf BEIDEN Beinen.
+  'handover.signOut': 'Sign out',
+  'handover.signIn': 'Counter-sign return',
+  'handover.askOut': 'Handover signed by:',
+  'handover.askIn': 'Return counter-signed by:',
+  'handover.state.both': 'signed on both legs',
+  'handover.state.out-only': 'only handover signed',
+  'handover.state.in-only': 'only return signed',
+  'handover.state.none': 'not signed',
+  'inventory.checkout.signState': 'Signature block to print (both legs)',
   // Bedarf 126 — „wie geplant" gegen „wie gebaut".
   'asBuilt.title': 'As-built sheet (as planned / as built)',
   'asBuilt.count': '{verified} of {total} entries verified',

--- a/src/renderer/store/checkoutStore.ts
+++ b/src/renderer/store/checkoutStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { v4 as uuidv4 } from 'uuid'
 import { STORAGE_KEYS } from '../lib/storageKeys'
+import { signHandover } from '../lib/handoverSignature'
 import type { CheckoutDamage, CheckoutLine, CheckoutRecord } from '../types/checkout'
 import {
   buildCheckout,
@@ -119,6 +120,21 @@ interface CheckoutState {
     /** Schaeden, beim Einchecken aufgenommen (Bedarf 68). */
     damaged?: CheckoutDamage[],
   ) => void
+  /**
+   * BEDARF 136 — quittieren. Liefert den Grund, wenn nicht quittiert wurde:
+   * „schon unterschrieben" und „noch nicht zurueck" verlangen verschiedene
+   * Antworten des Bedienenden, und ein wortloses Nichts ist von einem
+   * kaputten Programm nicht zu unterscheiden.
+   *
+   * Die Uhr wird HIER genommen, weil hier die Unterschrift geleistet wird —
+   * `lib/handoverSignature.ts` bleibt rein.
+   */
+  sign: (
+    recordId: string,
+    leg: import('../lib/handoverSignature').HandoverLeg,
+    name: string,
+    note?: string,
+  ) => import('../lib/handoverSignature').SignatureRefusal | 'unknown-record' | undefined
   /** Einen Beleg loeschen (Fehleingabe). Die Historie hat sonst kein Ventil. */
   removeRecord: (recordId: string) => void
 }
@@ -157,6 +173,30 @@ export const useCheckoutStore = create<CheckoutState>((set, get) => ({
       persist(records)
       return { records }
     }),
+
+  sign: (recordId, leg, name, note) => {
+    let absage: ReturnType<CheckoutState['sign']>
+    set((state) => {
+      const vorhanden = state.records.find((r) => r.id === recordId)
+      if (!vorhanden) {
+        absage = 'unknown-record'
+        return {}
+      }
+      const gesetzt = signHandover(vorhanden, leg, {
+        name,
+        at: new Date().toISOString(),
+        ...(note ? { note } : {}),
+      })
+      if ('refusal' in gesetzt) {
+        absage = gesetzt.refusal
+        return {}
+      }
+      const records = state.records.map((r) => (r.id === recordId ? gesetzt.record : r))
+      persist(records)
+      return { records }
+    })
+    return absage
+  },
 
   removeRecord: (recordId) =>
     set((state) => {

--- a/src/renderer/types/checkout.ts
+++ b/src/renderer/types/checkout.ts
@@ -87,9 +87,46 @@ export interface CheckoutLine {
 }
 
 /** Der Vorgang der Ausgabe. */
+/**
+ * Eine Unterschrift (Bedarf 136, P4).
+ *
+ *   > Each asset in a bulk handover has to be signed for separately;
+ *   > CHECK-IN HAS NO SIGNATURE AT ALL, so the return leg has no
+ *   > counter-signed evidence when a dispute arises weeks later.
+ *
+ * Belegt an `grokability/snipe-it#19070` (2026-05-26, offen: „they have to
+ * sign for each one separately… possible to have multiple assets on one sign
+ * out document?") und `#19114` (2026-05-29, offen): die Unterschrift gibt es
+ * bei der Abholung und NICHT bei der Rueckgabe.
+ *
+ * Die erste Haelfte war hier schon geloest: ein `CheckoutRecord` ist EIN
+ * Container mit eingefrorenem Inhalt, also EINE Unterschrift fuer alles darin
+ * — der Container IST die unterschreibbare Einheit (Bedarf 15). Was fehlte,
+ * ist die zweite: der Rueckweg.
+ *
+ * ES IST KEINE BILD-UNTERSCHRIFT. Der Beleg verlangt eine gegengezeichnete
+ * Spur, keine Grafik — und ein gemaltes Feld auf einem Tablet, das niemand
+ * pruefen kann, waere eine Zusage ueber Beweiskraft, die diese Anwendung
+ * nicht halten kann. Festgehalten wird, WER unterschrieben hat und WANN; das
+ * Papier daneben traegt den Stift.
+ */
+export interface CheckoutSignature {
+  /** Wer unterschrieben hat. Ohne Namen keine Unterschrift. */
+  name: string
+  /** Wann (ISO). Kommt von der Uhr des Aufrufers. */
+  at: string
+  /** Was dabei gesagt wurde („unter Vorbehalt", „Deckel fehlt"). */
+  note?: string
+}
+
 export interface CheckoutOut {
   /** ISO-Zeitstempel. */
   at: string
+  /**
+   * Wer die Ausgabe quittiert hat. Fehlt, solange niemand unterschrieben hat
+   * — und das steht dann auch so auf dem Blatt.
+   */
+  signature?: CheckoutSignature
   /** An wen -- Person, Truck, Kunde. Freitext, weil ein Lager sie alle kennt. */
   to: string
   /** Fuer welche Show, wenn bekannt. */
@@ -148,6 +185,15 @@ export interface CheckoutIn {
    * unvollstaendig aus, und der Schaden waere als Verlust verbucht.
    */
   damaged?: CheckoutDamage[]
+  /**
+   * Bedarf 136 — die GEGENZEICHNUNG. Genau die, die im Beleg fehlt.
+   *
+   * Ohne sie hat der Rueckweg keinen Beleg: wenn drei Wochen spaeter jemand
+   * fragt, in welchem Zustand das Case zurueckkam, steht Aussage gegen
+   * Aussage. Sie ist optional, weil eine Rueckgabe ohne Unterschrift
+   * vorkommt — aber dann sagt das Blatt das, statt die Luecke zu verschweigen.
+   */
+  signature?: CheckoutSignature
   note?: string
 }
 

--- a/tests/handoverSignature.test.ts
+++ b/tests/handoverSignature.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from 'vitest'
+import {
+  HANDOVER_SIGNATURE_HEADERS,
+  LEG_LABEL,
+  NOT_SIGNED,
+  SIGNATURE_REFUSAL_LABEL,
+  SIGNATURE_RULE,
+  SIGNATURE_STATE_LABEL,
+  handoverFindings,
+  handoverSignatureTable,
+  signHandover,
+  signatureRefusal,
+  signatureState,
+} from '../src/renderer/lib/handoverSignature'
+import type { CheckoutRecord } from '../src/renderer/types/checkout'
+import libQuelle from '../src/renderer/lib/handoverSignature.ts?raw'
+import typenQuelle from '../src/renderer/types/checkout.ts?raw'
+import storeQuelle from '../src/renderer/store/checkoutStore.ts?raw'
+import dialogQuelle from '../src/renderer/components/Inventory/InventoryDialog.tsx?raw'
+
+// ---------------------------------------------------------------------------
+// Eine Unterschrift je Container — und eine fuer den Rueckweg
+// (Bedarf 136, P4).
+//
+//   > Each asset in a bulk handover has to be signed for separately;
+//   > CHECK-IN HAS NO SIGNATURE AT ALL, so the return leg has no
+//   > counter-signed evidence when a dispute arises weeks later.
+//
+// Belegt an `grokability/snipe-it#19070` (2026-05-26) und `#19114`
+// (2026-05-29), beide offen.
+//
+// Die erste Haelfte war seit Bedarf 15 erfuellt: ein `CheckoutRecord` ist EIN
+// Container mit eingefrorenem Inhalt — eine Unterschrift fuer alles darin.
+// Was fehlte, ist der RUECKWEG, und der ist der teurere.
+// ---------------------------------------------------------------------------
+
+const jetzt = '2026-09-06T10:00:00.000Z'
+
+const beleg = (over: Partial<CheckoutRecord> = {}): CheckoutRecord => ({
+  id: 'v1',
+  nodeId: 'case-1',
+  nodeLabel: 'Case 1',
+  out: { at: '2026-09-01T08:00:00.000Z', to: 'Truck 3' },
+  contents: [],
+  ...over,
+})
+
+const zurueck = (over: Partial<CheckoutRecord> = {}): CheckoutRecord =>
+  beleg({ in: { at: '2026-09-05T18:00:00.000Z', missing: [], extra: [] }, ...over })
+
+// ── 1. Die Absage hat einen Namen ──────────────────────────────────────────
+
+describe('signatureRefusal', () => {
+  it('laesst die gewoehnliche Quittung zu', () => {
+    expect(signatureRefusal(beleg(), 'out', 'Lars')).toBeNull()
+    expect(signatureRefusal(zurueck(), 'in', 'Lars')).toBeNull()
+  })
+
+  it('lehnt die namenlose Unterschrift ab', () => {
+    expect(signatureRefusal(beleg(), 'out', '   ')).toBe('no-name')
+  })
+
+  it('lehnt die Gegenzeichnung ab, solange nichts zurueck ist', () => {
+    // Sonst quittierte jemand etwas, das noch im Truck liegt.
+    expect(signatureRefusal(beleg(), 'in', 'Lars')).toBe('not-returned')
+  })
+
+  it('ueberschreibt eine vorhandene Unterschrift NICHT', () => {
+    // `CheckoutRecord` ist append-only, „weil ein Beleg nicht nachtraeglich
+    // anders lauten darf". Eine Unterschrift, die sich stillschweigend
+    // austauschen laesst, ist keine.
+    const schon = beleg({ out: { at: jetzt, to: 'Truck 3', signature: { name: 'Anna', at: jetzt } } })
+    expect(signatureRefusal(schon, 'out', 'Lars')).toBe('already-signed')
+  })
+
+  it('haelt fuer jede Absage eine lesbare Ueberschrift bereit', () => {
+    for (const k of ['no-name', 'already-signed', 'not-returned'] as const) {
+      expect(SIGNATURE_REFUSAL_LABEL[k].length).toBeGreaterThan(20)
+    }
+  })
+})
+
+// ── 2. Das Setzen ──────────────────────────────────────────────────────────
+
+describe('signHandover', () => {
+  it('setzt die Unterschrift auf dem richtigen Bein', () => {
+    const r = signHandover(beleg(), 'out', { name: 'Lars', at: jetzt })
+    expect('record' in r && r.record.out.signature?.name).toBe('Lars')
+    expect('record' in r && r.record.in).toBeUndefined()
+  })
+
+  it('laesst den alten Datensatz unberuehrt', () => {
+    // Dieselbe Regel wie bei `closeCheckout`.
+    const alt = beleg()
+    signHandover(alt, 'out', { name: 'Lars', at: jetzt })
+    expect(alt.out.signature).toBeUndefined()
+  })
+
+  it('gegenzeichnet die Rueckgabe, ohne die Ausgabe anzufassen', () => {
+    const r = signHandover(zurueck(), 'in', { name: 'Lars', at: jetzt })
+    expect('record' in r && r.record.in?.signature?.name).toBe('Lars')
+    expect('record' in r && r.record.out.signature).toBeUndefined()
+  })
+
+  it('schneidet Leerraum ab und laesst die leere Bemerkung weg', () => {
+    const r = signHandover(beleg(), 'out', { name: '  Lars  ', at: jetzt, note: '   ' })
+    expect('record' in r && r.record.out.signature?.name).toBe('Lars')
+    expect('record' in r && 'note' in (r.record.out.signature ?? {})).toBe(false)
+  })
+
+  it('liefert die Absage, statt still nichts zu tun', () => {
+    const r = signHandover(beleg(), 'in', { name: 'Lars', at: jetzt })
+    expect('refusal' in r && r.refusal).toBe('not-returned')
+  })
+})
+
+// ── 3. Der Zustand ─────────────────────────────────────────────────────────
+
+describe('signatureState', () => {
+  it('unterscheidet die vier Faelle', () => {
+    expect(signatureState(beleg())).toBe('none')
+    expect(
+      signatureState(beleg({ out: { at: jetzt, to: 'x', signature: { name: 'A', at: jetzt } } })),
+    ).toBe('out-only')
+    expect(
+      signatureState(
+        zurueck({ in: { at: jetzt, missing: [], extra: [], signature: { name: 'B', at: jetzt } } }),
+      ),
+    ).toBe('in-only')
+    expect(
+      signatureState(
+        zurueck({
+          out: { at: jetzt, to: 'x', signature: { name: 'A', at: jetzt } },
+          in: { at: jetzt, missing: [], extra: [], signature: { name: 'B', at: jetzt } },
+        }),
+      ),
+    ).toBe('both')
+  })
+
+  it('haelt fuer jeden Zustand eine lesbare Ueberschrift bereit', () => {
+    for (const k of ['both', 'out-only', 'in-only', 'none'] as const) {
+      expect(SIGNATURE_STATE_LABEL[k].length).toBeGreaterThan(5)
+    }
+  })
+})
+
+// ── 4. Der Befund, um den es geht ──────────────────────────────────────────
+
+describe('handoverFindings', () => {
+  it('macht aus der fehlenden GEGENZEICHNUNG einen FEHLER', () => {
+    // Der Beleg beschreibt genau diesen Zustand als den, der wochenlang
+    // folgenlos aussieht und dann den Streit entscheidet.
+    const f = handoverFindings([zurueck()])
+    const offen = f.find((x) => x.kind === 'unsigned-in')
+    expect(offen?.severity).toBe('error')
+    expect(offen?.message).toContain('Aussage gegen Aussage')
+  })
+
+  it('macht aus der fehlenden Ausgabe-Quittung nur einen Hinweis', () => {
+    // Der Container ist noch unterwegs, die Unterschrift kann nachkommen —
+    // ein Fehler auf jedem laufenden Vorgang waere Laerm.
+    const f = handoverFindings([beleg()])
+    expect(f.map((x) => [x.kind, x.severity])).toEqual([['unsigned-out', 'warning']])
+  })
+
+  it('meldet nichts bei einem beidseitig quittierten Vorgang', () => {
+    expect(
+      handoverFindings([
+        zurueck({
+          out: { at: jetzt, to: 'x', signature: { name: 'A', at: jetzt } },
+          in: { at: jetzt, missing: [], extra: [], signature: { name: 'B', at: jetzt } },
+        }),
+      ]),
+    ).toEqual([])
+  })
+
+  it('meldet KEINE fehlende Gegenzeichnung, solange nichts zurueck ist', () => {
+    expect(handoverFindings([beleg()]).some((x) => x.kind === 'unsigned-in')).toBe(false)
+  })
+})
+
+// ── 5. Der Quittungs-Block ─────────────────────────────────────────────────
+
+describe('handoverSignatureTable', () => {
+  it('haelt den Spaltenkopf fest', () => {
+    expect(handoverSignatureTable(beleg()).headers).toEqual([...HANDOVER_SIGNATURE_HEADERS])
+  })
+
+  it('druckt IMMER beide Zeilen — auch die fuer ein Bein, das es noch nicht gibt', () => {
+    // Das Blatt faehrt mit dem Case mit. Wer die zweite Zeile erst druckt,
+    // wenn die Rueckgabe eingetragen ist, kommt genau einen Vorgang zu spaet —
+    // und dann unterschreibt wieder niemand.
+    const rows = handoverSignatureTable(beleg()).rows
+    expect(rows).toHaveLength(2)
+    expect(rows[0][1]).toBe(LEG_LABEL.out)
+    expect(rows[1][1]).toBe(LEG_LABEL.in)
+  })
+
+  it('setzt die STRICHLINIE, wo niemand unterschrieben hat', () => {
+    // Eine leere Zelle liest sich, als sei nichts vorgesehen.
+    const [aus] = handoverSignatureTable(beleg()).rows
+    expect(aus[2]).toBe(NOT_SIGNED)
+    expect(aus[5]).toBe(SIGNATURE_RULE)
+  })
+
+  it('setzt Name und Datum ein, wo unterschrieben wurde — und KEINE Strichlinie', () => {
+    const [aus] = handoverSignatureTable(
+      beleg({ out: { at: jetzt, to: 'x', signature: { name: 'Lars', at: jetzt, note: 'ok' } } }),
+    ).rows
+    expect(aus[2]).toBe('Lars')
+    expect(aus[3]).toBe('2026-09-06')
+    expect(aus[4]).toBe('ok')
+    expect(aus[5]).toBe('')
+  })
+
+  it('traegt bei der unquittierten Zeile das Datum DES BEINS, nicht der Unterschrift', () => {
+    const rows = handoverSignatureTable(zurueck()).rows
+    expect(rows[0][3]).toBe('2026-09-01')
+    expect(rows[1][3]).toBe('2026-09-05')
+  })
+})
+
+// ── 6. Reinheit, Store und Oberflaeche ─────────────────────────────────────
+
+describe('das Modul, der Store und die Oberflaeche', () => {
+  it('nimmt keine Uhr und keinen Store', () => {
+    expect(libQuelle).not.toContain('new Date(')
+    expect(libQuelle).not.toContain('useCheckoutStore')
+  })
+
+  it('fuehrt KEIN Bild der Unterschrift', () => {
+    // Ein gemaltes Feld, dessen Echtheit niemand pruefen kann, waere eine
+    // Zusage ueber Beweiskraft, die diese Anwendung nicht halten kann.
+    expect(typenQuelle).toContain('KEINE BILD-UNTERSCHRIFT')
+    expect(libQuelle).not.toContain('dataUrl')
+    expect(libQuelle).not.toContain('image')
+  })
+
+  it('haengt die Unterschrift an BEIDE Beine des Typs', () => {
+    const aus = typenQuelle.indexOf('export interface CheckoutOut')
+    const ein = typenQuelle.indexOf('export interface CheckoutIn')
+    expect(typenQuelle.slice(aus, typenQuelle.indexOf('}', aus))).toContain('signature?')
+    expect(typenQuelle.slice(ein, typenQuelle.indexOf('}', ein))).toContain('signature?')
+  })
+
+  it('nimmt die Uhr im STORE, wo die Unterschrift geleistet wird', () => {
+    // Auf den SIGN-Block geschnitten: `new Date()` steht im Store ohnehin
+    // dreimal (Ausgabe, Rueckgabe, Quittung), und eine Zusicherung auf die
+    // ganze Datei ginge durch, wenn ausgerechnet hier ein fester Zeitpunkt
+    // stuende. Die Gegenprobe hat genau das durchgelassen.
+    const block = storeQuelle.slice(
+      storeQuelle.indexOf('  sign: (recordId, leg, name, note) =>'),
+      storeQuelle.indexOf('  removeRecord: (recordId) =>'),
+    )
+    expect(block.length).toBeGreaterThan(0)
+    expect(block).toContain('at: new Date().toISOString()')
+    expect(block).toContain('signHandover(vorhanden, leg,')
+  })
+
+  it('gibt die Absage aus dem Store zurueck, statt sie zu schlucken', () => {
+    expect(storeQuelle).toContain("absage = 'unknown-record'")
+    expect(storeQuelle).toContain('absage = gesetzt.refusal')
+  })
+
+  it('bietet die Gegenzeichnung erst an, wenn etwas zurueck ist', () => {
+    expect(dialogQuelle).toContain("if (leg === 'in' && !r.in) return null")
+  })
+
+  it('zeigt die Absage, statt sie stumm zu verwerfen', () => {
+    expect(dialogQuelle).toContain('setSignRefusal(')
+    expect(dialogQuelle).toContain('{signRefusal && (')
+  })
+})


### PR DESCRIPTION
Bedarf 136 (P4) aus dem Recherche-Korpus.

> Each asset in a bulk handover has to be signed for separately; **check-in has no signature at all**, so the return leg has no counter-signed evidence when a dispute arises weeks later.

Belegt an `grokability/snipe-it#19070` (2026-05-26, offen) und `#19114` (2026-05-29, offen, zwei Zustimmungen).

## Die erste Hälfte war schon da

„One signature for a whole batch" ist seit Bedarf 15 erfüllt, ohne dass es jemand so genannt hätte: ein `CheckoutRecord` ist **ein** Container mit eingefrorenem Inhalt — der Container *ist* die unterschreibbare Einheit. Was fehlte, ist die zweite Hälfte, und sie ist die teurere: der **Rückweg**.

## Was gebaut ist

- `CheckoutSignature` an **beiden** Beinen: wer, wann, optional eine Bemerkung.
- `signatureRefusal` mit drei benannten Absagen: `no-name`, `not-returned` (sonst quittierte jemand etwas, das noch im Truck liegt) und `already-signed` — `CheckoutRecord` ist append-only, und eine Unterschrift, die sich stillschweigend austauschen lässt, ist keine.
- `handoverFindings`: die fehlende **Gegenzeichnung** ist ein Fehler, die fehlende Ausgabe-Quittung nur ein Hinweis (der Container ist noch unterwegs). Der Fehler nennt die Folge beim Namen.
- `handoverSignatureTable` druckt **immer beide Zeilen**, auch die für ein Bein, das es noch nicht gibt: das Blatt fährt mit dem Case mit, und wer die Rückgabe-Zeile erst später druckt, kommt einen Vorgang zu spät. Wo nichts quittiert ist, steht die Strichlinie für den Stift.

## Was nicht gebaut ist

**Keine Bild-Unterschrift.** Der Beleg verlangt eine gegengezeichnete *Spur*, keine Grafik — ein gemaltes Feld, dessen Echtheit niemand prüfen kann, wäre eine Zusage über Beweiskraft, die diese Anwendung nicht halten kann.

## Prüfung

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — 166 Test-Dateien grün (28 neue Fälle)
- `npm run lint` — 0 Errors
- Gegenprobe: 26 injizierte Defekte, alle rot. Eine Lücke fand sie selbst: die Zusicherung „der Store nimmt die Uhr" prüfte die ganze Datei, wo `new Date()` ohnehin dreimal steht — sie ging durch, als ausgerechnet im Quittungs-Zweig ein fester Zeitpunkt stand. Jetzt auf den Zweig geschnitten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_