### PR TITLE
netz: Meldungstexte in richtigem Deutsch statt ASCII-Ersatz (Bedarf 20)

### DIFF
--- a/src/renderer/lib/addressTemplate.ts
+++ b/src/renderer/lib/addressTemplate.ts
@@ -233,7 +233,7 @@ export function addressTemplateFindings(
           severity: 'error',
           key,
           message:
-            `Ebene "${layer.name.trim() || NO_RANGE_NAME}" fuehrt den Schluessel "${key}" zweimal ` +
+            `Ebene "${layer.name.trim() || NO_RANGE_NAME}" führt den Schlüssel "${key}" zweimal ` +
             `(${rangeName(vorher)} ${vorher.cidr} und ${rangeName(r)} ${r.cidr}). ` +
             'Dann ist nicht entscheidbar, welchen der beiden eine Haus-Ebene ersetzt.',
         })
@@ -267,9 +267,9 @@ export function addressTemplateFindings(
         message:
           `${rangeName(a)} (${a.cidr}, ${a.layerName.trim() || NO_RANGE_NAME}) und ` +
           `${rangeName(b)} (${b.cidr}, ${b.layerName.trim() || NO_RANGE_NAME}) ` +
-          'liegen auf denselben Adressen, und der aeussere der beiden ist keine ' +
+          'liegen auf denselben Adressen, und der äußere der beiden ist keine ' +
           'Klammer. Zwei Zwecke auf denselben Adressen erzeugen die doppelte IP, ' +
-          'die einen Teil des Netzes stehen laesst.',
+          'die einen Teil des Netzes stehen lässt.',
       })
     }
   }
@@ -299,9 +299,9 @@ export function addressTemplateFindings(
         severity: 'error',
         key,
         message:
-          `${rangeName(r)} (${r.cidr}) traegt den Schluessel "${key}", den der stehende Plan ` +
-          `nicht kennt — ersetzt also nichts — und ueberschneidet sich mit ` +
-          `${rangeName(kollision.r)} (${kollision.r.cidr}). Entweder ist der Schluessel ` +
+          `${rangeName(r)} (${r.cidr}) trägt den Schlüssel "${key}", den der stehende Plan ` +
+          `nicht kennt — ersetzt also nichts — und überschneidet sich mit ` +
+          `${rangeName(kollision.r)} (${kollision.r.cidr}). Entweder ist der Schlüssel ` +
           'vertippt und die gemeinte Ersetzung findet nicht statt, oder beide Bereiche ' +
           'gelten nebeneinander auf denselben Adressen.',
       })
@@ -328,7 +328,7 @@ export function addressTemplateFindings(
         message:
           `${wo} steht auf ${nic.ipAddress} — das liegt in der Klammer ` +
           `${rangeName(innerster)} (${innerster.cidr}), aber in keinem ihrer ` +
-          'Unterbereiche. Der Unterbereich, in den das Geraet gehoert, fehlt im Plan.',
+          'Unterbereiche. Der Unterbereich, in den das Gerät gehört, fehlt im Plan.',
       })
     }
 
@@ -342,7 +342,7 @@ export function addressTemplateFindings(
         key: fuerRolle[0].key,
         message:
           `${wo} ist "${ROLE_TEXT[nic.role]}" und steht auf ${nic.ipAddress}. Geplant ist ` +
-          `dafuer ${fuerRolle.map((r) => `${rangeName(r)} (${r.cidr})`).join(', ')}. ` +
+          `dafür ${fuerRolle.map((r) => `${rangeName(r)} (${r.cidr})`).join(', ')}. ` +
           'Die Adresse liegt in keinem davon.',
       })
     }
@@ -360,7 +360,7 @@ export function addressTemplateFindings(
         key: innerster.key,
         message:
           `${wo} steht in VLAN ${nic.vlanId}, ihre Adresse ${nic.ipAddress} liegt aber in ` +
-          `${rangeName(innerster)} (${innerster.cidr}), geplant fuer VLAN ` +
+          `${rangeName(innerster)} (${innerster.cidr}), geplant für VLAN ` +
           `${innerster.vlanId}.`,
       })
     }
@@ -518,16 +518,16 @@ export function proposeReaddress(
  */
 export const REFUSAL_TEXT: Readonly<Record<ReaddressRefusal, string>> = {
   'no-address': 'keine Adresse eingetragen',
-  'no-range': 'fuer diese Rolle ist kein Bereich geplant',
+  'no-range': 'für diese Rolle ist kein Bereich geplant',
   'already-inside': 'liegt bereits im geplanten Bereich',
   'host-does-not-fit': 'der Host-Anteil passt nicht in den Zielbereich',
-  'network-or-broadcast': 'waere die Netz- oder Broadcast-Adresse des Zielbereichs',
-  'already-taken': 'die vorgeschlagene Adresse traegt bereits ein anderes Geraet',
+  'network-or-broadcast': 'wäre die Netz- oder Broadcast-Adresse des Zielbereichs',
+  'already-taken': 'die vorgeschlagene Adresse trägt bereits ein anderes Gerät',
 }
 
 export const RANGE_HEADERS = [
   'Ebene',
-  'Schluessel',
+  'Schlüssel',
   'Bereich',
   'CIDR',
   'Art',

--- a/src/renderer/lib/dataDictionary.ts
+++ b/src/renderer/lib/dataDictionary.ts
@@ -348,7 +348,7 @@ export const COLUMN_GLOSSARY: Readonly<Record<string, string>> = {
   // Bedarf 20 — die vier Spalten des Adressbereichs-Blatts.
   Ebene:
     'Aus welcher Schicht der Bereich stammt: „stehend“ ist der Plan, der am Wagen hängt, „Haus“ die Überlagerung vor Ort. Die Haus-Ebene gewinnt.',
-  'Schluessel':
+  'Schlüssel':
     'Der Schlüssel, an dem sich die Ebenen treffen: die Haus-Ebene ersetzt den stehenden Bereich mit DEMSELBEN Schlüssel und lässt alle anderen stehen. Ein Tippfehler hier heisst, dass die gemeinte Ersetzung nicht stattfindet.',
   CIDR:
     'Der Adressbereich in CIDR-Schreibweise, immer kanonisch auf seine Netz-Adresse gerundet („10.0.5.7/24“ wird zu „10.0.5.0/24“).',

--- a/tests/addressTemplate.test.ts
+++ b/tests/addressTemplate.test.ts
@@ -684,6 +684,27 @@ describe('Engstellen', () => {
     expect(gefunden).toEqual(erwartet)
   })
 
+  it('schreibt seine Meldungen in richtigem Deutsch, nicht in ASCII-Ersatz', () => {
+    // AUFGEFALLEN AM SCREENSHOT, nicht am Test (2026-09-07): im Panel stand
+    // „der Unterbereich, in den das Geraet gehoert". Die Kommentare dieser
+    // Codebasis sind bewusst ASCII — die STRINGS sind es nicht, sie stehen
+    // im Dialog und auf dem Blatt neben Spaltenkoepfen wie „Gerät".
+    //
+    // Geprueft werden nur String-Literale ohne Kommentare, und nur Woerter,
+    // die als ASCII-Ersatz wirklich vorkommen. Ein Bezeichner oder eine Id
+    // faellt nicht darunter: die Liste enthaelt nur Woerter mit Umlaut.
+    const ohneKommentare = libQuelle
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^[ \t]*\/\/.*$/gm, '')
+    const literale = [...ohneKommentare.matchAll(/'((?:[^'\\\n]|\\.)*)'|`((?:[^`\\]|\\.)*)`/g)]
+      .map((m) => m[1] ?? m[2])
+      .filter(Boolean)
+    const ersatz =
+      /(Geraet|gehoert|ueber|waere|wuerde|fuer |Schluessel|laesst|traegt|aeuss|fuehrt|koenn|muess|naechst|loesch|groess|zurueck|Laenge|Groesse|Aenderung)/
+    const schlecht = literale.filter((l) => ersatz.test(l))
+    expect(schlecht, `ASCII-Ersatz in Meldungstexten: ${schlecht.join(' | ')}`).toEqual([])
+  })
+
   it('vergibt nirgends selbst eine Adresse', () => {
     // Die Datei darf rechnen, was eine Adresse WAERE. Schreiben tut sie
     // nichts — das ist die E-5-Entscheidung und die Haltung aus Bedarf 96.


### PR DESCRIPTION
## Woran es aufgefallen ist

Nicht an einem Test — an einem **Screenshot**. Im Adressbereichs-Panel (Analysen → Netzwerk) stand:

> „…das liegt in der Klammer Haus-Adressraum (10.0.0.0/8), aber in keinem ihrer Unterbereiche. Der Unterbereich, in den das **Geraet gehoert**, fehlt im Plan."

Direkt darüber, in derselben Ansicht, steht die Spalte **„Gerät"**. 58 Tests waren grün, weil sie auf Teilstrings prüften, die den Umlaut nicht enthielten.

## Was falsch war

Die **Kommentare** dieser Codebasis sind bewusst ASCII. Die **Strings** sind es nicht: sie stehen im Dialog, im CSV-Export und auf dem gedruckten Blatt, und dort liest sie ein Mensch neben richtig gesetzten Umlauten.

Betroffen in `lib/addressTemplate.ts`:

- alle sechs Befund-Texte (`overlap`, `key-twice`, `venue-orphan`, `device-outside`, `container-holds-device`, `vlan-mismatch`)
- die Ablehnungsgründe in `REFUSAL_TEXT`
- der Spaltenkopf `'Schluessel'` → `'Schlüssel'`

Mitgezogen: der Lexikon-Eintrag in `dataDictionary.ts`. Er wird über den **Spaltennamen** gefunden — ein alter Schlüssel hätte den bestehenden Guard „jede exportierte Spalte hat eine Erklärung" rot gemacht. Genau dafür ist der Guard da.

## Der Guard dagegen

`tests/addressTemplate.test.ts` bekommt einen Fall, der die String-Literale der Datei ohne Kommentare liest und gegen die ASCII-Ersatzformen prüft, die real vorkommen (`Geraet`, `gehoert`, `ueber`, `waere`, `fuer `, `Schluessel`, `laesst`, `traegt`, …). Bezeichner und Ids fallen nicht darunter, weil die Liste ausschließlich Wörter mit Umlaut enthält.

**4 Gegensonden**, darunter der ursprüngliche Fehler wörtlich — alle rot.

## Gemessen, aber bewusst nicht hier gefixt

Dieselbe Drift steht in **28 weiteren Dateien** unter `src/renderer/lib/` und `src/renderer/types/` — `archiveIsolation`, `cableRunChecks`, `ptpPlan`, `tallyMap`, `venueNetworkRequest`, `labelTargets` und andere.

Das ist ein eigener Durchgang und kein Nebenbei-Fix: ein Teil der Treffer sind **Ids und Slugs** (`post-uebergabe`, `kunden-uebersicht`, `ueberfaellig`), die in gespeicherten Dateien stehen und beim Umbenennen Daten brechen würden. Ein blindes Suchen-und-Ersetzen wäre hier schlimmer als die Drift. Steht als Aufgabe im Backlog, nicht als stiller Rest.

## Prüfung

- `npm test` — 173 Dateien, 2699 Tests grün
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npm run lint` — 0 Fehler (10 vorbestehende Warnungen)
- Screenshot nach dem Fix gegengeprüft: „in den das Gerät gehört", „geplant ist dafür", „Schlüssel"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_