### PR TITLE
a11y: jeder selbstgebaute Dialog ist mit der Tastatur bedienbar

### DIFF
--- a/docs/ui-audit.md
+++ b/docs/ui-audit.md
@@ -197,17 +197,38 @@ Inline-Fallback in `ErrorBoundary`). → Token-Schicht einführen.
 - Globaler `:focus-visible`-Ring war bereits vorhanden (`index.css`).
 - Lint dadurch sogar verbessert (124 statt 127 Fehler).
 
-### TODO (restliche Standalone-Dialoge → useDialogA11y adоptieren)
+### ~~TODO (restliche Standalone-Dialoge → useDialogA11y adoptieren)~~ — erledigt 2026-09-08
 
-Diese rollen noch eigenes `fixed inset-0`-Boilerplate ohne Focus-Trap/
-Escape — Hook analog `SettingsDialog`/`ExportDialog` anwenden:
-`RentmanImportDialog`, `RentmanCableExportDialog`, `NewRentmanDeviceWizard`,
-`AtemMvConfigDialog`, `AtemAudioRouterDialog`, `MultiviewerLayoutView`,
-`VideohubExportDialog`, `GreenGoExportDialog`, `GraphmlImportDialog`,
-`RackEditorDialog`, `RackImageCropDialog`, `NonRackAddDialog`,
-`PatchPanelCreateDialog`, `RackShelfCreateDialog`, `MobileShareDialog`,
-`LocationBomDialog`, `CableBomDialog`. (Panels `LibraryPanel`/
-`CableLibraryPanel` sind keine Modals — separat behandeln.)
+**Alle selbstgebauten Dialoge gehen jetzt über `useDialogA11y`**, und ein
+Wächter hält das fest: `tests/dialogTastaturbedienung.test.ts`.
+
+Die Liste, die hier stand, war an **beiden** Enden falsch — und beide Fehler
+kommen daher, dass sie von Hand geführt wurde:
+
+* **Sieben der siebzehn brauchten gar nichts mehr.** `RentmanCableExportDialog`,
+  `NonRackAddDialog`, `PatchPanelCreateDialog`, `RackShelfCreateDialog`,
+  `MobileShareDialog`, `LocationBomDialog` und `CableBomDialog` gehen längst
+  über `ModalShell` — und die hat den Hook seit derselben Phase.
+* **Neun Dialoge fehlten ganz.** Sie sind nach dem Audit entstanden und
+  niemand hat sie nachgetragen: `ReconcileDialog`, `DeliveryDialog`,
+  `DrumMicingDialog`, `WirelessRigDialog`, `RackInternalWireOverlay`,
+  `RackBuilderDialog`, `CommandPalette` und die vier Überlagerungen in
+  `LibraryPanel`/`CableLibraryPanel` — die beiden Panels sind zwar keine
+  Modals, die Dialoge **in** ihnen aber schon.
+
+**Deshalb ist der Wächter kein Listenabgleich, sondern ein Lauf über den
+Ordner:** er findet jede Datei unter `src/renderer/components`, die ein
+eigenes `fixed inset-0` aufspannt, und verlangt für sie den Hook (oder
+`ModalShell`). Wer morgen einen Dialog anlegt, wird rot, ohne dass jemand
+eine Liste pflegt. Dieselbe Lehre wie beim Lager-Vertrag in ADR-006: **die
+Domäne ist der Ordner, nicht eine Liste im Wächter.**
+
+Zwei Dialoge bekommen den Hook bewusst **ohne** sein Escape
+(`closeOnEscape: false`), weil sie eine eigene, klügere Behandlung haben:
+der `RackBuilderDialog` fragt bei ungesicherten Änderungen nach, die
+`CommandPalette` hat ihre eigene Tastensteuerung. Beide nehmen vom Hook nur
+Fokus-Falle und Fokus-Rückgabe — ein zweites Escape daneben würde an der
+Rückfrage vorbei schließen.
 
 ## Phase 4 — i18n
 

--- a/src/renderer/components/Atem/AtemAudioRouterDialog.tsx
+++ b/src/renderer/components/Atem/AtemAudioRouterDialog.tsx
@@ -17,6 +17,7 @@ import {
   serializeAudioConfigXml,
 } from '../../lib/atemAudioMappingXml'
 import { confirmDialog } from '../../lib/confirmDialog'
