### PR TITLE
style: Kopfzeile 40 px, Statusleiste 24 px, Dialog-Kopflinie (ADR-007 Abschnitt 6)

### DIFF
--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -542,7 +542,7 @@ export const MenuBar = ({
     projectHistory.canRedo,
   )
   return (
-    <header className="flex shrink-0 items-center justify-between gap-3 border-b border-[var(--cp-border)] bg-[var(--cp-surface-3)] px-3 py-1.5 text-cp-xs shadow-sm">
+    <header className="cp-topbar justify-between text-cp-xs">
       <input ref={cameraImportRef} type="file" accept=".cameras.json,.json" className="hidden" onChange={handleImportCameras} />
       <input ref={avplanImportRef} type="file" accept=".avplan,.json" className="hidden" onChange={handleImportAvplan} />
       <input ref={sourceMapImportRef} type="file" accept=".avsourcemap,.json" className="hidden" onChange={handleImportSourceMap} />

--- a/src/renderer/components/Layout/StatusBar.tsx
+++ b/src/renderer/components/Layout/StatusBar.tsx
@@ -165,7 +165,7 @@ export const StatusBar = ({
         : 'bg-emerald-700 text-emerald-50'
   const checkIcon = errorCount > 0 ? AlertCircle : warningCount > 0 ? AlertTriangle : CheckCircle2
   return (
-    <footer className="flex shrink-0 items-center justify-between gap-3 border-t border-[var(--cp-border)] bg-[var(--cp-surface-3)] px-3 py-1 text-cp-xs text-[var(--cp-text-secondary)]">
+    <footer className="cp-statusbar justify-between gap-3 text-cp-xs">
       <div className="flex min-w-0 items-center gap-3 overflow-hidden">
         <span className="truncate font-medium text-[var(--cp-text)]">{projectName}</span>
         <span className="text-[var(--cp-text-faint)]" aria-hidden="true">|</span>

--- a/src/renderer/components/shared/ModalShell.tsx
+++ b/src/renderer/components/shared/ModalShell.tsx
@@ -101,11 +101,14 @@ export const ModalShell = ({
         aria-labelledby={titleId}
         {...dialogProps}
         style={draggableKey ? drag.containerStyle : undefined}
-        className={`cp-modal-panel flex max-h-[90vh] w-full ${MAX_WIDTH_CLASS[maxWidth]} flex-col overflow-hidden rounded-cp-modal border border-cp-border bg-cp-surface-1 text-cp-text shadow-2xl outline-none`}
+        className={`cp-modal-panel flex max-h-[90vh] w-full ${MAX_WIDTH_CLASS[maxWidth]} flex-col overflow-hidden rounded-cp-modal border border-cp-border bg-cp-surface-1 text-cp-text outline-none`}
       >
         <header
           {...(draggableKey ? drag.headerProps : {})}
-          className="flex items-center justify-between border-b border-cp-border px-cp-4 py-cp-3 select-none"
+          /* ADR-007 Abschnitt 6: die Kopflinie ist der Akzent. `cp-panel-head`
+             traegt sie; `justify-between` und `select-none` bleiben, weil sie
+             zum Dialog gehoeren und nicht zum Rahmen. */
+          className="cp-panel-head justify-between select-none"
         >
           <h2 id={titleId} className="flex items-center text-cp-xl font-semibold">
             {titleIcon && <span className="mr-2">{titleIcon}</span>}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -704,3 +704,56 @@ button:disabled,
     scroll-behavior: auto !important;
   }
 }
+
+/* ── ADR-007 Abschnitt 6: der Rahmen ────────────────────────────────────────
+ *
+ * „Damit alle acht Werkzeuge gleich zu bedienen sind, steht der Rahmen fest."
+ * Die Suite hat dafuer `.av-topbar` (40 px), `.av-statusbar` (24 px) und
+ * `.av-panel-head` in `@avplan/ui`. Der Cable-Planner laeuft auch ALLEIN als
+ * Electron-App und kann das Paket nicht laden; deshalb stehen die drei
+ * Klassen hier mit denselben Zahlen.
+ *
+ * ALS KLASSE UND NICHT ALS UTILITY AM ELEMENT, und das ist der Punkt: `h-10`
+ * an der Kopfzeile waere dieselbe Zahl, aber keine Regel — sie stuende an
+ * einer Stelle im Markup und liesse sich beim naechsten Umbau still auf
+ * `py-1.5` zuruecksetzen (genau so stand sie vorher hier). Als benannte
+ * Klasse ist sie eine Zusage, die `tests/rahmenMasse.test.ts` messen kann.
+ *
+ * WAS HIER FEHLT: die Modul-Rail (56 px). Sie ordnet die MODULE der Suite —
+ * Kabel, Licht, Kameras — und gehoert deshalb in die Shell. Eine Rail im
+ * Cable-Planner haette genau einen Eintrag und waere 56 px verschenkte
+ * Breite, die nichts ordnet. */
+
+.cp-topbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: 40px;
+  flex: none;
+  padding: 0 12px;
+  background: var(--cp-surface-3);
+  border-bottom: 1px solid var(--cp-border);
+}
+
+.cp-statusbar {
+  display: flex;
+  align-items: center;
+  height: 24px;
+  flex: none;
+  padding: 0 12px;
+  background: var(--cp-surface-3);
+  border-top: 1px solid var(--cp-border);
+  font-size: 12px;
+  color: var(--cp-text-secondary);
+}
+
+/* Die Kopflinie eines Dialogs/Panels: „Dialoge sind Flaechen, keine Karten —
+ * kein Radius, kein Schatten, Kopflinie oben." Die Linie ist der Akzent, nicht
+ * eine Flaeche in Akzentfarbe: sie trennt, ohne einen Balken zu setzen. */
+.cp-panel-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--cp-accent);
+}

--- a/tests/rahmenMasse.test.ts
+++ b/tests/rahmenMasse.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import menuSrc from '../src/renderer/components/Layout/MenuBar.tsx?raw'
+import statusSrc from '../src/renderer/components/Layout/StatusBar.tsx?raw'
+import modalSrc from '../src/renderer/components/shared/ModalShell.tsx?raw'
+import { stripComments } from './support/stripComments'
+
+// ---------------------------------------------------------------------------
+// ADR-007 Abschnitt 6 — der Rahmen, in Zahlen.
+//
+//   > Damit alle acht Werkzeuge gleich zu bedienen sind, steht der Rahmen
+//   > fest. … Kopfzeile 40 px … Statusleiste unten, 24 px.
+//
+// WARUM DAS EINEN TEST BRAUCHT. Vor dieser Aenderung stand die Hoehe der
+// Kopfzeile nirgends: sie ergab sich aus `py-1.5` plus dem hoechsten Kind.
+// Das ist keine Zahl, sondern ein Zufall — er aendert sich, sobald jemand
+// einen Knopf mit mehr Innenabstand einbaut, und niemand merkt es. Genau so
+// laufen acht Werkzeuge auseinander, die „eigentlich gleich" aussehen sollen.
+//
+// Der Test misst die CSS-Klasse und nicht das Markup. Das ist Absicht: eine
+// Utility (`h-10`) am Element waere dieselbe Zahl, aber keine Regel — sie
+// stuende an einer Stelle und liesse sich beim naechsten Umbau still
+// zuruecksetzen. Eine benannte Klasse ist eine Zusage.
+//
+// GEGENGEPROBT: Hoehe in `.cp-topbar` auf 44 px geaendert -> rot; `cp-topbar`
+// im MenuBar durch die alte Utility-Kette ersetzt -> rot; `shadow-2xl` am
+// Dialog wieder eingesetzt -> rot.
+// ---------------------------------------------------------------------------
+
+const css = readFileSync(resolve(__dirname, '..', 'src', 'renderer', 'index.css'), 'utf8')
+
+/** Der Rumpf einer Klasse aus `index.css` — ohne Kommentare. */
+const regel = (klasse: string): string => {
+  const m = new RegExp(`\\.${klasse}\\s*\\{([^}]*)\\}`).exec(stripComments(css))
+  expect(m, `Regel .${klasse} fehlt in index.css`).not.toBeNull()
+  return m![1]
+}
+
+describe('ADR-007 Abschnitt 6: der Rahmen steht fest', () => {
+  it('die Kopfzeile ist 40 px hoch', () => {
+    expect(regel('cp-topbar')).toMatch(/height:\s*40px/)
+  })
+
+  it('die Statusleiste ist 24 px hoch', () => {
+    expect(regel('cp-statusbar')).toMatch(/height:\s*24px/)
+  })
+
+  it('beide sind unnachgiebig — sie schrumpfen nicht mit', () => {
+    // `flex: none` statt `shrink-0`: ohne das gibt eine volle Arbeitsflaeche
+    // der Kopfzeile Pixel weg, und die feste Zahl waere wieder keine.
+    expect(regel('cp-topbar')).toMatch(/flex:\s*none/)
+    expect(regel('cp-statusbar')).toMatch(/flex:\s*none/)
+  })
+
+  it('die Kopflinie eines Dialogs ist der Akzent', () => {
+    // „Kopflinie oben" — eine LINIE, kein Balken in Akzentfarbe. Deshalb
+    // border-bottom und kein background.
+    const kopf = regel('cp-panel-head')
+    expect(kopf).toMatch(/border-bottom:\s*1px solid var\(--cp-accent\)/)
+    expect(kopf).not.toMatch(/background/)
+  })
+
+  it('Kopfzeile, Statusleiste und Dialogkopf benutzen die Klassen wirklich', () => {
+    // Eine Regel, die niemand anwendet, ist Dekoration in einer CSS-Datei.
+    expect(stripComments(menuSrc)).toMatch(/<header className="cp-topbar/)
+    expect(stripComments(statusSrc)).toMatch(/<footer className="cp-statusbar/)
+    expect(stripComments(modalSrc)).toMatch(/className="cp-panel-head/)
+  })
+
+  it('Dialoge sind Flaechen, keine Karten — kein Schatten', () => {
+    // „Dialoge sind Flaechen, keine Karten: kein Radius, kein Schatten."
+    // Der Radius liegt bereits bei 0 (Token-Schicht); der Schatten stand
+    // noch am Panel.
+    expect(stripComments(modalSrc)).not.toMatch(/shadow-2xl|shadow-xl|shadow-lg/)
+  })
+})


### PR DESCRIPTION
ADR-007 Abschnitt 6 legt den Rahmen fest, damit alle acht Werkzeuge gleich zu bedienen sind. Im Cable-Planner stand davon bisher **keine einzige Zahl**.

Die Höhe der Kopfzeile ergab sich aus `py-1.5` plus dem höchsten Kind. Das ist keine Zahl, sondern ein Zufall: er ändert sich, sobald jemand einen Knopf mit mehr Innenabstand einbaut, und niemand merkt es. Genau so laufen acht Oberflächen auseinander, die „eigentlich gleich" aussehen sollen. Dasselbe galt für die Statusleiste.

## Drei Klassen in `index.css`

Dieselben Zahlen wie `.av-topbar`, `.av-statusbar` und `.av-panel-head` in `@avplan/ui`:

| Klasse | Maß |
| --- | --- |
| `.cp-topbar` | 40 px, `flex: none` |
| `.cp-statusbar` | 24 px, `flex: none` |
| `.cp-panel-head` | Kopflinie in der Akzentfarbe |

Sie stehen hier und nicht im Paket, weil der Cable-Planner auch **allein** als Electron-App läuft und `@avplan/ui` dort nicht geladen ist.

**Als Klasse und nicht als Utility am Element:** `h-10` an der Kopfzeile wäre dieselbe Zahl, aber keine Regel — sie stünde an einer Stelle im Markup und ließe sich beim nächsten Umbau still auf `py-1.5` zurücksetzen, also genau auf den Zustand, den dieser PR behebt.

`flex: none` statt `shrink-0`: ohne das gibt eine volle Arbeitsfläche der Kopfzeile Pixel weg, und die feste Zahl wäre wieder keine.

## Am Dialog

Zwei Punkte aus demselben Abschnitt: die Kopfzeile bekommt die Kopflinie — eine *Linie* in der Akzentfarbe, kein Balken, deshalb `border-bottom` und kein `background` — und `shadow-2xl` fällt weg. „Dialoge sind Flächen, keine Karten: kein Radius, kein Schatten." Der Radius liegt durch die Token-Schicht bereits bei 0; der Schatten stand noch am Panel.

## Was bewusst fehlt

Die **Modul-Rail (56 px)**. Sie ordnet die *Module der Suite* — Kabel, Licht, Kameras — und gehört in die Shell. Eine Rail im Cable-Planner hätte genau einen Eintrag und wäre 56 px verschenkte Breite, die nichts ordnet. Der Kommentar in `index.css` sagt das, damit es nicht als Versäumnis gelesen wird.

Die Kommandopalette auf `Strg/Cmd + K` gibt es hier bereits (`components/Layout/CommandPalette.tsx`).

## Prüfstand

`tests/rahmenMasse.test.ts` misst die sechs Zusagen, **alle vier Regeln gegengeprobt**: Höhe 40 → 44 rot · Klasse im MenuBar zurückgebaut rot · `shadow-2xl` wieder eingesetzt rot · `flex: none` entfernt rot.

`tsc` 0 Fehler · `lint` 0 Errors · 3036 Tests grün. (`npm run ui:smoke` braucht ein X-Display und läuft nur in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_