### PR TITLE
post: die Übergabe an die Post — Position, Mischer-Eingang, Aufnahme, Karten-Präfix (Bedarf 62)

### DIFF
--- a/src/renderer/components/Export/PacketSection.tsx
+++ b/src/renderer/components/Export/PacketSection.tsx
@@ -21,6 +21,7 @@ import { crewSheetTableForProject } from '../../lib/crewNetworkSheet'
 import { spectrumTableForProject } from '../../lib/spectrumPlan'
 import { deliveryTableForProject } from '../../lib/deliveryParity'
 import { tallyMapTableForProject } from '../../lib/tallyMap'
+import { handoverManifestTableForProject } from '../../lib/postHandover'
 import type { CsvTable } from '../../lib/csv'
 import type { CablePlannerProject } from '../../types/project'
 
@@ -58,6 +59,10 @@ const KANDIDATEN: ReadonlyArray<Kandidat> = [
   { id: 'spektrum-plan', label: 'Spektrum-Plan', table: spectrumTableForProject },
   { id: 'ausspielung', label: 'Ausspielung', table: deliveryTableForProject },
   { id: 'tally-karte', label: 'Tally-Karte', table: tallyMapTableForProject },
+  // Bedarf 62 — das Blatt, mit dem die Post die Karten wiederfindet, ohne die
+  // Crew anzurufen. Es gehoert in den Stapel und nicht in einen eigenen
+  // Dialog: es geht mit den Karten mit, und was mitgeht, wird zusammengeheftet.
+  { id: 'post-uebergabe', label: 'Übergabe an die Post', table: handoverManifestTableForProject },
 ]
 
 export const PacketSection = () => {

--- a/src/renderer/lib/ajaCatalog.ts
+++ b/src/renderer/lib/ajaCatalog.ts
@@ -8,6 +8,7 @@
 // einmalig gemintet, versionsstabil.
 // ───────────────────────────────────────────────────────────────────────────
 import type { EquipmentTemplate, Port } from '../types/equipment'
+import type { RecordingCapability } from './recording'
 
 const num = (base: string, n: number, connectorType: Port['connectorType'], bidi = false): Port[] =>
   Array.from({ length: n }, (_, i) => ({
@@ -23,6 +24,10 @@ interface AjaEntry {
    *  FixtureTypeID). Autoritativer Schluessel fuer Import/Aufloesung —
    *  versionsstabil, unabhaengig vom Modellnamen. */
   deviceTypeId: string
+  /** Zeichnet dieses Modell auf, und in welcher Form (Bedarf 62)? Fehlt das
+   *  Feld, ist das die Datenblatt-Aussage „zeichnet nicht auf" — siehe
+   *  `recording.ts`. */
+  records?: RecordingCapability
   /** Lowercase substrings that must ALL appear in the source name. */
   match: string[]
   template: EquipmentTemplate
@@ -109,6 +114,7 @@ export const AJA_CATALOG: AjaEntry[] = [
   {
     match: ['ki pro', 'ultra', '12g'],
     deviceTypeId: 'ecf80e2e-5376-4f86-865f-ce146e90d032',
+    records: 'per-device',
     template: {
       manufacturerUrl: 'https://www.aja.com/products/ki-pro-ultra-12g',
       name: 'AJA Ki Pro Ultra 12G',
@@ -232,6 +238,7 @@ export const AJA_CATALOG: AjaEntry[] = [
   {
     match: ['helo', 'plus'],
     deviceTypeId: '48011180-869a-490a-a041-a6d797196acb',
+    records: 'per-device',
     template: {
       manufacturerUrl: 'https://www.aja.com/products/helo-plus',
       name: 'AJA HELO Plus',

--- a/src/renderer/lib/blackmagicCatalog.ts
+++ b/src/renderer/lib/blackmagicCatalog.ts
@@ -1,4 +1,5 @@
 import type { EquipmentTemplate, Port } from '../types/equipment'
+import type { RecordingCapability } from './recording'
 
 // Known Blackmagic Design device templates with port counts taken from the
 // official datasheets. Matched by name substrings so Rentman items like
@@ -28,6 +29,10 @@ interface BlackmagicEntry {
    *  exportVideohub.ts → videohubPresets). Datenblatt-Fakt statt
    *  Port-Zaehl-Schaetzung. */
   videohubPresetKey?: string
+  /** Zeichnet dieses Geraet auf, und in welcher Form (Bedarf 62)?
+   *  EIGENES Feld und kein `kind`-Wert: ein ATEM ISO ist Mischer UND
+   *  Recorder, `kind` kann nur eines von beidem sagen. */
+  records?: RecordingCapability
   /** Name patterns (lowercased) that must ALL appear in the source name. */
   match: string[]
   template: EquipmentTemplate
@@ -252,6 +257,9 @@ export const BLACKMAGIC_CATALOG: BlackmagicEntry[] = [
     match: ['atem', 'mini', 'extreme', 'iso'],
     deviceTypeId: '4622e885-df82-430e-9512-fca13b673b4d',
     kind: 'atem',
+    // Der ISO zeichnet je Eingang eine Datei auf — die Kanalnummer IST die
+    // Eingangsnummer, und die steht schon im Kabelgraph (Bedarf 62).
+    records: 'per-input',
     template: {
       name: 'Blackmagic ATEM Mini Extreme ISO',
       category: 'Video Mixer',
@@ -296,6 +304,7 @@ export const BLACKMAGIC_CATALOG: BlackmagicEntry[] = [
     match: ['atem', 'mini', 'pro', 'iso'],
     deviceTypeId: 'a252049d-992a-432b-8084-d1f794c79c4a',
     kind: 'atem',
+    records: 'per-input',
     template: {
       name: 'Blackmagic ATEM Mini Pro ISO',
       category: 'Video Mixer',
@@ -350,6 +359,9 @@ export const BLACKMAGIC_CATALOG: BlackmagicEntry[] = [
   {
     match: ['hyperdeck', 'hd plus'],
     deviceTypeId: 'e6699d97-5974-430e-981d-2a6bad93e116',
+    // Ein HyperDeck zeichnet auf, was an seinem Eingang anliegt — eine
+    // Aufzeichnung, keine Kanalnummer.
+    records: 'per-device',
     template: {
       name: 'Blackmagic Hyperdeck Studio HD Plus',
       category: 'Video',

--- a/src/renderer/lib/dataDictionary.ts
+++ b/src/renderer/lib/dataDictionary.ts
@@ -267,6 +267,17 @@ export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
   Maske: 'Die Subnetzmaske des Segments.',
   Menge: 'Die Stückzahl dieser Position.',
   Mischer: 'Der Bildmischer, auf den sich die Eingangsnummer bezieht.',
+  'Mischer-Eingang':
+    'Die 1-basierte Eingangsnummer am Mischer — dieselbe, mit der er den ' +
+    'Eingang auf dem Draht adressiert (Tally, UMD, ISO-Kanal).',
+  'Karten-Präfix':
+    'Unter welchem Kürzel die Post die Karten dieser Rolle wiederfindet. ' +
+    'NUR das Präfix: Drehtag und Kartennummer entstehen am Set und stehen ' +
+    'nicht im Plan.',
+  Aufzeichnung:
+    'Wo die Aufzeichnung dieser Rolle landet — ein Mischer mit ISO-Kanal ' +
+    'oder ein eigener Recorder mit seinem Eingang. Steht im Plan keiner, ' +
+    'sagt die Zelle genau das.',
   Modell: 'Der Gerätetyp — nicht die einzelne Einheit.',
   Nachher:
     'Der Stand NACH der Aenderung: beim Vergleich zweier Importe der zweite Stand, auf dem Umbenennungs-Blatt der Text nach der Umbenennung, auf dem Umbau-Zettel der Eingang, der auf diesen Ausgang kommt.',
@@ -302,6 +313,7 @@ export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
   'Quelle (Plan)': 'Die Quelle, die der Plan für den zugeordneten Kanal führt.',
   Reservierung: 'Die Menge, die im Warenwirtschaftssystem reserviert ist.',
   Rolle: 'Wofür das Gerät oder die Schnittstelle in diesem Zusammenhang steht.',
+  Nummer: 'Die redaktionelle Nummer der Rolle — die Zahl, die in der Regie gesprochen wird.',
   'Schätzung': 'Der geschätzte Betrag dieser Position.',
   Schaden: 'Was an der Einheit beschädigt ist.',
   Schlagworte: 'Die Schlagworte für die Plattform-Formulare.',

--- a/src/renderer/lib/deviceTypeRegistry.ts
+++ b/src/renderer/lib/deviceTypeRegistry.ts
@@ -11,6 +11,7 @@
 // (manuell angelegt, Rentman/GraphML-Import ohne Katalog-Zuordnung).
 // ───────────────────────────────────────────────────────────────────────────
 import type { EquipmentTemplate } from '../types/equipment'
+import type { RecordingCapability } from './recording'
 import { CAMERA_CATALOG } from './cameraCatalog'
 import { BLACKMAGIC_CATALOG } from './blackmagicCatalog'
 import { GREENGO_CATALOG } from './greengoCatalog'
@@ -36,6 +37,15 @@ export interface DeviceTypeInfo {
   networkKind?: 'switch' | 'router'
   /** Videohubs: expliziter Export-Preset-Key (Datenblatt-Fakt). */
   videohubPresetKey?: string
+  /**
+   * Zeichnet dieses Modell auf, und in welcher Form (Bedarf 62)?
+   *
+   * Eigenes Feld neben `kind`, weil beides zugleich gilt: ein ATEM Mini Pro
+   * ISO ist Mischer UND Recorder. Fehlt das Feld bei einem Katalog-Eintrag,
+   * ist das die Datenblatt-Aussage „zeichnet nicht auf" — `detectRecording`
+   * laesst die Namens-Heuristik dann bewusst nicht mehr darueber.
+   */
+  records?: RecordingCapability
 }
 
 /** Lazy aufgebaut, damit der Modul-Import billig bleibt. */
@@ -59,6 +69,7 @@ const buildRegistry = (): Map<string, DeviceTypeInfo> => {
       template: { ...e.template, deviceTypeId: e.deviceTypeId },
       kind: e.kind,
       videohubPresetKey: e.videohubPresetKey,
+      records: e.records,
     })
   }
   for (const e of GREENGO_CATALOG) {
@@ -69,7 +80,10 @@ const buildRegistry = (): Map<string, DeviceTypeInfo> => {
     })
   }
   for (const e of MONITOR_CATALOG) {
-    put(e.deviceTypeId, { template: { ...e.template, deviceTypeId: e.deviceTypeId } })
+    put(e.deviceTypeId, {
+      template: { ...e.template, deviceTypeId: e.deviceTypeId },
+      records: e.records,
+    })
   }
   for (const e of UBIQUITI_CATALOG) {
     put(e.deviceTypeId, {
@@ -78,13 +92,19 @@ const buildRegistry = (): Map<string, DeviceTypeInfo> => {
     })
   }
   for (const e of MISC_CATALOG) {
-    put(e.deviceTypeId, { template: { ...e.template, deviceTypeId: e.deviceTypeId } })
+    put(e.deviceTypeId, {
+      template: { ...e.template, deviceTypeId: e.deviceTypeId },
+      records: e.records,
+    })
   }
   // AJA/Ross/Lynx/Switcher: KEIN kind 'videohub' fuer fremde Router (KUMO,
   // Ultrix, NK) — der Videohub-Export spricht das Blackmagic-Protokoll
   // (Port 9990), das diese Geraete nicht verstehen. Rolle bleibt null.
   for (const e of AJA_CATALOG) {
-    put(e.deviceTypeId, { template: { ...e.template, deviceTypeId: e.deviceTypeId } })
+    put(e.deviceTypeId, {
+      template: { ...e.template, deviceTypeId: e.deviceTypeId },
+      records: e.records,
+    })
   }
   for (const e of ROSS_CATALOG) {
     put(e.deviceTypeId, { template: { ...e.template, deviceTypeId: e.deviceTypeId } })

--- a/src/renderer/lib/documentRegistry.ts
+++ b/src/renderer/lib/documentRegistry.ts
@@ -30,6 +30,7 @@ import { buildPtpPlan, ptpTable } from './ptpPlan'
 import { crewSheetTableForProject } from './crewNetworkSheet'
 import { spectrumTableForProject } from './spectrumPlan'
 import { multicastTableForProject } from './multicastPlan'
+import { handoverManifestTableForProject } from './postHandover'
 import { fallbackTable } from './fallbackPlan'
 import { eventMetadataTable } from './eventMetadata'
 import { transmissionRecordTable } from './transmissionRecord'
@@ -139,6 +140,12 @@ export const DOCUMENT_STANDS: Record<string, (project: CablePlannerProject) => s
   // sich mit jeder Umformulierung aendert, meldete jedes gedruckte Exemplar
   // als veraltet.
   'multicast-plan': ofTable(multicastTableForProject),
+  // Bedarf 62 — die Uebergabe an die Post. Reproduzierbar, weil das Manifest
+  // allein aus `sourceIdentities`, `equipment` und `cables` folgt: keine
+  // Nutzer-Einstellung beim Export, keine Sprache (die Zellen tragen
+  // kanonisches Deutsch aus `recordText` und `PREFIX_BASIS_LABEL`) und keine
+  // Uhr — das Karten-Praefix kommt aus der Rolle und nicht aus dem Drehtag.
+  'post-uebergabe': ofTable(handoverManifestTableForProject),
   // Bedarf 89 — das Sicherheitsnetz als Blatt mit Stand. Reproduzierbar: der
   // Inhalt folgt allein aus den Regeln und den Zielen. Die BEFUNDE stehen
   // nicht drin -- sie tragen Fliesstext.
@@ -259,6 +266,7 @@ export const DOCUMENT_LABELS: Record<string, string> = {
   'crew-netz': 'Netz-Merkblatt (Crew)',
   'spektrum-plan': 'Spektrum-Plan',
   'multicast-plan': 'Multicast-Adressplan',
+  'post-uebergabe': 'Übergabe an die Post',
   'ausweich-plan': 'Ausweich-Plan (Sicherheitsnetz)',
   'event-metadaten': 'Angaben zur Veranstaltung',
   sendebericht: 'Sendebericht',

--- a/src/renderer/lib/miscCatalog.ts
+++ b/src/renderer/lib/miscCatalog.ts
@@ -1,4 +1,5 @@
 import type { EquipmentTemplate, Port } from '../types/equipment'
+import type { RecordingCapability } from './recording'
 
 // Miscellaneous professional A/V equipment templates for rental catalog matching.
 // Covers: Rosendahl nanosyncs sync generators, Behringer X32 digital mixers,
@@ -31,6 +32,10 @@ interface MiscEntry {
    *  FixtureTypeID). Autoritativer Schluessel fuer Import/Aufloesung —
    *  versionsstabil, unabhaengig vom Modellnamen. */
   deviceTypeId: string
+  /** Zeichnet dieses Modell auf, und in welcher Form (Bedarf 62)? Fehlt das
+   *  Feld, ist das die Datenblatt-Aussage „zeichnet nicht auf" — siehe
+   *  `recording.ts`. */
+  records?: RecordingCapability
   /** Lowercase substrings that must ALL appear in the source name. */
   match: string[]
   template: EquipmentTemplate
@@ -227,6 +232,7 @@ export const MISC_CATALOG: MiscEntry[] = [
   {
     match: ['aja', 'kipro'],
     deviceTypeId: '17528d76-a3d0-4002-afee-e164d50509f0',
+    records: 'per-device',
     template: {
       name: 'AJA KiPro Recorder',
       category: VIDEO,

--- a/src/renderer/lib/monitorCatalog.ts
+++ b/src/renderer/lib/monitorCatalog.ts
@@ -1,4 +1,5 @@
 import type { EquipmentTemplate, Port } from '../types/equipment'
+import type { RecordingCapability } from './recording'
 
 // Broadcast monitor / monitor-recorder templates sourced from official datasheets.
 // Matched by name substrings so Rentman items resolve to the correct port layout
@@ -25,6 +26,10 @@ interface MonitorEntry {
    *  FixtureTypeID). Autoritativer Schluessel fuer Import/Aufloesung —
    *  versionsstabil, unabhaengig vom Modellnamen. */
   deviceTypeId: string
+  /** Zeichnet dieses Modell auf, und in welcher Form (Bedarf 62)? Fehlt das
+   *  Feld, ist das die Datenblatt-Aussage „zeichnet nicht auf" — siehe
+   *  `recording.ts`. */
+  records?: RecordingCapability
   /** Lowercase substrings that must ALL appear in the source name. */
   match: string[]
   template: EquipmentTemplate
@@ -91,6 +96,7 @@ export const MONITOR_CATALOG: MonitorEntry[] = [
   {
     match: ['shogun', 'ultra'],
     deviceTypeId: '37ca86f0-451a-4e6a-85aa-80e23beb6a3f',
+    records: 'per-device',
     template: {
       name: 'Atomos Shogun Ultra',
       category: MON,
@@ -103,6 +109,7 @@ export const MONITOR_CATALOG: MonitorEntry[] = [
   {
     match: ['shogun', 'connect'],
     deviceTypeId: '2e9c5687-76b7-4e8f-9262-a50b92bbe064',
+    records: 'per-device',
     template: {
       name: 'Atomos Shogun Connect',
       category: MON,
@@ -115,6 +122,7 @@ export const MONITOR_CATALOG: MonitorEntry[] = [
   {
     match: ['shogun', 'inferno'],
     deviceTypeId: 'a37271a6-a807-49f3-ba22-a4486ebed9a7',
+    records: 'per-device',
     template: {
       name: 'Atomos Shogun Inferno',
       category: MON,
@@ -127,6 +135,7 @@ export const MONITOR_CATALOG: MonitorEntry[] = [
   {
     match: ['sumo', '19m'],
     deviceTypeId: '02b44704-82d1-4b1d-89b1-ae107832ea78',
+    records: 'per-device',
     template: {
       name: 'Atomos Sumo 19M',
       category: MON,
@@ -148,6 +157,7 @@ export const MONITOR_CATALOG: MonitorEntry[] = [
   {
     match: ['sumo', '19'],
     deviceTypeId: 'e44ee4b8-842c-4bad-a628-e6c0d71ae782',
+    records: 'per-device',
     template: {
       name: 'Atomos Sumo 19',
       category: MON,
@@ -167,6 +177,7 @@ export const MONITOR_CATALOG: MonitorEntry[] = [
   {
     match: ['ninja', 'v+'],
     deviceTypeId: '86bc69fc-7c67-4a72-b454-e3b9be3ed099',
+    records: 'per-device',
     template: {
       name: 'Atomos Ninja V+',
       category: MON,
@@ -179,6 +190,7 @@ export const MONITOR_CATALOG: MonitorEntry[] = [
   {
     match: ['ninja', 'v'],
     deviceTypeId: 'bbf307e6-9e91-4991-822e-9f089ef44e10',
+    records: 'per-device',
     template: {
       name: 'Atomos Ninja V',
       category: MON,

--- a/src/renderer/lib/postHandover.ts
+++ b/src/renderer/lib/postHandover.ts
@@ -1,0 +1,389 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Die Übergabe an die Post (Bedarf 62, P2).
+//
+// ─── DER BEFUND ────────────────────────────────────────────────────────────
+//
+//   > Card labelling and media reports are a manual discipline; CAMERA
+//   > IDENTITY IN POST ('B_Day1_003') HAS NO LINK TO THE PLANNED POSITION,
+//   > and renaming originals breaks metadata.
+//
+// Die Bedarfs-Datenbank sagt auch, was zu bauen ist:
+//
+//   > Emit a per-show manifest mapping camera position -> switcher input ->
+//   > ISO/record channel -> card label, printable and exportable, so post can
+//   > reconcile without asking the crew.
+//
+// ─── WAS DER PLAN BEANTWORTEN KANN, UND WAS NICHT ──────────────────────────
+//
+// Drei der vier Spalten stehen schon im Kabelgraph — die Rolle, das Geraet,
+// das sie realisiert, und der Mischer-Eingang (`switcherLinkFor`). Die vierte
+// zerfaellt in zwei sehr verschiedene Faelle, und genau diese Unterscheidung
+// ist der Grund, warum es `recording.ts` gibt:
+//
+//   ATEM ISO      zeichnet JE EINGANG auf. Der Aufnahmekanal IST die
+//                 Eingangsnummer — der Plan weiss ihn also bereits.
+//   HyperDeck &c. zeichnen auf, WAS AM EINGANG ANLIEGT. Welche Rolle darin
+//                 landet, sagt die Verkabelung; eine Kanalnummer gibt es
+//                 nicht, und eine zu erfinden schickte die Post an eine
+//                 Datei, die es nicht gibt.
+//
+// Steht im Plan gar kein Recorder, sagt das Blatt genau das. „Kein Recorder
+// im Plan" ist eine Auskunft; eine leere Zelle ist keine.
+//
+// ─── DIE KARTENBESCHRIFTUNG IST EIN PRAEFIX UND KEINE DATEINAME ────────────
+//
+// Der Beleg nennt `B_Day1_003`: Kameraletter, Drehtag, Kartennummer. Von den
+// dreien gehoert dem Plan genau EINES — der Buchstabe, denn er ist die Rolle.
+// Drehtag und Kartennummer entstehen am Set und stehen nirgends in dieser
+// Datei. Das Blatt liefert deshalb das PRAEFIX und sagt, worauf es beruht;
+// es baut keinen Dateinamen zusammen, den niemand zugesagt hat.
+//
+// Der Buchstabe kommt aus der Rollen-NUMMER (1 → A … 26 → Z), weil genau das
+// die Zuordnung ist, die die Regie ohnehin spricht. Ohne Nummer — oder jenseits
+// von 26 — traegt das Praefix den bereinigten Rollennamen, und die Spalte
+// „Grundlage" sagt, welcher der beiden Faelle vorliegt. Ein 27. Buchstabe
+// waere eine erfundene Regel, und zwar eine, die zwei Rollen denselben Namen
+// geben koennte.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { CablePlannerProject } from '../types/project'
+import type { CsvTable } from './csv'
+import {
+  buildGraphContext,
+  deriveLabels,
+  isReferencePort,
+  resolveSignalSource,
+  switcherLinkFor,
+} from './labelDerivation'
+import { detectRecording } from './recording'
+
+/** Was in der Aufnahme-Spalte steht, wo der Plan keinen Recorder kennt. */
+export const NO_RECORDER = 'kein Recorder im Plan'
+/** Was in der Mischer-Spalte steht, wo die Rolle keinen Mischer erreicht. */
+export const NO_SWITCHER = 'kein Mischer-Eingang im Plan'
+
+/** Worauf das Karten-Praefix beruht. */
+export type CardPrefixBasis =
+  /** Aus der Rollen-Nummer abgeleiteter Buchstabe (1 → A). */
+  | 'number'
+  /** Aus dem Rollen-Namen bereinigt — keine Nummer, oder jenseits von Z. */
+  | 'name'
+
+export const PREFIX_BASIS_LABEL: Readonly<Record<CardPrefixBasis, string>> = {
+  number: 'Rollen-Nummer',
+  name: 'Rollen-Name',
+}
+
+/**
+ * Der Buchstabe zur Nummer — nur 1..26.
+ *
+ * Jenseits davon gibt es KEINEN. Ein zweistelliges Schema („AA") waere eine
+ * Regel, die dieses Haus nie vereinbart hat, und der Beleg nennt genau einen
+ * Buchstaben. Die Antwort ist deshalb `null` und nicht ein erfundenes Kuerzel.
+ */
+export const cameraLetter = (n: number | undefined): string | null => {
+  if (n === undefined || !Number.isInteger(n) || n < 1 || n > 26) return null
+  return String.fromCharCode(64 + n)
+}
+
+/**
+ * Der Rollen-Name als Karten-Praefix.
+ *
+ * Karten-Ordner und Media-Manager vertragen keine Umlaute und keine
+ * Leerzeichen zuverlaessig — das ist derselbe Grund, aus dem `danteNaming`
+ * existiert. Bereinigt wird deshalb auf ASCII-Buchstaben, Ziffern und
+ * Unterstrich; alles andere wird EIN Unterstrich, und Raender fallen weg.
+ *
+ * Bleibt nichts uebrig (eine Rolle, die nur aus Sonderzeichen besteht), ist
+ * das Ergebnis der leere String — und der Aufrufer nennt das, statt einen
+ * Namen zu erfinden.
+ */
+export const sanitisePrefix = (name: string): string =>
+  name
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^A-Za-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+
+/** Wo die Aufzeichnung dieser Rolle landet. */
+export type RecordBinding =
+  /** Ein Mischer mit ISO-Aufzeichnung: der Kanal ist der Eingang. */
+  | { kind: 'switcher-iso'; recorder: string; channel: number }
+  /** Ein eigener Recorder: das Geraet und sein Eingang. */
+  | { kind: 'recorder'; recorder: string; input: number }
+  /** Kein Recorder im Plan — eine Auskunft, keine Luecke. */
+  | { kind: 'none' }
+
+export interface HandoverRow {
+  roleId: string
+  roleName: string
+  roleNumber?: number
+  /** Das Praefix, unter dem die Post diese Rolle wiederfindet. */
+  cardPrefix: string
+  cardPrefixBasis: CardPrefixBasis
+  /** Geraet, das die Rolle realisiert. */
+  equipmentId: string
+  equipmentName: string
+  /** Mischer und Eingang — fehlt, wenn die Rolle keinen erreicht. */
+  switcherName?: string
+  switcherInput?: number
+  record: RecordBinding
+}
+
+export interface HandoverGap {
+  roleId: string
+  roleName: string
+  /** Klartext, warum diese Rolle nicht auf dem Blatt steht. */
+  reason: string
+}
+
+export interface HandoverManifest {
+  rows: HandoverRow[]
+  /**
+   * Rollen ohne Geraet — sie haben keine Zeile, weil es nichts gibt, das
+   * aufgezeichnet wird. GERECHNET und nicht gefuehrt: wer das Geraet
+   * zuordnet, sieht die Luecke von selbst verschwinden.
+   */
+  gaps: HandoverGap[]
+}
+
+const NO_PREFIX = 'ohne Praefix'
+
+/**
+ * Das Praefix einer Rolle, samt seiner Grundlage.
+ *
+ * DIE ENGSTELLE fuer die Beschriftung: Blatt, CSV und jede kuenftige Ausgabe
+ * lesen dieselbe Ableitung. Zwei Ableitungen koennten sich unterscheiden, und
+ * dann trueg die Karte im Koffer einen anderen Buchstaben als die Liste, mit
+ * der die Post sie sucht — genau der Zustand, den der Bedarf beklagt.
+ */
+export const cardPrefixFor = (role: {
+  name: string
+  number?: number
+}): { prefix: string; basis: CardPrefixBasis } => {
+  const letter = cameraLetter(role.number)
+  if (letter) return { prefix: letter, basis: 'number' }
+  const sauber = sanitisePrefix(role.name)
+  return { prefix: sauber || NO_PREFIX, basis: 'name' }
+}
+
+/** Ein Eingang eines eigenen Recorders, samt der Quelle, die dort ankommt. */
+interface RecorderInput {
+  recorderId: string
+  recorderName: string
+  /** 1-basierte Position des Eingangs — die Nummer, die am Geraet steht. */
+  inputIndex: number
+  portId: string
+  sourceEquipmentId: string
+}
+
+/**
+ * Die Eingaenge aller eigenen Recorder im Plan, aufgeloest.
+ *
+ * `sources` aus `deriveLabels` hilft hier NICHT: es fuehrt nur Mischer- und
+ * Router-Senken (`kind !== 'atem' && kind !== 'videohub'` faellt dort heraus).
+ * Ein HyperDeck steht damit in keiner Zeile — nachgemessen, nicht vermutet:
+ * die erste Fassung dieser Datei las `sources` und fand nie einen Recorder.
+ *
+ * Aufgeloest wird mit `resolveSignalSource`, also mit DERSELBEN
+ * Rueckwaertssuche wie die Label-Ableitung. Eine eigene Traversierung waere
+ * eine zweite Wahrheit ueber denselben Graphen.
+ *
+ * `isReferencePort` haelt Genlock-, Timecode- und Rueckweg-Eingaenge heraus.
+ * Ohne diese Zeile zaehlte der Referenz-Eingang eines HyperDecks als
+ * Aufnahmeweg, und auf dem Blatt staende der Sync-Generator als Motiv.
+ */
+const recorderInputsOf = (
+  equipment: readonly { id: string; name: string; inputs: { id: string; name?: string }[] }[],
+  ctx: ReturnType<typeof buildGraphContext>,
+  isRecorder: (equipmentId: string) => ReturnType<typeof detectRecording>,
+): RecorderInput[] => {
+  const out: RecorderInput[] = []
+  for (const device of equipment) {
+    if (isRecorder(device.id) !== 'per-device') continue
+    device.inputs.forEach((port, idx) => {
+      const voll = ctx.portById.get(port.id)
+      if (voll && isReferencePort(voll)) return
+      const resolved = resolveSignalSource(port.id, ctx)
+      if (!resolved) return
+      out.push({
+        recorderId: device.id,
+        recorderName: device.name,
+        inputIndex: idx + 1,
+        portId: port.id,
+        sourceEquipmentId: resolved.equipmentId,
+      })
+    })
+  }
+  return out
+}
+
+/**
+ * Wo die Aufzeichnung dieser Rolle landet — aus dem Graph, nicht aus einem
+ * zusaetzlichen Feld.
+ *
+ * Die Reihenfolge ist Absicht: erst der Mischer, den die Rolle ohnehin
+ * speist. Zeichnet der selbst je Eingang auf, ist die Frage beantwortet und
+ * die Nummer ist dieselbe, die auch Tally und UMD benutzen — eine zweite
+ * Zahl fuer dieselbe Sache waere die zweite Wahrheit, gegen die ADR-001
+ * geschrieben ist. Erst danach wird nach einem eigenen Recorder gesucht.
+ */
+const recordBindingFor = (
+  recorderInputs: readonly RecorderInput[],
+  eqById: Map<string, { id: string; name: string }>,
+  isRecorder: (equipmentId: string) => ReturnType<typeof detectRecording>,
+  deviceId: string,
+  switcherLink: { sinkEquipmentId: string; inputIndex: number } | null | undefined,
+): RecordBinding => {
+  if (switcherLink && isRecorder(switcherLink.sinkEquipmentId) === 'per-input') {
+    const mischer = eqById.get(switcherLink.sinkEquipmentId)
+    if (mischer) {
+      return { kind: 'switcher-iso', recorder: mischer.name, channel: switcherLink.inputIndex }
+    }
+  }
+  // Deterministisch, aus demselben Grund wie in `switcherLinkFor`: die
+  // Eingaenge folgen der Reihenfolge des `equipment`-Arrays, und ein `find()`
+  // darauf machte das Blatt zu einer Funktion des Bearbeitungsverlaufs.
+  const treffer = recorderInputs
+    .filter((r) => r.sourceEquipmentId === deviceId)
+    .sort(
+      (a, b) =>
+        a.inputIndex - b.inputIndex ||
+        a.recorderId.localeCompare(b.recorderId) ||
+        a.portId.localeCompare(b.portId),
+    )[0]
+  if (!treffer) return { kind: 'none' }
+  return { kind: 'recorder', recorder: treffer.recorderName, input: treffer.inputIndex }
+}
+
+/**
+ * Das Manifest fuer die Post.
+ *
+ * Eine Zeile je Rolle UND Geraet: ein Haupt-/Backup-Paar sind zwei
+ * Aufzeichnungen und damit zwei Zeilen. Sie zu einer zusammenzuziehen
+ * hiesse, die zweite verschwinden zu lassen — und das ist die, nach der
+ * hinterher niemand sucht.
+ */
+export const buildHandoverManifest = (
+  project: Pick<CablePlannerProject, 'equipment' | 'cables' | 'sourceIdentities'>,
+): HandoverManifest => {
+  const identities = project.sourceIdentities ?? []
+  const { sources } = deriveLabels({
+    equipment: project.equipment,
+    cables: project.cables,
+    sourceIdentities: identities,
+  })
+  // `buildGraphContext` liefert dieselbe Geraete-Auflösung, die auch die
+  // Label-Ableitung benutzt — kein zweiter Index über dasselbe Array.
+  const ctx = buildGraphContext(project.equipment, project.cables)
+  const { eqById } = ctx
+  const aufnahmeCache = new Map<string, ReturnType<typeof detectRecording>>()
+  const isRecorder = (equipmentId: string) => {
+    const bekannt = aufnahmeCache.get(equipmentId)
+    if (bekannt !== undefined) return bekannt
+    const device = eqById.get(equipmentId)
+    const wert = device ? detectRecording(device) : null
+    aufnahmeCache.set(equipmentId, wert)
+    return wert
+  }
+
+  const recorderInputs = recorderInputsOf(project.equipment, ctx, isRecorder)
+
+  const rows: HandoverRow[] = []
+  const gaps: HandoverGap[] = []
+
+  for (const identity of identities) {
+    const devices = project.equipment.filter((e) => e.sourceIdentityId === identity.id)
+    if (devices.length === 0) {
+      gaps.push({
+        roleId: identity.id,
+        roleName: identity.name,
+        reason: 'Der Rolle ist kein Gerät zugeordnet — es gibt nichts, was aufgezeichnet wird.',
+      })
+      continue
+    }
+    const { prefix, basis } = cardPrefixFor(identity)
+    for (const device of devices) {
+      const link = switcherLinkFor(sources, [device.id])
+      const switcher = link ? eqById.get(link.sinkEquipmentId) : undefined
+      rows.push({
+        roleId: identity.id,
+        roleName: identity.name,
+        ...(identity.number !== undefined ? { roleNumber: identity.number } : {}),
+        cardPrefix: prefix,
+        cardPrefixBasis: basis,
+        equipmentId: device.id,
+        equipmentName: device.name,
+        ...(switcher && link
+          ? { switcherName: switcher.name, switcherInput: link.inputIndex }
+          : {}),
+        record: recordBindingFor(recorderInputs, eqById, isRecorder, device.id, link),
+      })
+    }
+  }
+
+  // Feste Ordnung, damit derselbe Plan zweimal dasselbe Blatt ergibt
+  // (ADR-004): nach Rollen-Nummer, dann Name, dann Geraet. Ohne sie waere der
+  // Fingerabdruck eine Funktion der Bearbeitungs-Reihenfolge.
+  const nummer = (r: HandoverRow) => r.roleNumber ?? Number.MAX_SAFE_INTEGER
+  rows.sort(
+    (a, b) =>
+      nummer(a) - nummer(b) ||
+      a.roleName.localeCompare(b.roleName, 'de') ||
+      a.equipmentName.localeCompare(b.equipmentName, 'de') ||
+      a.equipmentId.localeCompare(b.equipmentId),
+  )
+  gaps.sort((a, b) => a.roleName.localeCompare(b.roleName, 'de') || a.roleId.localeCompare(b.roleId))
+
+  return { rows, gaps }
+}
+
+/** Die Aufnahme-Spalte im Klartext. Kanonisches Deutsch — sie steht auf Papier. */
+export const recordText = (binding: RecordBinding): string => {
+  switch (binding.kind) {
+    case 'switcher-iso':
+      return `${binding.recorder} · ISO-Kanal ${binding.channel}`
+    case 'recorder':
+      return `${binding.recorder} · Eingang ${binding.input}`
+    case 'none':
+      return NO_RECORDER
+  }
+}
+
+/**
+ * Das Blatt.
+ *
+ * Die Praefix-Grundlage steht MIT auf dem Blatt. Ohne sie saehe ein „A" aus
+ * der Nummer genauso aus wie ein „A" aus dem Namen — und wer zwei Shows
+ * zusammenlegt, koennte nicht sehen, dass die eine Spalte eine Zusage ist und
+ * die andere eine Bereinigung.
+ */
+export const handoverManifestTable = (manifest: HandoverManifest): CsvTable => ({
+  headers: [
+    'Karten-Präfix',
+    'Grundlage',
+    'Rolle',
+    'Nummer',
+    'Gerät',
+    'Mischer',
+    'Mischer-Eingang',
+    'Aufzeichnung',
+  ],
+  rows: manifest.rows.map((r) => [
+    r.cardPrefix,
+    PREFIX_BASIS_LABEL[r.cardPrefixBasis],
+    r.roleName,
+    r.roleNumber ?? '',
+    r.equipmentName,
+    r.switcherName ?? NO_SWITCHER,
+    r.switcherInput ?? '',
+    recordText(r.record),
+  ]),
+})
+
+/** Dasselbe Blatt direkt aus dem Projekt — der Weg fuer Register und Export. */
+export const handoverManifestTableForProject = (
+  project: Pick<CablePlannerProject, 'equipment' | 'cables' | 'sourceIdentities'>,
+): CsvTable => handoverManifestTable(buildHandoverManifest(project))

--- a/src/renderer/lib/recording.ts
+++ b/src/renderer/lib/recording.ts
@@ -1,0 +1,88 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Zeichnet dieses Geraet auf — und in welcher Form? (Bedarf 62)
+//
+// ─── WARUM DAS KEIN `DeviceKind` IST ───────────────────────────────────────
+//
+// `deviceKind.ts` fuehrt eine ROLLE: Videohub, ATEM, Multiviewer, GreenGo.
+// Aufzeichnen ist keine Rolle, sondern eine FAEHIGKEIT — und die faellt nicht
+// mit der Rolle zusammen:
+//
+//   • Ein ATEM Mini Pro ISO ist Mischer UND Recorder.
+//   • Ein Atomos Shogun ist Monitor UND Recorder.
+//   • Ein HyperDeck ist nur Recorder.
+//
+// Ein einzelnes Enum koennte fuer die ersten beiden nur eines von beidem
+// sagen, und welches es sagt, entschiede der, der es zuerst eintraegt. Was
+// dabei verloren ginge, faellt niemandem auf: der Mischer bliebe ein Mischer
+// und die Aufzeichnung verschwaende aus dem Plan — genau die Spalte, die
+// Bedarf 62 verlangt.
+//
+// ─── DIE ZWEI FORMEN SIND VERSCHIEDENE AUSKUENFTE ──────────────────────────
+//
+//   `per-input`   Ein Kanal JE EINGANG. Ein ATEM ISO schreibt pro Eingang
+//                 eine Datei; die Kanalnummer IST die Eingangsnummer, und
+//                 damit steht sie schon im Kabelgraph.
+//   `per-device`  EINE Aufzeichnung dessen, was am Eingang anliegt
+//                 (HyperDeck, Ki Pro, Shogun). Welche Rolle darin landet,
+//                 sagt die Verkabelung — nicht das Geraet.
+//
+// Sie zusammenzuwerfen hiesse, fuer den HyperDeck eine Kanalnummer zu
+// erfinden, die es nicht gibt.
+//
+// ─── AUFLOESUNGS-REIHENFOLGE ───────────────────────────────────────────────
+//
+// Dieselbe wie in `deviceKind.ts`: (1) stabile Geraetetyp-ID → Datenblatt-
+// Tatsache aus dem Katalog; (2) Namens-Heuristik als Rueckfall fuer Geraete
+// OHNE ID (von Hand angelegt, Rentman-/GraphML-Import ohne Katalog-Treffer).
+// Die Heuristik schreibt nichts ins Modell — sie beantwortet eine Frage.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+import type { EquipmentItem } from '../types/equipment'
+import { resolveDeviceType } from './deviceTypeRegistry'
+
+export type RecordingCapability =
+  /** Ein Aufnahmekanal je Eingang — die Kanalnummer ist die Eingangsnummer. */
+  | 'per-input'
+  /** Eine Aufzeichnung dessen, was am Eingang anliegt. */
+  | 'per-device'
+
+export const RECORDING_LABEL: Readonly<Record<RecordingCapability, string>> = {
+  'per-input': 'Kanal je Eingang',
+  'per-device': 'eine Aufzeichnung',
+}
+
+/**
+ * Namen, die einen Recorder ohne Katalog-Eintrag erkennen lassen.
+ *
+ * Bewusst kurz und auf Modellfamilien beschraenkt, die nichts anderes sind:
+ * ein Regex auf „record" allein traefe „Recorder-Kabel" und „Aufnahmeraum".
+ * Der Rueckfall darf lieber schweigen als raten — ein erfundener
+ * Aufnahmekanal auf einem Uebergabeblatt schickt die Post an eine Datei, die
+ * es nicht gibt.
+ */
+const PER_DEVICE_NAME =
+  /hyperdeck|ki\s?pro|kipro|\bhelo\b|shogun|ninja\s?v|\bsumo\s?19\b|odyssey\s?7q|pix-?e|\bblackjack\b/i
+
+/** ATEM-Modelle mit ISO-Aufzeichnung tragen „ISO" im Modellnamen. */
+const PER_INPUT_NAME = /\biso\b/i
+
+/**
+ * Zeichnet dieses Geraet auf?
+ *
+ * `null` heisst „nach allem, was der Plan hergibt: nein". Das ist eine
+ * Auskunft und kein Schweigen — `postHandover` macht daraus die Zeile
+ * „kein Recorder im Plan" statt einer leeren Zelle.
+ */
+export const detectRecording = (device: EquipmentItem): RecordingCapability | null => {
+  const resolved = resolveDeviceType(device.deviceTypeId)
+  // Katalog-Geraet: das Datenblatt entscheidet, auch wenn es „nein" sagt.
+  // Ein Katalog-Treffer ohne `records` ist die AUSSAGE, dass dieses Modell
+  // nicht aufzeichnet — die Heuristik darf sie nicht ueberstimmen.
+  if (resolved) return resolved.records ?? null
+
+  const name = device.name
+  if (PER_INPUT_NAME.test(name) && /\batem\b/i.test(name)) return 'per-input'
+  if (PER_DEVICE_NAME.test(name)) return 'per-device'
+  return null
+}

--- a/tests/postHandover.test.ts
+++ b/tests/postHandover.test.ts
@@ -1,0 +1,394 @@
+import { describe, expect, it } from 'vitest'
+import {
+  NO_RECORDER,
+  NO_SWITCHER,
+  buildHandoverManifest,
+  cameraLetter,
+  cardPrefixFor,
+  handoverManifestTable,
+  recordText,
+  sanitisePrefix,
+} from '../src/renderer/lib/postHandover'
+import { detectRecording } from '../src/renderer/lib/recording'
+import { resolveDeviceType } from '../src/renderer/lib/deviceTypeRegistry'
+import { BLACKMAGIC_CATALOG } from '../src/renderer/lib/blackmagicCatalog'
+import { MONITOR_CATALOG } from '../src/renderer/lib/monitorCatalog'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+import type { Cable } from '../src/renderer/types/cable'
+import type { SourceIdentity } from '../src/renderer/types/sourceIdentity'
+import quelle from '../src/renderer/lib/postHandover.ts?raw'
+import registerQuelle from '../src/renderer/lib/documentRegistry.ts?raw'
+import packetQuelle from '../src/renderer/components/Export/PacketSection.tsx?raw'
+
+// ---------------------------------------------------------------------------
+// Die Uebergabe an die Post (Bedarf 62, P2).
+//
+//   > Card labelling and media reports are a manual discipline; CAMERA
+//   > IDENTITY IN POST ('B_Day1_003') HAS NO LINK TO THE PLANNED POSITION.
+//
+// Der teuerste Fehler waere hier eine erfundene Kanalnummer: ein HyperDeck
+// hat keine, und eine auf dem Blatt schickt die Post an eine Datei, die es
+// nicht gibt. Der groesste Teil dieser Tests haelt deshalb fest, WAS NICHT
+// behauptet wird.
+// ---------------------------------------------------------------------------
+
+const port = (id: string, name: string) =>
+  ({ id, name, type: 'video', connectorType: 'BNC' }) as never
+
+const geraet = (id: string, name: string, extra: Partial<EquipmentItem> = {}): EquipmentItem =>
+  ({
+    id,
+    name,
+    type: 'camera',
+    x: 0,
+    y: 0,
+    inputs: [],
+    outputs: [],
+    ...extra,
+  }) as unknown as EquipmentItem
+
+const kabel = (id: string, from: string, fromPort: string, to: string, toPort: string): Cable =>
+  ({
+    id,
+    fromEquipmentId: from,
+    fromPortId: fromPort,
+    toEquipmentId: to,
+    toPortId: toPort,
+  }) as unknown as Cable
+
+const rolle = (id: string, name: string, number?: number): SourceIdentity =>
+  ({ id, name, ...(number !== undefined ? { number } : {}) }) as SourceIdentity
+
+/** Kamera 1 → ATEM (kein ISO). Die Grundform, auf der die anderen aufbauen. */
+const aufbau = (mischerName = 'ATEM 4 M/E') => {
+  const cam = geraet('cam1', 'Kamera 1', {
+    sourceIdentityId: 'r1',
+    outputs: [port('cam1-out', 'SDI Out')],
+  } as never)
+  const atem = geraet('sw1', mischerName, {
+    type: 'switcher',
+    inputs: [port('sw1-in1', 'SDI In 1'), port('sw1-in2', 'SDI In 2')],
+  } as never)
+  return {
+    equipment: [cam, atem],
+    cables: [kabel('c1', 'cam1', 'cam1-out', 'sw1', 'sw1-in2')],
+    sourceIdentities: [rolle('r1', 'Kamera 1', 2)],
+  }
+}
+
+describe('Bedarf 62 — die Übergabe an die Post', () => {
+  // -- 1 --------------------------------------------------------------------
+  it('der Kamerabuchstabe kommt aus der Rolle und hoert bei Z auf', () => {
+    expect(cameraLetter(1)).toBe('A')
+    expect(cameraLetter(2)).toBe('B')
+    expect(cameraLetter(26)).toBe('Z')
+    // Jenseits von 26 gibt es KEINEN Buchstaben. „AA" waere eine Regel, die
+    // niemand vereinbart hat — und zwei Rollen koennten darunter denselben
+    // Namen bekommen.
+    expect(cameraLetter(27)).toBeNull()
+    expect(cameraLetter(0)).toBeNull()
+    expect(cameraLetter(-3)).toBeNull()
+    expect(cameraLetter(1.5)).toBeNull()
+    expect(cameraLetter(undefined)).toBeNull()
+  })
+
+  // -- 2 --------------------------------------------------------------------
+  it('ohne Nummer traegt das Praefix den bereinigten Namen — und sagt das', () => {
+    expect(cardPrefixFor({ name: 'Kamera 1', number: 3 })).toEqual({
+      prefix: 'C',
+      basis: 'number',
+    })
+    // Ohne Nummer und jenseits von Z ist die Grundlage eine ANDERE, und das
+    // steht in der Antwort: ein „A" aus der Nummer und ein „A" aus dem Namen
+    // saehen auf dem Blatt sonst gleich aus.
+    expect(cardPrefixFor({ name: 'Bühne links' })).toEqual({
+      prefix: 'Buhne_links',
+      basis: 'name',
+    })
+    expect(cardPrefixFor({ name: 'Kamera 1', number: 27 }).basis).toBe('name')
+
+    // Umlaute, Leerzeichen und Sonderzeichen ueberleben Karten-Ordner nicht.
+    expect(sanitisePrefix('Kamera 1')).toBe('Kamera_1')
+    expect(sanitisePrefix('Über/Kopf')).toBe('Uber_Kopf')
+    expect(sanitisePrefix('  Rand  ')).toBe('Rand')
+    // Bleibt nichts uebrig, wird nichts erfunden.
+    expect(sanitisePrefix('///')).toBe('')
+    expect(cardPrefixFor({ name: '///' }).prefix).toBe('ohne Praefix')
+  })
+
+  // -- 3 --------------------------------------------------------------------
+  it('das Datenblatt entscheidet, ob ein Geraet aufzeichnet', () => {
+    const hyperdeck = BLACKMAGIC_CATALOG.find((e) =>
+      e.template.name.includes('Hyperdeck'),
+    )!
+    const isoMischer = BLACKMAGIC_CATALOG.find((e) =>
+      e.template.name.includes('Mini Pro ISO'),
+    )!
+    expect(resolveDeviceType(hyperdeck.deviceTypeId)?.records).toBe('per-device')
+    expect(resolveDeviceType(isoMischer.deviceTypeId)?.records).toBe('per-input')
+    // Ein Shogun ist Monitor UND Recorder — genau der Fall, den ein einzelnes
+    // `kind` nicht sagen koennte.
+    const shogun = MONITOR_CATALOG.find((e) => e.template.name.includes('Shogun Ultra'))!
+    expect(resolveDeviceType(shogun.deviceTypeId)?.records).toBe('per-device')
+
+    expect(
+      detectRecording(geraet('x', 'egal', { deviceTypeId: hyperdeck.deviceTypeId } as never)),
+    ).toBe('per-device')
+    expect(
+      detectRecording(geraet('x', 'egal', { deviceTypeId: isoMischer.deviceTypeId } as never)),
+    ).toBe('per-input')
+  })
+
+  it('ein Katalog-Treffer ohne Aufnahme ist eine AUSSAGE, kein Schweigen', () => {
+    // Ein Katalog-Geraet, das nicht aufzeichnet, bleibt auch dann „nein",
+    // wenn sein Name die Heuristik ansprechen wuerde. Sonst ueberstimmte ein
+    // Regex das Datenblatt — und zwar unbemerkt.
+    const atemOhneIso = BLACKMAGIC_CATALOG.find(
+      (e) => e.template.name === 'Blackmagic ATEM Mini Pro',
+    )
+    if (atemOhneIso) {
+      expect(resolveDeviceType(atemOhneIso.deviceTypeId)?.records).toBeUndefined()
+      expect(
+        detectRecording(geraet('x', 'ATEM Mini Pro ISO', {
+          deviceTypeId: atemOhneIso.deviceTypeId,
+        } as never)),
+      ).toBeNull()
+    }
+    // Ohne Katalog-Zuordnung greift die Heuristik.
+    expect(detectRecording(geraet('x', 'HyperDeck Studio 4K'))).toBe('per-device')
+    expect(detectRecording(geraet('x', 'ATEM Mini Extreme ISO'))).toBe('per-input')
+    // „ISO" ALLEIN macht keinen ISO-Mischer: es steht auf Objektiven, in
+    // Empfindlichkeitsangaben und in Dateinamen. Ohne die ATEM-Bedingung
+    // bekaeme ein „ISO 800 Monitor" eine Kanalnummer je Eingang.
+    expect(detectRecording(geraet('x', 'Monitor ISO 800'))).toBeNull()
+    expect(detectRecording(geraet('x', 'ISO-Konverter'))).toBeNull()
+    // Und sie schweigt lieber, als zu raten.
+    expect(detectRecording(geraet('x', 'Aufnahmeraum-Panel'))).toBeNull()
+    expect(detectRecording(geraet('x', 'Sony FX9'))).toBeNull()
+  })
+
+  // -- 4 --------------------------------------------------------------------
+  it('ohne Recorder im Plan steht das auf dem Blatt', () => {
+    const m = buildHandoverManifest(aufbau())
+    expect(m.rows).toHaveLength(1)
+    expect(m.rows[0].cardPrefix).toBe('B')
+    expect(m.rows[0].switcherName).toBe('ATEM 4 M/E')
+    expect(m.rows[0].switcherInput).toBe(2)
+    expect(m.rows[0].record).toEqual({ kind: 'none' })
+    // Gegen den TEXT und nicht gegen die Konstante: `toBe(NO_RECORDER)` bliebe
+    // auch dann gruen, wenn jemand die Konstante auf '' setzt — und genau das
+    // ist der Fall, gegen den dieses Blatt geschrieben ist. Nachgemessen: die
+    // Gegenprobe „kein Recorder wird zur leeren Zelle" ueberlebte so.
+    expect(recordText(m.rows[0].record)).toBe('kein Recorder im Plan')
+    expect(NO_RECORDER).toBe('kein Recorder im Plan')
+  })
+
+  // -- 5 --------------------------------------------------------------------
+  it('ein ISO-Mischer beantwortet die Frage mit der Eingangsnummer', () => {
+    const plan = aufbau('ATEM Mini Extreme ISO')
+    const m = buildHandoverManifest(plan)
+    expect(m.rows[0].record).toEqual({
+      kind: 'switcher-iso',
+      recorder: 'ATEM Mini Extreme ISO',
+      channel: 2,
+    })
+    // Es ist DIESELBE Zahl wie der Mischer-Eingang — keine zweite Wahrheit
+    // ueber dieselbe Sache.
+    expect(m.rows[0].switcherInput).toBe(2)
+    expect(recordText(m.rows[0].record)).toContain('ISO-Kanal 2')
+  })
+
+  // -- 6 --------------------------------------------------------------------
+  it('ein eigener Recorder nennt Geraet und Eingang, aber keinen Kanal', () => {
+    const plan = aufbau()
+    const rec = geraet('rec1', 'HyperDeck Studio HD Plus', {
+      type: 'recorder',
+      inputs: [port('rec1-in1', 'SDI In 1'), port('rec1-in2', 'SDI In 2')],
+    } as never)
+    plan.equipment.push(rec)
+    plan.cables.push(kabel('c2', 'cam1', 'cam1-out', 'rec1', 'rec1-in1'))
+    const m = buildHandoverManifest(plan)
+    expect(m.rows[0].record).toEqual({
+      kind: 'recorder',
+      recorder: 'HyperDeck Studio HD Plus',
+      input: 1,
+    })
+    // Kein „Kanal": den gibt es bei einem HyperDeck nicht.
+    expect(recordText(m.rows[0].record)).toBe('HyperDeck Studio HD Plus · Eingang 1')
+    expect(recordText(m.rows[0].record)).not.toContain('Kanal')
+  })
+
+  it('der Referenz-Eingang eines Recorders ist kein Aufnahmeweg', () => {
+    // Ohne diese Regel zaehlte der Genlock-Eingang als Aufnahmeweg, und auf
+    // dem Blatt staende der Sync-Generator als das, was aufgezeichnet wird.
+    // Geprueft wird der PORT-Name — `isReferencePort`, dieselbe Liste wie in
+    // der Label-Ableitung.
+    const plan = aufbau()
+    const sync = geraet('sync', 'Sync-Generator', {
+      outputs: [port('sync-out', 'Ref Out')],
+    } as never)
+    const rec = geraet('rec1', 'HyperDeck Studio HD Plus', {
+      inputs: [port('rec1-ref', 'Ref In'), port('rec1-in1', 'SDI In 1')],
+    } as never)
+    plan.equipment.push(sync, rec)
+    plan.cables.push(kabel('c2', 'sync', 'sync-out', 'rec1', 'rec1-ref'))
+    // Nur die Referenz haengt dran: fuer die Kamera gibt es keinen Recorder.
+    expect(buildHandoverManifest(plan).rows[0].record).toEqual({ kind: 'none' })
+
+    // Und der Sync-Generator taucht auch dann nirgends als Motiv auf, wenn er
+    // eine Rolle traegt.
+    plan.sourceIdentities.push(rolle('r9', 'Sync', 9))
+    plan.equipment[plan.equipment.length - 2] = geraet('sync', 'Sync-Generator', {
+      sourceIdentityId: 'r9',
+      outputs: [port('sync-out', 'Ref Out')],
+    } as never)
+    const zeile = buildHandoverManifest(plan).rows.find((r) => r.roleId === 'r9')!
+    expect(zeile.record).toEqual({ kind: 'none' })
+  })
+
+  it('bei zwei Recordern gewinnt der kleinste Eingang, nicht der erstbeste', () => {
+    // `recorderInputs` folgt der Reihenfolge des `equipment`-Arrays, und die
+    // ist eine Bearbeitungs-Reihenfolge. Ohne feste Ordnung traege dasselbe
+    // Projekt nach einem Umsortieren einen anderen Eingang auf dem Blatt.
+    const plan = aufbau()
+    const rec2 = geraet('rec2', 'HyperDeck B', {
+      inputs: [port('rec2-in1', 'SDI In 1'), port('rec2-in2', 'SDI In 2')],
+    } as never)
+    const rec1 = geraet('rec1', 'HyperDeck A', {
+      inputs: [port('rec1-in1', 'SDI In 1'), port('rec1-in2', 'SDI In 2')],
+    } as never)
+    // Die Kamera liegt auf Eingang 2 des zuerst angelegten und auf Eingang 1
+    // des zweiten — der erstbeste Treffer waere die 2.
+    plan.equipment.push(rec2, rec1)
+    plan.cables.push(
+      kabel('c2', 'cam1', 'cam1-out', 'rec2', 'rec2-in2'),
+      kabel('c3', 'cam1', 'cam1-out', 'rec1', 'rec1-in1'),
+    )
+    expect(buildHandoverManifest(plan).rows[0].record).toEqual({
+      kind: 'recorder',
+      recorder: 'HyperDeck A',
+      input: 1,
+    })
+    // Und umsortiert kommt dasselbe heraus.
+    const gedreht = buildHandoverManifest({ ...plan, equipment: [...plan.equipment].reverse() })
+    expect(gedreht.rows[0].record).toEqual({
+      kind: 'recorder',
+      recorder: 'HyperDeck A',
+      input: 1,
+    })
+  })
+
+  it('der ISO-Mischer gewinnt vor dem eigenen Recorder', () => {
+    // Beides zugleich ist der Normalfall in kleinen Aufbauten. Die Reihenfolge
+    // ist Absicht: der Mischer-Eingang steht ohnehin auf dem Blatt, und die
+    // ISO-Datei traegt genau diese Nummer.
+    const plan = aufbau('ATEM Mini Pro ISO')
+    const rec = geraet('rec1', 'HyperDeck Studio HD Plus', {
+      inputs: [port('rec1-in1', 'SDI In 1')],
+    } as never)
+    plan.equipment.push(rec)
+    plan.cables.push(kabel('c2', 'cam1', 'cam1-out', 'rec1', 'rec1-in1'))
+    expect(buildHandoverManifest(plan).rows[0].record.kind).toBe('switcher-iso')
+  })
+
+  // -- 7 --------------------------------------------------------------------
+  it('eine Rolle ohne Geraet ist eine gerechnete Luecke, keine Zeile', () => {
+    const plan = aufbau()
+    plan.sourceIdentities.push(rolle('r2', 'Kamera 2', 3))
+    const m = buildHandoverManifest(plan)
+    expect(m.rows.map((r) => r.roleId)).toEqual(['r1'])
+    expect(m.gaps).toHaveLength(1)
+    expect(m.gaps[0].roleId).toBe('r2')
+    expect(m.gaps[0].reason).toContain('kein Gerät')
+
+    // Wer das Geraet zuordnet, sieht die Luecke von selbst verschwinden.
+    plan.equipment.push(
+      geraet('cam2', 'Kamera 2', {
+        sourceIdentityId: 'r2',
+        outputs: [port('cam2-out', 'SDI Out')],
+      } as never),
+    )
+    const danach = buildHandoverManifest(plan)
+    expect(danach.gaps).toHaveLength(0)
+    expect(danach.rows).toHaveLength(2)
+  })
+
+  // -- 8 --------------------------------------------------------------------
+  it('Haupt und Backup sind ZWEI Aufzeichnungen und damit zwei Zeilen', () => {
+    const plan = aufbau()
+    plan.equipment.push(
+      geraet('cam1b', 'Kamera 1 Backup', {
+        sourceIdentityId: 'r1',
+        outputs: [port('cam1b-out', 'SDI Out')],
+      } as never),
+    )
+    plan.cables.push(kabel('c2', 'cam1b', 'cam1b-out', 'sw1', 'sw1-in1'))
+    const m = buildHandoverManifest(plan)
+    // Beide tragen dasselbe Praefix (es ist dieselbe Rolle), aber eigene
+    // Zeilen — die zweite ist die, nach der hinterher niemand sucht.
+    expect(m.rows).toHaveLength(2)
+    expect(m.rows.map((r) => r.cardPrefix)).toEqual(['B', 'B'])
+    expect(m.rows.map((r) => r.switcherInput)).toEqual([2, 1])
+  })
+
+  // -- 9 --------------------------------------------------------------------
+  it('derselbe Plan ergibt zweimal dasselbe Blatt', () => {
+    const plan = aufbau()
+    plan.sourceIdentities.push(rolle('r0', 'Reserve'))
+    plan.equipment.push(
+      geraet('cam0', 'Reserve-Kamera', { sourceIdentityId: 'r0' } as never),
+    )
+    const a = buildHandoverManifest(plan)
+    // Umgestellte Eingabe, gleiches Ergebnis: die Reihenfolge im
+    // `equipment`-Array ist eine Bearbeitungs-Reihenfolge und darf das Blatt
+    // nicht bestimmen.
+    const b = buildHandoverManifest({
+      ...plan,
+      equipment: [...plan.equipment].reverse(),
+      sourceIdentities: [...plan.sourceIdentities].reverse(),
+    })
+    expect(b.rows).toEqual(a.rows)
+    // Nummerierte Rollen zuerst, dann die ohne Nummer.
+    expect(a.rows.map((r) => r.roleName)).toEqual(['Kamera 1', 'Reserve'])
+  })
+
+  // -- 10 -------------------------------------------------------------------
+  it('das Blatt traegt die Grundlage des Praefixes mit', () => {
+    const plan = aufbau()
+    plan.sourceIdentities.push(rolle('r0', 'Reserve'))
+    plan.equipment.push(geraet('cam0', 'Reserve-Kamera', { sourceIdentityId: 'r0' } as never))
+    const table = handoverManifestTable(buildHandoverManifest(plan))
+    expect(table.headers[0]).toBe('Karten-Präfix')
+    expect(table.headers[1]).toBe('Grundlage')
+    expect(table.rows[0][1]).toBe('Rollen-Nummer')
+    expect(table.rows[1][1]).toBe('Rollen-Name')
+    // Und die Rolle ohne Mischer sagt das, statt eine leere Zelle zu zeigen.
+    expect(table.rows[1][5]).toBe('kein Mischer-Eingang im Plan')
+    expect(table.rows[1][7]).toBe('kein Recorder im Plan')
+    expect(NO_SWITCHER).toBe('kein Mischer-Eingang im Plan')
+  })
+
+  // -- 11 -------------------------------------------------------------------
+  it('der Weg ist verdrahtet', () => {
+    // Das Blatt hat einen Stand (ADR-004) und liegt im Papierstapel.
+    expect(registerQuelle).toMatch(/'post-uebergabe': ofTable\(handoverManifestTableForProject\)/)
+    expect(registerQuelle).toMatch(/'post-uebergabe': 'Übergabe an die Post'/)
+    // Der Import allein ist keine Verdrahtung — gepruft wird der EINTRAG in
+    // der Kandidaten-Liste. Nachgemessen: gegen den blossen Namen blieb die
+    // Gegenprobe „das Blatt fehlt im Papierstapel" gruen.
+    expect(packetQuelle).toMatch(
+      /\{ id: 'post-uebergabe', label: '[^']+', table: handoverManifestTableForProject \}/,
+    )
+    // Die Mischer-Nummer kommt aus der Engstelle und nicht aus einem eigenen
+    // `find()` — genau daran ist die Tally-Karte einmal gescheitert.
+    expect(quelle).toMatch(/switcherLinkFor\(sources, \[device\.id\]\)/)
+    expect(quelle).not.toMatch(/sources\.find\(/)
+    // Der Recorder-Weg laeuft NICHT ueber `sources`: das fuehrt nur Mischer-
+    // und Router-Senken, ein HyperDeck steht dort in keiner Zeile. Gemessen,
+    // nicht vermutet — die erste Fassung las `sources` und fand nie einen.
+    expect(quelle).toMatch(/resolveSignalSource\(port\.id, ctx\)/)
+    expect(quelle).toMatch(/isReferencePort\(voll\)/)
+    // Rein: keine Uhr, kein Store, kein IO.
+    expect(quelle).not.toMatch(/\bDate\.now\b|new Date\(|useProjectStore|window\./)
+  })
+})


### PR DESCRIPTION
## Der Befund

> Card labelling and media reports are a manual discipline; **camera identity in post (`B_Day1_003`) has no link to the planned position**, and renaming originals breaks metadata.

Die Bedarfs-Datenbank sagt auch, was zu bauen ist: ein Manifest je Show, das Position → Mischer-Eingang → ISO-/Aufnahmekanal → Kartenbeschriftung abbildet, druck- und exportierbar, „so post can reconcile without asking the crew".

## Aufzeichnen ist eine Fähigkeit und keine Rolle

`lib/recording.ts` ist neu, weil `DeviceKind` die Frage nicht beantworten kann:

| Gerät | Rolle | zeichnet auf |
| --- | --- | --- |
| ATEM Mini Pro ISO | Mischer | ja, je Eingang |
| Atomos Shogun | Monitor | ja, eine Aufzeichnung |
| HyperDeck | — | ja, eine Aufzeichnung |

Ein einzelnes Enum sagte für die ersten beiden nur eines von beidem — und welches, entschiede der, der es zuerst einträgt. Was dabei verschwindet, ist genau die Spalte, um die es hier geht. `records` steht deshalb als **eigenes Feld neben `kind`**.

Die zwei Formen sind verschiedene Auskünfte und bleiben getrennt:

- **`per-input`** — ein Kanal je Eingang. Die Kanalnummer **ist** die Eingangsnummer und steht damit schon im Kabelgraph; sie ein zweites Mal zu rechnen wäre die zweite Wahrheit, gegen die ADR-001 geschrieben ist.
- **`per-device`** — eine Aufzeichnung dessen, was am Eingang anliegt. Eine Kanalnummer gibt es hier **nicht**, und eine zu erfinden schickte die Post an eine Datei, die es nicht gibt.

Aufgelöst wird wie in `deviceKind.ts`: Gerätetyp-ID autoritativ, Namens-Heuristik nur als Rückfall. Ein Katalog-Treffer **ohne** `records` ist die Datenblatt-Aussage „zeichnet nicht auf" und wird von der Heuristik nicht mehr überstimmt — sonst gäbe ein Regex einem Modell eine Fähigkeit, die sein Datenblatt ihm abspricht.

## Was der Plan nicht beantwortet, sagt er

- Kein Recorder im Plan → *„kein Recorder im Plan"* statt einer leeren Zelle. Kein Mischer-Eingang → ebenso.
- Eine Rolle ohne Gerät bekommt keine Zeile, sondern steht in `gaps` — **gerechnet**: wer das Gerät zuordnet, sieht die Lücke von selbst verschwinden.
- Haupt und Backup sind **zwei** Aufzeichnungen und damit zwei Zeilen. Sie zusammenzuziehen ließe die zweite verschwinden, und das ist die, nach der hinterher niemand sucht.

## Das Karten-Präfix ist ein Präfix und kein Dateiname

Der Beleg nennt `B_Day1_003` — Kameraletter, Drehtag, Kartennummer. Von den dreien gehört dem Plan genau **eines**: der Buchstabe, denn er ist die Rolle. Drehtag und Kartennummer entstehen am Set.

Das Blatt liefert deshalb nur das Präfix und nennt seine **Grundlage** mit: ein „A" aus der Nummer und ein „A" aus dem Namen sähen sonst gleich aus. Jenseits von Z gibt es keinen Buchstaben — „AA" wäre eine Regel, die niemand vereinbart hat, und zwei Rollen könnten darunter denselben Namen bekommen.

## Ein Fund beim Bauen

`sources` aus `deriveLabels` führt **nur** Mischer- und Router-Senken (`kind !== 'atem' && kind !== 'videohub'` fällt dort heraus). Ein HyperDeck steht dort in keiner Zeile — die erste Fassung dieser Datei las `sources` und fand deshalb **nie** einen Recorder; gemessen, nicht vermutet.

Die Recorder-Eingänge werden jetzt mit `resolveSignalSource` aufgelöst, also mit derselben Rückwärtssuche wie die Label-Ableitung, und `isReferencePort` hält Genlock-, Timecode- und Rückweg-Eingänge heraus: ohne diese Zeile stünde der Sync-Generator als das auf dem Blatt, was aufgezeichnet wird.

## Verdrahtet

Das Blatt hat einen Stand (`DOCUMENT_STANDS['post-uebergabe']` — reproduzierbar aus `sourceIdentities`/`equipment`/`cables`, keine Nutzer-Einstellung, keine Sprache, keine Uhr) und liegt im Papierstapel, weil es mit den Karten mitgeht. Die vier neuen Spalten stehen im Daten-Lexikon; der Guard hat sie eingefordert.

## Aus den Gegenproben mitgenommen

Fünf Zusicherungen waren wertlos und sind ersetzt:

- zwei prüften den Zellentext gegen die **Konstante** — `toBe(NO_RECORDER)` bliebe auch gegen `NO_RECORDER = ''` grün, also genau gegen den Fall, für den das Blatt geschrieben ist;
- eine ließ den erstbesten statt des kleinsten Recorder-Eingangs durch (dasselbe Determinismus-Loch wie einst in der Tally-Karte);
- eine hielt jedes „ISO" im Namen für einen ISO-Mischer (ein „Monitor ISO 800" hätte Kanalnummern bekommen);
- eine prüfte die Verdrahtung gegen den bloßen **Import** statt gegen den Listen-Eintrag.

## Geprüft

**25 Gegenproben, jede rot:** Buchstabe über Z hinaus, Null als Buchstabe, verschwiegene Präfix-Grundlage, Umlaute unzerlegt, erfundenes Leer-Präfix, verschobener ISO-Kanal, jeder Mischer als ISO-Recorder, erfundene Kanalnummer für den eigenen Recorder, leere Zelle statt Auskunft (2×), Referenz-Eingang als Aufnahmeweg, jedes Gerät als Recorder, still verschwundene Rolle, Haupt+Backup zusammengezogen, Eingabe-Reihenfolge, erstbester Recorder-Treffer, fehlende Grundlage auf dem Blatt, Heuristik über Datenblatt, jedes „ISO", jedes Aufnahme-Wort, Register ohne Durchreichung, verlorene Katalog-Angaben (2×), Blatt ohne Stand, Blatt nicht im Stapel.

Volle Suite 2629 grün · 2 skipped · `tsc` auf app/main/preload sauber · Lint 0 Errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_