### PR TITLE
as-built: die Verkabelung kommt aufs As-built-Blatt (B-9)

### DIFF
--- a/src/renderer/components/Network/ReconcileDialog.tsx
+++ b/src/renderer/components/Network/ReconcileDialog.tsx
@@ -20,6 +20,7 @@ import {
 import {
   asBuiltSummary,
   asBuiltTable,
+  fromCabling,
   fromNetworkReport,
   mergeEntries,
   unverifiedEntries,
@@ -46,6 +47,8 @@ export const ReconcileDialog = () => {
   const open = useUiStore((s) => s.reconcileOpen)
   const setOpen = useUiStore((s) => s.setReconcileOpen)
   const equipment = useProjectStore((s) => s.project.equipment)
+  const cables = useProjectStore((s) => s.project.cables)
+  const checkState = useProjectStore((s) => s.project.checkState)
   const projectName = useProjectStore((s) => s.project.metadata.name)
 
   const [scan, setScan] = useState<NetworkScan | null>(null)
@@ -72,8 +75,22 @@ export const ReconcileDialog = () => {
         .map((e) => ({ subject: e.name, field: 'IP-Adresse', planned: e.ipAddress })),
       'network-scan',
     )
-    return mergeEntries(geplant, report ? fromNetworkReport(report) : [])
-  }, [equipment, report])
+    // B-9 — die Verkabelung gehoert auf DASSELBE Blatt.
+    //
+    // Ein zweites „As-built (Kabel)"-Dokument waere genau die Vervielfachung,
+    // gegen die dieses Modul gebaut ist: die Post haette dann zwei Blaetter
+    // und muesste sie selbst zusammenlegen. `mergeEntries` haelt sie
+    // auseinander, weil das FELD Teil des Schluessels ist — „IP-Adresse" und
+    // „Verbindung gesteckt" kollidieren nicht.
+    //
+    // Der Zeitpunkt kommt aus `checkState.receivedAt` und nicht von hier: der
+    // Dialog weiss nicht, wann jemand abgehakt hat, und darf es nicht raten.
+    return mergeEntries(
+      geplant,
+      report ? fromNetworkReport(report) : [],
+      fromCabling(cables, equipment, checkState),
+    )
+  }, [equipment, report, cables, checkState])
 
   const asBuiltStand = useMemo(() => asBuiltSummary(asBuilt), [asBuilt])
 

--- a/src/renderer/lib/asBuilt.ts
+++ b/src/renderer/lib/asBuilt.ts
@@ -31,6 +31,20 @@
 // deshalb NICHTS neu — es nimmt, was die vier schon liefern, und bringt es in
 // EINE Zeilenform mit EINEM Urteil.
 //
+// ─── UND EINE FÜNFTE, DIE ES NOCH NICHT GAB (B-9) ──────────────────────────
+//
+// Die vier befragen GERÄTE. Keines von ihnen weiss, ob ein Kabel steckt.
+// Genau das war B-9s Befund: für den Gerätezustand existiert der Abgleich,
+// für die VERKABELUNG gibt es die Datenspur (`checkState.ports`) und keine
+// Gegenüberstellung.
+//
+// `fromCabling` ist deshalb der einzige Zubringer, der etwas RECHNET statt
+// zu übersetzen — und das ist kein Bruch der Regel darüber, sondern ihr
+// Grund: eine zweite Rechnung wäre eine zweite Wahrheit, eine ERSTE ist
+// schlicht die Antwort auf eine Frage, die bis hierher niemand gestellt hat.
+// Es gibt kein `cablingReconcile`, das sie schon beantwortet hätte; die Haken
+// vom Handy standen als Häkchen im Canvas und gingen in kein Dokument ein.
+//
 // ─── DIE REGEL, DIE DAS BLATT TRÄGT ────────────────────────────────────────
 //
 // OHNE ABLESUNG GIBT ES KEIN „STIMMT". Eine Zeile, zu der kein Gerät befragt
@@ -57,7 +71,8 @@ import type { LiveComparison } from './atemLiveCompare'
 import { allDeltas } from './atemLiveCompare'
 import type { ReconcileReport } from './networkReconcile'
 import { salvoChanges } from './salvoSheet'
-import type { VideohubCrosspoints } from '../types/equipment'
+import type { EquipmentItem, VideohubCrosspoints } from '../types/equipment'
+import type { Cable } from '../types/cable'
 import type { CsvTable } from './csv'
 
 /** Woher eine Ablesung stammt. */
@@ -70,6 +85,8 @@ export type ReadingSource =
   | 'videohub'
   /** Die Vermietungs-Software. */
   | 'erp'
+  /** B-9 — der Haken vom Handy: was der Field-Tech vor Ort abgehakt hat. */
+  | 'field-check'
   /** Von Hand eingetragen, weil niemand das Gerät befragen kann. */
   | 'manual'
 
@@ -78,6 +95,7 @@ export const READING_SOURCE_LABEL: Readonly<Record<ReadingSource, string>> = {
   atem: 'Mischer',
   videohub: 'Router',
   erp: 'Vermietung',
+  'field-check': 'Aufbau vor Ort',
   manual: 'von Hand',
 }
 
@@ -274,6 +292,146 @@ export function fromCrosspoints(
     if (c.to !== undefined) entry.actual = String(c.to + 1)
     return entry
   })
+}
+
+/**
+ * B-9 — die FÜNFTE Quelle: der Aufbau selbst.
+ *
+ *   > Für die **Verkabelung** gibt es die Datenspur (`checkState.ports`), aber
+ *   > keine Gegenüberstellung Soll-Kabel gegen gesteckte Ports.
+ *
+ * Die vier Quellen darüber befragen GERÄTE. Keine von ihnen weiss, ob ein
+ * Kabel steckt — ein Mischer meldet seine Kreuzpunkte, nicht sein SDI-Blech.
+ * Der einzige, der es weiss, ist der Mensch auf der Leiter, und der hat es
+ * längst gemeldet: `checkState` trägt seit v7.9.3 genau diese Haken, gesetzt
+ * über `POST /checks` vom Handy. Sie standen bis hierher nur als Häkchen am
+ * Port im Canvas und gingen in kein einziges Dokument ein.
+ *
+ * ─── DIE OFFENE FRAGE VON B-9, UND WARUM SIE KEINE MEHR IST ────────────────
+ *
+ * B-9 fragte: „Wo wohnt der As-built-Zustand — eigene Spur je Feld, oder
+ * Plan-Überschreiben mit Revisionen? Entscheidet, ob `Provenance` einen
+ * fünften Wert braucht."
+ *
+ * Beantwortet hat die Frage dieses Modul, bevor sie gestellt wurde: der
+ * As-built-Zustand wohnt in einer EIGENEN SPUR (`AsBuiltEntry` mit
+ * `ReadingSource`), das Blatt stellt Absicht und Beobachtung nebeneinander,
+ * und in den Plan zurück schreibt es nichts. Deshalb braucht `Provenance`
+ * keinen fünften Wert: `Provenance` sagt, woher eine Angabe IM PLAN stammt,
+ * und eine Ablesung wird nie eine Angabe im Plan. Die Verkabelung fügt sich
+ * hier ohne Sonderweg ein — sie war schlicht die einzige der fünf Quellen,
+ * die noch niemand angeschlossen hatte.
+ *
+ * ─── WELCHE URTEILE HIER ÜBERHAUPT ENTSTEHEN KÖNNEN ────────────────────────
+ *
+ * Der Haken ist BINÄR und kennt kein „nein". `false` heisst „noch nicht
+ * abgehakt", nicht „nicht gesteckt" — das Handy setzt und löscht denselben
+ * Wert. Daraus eine `missing`-Zeile zu machen wäre eine Ablesung, die
+ * niemand gemacht hat. Diese Quelle liefert deshalb nur:
+ *
+ *   `match`         Plan will die Verbindung, jemand hat sie abgehakt.
+ *   `not-verified`  Plan will sie, niemand war dran.
+ *   `unexpected`    Abgehakt ist etwas, das der Plan nicht (mehr) kennt.
+ *
+ * `unexpected` ist der Fall, der die Arbeit trägt: er entsteht, wenn der Plan
+ * sich geändert hat, NACHDEM die Crew losgezogen ist. Ein Kabel, das aus dem
+ * Plan geflogen ist, während sein Haken stehenblieb, steckt draussen immer
+ * noch.
+ *
+ * ─── DER ZEITPUNKT ─────────────────────────────────────────────────────────
+ *
+ * `receivedAt` kommt aus `checkState` und ist die Ankunft der Meldung
+ * (`mobileSyncSlice.setCheckState`). Fehlt er — Projekt aus der Zeit vor dem
+ * Feld —, dann trägt KEINE Zeile hier einen Zeitpunkt, und das Blatt sagt
+ * durchgehend „nicht nachgesehen". Das ist die richtige Auskunft: Haken,
+ * deren Alter niemand kennt, sind keine Ablesung.
+ */
+export function fromCabling(
+  cables: readonly Cable[],
+  equipment: readonly EquipmentItem[],
+  checkState:
+    | { ports: Record<string, boolean>; cables: Record<string, boolean>; receivedAt?: string }
+    | undefined,
+): AsBuiltEntry[] {
+  const at = checkState?.receivedAt
+  const hakenKabel = checkState?.cables ?? {}
+  const hakenPorts = checkState?.ports ?? {}
+
+  const eqById = new Map(equipment.map((e) => [e.id, e]))
+  const portName = (deviceId: string, portId: string): string | undefined => {
+    const device = eqById.get(deviceId)
+    if (!device) return undefined
+    const port = [...device.inputs, ...device.outputs].find((p) => p.id === portId)
+    if (!port) return undefined
+    return `${device.name} · ${port.name}`
+  }
+
+  const kabelName = (c: Cable): string => {
+    if (c.name.trim()) return c.name.trim()
+    const von = portName(c.fromEquipmentId, c.fromPortId) ?? c.fromPortId
+    const nach = portName(c.toEquipmentId, c.toPortId) ?? c.toPortId
+    return `${von} → ${nach}`
+  }
+
+  const zeilen: AsBuiltEntry[] = []
+
+  // (a) Jede geplante Verbindung — abgehakt oder nicht.
+  for (const c of cables) {
+    const eintrag: AsBuiltEntry = {
+      subject: kabelName(c),
+      field: 'Verbindung gesteckt',
+      planned: 'ja',
+      source: 'field-check',
+    }
+    if (hakenKabel[c.id] === true && at) {
+      eintrag.actual = 'ja'
+      eintrag.at = at
+    }
+    zeilen.push(eintrag)
+  }
+
+  // (b) Haken an Kabeln, die der Plan nicht mehr kennt.
+  const kabelIds = new Set(cables.map((c) => c.id))
+  for (const [id, gesetzt] of Object.entries(hakenKabel)) {
+    if (!gesetzt || kabelIds.has(id) || !at) continue
+    zeilen.push({
+      subject: `Kabel ${id}`,
+      field: 'Verbindung gesteckt',
+      actual: 'ja',
+      source: 'field-check',
+      at,
+    })
+  }
+
+  // (c) Ports — NUR die abgehakten.
+  //
+  // Ein Port trägt seinen Soll-Zustand schon in seinem Kabel; eine zweite
+  // „noch nicht abgehakt"-Zeile je Ende verdoppelte bloss die Lücke, die die
+  // Kabelzeile (a) bereits meldet. Wo ein Haken sitzt, trägt der Port dagegen
+  // etwas Eigenes bei: dass jemand ihn angefasst hat — und, wenn der Plan
+  // dort kein Kabelende führt, dass der Plan das nicht erklärt.
+  const geplanteEnden = new Set<string>()
+  for (const c of cables) {
+    geplanteEnden.add(`${c.fromEquipmentId}|${c.fromPortId}`)
+    geplanteEnden.add(`${c.toEquipmentId}|${c.toPortId}`)
+  }
+  for (const [key, gesetzt] of Object.entries(hakenPorts)) {
+    if (!gesetzt || !at) continue
+    const trenner = key.indexOf('|')
+    const deviceId = trenner < 0 ? key : key.slice(0, trenner)
+    const portId = trenner < 0 ? '' : key.slice(trenner + 1)
+    const eintrag: AsBuiltEntry = {
+      subject: portName(deviceId, portId) ?? key,
+      field: 'Port gesteckt',
+      actual: 'ja',
+      source: 'field-check',
+      at,
+    }
+    if (geplanteEnden.has(key)) eintrag.planned = 'ja'
+    zeilen.push(eintrag)
+  }
+
+  return zeilen
 }
 
 /**

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -474,6 +474,8 @@ export interface ProjectState {
   /** v7.9.3 — Mobile-Viewer Check-State setzen (vom POST /checks-IPC).
    *  Komplettes Objekt-Replace damit gelöschte Checks (false → kein
    *  key) auch übernommen werden. */
