### PR TITLE
Medien-Station als Plan-Endpunkt + jeder Dialog tastaturbedienbar

### DIFF
--- a/src/renderer/lib/catalogueEvidence.ts
+++ b/src/renderer/lib/catalogueEvidence.ts
@@ -44,6 +44,7 @@ import { BROADCAST_TOOLS_CATALOG } from './broadcastToolsCatalog'
 import { CAMERA_CATALOG } from './cameraCatalog'
 import { GREENGO_CATALOG } from './greengoCatalog'
 import { LYNX_CATALOG } from './lynxCatalog'
+import { MEDIA_STATION_CATALOG } from './mediaStationCatalog'
 import { MIC_CATALOG } from './micCatalog'
 import { MISC_CATALOG } from './miscCatalog'
 import { MONITOR_CATALOG } from './monitorCatalog'
@@ -81,6 +82,7 @@ export const CATALOGUES: ReadonlyArray<{ name: string; entries: readonly Evidenc
   { name: 'camera', entries: CAMERA_CATALOG },
   { name: 'greengo', entries: GREENGO_CATALOG },
   { name: 'lynx', entries: LYNX_CATALOG },
+  { name: 'mediaStation', entries: MEDIA_STATION_CATALOG },
   { name: 'mic', entries: MIC_CATALOG },
   { name: 'misc', entries: MISC_CATALOG },
   { name: 'monitor', entries: MONITOR_CATALOG },

--- a/src/renderer/lib/deviceTypeRegistry.ts
+++ b/src/renderer/lib/deviceTypeRegistry.ts
@@ -27,6 +27,7 @@ import { BROADCAST_TOOLS_CATALOG } from './broadcastToolsCatalog'
 import { AUDIO_CATALOG } from './audioCatalog'
 import { WIRELESS_AUDIO_CATALOG } from './wirelessAudioCatalog'
 import { MIC_CATALOG } from './micCatalog'
+import { MEDIA_STATION_CATALOG } from './mediaStationCatalog'
 
 export interface DeviceTypeInfo {
   /** Datenblatt-Template (inkl. deviceTypeId). */
@@ -125,6 +126,9 @@ const buildRegistry = (): Map<string, DeviceTypeInfo> => {
     put(e.deviceTypeId, { template: { ...e.template, deviceTypeId: e.deviceTypeId } })
   }
   for (const e of MIC_CATALOG) {
+    put(e.deviceTypeId, { template: { ...e.template, deviceTypeId: e.deviceTypeId } })
+  }
+  for (const e of MEDIA_STATION_CATALOG) {
     put(e.deviceTypeId, { template: { ...e.template, deviceTypeId: e.deviceTypeId } })
   }
   for (const e of AVNETWORK_CATALOG) {

--- a/src/renderer/lib/mediaStationCatalog.ts
+++ b/src/renderer/lib/mediaStationCatalog.ts
@@ -1,0 +1,91 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Medien-Station als PLAN-ENDPUNKT.
+//
+// Die offene Haelfte einer Zeile in `av-planner-suite/docs/research/synthesis/
+// FEATURE-MATRIX.md`:
+//
+//   > „Media playback — YES as a planned endpoint" ist im `cable-planner`
+//   > nicht eingeloest; `pi-media-station` kommt dort als Geraet oder
+//   > Endpunkt nicht vor.
+//
+// Die Matrix sagt zu Medien-Wiedergabe zweierlei, und beides gilt: als
+// KONKURRENT zu QLab, Resolume oder disguise wird nichts gebaut (WON'T), als
+// geplanter ENDPUNKT gehoert die Station in den Plan. Bis hierher stand nur
+// die Absage im Dokument; die Zusage war nirgends eingeloest. Eine Station,
+// die man nicht auf die Flaeche ziehen kann, taucht in keiner Stueckliste, in
+// keiner Kommissionierliste und auf keinem Kabelplan auf — sie wird vor Ort
+// von Hand mitgedacht, und genau das ist der Schaden, gegen den dieser
+// Planer gebaut ist.
+//
+// ─── WORAUS DIE PORTS STAMMEN ──────────────────────────────────────────────
+//
+// Aus dem Repo der Station selbst (`larszu/pi-media-station`), nicht aus
+// einem Datenblatt: der Hersteller dieses Geraets ist dieses Projekt. Der
+// `manufacturerUrl` zeigt deshalb auf das Repo — das ist hier die
+// Datenblatt-Quelle im Sinne der Belegkette und keine Verlegenheitsangabe.
+//
+// Gelesen wurde: der Display-Modus faehrt EINEN Chromium im Kiosk
+// (`--kiosk`), also genau eine Bildausgabe; der Manager und die mDNS-Meldung
+// laufen ueber das Netz; der HC-SR04 haengt an GPIO.
+//
+// ─── WAS BEWUSST NICHT IM TEMPLATE STEHT ───────────────────────────────────
+//
+// **Keine analoge Klinke.** Sie waere der bequeme dritte Port und eine
+// Aussage ueber die PLATINE, die dieses Repo gar nicht festlegt: der
+// Raspberry Pi 5 hat die 3,5-mm-Buchse nicht mehr, der Pi 4 hat sie. Ein
+// Port, den die Haelfte der Boards nicht besitzt, erzeugt ein Kabel auf der
+// Kommissionierliste, das vor Ort ins Leere geht. Der Ton faehrt per Vorgabe
+// ueber HDMI; wer die Station analog fahren will, haengt die Buchse von Hand
+// an — eine Entscheidung, die dann im Plan steht statt in einer Annahme.
+//
+// **Kein zweiter HDMI.** Der Pi 4 hat zwei Micro-HDMI, die Software treibt
+// aber genau eine Anzeige. Das Template beschreibt die STATION, wie ihre
+// Software sie definiert, nicht den Stecker-Vorrat der Platine.
+//
+// **Kein Sensor-Port.** Der HC-SR04 haengt mit vier Draehten an GPIO 23/24.
+// Das ist Innenverkabelung des Geraets und kein Weg im Signalfluss; er
+// gehoert so wenig auf den Kabelplan wie das Netzteilkabel im Gehaeuse.
+//
+// Diese drei Auslassungen sind der Grund, warum hier ein eigener Katalog
+// steht und kein Eintrag in `miscCatalog`: der ist an einer Rentman-Liste
+// eines Vermieters gemessen, und diese Station kommt in keiner vor.
+// ───────────────────────────────────────────────────────────────────────────
+import type { EquipmentTemplate } from '../types/equipment'
+
+interface MediaStationEntry {
+  /** Stabile Geraetetyp-Identitaet (GUID, GDTF/DIN-SPEC-15800-analog). */
+  deviceTypeId: string
+  /** Lowercase substrings that must ALL appear in the source name. */
+  match: string[]
+  template: EquipmentTemplate
+}
+
+/** Katalog-Template inkl. seiner stabilen Geraetetyp-ID. */
+const withTypeId = (e: MediaStationEntry): EquipmentTemplate => ({
+  ...e.template,
+  deviceTypeId: e.deviceTypeId,
+})
+
+export const MEDIA_STATION_CATALOG: MediaStationEntry[] = [
+  // LZ Media Station — sensorgesteuerte Zuspiel-Station auf Raspberry Pi.
+  // Repo gelesen 2026-09-08; der Hersteller dieses Geraets ist dieses Projekt.
+  // Quelle: https://github.com/larszu/pi-media-station
+  {
+    match: ['media', 'station'],
+    deviceTypeId: '5eb14ff7-48ab-4125-a67b-bb7344b08a66',
+    template: {
+      manufacturerUrl: 'https://github.com/larszu/pi-media-station',
+      name: 'LZ Media Station',
+      category: 'Video',
+      inputs: [
+        { id: '', name: 'LAN (RJ45)', type: 'Ethernet/RJ45', connectorType: 'Ethernet/RJ45', direction: 'bidirectional' },
+      ],
+      outputs: [
+        { id: '', name: 'Display Out (HDMI)', type: 'HDMI', connectorType: 'HDMI' },
+      ],
+      width: 220, height: 120,
+    },
+  },
+]
+
+export const mediaStationTemplates: EquipmentTemplate[] = MEDIA_STATION_CATALOG.map(withTypeId)

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -46,6 +46,7 @@ import { ubiquitiTemplates } from '../lib/ubiquitiCatalog'
 import { monitorTemplates } from '../lib/monitorCatalog'
 import { cameraTemplates } from '../lib/cameraCatalog'
 import { miscTemplates } from '../lib/miscCatalog'
+import { mediaStationTemplates } from '../lib/mediaStationCatalog'
 import { greengoTemplates } from '../lib/greengoCatalog'
 import { ajaTemplates } from '../lib/ajaCatalog'
 import { rossTemplates } from '../lib/rossCatalog'
@@ -111,7 +112,7 @@ const runLibraryMigration = () => {
     const existing: EquipmentTemplate[] = raw ? JSON.parse(raw) : []
     const byName = new Map(existing.map((t) => [t.name, t]))
     let added = false
-    for (const t of [...blackmagicTemplates, ...ubiquitiTemplates, ...monitorTemplates, ...cameraTemplates, ...miscTemplates, ...greengoTemplates, ...ajaTemplates, ...rossTemplates, ...lynxTemplates, ...switcherTemplates, ...avNetworkTemplates, ...broadcastToolsTemplates, ...audioTemplates, ...wirelessAudioTemplates, ...micTemplates]) {
+    for (const t of [...blackmagicTemplates, ...ubiquitiTemplates, ...monitorTemplates, ...cameraTemplates, ...miscTemplates, ...greengoTemplates, ...ajaTemplates, ...rossTemplates, ...lynxTemplates, ...switcherTemplates, ...avNetworkTemplates, ...broadcastToolsTemplates, ...audioTemplates, ...wirelessAudioTemplates, ...micTemplates, ...mediaStationTemplates]) {
       if (!byName.has(t.name)) {
         byName.set(t.name, t)
         added = true

--- a/tests/catalogSourceUrls.test.ts
+++ b/tests/catalogSourceUrls.test.ts
@@ -89,7 +89,9 @@ describe('jeder Quellen-Kommentar steht auch als Feld im Eintrag', () => {
   it('findet ueberhaupt welche — sonst prueft der Test nichts', () => {
     // Ohne diese Zusicherung waere der Test auch dann gruen, wenn das
     // Muster nicht mehr passt und `pairs()` leer zurueckkommt.
-    expect(pairs().length).toBe(253)
+    // 253 + 1: `mediaStationCatalog` ist mit EINEM belegten Eintrag
+    // dazugekommen (die Medien-Station als Plan-Endpunkt).
+    expect(pairs().length).toBe(254)
   })
 
   it('deckt die neun Kataloge ab, die Belege fuehren', () => {
@@ -100,6 +102,7 @@ describe('jeder Quellen-Kommentar steht auch als Feld im Eintrag', () => {
       'avNetworkCatalog.ts',
       'broadcastToolsCatalog.ts',
       'lynxCatalog.ts',
+      'mediaStationCatalog.ts',
       'micCatalog.ts',
       'rossCatalog.ts',
       'switcherCatalog.ts',
@@ -217,6 +220,6 @@ describe('der Beleg zeigt auf den Hersteller, nicht auf einen Haendler', () => {
   it('prueft alle Belege, nicht nur die mit Feld', () => {
     // Ohne diese Zusicherung waere der Haendler-Test auch dann gruen, wenn
     // `pairs()` nichts mehr faende.
-    expect(pairs().filter((p) => p.field).length).toBe(253)
+    expect(pairs().filter((p) => p.field).length).toBe(254)
   })
 })

--- a/tests/catalogueEvidence.test.ts
+++ b/tests/catalogueEvidence.test.ts
@@ -68,7 +68,11 @@ describe('Initiative 11 — trägt diese Katalog-Zeile ein Datenblatt?', () => {
       }
     }
     // Die Zahl aus dem Scoping-Papier — gegen den Baum gehalten, nicht geglaubt.
-    expect(kommentare).toBe(253)
+    // 253 + 1: `mediaStationCatalog` ist mit EINEM belegten Eintrag dazugekommen
+    // (die Medien-Station als Plan-Endpunkt). Sein Beleg ist das Repo der
+    // Station selbst — bei einem Geraet, dessen Hersteller dieses Projekt ist,
+    // IST das Repo das Datenblatt und keine Verlegenheitsangabe.
+    expect(kommentare).toBe(254)
   })
 
   it('2. die Abdeckung wird gerechnet', () => {
@@ -76,8 +80,8 @@ describe('Initiative 11 — trägt diese Katalog-Zeile ein Datenblatt?', () => {
     // Die Summen stammen aus derselben Rechnung wie die Zeilen.
     expect(bericht.entries).toBe(bericht.perCatalogue.reduce((s, c) => s + c.entries, 0))
     expect(bericht.sourced + bericht.unsourced).toBe(bericht.entries)
-    expect(bericht.sourced).toBe(253)
-    expect(bericht.entries).toBe(412)
+    expect(bericht.sourced).toBe(254)
+    expect(bericht.entries).toBe(413)
 
     // Die sechs Kataloge ohne Beleg sind genau die, die B-11 nennt — und die
     // Liste wird GERECHNET, nicht aufgezählt: trägt einer von ihnen morgen
@@ -94,7 +98,7 @@ describe('Initiative 11 — trägt diese Katalog-Zeile ein Datenblatt?', () => {
     // das ist der Zweck: die Abdeckung soll nicht lautlos sinken koennen.
     const vollstaendig = [
       'aja', 'audio', 'avNetwork', 'broadcastTools', 'lynx',
-      'mic', 'ross', 'switcher', 'wirelessAudio',
+      'mediaStation', 'mic', 'ross', 'switcher', 'wirelessAudio',
     ]
     const bericht = evidenceReport()
     for (const name of vollstaendig) {

--- a/tests/medienStationEndpunkt.test.ts
+++ b/tests/medienStationEndpunkt.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import { MEDIA_STATION_CATALOG, mediaStationTemplates } from '../src/renderer/lib/mediaStationCatalog'
+import { resolveDeviceType } from '../src/renderer/lib/deviceTypeRegistry'
+import { evidenceForType } from '../src/renderer/lib/catalogueEvidence'
+import quelle from '../src/renderer/lib/mediaStationCatalog.ts?raw'
+import storeQuelle from '../src/renderer/store/projectStore.ts?raw'
+
+// ---------------------------------------------------------------------------
+// Die Medien-Station als PLAN-ENDPUNKT.
+//
+// Die offene Haelfte einer Zeile in der FEATURE-MATRIX der Suite:
+//
+//   > „Media playback — YES as a planned endpoint" ist im `cable-planner`
+//   > nicht eingeloest; `pi-media-station` kommt dort als Geraet oder
+//   > Endpunkt nicht vor.
+//
+// Die Matrix sagt zweierlei, und beides gilt: als KONKURRENT zu QLab oder
+// disguise wird nichts gebaut, als geplanter ENDPUNKT gehoert die Station in
+// den Plan. Bis hierher stand nur die Absage im Dokument.
+//
+// Was dieser Test vor allem absichert, sind die AUSLASSUNGEN. Ein Katalog-
+// Eintrag ist schnell erweitert; die drei Ports, die hier NICHT stehen, sind
+// die Arbeit daran.
+// ---------------------------------------------------------------------------
+
+const station = () => MEDIA_STATION_CATALOG[0]
+
+describe('die Medien-Station ist im Plan platzierbar', () => {
+  it('steht in der Bibliothek, die der Store beim Start setzt', () => {
+    // Ein Katalog, den niemand einhaengt, ist eine Datei und kein Geraet.
+    //
+    // GESCHAERFT NACH DER GEGENPROBE: die erste Fassung suchte den Namen
+    // irgendwo in der Datei — und blieb gruen, als die Einhaengung entfernt
+    // wurde, weil die IMPORT-Zeile stehenblieb. Der Waechter prueft damit
+    // den Zustand, den der Fix erzeugt, statt den, den der Defekt braucht.
+    // Geprueft wird deshalb die Saat-Liste selbst.
+    const saat = storeQuelle.slice(
+      storeQuelle.indexOf('for (const t of ['),
+      storeQuelle.indexOf('if (!byName.has(t.name))'),
+    )
+    expect(saat).not.toBe('')
+    expect(saat).toContain('...mediaStationTemplates')
+    expect(mediaStationTemplates).toHaveLength(MEDIA_STATION_CATALOG.length)
+  })
+
+  it('loest ueber ihre Geraetetyp-Id auf', () => {
+    const typ = resolveDeviceType(station().deviceTypeId)
+    expect(typ?.template.name).toBe('LZ Media Station')
+  })
+
+  it('traegt einen Beleg, und der zeigt aufs Repo der Station', () => {
+    // Bei einem Geraet, dessen Hersteller dieses Projekt IST, ist das Repo
+    // das Datenblatt — nicht eine Verlegenheitsangabe.
+    const beleg = evidenceForType(station().deviceTypeId)
+    expect(beleg.kind).toBe('sourced')
+    if (beleg.kind === 'sourced') {
+      expect(beleg.url).toContain('github.com/larszu/pi-media-station')
+    }
+  })
+})
+
+describe('was NICHT im Template steht, und warum', () => {
+  it('hat keine analoge Klinke', () => {
+    // Sie waere eine Aussage ueber die PLATINE, die das Repo der Station gar
+    // nicht festlegt: der Pi 5 hat die 3,5-mm-Buchse nicht mehr, der Pi 4
+    // hat sie. Ein Port, den die Haelfte der Boards nicht besitzt, erzeugt
+    // ein Kabel auf der Kommissionierliste, das vor Ort ins Leere geht.
+    const alle = [...station().template.inputs, ...station().template.outputs]
+    expect(alle.some((p) => /klinke|3,5|3\.5|jack/i.test(p.name))).toBe(false)
+  })
+
+  it('hat genau EINE Bildausgabe', () => {
+    // Der Pi 4 hat zwei Micro-HDMI, die Software treibt eine Anzeige
+    // (Chromium `--kiosk`). Das Template beschreibt die Station, wie ihre
+    // Software sie definiert, nicht den Stecker-Vorrat der Platine.
+    const hdmi = station().template.outputs.filter((p) => p.connectorType === 'HDMI')
+    expect(hdmi).toHaveLength(1)
+  })
+
+  it('hat keinen Sensor-Port', () => {
+    // Der HC-SR04 haengt mit vier Draehten an GPIO 23/24. Das ist
+    // Innenverkabelung und kein Weg im Signalfluss.
+    const alle = [...station().template.inputs, ...station().template.outputs]
+    expect(alle.some((p) => /sensor|gpio|hc-sr04/i.test(p.name))).toBe(false)
+  })
+
+  it('begruendet jede der drei Auslassungen im Quelltext', () => {
+    // Eine Auslassung ohne Grund liest sich wie ein Versaeumnis, und der
+    // Naechste traegt sie „nach". Genau das soll nicht passieren.
+    expect(quelle).toContain('Keine analoge Klinke')
+    expect(quelle).toContain('Kein zweiter HDMI')
+    expect(quelle).toContain('Kein Sensor-Port')
+  })
+})
+
+describe('die Station ist ein Endpunkt und kein Zuspiel-Werkzeug', () => {
+  it('bringt keine Wiedergabe-Logik mit', () => {
+    // Die Matrix-Zeile ist zweigeteilt: „WONT as a competitor; YES as a
+    // planned endpoint". Ein Katalog-Eintrag ist die zweite Haelfte. Wer
+    // hier anfaengt, Abspiellisten oder Zonen zu modellieren, hat die erste
+    // Haelfte gekippt, ohne sie zu entscheiden.
+    expect(quelle).not.toMatch(/playlist|Abspielliste|zone|Zone/i)
+    expect(quelle).not.toMatch(/export function play|schedule|cue/i)
+  })
+})


### PR DESCRIPTION
Zwei Stücke, beide aus den Doku-Plänen abgearbeitet.

---

# 1 · Die Medien-Station ist ein Plan-Endpunkt, nicht nur ein Satz

Die offene Hälfte einer Zeile in `av-planner-suite/docs/research/synthesis/FEATURE-MATRIX.md`:

> „Media playback — YES as a planned endpoint" ist im `cable-planner` nicht eingelöst; `pi-media-station` kommt dort als Gerät oder Endpunkt nicht vor.

Die Matrix sagt **zweierlei, und beides gilt**: als *Konkurrent* zu QLab, Resolume oder disguise wird nichts gebaut (`WON'T`), als geplanter *Endpunkt* gehört die Station in den Plan. Bis hierher stand nur die Absage im Dokument.

**Warum das kein Schönheitsfehler war:** eine Station, die man nicht auf die Fläche ziehen kann, taucht in keiner Stückliste, in keiner Kommissionierliste und auf keinem Kabelplan auf. Sie wird vor Ort von Hand mitgedacht — und genau dagegen ist dieser Planer gebaut.

`lib/mediaStationCatalog.ts` mit einem Eintrag, eingehängt in die drei Stellen, die ein Katalog braucht: `deviceTypeRegistry` (Auflösung über die Gerätetyp-Id), `catalogueEvidence` (Belegkette), Bibliotheks-Saat im `projectStore`.

**Woraus die Ports stammen:** aus dem Repo der Station selbst — der Hersteller dieses Geräts *ist* dieses Projekt, also ist das Repo hier die Datenblatt-Quelle und keine Verlegenheitsangabe.

### Was bewusst *nicht* im Template steht

Das ist die eigentliche Arbeit an diesem Eintrag.

| | Grund |
|---|---|
| **keine analoge Klinke** | Eine Aussage über die *Platine*, die das Repo nicht festlegt: der Pi 5 hat die 3,5-mm-Buchse nicht mehr, der Pi 4 hat sie. Ein Port, den die Hälfte der Boards nicht besitzt, erzeugt ein Kabel auf der Kommissionierliste, das vor Ort ins Leere geht. |
| **kein zweiter HDMI** | Der Pi 4 hat zwei Micro-HDMI, die Software treibt eine Anzeige. |
| **kein Sensor-Port** | Der HC-SR04 hängt mit vier Drähten an GPIO 23/24 — Innenverkabelung, kein Weg im Signalfluss. |

`tests/medienStationEndpunkt.test.ts` (8) sichert vor allem die **Auslassungen** ab — samt der Zusicherung, dass jede im Quelltext *begründet* ist. Dazu ein Test, der die **erste** Hälfte der Matrix-Zeile hält: keine Abspiellisten, keine Zonen, kein Cue.

**Gegenproben:** Klinke nachgetragen (ROT) · zweiter HDMI (ROT) · Beleg entfernt (ROT) · Katalog nicht eingehängt (**zuerst GRÜN** — der Wächter fand die stehengebliebene Import-Zeile; er prüft jetzt die Saat-Liste selbst).

---

# 2 · Jeder selbstgebaute Dialog ist mit der Tastatur bedienbar

Phase 3 der UI-Prüfung (`docs/ui-audit.md`) hatte einen Rest: **siebzehn** Standalone-Dialoge mit eigenem `fixed inset-0`-Gerüst, ohne Fokus-Falle, ohne Fokus-Rückgabe, teils ohne Escape. Wer mit der Tastatur arbeitet, tabbte aus dem offenen Dialog heraus in die Seite dahinter und fand nicht zurück.

**Die Liste war an beiden Enden falsch** — beides, weil sie von Hand geführt wurde:

- **Sieben der siebzehn** brauchten gar nichts mehr: sie gehen längst über `ModalShell`, und die hat den Hook seit derselben Phase.
- **Neun Dialoge fehlten ganz.** Nach dem Audit entstanden, nie nachgetragen: Abgleich, Ausspielung, Drum-Mikrofonierung, Funkstrecken, Rack-Verkabelung, Rack-Builder, Befehlspalette und die vier Überlagerungen in den beiden Bibliotheks-Panels (die Panels sind keine Modals — die Dialoge *in* ihnen schon).

Umgestellt: **vierzehn Dateien, sechzehn Dialog-Flächen.**

### Vier Stellen brauchten mehr als das Muster

- `RackBuilderDialog` und `CommandPalette` bekommen den Hook mit `closeOnEscape: false` — beide haben eine eigene, klügere Behandlung; ein zweites Escape daneben würde an der Rückfrage vorbei schließen.
- `RentmanImportDialog` schließt über `safeClose`: der Dialog lehnt das Schließen ab, solange ein Import läuft.
- `GreenGoExportDialog`: Escape bricht das **Innerste** ab — liegt eine Import-Zuordnung offen, nimmt Escape sie zurück statt den Dialog zu schließen.

Wo ein Dialog eine vorhandene Zieh-Container-Ref hat, bekommt der Hook sie über seine `ref`-Option mit, statt eine zweite danebenzustellen.

### Der Wächter läuft, statt zu listen

`tests/dialogTastaturbedienung.test.ts` geht über `src/renderer/components` und findet jede Datei mit eigenem `fixed inset-0`. **Wer morgen einen Dialog anlegt, wird rot, ohne dass jemand eine Liste pflegt** — dieselbe Lehre wie beim Lager-Vertrag in ADR-006: *die Domäne ist der Ordner, nicht eine Liste im Wächter.* Genau daran ist die Audit-Liste zweimal gescheitert.

### Zweimal hat eine Gegenprobe den Wächter erwischt, nicht den Fix

1. „Dialog ohne lesbaren Namen" blieb **grün** — der Test suchte `aria-label` *irgendwo* in der Datei, und der Schließen-Knopf daneben hat eins. Er prüft jetzt die Umgebung jeder `{...dialogProps}`-Stelle.
2. „Hook verdrahtet" wurde **rot**, als eine Datei die Bindungen beim Auseinandernehmen umbenannte (`panelRef: netBoxRef`) — obwohl alles richtig war. Er liest die Namen jetzt *aus dem Aufruf*. Ein Wächter, der an einer Umbenennung rot wird, wird geändert statt gelesen.

Das Umbenennen war kein Geschmack: `ref={netBox.panelRef}` liest während des Renderns eine Eigenschaft eines Ref-Trägers, und `react-hooks/refs` macht daraus einen Fehler. Eine Regel zu unterdrücken, um eine Schreibweise zu behalten, wäre der schlechtere Handel.

---

## Geprüft

3067 Tests grün (2 skipped), `npx tsc -p tsconfig.app.json --noEmit` = 0, `npm run lint` = 0 Errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT