### PR TITLE
mobile: Adressen jenseits des LANs zurückhalten und benennen (Bedarf 133)

### DIFF
--- a/src/main/ipc/mobileShareIpc.ts
+++ b/src/main/ipc/mobileShareIpc.ts
@@ -4,6 +4,7 @@ import { existsSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import {
   getMobileShareStatus,
+  setMobileShareAllowBeyondLan,
   setMobileShareProject,
   setMobileShareChecksHandler,
   setMobileShareCableAddedHandler,
@@ -91,6 +92,10 @@ export const registerMobileShareIpc = () => {
     return { ok: true }
   })
   ipcMain.handle('mobileShare:status', () => getMobileShareStatus())
+  // BEDARF 133 — Adressen ueber das LAN hinaus freigeben. Eine ausdrueckliche
+  // Entscheidung des Nutzers und keine, die sich aus der Netzwerkkarte ergibt.
+  ipcMain.handle('mobileShare:setAllowBeyondLan', (_event, allow: unknown) =>
+    setMobileShareAllowBeyondLan(allow === true))
   ipcMain.handle('mobileShare:setProject', (_event, project: unknown) => {
     setMobileShareProject(project)
     return { ok: true }

--- a/src/main/preload.cts
+++ b/src/main/preload.cts
@@ -329,6 +329,10 @@ contextBridge.exposeInMainWorld('cablePlanner', {
         port: number
         urls: string[]
         hasProject: boolean
+        // BEDARF 133 — Adressen, die es gibt und die NICHT angeboten werden.
+        // Eine zurueckgehaltene Adresse, die niemand nennt, ist fuer den
+        // Nutzer dasselbe wie eine, die es nicht gibt.
+        withheld: { address: string; reach: string; reason: string }[]
       }>,
     stop: () => ipcRenderer.invoke('mobileShare:stop') as Promise<{ ok: boolean }>,
     status: () =>
@@ -337,6 +341,16 @@ contextBridge.exposeInMainWorld('cablePlanner', {
         port: number
         urls: string[]
         hasProject: boolean
+        withheld: { address: string; reach: string; reason: string }[]
+      }>,
+    // BEDARF 133 — Adressen ueber das LAN hinaus freigeben. Ausdruecklich und
+    // nur fuer diese Sitzung: `stop` setzt es zurueck.
+    setAllowBeyondLan: (allow: boolean) =>
+      ipcRenderer.invoke('mobileShare:setAllowBeyondLan', allow) as Promise<{
+        port: number
+        urls: string[]
+        hasProject: boolean
+        withheld: { address: string; reach: string; reason: string }[]
       }>,
     setProject: (project: unknown) =>
       ipcRenderer.invoke('mobileShare:setProject', project) as Promise<{ ok: boolean }>,

--- a/src/main/services/mobileShareServer.ts
+++ b/src/main/services/mobileShareServer.ts
@@ -43,6 +43,7 @@ import { networkInterfaces } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { randomBytes } from 'node:crypto'
 import { stripSecrets } from '../util/stripSecrets.js'
+import { shareAddresses, type WithheldAddress } from '../util/lanReach.js'
 
 const MIME_TYPES: Record<string, string> = {
   '.html': 'text/html; charset=utf-8',
@@ -74,6 +75,22 @@ interface MobileShareState {
    *  data/write route (?t= query or X-CP-Token header). Empty when the
    *  server is stopped. */
   token: string
+  /**
+   * BEDARF 133 — ob Adressen ueber das LAN hinaus angeboten werden duerfen.
+   *
+   * Vorgabe `false`. Der Server bindet auf `0.0.0.0`, und bis 2026-09-07 wurde
+   * JEDE nicht-interne IPv4 des Rechners als Freigabe-Adresse angeboten —
+   * samt Token in der URL. Auf einem Hallen-WLAN ist das richtig; an einer
+   * oeffentlich erreichbaren Adresse war es ein Bearer-Token im offenen Netz,
+   * ohne dass es jemand entschieden haette. Es ergab sich aus der
+   * Netzwerkkarte.
+   *
+   * Die Quelle (`cpvalente/ontime#1423`) verlangt Zugriffskontrolle genau
+   * fuer Aufstellungen, die „globally available" sind. Also: der LAN-Weg
+   * bleibt leicht, der Weg darueber hinaus verlangt eine ausdrueckliche
+   * Entscheidung.
+   */
+  allowBeyondLan: boolean
   project: unknown | null
   /** Cached JSON serialization of `project` with secrets stripped. Built
    *  once per setProject() so each /project.json poll doesn't re-stringify
@@ -127,6 +144,7 @@ const state: MobileShareState = {
   server: null,
   port: 0,
   token: '',
+  allowBeyondLan: false,
   project: null,
   serialized: null,
   rendererDir: '',
@@ -548,14 +566,34 @@ export interface MobileShareInfo {
   port: number
   urls: string[]
   hasProject: boolean
+  /**
+   * BEDARF 133 — Adressen, unter denen der Rechner erreichbar ist und die
+   * NICHT angeboten werden, mit Grund.
+   *
+   * Der Dialog zeigt sie. Eine zurueckgehaltene Adresse, die niemand nennt,
+   * ist fuer den Nutzer dasselbe wie eine, die es nicht gibt — und dann
+   * sucht er den Fehler in der Netzwerktechnik.
+   */
+  withheld: WithheldAddress[]
 }
 
 /** Build the phone-facing viewer URLs, embedding the session token so the
  *  QR/links carry it transparently. */
 const buildUrls = (port: number): string[] => {
   const q = state.token ? `?t=${state.token}` : ''
-  return collectLanAddresses().map((ip) => `http://${ip}:${port}/mobile.html${q}`)
+  return shareAddresses(collectLanAddresses(), { allowBeyondLan: state.allowBeyondLan }).offered
+    .map((ip) => `http://${ip}:${port}/mobile.html${q}`)
 }
+
+/**
+ * BEDARF 133 — was NICHT angeboten wird, und warum.
+ *
+ * Aus DERSELBEN Einordnung wie die angebotenen Adressen (`shareAddresses`):
+ * zwei Rechnungen koennten sich widersprechen, und dann stuende eine Adresse
+ * oben als angeboten und unten als zurueckgehalten.
+ */
+const buildWithheld = (): WithheldAddress[] =>
+  shareAddresses(collectLanAddresses(), { allowBeyondLan: state.allowBeyondLan }).withheld
 
 export const startMobileShareServer = async (
   rendererDir: string,
@@ -566,6 +604,7 @@ export const startMobileShareServer = async (
       port: state.port,
       urls: buildUrls(state.port),
       hasProject: state.project !== null,
+      withheld: buildWithheld(),
     }
   }
   state.rendererDir = pathResolve(rendererDir)
@@ -580,6 +619,25 @@ export const startMobileShareServer = async (
     port,
     urls: buildUrls(port),
     hasProject: state.project !== null,
+    withheld: buildWithheld(),
+  }
+}
+
+/**
+ * BEDARF 133 — Adressen ueber das LAN hinaus freigeben oder wieder sperren.
+ *
+ * Eine ausdrueckliche Entscheidung des Nutzers, und sie gilt nur fuer diese
+ * Sitzung: `stopMobileShareServer` setzt sie zurueck. Wer den Rechner morgen
+ * woanders aufstellt, faengt wieder beim LAN an — eine Freigabe, die eine
+ * Ortsaenderung ueberlebt, ist keine Entscheidung ueber DIESES Netz.
+ */
+export const setMobileShareAllowBeyondLan = (allow: boolean): MobileShareInfo => {
+  state.allowBeyondLan = allow
+  return {
+    port: state.port,
+    urls: buildUrls(state.port),
+    hasProject: state.project !== null,
+    withheld: buildWithheld(),
   }
 }
 
@@ -589,6 +647,9 @@ export const stopMobileShareServer = (): void => {
   state.server = null
   state.port = 0
   state.token = ''
+  // Die Freigabe gilt fuer DIESES Netz und diese Sitzung. Wer den Rechner
+  // morgen woanders aufstellt, faengt wieder beim LAN an.
+  state.allowBeyondLan = false
   state.project = null
   state.serialized = null
   state.devProxyUrl = undefined
@@ -656,6 +717,7 @@ export const getMobileShareStatus = (): MobileShareInfo & { running: boolean } =
   port: state.port,
   urls: state.server ? buildUrls(state.port) : [],
   hasProject: state.project !== null,
+  withheld: state.server ? buildWithheld() : [],
 })
 
 void __filename // keep ESM file-url alive

--- a/src/main/util/lanReach.ts
+++ b/src/main/util/lanReach.ts
@@ -1,0 +1,165 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Wie weit reicht diese Adresse? (Bedarf 133, P4)
+//
+//   > Venue internet is unreliable or absent; cloud-only rundown products are
+//   > unusable as the primary show layer on site. BUT managers also need
+//   > multi-site and remote viewers, and IMMEDIATELY WANT ACCESS CONTROL when
+//   > they get it.
+//
+// Belege: `cpvalente/ontime#1423` (2025-01-03) — Passwortschutz wird
+// ausdrücklich für Aufstellungen verlangt, die „globally available (open
+// network or internet)" sind — und `#1547` (2025-03-18), eine Show über zwei
+// Standorte mit gemeinsamer Ansicht.
+//
+// ─── DIE SPANNUNG STEHT IM BEDARF SELBST ───────────────────────────────────
+//
+// Die Quelle sagt nicht „LAN oder Netz", sondern: BEIDES muss vorgesehen
+// sein, und das Zweite zieht sofort eine Zugriffskontrolle nach sich. Genau
+// das ist hier gebaut — und zwar so herum, dass der LAN-Weg leicht bleibt und
+// der Weg darüber hinaus eine ausdrückliche Entscheidung verlangt.
+//
+// ─── WAS HIER WIRKLICH DER FEHLER WAR ──────────────────────────────────────
+//
+// `mobileShareServer` bindet auf `0.0.0.0` und bot bisher JEDE nicht-interne
+// IPv4 des Rechners als Freigabe-Adresse an — samt Token in der URL. Auf einem
+// Hallen-WLAN ist das genau richtig: kurze Wege, ein QR-Code, fertig.
+//
+// Steht der Rechner aber an einer öffentlich erreichbaren Adresse — ein
+// Hotel-Uplink ohne NAT, ein Uni-Netz mit öffentlichem /16, ein Server mit
+// fester IP —, dann war dieselbe Zeile ein Bearer-Token in einer URL im
+// offenen Netz. Niemand hatte das entschieden; es ergab sich aus der
+// Netzwerkkarte.
+//
+// Deshalb: Adressen jenseits des LANs werden NICHT ANGEBOTEN, sondern
+// ZURÜCKGEHALTEN UND BENANNT. Wer sie braucht, schaltet sie frei — und liest
+// dabei, was er tut. Eine Freigabe, die sich aus der Netzwerkkarte ergibt, ist
+// keine Entscheidung.
+//
+// REIN: keine Datei, kein Netz, keine Uhr. Die Adressen kommen von aussen.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Wie weit eine Adresse trägt. */
+export type Reach =
+  /** Nur dieser Rechner. */
+  | 'loopback'
+  /** Das lokale Netz — nicht aus dem Internet erreichbar. */
+  | 'private'
+  /**
+   * Alles andere: potenziell aus dem offenen Netz erreichbar.
+   *
+   * „Potenziell", weil dieser Rechner nicht wissen kann, ob eine Firewall
+   * davor steht. Genau deshalb wird die Adresse zurueckgehalten und nicht
+   * bewertet: eine Vermutung ueber fremde Netzwerktechnik ist keine
+   * Zugriffskontrolle.
+   */
+  | 'beyond-lan';
+
+export const REACH_LABEL: Readonly<Record<Reach, string>> = {
+  loopback: 'nur dieser Rechner',
+  private: 'lokales Netz',
+  'beyond-lan': 'über das lokale Netz hinaus erreichbar',
+};
+
+const oktette = (ip: string): number[] | null => {
+  const teile = ip.trim().split('.');
+  if (teile.length !== 4) return null;
+  const zahlen = teile.map((t) => (/^\d{1,3}$/.test(t) ? Number(t) : NaN));
+  return zahlen.every((n) => Number.isInteger(n) && n >= 0 && n <= 255) ? zahlen : null;
+};
+
+/**
+ * Wie weit traegt diese Adresse?
+ *
+ * IPv4 nach RFC 1918 (10/8, 172.16/12, 192.168/16), dazu CGNAT (100.64/10,
+ * RFC 6598) und Link-Local (169.254/16, RFC 3927) gelten als lokal. IPv6
+ * entsprechend: `::1` ist Loopback, `fe80::/10` Link-Local und `fc00::/7`
+ * Unique-Local.
+ *
+ * ALLES ANDERE gilt als „darueber hinaus" — auch eine Adresse, die dieser
+ * Rechner nicht einordnen kann. Das ist Absicht: im Zweifel wird
+ * ZURUECKGEHALTEN und nicht angeboten. Die andere Richtung waere eine
+ * Freigabe aus Unkenntnis.
+ */
+export function classifyAddress(ip: string): Reach {
+  const roh = ip.trim().toLowerCase();
+  if (!roh) return 'beyond-lan';
+
+  // IPv6 zuerst: eine Zone-Id (`fe80::1%eth0`) gehoert zur Adresse.
+  if (roh.includes(':')) {
+    const ohneZone = roh.split('%')[0];
+    if (ohneZone === '::1') return 'loopback';
+    if (/^fe[89ab][0-9a-f]:/.test(ohneZone)) return 'private';
+    if (/^f[cd][0-9a-f]{2}:/.test(ohneZone)) return 'private';
+    // IPv4-mapped (`::ffff:192.168.1.5`) wird als das behandelt, was es ist.
+    const eingebettet = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/.exec(ohneZone);
+    if (eingebettet) return classifyAddress(eingebettet[1]);
+    return 'beyond-lan';
+  }
+
+  const o = oktette(roh);
+  if (!o) return 'beyond-lan';
+  const [a, b] = o;
+  if (a === 127) return 'loopback';
+  if (a === 10) return 'private';
+  if (a === 192 && b === 168) return 'private';
+  if (a === 172 && b >= 16 && b <= 31) return 'private';
+  if (a === 100 && b >= 64 && b <= 127) return 'private';
+  if (a === 169 && b === 254) return 'private';
+  return 'beyond-lan';
+}
+
+export interface WithheldAddress {
+  address: string;
+  reach: Reach;
+  reason: string;
+}
+
+export interface ShareAddresses {
+  /** Adressen, unter denen die Freigabe angeboten wird. */
+  offered: string[];
+  /** Adressen, die es gibt und die NICHT angeboten werden — mit Grund. */
+  withheld: WithheldAddress[];
+  /** Ob mindestens eine zurueckgehaltene Adresse ueber das LAN hinausreicht. */
+  hasBeyondLan: boolean;
+}
+
+/**
+ * Der Satz, der die Freigabe erklaert.
+ *
+ * Steht im Modul und nicht nur im Kommentar, damit die Oberflaeche ihn zeigen
+ * kann, ohne ihn ein zweites Mal zu formulieren — und damit er nur an EINER
+ * Stelle geaendert werden muss, wenn sich die Regel aendert.
+ */
+export const BEYOND_LAN_REASON =
+  'Diese Adresse ist möglicherweise aus dem offenen Netz erreichbar. Das '
+  + 'Freigabe-Token steht in der URL, und ein Token in einer URL ist im offenen '
+  + 'Netz keine Zugriffskontrolle: wer den Link weitergibt oder mitliest, hat '
+  + 'Zugang. Freigabe hier ausdrücklich einschalten, wenn das gewollt ist.';
+
+/**
+ * Welche Adressen angeboten werden — und welche nicht.
+ *
+ * DIE ENGSTELLE. Beide Listen entstehen hier, aus derselben Einordnung: zwei
+ * Rechnungen koennten sich widersprechen, und dann stuende eine Adresse oben
+ * als angeboten und unten als zurueckgehalten.
+ *
+ * `allowBeyondLan` ist eine AUSDRUECKLICHE Entscheidung des Nutzers und hat
+ * deshalb keinen Vorgabewert im Aufruf-Sinn: ohne sie bleibt es beim LAN. Eine
+ * Freigabe, die sich aus der Netzwerkkarte ergibt, ist keine Entscheidung.
+ */
+export function shareAddresses(
+  addresses: readonly string[],
+  opts: { allowBeyondLan: boolean },
+): ShareAddresses {
+  const offered: string[] = [];
+  const withheld: WithheldAddress[] = [];
+  for (const ip of addresses) {
+    const reach = classifyAddress(ip);
+    if (reach !== 'beyond-lan' || opts.allowBeyondLan) {
+      offered.push(ip);
+      continue;
+    }
+    withheld.push({ address: ip, reach, reason: BEYOND_LAN_REASON });
+  }
+  return { offered, withheld, hasBeyondLan: withheld.length > 0 };
+}

--- a/src/renderer/components/MobileShare/MobileShareDialog.tsx
+++ b/src/renderer/components/MobileShare/MobileShareDialog.tsx
@@ -36,11 +36,26 @@ import { useUiStore } from '../../store/uiStore'
 import { cablePlannerApi, hasDesktopBridge } from '../../lib/bridge'
 import { useTranslation } from '../../lib/i18n'
 
+interface WithheldAddress {
+  address: string
+  reach: string
+  reason: string
+}
+
 interface ShareStatus {
   running: boolean
   port: number
   urls: string[]
   hasProject: boolean
+  /**
+   * BEDARF 133 — Adressen, unter denen der Rechner erreichbar ist und die
+   * NICHT angeboten werden.
+   *
+   * Sie werden GEZEIGT und nicht verschwiegen: eine zurueckgehaltene Adresse,
+   * die niemand nennt, ist fuer den Nutzer dasselbe wie eine, die es nicht
+   * gibt — und dann sucht er den Fehler in der Netzwerktechnik.
+   */
+  withheld: WithheldAddress[]
 }
 
 const renderQrTo = async (url: string): Promise<string> => {
@@ -76,6 +91,7 @@ export const MobileShareDialog = () => {
     port: 0,
     urls: [],
     hasProject: false,
+    withheld: [],
   })
   const [busy, setBusy] = useState(false)
   const [qrDataUrl, setQrDataUrl] = useState<string>('')
@@ -117,11 +133,24 @@ export const MobileShareDialog = () => {
     }
   }
 
+  // BEDARF 133 — die ausdrueckliche Entscheidung. Sie gilt nur fuer diese
+  // Sitzung: `stop` setzt sie im Main-Prozess zurueck, und wer den Rechner
+  // morgen woanders aufstellt, faengt wieder beim LAN an.
+  const handleAllowBeyondLan = async () => {
+    setBusy(true)
+    try {
+      const result = await cablePlannerApi.mobileShare.setAllowBeyondLan(true)
+      setStatus({ ...result, running: true })
+    } finally {
+      setBusy(false)
+    }
+  }
+
   const handleStop = async () => {
     setBusy(true)
     try {
       await cablePlannerApi.mobileShare.stop()
-      setStatus({ running: false, port: 0, urls: [], hasProject: false })
+      setStatus({ running: false, port: 0, urls: [], hasProject: false, withheld: [] })
     } finally {
       setBusy(false)
     }
@@ -163,8 +192,17 @@ export const MobileShareDialog = () => {
           {status.running ? (
             <div className="space-y-3">
               <div className="flex flex-col items-center gap-2 rounded border border-emerald-700 bg-emerald-950/30 p-3">
+                {/* Drei Zustaende, nicht zwei. Laeuft der Server, ist aber
+                    keine Adresse uebrig — jede wurde zurueckgehalten (Bedarf
+                    133) —, dann pulste hier frueher ein Platzhalter, der nie
+                    fertig wird: „niemand hat nachgesehen" statt „da ist
+                    nichts". Der Zustand wird jetzt benannt. */}
                 {qrDataUrl ? (
                   <img src={qrDataUrl} alt={t('mobile.dialog.qrAlt', 'QR-Code')} className="rounded bg-white p-2" />
+                ) : status.urls.length === 0 ? (
+                  <div className="flex h-[240px] w-[240px] items-center justify-center rounded border border-cp-border bg-cp-surface-2 p-3 text-center text-cp-xs text-cp-text-secondary">
+                    {t('mobile.dialog.noAddress', 'Keine Adresse freigegeben — der Server läuft, aber es gibt kein lokales Netz, unter dem er erreichbar wäre.')}
+                  </div>
                 ) : (
                   <div className="h-[240px] w-[240px] animate-pulse rounded bg-cp-surface-2" />
                 )}
@@ -211,6 +249,45 @@ export const MobileShareDialog = () => {
                       </button>
                     ))}
                   </div>
+                </div>
+              )}
+              {/* ── BEDARF 133 — was NICHT angeboten wird, und warum ──────
+                  „Managers also need multi-site and remote viewers, and
+                  IMMEDIATELY WANT ACCESS CONTROL when they get it."
+                  (cpvalente/ontime#1423)
+
+                  Der Server bindet auf 0.0.0.0. Adressen jenseits des LANs
+                  werden deshalb zurueckgehalten — aber GENANNT: eine
+                  verschwiegene Adresse ist fuer den Nutzer dasselbe wie eine,
+                  die es nicht gibt, und dann sucht er den Fehler in der
+                  Netzwerktechnik. Wer sie braucht, schaltet sie frei und
+                  liest dabei, was er tut. */}
+              {status.withheld.length > 0 && (
+                <div className="rounded border border-amber-700 bg-amber-950/40 p-2">
+                  <div className="mb-1 text-[10px] uppercase tracking-wide text-amber-300">
+                    {t('mobile.dialog.withheldTitle', 'Nicht freigegeben')}
+                  </div>
+                  <div className="mb-1 flex flex-wrap gap-1">
+                    {status.withheld.map((w) => (
+                      <span
+                        key={w.address}
+                        className="rounded border border-amber-700 bg-cp-surface-1 px-2 py-0.5 font-mono text-[10px] text-amber-200"
+                      >
+                        {w.address}
+                      </span>
+                    ))}
+                  </div>
+                  <p className="text-[11px] leading-snug text-cp-text-secondary">
+                    {status.withheld[0].reason}
+                  </p>
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => void handleAllowBeyondLan()}
+                    className="mt-1 rounded border border-amber-600 px-2 py-0.5 text-[10px] text-amber-200 hover:bg-amber-900/60"
+                  >
+                    {t('mobile.dialog.allowBeyondLan', 'Trotzdem freigeben (nur für diese Sitzung)')}
+                  </button>
                 </div>
               )}
               <div className="flex items-center justify-between">

--- a/src/renderer/lib/bridge.ts
+++ b/src/renderer/lib/bridge.ts
@@ -2,6 +2,22 @@ import type { CablePlannerProject } from '../types/project'
 import type { NetboxRack, NetboxSite, NetboxSnapshot } from '../types/netbox'
 import { downloadBlob } from './downloadBlob'
 
+/**
+ * BEDARF 133 — was die Freigabe anbietet, und was sie zurueckhaelt.
+ *
+ * `withheld` ist kein Zusatz, sondern die zweite Haelfte der Auskunft: eine
+ * zurueckgehaltene Adresse, die niemand nennt, ist fuer den Nutzer dasselbe
+ * wie eine, die es nicht gibt — und dann sucht er den Fehler in der
+ * Netzwerktechnik statt in einer Entscheidung, die diese Anwendung getroffen
+ * hat.
+ */
+export interface MobileShareInfo {
+  port: number
+  urls: string[]
+  hasProject: boolean
+  withheld: { address: string; reach: string; reason: string }[]
+}
+
 type OpenProjectResponse = {
   filePath: string
   data: CablePlannerProject
@@ -351,10 +367,18 @@ type CablePlannerApi = {
     deleteItem: (params: { kind: 'device' | 'group'; name: string }) => Promise<boolean>
   }
   mobileShare: {
-    start: () => Promise<{ port: number; urls: string[]; hasProject: boolean }>
+    start: () => Promise<MobileShareInfo>
     stop: () => Promise<{ ok: boolean }>
-    status: () => Promise<{ running: boolean; port: number; urls: string[]; hasProject: boolean }>
+    status: () => Promise<MobileShareInfo & { running: boolean }>
     setProject: (project: unknown) => Promise<{ ok: boolean }>
+    /**
+     * BEDARF 133 — Adressen ueber das LAN hinaus freigeben.
+     *
+     * Ausdruecklich und nur fuer diese Sitzung: `stop` setzt es im
+     * Main-Prozess zurueck. Eine Freigabe, die sich aus der Netzwerkkarte
+     * ergibt, ist keine Entscheidung.
+     */
+    setAllowBeyondLan: (allow: boolean) => Promise<MobileShareInfo>
     /** v7.9.3 — Listener für CheckState-Updates vom Mobile-Viewer.
      *  Wird vom Renderer registriert; der Main-Prozess schickt
      *  'mobileShare:checksUpdate' Events sobald POST /checks
@@ -940,8 +964,11 @@ const webFallbackApi: CablePlannerApi = {
       throw new Error('Handy-Zugriff erfordert die Desktop-App.')
     },
     stop: async () => ({ ok: true }),
-    status: async () => ({ running: false, port: 0, urls: [], hasProject: false }),
+    status: async () => ({ running: false, port: 0, urls: [], hasProject: false, withheld: [] }),
     setProject: async () => ({ ok: true }),
+    setAllowBeyondLan: async () => {
+      throw new Error('Handy-Zugriff erfordert die Desktop-App.')
+    },
     onChecksUpdate: () => () => {},
     onCableAdded: () => () => {},
     onPendingChange: () => () => {},

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -1642,6 +1642,10 @@ export const en: Dict = {
   'mobile.dialog.activeUrl': 'Active URL',
   'mobile.dialog.copyToClipboard': 'Copy to clipboard',
   'mobile.dialog.altUrls': 'Alternative LAN addresses (in case one is unreachable)',
+  'mobile.dialog.noAddress':
+    'No address shared — the server is running, but there is no local network it could be reached on.',
+  'mobile.dialog.withheldTitle': 'Not shared',
+  'mobile.dialog.allowBeyondLan': 'Share anyway (this session only)',
   'mobile.dialog.portLabel': 'Port',
   'mobile.dialog.projectSynced': 'Project synced',
   'mobile.dialog.noProject': 'No project loaded',

--- a/tests/lanReach.test.ts
+++ b/tests/lanReach.test.ts
@@ -1,0 +1,191 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Wie weit reicht diese Adresse? (Bedarf 133, P4)
+//
+//   > Venue internet is unreliable or absent […] BUT managers also need
+//   > multi-site and remote viewers, and IMMEDIATELY WANT ACCESS CONTROL when
+//   > they get it.
+//
+// Belege: `cpvalente/ontime#1423` (2025-01-03) — Passwortschutz ausdrücklich
+// für Aufstellungen, die „globally available (open network or internet)" sind
+// — und `#1547` (2025-03-18), eine Show über zwei Standorte.
+//
+// WAS HIER GEPRÜFT WIRD, und warum jede Zeile davon nötig ist:
+//
+//  1. DIE EINORDNUNG STIMMT. RFC 1918, CGNAT, Link-Local und die
+//     IPv6-Entsprechungen gelten als lokal — der Rest nicht. Wer hier
+//     danebenliegt, gibt entweder das Hallen-WLAN nicht frei (ärgerlich) oder
+//     eine öffentliche Adresse (gefährlich).
+//
+//  2. IM ZWEIFEL WIRD ZURÜCKGEHALTEN. Eine Adresse, die dieser Rechner nicht
+//     einordnen kann, gilt als „darüber hinaus". Die andere Richtung wäre
+//     eine Freigabe aus Unkenntnis.
+//
+//  3. ZURÜCKGEHALTEN HEISST BENANNT. Eine Adresse, die niemand nennt, ist für
+//     den Nutzer dasselbe wie eine, die es nicht gibt — und dann sucht er den
+//     Fehler in der Netzwerktechnik statt in einer Entscheidung, die diese
+//     Anwendung getroffen hat.
+//
+//  4. BEIDE LISTEN KOMMEN AUS DERSELBEN EINORDNUNG. Sonst stünde eine Adresse
+//     oben als angeboten und unten als zurückgehalten.
+//
+//  5. DIE FREIGABE IST EINE ENTSCHEIDUNG. Ohne sie bleibt es beim LAN — eine
+//     Freigabe, die sich aus der Netzwerkkarte ergibt, ist keine.
+//
+//  6. DER WEG IST VERDRAHTET — und die Freigabe überlebt kein `stop()`.
+// ───────────────────────────────────────────────────────────────────────────
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import {
+  BEYOND_LAN_REASON,
+  REACH_LABEL,
+  classifyAddress,
+  shareAddresses,
+  type Reach,
+} from '../src/main/util/lanReach'
+
+const lies = (rel: string): string => readFileSync(new URL(rel, import.meta.url), 'utf8')
+
+/**
+ * Quelltext OHNE Kommentare.
+ *
+ * Wer eine abgeschaffte Bauform verbietet, muss sie in der Begruendung
+ * zitieren duerfen — sonst steht im Code kein Wort mehr darueber, warum sie
+ * weg ist. Also erst die Kommentare weg, dann pruefen.
+ */
+const ohneKommentare = (rel: string): string =>
+  lies(rel)
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^[ \t]*\/\/.*$/gm, '')
+
+describe('Bedarf 133 — wie weit reicht diese Adresse?', () => {
+  it('1. die Einordnung stimmt', () => {
+    // Loopback.
+    expect(classifyAddress('127.0.0.1')).toBe('loopback')
+    expect(classifyAddress('127.255.255.254')).toBe('loopback')
+    expect(classifyAddress('::1')).toBe('loopback')
+
+    // RFC 1918 — das Hallen-WLAN.
+    for (const ip of ['10.0.0.5', '10.255.255.255', '192.168.1.42', '172.16.0.1', '172.31.255.254']) {
+      expect(classifyAddress(ip), ip).toBe('private')
+    }
+    // CGNAT (RFC 6598) und Link-Local (RFC 3927) sind ebenfalls nicht aus dem
+    // Internet erreichbar.
+    expect(classifyAddress('100.64.0.1')).toBe('private')
+    expect(classifyAddress('100.127.255.254')).toBe('private')
+    expect(classifyAddress('169.254.10.20')).toBe('private')
+    // IPv6: Link-Local und Unique-Local, auch mit Zone-Id.
+    expect(classifyAddress('fe80::1')).toBe('private')
+    expect(classifyAddress('fe80::1%eth0')).toBe('private')
+    expect(classifyAddress('fd00::1234')).toBe('private')
+
+    // DIE RAENDER. 172.15 und 172.32 liegen AUSSERHALB von 172.16/12 — genau
+    // hier liegt der klassische Fehler, und er faellt in die gefaehrliche
+    // Richtung.
+    expect(classifyAddress('172.15.255.255')).toBe('beyond-lan')
+    expect(classifyAddress('172.32.0.1')).toBe('beyond-lan')
+    expect(classifyAddress('100.63.255.255')).toBe('beyond-lan')
+    expect(classifyAddress('100.128.0.1')).toBe('beyond-lan')
+    expect(classifyAddress('169.253.0.1')).toBe('beyond-lan')
+
+    // Oeffentlich erreichbar.
+    for (const ip of ['8.8.8.8', '93.184.216.34', '11.0.0.1', '2001:db8::1']) {
+      expect(classifyAddress(ip), ip).toBe('beyond-lan')
+    }
+    // IPv4-mapped IPv6 wird als das behandelt, was es ist.
+    expect(classifyAddress('::ffff:192.168.1.5')).toBe('private')
+    expect(classifyAddress('::ffff:8.8.8.8')).toBe('beyond-lan')
+
+    for (const r of ['loopback', 'private', 'beyond-lan'] as Reach[]) {
+      expect(REACH_LABEL[r].length).toBeGreaterThan(5)
+    }
+  })
+
+  it('2. im Zweifel wird zurueckgehalten', () => {
+    // Was sich nicht einordnen laesst, gilt als „darueber hinaus". Die andere
+    // Richtung waere eine Freigabe aus Unkenntnis.
+    for (const murks of ['', '   ', 'nicht.eine.adresse', '999.1.1.1', '10.0.0', '10.0.0.0.1', '10.0.0.256']) {
+      expect(classifyAddress(murks), JSON.stringify(murks)).toBe('beyond-lan')
+    }
+  })
+
+  it('3. zurueckgehalten heisst benannt', () => {
+    const r = shareAddresses(['192.168.1.5', '93.184.216.34'], { allowBeyondLan: false })
+    expect(r.offered).toEqual(['192.168.1.5'])
+    expect(r.withheld).toHaveLength(1)
+    expect(r.withheld[0].address).toBe('93.184.216.34')
+    expect(r.withheld[0].reach).toBe('beyond-lan')
+    // Der Grund steht dabei, und er sagt WARUM ein Token in einer URL im
+    // offenen Netz keine Zugriffskontrolle ist.
+    expect(r.withheld[0].reason).toBe(BEYOND_LAN_REASON)
+    expect(BEYOND_LAN_REASON).toMatch(/Token/)
+    expect(BEYOND_LAN_REASON.length).toBeGreaterThan(80)
+    expect(r.hasBeyondLan).toBe(true)
+  })
+
+  it('4. beide Listen kommen aus derselben Einordnung', () => {
+    const alle = ['127.0.0.1', '10.0.0.5', '172.15.0.1', 'fe80::1', '8.8.8.8']
+    const r = shareAddresses(alle, { allowBeyondLan: false })
+    // Keine Adresse verschwindet, und keine steht in beiden Listen.
+    expect(r.offered.length + r.withheld.length).toBe(alle.length)
+    for (const w of r.withheld) expect(r.offered).not.toContain(w.address)
+    for (const o of r.offered) expect(r.withheld.map((w) => w.address)).not.toContain(o)
+    // Und die Einordnung ist dieselbe wie die von `classifyAddress`.
+    for (const o of r.offered) expect(classifyAddress(o)).not.toBe('beyond-lan')
+    for (const w of r.withheld) expect(classifyAddress(w.address)).toBe('beyond-lan')
+  })
+
+  it('5. die Freigabe ist eine Entscheidung', () => {
+    const alle = ['192.168.1.5', '93.184.216.34']
+    // Ohne sie: das LAN.
+    expect(shareAddresses(alle, { allowBeyondLan: false }).offered).toEqual(['192.168.1.5'])
+    // Mit ihr: alles — und nichts bleibt zurueckgehalten, ueber das dann
+    // faelschlich gewarnt wuerde.
+    const frei = shareAddresses(alle, { allowBeyondLan: true })
+    expect(frei.offered).toEqual(alle)
+    expect(frei.withheld).toHaveLength(0)
+    expect(frei.hasBeyondLan).toBe(false)
+
+    // Ein reines LAN meldet nichts — eine Warnung ohne Anlass wird beim
+    // zweiten Mal weggeklickt und dann auch die mit Anlass.
+    const nurLan = shareAddresses(['10.0.0.5', '127.0.0.1'], { allowBeyondLan: false })
+    expect(nurLan.withheld).toHaveLength(0)
+    expect(nurLan.hasBeyondLan).toBe(false)
+  })
+
+  it('6. der Weg ist verdrahtet', () => {
+    const server = ohneKommentare('../src/main/services/mobileShareServer.ts')
+    // Die Freigabe-URLs kommen aus der Einordnung und nicht mehr aus der
+    // rohen Adressliste.
+    expect(server).toMatch(/shareAddresses\(collectLanAddresses\(\), \{ allowBeyondLan: state\.allowBeyondLan \}\)\.offered/)
+    // Was zurueckgehalten wird, geht mit an den Renderer.
+    expect(server).toMatch(/withheld: WithheldAddress\[\]/)
+    expect(server).toMatch(/withheld: buildWithheld\(\)/)
+    // Vorgabe: LAN. Eine Freigabe, die sich aus der Netzwerkkarte ergibt, ist
+    // keine Entscheidung.
+    expect(server).toMatch(/allowBeyondLan: false,/)
+    // Und sie ueberlebt kein `stop()`: wer den Rechner morgen woanders
+    // aufstellt, faengt wieder beim LAN an.
+    const stop = /export const stopMobileShareServer[\s\S]*?\n\}/.exec(server)?.[0] ?? ''
+    expect(stop).toMatch(/state\.allowBeyondLan = false/)
+
+    // Der Dialog zeigt die zurueckgehaltenen Adressen samt Grund und bietet
+    // die ausdrueckliche Freigabe an.
+    const dialog = ohneKommentare('../src/renderer/components/MobileShare/MobileShareDialog.tsx')
+    expect(dialog).toMatch(/status\.withheld\.length > 0/)
+    expect(dialog).toMatch(/status\.withheld\[0\]\.reason/)
+    expect(dialog).toMatch(/setAllowBeyondLan\(true\)/)
+
+    // Und wenn NICHTS uebrig bleibt, weil jede Adresse zurueckgehalten
+    // wurde: Der Zustand wird benannt. Ein ewig pulsender Platzhalter an
+    // der Stelle des QR-Codes hiesse „niemand hat nachgesehen" — dabei
+    // hat jemand nachgesehen und entschieden.
+    expect(dialog).toMatch(/status\.urls\.length === 0 \? \(/)
+    expect(dialog).toMatch(/mobile\.dialog\.noAddress/)
+
+    // Und der IPC-Kanal ist domaenen-praefixiert wie alle anderen.
+    const ipc = ohneKommentare('../src/main/ipc/mobileShareIpc.ts')
+    expect(ipc).toMatch(/'mobileShare:setAllowBeyondLan'/)
+    // Nur ein echtes `true` schaltet frei — kein truthy-Wert aus dem Renderer.
+    expect(ipc).toMatch(/allow === true/)
+  })
+})


### PR DESCRIPTION
## Worum es geht

Bedarf 133 (P4) aus der Recherche:

> Venue internet is unreliable or absent; cloud-only rundown products are unusable as the primary show layer on site. **BUT managers also need multi-site and remote viewers, and IMMEDIATELY WANT ACCESS CONTROL when they get it.**

Belege: `cpvalente/ontime#1423` (2025-01-03) — Passwortschutz wird ausdrücklich für Aufstellungen verlangt, die „globally available (open network or internet)" sind — und `#1547` (2025-03-18), eine Show über zwei Standorte mit gemeinsamer Ansicht.

Die Spannung steht im Bedarf selbst: nicht „LAN oder Netz", sondern beides, und das Zweite zieht sofort eine Zugriffskontrolle nach sich. Genau so herum ist es gebaut — der LAN-Weg bleibt leicht, der Weg darüber hinaus verlangt eine ausdrückliche Entscheidung.

## Der Defekt, der dabei auffiel

`mobileShareServer` bindet auf `0.0.0.0` und bot bisher **jede** nicht-interne IPv4 des Rechners als Freigabe-Adresse an — samt Token in der URL. Im Hallen-WLAN ist das genau richtig: kurze Wege, ein QR-Code, fertig.

Steht der Rechner aber an einer öffentlich erreichbaren Adresse — ein Hotel-Uplink ohne NAT, ein Uni-Netz mit öffentlichem /16, ein Server mit fester IP —, dann war dieselbe Zeile ein Bearer-Token in einer URL im offenen Netz. Niemand hatte das entschieden; es ergab sich aus der Netzwerkkarte.

## Was sich ändert

- **`src/main/util/lanReach.ts`** (neu, rein — keine Datei, kein Netz, keine Uhr) ordnet eine Adresse ein: `loopback` / `private` / `beyond-lan`. Lokal sind RFC 1918 (10/8, 172.16/12, 192.168/16), CGNAT (100.64/10, RFC 6598), Link-Local (169.254/16, RFC 3927) und die IPv6-Entsprechungen (`::1`, `fe80::/10`, `fc00::/7`; IPv4-mapped wird ausgepackt). **Alles andere** gilt als „darüber hinaus" — auch eine Adresse, die sich nicht einordnen lässt. Im Zweifel wird zurückgehalten; die andere Richtung wäre eine Freigabe aus Unkenntnis.
- **`shareAddresses` ist die Engstelle.** Angebotene und zurückgehaltene Adressen entstehen aus derselben Einordnung. Zwei Rechnungen könnten sich widersprechen, und dann stünde eine Adresse oben als angeboten und unten als zurückgehalten.
- **Zurückgehalten heißt benannt.** Der Dialog zeigt die Adressen und den Grund (`BEYOND_LAN_REASON` liegt im Modul, nicht nur im Kommentar, damit die Oberfläche ihn nicht ein zweites Mal formuliert). Eine verschwiegene Adresse ist für den Nutzer dasselbe wie eine, die es nicht gibt — und dann sucht er den Fehler in der Netzwerktechnik statt in einer Entscheidung, die diese Anwendung getroffen hat.
- **Die Freigabe ist eine Entscheidung.** „Trotzdem freigeben (nur für diese Sitzung)" geht über `mobileShare:setAllowBeyondLan`; nur ein echtes `true` schaltet frei. `stopMobileShareServer` setzt sie zurück — wer den Rechner morgen woanders aufstellt, fängt wieder beim LAN an.
- **Ein reines LAN meldet nichts.** Eine Warnung ohne Anlass wird beim zweiten Mal weggeklickt und dann auch die mit Anlass.

Nebenbei repariert: läuft der Server, ist aber keine Adresse übrig, pulste an der Stelle des QR-Codes ein Platzhalter, der nie fertig wird — „niemand hat nachgesehen" statt „da ist nichts". Der Zustand wird jetzt benannt (`mobile.dialog.noAddress`).

## Geprüft

- `tests/lanReach.test.ts`, sechs Blöcke — darunter die Ränder 172.15/172.32 und 100.63/100.128, an denen der klassische Fehler in die gefährliche Richtung fällt.
- **22 Gegenproben, jede rot:** Rand um eins verschoben, unparsbare Adresse als lokal, IPv4-in-IPv6 nicht ausgepackt, Freigabe übergangen, Grund entfernt, Vorgabe auf frei, Reset in `stop()` gelöscht, Dialog verschweigt das Zurückgehaltene, IPC nimmt jeden truthy-Wert.
- Volle Suite: 2599 grün, 2 skipped. `tsc` auf `app`/`main`/`preload` sauber, `lint` 0 Errors. Der EN-Erreichbarkeits-Guard hat die zwei neuen Keys eingefordert; sie sind übersetzt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_