### PR TITLE
export: Gerätekonfiguration mit Herkunfts-Blatt (Bedarf 43)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -413,6 +413,32 @@ plain-text Routing-/Label-Blöcke. Smart-Routing erkennt Quellen anhand
 ihrer Namen (Fuzzy-Match mit AI-Provider-Fallback bei niedriger
 Score-Schwelle).
 
+### 6.5b · Gerätekonfigurationen tragen ihre Herkunft daneben (Bedarf 43)
+
+Jede Datei, die dieses Programm an ein **fremdes Gerät** ausgibt — Videohub
+(Routing und Beschriftungen), Green-GO `.gg5`, ATEM-Audio-XML, die Geräteliste
+für `tally-pi` — geht über `lib/deviceConfigExport.ts#exportDeviceConfig` und
+bekommt ein zweites File daneben: `<datei>.herkunft.txt` mit Projekt, Stand,
+Dokument-Stempel (ADR-004), App-Version und einer Prüfsumme über den Inhalt
+der Konfigurationsdatei.
+
+**Die Gerätedatei selbst wird nicht angefasst.** Ob Blackmagics Videohub Setup
+eine `#`-Zeile überliest, ob der Green-GO-Editor ein unbekanntes JSON-Feld
+durchlässt, ob der ATEM-Importer ein zusätzliches Kommentar akzeptiert — das
+steht ohne die Hersteller-Spezifikation nicht fest, und die liegt hier nicht
+vor. Dass *unser* Parser (`parseVideohubLabelsTxt`) `#`-Zeilen überspringt,
+sagt nichts über das Gerät: die Datei geht dorthin, nicht zu uns zurück. Eine
+Konfiguration, die das Pult beim Laden zurückweist, ist beim Load-in schlimmer
+als eine ohne Herkunft.
+
+Das Blatt geht **zuerst** raus, die Konfiguration danach: bricht der Browser
+die zweite Ausgabe ab, fehlt das Blatt und nicht die Datei, die die Show
+braucht.
+
+`deviceConfigProvenance.ts` ist rein (keine Uhr, kein Store);
+`deviceConfigExport.ts` setzt Stempel, Uhr und Version zusammen und ist die
+einzige unreine Zeile des Wegs.
+
 ### 6.6 · Mobile-Share
 
 `mobileShareServer.ts` startet einen `node:http`-Server auf ephemerem Port
@@ -603,5 +629,6 @@ standalone, keine Edits. Wird über `.github/workflows/pages.yml`
 | Neuer Settings-Tab | `src/renderer/components/Settings/tabs/` + Eintrag in `SettingsDialog.tsx` Sidebar |
 | Neues Geheimnis (Token, Key) | `credentialsService.ts` (`keytar`) + eigener IPC-Namensraum — **niemals** ein Feld im Projekt |
 | Neues gestempeltes Dokument | Tabelle in `lib/`, Eintrag in `DOCUMENT_STANDS` (`documentRegistry.ts`), Export via `csvFromTable(..., stamp, docId)` |
+| Neue **Gerätekonfiguration** (Datei, die an ein fremdes Gerät geht) | `lib/deviceConfigExport.ts#exportDeviceConfig` — **nicht** `downloadBlob` direkt: sonst geht die Datei ohne Herkunfts-Blatt raus (Bedarf 43) |
 | Alle Adressen eines Geräts lesen | `lib/networkInterfaces.ts#deviceInterfaces` — **nicht** `item.ipAddress` (das ist nur Schnittstelle 0) |
 | CSV lesen | `lib/csvParse.ts#parseCsv` — die eine Stelle; ein zweiter Parser antwortet beim ersten Semikolon im Feld anders |

--- a/src/renderer/components/Atem/AtemAudioRouterDialog.tsx
+++ b/src/renderer/components/Atem/AtemAudioRouterDialog.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useUiStore } from '../../store/uiStore'
 import { useProjectStore } from '../../store/projectStore'
 import { useDraggablePosition } from '../../hooks/useDraggablePosition'
-import { downloadBlob } from '../../lib/downloadBlob'
+import { exportDeviceConfig } from '../../lib/deviceConfigExport'
 import { buildExportFilenameWithSuffix } from '../../lib/exportFilename'
 import { LIMITS } from '../../lib/layoutConstants'
 import { cablePlannerApi, hasDesktopBridge } from '../../lib/bridge'
@@ -225,7 +225,13 @@ export const AtemAudioRouterDialog = () => {
     setBusy(true)
     try {
       const xml = serializeAudioConfigXml(draft)
-      downloadBlob(
+      // BEDARF 43 — mit Herkunfts-Blatt daneben. Die Datei selbst bleibt
+      // unberuehrt: was ATEM Setup an zusaetzlichem XML durchlaesst, steht
+      // hier nicht fest, und eine zurueckgewiesene Datei ist beim Load-in
+      // schlimmer als eine ohne Herkunft.
+      exportDeviceConfig(
+        equipment.name || 'ATEM',
+        'Audio-Zuordnung',
         // v7.9.116 — Einheitlicher Stempel.
         buildExportFilenameWithSuffix(equipment.name, 'AudioConfig', 'xml'),
         xml,

--- a/src/renderer/components/Export/ExportDialog.tsx
+++ b/src/renderer/components/Export/ExportDialog.tsx
@@ -41,6 +41,7 @@ import {
 import { printPdfBlob } from '../../lib/printPdfBlob'
 import { sanitizeForPdf } from '../../lib/sanitizeForPdf'
 import { downloadBlob } from '../../lib/downloadBlob'
+import { exportDeviceConfig } from '../../lib/deviceConfigExport'
 import { buildTallyMap, tallyMapCsv, toTallyPiDevices } from '../../lib/tallyMap'
 import { TallyPreShowPanel } from '../Tally/TallyPreShowPanel'
 import { toCsv } from '../../lib/csv'
@@ -1388,7 +1389,10 @@ const TallySection = () => {
     )
   }
   const downloadTallyPi = () => {
-    downloadBlob(
+    // BEDARF 43 — die Geraetedatei fuer den Pi geht mit Herkunfts-Blatt raus.
+    exportDeviceConfig(
+      'tally-pi',
+      'Geräteliste für die Tally-Karte',
       buildExportFilenameWithSuffix(project.metadata?.name, 'tally-devices', 'json'),
       JSON.stringify({ devices: toTallyPiDevices(map) }, null, 2),
       'application/json',

--- a/src/renderer/components/Export/GreenGoExportDialog.tsx
+++ b/src/renderer/components/Export/GreenGoExportDialog.tsx
@@ -24,6 +24,7 @@ import {
   parseIntercomMatrixXlsx,
 } from '../../lib/intercomMatrixXlsx'
 import { downloadBlob } from '../../lib/downloadBlob'
+import { exportDeviceConfig } from '../../lib/deviceConfigExport'
 import { buildExportFilenameWithSuffix } from '../../lib/exportFilename'
 import { useTranslation, format } from '../../lib/i18n'
 
@@ -276,7 +277,16 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
     if (exportBlocked) return
     updateGreenGoConfig(config)
     // v7.9.116 — Einheitlicher Stempel, gg5-Endung beibehalten.
-    downloadFile(buildExportFilenameWithSuffix(config.systemName || 'GreenGo', 'config', 'gg5'), buildGg5File(config))
+    // BEDARF 43 — mit Herkunfts-Blatt. Die .gg5 traegt die Version des
+    // HERSTELLER-Formats (`fileCreatedVersion`), aber nichts ueber den Plan,
+    // aus dem sie stammt.
+    exportDeviceConfig(
+      'Green-GO',
+      'Intercom-Konfiguration',
+      buildExportFilenameWithSuffix(config.systemName || 'GreenGo', 'config', 'gg5'),
+      buildGg5File(config),
+      'application/json;charset=utf-8',
+    )
   }
 
   // ── Herstellerneutraler Austausch (B-8) ───────────────────────────────────

--- a/src/renderer/components/Export/VideohubExportDialog.tsx
+++ b/src/renderer/components/Export/VideohubExportDialog.tsx
@@ -12,6 +12,7 @@ import type { Port, VideohubSalvo } from '../../types/equipment'
 import { useTranslation, format as fmt } from '../../lib/i18n'
 import { videohubPresetForDevice } from '../../lib/deviceKind'
 import { downloadBlob } from '../../lib/downloadBlob'
+import { exportDeviceConfig } from '../../lib/deviceConfigExport'
 import { buildExportFilenameWithSuffix } from '../../lib/exportFilename'
 import { buildVideohubControlLabelsPdf } from '../../lib/exportVideohubLabels'
 import {
@@ -84,9 +85,6 @@ const buildDefaultRouting = (totalIn: number, totalOut: number): Record<number, 
   for (let i = 0; i < totalOut; i++) r[i] = i < totalIn ? i : 0
   return r
 }
-
-const downloadTextFile = (filename: string, content: string) =>
-  downloadBlob(filename, content, 'text/plain;charset=utf-8')
 
 /**
  * BEDARF 121 — der Umbau-Zettel.
@@ -766,7 +764,16 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
       `${preset.key}_${baseSuffix}`,
       'txt',
     )
-    downloadTextFile(fileName, preview)
+    // BEDARF 43 — die Datei geht mit einem Herkunfts-Blatt daneben raus.
+    // Ohne es liegen auf dem Rechner des Freelancers fuenf aehnlich benannte
+    // Dateien, und welche zu welcher Show gehoert, weiss niemand mehr.
+    exportDeviceConfig(
+      device.name || 'Blackmagic Videohub',
+      format === 'labels' ? 'Anschluss-Beschriftungen' : 'Kreuzschienen-Routing',
+      fileName,
+      preview,
+      'text/plain;charset=utf-8',
+    )
   }
 
   // #502 — Druckbare Beschriftungs-Labels (Smart-Control-Raster) als PDF,

--- a/src/renderer/lib/deviceConfigExport.ts
+++ b/src/renderer/lib/deviceConfigExport.ts
@@ -1,0 +1,48 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Bedarf 43 — die eine Stelle, an der eine Gerätekonfiguration diesen Planer
+// verlässt.
+//
+// `deviceConfigProvenance` ist rein: es kennt weder Store noch Uhr noch
+// App-Version. Diese Datei setzt beides zusammen und ist damit die einzige
+// unreine Zeile des Wegs. Getrennt, damit das Blatt selbst prüfbar bleibt —
+// derselbe Ursprung und derselbe Inhalt ergeben zweimal denselben Text, und
+// genau das lässt sich nur an einer Funktion ohne Uhr festhalten.
+//
+// Der Zustand kommt über `getState()` und nicht über einen Selektor: das hier
+// läuft in einem Klick-Handler, nicht im Rendern. Ein Abonnement auf das ganze
+// Projekt ließe jeden Dialog bei jeder Änderung neu zeichnen, ohne dass er
+// etwas davon anzeigt.
+// ───────────────────────────────────────────────────────────────────────────
+import { useProjectStore } from '../store/projectStore'
+import { APP_VERSION } from './appInfo'
+import { stampForPlan } from './documentStamp'
+import { downloadDeviceConfig } from './deviceConfigProvenance'
+
+/**
+ * Eine Gerätekonfiguration ausgeben — samt Herkunfts-Blatt.
+ *
+ * `device` und `what` stehen im Klartext auf dem Blatt: „Blackmagic Videohub"
+ * und „Anschluss-Beschriftungen". Beides ist für einen Menschen gedacht, der
+ * die Datei in einem halben Jahr im Download-Ordner findet, und nicht für eine
+ * Auswertung — deshalb Text und keine Kennung.
+ */
+export const exportDeviceConfig = (
+  device: string,
+  what: string,
+  filename: string,
+  content: string,
+  mimeType: string,
+): void => {
+  const project = useProjectStore.getState().project
+  downloadDeviceConfig(
+    {
+      device,
+      what,
+      filename,
+      stamp: stampForPlan(project, new Date()),
+      app: `Cable Planner ${APP_VERSION}`,
+    },
+    content,
+    mimeType,
+  )
+}

--- a/src/renderer/lib/deviceConfigProvenance.ts
+++ b/src/renderer/lib/deviceConfigProvenance.ts
@@ -1,0 +1,177 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Bedarf 43 (P2) — eine Gerätekonfiguration, die sagt, woher sie kommt.
+//
+// ─── DER BEFUND ────────────────────────────────────────────────────────────
+//
+//   > The config the freelancer carries between clients BREAKS ON IMPORT, and
+//   > the rebuild happens during load-in in front of the client.
+//
+// Drei unabhängige Belege 2021–2024, alle dieselbe Sorte Schaden:
+// `bitfocus/companion#1603` — beim Import verrutschten Zeilen, und der
+// Meldende hatte den älteren Installer nicht mehr: „I would be doomed now".
+// Dazu: „Every month or so I lose the configuration and have to reimport it."
+//
+// Die Bedarfs-Datenbank nennt die Maßnahme:
+//
+//   > The suite's own device exports (Videohub routing and labels, ATEM
+//   > multiviewer XML, Green-GO config) are the same artefact class. VERSION
+//   > THEM, diff them against the machine, and never silently replace.
+//
+// ─── WAS ES SCHON GAB UND WAS FEHLTE ───────────────────────────────────────
+//
+// Zwei der drei Teile sind gebaut. „Never silently replace" ist Initiative 10
+// (Confirmed-State-Disziplin in `VideohubExportDialog`, `AtemAudioRouterDialog`
+// und `AtemMvConfigDialog`), und „diff them against the machine" leisten
+// `atemLiveCompare` und der Status-Abgleich der Videohub-Ansicht.
+//
+// „VERSION THEM" fehlte. Nachgesehen 2026-09-07: die Green-GO-Datei schreibt
+// `fileCreatedVersion: '5.0.6-6684'` — die Version des HERSTELLER-FORMATS —,
+// die Videohub-Labels-Datei schreibt gar nichts, und das ATEM-Audio-XML
+// ebenso wenig. Keine der drei sagt, aus welchem PLAN und aus welchem STAND
+// sie stammt. Auf dem Laptop des Freelancers liegen danach fünf Dateien mit
+// ähnlichen Namen, und welche zu welcher Show gehört, weiß niemand mehr.
+//
+// ─── WARUM DIE ANGABE NEBEN DER DATEI STEHT UND NICHT IN IHR ───────────────
+//
+// Das ist die eigentliche Entscheidung dieses Moduls, und sie geht gegen die
+// bequeme Lösung.
+//
+// In die Datei zu schreiben hieße, ein fremdes Format zu erweitern. Ob
+// Blackmagics Videohub Setup eine `#`-Zeile überliest, ob der Green-GO-Editor
+// ein unbekanntes JSON-Feld durchlässt, ob der ATEM-Importer ein zusätzliches
+// XML-Kommentar akzeptiert — das ist ohne die Hersteller-Spezifikation NICHT
+// zu wissen, und die liegt hier nicht vor. Dass UNSER Parser
+// (`parseVideohubLabelsTxt`) `#`-Zeilen überspringt, sagt nichts über das
+// Gerät: die Datei geht dorthin, nicht zu uns zurück.
+//
+// Eine Konfigurationsdatei, die das Pult beim Laden zurückweist, ist beim
+// Load-in schlimmer als eine ohne Herkunft — genau die Situation, die der
+// Beleg beschreibt. Also wird die Gerätedatei NICHT ANGEFASST, und die
+// Herkunft geht als eigenes Blatt daneben.
+//
+// Und die Reihenfolge ist Absicht: das Blatt geht ZUERST raus, die Konfigu-
+// ration danach. Bricht der Browser die zweite Ausgabe ab, fehlt das Blatt —
+// nicht die Datei, die die Show braucht.
+//
+// ─── DIE PRÜFSUMME IST ZUM VERGLEICHEN DA ──────────────────────────────────
+//
+// Sie wird über den Inhalt der Konfigurationsdatei gerechnet, mit derselben
+// Ableitung wie der Dokument-Stempel (ADR-004). Ihr Sinn ist NICHT, dass
+// jemand sie nachrechnet — dafür gibt es hier kein Werkzeug, und eine Zahl,
+// zu der die Probe fehlt, wäre eine Behauptung. Ihr Sinn ist der VERGLEICH:
+// zwei Blätter mit verschiedenen Prüfsummen gehören zu zwei verschiedenen
+// Dateien, und das ist am Telefon in fünf Sekunden geklärt. Dieselbe
+// Begründung wie bei den acht Hex-Zeichen des Stempels.
+//
+// REIN: keine Uhr (der Zeitpunkt kommt herein), kein Store. Das Herunterladen
+// ist der einzige Seiteneffekt und steht am Ende.
+// ───────────────────────────────────────────────────────────────────────────
+import { downloadBlob } from './downloadBlob'
+import { fingerprint, stampLine, type DocumentStamp } from './documentStamp'
+
+/** Woher eine Gerätekonfiguration stammt. */
+export interface DeviceConfigOrigin {
+  /** Welches Gerät die Datei bekommt, im Klartext („Blackmagic Videohub"). */
+  device: string
+  /** Was in ihr steht, im Klartext („Anschluss-Beschriftungen"). */
+  what: string
+  /** Der Dateiname der Konfigurationsdatei selbst. */
+  filename: string
+  /** Der Stempel des Plans (ADR-004) — Projekt, Revision, Abweichung. */
+  stamp: DocumentStamp
+  /** Version der Anwendung, die sie erzeugt hat. */
+  app: string
+}
+
+/** Die Endung des Herkunfts-Blattes. */
+export const PROVENANCE_SUFFIX = '.herkunft.txt'
+
+/**
+ * Der Name des Blattes zu einer Konfigurationsdatei.
+ *
+ * Der volle Dateiname bleibt stehen, die Endung kommt dazu: `routing.txt`
+ * wird `routing.txt.herkunft.txt`. Die Endung zu ERSETZEN wäre hübscher und
+ * falsch — zwei Konfigurationen desselben Geräts in verschiedenen Formaten
+ * (`.txt` und `.csv`) bekämen dasselbe Blatt, und eines überschriebe das
+ * andere im Download-Ordner.
+ */
+export const provenanceFilename = (configFilename: string): string =>
+  `${configFilename}${PROVENANCE_SUFFIX}`
+
+/** Datum/Uhrzeit kurz und lesbar. Wie in `documentStamp`, damit es gleich aussieht. */
+const fmtDate = (iso: string): string => {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  const p = (n: number) => String(n).padStart(2, '0')
+  return `${p(d.getDate())}.${p(d.getMonth() + 1)}.${d.getFullYear()} ${p(d.getHours())}:${p(d.getMinutes())}`
+}
+
+const zeile = (label: string, wert: string): string => `${label.padEnd(14)}${wert}`
+
+/**
+ * Das Herkunfts-Blatt als Text.
+ *
+ * Reine Funktion: derselbe Ursprung und derselbe Inhalt ergeben zweimal
+ * dasselbe Blatt. Der Zeitpunkt steht im Stempel und kommt damit von außen.
+ */
+export const provenanceText = (origin: DeviceConfigOrigin, content: string): string => {
+  const summe = fingerprint(content)
+  return `Herkunft dieser Gerätekonfiguration
+===================================
+
+${zeile('Datei:', origin.filename)}
+${zeile('Für:', origin.device)}
+${zeile('Inhalt:', origin.what)}
+${zeile('Prüfsumme:', `#${summe}`)}
+
+Aus dem Plan
+------------
+${zeile('Projekt:', origin.stamp.project)}
+${zeile('Stand:', origin.stamp.revision ? (origin.stamp.drifted ? `${origin.stamp.revision} + Änderungen` : origin.stamp.revision) : 'keine Revision festgeschrieben')}
+${zeile('Stempel:', stampLine(origin.stamp))}
+${zeile('Anwendung:', origin.app)}
+${zeile('Erzeugt:', fmtDate(origin.stamp.printedAt))}
+
+Wozu dieses Blatt
+-----------------
+Eine Gerätekonfiguration ohne Herkunft ist ein halbes Jahr später nicht mehr
+zuzuordnen. Auf dem Rechner liegen dann mehrere Dateien mit ähnlichen Namen,
+und welche zu welcher Show gehört, weiß niemand mehr — der Neuaufbau passiert
+beim Load-in vor dem Kunden.
+
+Die Prüfsumme ist zum VERGLEICHEN da, nicht zum Nachrechnen: zwei Blätter mit
+verschiedenen Prüfsummen gehören zu zwei verschiedenen Dateien. Das ist am
+Telefon in fünf Sekunden geklärt.
+
+Warum das hier neben der Datei steht und nicht in ihr
+-----------------------------------------------------
+Weil die Konfigurationsdatei einem fremden Gerät gehört. Ob dessen Importer
+eine zusätzliche Zeile, ein unbekanntes Feld oder ein Kommentar überliest, ist
+ohne die Hersteller-Spezifikation nicht zu wissen. Eine Datei, die das Pult
+beim Laden zurückweist, ist schlimmer als eine ohne Herkunft — deshalb bleibt
+sie unberührt.
+`
+}
+
+/**
+ * Eine Gerätekonfiguration herunterladen — mit ihrem Herkunfts-Blatt.
+ *
+ * DIE Stelle, über die jede Gerätekonfiguration dieses Planers hinausgeht.
+ * Ein zweiter Weg daneben wäre eine Datei ohne Blatt, und die fällt niemandem
+ * auf, bis sie in einem halben Jahr auf einem Laptop liegt.
+ *
+ * Das Blatt zuerst: bricht der Browser die zweite Ausgabe ab, fehlt das
+ * Blatt und nicht die Datei, die die Show braucht.
+ */
+export const downloadDeviceConfig = (
+  origin: DeviceConfigOrigin,
+  content: string,
+  mimeType: string,
+): void => {
+  downloadBlob(
+    provenanceFilename(origin.filename),
+    provenanceText(origin, content),
+    'text/plain;charset=utf-8',
+  )
+  downloadBlob(origin.filename, content, mimeType)
+}

--- a/tests/deviceConfigProvenance.test.ts
+++ b/tests/deviceConfigProvenance.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import {
+  PROVENANCE_SUFFIX,
+  provenanceFilename,
+  provenanceText,
+  type DeviceConfigOrigin,
+} from '../src/renderer/lib/deviceConfigProvenance'
+import { fingerprint, type DocumentStamp } from '../src/renderer/lib/documentStamp'
+import { parseVideohubLabelsTxt } from '../src/renderer/lib/exportVideohub'
+
+// ---------------------------------------------------------------------------
+// Bedarf 43 (P2) — eine Gerätekonfiguration, die sagt, woher sie kommt.
+//
+//   > The config the freelancer carries between clients BREAKS ON IMPORT, and
+//   > the rebuild happens during load-in in front of the client.
+//
+// Der teuerste Fehler wäre hier, die Herkunft IN die Gerätedatei zu schreiben:
+// eine Datei, die das Pult beim Laden zurückweist, ist beim Load-in schlimmer
+// als eine ohne Herkunft. Das Blatt steht deshalb daneben — und diese Prüfung
+// hält fest, dass es dabei bleibt.
+// ---------------------------------------------------------------------------
+
+const quelle = (rel: string) => readFileSync(new URL(rel, import.meta.url), 'utf8')
+
+const stamp = (over: Partial<DocumentStamp> = {}): DocumentStamp => ({
+  project: 'Stadthalle Herbst',
+  revision: 'Rev 2',
+  drifted: false,
+  printedAt: '2026-09-07T09:12:00.000Z',
+  fingerprint: '7f3a91cc',
+  ...over,
+})
+
+const origin = (over: Partial<DeviceConfigOrigin> = {}): DeviceConfigOrigin => ({
+  device: 'Blackmagic Videohub',
+  what: 'Anschluss-Beschriftungen',
+  filename: '20260907_Videohub_001_labels.txt',
+  stamp: stamp(),
+  app: 'Cable Planner 1.4.2',
+  ...over,
+})
+
+// ── 1. Die Gerätedatei bleibt unberührt ────────────────────────────────────
+
+describe('die Konfigurationsdatei wird nicht angefasst', () => {
+  it('das Blatt steht NEBEN der Datei, nicht in ihr', () => {
+    // Der ganze Punkt des Moduls. Was ein fremder Importer an zusätzlichen
+    // Zeilen, Feldern oder Kommentaren überliest, steht ohne die
+    // Hersteller-Spezifikation nicht fest — und die liegt hier nicht vor.
+    expect(provenanceFilename('routing.txt')).toBe('routing.txt.herkunft.txt')
+    expect(PROVENANCE_SUFFIX).toBe('.herkunft.txt')
+    const q = quelle('../src/renderer/lib/deviceConfigProvenance.ts')
+    // Der Inhalt geht unverändert durch: kein Anhängen, kein Voranstellen.
+    expect(q).toMatch(/downloadBlob\(origin\.filename, content, mimeType\)/)
+    expect(q).not.toMatch(/content \+|\+ content|content\.replace/)
+  })
+
+  it('ersetzt die Endung nicht, sondern hängt an', () => {
+    // Zwei Konfigurationen desselben Geräts in verschiedenen Formaten bekämen
+    // sonst dasselbe Blatt, und eines überschriebe das andere im
+    // Download-Ordner.
+    expect(provenanceFilename('hub.txt')).not.toBe(provenanceFilename('hub.csv'))
+  })
+
+  it('eine echte Videohub-Datei bleibt danach dieselbe', () => {
+    // Gegenprobe am eigenen Parser: der Inhalt, den der Export erzeugt, geht
+    // unverändert weiter — das Blatt ist nirgends darin gelandet.
+    const datei = 'Input, 1, Cam 1\nInput, 2, Cam 2\nOutput, 1, PGM\n'
+    const gelesen = parseVideohubLabelsTxt(datei)
+    expect(gelesen.inputs[0]).toBe('Cam 1')
+    expect(provenanceText(origin(), datei)).not.toContain('Input, 1, Cam 1')
+  })
+})
+
+// ── 2. Was auf dem Blatt steht ─────────────────────────────────────────────
+
+describe('das Herkunfts-Blatt', () => {
+  it('nennt Datei, Gerät, Inhalt und den Plan', () => {
+    const t = provenanceText(origin(), 'egal')
+    expect(t).toContain('20260907_Videohub_001_labels.txt')
+    expect(t).toContain('Blackmagic Videohub')
+    expect(t).toContain('Anschluss-Beschriftungen')
+    expect(t).toContain('Stadthalle Herbst')
+    expect(t).toContain('Cable Planner 1.4.2')
+  })
+
+  it('rechnet die Prüfsumme über die KONFIGURATION, nicht über sich selbst', () => {
+    // Sonst wäre sie zum Vergleichen wertlos: zwei verschiedene Konfigurationen
+    // desselben Plans trügen dieselbe Zahl.
+    const a = provenanceText(origin(), 'inhalt A')
+    const b = provenanceText(origin(), 'inhalt B')
+    expect(a).toContain(`#${fingerprint('inhalt A')}`)
+    expect(b).toContain(`#${fingerprint('inhalt B')}`)
+    expect(a).not.toBe(b)
+  })
+
+  it('sagt, dass der Plan seit der Revision weitergelaufen ist', () => {
+    // „Rev 2" allein läse sich als *diese Datei ist Rev 2*. Weicht der Plan
+    // ab, sagt das Blatt es hin — dieselbe Regel wie `stampLine`.
+    expect(provenanceText(origin(), 'x')).toContain('Rev 2')
+    expect(provenanceText(origin(), 'x')).not.toContain('Rev 2 + Änderungen')
+    const gewandert = origin({ stamp: stamp({ drifted: true }) })
+    expect(provenanceText(gewandert, 'x')).toContain('Rev 2 + Änderungen')
+  })
+
+  it('nennt eine fehlende Revision beim Namen', () => {
+    // Eine leere Zeile läse sich als „noch nicht ausgefüllt". „Keine Revision
+    // festgeschrieben" ist eine Aussage über den Plan.
+    const ohne = origin({ stamp: stamp({ revision: undefined }) })
+    expect(provenanceText(ohne, 'x')).toContain('keine Revision festgeschrieben')
+  })
+
+  it('sagt selbst, warum es nicht in der Datei steht', () => {
+    // Wer das Blatt in einem halben Jahr findet, soll den Grund lesen können,
+    // statt die Entscheidung für Nachlässigkeit zu halten.
+    const t = provenanceText(origin(), 'x')
+    expect(t).toContain('neben der Datei steht und nicht in ihr')
+    expect(t).toContain('zurückweist')
+  })
+
+  it('ist rein — zweimal derselbe Text', () => {
+    // Der Zeitpunkt kommt im Stempel herein und wird nicht hier geholt.
+    expect(provenanceText(origin(), 'x')).toBe(provenanceText(origin(), 'x'))
+    const q = quelle('../src/renderer/lib/deviceConfigProvenance.ts')
+    expect(q).not.toMatch(/Date\.now\(\)|new Date\(\)|useProjectStore/)
+  })
+})
+
+// ── 3. Die Reihenfolge und die Engstelle ───────────────────────────────────
+
+describe('der Weg nach draußen', () => {
+  it('gibt das Blatt ZUERST aus', () => {
+    // Bricht der Browser die zweite Ausgabe ab, fehlt das Blatt — nicht die
+    // Datei, die die Show braucht.
+    const q = quelle('../src/renderer/lib/deviceConfigProvenance.ts')
+    const blatt = q.indexOf('provenanceFilename(origin.filename)')
+    const datei = q.indexOf('downloadBlob(origin.filename, content, mimeType)')
+    expect(blatt).toBeGreaterThan(-1)
+    expect(datei).toBeGreaterThan(blatt)
+  })
+
+  it('jede Gerätekonfiguration geht über dieselbe Stelle', () => {
+    // Ein zweiter Weg daneben wäre eine Datei ohne Blatt, und die fällt
+    // niemandem auf, bis sie in einem halben Jahr auf einem Laptop liegt.
+    const sites: Array<[string, string]> = [
+      ['../src/renderer/components/Export/VideohubExportDialog.tsx', 'Kreuzschienen-Routing'],
+      ['../src/renderer/components/Export/GreenGoExportDialog.tsx', 'Intercom-Konfiguration'],
+      ['../src/renderer/components/Atem/AtemAudioRouterDialog.tsx', 'Audio-Zuordnung'],
+      ['../src/renderer/components/Export/ExportDialog.tsx', 'Geräteliste für die Tally-Karte'],
+    ]
+    for (const [datei, was] of sites) {
+      const q = quelle(datei)
+      expect(q, datei).toMatch(/exportDeviceConfig\(/)
+      expect(q, datei).toContain(was)
+    }
+  })
+
+  it('die unreine Stelle ist genau eine', () => {
+    // Uhr, Store und App-Version stehen in `deviceConfigExport`, damit das
+    // Blatt selbst prüfbar bleibt.
+    const q = quelle('../src/renderer/lib/deviceConfigExport.ts')
+    expect(q).toMatch(/useProjectStore\.getState\(\)\.project/)
+    expect(q).toMatch(/stampForPlan\(project, new Date\(\)\)/)
+    expect(q).toMatch(/APP_VERSION/)
+  })
+})


### PR DESCRIPTION
## Der Bedarf

**43 (P2) — „A portable toolkit config that survives a version change and a new venue's IP scheme"**

> The config the freelancer carries between clients **breaks on import**, and the rebuild happens during load-in in front of the client.

Drei unabhängige Belege 2021–2024: [`bitfocus/companion#1603`](https://github.com/bitfocus/companion/issues/1603) — beim Import verrutschten Zeilen, und der Meldende hatte den älteren Installer nicht mehr: *„I would be doomed now"*. Dazu: *„Every month or so I lose the configuration and have to reimport it."*

Die Maßnahme hat drei Teile: *„The suite's own device exports … are the same artefact class. **Version them**, diff them against the machine, and never silently replace."*

## Was es schon gab und was fehlte

| Teil | Stand |
|---|---|
| *never silently replace* | gebaut — Initiative 10 (Confirmed-State-Disziplin in `VideohubExportDialog`, `AtemAudioRouterDialog`, `AtemMvConfigDialog`) |
| *diff them against the machine* | gebaut — `atemLiveCompare`, Status-Abgleich der Videohub-Ansicht |
| **version them** | **fehlte** |

Nachgesehen 2026-09-07: die Green-GO-Datei schreibt `fileCreatedVersion: '5.0.6-6684'` — die Version des **Hersteller-Formats** —, die Videohub-Labels-Datei schreibt gar nichts, das ATEM-Audio-XML ebenso wenig. Keine der drei sagt, aus welchem **Plan** und welchem **Stand** sie stammt.

## Warum die Angabe neben der Datei steht und nicht in ihr

Das ist die eigentliche Entscheidung, und sie geht gegen die bequeme Lösung.

In die Datei zu schreiben hieße, ein fremdes Format zu erweitern. Ob Blackmagics Videohub Setup eine `#`-Zeile überliest, ob der Green-GO-Editor ein unbekanntes JSON-Feld durchlässt, ob der ATEM-Importer ein zusätzliches Kommentar akzeptiert — das ist ohne die Hersteller-Spezifikation **nicht zu wissen**, und die liegt hier nicht vor. Dass *unser* Parser (`parseVideohubLabelsTxt`) `#`-Zeilen überspringt, sagt nichts über das Gerät: die Datei geht dorthin, nicht zu uns zurück.

Eine Konfigurationsdatei, die das Pult beim Laden zurückweist, ist beim Load-in schlimmer als eine ohne Herkunft — genau die Situation aus dem Beleg. Also bleibt die Gerätedatei **unberührt**, und die Herkunft geht als eigenes Blatt daneben: `<datei>.herkunft.txt`.

- Die Endung wird **angehängt** und nicht ersetzt: zwei Konfigurationen desselben Geräts in verschiedenen Formaten bekämen sonst dasselbe Blatt, und eines überschriebe das andere im Download-Ordner.
- Das Blatt geht **zuerst** raus, die Konfiguration danach. Bricht der Browser die zweite Ausgabe ab, fehlt das Blatt — nicht die Datei, die die Show braucht.

## Die Prüfsumme ist zum Vergleichen da

Gerechnet über den **Inhalt der Konfigurationsdatei**, mit derselben Ableitung wie der Dokument-Stempel (ADR-004). Ihr Sinn ist *nicht*, dass jemand sie nachrechnet — dafür gibt es hier kein Werkzeug, und eine Zahl, zu der die Probe fehlt, wäre eine Behauptung. Ihr Sinn ist der **Vergleich**: zwei Blätter mit verschiedenen Prüfsummen gehören zu zwei verschiedenen Dateien, in fünf Sekunden am Telefon geklärt. Dieselbe Begründung wie bei den acht Hex-Zeichen des Stempels.

## Zwei Dateien, zwei Verantwortungen

- `deviceConfigProvenance.ts` ist **rein**: keine Uhr, kein Store, keine App-Version. Derselbe Ursprung und derselbe Inhalt ergeben zweimal denselben Text — und genau das lässt sich nur an einer Funktion ohne Uhr festhalten.
- `deviceConfigExport.ts` setzt Stempel, Uhr und Version zusammen und ist die einzige unreine Zeile des Wegs. Der Zustand kommt über `getState()` statt über einen Selektor: das läuft in einem Klick-Handler, und ein Abonnement auf das ganze Projekt ließe jeden Dialog bei jeder Änderung neu zeichnen.

## Vier Ausgänge, eine Stelle

Videohub (Routing und Beschriftungen), Green-GO `.gg5`, ATEM-Audio-XML und die Geräteliste für `tally-pi` gehen jetzt über `exportDeviceConfig`.

Der zweite Commit trägt das in `docs/architecture.md` nach — Abschnitt 6.5b mit der Begründung, und die Zeile in der Quick-Reference-Tabelle, wo jemand tatsächlich nachschlägt: *„Neue Gerätekonfiguration → `exportDeviceConfig`, **nicht** `downloadBlob` direkt."* Ohne sie greift der nächste zum gewohnten Weg, und die Datei geht ohne Blatt raus — was niemandem auffällt, bis sie in einem halben Jahr auf einem Laptop liegt.

## Was hier ausdrücklich nicht passiert

Der zweite Teil des Bedarfs — *„changing every device IP at a new venue is manual, connection by connection"* — bleibt liegen. Adressen zu **vergeben** hängt an der offenen Eigentümer-Frage **E-5** (woher Subnetze kommen: abgeleitet oder aus einem projektweiten Pool), und `addressPlan.ts` hält genau deshalb schon heute die Hand still. Ein Werkzeug, das währenddessen ein ganzes Adress-Schema umschreibt, entschiede E-5 stillschweigend.

## Prüfläufe

`vitest` **2641** grün (2 skipped) · `tsc -p tsconfig.app.json --noEmit` 0 Fehler · `eslint` 0 Fehler · **15 Gegenproben, alle rot** (darunter: die Herkunft wandert in die Datei, die Datei geht zuerst, die Prüfsumme geht über das Blatt statt über die Datei, jeder der vier Ausgänge ohne Blatt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT