### PR TITLE
lager: Katalog-Typ aus der Stückliste zuweisen — ADR-002 „Was offen bleibt"

### DIFF
--- a/src/renderer/components/Export/ExportDialog.tsx
+++ b/src/renderer/components/Export/ExportDialog.tsx
@@ -18,6 +18,7 @@ import jsPDF from 'jspdf'
 import { useUiStore } from '../../store/uiStore'
 import { PacketSection } from './PacketSection'
 import { useProjectStore } from '../../store/projectStore'
+import { listDeviceTypes } from '../../lib/deviceTypeRegistry'
 import { AlertTriangle, Check, Download, Lightbulb, Package as PackageIcon } from 'lucide-react'
 import { useTranslation, format } from '../../lib/i18n'
 import { detectLayerForConnector, type StandardLayer } from '../../lib/cableLayers'
@@ -1558,6 +1559,19 @@ const DeviceBomSection = () => {
   // davon in der Werkstatt standen.
   const units = useEinheiten()
   const typBestaetigen = useTypBestaetigen()
+  // ADR-002, die zweite Haelfte des Auswegs: Der Vorschlag laesst sich auf der
+  // LAGER-Position bestaetigen (`typBestaetigen`) — aber eine Zeile ohne
+  // Katalog-Typ im PLAN blieb ohne Handlung. Sie stand mit „(ohne Katalog-Typ)"
+  // da, und wer das lesen konnte, musste das Geraet auf dem Canvas suchen und
+  // im Eigenschaften-Panel einzeln zuweisen. Bei drei gleichen Kameras dreimal.
+  const updateEquipment = useProjectStore((s) => s.updateEquipment)
+  const katalogTypen = useMemo(() => listDeviceTypes(), [])
+  const typZuweisen = (ids: string[], deviceTypeId: string) => {
+    // Alle Geraete der Zeile in einem Zug: Der Bedarf ist der Typ, gezaehlt.
+    // Eine halb zugewiesene Zeile zerfiele beim naechsten Abgleich in eine
+    // Tatsache und mehrere Vermutungen.
+    for (const id of ids) updateEquipment(id, { deviceTypeId })
+  }
 
   // `drumKit` und `wirelessRig` sind eigene Projektfelder und standen in
   // keiner Stueckliste. Beide tragen echte Katalog-GUIDs; das Zubehoer der
@@ -1634,6 +1648,41 @@ const DeviceBomSection = () => {
                         >
                           {t('export.devicebom.noType', '(ohne Katalog-Typ)')}
                         </span>
+                      )}
+                      {/* Der Ausweg aus „(ohne Katalog-Typ)": ein Griff, der
+                          allen Geraeten dieser Zeile die Katalog-Identitaet
+                          gibt. Ab dann deckt der Abgleich ueber die GUID —
+                          eine Tatsache statt eines Namensvergleichs, und zwar
+                          dauerhaft im Plan, nicht nur in dieser Ansicht.
+
+                          NUR wo es ein Ziel gibt: Rack-Innenleben und
+                          Zusatz-Bedarfe haben kein eigenes EquipmentItem
+                          (`typeTargetIds` ist dort leer). Ein Auswahlfeld,
+                          das dort ins Leere schriebe, waere schlimmer als
+                          keines. */}
+                      {row.modelIsDeviceName && row.typeTargetIds.length > 0 && (
+                        <select
+                          value=""
+                          onChange={(event) => {
+                            if (event.target.value) {
+                              typZuweisen(row.typeTargetIds, event.target.value)
+                            }
+                          }}
+                          className="ml-2 max-w-[14rem] rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-[10px] text-cp-text-secondary"
+                          title={t(
+                            'export.devicebom.assignTitle',
+                            'Schreibt den Katalog-Typ auf alle Geräte dieser Zeile. Danach deckt der Lager-Abgleich über die Katalog-Identität statt über den Namen.',
+                          )}
+                        >
+                          <option value="">
+                            {t('export.devicebom.assign', 'Typ zuweisen…')}
+                          </option>
+                          {katalogTypen.map((c) => (
+                            <option key={c.id} value={c.id}>
+                              {c.category ? `${c.name} · ${c.category}` : c.name}
+                            </option>
+                          ))}
+                        </select>
                       )}
                     </td>
                     <td className={`px-2 py-1 ${OUTCOME_STYLE[row.outcome] ?? ''}`} title={row.reason}>

--- a/src/renderer/lager/lib/inventoryCoverage.ts
+++ b/src/renderer/lager/lib/inventoryCoverage.ts
@@ -48,6 +48,16 @@ export interface DemandLine {
   quantity: number
   /** Die Plan-Geraete, die diese Zeile ausmachen. */
   equipmentIds: string[]
+  /** Die Plan-Geraete, denen ein Katalog-Typ zugewiesen werden DARF.
+   *
+   *  Nicht dasselbe wie `equipmentIds`, und der Unterschied ist der ganze
+   *  Zweck des Feldes: Ein Rack-Innenleben traegt hier die Id des RACKS
+   *  (mehr weiss der Snapshot nicht), und ein Zusatz-Bedarf gar keine. Wer
+   *  aus `equipmentIds` einen Typ zuwiese, schriebe dem Rack den Typ des
+   *  Geraets in seinem Bauch — die Behauptung, das Rack SEI eine URSA. Nur
+   *  Geraete aus der ersten Phase stehen fuer sich selbst; nur die stehen
+   *  hier. */
+  typeTargetIds: string[]
   /** true, wenn `label` nur der Instanzname ist — dann ist er als
    *  Modellbezeichnung wenig wert, und die UI soll das zeigen koennen. */
   labelIsDeviceName: boolean
@@ -195,6 +205,7 @@ export const deriveDemand = (
     if (existing) {
       existing.quantity += 1
       existing.equipmentIds.push(...zeile.equipmentIds)
+      existing.typeTargetIds.push(...zeile.typeTargetIds)
       if (ausRack && !existing.fromRacks?.includes(ausRack)) {
         existing.fromRacks = [...(existing.fromRacks ?? []), ausRack]
       }
@@ -220,6 +231,9 @@ export const deriveDemand = (
       label,
       ...(eq.category ? { category: eq.category } : {}),
       equipmentIds: [eq.id],
+      // Ein Geraet auf dem Canvas steht fuer sich selbst — es darf den Typ
+      // bekommen, den die Zeile meint.
+      typeTargetIds: [eq.id],
       labelIsDeviceName: !type,
     })
   }
@@ -261,6 +275,10 @@ export const deriveDemand = (
         {
           label: name,
           equipmentIds: [eq.id],
+          // Leer, und zwar mit Absicht: `eq` ist das RACK, nicht das Geraet
+          // in seinem Bauch. Das Geraet hat im Plan kein eigenes
+          // EquipmentItem, dem sich etwas zuweisen liesse.
+          typeTargetIds: [],
           labelIsDeviceName: true,
         },
         eq.name.trim() || eq.id,
@@ -297,6 +315,9 @@ export const deriveDemand = (
       ...(z.category ? { category: z.category } : {}),
       quantity: z.quantity,
       equipmentIds: [],
+      // Drum-Mikrofonierung und Funkstrecken-Plan sind eigene Projektfelder;
+      // es gibt kein EquipmentItem, an dem eine Zuweisung haengen koennte.
+      typeTargetIds: [],
       labelIsDeviceName: !z.deviceTypeId,
       fromPlanParts: [z.herkunft],
     })

--- a/src/renderer/lager/lib/planBom.ts
+++ b/src/renderer/lager/lib/planBom.ts
@@ -64,6 +64,21 @@ export interface PlanBomRow {
   /** Katalog-Identität des Bedarfs. Zusammen mit `itemId` ist das alles, was
    *  eine Bestätigung braucht: die Identität auf die Position schreiben. */
   deviceTypeId?: string
+  /** Die Plan-Geraete dieser Zeile, denen ein Katalog-Typ zugewiesen werden
+   *  darf — leer, wo es keine gibt (Rack-Innenleben, Zusatz-Bedarfe).
+   *
+   *  ADR-002 nannte als naechsten Schritt einen Knopf, „der einem Plan-Geraet
+   *  den Katalog-Typ zuweist". Die andere Haelfte — die Bestaetigung eines
+   *  Vorschlags auf der LAGER-Position — steht seit `useTypBestaetigen`; diese
+   *  hier fehlte, und ohne die Ids kann die Tabelle sie nicht bauen: sie kennt
+   *  bis dahin nur einen Modellnamen, nicht die Geraete dahinter.
+   *
+   *  Es sind ALLE Geraete der Zeile, nicht eines: Der Bedarf ist der Typ,
+   *  gezaehlt („dreimal URSA Broadcast G2"). Wer die Zuweisung auf ein Geraet
+   *  beschraenkte, zerlegte die Zeile beim naechsten Aufbau in eine gedeckte
+   *  und zwei geratene — und genau diese Aufspaltung ist es, gegen die der
+   *  Resolver drei Ausgaenge hat. */
+  typeTargetIds: string[]
 }
 
 export interface PlanBom {
@@ -137,6 +152,7 @@ const rowOf = (
       ? { reason: [line.reason, rackHinweis].filter(Boolean).join(' ') }
       : {}),
     modelIsDeviceName: line.demand.labelIsDeviceName,
+    typeTargetIds: line.demand.typeTargetIds,
     ...(line.itemId ? { itemId: line.itemId } : {}),
     ...(line.demand.deviceTypeId ? { deviceTypeId: line.demand.deviceTypeId } : {}),
   }

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -2340,6 +2340,10 @@ export const en: Dict = {
   'export.devicebom.noType': '(no catalogue type)',
   'export.devicebom.noTypeTitle':
     'No catalogue type — the model name here is only the device name. Assigning a catalogue type turns the coverage into a fact.',
+  // ADR-002 — die Plan-Haelfte des Auswegs aus „(ohne Katalog-Typ)".
+  'export.devicebom.assign': 'Assign type…',
+  'export.devicebom.assignTitle':
+    'Writes the catalogue type onto every device in this row. Stock coverage then matches on the catalogue identity instead of the name.',
   'export.devicebom.short': '— {n} missing',
   // Bedarf 80 — die Zahl traegt ihre Qualifizierung mit.
   'export.devicebom.committed': '(of {stock} · {n} checked out)',

--- a/tests/planTypZuweisung.test.ts
+++ b/tests/planTypZuweisung.test.ts
@@ -1,0 +1,226 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { deriveDemand } from '../src/renderer/lager/lib/inventoryCoverage'
+import { buildPlanBom } from '../src/renderer/lager/lib/planBom'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+import type { InventoryItem, StorageNode } from '../src/renderer/lager/types/inventory'
+import type { ZusatzBedarf } from '../src/renderer/lib/planDemandExtras'
+
+// ───────────────────────────────────────────────────────────────────────────
+// ADR-002, „Was offen bleibt" — die PLAN-Haelfte des Auswegs.
+//
+// Der Ausweg aus `proposed-by-name` hatte bisher nur eine Haelfte: Ein
+// Vorschlag liess sich auf der LAGER-Position bestaetigen (`useTypBestaetigen`,
+// Knopf „Bestaetigen"). Die andere Haelfte — einem PLAN-Geraet den Katalog-Typ
+// geben — stand nur im Eigenschaften-Panel, Geraet fuer Geraet. Wer die
+// Stueckliste las und dort „(ohne Katalog-Typ)" sah, musste das Geraet auf dem
+// Canvas suchen und einzeln zuweisen; bei drei gleichen Kameras dreimal.
+//
+// Die Zeile weiss, welche Geraete sie ausmachen. Was ihr fehlte, war der Weg
+// von der Zeile zu diesen Ids — und zwar zu DEN RICHTIGEN: `equipmentIds`
+// enthaelt bei einem Rack-Innenleben die Id des RACKS, nicht die des Geraets
+// darin. Deshalb `typeTargetIds`, und deshalb diese Datei.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Echte Katalog-Eintraege, damit die Registry den Modellnamen liefert. */
+const F55_ID = 'eb02ca7e-856c-40ab-9a73-d1e98110f003'
+const F55_MODEL = 'Sony PMW-F55'
+
+const eq = (over: Partial<EquipmentItem>): EquipmentItem =>
+  ({
+    id: 'e1',
+    name: 'Gerät',
+    category: 'Kameras',
+    inputs: [],
+    outputs: [],
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 160,
+    ...over,
+  }) as EquipmentItem
+
+const rack = (name: string, namen: string[]): EquipmentItem =>
+  eq({
+    id: `rack-${name}`,
+    name,
+    category: 'Rack',
+    rackInternalSnapshot: {
+      items: namen.map((n, i) => ({ name: n, startUnit: i + 1, rackUnits: 1 })),
+      cables: [],
+      totalUnits: namen.length,
+    },
+  })
+
+const item = (over: Partial<InventoryItem>): InventoryItem =>
+  ({ id: 'i1', model: 'Modell', quantity: 1, createdAt: 't', updatedAt: 't', ...over }) as InventoryItem
+
+const NODES: StorageNode[] = [
+  { id: 'depot', name: 'Depot', kind: 'depot', createdAt: 't', updatedAt: 't' } as StorageNode,
+]
+
+describe('typeTargetIds — wem die Zeile einen Katalog-Typ geben darf', () => {
+  it('nennt das Canvas-Geraet, das die Zeile ausmacht', () => {
+    const d = deriveDemand([eq({ id: 'a', name: 'Kamera links' })])
+    expect(d).toHaveLength(1)
+    expect(d[0].typeTargetIds).toEqual(['a'])
+  })
+
+  it('nennt ALLE Geraete der Zeile, nicht nur das erste', () => {
+    // Der Bedarf ist der Typ, gezaehlt. Wer nur das erste Geraet zuwiese,
+    // zerlegte die Zeile beim naechsten Abgleich in eine Tatsache und zwei
+    // Vermutungen — genau die Aufspaltung, gegen die der Resolver drei
+    // Ausgaenge hat.
+    const d = deriveDemand([
+      eq({ id: 'a', name: 'URSA' }),
+      eq({ id: 'b', name: 'URSA' }),
+      eq({ id: 'c', name: 'URSA' }),
+    ])
+    expect(d).toHaveLength(1)
+    expect(d[0].quantity).toBe(3)
+    expect(d[0].typeTargetIds).toEqual(['a', 'b', 'c'])
+  })
+
+  it('bleibt beim Rack-Innenleben LEER — dort gibt es kein Geraet zum Zuweisen', () => {
+    // DIE Zeile, an der ein Griff nach `equipmentIds` auffliegt: Dort steht
+    // die Id des Racks. Wer daraus zuwiese, schriebe dem Rack den Typ des
+    // Geraets in seinem Bauch — die Behauptung, das FOH-Rack SEI eine CL5.
+    const d = deriveDemand([rack('FOH Rack', ['Yamaha CL5'])])
+    const cl5 = d.find((x) => x.label === 'Yamaha CL5')
+    expect(cl5).toBeDefined()
+    expect(cl5!.equipmentIds).toEqual(['rack-FOH Rack'])
+    expect(cl5!.typeTargetIds).toEqual([])
+  })
+
+  it('bleibt bei Zusatz-Bedarfen LEER — Drum-Kit und Funkstrecke sind keine EquipmentItems', () => {
+    const zusatz: ZusatzBedarf[] = [
+      { label: 'Mikrofonstativ kurz', quantity: 4, herkunft: 'Drum-Mikrofonierung' },
+    ]
+    const d = deriveDemand([], zusatz)
+    const stativ = d.find((x) => x.label === 'Mikrofonstativ kurz')
+    expect(stativ).toBeDefined()
+    expect(stativ!.typeTargetIds).toEqual([])
+  })
+
+  it('mischt nicht: eine Zeile aus Canvas-Geraet UND Rack-Inhalt nennt nur das Canvas-Geraet', () => {
+    // Dieselbe CL5 liegt einmal auf dem Canvas und steckt einmal im Rack.
+    // Der Bedarf ist 2 — aber zuweisen laesst sich nur dem einen, das es im
+    // Plan wirklich als Geraet gibt.
+    const d = deriveDemand([
+      eq({ id: 'pult', name: 'Yamaha CL5', category: '' }),
+      rack('FOH Rack', ['Yamaha CL5']),
+    ])
+    const cl5 = d.find((x) => x.label === 'Yamaha CL5')
+    expect(cl5).toBeDefined()
+    expect(cl5!.quantity).toBe(2)
+    expect(cl5!.typeTargetIds).toEqual(['pult'])
+  })
+
+  it('ist auch bei einer Zeile gesetzt, die den Typ schon hat', () => {
+    // Damit ein spaeteres Umsetzen (falscher Typ zugewiesen) moeglich bleibt.
+    const d = deriveDemand([eq({ id: 'a', name: 'Kamera 1', deviceTypeId: F55_ID })])
+    expect(d[0].label).toBe(F55_MODEL)
+    expect(d[0].typeTargetIds).toEqual(['a'])
+  })
+})
+
+describe('die Stueckliste traegt die Ids bis in die Zeile', () => {
+  it('gibt sie an PlanBomRow weiter', () => {
+    const bom = buildPlanBom([eq({ id: 'a', name: 'Kamera links' })], [], NODES)
+    expect(bom.rows).toHaveLength(1)
+    expect(bom.rows[0].modelIsDeviceName).toBe(true)
+    expect(bom.rows[0].typeTargetIds).toEqual(['a'])
+  })
+
+  it('liefert fuer Rack-Inhalt eine Zeile OHNE Ziel', () => {
+    const bom = buildPlanBom([rack('FOH Rack', ['Yamaha CL5'])], [], NODES)
+    const cl5 = bom.rows.find((r) => r.model === 'Yamaha CL5')
+    expect(cl5).toBeDefined()
+    expect(cl5!.typeTargetIds).toEqual([])
+  })
+
+  it('macht aus einem Fehlbestand eine Deckung, sobald der Typ steht', () => {
+    // Der ganze Zweck der Zuweisung, an der Deckung gemessen. Und der Fall
+    // ist haerter, als er klingt: Der Namensvergleich greift NUR, wenn die
+    // LAGER-Position selbst keine Typ-Identitaet traegt. Ein sauber gepflegtes
+    // Lager (Position mit GUID) und ein Plan-Geraet ohne Typ ergeben deshalb
+    // nicht einmal einen Vorschlag, sondern „nicht im Lager" — die Kamera
+    // steht im Regal und fehlt auf der Liste. Genau diese Zeile loest die
+    // Zuweisung auf.
+    const lager = [item({ id: 'i1', model: F55_MODEL, quantity: 2, deviceTypeId: F55_ID })]
+
+    const vorher = buildPlanBom(
+      [eq({ id: 'a', name: F55_MODEL }), eq({ id: 'b', name: F55_MODEL })],
+      lager,
+      NODES,
+    )
+    expect(vorher.rows[0].outcome).toBe('unmatched')
+    expect(vorher.rows[0].typeTargetIds).toEqual(['a', 'b'])
+
+    // Genau das, was der Griff in der Tabelle tut: `deviceTypeId` auf ALLE
+    // Ids der Zeile schreiben.
+    const nachher = buildPlanBom(
+      vorher.rows[0].typeTargetIds.map((id) => eq({ id, name: F55_MODEL, deviceTypeId: F55_ID })),
+      lager,
+      NODES,
+    )
+    expect(nachher.rows).toHaveLength(1)
+    expect(nachher.rows[0].outcome).toBe('matched-by-type')
+    expect(nachher.rows[0].modelIsDeviceName).toBe(false)
+  })
+
+  it('bliebe halb offen, wenn nur das erste Geraet den Typ bekaeme', () => {
+    // Die Gegenprobe zur vorigen Zeile: Zwei Geraete, nur eines zugewiesen —
+    // aus einer Zeile werden zwei, und eine davon meldet weiterhin einen
+    // Fehlbestand fuer Technik, die im Regal steht. Das ist der Zustand, den
+    // die Zuweisung ueber ALLE Ids verhindert.
+    const lager = [item({ id: 'i1', model: F55_MODEL, quantity: 2, deviceTypeId: F55_ID })]
+    const halb = buildPlanBom(
+      [eq({ id: 'a', name: F55_MODEL, deviceTypeId: F55_ID }), eq({ id: 'b', name: F55_MODEL })],
+      lager,
+      NODES,
+    )
+    expect(halb.rows).toHaveLength(2)
+    expect(halb.rows.map((r) => r.outcome).sort()).toEqual(['matched-by-type', 'unmatched'])
+  })
+
+  it('deckt den Vorschlags-Fall mit ab: ungetypte Lager-Position, ungetypter Plan', () => {
+    // Traegt die Lager-Position keine Identitaet, greift der Namensvergleich —
+    // und die Zeile ist ein VORSCHLAG. Auch hier ist die Zuweisung im Plan der
+    // halbe Weg; den Rest macht „Bestaetigen" auf der Lager-Position.
+    const lager = [item({ id: 'i1', model: F55_MODEL, quantity: 2 })]
+    const bom = buildPlanBom([eq({ id: 'a', name: F55_MODEL })], lager, NODES)
+    expect(bom.rows[0].outcome).toBe('proposed-by-name')
+    expect(bom.rows[0].typeTargetIds).toEqual(['a'])
+  })
+})
+
+describe('die Tabelle bietet den Griff an — und nur, wo er trifft', () => {
+  const src = readFileSync('src/renderer/components/Export/ExportDialog.tsx', 'utf8')
+
+  it('zeigt das Auswahlfeld nur bei einer Zeile ohne Typ UND mit Ziel', () => {
+    // Ohne die zweite Bedingung stuende bei jedem Rack-Innenleben ein
+    // Auswahlfeld, das ins Leere schreibt.
+    expect(src).toMatch(/row\.modelIsDeviceName && row\.typeTargetIds\.length > 0/)
+  })
+
+  it('schreibt an ALLE Ids der Zeile, nicht an eine', () => {
+    const aufruf = src.match(/typZuweisen\(([^)]*)\)/)
+    expect(aufruf).not.toBeNull()
+    expect(aufruf![1]).toContain('row.typeTargetIds')
+    expect(aufruf![1]).not.toMatch(/typeTargetIds\[\d\]/)
+  })
+
+  it('schreibt in den PLAN, nicht ins Lager', () => {
+    // `typBestaetigen` schreibt auf die Lager-Position; das hier ist die
+    // andere Haelfte und muss ueber `updateEquipment` gehen, sonst behauptet
+    // die Zeile eine Deckung, die im Plan nicht steht.
+    const koerper = src.slice(src.indexOf('const typZuweisen'))
+    const ende = koerper.indexOf('\n  }')
+    expect(koerper.slice(0, ende)).toMatch(/updateEquipment\([^)]*\{ deviceTypeId \}\)/)
+  })
+
+  it('nimmt die Auswahl aus dem Katalog, nicht aus einer eigenen Liste', () => {
+    expect(src).toMatch(/listDeviceTypes\(\)/)
+  })
+})


### PR DESCRIPTION
ADR-002 nannte unter **„Was offen bleibt"** genau einen nächsten Schritt:

> Ein Knopf, der einem Plan-Gerät den Katalog-Typ zuweist und die Bestätigung eines Vorschlags als `deviceTypeId` festschreibt, wäre der nächste Schritt — dann wandert die Deckung Zeile für Zeile von *Vorschlag* nach *Tatsache*, und zwar dauerhaft.

Die **zweite Hälfte** steht seit `useTypBestaetigen` — der Knopf „Bestätigen" schreibt die Katalog-Identität auf die **Lager-Position**. Die **erste** fehlte: Wer in der Geräte-Stückliste `(ohne Katalog-Typ)` las, musste das Gerät auf dem Canvas suchen und im Eigenschaften-Panel einzeln zuweisen. Bei drei gleichen Kameras dreimal.

## Warum das mehr ist als Bequemlichkeit

Der Namensvergleich im Resolver greift **nur, wenn die Lager-Position selbst keine Typ-Identität trägt** (`byModel` wird aus `untyped` gebaut). Ein sauber gepflegtes Lager — Position mit GUID — und ein Plan-Gerät ohne Typ ergeben deshalb **nicht einmal einen Vorschlag, sondern `unmatched`**: Die Kamera steht im Regal und fehlt auf der Kommissionier-Liste. Genau diese Zeile löst die Zuweisung auf; im Test nachgestellt (`macht aus einem Fehlbestand eine Deckung, sobald der Typ steht`).

## `typeTargetIds` — und warum nicht `equipmentIds`

Die Zeile weiß, welche Geräte sie ausmachen. Was fehlte, war der Weg von der Zeile zu **den richtigen** Ids:

| Herkunft der Zeile | `equipmentIds` | `typeTargetIds` |
| --- | --- | --- |
| Gerät auf dem Canvas | die Geräte-Id | dieselbe — es steht für sich selbst |
| Rack-Innenleben (`rackInternalSnapshot`) | die Id des **Racks** | **leer** |
| Zusatz-Bedarf (Drum-Kit, Funkstrecke) | leer | leer |

Wer aus `equipmentIds` zuwiese, schriebe dem FOH-Rack den Typ des Pults in seinem Bauch — die Behauptung, das Rack *sei* eine CL5. Deshalb ein eigenes Feld statt einer bequemen Wiederverwendung.

## Die Änderung

- `DemandLine.typeTargetIds` (`inventoryCoverage.ts`), gefüllt nur in der ersten Phase, in `zaehle` mitgeführt.
- `PlanBomRow.typeTargetIds` (`planBom.ts`) trägt sie bis in die Tabelle.
- `ExportDialog.tsx`: Auswahlfeld **„Typ zuweisen…"** in der Modell-Spalte, sichtbar nur bei `row.modelIsDeviceName && row.typeTargetIds.length > 0`. Es schreibt über `updateEquipment` an **alle** Geräte der Zeile — der Bedarf ist der Typ, gezählt; eine halb zugewiesene Zeile zerfiele beim nächsten Abgleich in eine Tatsache und mehrere Fehlbestände.
- Auswahl aus `listDeviceTypes()`, keine zweite Liste.
- EN-Einträge `export.devicebom.assign` / `.assignTitle`.

## Prüfung

`tests/planTypZuweisung.test.ts` — 15 Tests. **Fünf Gegenproben, alle rot:**

1. Zeile zieht `equipmentIds` statt `typeTargetIds` → 1 rot
2. Rack-Phase füllt `typeTargetIds` mit der Rack-Id → 3 rot
3. UI schreibt nur an `typeTargetIds[0]` → 1 rot
4. Auswahlfeld ohne die Ziel-Bedingung → 1 rot
5. Zuweisung schreibt ins Lager (`typBestaetigen`) statt in den Plan → 1 rot

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npm run lint` 0 Errors · `npx vitest run` 199 Dateien, 3082 Tests grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_