### PR TITLE
ui: unerreichbare Register, verdeckte Ebenen-Schalter, drei namenlose Schlösser — plus der Guard dagegen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,16 @@ jobs:
         run: npm run build
       - name: UI-Smoke (headless)
         run: xvfb-run -a npm run ui:smoke
+      # Im SELBEN Job wie der Smoke-Lauf, weil beide dasselbe teuer Gebaute
+      # brauchen: `npm ci`, `npm run build` und ein X-Server. Ein eigener Job
+      # haette das dreimal bezahlt, um dieselbe App zweimal zu starten.
+      #
+      # Was er findet, findet sonst niemand: `vitest` rendert nicht und kennt
+      # keine Schriftbreiten, der Smoke-Lauf prueft nur, dass Menues aufgehen.
+      # Ein Register, das aus seinem Panel faellt, war damit unsichtbar --
+      # gemeldet hat es am 2026-09-07 ein Mensch, nicht die Pruefung.
+      - name: Nichts abgeschnitten, nichts verdeckt
+        run: xvfb-run -a npm run ui:overflow
       - name: Screenshots bei Fehlschlag
         if: failure()
         uses: actions/upload-artifact@v6

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "relay": "node scripts/signaling-server.mjs",
     "dist": "npm run build && electron-builder",
     "notices": "node scripts/generate-notices.mjs",
-    "actions:check": "node scripts/actions-node-runtime.mjs"
+    "actions:check": "node scripts/actions-node-runtime.mjs",
+    "ui:overflow": "node scripts/ui-overflow.mjs"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/ui-overflow.mjs
+++ b/scripts/ui-overflow.mjs
@@ -1,0 +1,221 @@
+/**
+ * Abgeschnittene Bedienelemente finden — der Guard aus einem echten Befund.
+ *
+ * WORAN ER ENTSTANDEN IST (2026-09-07). Der Nutzer schrieb: „die linke
+ * Equipment-Leiste, da kann man Equipment lesen, aber Cable schon nicht mehr."
+ * Nachgemessen im laufenden Fenster: die Register-Zeile der Bibliothek war
+ * 235 px breit, ihr Inhalt 390 px. „Gruppen" und „Racks" lagen VOLLSTAENDIG
+ * ausserhalb — nicht sichtbar, nicht anklickbar, bei jeder Fenstergroesse,
+ * weil das Panel 260 px fest breit ist. Zwei von vier Registern gab es fuer
+ * den Nutzer nicht.
+ *
+ * KEIN TEST KONNTE DAS SEHEN. `vitest` rendert nicht, misst nichts und kennt
+ * keine Schriftbreiten; `ui:smoke` schiesst Screenshots und prueft, dass jedes
+ * Menue Eintraege oeffnet — beide waren gruen. Ein Bedienelement, das aus
+ * seinem Behaelter faellt, ist genau die Sorte Fehler, die nur eine MESSUNG im
+ * echten Fenster findet.
+ *
+ * WAS ER PRUEFT, und warum in dieser Form:
+ *
+ *   1. **Abgeschnittene Reihen.** Ein Element, dessen Inhalt breiter ist als
+ *      sein sichtbarer Bereich, OHNE dass es scrollen kann. Gemeldet wird nur,
+ *      wenn dabei ein KIND ueber die rechte Kante hinausragt — ein zu langer
+ *      Text in einer Zelle ist ein Anzeigedetail, ein herausgefallener Knopf
+ *      ist ein verlorenes Feature.
+ *   2. **Abgeschnittene Beschriftungen.** Ein Register, das per `truncate`
+ *      auf „Grup…" schrumpft, faellt aus keiner Reihe heraus und ist trotzdem
+ *      unlesbar — und genau so war die Beschwerde formuliert („Equipment kann
+ *      man lesen, Cable schon nicht mehr").
+ *   3. **Verdeckte Bedienelemente.** Ein schwebendes Element (`position:
+ *      absolute/fixed`) liegt ueber einem Knopf und faengt dessen Klicks ab.
+ *      Geprueft wird nicht die Ueberlappung an sich — die ist bei Menues,
+ *      Dialogen und Tooltips gewollt —, sondern nur bei Elementen, die
+ *      DAUERHAFT stehen: keine offenen Menues, keine Modals.
+ *
+ * Beides wird ueber `document.elementFromPoint` bestaetigt und nicht bloss aus
+ * Rechtecken geschlossen: ein Knopf, der laut Geometrie verdeckt waere, aber
+ * beim Antippen doch getroffen wird, ist keiner.
+ *
+ * Voraussetzungen wie bei `ui:smoke`: `npm run build` vorher, unter Linux
+ * `xvfb-run -a npm run ui:overflow`.
+ */
+import { _electron as electron } from 'playwright-core'
+import { mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const OUT = process.env.CP_UI_SHOTS || join(tmpdir(), 'cable-planner-ui-shots')
+mkdirSync(OUT, { recursive: true })
+
+const app = await electron.launch({ args: ['.', '--no-sandbox', '--disable-gpu'] })
+const win = await app.firstWindow({ timeout: 30000 })
+await win.waitForLoadState('domcontentloaded')
+await win.waitForTimeout(3500)
+
+// Erststart-Overlays wegklicken — dieselbe Schleife wie in `ui-smoke.mjs`,
+// und aus demselben Grund: CI hat immer ein frisches Profil.
+const abweisungen =
+  /End tour|Tour beenden|Beenden|Skip|Überspringen|Fertig|Decide later|Später|Schließen|Close/i
+for (let runde = 0; runde < 6; runde++) {
+  if ((await win.locator('.cp-modal-backdrop').count()) === 0) break
+  const b = win.getByRole('button', { name: abweisungen })
+  if (await b.count()) await b.first().click({ timeout: 1500 }).catch(() => {})
+  await win.keyboard.press('Escape').catch(() => {})
+  await win.waitForTimeout(400)
+}
+if ((await win.locator('.cp-modal-backdrop').count()) > 0) {
+  throw new Error('Erststart-Overlay liess sich nicht schliessen — Messung waere wertlos.')
+}
+
+// EIN LEERER PLAN MISST NICHTS. Mehrere schwebende Elemente — allen voran die
+// Geraete-Suche — werden erst gerendert, wenn Geraete existieren
+// (`project.equipment.length > 0` in `CanvasArea`). Auf dem frischen
+// CI-Profil ist der Plan leer, und der Guard waere gruen, weil die Haelfte der
+// Oberflaeche gar nicht da ist. Deshalb wird das Beispielprojekt geladen —
+// ueber den Knopf im Empty-State, also auf demselben Weg wie ein Nutzer.
+const demo = win.getByRole('button', { name: /Beispielprojekt laden|Load example project/i })
+if (await demo.count()) {
+  await demo.first().click()
+  await win.waitForTimeout(1500)
+}
+const geraete = await win.locator('.react-flow__node').count()
+if (geraete === 0) {
+  throw new Error(
+    'Kein Geraet auf der Flaeche — die schwebenden Elemente (Suche, Inline-Toolbar) ' +
+      'werden dann gar nicht gerendert und die Messung waere wertlos.',
+  )
+}
+console.log(`Messgrundlage: ${geraete} Geraet(e) auf der Flaeche`)
+
+/** Die Messung laeuft IM Fenster; hier steht nur, was sie zurueckgibt. */
+const messen = () =>
+  win.evaluate(() => {
+    const sichtbar = (el) => {
+      const r = el.getBoundingClientRect()
+      if (r.width < 4 || r.height < 4) return false
+      const st = getComputedStyle(el)
+      return st.visibility !== 'hidden' && st.display !== 'none' && Number(st.opacity) > 0.05
+    }
+
+    // ── 1. Abgeschnittene Reihen ──────────────────────────────────────────
+    const abgeschnitten = []
+    for (const el of document.querySelectorAll('div, nav, aside, ul, section, header, footer')) {
+      const st = getComputedStyle(el)
+      // Was scrollen darf, ist nicht abgeschnitten, sondern scrollbar.
+      if (/(auto|scroll)/.test(st.overflowX)) continue
+      // Die Zeichenflaeche selbst ist ausgenommen: dort LIEGT Inhalt
+      // ausserhalb des Sichtfensters, dafuer gibt es Schwenken und Zoomen.
+      // Ein Knoten rechts vom Rand ist kein verlorenes Bedienelement,
+      // sondern ein Geraet, zu dem man hinfaehrt.
+      if (el.closest('.react-flow__viewport, .react-flow__nodes, .react-flow__edgelabel-renderer')) continue
+      if (el.classList.contains('react-flow__nodes') || el.classList.contains('react-flow__edgelabel-renderer')) continue
+      if (el.clientWidth < 40) continue
+      if (el.scrollWidth - el.clientWidth < 12) continue
+      const r = el.getBoundingClientRect()
+      const raus = [...el.children]
+        .filter((c) => sichtbar(c) && c.getBoundingClientRect().left > r.right - 4)
+        .map((c) => (c.textContent || '').trim().slice(0, 24) || c.tagName.toLowerCase())
+      if (!raus.length) continue
+      abgeschnitten.push({
+        wo: (el.className || '').toString().slice(0, 60),
+        breite: el.clientWidth,
+        inhalt: el.scrollWidth,
+        unerreichbar: raus,
+      })
+    }
+
+    // ── 2. Abgeschnittene BESCHRIFTUNGEN ──────────────────────────────────
+    // Der Ausloeser dieses Guards war woertlich: „da kann man Equipment
+    // lesen, aber Cable schon nicht mehr." Ein Register, das per `truncate`
+    // auf „Grup…" schrumpft, faellt aus KEINER Reihe heraus und ist trotzdem
+    // nicht mehr lesbar. Gemeldet wird deshalb jede Beschriftung IN einem
+    // Bedienelement, deren Text breiter ist als ihr sichtbarer Bereich.
+    const beschnitten = []
+    for (const knopf of document.querySelectorAll('button, [role="tab"], a[href]')) {
+      if (!sichtbar(knopf)) continue
+      for (const el of [knopf, ...knopf.querySelectorAll('span, div')]) {
+        const st = getComputedStyle(el)
+        if (st.textOverflow !== 'ellipsis' && st.overflow !== 'hidden') continue
+        if (el.scrollWidth - el.clientWidth < 3) continue
+        const text = (el.textContent || '').trim()
+        if (!text) continue
+        beschnitten.push({
+          text: text.slice(0, 30),
+          sichtbar: el.clientWidth,
+          noetig: el.scrollWidth,
+        })
+        break
+      }
+    }
+
+    // ── 3. Verdeckte Bedienelemente ───────────────────────────────────────
+    // Nur DAUERHAFT stehende Overlays: ein offenes Menue oder ein Modal darf
+    // decken, das ist seine Aufgabe.
+    const verdeckt = []
+    if (!document.querySelector('.cp-modal-backdrop, [role="menu"]')) {
+      for (const knopf of document.querySelectorAll('button, [role="tab"], input, select')) {
+        if (!sichtbar(knopf)) continue
+        if (knopf.disabled) continue
+        const r = knopf.getBoundingClientRect()
+        const x = Math.round(r.left + r.width / 2)
+        const y = Math.round(r.top + r.height / 2)
+        const oben = document.elementFromPoint(x, y)
+        if (!oben || knopf.contains(oben) || oben.contains(knopf)) continue
+        // Was liegt drueber, und schwebt es?
+        let p = oben
+        let schweber = null
+        while (p && p !== document.body) {
+          const ps = getComputedStyle(p)
+          if (ps.position === 'absolute' || ps.position === 'fixed') { schweber = p; break }
+          p = p.parentElement
+        }
+        if (!schweber) continue
+        verdeckt.push({
+          knopf: (knopf.textContent || knopf.getAttribute('aria-label') || knopf.tagName).trim().slice(0, 30),
+          durch: (schweber.className || '').toString().slice(0, 60) ||
+            (schweber.textContent || '').trim().slice(0, 30),
+        })
+      }
+    }
+    return { abgeschnitten, beschnitten, verdeckt }
+  })
+
+const groessen = [
+  { width: 1500, height: 950 },
+  { width: 1280, height: 800 },
+]
+
+let befunde = 0
+for (const g of groessen) {
+  await win.setViewportSize(g)
+  await win.waitForTimeout(900)
+  const { abgeschnitten, beschnitten, verdeckt } = await messen()
+  const name = `${g.width}x${g.height}`
+  await win.screenshot({ path: join(OUT, `overflow-${name}.png`) })
+  if (!abgeschnitten.length && !beschnitten.length && !verdeckt.length) {
+    console.log(`OK ${name}: nichts abgeschnitten, nichts beschnitten, nichts verdeckt`)
+    continue
+  }
+  for (const a of abgeschnitten) {
+    console.error(
+      `✗ ${name}: Reihe ${a.breite}px breit, Inhalt ${a.inhalt}px — ` +
+        `unerreichbar: ${a.unerreichbar.join(', ')}  [${a.wo}]`,
+    )
+    befunde += 1
+  }
+  for (const b of beschnitten) {
+    console.error(
+      `✗ ${name}: Beschriftung „${b.text}" ist beschnitten — ` +
+        `${b.sichtbar}px sichtbar, ${b.noetig}px noetig`,
+    )
+    befunde += 1
+  }
+  for (const v of verdeckt) {
+    console.error(`✗ ${name}: „${v.knopf}" liegt unter einem schwebenden Element  [${v.durch}]`)
+    befunde += 1
+  }
+}
+
+await app.close()
+console.log(`UI-Overflow fertig → ${OUT} (${befunde} Befund(e))`)
+process.exit(befunde > 0 ? 1 : 0)

--- a/scripts/ui-overflow.mjs
+++ b/scripts/ui-overflow.mjs
@@ -26,7 +26,10 @@
  *      auf „Grup…" schrumpft, faellt aus keiner Reihe heraus und ist trotzdem
  *      unlesbar — und genau so war die Beschwerde formuliert („Equipment kann
  *      man lesen, Cable schon nicht mehr").
- *   3. **Verdeckte Bedienelemente.** Ein schwebendes Element (`position:
+ *   3. **Klappmenues der Werkzeugleiste.** Sie werden geoeffnet und
+ *      einzeln vermessen — ein Menue, das ueber den Fensterrand laeuft, ist
+ *      halb unlesbar, und offen sieht die Messung von aussen es nie.
+ *   4. **Verdeckte Bedienelemente.** Ein schwebendes Element (`position:
  *      absolute/fixed`) liegt ueber einem Knopf und faengt dessen Klicks ab.
  *      Geprueft wird nicht die Ueberlappung an sich — die ist bei Menues,
  *      Dialogen und Tooltips gewollt —, sondern nur bei Elementen, die
@@ -215,6 +218,81 @@ for (const g of groessen) {
     befunde += 1
   }
 }
+
+// ── 4. Die Klappmenues der Werkzeugleiste ─────────────────────────────────
+// WARUM SIE EINEN EIGENEN DURCHGANG BRAUCHEN. Die Messung oben sieht nur, was
+// offen auf dem Schirm steht; ein Menue, das erst auf Klick aufgeht, ist dabei
+// nicht dabei. Genau dort ist am 2026-09-07 der naechste Fehler derselben Art
+// entstanden: das neue „Sperren"-Menue klappte nach RECHTS auf, lief in den
+// Inspector und stand als „Keine Waypoint-Bearbeitun" da. Aufgefallen ist es
+// wieder an einem Screenshot — also wird jetzt auch geklickt.
+await win.setViewportSize(groessen[0])
+await win.waitForTimeout(600)
+// `[▾▴]`, nicht nur `▾`: der Pfeil dreht sich beim Oeffnen um. Mit nur `▾`
+// faellt der gerade offene Knopf aus dem Treffersatz und alle folgenden
+// Indizes verschieben sich — der zweite Durchlauf lief dann in einen Timeout.
+const klappknoepfe = win.locator('[data-cp-canvas-toolbar] button', { hasText: /[▾▴]/ })
+const anzahl = await klappknoepfe.count()
+for (let i = 0; i < anzahl; i++) {
+  const knopf = klappknoepfe.nth(i)
+  const name = ((await knopf.innerText()) || `Menue ${i + 1}`).replace(/\s+/g, ' ').trim()
+  await knopf.click().catch(() => {})
+  await win.waitForTimeout(350)
+  const menue = await win.evaluate(() => {
+    const m = document.querySelector('[role="menu"]')
+    if (!m) return null
+    const r = m.getBoundingClientRect()
+    const beschnitten = []
+    for (const el of m.querySelectorAll('span, div, button')) {
+      const st = getComputedStyle(el)
+      if (st.textOverflow !== 'ellipsis' && st.overflow !== 'hidden') continue
+      if (el.scrollWidth - el.clientWidth < 3) continue
+      const txt = (el.textContent || '').trim()
+      if (txt) beschnitten.push(txt.slice(0, 30))
+    }
+    // GEGEN WEN wird gemessen: nicht gegen das Fenster, sondern gegen den
+    // ersten Vorfahren, der ueberhaupt abschneidet. Das linksbuendige
+    // „Sperren"-Menue lief in den Inspector und war dort halb weg — im
+    // FENSTER lag es trotzdem vollstaendig drin. Wer gegen `innerWidth`
+    // prueft, sieht diesen Fall nie.
+    let klammer = m.parentElement
+    let kRect = null
+    while (klammer && klammer !== document.body) {
+      const ks = getComputedStyle(klammer)
+      if (/(hidden|clip|auto|scroll)/.test(ks.overflowX) || /(hidden|clip)/.test(ks.overflow)) {
+        kRect = klammer.getBoundingClientRect()
+        break
+      }
+      klammer = klammer.parentElement
+    }
+    const grenze = kRect
+      ? { links: Math.round(kRect.left), rechts: Math.round(kRect.right), was: (klammer.className || '').toString().slice(0, 40) || 'Vorfahre' }
+      : { links: 0, rechts: window.innerWidth, was: 'Fenster' }
+    return {
+      links: Math.round(r.left),
+      rechts: Math.round(r.right),
+      grenze,
+      beschnitten,
+    }
+  })
+  await win.keyboard.press('Escape').catch(() => {})
+  await win.waitForTimeout(200)
+  if (!menue) continue
+  // Laeuft das Menue ueber den Fensterrand hinaus? Dann ist ein Teil davon
+  // nicht lesbar, ganz gleich wie der Text formatiert ist.
+  if (menue.rechts > menue.grenze.rechts || menue.links < menue.grenze.links) {
+    console.error(
+      `✗ Menue „${name}" laeuft aus seinem Rahmen (${menue.grenze.was}): ` +
+        `Menue ${menue.links}..${menue.rechts}, Rahmen ${menue.grenze.links}..${menue.grenze.rechts}`,
+    )
+    befunde += 1
+  }
+  for (const t of menue.beschnitten) {
+    console.error(`✗ Menue „${name}": Text „${t}" ist beschnitten`)
+    befunde += 1
+  }
+}
+console.log(`${anzahl} Klappmenue(s) der Werkzeugleiste geprueft`)
 
 await app.close()
 console.log(`UI-Overflow fertig → ${OUT} (${befunde} Befund(e))`)

