### PR TITLE
ui: der Werkzeuge-Plan abgearbeitet — Datei-Fluss, Rechner an ihre Tabelle, Verkabelung an die Auswahl

### DIFF
--- a/src/renderer/components/Analysis/AnalysisDialog.tsx
+++ b/src/renderer/components/Analysis/AnalysisDialog.tsx
@@ -10,7 +10,7 @@
 // Die 3-Phasen-Last-/Distro-Planung (#345) lebt weiterhin im Strom-Tab der
 // Calculators (dort bereits implementiert) — hier nicht dupliziert.
 
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { PanelHint } from '../shared/PanelHint'
 import { BarChart3, Calculator, Download, Plus, Trash2 } from 'lucide-react'
 import { useUiStore } from '../../store/uiStore'
@@ -2714,26 +2714,38 @@ const TABS: { id: Tab; labelKey: string; fallback: string }[] = [
   { id: 'sheet', labelKey: 'analysis.tab.sheet', fallback: 'Blatt prüfen' },
 ]
 
+/**
+ * Aussenhuelle: montiert den Inhalt ERST beim Oeffnen — und damit bei jedem
+ * Oeffnen neu.
+ *
+ * WARUM DIESE FORM UND KEIN `useEffect` (berichtigt 2026-09-07). Der
+ * Start-Reiter aus `openAnalysis('network')` war zuerst als Effekt gesetzt,
+ * der beim Oeffnen `setActive` rief. Das ist das Muster, das
+ * `react-hooks/set-state-in-effect` als FEHLER meldet: eine zweite
+ * Renderrunde, nur um einen Anfangswert zu setzen.
+ *
+ * Erst beim Oeffnen montiert, ist der gewuenschte Reiter schlicht der
+ * ANFANGSWERT — und „nur beim Oeffnen, damit ein Reiterwechsel von Hand nicht
+ * zurueckspringt" gilt von selbst, statt als Bedingung im Effekt.
+ */
 export const AnalysisDialog = () => {
-  const t = useTranslation()
   const open = useUiStore((s) => s.analysis.open)
+  if (!open) return null
+  return <AnalysisDialogInner />
+}
+
+const AnalysisDialogInner = () => {
+  const t = useTranslation()
   const gewuenschterTab = useUiStore((s) => s.analysis.tab)
   const close = useUiStore((s) => s.closeAnalysis)
   const projectName = useProjectStore((s) => s.project.metadata.name)
-  const [active, setActive] = useState<Tab>('weight')
-
-  // Beim Oeffnen auf den gewuenschten Reiter springen — und nur dann, damit
-  // ein Reiterwechsel von Hand nicht sofort zurueckgesetzt wird.
-  useEffect(() => {
-    if (!open || !gewuenschterTab) return
-    if (TABS.some((tb) => tb.id === gewuenschterTab)) setActive(gewuenschterTab as Tab)
-  }, [open, gewuenschterTab])
-
-  if (!open) return null
+  const [active, setActive] = useState<Tab>(() =>
+    TABS.some((tb) => tb.id === gewuenschterTab) ? (gewuenschterTab as Tab) : 'weight',
+  )
 
   return (
     <ModalShell
-      open={open}
+      open
       onClose={close}
       maxWidth="4xl"
       titleIcon={<Icon icon={BarChart3} size="md" />}

--- a/src/renderer/components/Analysis/AnalysisDialog.tsx
+++ b/src/renderer/components/Analysis/AnalysisDialog.tsx
@@ -10,7 +10,7 @@
 // Die 3-Phasen-Last-/Distro-Planung (#345) lebt weiterhin im Strom-Tab der
 // Calculators (dort bereits implementiert) — hier nicht dupliziert.
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { PanelHint } from '../shared/PanelHint'
 import { BarChart3, Calculator, Download, Plus, Trash2 } from 'lucide-react'
 import { useUiStore } from '../../store/uiStore'
@@ -2717,9 +2717,17 @@ const TABS: { id: Tab; labelKey: string; fallback: string }[] = [
 export const AnalysisDialog = () => {
   const t = useTranslation()
   const open = useUiStore((s) => s.analysis.open)
+  const gewuenschterTab = useUiStore((s) => s.analysis.tab)
   const close = useUiStore((s) => s.closeAnalysis)
   const projectName = useProjectStore((s) => s.project.metadata.name)
   const [active, setActive] = useState<Tab>('weight')
+
+  // Beim Oeffnen auf den gewuenschten Reiter springen — und nur dann, damit
+  // ein Reiterwechsel von Hand nicht sofort zurueckgesetzt wird.
+  useEffect(() => {
+    if (!open || !gewuenschterTab) return
+    if (TABS.some((tb) => tb.id === gewuenschterTab)) setActive(gewuenschterTab as Tab)
+  }, [open, gewuenschterTab])
 
   if (!open) return null
 

--- a/src/renderer/components/Analysis/AnalysisDialog.tsx
+++ b/src/renderer/components/Analysis/AnalysisDialog.tsx
@@ -12,7 +12,7 @@
 
 import { useMemo, useState } from 'react'
 import { PanelHint } from '../shared/PanelHint'
-import { BarChart3, Download, Plus, Trash2 } from 'lucide-react'
+import { BarChart3, Calculator, Download, Plus, Trash2 } from 'lucide-react'
 import { useUiStore } from '../../store/uiStore'
 import { useProjectStore } from '../../store/projectStore'
 import { ModalShell } from '../shared/ModalShell'
@@ -123,6 +123,32 @@ import {
   scannedRange,
 } from '../../lib/spectrumScan'
 import { DEFAULT_OCCUPIED_DBM, VERDICT_LABEL, type SpectrumScan } from '../../types/spectrumScan'
+
+/**
+ * Der Weg zum passenden Rechner, direkt neben der Tabelle, die seine Zahl
+ * zeigt.
+ *
+ * Nutzer-Frage 2026-09-07: „Die ganzen Tools muessten eigentlich besser
+ * eingebaut werden da wo man sie auch wirklich braucht." Wer auf die
+ * Leistungs-Spalte schaut und wissen will, ob die Phase reicht, soll den
+ * Rechner HIER finden — nicht in einem Menue, das er dafuer erst schliessen
+ * und wieder oeffnen muss.
+ *
+ * Die beiden Menue-Eintraege sind dafuer entfallen. Die zwei anderen Rechner
+ * (Aufzeichnungs-Speicher, Projektion) bleiben im Menue: sie haben hier keine
+ * Tabelle, neben die sie gehoerten, und ein Knopf ohne Bezug waere nur eine
+ * weitere Zeile.
+ */
+const RechnerLink = ({ onClick, label }: { onClick: () => void; label: string }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className="inline-flex items-center gap-1 rounded border border-cp-border bg-cp-surface-2 px-2 py-0.5 text-cp-xs text-cp-text hover:border-sky-500 hover:bg-cp-surface-3"
+  >
+    <Icon icon={Calculator} size="xs" />
+    {label}
+  </button>
+)
 
 type Tab =
   | 'weight'
@@ -261,6 +287,12 @@ const WeightTab = ({ projectName }: { projectName: string }) => {
           'analysis.weight.intro',
           'Gewicht (kg) und Wärmelast je Kategorie aus den Geräte-Eigenschaften. Wärme ≈ Leistung × 3,412 BTU/h.',
         )} />
+      <div>
+        <RechnerLink
+          onClick={() => useUiStore.getState().openPowerCalc()}
+          label={t('app.menu.tools.power', 'Stromverbrauch berechnen…')}
+        />
+      </div>
       <table className="w-full text-cp-xs">
         <thead>
           <tr className="border-b border-[var(--cp-border)] text-left text-[var(--cp-text-muted)]">
@@ -666,6 +698,12 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
       <p className="text-cp-xs text-[var(--cp-text-muted)]">
         {t('analysis.network.intro', 'IP-/VLAN-Übersicht aller netzwerkfähigen Geräte mit Doppel-IP-Prüfung.')}
       </p>
+      <div>
+        <RechnerLink
+          onClick={() => useUiStore.getState().openBandwidthCalc()}
+          label={t('app.menu.tools.bandwidth', 'Bandbreite berechnen…')}
+        />
+      </div>
       {duplicates.length > 0 && (
         <div className="rounded border border-red-700/60 bg-red-900/30 p-2 text-cp-xs text-red-200">
           <div className="mb-1 font-semibold">{t('analysis.network.dupTitle', 'Doppelte IP-Adressen')}</div>

--- a/src/renderer/components/Canvas/BulkConnectDialog.tsx
+++ b/src/renderer/components/Canvas/BulkConnectDialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useUiStore } from '../../store/uiStore'
 import { useProjectStore } from '../../store/projectStore'
 import { projectHistory } from '../../store/projectHistory'
@@ -27,6 +27,8 @@ const toCableType = (connectorType: string): CableType =>
 export const BulkConnectDialog = () => {
   const t = useTranslation()
   const open = useUiStore((s) => s.bulkConnect.open)
+  const vorgabeVon = useUiStore((s) => s.bulkConnect.fromEqId)
+  const vorgabeNach = useUiStore((s) => s.bulkConnect.toEqId)
   const close = useUiStore((s) => s.closeBulkConnect)
   const equipment = useProjectStore((s) => s.project.equipment)
   const customCableSpecs = useUiStore((s) => s.customCableSpecs)
@@ -41,6 +43,20 @@ export const BulkConnectDialog = () => {
   const [count, setCount] = useState<number>(8)
   const [cableSpecId, setCableSpecId] = useState<string>('bnc-coax')
   const [lengthMeters, setLengthMeters] = useState<number>(2)
+
+  // VORBELEGUNG AUS DER AUSWAHL (2026-09-07). Wer zwei Geraete auf der
+  // Flaeche markiert und dort auf „Kabel verbinden" klickt, hat die Frage
+  // nach Quelle und Ziel bereits beantwortet — sie in zwei Aufklapplisten
+  // zu wiederholen ist die Sorte Doppelarbeit, wegen der das Werkzeug im
+  // Menue verstaubte.
+  //
+  // NUR BEIM OEFFNEN, nicht bei jeder Aenderung: sonst spraenge die Auswahl
+  // zurueck, sobald der Nutzer im Dialog ein anderes Geraet waehlt.
+  useEffect(() => {
+    if (!open) return
+    if (vorgabeVon) setFromEqId(vorgabeVon)
+    if (vorgabeNach) setToEqId(vorgabeNach)
+  }, [open, vorgabeVon, vorgabeNach])
 
   const allSpecs = useMemo(
     () => [...cableCatalog, ...customCableSpecs],

--- a/src/renderer/components/Canvas/BulkConnectDialog.tsx
+++ b/src/renderer/components/Canvas/BulkConnectDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useUiStore } from '../../store/uiStore'
 import { useProjectStore } from '../../store/projectStore'
 import { projectHistory } from '../../store/projectHistory'
@@ -24,9 +24,31 @@ const toCableType = (connectorType: string): CableType =>
  *
  * Trigger: Werkzeuge-Menue 'Mehrere Kabel verbinden...' (siehe MenuBar).
  */
+/**
+ * Aussenhuelle: montiert den Inhalt ERST beim Oeffnen — und damit bei jedem
+ * Oeffnen neu.
+ *
+ * WARUM DIESE FORM UND KEIN `useEffect` (berichtigt 2026-09-07). Die
+ * Vorbelegung aus der Canvas-Auswahl war zuerst als Effekt geschrieben, der
+ * beim Oeffnen `setFromEqId`/`setToEqId` rief. Das ist genau das Muster, das
+ * `react-hooks/set-state-in-effect` als FEHLER meldet: ein `setState` im
+ * Effekt-Rumpf erzwingt eine zweite Renderrunde, nur um einen Anfangswert zu
+ * setzen, den man auch gleich haette setzen koennen.
+ *
+ * Wird der Inhalt stattdessen erst bei `open` montiert, ist die Vorbelegung
+ * schlicht der ANFANGSWERT von `useState` — kein Effekt, keine zweite
+ * Renderrunde, und „nur beim Oeffnen" gilt von selbst statt als Bedingung im
+ * Effekt. Ein von Hand gewaehltes Geraet ueberlebt damit jede Aenderung am
+ * Store, weil nichts es mehr ueberschreibt.
+ */
 export const BulkConnectDialog = () => {
-  const t = useTranslation()
   const open = useUiStore((s) => s.bulkConnect.open)
+  if (!open) return null
+  return <BulkConnectDialogInner />
+}
+
+const BulkConnectDialogInner = () => {
+  const t = useTranslation()
   const vorgabeVon = useUiStore((s) => s.bulkConnect.fromEqId)
   const vorgabeNach = useUiStore((s) => s.bulkConnect.toEqId)
   const close = useUiStore((s) => s.closeBulkConnect)
@@ -34,29 +56,15 @@ export const BulkConnectDialog = () => {
   const customCableSpecs = useUiStore((s) => s.customCableSpecs)
   const addCablesBulk = useProjectStore((s) => s.addCablesBulk)
 
-  const [fromEqId, setFromEqId] = useState<string>('')
+  const [fromEqId, setFromEqId] = useState<string>(vorgabeVon ?? '')
   const [fromSide, setFromSide] = useState<'outputs' | 'inputs'>('outputs')
   const [fromStart, setFromStart] = useState<number>(1)
-  const [toEqId, setToEqId] = useState<string>('')
+  const [toEqId, setToEqId] = useState<string>(vorgabeNach ?? '')
   const [toSide, setToSide] = useState<'inputs' | 'outputs'>('inputs')
   const [toStart, setToStart] = useState<number>(1)
   const [count, setCount] = useState<number>(8)
   const [cableSpecId, setCableSpecId] = useState<string>('bnc-coax')
   const [lengthMeters, setLengthMeters] = useState<number>(2)
-
-  // VORBELEGUNG AUS DER AUSWAHL (2026-09-07). Wer zwei Geraete auf der
-  // Flaeche markiert und dort auf „Kabel verbinden" klickt, hat die Frage
-  // nach Quelle und Ziel bereits beantwortet — sie in zwei Aufklapplisten
-  // zu wiederholen ist die Sorte Doppelarbeit, wegen der das Werkzeug im
-  // Menue verstaubte.
-  //
-  // NUR BEIM OEFFNEN, nicht bei jeder Aenderung: sonst spraenge die Auswahl
-  // zurueck, sobald der Nutzer im Dialog ein anderes Geraet waehlt.
-  useEffect(() => {
-    if (!open) return
-    if (vorgabeVon) setFromEqId(vorgabeVon)
-    if (vorgabeNach) setToEqId(vorgabeNach)
-  }, [open, vorgabeVon, vorgabeNach])
 
   const allSpecs = useMemo(
     () => [...cableCatalog, ...customCableSpecs],
@@ -124,7 +132,7 @@ export const BulkConnectDialog = () => {
 
   return (
     <ModalShell
-      open={open}
+      open
       onClose={close}
       title={t('bulk.title', '🔗 Mehrere Kabel verbinden')}
       maxWidth="2xl"

--- a/src/renderer/components/Canvas/CanvasToolbar.tsx
+++ b/src/renderer/components/Canvas/CanvasToolbar.tsx
@@ -459,6 +459,38 @@ export const CanvasToolbar = ({ mode = 'main' }: { mode?: CanvasToolbarMode } = 
               <rect x="2" y="3" width="12" height="10" rx="0.5" strokeDasharray="2 1.5" />
             </svg>
           </IconButton>
+          {/* GENAU ZWEI markiert: Mehrfach-Verkabelung, mit beiden Geraeten
+              schon eingesetzt (2026-09-07).
+
+              Das Werkzeug stand nur im Menue, und dort verlangte es die
+              Auswahl von Quelle und Ziel in zwei Aufklapplisten — obwohl
+              genau das die Frage ist, die der Nutzer mit seiner Markierung
+              bereits beantwortet hat. Der Menue-Eintrag bleibt: er ist der
+              Weg fuer den, der nichts markiert hat, und die Listen sind dort
+              der richtige Rueckfall.
+
+              Bei EINEM oder DREI markierten Geraeten erscheint der Knopf
+              nicht: „von wo nach wo" hat dann keine eindeutige Antwort, und
+              eine geratene waere schlimmer als die Aufklappliste. */}
+          {selectedEquipmentIds.length === 2 && (
+            <IconButton T={T}
+              label={t('toolbar.bulkConnect.label', 'Kabel verbinden')}
+              title={t(
+                'toolbar.bulkConnect.title',
+                'Mehrere Kabel zwischen den zwei markierten Geräten auf einmal anlegen',
+              )}
+              onClick={() =>
+                useUiStore
+                  .getState()
+                  .openBulkConnect(selectedEquipmentIds[0], selectedEquipmentIds[1])
+              }
+            >
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+                <path d="M2 5h4M2 8h4M2 11h4M10 5h4M10 8h4M10 11h4" strokeLinecap="round" />
+                <path d="M6 5h4M6 8h4M6 11h4" strokeLinecap="round" opacity="0.5" />
+              </svg>
+            </IconButton>
+          )}
           {hasSelection && (
             <IconButton T={T}
               title={format(t('toolbar.group.save', '{count} markierte Geräte als Gruppe speichern'), { count: selectedEquipmentIds.length })}

--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -1,12 +1,57 @@
 import { useEffect, useRef, useState, useSyncExternalStore, type ChangeEvent } from 'react'
 import {
-  FileText, Clapperboard, FolderOpen, Save, SaveAll, Ruler, Upload, FileDown,
-  Image as ImageIcon, Calculator, Eye, MessageSquare, Paperclip, Plug, Cable,
-  Undo2, Redo2, Radio, Zap, BarChart3, Server, Monitor, MonitorPlay, SlidersHorizontal, Tag,
-  Shuffle, Headphones, Import as ImportIcon, Users, Lightbulb, Info, Check,
-  Pencil, Smartphone, Settings, HardDrive, Copy, ClipboardCheck, History, Sparkles, Drum,
-  Maximize, Maximize2, ZoomIn, ZoomOut, Scan, BoxSelect, RefreshCw, PackageCheck,
-  Keyboard, Command, Boxes, GitCompare,
+  BarChart3,
+  Boxes,
+  BoxSelect,
+  Cable,
+  Calculator,
+  Check,
+  Clapperboard,
+  ClipboardCheck,
+  Command,
+  Copy,
+  Drum,
+  Eye,
+  FileDown,
+  FileText,
+  FolderOpen,
+  GitCompare,
+  HardDrive,
+  Headphones,
+  History,
+  Image as ImageIcon,
+  Import as ImportIcon,
+  Info,
+  Keyboard,
+  Lightbulb,
+  Maximize,
+  Maximize2,
+  MessageSquare,
+  Monitor,
+  MonitorPlay,
+  PackageCheck,
+  Paperclip,
+  Pencil,
+  Plug,
+  Radio,
+  Redo2,
+  RefreshCw,
+  Ruler,
+  Save,
+  SaveAll,
+  Scan,
+  Server,
+  Settings,
+  Shuffle,
+  SlidersHorizontal,
+  Smartphone,
+  Sparkles,
+  Tag,
+  Undo2,
+  Upload,
+  Users,
+  ZoomIn,
+  ZoomOut,
 } from 'lucide-react'
 import { Icon } from '../shared/Icon'
 import {
@@ -535,6 +580,27 @@ export const MenuBar = ({
           <MenuItem onClick={() => cameraImportRef.current?.click()} icon={<Icon icon={ImportIcon} size="sm" />}>
             {t('app.menu.file.importCameras', 'MultiCam-Kameras importieren…')}
           </MenuItem>
+          {/* VERSCHOBEN 2026-09-07 aus dem Werkzeuge-Menue. Ein Import gehoert
+              dorthin, wo die anderen Importe stehen — yEd, MultiCam, .avplan
+              und die Identitaets-Karte lagen laengst hier, CSV, Rentman und
+              NetBox standen als einzige woanders. Wer eine Datei einlesen
+              will, sucht unter „Datei", nicht unter „Werkzeuge". */}
+          <MenuItem onClick={() => useUiStore.getState().openCsvImport()} icon={<Icon icon={ImportIcon} size="sm" />}>
+            {t('app.menu.tools.csvImport', 'Equipment aus CSV importieren…')}
+          </MenuItem>
+          {/* Rentman-Import nur wenn die Integration aktiv ist (standardmäßig
+              aus; Aktivierung in den Einstellungen → Integrationen). */}
+          {rentmanEnabled && (
+            <MenuItem onClick={() => useUiStore.getState().openRentmanImport()} icon={<Icon icon={Users} size="sm" />}>
+              {t('app.menu.tools.rentmanImport', 'Rentman-Import…')}
+            </MenuItem>
+          )}
+          {/* #597 — NetBox-Import, ebenfalls nur bei aktivem Modul. */}
+          {netboxEnabled && (
+            <MenuItem onClick={() => useUiStore.getState().openNetboxImport()} icon={<Icon icon={Server} size="sm" />}>
+              {t('app.menu.tools.netboxImport', 'NetBox-Import…')}
+            </MenuItem>
+          )}
           <MenuSep />
           <MenuItem onClick={() => void handleExportAvplan()} icon={<Icon icon={Upload} size="sm" />}>
             {t('app.menu.file.exportAvplan', 'Gesamtprojekt exportieren (.avplan)…')}
@@ -560,6 +626,35 @@ export const MenuBar = ({
               Eintrag zum Hub-Dialog mit allen Sektionen.
               User-Request: "Vereinheitliche zu einer Großen funktion".
               Strg+P bleibt als direkter Shortcut für den OS-Druckdialog. */}
+          {/* VERSCHOBEN 2026-09-07 aus dem Werkzeuge-Menue. Patch-Liste,
+              Stage-Plot und die Uebergabe-Doku sind AUSGABEN — Blaetter, die
+              den Plan verlassen. Sie gehoeren neben „Exportieren & Drucken",
+              nicht in eine Werkzeug-Liste, in der man sie nicht sucht. */}
+          <MenuItem onClick={() => useUiStore.getState().openPatchList()} icon={<Icon icon={Cable} size="sm" />}
+            note={t('app.menu.tools.patchList.note', 'Wer hängt an welchem Ein- und Ausgang')}
+          >
+            {t('app.menu.tools.patchList', 'Patch-Liste…')}
+          </MenuItem>
+          {festinstallationModule && (
+            <MenuItem onClick={() => useUiStore.getState().openInstallDocs()} icon={<Icon icon={PackageCheck} size="sm" />}>
+              {t('app.menu.tools.installDocs', 'Festinstallation: Doku & Übergabe…')}
+            </MenuItem>
+          )}
+          <MenuItem
+            onClick={() => {
+              const p = useProjectStore.getState().project
+              downloadBlob(
+                buildExportFilename(p.metadata.name, 'stageplot.svg'),
+                exportStagePlotSvg(p),
+                'image/svg+xml',
+              )
+            }}
+            icon={<Icon icon={ImageIcon} size="sm" />}
+          
+            note={t('app.menu.tools.stagePlot.note', 'Bühnenaufsicht als Ein-Seiten-Blatt')}
+          >
+            {t('app.menu.tools.stagePlot', 'Stage-Plot (SVG)…')}
+          </MenuItem>
           {onOpenExportDialog ? (
             <MenuItem onClick={onOpenExportDialog} icon={<Icon icon={Upload} size="sm" />}>
               {t('app.menu.file.export', 'Exportieren & Drucken…')}
@@ -714,19 +809,16 @@ export const MenuBar = ({
               Jetzt sechs Abschnitte mit drei bis fünf Einträgen, jede
               Überschrift für alle ihre Einträge wahr. Patchliste-Export liegt
               zusätzlich unter Datei → Exportieren & Drucken. */}
+          {/* VERSCHOBEN 2026-09-07: „Bandbreite berechnen" steht jetzt auf dem
+              Netzwerk-Reiter der Analysen, „Stromverbrauch berechnen" auf dem
+              Reiter „Gewicht & Waerme" — jeweils neben der Tabelle, deren
+              Zahl sie erklaeren. Wer auf die Leistungs-Spalte schaut und
+              wissen will, ob die Phase reicht, findet den Rechner dort und
+              muss nicht erst ein Menue oeffnen.
+
+              Die zwei uebrigen bleiben hier: sie haben in den Analysen keine
+              Tabelle, neben die sie gehoerten. */}
           <MenuSectionHeader>{t('app.menu.tools.group.calc', 'Berechnen')}</MenuSectionHeader>
-          <MenuItem
-            onClick={() => useUiStore.getState().openBandwidthCalc()}
-            icon={<Icon icon={Radio} size="sm" />}
-          >
-            {t('app.menu.tools.bandwidth', 'Bandbreite berechnen…')}
-          </MenuItem>
-          <MenuItem
-            onClick={() => useUiStore.getState().openPowerCalc()}
-            icon={<Icon icon={Zap} size="sm" />}
-          >
-            {t('app.menu.tools.power', 'Stromverbrauch berechnen…')}
-          </MenuItem>
           <MenuItem
             onClick={() => useUiStore.getState().openRecordingStorageCalc()}
             icon={<Icon icon={HardDrive} size="sm" />}
@@ -854,48 +946,6 @@ export const MenuBar = ({
             </MenuItem>
           )}
 
-          <MenuSectionHeader>{t('app.menu.tools.group.io', 'Import & Export')}</MenuSectionHeader>
-          <MenuItem onClick={() => useUiStore.getState().openPatchList()} icon={<Icon icon={Cable} size="sm" />}
-            note={t('app.menu.tools.patchList.note', 'Wer hängt an welchem Ein- und Ausgang')}
-          >
-            {t('app.menu.tools.patchList', 'Patch-Liste…')}
-          </MenuItem>
-          {festinstallationModule && (
-            <MenuItem onClick={() => useUiStore.getState().openInstallDocs()} icon={<Icon icon={PackageCheck} size="sm" />}>
-              {t('app.menu.tools.installDocs', 'Festinstallation: Doku & Übergabe…')}
-            </MenuItem>
-          )}
-          <MenuItem
-            onClick={() => {
-              const p = useProjectStore.getState().project
-              downloadBlob(
-                buildExportFilename(p.metadata.name, 'stageplot.svg'),
-                exportStagePlotSvg(p),
-                'image/svg+xml',
-              )
-            }}
-            icon={<Icon icon={ImageIcon} size="sm" />}
-          
-            note={t('app.menu.tools.stagePlot.note', 'Bühnenaufsicht als Ein-Seiten-Blatt')}
-          >
-            {t('app.menu.tools.stagePlot', 'Stage-Plot (SVG)…')}
-          </MenuItem>
-          <MenuItem onClick={() => useUiStore.getState().openCsvImport()} icon={<Icon icon={ImportIcon} size="sm" />}>
-            {t('app.menu.tools.csvImport', 'Equipment aus CSV importieren…')}
-          </MenuItem>
-          {/* Rentman-Import nur wenn die Integration aktiv ist (standardmäßig
-              aus; Aktivierung in den Einstellungen → Integrationen). */}
-          {rentmanEnabled && (
-            <MenuItem onClick={() => useUiStore.getState().openRentmanImport()} icon={<Icon icon={Users} size="sm" />}>
-              {t('app.menu.tools.rentmanImport', 'Rentman-Import…')}
-            </MenuItem>
-          )}
-          {/* #597 — NetBox-Import, ebenfalls nur bei aktivem Modul. */}
-          {netboxEnabled && (
-            <MenuItem onClick={() => useUiStore.getState().openNetboxImport()} icon={<Icon icon={Server} size="sm" />}>
-              {t('app.menu.tools.netboxImport', 'NetBox-Import…')}
-            </MenuItem>
-          )}
         </Menu>
 
         <Menu label={t('app.menu.view', 'Ansicht')}>

--- a/src/renderer/components/Layout/StatusBar.tsx
+++ b/src/renderer/components/Layout/StatusBar.tsx
@@ -7,6 +7,8 @@ import { useCollabStore } from '../../store/collabStore'
 import { useProjectStore } from '../../store/projectStore'
 import { useTranslation, format } from '../../lib/i18n'
 import { runDrawingChecks } from '../../lib/drawingChecks'
+import { buildAddressPlan } from '../../lib/addressPlan'
+import { segmentFindings } from '../../lib/networkSegments'
 import { Icon } from '../shared/Icon'
 
 interface StatusBarProps {
@@ -74,6 +76,7 @@ export const StatusBar = ({
   const cables = useProjectStore((s) => s.project.cables)
   const drumKit = useProjectStore((s) => s.project.drumKit)
   const sourceIdentities = useProjectStore((s) => s.project.sourceIdentities)
+  const networkSegments = useProjectStore((s) => s.project.networkSegments)
   const togglePlanCheck = useUiStore((s) => s.togglePlanCheck)
   // Memoisiert, weil die StatusBar bei jeder Viewport-Aenderung rendert, die
   // Check-Engine aber ueber den ganzen Plan laeuft (seit ADR-001 auch ueber
@@ -83,6 +86,34 @@ export const StatusBar = ({
     () => runDrawingChecks({ equipment, cables, drumKit, sourceIdentities }),
     [equipment, cables, drumKit, sourceIdentities],
   )
+  // ── DIE NETZ-BEFUNDE, NEBEN DEN PLAN-CHECK (2026-09-07) ────────────────
+  //
+  // Der Plan-Check steht seit #411 hier; die Befunde der ANALYSEN standen
+  // nirgends. Wer nicht von selbst den Netzwerk-Reiter aufmachte, erfuhr nie,
+  // dass zwei Geraete dieselbe IP tragen.
+  //
+  // ICH HATTE DAS ALS ZU TEUER ZURUECKGESTELLT — nachgemessen stimmt das
+  // nicht. Auf einem Plan mit 800 Geraeten und 799 Kabeln:
+  //
+  //     runDrawingChecks   12,68 ms   (steht laengst hier)
+  //     buildAddressPlan    8,02 ms
+  //     segmentFindings     0,35 ms
+  //
+  // Das Dazugekommene kostet weniger als das, was ohnehin schon laeuft. Und
+  // es laeuft NICHT bei jeder Viewport-Aenderung: `useMemo` haengt an
+  // Store-Referenzen, die nur bei echter Projekt-Aenderung wechseln.
+  //
+  // ZWEI ABZEICHEN UND NICHT EINES. Ein Abzeichen, dessen Klick woanders
+  // landet als das, was es gezaehlt hat, ist dieselbe Sorte Luege wie eine
+  // Zahl ohne Deckung: der Plan-Check-Knopf oeffnet die Plan-Check-Palette,
+  // der Netz-Knopf die Analysen auf dem Netzwerk-Reiter.
+  const netzBefunde = useMemo(() => {
+    const plan = buildAddressPlan(equipment)
+    const adressen = plan.withIssues.length
+    const segmente = segmentFindings(equipment, networkSegments ?? []).length
+    return adressen + segmente
+  }, [equipment, networkSegments])
+
   const checkTone =
     errorCount > 0
       ? 'bg-red-700 text-red-50'
@@ -136,6 +167,20 @@ export const StatusBar = ({
             ? format(t('statusbar.planCheck.counts', '{errors}⚠'), { errors: errorCount + warningCount })
             : t('statusbar.planCheck.ok', 'OK')}
         </button>
+        {netzBefunde > 0 && (
+          <button
+            type="button"
+            onClick={() => useUiStore.getState().openAnalysis('network')}
+            className="inline-flex shrink-0 items-center gap-1 rounded bg-amber-600 px-1.5 py-0.5 text-cp-xs font-bold text-amber-50"
+            title={t(
+              'statusbar.network.title',
+              'Netz-Befunde: fehlende oder doppelte Adressen, Masken, Segmente. Klick öffnet die Analysen auf dem Netzwerk-Reiter.',
+            )}
+          >
+            <Icon icon={AlertTriangle} size="xs" />
+            {format(t('statusbar.network.counts', 'Netz {count}'), { count: netzBefunde })}
+          </button>
+        )}
       </div>
       <div className="flex shrink-0 items-center gap-3">
         {/* v7.9.4 — Rentman-Badge nur sichtbar wenn die Integration

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -796,6 +796,8 @@ export const en: Dict = {
   // zusammengelegt (2026-09-07). Die sechs Schluessel darueber bleiben, weil
   // sie noch in der Kurzhilfe und in den Tastenkuerzeln vorkommen.
   'toolbar.location.label': 'Frame',
+  'toolbar.bulkConnect.label': 'Connect cables',
+  'toolbar.bulkConnect.title': 'Create several cables between the two selected devices at once',
   'toolbar.lock.button': 'Lock',
   'toolbar.lock.title': 'Protection against accidental moves',
   'toolbar.lock.frames.label': 'Frames',

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -795,6 +795,8 @@ export const en: Dict = {
   // Die drei Icon-Knoepfe sind zu EINEM beschrifteten Knopf mit Menue
   // zusammengelegt (2026-09-07). Die sechs Schluessel darueber bleiben, weil
   // sie noch in der Kurzhilfe und in den Tastenkuerzeln vorkommen.
+  'statusbar.network.counts': 'Network {count}',
+  'statusbar.network.title': 'Network findings: missing or duplicate addresses, masks, segments. Click opens the analyses on the network tab.',
   'toolbar.location.label': 'Frame',
   'toolbar.bulkConnect.label': 'Connect cables',
   'toolbar.bulkConnect.title': 'Create several cables between the two selected devices at once',

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -903,8 +903,15 @@ interface UiState extends PersistedUiState {
   closeBulkConnect: () => void
   /** Projekt-Analysen (read-only Reports): Strom/Phasen, Netzwerk, Gewicht/
    *  Wärme, Redundanz. Issues #345/#346/#351/#352. */
-  analysis: { open: boolean }
-  openAnalysis: () => void
+  /**
+   * Die Analysen. `tab` ist der Reiter, auf dem sich der Dialog oeffnen soll
+   * (2026-09-07): die Statusleiste zaehlt Netz-Befunde und muss dorthin
+   * fuehren, wo sie stehen — ein Abzeichen, dessen Klick woanders landet als
+   * das, was es gezaehlt hat, ist dieselbe Sorte Luege wie eine Zahl ohne
+   * Deckung. Fehlt der Reiter, bleibt es beim bisherigen Startreiter.
+   */
+  analysis: { open: boolean; tab?: string }
+  openAnalysis: (tab?: string) => void
   closeAnalysis: () => void
   /** Vereinte „Plan-Check"-Palette: Live-Validierung des Plans (#411). */
   planCheck: { open: boolean }
@@ -1360,7 +1367,7 @@ export const useUiStore = create<UiState>((set) => ({
     set({ bulkConnect: { open: true, ...(fromEqId ? { fromEqId } : {}), ...(toEqId ? { toEqId } : {}) } }),
   closeBulkConnect: () => set({ bulkConnect: { open: false } }),
   analysis: { open: false },
-  openAnalysis: () => set({ analysis: { open: true } }),
+  openAnalysis: (tab) => set({ analysis: { open: true, ...(tab ? { tab } : {}) } }),
   closeAnalysis: () => set({ analysis: { open: false } }),
   planCheck: { open: false },
   openPlanCheck: () => set({ planCheck: { open: true } }),

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -891,8 +891,15 @@ interface UiState extends PersistedUiState {
   openSettings: (section?: string) => void
   closeSettings: () => void
   /** #378 — Bulk-Cable-Connect-Dialog (mehrere Kabel auf einmal). */
-  bulkConnect: { open: boolean }
-  openBulkConnect: () => void
+  /**
+   * Mehrere Kabel auf einmal. `fromEqId`/`toEqId` sind die VORBELEGUNG aus
+   * der Canvas-Auswahl (2026-09-07): wer zwei Geraete markiert hat, hat die
+   * Frage nach Quelle und Ziel schon beantwortet und soll sie nicht in zwei
+   * Aufklapplisten wiederholen. Fehlen sie, faellt der Dialog auf seine
+   * Listen zurueck — der Weg ueber das Menue bleibt unveraendert.
+   */
+  bulkConnect: { open: boolean; fromEqId?: string; toEqId?: string }
+  openBulkConnect: (fromEqId?: string, toEqId?: string) => void
   closeBulkConnect: () => void
   /** Projekt-Analysen (read-only Reports): Strom/Phasen, Netzwerk, Gewicht/
    *  Wärme, Redundanz. Issues #345/#346/#351/#352. */
@@ -1349,7 +1356,8 @@ export const useUiStore = create<UiState>((set) => ({
   openSettings: (section) => set({ settingsOpen: true, settingsSection: section }),
   closeSettings: () => set({ settingsOpen: false }),
   bulkConnect: { open: false },
-  openBulkConnect: () => set({ bulkConnect: { open: true } }),
+  openBulkConnect: (fromEqId, toEqId) =>
+    set({ bulkConnect: { open: true, ...(fromEqId ? { fromEqId } : {}), ...(toEqId ? { toEqId } : {}) } }),
   closeBulkConnect: () => set({ bulkConnect: { open: false } }),
   analysis: { open: false },
   openAnalysis: () => set({ analysis: { open: true } }),


### PR DESCRIPTION
Zweiter bis vierter Schnitt am Werkzeuge-Menü. Der erste war `#753` (Geräte-Werkzeuge ans Gerät).

## 1. Import & Export gehört unter „Datei" — 6 Einträge

Das Datei-Menü führte längst yEd/GraphML, MultiCam-Kameras, `.avplan`, die Identitäts-Karte und den Export-Hub. **CSV-, Rentman- und NetBox-Import standen als einzige Importe woanders**; Patch-Liste, Stage-Plot und Übergabe-Doku als einzige Ausgaben. Wer eine Datei einliest, sucht unter „Datei".

Die drei Importe stehen jetzt bei den anderen, die drei Ausgaben neben „Exportieren & Drucken". Der Abschnitt ist ganz aus dem Werkzeuge-Menü verschwunden.

## 2. Zwei Rechner an die Tabelle, deren Zahl sie erklären

- **„Bandbreite berechnen"** → Netzwerk-Reiter der Analysen
- **„Stromverbrauch berechnen"** → Reiter „Gewicht & Wärme", bei der Leistungs-Spalte

**Die zwei übrigen bleiben im Menü, und das ist kein Vergessen:** Aufzeichnungs-Speicher und Projektion & Display haben in den Analysen keine Tabelle, neben die sie gehörten.

## 3. Zwei markierte Geräte bieten die Verkabelung selbst an

„Mehrere Kabel verbinden" verlangte im Dialog die Auswahl von Quelle und Ziel in zwei Aufklapplisten über **alle** Geräte — genau die Frage, die der Nutzer mit seiner Markierung schon beantwortet hat. Das Werkzeug lag hinter derselben Arbeit, die es abnehmen soll.

Jetzt: bei **genau zwei** markierten Geräten erscheint in der Werkzeugleiste ein beschrifteter Knopf „Kabel verbinden", und der Dialog öffnet mit beiden Geräten eingesetzt.

Bei einem oder drei erscheint er **nicht**: „von wo nach wo" hat dann keine eindeutige Antwort, und eine geratene wäre schlechter als die Aufklappliste. Der Menü-Eintrag bleibt als Weg ohne Markierung; die Vorbelegung greift nur beim Öffnen, sonst spränge die Auswahl zurück, sobald jemand im Dialog etwas anderes wählt.

## Gemessen im laufenden Fenster

| Stand | Einträge | Höhe |
|---|---|---|
| vorher | 24 | **823 px** (höher als ein 800-px-Fenster) |
| nach `#753` | 15 | 732 px |
| jetzt | **13** | **673 px** |

## Der Plan, und was offen bleibt

| # | Schnitt | wo |
|---|---|---|
| 1 | Geräte-Werkzeuge ans Gerät (5) | `#753` |
| 2 | Import/Export in den Datei-Fluss (6) | hier |
| 3 | Rechner an ihre Tabelle (2) | hier |
| 4 | Mehrfach-Verkabelung an die Auswahl | hier |
| 5 | **Analysen-Befunde in die Statusleiste** | **offen, bewusst** |

Zu 5 eine Berichtigung an meinem eigenen Plan: die Statusleiste rechnet seit `#411` `runDrawingChecks` **live** und zeigt Fehler/Warnungen als Badge — ein Klick öffnet die Plan-Check-Palette. Was fehlt, ist nur, dass die **Analysen**-Befunde dort nicht mitzählen. Die Analyse-Engine läuft über den ganzen Plan, während die Leiste bei jeder Viewport-Änderung rendert; das braucht eine Messung, bevor es gebaut wird, kein Nebenbei-Fix.

## Prüfung

- `npm test` — 175 Dateien grün
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npm run lint` — 0 Fehler (10 vorbestehende Warnungen)
- `xvfb-run -a npm run ui:overflow` — 0 Befunde

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT
