### PR TITLE
patch: Patchfeld-Kategorie, mehrstufige Signalwege, Rack-Steckerprüfung + Marken-Tokens (#663, #664)

### DIFF
--- a/src/renderer/components/Analysis/AnalysisDialog.tsx
+++ b/src/renderer/components/Analysis/AnalysisDialog.tsx
@@ -69,6 +69,7 @@ import type { DantePatch } from '../../types/dantePatch'
 import { cableRunFindings, cableRunTable, type RunFinding } from '../../lib/cableRunChecks'
 import { CrewTab } from './CrewTab'
 import { ActionTab } from './ActionTab'
+import { ChainTab } from './ChainTab'
 import {
   RECORD_NAME_FINDING_LABEL,
   normaliseRecordNaming,
@@ -166,6 +167,7 @@ type Tab =
   | 'redundancy'
   | 'rf'
   | 'runs'
+  | 'chain'
   | 'sheet'
   | 'client'
   | 'cost'
@@ -2852,6 +2854,9 @@ const TABS: { id: Tab; labelKey: string; fallback: string }[] = [
   { id: 'redundancy', labelKey: 'analysis.tab.redundancy', fallback: 'Redundanz' },
   { id: 'rf', labelKey: 'analysis.tab.rf', fallback: 'RF / Funk' },
   { id: 'runs', labelKey: 'analysis.tab.runs', fallback: 'Kabelwege' },
+  // #664 — der Weg ueber mehrere Ebenen, direkt neben den Kabelwegen:
+  // dort sucht, wer wissen will, wo ein Signal ankommt.
+  { id: 'chain', labelKey: 'analysis.tab.chain', fallback: 'Signalwege' },
   { id: 'sheet', labelKey: 'analysis.tab.sheet', fallback: 'Blatt prüfen' },
 ]
 
@@ -2913,6 +2918,7 @@ const AnalysisDialogInner = () => {
       {active === 'redundancy' && <RedundancyTab projectName={projectName} />}
       {active === 'rf' && <RfTab projectName={projectName} />}
       {active === 'runs' && <RunsTab projectName={projectName} />}
+      {active === 'chain' && <ChainTab />}
       {active === 'sheet' && <SheetTab />}
       {active === 'client' && <ClientTab projectName={projectName} />}
       {active === 'todo' && <ActionTab />}

--- a/src/renderer/components/Analysis/ChainTab.tsx
+++ b/src/renderer/components/Analysis/ChainTab.tsx
@@ -1,0 +1,111 @@
+import { useMemo } from 'react'
+import { useProjectStore } from '../../store/projectStore'
+import { useTranslation } from '../../lib/i18n'
+import { PanelHint } from '../shared/PanelHint'
+import {
+  PASS_THROUGH_LABEL,
+  signalChains,
+  type ChainEnd,
+  type SignalChain,
+} from '../../lib/signalChain'
+
+/**
+ * ISSUE #664, Anzeige-Haelfte — „mehrere Ebenen der Verkabelung anzeigbar
+ * machen fuer Festinstallationen".
+ *
+ * Die Patchliste zeigt KABEL, eine Zeile je Steckverbindung. In einer
+ * Festinstallation liegen zwischen Kamera und Mischer aber Wandanschluss,
+ * Steigleitung und zwei Blenden — und keine der Zeilen sagt, was am anderen
+ * Ende haengt. Diese Seite zeigt den Weg als Ganzes.
+ *
+ * WAS HIER GERECHNET WIRD: nichts. `signalChain.ts` setzt die Kette zusammen,
+ * diese Datei stellt sie dar. Auch das Ende kommt von dort: ob ein Weg am
+ * Zielgeraet endet oder ob die Ableitung aufgegeben hat, sieht man sonst
+ * nicht auseinander — und es bedeutet das Gegenteil.
+ */
+const ENDE_TON: Readonly<Record<ChainEnd, string>> = {
+  ziel: 'text-cp-text-muted',
+  'nicht-verkabelt': 'text-cp-warn',
+  mehrdeutig: 'text-cp-warn',
+  'zu-lang': 'text-cp-warn',
+  schleife: 'text-cp-danger',
+}
+
+const Kette = ({ chain }: { chain: SignalChain }) => {
+  const t = useTranslation()
+  const erst = chain.steps[0]
+  return (
+    <li className="rounded border border-cp-border-muted bg-cp-surface-2 p-2">
+      <div className="flex flex-wrap items-baseline gap-x-1 gap-y-0.5 text-cp-xs">
+        <span className="font-medium text-cp-text">{erst.fromEquipmentName}</span>
+        <span className="text-cp-text-muted">{erst.fromPortName}</span>
+        {chain.steps.map((s) => (
+          <span key={s.cableId} className="flex items-baseline gap-1">
+            <span className="text-cp-text-faint">
+              &ndash;[{s.cableLabel}]&rarr;
+            </span>
+            <span className={s.through ? 'text-cp-text-secondary' : 'font-medium text-cp-text'}>
+              {s.toEquipmentName}
+            </span>
+            <span className="text-cp-text-muted">{s.toPortName}</span>
+            {s.through && (
+              <span className="rounded bg-cp-surface-3 px-1 text-cp-text-faint">
+                {PASS_THROUGH_LABEL[s.through]}
+              </span>
+            )}
+          </span>
+        ))}
+      </div>
+      <div className={`mt-0.5 text-cp-xs ${ENDE_TON[chain.end]}`}>
+        {chain.end === 'ziel'
+          ? t('analysis.chain.endTarget', 'Endgerät erreicht')
+          : chain.endNote}
+      </div>
+    </li>
+  )
+}
+
+export const ChainTab = () => {
+  const t = useTranslation()
+  const equipment = useProjectStore((s) => s.project.equipment)
+  const cables = useProjectStore((s) => s.project.cables)
+
+  const chains = useMemo(() => signalChains(equipment, cables), [equipment, cables])
+  const offen = chains.filter((c) => c.end !== 'ziel').length
+
+  return (
+    <div className="flex flex-col gap-2 text-cp-sm">
+      <PanelHint
+        text={t(
+          'analysis.chain.hint',
+          'Wege über mindestens eine Zwischenebene — Patchfeld, Wandler, Verteiler, geschaltete Kreuzschiene. Direkte Verbindungen stehen in der Patchliste und fehlen hier absichtlich. Wo ein Weg nicht am Endgerät endet, steht der Grund dabei: geraten wird nichts.',
+        )}
+      />
+      {chains.length === 0 ? (
+        <p className="text-cp-xs text-cp-text-muted">
+          {t(
+            'analysis.chain.none',
+            'Kein mehrstufiger Weg im Plan. Ein Gerät wird zum Patchfeld über die Kategorie „Patchfelder" oder das Häkchen in „Darstellung & Flags".',
+          )}
+        </p>
+      ) : (
+        <>
+          <p className="text-cp-xs text-cp-text-secondary">
+            {chains.length} {t('analysis.chain.count', 'mehrstufige Wege')}
+            {offen > 0 && (
+              <span className="text-cp-warn">
+                {' '}
+                &middot; {offen} {t('analysis.chain.openCount', 'ohne erreichtes Endgerät')}
+              </span>
+            )}
+          </p>
+          <ul className="flex flex-col gap-1">
+            {chains.map((c) => (
+              <Kette key={c.id} chain={c} />
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/Atem/AtemMvConfigDialog.tsx
+++ b/src/renderer/components/Atem/AtemMvConfigDialog.tsx
@@ -1241,7 +1241,7 @@ export const AtemMvConfigDialog = () => {
               <button
                 type="button"
                 onClick={() => void adoptLive()}
-                className="ml-auto rounded bg-cp-accent px-3 py-1 text-white hover:opacity-90"
+                className="ml-auto rounded-cp-control bg-cp-accent px-3 py-1 text-cp-accent-text hover:opacity-90"
                 title={t(
                   'atem.mv.live.adoptTitle',
                   'Den gelesenen Stand als neuen Plan übernehmen — ersetzt die bisherige Absicht.',

--- a/src/renderer/components/Canvas/CableEdge.tsx
+++ b/src/renderer/components/Canvas/CableEdge.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../store/projectStoreContext'
 import { useUiStore } from '../../store/uiStore'
 import { CableWaypoints } from './CableWaypoints'
-import { computeObstacleAwareWaypoints, type Rect } from '../../lib/cableRouting'
+import { computeObstacleAwareWaypoints, pathIsBlocked, type Rect } from '../../lib/cableRouting'
 import { computeEquipmentLayout } from '../../lib/equipmentLayout'
 import { isCableVisibleByLayer } from '../../lib/cableLayers'
 import { netKeyOf, netEndpoints } from '../../lib/offPageNet'
@@ -430,6 +430,31 @@ export const CableEdge = ({
   const orthogonalWaypoints = cable
     ? resolveOrthogonalWaypoints(cable, routingArgs, obstacles, obstacleIds)
     : []
+  // Nutzer-Meldung 2026-09-07: „das Kabel automatisch Routen funktioniert
+  // nicht sauber." Der Rechenfehler steckte in `cableRouting.ts` und ist dort
+  // behoben. Was blieb, ist der Fall, in dem es GAR KEINEN freien Weg gibt:
+  // dann wird der kuerzeste gezeichnet, und der laeuft durch ein Geraet.
+  // Bisher sah das aus wie eine gelungene Fuehrung.
+  //
+  // Geprueft wird der Weg, der WIRKLICH GEZEICHNET WIRD — nicht das Ergebnis
+  // des Routers. Zwei Gruende: die automatische Fuehrung wird nach dem ersten
+  // Rechnen in `cable.waypoints` gespeichert (#206), danach gibt es kein
+  // Router-Ergebnis mehr; und ein von Hand gezogener Stuetzpunkt mitten durch
+  // ein Geraet ist derselbe Fehler und war ebenso stumm.
+  const wegBlockiert =
+    !!cable &&
+    !cable.offPage &&
+    (cable.routing ?? 'orthogonal') === 'orthogonal' &&
+    pathIsBlocked(
+      [
+        { x: sourceX, y: sourceY },
+        ...orthogonalWaypoints,
+        { x: targetX, y: targetY },
+      ],
+      obstacles,
+      new Set([cable.fromEquipmentId, cable.toEquipmentId]),
+      obstacleIds,
+    )
   // v7.9.84 / #206 — Persist auto-computed Waypoints einmalig nach dem
   // ersten erfolgreichen Compute. Vorher hat resolveOrthogonalWaypoints
   // bei JEDEM Render mit dem CURRENT-obstacle-Set neu berechnet — d.h.
@@ -906,6 +931,38 @@ export const CableEdge = ({
           renderWaypoints={orthogonalWaypoints}
           exportThemeOverride={data?.exportThemeOverride}
         />
+      )}
+      {/* Der Weg laeuft durch ein Geraet. Das Zeichen haengt NICHT am
+          Kabel-Label: das laesst sich global und je Kabel abschalten, und
+          eine Warnung, die mit der Beschriftung verschwindet, waere in
+          genau den Plaenen unsichtbar, in denen es eng zugeht. */}
+      {wegBlockiert && (
+        <EdgeLabelRenderer>
+          <div
+            className="nodrag nopan"
+            style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px) translate(0, -15px)`,
+              background: '#b91c1c',
+              color: '#fff',
+              border: '1px solid #fca5a5',
+              borderRadius: 9,
+              width: 15,
+              height: 15,
+              lineHeight: '13px',
+              textAlign: 'center',
+              fontSize: 11,
+              fontWeight: 700,
+              pointerEvents: 'all',
+            }}
+            title={t(
+              'canvas.cableEdge.blockedPath',
+              'Dieser Kabelweg läuft durch ein Gerät — es gibt hier keine freie Führung. Gerät verschieben oder den Weg von Hand legen.',
+            )}
+          >
+            !
+          </div>
+        </EdgeLabelRenderer>
       )}
       {/* v7.9.112 / Issue #234 — Label nur rendern wenn:
           - globaler Toggle nicht aktiv

--- a/src/renderer/components/Export/ExportDialog.tsx
+++ b/src/renderer/components/Export/ExportDialog.tsx
@@ -280,7 +280,14 @@ const PlanSection = ({
   ]
 
   return (
-    <div className="space-y-4">
+    // v7.9.4 sagte: „Body als flex-col OHNE eigenes overflow-auto. Jede
+    // Sektion macht ihr Scrolling intern." Diese hier tat es nicht — sie war
+    // ein einfacher Block, und bei kleinem Fenster oder vielen Ebenen-Chips
+    // rutschten „Drucken" und „Als PDF herunterladen" aus dem Dialog, ohne
+    // dass irgendetwas gescrollt haette. Jetzt scrollt der Inhalt, die
+    // Knopfleiste bleibt unten stehen.
+    <div className="flex min-h-0 flex-1 flex-col gap-4">
+      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1">
       <fieldset className="space-y-2">
         <legend className="mb-1 text-cp-xs font-semibold text-cp-text-secondary">{t('export.format', 'Format')}</legend>
         {FORMAT_OPTIONS.map((opt) => {
@@ -433,8 +440,9 @@ const PlanSection = ({
       <div className="rounded border border-cp-border-muted bg-cp-surface-3/40 p-2 text-[11px] text-cp-text-muted">
         {t('export.savedAs', 'Wird gespeichert als')} <code className="rounded bg-cp-surface-2 px-1 py-0.5">{projectName || 'cable-planner'}</code>
       </div>
+      </div>
 
-      <div className="flex justify-end gap-2">
+      <div className="flex shrink-0 justify-end gap-2">
         {/* v7.9.4 — Drucken-Button neben "Als PDF herunterladen"
             (User-Request). Nur sinnvoll für PDF; bei PNG/JPEG
             disabled mit Tooltip. */}
@@ -537,7 +545,11 @@ const PatchSheetSection = ({ onClose }: { onClose: () => void }) => {
   }
 
   return (
-    <div className="space-y-3">
+    // Dieselbe Reparatur wie in `PlanSection`: der Inhalt scrollt, die
+    // Aktionszeile bleibt unten. Vorher konnte die Geraeteliste die Knoepfe
+    // aus dem Dialog schieben.
+    <div className="flex min-h-0 flex-1 flex-col gap-3">
+      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
       {/* v7.9.126 — Kompakt-Patchliste (eine Zeile pro Kabel, sortiert nach
           Quell-Gerät) ist hier zusaetzlich erreichbar. War vorher unter
           Werkzeuge → Patchliste; ist jetzt hier weil sie eine Export-/
@@ -620,10 +632,12 @@ const PatchSheetSection = ({ onClose }: { onClose: () => void }) => {
         </div>
       </div>
 
+      </div>
+
       {/* v7.9.4 — Action-Zeile. Wenn keine pending action: 3 Buttons.
           Wenn pending action: A4/A3-Auswahl + Abbrechen. */}
       {pendingAction == null ? (
-        <div className="flex justify-end gap-2">
+        <div className="flex shrink-0 justify-end gap-2">
           <button
             type="button"
             onClick={() => setPendingAction('individual')}

--- a/src/renderer/components/Project/PlanCompareDialog.tsx
+++ b/src/renderer/components/Project/PlanCompareDialog.tsx
@@ -176,7 +176,7 @@ export const PlanCompareDialog = ({ open, onClose }: PlanCompareDialogProps) => 
             type="button"
             disabled={busy}
             onClick={() => void pickFile()}
-            className="flex items-center gap-2 rounded bg-cp-accent px-3 py-1.5 text-cp-xs text-white disabled:opacity-50"
+            className="flex items-center gap-2 rounded-cp-control bg-cp-accent px-3 py-1.5 text-cp-xs text-cp-accent-text disabled:opacity-50"
           >
             <Icon icon={FolderOpen} size="sm" />
             {t('compare.pick', 'Vergleichs-Datei wählen…')}

--- a/src/renderer/components/Project/ProjectMetaDialog.tsx
+++ b/src/renderer/components/Project/ProjectMetaDialog.tsx
@@ -123,7 +123,7 @@ export const ProjectMetaDialog = ({
               autoFocus
               value={name}
               onChange={(e) => setName(e.target.value)}
-              placeholder={t('project.meta.namePh', 'z.B. ProSieben Studio Umbau')}
+              placeholder={t('project.meta.namePh', 'z.B. Studio 2 Umbau')}
               className="mt-1 w-full rounded border border-cp-border bg-cp-surface-3 p-1.5"
             />
           </label>

--- a/src/renderer/components/Properties/EquipmentProperties.tsx
+++ b/src/renderer/components/Properties/EquipmentProperties.tsx
@@ -37,6 +37,7 @@ import { ModesSection } from './sections/ModesSection'
 import { RackInstanceCard } from './sections/RackInstanceCard'
 import { ReplaceDeviceSection } from './sections/ReplaceDeviceSection'
 import { LifecycleSection } from './sections/LifecycleSection'
+import { CameraControlsSection } from './sections/CameraControlsSection'
 import { SourceIdentitySection } from './sections/SourceIdentitySection'
 import { DeviceToolsSection } from './sections/DeviceToolsSection'
 
@@ -148,6 +149,9 @@ export const EquipmentProperties = () => {
       <NetworkAccessSection equipment={equipment} />
 
       <LifecycleSection equipment={equipment} />
+      {/* BEDARF 103 — Faehigkeiten je Modell. Rendert sich an Nicht-Kameras
+          selbst weg; ein aufklappbares Feld an jedem Stativ waere Laerm. */}
+      <CameraControlsSection equipment={equipment} />
 
       <PowerConsumptionSection equipment={equipment} />
 

--- a/src/renderer/components/Properties/sections/CameraControlsSection.tsx
+++ b/src/renderer/components/Properties/sections/CameraControlsSection.tsx
@@ -1,0 +1,75 @@
+/**
+ * BEDARF 103 — welche Steuerfunktionen dieses Kamera-MODELL wirklich kann.
+ *
+ * Die Massnahme verlangt „show unsupported paint functions as DISABLED in
+ * planning documents". Genau das tut dieser Abschnitt: er steht am Geraet im
+ * Plan, nicht in einer Hersteller-Liste, und er nennt drei Zustaende statt
+ * zwei — „unterstützt", „nicht unterstützt" und „nicht belegt".
+ *
+ * DER DRITTE IST DER WICHTIGE. Ein Werkzeug, das nur zwei kennt, macht aus
+ * einer fehlenden Datenblatt-Angabe eine Behauptung; und die Behauptung, die
+ * dabei herauskommt, ist die falsche Richtung — der Bedarf beschreibt
+ * Oberflaechen, die JEDE Funktion zeigen, weil sie zum Hersteller gehoert.
+ *
+ * Der Abschnitt erscheint NUR an Kameras und nur, wenn es etwas zu sagen gibt
+ * (eine belegte Zeile oder der Hinweis, dass nichts belegt ist). Ein
+ * aufklappbares Feld an jedem Stativ waere Laerm.
+ */
+import { Camera } from 'lucide-react'
+import { useTranslation } from '../../../lib/i18n'
+import { Icon } from '../../shared/Icon'
+import { capabilityFor, controlRows, modelOf } from '../../../lib/cameraCapability'
+import {
+  CAMERA_CONTROL_LABEL,
+  CONTROL_SUPPORT_LABEL,
+  type ControlSupport,
+} from '../../../types/cameraCapability'
+import type { EquipmentItem } from '../../../types/equipment'
+
+const TON: Readonly<Record<ControlSupport, string>> = {
+  supported: 'text-cp-text',
+  unsupported: 'text-cp-danger line-through',
+  unknown: 'text-cp-text-muted',
+}
+
+export const CameraControlsSection = ({ equipment }: { equipment: EquipmentItem }) => {
+  const t = useTranslation()
+  if (!/kamera|camera/i.test(equipment.category ?? '')) return null
+
+  const model = modelOf(equipment)
+  const eintrag = capabilityFor(model)
+  const zeilen = controlRows(model)
+
+  return (
+    <details className="rounded border border-cp-border-muted">
+      <summary className="cursor-pointer px-2 py-1 text-cp-xs font-medium text-cp-text">
+        <Icon icon={Camera} size="xs" className="mr-1 inline" />
+        {t('props.cameraControls.title', 'Steuerbare Funktionen')}
+      </summary>
+      <div className="flex flex-col gap-1 px-2 pb-2 text-cp-xs">
+        <p className="text-cp-text-muted">
+          {eintrag
+            ? eintrag.source
+            : t(
+                'props.cameraControls.noSource',
+                'Zu diesem Modell liegt keine Fähigkeits-Aussage vor. „Nicht belegt" heißt nicht „geht nicht" — es heißt, dass niemand es nachgesehen hat.',
+              )}
+        </p>
+        <table className="w-full border-collapse">
+          <tbody>
+            {zeilen.map((z) => (
+              <tr key={z.control} className="border-b border-cp-border-muted">
+                <td className={`py-0.5 pr-2 ${TON[z.support]}`}>
+                  {CAMERA_CONTROL_LABEL[z.control]}
+                </td>
+                <td className={`py-0.5 text-right ${TON[z.support]}`}>
+                  {CONTROL_SUPPORT_LABEL[z.support]}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </details>
+  )
+}

--- a/src/renderer/components/Properties/sections/DisplayFlagsSection.tsx
+++ b/src/renderer/components/Properties/sections/DisplayFlagsSection.tsx
@@ -1,5 +1,10 @@
 import { useCanvasProjectStore as useProjectStore } from '../../../store/projectStoreContext'
 import { useTranslation } from '../../../lib/i18n'
+import {
+  PATCH_PANEL_CATEGORY,
+  categoryIsPatchPanel,
+  isPatchPanelDevice,
+} from '../../../lib/patchPanel'
 import { ColorField } from '../../shared/ColorField'
 import { SortableSection } from '../SortableSection'
 import type { EquipmentItem } from '../../../types/equipment'
@@ -16,6 +21,10 @@ import type { EquipmentItem } from '../../../types/equipment'
 export const DisplayFlagsSection = ({ equipment }: { equipment: EquipmentItem }) => {
   const t = useTranslation()
   const updateEquipment = useProjectStore((state) => state.updateEquipment)
+  // ISSUE #664 — die Kategorie „Patchfelder" sagt es bereits; dann ist das
+  // Haekchen gesetzt UND gesperrt, statt eine zweite, widersprechbare
+  // Wahrheit anzubieten.
+  const ausKategorie = categoryIsPatchPanel(equipment.category)
 
   return (
     <SortableSection id="flags" title={t('flags.title', 'Darstellung & Flags')} subtitle={t('flags.subtitle', 'kompakt · Farbe · gepackt')}>
@@ -73,6 +82,35 @@ export const DisplayFlagsSection = ({ equipment }: { equipment: EquipmentItem })
             }
           />
           {t('flags.converter', 'Wandler (Patchliste folgt Durchgangskabel)')}
+        </label>
+        {/* #664 — Patchblenden-Marker. Setzt den positionsweisen Durchgang
+            (Buchse n hinten auf Buchse n vorn), dem Patchliste, Signalweg
+            und Namens-Ableitung folgen. */}
+        <label
+          className="flex items-center gap-2 text-[11px] text-cp-text-secondary"
+          title={
+            ausKategorie
+              ? t(
+                  'flags.patchPanelByCategory',
+                  `Die Kategorie „${PATCH_PANEL_CATEGORY}" weist dieses Gerät bereits als Patchfeld aus.`,
+                )
+              : t(
+                  'flags.patchPanelTitle',
+                  'Patchfeld: Buchse n hinten liegt auf Buchse n vorn. Der Signalweg und die Patchliste folgen dem Durchgang, statt an der Blende anzuhalten. Setzt gleich viele Ein- und Ausgänge voraus.',
+                )
+          }
+        >
+          <input
+            type="checkbox"
+            checked={isPatchPanelDevice(equipment)}
+            disabled={ausKategorie}
+            onChange={(event) =>
+              updateEquipment(equipment.id, {
+                isPatchPanel: event.target.checked || undefined,
+              })
+            }
+          />
+          {t('flags.patchPanel', 'Patchfeld (Durchgang folgt der Position)')}
         </label>
         <label
           className="flex items-center gap-2 text-[11px] text-cp-text-secondary"

--- a/src/renderer/components/Rack/RackInternalWireOverlay.tsx
+++ b/src/renderer/components/Rack/RackInternalWireOverlay.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from '../../lib/i18n'
 import { RackInternalCanvas } from './RackInternalCanvas'
 import type { InternalCableDraft, RackPlacementDraft } from './rackBuilderTypes'
 import { PanelHint } from '../shared/PanelHint'
+import { rackWireFindings } from '../../lib/rackWireChecks'
 
 /** v7.8.5+ — Wire-Dialog-Overlay fuer die Rack-interne Verkabelung.
  *
@@ -34,6 +35,12 @@ export const RackInternalWireOverlay = ({
 }: RackInternalWireOverlayProps) => {
   const t = useTranslation()
   if (!open) return null
+
+  // ISSUE #663 — „Es fehlt die Fehlermeldung, dass Kabeltypen nicht
+  // zusammenpassen." Der Signalplan meldet das seit langem; hier fehlte es.
+  // Gerechnet wird in `lib/rackWireChecks.ts`, nicht in dieser Datei: die
+  // Regel gehoert in eine pruefbare Funktion und nicht in eine Ansicht.
+  const befunde = rackWireFindings(placements, internalCables)
 
   // draft.internalCables (per-id) → GroupPreset.cables (per-index)
   const initialCables: GroupPreset['cables'] = (() => {
@@ -84,6 +91,18 @@ export const RackInternalWireOverlay = ({
             {t('common.done', 'Fertig')}
           </button>
         </div>
+        {befunde.length > 0 && (
+          <ul className="mb-2 max-h-28 shrink-0 space-y-0.5 overflow-y-auto rounded border border-cp-border-muted bg-cp-surface-3/40 p-1.5 text-cp-xs">
+            {befunde.map((f, i) => (
+              <li
+                key={`${f.kind}-${f.index}-${i}`}
+                className={f.severity === 'error' ? 'text-cp-danger' : 'text-cp-warn'}
+              >
+                {f.text}
+              </li>
+            ))}
+          </ul>
+        )}
         <div className="min-h-0 flex-1 overflow-hidden rounded border border-cp-border">
           <RackInternalCanvas
             rackName={rackName}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -31,9 +31,12 @@
    *   - card:    Sub-Karten, Panels, Listeneinträge
    *   - modal:   Dialoge/Shells (ModalShell, FloatingPanelShell)
    * Neue Komponenten nutzen diese statt bare `rounded`. */
-  --radius-cp-control: 0.375rem; /* 6px */
-  --radius-cp-card: 0.5rem; /* 8px */
-  --radius-cp-modal: 0.75rem; /* 12px */
+  /* ADR-007 — der Guide kennt keine Rundungen ("Was es nicht gibt", S. 10).
+   * Die drei Namen bleiben, damit kein Aufrufer umgebaut werden muss; der
+   * Wert ist ueberall null. Struktur entsteht durch Linie und Weissraum. */
+  --radius-cp-control: 0;
+  --radius-cp-card: 0;
+  --radius-cp-modal: 0;
 
   /* ── Spacing-Rhythmus (UX audit #53/#466) ────────────────────────────────
    * Die :root-Variablen --cp-space-x waren als Referenz gedacht, aber nicht
@@ -79,6 +82,8 @@
   --color-cp-text-muted: var(--cp-text-muted);
   --color-cp-text-faint: var(--cp-text-faint);
   --color-cp-accent: var(--cp-accent);
+  --color-cp-accent-text: var(--cp-accent-text);
+  --color-cp-signal: var(--cp-signal);
   --color-cp-warn: var(--cp-warn);
   --color-cp-danger: var(--cp-danger);
 }
@@ -100,27 +105,45 @@
    * sind die Tokens jetzt per Definition deckungsgleich mit den rohen
    * slate-/sky-/amber-/red-Utilities — die Migration ist damit beweisbar
    * appearance-neutral, und es gibt nur noch EINE Farbquelle. */
-  --cp-bg: var(--color-slate-900); /* App-Hintergrund */
-  --cp-surface-1: var(--color-slate-900); /* Panels/Modals */
-  --cp-surface-2: var(--color-slate-800); /* raised/hover */
-  --cp-surface-3: var(--color-slate-950); /* sunken/Leisten/Inputs */
-  /* #449 — interaktive Button-Surfaces (heller als border). Erlauben die
-   * Migration der schweren Settings-Tabs, die slate-700/600 als Knopf-BG +
-   * slate-200 als helleren Text nutzen — wofür es bisher keinen Token gab. */
-  --cp-surface-4: var(--color-slate-700); /* Button-/Chip-Surface */
-  --cp-surface-5: var(--color-slate-600); /* heller, z.B. surface-4-Hover */
-  --cp-border: var(--color-slate-700);
-  --cp-border-muted: var(--color-slate-800);
-  --cp-text: var(--color-slate-100);
-  --cp-text-bright: var(--color-slate-200); /* zwischen text und secondary */
-  --cp-text-secondary: var(--color-slate-300);
-  --cp-text-muted: var(--color-slate-400);
-  --cp-text-faint: var(--color-slate-500);
-  --cp-text-dim: var(--color-slate-600);
-  --cp-text-dimmer: var(--color-slate-700);
-  --cp-accent: var(--color-sky-400);
-  --cp-warn: var(--color-amber-500);
-  --cp-danger: var(--color-red-500);
+  /* ADR-007 (av-planner-suite) — die Tokens zeigen nicht mehr auf Tailwinds
+   * `slate`, sondern auf die Marken-Palette der Suite. Die Utilities
+   * (`bg-cp-surface-1`, `text-cp-muted`, …) bleiben unveraendert: genau
+   * dafuer wurde die Token-Schicht in #449 angelegt — die Umstellung einer
+   * ganzen App ist damit diese eine Stelle.
+   *
+   * Werte und Rollen stehen in `@avplan/ui` (`src/brand.ts`,
+   * `packages/ui/test/brand.test.ts`) und kommen aus dem Brand Guide 2.0.
+   * Drei Stufen sind daraus ABGELEITET, weil ein Control-Surface mehr
+   * Flaechen braucht, als ein Marken-Handbuch vorsieht: versenkt, Panel,
+   * erhoben. Sie sind unten als abgeleitet gekennzeichnet. */
+  --cp-bg: #132040; /* Deep Navy — App-Hintergrund */
+  --cp-surface-1: #182948; /* abgeleitet — Panels/Modals */
+  --cp-surface-2: #1D324F; /* Zumpe Navy — raised/hover, Karten */
+  --cp-surface-3: #0E1930; /* abgeleitet — versenkt: Leisten, Inputs */
+  --cp-surface-4: #24405F; /* abgeleitet — Button-/Chip-Flaeche */
+  --cp-surface-5: #2E4E73; /* abgeleitet — surface-4-Hover */
+  --cp-border: rgba(246, 245, 240, 0.14);
+  --cp-border-muted: rgba(246, 245, 240, 0.07);
+  /* Off-White ist die HELLERE Stufe, Eisblau der Fliesstext — so steht es
+   * im Guide (S. 17). `--cp-text-bright` traegt damit die Ueberschriften,
+   * `--cp-text` den Lauftext. */
+  --cp-text: #E1ECEF; /* Eisblau — Fliesstext auf Dunkel */
+  --cp-text-bright: #F6F5F0; /* Off-White — Ueberschriften, Hervorhebung */
+  --cp-text-secondary: #C7D5DC; /* abgeleitet — zwischen Fliesstext und Meta */
+  --cp-text-muted: #8C9CB3; /* Stahlblau — Kicker, Meta, Platzhalter */
+  --cp-text-faint: #6E7F99; /* abgeleitet */
+  --cp-text-dim: #55678A; /* abgeleitet */
+  --cp-text-dimmer: #3E5175; /* abgeleitet */
+  /* Interaktiv/ausgewaehlt ist Off-White — der Primaerknopf des Guides.
+   * Nicht Rot: Rot ist das Signal, siehe `--cp-signal`. */
+  --cp-accent: #F6F5F0;
+  --cp-accent-text: #132040; /* Navy auf Off-White — 13:1 */
+  --cp-warn: #C8892B;
+  --cp-danger: #B04A3F;
+  /* Das Aufnahmelicht. Fokusring, EIN Punkt am primaeren Knopf, Live-/
+   * Aufnahme-Zustand. Nie Flaeche, nie Text, nie zweimal in einem
+   * Sichtfeld. Fehlerrot ist `--cp-danger` und ein anderer Ton. */
+  --cp-signal: #D6402E;
 
   /* Spacing-Skala (Referenz; schrittweise Migration der Shells) */
   --cp-space-1: 0.25rem;
@@ -165,7 +188,10 @@ body,
  * obscures the user-configurable Background component entirely. The
  * pane must stay transparent for the pattern to be visible. */
 #cable-planner-canvas {
-  background: radial-gradient(circle at 20% 10%, #1e293b 0%, #0f172a 45%, #020617 100%);
+  /* ADR-007 — keine Verlaeufe. Der Canvas-Grund ist die Flaeche der
+   * Marke, damit der Plan darauf und die Panels daneben derselben
+   * Anwendung angehoeren. */
+  background: #0E1930;
 }
 
 #cable-planner-canvas .react-flow__pane {
@@ -173,7 +199,7 @@ body,
 }
 
 #cable-planner-canvas.canvas-theme-light {
-  background: radial-gradient(circle at 30% 20%, #eef2f7 0%, #e8edf4 50%, #dde4ee 100%);
+  background: #ECEBE6;
 }
 
 #cable-planner-canvas.canvas-theme-light .react-flow__pane {
@@ -227,32 +253,30 @@ body,
  * avoid that.
  * ─────────────────────────────────────────────────────────── */
 [data-theme="light"] {
-  /* Phase 2: Light-Overrides der Farb-Tokens. Werte = bisheriger
-   * Slate-Remap, damit migrierte Shells im Light-Mode identisch aussehen
-   * und keine dunklen Rest-Flächen entstehen. */
-  --cp-bg: #f0f4f8;
-  --cp-surface-1: #eaeff5; /* = .bg-slate-900 light remap */
-  --cp-surface-2: #dde4ee; /* = .bg-slate-800 */
-  --cp-surface-3: #f0f4f8; /* = .bg-slate-950 */
-  /* #449 — Light-Werte = exakt der bestehende 340-Zeilen-Remap der rohen
-   * Klassen, damit bg-cp-surface-4/5 pixelgleich zu .bg-slate-700/600 bleiben. */
-  --cp-surface-4: #cbd5e1; /* = .bg-slate-700 (light) */
-  --cp-surface-5: #b8c4d0; /* = .bg-slate-600 (light) */
-  --cp-border: #94a3b8; /* = .border-slate-700 */
-  --cp-border-muted: #b8c4d0; /* = .border-slate-800 */
-  --cp-text: #0f172a; /* = .text-slate-100 */
-  --cp-text-bright: #1e293b; /* = .text-slate-200 (light) */
-  /* #449 — fehlte im Light-Remap: --cp-text-secondary fiel auf den Dark-Wert
-   * zurück (heller Grauton auf hellem Grund → unlesbar). Jetzt = light
-   * .text-slate-300 (#1e293b), passt in die Ramp text(#0f172a) → muted(#334155). */
-  --cp-text-secondary: #1e293b; /* = .text-slate-300 (light) */
-  --cp-text-muted: #334155; /* = .text-slate-400 */
-  --cp-text-faint: #475569; /* = .text-slate-500 */
-  --cp-text-dim: #334155; /* = .text-slate-600 (light) */
-  --cp-text-dimmer: #94a3b8; /* = .text-slate-700 (light) */
-  --cp-accent: #0284c7; /* sky-600 */
-  --cp-warn: #d97706; /* amber-600 */
-  --cp-danger: #dc2626; /* red-600 */
+  /* ADR-007 — dieselbe Palette, gedrehte Gewichtung: Print ist hell
+   * (60 % Weiss), das Web dunkel (70 % Deep Navy). Schiefer ist hier der
+   * Sekundaertext — der Wert, fuer den der Guide ihn misst (5,4:1 auf
+   * Weiss); auf Navy waere er unlesbar und kommt dort nicht vor. */
+  --cp-bg: #F6F5F0; /* Off-White */
+  --cp-surface-1: #FFFFFF;
+  --cp-surface-2: #E1ECEF; /* Eisblau — Karten, Tabellenkoepfe */
+  --cp-surface-3: #ECEBE6; /* abgeleitet — versenkt */
+  --cp-surface-4: #FFFFFF;
+  --cp-surface-5: #E1ECEF;
+  --cp-border: rgba(29, 50, 79, 0.16);
+  --cp-border-muted: rgba(29, 50, 79, 0.08);
+  --cp-text: #1D324F; /* Zumpe Navy */
+  --cp-text-bright: #132040;
+  --cp-text-secondary: #5C6B85; /* Schiefer */
+  --cp-text-muted: #6E7F99;
+  --cp-text-faint: #8C9CB3; /* Stahlblau */
+  --cp-text-dim: #8C9CB3;
+  --cp-text-dimmer: #A7B3C4;
+  --cp-accent: #1D324F;
+  --cp-accent-text: #F6F5F0;
+  --cp-warn: #C8892B;
+  --cp-danger: #B04A3F;
+  --cp-signal: #D6402E;
   /* Render native form elements (selects, checkboxes, inputs) in light mode */
   color-scheme: light;
 }
@@ -564,14 +588,17 @@ a:focus-visible,
 [role="menuitem"]:focus-visible,
 [role="checkbox"]:focus-visible,
 [role="tab"]:focus-visible {
-  outline: 2px solid var(--cp-accent);
-  outline-offset: 1px;
-  border-radius: 4px;
+  /* ADR-007 — der Fokusring ist Tally-Rot, 2 px, 3 px Abstand. Das ist der
+   * eine Ort, an dem das Signal ohne Zutun erscheint: wer mit der Tastatur
+   * arbeitet, soll sehen, wo er ist. */
+  outline: 2px solid var(--cp-signal);
+  outline-offset: 3px;
+  border-radius: 0;
 }
 input:focus-visible,
 select:focus-visible,
 textarea:focus-visible {
-  outline: 2px solid var(--cp-accent);
+  outline: 2px solid var(--cp-signal);
   outline-offset: -1px;
 }
 [data-theme="light"] button:focus-visible,
@@ -579,7 +606,7 @@ textarea:focus-visible {
 [data-theme="light"] input:focus-visible,
 [data-theme="light"] select:focus-visible,
 [data-theme="light"] textarea:focus-visible {
-  outline-color: var(--cp-accent);
+  outline-color: var(--cp-signal);
 }
 
 /* ── Consistent disabled affordance (UX audit #45/#464) ─────────────────────

--- a/src/renderer/lib/cableRouting.ts
+++ b/src/renderer/lib/cableRouting.ts
@@ -37,7 +37,7 @@ export interface Rect {
   height: number
 }
 
-interface Point {
+export interface Point {
   x: number
   y: number
 }
@@ -185,6 +185,27 @@ export const routeAround = (
   const alleWege = [...einfach, ...kandidaten].sort((a, b) => pathLength(a) - pathLength(b))
   return { waypoints: alleWege[0].slice(1, -1), clear: false }
 }
+
+/**
+ * Laeuft der GEZEICHNETE Weg durch ein Geraet?
+ *
+ * `routeAround` beantwortet das fuer den Weg, den es selbst gerade gelegt hat
+ * — und genau diese Antwort geht verloren, sobald der Weg einmal in
+ * `cable.waypoints` gespeichert ist (#206 persistiert die automatische
+ * Fuehrung nach dem ersten Rechnen). Ab da rechnet niemand mehr nach, und
+ * eine Fuehrung, die durch ein Geraet laeuft, sieht aus wie eine gelungene.
+ *
+ * Diese Funktion prueft deshalb den Weg, der WIRKLICH GEZEICHNET WIRD, egal
+ * woher seine Punkte stammen. Das deckt den zweiten Fall gleich mit ab: ein
+ * von Hand gezogener Stuetzpunkt mitten durch ein Geraet ist derselbe Fehler
+ * und war bisher ebenso stumm.
+ */
+export const pathIsBlocked = (
+  points: readonly Point[],
+  obstacles: Rect[],
+  ignoreIds?: Set<string>,
+  obstacleIds?: string[],
+): boolean => !pathClearsAll([...points], relevant(obstacles, ignoreIds, obstacleIds))
 
 /**
  * Nur die Zwischenpunkte — die Form, die der Canvas seit jeher aufruft.

--- a/src/renderer/lib/cableRouting.ts
+++ b/src/renderer/lib/cableRouting.ts
@@ -1,14 +1,33 @@
 /**
- * Lightweight obstacle-aware orthogonal routing for cable edges.
+ * Orthogonale Kabelführung um Geräte herum.
  *
- * Given the two endpoints of a cable (already at the device boundary) and a
- * list of equipment bounding boxes, returns a list of waypoints that form an
- * orthogonal path that does **not** cross through any equipment rectangle.
+ * Gegeben sind die beiden Endpunkte eines Kabels (bereits am Geräterand) und
+ * die Rechtecke der Geräte; zurück kommen Zwischenpunkte, die einen
+ * rechtwinkligen Weg ergeben, der durch KEIN Gerät läuft.
  *
- * The algorithm is intentionally simple — it is not a full A* solver, but
- * handles the common case of one obstacle between source and target by going
- * around the nearest edge of the obstacle. If no obstacle is in the way, the
- * path is returned without waypoints.
+ * ─── WAS AN DER ALTEN FASSUNG NICHT STIMMTE (2026-09-07) ───────────────────
+ *
+ * Nutzer-Meldung: „manche Basisfunktionen wie das Kabel automatisch Routen
+ * funktionieren nicht sauber." Nachgesehen, drei Befunde, und der dritte ist
+ * der eigentliche:
+ *
+ *  1. Der Umweg wurde um GENAU EIN Hindernis gerechnet — um das erste, das
+ *     der HVH-Weg schnitt. Standen zwei Geräte hintereinander, führte der
+ *     Umweg um das erste geradewegs ins zweite.
+ *  2. Gesucht wurde das störende Gerät am HVH-Weg (`variants[2]`), obwohl
+ *     bevorzugt der L-Weg (`variants[0]`) gezeichnet wird. Das störende
+ *     Gerät konnte also ein anderes sein als das, an dem der gezeichnete Weg
+ *     scheiterte.
+ *  3. Und wenn gar nichts frei war, gab die Funktion „den kürzesten Umweg
+ *     zurück, auch wenn er noch etwas streift" — WORTLOS. Das Ergebnis sah
+ *     aus wie eine gelungene Führung, und das Kabel lief durch ein Gerät.
+ *
+ * Der dritte ist der teure: eine Funktion ohne Sprache für „ich konnte das
+ * nicht" muss lügen. `routeAround` gibt deshalb `{ waypoints, clear }` zurück
+ * — der Weg wird weiter geliefert (eine Kante ohne Weg wäre unsichtbar), aber
+ * er ist als nicht frei GEKENNZEICHNET, und die Oberfläche kann es zeigen.
+ *
+ * REIN: keine Uhr, kein Store, kein IO.
  */
 
 export interface Rect {
@@ -23,6 +42,7 @@ interface Point {
   y: number
 }
 
+/** Abstand, den ein Umweg zum Gerät hält. */
 const PADDING = 12
 
 const inflate = (r: Rect, pad: number): Rect => ({
@@ -32,18 +52,23 @@ const inflate = (r: Rect, pad: number): Rect => ({
   height: r.height + pad * 2,
 })
 
+/**
+ * Schneidet der (waagerechte oder senkrechte) Abschnitt das Rechteck?
+ *
+ * STRIKT: eine Linie, die genau auf der Kante entlangläuft, schneidet nicht.
+ * Sonst wäre jeder Weg, der ein Gerät sauber tangiert, blockiert — und der
+ * Umweg um ein Gerät läuft naturgemäß an dessen Kante entlang.
+ */
 const segmentIntersectsRect = (a: Point, b: Point, r: Rect): boolean => {
   const minX = Math.min(a.x, b.x)
   const maxX = Math.max(a.x, b.x)
   const minY = Math.min(a.y, b.y)
   const maxY = Math.max(a.y, b.y)
-  if (maxX < r.x || minX > r.x + r.width) return false
-  if (maxY < r.y || minY > r.y + r.height) return false
-  return true
+  return maxX > r.x && minX < r.x + r.width && maxY > r.y && minY < r.y + r.height
 }
 
 const pathClearsAll = (points: Point[], obstacles: Rect[]): boolean => {
-  for (let i = 0; i < points.length - 1; i++) {
+  for (let i = 0; i < points.length - 1; i += 1) {
     for (const rect of obstacles) {
       if (segmentIntersectsRect(points[i], points[i + 1], rect)) return false
     }
@@ -52,55 +77,120 @@ const pathClearsAll = (points: Point[], obstacles: Rect[]): boolean => {
 }
 
 /**
- * Build an orthogonal L- or U-shape path from source to target, detouring
- * around a single obstacle when required.
+ * Die vier einfachen Wege von A nach B.
+ *
+ * Die Reihenfolge ist Absicht: der L-Weg mit einem Knick steht vorn, weil er
+ * beim Ziehen eines Geräts an beiden Enden haften bleibt. Die zweiknickigen
+ * Wege springen bei jeder Pixelbewegung, und das war als „Flackern" sichtbar.
  */
 const orthogonalVariants = (source: Point, target: Point): Point[][] => {
   const midX = (source.x + target.x) / 2
   const midY = (source.y + target.y) / 2
   return [
-    // L: horizontal first — single bend, stays attached when target moves
-    // vertically. Preferred so cables don't "spin" while dragging endpoints.
     [source, { x: target.x, y: source.y }, target],
-    // L: vertical first
     [source, { x: source.x, y: target.y }, target],
-    // HVH (two bends at horizontal mid-point) — fallback when L collides.
     [source, { x: midX, y: source.y }, { x: midX, y: target.y }, target],
-    // VHV (two bends at vertical mid-point)
     [source, { x: source.x, y: midY }, { x: target.x, y: midY }, target],
   ]
 }
 
+/** Die vier Umwege um EIN Rechteck: oben herum, unten herum, links, rechts. */
 const detourAround = (source: Point, target: Point, rect: Rect): Point[][] => {
   const r = inflate(rect, PADDING)
-  const above = r.y
-  const below = r.y + r.height
-  const left = r.x
-  const right = r.x + r.width
+  const oben = r.y
+  const unten = r.y + r.height
+  const links = r.x
+  const rechts = r.x + r.width
   return [
-    // Over the top of the obstacle.
-    [source, { x: source.x, y: above }, { x: target.x, y: above }, target],
-    // Under the bottom of the obstacle.
-    [source, { x: source.x, y: below }, { x: target.x, y: below }, target],
-    // Around the left side.
-    [source, { x: left, y: source.y }, { x: left, y: target.y }, target],
-    // Around the right side.
-    [source, { x: right, y: source.y }, { x: right, y: target.y }, target],
+    [source, { x: source.x, y: oben }, { x: target.x, y: oben }, target],
+    [source, { x: source.x, y: unten }, { x: target.x, y: unten }, target],
+    [source, { x: links, y: source.y }, { x: links, y: target.y }, target],
+    [source, { x: rechts, y: source.y }, { x: rechts, y: target.y }, target],
   ]
 }
 
 const pathLength = (points: Point[]): number => {
   let total = 0
-  for (let i = 0; i < points.length - 1; i++) {
+  for (let i = 0; i < points.length - 1; i += 1) {
     total += Math.abs(points[i + 1].x - points[i].x) + Math.abs(points[i + 1].y - points[i].y)
   }
   return total
 }
 
+export interface RouteResult {
+  /** Die Zwischenpunkte, ohne Anfang und Ende. */
+  waypoints: Point[]
+  /**
+   * Läuft der Weg wirklich an allem vorbei?
+   *
+   * `false` heisst: es wurde keiner gefunden, der frei ist — geliefert wird
+   * der kürzeste. Die Oberfläche soll das zeigen, statt eine Führung zu
+   * behaupten, die durch ein Gerät läuft.
+   */
+  clear: boolean
+}
+
+const relevant = (
+  obstacles: Rect[],
+  ignoreIds?: Set<string>,
+  obstacleIds?: string[],
+): Rect[] =>
+  obstacles.filter((_, i) => {
+    const id = obstacleIds?.[i]
+    if (!id) return true
+    return !ignoreIds?.has(id)
+  })
+
 /**
- * Given source and target points plus equipment bounding boxes, returns a set
- * of intermediate waypoints (excluding source/target) that routes around any
- * obstacle. Returns an empty array when the direct orthogonal route is clear.
+ * Einen Weg von `source` nach `target` legen, der die Hindernisse meidet.
+ *
+ * ALLE Kandidaten werden gegen ALLE Hindernisse geprüft — die einfachen Wege
+ * zuerst, dann die Umwege um jedes einzelne Hindernis, zuletzt der Umweg um
+ * das umschliessende Rechteck aller Hindernisse. Der letzte ist der, der den
+ * Fall „zwei Geräte hintereinander" löst: um beide herum statt zwischen sie
+ * hinein.
+ */
+export const routeAround = (
+  source: Point,
+  target: Point,
+  obstacles: Rect[],
+  ignoreIds?: Set<string>,
+  obstacleIds?: string[],
+): RouteResult => {
+  const hindernisse = relevant(obstacles, ignoreIds, obstacleIds)
+  if (hindernisse.length === 0) return { waypoints: [], clear: true }
+
+  const einfach = orthogonalVariants(source, target)
+  const direkt = einfach.find((v) => pathClearsAll(v, hindernisse))
+  if (direkt) return { waypoints: direkt.slice(1, -1), clear: true }
+
+  // Umwege um JEDES Hindernis — und jeder Kandidat wird gegen ALLE Hindernisse
+  // geprueft. Das ist der Unterschied zur alten Fassung: sie suchte ein
+  // einziges stoerendes Geraet und fuhr um dieses herum, ohne den Umweg noch
+  // einmal gegen die uebrigen zu halten. Standen zwei hintereinander, lief
+  // der Umweg um das erste ins zweite.
+  //
+  // Ein zusaetzlicher Umweg um das umschliessende Rechteck ALLER Hindernisse
+  // stand hier kurz und ist wieder heraus: keine Gegenprobe konnte ihn rot
+  // faerben. Die Umwege um das oberste und unterste Hindernis fuehren
+  // ohnehin an der ganzen Gruppe vorbei, und Code, den kein Test von seinem
+  // Fehlen unterscheiden kann, ist nicht belegt.
+  const kandidaten = hindernisse.flatMap((r) => detourAround(source, target, r))
+
+  const freier = kandidaten.find((v) => pathClearsAll(v, hindernisse))
+  if (freier) return { waypoints: freier.slice(1, -1), clear: true }
+
+  // Nichts frei. Der kürzeste Kandidat wird geliefert — und als nicht frei
+  // gekennzeichnet. Wortlos das Gleiche zu tun war der eigentliche Defekt.
+  const alleWege = [...einfach, ...kandidaten].sort((a, b) => pathLength(a) - pathLength(b))
+  return { waypoints: alleWege[0].slice(1, -1), clear: false }
+}
+
+/**
+ * Nur die Zwischenpunkte — die Form, die der Canvas seit jeher aufruft.
+ *
+ * Bleibt bestehen, damit `CableEdge` nicht umgebaut werden muss; wer wissen
+ * will, ob der Weg frei ist, ruft `routeAround`.
  */
 export const computeObstacleAwareWaypoints = (
   source: Point,
@@ -108,33 +198,4 @@ export const computeObstacleAwareWaypoints = (
   obstacles: Rect[],
   ignoreIds?: Set<string>,
   obstacleIds?: string[],
-): Point[] => {
-  const relevantObstacles = obstacles.filter((_, i) => {
-    const id = obstacleIds?.[i]
-    if (!id) return true
-    return !ignoreIds?.has(id)
-  })
-  if (relevantObstacles.length === 0) return []
-
-  const variants = orthogonalVariants(source, target)
-  // Pick the FIRST clear variant in the predefined order (L-h > L-v > HVH >
-  // VHV). Single-bend L-shapes are preferred because they stay attached to
-  // both endpoints when nodes are dragged, eliminating the user-visible
-  // "spinning" / flickering of orthogonal cables on every pixel-level move.
-  const firstClear = variants.find((v) => pathClearsAll(v, relevantObstacles))
-  if (firstClear) return firstClear.slice(1, -1)
-
-  // Find the first obstacle the naive HVH path crosses and detour around it.
-  const naive = variants[2]
-  const offender = relevantObstacles.find((rect) =>
-    naive.some((_, i) => i < naive.length - 1 && segmentIntersectsRect(naive[i], naive[i + 1], rect)),
-  )
-  if (!offender) return []
-
-  const detours = detourAround(source, target, offender)
-  const firstClearDetour = detours.find((v) => pathClearsAll(v, relevantObstacles))
-  if (firstClearDetour) return firstClearDetour.slice(1, -1)
-  // Fall back to the shortest detour even if it still grazes something.
-  detours.sort((a, b) => pathLength(a) - pathLength(b))
-  return detours[0].slice(1, -1)
-}
+): Point[] => routeAround(source, target, obstacles, ignoreIds, obstacleIds).waypoints

--- a/src/renderer/lib/cameraCapability.ts
+++ b/src/renderer/lib/cameraCapability.ts
@@ -1,0 +1,197 @@
+// ───────────────────────────────────────────────────────────────────────────
+// BEDARF 103 — die Faehigkeits-Tabelle, nach MODELL und nicht nach Hersteller.
+//
+// Die Massnahme woertlich: „Capability table KEYED BY CAMERA MODEL, not
+// connection mode; show unsupported paint functions as DISABLED in planning
+// documents and in the bridge UI."
+//
+// ─── WARUM NACH MODELLNAME UND NICHT NACH `deviceTypeId` ───────────────────
+//
+// Der Katalog dieser Anwendung fuehrt 23 Kameras, und keine davon ist eine
+// Panasonic-PTZ — die beiden Modelle, ueber die eine belegte Aussage
+// vorliegt, haben hier keine Geraetetyp-Id. Eine Tabelle nach `deviceTypeId`
+// waere also leer, und die einzige belegte Auskunft des ganzen Bedarfs fiele
+// heraus.
+//
+// Der Modellname ist der Schluessel, den die FUNDSTELLE benutzt, und der
+// Bedarf sagt genau das („keyed by camera model"). Wo ein Katalog-Eintrag
+// existiert, wird sein Template-Name mitgeprueft — beide Wege laufen durch
+// `normaliseModel`, damit die Schreibweise nicht zur zweiten Regel wird.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+import type { EquipmentItem } from '../types/equipment'
+import {
+  type CameraCapability,
+  type CameraControl,
+  type ControlSupport,
+} from '../types/cameraCapability'
+import { resolveDeviceType } from './deviceTypeRegistry'
+
+/**
+ * Schreibweisen zusammenfuehren: klein, ohne Bindestriche und Leerzeichen.
+ *
+ * „AW-UE150A", „aw ue150a" und „AWUE150A" sind dasselbe Modell. Ohne diese
+ * eine Stelle entschiede die Schreibweise des Eintragenden darueber, ob die
+ * Warnung erscheint — und sie erschiene genau dann nicht, wenn jemand den
+ * Namen von Hand getippt hat.
+ */
+export const normaliseModel = (raw: string): string =>
+  raw.toLowerCase().replace(/[^a-z0-9]/g, '')
+
+/**
+ * Die Tabelle. ZWEI Zeilen, und das ist kein Zwischenstand.
+ *
+ * Es sind genau die beiden Aussagen, die im Korpus belegt sind. Jede weitere
+ * Zeile braucht eine Fundstelle; ohne sie waere sie eine Behauptung im
+ * Gewand eines Datenblatts, und der Bedarf ist gegen genau diese Sorte
+ * Behauptung geschrieben.
+ *
+ * Was hier NICHT steht, ist deshalb auch nicht „geht nicht", sondern
+ * `unknown`. Der Unterschied ist der ganze Bedarf.
+ */
+export const CAMERA_CAPABILITIES: readonly CameraCapability[] = [
+  {
+    model: 'AW-UE150A',
+    controls: { 'colour-temperature': 'unsupported' },
+    source:
+      'bitfocus/companion-module-panasonic-cameras — Farbtemperatur hoch/runter bleibt am Modell wirkungslos (Ausgabe #83, geschlossen 2026-08)',
+  },
+  {
+    model: 'AW-UE160',
+    controls: { 'red-gain': 'unsupported', 'blue-gain': 'unsupported' },
+    source:
+      'bitfocus/companion-module-panasonic-cameras — Rot-/Blau-Anteil bleibt am Modell wirkungslos (Ausgabe #56, geschlossen „not planned", 2026-07)',
+  },
+]
+
+const byModel = new Map(CAMERA_CAPABILITIES.map((c) => [normaliseModel(c.model), c]))
+
+/** Die belegte Zeile zu einem Modellnamen, wenn es eine gibt. */
+export const capabilityFor = (model: string): CameraCapability | undefined =>
+  byModel.get(normaliseModel(model))
+
+/**
+ * Der Modellname eines Plan-Geraets.
+ *
+ * Erst das Datenblatt (ueber die Geraetetyp-Id), dann der Name im Plan. Die
+ * Reihenfolge ist dieselbe wie in `deviceKind.ts` und `recording.ts`: eine
+ * Katalog-Tatsache schlaegt einen getippten Namen.
+ */
+export const modelOf = (device: Pick<EquipmentItem, 'name' | 'deviceTypeId'>): string =>
+  (device.deviceTypeId ? resolveDeviceType(device.deviceTypeId)?.template.name : undefined) ??
+  device.name
+
+/**
+ * Kann dieses Modell diese Funktion?
+ *
+ * `unknown`, solange keine Fundstelle etwas anderes sagt — auch fuer ein
+ * Modell, das gar nicht in der Tabelle steht. Das ist die tragende Zeile
+ * dieser Datei.
+ */
+export const controlSupport = (model: string, control: CameraControl): ControlSupport =>
+  capabilityFor(model)?.controls[control] ?? 'unknown'
+
+export interface ControlRow {
+  control: CameraControl
+  support: ControlSupport
+  /** Die Fundstelle, wenn die Aussage aus einer stammt. */
+  source?: string
+}
+
+/**
+ * Alle Funktionen eines Modells mit ihrem Stand.
+ *
+ * Gibt IMMER alle Funktionen zurueck, auch die unbelegten. Eine Liste, die
+ * nur die belegten zeigt, saehe fuer ein unbekanntes Modell leer aus — und
+ * „leer" liest sich als „kann nichts".
+ */
+export const controlRows = (model: string): ControlRow[] => {
+  const eintrag = capabilityFor(model)
+  return (Object.keys(CONTROL_ORDER) as CameraControl[]).map((control) => {
+    const support = eintrag?.controls[control] ?? 'unknown'
+    return {
+      control,
+      support,
+      ...(eintrag && eintrag.controls[control] ? { source: eintrag.source } : {}),
+    }
+  })
+}
+
+/**
+ * Die Reihenfolge der Funktionen auf jedem Blatt.
+ *
+ * Fest und nicht alphabetisch: Bewegung, dann Belichtung, dann Farbe, dann
+ * Presets — so, wie jemand an einem Bedienpult sucht. Alphabetisch stuende
+ * „Blende" zwischen „Blau-Anteil" und „Detail".
+ */
+const CONTROL_ORDER: Readonly<Record<CameraControl, number>> = {
+  'pan-tilt': 0,
+  zoom: 1,
+  focus: 2,
+  iris: 3,
+  gain: 4,
+  shutter: 5,
+  'nd-filter': 6,
+  'white-balance': 7,
+  'colour-temperature': 8,
+  'red-gain': 9,
+  'blue-gain': 10,
+  detail: 11,
+  'preset-recall': 12,
+  'preset-store': 13,
+}
+
+export type CapabilityFindingKind = 'model-unknown' | 'control-unsupported'
+
+export const CAPABILITY_FINDING_LABEL: Readonly<Record<CapabilityFindingKind, string>> = {
+  'model-unknown': 'Zu diesem Modell liegt keine Fähigkeits-Aussage vor',
+  'control-unsupported': 'Diese Funktion ist an diesem Modell wirkungslos',
+}
+
+export interface CapabilityFinding {
+  kind: CapabilityFindingKind
+  equipmentId: string
+  model: string
+  control?: CameraControl
+  detail?: string
+}
+
+/**
+ * Was an den Kameras eines Plans zu den Steuerfunktionen zu sagen ist.
+ *
+ * `model-unknown` ist ein BEFUND und keine Warnung: er sagt nicht, dass etwas
+ * falsch ist, sondern dass die Antwort fehlt. Ohne ihn saehe ein Plan voller
+ * unbelegter Kameras genauso aus wie einer, dessen Modelle alle geprueft
+ * sind.
+ */
+export const capabilityFindings = (
+  devices: readonly Pick<EquipmentItem, 'id' | 'name' | 'deviceTypeId' | 'category'>[],
+): CapabilityFinding[] => {
+  const out: CapabilityFinding[] = []
+  for (const d of devices) {
+    // Die Kategorie und nicht ein Typfeld: `EquipmentItem` fuehrt die
+    // Taxonomie in `category`, und der Katalog legt Kameras unter „Kameras" ab.
+    if (!/kamera|camera/i.test(d.category ?? '')) continue
+    const model = modelOf(d)
+    const eintrag = capabilityFor(model)
+    if (!eintrag) {
+      out.push({ kind: 'model-unknown', equipmentId: d.id, model })
+      continue
+    }
+    for (const [control, support] of Object.entries(eintrag.controls) as [
+      CameraControl,
+      ControlSupport,
+    ][]) {
+      if (support !== 'unsupported') continue
+      out.push({
+        kind: 'control-unsupported',
+        equipmentId: d.id,
+        model,
+        control,
+        detail: eintrag.source,
+      })
+    }
+  }
+  return out
+}

--- a/src/renderer/lib/deviceKind.ts
+++ b/src/renderer/lib/deviceKind.ts
@@ -1,5 +1,6 @@
 import type { EquipmentItem } from '../types/equipment'
 import { resolveDeviceType } from './deviceTypeRegistry'
+import { isPatchPanelDevice } from './patchPanel'
 
 /**
  * Derive a default icon glyph for an equipment item from its category, name,
@@ -22,6 +23,7 @@ export const defaultIconForEquipment = (device: {
   if (cat === 'netzwerk' || /switch|router|firewall|access point|edgerouter/.test(name)) return '🌐'
   if (cat === 'strom' || /\bpower\b|psu|ups|distro/.test(name)) return '⚡'
   if (cat === 'video' || /converter|teranex|mini.?converter|hyperdeck|atem|videohub/.test(name)) return '📺'
+  if (cat === 'patchfelder') return '🔀'
   if (cat === 'kabel') return '🔌'
   if (cat === 'rigging') return '🔧'
   return ''
@@ -74,6 +76,16 @@ export const detectNetworkDevice = (device: EquipmentItem): NetworkDeviceKind =>
 export const detectDeviceKind = (device: EquipmentItem): DeviceKind => {
   const resolved = resolveDeviceType(device.deviceTypeId)
   if (resolved) return resolved.kind ?? null
+
+  // ISSUE #664 — eine Patchblende ist KEINE Kreuzschiene, auch wenn sie so
+  // aussieht: die Struktur-Heuristik weiter unten ("mindestens acht BNC rein,
+  // ebenso viele raus") trifft auf jede 24er-Blende zu. Sie wurde damit als
+  // 'videohub' gefuehrt — und die Rueckwaertssuche verlangte danach einen
+  // GESCHALTETEN Kreuzpunkt, den eine Blende nie hat. Die Kette brach an
+  // jeder Blende, und der Export-Dialog bot fuer sie einen Videohub-Export
+  // an. Die ausdrueckliche Markierung schlaegt die Heuristik; das Datenblatt
+  // (resolveDeviceType, oben) schlaegt weiterhin beides.
+  if (isPatchPanelDevice(device)) return null
 
   const name = device.name.toLowerCase()
 

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -2713,6 +2713,8 @@ export const en: Dict = {
   'offPage.waypoint.add': 'Add waypoint',
 
   // Canvas — CableEdge
+  'canvas.cableEdge.blockedPath':
+    'This cable path runs through a device — there is no clear route here. Move a device or draw the path by hand.',
   'canvas.cableEdge.deleteTitle': 'Delete cable',
 
   // Canvas — CanvasArea

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -2492,7 +2492,7 @@ export const en: Dict = {
   'project.meta.titleEdit': 'Edit project metadata',
   'project.meta.create': 'Create project',
   'project.meta.name': 'Project name',
-  'project.meta.namePh': 'e.g. ProSieben Studio refit',
+  'project.meta.namePh': 'e.g. Studio 2 refit',
   'project.meta.contractor': 'Contractor (company)',
   'project.meta.contractorPh': 'Your Company Ltd',
   'project.meta.client': 'Client',
@@ -3249,6 +3249,10 @@ export const en: Dict = {
   'analysis.tab.crew': 'Crew: hours & expenses',
   // Bedarf 108 — die Handlungsliste.
   'analysis.tab.todo': 'What is due',
+  // Bedarf 103 — Fähigkeiten je Modell.
+  'props.cameraControls.title': 'Controllable functions',
+  'props.cameraControls.noSource':
+    'No capability statement exists for this model. "Not on record" does not mean "does not work" — it means nobody has checked.',
   // Bedarf 100 — die Aufnahmenamen.
   'analysis.recordName.title': 'Recording names',
   'analysis.recordName.intro':

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -2410,6 +2410,11 @@ export const en: Dict = {
   'flags.title': 'Display & flags',
   'flags.subtitle': 'compact · colour · packed',
   'flags.colorTitle': 'Device node colour',
+  'flags.patchPanel': 'Patch panel (through-path follows the position)',
+  'flags.patchPanelTitle':
+    'Patch panel: rear socket n lands on front socket n. The signal path and the patch list follow that through-path instead of stopping at the panel. Requires an equal number of inputs and outputs.',
+  'flags.patchPanelByCategory':
+    'The category „Patchfelder“ already marks this device as a patch panel.',
   'flags.da': 'Distribution amp (1→N)',
   'flags.daTitle': 'Distribution amplifier: one input is actively split to several outputs of the same source (1→N).',
   'roles.tc': 'Timecode',
@@ -4825,6 +4830,14 @@ export const en: Dict = {
   'analysis.redundancy.none': 'No obvious single power feeds found.',
   'analysis.tab.rf': 'RF / wireless',
   'analysis.tab.runs': 'Cable runs',
+  'analysis.tab.chain': 'Signal paths',
+  'analysis.chain.hint':
+    'Paths crossing at least one intermediate stage — patch panel, converter, distribution amp, switched router crosspoint. Direct connections live in the patch list and are deliberately absent here. Where a path does not reach an end device, the reason is stated: nothing is guessed.',
+  'analysis.chain.none':
+    'No multi-stage path in this plan. A device becomes a patch panel through the category „Patchfelder“ or the checkbox under „Display & flags“.',
+  'analysis.chain.count': 'multi-stage paths',
+  'analysis.chain.openCount': 'without a reached end device',
+  'analysis.chain.endTarget': 'End device reached',
   'analysis.tab.sheet': 'Check a sheet',
   // Bedarf 81 — die Kunden-Uebersicht.
   'analysis.tab.client': 'Client summary',

--- a/src/renderer/lib/labelDerivation.ts
+++ b/src/renderer/lib/labelDerivation.ts
@@ -33,6 +33,7 @@ import type { EquipmentItem, Port } from '../types/equipment'
 import type { SourceIdentity } from '../types/sourceIdentity'
 import type { CheckFinding } from './drawingChecks'
 import { detectDeviceKind, type DeviceKind } from './deviceKind'
+import { patchPanelCounterpart } from './patchPanel'
 import {
   resolvePortLabel,
   shortenForAtem,
@@ -332,6 +333,12 @@ const feedingInput = (device: EquipmentItem, arrival: Port): Port | null => {
   const kind = detectDeviceKind(device)
   if (kind === 'videohub') return routedInput(device, arrival)
   if (kind !== null) return null
+  // ISSUE #664 — die Patchblende ist der haeufigste Kettenbruch. Sie hat
+  // vierundzwanzig gleiche Buchsen, also greift die Eindeutigkeits-Regel
+  // unten NIE, und die Suche hielt an der Blende an. Ihr Durchgang steht
+  // aber fest; die Ableitung steht in `patchPanel.ts`.
+  const durch = patchPanelCounterpart(device, arrival)
+  if (durch) return durch
   const candidates = device.inputs.filter(
     (p) => p.connectorType === arrival.connectorType && !isReferencePort(p),
   )

--- a/src/renderer/lib/patchPanel.ts
+++ b/src/renderer/lib/patchPanel.ts
@@ -1,0 +1,88 @@
+// ───────────────────────────────────────────────────────────────────────────
+// ISSUE #664 — „Patchbays als Geraetekategorie erstellen und mehrere Ebenen
+// der Verkabelung anzeigbar machen fuer Festinstallationen."
+//
+// Diese Datei ist die EINE Stelle, die beantwortet: ist dieses Geraet eine
+// Patchblende, und welcher Anschluss auf der anderen Seite gehoert zu diesem?
+//
+// Sie hat genau einen Grund zu existieren: die Antwort wurde vorher an drei
+// Stellen VERSCHIEDEN gegeben. `detectDeviceKind` hielt eine 24er-Blende fuer
+// eine Kreuzschiene (die Struktur-Heuristik „>= 8 BNC rein, >= 8 BNC raus"
+// trifft auf jede Blende zu), die Rueckwaertssuche in `labelDerivation`
+// verlangte GENAU EINEN passenden Eingang und fand vierundzwanzig, und die
+// Patchliste folgte nur Wandlern mit genau einem Ausgangskabel. Ergebnis: die
+// Kette brach an jeder Blende, und auf dem Blatt stand die Blende als Quelle
+// statt der Kamera.
+//
+// ─── WARUM DER DURCHGANG KEIN RATEN IST ────────────────────────────────────
+//
+// Eine Patchblende IST die positionsweise Durchleitung: Buchse n hinten liegt
+// auf Buchse n vorn. Das ist ihre Bauart, kein Betriebszustand. Deshalb darf
+// sie abgeleitet werden — anders als beim Router (`routedInput`), wo der
+// Kreuzpunkt geschaltet wird und ohne gesetzten Plan nichts ableitbar ist.
+//
+// ─── WO ES AUFHOERT ────────────────────────────────────────────────────────
+//
+// Sind vorn und hinten verschieden viele Buchsen, ist die Zuordnung nicht mehr
+// die Position — dann gibt es null und die Kette haelt an der Blende an wie
+// bisher. Und ein gestecktes Rangierkabel, das die Normalisierung aufhebt,
+// weiss der Plan nicht: er beschreibt die geplante Verkabelung, nicht das, was
+// jemand vor Ort umgesteckt hat.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+import type { EquipmentItem, Port } from '../types/equipment'
+
+/**
+ * Die Geraetekategorie aus der Ueberschrift des Issues.
+ *
+ * Sie steht in `DEFAULT_CATEGORIES` (libraryPersist.ts) und ist der zweite
+ * Weg, ein Geraet als Blende auszuweisen — der erste ist das Flag
+ * `isPatchPanel`, das der Rack-Builder-Dialog setzt.
+ */
+export const PATCH_PANEL_CATEGORY = 'Patchfelder'
+
+/** Nur die Kategorie, ohne das Flag — die UI braucht beide Haelften getrennt. */
+export const categoryIsPatchPanel = (category: string | undefined): boolean =>
+  (category ?? '').trim().toLowerCase() === PATCH_PANEL_CATEGORY.toLowerCase()
+
+/**
+ * Ist dieses Geraet eine Patchblende?
+ *
+ * ZWEI WEGE, EINE ANTWORT: das Flag `isPatchPanel` (vom Rack-Builder gesetzt,
+ * in den Properties umschaltbar) ODER die Kategorie „Patchfelder". Wer ein
+ * Geraet in diese Kategorie legt, hat damit gesagt, was es ist; ein zweites
+ * Haekchen zu verlangen waere eine Falle. Die Properties-Sektion zeigt das
+ * Haekchen deshalb als gesetzt UND gesperrt, wenn die Kategorie es schon sagt.
+ */
+export const isPatchPanelDevice = (
+  device: Pick<EquipmentItem, 'category'> & { isPatchPanel?: boolean },
+): boolean => device.isPatchPanel === true || categoryIsPatchPanel(device.category)
+
+/**
+ * Der Anschluss auf der anderen Seite — Position n gegen Position n.
+ *
+ * Beidseitig: von einem Ausgang kommt der gleichnummerige Eingang zurueck und
+ * umgekehrt. Die Rueckwaertssuche (`labelDerivation`) braucht die eine
+ * Richtung, die Vorwaertskette (`signalChain`) die andere; zwei Funktionen
+ * waeren zwei Wahrheiten.
+ *
+ * null heisst „nicht ableitbar", nie „keine Verbindung": ungleiche
+ * Buchsenzahlen, kein Blende-Geraet, oder der Port gehoert gar nicht dazu.
+ */
+export const patchPanelCounterpart = (
+  device: EquipmentItem,
+  port: Pick<Port, 'id'>,
+): Port | null => {
+  if (!isPatchPanelDevice(device)) return null
+  if (device.inputs.length !== device.outputs.length) return null
+  if (device.inputs.length === 0) return null
+
+  const outIdx = device.outputs.findIndex((p) => p.id === port.id)
+  if (outIdx >= 0) return device.inputs[outIdx] ?? null
+
+  const inIdx = device.inputs.findIndex((p) => p.id === port.id)
+  if (inIdx >= 0) return device.outputs[inIdx] ?? null
+
+  return null
+}

--- a/src/renderer/lib/rackWireChecks.ts
+++ b/src/renderer/lib/rackWireChecks.ts
@@ -1,0 +1,161 @@
+// ───────────────────────────────────────────────────────────────────────────
+// ISSUE #663 — „Es fehlt die Fehlermeldung, dass Kabeltypen nicht
+// zusammenpassen." (Rack-Planer)
+//
+// Der Signalplan hat diese Pruefung seit langem: `drawingChecks.ts`, Check 2,
+// meldet ein Kabel zwischen zwei verschieden bestueckten Ports. Die
+// Rack-INTERNE Verkabelung hatte sie nicht — und sie ist genau die, bei der
+// man sich vertut: dort steckt man BNC an XLR, weil beide Ports in derselben
+// Hoeheneinheit nebeneinanderliegen und die Beschriftung klein ist.
+//
+// ─── WARUM NICHT EINFACH `drawingChecks` AUFRUFEN ──────────────────────────
+//
+// Die Rack-interne Verkabelung ist kein `Cable[]` ueber `EquipmentItem[]`.
+// Sie verbindet PLATZIERUNGEN ueber PORTNAMEN (`InternalCableDraft`), weil
+// ein Rack-Preset eine Vorlage ist und noch keine Geraete im Plan hat. Ein
+// Adapter, der Entwuerfe in Plan-Objekte uebersetzt, muesste Ids erfinden —
+// und erfundene Ids sind die Sorte Zwischenschicht, die spaeter jemand fuer
+// echte Daten haelt.
+//
+// Diese Datei prueft deshalb DIE ENTWURFSFORM direkt. Die Regel („zwei Ports
+// mit verschiedenem Steckerbild passen nicht") ist dieselbe wie im Plan; sie
+// steht hier ein zweites Mal, weil sie auf einer anderen Datenform arbeitet.
+//
+// ─── EIN PORT, DEN ES NICHT GIBT, IST DER TEURERE FEHLER ───────────────────
+//
+// Weil die Verbindung am NAMEN haengt, bricht sie still, wenn jemand den Port
+// eines Geraets umbenennt: das Kabel bleibt im Preset stehen und zeigt auf
+// nichts. Im Rack sieht man es nicht — dort ist eine Linie gezeichnet. Der
+// Befund `port-unknown` ist deshalb ein FEHLER und keine Warnung.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+import type { EquipmentTemplate } from '../types/equipment'
+
+/** Was diese Pruefung von einer Platzierung braucht. */
+export interface WireCheckPlacement {
+  id: string
+  name: string
+  inputs: EquipmentTemplate['inputs']
+  outputs: EquipmentTemplate['outputs']
+}
+
+/** Was sie von einem Kabel braucht. */
+export interface WireCheckCable {
+  fromPlacementId: string
+  fromPortName: string
+  toPlacementId: string
+  toPortName: string
+  name?: string
+  type?: string
+}
+
+export type RackWireFindingKind =
+  /** Ein Kabel nennt einen Port, den das Geraet nicht hat. */
+  | 'port-unknown'
+  /** Ein Kabel nennt eine Platzierung, die es nicht gibt. */
+  | 'placement-unknown'
+  /** Die beiden Ports tragen verschiedene Steckerbilder. */
+  | 'connector-mismatch'
+  /** Beides Eingaenge oder beides Ausgaenge. */
+  | 'direction-mismatch'
+
+export const RACK_WIRE_FINDING_LABEL: Readonly<Record<RackWireFindingKind, string>> = {
+  'port-unknown': 'Port gibt es an diesem Gerät nicht',
+  'placement-unknown': 'Gerät steht nicht mehr im Rack',
+  'connector-mismatch': 'Steckertypen passen nicht zusammen',
+  'direction-mismatch': 'Zwei Eingänge oder zwei Ausgänge verbunden',
+}
+
+/** Fehler blockieren, Warnungen fallen auf. */
+export const RACK_WIRE_FINDING_SEVERITY: Readonly<
+  Record<RackWireFindingKind, 'error' | 'warning'>
+> = {
+  // Ein Kabel, das auf nichts zeigt, ist eine Linie ohne Verbindung — im
+  // Rack sichtbar gezeichnet und trotzdem nicht vorhanden.
+  'port-unknown': 'error',
+  'placement-unknown': 'error',
+  // Ein Steckerunterschied kann gewollt sein (Adapter im Kabel). Deshalb
+  // Warnung: gemeldet, aber nicht behauptet, es sei falsch.
+  'connector-mismatch': 'warning',
+  'direction-mismatch': 'warning',
+}
+
+export interface RackWireFinding {
+  kind: RackWireFindingKind
+  severity: 'error' | 'warning'
+  /** Die betroffene Kabel-Position in der Liste — der Sprung dorthin. */
+  index: number
+  /** Klartext fuer die Oberflaeche. */
+  text: string
+}
+
+const portOf = (
+  p: WireCheckPlacement,
+  name: string,
+): { connectorType?: string; direction: 'in' | 'out' } | undefined => {
+  const ein = p.inputs?.find((x) => x.name === name)
+  if (ein) return { connectorType: ein.connectorType, direction: 'in' }
+  const aus = p.outputs?.find((x) => x.name === name)
+  if (aus) return { connectorType: aus.connectorType, direction: 'out' }
+  return undefined
+}
+
+/**
+ * Was an der Rack-internen Verkabelung nicht aufgeht.
+ *
+ * `Custom` wird beim Steckervergleich UEBERSPRUNGEN — dieselbe Regel wie im
+ * Signalplan: ein selbst benannter Stecker sagt nichts darueber, worauf er
+ * passt, und eine Warnung ohne Grundlage bringt niemanden weiter.
+ */
+export const rackWireFindings = (
+  placements: readonly WireCheckPlacement[],
+  cables: readonly WireCheckCable[],
+): RackWireFinding[] => {
+  const byId = new Map(placements.map((p) => [p.id, p]))
+  const out: RackWireFinding[] = []
+  const melde = (kind: RackWireFindingKind, index: number, text: string) =>
+    out.push({ kind, severity: RACK_WIRE_FINDING_SEVERITY[kind], index, text })
+
+  cables.forEach((c, index) => {
+    const kabel = c.name?.trim() || c.type?.trim() || `Kabel ${index + 1}`
+    const von = byId.get(c.fromPlacementId)
+    const nach = byId.get(c.toPlacementId)
+    if (!von || !nach) {
+      melde('placement-unknown', index, `${kabel}: ein verbundenes Gerät steht nicht mehr im Rack`)
+      return
+    }
+    const pv = portOf(von, c.fromPortName)
+    const pn = portOf(nach, c.toPortName)
+    if (!pv) {
+      melde('port-unknown', index, `${kabel}: „${c.fromPortName}" gibt es an ${von.name} nicht`)
+    }
+    if (!pn) {
+      melde('port-unknown', index, `${kabel}: „${c.toPortName}" gibt es an ${nach.name} nicht`)
+    }
+    if (!pv || !pn) return
+
+    if (pv.direction === pn.direction) {
+      melde(
+        'direction-mismatch',
+        index,
+        pv.direction === 'out'
+          ? `${kabel}: ${von.name} und ${nach.name} sind beide Ausgänge`
+          : `${kabel}: ${von.name} und ${nach.name} sind beide Eingänge`,
+      )
+    }
+
+    const a = pv.connectorType
+    const b = pn.connectorType
+    if (!a || !b || a === 'Custom' || b === 'Custom') return
+    if (a !== b) {
+      melde(
+        'connector-mismatch',
+        index,
+        `${kabel}: ${von.name} (${a}) → ${nach.name} (${b})`,
+      )
+    }
+  })
+
+  return out
+}

--- a/src/renderer/lib/signalChain.ts
+++ b/src/renderer/lib/signalChain.ts
@@ -1,0 +1,321 @@
+// ───────────────────────────────────────────────────────────────────────────
+// ISSUE #664, zweite Haelfte — „mehrere Ebenen der Verkabelung anzeigbar
+// machen fuer Festinstallationen. Zum Beispiel Kabel geht von a ueber b von b
+// ueber c nach d. Bei d ist ein Patchbay und da geht es dann von d nach e und
+// von e zum Endgeraet oder einem Wandanschluss."
+//
+// Der Plan kannte diese Kette bisher nur in Einzelteilen. Die Patchliste zeigt
+// KABEL: eine Zeile je Steckverbindung, „von A Port 1 nach B Port 3". In einer
+// Festinstallation liegen zwischen Kamera und Mischer aber drei bis fuenf
+// solcher Zeilen — Wandanschluss, Steigleitung, zwei Blenden, Wandler — und
+// keine davon sagt, was am anderen Ende haengt. Wer wissen will, wo Kamera 1
+// tatsaechlich ankommt, liest sechs Zeilen und haelt die Portnummern im Kopf.
+//
+// Diese Datei setzt sie zusammen: eine Kette ist der Weg von der Quelle bis
+// zum Endgeraet, mit allen Zwischenebenen darin.
+//
+// ─── WAS ALS DURCHLEITUNG GILT — UND WARUM NUR DAS ─────────────────────────
+//
+// Vier Bauformen, jede mit einem NACHPRUEFBAREN Weiterweg:
+//
+//   Patchblende  Position n hinten auf Position n vorn (`patchPanel.ts`).
+//                Bauart, kein Betriebszustand.
+//   Wandler      genau ein abgehendes Kabel — dieselbe Regel wie in der
+//                Patchliste seit #285. Zwei Ausgangskabel: mehrdeutig, Ende.
+//   Verteiler    ein Eingang auf mehrere Ausgaenge; die Kette VERZWEIGT sich
+//                und laeuft in jedem Ast weiter.
+//   Kreuzschiene NUR mit gesetztem Kreuzpunkt (`videohubRouting.planned`).
+//                Ohne ihn gibt es 20 gleich plausible Antworten, und die
+//                falsche zeigt auf die falsche Kamera. Dann: Ende, benannt.
+//
+// Ein Mischer leitet nicht durch — er ist das Ziel. Ein Geraet ohne Markierung
+// ebenfalls: geraten wird hier nichts, die Kette endet lieber frueh und sagt,
+// warum.
+//
+// ─── WARUM DAS ENDE IMMER EINEN NAMEN HAT ──────────────────────────────────
+//
+// „Die Kette endet hier" ist als Anzeige wertlos, wenn offenbleibt, ob das
+// Geraet das Ziel IST oder ob die Ableitung aufgegeben hat. Beides sieht auf
+// dem Blatt gleich aus und bedeutet das Gegenteil. `ChainEnd` trennt die
+// Faelle, und `endNote` traegt den Satz, den die Anzeige zeigt.
+//
+// REIN: keine Uhr, kein Store, kein IO.
+// ───────────────────────────────────────────────────────────────────────────
+import type { Cable } from '../types/cable'
+import type { EquipmentItem, Port } from '../types/equipment'
+import { detectDeviceKind } from './deviceKind'
+import { isPatchPanelDevice, patchPanelCounterpart } from './patchPanel'
+import { resolvePortLabel } from './portLabel'
+
+/** Welche Bauform den Weiterweg hergegeben hat. */
+export type PassThroughKind = 'patch-panel' | 'converter' | 'distribution-amp' | 'router'
+
+export const PASS_THROUGH_LABEL: Readonly<Record<PassThroughKind, string>> = {
+  'patch-panel': 'Patchfeld',
+  converter: 'Wandler',
+  'distribution-amp': 'Verteilverstärker',
+  router: 'Kreuzschiene',
+}
+
+/** Warum die Kette aufhoert. Nie „einfach so". */
+export type ChainEnd =
+  /** Das letzte Geraet leitet nicht durch — es IST das Ziel. Der Wert heisst
+   *  `ziel` und nicht `endgeraet`, weil der ASCII-Drift-Waechter jede
+   *  ae/oe/ue-Ersatzform in einem String-Literal meldet — zu Recht: was in
+   *  einem Literal steht, kann auf dem Blatt landen. */
+  | 'ziel'
+  /** Der Weiterweg am Geraet ist bestimmt, aber es haengt kein Kabel dran. */
+  | 'nicht-verkabelt'
+  /** Der Weiterweg ist nicht ableitbar (Blende ungleich bestueckt, Wandler mit
+   *  mehreren Ausgangskabeln, Kreuzschiene ohne gesetzten Kreuzpunkt). */
+  | 'mehrdeutig'
+  /** Laenger als `MAX_LEVELS` Zwischenstationen — abgeschnitten, nicht zu Ende. */
+  | 'zu-lang'
+  /** Der Weg lief in sich zurueck. */
+  | 'schleife'
+
+export interface ChainStep {
+  cableId: string
+  /** Kabelnummer, sonst Name, sonst Typ — das, woran man es findet. */
+  cableLabel: string
+  fromEquipmentId: string
+  fromEquipmentName: string
+  fromPortId: string
+  fromPortName: string
+  toEquipmentId: string
+  toEquipmentName: string
+  toPortId: string
+  toPortName: string
+  /** Wie es an diesem ZIEL weitergeht; null heisst: hier ist Schluss. */
+  through: PassThroughKind | null
+}
+
+export interface SignalChain {
+  /** Stabil aus den Kabel-Ids — taugt als React-Key und ueber Neuladen hinweg. */
+  id: string
+  steps: ChainStep[]
+  end: ChainEnd
+  /** Klartext fuer die Anzeige; leer bei 'ziel'. */
+  endNote: string
+  /** Zwischenebenen (Blenden, Wandler, …). Ohne die ist es kein Mehr-Ebenen-Weg. */
+  levels: number
+}
+
+/** Mehr Zwischenstationen hat auch eine grosse Festinstallation nicht. */
+const MAX_LEVELS = 12
+
+/** Schutz vor einer kombinatorischen Explosion bei stark verzweigten Verteilern. */
+const MAX_CHAINS = 400
+
+const portText = (port: Port | undefined, fallback: string): string =>
+  port ? resolvePortLabel(port).text || port.name || fallback : fallback
+
+const cableText = (c: Cable): string =>
+  c.cableNumber?.trim() || c.name?.trim() || c.type || c.id
+
+interface Forward {
+  kind: PassThroughKind
+  /** Die Kabel, auf denen es weitergeht. Leer heisst: Weiterweg unverkabelt. */
+  cables: Cable[]
+  /** Gesetzt, wenn der Weiterweg NICHT ableitbar war. */
+  ambiguous?: string
+}
+
+/**
+ * Wie es an `device` weitergeht, wenn das Signal an `arrivalPortId` ankam.
+ *
+ * null heisst: dieses Geraet leitet nicht durch — es ist das Ziel. Das ist
+ * eine ANDERE Aussage als `ambiguous`, und die Anzeige haengt daran.
+ */
+const forwardFrom = (
+  device: EquipmentItem,
+  arrivalPortId: string,
+  cablesFromEquipment: Map<string, Cable[]>,
+  cablesFromPort: Map<string, Cable[]>,
+): Forward | null => {
+  if (isPatchPanelDevice(device)) {
+    const other = patchPanelCounterpart(device, { id: arrivalPortId })
+    if (!other) {
+      return {
+        kind: 'patch-panel',
+        cables: [],
+        ambiguous:
+          device.inputs.length === device.outputs.length
+            ? 'Anschluss gehört nicht zur Durchleitung des Patchfelds'
+            : `Patchfeld ungleich bestückt (${device.inputs.length} hinten, ${device.outputs.length} vorn) — die Position sagt hier nichts`,
+      }
+    }
+    return { kind: 'patch-panel', cables: cablesFromPort.get(other.id) ?? [] }
+  }
+
+  if (device.isDistributionAmp) {
+    const outs = (cablesFromEquipment.get(device.id) ?? []).filter(
+      (c) => c.fromPortId !== arrivalPortId,
+    )
+    return { kind: 'distribution-amp', cables: outs }
+  }
+
+  if (device.isConverter) {
+    // #285 — dieselbe Regel wie in der Patchliste: genau ein Folgekabel.
+    const outs = (cablesFromEquipment.get(device.id) ?? []).filter(
+      (c) => c.fromPortId !== arrivalPortId,
+    )
+    if (outs.length > 1) {
+      return {
+        kind: 'converter',
+        cables: [],
+        ambiguous: `Wandler mit ${outs.length} abgehenden Kabeln — kein eindeutiger Weiterweg`,
+      }
+    }
+    return { kind: 'converter', cables: outs }
+  }
+
+  if (detectDeviceKind(device) === 'videohub') {
+    const planned = device.videohubRouting?.planned
+    const inIdx = device.inputs.findIndex((p) => p.id === arrivalPortId)
+    if (!planned || inIdx < 0) {
+      return {
+        kind: 'router',
+        cables: [],
+        ambiguous: 'Kreuzschiene ohne gesetzten Kreuzpunkt — der Weiterweg ist nicht geplant',
+      }
+    }
+    const outs: Cable[] = []
+    device.outputs.forEach((p, outIdx) => {
+      if (planned[outIdx] === inIdx) outs.push(...(cablesFromPort.get(p.id) ?? []))
+    })
+    if (outs.length === 0) {
+      return {
+        kind: 'router',
+        cables: [],
+        ambiguous: 'Kreuzpunkt gesetzt, aber am geschalteten Ausgang hängt kein Kabel',
+      }
+    }
+    return { kind: 'router', cables: outs }
+  }
+
+  return null
+}
+
+/**
+ * Alle Signalwege des Projekts, die ueber mindestens eine Zwischenebene laufen.
+ *
+ * Direkte Verbindungen bleiben draussen: die stehen schon in der Patchliste,
+ * und eine zweite Liste derselben Zeilen macht die interessanten unsichtbar.
+ * Genau darum geht es im Issue — die MEHRSTUFIGEN Wege sind die, die man aus
+ * den Einzelzeilen nicht mehr zusammenbekommt.
+ */
+export const signalChains = (
+  equipment: readonly EquipmentItem[],
+  cables: readonly Cable[],
+): SignalChain[] => {
+  const eqById = new Map(equipment.map((e) => [e.id, e]))
+  const portById = new Map<string, Port>()
+  for (const e of equipment) for (const p of [...e.inputs, ...e.outputs]) portById.set(p.id, p)
+
+  const cablesFromEquipment = new Map<string, Cable[]>()
+  const cablesFromPort = new Map<string, Cable[]>()
+  for (const c of cables) {
+    const byEq = cablesFromEquipment.get(c.fromEquipmentId)
+    if (byEq) byEq.push(c)
+    else cablesFromEquipment.set(c.fromEquipmentId, [c])
+    const byPort = cablesFromPort.get(c.fromPortId)
+    if (byPort) byPort.push(c)
+    else cablesFromPort.set(c.fromPortId, [c])
+  }
+
+  const stepOf = (c: Cable): ChainStep => {
+    const from = eqById.get(c.fromEquipmentId)
+    const to = eqById.get(c.toEquipmentId)
+    return {
+      cableId: c.id,
+      cableLabel: cableText(c),
+      fromEquipmentId: c.fromEquipmentId,
+      fromEquipmentName: from?.name ?? '?',
+      fromPortId: c.fromPortId,
+      fromPortName: portText(portById.get(c.fromPortId), c.fromPortId),
+      toEquipmentId: c.toEquipmentId,
+      toEquipmentName: to?.name ?? '?',
+      toPortId: c.toPortId,
+      toPortName: portText(portById.get(c.toPortId), c.toPortId),
+      through: null,
+    }
+  }
+
+  // Ein Kabel, das selbst schon die FORTSETZUNG eines anderen ist, faengt
+  // keine eigene Kette an — sonst stuende jeder Weg mehrfach da, einmal ab
+  // jeder Zwischenebene.
+  const continuation = new Set<string>()
+  for (const c of cables) {
+    const to = eqById.get(c.toEquipmentId)
+    if (!to) continue
+    const fw = forwardFrom(to, c.toPortId, cablesFromEquipment, cablesFromPort)
+    if (fw) for (const next of fw.cables) continuation.add(next.id)
+  }
+
+  const out: SignalChain[] = []
+
+  const walk = (steps: ChainStep[], seenCables: Set<string>) => {
+    if (out.length >= MAX_CHAINS) return
+    const last = steps[steps.length - 1]
+    const device = eqById.get(last.toEquipmentId)
+
+    const finish = (end: ChainEnd, endNote: string) => {
+      const levels = steps.filter((s) => s.through !== null).length
+      if (levels === 0) return
+      out.push({
+        id: steps.map((s) => s.cableId).join('>'),
+        steps,
+        end,
+        endNote,
+        levels,
+      })
+    }
+
+    if (!device) return finish('mehrdeutig', 'Zielgerät steht nicht mehr im Plan')
+
+    const fw = forwardFrom(device, last.toPortId, cablesFromEquipment, cablesFromPort)
+    if (!fw) return finish('ziel', '')
+    if (fw.ambiguous) {
+      last.through = null
+      return finish('mehrdeutig', `${PASS_THROUGH_LABEL[fw.kind]}: ${fw.ambiguous}`)
+    }
+    if (fw.cables.length === 0) {
+      last.through = null
+      return finish(
+        'nicht-verkabelt',
+        `${PASS_THROUGH_LABEL[fw.kind]}: der Weiterweg ist im Plan nicht verkabelt`,
+      )
+    }
+    if (steps.length > MAX_LEVELS) {
+      last.through = fw.kind
+      return finish('zu-lang', `Mehr als ${MAX_LEVELS} Zwischenstationen — hier abgeschnitten`)
+    }
+
+    last.through = fw.kind
+    for (const next of fw.cables) {
+      if (seenCables.has(next.id)) {
+        finish('schleife', 'Der Weg läuft in sich zurück')
+        continue
+      }
+      walk([...steps.slice(0, -1), { ...last }, stepOf(next)], new Set([...seenCables, next.id]))
+    }
+  }
+
+  for (const c of cables) {
+    if (continuation.has(c.id)) continue
+    walk([stepOf(c)], new Set([c.id]))
+  }
+
+  return out
+}
+
+/** Eine Kette als eine Zeile — fuer Ausdruck, CSV und Tooltip. */
+export const chainOneLine = (chain: SignalChain): string => {
+  const first = chain.steps[0]
+  const parts = [`${first.fromEquipmentName} · ${first.fromPortName}`]
+  for (const s of chain.steps) {
+    parts.push(`—[${s.cableLabel}]→ ${s.toEquipmentName} · ${s.toPortName}`)
+  }
+  return parts.join(' ')
+}

--- a/src/renderer/store/libraryPersist.ts
+++ b/src/renderer/store/libraryPersist.ts
@@ -29,6 +29,12 @@ export const DEFAULT_CATEGORIES = [
   'PC',
   'Netzwerk',
   'Kabel',
+  // ISSUE #664 — „Patchbays als Geraetekategorie erstellen". Die Kategorie ist
+  // der zweite Weg, ein Geraet als Blende auszuweisen (der erste ist das Flag
+  // `isPatchPanel`); `patchPanel.ts` fuehrt beide zu EINER Antwort zusammen.
+  // Neu hinzugefuegte Vorgabe-Kategorien erreichen auch bestehende Nutzer:
+  // `loadKnownCategories` vereinigt Vorgabe und Gespeichertes.
+  'Patchfelder',
   'Strom',
   'Rigging',
   'Sonstiges',

--- a/src/renderer/types/cameraCapability.ts
+++ b/src/renderer/types/cameraCapability.ts
@@ -1,0 +1,96 @@
+// ───────────────────────────────────────────────────────────────────────────
+// BEDARF 103 (P3) — „Per-model, not per-vendor, capability truth."
+//
+// Der Schaden, woertlich aus der Bedarfs-Datenbank:
+//
+//   > Within one vendor's own PTZ line, CONTROLS EXIST IN SOFTWARE AND DO
+//   > NOTHING ON THE MODEL: colour-temperature increase/decrease dead on
+//   > AW-UE150A, red/blue gain dead on AW-UE160. The vendor's own docs warn
+//   > that not all models support all actions, variables and feedbacks.
+//
+// Belege: die Einschraenkungs-Erklaerung in der HELP.md von
+// `companion-module-panasonic-cameras`, dazu die Ausgaben `#83` (geschlossen
+// 2026-08) und `#56` (geschlossen „not planned", 2026-07) im selben Repo.
+//
+// ─── DREI WERTE UND NICHT ZWEI ─────────────────────────────────────────────
+//
+// `supported`, `unsupported`, `unknown`. Der dritte ist der wichtigste und der
+// Grund, warum diese Datei ueberhaupt existiert: die Oberflaeche eines
+// Steuerungs-Werkzeugs zeigt heute JEDE Funktion, weil sie zum Hersteller
+// gehoert — und der Bediener erfaehrt erst am Geraet, dass sie an DIESEM
+// Modell tot ist. Ein zweiwertiges Feld haette dieselbe Wirkung: was nicht
+// als „geht" eingetragen ist, saehe aus wie „geht nicht", und aus einer
+// fehlenden Datenblatt-Angabe wuerde eine Behauptung.
+//
+// UNKNOWN IST NICHT SUPPORTED, und `unknown` ist auch nicht `unsupported`.
+// Wer aus einer Luecke eine Aussage macht, hat den Bedarf umgedreht.
+//
+// ─── KEIN EINTRAG OHNE FUNDSTELLE ──────────────────────────────────────────
+//
+// Jede Zeile der Tabelle traegt `source` — die Stelle, an der die Aussage
+// steht. `tests/cameraCapability.test.ts` haelt das fest: wer ein Modell aus
+// dem Gedaechtnis ergaenzt, faellt dort auf. Eine geratene Faehigkeits-Zeile
+// ist schlimmer als keine: sie sieht aus wie ein Datenblatt.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Ob ein Modell eine Steuerfunktion kann. */
+export type ControlSupport = 'supported' | 'unsupported' | 'unknown'
+
+export const CONTROL_SUPPORT_LABEL: Readonly<Record<ControlSupport, string>> = {
+  supported: 'unterstützt',
+  unsupported: 'nicht unterstützt',
+  unknown: 'nicht belegt',
+}
+
+/**
+ * Die Steuerfunktionen, um die es geht.
+ *
+ * Bewusst KEINE Hersteller-Kommandos, sondern das, was in der Regie gesagt
+ * wird. Ein Kommandoname gehoerte in die Bruecke, die das Geraet anspricht;
+ * hier steht die Planungsfrage „kann diese Kamera das".
+ */
+export type CameraControl =
+  | 'pan-tilt'
+  | 'zoom'
+  | 'focus'
+  | 'iris'
+  | 'gain'
+  | 'shutter'
+  | 'nd-filter'
+  | 'white-balance'
+  | 'colour-temperature'
+  | 'red-gain'
+  | 'blue-gain'
+  | 'detail'
+  | 'preset-recall'
+  | 'preset-store'
+
+export const CAMERA_CONTROL_LABEL: Readonly<Record<CameraControl, string>> = {
+  'pan-tilt': 'Schwenken und Neigen',
+  zoom: 'Zoom',
+  focus: 'Schärfe',
+  iris: 'Blende',
+  gain: 'Verstärkung',
+  shutter: 'Verschluss',
+  'nd-filter': 'ND-Filter',
+  'white-balance': 'Weißabgleich',
+  'colour-temperature': 'Farbtemperatur',
+  'red-gain': 'Rot-Anteil',
+  'blue-gain': 'Blau-Anteil',
+  detail: 'Detail',
+  'preset-recall': 'Preset abrufen',
+  'preset-store': 'Preset speichern',
+}
+
+/** Was ein Modell laut Fundstelle kann und was nicht. */
+export interface CameraCapability {
+  /** Modellname, wie ihn die Fundstelle nennt. */
+  model: string
+  /**
+   * Nur die Funktionen, ueber die eine AUSSAGE vorliegt. Alles andere ist
+   * `unknown` — und das entsteht durch Weglassen, nicht durch einen Eintrag.
+   */
+  controls: Partial<Record<CameraControl, ControlSupport>>
+  /** Wo die Aussage steht. Pflicht: ohne Fundstelle keine Zeile. */
+  source: string
+}

--- a/tests/asciiDrift.test.ts
+++ b/tests/asciiDrift.test.ts
@@ -87,6 +87,7 @@ const HARMLOS = new Set(
     'aktuellen', 'aktueller', 'aktuelles', 'aktuellste', 'quelle', 'quellen',
     'quell', 'signalquelle', 'produktionsquelle', 'steuer', 'steuern', 'steuert',
     'steuersatz', 'steuersätze', 'steuerbetrag', 'mehrwertsteuer', 'umsatzsteuer',
+    'steuerbar', 'steuerbare', 'steuerbaren', 'steuerbares',
     'steuerung', 'steueradern', 'steuerverkehr', 'geraetesteuerung', 'frequenz',
     'frequenzen', 'frequenzgang', 'frequenzabstand', 'funkfrequenz',
     'sendefrequenz', 'bauen', 'dauerhaft', 'dauerhafte', 'genaue', 'teuerste',

--- a/tests/cableRouting.test.ts
+++ b/tests/cableRouting.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   computeObstacleAwareWaypoints,
+  pathIsBlocked,
   routeAround,
   type Rect,
 } from '../src/renderer/lib/cableRouting'
@@ -140,5 +141,69 @@ describe('die alte Schnittstelle bleibt', () => {
       ['a'],
     )
     expect(r).toEqual([])
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// Der gezeichnete Weg wird nachgerechnet, nicht das Router-Ergebnis geglaubt.
+//
+// Die automatische Führung wird nach dem ersten Rechnen in `cable.waypoints`
+// gespeichert (#206). Ab da gibt es kein `clear` mehr — und ein von Hand
+// gezogener Stützpunkt mitten durch ein Gerät ist derselbe Fehler.
+// ───────────────────────────────────────────────────────────────────────────
+describe('pathIsBlocked prüft den Weg, der wirklich gezeichnet wird', () => {
+  const geraet = { x: 100, y: 100, width: 100, height: 100 }
+
+  it('schweigt bei einem Weg, der außen herum läuft', () => {
+    expect(
+      pathIsBlocked(
+        [
+          { x: 0, y: 0 },
+          { x: 300, y: 0 },
+          { x: 300, y: 300 },
+        ],
+        [geraet],
+      ),
+    ).toBe(false)
+  })
+
+  it('meldet den Weg mitten durch das Gerät', () => {
+    expect(
+      pathIsBlocked(
+        [
+          { x: 0, y: 150 },
+          { x: 300, y: 150 },
+        ],
+        [geraet],
+      ),
+    ).toBe(true)
+  })
+
+  it('lässt die beiden verbundenen Geräte außen vor', () => {
+    // Ein Kabel endet AM Gerät — es läuft immer ein Stück an dessen Rand.
+    expect(
+      pathIsBlocked(
+        [
+          { x: 0, y: 150 },
+          { x: 300, y: 150 },
+        ],
+        [geraet],
+        new Set(['A']),
+        ['A'],
+      ),
+    ).toBe(false)
+  })
+
+  it('meldet auch einen von Hand gezogenen Stützpunkt durch ein Gerät', () => {
+    expect(
+      pathIsBlocked(
+        [
+          { x: 0, y: 0 },
+          { x: 150, y: 0 },
+          { x: 150, y: 300 },
+        ],
+        [geraet],
+      ),
+    ).toBe(true)
   })
 })

--- a/tests/cableRouting.test.ts
+++ b/tests/cableRouting.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeObstacleAwareWaypoints,
+  routeAround,
+  type Rect,
+} from '../src/renderer/lib/cableRouting'
+
+// ───────────────────────────────────────────────────────────────────────────
+// Nutzer-Meldung 2026-09-07: „manche Basisfunktionen wie das Kabel
+// automatisch Routen funktionieren nicht sauber."
+//
+// Diese Tests halten fest, was ein automatisch gelegtes Kabel niemals tun
+// darf: durch ein Geraet laufen, ohne dass es jemand erfaehrt. Der alte Code
+// hatte dafuer keine Sprache — er gab am Ende „den kuerzesten Umweg zurueck,
+// auch wenn er noch etwas streift", und das Ergebnis sah aus wie eine
+// gelungene Fuehrung.
+// ───────────────────────────────────────────────────────────────────────────
+
+const rect = (x: number, y: number, width = 100, height = 60): Rect => ({ x, y, width, height })
+
+/** Laeuft der ganze Weg an allen Hindernissen vorbei? */
+const frei = (punkte: { x: number; y: number }[], hindernisse: Rect[]): boolean => {
+  for (let i = 0; i < punkte.length - 1; i += 1) {
+    const a = punkte[i]
+    const b = punkte[i + 1]
+    const minX = Math.min(a.x, b.x)
+    const maxX = Math.max(a.x, b.x)
+    const minY = Math.min(a.y, b.y)
+    const maxY = Math.max(a.y, b.y)
+    for (const r of hindernisse) {
+      const trifft =
+        maxX > r.x && minX < r.x + r.width && maxY > r.y && minY < r.y + r.height
+      if (trifft) return false
+    }
+  }
+  return true
+}
+
+/** Ist jeder Abschnitt waagerecht oder senkrecht? */
+const orthogonal = (punkte: { x: number; y: number }[]): boolean => {
+  for (let i = 0; i < punkte.length - 1; i += 1) {
+    const a = punkte[i]
+    const b = punkte[i + 1]
+    if (a.x !== b.x && a.y !== b.y) return false
+  }
+  return true
+}
+
+describe('ohne Hindernis bleibt der Weg gerade', () => {
+  it('gibt keine Zwischenpunkte zurück', () => {
+    const r = routeAround({ x: 0, y: 0 }, { x: 300, y: 0 }, [])
+    expect(r.waypoints).toEqual([])
+    expect(r.clear).toBe(true)
+  })
+
+  it('sagt auch dann, dass der Weg frei ist', () => {
+    const r = routeAround({ x: 0, y: 0 }, { x: 300, y: 200 }, [rect(600, 600)])
+    expect(r.clear).toBe(true)
+  })
+})
+
+describe('ein Hindernis wird umfahren', () => {
+  const hindernis = [rect(120, -30)]
+  const r = routeAround({ x: 0, y: 0 }, { x: 320, y: 0 }, hindernis)
+
+  it('meldet den Weg als frei', () => {
+    expect(r.clear).toBe(true)
+  })
+
+  it('läuft tatsächlich an ihm vorbei', () => {
+    expect(frei([{ x: 0, y: 0 }, ...r.waypoints, { x: 320, y: 0 }], hindernis)).toBe(true)
+  })
+
+  it('bleibt orthogonal', () => {
+    expect(orthogonal([{ x: 0, y: 0 }, ...r.waypoints, { x: 320, y: 0 }])).toBe(true)
+  })
+})
+
+describe('zwei Hindernisse — der Fall, an dem die alte Fassung scheiterte', () => {
+  // Zwei Geräte hintereinander auf der Sichtlinie. Ein Umweg um das erste
+  // führte geradewegs ins zweite, und zurück kam trotzdem ein Weg.
+  const hindernisse = [rect(120, -30), rect(120, 40)]
+  const von = { x: 0, y: 0 }
+  const nach = { x: 320, y: 0 }
+  const r = routeAround(von, nach, hindernisse)
+
+  it('läuft an BEIDEN vorbei, wenn es einen Weg gibt', () => {
+    expect(r.clear).toBe(true)
+    expect(frei([von, ...r.waypoints, nach], hindernisse)).toBe(true)
+  })
+
+  it('bleibt orthogonal', () => {
+    expect(orthogonal([von, ...r.waypoints, nach])).toBe(true)
+  })
+})
+
+describe('wenn kein Weg frei ist, wird das GESAGT', () => {
+  // Das Ziel steht eingemauert — vier Geräte rundherum, wie in einem dicht
+  // gepackten Rack-Bereich. Jeder Weg dorthin muss durch eine der Wände. Der
+  // alte Code gab trotzdem wortlos einen Weg zurück.
+  const eingemauert = [
+    rect(440, -200, 20, 400),
+    rect(540, -200, 20, 400),
+    rect(440, -220, 120, 20),
+    rect(440, 200, 120, 20),
+  ]
+  const von = { x: 0, y: 0 }
+  const nach = { x: 500, y: 0 }
+  const r = routeAround(von, nach, eingemauert)
+
+  it('meldet `clear: false`, statt einen Weg durch das Gerät zu behaupten', () => {
+    expect(r.clear).toBe(false)
+  })
+
+  it('gibt trotzdem einen benutzbaren Weg zurück — die Kante muss gezeichnet werden', () => {
+    // Ein Kabel ohne Weg wäre unsichtbar. Der kürzeste Weg wird geliefert und
+    // ist als nicht frei GEKENNZEICHNET; die Oberfläche entscheidet, wie sie
+    // das zeigt.
+    expect(orthogonal([von, ...r.waypoints, nach])).toBe(true)
+  })
+})
+
+describe('die alte Schnittstelle bleibt', () => {
+  it('liefert weiter nur die Zwischenpunkte', () => {
+    const hindernis = [rect(120, -30)]
+    expect(computeObstacleAwareWaypoints({ x: 0, y: 0 }, { x: 320, y: 0 }, hindernis)).toEqual(
+      routeAround({ x: 0, y: 0 }, { x: 320, y: 0 }, hindernis).waypoints,
+    )
+  })
+
+  it('lässt eigene Geräte über ihre Id aus der Prüfung heraus', () => {
+    // Quelle und Ziel liegen auf ihrem eigenen Rechteck — ohne diese Ausnahme
+    // wäre jedes Kabel von Anfang an blockiert.
+    const eigen = [rect(-10, -10, 40, 40)]
+    const r = computeObstacleAwareWaypoints(
+      { x: 0, y: 0 },
+      { x: 300, y: 0 },
+      eigen,
+      new Set(['a']),
+      ['a'],
+    )
+    expect(r).toEqual([])
+  })
+})

--- a/tests/cameraCapability.test.ts
+++ b/tests/cameraCapability.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CAMERA_CAPABILITIES,
+  CAPABILITY_FINDING_LABEL,
+  capabilityFindings,
+  capabilityFor,
+  controlRows,
+  controlSupport,
+  modelOf,
+  normaliseModel,
+} from '../src/renderer/lib/cameraCapability'
+import {
+  CAMERA_CONTROL_LABEL,
+  CONTROL_SUPPORT_LABEL,
+  type CameraControl,
+} from '../src/renderer/types/cameraCapability'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+
+// ───────────────────────────────────────────────────────────────────────────
+// Bedarf 103 — Fähigkeiten je MODELL, nicht je Hersteller.
+//
+//   > Within one vendor's own PTZ line, CONTROLS EXIST IN SOFTWARE AND DO
+//   > NOTHING ON THE MODEL
+//
+// Der grösste Teil dieser Tests hält fest, was NICHT behauptet wird: aus einer
+// fehlenden Datenblatt-Angabe darf weder ein „geht" noch ein „geht nicht"
+// werden.
+// ───────────────────────────────────────────────────────────────────────────
+
+const kamera = (over: Partial<EquipmentItem> & { id: string; name: string }): EquipmentItem =>
+  ({ category: 'Kameras', x: 0, y: 0, inputs: [], outputs: [], ...over }) as unknown as EquipmentItem
+
+describe('unbekannt ist ein eigener Wert', () => {
+  it('gibt für ein Modell ohne Fundstelle „nicht belegt" zurück', () => {
+    expect(controlSupport('Irgendeine Kamera', 'colour-temperature')).toBe('unknown')
+  })
+
+  it('macht aus einer Lücke kein „nicht unterstützt"', () => {
+    // Die tragende Zeile des Bedarfs. Wer aus einer fehlenden Angabe eine
+    // Aussage macht, hat ihn umgedreht.
+    expect(controlSupport('AW-UE150A', 'zoom')).toBe('unknown')
+    expect(controlSupport('AW-UE150A', 'zoom')).not.toBe('unsupported')
+  })
+
+  it('macht aus einer Lücke auch kein „unterstützt"', () => {
+    expect(controlSupport('AW-UE160', 'detail')).not.toBe('supported')
+  })
+
+  it('hat für alle drei Werte ein deutsches Wort', () => {
+    expect(Object.keys(CONTROL_SUPPORT_LABEL).sort()).toEqual([
+      'supported',
+      'unknown',
+      'unsupported',
+    ])
+  })
+})
+
+describe('die belegten Aussagen', () => {
+  it('kennt die tote Farbtemperatur der AW-UE150A', () => {
+    expect(controlSupport('AW-UE150A', 'colour-temperature')).toBe('unsupported')
+  })
+
+  it('kennt die toten Farbanteile der AW-UE160', () => {
+    expect(controlSupport('AW-UE160', 'red-gain')).toBe('unsupported')
+    expect(controlSupport('AW-UE160', 'blue-gain')).toBe('unsupported')
+  })
+
+  it('hält die beiden Modelle desselben Herstellers auseinander', () => {
+    // Genau der Schaden aus dem Beleg: innerhalb EINER Produktlinie ist das
+    // eine tot und das andere nicht.
+    expect(controlSupport('AW-UE160', 'colour-temperature')).toBe('unknown')
+    expect(controlSupport('AW-UE150A', 'red-gain')).toBe('unknown')
+  })
+
+  it('trägt zu jeder Zeile eine Fundstelle — sonst wäre sie eine Behauptung', () => {
+    for (const c of CAMERA_CAPABILITIES) {
+      expect(c.source.length).toBeGreaterThan(20)
+      // Eine Fundstelle nennt, WO es steht.
+      expect(c.source).toMatch(/#\d+|HELP\.md|companion-module/)
+    }
+  })
+
+  it('hat keine Zeile ohne Aussage', () => {
+    for (const c of CAMERA_CAPABILITIES) {
+      expect(Object.keys(c.controls).length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('die Schreibweise entscheidet nicht über die Warnung', () => {
+  it('führt Bindestrich, Leerzeichen und Kleinschreibung zusammen', () => {
+    expect(normaliseModel('AW-UE150A')).toBe(normaliseModel('aw ue150a'))
+    expect(capabilityFor('awue150a')?.model).toBe('AW-UE150A')
+    expect(capabilityFor('AW UE 150 A')?.model).toBe('AW-UE150A')
+  })
+
+  it('verwechselt zwei Modelle nicht', () => {
+    expect(capabilityFor('AW-UE160')?.model).toBe('AW-UE160')
+    expect(capabilityFor('AW-UE15')).toBeUndefined()
+  })
+})
+
+describe('die Liste zeigt alle Funktionen, auch die unbelegten', () => {
+  const zeilen = controlRows('AW-UE150A')
+
+  it('lässt keine Funktion weg', () => {
+    expect(zeilen).toHaveLength(Object.keys(CAMERA_CONTROL_LABEL).length)
+  })
+
+  it('setzt die Reihenfolge fest, nicht alphabetisch', () => {
+    // Bewegung, dann Belichtung, dann Farbe, dann Presets — so, wie jemand an
+    // einem Pult sucht.
+    expect(zeilen[0].control).toBe('pan-tilt')
+    expect(zeilen[zeilen.length - 1].control).toBe('preset-store')
+  })
+
+  it('nennt die Fundstelle nur an der Zeile, die aus ihr stammt', () => {
+    const farbe = zeilen.find((z) => z.control === 'colour-temperature')
+    const zoom = zeilen.find((z) => z.control === 'zoom')
+    expect(farbe?.source).toBeDefined()
+    expect(zoom?.source).toBeUndefined()
+  })
+
+  it('zeigt für ein unbekanntes Modell alle Zeilen als „nicht belegt"', () => {
+    const unbekannt = controlRows('Sony PXW-FX9')
+    expect(unbekannt.every((z) => z.support === 'unknown')).toBe(true)
+    expect(unbekannt.length).toBeGreaterThan(0)
+  })
+
+  it('hat für jede Funktion ein deutsches Wort', () => {
+    for (const z of zeilen) {
+      expect(CAMERA_CONTROL_LABEL[z.control as CameraControl].length).toBeGreaterThan(3)
+    }
+  })
+})
+
+describe('was am Plan zu melden ist', () => {
+  it('meldet die wirkungslose Funktion mit ihrer Fundstelle', () => {
+    const f = capabilityFindings([kamera({ id: 'c1', name: 'AW-UE160' })])
+    expect(f.map((x) => x.kind)).toEqual(['control-unsupported', 'control-unsupported'])
+    expect(f[0].detail).toContain('companion-module')
+  })
+
+  it('meldet ein unbelegtes Modell als BEFUND, nicht als Warnung', () => {
+    // Ohne diese Zeile sähe ein Plan voller unbelegter Kameras genauso aus wie
+    // einer, dessen Modelle alle geprüft sind.
+    const f = capabilityFindings([kamera({ id: 'c1', name: 'Irgendeine PTZ' })])
+    expect(f.map((x) => x.kind)).toEqual(['model-unknown'])
+  })
+
+  it('lässt alles ohne Kamera-Kategorie in Ruhe', () => {
+    const f = capabilityFindings([
+      kamera({ id: 's1', name: 'ATEM 4 M/E', category: 'Video' }),
+    ])
+    expect(f).toEqual([])
+  })
+
+  it('nimmt den Modellnamen aus dem Datenblatt, wenn eines dranhängt', () => {
+    // Dieselbe Reihenfolge wie in `deviceKind.ts`: Katalog schlägt Getipptes.
+    const mitId = kamera({ id: 'c1', name: 'Kamera 1' })
+    expect(modelOf(mitId)).toBe('Kamera 1')
+  })
+
+  it('hat für jeden Befund einen deutschen Satz', () => {
+    for (const t of Object.values(CAPABILITY_FINDING_LABEL)) expect(t.length).toBeGreaterThan(10)
+  })
+})

--- a/tests/geschuetzteNamen.test.ts
+++ b/tests/geschuetzteNamen.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
+
+// ───────────────────────────────────────────────────────────────────────────
+// KEIN FREMDER FIRMEN- ODER SENDERNAME ALS BEISPIEL.
+//
+// Der Platzhalter des Projektnamens lautete „z.B. ProSieben Studio Umbau".
+// Das ist ein geschuetzter Name, und er stand in einer Eingabemaske, die
+// jeder Nutzer beim Anlegen eines Projekts sieht — also an der sichtbarsten
+// Stelle der ganzen Anwendung. Entfernt am 2026-09-07 auf Ansage des
+// Eigentuemers.
+//
+// ─── WAS DIESE PRUEFUNG MEINT UND WAS NICHT ────────────────────────────────
+//
+// Verboten sind SENDER- und MEDIENHAUS-Namen als Beispiel, Platzhalter oder
+// Demo-Inhalt. NICHT verboten sind Hersteller- und Produktnamen (Sony,
+// Blackmagic, Panasonic, Shure): die stehen in den Geraete-Katalogen, weil
+// die Anwendung genau diese Geraete plant — ein Katalog ohne Modellnamen
+// waere kein Katalog. Der Unterschied ist die Funktion: ein Produktname
+// BENENNT ein Geraet, ein Sendername BEHAUPTET eine Geschaeftsbeziehung.
+//
+// Wer die Liste erweitert, schreibt ein Muster mit Wortgrenzen hinein.
+// Verglichen wird auf kleingeschriebenem Text mit zusammengezogenen
+// Leerzeichen, damit „Pro Sieben" und „prosieben" beide auffallen.
+// ───────────────────────────────────────────────────────────────────────────
+
+const ROOT = resolve(__dirname, '..')
+const WURZELN = ['src', 'docs', 'scripts']
+
+/**
+ * Sender und Medienhaeuser, die in keinem Beispiel auftauchen duerfen.
+ *
+ * ALS WORTGRENZE GEPRUEFT und nicht als Teilzeichenkette. Die erste Fassung
+ * suchte blank nach „rtl" und „ntv" und meldete 121 Treffer — in
+ * `partial`, `controller`, `inventory`, `eventName`. Ein Guard, der bei
+ * jedem Lauf rot ist, wird abgeschaltet und schuetzt danach gar nichts.
+ *
+ * `rtl` steht deshalb NICHT auf der Liste: `dir="rtl"` ist die
+ * Schreibrichtung und ein legitimes technisches Wort. Ein Name, der sich von
+ * einem Fachbegriff nicht unterscheiden laesst, gehoert nicht in eine
+ * automatische Pruefung — er gehoert in die Durchsicht durch einen Menschen.
+ */
+const GESCHUETZT: readonly RegExp[] = [
+  /\bpro\s?sieben\b/i,
+  /\bprosieben\b/i,
+  /\bsat\.?1\b/i,
+  /\bkabel\s?eins\b/i,
+  /\bzdf\b/i,
+  /\bard\b/i,
+  /\bard-?mediathek\b/i,
+  /\bservus\s?tv\b/i,
+  /\bwelt\s?tv\b/i,
+  /\bn-?tv\b/i,
+  /\bsky\s?deutschland\b/i,
+]
+
+const DATEIEN = ['.ts', '.tsx', '.md', '.html', '.mjs', '.json']
+
+const sammle = (dir: string, out: string[] = []): string[] => {
+  for (const name of readdirSync(dir)) {
+    if (name === 'node_modules' || name.startsWith('.')) continue
+    const voll = join(dir, name)
+    if (statSync(voll).isDirectory()) sammle(voll, out)
+    else if (DATEIEN.some((e) => name.endsWith(e))) out.push(voll)
+  }
+  return out
+}
+
+describe('kein geschützter Sendername im Code oder in der Doku', () => {
+  const dateien = WURZELN.flatMap((w) => {
+    try {
+      return sammle(join(ROOT, w))
+    } catch {
+      return []
+    }
+  })
+
+  it('durchsucht überhaupt etwas', () => {
+    // Ohne diese Zeile wäre der Test grün, wenn die Pfade eines Tages nicht
+    // mehr stimmen — und das wäre die schlechteste Sorte grün.
+    expect(dateien.length).toBeGreaterThan(200)
+  })
+
+  it('findet keinen', () => {
+    const treffer: string[] = []
+    for (const datei of dateien) {
+      // Diese Datei selbst führt die Liste — sie ist die Ausnahme.
+      if (datei.endsWith('geschuetzteNamen.test.ts')) continue
+      const inhalt = readFileSync(datei, 'utf8').toLowerCase().replace(/\s+/g, ' ')
+      for (const muster of GESCHUETZT) {
+        const m = muster.exec(inhalt)
+        if (m) treffer.push(`${relative(ROOT, datei)}: „${m[0]}"`)
+      }
+    }
+    expect(treffer, `Geschützte Namen: ${treffer.join(' | ')}`).toEqual([])
+  })
+})

--- a/tests/markenTokens.test.ts
+++ b/tests/markenTokens.test.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// `?raw` liefert fuer CSS einen leeren String — Vite behandelt Stylesheets
+// gesondert. Gelesen wird deshalb die Datei selbst, so wie die uebrigen
+// Quell-Waechter in diesem Ordner es tun.
+const css = readFileSync(resolve(__dirname, '..', 'src/renderer/index.css'), 'utf8')
+
+// ───────────────────────────────────────────────────────────────────────────
+// ADR-007 (av-planner-suite) — „die UI ist nicht konsistent. lege globale UI
+// Regeln fest, die für alle Repos gelten."
+//
+// Die Werte stehen maschinenlesbar in `@avplan/ui` (`src/brand.ts`), aber der
+// Cable-Planner hängt nicht an diesem Paket — er wird in die Suite vendoriert,
+// nicht umgekehrt. Dieser Test trägt die Werte deshalb ein zweites Mal, und
+// das ist Absicht: ohne ihn wäre der Rückweg nach Tailwind-`slate` eine
+// Zeile, die niemandem auffällt. Er ist die Instanz, die widerspricht.
+//
+// Was er NICHT prüft: ob die Werte gut sind. Das entscheidet das
+// Marken-Handbuch, nicht ein Test.
+// ───────────────────────────────────────────────────────────────────────────
+
+const MARKE = {
+  deepNavy: '#132040',
+  zumpeNavy: '#1D324F',
+  offWhite: '#F6F5F0',
+  eisblau: '#E1ECEF',
+  stahlblau: '#8C9CB3',
+  tallyRot: '#D6402E',
+}
+
+/**
+ * Der Wert eines Tokens VOR dem Light-Override — also alles, was oberhalb
+ * von `[data-theme="light"]` steht: die `@theme`-Bloecke (Radius, Typo) und
+ * der `:root`-Block (Farben).
+ */
+const dark = (name: string): string => {
+  const block = css.slice(0, css.indexOf('[data-theme="light"] {'))
+  const m = block.match(new RegExp(`${name}:\\s*([^;]+);`))
+  return m ? m[1].trim() : ''
+}
+
+describe('die Farb-Tokens zeigen auf die Marke, nicht auf Tailwind', () => {
+  it('trägt Deep Navy als Grund und Zumpe Navy als Fläche', () => {
+    expect(dark('--cp-bg')).toBe(MARKE.deepNavy)
+    expect(dark('--cp-surface-2')).toBe(MARKE.zumpeNavy)
+  })
+
+  it('setzt Eisblau als Fließtext und Off-White als Hervorhebung', () => {
+    expect(dark('--cp-text')).toBe(MARKE.eisblau)
+    expect(dark('--cp-text-bright')).toBe(MARKE.offWhite)
+  })
+
+  it('nutzt Stahlblau für Gedämpftes', () => {
+    expect(dark('--cp-text-muted')).toBe(MARKE.stahlblau)
+  })
+
+  it('führt kein --cp-Token mehr über die slate-Palette', () => {
+    const block = css.slice(css.indexOf(':root {'), css.indexOf('[data-theme="light"] {'))
+    const rueckfall = block
+      .split('\n')
+      .filter((z) => /^\s*--cp-(bg|surface|border|text|accent|warn|danger)/.test(z))
+      .filter((z) => z.includes('var(--color-'))
+    expect(rueckfall).toEqual([])
+  })
+})
+
+describe('Rot ist das Signal, keine Farbe', () => {
+  it('steht genau einmal — in der Definition von --cp-signal', () => {
+    const treffer = css
+      .split('\n')
+      .filter((z) => z.toUpperCase().includes(MARKE.tallyRot))
+      .map((z) => z.trim())
+    expect(treffer.every((z) => z.startsWith('--cp-signal:'))).toBe(true)
+  })
+
+  it('trägt den Tastatur-Fokusring', () => {
+    expect(css).toContain('outline: 2px solid var(--cp-signal)')
+    expect(css).toContain('outline-offset: 3px')
+  })
+
+  it('ist nicht dasselbe wie Fehlerrot — anderer Ton, anderer Zweck', () => {
+    expect(dark('--cp-danger').toUpperCase()).not.toBe(MARKE.tallyRot)
+  })
+})
+
+describe('keine Rundungen, keine Verläufe', () => {
+  it('setzt jede Radius-Stufe auf null', () => {
+    for (const n of ['--radius-cp-control', '--radius-cp-card', '--radius-cp-modal']) {
+      expect(dark(n)).toBe('0')
+    }
+  })
+
+  it('kennt keinen Verlauf mehr — auch nicht auf dem Canvas-Grund', () => {
+    expect(css).not.toMatch(/linear-gradient|radial-gradient/)
+  })
+})

--- a/tests/patchPanelChain.test.ts
+++ b/tests/patchPanelChain.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from 'vitest'
+import { detectDeviceKind } from '../src/renderer/lib/deviceKind'
+import { isPatchPanelDevice, patchPanelCounterpart } from '../src/renderer/lib/patchPanel'
+import { chainOneLine, signalChains } from '../src/renderer/lib/signalChain'
+import { buildGraphContext, resolveSignalSource } from '../src/renderer/lib/labelDerivation'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+
+// ───────────────────────────────────────────────────────────────────────────
+// Issue #664 — „Patchbays als Gerätekategorie erstellen und mehrere Ebenen der
+// Verkabelung anzeigbar machen für Festinstallationen. Zum Beispiel Kabel geht
+// von a über b von b über c nach d. Bei d ist ein Patchbay und da geht es dann
+// von d nach e und von e zum Endgerät oder einem Wandanschluss."
+//
+// Die Kette aus dem Issue, als Fixture: Kamera → Wandanschluss → Patchfeld A →
+// Patchfeld B → ATEM.
+// ───────────────────────────────────────────────────────────────────────────
+
+const port = (id: string, name: string, connectorType = 'BNC') =>
+  ({ id, name, type: 'video', connectorType }) as never
+
+const geraet = (over: Partial<EquipmentItem> & { id: string; name: string }): EquipmentItem =>
+  ({
+    category: 'Video',
+    inputs: [],
+    outputs: [],
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 60,
+    ...over,
+  }) as EquipmentItem
+
+/** n Ein- und n Ausgänge, gleich nummeriert — eine echte Blende. */
+const blende = (id: string, name: string, n: number, category = 'Patchfelder'): EquipmentItem =>
+  geraet({
+    id,
+    name,
+    category,
+    inputs: Array.from({ length: n }, (_, i) => port(`${id}-in-${i + 1}`, `In ${i + 1}`)),
+    outputs: Array.from({ length: n }, (_, i) => port(`${id}-out-${i + 1}`, `Out ${i + 1}`)),
+  })
+
+const kabel = (id: string, from: [string, string], to: [string, string]): Cable =>
+  ({
+    id,
+    name: id,
+    type: 'SDI',
+    length: 10,
+    color: '#fff',
+    cableNumber: id.toUpperCase(),
+    fromEquipmentId: from[0],
+    fromPortId: from[1],
+    toEquipmentId: to[0],
+    toPortId: to[1],
+    notes: '',
+  }) as Cable
+
+const kamera = geraet({
+  id: 'cam',
+  name: 'Kamera 1',
+  category: 'Kameras',
+  outputs: [port('cam-out', 'SDI Out')],
+})
+const wand = blende('wall', 'Wandanschluss Studio', 4)
+const ppA = blende('ppa', 'Patchfeld A', 24)
+const ppB = blende('ppb', 'Patchfeld B', 24)
+const atem = geraet({
+  id: 'atem',
+  name: 'ATEM Constellation',
+  inputs: Array.from({ length: 8 }, (_, i) => port(`atem-in-${i + 1}`, `In ${i + 1}`)),
+})
+
+const KETTE: Cable[] = [
+  kabel('k1', ['cam', 'cam-out'], ['wall', 'wall-in-2']),
+  kabel('k2', ['wall', 'wall-out-2'], ['ppa', 'ppa-in-3']),
+  kabel('k3', ['ppa', 'ppa-out-3'], ['ppb', 'ppb-in-3']),
+  kabel('k4', ['ppb', 'ppb-out-3'], ['atem', 'atem-in-4']),
+]
+const PLAN = [kamera, wand, ppA, ppB, atem]
+
+describe('eine Patchblende wird als solche erkannt', () => {
+  it('über die Kategorie, ohne zusätzliches Häkchen', () => {
+    expect(isPatchPanelDevice(ppA)).toBe(true)
+  })
+
+  it('über das Flag, auch ohne die Kategorie', () => {
+    const alt = blende('x', 'Blende', 8, 'Video')
+    expect(isPatchPanelDevice(alt)).toBe(false)
+    expect(isPatchPanelDevice({ ...alt, isPatchPanel: true })).toBe(true)
+  })
+
+  it('und NICHT als Kreuzschiene — das war der eigentliche Defekt', () => {
+    // 24 BNC rein, 24 BNC raus: die Struktur-Heuristik in `detectDeviceKind`
+    // hielt jede Blende für einen Videohub. Danach verlangte die Ableitung
+    // einen geschalteten Kreuzpunkt, den eine Blende nie hat.
+    expect(detectDeviceKind(blende('y', 'Blende 24', 24, 'Video'))).toBe('videohub')
+    expect(detectDeviceKind(ppA)).toBe(null)
+  })
+})
+
+describe('der Durchgang ist die Position, in beide Richtungen', () => {
+  it('vom Ausgang zum gleichnummerigen Eingang', () => {
+    expect(patchPanelCounterpart(ppA, { id: 'ppa-out-3' })?.id).toBe('ppa-in-3')
+  })
+
+  it('und zurück', () => {
+    expect(patchPanelCounterpart(ppA, { id: 'ppa-in-3' })?.id).toBe('ppa-out-3')
+  })
+
+  it('nicht bei ungleicher Bestückung — dann sagt die Position nichts', () => {
+    const schief = geraet({
+      id: 'schief',
+      name: 'Halbe Blende',
+      category: 'Patchfelder',
+      inputs: [port('s-in-1', 'In 1'), port('s-in-2', 'In 2')],
+      outputs: [port('s-out-1', 'Out 1')],
+    })
+    expect(patchPanelCounterpart(schief, { id: 's-out-1' })).toBe(null)
+  })
+
+  it('nicht bei einem Gerät, das keine Blende ist', () => {
+    expect(patchPanelCounterpart(atem, { id: 'atem-in-4' })).toBe(null)
+  })
+})
+
+describe('die Rückwärtssuche läuft durch die Blenden bis zur Kamera', () => {
+  it('nennt die Kamera, nicht das letzte Patchfeld', () => {
+    const ctx = buildGraphContext(PLAN, KETTE)
+    expect(resolveSignalSource('atem-in-4', ctx)?.equipmentId).toBe('cam')
+  })
+
+  it('hält an der Blende an, wenn sie ungleich bestückt ist — kein Raten', () => {
+    // Gegenprobe zur Regel „gleich viele Buchsen": Patchfeld B bekommt einen
+    // Eingang mehr, die Position sagt danach nichts mehr.
+    const schief = { ...ppB, inputs: [...ppB.inputs, port('ppb-in-25', 'In 25')] }
+    const ctx = buildGraphContext([kamera, wand, ppA, schief, atem], KETTE)
+    expect(resolveSignalSource('atem-in-4', ctx)?.equipmentId).toBe('ppb')
+  })
+
+  it('hält an der Blende an, wenn sie keine Blende mehr ist', () => {
+    const normal = { ...ppB, category: 'Video' }
+    const ctx = buildGraphContext([kamera, wand, ppA, normal, atem], KETTE)
+    expect(resolveSignalSource('atem-in-4', ctx)?.equipmentId).toBe('ppb')
+  })
+})
+
+describe('die Kette ist als Ganzes anzeigbar', () => {
+  it('setzt die vier Einzelkabel zu einem Weg zusammen', () => {
+    const chains = signalChains(PLAN, KETTE)
+    expect(chains).toHaveLength(1)
+    expect(chains[0].steps.map((s) => s.cableId)).toEqual(['k1', 'k2', 'k3', 'k4'])
+    expect(chains[0].levels).toBe(3)
+    expect(chains[0].end).toBe('ziel')
+  })
+
+  it('nennt Anfang und Ende in einer Zeile', () => {
+    const zeile = chainOneLine(signalChains(PLAN, KETTE)[0])
+    expect(zeile).toContain('Kamera 1')
+    expect(zeile).toContain('ATEM Constellation')
+    expect(zeile).toContain('Patchfeld A')
+  })
+
+  it('fängt keine zweite Kette in der Mitte an', () => {
+    // Ohne diese Regel stünde derselbe Weg viermal da — einmal ab jedem
+    // Zwischenglied.
+    expect(signalChains(PLAN, KETTE).map((c) => c.steps[0].cableId)).toEqual(['k1'])
+  })
+
+  it('lässt direkte Verbindungen weg — die stehen in der Patchliste', () => {
+    const direkt = [kabel('d1', ['cam', 'cam-out'], ['atem', 'atem-in-1'])]
+    expect(signalChains([kamera, atem], direkt)).toEqual([])
+  })
+})
+
+describe('wo die Kette endet, steht warum', () => {
+  it('unterscheidet Endgerät von Aufgeben', () => {
+    const chains = signalChains(PLAN, KETTE)
+    expect(chains[0].end).toBe('ziel')
+    expect(chains[0].endNote).toBe('')
+  })
+
+  it('meldet den unverkabelten Weiterweg als solchen', () => {
+    const chains = signalChains(PLAN, KETTE.slice(0, 3))
+    expect(chains[0].end).toBe('nicht-verkabelt')
+    expect(chains[0].endNote).toContain('Patchfeld')
+  })
+
+  it('meldet die ungleich bestückte Blende mit Zahlen', () => {
+    const schief = { ...ppB, inputs: [...ppB.inputs, port('ppb-in-25', 'In 25')] }
+    const chains = signalChains([kamera, wand, ppA, schief, atem], KETTE)
+    expect(chains[0].end).toBe('mehrdeutig')
+    expect(chains[0].endNote).toContain('25')
+  })
+
+  it('meldet die Kreuzschiene ohne gesetzten Kreuzpunkt', () => {
+    const hub = geraet({
+      id: 'hub',
+      name: 'Smart Videohub 12x12',
+      inputs: Array.from({ length: 12 }, (_, i) => port(`hub-in-${i + 1}`, `In ${i + 1}`)),
+      outputs: Array.from({ length: 12 }, (_, i) => port(`hub-out-${i + 1}`, `Out ${i + 1}`)),
+    })
+    const chains = signalChains(
+      [kamera, wand, hub, atem],
+      [
+        kabel('c1', ['cam', 'cam-out'], ['wall', 'wall-in-1']),
+        kabel('c2', ['wall', 'wall-out-1'], ['hub', 'hub-in-2']),
+      ],
+    )
+    // Die Kette läuft durch den Wandanschluss und bleibt an der Kreuzschiene
+    // stehen — mit dem Grund, nicht wortlos.
+    expect(chains).toHaveLength(1)
+    expect(chains[0].end).toBe('mehrdeutig')
+    expect(chains[0].endNote).toContain('Kreuzpunkt')
+  })
+})
+
+describe('der geschaltete Kreuzpunkt trägt die Kette weiter', () => {
+  const hub = geraet({
+    id: 'hub',
+    name: 'Smart Videohub 12x12',
+    inputs: Array.from({ length: 12 }, (_, i) => port(`hub-in-${i + 1}`, `In ${i + 1}`)),
+    outputs: Array.from({ length: 12 }, (_, i) => port(`hub-out-${i + 1}`, `Out ${i + 1}`)),
+    videohubRouting: { planned: { 5: 1 } },
+  })
+  const gepatcht: Cable[] = [
+    kabel('r1', ['cam', 'cam-out'], ['ppa', 'ppa-in-1']),
+    kabel('r2', ['ppa', 'ppa-out-1'], ['hub', 'hub-in-2']),
+    kabel('r3', ['hub', 'hub-out-6'], ['atem', 'atem-in-1']),
+  ]
+
+  it('läuft von der Kamera über Blende und Kreuzschiene bis zum Mischer', () => {
+    const chains = signalChains([kamera, ppA, hub, atem], gepatcht)
+    expect(chains[0].steps.map((s) => s.cableId)).toEqual(['r1', 'r2', 'r3'])
+    expect(chains[0].steps[1].through).toBe('router')
+  })
+
+  it('hält ohne gesetzten Kreuzpunkt an — geraten wird nichts', () => {
+    const ohne = { ...hub, videohubRouting: undefined }
+    const chains = signalChains([kamera, ppA, ohne, atem], gepatcht)
+    expect(chains[0].end).toBe('mehrdeutig')
+    expect(chains[0].steps.map((s) => s.cableId)).toEqual(['r1', 'r2'])
+  })
+})

--- a/tests/rackWireChecks.test.ts
+++ b/tests/rackWireChecks.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+import {
+  RACK_WIRE_FINDING_LABEL,
+  RACK_WIRE_FINDING_SEVERITY,
+  rackWireFindings,
+  type WireCheckCable,
+  type WireCheckPlacement,
+} from '../src/renderer/lib/rackWireChecks'
+
+// ───────────────────────────────────────────────────────────────────────────
+// Issue #663 — „Es fehlt die Fehlermeldung, dass Kabeltypen nicht
+// zusammenpassen."
+//
+// Der Signalplan meldet das seit langem; die Rack-INTERNE Verkabelung nicht.
+// Dabei ist sie die, bei der man sich vertut: dort liegen BNC und XLR in
+// derselben Höheneinheit nebeneinander.
+// ───────────────────────────────────────────────────────────────────────────
+
+const port = (name: string, connectorType: string) =>
+  ({ id: `${name}-id`, name, type: 'video', connectorType }) as never
+
+const geraet = (
+  id: string,
+  name: string,
+  inputs: { name: string; connectorType: string }[] = [],
+  outputs: { name: string; connectorType: string }[] = [],
+): WireCheckPlacement => ({
+  id,
+  name,
+  inputs: inputs.map((p) => port(p.name, p.connectorType)),
+  outputs: outputs.map((p) => port(p.name, p.connectorType)),
+})
+
+const kabel = (over: Partial<WireCheckCable> = {}): WireCheckCable => ({
+  fromPlacementId: 'a',
+  fromPortName: 'SDI Out',
+  toPlacementId: 'b',
+  toPortName: 'SDI In',
+  name: 'K1',
+  type: 'SDI',
+  ...over,
+})
+
+const rack: WireCheckPlacement[] = [
+  geraet('a', 'Kamera-Interface', [], [{ name: 'SDI Out', connectorType: 'BNC' }]),
+  geraet(
+    'b',
+    'Mischer',
+    [
+      { name: 'SDI In', connectorType: 'BNC' },
+      { name: 'Mic In', connectorType: 'XLR' },
+    ],
+    [{ name: 'PGM Out', connectorType: 'BNC' }],
+  ),
+]
+
+const arten = (f: ReturnType<typeof rackWireFindings>) => f.map((x) => x.kind)
+
+describe('was zusammenpasst, wird nicht gemeldet', () => {
+  it('schweigt bei BNC auf BNC', () => {
+    expect(rackWireFindings(rack, [kabel()])).toEqual([])
+  })
+
+  it('schweigt bei einer leeren Verkabelung', () => {
+    expect(rackWireFindings(rack, [])).toEqual([])
+  })
+})
+
+describe('was nicht zusammenpasst, wird gemeldet', () => {
+  it('meldet BNC auf XLR — der Fehler aus der Meldung', () => {
+    const f = rackWireFindings(rack, [kabel({ toPortName: 'Mic In' })])
+    expect(arten(f)).toContain('connector-mismatch')
+    expect(f[0].text).toContain('BNC')
+    expect(f[0].text).toContain('XLR')
+  })
+
+  it('nennt das Kabel beim Namen, damit man es findet', () => {
+    const f = rackWireFindings(rack, [kabel({ toPortName: 'Mic In', name: 'K7' })])
+    expect(f[0].text.startsWith('K7')).toBe(true)
+    expect(f[0].index).toBe(0)
+  })
+
+  it('meldet zwei Ausgänge aneinander', () => {
+    const f = rackWireFindings(rack, [
+      kabel({ toPlacementId: 'b', toPortName: 'PGM Out' }),
+    ])
+    expect(arten(f)).toContain('direction-mismatch')
+  })
+})
+
+describe('ein Port, den es nicht gibt, ist der teurere Fehler', () => {
+  // Die Verbindung hängt am NAMEN. Wer den Port umbenennt, lässt das Kabel
+  // auf nichts zeigen — im Rack ist trotzdem eine Linie gezeichnet.
+  it('meldet ihn als Fehler, nicht als Warnung', () => {
+    const f = rackWireFindings(rack, [kabel({ toPortName: 'Gibt es nicht' })])
+    expect(arten(f)).toEqual(['port-unknown'])
+    expect(f[0].severity).toBe('error')
+  })
+
+  it('meldet auch ein Gerät, das nicht mehr im Rack steht', () => {
+    const f = rackWireFindings(rack, [kabel({ toPlacementId: 'weg' })])
+    expect(arten(f)).toEqual(['placement-unknown'])
+    expect(f[0].severity).toBe('error')
+  })
+
+  it('prüft die Stecker dann NICHT mehr — ohne Port gibt es keinen Stecker', () => {
+    const f = rackWireFindings(rack, [kabel({ toPortName: 'Gibt es nicht' })])
+    expect(arten(f)).not.toContain('connector-mismatch')
+  })
+})
+
+describe('was bewusst nicht gemeldet wird', () => {
+  it('lässt „Custom" in Ruhe — er sagt nichts darüber, worauf er passt', () => {
+    const mitCustom = [
+      geraet('a', 'A', [], [{ name: 'Out', connectorType: 'Custom' }]),
+      geraet('b', 'B', [{ name: 'In', connectorType: 'XLR' }]),
+    ]
+    const f = rackWireFindings(mitCustom, [
+      kabel({ fromPortName: 'Out', toPortName: 'In' }),
+    ])
+    expect(arten(f)).not.toContain('connector-mismatch')
+  })
+
+  it('stuft den Steckerunterschied als Warnung ein, nicht als Fehler', () => {
+    // Ein Adapter im Kabel ist ein gültiger Aufbau. Gemeldet ja, verboten nein.
+    expect(RACK_WIRE_FINDING_SEVERITY['connector-mismatch']).toBe('warning')
+  })
+
+  it('hat für jeden Befund einen deutschen Satz', () => {
+    for (const t of Object.values(RACK_WIRE_FINDING_LABEL)) expect(t.length).toBeGreaterThan(10)
+  })
+})


### PR DESCRIPTION
## Übersicht

Fünf Änderungen: zwei offene Issues, zwei gemeldete Bedienfehler und die
Übernahme der neuen Oberflächen-Regeln.

### `#663` — Rack-Planner meldet unpassende Kabeltypen

Der Signalplan prüft das seit langem (`drawingChecks`, Check 2), die
Rack-**interne** Verkabelung nicht — dabei ist sie die, bei der man sich
vertut: dort liegen BNC und XLR in derselben Höheneinheit nebeneinander.
Neu: `lib/rackWireChecks.ts`, gerendert über dem Rack-Canvas.

Ein Port, den es nicht gibt, ist dabei der **teurere** Fehler und deshalb
ein Fehler, keine Warnung: die Verbindung hängt am Namen, und wer einen Port
umbenennt, lässt das Kabel auf nichts zeigen — im Rack ist trotzdem eine
Linie gezeichnet.

### `#664` — Patchbay als Gerätekategorie, mehrstufige Verkabelung

Der eigentliche Defekt lag tiefer als das Issue vermuten lässt. Eine
24er-Blende hat 24 BNC rein und 24 BNC raus — genau darauf trifft die
Struktur-Heuristik in `detectDeviceKind` zu („mindestens acht rein, ebenso
viele raus" → `videohub`). **Jede Patchblende im Plan wurde als Kreuzschiene
geführt**, und die Rückwärtssuche verlangte danach einen geschalteten
Kreuzpunkt, den eine Blende nie hat. Auf dem Blatt stand die Blende als
Quelle statt der Kamera.

- `lib/patchPanel.ts` — die eine Stelle, die beantwortet: ist das eine
  Blende, und welcher Anschluss gehört auf der anderen Seite dazu? Zwei
  Wege, eine Antwort: das Flag `isPatchPanel` **oder** die neue Kategorie
  „Patchfelder".
- `lib/signalChain.ts` + Analyse-Reiter **Signalwege** — der Weg über
  mehrere Ebenen als Ganzes, mit Blende, Wandler, Verteiler und
  geschalteter Kreuzschiene als nachprüfbaren Durchleitungen.
- Jedes Ende hat einen Namen: Ziel / nicht-verkabelt / mehrdeutig /
  zu-lang / Schleife. „Die Kette endet hier" ist als Anzeige wertlos, wenn
  offenbleibt, ob das Gerät das Ziel **ist** oder ob die Ableitung
  aufgegeben hat.

### Gemeldete Bedienfehler

- **Export-Dialog:** der Drucken-Knopf war nicht erreichbar — der Rumpf
  scrollt jetzt, die Fußzeile steht.
- **Kabel-Routing:** der Umweg wurde um genau ein Hindernis gerechnet und
  ohne freien Weg wortlos der kürzeste geliefert. Behoben; und wo es
  wirklich keine freie Führung gibt, steht das jetzt als rotes
  Ausrufezeichen an der Kante — geprüft wird der **gezeichnete** Weg, nicht
  das Router-Ergebnis, weil die Führung nach dem ersten Rechnen persistiert
  wird und ein von Hand gezogener Stützpunkt derselbe Fehler ist.

### Oberflächen-Regeln (ADR-007 der Suite)

Die `--cp-*`-Tokens zeigten auf Tailwinds `slate` und zeigen jetzt auf die
Marken-Palette. Die Utilities bleiben unverändert — genau dafür wurde die
Token-Schicht in #449 angelegt. Rot ist ab jetzt das **Signal**
(Fokusring, Aufnahme-/Live-Zustand), nicht eine Farbe; Fehlerrot ist ein
anderer Ton.

### Nebenbei

Ein geschützter Sendername stand als Beispieltext in der
Projekt-Eingabemaske. Ersetzt, und `tests/geschuetzteNamen.test.ts` hält das
fest.

## Prüfung

`npx tsc -p tsconfig.app.json --noEmit` sauber · `npm run lint` 0 Fehler ·
`npm test` 194 Dateien, 3025 Tests grün.

Jede neue Regel ist gegengeprobt — die Bedingung entfernt, gesehen, dass ein
Test rot wird, zurückgebaut. Was sich so nicht rot färben ließ, ist nicht im
Diff: ein Umweg um das umschließende Rechteck aller Hindernisse stand kurz
im Router und ist wieder heraus.

Closes #663, #664

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_