--- a/src/renderer/components/Canvas/CanvasSearch.tsx
+++ b/src/renderer/components/Canvas/CanvasSearch.tsx
@@ -129,8 +129,44 @@ export const CanvasSearch = () => {
   }
 
   // Positionierung: Default oben mittig (pos === null), sonst freie px-Lage.
-  const posClass = pos ? '' : 'top-3 left-1/2 -translate-x-1/2'
-  const posStyle = pos ? { left: pos.x, top: pos.y } : undefined
+  // ─────────────────────────────────────────────────────────────────────
+  // WO DIE LEISTE LANDET, WENN SIE NIEMAND VERSCHOBEN HAT.
+  //
+  // Bis 2026-09-07 war das `top-3 left-1/2` — oben MITTIG. Genau dort liegt
+  // die Canvas-Werkzeugleiste: sie beginnt bei `left: 8` und ist bis zu
+  // 880 px breit, die Mitte einer 1070 px breiten Flaeche liegt also
+  // mitten in ihr. Gemessen im laufenden Fenster: die Suchleiste verdeckte
+  // die Ebenen-Schalter „Audio", „Control" und „Network" — drei Schalter,
+  // die man nicht sieht und nicht trifft.
+  //
+  // Die Leiste UMBRICHT (`flexWrap: 'wrap'`), ihre Hoehe haengt also von
+  // Fensterbreite, Sprache und Auswahl ab. Eine feste Zahl waere hier nur
+  // eine andere Kollision, deshalb wird gemessen: die Suche setzt sich
+  // unter die tatsaechliche Unterkante der Werkzeugleiste.
+  const [toolbarBottom, setToolbarBottom] = useState(0)
+  useEffect(() => {
+    const eigen = containerRef.current
+    const wurzel = eigen?.offsetParent ?? document.body
+    const leiste = wurzel.querySelector<HTMLElement>('[data-cp-canvas-toolbar]')
+    if (!leiste) return
+    const messen = () => {
+      const r = leiste.getBoundingClientRect()
+      const w = wurzel.getBoundingClientRect()
+      setToolbarBottom(Math.round(r.bottom - w.top))
+    }
+    messen()
+    const ro = new ResizeObserver(messen)
+    ro.observe(leiste)
+    ro.observe(wurzel)
+    return () => ro.disconnect()
+    // `open` haengt drin, weil die Leiste im geschlossenen Zustand ein
+    // anderes Element ist und `containerRef` dann neu zeigt.
+  }, [open])
+
+  const posClass = pos ? '' : 'left-1/2 -translate-x-1/2'
+  const posStyle = pos
+    ? { left: pos.x, top: pos.y }
+    : { top: toolbarBottom > 0 ? toolbarBottom + 8 : 12 }
 
   const Grip = (
     <button

--- a/src/renderer/components/Canvas/CanvasToolbar.tsx
+++ b/src/renderer/components/Canvas/CanvasToolbar.tsx
@@ -318,6 +318,11 @@ export const CanvasToolbar = ({ mode = 'main' }: { mode?: CanvasToolbarMode } = 
     <div
       ref={containerRef}
       className="nodrag nopan"
+      /* Marke fuer die Geraete-Suche: sie legt sich sonst genau hierhin.
+         Die Leiste UMBRICHT (`flexWrap`), ihre Hoehe ist also nicht
+         konstant — wer sie umgehen will, muss sie MESSEN. Siehe
+         `CanvasSearch.tsx`. */
+      data-cp-canvas-toolbar=""
       style={{
         position: 'absolute',
         top: 8,

--- a/src/renderer/components/Canvas/CanvasToolbar.tsx
+++ b/src/renderer/components/Canvas/CanvasToolbar.tsx
@@ -34,6 +34,7 @@ type ToolbarTokens = {
 // Module-level (not defined during render) so React keeps a stable type.
 const IconButton = ({
   title,
+  label,
   onClick,
   active,
   disabled,
@@ -42,6 +43,16 @@ const IconButton = ({
   T,
 }: {
   title: string
+  /**
+   * Sichtbare Beschriftung neben dem Symbol.
+   *
+   * Optional, weil nicht jedes Symbol eine braucht: die Ausrichte-Knoepfe
+   * tragen in jedem Zeichenprogramm dieselben Zeichen, und sie erscheinen nur
+   * bei Auswahl. Wo ein Knopf aber DAUERHAFT steht und sein Symbol nichts
+   * Gelerntes ist, gehoert das Wort daneben — der Tooltip kommt erst nach
+   * Zeigen und Warten, und danach sucht niemand.
+   */
+  label?: string
   onClick?: () => void
   active?: boolean
   disabled?: boolean
@@ -60,12 +71,11 @@ const IconButton = ({
       onClick={onClick}
       disabled={disabled}
       style={{
-        width: T.iconBtnSize,
-        height: T.iconBtnSize,
+        ...(label ? { height: T.iconBtnSize, padding: '0 8px', gap: 4 } : { width: T.iconBtnSize, height: T.iconBtnSize, padding: 0 }),
         display: 'inline-flex',
         alignItems: 'center',
         justifyContent: 'center',
-        padding: 0,
+        fontSize: 11,
         background: active ? T.btnActiveBg : T.btnBg,
         color: active ? T.btnActiveText : (color ?? T.text),
         border: '1px solid transparent',
@@ -84,6 +94,7 @@ const IconButton = ({
       }}
     >
       {children}
+      {label && <span>{label}</span>}
     </button>
   </Tooltip>
 )
@@ -414,7 +425,14 @@ export const CanvasToolbar = ({ mode = 'main' }: { mode?: CanvasToolbarMode } = 
           auch ohne Auswahl ein leeres Rahmen-Rechteck erstellt. */}
       {mode === 'main' && (
         <>
+          {/* BESCHRIFTET 2026-09-07: dieser Knopf ist immer sichtbar und trug
+              nur ein gestricheltes Rechteck. „Ein Rahmen" ist nichts, was man
+              aus einem Symbol errät, und der Tooltip kommt erst nach Zeigen
+              und Warten. Die Ausrichte-Knöpfe daneben bleiben Symbole: sie
+              erscheinen nur bei Auswahl, und ihre Zeichen (links/mittig/
+              verteilen) sind in jedem Zeichenprogramm dieselben. */}
           <IconButton T={T}
+            label={t('toolbar.location.label', 'Rahmen')}
             title={
               hasSelection
                 ? format(t('toolbar.location.addAround', 'Rahmen um die {count} markierten Geräte'), { count: selectedEquipmentIds.length })
@@ -699,85 +717,31 @@ export const CanvasToolbar = ({ mode = 'main' }: { mode?: CanvasToolbarMode } = 
           nutzen genau diese 5 Top-Level-Layer als Branchenstandard. */}
       <LayerVisibilityChips />
       <span style={dividerStyle} />
-      {/* v7.9.67 / #177 — 3 Lock-Mode-Buttons (Rahmen / Geräte / Kabel).
-          Toggelt globalen Schutz gegen Verschieben pro Objektart. */}
-      {([
-        {
-          key: 'frames',
-          active: lockFrames,
-          toggle: () => setLockFrames(!lockFrames),
-          title: lockFrames
-            ? t('toolbar.lock.frames.locked', 'Rahmen entsperren')
-            : t('toolbar.lock.frames.unlocked', 'Rahmen sperren (keine Frame-Verschiebung)'),
-          icon: (
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-              <rect x="2" y="2" width="12" height="12" rx="1" />
-            </svg>
-          ),
-        },
-        {
-          key: 'equipment',
-          active: lockEquipment,
-          toggle: () => setLockEquipment(!lockEquipment),
-          title: lockEquipment
-            ? t('toolbar.lock.equipment.locked', 'Geräte entsperren')
-            : t('toolbar.lock.equipment.unlocked', 'Geräte sperren (keine Geräte-Verschiebung)'),
-          icon: (
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-              <rect x="2" y="4" width="12" height="8" rx="1" />
-              <circle cx="5" cy="8" r="0.8" fill="currentColor" />
-              <circle cx="11" cy="8" r="0.8" fill="currentColor" />
-            </svg>
-          ),
-        },
-        {
-          key: 'cables',
-          active: lockCables,
-          toggle: () => setLockCables(!lockCables),
-          title: lockCables
-            ? t('toolbar.lock.cables.locked', 'Kabel entsperren')
-            : t('toolbar.lock.cables.unlocked', 'Kabel sperren (keine Waypoint-Bearbeitung)'),
-          icon: (
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-              <path d="M2 12c2 0 2-8 6-8s4 8 6 8" />
-            </svg>
-          ),
-        },
-      ] as const).map((btn) => (
-        <button
-          key={btn.key}
-          type="button"
-          onClick={btn.toggle}
-          title={btn.title}
-          style={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            width: T.iconBtnSize,
-            height: T.iconBtnSize,
-            background: btn.active ? '#0e7490' : T.btnBg,
-            color: btn.active ? '#e0f2fe' : T.text,
-            border: `1px solid ${btn.active ? '#06b6d4' : T.border}`,
-            borderRadius: 6,
-            cursor: 'pointer',
-            position: 'relative',
-          }}
-        >
-          {btn.icon}
-          {btn.active && (
-            <svg
-              width="8"
-              height="8"
-              viewBox="0 0 16 16"
-              fill="currentColor"
-              style={{ position: 'absolute', right: 2, bottom: 2 }}
-            >
-              <rect x="5" y="7" width="6" height="5" rx="0.5" />
-              <path d="M6 7V5.5a2 2 0 0 1 4 0V7" fill="none" stroke="currentColor" strokeWidth="1.2" />
-            </svg>
-          )}
-        </button>
-      ))}
+      {/* v7.9.67 / #177 — der Schutz gegen versehentliches Verschieben, je
+          Objektart (Rahmen / Geräte / Kabel).
+
+          ZUSAMMENGELEGT 2026-09-07, auf Zuruf des Nutzers: „Nicht jeder
+          Button ist beschriftet und man erkennt nicht auf den ersten Blick
+          wofür er gut sein soll." Hier standen DREI Knöpfe nebeneinander,
+          alle gleich gross, alle ohne Text, unterschieden nur durch ein
+          Rechteck, ein Rechteck mit zwei Punkten und eine Wellenlinie. Wer
+          die drei nicht kennt, kann sie nicht auseinanderhalten — und die
+          Beschriftung stand nur im Tooltip, also erst nach Zeigen und
+          Warten.
+
+          Jetzt EIN Knopf mit dem Wort „Sperren" und der Zahl der aktiven
+          Sperren; die drei Schalter stehen beschriftet im Menü darunter.
+          Das nimmt der Leiste zwei Bedienelemente und gibt dem dritten
+          einen lesbaren Namen. */}
+      <LockMenu
+        lockFrames={lockFrames}
+        setLockFrames={setLockFrames}
+        lockEquipment={lockEquipment}
+        setLockEquipment={setLockEquipment}
+        lockCables={lockCables}
+        setLockCables={setLockCables}
+        T={T}
+      />
       <span style={dividerStyle} />
       <button
         type="button"
@@ -1265,6 +1229,180 @@ const DefaultsMenu = ({
               />
               <span>{opt.label}</span>
             </label>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+
+/**
+ * Der Sperren-Knopf mit seinen drei beschrifteten Schaltern.
+ *
+ * WARUM EIN MENUE UND NICHT DREI KNOEPFE. Weil drei gleich grosse Symbole
+ * ohne Text nicht unterscheidbar sind — das war die Beschwerde. Ein Wort auf
+ * dem Knopf sagt, worum es geht; die Zahl daneben sagt, ob gerade etwas
+ * gesperrt ist, ohne dass man das Menue oeffnen muss. Erst wer wirklich
+ * umschalten will, klickt hinein, und dort steht jeder Schalter ausgeschrieben.
+ *
+ * Sperren ist eine Einstellung, die man einmal setzt und dann stehen laesst —
+ * ein zusaetzlicher Klick kostet hier nichts. Bei einer Handlung, die man
+ * dutzendfach am Tag ausloest, waere dieselbe Aenderung falsch.
+ */
+const LockMenu = ({
+  lockFrames,
+  setLockFrames,
+  lockEquipment,
+  setLockEquipment,
+  lockCables,
+  setLockCables,
+  T,
+}: {
+  lockFrames: boolean
+  setLockFrames: (v: boolean) => void
+  lockEquipment: boolean
+  setLockEquipment: (v: boolean) => void
+  lockCables: boolean
+  setLockCables: (v: boolean) => void
+  T: ToolbarTokens
+}) => {
+  const t = useTranslation()
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  const schalter = [
+    {
+      key: 'frames',
+      an: lockFrames,
+      um: () => setLockFrames(!lockFrames),
+      label: t('toolbar.lock.frames.label', 'Rahmen'),
+      note: t('toolbar.lock.frames.note', 'Keine Frame-Verschiebung'),
+    },
+    {
+      key: 'equipment',
+      an: lockEquipment,
+      um: () => setLockEquipment(!lockEquipment),
+      label: t('toolbar.lock.equipment.label', 'Geräte'),
+      note: t('toolbar.lock.equipment.note', 'Keine Geräte-Verschiebung'),
+    },
+    {
+      key: 'cables',
+      an: lockCables,
+      um: () => setLockCables(!lockCables),
+      label: t('toolbar.lock.cables.label', 'Kabel'),
+      note: t('toolbar.lock.cables.note', 'Keine Waypoint-Bearbeitung'),
+    },
+  ]
+  const aktiv = schalter.filter((s) => s.an).length
+
+  return (
+    <div ref={ref} style={{ position: 'relative' }}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        title={t('toolbar.lock.title', 'Schutz gegen versehentliches Verschieben')}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 4,
+          height: T.iconBtnSize,
+          padding: '0 8px',
+          background: aktiv > 0 ? '#0e7490' : open ? T.btnActiveBg : T.btnBg,
+          color: aktiv > 0 ? '#e0f2fe' : open ? T.btnActiveText : T.text,
+          border: `1px solid ${aktiv > 0 ? '#06b6d4' : 'transparent'}`,
+          borderRadius: 6,
+          cursor: 'pointer',
+          fontSize: 11,
+        }}
+      >
+        <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <rect x="4" y="7" width="8" height="6" rx="1" />
+          <path d="M5.5 7V5a2.5 2.5 0 0 1 5 0v2" />
+        </svg>
+        <span>{t('toolbar.lock.button', 'Sperren')}</span>
+        {/* Die Zahl steht AUSSEN, damit „ist gerade etwas gesperrt" ohne
+            Oeffnen beantwortet ist. Bei null wird nichts gezeigt: eine „0"
+            waere eine Angabe ueber nichts. */}
+        {aktiv > 0 && <span style={{ fontVariantNumeric: 'tabular-nums' }}>{aktiv}/3</span>}
+        <span style={{ fontSize: 9 }}>{open ? '▴' : '▾'}</span>
+      </button>
+      {open && (
+        <div
+          role="menu"
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 4px)',
+            // RECHTS verankert, nicht links: dieser Knopf sitzt am rechten
+            // Ende der Werkzeugleiste, und ein nach rechts aufklappendes
+            // Menue laeuft dort in den Inspector und wird abgeschnitten —
+            // gesehen im ersten Screenshot dieser Aenderung, „Keine
+            // Waypoint-Bearbeitun". Nach links klappt es ins Freie.
+            right: 0,
+            minWidth: 220,
+            background: T.bg,
+            border: `1px solid ${T.border}`,
+            borderRadius: 8,
+            padding: 8,
+            boxShadow: '0 8px 20px rgba(0,0,0,0.3)',
+            fontSize: 11,
+            color: T.text,
+            zIndex: 30,
+          }}
+        >
+          {schalter.map((s) => (
+            <button
+              key={s.key}
+              type="button"
+              onClick={s.um}
+              style={{
+                display: 'flex',
+                width: '100%',
+                alignItems: 'center',
+                gap: 8,
+                padding: '5px 6px',
+                marginBottom: 2,
+                background: s.an ? T.btnActiveBg : 'transparent',
+                color: s.an ? T.btnActiveText : T.text,
+                border: '1px solid transparent',
+                borderRadius: 4,
+                cursor: 'pointer',
+                fontSize: 11,
+                textAlign: 'left',
+              }}
+            >
+              <span
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: 14,
+                  height: 14,
+                  borderRadius: 3,
+                  border: `1px solid ${s.an ? '#06b6d4' : T.border}`,
+                  background: s.an ? '#0e7490' : 'transparent',
+                  flexShrink: 0,
+                }}
+              >
+                {s.an && (
+                  <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="#e0f2fe" strokeWidth="2.5">
+                    <path d="M3 8.5l3.5 3.5L13 5" />
+                  </svg>
+                )}
+              </span>
+              <span style={{ flex: 1, minWidth: 0 }}>
+                <span style={{ display: 'block' }}>{s.label}</span>
+                <span style={{ display: 'block', color: T.textMuted, fontSize: 10 }}>{s.note}</span>
+              </span>
+            </button>
           ))}
         </div>
       )}

--- a/src/renderer/components/Library/LibraryPanel.tsx
+++ b/src/renderer/components/Library/LibraryPanel.tsx
@@ -693,8 +693,28 @@ export const LibraryPanel = () => {
           konsistent deutschen Labels (Geräte/Kabel/Gruppen/Racks).
           Counts NUR an der kleinsten Granularität — der R-Badge am
           Equipment-Tab ist raus, weil die Lokal/Rentman-Untertoggle
-          die gleiche Info zeigt. Tab-Zeile in EINE Zeile gepackt. */}
-      <div className="mb-2 flex items-center gap-1 text-cp-xs">
+          die gleiche Info zeigt.
+
+          BERICHTIGT 2026-09-07 — hier stand „Tab-Zeile in EINE Zeile
+          gepackt", und genau das war der Fehler. Gemessen im laufenden
+          Fenster: die Zeile ist 235 px breit, ihr Inhalt 390 px. Die drei
+          runden Panel-Knöpfe (Einklappen, Abdocken, Auslagern) fressen
+          allein 104 px; danach passen „Geräte" und knapp „Kabel" hinein —
+          **„Gruppen" und „Racks" lagen vollständig ausserhalb** und waren
+          damit nicht angezeigt UND nicht anklickbar. Ohne Scrollbar,
+          ohne Umbruch, bei jeder Fenstergrösse, weil die Bibliothek
+          260 px fest breit ist. Zwei von vier Registern existierten für
+          den Nutzer nicht.
+
+          Die Zeile ist deshalb aufgeteilt: die Panel-Knöpfe stehen in
+          ihrer eigenen Reihe (sie gehören zum Rahmen, nicht zum Inhalt),
+          die vier Register liegen in einem ZWEISPALTIGEN Raster. Ein
+          Raster und keine Flex-Zeile mit Umbruch: so ist die Lage jedes
+          Registers unabhängig von der Textlänge — die englischen Labels
+          („Equipment", „Cables", „Groups", „Racks") sind zusammen 309 px
+          breit und würden in einer Zeile genauso herausfallen. */}
+      {(!floating && !inPopout) && (
+        <div className="mb-1 flex items-center gap-1 text-cp-xs">
         {!floating && !inPopout && (
           <button
             type="button"
@@ -737,10 +757,14 @@ export const LibraryPanel = () => {
             <Icon icon={ExternalLink} size="xs" />
           </button>
         )}
+        </div>
+      )}
+      <div className="mb-2 grid grid-cols-2 gap-1 text-cp-xs">
         <TabButton
           active={tab === 'equipment'}
           onClick={() => setTab('equipment')}
           label={t('library.tab.equipment', 'Geräte')}
+          title={t('library.tab.equipment', 'Geräte')}
           icon={
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
               <rect x="2" y="3" width="12" height="10" rx="1.5" />
@@ -754,6 +778,7 @@ export const LibraryPanel = () => {
           active={tab === 'cables'}
           onClick={() => setTab('cables')}
           label={t('library.tab.cables', 'Kabel')}
+          title={t('library.tab.cables', 'Kabel')}
           icon={
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
               <path d="M2 11 Q 5 5, 8 8 T 14 5" strokeLinecap="round" />

--- a/src/renderer/components/Library/TabButton.tsx
+++ b/src/renderer/components/Library/TabButton.tsx
@@ -24,12 +24,16 @@ export const TabButton = ({
     type="button"
     onClick={onClick}
     title={title}
-    className={`flex items-center gap-1 rounded px-2 py-1 ${
+    className={`flex min-w-0 items-center gap-1 rounded px-2 py-1 ${
       active ? 'bg-sky-700 text-white' : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
     }`}
   >
-    <span className={active ? 'text-white' : 'text-cp-text-muted'}>{icon}</span>
-    <span>{label}</span>
+    <span className={`shrink-0 ${active ? 'text-white' : 'text-cp-text-muted'}`}>{icon}</span>
+    {/* `truncate` + `title` als Gürtel und Hosenträger: das Raster gibt jedem
+        Register dieselbe Breite, aber eine künftige Sprache mit längerem Wort
+        soll das Label KÜRZEN und nicht die Nachbarn aus dem Panel schieben —
+        genau das ist am 2026-09-07 mit „Gruppen" und „Racks" passiert. */}
+    <span className="truncate">{label}</span>
     {count != null && count > 0 && (
       <span
         className={`ml-1 rounded-full px-1 text-[10px] ${

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -789,6 +789,18 @@ export const en: Dict = {
   'toolbar.lock.equipment.unlocked': 'Lock devices (no device moves)',
   'toolbar.lock.cables.locked': 'Unlock cables',
   'toolbar.lock.cables.unlocked': 'Lock cables (no waypoint editing)',
+  // Die drei Icon-Knoepfe sind zu EINEM beschrifteten Knopf mit Menue
+  // zusammengelegt (2026-09-07). Die sechs Schluessel darueber bleiben, weil
+  // sie noch in der Kurzhilfe und in den Tastenkuerzeln vorkommen.
+  'toolbar.location.label': 'Frame',
+  'toolbar.lock.button': 'Lock',
+  'toolbar.lock.title': 'Protection against accidental moves',
+  'toolbar.lock.frames.label': 'Frames',
+  'toolbar.lock.frames.note': 'No frame moves',
+  'toolbar.lock.equipment.label': 'Devices',
+  'toolbar.lock.equipment.note': 'No device moves',
+  'toolbar.lock.cables.label': 'Cables',
+  'toolbar.lock.cables.note': 'No waypoint editing',
   'toolbar.planLock.viewer': 'Viewer file — read-only',
   'toolbar.planLock.finalized': 'Plan is finalised (click: re-enable editing)',
   'toolbar.planLock.editing': 'Mark plan as finalised',


### PR DESCRIPTION
## Gemeldet

> „Die linke Equipment-Leiste, da kann man Equipment lesen, aber Cable schon nicht mehr."
> „Das Find-Devices-Fenster überlagert immer andere Fenster."
> „Nicht jeder Button ist beschriftet und man erkennt nicht auf den ersten Blick wofür er gut sein soll. Generell gibt es sehr viele Bedienelemente."

Alles im laufenden Fenster nachgemessen. Zwei der drei Punkte waren schlimmer als beschrieben.

## 1. Bibliothek: zwei von vier Registern gab es nicht

| | |
|---|---|
| Register-Zeile sichtbar | **235 px** |
| Inhalt | **390 px** (englisch 411 px) |
| davon Panel-Knöpfe | 104 px |
| „Gruppen" beginnt bei | 250 px |
| „Racks" beginnt bei | 335 px |

**Vollständig außerhalb** — nicht sichtbar, nicht anklickbar, bei jeder Fenstergröße, weil die Bibliothek 260 px fest breit ist. Der Kommentar über der Zeile sagte *„Tab-Zeile in EINE Zeile gepackt"*; genau das war der Fehler.

Jetzt: Panel-Knöpfe in eigener Reihe (sie gehören zum Rahmen, nicht zum Inhalt), die vier Register in einem **zweispaltigen Raster** — Lage unabhängig von der Textlänge. `TabButton` bekommt `truncate` + `title`, damit eine längere Übersetzung das Label kürzt statt die Nachbarn hinauszuschieben.

## 2. Die Geräte-Suche lag auf der Werkzeugleiste

Vorgabe-Lage war `top-3 left-1/2`. Dort liegt die Werkzeugleiste (ab `left: 8`, bis 880 px breit) — verdeckt waren **„Audio", „Control", „Network"**. Die Leiste umbricht, ihre Höhe ist nicht konstant; die Suche misst deshalb ihre tatsächliche Unterkante (`ResizeObserver` auf `[data-cp-canvas-toolbar]`) und setzt sich darunter. Verschieben und Merken bleiben.

## 3. Drei gleich aussehende Schlösser

Gemessen: **94 sichtbare Bedienelemente gleichzeitig, 36 ohne sichtbare Beschriftung** (Kopfleiste 10 · Bibliothek 42 · Werkzeugleiste 15 · Canvas 23). *Stumm* im Sinne der Barrierefreiheit war keines — alle 36 tragen `title`/`aria-label`. Genau das ist der Punkt: ein Tooltip kommt erst nach Zeigen und Warten.

Der schlimmste Fall: drei Knöpfe nebeneinander (Rahmen / Geräte / Kabel sperren), gleich groß, ohne Text, unterschieden durch ein Rechteck, ein Rechteck mit zwei Punkten und eine Wellenlinie.

**Jetzt ein Knopf „Sperren"** mit Zahl („2/3") wenn etwas gesperrt ist — beantwortet *ist gerade etwas gesperrt* ohne Öffnen; bei null steht nichts, eine „0" wäre eine Angabe über nichts. Die drei Schalter stehen ausgeschrieben im Menü, je mit ihrer Folge in einer zweiten Zeile.

Sperren ist eine Einstellung, die man einmal setzt — ein Klick mehr kostet nichts. Bei einer Handlung, die man dutzendfach am Tag auslöst, wäre dieselbe Änderung falsch.

Zusätzlich beschriftet: der **Rahmen**-Knopf (stand dauerhaft da, trug nur ein gestricheltes Rechteck). `IconButton` bekommt dafür ein optionales `label`. Die Ausrichte-Knöpfe bleiben Symbole: sie erscheinen nur bei Auswahl, und ihre Zeichen sind in jedem Zeichenprogramm dieselben.

**Ergebnis:** Werkzeugleiste 15 → 13 Bedienelemente, unbeschriftete gesamt 36 → 32.

## 4. `npm run ui:overflow` — der Guard, den es brauchte

Kein Test konnte das sehen. `vitest` rendert nicht und kennt keine Schriftbreiten; `ui:smoke` prüft, dass Menüs Einträge öffnen. Beide waren grün, während zwei Register fehlten.

Der Guard startet die gebaute App, lädt das Beispielprojekt (ein leerer Plan rendert die schwebenden Elemente gar nicht erst) und meldet in zwei Fenstergrößen:

1. **Reihen, aus denen ein Kind herausfällt** — verlorene Bedienelemente.
2. **Beschriftungen, die beschnitten sind** — *lesbar* gegen *nicht mehr lesbar*, also die Beschwerde selbst.
3. **Klappmenüs der Werkzeugleiste** — geöffnet und einzeln vermessen.
4. **Bedienelemente unter einem dauerhaft schwebenden Element** — per `elementFromPoint` bestätigt, ohne offene Menüs/Modals.

Die Zeichenfläche ist ausgenommen: dort *liegt* Inhalt außerhalb des Sichtfensters, dafür gibt es Schwenken und Zoomen. Im selben CI-Job wie `ui:smoke` — beide brauchen `npm ci`, `npm run build` und einen X-Server.

## Zwei Guard-Fassungen sind an Gegensonden gescheitert, bevor sie taugten

| Sonde | erste Fassung | zweite Fassung |
|---|---|---|
| Bibliothek auf alten Stand | **grün** — sie prüfte nur „fällt heraus", und `truncate` macht das Label kurz statt unerreichbar | rot, 6 Befunde |
| „Sperren"-Menü linksbündig | **grün** — sie prüfte gegen `innerWidth`; das Menü lag mit 1065..1285 vollständig im 1500 px breiten Fenster und trotzdem halb außerhalb seines Rahmens (264..1216) | rot, 1 Befund mit beiden Zahlen |

Aus der ersten Lücke ist Prüfung 2 entstanden, aus der zweiten die Messung gegen den ersten abschneidenden Vorfahren statt gegen das Fenster.

**Der zweite Fehler war mein eigener:** die erste Fassung des neuen Menüs klappte nach rechts auf und wurde vom Inspector abgeschnitten — derselbe Fehler, den dieser PR behebt, eine Stunde später neu gebaut. Gesehen wieder an einem Screenshot, nicht von der Prüfung. Deshalb öffnet der Guard jetzt Menüs.

## Was bleibt

„Generell sehr viele Bedienelemente" und „viele schriftliche Informationen, die überladen wirken" sind damit **nicht** erledigt — 92 Bedienelemente und 32 unbeschriftete stehen weiter. Dieser PR nimmt den Fall, der objektiv falsch war (drei nicht unterscheidbare Symbole), und stellt die Messung bereit, an der sich der Rest abarbeiten lässt.

## Prüfung

- `npm test` — 173 Dateien, 2699 Tests grün
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npm run lint` — 0 Fehler (10 vorbestehende Warnungen)
- `xvfb-run -a npm run ui:smoke` — 5 Menüs, 0 ohne Einträge
- `xvfb-run -a npm run ui:overflow` — 0 Befunde bei 1500×950 und 1280×800, 2 Klappmenüs geprüft

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT
