### PR TITLE
katalog: Beleg-Abdeckung rechnen und den fehlenden Beleg benennen (Initiative 11)

### DIFF
--- a/src/renderer/components/Properties/sections/OptionalFieldsSection.tsx
+++ b/src/renderer/components/Properties/sections/OptionalFieldsSection.tsx
@@ -4,6 +4,7 @@ import { pickImageAsDataUri } from '../../../lib/readImageAsDataUri'
 import { promptDialog } from '../../../lib/promptDialog'
 import { SortableSection } from '../SortableSection'
 import { resolveDeviceType } from '../../../lib/deviceTypeRegistry'
+import { evidenceForType } from '../../../lib/catalogueEvidence'
 import type { EquipmentItem } from '../../../types/equipment'
 
 const ICON_GLYPHS = ['📷', '🖥', '💻', '📺', '🎙', '💡', '🌐', '⚡', '🔌', '🔧', '⇄'] as const
@@ -22,6 +23,11 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
   const catalogType = resolveDeviceType(equipment.deviceTypeId)
   const inheritedUrl = catalogType?.template.manufacturerUrl
   const inheritedName = catalogType?.template.name
+  // Initiative 11, Schritt 3 — und der Fall, den es bis hierher nicht gab:
+  // der Katalog-Typ OHNE Datenblatt. `no-type` (von Hand angelegt, Import)
+  // ist etwas anderes als `unsourced` (Katalog-Eintrag ohne Beleg); als
+  // leeres Feld sahen beide gleich aus.
+  const typBeleg = evidenceForType(equipment.deviceTypeId)
 
   // #580 — Verifizierung: eine Person bestätigt, dass die Ports/Daten des
   // Geräts korrekt sind. Name kommt aus dem Projekt-Autor (Einstellungen);
@@ -159,6 +165,24 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
               ein ebenso unerreichbares Feld gewandert. Das eigene Feld
               gewinnt, wenn es gesetzt ist: es ist die Ausnahme, die jemand
               bewusst eingetragen hat. */}
