### PR TITLE
freigabe: die LAN-Freigabe hängt an einer Show (Bedarf 127)

### DIFF
--- a/src/main/services/mobileShareServer.ts
+++ b/src/main/services/mobileShareServer.ts
@@ -44,6 +44,7 @@ import { fileURLToPath } from 'node:url'
 import { randomBytes } from 'node:crypto'
 import { stripSecrets } from '../util/stripSecrets.js'
 import { shareAddresses, type WithheldAddress } from '../util/lanReach.js'
+import { showIdOf, showMismatch } from '../util/shareShow.js'
 
 const MIME_TYPES: Record<string, string> = {
   '.html': 'text/html; charset=utf-8',
@@ -91,6 +92,14 @@ interface MobileShareState {
    * Entscheidung.
    */
   allowBeyondLan: boolean
+  /**
+   * BEDARF 127 — die Show, die gerade freigegeben ist.
+   *
+   * Steht neben dem Projekt und nicht in ihm, damit die Pruefung des
+   * Rueckwegs nicht bei jedem Aufruf durch das ganze Projekt greifen muss.
+   * Gesetzt wird sie an EINER Stelle, zusammen mit dem Projekt selbst.
+   */
+  showId: string | null
   project: unknown | null
   /** Cached JSON serialization of `project` with secrets stripped. Built
    *  once per setProject() so each /project.json poll doesn't re-stringify
@@ -145,6 +154,7 @@ const state: MobileShareState = {
   port: 0,
   token: '',
   allowBeyondLan: false,
+  showId: null,
   project: null,
   serialized: null,
   rendererDir: '',
@@ -297,6 +307,36 @@ const handleRequest = (req: IncomingMessage, res: ServerResponse) => {
     return
   }
 
+  /**
+   * BEDARF 127 — gehoert dieser Rueckweg zur freigegebenen Show?
+   *
+   * DIE ENGSTELLE fuer alle drei Schreibwege (`/checks`, `/cables`,
+   * `/pending-changes`). Sie fragen hier und vergleichen nicht selbst: drei
+   * eigene Vergleiche waeren drei Gelegenheiten, einen zu vergessen — und
+   * vergessen wuerde man den seltensten, also den, bei dem es am laengsten
+   * niemandem auffaellt.
+   *
+   * 409 und nicht 400: der Aufruf ist nicht falsch gebaut, er kommt in eine
+   * Lage, die sich seit dem Laden der Seite geaendert hat. Der Grund geht
+   * mit — eine abgewiesene Rueckmeldung ohne Erklaerung sieht am Handy aus
+   * wie ein Netzfehler, und dann drueckt der Field-Tech noch dreimal.
+   */
+  const showOk = (parsed: Record<string, unknown>): boolean => {
+    const sent = typeof parsed.projectId === 'string' && parsed.projectId.trim().length > 0
+      ? parsed.projectId
+      : null
+    const pruefung = showMismatch(state.showId, sent)
+    if (pruefung.ok) return true
+    res.statusCode = 409
+    applyCors(req, res)
+    res.end(JSON.stringify({
+      error: pruefung.rejection,
+      reason: pruefung.reason,
+      servedShow: pruefung.served,
+    }))
+    return false
+  }
+
   // v7.9.3 — POST /checks: das Mobile-View schickt nach jedem Toggle
   // einen vollständigen CheckState. Wir leiten ihn via Callback an
   // den Renderer weiter, der dann project.checkState updated → das
@@ -320,9 +360,11 @@ const handleRequest = (req: IncomingMessage, res: ServerResponse) => {
       if (aborted) return
       try {
         const parsed = JSON.parse(body) as {
+          projectId?: string
           ports?: Record<string, boolean>
           cables?: Record<string, boolean>
         }
+        if (!showOk(parsed)) return
         const checks = {
           ports: parsed.ports && typeof parsed.ports === 'object' ? parsed.ports : {},
           cables: parsed.cables && typeof parsed.cables === 'object' ? parsed.cables : {},
@@ -370,6 +412,7 @@ const handleRequest = (req: IncomingMessage, res: ServerResponse) => {
       if (aborted) return
       try {
         const parsed = JSON.parse(body) as Record<string, unknown>
+        if (!showOk(parsed)) return
         const fromEquipmentId = String(parsed.fromEquipmentId ?? '').trim()
         const fromPortId = String(parsed.fromPortId ?? '').trim()
         const toEquipmentId = String(parsed.toEquipmentId ?? '').trim()
@@ -433,6 +476,7 @@ const handleRequest = (req: IncomingMessage, res: ServerResponse) => {
       if (aborted) return
       try {
         const parsed = JSON.parse(body) as Record<string, unknown>
+        if (!showOk(parsed)) return
         const summary = String(parsed.summary ?? '').trim()
         const kind = String(parsed.kind ?? '').trim()
         if (!summary || !kind) {
@@ -652,11 +696,16 @@ export const stopMobileShareServer = (): void => {
   state.allowBeyondLan = false
   state.project = null
   state.serialized = null
+  state.showId = null
   state.devProxyUrl = undefined
 }
 
 export const setMobileShareProject = (project: unknown): void => {
   state.project = project
+  // Bedarf 127 — die Show wandert MIT dem Projekt. Wer sie hier nicht
+  // nachzieht, laesst die Freigabe auf die alte Show zeigen und nimmt
+  // Rueckwege an, die in die neue gehoeren.
+  state.showId = showIdOf(project)
   // Strip secrets and pre-serialize once; /project.json serves the cached
   // string so polling phones don't re-stringify the project each request.
   try {

--- a/src/main/util/shareShow.ts
+++ b/src/main/util/shareShow.ts
@@ -1,0 +1,111 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Welche Show hängt gerade an dieser Freigabe? (Bedarf 127, P4)
+//
+//   > One machine, one operator, one file; A HOUSE RUNNING ROUGHLY 65 EVENTS A
+//   > YEAR cannot have team members working concurrently ON SEPARATE SHOWS,
+//   > and there is no client-facing view.
+//
+// Belege: `cpvalente/ontime#1325` (2024 — rund 65 Veranstaltungen im Jahr,
+// gewünscht sind Anmeldung, Zugriff je Veranstaltung und gleichzeitiges
+// Bearbeiten; ohne Umsetzung geschlossen) und `bitfocus/companion#1738` (kein
+// Abgleich zwischen den Rechnern zweier Operator).
+//
+// ─── DER DEFEKT, DEN DAS HIER ABSTELLT ─────────────────────────────────────
+//
+// Die LAN-Freigabe kannte bisher keine Show, sondern nur „das gerade geladene
+// Projekt". `setMobileShareProject` tauschte es wortlos aus. Wer am Desktop
+// eine andere Show öffnete, während unten in der Halle drei Handys am
+// QR-Code hingen, hatte:
+//
+//  * dieselbe URL, dasselbe Token, eine ANDERE Show auf jedem Handy — ohne
+//    ein Wort, mitten im Aufbau; und
+//  * jeden Rückweg (`/checks`, `/cables`, `/pending-changes`) auf die NEUE
+//    Show gebucht. Der Field-Tech hakt Ports der Show von gestern ab, und die
+//    Häkchen landen in der von heute.
+//
+// Das Zweite ist das Schlimmere: das Erste sieht man, das Zweite nicht.
+//
+// ─── DIE ENTSCHEIDUNG LIEGT AN EINER STELLE ────────────────────────────────
+//
+// `showMismatch` ist die eine Prüfung, durch die alle drei Schreibwege gehen.
+// Drei eigene Vergleiche in drei Handlern wären drei Gelegenheiten, einen zu
+// vergessen — und vergessen würde man den, der am seltensten benutzt wird,
+// also den, bei dem es am längsten niemandem auffällt.
+//
+// REIN: keine Datei, kein Netz, keine Uhr.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Warum ein Rückweg nicht angenommen wurde. */
+export type ShowRejection =
+  /** Der Schreibweg nennt eine andere Show als die, die gerade freigegeben ist. */
+  | 'other-show'
+  /** Der Schreibweg nennt gar keine Show. */
+  | 'no-show-sent'
+  /** Die freigegebene Show hat keine Kennung — dann ist nichts zu vergleichen. */
+  | 'no-show-served'
+
+export const SHOW_REJECTION_REASON: Readonly<Record<ShowRejection, string>> = {
+  'other-show':
+    'Diese Rückmeldung gehört zu einer anderen Show als der gerade freigegebenen. '
+    + 'Sie wurde NICHT übernommen: am Desktop ist inzwischen ein anderes Projekt '
+    + 'offen, und die Häkchen gehören zu dem, an dem der Kollege in der Halle steht.',
+  'no-show-sent':
+    'Diese Rückmeldung nennt keine Show. Sie wurde nicht übernommen — ohne Kennung '
+    + 'lässt sich nicht sagen, in welches Projekt sie gehört, und geraten wird hier nicht.',
+  'no-show-served':
+    'Die freigegebene Show trägt keine Kennung. Solange das so ist, wird kein '
+    + 'Rückweg angenommen: es gibt nichts, wogegen sich prüfen ließe.',
+}
+
+/**
+ * Die Kennung einer Show, so wie sie im Projekt steht.
+ *
+ * `null` heisst „diese Show hat keine" — ein eigener Fall und NICHT der leere
+ * String, der sich gegen einen anderen leeren String vergleichen liesse und
+ * damit zwei kennungslose Shows fuer dieselbe hielte.
+ */
+export function showIdOf(project: unknown): string | null {
+  if (!project || typeof project !== 'object') return null
+  const meta = (project as { metadata?: unknown }).metadata
+  if (!meta || typeof meta !== 'object') return null
+  const id = (meta as { projectId?: unknown }).projectId
+  return typeof id === 'string' && id.trim().length > 0 ? id : null
+}
+
+export interface ShowCheck {
+  ok: boolean
+  rejection: ShowRejection | null
+  reason: string | null
+  /** Die Show, die gerade freigegeben ist. */
+  served: string | null
+  /** Die Show, die der Rueckweg nennt. */
+  sent: string | null
+}
+
+/**
+ * Darf dieser Rueckweg auf die freigegebene Show gebucht werden?
+ *
+ * DIE ENGSTELLE. Alle drei Schreibwege fragen hier — und die Antwort ist nie
+ * ein blosses Ja oder Nein, sondern traegt den Grund mit: eine abgewiesene
+ * Rueckmeldung, die niemand erklaert, sieht am Handy aus wie ein Netzfehler,
+ * und dann drueckt der Field-Tech noch dreimal.
+ *
+ * Ohne Kennung wird NICHT angenommen. Der Mobile-Client wird von genau diesem
+ * Server ausgeliefert und schickt sie immer; wer sie weglaesst, ist entweder
+ * ein von Hand gebauter Aufruf oder eine Seite, die seit dem Show-Wechsel
+ * offen liegt. In beiden Faellen ist Zurueckweisen die richtige Antwort —
+ * annehmen hiesse, im Zweifel in irgendein Projekt zu schreiben.
+ */
+export function showMismatch(served: string | null, sent: string | null): ShowCheck {
+  const nein = (rejection: ShowRejection): ShowCheck => ({
+    ok: false,
+    rejection,
+    reason: SHOW_REJECTION_REASON[rejection],
+    served,
+    sent,
+  })
+  if (served === null) return nein('no-show-served')
+  if (sent === null) return nein('no-show-sent')
+  if (served !== sent) return nein('other-show')
+  return { ok: true, rejection: null, reason: null, served, sent }
+}

--- a/src/mobile/MobileApp.tsx
+++ b/src/mobile/MobileApp.tsx
@@ -133,15 +133,32 @@ const apiFetch = (path: string, init?: RequestInit): Promise<Response> => {
   return fetch(`${url}${sep}t=${encodeURIComponent(activeToken)}`, { ...init, headers })
 }
 
-const CHECK_KEY = (projectName: string) => `cable-planner-mobile:checks:${projectName}`
+/**
+ * BEDARF 127 — welche Show ist das hier?
+ *
+ * Der SCHLUESSEL fuer alles, was dieses Handy lokal ablegt, und die Kennung,
+ * die an jedem Rueckweg mitgeht. Vorher stand hier der Projekt-NAME: zwei
+ * Shows „Konzert" teilten sich einen Speicher, und die Haken der einen
+ * standen in der anderen.
+ */
+const showIdOf = (project: unknown): string | null => {
+  const meta = (project as { metadata?: { projectId?: unknown } } | null)?.metadata
+  const id = meta?.projectId
+  return typeof id === 'string' && id.trim().length > 0 ? id : null
+}
+
+const CHECK_KEY = (showId: string) => `cable-planner-mobile:checks:${showId}`
 // v7.9.54 — Offline-Cache des kompletten Projekts. Ein Eintrag pro
 // Hostname/Port-Origin, damit verschiedene Geräte-Sessions sich nicht
 // gegenseitig überschreiben. So überlebt eine Session den
 // Funkverbindungs-Verlust und der Techniker kann lokal weiter haken
 // setzen, die beim nächsten Re-Connect automatisch synchronisiert werden.
-const PROJECT_CACHE_KEY = `cable-planner-mobile:project-cache:${
+// BEDARF 127 — und ZUSAETZLICH je Show. Ein Cache je Origin allein hiess:
+// wer am Desktop die Show wechselt, bekommt beim naechsten Funkloch den Plan
+// der anderen Show angezeigt — mit Zeitstempel, also glaubwuerdig.
+const PROJECT_CACHE_KEY = (showId: string | null) => `cable-planner-mobile:project-cache:${
   typeof window !== 'undefined' ? window.location.host : 'unknown'
-}`
+}${showId ? `:${showId}` : ''}`
 interface ProjectCacheEnvelope {
   cachedAt: string
   project: unknown
@@ -152,9 +169,9 @@ interface CheckState {
   ports: Record<string, boolean>
 }
 
-const loadChecks = (projectName: string): CheckState => {
+const loadChecks = (showId: string): CheckState => {
   try {
-    const raw = localStorage.getItem(CHECK_KEY(projectName))
+    const raw = localStorage.getItem(CHECK_KEY(showId))
     if (!raw) return { cables: {}, ports: {} }
     return JSON.parse(raw) as CheckState
   } catch {
@@ -162,9 +179,9 @@ const loadChecks = (projectName: string): CheckState => {
   }
 }
 
-const saveChecks = (projectName: string, state: CheckState) => {
+const saveChecks = (showId: string, state: CheckState) => {
   try {
-    localStorage.setItem(CHECK_KEY(projectName), JSON.stringify(state))
+    localStorage.setItem(CHECK_KEY(showId), JSON.stringify(state))
   } catch {
     /* ignore quota */
   }
@@ -174,15 +191,44 @@ const saveChecks = (projectName: string, state: CheckState) => {
 const cacheProject = (project: unknown): void => {
   try {
     const env: ProjectCacheEnvelope = { cachedAt: new Date().toISOString(), project }
-    localStorage.setItem(PROJECT_CACHE_KEY, JSON.stringify(env))
+    localStorage.setItem(PROJECT_CACHE_KEY(showIdOf(project)), JSON.stringify(env))
+    rememberShow(showIdOf(project))
   } catch {
     /* quota / private-mode → einfach skippen, ist nur ein Cache */
   }
 }
 
-const loadCachedProject = (): { cachedAt: string; project: unknown } | null => {
+/**
+ * Welche Show dieser Freigabe-Zugang zuletzt ausgeliefert hat.
+ *
+ * Beim Start ohne Verbindung weiss das Handy noch nicht, um welche Show es
+ * geht — der Zeiger sagt es. Er ist eine ERINNERUNG und keine Zusage: steht
+ * der Desktop inzwischen auf einer anderen Show, faellt das beim ersten
+ * erfolgreichen Abruf auf.
+ */
+const LAST_SHOW_KEY = `cable-planner-mobile:last-show:${
+  typeof window !== 'undefined' ? window.location.host : 'unknown'
+}`
+
+const rememberShow = (showId: string | null): void => {
   try {
-    const raw = localStorage.getItem(PROJECT_CACHE_KEY)
+    if (showId) localStorage.setItem(LAST_SHOW_KEY, showId)
+  } catch {
+    /* quota / private-mode */
+  }
+}
+
+const lastShow = (): string | null => {
+  try {
+    return localStorage.getItem(LAST_SHOW_KEY)
+  } catch {
+    return null
+  }
+}
+
+const loadCachedProject = (showId: string | null = lastShow()): { cachedAt: string; project: unknown } | null => {
+  try {
+    const raw = localStorage.getItem(PROJECT_CACHE_KEY(showId))
     if (!raw) return null
     const parsed = JSON.parse(raw) as Partial<ProjectCacheEnvelope>
     if (parsed && typeof parsed.cachedAt === 'string' && parsed.project) {
@@ -1006,6 +1052,13 @@ const ProjectView = ({
   onUnload: () => void
 }) => {
   const projectName = project.metadata?.name || 'cable-planner'
+  // BEDARF 127 — die Show, an der dieses Handy gerade haengt. Der Name taugt
+  // dafuer nicht: zwei Shows heissen leicht gleich, und dann stehen die Haken
+  // der einen in der anderen. Fehlt die Kennung, wird auf den Namen
+  // zurueckgefallen — aber der Rueckweg geht dann NICHT raus (der Server
+  // weist ihn ohnehin ab), statt in irgendein Projekt zu schreiben.
+  const showId = showIdOf(project)
+  const speicherKey = showId ?? `name:${projectName}`
   // v7.9.3 — Initial-State kommt jetzt PRIMÄR aus project.checkState
   // (Desktop ist Source-of-Truth) und nur als Fallback aus localStorage
   // (für Offline-Sessions). Nach jedem Toggle wird der State zusätzlich
@@ -1018,22 +1071,27 @@ const ProjectView = ({
         cables: fromProject.cables ?? {},
       }
     }
-    return loadChecks(projectName)
+    return loadChecks(showId ?? `name:${projectName}`)
   })
   const [filter, setFilter] = useState('')
   const [onlyOpen, setOnlyOpen] = useState(false)
 
   useEffect(() => {
-    saveChecks(projectName, checks)
+    saveChecks(speicherKey, checks)
     // POST to the desktop server so the Cable Planner Canvas shows
     // the green tick at this port immediately. Fire-and-forget; offline
     // Mobile-Sessions fallen auf localStorage zurück (siehe oben).
+    //
+    // BEDARF 127 — die Show geht MIT. Ohne sie weist der Server den Rueckweg
+    // ab, und das ist richtig so: am Desktop kann inzwischen ein anderes
+    // Projekt offen sein, und diese Haken gehoeren zu dem, an dem der Kollege
+    // in der Halle steht.
     void apiFetch('/checks', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(checks),
+      body: JSON.stringify({ ...checks, projectId: showId }),
     }).catch(() => {})
-  }, [projectName, checks])
+  }, [speicherKey, showId, checks])
 
   // v7.9.54 — Reconnect-Resync. Wenn der Online-Status von false → true
   // wechselt (= Funkverbindung wieder da), schicken wir EINMAL den
@@ -1049,10 +1107,10 @@ const ProjectView = ({
       void apiFetch('/checks', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(checks),
+        body: JSON.stringify({ ...checks, projectId: showId }),
       }).catch(() => {})
     }
-  }, [online, checks])
+  }, [online, showId, checks])
 
   // #180 — Zwei Betriebsmodi: Patchliste (Default) + Planansicht.
   const [viewMode, setViewMode] = useState<'list' | 'plan'>('list')
@@ -1507,6 +1565,9 @@ export const MobileApp = () => {
   // setzt online basierend auf dem Ergebnis. Spätere Polls toggeln es.
   const [online, setOnline] = useState(true)
   const [cachedAt, setCachedAt] = useState<string | null>(null)
+  // BEDARF 127 — der Desktop steht inzwischen auf einer anderen Show. Der
+  // Plan bleibt stehen; die Seite sagt es, und der Wechsel ist ein Neuladen.
+  const [showSwitched, setShowSwitched] = useState(false)
 
   // When loaded via the desktop app's LAN share server, a sibling
   // /project.json endpoint serves the live project. Auto-fetch on
@@ -1567,6 +1628,26 @@ export const MobileApp = () => {
         if (!r.ok) throw new Error(`project ${r.status}`)
         const next = (await r.json()) as CablePlannerProject
         if (next && Array.isArray(next.equipment)) {
+          // BEDARF 127 — der Show-Wechsel wird BEMERKT und nicht vollzogen.
+          //
+          // Bisher tauschte dieser Abruf den Plan wortlos aus: wer am Desktop
+          // eine andere Show oeffnete, hatte auf jedem Handy in der Halle
+          // dieselbe URL, dasselbe Token und eine andere Show — mitten im
+          // Aufbau, ohne ein Wort. Jetzt bleibt der Plan stehen und die Seite
+          // sagt, was passiert ist; der Wechsel ist ein Neuladen, also eine
+          // Handlung des Nutzers.
+          // `project` ist hier die Show, mit der diese Seite geladen wurde:
+          // der Effekt haengt an `project !== null` und laeuft beim Wechsel
+          // des Inhalts nicht neu. Genau das ist gemeint — verglichen wird
+          // gegen das, was dieses Handy bekommen hat, nicht gegen den
+          // vorletzten Abruf.
+          const jetzt = showIdOf(next)
+          const bisher = showIdOf(project)
+          if (bisher !== null && jetzt !== null && jetzt !== bisher) {
+            setShowSwitched(true)
+            setOnline(true)
+            return
+          }
           setProject(next)
           setOnline(true)
           cacheProject(next)
@@ -1582,6 +1663,26 @@ export const MobileApp = () => {
   return (
     <div className="min-h-screen bg-cp-bg text-cp-text">
       <ConnectionSettings />
+      {/* BEDARF 127 — am Desktop steht jetzt eine andere Show. Der Plan auf
+          diesem Handy bleibt der, mit dem es geladen wurde: ein stiller Tausch
+          mitten im Aufbau ist genau der Schaden, den `ontime#1325` beschreibt.
+          Der Wechsel ist ein Neuladen und damit eine Entscheidung. */}
+      {showSwitched && (
+        <div className="mx-auto max-w-md p-2">
+          <div className="rounded border border-amber-600 bg-amber-950/60 p-2 text-[11px] text-amber-100">
+            <b>Am Desktop ist jetzt eine andere Show offen.</b> Dieser Plan bleibt
+            stehen — er gehört zu der Show, mit der diese Seite geladen wurde.
+            Häkchen und Meldungen gehen bis zum Neuladen nicht mehr durch.
+            <button
+              type="button"
+              className="mt-1 block rounded border border-amber-500 px-2 py-0.5 text-[11px]"
+              onClick={() => window.location.reload()}
+            >
+              Zur neuen Show wechseln (neu laden)
+            </button>
+          </div>
+        </div>
+      )}
       {!autoLoadAttempted ? (
         <div className="grid min-h-screen place-items-center p-4 text-xs text-cp-text-muted">
           <div className="animate-pulse">Lade Projekt vom Desktop…</div>
@@ -1713,6 +1814,8 @@ const AddCableModal = ({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          // BEDARF 127 — welche Show. Ohne sie weist der Server ab.
+          projectId: showIdOf(project),
           fromEquipmentId: fromEqId,
           fromPortId,
           toEquipmentId: toEqId,
@@ -2017,6 +2120,8 @@ const MobileReportModal = ({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          // BEDARF 127 — welche Show. Ohne sie weist der Server ab.
+          projectId: showIdOf(project),
           author: reporter.trim() || undefined,
           kind,
           summary,

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -638,6 +638,19 @@ export interface ProjectState {
  */
 const initialDrops: LoadDrop[] = []
 
+/**
+ * Eine neue Show-Kennung (Bedarf 127).
+ *
+ * `crypto.randomUUID` gibt es im Renderer wie im Test-Runner; der Rueckfall
+ * ist da, damit das Laden eines Projekts nicht an einer fehlenden Web-Crypto
+ * scheitert — ohne Kennung wuerde die LAN-Freigabe jeden Rueckweg abweisen,
+ * und der Aufbau stuende wegen einer Zufallsquelle.
+ */
+const newProjectId = (): string =>
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `show-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+
 const healProjectPositions = (
   project: CablePlannerProject,
   onDrop?: (drop: LoadDrop) => void,
@@ -910,6 +923,14 @@ const healProjectPositions = (
     metadata: {
       ...healRentmanCableMap(project.metadata),
       ...(venueAnswers ? { venueAnswers } : {}),
+      // Bedarf 127 — die Show-Kennung. Sie wird HIER vergeben und nirgends
+      // sonst: das ist die Schema-Migrationsschicht, und ein zweiter Ort, an
+      // dem eine Kennung entsteht, ergaebe zwei Kennungen fuer eine Show.
+      //
+      // Vergeben wird nur, was fehlt. Eine vorhandene Kennung anzufassen
+      // hiesse, aus einer Show beim blossen Oeffnen eine andere zu machen —
+      // und genau daran haengt die LAN-Freigabe.
+      projectId: project.metadata.projectId?.trim() || newProjectId(),
     },
   }
 }

--- a/src/renderer/types/project.ts
+++ b/src/renderer/types/project.ts
@@ -35,6 +35,24 @@ export interface CableNumberingScheme {
 }
 
 export interface ProjectMetadata {
+  /**
+   * BEDARF 127 — welche Show das hier ist.
+   *
+   *   > A house running roughly 65 events a year cannot have team members
+   *   > working concurrently on SEPARATE SHOWS.
+   *
+   * Beleg: `cpvalente/ontime#1325` (2024).
+   *
+   * Die Kennung wird beim Laden vergeben (`healProjectPositions`) und wandert
+   * mit der Datei. Sie ueberlebt das Umbenennen — ein umbenanntes Projekt ist
+   * dieselbe Show —, und sie ist der Anker der LAN-Freigabe: der Rueckweg vom
+   * Handy nennt sie, und der Server nimmt nur an, was zu der Show gehoert, die
+   * er gerade ausliefert.
+   *
+   * Optional, weil aeltere Dateien sie nicht haben; nach dem ersten Laden und
+   * Speichern traegt sie jede.
+   */
+  projectId?: string
   name: string
   description: string
   createdAt: string

--- a/tests/shareShow.test.ts
+++ b/tests/shareShow.test.ts
@@ -1,0 +1,167 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Welche Show hängt gerade an dieser Freigabe? (Bedarf 127, P4)
+//
+//   > One machine, one operator, one file; a house running roughly 65 events a
+//   > year cannot have team members working concurrently ON SEPARATE SHOWS.
+//
+// Belege: `cpvalente/ontime#1325` (2024) und `bitfocus/companion#1738`.
+//
+// WAS HIER GEPRÜFT WIRD, und warum jede Zeile davon nötig ist:
+//
+//  1. EINE SHOW HAT EINE KENNUNG, UND „KEINE" IST EIN EIGENER FALL. Zwei
+//     kennungslose Shows sind nicht dieselbe Show.
+//
+//  2. IM ZWEIFEL WIRD NICHT GEBUCHT. Fehlt die Kennung auf einer der beiden
+//     Seiten, wird der Rückweg abgewiesen — annehmen hieße, im Zweifel in
+//     irgendein Projekt zu schreiben.
+//
+//  3. ABGEWIESEN HEISST BEGRÜNDET. Eine Rückmeldung, die ohne Erklärung
+//     verschwindet, sieht am Handy aus wie ein Netzfehler — und dann drückt
+//     der Field-Tech noch dreimal.
+//
+//  4. ALLE DREI SCHREIBWEGE GEHEN DURCH DIESELBE PRÜFUNG. Drei eigene
+//     Vergleiche wären drei Gelegenheiten, einen zu vergessen.
+//
+//  5. DIE FREIGABE ZIEHT DIE SHOW MIT. Wer das Projekt tauscht und die
+//     Kennung stehen lässt, hat den Defekt nur verschoben.
+//
+//  6. DIE KENNUNG ENTSTEHT AN DER MIGRATIONS-STELLE — und wird dort nur
+//     vergeben, wenn sie fehlt. Beim bloßen Öffnen aus einer Show eine andere
+//     zu machen, wäre schlimmer als gar keine Kennung.
+//
+//  7. DAS HANDY SPEICHERT JE SHOW, NICHT JE NAME. Zwei Shows „Konzert"
+//     teilten sich sonst einen Haken-Speicher.
+//
+//  8. DER SHOW-WECHSEL WIRD BEMERKT UND NICHT VOLLZOGEN.
+// ───────────────────────────────────────────────────────────────────────────
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import {
+  SHOW_REJECTION_REASON,
+  showIdOf,
+  showMismatch,
+  type ShowRejection,
+} from '../src/main/util/shareShow'
+
+const lies = (rel: string): string => readFileSync(new URL(rel, import.meta.url), 'utf8')
+
+/**
+ * Quelltext OHNE Kommentare.
+ *
+ * Ein Waechter, den sein eigener Kommentar zufrieden stellt, prueft nichts.
+ */
+const ohneKommentare = (rel: string): string =>
+  lies(rel)
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^[ \t]*\/\/.*$/gm, '')
+
+describe('Bedarf 127 — welche Show hängt an dieser Freigabe?', () => {
+  it('1. eine Show hat eine Kennung, und „keine" ist ein eigener Fall', () => {
+    expect(showIdOf({ metadata: { projectId: 'abc' } })).toBe('abc')
+    // Alles, was keine Kennung ist, ist `null` — und nicht der leere String,
+    // der sich gegen einen anderen leeren String vergleichen liesse.
+    expect(showIdOf({ metadata: { projectId: '   ' } })).toBeNull()
+    expect(showIdOf({ metadata: {} })).toBeNull()
+    expect(showIdOf({})).toBeNull()
+    expect(showIdOf(null)).toBeNull()
+    expect(showIdOf('nicht mal ein Objekt')).toBeNull()
+    expect(showIdOf({ metadata: { projectId: 42 } })).toBeNull()
+  })
+
+  it('2. im Zweifel wird nicht gebucht', () => {
+    // Zwei kennungslose Seiten sind NICHT dieselbe Show.
+    expect(showMismatch(null, null).ok).toBe(false)
+    expect(showMismatch(null, 'a').ok).toBe(false)
+    expect(showMismatch('a', null).ok).toBe(false)
+    expect(showMismatch('a', 'b').ok).toBe(false)
+    // Und nur die Uebereinstimmung geht durch.
+    expect(showMismatch('a', 'a').ok).toBe(true)
+    expect(showMismatch('a', 'a').rejection).toBeNull()
+  })
+
+  it('3. abgewiesen heisst begründet', () => {
+    const faelle: Array<[string | null, string | null, ShowRejection]> = [
+      ['a', 'b', 'other-show'],
+      ['a', null, 'no-show-sent'],
+      [null, 'a', 'no-show-served'],
+    ]
+    for (const [served, sent, erwartet] of faelle) {
+      const r = showMismatch(served, sent)
+      expect(r.rejection, `${served} / ${sent}`).toBe(erwartet)
+      expect(r.reason).toBe(SHOW_REJECTION_REASON[erwartet])
+      // Der Grund sagt, was passiert ist, und nicht nur dass etwas war.
+      expect(r.reason!.length).toBeGreaterThan(60)
+      // Und beide Seiten stehen dabei: ohne sie ist die Meldung nicht
+      // nachvollziehbar, und am Handy sieht sie aus wie ein Netzfehler.
+      expect(r.served).toBe(served)
+      expect(r.sent).toBe(sent)
+    }
+    for (const art of Object.keys(SHOW_REJECTION_REASON) as ShowRejection[]) {
+      expect(SHOW_REJECTION_REASON[art].length).toBeGreaterThan(60)
+    }
+  })
+
+  it('4. alle drei Schreibwege gehen durch dieselbe Prüfung', () => {
+    const server = ohneKommentare('../src/main/services/mobileShareServer.ts')
+    // Die eine Pruefung.
+    expect(server).toMatch(/const showOk = \(parsed: Record<string, unknown>\): boolean =>/)
+    expect(server).toMatch(/showMismatch\(state\.showId, sent\)/)
+    // 409 und nicht 400: der Aufruf ist nicht falsch gebaut, die Lage hat
+    // sich geaendert.
+    expect(server).toMatch(/res\.statusCode = 409/)
+    // Und jeder der drei Wege fragt sie — VOR dem Weiterreichen.
+    const wege = server.match(/if \(!showOk\(parsed\)\) return/g) ?? []
+    expect(wege).toHaveLength(3)
+    for (const cb of ['onChecksUpdate', 'onCableAdded', 'onPendingChange']) {
+      const vorher = server.indexOf('if (!showOk(parsed)) return', server.indexOf(cb) - 4000)
+      expect(vorher, cb).toBeGreaterThan(-1)
+      expect(vorher).toBeLessThan(server.indexOf(`state.${cb}?.`))
+    }
+  })
+
+  it('5. die Freigabe zieht die Show mit', () => {
+    const server = ohneKommentare('../src/main/services/mobileShareServer.ts')
+    // Gesetzt wird sie zusammen mit dem Projekt — ein zweiter Ort waere ein
+    // zweiter Stand.
+    expect(server).toMatch(/state\.showId = showIdOf\(project\)/)
+    // Und `stop()` raeumt sie mit weg: eine stehengebliebene Kennung naehme
+    // nach dem Neustart Rueckwege fuer eine Show an, die niemand freigegeben
+    // hat.
+    const stop = /export const stopMobileShareServer[\s\S]*?\n\}/.exec(server)?.[0] ?? ''
+    expect(stop).toMatch(/state\.showId = null/)
+  })
+
+  it('6. die Kennung entsteht an der Migrations-Stelle', () => {
+    const store = ohneKommentare('../src/renderer/store/projectStore.ts')
+    // `healProjectPositions` ist laut CLAUDE.md die Schema-Migrationsschicht.
+    expect(store).toMatch(/projectId: project\.metadata\.projectId\?\.trim\(\) \|\| newProjectId\(\)/)
+    // Vergeben wird nur genau hier.
+    // GENAU EIN Aufruf: ein zweiter Ort, an dem eine Kennung entsteht,
+    // ergaebe zwei Kennungen fuer eine Show.
+    expect(store.match(/newProjectId\(\)/g) ?? []).toHaveLength(1)
+    // Und das Typfeld gibt es wirklich.
+    expect(ohneKommentare('../src/renderer/types/project.ts')).toMatch(/projectId\?: string/)
+  })
+
+  it('7. das Handy speichert je Show, nicht je Name', () => {
+    const mobil = ohneKommentare('../src/mobile/MobileApp.tsx')
+    expect(mobil).toMatch(/const CHECK_KEY = \(showId: string\)/)
+    expect(mobil).toMatch(/const PROJECT_CACHE_KEY = \(showId: string \| null\)/)
+    // Der Rueckweg traegt die Kennung — sonst weist der Server ihn ab.
+    expect(mobil.match(/projectId: showId[,\s]/g) ?? []).toHaveLength(2)
+    expect(mobil.match(/projectId: showIdOf\(project\)/g) ?? []).toHaveLength(2)
+  })
+
+  it('8. der Show-Wechsel wird bemerkt und nicht vollzogen', () => {
+    const mobil = ohneKommentare('../src/mobile/MobileApp.tsx')
+    expect(mobil).toMatch(/setShowSwitched\(true\)/)
+    expect(mobil).toMatch(/\{showSwitched && \(/)
+    // Der Abruf, der den Wechsel bemerkt, tauscht den Plan NICHT aus: das
+    // `return` steht vor `setProject(next)`.
+    const poll = /const jetzt = showIdOf\(next\)[\s\S]*?setCachedAt\(new Date\(\)\.toISOString\(\)\)/
+      .exec(mobil)?.[0] ?? ''
+    expect(poll).not.toBe('')
+    expect(poll.indexOf('setShowSwitched(true)')).toBeLessThan(poll.indexOf('setProject(next)'))
+    expect(poll).toMatch(/setShowSwitched\(true\)\s*\n\s*setOnline\(true\)\s*\n\s*return/)
+  })
+})


### PR DESCRIPTION
## Worum es geht

Bedarf 127 (P4) aus der Recherche:

> One machine, one operator, one file; a house running roughly 65 events a year cannot have team members working concurrently **on separate shows**, and there is no client-facing view.

Belege: `cpvalente/ontime#1325` (2024 — Anmeldung, Zugriff je Veranstaltung und gleichzeitiges Bearbeiten gewünscht; ohne Umsetzung geschlossen) und `bitfocus/companion#1738` (kein Abgleich zwischen den Rechnern zweier Operator).

## Der Defekt, den das abstellt

Die LAN-Freigabe kannte keine Show, sondern nur „das gerade geladene Projekt". `setMobileShareProject` tauschte es wortlos aus. Wer am Desktop eine andere Show öffnete, während unten in der Halle drei Handys am QR-Code hingen, hatte:

- dieselbe URL, dasselbe Token, eine **andere Show** auf jedem Handy — ohne ein Wort, mitten im Aufbau; und
- **jeden Rückweg** (`/checks`, `/cables`, `/pending-changes`) auf die neue Show gebucht. Der Field-Tech hakt Ports der Show von gestern ab, und die Häkchen landen in der von heute.

Das Zweite ist das Schlimmere: das Erste sieht man, das Zweite nicht.

## Was sich ändert

- **`metadata.projectId`** ist die Kennung einer Show. Vergeben wird sie in `healProjectPositions` — der Schema-Migrationsschicht — und nur, wenn sie fehlt: beim bloßen Öffnen aus einer Show eine andere zu machen wäre schlimmer als gar keine Kennung. Sie überlebt das Umbenennen, denn eine umbenannte Show ist dieselbe Show.
- **`src/main/util/shareShow.ts`** (neu, rein) trifft die eine Entscheidung. `showMismatch` ist die Engstelle, durch die **alle drei** Schreibwege gehen — drei eigene Vergleiche wären drei Gelegenheiten, einen zu vergessen, und vergessen würde man den seltensten, also den, bei dem es am längsten niemandem auffällt.
- **Ohne Kennung wird nicht gebucht**, auf keiner der beiden Seiten. Zwei kennungslose Shows sind nicht dieselbe Show; annehmen hieße, im Zweifel in irgendein Projekt zu schreiben.
- Abgewiesen wird mit **409 und mit Grund** — nicht 400: der Aufruf ist nicht falsch gebaut, die Lage hat sich seit dem Laden der Seite geändert. Eine Rückmeldung, die ohne Erklärung verschwindet, sieht am Handy aus wie ein Netzfehler, und dann drückt der Field-Tech noch dreimal.
- **Das Handy speichert je Show statt je Name.** Zwei Shows „Konzert" teilten sich bisher einen Haken-Speicher, und der Offline-Cache lag nur je Origin — nach einem Show-Wechsel zeigte das nächste Funkloch den Plan der anderen Show, mit Zeitstempel, also glaubwürdig.
- **Der Show-Wechsel wird bemerkt und nicht vollzogen.** Der Plan auf dem Handy bleibt der, mit dem die Seite geladen wurde; die Seite sagt, was passiert ist. Der Wechsel ist ein Neuladen und damit eine Entscheidung.

## Geprüft

- `tests/shareShow.test.ts`, acht Blöcke.
- **23 Gegenproben, jede rot:** leere Kennung als Kennung, zwei kennungslose Shows als dieselbe, fehlende Kennung angenommen, andere Show angenommen, Abweisung ohne Grund, je einer der drei Schreibwege ungeprüft, 400 statt 409, Show überlebt `stop()`, Kennung bei jedem Laden neu vergeben, Handy speichert wieder je Name, Rückweg ohne Kennung, Show-Wechsel still vollzogen.
- Volle Suite: 2607 grün, 2 skipped. `tsc` auf `app`/`main`/`preload` sauber, `lint` 0 Errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_