+  /** B-9 — `receivedAt` setzt der Slice selbst; der Aufrufer liefert nur die
+   *  Haken. Wer den Zeitpunkt mitgeben duerfte, koennte ihn faelschen. */
   setCheckState: (checks: { ports: Record<string, boolean>; cables: Record<string, boolean> }) => void
   /** Einzelnen Port-Check (Mobile-Haeckchen) im Canvas entfernen.
    *  User-Request: "man muss die haken an den ports die man mobil

--- a/src/renderer/store/slices/mobileSyncSlice.ts
+++ b/src/renderer/store/slices/mobileSyncSlice.ts
@@ -33,7 +33,21 @@ export type MobileSyncSlice = Pick<
 export const createMobileSyncSlice: StateCreator<ProjectState, [], [], MobileSyncSlice> = (set) => ({
   setCheckState: (checks) =>
     set((state) => {
-      const updated = { ...state.project, checkState: checks }
+      // B-9 — HIER faellt der Zeitpunkt an, und nirgends sonst.
+      //
+      // Diese Funktion laeuft, wenn das Handy `POST /checks` geschickt hat
+      // (App.tsx, `onChecksUpdate`) — nicht in einer Schleife, nicht beim
+      // Rendern. Der Stempel ist damit die Ankunft der Meldung, und das ist
+      // der einzige Zeitpunkt, den dieser Plan ueber die Haken wissen kann.
+      //
+      // Er steht hier statt beim Aufrufer, weil ein Zeitpunkt, den der
+      // Aufrufer mitgeben duerfte, kein Beleg mehr waere: das As-built-Blatt
+      // liest ihn als „nachgesehen am", und wer ihn setzen kann, kann
+      // „nachgesehen" behaupten, ohne nachgesehen zu haben.
+      const updated = {
+        ...state.project,
+        checkState: { ...checks, receivedAt: new Date().toISOString() },
+      }
       scheduleProjectAutosave(updated)
       return { project: updated }
     }),
@@ -45,9 +59,12 @@ export const createMobileSyncSlice: StateCreator<ProjectState, [], [], MobileSyn
       if (!cur.ports[key]) return state
       const nextPorts = { ...cur.ports }
       delete nextPorts[key]
+      // `receivedAt` bleibt stehen: der Planer hat EINEN Haken zurueckgenommen,
+      // nicht die Meldung des Handys ungeschehen gemacht. Die uebrigen Haken
+      // stammen weiterhin aus derselben Ablesung.
       const updated = {
         ...state.project,
-        checkState: { ports: nextPorts, cables: cur.cables },
+        checkState: { ...cur, ports: nextPorts, cables: cur.cables },
       }
       scheduleProjectAutosave(updated)
       return { project: updated }
@@ -61,7 +78,7 @@ export const createMobileSyncSlice: StateCreator<ProjectState, [], [], MobileSyn
       delete nextCables[cableId]
       const updated = {
         ...state.project,
-        checkState: { ports: cur.ports, cables: nextCables },
+        checkState: { ...cur, ports: cur.ports, cables: nextCables },
       }
       scheduleProjectAutosave(updated)
       return { project: updated }
@@ -76,6 +93,9 @@ export const createMobileSyncSlice: StateCreator<ProjectState, [], [], MobileSyn
       ) {
         return state
       }
+      // Hier faellt `receivedAt` WEG — und zwar absichtlich. Nach „alle Haken
+      // loeschen" ist nichts mehr abgelesen; ein stehengebliebener Zeitpunkt
+      // wuerde einem leeren Stand ein Alter geben, das er nicht hat.
       const updated = {
         ...state.project,
         checkState: { ports: {}, cables: {} },

--- a/src/renderer/types/project.ts
+++ b/src/renderer/types/project.ts
@@ -193,6 +193,22 @@ export interface CablePlannerProject {
   checkState?: {
     ports: Record<string, boolean>
     cables: Record<string, boolean>
+    /** B-9 — WANN dieser Stand hereinkam (ISO). Gesetzt von `setCheckState`,
+     *  also in dem Moment, in dem der Desktop die Meldung des Handys
+     *  entgegennimmt.
+     *
+     *  Das ist nicht die Sekunde, in der jemand auf der Leiter getippt hat —
+     *  die kennt dieser Plan nicht und soll sie auch nicht behaupten. Es ist
+     *  der fruehestmoegliche Zeitpunkt, den er WEISS, und genau darum steht
+     *  er hier: das As-built-Blatt verlangt zu jeder Ablesung einen
+     *  Zeitpunkt, und ein Haken ohne Zeitpunkt ist keine Ablesung, sondern
+     *  eine Behauptung (`lib/asBuilt.ts`).
+     *
+     *  Optional und OHNE Default in `healProjectPositions`: eine Zeit zu
+     *  erfinden waere schlimmer als keine zu haben. Ein Projekt aus der Zeit
+     *  vor diesem Feld hat Haken, deren Alter niemand kennt — und das
+     *  As-built-Blatt sagt dann „nicht nachgesehen" statt „stimmt". */
+    receivedAt?: string
   }
   /** v7.9.3 — Lock-Status des Projekts:
    *   - 'editing' (Default): voll bearbeitbar

--- a/tests/asBuilt.test.ts
+++ b/tests/asBuilt.test.ts
@@ -7,6 +7,7 @@ import {
   asBuiltSummary,
   asBuiltTable,
   asBuiltVerdict,
+  fromCabling,
   fromCrosspoints,
   fromLiveComparison,
   fromNetworkReport,
@@ -16,8 +17,11 @@ import {
 } from '../src/renderer/lib/asBuilt'
 import type { LiveComparison } from '../src/renderer/lib/atemLiveCompare'
 import type { ReconcileReport } from '../src/renderer/lib/networkReconcile'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
 import libQuelle from '../src/renderer/lib/asBuilt.ts?raw'
 import dialogQuelle from '../src/renderer/components/Network/ReconcileDialog.tsx?raw'
+import sliceQuelle from '../src/renderer/store/slices/mobileSyncSlice.ts?raw'
 
 // ---------------------------------------------------------------------------
 // „Wie geplant" gegen „wie gebaut" (Bedarf 126, P4).
@@ -308,6 +312,160 @@ describe('mergeEntries', () => {
   })
 })
 
+// ── 5b. Die fuenfte Quelle: die Verkabelung (B-9) ──────────────────────────
+
+const port = (id: string, name: string) => ({ id, name })
+
+const geraet = (id: string, name: string, ports: string[]): EquipmentItem =>
+  ({
+    id,
+    name,
+    category: 'test',
+    inputs: ports.map((p) => port(`${id}-${p}`, p)),
+    outputs: [],
+  }) as unknown as EquipmentItem
+
+const kabel = (over: Partial<Cable> = {}): Cable =>
+  ({
+    id: 'k1',
+    name: '',
+    type: 'BNC',
+    length: 5,
+    color: '#fff',
+    fromEquipmentId: 'a',
+    fromPortId: 'a-Out 1',
+    toEquipmentId: 'b',
+    toPortId: 'b-In 1',
+    notes: '',
+    ...over,
+  }) as unknown as Cable
+
+const rig: EquipmentItem[] = [geraet('a', 'Kamera 1', ['Out 1']), geraet('b', 'ATEM', ['In 1'])]
+
+describe('fromCabling — was kein Geraet beantworten kann', () => {
+  it('fuehrt eine geplante Verbindung OHNE Haken als „nicht nachgesehen"', () => {
+    // Der Kern der Regel: der Plan will das Kabel, aber niemand war dran.
+    // „stimmt" waere hier eine Behauptung ueber die Wirklichkeit.
+    const zeilen = fromCabling([kabel()], rig, { ports: {}, cables: {}, receivedAt: jetzt })
+    expect(zeilen).toHaveLength(1)
+    expect(asBuiltVerdict(zeilen[0])).toBe('not-verified')
+    expect(zeilen[0].planned).toBe('ja')
+  })
+
+  it('macht aus einem Haken eine Uebereinstimmung', () => {
+    const zeilen = fromCabling([kabel()], rig, {
+      ports: {},
+      cables: { k1: true },
+      receivedAt: jetzt,
+    })
+    expect(asBuiltVerdict(zeilen[0])).toBe('match')
+    expect(zeilen[0].at).toBe(jetzt)
+    expect(zeilen[0].source).toBe('field-check')
+  })
+
+  it('nennt die Verbindung beim Namen, sonst bei ihren beiden Enden', () => {
+    const ohneNamen = fromCabling([kabel()], rig, undefined)
+    expect(ohneNamen[0].subject).toBe('Kamera 1 · Out 1 → ATEM · In 1')
+    const mitNamen = fromCabling([kabel({ name: 'CAM1-PGM' })], rig, undefined)
+    expect(mitNamen[0].subject).toBe('CAM1-PGM')
+  })
+
+  it('meldet einen Haken an einem Kabel, das der Plan nicht mehr kennt', () => {
+    // DER Fall, der die Arbeit traegt: der Plan hat sich geaendert, nachdem
+    // die Crew losgezogen ist. Draussen steckt das Kabel weiterhin.
+    const zeilen = fromCabling([], rig, {
+      ports: {},
+      cables: { 'weg-1': true },
+      receivedAt: jetzt,
+    })
+    expect(zeilen).toHaveLength(1)
+    expect(asBuiltVerdict(zeilen[0])).toBe('unexpected')
+    expect(zeilen[0].subject).toContain('weg-1')
+  })
+
+  it('meldet einen Haken an einem Port, den der Plan nicht erklaert', () => {
+    const zeilen = fromCabling([], rig, {
+      ports: { 'a|a-Out 1': true },
+      cables: {},
+      receivedAt: jetzt,
+    })
+    const portZeile = zeilen.find((z) => z.field === 'Port gesteckt')
+    expect(portZeile?.subject).toBe('Kamera 1 · Out 1')
+    expect(asBuiltVerdict(portZeile!)).toBe('unexpected')
+  })
+
+  it('fuehrt einen abgehakten Port MIT Kabelende als Uebereinstimmung', () => {
+    const zeilen = fromCabling([kabel()], rig, {
+      ports: { 'a|a-Out 1': true },
+      cables: {},
+      receivedAt: jetzt,
+    })
+    const portZeile = zeilen.find((z) => z.field === 'Port gesteckt')
+    expect(asBuiltVerdict(portZeile!)).toBe('match')
+  })
+
+  it('fuehrt NICHT abgehakte Ports gar nicht auf', () => {
+    // Sonst stuende jede Luecke zweimal auf dem Blatt — einmal als Kabel und
+    // einmal je Ende —, und die Zahl unter dem Blatt waere doppelt so gross
+    // wie die Zahl der offenen Punkte.
+    const zeilen = fromCabling([kabel()], rig, { ports: {}, cables: {}, receivedAt: jetzt })
+    expect(zeilen.filter((z) => z.field === 'Port gesteckt')).toHaveLength(0)
+  })
+
+  it('macht aus einem Haken OHNE Zeitpunkt keine Ablesung', () => {
+    // Ein Projekt aus der Zeit vor `receivedAt`. Die Haken sind da, ihr Alter
+    // kennt niemand — also ist nichts nachgesehen.
+    const zeilen = fromCabling([kabel()], rig, { ports: {}, cables: { k1: true } })
+    expect(asBuiltVerdict(zeilen[0])).toBe('not-verified')
+    expect(zeilen[0].actual).toBeUndefined()
+  })
+
+  it('macht aus `false` kein „fehlt"', () => {
+    // Der Haken ist binaer und kennt kein „nein"; `false` heisst „noch nicht
+    // abgehakt". Eine `missing`-Zeile daraus waere eine Ablesung, die
+    // niemand gemacht hat.
+    const zeilen = fromCabling([kabel()], rig, {
+      ports: {},
+      cables: { k1: false },
+      receivedAt: jetzt,
+    })
+    expect(asBuiltVerdict(zeilen[0])).toBe('not-verified')
+  })
+
+  it('kommt ohne checkState zurecht', () => {
+    const zeilen = fromCabling([kabel()], rig, undefined)
+    expect(zeilen).toHaveLength(1)
+    expect(asBuiltVerdict(zeilen[0])).toBe('not-verified')
+  })
+
+  it('haelt eine lesbare Ueberschrift fuer die neue Quelle bereit', () => {
+    expect(READING_SOURCE_LABEL['field-check']).toBeTruthy()
+  })
+})
+
+describe('der Haken traegt seinen Zeitpunkt', () => {
+  it('gestempelt wird beim EMPFANG, nicht beim Lesen', () => {
+    // Wer den Zeitpunkt setzen darf, kann „nachgesehen" behaupten, ohne
+    // nachgesehen zu haben. Deshalb faellt er im Slice an, der die Meldung
+    // des Handys entgegennimmt — und nirgends sonst.
+    expect(sliceQuelle).toContain('receivedAt: new Date().toISOString()')
+    expect(sliceQuelle.match(/receivedAt: new Date/g) ?? []).toHaveLength(1)
+  })
+
+  it('bleibt stehen, wenn der Planer EINEN Haken zuruecknimmt', () => {
+    // Ein zurueckgenommener Haken macht die Meldung nicht ungeschehen; die
+    // uebrigen stammen weiter aus derselben Ablesung.
+    expect(sliceQuelle).toContain('checkState: { ...cur, ports: nextPorts, cables: cur.cables }')
+    expect(sliceQuelle).toContain('checkState: { ...cur, ports: cur.ports, cables: nextCables }')
+  })
+
+  it('faellt weg, wenn ALLE Haken geloescht werden', () => {
+    // Ein stehengebliebener Zeitpunkt gaebe einem leeren Stand ein Alter,
+    // das er nicht hat.
+    expect(sliceQuelle).toContain('checkState: { ports: {}, cables: {} }')
+  })
+})
+
 // ── 6. Die Oberflaeche ─────────────────────────────────────────────────────
 
 describe('der Abgleich-Dialog', () => {
@@ -316,12 +474,38 @@ describe('der Abgleich-Dialog', () => {
     // sich wie eine vollstaendige Pruefung — genau der Zustand, den der
     // Bedarf beklagt („post has no record").
     expect(dialogQuelle).toContain('unverifiedEntries(')
-    expect(dialogQuelle).toContain('mergeEntries(geplant, report ? fromNetworkReport(report) : [])')
+    // Nicht auf die Zeilenumbrueche festgenagelt: geprueft wird, dass BEIDE
+    // Seiten in denselben `mergeEntries`-Aufruf gehen — die geplanten
+    // Gegenstaende und der Bericht. Ein Waechter, der an einer Umformatierung
+    // rot wird, wird irgendwann geaendert statt gelesen.
+    const zusammenfuehrung = dialogQuelle.slice(
+      dialogQuelle.indexOf('return mergeEntries('),
+      dialogQuelle.indexOf('const asBuiltStand'),
+    )
+    expect(zusammenfuehrung).toContain('geplant')
+    expect(zusammenfuehrung).toContain('fromNetworkReport(report)')
   })
 
   it('nennt die Deckung in Zahlen, statt nur die Abweichungen zu zeigen', () => {
     expect(dialogQuelle).toContain('asBuiltSummary(asBuilt)')
     expect(dialogQuelle).toContain("t('asBuilt.count'")
+  })
+
+  it('nimmt die Verkabelung auf DASSELBE Blatt (B-9)', () => {
+    // Ein zweites „As-built (Kabel)"-Dokument waere die Vervielfachung, gegen
+    // die dieses Modul gebaut ist: die Post haette zwei Blaetter und muesste
+    // sie selbst zusammenlegen.
+    expect(dialogQuelle).toContain('fromCabling(cables, equipment, checkState)')
+    expect(dialogQuelle).not.toContain('asBuiltTable(kabelBlatt)')
+  })
+
+  it('liest den Zeitpunkt aus dem Plan, statt ihn zu stellen', () => {
+    // Der Dialog weiss nicht, wann jemand abgehakt hat.
+    const abschnitt = dialogQuelle.slice(
+      dialogQuelle.indexOf('const asBuilt = useMemo'),
+      dialogQuelle.indexOf('const asBuiltStand'),
+    )
+    expect(abschnitt).not.toContain('new Date(')
   })
 })
 


### PR DESCRIPTION
Letzte offene Hälfte von **B-9** (`av-planner-suite/docs/IMPLEMENTATION_BACKLOG.md`):

> Für den **Gerätezustand** existiert der Abgleich. Für die **Verkabelung** gibt es die Datenspur (`checkState.ports`), aber keine Gegenüberstellung Soll-Kabel gegen gesteckte Ports.

## Was war

`lib/asBuilt.ts` (Bedarf 126) führt vier Quellen auf einem Blatt zusammen — Netz-Scan, Mischer, Kreuzpunkte, Vermietung. **Alle vier befragen Geräte.** Keines von ihnen weiß, ob ein Kabel steckt; ein Mischer meldet seine Kreuzpunkte, nicht sein SDI-Blech.

Der Einzige, der es weiß, ist der Mensch auf der Leiter — und der hat es längst gemeldet: `checkState` trägt seit v7.9.3 genau diese Haken, gesetzt über `POST /checks` vom Handy. Sie standen bis hierher nur als Häkchen am Port im Canvas und gingen in **kein einziges Dokument** ein. Für die Post war die Verkabelung unbelegt, obwohl die Ablesung im Projekt lag.

## Was jetzt

`fromCabling(cables, equipment, checkState)` als fünfter Zubringer. Er ist der einzige, der etwas *rechnet* statt zu übersetzen — kein Bruch der Modul-Regel, sondern ihr Grund: eine **zweite** Rechnung wäre eine zweite Wahrheit, eine **erste** ist die Antwort auf eine Frage, die bis hierher niemand gestellt hat. Es gibt kein `cablingReconcile`, das sie schon beantwortet hätte.

Drei Urteile, und nur drei:

| Urteil | wann |
|---|---|
| `match` | Plan will die Verbindung, jemand hat sie abgehakt |
| `not-verified` | Plan will sie, niemand war dran |
| `unexpected` | abgehakt ist etwas, das der Plan nicht mehr kennt |

`missing` und `differs` sind aus einem **binären** Haken nicht herleitbar: `false` heißt „noch nicht abgehakt", nicht „nicht gesteckt" — das Handy setzt und löscht denselben Wert. Daraus ein „fehlt" zu machen wäre eine Ablesung, die niemand gemacht hat.

**`unexpected` ist der Fall, der die Arbeit trägt:** er entsteht, wenn der Plan sich geändert hat, *nachdem* die Crew losgezogen ist. Ein Kabel, das aus dem Plan geflogen ist, während sein Haken stehenblieb, steckt draußen immer noch.

Port-Zeilen nur für **abgehakte** Ports. Ein Port trägt seinen Soll-Zustand schon in seinem Kabel; eine zweite „noch nicht abgehakt"-Zeile je Ende verdoppelte bloß die Lücke, die die Kabelzeile meldet — und die Zahl unter dem Blatt wäre doppelt so groß wie die Zahl der offenen Punkte.

Alles auf **dasselbe** Blatt (`ReconcileDialog`). Ein „As-built (Kabel)" daneben wäre genau die Vervielfachung, gegen die das Modul gebaut ist.

## Der Zeitpunkt: `checkState.receivedAt`

Das Blatt verlangt zu jeder Ablesung einen Zeitpunkt — ein Haken ohne Zeitpunkt ist keine Ablesung, sondern eine Behauptung. `checkState` hatte keinen.

Neu ist `checkState.receivedAt`, gesetzt in `mobileSyncSlice.setCheckState`, also wenn der Desktop die Meldung des Handys entgegennimmt. Nicht die Sekunde, in der jemand getippt hat — die kennt dieser Plan nicht und soll sie nicht behaupten —, aber der frühestmögliche Zeitpunkt, den er *weiß*.

Er fällt im Slice an und nicht beim Aufrufer: **wer ihn setzen darf, kann „nachgesehen" behaupten, ohne nachgesehen zu haben.** Aus demselben Grund liest der Dialog ihn und stellt ihn nicht.

Bewusst **ohne** Default in `healProjectPositions`: ein Projekt aus der Zeit vor dem Feld hat Haken, deren Alter niemand kennt. Das Blatt sagt dort durchgehend „nicht nachgesehen" — eine Zeit zu erfinden wäre schlimmer als keine zu haben. `clearAllMobileChecks` löscht `receivedAt` mit; die beiden Einzel-Löschungen behalten es, weil ein zurückgenommener Haken die Meldung nicht ungeschehen macht.

## B-9s offene Frage ist keine mehr

B-9 fragte, wo der As-built-Zustand wohnt — eigene Spur je Feld oder Plan-Überschreiben mit Revisionen —, und ob `Provenance` einen fünften Wert braucht.

Beantwortet hat das `lib/asBuilt.ts`, bevor die Frage gestellt wurde: der Zustand wohnt in einer **eigenen Spur** (`AsBuiltEntry` mit `ReadingSource`), das Blatt stellt Absicht und Beobachtung nebeneinander, und in den Plan zurück schreibt es nichts. `Provenance` sagt, woher eine Angabe **im Plan** stammt — eine Ablesung wird nie eine Angabe im Plan. **Kein fünfter Wert.**

## Gegenproben

Sechs Eingriffe, alle rot, zurückgebaut grün:

| | Eingriff | |
|---|---|---|
| A | Port-Haken werden ignoriert | ROT |
| B | erfundener Zeitpunkt für alte Projekte | ROT |
| C | `false` gilt als abgehakt | ROT |
| D | der Dialog stellt den Zeitpunkt selbst | ROT |
| E | kein Stempel beim Empfang | ROT |
| F | Verkabelung nicht auf dem Blatt | ROT |
| Z | zurückgebaut | GRÜN |

## Nebenbei geschärft

Der Wächter „führt AUCH die Geräte, die der Scan nicht gesehen hat" hing an einer **einzeiligen Schreibweise** des `mergeEntries`-Aufrufs und wurde an der Umformatierung rot. Er prüft jetzt, dass beide Seiten in denselben Aufruf gehen. Ein Wächter, der an einer folgenlosen Umformatierung rot wird, wird irgendwann geändert statt gelesen.

## Geprüft

3052 Tests grün (2 skipped), `npx tsc -p tsconfig.app.json --noEmit` = 0, `npm run lint` = 0 Errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_