### PR TITLE
lager: Inventur ohne Scanner — abhaken statt scannen (Bedarf 150)

### DIFF
--- a/src/renderer/components/Inventory/InventoryDialog.tsx
+++ b/src/renderer/components/Inventory/InventoryDialog.tsx
@@ -63,7 +63,10 @@ import {
 import { ownershipNote, overdueSubhire, subhireStatus } from '../../lib/ownership'
 import type { CheckoutDamage, CheckoutRecord } from '../../types/checkout'
 import { damageEntries, damageTable, damageTally } from '../../lib/damageRegister'
-import { AUDIT_LABEL, auditRelocations, auditScan, auditTable, type AuditHit } from '../../lib/inventoryAudit'
+import {
+  AUDIT_LABEL, auditPick, auditRelocations, auditScan, auditTable, expectedAt, missingAt,
+  type AuditCandidate, type AuditHit,
+} from '../../lib/inventoryAudit'
 import { keepScreenAwake } from '../../lib/wakeLock'
 import {
   containerContents,
@@ -891,6 +894,27 @@ const LocationsTab = ({ dimsEditor, formatDims, codeCell }: LocationsTabProps) =
     setAuditDraft('')
   }
 
+  /**
+   * BEDARF 150 — der Scanner ist der schnelle Weg, nie der einzige.
+   *
+   * Getippte Codes gab es hier schon; die retten den leeren Akku. Sie retten
+   * NICHT das abgerissene Etikett und nicht das Case, das schon auf dem Lkw
+   * steht — wer den Code nicht lesen kann, kann ihn auch nicht tippen. Der
+   * Weg, der dann bleibt, ist die Liste dessen, was hier liegen soll.
+   */
+  const auditErwartet = useMemo(
+    () => (auditNode ? expectedAt(auditNode, { items, nodes, units }) : []),
+    [auditNode, items, nodes, units],
+  )
+  const auditFehlt = useMemo(
+    () => (auditNode ? missingAt(auditNode, { items, nodes, units }, auditHits) : []),
+    [auditNode, items, nodes, units, auditHits],
+  )
+  const auditPickNow = (c: AuditCandidate) => {
+    if (!auditNode) return
+    setAuditHits((h) => [auditPick(c, auditNode, { items, nodes, units }), ...h])
+  }
+
   /** Den TATSAECHLICHEN Ort uebernehmen — der Beleg verlangt genau das.
    *  Schreibend, deshalb ein eigener Klick und nicht automatisch. */
   const auditAdopt = () => {
@@ -1086,7 +1110,10 @@ const LocationsTab = ({ dimsEditor, formatDims, codeCell }: LocationsTabProps) =
                 type="button"
                 disabled={auditHits.length === 0}
                 onClick={() => {
-                  const t2 = auditTable(auditHits, nodes, node.id)
+                  // Mit den Fehlt-Zeilen: ein Blatt ohne sie zaehlt nur,
+                  // was jemand vorgezeigt hat, und laese sich wie eine
+                  // vollstaendige Inventur.
+                  const t2 = auditTable(auditHits, nodes, node.id, auditFehlt)
                   downloadBlob(`inventur-${node.name}.csv`, toCsv(t2.headers, t2.rows), 'text/csv')
                 }}
                 className="flex items-center gap-1 text-cp-text-secondary hover:text-cp-text disabled:opacity-40"
@@ -1108,9 +1135,57 @@ const LocationsTab = ({ dimsEditor, formatDims, codeCell }: LocationsTabProps) =
                 })}
               </button>
             </div>
+            {/* BEDARF 150 — die Liste dessen, was hier liegen soll. Sie ist
+                der Weg, der bleibt, wenn der Scanner leer oder das Etikett ab
+                ist: abhaken statt scannen. Was am Ende weder gescannt noch
+                abgehakt ist, steht als „Nicht gefunden" auf dem Blatt — das
+                ist das eigentliche Ergebnis einer Inventur, und ohne diese
+                Liste gab es dafuer keine Zeile. */}
+            {auditErwartet.length > 0 && (
+              <details className="mb-1.5 rounded border border-cp-border-muted bg-cp-surface-3 px-2 py-1">
+                <summary className="cursor-pointer text-cp-text-secondary">
+                  {format(
+                    // NICHT `inventory.auditExpected` — den Schluessel gibt
+                    // es unten schon mit „erwartet in {ort}". Zwei deutsche
+                    // Fassungen unter einem Schluessel heisst: die zweite
+                    // Uebersetzung ueberschreibt die erste, und irgendwo im
+                    // Englischen steht dann der falsche Satz.
+                    t('inventory.auditExpectedList', 'Ohne Scanner abhaken — hier erwartet: {n}, davon offen: {open}'),
+                    { n: auditErwartet.length, open: auditFehlt.length },
+                  )}
+                </summary>
+                <ul className="mt-1 flex max-h-48 flex-col gap-0.5 overflow-y-auto">
+                  {auditErwartet.map((c) => {
+                    const offen = auditFehlt.some((m) => m.key === c.key)
+                    return (
+                      <li key={c.key} className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          disabled={!offen}
+                          onClick={() => auditPickNow(c)}
+                          title={t(
+                            'inventory.auditPickHint',
+                            'Ohne Code als „liegt hier" verbuchen — das Blatt hält fest, dass es abgehakt und nicht gescannt wurde',
+                          )}
+                          className="rounded border border-cp-border px-1.5 py-0.5 text-cp-text-secondary hover:text-cp-text disabled:opacity-40"
+                        >
+                          {offen
+                            ? t('inventory.auditPick', 'hier')
+                            : t('inventory.auditPicked', 'erfasst')}
+                        </button>
+                        <span className={offen ? 'text-cp-text' : 'text-cp-text-muted line-through'}>
+                          {c.label}
+                          {c.model && c.model !== c.label ? ` · ${c.model}` : ''}
+                        </span>
+                      </li>
+                    )
+                  })}
+                </ul>
+              </details>
+            )}
             {auditHits.length === 0 ? (
               <div className="text-cp-text-muted">
-                {t('inventory.auditEmpty', 'Noch nichts gescannt.')}
+                {t('inventory.auditEmpty', 'Noch nichts erfasst.')}
               </div>
             ) : (
               <ul className="flex max-h-56 flex-col gap-0.5 overflow-y-auto">
@@ -1129,6 +1204,10 @@ const LocationsTab = ({ dimsEditor, formatDims, codeCell }: LocationsTabProps) =
                         Beleg ausdruecklich, und ohne beides „finds nothing
                         actionable". */}
                     {AUDIT_LABEL[h.outcome]} · {h.label || h.code}
+                    {/* Bedarf 150: gescannt oder abgehakt steht dran. Ein
+                        Etikett gelesen zu haben ist eine andere Auskunft als
+                        eine Zeile angeklickt zu haben. */}
+                    {h.via === 'pick' ? ` [${t('inventory.auditViaPick', 'aus der Liste')}]` : ''}
                     {h.model && h.model !== h.label ? ` (${h.model})` : ''}
                     {h.expected ? ` — ${format(t('inventory.auditExpected', 'erwartet in {ort}'), { ort: h.expected })}` : ''}
                   </li>

--- a/src/renderer/lib/dataDictionary.ts
+++ b/src/renderer/lib/dataDictionary.ts
@@ -68,6 +68,9 @@ export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
     'Woher die Ablesung stammt (Netz-Scan, Mischer, Router, Vermietung, von Hand). Ohne Ablesung steht in der Urteils-Spalte „nicht nachgesehen“.',
   'Abgelesen am':
     'Der Tag der Ablesung. Fehlt er, gilt die Zeile als ungeprüft — ein Verify-Lauf von gestern ist kein Verify-Lauf.',
+  // Bedarf 150 — der Scanner ist der schnelle Weg, nie der einzige.
+  'Wie erfasst':
+    'Womit die Inventur-Zeile belegt ist: „gescannt“ heißt, jemand hat das Etikett AM OBJEKT gelesen; „aus der Liste“ heißt, jemand hat eine Zeile der Erwartungsliste angehakt (der Weg, der bleibt, wenn der Scanner leer oder das Etikett ab ist). Ein Strich steht bei „Nicht gefunden“ — dort wurde weder gescannt noch angehakt. Die Spalte trennt eine Ablesung von einer Behauptung; sie zusammenzuwerfen wäre dieselbe stille Lüge, die das Lexikon an anderen Stellen verhindert.',
   // Bedarf 125 — das Multiviewer-Bild (`lib/mvSheet.ts`).
   Multiviewer:
     'Welcher Multiviewer des Mischers gemeint ist — Gerätename plus laufende Nummer, ab 1 gezählt wie am Gerät.',

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3842,7 +3842,14 @@ export const en: Dict = {
   'inventory.auditStart': 'Stock-take at this location',
   'inventory.auditTitle': 'Stock-take: {name}',
   'inventory.auditPh': 'Scan a code — a location label switches the location',
-  'inventory.auditEmpty': 'Nothing scanned yet.',
+  'inventory.auditEmpty': 'Nothing recorded yet.',
+  // Bedarf 150 — scannen ist der schnelle Weg, nie der einzige.
+  'inventory.auditExpectedList': 'Tick off without a scanner \u2014 expected here: {n}, still open: {open}',
+  'inventory.auditPick': 'here',
+  'inventory.auditPicked': 'recorded',
+  'inventory.auditPickHint':
+    'Record as \u201cit is here\u201d without a code \u2014 the sheet notes that it was ticked off, not scanned',
+  'inventory.auditViaPick': 'from the list',
   'inventory.auditExpected': 'expected in {ort}',
   'inventory.auditAdopt': 'Adopt location ({n})',
   'inventory.auditAdoptHint':

--- a/src/renderer/lib/inventoryAudit.ts
+++ b/src/renderer/lib/inventoryAudit.ts
@@ -60,10 +60,33 @@ export type AuditOutcome =
    *  und es als „nicht im Bestand" zu melden waere schlicht falsch. */
   | 'is-a-location'
 
+/**
+ * Wie ein Objekt in die Inventur kam (Bedarf 150).
+ *
+ * EIN SCAN UND EIN KLICK SIND NICHT DASSELBE. Wer scannt, hat das Etikett am
+ * Objekt gelesen; wer aus der Liste tippt, hat eine Zeile angeklickt und
+ * behauptet, das Ding liege hier. Beides ist zulaessig — das eine ist der
+ * schnelle Weg, das andere der, der bleibt, wenn der Scanner leer ist oder
+ * das Etikett fehlt. Beides in einen Topf zu werfen waere die stille Form
+ * derselben Luege, gegen die dieses Repo an mehreren Stellen anschreibt:
+ * Ablesung und Behauptung muessen unterscheidbar bleiben.
+ */
+export type AuditVia = 'scan' | 'pick'
+
+export const AUDIT_VIA_LABEL: Record<AuditVia, string> = {
+  scan: 'gescannt',
+  pick: 'aus der Liste',
+}
+
+/** Was in der Code-Spalte steht, wo es keinen Code gab. */
+export const NO_CODE = 'ohne Code'
+
 export interface AuditHit {
   outcome: AuditOutcome
-  /** Der gescannte Code, wie er eingegeben wurde. */
+  /** Der gescannte Code, wie er eingegeben wurde. Leer bei einem Listen-Haken. */
   code: string
+  /** Womit die Zeile belegt ist. Steht auf dem Blatt. */
+  via: AuditVia
   /** Menschenlesbare Bezeichnung des Getroffenen. Leer bei `not-in-inventory`. */
   label: string
   /** Modell — der Bedarf verlangt es ausdruecklich in der Ergebniszeile. */
@@ -93,25 +116,52 @@ export function auditScan(
 ): AuditHit {
   const roh = code.trim()
   const treffer = resolveInventoryCode(roh, sources)
-  if (!treffer) return { outcome: 'not-in-inventory', code: roh, label: '' }
+  if (!treffer) return { outcome: 'not-in-inventory', code: roh, via: 'scan', label: '' }
 
   if (treffer.kind === 'node') {
-    return { outcome: 'is-a-location', code: roh, label: treffer.node.name }
+    return { outcome: 'is-a-location', code: roh, via: 'scan', label: treffer.node.name }
   }
 
+  if (treffer.kind === 'unit') {
+    return einordnen({ unit: treffer.unit }, atNodeId, sources, roh, 'scan')
+  }
+  return einordnen({ item: treffer.item }, atNodeId, sources, roh, 'scan')
+}
+
+/**
+ * Die Einordnung — die eine Stelle, die entscheidet, was ein Objekt am
+ * gepruefen Ort bedeutet.
+ *
+ * Sie ist herausgezogen, damit der Listen-Weg (Bedarf 150) durch DIESELBE
+ * Regel geht wie der Scan. Ein zweiter Weg mit einer nachgebauten Einordnung
+ * driftet still von seinem Vorbild weg, und dann faellt derselbe Karton am
+ * Scanner als „am falschen Ort" und in der Liste als „am erwarteten Ort" auf.
+ *
+ * „Hier" schliesst Behaelter ein: wer vor Regal A3 steht und ein Objekt aus
+ * Case 1 in Regal A3 erfasst, hat es am richtigen Ort. Eine Inventur, die den
+ * Teilbaum nicht mitzaehlt, meldete jedes eingepackte Objekt als verstellt.
+ */
+function einordnen(
+  ziel: { unit: InventoryUnit } | { item: InventoryItem },
+  atNodeId: string,
+  sources: ScanSources,
+  code: string,
+  via: AuditVia,
+): AuditHit {
   const hier = new Set([atNodeId, ...descendantNodeIds(sources.nodes, atNodeId)])
 
-  if (treffer.kind === 'unit') {
-    const u: InventoryUnit = treffer.unit
+  if ('unit' in ziel) {
+    const u = ziel.unit
     const model = sources.items.find((i) => i.id === u.itemId)?.model
     // Bedarf 107 — die Inventur zaehlt im eigenen Haus.
     const label = unitLabel(u, 'house')
     if (!u.locationId) {
-      return { outcome: 'no-location', code: roh, label, ...(model ? { model } : {}), unitId: u.id }
+      return { outcome: 'no-location', code, via, label, ...(model ? { model } : {}), unitId: u.id }
     }
     return {
       outcome: hier.has(u.locationId) ? 'expected-here' : 'wrong-place',
-      code: roh,
+      code,
+      via,
       label,
       ...(model ? { model } : {}),
       expected: nodePathLabel(sources.nodes, u.locationId),
@@ -119,19 +169,151 @@ export function auditScan(
     }
   }
 
-  const it: InventoryItem = treffer.item
+  const it = ziel.item
   if (!it.locationId) {
-    return { outcome: 'no-location', code: roh, label: it.model, model: it.model, itemId: it.id }
+    return { outcome: 'no-location', code, via, label: it.model, model: it.model, itemId: it.id }
   }
   return {
     outcome: hier.has(it.locationId) ? 'expected-here' : 'wrong-place',
-    code: roh,
+    code,
+    via,
     label: it.model,
     model: it.model,
     expected: nodePathLabel(sources.nodes, it.locationId),
     itemId: it.id,
   }
 }
+
+// ───────────────────────────────────────────────────────────────────────────
+// BEDARF 150 — der Scanner ist der schnelle Weg, nie der einzige.
+//
+//   > A model-based reservation 'can only be turned into a concrete asset by
+//   > scanning. There is no way to fulfil one by SELECTING AN ASSET FROM A
+//   > LIST', and since model requests must all be fulfilled before checkout,
+//   > a coordinator without a working scanner is BLOCKED OUTRIGHT.
+//
+// Beleg: `Shelf-nu/shelf.nu#2831` (2026-08-10). Der Melder haelt fest, dass
+// jeder andere Weg im selben Programm eine Auswahl-Liste anbietet — nur
+// dieser eine nicht.
+//
+// WAS HIER VORHER SCHON GING UND WARUM ES NICHT REICHTE. Die Inventur nahm
+// getippte Codes an, nicht nur gescannte — das rettet den leeren Akku. Es
+// rettet NICHT den Fall, den das Lager haeufiger hat: das Etikett ist ab,
+// unlesbar, oder steckt in einem Case, das schon auf dem Lkw steht. Wer den
+// Code nicht lesen kann, kann ihn auch nicht tippen. Der Weg, der dann
+// bleibt, ist die Liste dessen, was hier liegen SOLL.
+//
+// UND DIE ZWEITE HAELFTE DERSELBEN SACHE: erst mit dieser Liste kann eine
+// Inventur ueberhaupt sagen, was FEHLT. Vorher war sie rein additiv — sie
+// zaehlte, was jemand erfasst hat, und ein Case, das niemand mehr findet,
+// hinterliess keine Zeile. Genau das ist aber das Ergebnis, wegen dem
+// inventiert wird.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Ein Eintrag der Liste dessen, was hier liegen soll. */
+export interface AuditCandidate {
+  /** Stabiler Schluessel fuer Liste und Abgleich. */
+  key: string
+  label: string
+  model?: string
+  /** Wo genau der Datensatz es vermutet (dieser Ort oder ein Behaelter darin). */
+  expected: string
+  itemId?: string
+  unitId?: string
+}
+
+const candidateKey = (h: { itemId?: string; unitId?: string }): string =>
+  h.unitId ? `u:${h.unitId}` : h.itemId ? `i:${h.itemId}` : ''
+
+/**
+ * Was der Datensatz an diesem Ort vermutet — die Liste zum Abhaken.
+ *
+ * Einheiten UND Artikel, denn beides traegt einen Lagerort. Der Teilbaum
+ * zaehlt mit: wer vor Regal A3 steht, sieht auch, was in Case 1 in Regal A3
+ * liegen soll — sonst waere die Liste bei jedem eingepackten Objekt leer,
+ * und das ist im Lager der Normalfall.
+ */
+export function expectedAt(atNodeId: string, sources: ScanSources): AuditCandidate[] {
+  const hier = new Set([atNodeId, ...descendantNodeIds(sources.nodes, atNodeId)])
+  const out: AuditCandidate[] = []
+
+  for (const u of sources.units) {
+    if (!u.locationId || !hier.has(u.locationId)) continue
+    const model = sources.items.find((i) => i.id === u.itemId)?.model
+    out.push({
+      key: `u:${u.id}`,
+      label: unitLabel(u, 'house'),
+      ...(model ? { model } : {}),
+      expected: nodePathLabel(sources.nodes, u.locationId),
+      unitId: u.id,
+    })
+  }
+  for (const it of sources.items) {
+    if (!it.locationId || !hier.has(it.locationId)) continue
+    out.push({
+      key: `i:${it.id}`,
+      label: it.model,
+      model: it.model,
+      expected: nodePathLabel(sources.nodes, it.locationId),
+      itemId: it.id,
+    })
+  }
+
+  // Feste Reihenfolge: das Blatt soll bei gleichem Bestand gleich aussehen.
+  return out.sort((a, b) => a.label.localeCompare(b.label, 'de') || a.key.localeCompare(b.key))
+}
+
+/**
+ * Einen Eintrag der Liste als „liegt hier" verbuchen — OHNE Code.
+ *
+ * Geht durch dieselbe Einordnung wie ein Scan (`einordnen`), traegt aber
+ * `via: 'pick'`: das Blatt soll spaeter unterscheiden koennen, ob jemand das
+ * Etikett gelesen oder eine Zeile angeklickt hat.
+ *
+ * Ein Eintrag, den `expectedAt` nicht kennt, ergibt `not-in-inventory` —
+ * dieselbe Auskunft wie ein unbekannter Code, statt eines erfundenen Objekts.
+ */
+export function auditPick(
+  candidate: AuditCandidate,
+  atNodeId: string,
+  sources: ScanSources,
+): AuditHit {
+  if (candidate.unitId) {
+    const u = sources.units.find((x) => x.id === candidate.unitId)
+    if (u) return einordnen({ unit: u }, atNodeId, sources, '', 'pick')
+  }
+  if (candidate.itemId) {
+    const it = sources.items.find((x) => x.id === candidate.itemId)
+    if (it) return einordnen({ item: it }, atNodeId, sources, '', 'pick')
+  }
+  return { outcome: 'not-in-inventory', code: '', via: 'pick', label: candidate.label }
+}
+
+/**
+ * Was hier liegen soll und niemand erfasst hat.
+ *
+ * Das ist das eigentliche Ergebnis einer Inventur, und bis Bedarf 150 gab es
+ * dafuer keine Zeile: die Liste zaehlte nur, was jemand vorgezeigt hat. Ein
+ * Case, das niemand mehr findet, verschwand damit auch aus dem Blatt.
+ */
+export function missingAt(
+  atNodeId: string,
+  sources: ScanSources,
+  hits: readonly AuditHit[],
+): AuditCandidate[] {
+  // NUR `expected-here` schliesst eine Luecke. Ein Objekt, das am falschen
+  // Ort auftaucht, ist damit nicht dort gefunden, wo der Datensatz es
+  // vermutet — dort fehlt es weiterhin. Wuerde hier jeder Treffer abgezogen,
+  // meldete das Blatt eine Luecke als geschlossen, die es nicht ist, und
+  // zwar ausgerechnet bei dem Fall, der im Lager der haeufigste ist.
+  const erfasst = new Set(
+    hits.filter((h) => h.outcome === 'expected-here').map(candidateKey).filter(Boolean),
+  )
+  return expectedAt(atNodeId, sources).filter((c) => !erfasst.has(c.key))
+}
+
+/** Was auf dem Blatt steht, wo etwas erwartet, aber nicht erfasst wurde. */
+export const NOT_FOUND = 'Nicht gefunden'
 
 /**
  * Das Inventur-Blatt.
@@ -141,20 +323,47 @@ export function auditScan(
  * eigene Spalte daneben: erst der Vergleich der beiden macht die Zeile
  * verwertbar.
  */
-export function auditTable(hits: AuditHit[], nodes: StorageNode[], atNodeId: string): CsvTable {
+export function auditTable(
+  hits: AuditHit[],
+  nodes: StorageNode[],
+  atNodeId: string,
+  /**
+   * Was hier erwartet wurde und niemand erfasst hat (Bedarf 150). Optional,
+   * damit ein Aufrufer ohne Bestandsquelle das Blatt weiterhin bekommt —
+   * ohne die Liste steht dann aber auch keine Fehlt-Zeile darauf, und das ist
+   * der ehrliche Zustand: nicht „nichts fehlt", sondern „nicht nachgesehen".
+   */
+  missing: readonly AuditCandidate[] = [],
+): CsvTable {
   const geprueft = nodePathLabel(nodes, atNodeId)
   return {
-    headers: ['Ergebnis', 'Code', 'Objekt', 'Modell', 'Erwartet in', 'Geprueft an'],
-    rows: hits.map((h): CsvCell[] => [
-      AUDIT_LABEL[h.outcome],
-      h.code,
-      h.label,
-      h.model ?? '',
-      // Leer heisst hier „kein Lagerort im Datensatz" und ist selbst die
-      // Aussage — nicht dasselbe wie ein falscher Ort.
-      h.expected ?? '',
-      geprueft,
-    ]),
+    headers: ['Ergebnis', 'Wie erfasst', 'Code', 'Objekt', 'Modell', 'Erwartet in', 'Geprueft an'],
+    rows: [
+      ...hits.map((h): CsvCell[] => [
+        AUDIT_LABEL[h.outcome],
+        AUDIT_VIA_LABEL[h.via],
+        // Ein Listen-Haken hat keinen Code. Die Zelle bleibt nicht leer: eine
+        // leere Zelle liest sich, als sei der Code vergessen worden.
+        h.via === 'pick' ? NO_CODE : h.code,
+        h.label,
+        h.model ?? '',
+        // Leer heisst hier „kein Lagerort im Datensatz" und ist selbst die
+        // Aussage — nicht dasselbe wie ein falscher Ort.
+        h.expected ?? '',
+        geprueft,
+      ]),
+      ...missing.map((c): CsvCell[] => [
+        NOT_FOUND,
+        // Weder gescannt noch angehakt — deshalb steht hier keines von
+        // beiden. Der Strich ist die Aussage.
+        '—',
+        NO_CODE,
+        c.label,
+        c.model ?? '',
+        c.expected,
+        geprueft,
+      ]),
+    ],
   }
 }
 

--- a/tests/inventoryAudit.test.ts
+++ b/tests/inventoryAudit.test.ts
@@ -96,8 +96,15 @@ describe('das Blatt traegt Modell UND Ort', () => {
   it('nennt beides plus den gepruefen Ort', () => {
     const hits = [auditScan('ITM-WEG', 'a3', lager())]
     const t = auditTable(hits, lager().nodes, 'a3')
-    expect(t.headers).toEqual(['Ergebnis', 'Code', 'Objekt', 'Modell', 'Erwartet in', 'Geprueft an'])
-    expect(t.rows[0]).toEqual(['Am falschen Ort', 'ITM-WEG', 'Stativ', 'Stativ', 'Regal B1', 'Regal A3'])
+    // Die Spalte „Wie erfasst" kam mit Bedarf 150 dazu: ein Scan und ein
+    // Haken in der Liste sind nicht dieselbe Auskunft, und das Blatt muss
+    // beides auseinanderhalten koennen.
+    expect(t.headers).toEqual([
+      'Ergebnis', 'Wie erfasst', 'Code', 'Objekt', 'Modell', 'Erwartet in', 'Geprueft an',
+    ])
+    expect(t.rows[0]).toEqual([
+      'Am falschen Ort', 'gescannt', 'ITM-WEG', 'Stativ', 'Stativ', 'Regal B1', 'Regal A3',
+    ])
   })
 
   it('haelt die Etiketten kanonisch deutsch', () => {
@@ -164,7 +171,10 @@ describe('Erreichbarkeit im Lager-Dialog', () => {
   it('zeigt das Ergebnis mit Modell und erwartetem Ort', () => {
     expect(inventarQuelle).toContain('AUDIT_LABEL[h.outcome]')
     expect(inventarQuelle).toContain("t('inventory.auditExpected'")
-    expect(inventarQuelle).toContain('auditTable(auditHits, nodes, node.id)')
+    // Bedarf 150: das Blatt geht jetzt MIT den Fehlt-Zeilen heraus. Ohne sie
+    // zaehlte es nur, was jemand vorgezeigt hat, und laese sich wie eine
+    // vollstaendige Inventur.
+    expect(inventarQuelle).toContain('auditTable(auditHits, nodes, node.id, auditFehlt)')
   })
 
   it('hat fuer jeden neuen Text einen EN-Eintrag', () => {

--- a/tests/scanFallback.test.ts
+++ b/tests/scanFallback.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AUDIT_VIA_LABEL,
+  NOT_FOUND,
+  NO_CODE,
+  auditPick,
+  auditScan,
+  auditTable,
+  expectedAt,
+  missingAt,
+  type AuditCandidate,
+} from '../src/renderer/lib/inventoryAudit'
+import type { InventoryItem, InventoryUnit, StorageNode } from '../src/renderer/types/inventory'
+import inventarQuelle from '../src/renderer/components/Inventory/InventoryDialog.tsx?raw'
+import mobileQuelle from '../src/mobile/MobileApp.tsx?raw'
+import auditQuelle from '../src/renderer/lib/inventoryAudit.ts?raw'
+
+// ---------------------------------------------------------------------------
+// Scannen ist der schnelle Weg, nie der einzige (Bedarf 150, P4).
+//
+//   > A model-based reservation 'can only be turned into a concrete asset by
+//   > scanning. There is no way to fulfil one by SELECTING AN ASSET FROM A
+//   > LIST', and since model requests must all be fulfilled before checkout,
+//   > a coordinator without a working scanner is BLOCKED OUTRIGHT.
+//
+// Beleg: `Shelf-nu/shelf.nu#2831` (2026-08-10). Der Melder haelt fest, dass
+// jeder andere Weg im selben Programm eine Auswahl-Liste anbietet — nur
+// dieser eine nicht.
+//
+// WAS HIER SCHON GING UND WARUM ES NICHT REICHTE. Die Inventur nahm getippte
+// Codes an. Das rettet den leeren Akku; es rettet NICHT das abgerissene
+// Etikett und nicht das Case, das schon auf dem Lkw steht. Wer den Code nicht
+// lesen kann, kann ihn auch nicht tippen.
+// ---------------------------------------------------------------------------
+
+const zeit = '2026-09-06T10:00:00.000Z'
+const node = (id: string, name: string, parentId?: string, code?: string): StorageNode =>
+  ({ id, name, kind: 'shelf', parentId, code, createdAt: zeit, updatedAt: zeit }) as StorageNode
+const item = (id: string, model: string, locationId?: string, code?: string): InventoryItem =>
+  ({ id, model, quantity: 1, locationId, code, createdAt: zeit, updatedAt: zeit }) as InventoryItem
+const unit = (id: string, itemId: string, locationId?: string, code?: string): InventoryUnit =>
+  ({ id, itemId, serial: `SN-${id}`, locationId, code, condition: 'ok', history: [], createdAt: zeit, updatedAt: zeit }) as unknown as InventoryUnit
+
+const lager = () => ({
+  nodes: [
+    node('a3', 'Regal A3'),
+    node('c1', 'Case 1', 'a3', 'CASE-1'),
+    node('b1', 'Regal B1'),
+  ],
+  items: [
+    item('hier', 'Klettband', 'a3', 'ITM-HIER'),
+    item('imcase', 'Gaffa', 'c1', 'ITM-CASE'),
+    item('woanders', 'Stativ', 'b1', 'ITM-WEG'),
+    item('ohneort', 'Adapter', undefined, 'ITM-LOS'),
+  ],
+  units: [unit('u1', 'hier', 'a3', 'UNIT-1')],
+})
+
+const finde = (liste: AuditCandidate[], label: string): AuditCandidate => {
+  const c = liste.find((x) => x.label === label)
+  if (!c) throw new Error(`"${label}" steht nicht in der Liste: ${liste.map((x) => x.label).join(', ')}`)
+  return c
+}
+
+describe('die Liste dessen, was hier liegen soll', () => {
+  it('nennt Einheiten UND Artikel, samt Inhalt der Behaelter darin', () => {
+    const liste = expectedAt('a3', lager())
+    const labels = liste.map((c) => c.label).sort()
+    // Klettband (direkt in A3), Gaffa (in Case 1 in A3), die Einheit in A3.
+    // Stativ liegt in B1 und Adapter nirgends — beide gehoeren nicht hierher.
+    expect(labels).toContain('Klettband')
+    expect(labels).toContain('Gaffa')
+    expect(labels).not.toContain('Stativ')
+    expect(labels).not.toContain('Adapter')
+  })
+
+  it('sagt bei jedem Eintrag, wo genau er erwartet wird', () => {
+    // Ohne diese Angabe stuende „Gaffa" in der Liste von Regal A3, und
+    // niemand wuesste, dass es in Case 1 liegen soll.
+    expect(finde(expectedAt('a3', lager()), 'Gaffa').expected).toBe('Regal A3 › Case 1')
+  })
+
+  it('liefert dieselbe Reihenfolge, egal wie der Bestand sortiert ist', () => {
+    // Nicht „zweimal derselbe Aufruf" — das waere auch ohne Sortierung wahr,
+    // weil eine Schleife ihre Eingabe in Reihenfolge abarbeitet. Geprueft
+    // wird die Unabhaengigkeit von der EINFUEGEREIHENFOLGE im Bestand: sonst
+    // saehe die Abhak-Liste nach jedem Import anders aus, und wer sie zweimal
+    // durchgeht, findet die Zeile nicht wieder, an der er war.
+    const vorwaerts = lager()
+    const rueckwaerts = lager()
+    rueckwaerts.items.reverse()
+    rueckwaerts.units.reverse()
+    const a = expectedAt('a3', vorwaerts).map((c) => c.key)
+    const b = expectedAt('a3', rueckwaerts).map((c) => c.key)
+    expect(a).toEqual(b)
+    expect(a.length).toBeGreaterThan(1)
+  })
+})
+
+describe('abhaken statt scannen — der Weg ohne Code', () => {
+  it('verbucht einen Eintrag ohne jeden Code', () => {
+    const hit = auditPick(finde(expectedAt('a3', lager()), 'Klettband'), 'a3', lager())
+    expect(hit.outcome).toBe('expected-here')
+    expect(hit.code).toBe('')
+    expect(hit.itemId).toBe('hier')
+  })
+
+  it('geht durch DIESELBE Einordnung wie ein Scan', () => {
+    // Der Kern: zwei Wege, eine Regel. Ein nachgebauter zweiter Vergleich
+    // driftet still, und dann faellt derselbe Karton am Scanner als „am
+    // falschen Ort" und in der Liste als „am erwarteten Ort" auf.
+    const gescannt = auditScan('ITM-CASE', 'a3', lager())
+    const gehakt = auditPick(finde(expectedAt('a3', lager()), 'Gaffa'), 'a3', lager())
+    expect(gehakt.outcome).toBe(gescannt.outcome)
+    expect(gehakt.expected).toBe(gescannt.expected)
+    expect(gehakt.itemId).toBe(gescannt.itemId)
+  })
+
+  it('haelt gescannt und abgehakt auseinander', () => {
+    // Wer scannt, hat das Etikett AM OBJEKT gelesen; wer abhakt, hat eine
+    // Zeile angeklickt. Beides ist zulaessig, beides ist nicht dasselbe.
+    expect(auditScan('ITM-HIER', 'a3', lager()).via).toBe('scan')
+    // BEIDE Zweige: der Artikel-Weg und der Einheiten-Weg. Ein Test, der nur
+    // einen davon anfasst, laesst den anderen still auf 'scan' stehen.
+    expect(auditPick(finde(expectedAt('a3', lager()), 'Klettband'), 'a3', lager()).via).toBe('pick')
+    const einheit = expectedAt('a3', lager()).find((c) => c.unitId)
+    expect(einheit, 'die Fixture-Einheit fehlt in der Liste').toBeTruthy()
+    expect(auditPick(einheit!, 'a3', lager()).via).toBe('pick')
+    expect(auditPick(einheit!, 'a3', lager()).unitId).toBe('u1')
+    expect(AUDIT_VIA_LABEL.scan).toBe('gescannt')
+    expect(AUDIT_VIA_LABEL.pick).toBe('aus der Liste')
+  })
+
+  it('erfindet kein Objekt, wenn der Eintrag im Bestand fehlt', () => {
+    const erfunden: AuditCandidate = { key: 'i:gibtsnicht', label: 'Phantom', expected: 'Regal A3', itemId: 'gibtsnicht' }
+    expect(auditPick(erfunden, 'a3', lager()).outcome).toBe('not-in-inventory')
+  })
+
+  it('meldet auch beim Abhaken den falschen Ort', () => {
+    // Wer vor A3 steht und einen Eintrag aus der B1-Liste abhakt, hat ihn am
+    // falschen Ort gefunden — der Weg ohne Code darf da nicht milder sein.
+    const ausB1 = finde(expectedAt('b1', lager()), 'Stativ')
+    const hit = auditPick(ausB1, 'a3', lager())
+    expect(hit.outcome).toBe('wrong-place')
+    expect(hit.expected).toBe('Regal B1')
+  })
+})
+
+describe('was fehlt, ist das eigentliche Ergebnis', () => {
+  it('nennt, was hier erwartet und nicht erfasst wurde', () => {
+    const offen = missingAt('a3', lager(), [auditScan('ITM-HIER', 'a3', lager())])
+    expect(offen.map((c) => c.label)).toContain('Gaffa')
+    expect(offen.map((c) => c.label)).not.toContain('Klettband')
+  })
+
+  it('zaehlt einen abgehakten Eintrag genauso als erfasst wie einen gescannten', () => {
+    const gehakt = auditPick(finde(expectedAt('a3', lager()), 'Gaffa'), 'a3', lager())
+    expect(missingAt('a3', lager(), [gehakt]).map((c) => c.label)).not.toContain('Gaffa')
+  })
+
+  it('laesst ein anderswo erwartetes Objekt nicht als hier fehlend erscheinen', () => {
+    expect(missingAt('a3', lager(), []).map((c) => c.label)).not.toContain('Stativ')
+  })
+
+  it('haelt ein Objekt am falschen Ort NICHT fuer hier gefunden', () => {
+    // Ein in A3 gescanntes Stativ ist nicht das, was A3 vermisst — es fehlt
+    // weiterhin in B1. Wuerde `missingAt` jeden Treffer abziehen, meldete es
+    // eine Luecke als geschlossen, die es nicht ist.
+    const hit = auditScan('ITM-WEG', 'a3', lager())
+    expect(hit.outcome).toBe('wrong-place')
+    expect(missingAt('b1', lager(), [hit]).map((c) => c.label)).toContain('Stativ')
+  })
+})
+
+describe('das Blatt', () => {
+  it('traegt die Herkunft jeder Zeile', () => {
+    const hits = [
+      auditScan('ITM-HIER', 'a3', lager()),
+      auditPick(finde(expectedAt('a3', lager()), 'Gaffa'), 'a3', lager()),
+    ]
+    const t = auditTable(hits, lager().nodes, 'a3')
+    expect(t.headers[1]).toBe('Wie erfasst')
+    expect(t.rows[0][1]).toBe('gescannt')
+    expect(t.rows[1][1]).toBe('aus der Liste')
+    // Und die Code-Spalte bleibt nicht leer: eine leere Zelle liest sich, als
+    // sei der Code vergessen worden.
+    expect(t.rows[1][2]).toBe(NO_CODE)
+  })
+
+  it('fuehrt das Nicht-Gefundene mit auf', () => {
+    const hits = [auditScan('ITM-HIER', 'a3', lager())]
+    const t = auditTable(hits, lager().nodes, 'a3', missingAt('a3', lager(), hits))
+    const fehlend = t.rows.filter((r) => r[0] === NOT_FOUND)
+    expect(fehlend.length).toBeGreaterThan(0)
+    expect(fehlend.map((r) => r[3])).toContain('Gaffa')
+    // Weder gescannt noch abgehakt — und das steht auch so da.
+    expect(fehlend[0][1]).toBe('—')
+  })
+
+  it('behauptet ohne Erwartungsliste nicht, dass nichts fehlt', () => {
+    // Der Aufrufer, der die Liste nicht mitgibt, bekommt keine Fehlt-Zeile —
+    // aber auch kein „vollstaendig". Das Blatt sagt dann schlicht nichts
+    // darueber, und das ist der ehrliche Zustand.
+    const t = auditTable([auditScan('ITM-HIER', 'a3', lager())], lager().nodes, 'a3')
+    expect(t.rows.some((r) => r[0] === NOT_FOUND)).toBe(false)
+  })
+})
+
+describe('kein Weg im Programm haengt allein am Code', () => {
+  it('die Inventur bietet die Liste zum Abhaken an', () => {
+    expect(inventarQuelle).toMatch(/expectedAt\(/)
+    // Und der Haken verbucht wirklich etwas: ein `auditPickNow`, das nur
+    // dasteht, ist eine Taste ohne Wirkung.
+    const handler = inventarQuelle.slice(
+      inventarQuelle.indexOf('const auditPickNow ='),
+      inventarQuelle.indexOf('/** Den TATSAECHLICHEN Ort uebernehmen'),
+    )
+    expect(handler).toMatch(/auditPick\(c, auditNode/)
+    expect(handler).toMatch(/setAuditHits\(/)
+    // Und die Liste steht wirklich im Panel, nicht nur im Zustand.
+    expect(inventarQuelle).toMatch(/auditErwartet\.map\(/)
+    // Die Herkunft steht an der Trefferzeile: gescannt oder abgehakt ist
+    // nicht dasselbe, und wer die Liste liest, muss es sehen.
+    expect(inventarQuelle).toMatch(/h\.via === 'pick'/)
+  })
+
+  it('das Inventur-Blatt geht mit den Fehlt-Zeilen heraus', () => {
+    expect(inventarQuelle).toMatch(/auditTable\(auditHits, nodes, node\.id, auditFehlt\)/)
+  })
+
+  it('die Code-Suche im Lager nimmt getippte Codes, nicht nur die Kamera', () => {
+    // Die Kamera-Taste haengt an `cameraSupported`; das Textfeld darf das
+    // NICHT tun, sonst gibt es auf einem Rechner ohne Kamera keinen Weg.
+    const block = inventarQuelle.slice(
+      inventarQuelle.indexOf("placeholder={t('inventory.scanPh'"),
+      inventarQuelle.indexOf('cameraSupported && ('),
+    )
+    expect(block).not.toMatch(/cameraSupported/)
+    expect(inventarQuelle).toMatch(/onClick=\{\(\) => handleScan\(\)\}/)
+  })
+
+  it('die Handy-Ansicht haelt ihre Texteingabe unabhaengig von der Kamera', () => {
+    // Im Studio-LAN laeuft die Ansicht typisch ueber http://; dort gibt es
+    // gar keinen Kamera-Scan. Ein Weg, der nur mit Kamera funktioniert,
+    // waere dort kein Weg.
+    expect(mobileQuelle).toMatch(/autoFocus=\{!canScan\}/)
+    expect(mobileQuelle).toMatch(/canScan \? \(/)
+  })
+
+  it('die Einordnung steht genau einmal', () => {
+    // Zwei Wege in die Inventur, eine Regel. Waeren es zwei Regeln, waere
+    // das Ergebnis vom Weg abhaengig — und niemand saehe es.
+    expect(auditQuelle.match(/function einordnen\(/g)?.length).toBe(1)
+    // Und `auditScan` ordnet nicht selbst ein: im eigenen Rumpf steht kein
+    // Vergleich gegen den Teilbaum mehr. Eine Pruefung ueber die ganze Datei
+    // saehe die Treffer in `einordnen` und ginge durch.
+    const rumpf = auditQuelle.slice(
+      auditQuelle.indexOf('export function auditScan('),
+      auditQuelle.indexOf('function einordnen('),
+    )
+    expect(rumpf).not.toMatch(/hier\.has\(/)
+    expect(rumpf).not.toMatch(/'expected-here'/)
+  })
+})


### PR DESCRIPTION
> A model-based reservation „can only be turned into a concrete asset by scanning. **There is no way to fulfil one by selecting an asset from a list**", and since model requests must all be fulfilled before checkout, a coordinator without a working scanner is **blocked outright**.
>
> — Bedarf 150, belegt an [`Shelf-nu/shelf.nu#2831`](https://github.com/Shelf-nu/shelf.nu/issues/2831) (2026-08-10). Der Melder hält fest, dass jeder andere Weg im selben Programm eine Auswahl-Liste anbietet — nur dieser eine nicht.

## Was hier schon ging und warum es nicht reichte

Die Inventur nahm getippte Codes an, nicht nur gescannte. Das rettet den leeren Akku. Es rettet **nicht** den Fall, den ein Lager häufiger hat: das Etikett ist ab, unlesbar, oder steckt in einem Case, das schon auf dem Lkw steht. Wer den Code nicht lesen kann, kann ihn auch nicht tippen.

## Was dazukommt

- **`expectedAt(ort, bestand)`** — die Liste dessen, was hier liegen *soll*: Einheiten und Artikel, Behälter-Inhalt eingeschlossen. Feste Reihenfolge, damit dieselbe Liste zweimal gleich aussieht.
- **`auditPick(eintrag, ort, bestand)`** — einen Eintrag ohne jeden Code als „liegt hier" verbuchen.
- **`missingAt(ort, bestand, treffer)`** — was hier erwartet wurde und niemand erfasst hat.
- Im Inventur-Panel eine aufklappbare Abhak-Liste; das CSV trägt die neue Spalte **„Wie erfasst"** und die Fehlt-Zeilen.

## Ein Scan und ein Klick sind nicht dasselbe

Wer scannt, hat das Etikett **am Objekt** gelesen; wer abhakt, hat eine Zeile angeklickt und behauptet, das Ding liege hier. Beides ist zulässig — das eine ist der schnelle Weg, das andere der, der bleibt. Beides in einen Topf zu werfen wäre die stille Form derselben Lüge, gegen die dieses Repo an mehreren Stellen anschreibt. Deshalb trägt jeder Treffer ein `via`, das Blatt eine eigene Spalte, und die Zeile im Panel den Zusatz „aus der Liste".

## Eine Einordnung, zwei Wege

Die Regel, was ein Objekt am geprüften Ort bedeutet, ist aus `auditScan` herausgezogen (`einordnen`) und wird vom Listen-Weg mitbenutzt. Ein zweiter, nachgebauter Vergleich driftet still — und dann fällt derselbe Karton am Scanner als „am falschen Ort" und in der Liste als „am erwarteten Ort" auf.

## Die zweite Hälfte: was fehlt

Die Inventur war rein additiv. Sie zählte, was jemand vorgezeigt hat; ein Case, das niemand mehr findet, hinterließ keine Zeile — obwohl das das Ergebnis ist, wegen dem inventiert wird.

`missingAt` füllt das, und zwar präzise: **nur ein `expected-here` schließt eine Lücke.** Ein Objekt, das am falschen Ort auftaucht, ist damit nicht dort gefunden, wo der Datensatz es vermutet — dort fehlt es weiterhin. Würde jeder Treffer abgezogen, meldete das Blatt ausgerechnet im häufigsten Fall eine Lücke als geschlossen.

Wer das Blatt ohne die Erwartungsliste zieht, bekommt keine Fehlt-Zeile — aber auch kein „vollständig". Das Blatt sagt dann nichts darüber, und das ist der ehrliche Zustand.

## Ein vermiedener Defekt nebenbei

Der erste Entwurf hängte den Text der Abhak-Liste an `inventory.auditExpected` — den Schlüssel gibt es unten schon mit „erwartet in {ort}". Zwei deutsche Fassungen unter einem Schlüssel heißt: die zweite Übersetzung überschreibt die erste, und irgendwo im Englischen steht dann der falsche Satz.

## Geprüft

- 167 Testdateien / 2593 Tests grün, `tsc --noEmit` ohne Fehler, Lint ohne Fehler
- **Gegenprobe: 18 eingespielte Defekte, jeder einzelne macht mindestens einen Test rot** — darunter der als „gescannt" verbuchte Haken (beide Zweige), das stillschweigend abgezogene Objekt am falschen Ort, die verschwundene Herkunfts-Spalte und die Taste ohne Wirkung

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_