+          {/* Initiative 11 — der FEHLENDE Beleg, ebenso benannt wie der
+              vorhandene. 159 von 412 Katalog-Eintraegen fuehren keinen
+              Datenblatt-Link (sechs Kataloge, siehe `catalogueEvidence.ts`);
+              am Geraet war das bisher von „hier hat nur gerade niemand
+              nachgesehen" nicht zu unterscheiden. Ein Strich auf dem Blatt
+              statt einer leeren Zelle — dieselbe Regel wie ueberall sonst
+              hier. */}
+          {!equipment.manufacturerUrl && !inheritedUrl && typBeleg.kind === 'unsourced' && (
+            <div className="mt-1 text-cp-xs text-cp-text-muted">
+              {format(
+                t(
+                  'eq.field.manufacturerUrlNoSource',
+                  'Der Katalog-Typ {name} führt kein Datenblatt — dieser Eintrag ist unbelegt.',
+                ),
+                { name: inheritedName ?? '' },
+              )}
+            </div>
+          )}
           {!equipment.manufacturerUrl && inheritedUrl && (
             <div className="mt-1 flex items-center gap-1 text-cp-xs">
               <span className="text-cp-text-muted">

--- a/src/renderer/lib/catalogueEvidence.ts
+++ b/src/renderer/lib/catalogueEvidence.ts
@@ -1,0 +1,169 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Welche Katalog-Zeile trägt ein Datenblatt — und welche nicht?
+// (Initiative 11, Schritt 2/3)
+//
+// ─── WAS BEIM NACHMESSEN HERAUSKAM ─────────────────────────────────────────
+//
+// `INITIATIVE-11-SCOPING.md` nennt als nächsten Schritt: „Lift the 253
+// existing `// Quelle:` comments into a field. Mechanical, reversible, loses
+// nothing." Nachgemessen am 2026-09-07: **das ist bereits geschehen.** Alle
+// 253 Kommentare stehen als `template.manufacturerUrl` im selben Eintrag —
+// nachgeprüft URL für URL, keine einzige Abweichung —, das Feld wandert über
+// `equipmentSlice` an das Gerät, die Eigenschaften-Leiste zeigt es mit
+// genannter Herkunft an, und `exportDevicePdf` druckt es.
+//
+// Das Papier stimmte, als es geschrieben wurde („No `provenance`, `source`,
+// or `verifiedAt` field exists"), und es stimmt bis heute — nur heißt das
+// Feld eben `manufacturerUrl`, und danach hatte niemand gesucht.
+//
+// ─── WAS DAMIT WIRKLICH OFFEN IST ──────────────────────────────────────────
+//
+// Zwei Dinge, und beide sind hier gebaut:
+//
+//  1. DIE ABDECKUNG WIRD NICHT GERECHNET. 253 von 412 Einträgen tragen ein
+//     Datenblatt; die übrigen 159 liegen in sechs Katalogen. Diese Zahlen
+//     standen als Prosa im Backlog (B-11) und nirgends im Code. Wer morgen
+//     dreißig Einträge ohne Beleg dazulegt, ändert die Zahl — und niemand
+//     merkt es. Ein Beleg-Anspruch, den nichts nachrechnet, ist eine
+//     Behauptung; genau die Sorte, gegen die dieses Repo sonst anschreibt.
+//
+//  2. „KEIN BELEG" IST UNSICHTBAR. Die Eigenschaften-Leiste zeigt den
+//     geerbten Link, wenn es einen gibt — und sonst nichts. Ein ATEM (32
+//     Einträge, kein einziger Beleg) sieht damit aus wie ein Gerät, bei dem
+//     nur gerade niemand nachgesehen hat. Das ist derselbe Unterschied wie
+//     zwischen einer leeren Zelle und einem Strich auf einem Blatt.
+//
+// REIN: keine Datei, kein Netz, keine Uhr.
+// ───────────────────────────────────────────────────────────────────────────
+import type { EquipmentTemplate } from '../types/equipment'
+import { AJA_CATALOG } from './ajaCatalog'
+import { AUDIO_CATALOG } from './audioCatalog'
+import { AVNETWORK_CATALOG } from './avNetworkCatalog'
+import { BLACKMAGIC_CATALOG } from './blackmagicCatalog'
+import { BROADCAST_TOOLS_CATALOG } from './broadcastToolsCatalog'
+import { CAMERA_CATALOG } from './cameraCatalog'
+import { GREENGO_CATALOG } from './greengoCatalog'
+import { LYNX_CATALOG } from './lynxCatalog'
+import { MIC_CATALOG } from './micCatalog'
+import { MISC_CATALOG } from './miscCatalog'
+import { MONITOR_CATALOG } from './monitorCatalog'
+import { ROSS_CATALOG } from './rossCatalog'
+import { SWITCHER_CATALOG } from './switcherCatalog'
+import { UBIQUITI_CATALOG } from './ubiquitiCatalog'
+import { WIRELESS_AUDIO_CATALOG } from './wirelessAudioCatalog'
+
+/** Das Wenige, das diese Rechnung von einem Katalog-Eintrag braucht. */
+interface EvidenceEntry {
+  deviceTypeId: string
+  template: Pick<EquipmentTemplate, 'name' | 'manufacturerUrl'>
+}
+
+/**
+ * Die Kataloge, ueber die gerechnet wird.
+ *
+ * DIESELBEN, die `deviceTypeRegistry` aufloest — und `tests/catalogueEvidence
+ * .test.ts` haelt das fest, indem es die Import-Zeilen beider Dateien
+ * vergleicht. Ohne diese Pruefung waere ein sechzehnter Katalog im Register
+ * eine Zeile, die hier fehlt: die Abdeckung saehe dann besser aus, als sie
+ * ist, und zwar unbemerkt.
+ *
+ * `connectorCatalog` und `wirelessCatalog` stehen hier so wenig wie dort:
+ * sie fuehren keine `EquipmentTemplate`s (Steckertypen bzw.
+ * `WirelessDevice`), und das Feld sitzt am Template. Das ist keine Luecke,
+ * sondern eine andere Datenklasse — B-11 haelt denselben Unterschied fest.
+ */
+export const CATALOGUES: ReadonlyArray<{ name: string; entries: readonly EvidenceEntry[] }> = [
+  { name: 'aja', entries: AJA_CATALOG },
+  { name: 'audio', entries: AUDIO_CATALOG },
+  { name: 'avNetwork', entries: AVNETWORK_CATALOG },
+  { name: 'blackmagic', entries: BLACKMAGIC_CATALOG },
+  { name: 'broadcastTools', entries: BROADCAST_TOOLS_CATALOG },
+  { name: 'camera', entries: CAMERA_CATALOG },
+  { name: 'greengo', entries: GREENGO_CATALOG },
+  { name: 'lynx', entries: LYNX_CATALOG },
+  { name: 'mic', entries: MIC_CATALOG },
+  { name: 'misc', entries: MISC_CATALOG },
+  { name: 'monitor', entries: MONITOR_CATALOG },
+  { name: 'ross', entries: ROSS_CATALOG },
+  { name: 'switcher', entries: SWITCHER_CATALOG },
+  { name: 'ubiquiti', entries: UBIQUITI_CATALOG },
+  { name: 'wirelessAudio', entries: WIRELESS_AUDIO_CATALOG },
+]
+
+export interface CatalogueCoverage {
+  name: string
+  entries: number
+  /** Eintraege mit Datenblatt-Link. */
+  sourced: number
+  /** Eintraege ohne — die Zahl, um die es geht. */
+  unsourced: number
+}
+
+export interface EvidenceReport {
+  perCatalogue: CatalogueCoverage[]
+  entries: number
+  sourced: number
+  unsourced: number
+}
+
+const hatBeleg = (e: EvidenceEntry): boolean =>
+  (e.template.manufacturerUrl ?? '').trim().length > 0
+
+/**
+ * Die Abdeckung, gerechnet.
+ *
+ * DIE ENGSTELLE. Anzeige, Pruefung und jede kuenftige Auswertung lesen DIESE
+ * Zahlen; zwei Rechnungen ueber dieselben Kataloge koennten sich
+ * unterscheiden, und dann stuende im Bericht etwas anderes als im Waechter.
+ *
+ * Feste Reihenfolge (nach Katalog-Name), damit derselbe Baum zweimal denselben
+ * Bericht ergibt — dieselbe Regel wie bei den Blaettern (ADR-004).
+ */
+export function evidenceReport(
+  catalogues: ReadonlyArray<{ name: string; entries: readonly EvidenceEntry[] }> = CATALOGUES,
+): EvidenceReport {
+  const perCatalogue = [...catalogues]
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(({ name, entries }) => {
+      const sourced = entries.filter(hatBeleg).length
+      return { name, entries: entries.length, sourced, unsourced: entries.length - sourced }
+    })
+  return {
+    perCatalogue,
+    entries: perCatalogue.reduce((s, c) => s + c.entries, 0),
+    sourced: perCatalogue.reduce((s, c) => s + c.sourced, 0),
+    unsourced: perCatalogue.reduce((s, c) => s + c.unsourced, 0),
+  }
+}
+
+/** Was ueber den Beleg eines Katalog-Typs bekannt ist. */
+export type TypeEvidence =
+  /** Der Typ traegt ein Datenblatt. */
+  | { kind: 'sourced'; url: string; catalogue: string }
+  /** Den Typ gibt es, aber er traegt keines — eine AUSSAGE, kein Schweigen. */
+  | { kind: 'unsourced'; catalogue: string }
+  /** Die Kennung gehoert zu keinem Katalog-Typ (von Hand angelegt, Import). */
+  | { kind: 'no-type' }
+
+/**
+ * Traegt DIESER Geraetetyp ein Datenblatt?
+ *
+ * Der Unterschied zwischen `unsourced` und `no-type` ist der ganze Punkt: das
+ * eine heisst „dieser Katalog-Eintrag hat keinen Beleg", das andere „dieses
+ * Geraet kommt aus keinem Katalog". Beides als leeres Feld anzuzeigen — so
+ * war es bis hierher — macht aus zwei verschiedenen Auskuenften dieselbe
+ * Nicht-Auskunft.
+ */
+export function evidenceForType(
+  deviceTypeId: string | undefined,
+  catalogues: ReadonlyArray<{ name: string; entries: readonly EvidenceEntry[] }> = CATALOGUES,
+): TypeEvidence {
+  if (!deviceTypeId) return { kind: 'no-type' }
+  for (const { name, entries } of catalogues) {
+    const treffer = entries.find((e) => e.deviceTypeId === deviceTypeId)
+    if (!treffer) continue
+    const url = (treffer.template.manufacturerUrl ?? '').trim()
+    return url ? { kind: 'sourced', url, catalogue: name } : { kind: 'unsourced', catalogue: name }
+  }
+  return { kind: 'no-type' }
+}

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -4938,6 +4938,8 @@ export const en: Dict = {
   'library.origin.web': 'Derived from {source} (connectors counted in the text): "{snippet}"',
   'library.origin.heuristic': 'Heuristic from name and category — not from a datasheet',
   'eq.field.manufacturerUrlInherited': 'From catalog type {name}:',
+  'eq.field.manufacturerUrlNoSource':
+    'Catalog type {name} carries no datasheet — this entry is unsourced.',
   'atem.audio.live.title': 'Read from the switcher',
   'atem.audio.live.differs': '{n} differences from the plan',
   'atem.audio.live.matches': 'Plan and device agree',

--- a/tests/catalogueEvidence.test.ts
+++ b/tests/catalogueEvidence.test.ts
@@ -1,0 +1,181 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Welche Katalog-Zeile trägt ein Datenblatt? (Initiative 11, Schritt 2/3)
+//
+// `INITIATIVE-11-SCOPING.md` nennt den Zweck des Schritts wörtlich:
+//
+//   > Step 2 alone would make a claim testable that the suite currently only
+//   > asserts.
+//
+// Genau das ist diese Datei. Was hier geprüft wird, und warum jede Zeile davon
+// nötig ist:
+//
+//  1. DIE 253 KOMMENTARE SIND SCHON DATEN. Der Plan hielt das für den nächsten
+//     Schritt; nachgemessen ist es der vorletzte. Geprüft wird nicht die
+//     Behauptung, sondern der Zustand: jeder `// Quelle:`-Kommentar steht als
+//     `manufacturerUrl` im Eintrag darunter.
+//
+//  2. DIE ABDECKUNG WIRD GERECHNET, NICHT ERINNERT. 253 von 412. Die Zahl
+//     stand als Prosa im Backlog und nirgends im Code.
+//
+//  3. DIE RATSCHE. Ein Katalog, der heute vollständig belegt ist, darf morgen
+//     keinen unbelegten Eintrag dazubekommen — sonst sinkt die Abdeckung
+//     lautlos, und die einzige Stelle, die es merkt, ist niemand.
+//
+//  4. „KEIN BELEG" IST EINE AUSSAGE. `unsourced` (Katalog-Eintrag ohne
+//     Datenblatt) und `no-type` (Gerät aus keinem Katalog) sind verschiedene
+//     Auskünfte; als leeres Feld sahen beide gleich aus.
+//
+//  5. DIE LISTE HIER UND DAS REGISTER LESEN DIESELBEN KATALOGE. Ein
+//     sechzehnter Katalog, der nur im Register steht, hieße: die Abdeckung
+//     sieht besser aus, als sie ist.
+//
+//  6. DERSELBE BAUM ERGIBT DENSELBEN BERICHT.
+//
+//  7. DER WEG IST VERDRAHTET.
+// ───────────────────────────────────────────────────────────────────────────
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { CATALOGUES, evidenceForType, evidenceReport } from '../src/renderer/lib/catalogueEvidence'
+
+// `__dirname` und nicht `import.meta.url`: unter vitest ist die Modul-URL
+// nicht zwingend `file:`, und `readdirSync` verlangt einen Pfad. Dieselbe
+// Bauform wie in `architekturAussagen.test.ts`.
+const ROOT = join(__dirname, '..')
+const LIB = join(ROOT, 'src', 'renderer', 'lib')
+
+const lies = (...teile: string[]): string => readFileSync(join(ROOT, ...teile), 'utf8')
+
+const ohneKommentare = (...teile: string[]): string =>
+  lies(...teile)
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^[ \t]*\/\/.*$/gm, '')
+
+describe('Initiative 11 — trägt diese Katalog-Zeile ein Datenblatt?', () => {
+  it('1. jeder `// Quelle:`-Kommentar steht auch als Feld', () => {
+    const dateien = readdirSync(LIB).filter((f) => f.endsWith('Catalog.ts'))
+    expect(dateien.length).toBeGreaterThan(10)
+
+    let kommentare = 0
+    for (const datei of dateien) {
+      const roh = lies('src', 'renderer', 'lib', datei)
+      const quellen = [...roh.matchAll(/\/\/\s*Quelle:\s*(\S+)/g)].map((m) => m[1])
+      const felder = new Set([...roh.matchAll(/manufacturerUrl:\s*'([^']+)'/g)].map((m) => m[1]))
+      kommentare += quellen.length
+      // Ein Beleg, der nur im Kommentar steht, ist zur Laufzeit keiner.
+      for (const q of quellen) {
+        expect(felder.has(q), `${datei}: ${q} steht nur im Kommentar`).toBe(true)
+      }
+    }
+    // Die Zahl aus dem Scoping-Papier — gegen den Baum gehalten, nicht geglaubt.
+    expect(kommentare).toBe(253)
+  })
+
+  it('2. die Abdeckung wird gerechnet', () => {
+    const bericht = evidenceReport()
+    // Die Summen stammen aus derselben Rechnung wie die Zeilen.
+    expect(bericht.entries).toBe(bericht.perCatalogue.reduce((s, c) => s + c.entries, 0))
+    expect(bericht.sourced + bericht.unsourced).toBe(bericht.entries)
+    expect(bericht.sourced).toBe(253)
+    expect(bericht.entries).toBe(412)
+
+    // Die sechs Kataloge ohne Beleg sind genau die, die B-11 nennt — und die
+    // Liste wird GERECHNET, nicht aufgezählt: trägt einer von ihnen morgen
+    // Belege nach, fällt er von selbst heraus.
+    const ohne = bericht.perCatalogue.filter((c) => c.sourced === 0).map((c) => c.name)
+    expect(ohne).toEqual(['blackmagic', 'camera', 'greengo', 'misc', 'monitor', 'ubiquiti'])
+    expect(bericht.perCatalogue.filter((c) => c.sourced === 0)
+      .reduce((s, c) => s + c.entries, 0)).toBe(159)
+  })
+
+  it('3. die Ratsche: ein vollständig belegter Katalog bleibt es', () => {
+    // Wer heute vollständig ist, ist es namentlich. Ein neuer Eintrag ohne
+    // Datenblatt in einem dieser Kataloge macht diese Zeile rot — und genau
+    // das ist der Zweck: die Abdeckung soll nicht lautlos sinken koennen.
+    const vollstaendig = [
+      'aja', 'audio', 'avNetwork', 'broadcastTools', 'lynx',
+      'mic', 'ross', 'switcher', 'wirelessAudio',
+    ]
+    const bericht = evidenceReport()
+    for (const name of vollstaendig) {
+      const k = bericht.perCatalogue.find((c) => c.name === name)
+      expect(k, `${name} fehlt in der Rechnung`).toBeDefined()
+      expect(k!.unsourced, `${name} hat einen Eintrag ohne Datenblatt dazubekommen`).toBe(0)
+    }
+    // Und die Gesamtzahl der unbelegten steigt nicht. Sinken darf sie —
+    // dann ist diese Zeile die Erinnerung, die Zahl nachzuziehen.
+    expect(bericht.unsourced).toBeLessThanOrEqual(159)
+  })
+
+  it('4. „kein Beleg" ist eine eigene Auskunft', () => {
+    const mitBeleg = CATALOGUES.find((c) => c.name === 'aja')!.entries[0]
+    const ohneBeleg = CATALOGUES.find((c) => c.name === 'blackmagic')!.entries[0]
+
+    const a = evidenceForType(mitBeleg.deviceTypeId)
+    expect(a.kind).toBe('sourced')
+    if (a.kind === 'sourced') {
+      expect(a.url).toBe(mitBeleg.template.manufacturerUrl)
+      expect(a.catalogue).toBe('aja')
+    }
+
+    const b = evidenceForType(ohneBeleg.deviceTypeId)
+    expect(b.kind).toBe('unsourced')
+    if (b.kind === 'unsourced') expect(b.catalogue).toBe('blackmagic')
+
+    // Kein Katalog-Typ ist etwas ANDERES als ein Typ ohne Beleg.
+    expect(evidenceForType('gibt-es-nicht').kind).toBe('no-type')
+    expect(evidenceForType(undefined).kind).toBe('no-type')
+
+    // Leerraum ist kein Beleg.
+    const leer = [{
+      name: 'test',
+      entries: [{ deviceTypeId: 'x', template: { name: 'X', manufacturerUrl: '   ' } }],
+    }]
+    expect(evidenceForType('x', leer).kind).toBe('unsourced')
+    expect(evidenceReport(leer).sourced).toBe(0)
+  })
+
+  it('5. Rechnung und Register lesen dieselben Kataloge', () => {
+    const katalogImporte = (...teile: string[]): string[] =>
+      [...ohneKommentare(...teile).matchAll(/from '\.\/(\w+Catalog)'/g)].map((m) => m[1]).sort()
+
+    const imRegister = katalogImporte('src', 'renderer', 'lib', 'deviceTypeRegistry.ts')
+    const inDerRechnung = katalogImporte('src', 'renderer', 'lib', 'catalogueEvidence.ts')
+    expect(imRegister.length).toBeGreaterThan(10)
+    expect(inDerRechnung).toEqual(imRegister)
+    expect(CATALOGUES).toHaveLength(imRegister.length)
+  })
+
+  it('6. derselbe Baum ergibt denselben Bericht', () => {
+    expect(evidenceReport()).toEqual(evidenceReport())
+
+    // Die feste Ordnung wird an einer UNSORTIERTEN Eingabe geprueft. Gegen
+    // `CATALOGUES` allein waere die Zusicherung wertlos: die Liste steht
+    // ohnehin alphabetisch, also saehe ein Bericht ohne jede Sortierung
+    // genauso aus. Eine Gegenprobe, die den `sort` ausbaut, blieb damit
+    // gruen — nachgemessen, nicht vermutet.
+    const durcheinander = [
+      { name: 'zeta', entries: [] },
+      { name: 'alpha', entries: [] },
+      { name: 'mitte', entries: [] },
+    ]
+    expect(evidenceReport(durcheinander).perCatalogue.map((c) => c.name))
+      .toEqual(['alpha', 'mitte', 'zeta'])
+
+    const namen = evidenceReport().perCatalogue.map((c) => c.name)
+    expect(namen).toEqual([...namen].sort())
+  })
+
+  it('7. der Weg ist verdrahtet', () => {
+    const panel = ohneKommentare(
+      'src', 'renderer', 'components', 'Properties', 'sections', 'OptionalFieldsSection.tsx',
+    )
+    expect(panel).toMatch(/evidenceForType\(equipment\.deviceTypeId\)/)
+    // Der fehlende Beleg wird genannt — und NUR er: `no-type` bleibt still,
+    // sonst stuende an jedem von Hand angelegten Geraet eine Meldung ohne
+    // Anlass.
+    expect(panel).toMatch(/typBeleg\.kind === 'unsourced'/)
+    expect(panel).toMatch(/manufacturerUrlNoSource/)
+    expect(panel).not.toMatch(/typBeleg\.kind === 'no-type'/)
+  })
+})


### PR DESCRIPTION
## Was der Plan sagte — und was das Nachmessen ergab

`INITIATIVE-11-SCOPING.md` nennt als nächsten Schritt:

> Lift the 253 existing `// Quelle:` comments into a field. Mechanical, reversible, loses nothing.

**Nachgemessen: der Schritt ist schon getan.** Alle 253 Kommentare stehen als `template.manufacturerUrl` im selben Eintrag — URL für URL nachgeprüft, keine einzige Abweichung. Das Feld wandert über `equipmentSlice` an das Gerät, die Eigenschaften-Leiste zeigt es mit genannter Herkunft, und `exportDevicePdf` druckt es. Das Papier stimmte, als es geschrieben wurde („No `provenance`, `source`, or `verifiedAt` field exists") — es hat nur nach den falschen drei Namen gesucht.

Damit ist der eigentliche Rest ein anderer. Beide Hälften stehen in diesem PR.

## 1. Die Abdeckung wurde nicht gerechnet

253 von 412 Einträgen tragen ein Datenblatt; die übrigen 159 liegen in sechs Katalogen. Diese Zahlen standen als Prosa im Backlog (B-11) und nirgends im Code. Wer morgen dreißig Einträge ohne Beleg dazulegt, ändert sie — und niemand merkt es.

`lib/catalogueEvidence.ts` rechnet sie jetzt. `evidenceReport` ist die Engstelle, aus der Anzeige und Prüfung dieselben Zahlen lesen.

## 2. „Kein Beleg" war unsichtbar

Die Eigenschaften-Leiste zeigte den geerbten Link, wenn es einen gab, und sonst nichts. Ein ATEM (32 Einträge, kein einziger Beleg) sah damit aus wie ein Gerät, bei dem nur gerade niemand nachgesehen hat.

`evidenceForType` unterscheidet deshalb **drei** Fälle — `sourced`, `unsourced` (Katalog-Eintrag ohne Datenblatt) und `no-type` (Gerät aus keinem Katalog) — und die Leiste sagt den mittleren an. Der dritte bleibt still: an einem von Hand angelegten Gerät wäre die Meldung eine Warnung ohne Anlass.

## Der Wächter

Er macht die Zusage prüfbar, was das Scoping-Papier ausdrücklich als Zweck des Schritts nennt („Step 2 alone would make a claim testable that the suite currently only asserts"):

- jeder `// Quelle:`-Kommentar steht auch als Feld — ein Beleg, der nur im Kommentar steht, ist zur Laufzeit keiner;
- die sechs unbelegten Kataloge werden **gerechnet** und nicht aufgezählt: wer Belege nachträgt, fällt von selbst aus der Liste;
- eine **Ratsche** — die neun heute vollständig belegten Kataloge dürfen keinen unbelegten Eintrag dazubekommen, und die Gesamtzahl der unbelegten steigt nicht;
- Rechnung und `deviceTypeRegistry` lesen dieselben Kataloge, verglichen über die Import-Zeilen beider Dateien. Ein sechzehnter Katalog nur im Register hieße: die Abdeckung sieht besser aus, als sie ist.

## Ein Fund aus den Gegenproben

Die Zusicherung „derselbe Baum ergibt denselben Bericht" prüft die feste Sortierung jetzt an einer **unsortierten** Eingabe. Gegen `CATALOGUES` allein war sie wertlos: die Liste steht ohnehin alphabetisch, also sah ein Bericht ganz ohne Sortierung genauso aus — die Gegenprobe, die den `sort` ausbaute, blieb grün.

## Geprüft

**13 Gegenproben, jede rot:** Leerraum als Beleg, Katalog aus der Rechnung, zweite Summenrechnung, unbelegt als belegt, `no-type` und `unsourced` zusammengelegt, Beleg nur im Kommentar, neuer Eintrag ohne Beleg, Katalog nur im Register, Dialog ohne Meldung, Meldung auch ohne Katalog.

Volle Suite 2614 grün · `tsc` sauber · Lint 0 Errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_