+import { useDialogA11y } from '../../hooks/useDialogA11y'
 import {
   allDeltas,
   audioMatrixAssignments,
@@ -192,6 +193,14 @@ export const AtemAudioRouterDialog = () => {
     setLive(null)
     setLiveReadAt('')
   }
+
+  // Phase 3 der UI-Pruefung. Der Haken bekommt die vorhandene Container-Ref
+  // mit, damit Fokus-Falle und Zieh-Container denselben Knoten meinen. Er
+  // steht VOR dem bedingten Ausstieg, weil Haken nicht bedingt aufgerufen
+  // werden duerfen.
+  const { panelRef, titleId, dialogProps } = useDialogA11y(open, close, {
+    ref: containerRef,
+  })
 
   if (!open || !equipment) return null
 
@@ -421,8 +430,10 @@ export const AtemAudioRouterDialog = () => {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
       <div
-        ref={containerRef}
+        ref={panelRef}
         style={containerStyle}
+        aria-labelledby={titleId}
+        {...dialogProps}
         className="flex h-full max-h-[92vh] w-full max-w-[95vw] flex-col rounded border border-slate-700 bg-slate-900 text-slate-100 shadow-2xl"
       >
         <header
@@ -430,7 +441,7 @@ export const AtemAudioRouterDialog = () => {
           className="flex items-center justify-between border-b border-slate-700 px-4 py-2 select-none"
         >
           <div>
-            <h2 className="text-cp-xl font-semibold">
+            <h2 id={titleId} className="text-cp-xl font-semibold">
               {t('atem.audio.title', 'ATEM Audio-Konfiguration')} — {equipment.name}
             </h2>
             <div className="text-[11px] text-slate-400">

--- a/src/renderer/components/Atem/AtemMvConfigDialog.tsx
+++ b/src/renderer/components/Atem/AtemMvConfigDialog.tsx
@@ -32,6 +32,7 @@ import {
   type AtemMvCapabilities,
 } from '../../lib/atemMvLayout'
 import { PanelHint } from '../shared/PanelHint'
+import { useDialogA11y } from '../../hooks/useDialogA11y'
 
 /** v7.9.4 — Quadranten-basiertes Render-Helper. Wir rendern NICHT
  *  mehr basierend auf ATEM-Layout-IDs, sondern auf einem direkten
@@ -659,14 +660,21 @@ const AtemMvDevicePicker = () => {
     () => equipment.filter((e) => detectDeviceKind(e) === 'atem' || !!e.atemMvConfig),
     [equipment],
   )
+  // Phase 3 der UI-Pruefung. Beide Felder dieser Datei — Geraete-Picker und
+  // Editor — bekommen ihren eigenen Haken; sie sind zwei Dialoge, die
+  // nacheinander stehen, nicht ineinander.
+  const { panelRef, titleId, dialogProps } = useDialogA11y(true, close)
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={close}>
       <div
+        ref={panelRef}
+        aria-labelledby={titleId}
+        {...dialogProps}
         className="flex max-h-[80vh] w-[440px] max-w-[95vw] flex-col rounded-cp-card border border-cp-border bg-cp-surface-1 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between border-b border-cp-border px-4 py-2">
-          <h2 className="flex items-center gap-2 text-cp-base font-semibold text-cp-text-bright">
+          <h2 id={titleId} className="flex items-center gap-2 text-cp-base font-semibold text-cp-text-bright">
             <Icon icon={Monitor} size="sm" />
             {t('atemMv.picker.title', 'ATEM Multiviewer — Gerät wählen')}
           </h2>
@@ -872,6 +880,14 @@ export const AtemMvConfigDialog = () => {
         : null,
     [config.multiViewers, live],
   )
+
+  // Phase 3 der UI-Pruefung, zweiter Haken dieser Datei — fuer den Editor.
+  // Vor den bedingten Ausstiegen, weil Haken nicht bedingt laufen duerfen.
+  const {
+    panelRef: editorRef,
+    titleId: editorTitleId,
+    dialogProps: editorDialogProps,
+  } = useDialogA11y(slot.open, close)
 
   if (!slot.open) return null
   // #402 — Ohne vorausgewähltes Gerät (Werkzeuge-Menü) zuerst den Picker.
@@ -1164,11 +1180,14 @@ export const AtemMvConfigDialog = () => {
       onClick={close}
     >
       <div
+        ref={editorRef}
+        aria-labelledby={editorTitleId}
+        {...editorDialogProps}
         className="flex max-h-[95vh] w-[960px] max-w-[95vw] flex-col rounded-cp-card border border-cp-border bg-cp-surface-1 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between border-b border-cp-border px-4 py-2">
-          <h2 className="text-cp-base font-semibold text-cp-text">
+          <h2 id={editorTitleId} className="text-cp-base font-semibold text-cp-text">
             {format(t('atem.mv.dialogTitle', 'Multiviewer-Layout · {name}'), { name: equipment.name })}
           </h2>
           <button

--- a/src/renderer/components/Atem/MultiviewerLayoutView.tsx
+++ b/src/renderer/components/Atem/MultiviewerLayoutView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { cablePlannerApi, type AtemStateSummary, type AtemMultiviewer } from '../../lib/bridge'
 import { useTranslation } from '../../lib/i18n'
+import { useDialogA11y } from '../../hooks/useDialogA11y'
 
 interface MultiviewerLayoutViewProps {
   onClose: () => void
@@ -244,6 +245,8 @@ const MultiviewerPanel = ({ mv }: { mv: AtemMultiviewer }) => {
 }
 
 export const MultiviewerLayoutView = ({ onClose }: MultiviewerLayoutViewProps) => {
+  // Phase 3 der UI-Pruefung: Escape, Fokus-Falle und Fokus-Rueckgabe aus dem
+  // Haken. Die Ansicht wird bedingt gemontiert und kennt kein `open`.
   const t = useTranslation()
   const [state, setState] = useState<AtemStateSummary | null>(null)
   const [connected, setConnected] = useState(false)
@@ -279,12 +282,19 @@ export const MultiviewerLayoutView = ({ onClose }: MultiviewerLayoutViewProps) =
     (mv): mv is AtemMultiviewer => mv !== null && mv !== undefined,
   )
 
+  const { panelRef, titleId, dialogProps } = useDialogA11y(true, onClose)
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
-      <div className="flex max-h-[95vh] w-full max-w-6xl flex-col rounded border border-cp-surface-5 bg-cp-surface-1 text-cp-text">
+      <div
+        ref={panelRef}
+        aria-labelledby={titleId}
+        {...dialogProps}
+        className="flex max-h-[95vh] w-full max-w-6xl flex-col rounded border border-cp-surface-5 bg-cp-surface-1 text-cp-text"
+      >
         <header className="flex items-center justify-between border-b border-cp-border px-4 py-2">
           <div>
-            <h2 className="text-cp-xl font-semibold text-sky-300">
+            <h2 id={titleId} className="text-cp-xl font-semibold text-sky-300">
               {t('atem.mvLayout.title', 'Multiviewer Layout (Live)')}
             </h2>
             {state && (

--- a/src/renderer/components/Delivery/DeliveryDialog.tsx
+++ b/src/renderer/components/Delivery/DeliveryDialog.tsx
@@ -66,6 +66,7 @@ import {
   type DeliveryDestination,
 } from '../../types/delivery'
 import { PanelHint } from '../shared/PanelHint'
+import { useDialogA11y } from '../../hooks/useDialogA11y'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Die Ausspielung (Initiative 9). Ein Register der Ziele: Plattform, Ingest,
@@ -166,6 +167,10 @@ export const DeliveryDialog = () => {
   )
   const deviceName = (id?: string): string =>
     id ? (project.equipment.find((e) => e.id === id)?.name ?? id) : ''
+
+  // Phase 3 der UI-Pruefung: Escape, Fokus-Falle und Fokus-Rueckgabe aus dem
+  // Haken. Vor dem bedingten Ausstieg, weil Haken nicht bedingt laufen.
+  const { panelRef, titleId, dialogProps } = useDialogA11y(open, () => setOpen(false))
 
   if (!open) return null
 
@@ -476,9 +481,14 @@ export const DeliveryDialog = () => {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
-      <div className="flex max-h-[88vh] w-full max-w-5xl flex-col overflow-hidden rounded-lg border border-cp-border bg-cp-surface-1 shadow-xl">
+      <div
+        ref={panelRef}
+        aria-labelledby={titleId}
+        {...dialogProps}
+        className="flex max-h-[88vh] w-full max-w-5xl flex-col overflow-hidden rounded-lg border border-cp-border bg-cp-surface-1 shadow-xl"
+      >
         <div className="flex items-center justify-between border-b border-cp-border px-4 py-2.5">
-          <h2 className="flex items-center gap-2 text-cp-base font-semibold text-cp-text">
+          <h2 id={titleId} className="flex items-center gap-2 text-cp-base font-semibold text-cp-text">
             <Radio size={16} /> {t('delivery.title', 'Ausspielung')}
           </h2>
           <div className="flex items-center gap-2">

--- a/src/renderer/components/DrumMicing/DrumMicingDialog.tsx
+++ b/src/renderer/components/DrumMicing/DrumMicingDialog.tsx
@@ -14,6 +14,7 @@ import {
   DRUM_TECHNIQUES,
 } from '../../lib/drumMicing'
 import type { DrumKitPlan, DrumMicPlacement, DrumTechnique, DrumZone } from '../../types/drumKit'
+import { useDialogA11y } from '../../hooks/useDialogA11y'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // #Drum-Mikrofonierung — visuelles Schlagzeug (SVG-Draufsicht), Mic-Platzierung,
@@ -88,6 +89,10 @@ export const DrumMicingDialog = () => {
       window.setTimeout(() => setCopied(false), 1500)
     })
   }
+
+  // Phase 3 der UI-Pruefung: Escape, Fokus-Falle und Fokus-Rueckgabe aus dem
+  // Haken. Vor dem bedingten Ausstieg, weil Haken nicht bedingt laufen.
+  const { panelRef, titleId, dialogProps } = useDialogA11y(open, () => setOpen(false))
 
   if (!open) return null
 
@@ -205,9 +210,14 @@ export const DrumMicingDialog = () => {
 
   return (
     <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 p-4">
-      <div className="flex max-h-[90vh] w-full max-w-5xl flex-col overflow-hidden rounded-lg border border-cp-border bg-cp-bg shadow-2xl">
+      <div
+        ref={panelRef}
+        aria-labelledby={titleId}
+        {...dialogProps}
+        className="flex max-h-[90vh] w-full max-w-5xl flex-col overflow-hidden rounded-lg border border-cp-border bg-cp-bg shadow-2xl"
+      >
         <header className="flex shrink-0 items-center justify-between border-b border-cp-border-muted px-4 py-2.5">
-          <h2 className="text-cp-lg font-semibold">
+          <h2 id={titleId} className="text-cp-lg font-semibold">
             {t('drum.title', 'Drum-Mikrofonierung')}
           </h2>
           <button

--- a/src/renderer/components/Export/GreenGoExportDialog.tsx
+++ b/src/renderer/components/Export/GreenGoExportDialog.tsx
@@ -27,6 +27,7 @@ import { downloadBlob } from '../../lib/downloadBlob'
 import { exportDeviceConfig } from '../../lib/deviceConfigExport'
 import { buildExportFilenameWithSuffix } from '../../lib/exportFilename'
 import { useTranslation, format } from '../../lib/i18n'
+import { useDialogA11y } from '../../hooks/useDialogA11y'
 
 interface Props {
   onClose: () => void
@@ -358,8 +359,30 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
 
   // ── render ────────────────────────────────────────────────────────────────
 
+  // Phase 3 der UI-Pruefung.
+  //
+  // ESCAPE BRICHT DAS INNERSTE AB, NICHT DAS GANZE. Liegt eine Import-
+  // Zuordnung offen, nimmt Escape sie zurueck (`cancelImport`) statt den
+  // Dialog zu schliessen — sonst waere eine Taste, die man reflexhaft
+  // drueckt, der schnellste Weg, eine halb fertige Zuordnung zu verlieren.
+  //
+  // Der Haken haengt am AEUSSEREN Kasten, weil die Zuordnungs-Ueberlagerung
+  // ein Geschwister des Hauptfeldes IN diesem Kasten ist. Damit umschliesst
+  // die Fokus-Falle beide. Dass der Fokus bei offener Ueberlagerung noch
+  // hinter sie greifen kann, bleibt so — eine verschachtelte zweite Falle
+  // waere hier mehr Mechanik als Gewinn, und heute gibt es gar keine.
+  const { panelRef, dialogProps } = useDialogA11y(true, () => {
+    if (importResult) cancelImport()
+    else onClose()
+  })
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+    <div
+      ref={panelRef}
+      aria-label={t('greengo.title', 'GreenGo Intercom-Planung')}
+      {...dialogProps}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+    >
       <div className="flex max-h-[92vh] w-full max-w-4xl flex-col overflow-hidden rounded border border-emerald-700 bg-cp-surface-1 text-cp-text">
 
         {/* Header */}

--- a/src/renderer/components/Export/VideohubExportDialog.tsx
+++ b/src/renderer/components/Export/VideohubExportDialog.tsx
@@ -32,6 +32,7 @@ import { cablePlannerApi, hasDesktopBridge, type VideohubState } from '../../lib
 import { portDisplayLabel } from '../../lib/portLabel'
 import { roleLabelsByPort } from '../../lib/labelDerivation'
 import { isWithinDistance } from '../../lib/levenshtein'
+import { useDialogA11y } from '../../hooks/useDialogA11y'
 import { promptDialog } from '../../lib/promptDialog'
 import {
   changeoverTable,
@@ -217,6 +218,10 @@ const ChangeoverSheet = ({
 }
 
 export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShowMatrix }: Props) => {
+  // Phase 3 der UI-Pruefung: Escape, Fokus-Falle und Fokus-Rueckgabe kommen
+  // aus dem Haken statt aus eigenem Boilerplate. Der Dialog kennt kein
+  // `open` — er wird bedingt gemountet —, also ist der erste Parameter `true`.
+  const { panelRef, titleId, dialogProps } = useDialogA11y(true, onClose)
   const t = useTranslation()
   const equipment = useProjectStore((s) => s.project.equipment)
   const cables = useProjectStore((s) => s.project.cables)
@@ -909,9 +914,14 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-6">
-      <div className="flex max-h-[95vh] w-full max-w-6xl flex-col overflow-hidden rounded border border-cp-border bg-cp-surface-1 p-4 text-cp-text">
+      <div
+        ref={panelRef}
+        aria-labelledby={titleId}
+        {...dialogProps}
+        className="flex max-h-[95vh] w-full max-w-6xl flex-col overflow-hidden rounded border border-cp-border bg-cp-surface-1 p-4 text-cp-text"
+      >
         <div className="mb-3 flex items-center justify-between">
-          <h3 className="flex items-center gap-2 text-cp-xl font-semibold"><Icon icon={SlidersHorizontal} size="sm" /> {t('export.dialogTitle', 'Videohub konfigurieren · Labels + Routing')}</h3>
+          <h3 id={titleId} className="flex items-center gap-2 text-cp-xl font-semibold"><Icon icon={SlidersHorizontal} size="sm" /> {t('export.dialogTitle', 'Videohub konfigurieren · Labels + Routing')}</h3>
           <button
             type="button"
             onClick={onClose}

--- a/src/renderer/components/Import/GraphmlImportDialog.tsx
+++ b/src/renderer/components/Import/GraphmlImportDialog.tsx
@@ -39,6 +39,7 @@ export interface GraphmlImportDialogProps {
 
 import type { GraphmlDocument } from '../../lib/graphml/types'
 import { GraphmlViewer } from './GraphmlViewer'
+import { useDialogA11y } from '../../hooks/useDialogA11y'
 
 type Stage =
   | { kind: 'empty' }
@@ -130,6 +131,12 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
         c.inferredCableType.toLowerCase().includes(needle),
     )
   }, [stage, filterText])
+
+  // Phase 3 der UI-Pruefung: Escape, Fokus-Falle und Fokus-Rueckgabe aus dem
+  // Haken statt aus eigenem Boilerplate. Er steht VOR dem `if (!open)`, weil
+  // Haken nicht bedingt aufgerufen werden duerfen — `open` geht als Parameter
+  // hinein und schaltet die Wirkung.
+  const { panelRef, titleId, dialogProps } = useDialogA11y(open, onClose)
 
   if (!open) return null
 
@@ -666,9 +673,14 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-6">
-      <div className="flex h-[80vh] w-[min(1100px,95vw)] flex-col overflow-hidden rounded border border-cp-border bg-cp-surface-1 text-cp-text">
+      <div
+        ref={panelRef}
+        aria-labelledby={titleId}
+        {...dialogProps}
+        className="flex h-[80vh] w-[min(1100px,95vw)] flex-col overflow-hidden rounded border border-cp-border bg-cp-surface-1 text-cp-text"
+      >
         <div className="flex items-center justify-between border-b border-cp-border px-4 py-2">
-          <h3 className="text-cp-base font-semibold">{t('graphml.dialog.heading', 'yEd / GraphML importieren')}</h3>
+          <h3 id={titleId} className="text-cp-base font-semibold">{t('graphml.dialog.heading', 'yEd / GraphML importieren')}</h3>
           <button
             type="button"
             onClick={() => {

--- a/src/renderer/components/Layout/CommandPalette.tsx
+++ b/src/renderer/components/Layout/CommandPalette.tsx
@@ -21,6 +21,7 @@ import {
 import { createDemoProject } from '../../lib/demoProject'
 import { useTranslation } from '../../lib/i18n'
 import { Icon } from '../shared/Icon'
+import { useDialogA11y } from '../../hooks/useDialogA11y'
 
 interface Command {
   id: string
@@ -121,6 +122,14 @@ export const CommandPalette = () => {
     node?.scrollIntoView({ block: 'nearest' })
   }, [active])
 
+  // Phase 3 der UI-Pruefung — hier mit `closeOnEscape: false`. Die Palette
+  // hat ihre eigene Tastensteuerung (Pfeile, Enter, Escape) am Eingabefeld;
+  // ein zweites Escape darueber waere doppelt. Was ihr fehlte und was der
+  // Haken beitraegt, sind Fokus-Falle und Fokus-Rueckgabe.
+  const { panelRef, dialogProps } = useDialogA11y(open, close, {
+    closeOnEscape: false,
+  })
+
   if (!open) return null
 
   const runCmd = (c: Command) => {
@@ -151,7 +160,12 @@ export const CommandPalette = () => {
         if (e.target === e.currentTarget) close()
       }}
     >
-      <div className="w-full max-w-xl overflow-hidden rounded-cp-modal border border-cp-border bg-cp-surface-1 shadow-2xl">
+      <div
+        ref={panelRef}
+        aria-label={t('palette.placeholder', 'Befehl suchen…')}
+        {...dialogProps}
+        className="w-full max-w-xl overflow-hidden rounded-cp-modal border border-cp-border bg-cp-surface-1 shadow-2xl"
+      >
         <div className="flex items-center gap-2 border-b border-cp-border px-cp-4 py-cp-3">
           <Icon icon={Search} size="sm" className="text-cp-text-muted" />
           <input

--- a/src/renderer/components/Library/CableLibraryPanel.tsx
+++ b/src/renderer/components/Library/CableLibraryPanel.tsx
@@ -20,6 +20,7 @@ import {
 import { CSS } from '@dnd-kit/utilities'
 import { ALL_SIGNAL_STANDARDS, cableCatalog } from '../../types/cableSpec'
 import type { CableSpec, SignalStandard } from '../../types/cableSpec'
+import { useDialogA11y } from '../../hooks/useDialogA11y'
 import { ALL_CONNECTOR_TYPES } from '../../types/equipment'
 import type { ConnectorType } from '../../types/equipment'
 import { useProjectStore } from '../../store/projectStore'
@@ -83,6 +84,12 @@ const CableTypeEditor = ({
     [customSignalStandards],
   )
 
+  // Phase 3 der UI-Pruefung. Das Panel selbst ist kein Modal — dieser
+  // Kabeltyp-Editor darin schon, und er hatte weder Escape noch Fokus-Falle.
+  // Der Haken steht VOR dem bedingten Ausstieg: Haken duerfen nicht bedingt
+  // laufen, `open` schaltet stattdessen ihre Wirkung.
+  const { panelRef, titleId, dialogProps } = useDialogA11y(open, onCancel)
+
   if (!open) return null
 
   const trimmedName = name.trim()
@@ -109,9 +116,14 @@ const CableTypeEditor = ({
 
   return (
     <div className="fixed inset-0 z-[80] flex items-center justify-center bg-black/70 p-4">
-      <div className="w-full max-w-md rounded border border-cp-border bg-cp-surface-1 p-4 text-cp-text shadow-2xl">
+      <div
+        ref={panelRef}
+        aria-labelledby={titleId}
+        {...dialogProps}
+        className="w-full max-w-md rounded border border-cp-border bg-cp-surface-1 p-4 text-cp-text shadow-2xl"
+      >
         <div className="mb-3 flex items-center justify-between">
-          <h3 className="text-cp-base font-semibold">
+          <h3 id={titleId} className="text-cp-base font-semibold">
             {isEditing ? t('cableLib.editor.editTitle', 'Kabeltyp bearbeiten') : t('cableLib.editor.newTitle', 'Neuer Kabeltyp')}
           </h3>
           <button

--- a/src/renderer/components/Library/LibraryPanel.tsx
+++ b/src/renderer/components/Library/LibraryPanel.tsx
@@ -48,6 +48,7 @@ const connectorOptions = ALL_CONNECTOR_TYPES
 import { defaultGroup, buildPorts } from './libraryPanelHelpers'
 import type { PortGroupDraft } from './libraryPanelHelpers'
 import { PanelHint } from '../shared/PanelHint'
+import { useDialogA11y } from '../../hooks/useDialogA11y'
 
 
 
@@ -658,6 +659,33 @@ export const LibraryPanel = () => {
     }
   }
 
+  // Phase 3 der UI-Pruefung. Das Panel selbst ist kein Modal; die drei
+  // Ueberlagerungen darin sind es, und keine hatte Escape oder Fokus-Falle.
+  // Je eine eigene Falle, weil sie nacheinander stehen und nicht ineinander.
+  // Die Haken stehen VOR den bedingten Ausstiegen unten — Haken duerfen nicht
+  // bedingt laufen; ihre Wirkung schaltet der jeweilige Zustand.
+  //
+  // Auseinandergenommen und nicht als Objekt behalten: `ref={netBoxRef}`
+  // liest waehrend des Renderns eine Eigenschaft eines Ref-Traegers, und
+  // `react-hooks/refs` macht daraus einen Fehler. Der Zugriff ist harmlos,
+  // die Regel ist es nicht — und eine Regel zu unterdruecken, um eine
+  // Schreibweise zu behalten, ist der schlechtere Handel.
+  const {
+    panelRef: netBoxRef,
+    titleId: netBoxTitleId,
+    dialogProps: netBoxProps,
+  } = useDialogA11y(showNetBoxDialog, () => setShowNetBoxDialog(false))
+  const {
+    panelRef: anlegenRef,
+    titleId: anlegenTitleId,
+    dialogProps: anlegenProps,
+  } = useDialogA11y(showCreateDialog, () => setShowCreateDialog(false))
+  const {
+    panelRef: dubletteRef,
+    titleId: dubletteTitleId,
+    dialogProps: dubletteProps,
+  } = useDialogA11y(!!netBoxConflict, () => setNetBoxConflict(null))
+
   // #427 — In separates OS-Fenster ausgelagert: im Hauptfenster NICHT rendern
   // (sonst doppelt offen). In-flow Platzhalter besetzt die (0px) Grid-Spalte,
   // damit die nachfolgenden Grid-Kinder nicht verrutschen.
@@ -868,10 +896,15 @@ export const LibraryPanel = () => {
 
       {showNetBoxDialog && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-6">
-          <div className="max-h-[90vh] w-full max-w-3xl overflow-auto rounded border border-cp-border bg-cp-surface-1 p-4">
+          <div
+            ref={netBoxRef}
+            aria-labelledby={netBoxTitleId}
+            {...netBoxProps}
+            className="max-h-[90vh] w-full max-w-3xl overflow-auto rounded border border-cp-border bg-cp-surface-1 p-4"
+          >
             <div className="mb-3 flex items-start justify-between gap-3">
               <div>
-                <h3 className="text-cp-xl font-semibold">{t('library.netbox.title', 'NetBox Import')}</h3>
+                <h3 id={netBoxTitleId} className="text-cp-xl font-semibold">{t('library.netbox.title', 'NetBox Import')}</h3>
                 <PanelHint
                   className="mt-1 text-cp-xs text-cp-text-muted"
                   text={t(
@@ -991,8 +1024,13 @@ export const LibraryPanel = () => {
 
       {showCreateDialog && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-6">
-          <div className="max-h-[90vh] w-full max-w-2xl overflow-auto rounded border border-cp-border bg-cp-surface-1 p-4">
-            <h3 className="mb-3 text-cp-xl font-semibold">
+          <div
+            ref={anlegenRef}
+            aria-labelledby={anlegenTitleId}
+            {...anlegenProps}
+            className="max-h-[90vh] w-full max-w-2xl overflow-auto rounded border border-cp-border bg-cp-surface-1 p-4"
+          >
+            <h3 id={anlegenTitleId} className="mb-3 text-cp-xl font-semibold">
               {t('library.create.title', 'Eigenes Gerät anlegen')}
             </h3>
             <div className="mb-3 grid grid-cols-3 gap-2 text-cp-base">
@@ -1309,8 +1347,13 @@ export const LibraryPanel = () => {
 
       {netBoxConflict && (
         <div className="fixed inset-0 z-[75] flex items-center justify-center bg-black/70 p-6">
-          <div className="w-full max-w-xl rounded border border-amber-600 bg-cp-surface-1 p-4 text-cp-text">
-            <h3 className="mb-2 text-cp-xl font-semibold text-amber-300">{t('library.duplicate.title', 'Gerät existiert bereits')}</h3>
+          <div
+            ref={dubletteRef}
+            aria-labelledby={dubletteTitleId}
+            {...dubletteProps}
+            className="w-full max-w-xl rounded border border-amber-600 bg-cp-surface-1 p-4 text-cp-text"
+          >
+            <h3 id={dubletteTitleId} className="mb-2 text-cp-xl font-semibold text-amber-300">{t('library.duplicate.title', 'Gerät existiert bereits')}</h3>
             <p className="mb-3 text-cp-base text-cp-text-secondary">
               {format(
                 t('library.netbox.duplicateIntro', '{name} ist bereits in der lokalen Library. Wahlen, wie importiert werden soll.'),

--- a/src/renderer/components/Network/ReconcileDialog.tsx
+++ b/src/renderer/components/Network/ReconcileDialog.tsx
@@ -26,6 +26,7 @@ import {
   unverifiedEntries,
 } from '../../lib/asBuilt'
 import { PanelHint } from '../shared/PanelHint'
+import { useDialogA11y } from '../../hooks/useDialogA11y'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Plan gegen Vorgefundenes (Bedarf 21).
@@ -94,6 +95,10 @@ export const ReconcileDialog = () => {
 
   const asBuiltStand = useMemo(() => asBuiltSummary(asBuilt), [asBuilt])
 
+  // Phase 3 der UI-Pruefung: Escape, Fokus-Falle und Fokus-Rueckgabe aus dem
+  // Haken. Vor dem bedingten Ausstieg, weil Haken nicht bedingt laufen.
+  const { panelRef, titleId, dialogProps } = useDialogA11y(open, () => setOpen(false))
+
   if (!open) return null
 
   const load = async () => {
@@ -159,9 +164,14 @@ export const ReconcileDialog = () => {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
-      <div className="flex max-h-[88vh] w-full max-w-4xl flex-col overflow-hidden rounded-lg border border-cp-border bg-cp-surface-1 shadow-xl">
+      <div
+        ref={panelRef}
+        aria-labelledby={titleId}
+        {...dialogProps}
+        className="flex max-h-[88vh] w-full max-w-4xl flex-col overflow-hidden rounded-lg border border-cp-border bg-cp-surface-1 shadow-xl"
+      >
         <div className="flex items-center justify-between border-b border-cp-border px-4 py-2.5">
-          <h2 className="text-cp-base font-semibold text-cp-text">
+          <h2 id={titleId} className="text-cp-base font-semibold text-cp-text">
             {t('reconcile.title', 'Plan gegen Vorgefundenes')}
           </h2>
           <button

--- a/src/renderer/components/Rack/RackBuilderDialog.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialog.tsx
@@ -50,6 +50,7 @@ import {
   DEFAULT_ROW_HEIGHT, DRAFT_KEY, parseUnits, toPlacement, normalizeDraft,
   formatRackUnits, draftFromPreset,
 } from './rackBuilderHelpers'
+import { useDialogA11y } from '../../hooks/useDialogA11y'
 
 export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onSave }: RackBuilderDialogProps) => {
   const t = useTranslation()
@@ -585,13 +586,31 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
     onClose()
   }
 
+  // Phase 3 der UI-Pruefung — mit EINER Abweichung: `closeOnEscape: false`.
+  //
+  // Dieser Dialog hat seit v7.9.9 eine eigene Escape-Behandlung, und die kann
+  // der Haken nicht ersetzen: sie fragt bei ungesicherten Aenderungen nach
+  // (`closeWithConfirm`) und schweigt, solange ein Unter-Dialog offen ist.
+  // Ein zweites Escape daneben wuerde genau daran vorbei schliessen — also
+  // nimmt der Haken hier nur Fokus-Falle und Fokus-Rueckgabe, und das
+  // Schliessen bleibt, wo die Ruecksicht steht.
+  // `aria-label` statt `aria-labelledby`: die Ueberschrift lebt in
+  // `RackBuilderHeader`, und ein `aria-labelledby`, das auf nichts zeigt, ist
+  // schlechter als keins — der Screenreader liest dann gar nichts vor.
+  const { panelRef, dialogProps } = useDialogA11y(open, onClose, {
+    closeOnEscape: false,
+    ref: containerRef,
+  })
+
   if (!open) return null
 
   return (
     <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/70 p-2 sm:p-6">
       <div
-        ref={containerRef}
+        ref={panelRef}
         style={containerStyle}
+        aria-label={t('rack.newRack', 'Neues Rack')}
+        {...dialogProps}
         // v7.9.2 — responsive: kein fixes 1400px max-width, sondern
         // 100vw mit Padding. Verhindert horizontal-Scroll auf Laptops.
         className="flex max-h-[96vh] w-[min(1400px,calc(100vw-1rem))] flex-col overflow-hidden rounded border border-cp-border bg-cp-surface-1 p-3 text-cp-text shadow-2xl sm:p-4"

--- a/src/renderer/components/Rack/RackEditorDialog.tsx
+++ b/src/renderer/components/Rack/RackEditorDialog.tsx
@@ -33,6 +33,7 @@ import { useTranslation } from '../../lib/i18n'
 import { EquipmentNode } from '../Canvas/EquipmentNode'
 import { CableEdge } from '../Canvas/CableEdge'
 import { PanelHint } from '../shared/PanelHint'
+import { useDialogA11y } from '../../hooks/useDialogA11y'
 
 const nodeTypes = { equipment: EquipmentNode }
 const edgeTypes = { cable: CableEdge }
@@ -213,6 +214,13 @@ export const RackEditorDialog = () => {
     'cable-planner:modal-pos:rack-editor',
     slot.open,
   )
+  // Phase 3 der UI-Pruefung. Der Haken bekommt die VORHANDENE Container-Ref
+  // mit (`ref`-Option), damit Fokus-Falle und Zieh-Container denselben Knoten
+  // meinen — dafuer gibt es die Option, und eine zweite Ref daneben waere
+  // genau die Sorte stiller Widerspruch, die spaeter niemand mehr findet.
+  const { panelRef, titleId, dialogProps } = useDialogA11y(slot.open, close, {
+    ref: containerRef,
+  })
   if (!slot.open || !slot.rackInstanceId) return null
 
   return (
@@ -221,8 +229,10 @@ export const RackEditorDialog = () => {
       onMouseDown={(e) => e.target === e.currentTarget && close()}
     >
       <div
-        ref={containerRef}
+        ref={panelRef}
         style={containerStyle}
+        aria-labelledby={titleId}
+        {...dialogProps}
         className="flex h-[80vh] w-full max-w-5xl flex-col overflow-hidden rounded border border-cp-border bg-cp-surface-1 text-cp-text shadow-2xl"
       >
         <header
@@ -230,7 +240,7 @@ export const RackEditorDialog = () => {
           className="flex items-center justify-between border-b border-cp-border px-4 py-2 select-none"
         >
           <div>
-            <h2 className="text-cp-base font-semibold">{t('rackEditor.title', 'Rack-Editor')}</h2>
+            <h2 id={titleId} className="text-cp-base font-semibold">{t('rackEditor.title', 'Rack-Editor')}</h2>
             <PanelHint
               className="text-[10px] text-cp-text-muted"
               text={t(

--- a/src/renderer/components/Rack/RackImageCropDialog.tsx
+++ b/src/renderer/components/Rack/RackImageCropDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useDraggablePosition } from '../../hooks/useDraggablePosition'
 import { format, useTranslation } from '../../lib/i18n'
+import { useDialogA11y } from '../../hooks/useDialogA11y'
 
 interface CropRect {
   x: number
@@ -265,6 +266,17 @@ export const RackImageCropDialog = ({
     }
   }
 
+  // Phase 3 der UI-Pruefung. Der Haken bekommt die vorhandene Container-Ref
+  // mit, damit Fokus-Falle und Zieh-Container denselben Knoten meinen.
+  //
+  // Sein `onKeyDown` sitzt am INNEREN Kasten, die vorhandene Pfeiltasten-
+  // Steuerung am aeusseren. Das vertraegt sich: der Haken greift nur nach
+  // Escape und Tab, alles andere blubbert weiter nach aussen zur
+  // Zuschnitt-Steuerung. Escape gab es hier vorher gar nicht.
+  const { panelRef, titleId, dialogProps } = useDialogA11y(open, onCancel, {
+    ref: containerRef,
+  })
+
   if (!open || !imageSrc) return null
 
   const finalizeCrop = () => {
@@ -305,8 +317,10 @@ export const RackImageCropDialog = ({
       onKeyDown={onKeyDown}
     >
       <div
-        ref={containerRef}
+        ref={panelRef}
         style={containerStyle}
+        aria-labelledby={titleId}
+        {...dialogProps}
         className="max-h-[94vh] w-full max-w-5xl overflow-auto rounded border border-cp-border bg-cp-surface-1 p-4 text-cp-text shadow-2xl"
       >
         <div
@@ -314,7 +328,7 @@ export const RackImageCropDialog = ({
           className="mb-3 flex items-start justify-between gap-3 select-none"
         >
           <div>
-            <h3 className="text-cp-xl font-semibold">
+            <h3 id={titleId} className="text-cp-xl font-semibold">
               {format(
                 side === 'front'
                   ? t('rackCrop.titleFront', 'Front Grafik zuschneiden ({units} HE)')

--- a/src/renderer/components/Rack/RackInternalWireOverlay.tsx
+++ b/src/renderer/components/Rack/RackInternalWireOverlay.tsx
@@ -4,6 +4,7 @@ import { RackInternalCanvas } from './RackInternalCanvas'
 import type { InternalCableDraft, RackPlacementDraft } from './rackBuilderTypes'
 import { PanelHint } from '../shared/PanelHint'
 import { rackWireFindings } from '../../lib/rackWireChecks'
+import { useDialogA11y } from '../../hooks/useDialogA11y'
 
 /** v7.8.5+ — Wire-Dialog-Overlay fuer die Rack-interne Verkabelung.
  *
@@ -34,6 +35,10 @@ export const RackInternalWireOverlay = ({
   onPlacementMoved,
 }: RackInternalWireOverlayProps) => {
   const t = useTranslation()
+  // Phase 3 der UI-Pruefung: Escape, Fokus-Falle und Fokus-Rueckgabe aus dem
+  // Haken. Vor dem bedingten Ausstieg, weil Haken nicht bedingt laufen.
+  const { panelRef, titleId, dialogProps } = useDialogA11y(open, onClose)
+
   if (!open) return null
 
   // ISSUE #663 — „Es fehlt die Fehlermeldung, dass Kabeltypen nicht
@@ -71,10 +76,15 @@ export const RackInternalWireOverlay = ({
 
   return (
     <div className="fixed inset-0 z-[80] flex items-center justify-center bg-black/70 p-2 sm:p-6">
-      <div className="flex h-[92vh] w-[min(1500px,calc(100vw-1rem))] flex-col rounded border border-cp-border bg-cp-surface-1 p-3 text-cp-text shadow-2xl">
+      <div
+        ref={panelRef}
+        aria-labelledby={titleId}
+        {...dialogProps}
+        className="flex h-[92vh] w-[min(1500px,calc(100vw-1rem))] flex-col rounded border border-cp-border bg-cp-surface-1 p-3 text-cp-text shadow-2xl"
+      >
         <div className="mb-2 flex items-center justify-between gap-3">
           <div>
-            <h3 className="text-cp-xl font-semibold">{t('rack.wire.title', 'Rack-Verkabelung')}: {rackName || t('rack.unnamed', '(unbenannt)')}</h3>
+            <h3 id={titleId} className="text-cp-xl font-semibold">{t('rack.wire.title', 'Rack-Verkabelung')}: {rackName || t('rack.unnamed', '(unbenannt)')}</h3>
             <PanelHint
               className="mt-1 text-cp-xs text-cp-text-muted"
               text={t(

--- a/src/renderer/components/Rentman/NewRentmanDeviceWizard.tsx
+++ b/src/renderer/components/Rentman/NewRentmanDeviceWizard.tsx
@@ -8,6 +8,7 @@ import { suggestFromWeb } from '../../lib/webPortSuggestions'
 import { useProjectStore } from '../../store/projectStore'
 import { format, useTranslation } from '../../lib/i18n'
 import { CategorySelect } from '../shared/CategorySelect'
+import { useDialogA11y } from '../../hooks/useDialogA11y'
 
 const connectorOptions: ConnectorType[] = [
   'XLR',
@@ -82,6 +83,10 @@ export const NewRentmanDeviceWizard = ({
   }, [current])
 
   const progress = useMemo(() => `${Math.min(index + 1, items.length)} / ${items.length}`, [index, items.length])
+
+  // Phase 3 der UI-Pruefung. Vor dem bedingten Ausstieg, weil Haken nicht
+  // bedingt laufen duerfen; `open` schaltet stattdessen ihre Wirkung.
+  const { panelRef, titleId, dialogProps } = useDialogA11y(open, onCancel)
 
   if (!open || !current) return null
 
@@ -181,10 +186,15 @@ export const NewRentmanDeviceWizard = ({
 
   return (
     <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/70 p-6">
-      <div className="max-h-[90vh] w-full max-w-3xl overflow-auto rounded border border-cp-border bg-cp-surface-1 p-4 text-cp-text">
+      <div
+        ref={panelRef}
+        aria-labelledby={titleId}
+        {...dialogProps}
+        className="max-h-[90vh] w-full max-w-3xl overflow-auto rounded border border-cp-border bg-cp-surface-1 p-4 text-cp-text"
+      >
         <div className="mb-3 flex items-center justify-between">
           <div>
-            <h3 className="text-cp-xl font-semibold">
+            <h3 id={titleId} className="text-cp-xl font-semibold">
               {format(t('rentman.wizard.title', 'Neues Rentman-Gerät ({progress})'), { progress })}
             </h3>
             <p className="mt-1 text-cp-xs text-cp-text-muted">

--- a/src/renderer/components/Rentman/RentmanImportDialog.tsx
+++ b/src/renderer/components/Rentman/RentmanImportDialog.tsx
@@ -43,6 +43,7 @@ import type {
   RentmanProject, RentmanEquipment, DetectedCableRow,
 } from './rentmanImportHelpers'
 import { PanelHint } from '../shared/PanelHint'
+import { useDialogA11y } from '../../hooks/useDialogA11y'
 
 interface RentmanImportDialogProps {
   open: boolean
@@ -320,6 +321,17 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, linkedProjectId, projects.length, selectedProjectId])
+
+  // Phase 3 der UI-Pruefung. Escape geht ueber `safeClose` und nicht ueber
+  // `onClose`: dieser Dialog lehnt das Schliessen ab, solange ein Import
+  // laeuft, und eine Taste, die diese Sperre umgeht, waere schlimmer als
+  // keine Taste — sie bricht den Vorgang halb ab.
+  //
+  // Der Haken haengt am AEUSSEREN Kasten, weil dieser Dialog je nach Zustand
+  // eines von fuenf Feldern zeigt; die Fokus-Falle muss sie alle umschliessen.
+  // Deshalb `aria-label` statt `aria-labelledby`: es gibt keine EINE
+  // Ueberschrift, und auf eine von fuenfen zu zeigen waere falsch.
+  const { panelRef, dialogProps } = useDialogA11y(open, safeClose)
 
   if (!open) {
     return null
@@ -1035,7 +1047,12 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
   const activeMergeItem = mergeQueue[mergeIndex] ?? null
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-6">
+    <div
+      ref={panelRef}
+      aria-label={t('rentman.import.title', 'Aus Rentman importieren')}
+      {...dialogProps}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-6"
+    >
       {/* ── Confirmation: switch linked Rentman project ── */}
       {pendingProjectSwitch && (
         <div className="w-full max-w-md rounded border border-amber-600 bg-cp-surface-1 p-5 text-cp-text shadow-xl">

--- a/src/renderer/components/Wireless/WirelessRigDialog.tsx
+++ b/src/renderer/components/Wireless/WirelessRigDialog.tsx
@@ -10,6 +10,7 @@ import { collectTransmitters } from '../../lib/spectrumPlan'
 import type { WirelessRigPlan, WirelessChannel } from '../../types/wirelessRig'
 import { MicPlotPanel } from './MicPlotPanel'
 import { PanelHint } from '../shared/PanelHint'
+import { useDialogA11y } from '../../hooks/useDialogA11y'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Funkstrecken / Gesang — Kanalplan: je Kanal Body + kompatible Kapsel/Headset +
@@ -56,6 +57,10 @@ export const WirelessRigDialog = () => {
 
   const [freqDraft, setFreqDraft] = useState<Record<string, string>>({})
 
+  // Phase 3 der UI-Pruefung: Escape, Fokus-Falle und Fokus-Rueckgabe aus dem
+  // Haken. Vor dem bedingten Ausstieg, weil Haken nicht bedingt laufen.
+  const { panelRef, titleId, dialogProps } = useDialogA11y(open, () => setOpen(false))
+
   if (!open) return null
 
   const addChannel = () => {
@@ -94,9 +99,14 @@ export const WirelessRigDialog = () => {
 
   return (
     <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 p-4">
-      <div className="flex max-h-[90vh] w-full max-w-5xl flex-col overflow-hidden rounded-lg border border-cp-border bg-cp-bg shadow-2xl">
+      <div
+        ref={panelRef}
+        aria-labelledby={titleId}
+        {...dialogProps}
+        className="flex max-h-[90vh] w-full max-w-5xl flex-col overflow-hidden rounded-lg border border-cp-border bg-cp-bg shadow-2xl"
+      >
         <header className="flex shrink-0 items-center justify-between border-b border-cp-border-muted px-4 py-2.5">
-          <h2 className="flex items-center gap-2 text-cp-lg font-semibold">
+          <h2 id={titleId} className="flex items-center gap-2 text-cp-lg font-semibold">
             <Radio size={18} /> {t('wireless.title', 'Funkstrecken / Gesang')}
           </h2>
           <button

--- a/tests/dialogTastaturbedienung.test.ts
+++ b/tests/dialogTastaturbedienung.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+// ---------------------------------------------------------------------------
+// Jeder modale Dialog ist mit der Tastatur bedienbar (UI-Pruefung, Phase 3).
+//
+// Der Befund stand in `docs/ui-audit.md` und war doppelt richtig:
+//
+//   > `ModalShell`: kein `aria-modal`, kein `aria-labelledby`, keine
+//   > Focus-Trap, kein Escape-to-close, keine Fokus-Rueckgabe.
+//
+// Die Shell hat das laengst; was blieb, war eine Liste von siebzehn
+// Standalone-Dialogen, die ihr eigenes `fixed inset-0`-Geruest rollen.
+//
+// ─── WARUM DIESER WAECHTER LAEUFT UND NICHT DIE LISTE ──────────────────────
+//
+// Die Liste im Audit war an zwei Enden falsch, und beide Fehler kommen
+// daher, dass sie VON HAND gefuehrt wurde:
+//
+//   * SIEBEN der siebzehn brauchten gar nichts mehr — sie gehen laengst
+//     ueber `ModalShell`, und die hat den Haken seit derselben Phase.
+//   * NEUN Dialoge fehlten in ihr ganz. Sie sind nach dem Audit entstanden
+//     (Ausspielung, Drum-Mikrofonierung, Funkstrecken, Rack-Verkabelung,
+//     Abgleich, Befehlspalette …) und niemand hat sie nachgetragen.
+//
+// Dieselbe Lehre wie beim Lager-Vertrag: DIE DOMAENE IST DER ORDNER, NICHT
+// EINE LISTE IM WAECHTER. Dieser Test laeuft deshalb ueber
+// `src/renderer/components` und findet jede Datei, die ein eigenes
+// `fixed inset-0` aufspannt. Wer morgen einen Dialog anlegt, wird hier rot,
+// ohne dass jemand eine Liste pflegt.
+// ---------------------------------------------------------------------------
+
+const WURZEL = join(process.cwd(), 'src', 'renderer', 'components')
+
+const dateien = (dir: string): string[] =>
+  readdirSync(dir).flatMap((eintrag) => {
+    const pfad = join(dir, eintrag)
+    if (statSync(pfad).isDirectory()) return dateien(pfad)
+    return pfad.endsWith('.tsx') ? [pfad] : []
+  })
+
+/** Ein eigenes `fixed inset-0` ist die Signatur eines selbstgebauten Modals. */
+const MODAL = /className="fixed inset-0/
+
+const modale = (): string[] =>
+  dateien(WURZEL)
+    .filter((f) => MODAL.test(readFileSync(f, 'utf8')))
+    .map((f) => relative(WURZEL, f))
+    .sort()
+
+const inhalt = (rel: string): string => readFileSync(join(WURZEL, rel), 'utf8')
+
+describe('jeder selbstgebaute Dialog ist mit der Tastatur bedienbar', () => {
+  it('findet ueberhaupt Dialoge — sonst prueft der Test nichts', () => {
+    // Ohne diese Zusicherung waere der Test auch dann gruen, wenn das Muster
+    // nicht mehr passt und die Liste leer zurueckkommt.
+    expect(modale().length).toBeGreaterThan(10)
+  })
+
+  it('zieht Escape, Fokus-Falle und Fokus-Rueckgabe aus DEM EINEN Haken', () => {
+    // `ModalShell` benutzt denselben Haken — eine Datei, die ueber sie geht,
+    // ist damit gedeckt.
+    const ohne = modale().filter((rel) => {
+      const src = inhalt(rel)
+      return !src.includes('useDialogA11y') && !src.includes('ModalShell')
+    })
+    expect(ohne, `ohne Tastatur-Bedienung: ${ohne.join(', ')}`).toEqual([])
+  })
+
+  it('haengt den Haken an einen Kasten, nicht nur an den Import', () => {
+    // GESCHAERFT NACH ZWEI GEGENPROBEN.
+    //
+    // Die erste Fassung suchte nur den NAMEN `useDialogA11y` und blieb gruen,
+    // als die Verwendung entfernt wurde und die Import-Zeile stehenblieb.
+    //
+    // Die zweite suchte die Namen `panelRef` und `dialogProps` — und wurde
+    // rot, als eine Datei sie beim Auseinandernehmen umbenannte
+    // (`panelRef: netBoxRef`), obwohl alles richtig verdrahtet war. Ein
+    // Waechter, der an einer Umbenennung rot wird, wird geaendert statt
+    // gelesen.
+    //
+    // Geprueft werden deshalb DIE NAMEN, DIE DIE DATEI SELBST BINDET: aus
+    // jedem `useDialogA11y`-Aufruf werden sie ausgelesen, und dann muss der
+    // Ref-Name in einem `ref={…}` und der Props-Name in einer Ausbreitung
+    // stehen.
+    const halb = modale().filter((rel) => {
+      const src = inhalt(rel)
+      const aufrufe = [...src.matchAll(/const\s*\{([^}]*)\}\s*=\s*useDialogA11y/g)]
+      if (aufrufe.length === 0) return false
+      return aufrufe.some((m) => {
+        const gebunden = (feld: string): string | null => {
+          const treffer = new RegExp(`${feld}\\s*(?::\\s*(\\w+))?`).exec(m[1])
+          if (!treffer) return null
+          return treffer[1] ?? feld
+        }
+        const refName = gebunden('panelRef')
+        const propsName = gebunden('dialogProps')
+        if (!refName || !propsName) return true
+        return (
+          !new RegExp(`ref=\\{${refName}\\}`).test(src) ||
+          !new RegExp(`\\{\\.\\.\\.${propsName}\\}`).test(src)
+        )
+      })
+    })
+    expect(halb, `Haken importiert, aber nicht verdrahtet: ${halb.join(', ')}`).toEqual([])
+  })
+
+  it('beschriftet jeden Dialog — entweder ueber eine Ueberschrift oder direkt', () => {
+    // Ein `role="dialog"` ohne Namen liest der Screenreader als „Dialog".
+    // Und ein `aria-labelledby`, das auf nichts zeigt, ist schlechter als
+    // keins: dann liest er gar nichts.
+    // GESCHAERFT NACH DER GEGENPROBE: die erste Fassung suchte `aria-label`
+    // IRGENDWO in der Datei — und blieb gruen, als die Beschriftung vom
+    // Dialog verschwand, weil der Schliessen-Knopf daneben eine hat. Geprueft
+    // wird deshalb die Umgebung JEDER `{...dialogProps}`-Stelle, also der
+    // Kasten, der `role="dialog"` bekommt.
+    const namenlos = modale().filter((rel) => {
+      const src = inhalt(rel)
+      const stellen = [...src.matchAll(/\{\.\.\.[\w.]*[Dd]ialogProps\}/g)]
+      if (stellen.length === 0) return false
+      return stellen.some((m) => {
+        const von = Math.max(0, (m.index ?? 0) - 220)
+        const umgebung = src.slice(von, (m.index ?? 0) + 220)
+        const zeigtAufTitel = /aria-labelledby=\{[^}]*titleId\}/i.test(umgebung)
+        if (zeigtAufTitel) return !/id=\{[^}]*titleId\}/i.test(src)
+        return !/aria-label=\{/.test(umgebung)
+      })
+    })
+    expect(namenlos, `Dialog ohne lesbaren Namen: ${namenlos.join(', ')}`).toEqual([])
+  })
+})
+
+describe('der Haken selbst', () => {
+  const haken = readFileSync(
+    join(process.cwd(), 'src', 'renderer', 'hooks', 'useDialogA11y.ts'),
+    'utf8',
+  )
+
+  it('gibt den Fokus an den Ausloeser zurueck', () => {
+    // Ohne Rueckgabe steht der Fokus nach dem Schliessen am Seitenanfang, und
+    // wer per Tastatur arbeitet, faengt jedes Mal von vorn an.
+    expect(haken).toContain('lastFocusedRef')
+  })
+
+  it('laesst sich das Schliessen abschalten', () => {
+    // Zwei Dialoge brauchen das: der Rack-Builder fragt bei ungesicherten
+    // Aenderungen nach, die Befehlspalette hat ihre eigene Tastensteuerung.
+    // Ein Escape daneben wuerde an beidem vorbei schliessen.
+    expect(haken).toContain('closeOnEscape')
+  })
+
+  it('nimmt eine fremde Ref, statt eine zweite danebenzustellen', () => {
+    // Die zieh- und die falle-tragende Ref muessen denselben Knoten meinen.
+    expect(haken).toContain('ref?: RefObject')
+  })
+})


### PR DESCRIPTION
Phase 3 der UI-Prüfung (`docs/ui-audit.md`) hatte einen Rest: **siebzehn** Standalone-Dialoge mit eigenem `fixed inset-0`-Gerüst, ohne Fokus-Falle, ohne Fokus-Rückgabe, teils ohne Escape. Wer mit der Tastatur arbeitet, tabbte aus dem offenen Dialog heraus in die Seite dahinter und fand nicht zurück.

## Die Liste war an beiden Enden falsch

Beides, weil sie von Hand geführt wurde:

- **Sieben der siebzehn** brauchten gar nichts mehr: `RentmanCableExportDialog`, `NonRackAddDialog`, `PatchPanelCreateDialog`, `RackShelfCreateDialog`, `MobileShareDialog`, `LocationBomDialog`, `CableBomDialog` gehen längst über `ModalShell` — und die hat den Hook seit derselben Phase.
- **Neun Dialoge fehlten ganz.** Nach dem Audit entstanden, nie nachgetragen: `ReconcileDialog`, `DeliveryDialog`, `DrumMicingDialog`, `WirelessRigDialog`, `RackInternalWireOverlay`, `RackBuilderDialog`, `CommandPalette` und die vier Überlagerungen in `LibraryPanel`/`CableLibraryPanel` — die Panels sind keine Modals, die Dialoge **in** ihnen schon.

Umgestellt: **vierzehn Dateien, sechzehn Dialog-Flächen.**

## Vier Stellen brauchten mehr als das Muster

| Dialog | Abweichung | Warum |
|---|---|---|
| `RackBuilderDialog` | `closeOnEscape: false` | fragt bei ungesicherten Änderungen nach — ein zweites Escape schlösse an der Rückfrage vorbei |
| `CommandPalette` | `closeOnEscape: false` | hat ihre eigene Tastensteuerung |
| `RentmanImportDialog` | schließt über `safeClose` | der Dialog lehnt das Schließen ab, solange ein Import läuft; eine Taste, die das umgeht, bricht den Vorgang halb ab |
| `GreenGoExportDialog` | Escape bricht das **Innerste** ab | liegt eine Import-Zuordnung offen, nimmt Escape sie zurück statt den Dialog zu schließen — sonst ist eine reflexhaft gedrückte Taste der schnellste Weg, eine halb fertige Zuordnung zu verlieren |

Wo ein Dialog eine vorhandene Zieh-Container-Ref hat (Rack-Editor, Rack-Zuschnitt, Audio-Router, Rack-Builder), bekommt der Hook sie über seine `ref`-Option mit, statt eine zweite danebenzustellen.

## Der Wächter läuft, statt zu listen

`tests/dialogTastaturbedienung.test.ts` geht über `src/renderer/components` und findet jede Datei, die ein eigenes `fixed inset-0` aufspannt. Für die verlangt er den Hook (oder `ModalShell`), die richtige Verdrahtung und einen lesbaren Namen.

**Wer morgen einen Dialog anlegt, wird rot, ohne dass jemand eine Liste pflegt.** Dieselbe Lehre wie beim Lager-Vertrag in ADR-006: *die Domäne ist der Ordner, nicht eine Liste im Wächter.* Genau daran ist die Audit-Liste zweimal gescheitert.

## Gegenproben

Drei Eingriffe, alle rot: ein neuer Dialog ohne jede Tastatur-Bedienung · ein Hook importiert, aber nicht verdrahtet · ein Dialog ohne lesbaren Namen.

**Zweimal hat eine Gegenprobe den Wächter erwischt, nicht den Fix:**

1. „Dialog ohne lesbaren Namen" blieb **grün** — der Test suchte `aria-label` *irgendwo* in der Datei, und der Schließen-Knopf daneben hat eins. Er prüft jetzt die Umgebung jeder `{...dialogProps}`-Stelle, also den Kasten, der `role="dialog"` bekommt.
2. „Hook verdrahtet" wurde **rot**, als eine Datei die Bindungen beim Auseinandernehmen umbenannte (`panelRef: netBoxRef`) — obwohl alles richtig war. Er liest die Namen jetzt *aus dem Aufruf*, statt feste zu erwarten. Ein Wächter, der an einer Umbenennung rot wird, wird geändert statt gelesen.

Das Umbenennen war kein Geschmack: `ref={netBox.panelRef}` liest während des Renderns eine Eigenschaft eines Ref-Trägers, und `react-hooks/refs` macht daraus einen Fehler. Eine Regel zu unterdrücken, um eine Schreibweise zu behalten, wäre der schlechtere Handel.

## Geprüft

3067 Tests grün (2 skipped), `npx tsc -p tsconfig.app.json --noEmit` = 0, `npm run lint` = 0 Errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_