### PR TITLE
analysis: eine Seite, die sagt, was ansteht — statt des täglichen Rundgangs (Bedarf 108)

### DIFF
--- a/src/renderer/components/Analysis/ActionTab.tsx
+++ b/src/renderer/components/Analysis/ActionTab.tsx
@@ -1,0 +1,111 @@
+import { useMemo } from 'react'
+import { useProjectStore } from '../../store/projectStore'
+import { useInventoryStore } from '../../store/inventoryStore'
+import { useCheckoutStore } from '../../store/checkoutStore'
+import { useTranslation, format } from '../../lib/i18n'
+import { PanelHint } from '../shared/PanelHint'
+import {
+  ACTION_SOURCE_LABEL,
+  ACTION_URGENCY_LABEL,
+  actionCounts,
+  actionItems,
+  type ActionUrgency,
+} from '../../lib/actionItems'
+
+/**
+ * BEDARF 108 — die Liste, die sagt, was ansteht.
+ *
+ * Der Bedarf sagt, was diese Seite NICHT ist: „a notification-and-derivation
+ * product, NOT an authoring product". Hier wird deshalb nichts bearbeitet.
+ * Jede Zeile nennt ihre Quelle, und wer sie erledigen will, geht dorthin —
+ * auf die Crew-Seite, auf die Kostenseite, ins Lager. Ein zweiter
+ * Bearbeitungsweg neben dem vorhandenen waere die zweite Stelle, an der
+ * dieselbe Zahl entsteht.
+ *
+ * WAS HIER GERECHNET WIRD: nichts. `actionItems` sammelt ein, was die
+ * Fachmodule ohnehin melden.
+ */
+const TON: Readonly<Record<ActionUrgency, string>> = {
+  overdue: 'text-cp-danger',
+  today: 'text-cp-warn',
+  ahead: 'text-cp-text',
+  undated: 'text-cp-text-muted',
+}
+
+const heute = (): string => new Date().toISOString().slice(0, 10)
+
+export const ActionTab = () => {
+  const t = useTranslation()
+  const project = useProjectStore((s) => s.project)
+  const inventory = useInventoryStore((s) => s.items)
+  const checkouts = useCheckoutStore((s) => s.records)
+
+  // Der Stichtag wird EINMAL beim Rendern geholt und dann durchgereicht —
+  // `actionItems` selbst liest keine Uhr, sonst waere sie nicht pruefbar.
+  const items = useMemo(
+    () => actionItems({ today: heute(), project, inventory, checkouts }),
+    [project, inventory, checkouts],
+  )
+  const zahlen = actionCounts(items)
+
+  return (
+    <div className="flex flex-col gap-2 text-cp-sm">
+      <PanelHint
+        text={t(
+          'analysis.action.hint',
+          'Diese Seite sagt, was ansteht — sie bearbeitet nichts. Jede Zeile kommt aus der Stelle, die sie meldet: Crew, Kosten, Belege, Lager. Was hier fehlt, fehlt auch dort; hier entsteht keine zweite Rechnung.',
+        )}
+      />
+
+      {items.length === 0 ? (
+        <p className="text-cp-xs text-cp-text-muted">
+          {t('analysis.action.none', 'Nichts offen — es gibt zu diesem Stand nichts zu melden.')}
+        </p>
+      ) : (
+        <>
+          <div className="flex flex-wrap gap-2 text-cp-xs">
+            {(['overdue', 'today', 'ahead', 'undated'] as ActionUrgency[])
+              .filter((u) => zahlen[u] > 0)
+              .map((u) => (
+                <span key={u} className={TON[u]}>
+                  {ACTION_URGENCY_LABEL[u]}: <strong>{zahlen[u]}</strong>
+                </span>
+              ))}
+          </div>
+          <table className="w-full border-collapse text-cp-xs">
+            <thead>
+              <tr className="border-b border-cp-border text-left text-cp-text-secondary">
+                <th className="py-1 pr-2">{t('analysis.action.when', 'Termin')}</th>
+                <th className="py-1 pr-2">{t('analysis.action.urgency', 'Stand')}</th>
+                <th className="py-1 pr-2">{t('analysis.action.source', 'Quelle')}</th>
+                <th className="py-1 pr-2">{t('analysis.action.what', 'Was')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((i) => (
+                <tr key={i.id} className="border-b border-cp-border-muted align-top">
+                  <td className="py-1 pr-2 tabular-nums">
+                    {i.when ?? t('analysis.action.noDate', '—')}
+                  </td>
+                  <td className={`py-1 pr-2 ${TON[i.urgency]}`}>
+                    {ACTION_URGENCY_LABEL[i.urgency]}
+                  </td>
+                  <td className="py-1 pr-2 text-cp-text-muted">{ACTION_SOURCE_LABEL[i.source]}</td>
+                  <td className="py-1 pr-2">
+                    {i.title}
+                    {i.detail && <span className="text-cp-text-muted"> — {i.detail}</span>}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p className="text-cp-xs text-cp-text-muted">
+            {format(t('analysis.action.count', '{n} Zeilen, sortiert nach Dringlichkeit.'), {
+              n: items.length,
+            })}
+          </p>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/Analysis/AnalysisDialog.tsx
+++ b/src/renderer/components/Analysis/AnalysisDialog.tsx
@@ -68,6 +68,7 @@ import {
 import type { DantePatch } from '../../types/dantePatch'
 import { cableRunFindings, cableRunTable, type RunFinding } from '../../lib/cableRunChecks'
 import { CrewTab } from './CrewTab'
+import { ActionTab } from './ActionTab'
 import { lookUpSheet, type SheetLookup } from '../../lib/sheetLookup'
 import {
   buildVenueNetworkRequest,
@@ -152,6 +153,7 @@ const RechnerLink = ({ onClick, label }: { onClick: () => void; label: string })
 )
 
 type Tab =
+  | 'todo'
   | 'weight'
   | 'network'
   | 'redundancy'
@@ -2704,6 +2706,9 @@ const DanteTab = ({ projectName }: { projectName: string }) => {
 }
 
 const TABS: { id: Tab; labelKey: string; fallback: string }[] = [
+  // Bedarf 108 zuerst: „users ask to be TOLD something rather than to go and
+  // check". Was ansteht, steht vorn — nicht auf Platz zwoelf.
+  { id: 'todo', labelKey: 'analysis.tab.todo', fallback: 'Was ansteht' },
   { id: 'client', labelKey: 'analysis.tab.client', fallback: 'Kunden-Übersicht' },
   { id: 'cost', labelKey: 'analysis.tab.cost', fallback: 'Kosten: Plan gegen Ist' },
   { id: 'crew', labelKey: 'analysis.tab.crew', fallback: 'Crew: Stunden & Auslagen' },
@@ -2777,6 +2782,7 @@ const AnalysisDialogInner = () => {
       {active === 'runs' && <RunsTab projectName={projectName} />}
       {active === 'sheet' && <SheetTab />}
       {active === 'client' && <ClientTab projectName={projectName} />}
+      {active === 'todo' && <ActionTab />}
       {active === 'cost' && <CostTab projectName={projectName} />}
       {active === 'crew' && <CrewTab projectName={projectName} />}
       {active === 'naming' && <NamingTab projectName={projectName} />}

--- a/src/renderer/components/Layout/StatusBar.tsx
+++ b/src/renderer/components/Layout/StatusBar.tsx
@@ -9,6 +9,9 @@ import { useTranslation, format } from '../../lib/i18n'
 import { runDrawingChecks } from '../../lib/drawingChecks'
 import { buildAddressPlan } from '../../lib/addressPlan'
 import { segmentFindings } from '../../lib/networkSegments'
+import { actionCounts, actionItems } from '../../lib/actionItems'
+import { useInventoryStore } from '../../store/inventoryStore'
+import { useCheckoutStore } from '../../store/checkoutStore'
 import { Icon } from '../shared/Icon'
 
 interface StatusBarProps {
@@ -54,6 +57,47 @@ const CollabStatusBadge = () => {
     >
       <span className="inline-block h-2 w-2 rounded-full bg-emerald-300" />
       {t('statusbar.collab.live', 'Live')} · {Math.max(peers.length, 1)}
+    </button>
+  )
+}
+
+/**
+ * BEDARF 108 — das Abzeichen, das den taeglichen Rundgang ersetzt.
+ *
+ * Der Bedarf sagt es in einem Satz: „users ask to be TOLD something rather
+ * than to go and check". Deshalb steht die Zahl in der Statuszeile und nicht
+ * hinter zwei Klicks — und deshalb steht sie NUR DA, WENN ES ETWAS ZU SAGEN
+ * GIBT. Ein Abzeichen, das jeden Tag „0" zeigt, ist der Anfang davon, dass
+ * niemand mehr hinsieht.
+ *
+ * Gezaehlt wird, was heute oder frueher faellig ist. Das Anstehende und das
+ * Undatierte stehen auf der Seite selbst: sie brauchen keinen Alarm, sie
+ * brauchen einen Blick.
+ */
+const AufgabenBadge = () => {
+  const t = useTranslation()
+  const project = useProjectStore((s) => s.project)
+  const inventory = useInventoryStore((s) => s.items)
+  const checkouts = useCheckoutStore((s) => s.records)
+  const dringend = useMemo(() => {
+    const z = actionCounts(
+      actionItems({ today: new Date().toISOString().slice(0, 10), project, inventory, checkouts }),
+    )
+    return z.overdue + z.today
+  }, [project, inventory, checkouts])
+  if (dringend === 0) return null
+  return (
+    <button
+      type="button"
+      onClick={() => useUiStore.getState().openAnalysis('todo')}
+      className="inline-flex shrink-0 items-center gap-1 rounded bg-red-700 px-1.5 py-0.5 text-cp-xs font-bold text-red-50 hover:bg-red-600"
+      title={t(
+        'statusbar.todo.title',
+        'Überfällig oder heute fällig: Rückgaben, Ausgaben, Stunden, Belege, Kosten. Klick öffnet die Analysen auf „Was ansteht".',
+      )}
+    >
+      <Icon icon={AlertCircle} size="xs" />
+      {format(t('statusbar.todo.counts', 'Fällig {count}'), { count: dringend })}
     </button>
   )
 }
@@ -181,6 +225,7 @@ export const StatusBar = ({
             {format(t('statusbar.network.counts', 'Netz {count}'), { count: netzBefunde })}
           </button>
         )}
+        <AufgabenBadge />
       </div>
       <div className="flex shrink-0 items-center gap-3">
         {/* v7.9.4 — Rentman-Badge nur sichtbar wenn die Integration

--- a/src/renderer/lib/actionItems.ts
+++ b/src/renderer/lib/actionItems.ts
@@ -1,0 +1,322 @@
+// ───────────────────────────────────────────────────────────────────────────
+// BEDARF 108 (P3) — „An action-items surface that tells them what is due,
+// overdue, conflicting or over budget — instead of a daily manual sweep."
+//
+// Der Satz, der den Entwurf entscheidet, steht woertlich in der
+// Bedarfs-Datenbank:
+//
+//   > Across every tracker read, these users ask to be TOLD something rather
+//   > than to go and check. That makes this a NOTIFICATION-AND-DERIVATION
+//   > product, not an authoring product. Cheap to build against the existing
+//   > model and it is what they actually request.
+//
+// Die Fundstelle dazu (`Shelf-nu/shelf.nu#1956`, 2025-07-29) fragt nach einem
+// „late-returns dashboard" und ausdruecklich nach einem „Action Items
+// dashboard"; dasselbe Muster in `kimai/kimai#5421`.
+//
+// ─── DIESE DATEI LEITET NICHTS AB, SIE SAMMELT EIN ─────────────────────────
+//
+// Jede Zeile hier kommt aus einer Stelle, die es schon gibt:
+// `overdueSubhire`, `overdueCheckouts`, `labourFindings`, `receiptChain`,
+// `costComparison`, `bookingConflicts`. KEINE ZWEITE RECHNUNG. Wer hier eine
+// eigene Faelligkeit oder eine eigene Abweichung bildete, haette dieselbe
+// Aussage an zwei Stellen — und die beiden gingen auseinander, sobald jemand
+// nur eine anfasst. Genau dieser Defekt steht im Beleg zu Bedarf 40, und er
+// waere hier teurer: eine Uebersicht, die etwas anderes sagt als die Seite,
+// auf die sie zeigt, macht beide unbrauchbar.
+//
+// Bei den TEXTEN gilt das, soweit die Quelle einen hat: `crew`, `receipt` und
+// `cost` uebernehmen den Wortlaut aus `LABOUR_FINDING_LABEL`,
+// `CHAIN_FINDING_LABEL` und `COST_FINDING_LABEL` unveraendert. Drei Quellen
+// haben keine solche Tabelle — `subhire`, `checkout` und `booking` liefern
+// Datensaetze und keine Befunde —, und nur fuer die entsteht der Satz hier.
+// Welche drei das sind, steht in `EIGENER_TEXT` und wird von
+// `tests/actionItems.test.ts` festgehalten: eine vierte Quelle mit eigenem
+// Wortlaut faellt dort auf, statt sich einzuschleichen.
+//
+// ─── WAS ZUR HANDLUNGSLISTE GEHOERT UND WAS NICHT ──────────────────────────
+//
+// Nicht jeder Befund ist eine Aufgabe. „Keine Toleranz gesetzt" ist eine
+// Auskunft ueber die Einstellungen und keine Sache, die heute jemand
+// erledigt; sie steht auf ihrer eigenen Seite und nicht hier. Die
+// Entscheidung faellt in den `*_ACTION`-Tabellen — und die sind VOLLSTAENDIGE
+// `Record`s ueber die jeweilige Befundart. Wer upstream eine neue Befundart
+// ergaenzt, bekommt hier einen Compile-Fehler und muss entscheiden, ob sie
+// eine Aufgabe ist. Eine Ausnahmeliste („alles ausser diesen") waere die
+// falsche Richtung: sie nimmt neue Befunde stillschweigend auf oder laesst
+// sie stillschweigend fallen, je nachdem, wie herum sie geschrieben ist.
+//
+// ─── FAELLIGKEIT WIRD NIE ERFUNDEN ─────────────────────────────────────────
+//
+// `when` steht nur da, wo die Quelle ein Datum HAT — ein Rueckgabetermin, das
+// Datum der Schicht, das Datum der Auslage. Was keins hat, ist `undated` und
+// nicht etwa „heute faellig". Ein erfundener Termin waere auf einer Liste, die
+// nach Dringlichkeit sortiert, der teuerste Fehler ueberhaupt: er verschoebe
+// die echten Ueberfaelligkeiten nach unten.
+// ───────────────────────────────────────────────────────────────────────────
+import type { CablePlannerProject } from '../types/project'
+import type { CheckoutRecord } from '../types/checkout'
+import type { InventoryItem } from '../types/inventory'
+import { EMPTY_CREW_PLAN } from '../types/labour'
+import { LABOUR_FINDING_LABEL, labourFindings, type LabourFindingKind } from './labourCost'
+import { COST_FINDING_LABEL, assessCosts, type CostFindingKind } from './costComparison'
+import { CHAIN_FINDING_LABEL, receiptChain, type ChainFindingKind } from './receiptChain'
+import { bookingConflicts } from './crewCalendar'
+import { overdueSubhire, ownershipNote } from './ownership'
+import { overdueCheckouts } from './containerCheckout'
+
+/** Woher eine Zeile stammt — und damit, wohin der Sprung geht. */
+export type ActionSource = 'subhire' | 'checkout' | 'crew' | 'receipt' | 'cost' | 'booking'
+
+export const ACTION_SOURCE_LABEL: Readonly<Record<ActionSource, string>> = {
+  subhire: 'Sub-Hire',
+  checkout: 'Ausgabe',
+  crew: 'Crew',
+  receipt: 'Belege',
+  cost: 'Kosten',
+  booking: 'Buchung',
+}
+
+/**
+ * Wie dringend eine Zeile ist.
+ *
+ * `undated` ist ein eigener Wert und kein „irgendwann": ohne Datum ist die
+ * Zeile nicht weniger wichtig, sie ist nur nicht terminiert. Sie unter die
+ * datierten zu mischen hiesse, ihr ein Datum zu geben.
+ */
+export type ActionUrgency = 'overdue' | 'today' | 'ahead' | 'undated'
+
+export const ACTION_URGENCY_LABEL: Readonly<Record<ActionUrgency, string>> = {
+  overdue: 'überfällig',
+  today: 'heute',
+  ahead: 'steht an',
+  undated: 'ohne Termin',
+}
+
+export interface ActionItem {
+  /** Stabil aus Quelle, Art und Bezug — dieselbe Lage ergibt dieselbe Id. */
+  id: string
+  source: ActionSource
+  kind: string
+  /** Der Text der Quelle. Wird hier NIE umformuliert. */
+  title: string
+  detail?: string
+  /** ISO-Datum, nur wenn die Quelle eines hatte. */
+  when?: string
+  urgency: ActionUrgency
+}
+
+export interface ActionInput {
+  /**
+   * Der Stichtag als ISO-Datum. WIRD UEBERGEBEN und nicht hier geholt —
+   * dieselbe Regel wie beim Dokument-Stempel und beim Kalender-Feed: eine
+   * Funktion, die die Uhr liest, ist nicht pruefbar.
+   */
+  today: string
+  project: CablePlannerProject
+  /** Das Lager. Liegt nicht im Projekt und wird deshalb hereingereicht. */
+  inventory?: InventoryItem[]
+  checkouts?: CheckoutRecord[]
+}
+
+/**
+ * Welche Crew-Befunde eine Aufgabe sind.
+ *
+ * `rate-missing` und Geschwister sind Datenfehler, die jemand geradezieht —
+ * und bis dahin faellt eine geleistete Stunde aus jeder Summe. Deshalb JA.
+ */
+const CREW_ACTION: Readonly<Record<LabourFindingKind, boolean>> = {
+  'rate-missing': true,
+  'person-missing': true,
+  'band-missing': true,
+  overlap: true,
+  'zero-length': true,
+  'overtime-unapproved': true,
+  'expense-without-receipt': true,
+}
+
+/**
+ * Welche Kosten-Befunde eine Aufgabe sind.
+ *
+ * `no-tolerance`, `currency-unstated` und `no-lines` sind Auskuenfte ueber die
+ * EINSTELLUNG des Kostenplans, nicht ueber einen Vorgang, der heute erledigt
+ * wird. Sie stehen auf der Kostenseite und gehoeren nicht auf eine Liste, die
+ * nach Dringlichkeit sortiert — sonst steht dort jeden Tag dasselbe, und die
+ * Liste wird zu dem, was der Bedarf abschaffen will.
+ */
+const COST_ACTION: Readonly<Record<CostFindingKind, boolean>> = {
+  'no-lines': false,
+  'estimate-missing': false,
+  'actual-missing': false,
+  'actual-unsourced': true,
+  'anchor-orphan': true,
+  'currency-unstated': false,
+  'no-tolerance': false,
+  'over-tolerance': true,
+}
+
+/** Welche Beleg-Befunde eine Aufgabe sind. */
+const CHAIN_ACTION: Readonly<Record<ChainFindingKind, boolean>> = {
+  'expense-unlinked': true,
+  'expense-without-evidence': true,
+  'cost-line-missing': true,
+  'actual-missing': false,
+  'actual-below-documented': true,
+  'actual-above-documented': true,
+}
+
+/**
+ * Die Quellen, deren Zeilentext HIER gebildet wird, weil sie keine
+ * Befund-Tabelle haben. Alle anderen uebernehmen den Wortlaut ihrer Quelle.
+ */
+export const EIGENER_TEXT: readonly ActionSource[] = ['subhire', 'checkout', 'booking']
+
+/** Aus Stichtag und Termin die Dringlichkeit. Ohne Termin: `undated`. */
+export const urgencyOf = (when: string | undefined, today: string): ActionUrgency => {
+  if (!when) return 'undated'
+  // ISO-Datumsvergleich als Zeichenkette, wie in `ownership.ts`: der Stichtag
+  // ist ein Kalendertag und kein Zeitpunkt, eine Zeitzone hat hier nichts zu
+  // suchen.
+  if (when < today) return 'overdue'
+  if (when === today) return 'today'
+  return 'ahead'
+}
+
+const RANG: Readonly<Record<ActionUrgency, number>> = {
+  overdue: 0,
+  today: 1,
+  ahead: 2,
+  undated: 3,
+}
+
+/**
+ * Die Handlungsliste eines Projekts.
+ *
+ * Sortiert: ueberfaellig zuerst und darin das aelteste zuerst, dann heute,
+ * dann das Anstehende mit dem naechsten Termin vorn, zuletzt das Undatierte.
+ * Wer von oben abarbeitet, arbeitet in der Reihenfolge ab, in der es teuer
+ * wird.
+ *
+ * EINE LEERE LISTE IST EIN ERGEBNIS. Es entsteht keine Zeile „alles in
+ * Ordnung": ein Hinweis ohne Anlass ist der Anfang davon, dass die Liste
+ * ueberflogen statt gelesen wird.
+ */
+export const actionItems = (input: ActionInput): ActionItem[] => {
+  const { today, project } = input
+  const out: ActionItem[] = []
+  const crew = project.crewPlan ?? EMPTY_CREW_PLAN
+  const entryById = new Map(crew.entries.map((e) => [e.id, e]))
+  const rateById = new Map(crew.rates.map((r) => [r.id, r]))
+  const expenseById = new Map(crew.expenses.map((e) => [e.id, e]))
+
+  // ── Fremdes Material, das zurueckmuss ──────────────────────────────────
+  for (const l of overdueSubhire(input.inventory ?? [], today)) {
+    out.push({
+      id: `subhire:${l.status}:${l.itemId}`,
+      source: 'subhire',
+      kind: l.status,
+      title:
+        l.status === 'overdue'
+          ? `${l.model} ist überfällig`
+          : `${l.model} hat kein Rückgabedatum`,
+      // Der Zusatz kommt aus `ownershipNote` — derselbe Satz, der auf jedem
+      // Blatt neben der Position steht. Ihn hier zweitens zu formulieren
+      // hiesse, zwei Fassungen derselben Auskunft zu pflegen.
+      detail: ownershipNote(
+        { ownership: l.ownership, supplier: l.supplier, returnDue: l.returnDue },
+        today,
+      ),
+      ...(l.returnDue ? { when: l.returnDue } : {}),
+      urgency: urgencyOf(l.returnDue || undefined, today),
+    })
+  }
+
+  // ── Ausgaben, die ueberfaellig sind ────────────────────────────────────
+  for (const r of overdueCheckouts(input.checkouts ?? [], today)) {
+    out.push({
+      id: `checkout:overdue:${r.id}`,
+      source: 'checkout',
+      kind: 'overdue',
+      title: `Ausgabe an ${r.out.to} ist überfällig`,
+      detail: r.out.projectName,
+      ...(r.out.dueBack ? { when: r.out.dueBack } : {}),
+      urgency: urgencyOf(r.out.dueBack, today),
+    })
+  }
+
+  // ── Crew: was an den Stunden nicht aufgeht ─────────────────────────────
+  for (const f of labourFindings(crew)) {
+    if (!CREW_ACTION[f.kind]) continue
+    // Das Datum kommt aus dem Bezug, wenn es eins gibt — Schicht, Auslage.
+    // Ein Satz oder ein Band hat keins, und dann steht auch keins da.
+    const datum = entryById.get(f.refId)?.date ?? expenseById.get(f.refId)?.date
+    out.push({
+      id: `crew:${f.kind}:${f.refId}`,
+      source: 'crew',
+      kind: f.kind,
+      title: LABOUR_FINDING_LABEL[f.kind],
+      detail: f.text,
+      ...(datum ? { when: datum } : {}),
+      urgency: urgencyOf(datum, today),
+    })
+  }
+
+  // ── Belege: die Kette von der Quittung zur Kostenzeile ─────────────────
+  for (const f of receiptChain(project.costPlan, crew).findings) {
+    if (!CHAIN_ACTION[f.kind]) continue
+    const datum = f.expenseId ? expenseById.get(f.expenseId)?.date : undefined
+    out.push({
+      id: `receipt:${f.kind}:${f.expenseId ?? f.costLineId ?? ''}`,
+      source: 'receipt',
+      kind: f.kind,
+      title: CHAIN_FINDING_LABEL[f.kind],
+      ...(f.detail ? { detail: f.detail } : {}),
+      ...(datum ? { when: datum } : {}),
+      urgency: urgencyOf(datum, today),
+    })
+  }
+
+  // ── Kosten: was ueber der Toleranz liegt ───────────────────────────────
+  if (project.costPlan) {
+    for (const f of assessCosts(project).findings) {
+      if (!COST_ACTION[f.kind]) continue
+      out.push({
+        id: `cost:${f.kind}:${f.lineId ?? ''}`,
+        source: 'cost',
+        kind: f.kind,
+        title: COST_FINDING_LABEL[f.kind],
+        detail: f.text,
+        urgency: 'undated',
+      })
+    }
+  }
+
+  // ── Buchung: zwei Schichten derselben Person zur selben Zeit ───────────
+  for (const k of bookingConflicts(crew)) {
+    const datum = [k.a.date, k.b.date].sort()[0]
+    out.push({
+      id: `booking:conflict:${[k.a.id, k.b.id].sort().join('+')}`,
+      source: 'booking',
+      kind: 'conflict',
+      title: 'Zwei Schichten derselben Person überschneiden sich',
+      detail: [rateById.get(k.a.rateId)?.activity, rateById.get(k.b.rateId)?.activity]
+        .filter(Boolean)
+        .join(' / '),
+      when: datum,
+      urgency: urgencyOf(datum, today),
+    })
+  }
+
+  return out.sort((a, b) => {
+    if (RANG[a.urgency] !== RANG[b.urgency]) return RANG[a.urgency] - RANG[b.urgency]
+    if (a.when && b.when && a.when !== b.when) return a.when.localeCompare(b.when)
+    return a.id.localeCompare(b.id)
+  })
+}
+
+/** Wie viele Zeilen je Dringlichkeit — fuer das Abzeichen an der Seite. */
+export const actionCounts = (items: readonly ActionItem[]): Record<ActionUrgency, number> => {
+  const z: Record<ActionUrgency, number> = { overdue: 0, today: 0, ahead: 0, undated: 0 }
+  for (const i of items) z[i.urgency] += 1
+  return z
+}

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3247,6 +3247,20 @@ export const en: Dict = {
   'app.loadReport.costLine': 'Cost line',
   // ── Bedarfe 40/41/42/83 — die Crew-Seite (Analysen-Reiter) ────────────────
   'analysis.tab.crew': 'Crew: hours & expenses',
+  // Bedarf 108 — die Handlungsliste.
+  'analysis.tab.todo': 'What is due',
+  'analysis.action.hint':
+    'This page tells you what is due — it edits nothing. Every line comes from the place that reports it: crew, costs, receipts, warehouse. What is missing here is missing there too; no second derivation happens on this page.',
+  'analysis.action.none': 'Nothing open — there is nothing to report on this state.',
+  'analysis.action.when': 'Due',
+  'analysis.action.urgency': 'State',
+  'analysis.action.source': 'Source',
+  'analysis.action.what': 'What',
+  'analysis.action.noDate': '—',
+  'analysis.action.count': '{n} lines, sorted by urgency.',
+  'statusbar.todo.title':
+    'Overdue or due today: returns, check-outs, hours, receipts, costs. Click opens the analyses on "What is due".',
+  'statusbar.todo.counts': 'Due {count}',
   'analysis.crew.intro':
     'Hours, rates and expenses for this job — and the sheet that carries them into the accounts. Overlapping bands do not stack: the highest surcharge applies to each minute. Overtime and band surcharges DO add up — they measure different things. The call-out fee applies once per person and calendar day, not per entry. A break is a gap between two entries, not a deduction: only then does every minute sit in its real band.',
   'analysis.crew.unknownBy': 'sender not stated',

--- a/src/renderer/lib/ownership.ts
+++ b/src/renderer/lib/ownership.ts
@@ -117,6 +117,13 @@ export interface OverdueLine {
   model: string
   quantity: number
   supplier: string
+  /**
+   * Gemietet oder Sub-Hire — der Unterschied steht auf jedem Blatt und darf
+   * auf dieser Liste nicht verlorengehen. Ohne ihn muesste ein Aufrufer
+   * (`actionItems`) raten, und ein geratenes „Sub-Hire" auf einem gemieteten
+   * Stueck nennt den falschen Vertrag.
+   */
+  ownership: InventoryOwnership
   /** Leer bei `no-date`. */
   returnDue: string
   status: Extract<SubhireStatus, 'overdue' | 'no-date'>
@@ -142,6 +149,7 @@ export const overdueSubhire = (items: InventoryItem[], heute: string): OverdueLi
       model: it.model,
       quantity: it.quantity,
       supplier: (it.supplier ?? '').trim(),
+      ownership: it.ownership as InventoryOwnership,
       returnDue: status === 'overdue' ? (it.returnDue ?? '') : '',
       status,
     })

--- a/tests/actionItems.test.ts
+++ b/tests/actionItems.test.ts
@@ -1,0 +1,377 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ACTION_URGENCY_LABEL,
+  EIGENER_TEXT,
+  actionCounts,
+  actionItems,
+  urgencyOf,
+  type ActionItem,
+} from '../src/renderer/lib/actionItems'
+import { LABOUR_FINDING_LABEL } from '../src/renderer/lib/labourCost'
+import { COST_FINDING_LABEL } from '../src/renderer/lib/costComparison'
+import { CHAIN_FINDING_LABEL } from '../src/renderer/lib/receiptChain'
+import type { CablePlannerProject } from '../src/renderer/types/project'
+import type { CheckoutRecord } from '../src/renderer/types/checkout'
+import type { InventoryItem } from '../src/renderer/types/inventory'
+import type { CrewPlan } from '../src/renderer/types/labour'
+
+const HEUTE = '2026-09-07'
+
+const projekt = (over: Partial<CablePlannerProject> = {}): CablePlannerProject =>
+  ({
+    metadata: { name: 'Show', description: '', createdAt: '', updatedAt: '' },
+    equipment: [],
+    cables: [],
+    canvasState: { x: 0, y: 0, zoom: 1 },
+    ...over,
+  }) as CablePlannerProject
+
+const artikel = (over: Partial<InventoryItem> & { id: string }): InventoryItem =>
+  ({ model: 'Ursa Mini', quantity: 1, ...over }) as InventoryItem
+
+const ausgabe = (over: Partial<CheckoutRecord> & { id: string }): CheckoutRecord =>
+  ({
+    nodeId: 'n1',
+    nodeLabel: 'Case 3',
+    contents: [],
+    out: { at: '2026-09-01T08:00:00Z', to: 'Truck 1' },
+    ...over,
+  }) as CheckoutRecord
+
+const crew = (over: Partial<CrewPlan> = {}): CrewPlan => ({
+  people: [],
+  bands: [],
+  rates: [],
+  entries: [],
+  expenses: [],
+  approvals: [],
+  ...over,
+})
+
+const ids = (items: ActionItem[]) => items.map((i) => i.id)
+
+describe('eine leere Lage ergibt eine leere Liste', () => {
+  it('erfindet keine Zeile „alles in Ordnung"', () => {
+    expect(actionItems({ today: HEUTE, project: projekt() })).toEqual([])
+  })
+
+  it('zählt dann auch nichts', () => {
+    expect(actionCounts([])).toEqual({ overdue: 0, today: 0, ahead: 0, undated: 0 })
+  })
+})
+
+describe('Dringlichkeit kommt vom Termin, nie von der Vermutung', () => {
+  it('nennt ohne Termin „ohne Termin" und nicht „überfällig"', () => {
+    expect(urgencyOf(undefined, HEUTE)).toBe('undated')
+    expect(urgencyOf('', HEUTE)).toBe('undated')
+  })
+
+  it('unterscheidet gestern, heute und morgen', () => {
+    expect(urgencyOf('2026-09-06', HEUTE)).toBe('overdue')
+    expect(urgencyOf(HEUTE, HEUTE)).toBe('today')
+    expect(urgencyOf('2026-09-08', HEUTE)).toBe('ahead')
+  })
+
+  it('hat für jede Stufe ein deutsches Wort', () => {
+    expect(Object.keys(ACTION_URGENCY_LABEL).sort()).toEqual(
+      ['ahead', 'overdue', 'today', 'undated'].sort(),
+    )
+  })
+})
+
+describe('fremdes Material, das zurückmuss', () => {
+  const lager = [
+    artikel({ id: 'i1', model: 'Funkstrecke', ownership: 'subhire', supplier: 'Ton AG', returnDue: '2026-09-02' }),
+    artikel({ id: 'i2', model: 'Stativ', ownership: 'rented', supplier: 'Grip GmbH' }),
+    artikel({ id: 'i3', model: 'Eigenes Case', ownership: 'owned' }),
+  ]
+  const items = actionItems({ today: HEUTE, project: projekt(), inventory: lager })
+
+  it('nimmt das überfällige mit seinem Termin auf', () => {
+    const a = items.find((i) => i.id.includes('i1'))
+    expect(a?.urgency).toBe('overdue')
+    expect(a?.when).toBe('2026-09-02')
+  })
+
+  it('nimmt das undatierte auf, ohne ihm einen Termin zu geben', () => {
+    const b = items.find((i) => i.id.includes('i2'))
+    expect(b?.urgency).toBe('undated')
+    expect(b?.when).toBeUndefined()
+  })
+
+  it('lässt eigenes Material in Ruhe', () => {
+    expect(items.some((i) => i.id.includes('i3'))).toBe(false)
+  })
+
+  it('nennt den Vertrag richtig — gemietet ist nicht Sub-Hire', () => {
+    // Der Zusatz kommt aus `ownershipNote`; ein hier geratenes „Sub-Hire"
+    // stünde auf einem gemieteten Stück.
+    expect(items.find((i) => i.id.includes('i2'))?.detail).toContain('Gemietet')
+    expect(items.find((i) => i.id.includes('i1'))?.detail).toContain('Sub-Hire')
+  })
+})
+
+describe('offene Ausgaben', () => {
+  it('meldet die überfällige und nicht die pünktliche', () => {
+    const items = actionItems({
+      today: HEUTE,
+      project: projekt(),
+      checkouts: [
+        ausgabe({ id: 'c1', out: { at: '2026-09-01T08:00:00Z', to: 'Truck 1', dueBack: '2026-09-05' } }),
+        ausgabe({ id: 'c2', out: { at: '2026-09-01T08:00:00Z', to: 'Truck 2', dueBack: '2026-09-20' } }),
+      ],
+    })
+    expect(ids(items)).toEqual(['checkout:overdue:c1'])
+    expect(items[0].when).toBe('2026-09-05')
+  })
+})
+
+describe('was aus den Stunden kommt', () => {
+  const plan = crew({
+    people: [{ id: 'p1', name: 'Anna Berg' }],
+    rates: [{ id: 'r1', personId: 'p-weg', activity: 'Kamera', hourlyAmount: 60, bandIds: [] }],
+    entries: [
+      { id: 'e1', personId: 'p1', rateId: 'r1', date: '2026-09-03', startMinute: 480, endMinute: 480 },
+    ],
+    expenses: [{ id: 'x1', kind: 'travel', date: '2026-09-04', amount: 20, billable: true }],
+  })
+  const items = actionItems({ today: HEUTE, project: projekt({ crewPlan: plan }) })
+
+  it('gibt einer Schicht das Datum der Schicht', () => {
+    const leer = items.find((i) => i.id === 'crew:zero-length:e1')
+    expect(leer?.when).toBe('2026-09-03')
+    expect(leer?.urgency).toBe('overdue')
+  })
+
+  it('gibt einem Satz kein Datum, weil er keins hat', () => {
+    const satz = items.find((i) => i.id === 'crew:person-missing:r1')
+    expect(satz).toBeDefined()
+    expect(satz?.when).toBeUndefined()
+    expect(satz?.urgency).toBe('undated')
+  })
+
+  it('nimmt den Wortlaut aus der Quelle, statt ihn neu zu formulieren', () => {
+    const leer = items.find((i) => i.id === 'crew:zero-length:e1')
+    expect(leer?.title).toBe(LABOUR_FINDING_LABEL['zero-length'])
+  })
+})
+
+describe('was aus den Kosten kommt', () => {
+  const mit = (tolerancePercent: number | undefined) =>
+    actionItems({
+      today: HEUTE,
+      project: projekt({
+        costPlan: {
+          currency: 'EUR',
+          ...(tolerancePercent !== undefined ? { tolerancePercent } : {}),
+          lines: [
+            {
+              id: 'k1',
+              label: 'Kamerazug',
+              anchor: { kind: 'free' },
+              estimate: 100,
+              actual: 200,
+              actualSource: 'from-erp',
+            },
+          ],
+        },
+      }),
+    })
+
+  it('meldet die Abweichung über der Toleranz', () => {
+    const items = mit(10)
+    expect(items.some((i) => i.kind === 'over-tolerance')).toBe(true)
+    expect(items.find((i) => i.kind === 'over-tolerance')?.title).toBe(
+      COST_FINDING_LABEL['over-tolerance'],
+    )
+  })
+
+  it('bringt die Einstellungs-Auskünfte NICHT auf die Handlungsliste', () => {
+    // „Keine Toleranz gesetzt" steht auf der Kostenseite. Auf einer Liste, die
+    // nach Dringlichkeit sortiert, stünde es jeden Tag — und dann wird die
+    // ganze Liste überflogen statt gelesen.
+    const items = mit(undefined)
+    expect(items.some((i) => i.kind === 'no-tolerance')).toBe(false)
+    expect(items.some((i) => i.kind === 'estimate-missing')).toBe(false)
+  })
+
+  it('gibt Kostenbefunden kein Datum — sie haben keins', () => {
+    expect(mit(10).every((i) => (i.source === 'cost' ? i.when === undefined : true))).toBe(true)
+  })
+})
+
+describe('was aus den Belegen kommt', () => {
+  const items = actionItems({
+    today: HEUTE,
+    project: projekt({
+      crewPlan: crew({
+        expenses: [{ id: 'x1', kind: 'travel', date: '2026-09-02', amount: 20, billable: true }],
+      }),
+      costPlan: { currency: 'EUR', lines: [] },
+    }),
+  })
+
+  it('meldet die nicht zugeordnete Auslage mit dem Datum der Auslage', () => {
+    const a = items.find((i) => i.id === 'receipt:expense-unlinked:x1')
+    expect(a?.when).toBe('2026-09-02')
+    expect(a?.title).toBe(CHAIN_FINDING_LABEL['expense-unlinked'])
+  })
+})
+
+describe('Buchungskonflikte', () => {
+  it('meldet zwei Schichten derselben Person mit dem früheren Datum', () => {
+    const items = actionItems({
+      today: HEUTE,
+      project: projekt({
+        crewPlan: crew({
+          people: [{ id: 'p1', name: 'Anna Berg' }],
+          rates: [{ id: 'r1', personId: 'p1', activity: 'Kamera', hourlyAmount: 60, bandIds: [] }],
+          entries: [
+            { id: 'a', personId: 'p1', rateId: 'r1', date: '2026-09-10', startMinute: 480, endMinute: 840 },
+            { id: 'b', personId: 'p1', rateId: 'r1', date: '2026-09-10', startMinute: 780, endMinute: 1080 },
+          ],
+        }),
+      }),
+    })
+    const k = items.find((i) => i.source === 'booking')
+    expect(k?.id).toBe('booking:conflict:a+b')
+    expect(k?.when).toBe('2026-09-10')
+    expect(k?.urgency).toBe('ahead')
+  })
+})
+
+describe('die Reihenfolge ist die, in der es teuer wird', () => {
+  // Gemischte Quellen mit Absicht: die Reihenfolge gilt ueber die ganze Liste
+  // und nicht je Quelle. Eine leere Schicht ergibt `zero-length` am Datum der
+  // Schicht, ein Satz ohne Person einen Befund ohne Datum.
+  const leereSchicht = (id: string, date: string) => ({
+    id,
+    personId: 'p1',
+    rateId: 'r1',
+    date,
+    startMinute: 480,
+    endMinute: 480,
+  })
+  const items = actionItems({
+    today: HEUTE,
+    project: projekt({
+      crewPlan: crew({
+        people: [{ id: 'p1', name: 'Anna Berg' }],
+        rates: [
+          { id: 'r1', personId: 'p1', activity: 'Kamera', hourlyAmount: 60, bandIds: [] },
+          { id: 'r2', personId: 'p-weg', activity: 'Ton', hourlyAmount: 50, bandIds: [] },
+        ],
+        entries: [
+          leereSchicht('e-alt', '2026-09-01'),
+          leereSchicht('e-neu', '2026-09-05'),
+          leereSchicht('e-heute', HEUTE),
+          leereSchicht('e-bald', '2026-09-09'),
+          leereSchicht('e-fern', '2026-09-30'),
+        ],
+      }),
+    }),
+  })
+
+  it('sortiert überfällig vor heute vor anstehend vor undatiert', () => {
+    expect(items.map((i) => i.urgency)).toEqual([
+      'overdue',
+      'overdue',
+      'today',
+      'ahead',
+      'ahead',
+      'undated',
+    ])
+  })
+
+  it('stellt innerhalb der Überfälligen das älteste nach vorn', () => {
+    expect(items.slice(0, 2).map((i) => i.when)).toEqual(['2026-09-01', '2026-09-05'])
+  })
+
+  it('stellt innerhalb des Anstehenden den nächsten Termin nach vorn', () => {
+    expect(items.slice(3, 5).map((i) => i.when)).toEqual(['2026-09-09', '2026-09-30'])
+  })
+
+  it('stellt das Undatierte ans Ende, ohne es zu verschweigen', () => {
+    expect(items[5].id).toBe('crew:person-missing:r2')
+  })
+
+  it('zählt je Stufe', () => {
+    expect(actionCounts(items)).toEqual({ overdue: 2, today: 1, ahead: 2, undated: 1 })
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// Die Zusage des Modulkopfes: diese Datei LEITET NICHTS AB, sie sammelt ein.
+// Der Wortlaut kommt aus den Quellen — ausser bei den drei Quellen, die keine
+// Befund-Tabelle haben. Der Test haelt beides fest.
+// ───────────────────────────────────────────────────────────────────────────
+describe('der Wortlaut stammt aus der Quelle', () => {
+  const alleTexte = new Set<string>([
+    ...Object.values(LABOUR_FINDING_LABEL),
+    ...Object.values(COST_FINDING_LABEL),
+    ...Object.values(CHAIN_FINDING_LABEL),
+  ])
+
+  const volleLage = actionItems({
+    today: HEUTE,
+    project: projekt({
+      crewPlan: crew({
+        people: [{ id: 'p1', name: 'Anna Berg' }],
+        rates: [{ id: 'r1', personId: 'p1', activity: 'Kamera', hourlyAmount: 60, bandIds: [] }],
+        entries: [
+          { id: 'a', personId: 'p1', rateId: 'r1', date: '2026-09-10', startMinute: 480, endMinute: 840 },
+          { id: 'b', personId: 'p1', rateId: 'r1', date: '2026-09-10', startMinute: 780, endMinute: 1080 },
+        ],
+        expenses: [{ id: 'x1', kind: 'travel', date: '2026-09-02', amount: 20, billable: true }],
+      }),
+      costPlan: {
+        currency: 'EUR',
+        tolerancePercent: 10,
+        lines: [
+          {
+            id: 'k1',
+            label: 'Kamerazug',
+            anchor: { kind: 'free' },
+            estimate: 100,
+            actual: 200,
+            actualSource: 'from-erp',
+          },
+        ],
+      },
+    }),
+    inventory: [
+      artikel({ id: 'i1', model: 'Funkstrecke', ownership: 'subhire', supplier: 'Ton AG', returnDue: '2026-09-02' }),
+    ],
+    checkouts: [
+      ausgabe({ id: 'c1', out: { at: '2026-09-01T08:00:00Z', to: 'Truck 1', dueBack: '2026-09-05' } }),
+    ],
+  })
+
+  it('deckt alle sechs Quellen ab', () => {
+    expect([...new Set(volleLage.map((i) => i.source))].sort()).toEqual(
+      ['booking', 'checkout', 'cost', 'crew', 'receipt', 'subhire'].sort(),
+    )
+  })
+
+  it('formuliert nur bei den Quellen ohne Befund-Tabelle selbst', () => {
+    const selbst = [
+      ...new Set(volleLage.filter((i) => !alleTexte.has(i.title)).map((i) => i.source)),
+    ].sort()
+    expect(selbst).toEqual([...EIGENER_TEXT].sort())
+  })
+
+  it('vergibt stabile und eindeutige Kennungen', () => {
+    expect(new Set(ids(volleLage)).size).toBe(volleLage.length)
+    // Zweimal gerufen: dieselbe Lage, dieselben Kennungen. Sonst waere jede
+    // Oberflaeche, die sich einen Haken merkt, beim naechsten Rendern blind.
+    expect(ids(volleLage)).toEqual(ids([...volleLage]))
+  })
+
+  it('gibt keiner Zeile einen Termin, den ihre Quelle nicht hatte', () => {
+    for (const i of volleLage) {
+      if (i.when !== undefined) expect(i.when).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      if (i.urgency === 'undated') expect(i.when).toBeUndefined()
+      if (i.urgency !== 'undated') expect(i.when).toBeDefined()
+    }
+  })
+})


### PR DESCRIPTION
## Worum es geht

Bedarf 108 (P3): **„An action-items surface that tells them what is due, overdue, conflicting
or over budget — instead of a daily manual sweep."**

Belege: [`Shelf-nu/shelf.nu#1956`](https://github.com/Shelf-nu/shelf.nu/issues/1956) (2025-07-29 —
fragt wörtlich nach einem „Action Items dashboard" und einem „late-returns dashboard"),
dasselbe Muster in [`kimai/kimai#5421`](https://github.com/kimai/kimai/issues/5421).

Der Satz, der den Entwurf entscheidet:

> Across every tracker read, these users ask to be **TOLD** something rather than to go and check.
> That makes this a notification-and-derivation product, **not an authoring product**.
> Cheap to build against the existing model and it is what they actually request.

## Was gebaut wurde

`src/renderer/lib/actionItems.ts` ist eine **Sammelstelle**, keine zweite Rechnung. Sechs Quellen,
alle schon vorhanden:

| Quelle | Liefert |
|---|---|
| `overdueSubhire` | fremdes Material, überfällig oder ohne Rückgabedatum |
| `overdueCheckouts` | offene Ausgaben über ihrem Rückgabetermin |
| `labourFindings` | was an den Stunden nicht aufgeht |
| `receiptChain` | Auslagen ohne Kostenzeile, Ist gegen belegte Summe |
| `assessCosts` | Abweichung über der gesetzten Toleranz |
| `bookingConflicts` | zwei Schichten derselben Person |

Dazu: Reiter **„Was ansteht"** als *erster* in den Analysen, und ein Abzeichen in der Statuszeile
mit der Zahl der heute oder früher fälligen Zeilen.

## Die drei Entscheidungen

**Fälligkeit wird nie erfunden.** `when` steht nur da, wo die Quelle ein Datum *hat* — der
Rückgabetermin, das Datum der Schicht, das Datum der Auslage. Was keins hat, ist `undated`
und nicht „heute fällig". Auf einer nach Dringlichkeit sortierten Liste wäre ein erfundener
Termin der teuerste Fehler überhaupt: er schöbe die echten Überfälligkeiten nach unten.

**Nicht jeder Befund ist eine Aufgabe.** „Keine Toleranz gesetzt" ist eine Auskunft über die
*Einstellung* des Kostenplans. Auf einer Handlungsliste stünde sie jeden Tag — und danach wird
die Liste überflogen statt gelesen. Die Entscheidung fällt in `CREW_ACTION` / `COST_ACTION` /
`CHAIN_ACTION`, und das sind **vollständige `Record`s** über die jeweilige Befundart: eine neue
Befundart upstream ergibt hier einen Compile-Fehler statt still durchzurutschen. Eine
Ausnahmeliste („alles außer diesen") wäre die falsche Richtung.

**Der Wortlaut stammt aus der Quelle.** `crew`, `receipt` und `cost` übernehmen ihn unverändert
aus den `*_LABEL`-Tabellen. Genau drei Quellen haben keine solche Tabelle — `subhire`, `checkout`
und `booking` liefern Datensätze, keine Befunde. Die stehen in `EIGENER_TEXT`, und der Test
rechnet diese Liste aus der erzeugten Lage nach; eine vierte Quelle mit eigenem Wortlaut fällt
damit auf.

Und: das Statuszeilen-Abzeichen erscheint **nur, wenn es etwas zu sagen gibt**. Eines, das
jeden Tag „0" zeigt, ist der Anfang davon, dass niemand mehr hinsieht.

## Prüfung

`npm test`: 186 Dateien, 2898 Tests grün. `tsc --noEmit`: 0 Fehler. `npm run lint`: 0 Errors.
27 neue Tests.

| Injizierter Fehler | Folge |
|---|---|
| Ohne Termin gilt als „heute" | 7 rot |
| Einstellungs-Auskunft als Aufgabe geführt | 1 rot |
| Crew-Befunde selbst formuliert statt übernommen | 2 rot |
| Dringlichkeit beim Sortieren ignoriert | 4 rot |
| Vertrag geraten (`subhire` fest verdrahtet) | 1 rot |

## Nebenbei

`OverdueLine` trägt jetzt `ownership`. Ohne das musste der Aufrufer raten, ob eine überfällige
Position gemietet oder sub-hired ist — und ein geratenes „Sub-Hire" auf einem gemieteten Stück
nennt den falschen Vertrag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_