### PR TITLE
dev: Dev-Server auf 4181, wo die Suite ihn sucht (B-17)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ React 19 + TypeScript + Zustand + ReactFlow + Three.js, offline-first.
 ```bash
 npm install                              # Dependencies (rebuildet native Module: keytar, freetype2)
 npm run dev                              # Vite + 3× tsc-watch (main/preload/renderer) + Electron, hot-reload
-npm run dev:renderer                     # nur Renderer im Browser (localhost:5173) — Desktop-Features inert
+npm run dev:renderer                     # nur Renderer im Browser (localhost:4181) — Desktop-Features inert
 npm run build                            # build:main + build:preload + build:renderer
 npm run dist                             # build + electron-builder → Installer in release/
 npm run lint                             # eslint .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ npm install
 # Run the full Electron shell with hot-reload
 npm run dev
 
-# Renderer-only in a plain browser (desktop features inert) → localhost:5173
+# Renderer-only in a plain browser (desktop features inert) → localhost:4181
 npm run dev:renderer
 ```
 

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ npm run dist
 ```
 
 > Tip: `npm run dev` launches the full Electron shell. The renderer also runs
-> in a plain browser (`npm run dev:renderer` → `localhost:5173`) for quick UI
+> in a plain browser (`npm run dev:renderer` → `localhost:4181`) for quick UI
 > work, though desktop-only features (file I/O, ATEM/LAN) are inert there.
 
 ---

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "dev:renderer": "vite",
     "dev:main": "tsc -p tsconfig.main.json --watch",
     "dev:preload": "tsc -p tsconfig.preload.json --watch",
-    "dev:electron": "wait-on http-get://localhost:5173 dist/main/index.js dist/main/preload.cjs && cross-env VITE_DEV_SERVER_URL=http://localhost:5173 electron .",
+    "dev:electron": "wait-on http-get://localhost:4181 dist/main/index.js dist/main/preload.cjs && cross-env VITE_DEV_SERVER_URL=http://localhost:4181 electron .",
     "build": "npm run build:main && npm run build:preload && npm run build:renderer",
     "build:main": "tsc -p tsconfig.main.json && node scripts/mark-main-esm.mjs",
     "build:preload": "tsc -p tsconfig.preload.json",

--- a/scripts/drag-test.mjs
+++ b/scripts/drag-test.mjs
@@ -6,7 +6,7 @@
  * Prüft, dass Geräte-Knoten, Location-Rahmen und die Inline-Auswahl-Toolbar
  * (#118) sich verhalten wie erwartet, und meldet Renderer-Konsolenfehler.
  *
- * Voraussetzung: `npm run dev:renderer` läuft auf :5173.
+ * Voraussetzung: `npm run dev:renderer` läuft auf :4181.
  * Lauf:          npm run test:drag   (oder: node scripts/drag-test.mjs)
  *   Browser-Pfad ggf. via CP_CHROME=… überschreiben (Sandbox), Screenshots
  *   landen in CP_UI_SHOTS (Default /tmp/cp-drag-shots).
@@ -15,7 +15,7 @@ import { chromium } from 'playwright-core'
 import { mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 
-const URL = process.env.CP_URL || 'http://localhost:5173/'
+const URL = process.env.CP_URL || 'http://localhost:4181/'
 const OUT = process.env.CP_UI_SHOTS || '/tmp/cp-drag-shots'
 mkdirSync(OUT, { recursive: true })
 

--- a/tests/ciFaehrtJedePruefung.test.ts
+++ b/tests/ciFaehrtJedePruefung.test.ts
@@ -74,7 +74,7 @@ const istPruefung = (name: string): boolean =>
 const OHNE_CI: Record<string, string> = {
   'test:watch': 'Interaktiver Watch-Modus. In CI waere er ein Lauf, der nie endet.',
   'test:drag':
-    'Braucht einen laufenden `dev:renderer` auf localhost:5173 und einen echten Browser. ' +
+    'Braucht einen laufenden `dev:renderer` auf localhost:4181 und einen echten Browser. ' +
     'Ein CI-Job dafuer muesste den Dev-Server hochfahren und wieder abraeumen; bis jemand das baut, ' +
     'ist der Lauf ein Werkzeug fuer die Hand, keine Zusicherung.',
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -71,6 +71,19 @@ export default defineConfig({
   // Use relative asset paths so file:// loading from Electron works.
   base: './',
   server: {
+    // Suite-Einbettung (Backlog B-17): Die Shell erwartet den Cable-Planer im
+    // Entwicklungsbetrieb auf 4181 — so steht es in ihrer `registry.ts` und in
+    // ihrer README. Ohne feste Angabe landete er auf dem Vite-Standard 5173,
+    // wo ihn niemand sucht; startete daneben ein zweiter Planer, rueckte einer
+    // von beiden still auf 5174 weiter. Die Shell zeigte dann „Signal-Flow ist
+    // gerade nicht erreichbar", und der Fehler sah aus wie ein Fehler der
+    // Shell.
+    //
+    // `strictPort`, damit ein besetzter Port ABBRICHT statt weiterzuruecken.
+    // Genau das stille Weiterruecken ist der Defekt; ein Startfehler mit
+    // Portnummer ist die bessere Meldung.
+    port: 4181,
+    strictPort: true,
     proxy: {
       '/api/rentman': {
         target: 'https://api.rentman.net',


### PR DESCRIPTION
Die Shell der av-planner-suite erwartet den Cable-Planer im Entwicklungsbetrieb auf `localhost:4181` — so steht es in ihrer `modules/registry.ts` und in ihrer README. Hier stand **gar kein Port**, also nahm Vite seinen Standard 5173. Dort sucht die Shell nicht.

Es war nicht der Ausnahme-, sondern der Normalfall: wer der Suite-README Schritt für Schritt folgte, sah sechs Sekunden „wird geladen…" und danach *„Signal-Flow ist gerade nicht erreichbar"* — ein Fehler, der aussah wie einer der Shell, und die Suche begann an der falschen Stelle. Startete daneben ein zweiter Planer, rückte einer von beiden zusätzlich still auf 5174 weiter.

`strictPort: true`, damit ein besetzter Port **abbricht** statt weiterzurücken. Genau dieses stille Weiterrücken ist die zweite Hälfte des Defekts: die Zahl in der Konfiguration stimmt dann zwar, der laufende Server hört aber woanders. Ein Startfehler mit Portnummer ist die bessere Meldung.

Nachgezogen, wo 5173 sonst noch als Adresse stand: `dev:electron` (wait-on und `VITE_DEV_SERVER_URL`), README, CLAUDE.md, CONTRIBUTING.md, `scripts/drag-test.mjs` und der Hinweistext in `tests/ciFaehrtJedePruefung.test.ts`. Die übrigen Treffer sind Fließtext über fremde Dev-Server und bleiben.

**Nur Entwickler-Schaden**: die ausgelieferte Desktop-App nimmt den gebündelten Pfad und war nie betroffen.

Die Suite bekommt dazu einen Wächter (`devports:check`), der Shell-Fallback und `vite.config.ts` gegeneinander misst — zwei Quellen, die beide Code sind, statt einer Zahl in einer README, die veralten kann.

`tsc` 0 Fehler · 3036 Tests grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_