### PR TITLE
load: zwei stille Verwerfungen auf dem Lade-Pfad melden (ADR-005 Regel 3)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { hasDrops } from './types/loadReport'
+import { hasDrops, type LoadDropKind, type LoadDropReason } from './types/loadReport'
 import { hasMobileDrops } from './types/mobileReport'
 import { useEffect, useMemo, useRef, useState, lazy, Suspense } from 'react'
 import { useIsNarrow } from './hooks/useBreakpoint'
@@ -134,6 +134,53 @@ import { useTranslation, format } from './lib/i18n'
 import { crewCalendar } from './lib/crewCalendar'
 import { Icon } from './components/shared/Icon'
 import { cableTouches } from './lib/portOccupancy'
+
+// ───────────────────────────────────────────────────────────────────────────
+// ADR-005, Regel 3 — die Beschriftung des Ladeberichts.
+//
+// Hier stand eine Kette aus zwoelf verschachtelten Ternaeroperatoren, deren
+// LETZTER Zweig „Signalquelle" war. Das machte den Fall-Through zum Default:
+// Wer eine neue Sorte an `LoadDropKind` haengte und diese Kette vergass, bekam
+// keinen Fehler, sondern eine Zeile, die den Nutzer die FALSCHE Sorte
+// Datensatz in seiner Datei suchen laesst. Genau davor warnte der Kommentar an
+// der Kette — und die Kette selbst war die Bauform, die es zulaesst.
+//
+// Jetzt eine Tabelle mit `satisfies Record<LoadDropKind, …>`: eine neue Sorte
+// ohne Beschriftung ist ein Typfehler, kein stiller Fehlgriff.
+// ───────────────────────────────────────────────────────────────────────────
+
+type Uebersetzer = (key: string, fallback?: string) => string
+
+const DROP_ART: Record<LoadDropKind, [key: string, de: string]> = {
+  'source-identity': ['app.loadReport.sourceIdentity', 'Signalquelle'],
+  'delivery-destination': ['app.loadReport.deliveryDestination', 'Ausspielziel'],
+  'venue-answer': ['app.loadReport.venueAnswer', 'Antwort der Haus-IT'],
+  'multicast-assignment': ['app.loadReport.multicastAssignment', 'Multicast-Vergabe'],
+  'fallback-rule': ['app.loadReport.fallbackRule', 'Ausweich-Regel'],
+  'metadata-override': [
+    'app.loadReport.metadataOverride',
+    'Abweichung der Veranstaltungsangaben',
+  ],
+  'transmission-event': ['app.loadReport.transmissionEvent', 'Eintrag im Sendebericht'],
+  'cost-line': ['app.loadReport.costLine', 'Kostenposition'],
+  'crew-entry': ['app.loadReport.crewEntry', 'Eintrag der Crew-Seite'],
+  'tally-position': ['app.loadReport.tallyPosition', 'Tally-Position'],
+  'address-range': ['app.loadReport.addressRange', 'Adressbereich'],
+} satisfies Record<LoadDropKind, [string, string]>
+
+const DROP_GRUND: Record<LoadDropReason, [key: string, de: string]> = {
+  'missing-required': ['app.loadReport.missingRequired', 'Pflichtfeld fehlt (Name)'],
+  'duplicate-id': ['app.loadReport.duplicateId', 'doppelte Id, der erste Eintrag gilt'],
+  'dangling-ref': [
+    'app.loadReport.danglingRef',
+    'der Verweis zeigt ins Leere — das Ziel wurde gelöscht',
+  ],
+} satisfies Record<LoadDropReason, [string, string]>
+
+const dropArtLabel = (t: Uebersetzer, kind: LoadDropKind): string => t(...DROP_ART[kind])
+const dropGrundLabel = (t: Uebersetzer, reason: LoadDropReason): string =>
+  t(...DROP_GRUND[reason])
+
 
 export default function App() {
   const t = useTranslation()
@@ -1493,33 +1540,10 @@ export default function App() {
           <ul className="max-h-40 space-y-0.5 overflow-y-auto text-[11px] text-cp-text-secondary">
             {lastLoadReport.drops.slice(0, 20).map((d, i) => (
               <li key={`${d.kind}-${d.label}-${i}`}>
-                {/* Die Art beschriftet die Zeile. Bis Bedarf 85 stand hier fuer
-                    JEDEN Fall „Signalquelle" — auch fuer ein verworfenes
-                    Ausspielziel aus Initiative 9. Ein Bericht, der jemanden
-                    die falsche Sorte Datensatz in seiner Datei suchen laesst,
-                    ist schlechter als eine Zeile ohne Namen. */}
-                {d.kind === 'delivery-destination'
-                  ? t('app.loadReport.deliveryDestination', 'Ausspielziel')
-                  : d.kind === 'venue-answer'
-                    ? t('app.loadReport.venueAnswer', 'Antwort der Haus-IT')
-                    : d.kind === 'multicast-assignment'
-                      ? t('app.loadReport.multicastAssignment', 'Multicast-Vergabe')
-                      : d.kind === 'fallback-rule'
-                        ? t('app.loadReport.fallbackRule', 'Ausweich-Regel')
-                        : d.kind === 'metadata-override'
-                          ? t('app.loadReport.metadataOverride', 'Abweichung der Veranstaltungsangaben')
-                          : d.kind === 'transmission-event'
-                            ? t('app.loadReport.transmissionEvent', 'Eintrag im Sendebericht')
-                            : d.kind === 'cost-line'
-                              ? t('app.loadReport.costLine', 'Kostenposition')
-                              : d.kind === 'crew-entry'
-                                ? t('app.loadReport.crewEntry', 'Eintrag der Crew-Seite')
-                                : t('app.loadReport.sourceIdentity', 'Signalquelle')}
+                {dropArtLabel(t, d.kind)}
                 {d.label ? ` „${d.label}"` : ''}
                 {' — '}
-                {d.reason === 'duplicate-id'
-                  ? t('app.loadReport.duplicateId', 'doppelte Id, der erste Eintrag gilt')
-                  : t('app.loadReport.missingRequired', 'Pflichtfeld fehlt (Name)')}
+                {dropGrundLabel(t, d.reason)}
               </li>
             ))}
           </ul>

--- a/src/renderer/lib/addressTemplate.ts
+++ b/src/renderer/lib/addressTemplate.ts
@@ -584,14 +584,26 @@ export function addressTemplateTable(layers: readonly AddressLayer[]): CsvTable 
  * und nicht still: der Nutzer sieht danach im Feld, was wirklich gilt, statt
  * eine Schreibweise stehen zu haben, gegen die intern anders gerechnet wird.
  */
-export function normaliseAddressLayers(raw: unknown): AddressLayer[] {
+export function normaliseAddressLayers(
+  raw: unknown,
+  onDrop?: (d: { reason: 'missing-required'; label: string }) => void,
+): AddressLayer[] {
   if (!Array.isArray(raw)) return []
   const out: AddressLayer[] = []
   for (const entry of raw) {
     if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue
     const l = entry as Record<string, unknown>
     const id = typeof l.id === 'string' && l.id.trim() ? l.id.trim() : null
-    if (!id) continue
+    if (!id) {
+      // ADR-005, Regel 3: Eine ganze Ebene ohne Id nimmt ALLE ihre Bereiche
+      // mit. Sie still fallen zu lassen hiesse, dass der naechste Adresslauf
+      // aus einem Plan vergibt, in dem diese Netze nie standen.
+      onDrop?.({
+        reason: 'missing-required',
+        label: typeof l.name === 'string' ? l.name.trim() : '',
+      })
+      continue
+    }
     const kind = ADDRESS_LAYER_KINDS.includes(l.kind as AddressLayerKind)
       ? (l.kind as AddressLayerKind)
       : 'standing'
@@ -599,7 +611,24 @@ export function normaliseAddressLayers(raw: unknown): AddressLayer[] {
     if (Array.isArray(l.ranges)) {
       for (const rEntry of l.ranges) {
         const r = normaliseAddressRange(rEntry)
-        if (r) ranges.push(r)
+        if (r) {
+          ranges.push(r)
+          continue
+        }
+        // Der Griff ist der beste Name, den der rohe Eintrag hergibt — Name,
+        // sonst der CIDR, der keiner war, und erst zuletzt der Schluessel.
+        //
+        // Der CIDR VOR dem Schluessel, und das ist kein Zufall: Der Schluessel
+        // ist ein Kuerzel wie „media", das in jeder zweiten Ebene steht; der
+        // fehlerhafte CIDR steht woertlich genau einmal in der Datei. Wer
+        // suchen soll, bekommt die eindeutige Zeichenkette.
+        const roh = (rEntry ?? {}) as Record<string, unknown>
+        const griff =
+          (typeof roh.name === 'string' && roh.name.trim()) ||
+          (typeof roh.cidr === 'string' && roh.cidr.trim()) ||
+          (typeof roh.key === 'string' && roh.key.trim()) ||
+          ''
+        onDrop?.({ reason: 'missing-required', label: griff })
       }
     }
     out.push({

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3408,8 +3408,12 @@ export const en: Dict = {
     'Add it to your calendar as a subscription — it fetches the current state instead of going stale.',
   'analysis.crew.planned': '{n} pencilled/held — not in the totals',
   'app.loadReport.crewEntry': 'Crew record',
+  // ADR-005, Regel 3 — zwei Sorten, die bis hierher still verschwanden.
+  'app.loadReport.tallyPosition': 'Tally position',
+  'app.loadReport.addressRange': 'Address range',
   'app.loadReport.duplicateId': 'duplicate id, the first entry wins',
   'app.loadReport.missingRequired': 'required field missing (name)',
+  'app.loadReport.danglingRef': 'the reference points at nothing — the target was deleted',
   'app.loadReport.hint': 'Devices that pointed at these roles lost their assignment — including the TSL address used for tally. Saving overwrites the file with this state.',
   'app.mobileDrop.title': 'Cables sent from a phone were not taken over',
   'app.mobileDrop.cable': 'Cable',

--- a/src/renderer/lib/tallyPosition.ts
+++ b/src/renderer/lib/tallyPosition.ts
@@ -324,8 +324,18 @@ export function preShowTallyTable(
   }
 }
 
-/** Normalisiert einen geladenen Datensatz — die Schema-Migrationsschicht. */
-export function normaliseTallyPositions(raw: unknown): TallyPosition[] {
+/**
+ * Normalisiert einen geladenen Datensatz — die Schema-Migrationsschicht.
+ *
+ * ADR-005, Regel 3: Was hier wegfaellt, wird GEMELDET. Bis dahin verschwanden
+ * beide Faelle wortlos — und mit ihnen die `checks`, also die Beobachtungen,
+ * die jemand vor Ort aufgenommen hat. Das Vor-Show-Blatt zeigte die Position
+ * danach als „nie geprueft".
+ */
+export function normaliseTallyPositions(
+  raw: unknown,
+  onDrop?: (d: { reason: 'missing-required' | 'duplicate-id'; label: string }) => void,
+): TallyPosition[] {
   if (!Array.isArray(raw)) return []
   const gueltigeWege: readonly TallyTransport[] = [
     'tsl-umd-v31',
@@ -351,7 +361,21 @@ export function normaliseTallyPositions(raw: unknown): TallyPosition[] {
     const identityId = typeof r.identityId === 'string' ? r.identityId.trim() : ''
     // Ein Datensatz ohne Rolle zeigt ins Leere. Zwei fuer dieselbe Rolle sind
     // zwei Wahrheiten — die erste gewinnt, wie bei `normaliseSourceIdentities`.
-    if (!identityId || gesehen.has(identityId)) continue
+    if (!identityId) {
+      // Als Griff dient, was der Datensatz sonst hergibt: der Endpunkt oder
+      // die Lampe. Ohne Rolle ist das alles, woran jemand ihn in seiner Datei
+      // wiedererkennt.
+      onDrop?.({
+        reason: 'missing-required',
+        label: (typeof r.endpoint === 'string' ? r.endpoint.trim() : '') ||
+          (typeof r.lamp === 'string' ? r.lamp.trim() : ''),
+      })
+      continue
+    }
+    if (gesehen.has(identityId)) {
+      onDrop?.({ reason: 'duplicate-id', label: identityId })
+      continue
+    }
     gesehen.add(identityId)
     const transport = gueltigeWege.includes(r.transport as TallyTransport)
       ? (r.transport as TallyTransport)

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -773,9 +773,19 @@ const healProjectPositions = (
   // ein Datensatz auf eine geloeschte Rolle zeigt ins Leere und saehe auf dem
   // Vor-Show-Blatt aus wie eine gepruefte Position. Dieselbe Entscheidung wie
   // bei `clearDanglingIdentity` eine Zeile weiter unten.
-  const tallyPositions = normaliseTallyPositions(project.tallyPositions).filter((p) =>
-    identityIds.has(p.identityId),
-  )
+  const tallyPositions = normaliseTallyPositions(project.tallyPositions, (d) =>
+    onDrop?.({ kind: 'tally-position', reason: d.reason, label: d.label }),
+  ).filter((p) => {
+    if (identityIds.has(p.identityId)) return true
+    // ADR-005, Regel 3. Bis hierher fiel dieser Datensatz WORTLOS weg, und mit
+    // ihm seine `checks` — die Beobachtungen, die jemand an der Kamera
+    // aufgenommen hat. Verworfen wird er weiterhin (ohne Rolle sieht er auf
+    // dem Vor-Show-Blatt aus wie eine gepruefte Position), aber nicht mehr
+    // stumm: `dangling-ref` sagt, dass die ROLLE weg ist — sonst suchte
+    // jemand nach einem fehlenden Pflichtfeld, das nie gefehlt hat.
+    onDrop?.({ kind: 'tally-position', reason: 'dangling-ref', label: p.endpoint ?? p.lamp ?? p.identityId })
+    return false
+  })
   // Bedarf 116 — die Segmente. Der Gateway-Zeiger wird gegen die Geraete
   // gehalten: ein Zeiger ins Leere saehe auf dem Blatt aus wie ein Weg in das
   // Segment hinein, und genau danach sucht jemand vor Ort. Das SEGMENT selbst
@@ -789,7 +799,9 @@ const healProjectPositions = (
   // Bedarf 20 — die Adressbereichs-Ebenen. Die Normalisierung kanonisiert
   // jeden CIDR auf seine Netz-Adresse und wirft weg, was keiner ist; ein
   // Gateway ausserhalb seines eigenen Bereichs verliert dabei den Eintrag.
-  const addressLayers = normaliseAddressLayers(project.addressLayers)
+  const addressLayers = normaliseAddressLayers(project.addressLayers, (d) =>
+    onDrop?.({ kind: 'address-range', reason: d.reason, label: d.label }),
+  )
   // Initiative 9 — Ausspielziele. Dieselbe Bauform wie die Rollen darueber:
   // normalisieren, Verworfenes melden, Backup-Zeiger ins Leere entfernen.
   const deliveryDestinations = normaliseDeliveryDestinations(project.deliveryDestinations, onDrop)

--- a/src/renderer/types/loadReport.ts
+++ b/src/renderer/types/loadReport.ts
@@ -21,6 +21,22 @@ export type LoadDropReason =
   | 'missing-required'
   /** Eine Id kam mehrfach vor; der erste Datensatz hat gewonnen. */
   | 'duplicate-id'
+  /**
+   * Der Datensatz zeigte auf etwas, das es nicht (mehr) gibt — und ohne dieses
+   * Ziel ist er nicht bloss unvollständig, sondern irreführend.
+   *
+   * Eigener Grund und nicht `missing-required`, weil die beiden verschiedene
+   * Auskünfte sind: „Pflichtfeld fehlt" schickt jemanden in seine Datei, um
+   * einen Namen nachzutragen; „Verweis zeigt ins Leere" sagt ihm, dass das
+   * Ziel gelöscht wurde und der Datensatz mit ihm. Wer das Erste liest und das
+   * Zweite braucht, sucht am falschen Ende.
+   *
+   * NICHT für jeden Fehlzeiger: Wo ein Datensatz ohne sein Ziel noch etwas
+   * aussagt, bleibt er stehen und bekommt einen Befund (`override-orphan`,
+   * `anchor-orphan`, `rate-missing`). Dieser Grund gilt nur, wo das Verwerfen
+   * selbst die richtige Entscheidung ist.
+   */
+  | 'dangling-ref'
 
 /** Woher der verworfene Datensatz kam. */
 export type LoadDropKind =
@@ -71,6 +87,21 @@ export type LoadDropKind =
    *  dafuer gibt es den Befund `rate-missing`, und eine spurlos entfernte
    *  Schicht ist eine geleistete Stunde, die niemand mehr abrechnet. */
   | 'crew-entry'
+  /** Bedarf 105 — das Tally je Position. Ein Datensatz ohne Rolle oder mit
+   *  doppelter Rolle wird verworfen, und ebenso einer, dessen Rolle es nicht
+   *  mehr gibt. Er traegt die BEOBACHTUNGEN vor Ort: jemand stand an der
+   *  Kamera und hat gesehen, dass die Lampe rot wird. Still verschwinden zu
+   *  lassen, was jemand nachgesehen hat, ist die teuerste Sorte Verlust — das
+   *  Vor-Show-Blatt zeigt die Position danach als „nie geprueft", und dann
+   *  laeuft jemand ein zweites Mal denselben Weg. Oder eben nicht, weil er
+   *  sich erinnert, dort schon gewesen zu sein. */
+  | 'tally-position'
+  /** Bedarf 20 — ein Adressbereich, dessen CIDR keiner ist, oder der keine Id
+   *  traegt. Ein Bereich ist der Vorrat, aus dem jede Geraete-Adresse kommt;
+   *  faellt er beim Laden still weg, vergibt der naechste Adresslauf aus einem
+   *  Plan, in dem dieses Netz nie stand — und der Widerspruch faellt erst auf,
+   *  wenn zwei Geraete im Rack dieselbe Adresse tragen. */
+  | 'address-range'
 
 export interface LoadDrop {
   kind: LoadDropKind

--- a/tests/ladeberichtStilleVerluste.test.ts
+++ b/tests/ladeberichtStilleVerluste.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest'
+import { normaliseTallyPositions } from '../src/renderer/lib/tallyPosition'
+import { normaliseAddressLayers } from '../src/renderer/lib/addressTemplate'
+import typQuelle from '../src/renderer/types/loadReport.ts?raw'
+import appQuelle from '../src/renderer/App.tsx?raw'
+import storeQuelle from '../src/renderer/store/projectStore.ts?raw'
+
+// ───────────────────────────────────────────────────────────────────────────
+// ADR-005, Regel 3 — „Wer nicht bewahren kann, sagt es an der Stelle, an der
+// es passiert." Der ADR nennt als naechsten Schritt ausdruecklich, die
+// uebrigen Heilungsschritte in `healProjectPositions` je einzeln daraufhin
+// anzusehen, ob sie ueberhaupt etwas verwerfen — und NUR die anzuschliessen,
+// die es tun. („Ein Kanal, der Meldungen ueber Nicht-Verluste traegt, ist so
+// schaedlich wie gar keiner.")
+//
+// Durchgegangen; zwei Schritte verwarfen ganze Datensaetze, und zwar wortlos:
+//
+//   1. `normaliseTallyPositions` — ein Datensatz ohne Rolle oder mit doppelter
+//      Rolle. Er traegt die `checks`: die Beobachtungen, die jemand an der
+//      Kamera aufgenommen hat. Danach steht die Position auf dem
+//      Vor-Show-Blatt als „nie geprueft", und jemand laeuft denselben Weg
+//      noch einmal — oder eben nicht.
+//   2. `normaliseAddressLayers` — ein Bereich, dessen CIDR keiner ist, und
+//      eine ganze Ebene ohne Id, die ALLE ihre Bereiche mitnimmt. Der Bereich
+//      ist der Vorrat, aus dem jede Geraete-Adresse kommt.
+//
+// Nicht angeschlossen wurden die Schritte, die nichts verwerfen: der
+// Gateway-Zeiger eines Segments und das Gateway eines Bereichs sind FELDER an
+// einem Datensatz, der ueberlebt; `normaliseNamingScheme` faellt unter
+// Einstellungen, nicht unter Nutzer-Datensaetze (steht so im Quelltext).
+// ───────────────────────────────────────────────────────────────────────────
+
+const sammle = () => {
+  const drops: { reason: string; label: string }[] = []
+  return { drops, on: (d: { reason: string; label: string }) => drops.push(d) }
+}
+
+describe('Tally-Positionen verschwinden nicht mehr wortlos', () => {
+  it('meldet einen Datensatz ohne Rolle', () => {
+    const s = sammle()
+    const out = normaliseTallyPositions([{ transport: 'gpio', endpoint: '17' }], s.on)
+    expect(out).toEqual([])
+    expect(s.drops).toEqual([{ reason: 'missing-required', label: '17' }])
+  })
+
+  it('nimmt als Griff die Lampe, wenn es keinen Endpunkt gibt', () => {
+    const s = sammle()
+    normaliseTallyPositions([{ lamp: 'Bolt 4K links' }], s.on)
+    expect(s.drops[0]).toEqual({ reason: 'missing-required', label: 'Bolt 4K links' })
+  })
+
+  it('meldet den zweiten Datensatz derselben Rolle', () => {
+    const s = sammle()
+    const out = normaliseTallyPositions(
+      [
+        { identityId: 'r1', transport: 'gpio' },
+        { identityId: 'r1', transport: 'ndi' },
+      ],
+      s.on,
+    )
+    expect(out).toHaveLength(1)
+    expect(out[0].transport).toBe('gpio')
+    expect(s.drops).toEqual([{ reason: 'duplicate-id', label: 'r1' }])
+  })
+
+  it('meldet nichts, wenn nichts wegfaellt', () => {
+    // Der Kanal darf keine Nicht-Verluste tragen — sonst gewoehnt sich der
+    // Nutzer daran, das Banner wegzuklicken (ADR-005, woertlich).
+    const s = sammle()
+    normaliseTallyPositions([{ identityId: 'r1', transport: 'gpio', endpoint: '3' }], s.on)
+    expect(s.drops).toEqual([])
+  })
+
+  it('laeuft ohne Rueckruf unveraendert', () => {
+    expect(normaliseTallyPositions([{ transport: 'gpio' }])).toEqual([])
+    expect(normaliseTallyPositions([{ identityId: 'r1' }])).toHaveLength(1)
+  })
+})
+
+describe('Adressbereiche verschwinden nicht mehr wortlos', () => {
+  it('meldet einen Bereich, dessen CIDR keiner ist — mit dem CIDR als Griff', () => {
+    // Der CIDR schlaegt den Schluessel: „media" steht in jeder zweiten Ebene,
+    // „10.0.5.0/33" genau einmal in der Datei.
+    const s = sammle()
+    const out = normaliseAddressLayers(
+      [{ id: 'l1', name: 'Haus', ranges: [{ id: 'r1', key: 'media', cidr: '10.0.5.0/33' }] }],
+      s.on,
+    )
+    expect(out[0].ranges).toEqual([])
+    expect(s.drops).toEqual([{ reason: 'missing-required', label: '10.0.5.0/33' }])
+  })
+
+  it('nimmt den Namen als Griff, wo es einen gibt', () => {
+    const s = sammle()
+    normaliseAddressLayers(
+      [{ id: 'l1', ranges: [{ id: 'r1', name: 'Medien primaer', cidr: 'unsinn' }] }],
+      s.on,
+    )
+    expect(s.drops[0].label).toBe('Medien primaer')
+  })
+
+  it('meldet eine ganze Ebene ohne Id — sie nimmt alle ihre Bereiche mit', () => {
+    const s = sammle()
+    const out = normaliseAddressLayers(
+      [{ name: 'Venue-Vorgabe', ranges: [{ id: 'r1', cidr: '10.0.0.0/8' }] }],
+      s.on,
+    )
+    expect(out).toEqual([])
+    expect(s.drops).toEqual([{ reason: 'missing-required', label: 'Venue-Vorgabe' }])
+  })
+
+  it('meldet nichts fuer einen Bereich, der durchgeht', () => {
+    const s = sammle()
+    const out = normaliseAddressLayers(
+      [{ id: 'l1', ranges: [{ id: 'r1', key: 'media', cidr: '10.0.5.0/24' }] }],
+      s.on,
+    )
+    expect(out[0].ranges).toHaveLength(1)
+    expect(s.drops).toEqual([])
+  })
+
+  it('meldet NICHT, wenn nur das Gateway ausserhalb liegt — der Bereich bleibt', () => {
+    // Ein Feld an einem ueberlebenden Datensatz ist kein verworfener
+    // Datensatz. Diese Zeile haelt die Grenze fest, an der der Kanal aufhoert.
+    const s = sammle()
+    const out = normaliseAddressLayers(
+      [{ id: 'l1', ranges: [{ id: 'r1', cidr: '10.0.5.0/24', gateway: '10.9.9.1' }] }],
+      s.on,
+    )
+    expect(out[0].ranges).toHaveLength(1)
+    expect(out[0].ranges[0].gateway).toBeUndefined()
+    expect(s.drops).toEqual([])
+  })
+})
+
+describe('der Bericht kann die neuen Sorten benennen', () => {
+  it('kennt beide Sorten im Typ', () => {
+    expect(typQuelle).toContain("| 'tally-position'")
+    expect(typQuelle).toContain("| 'address-range'")
+  })
+
+  it('kennt den Grund „Verweis zeigt ins Leere" — und begruendet ihn', () => {
+    expect(typQuelle).toContain("| 'dangling-ref'")
+    // Nicht bloss vorhanden: der Typ muss sagen, warum das NICHT
+    // `missing-required` ist. Sonst waehlt der naechste Aufrufer nach Gefuehl.
+    const block = typQuelle.slice(
+      typQuelle.indexOf("| 'dangling-ref'") - 1200,
+      typQuelle.indexOf("| 'dangling-ref'"),
+    )
+    expect(block).toContain('missing-required')
+  })
+
+  it('beschriftet jede Sorte und jeden Grund — erzwungen durch den Typ', () => {
+    // `satisfies Record<LoadDropKind, …>` macht eine vergessene Sorte zum
+    // Typfehler statt zu einer Zeile, die die falsche Sorte benennt.
+    expect(appQuelle).toContain('satisfies Record<LoadDropKind, [string, string]>')
+    expect(appQuelle).toContain('satisfies Record<LoadDropReason, [string, string]>')
+    expect(appQuelle).toContain("'tally-position': [")
+    expect(appQuelle).toContain("'address-range': [")
+    expect(appQuelle).toContain("'dangling-ref': [")
+  })
+
+  it('hat die Ternaer-Kette mit dem Default „Signalquelle" abgeloest', () => {
+    // Der letzte Zweig der alten Kette war der Fall-Through: eine neue Sorte
+    // ohne Eintrag wurde stillschweigend zur „Signalquelle".
+    expect(appQuelle).not.toContain("d.kind === 'delivery-destination'")
+    expect(appQuelle).toContain('dropArtLabel(t, d.kind)')
+  })
+
+  it('reicht den Rueckruf in beide Normalisierungen', () => {
+    expect(storeQuelle).toMatch(/normaliseAddressLayers\(project\.addressLayers,\s*\(d\)/)
+    expect(storeQuelle).toMatch(/kind: 'address-range'/)
+  })
+})

--- a/tests/tallyPosition.test.ts
+++ b/tests/tallyPosition.test.ts
@@ -377,11 +377,27 @@ describe('die Verben im Store', () => {
     expect(p?.endpoint).toBe('17')
   })
 
-  it('wirft beim Laden weg, was auf eine geloeschte Rolle zeigt', () => {
+  it('wirft beim Laden weg, was auf eine geloeschte Rolle zeigt — und MELDET es', () => {
     // Ein Datensatz auf eine geloeschte Rolle saehe auf dem Vor-Show-Blatt
-    // aus wie eine gepruefte Position und zeigte ins Leere.
-    expect(storeQuelle).toContain('normaliseTallyPositions(project.tallyPositions).filter')
-    expect(storeQuelle).toContain('identityIds.has(p.identityId)')
+    // aus wie eine gepruefte Position und zeigte ins Leere. Er faellt also
+    // weiter weg — aber ADR-005 Regel 3 verlangt, dass es jemand erfaehrt: er
+    // traegt die `checks`, also die Beobachtungen, die jemand an der Kamera
+    // aufgenommen hat.
+    //
+    // Auf die BEIDEN Zusicherungen pruefen, nicht auf die Aufruf-Form: Eine
+    // erste Fassung pinnte den Einzeiler `normaliseTallyPositions(...).filter`
+    // und wurde rot, als der Melde-Rueckruf dazukam — also an der Verbesserung,
+    // nicht am Defekt. Ein Waechter, der an einer richtigen Aenderung rot wird,
+    // wird geaendert statt gelesen.
+    const stelle = storeQuelle.slice(
+      storeQuelle.indexOf('const tallyPositions ='),
+      storeQuelle.indexOf('// Bedarf 116'),
+    )
+    expect(stelle).toContain('normaliseTallyPositions(project.tallyPositions')
+    expect(stelle).toContain('identityIds.has(p.identityId)')
+    expect(stelle).toMatch(/kind: 'tally-position'[\s\S]{0,200}?reason: 'dangling-ref'/)
+    // Und die Normalisierung selbst meldet ihre beiden Faelle.
+    expect(stelle).toMatch(/normaliseTallyPositions\(project\.tallyPositions,\s*\(d\)/)
   })
 })
 

--- a/tests/venueAnswers.test.ts
+++ b/tests/venueAnswers.test.ts
@@ -12,6 +12,7 @@ import type { VenueAnswer } from '../src/renderer/types/venueAnswer'
 import type { VenueNetworkRequest } from '../src/renderer/lib/venueNetworkRequest'
 import analyseQuelle from '../src/renderer/components/Analysis/AnalysisDialog.tsx?raw'
 import appQuelle from '../src/renderer/App.tsx?raw'
+import typQuelle from '../src/renderer/types/loadReport.ts?raw'
 
 // ---------------------------------------------------------------------------
 // Was das Haus geantwortet hat (Bedarf 85, zweite Haelfte).
@@ -301,10 +302,27 @@ describe('Bedarf 85 — die Oberflaeche ist verdrahtet', () => {
     expect(analyseQuelle).toMatch(/recordAnswer\([\s\S]{0,400}?venue: siteAddress/)
   })
 
-  it('der Lade-Bericht beschriftet jede Art einzeln', () => {
+  it('der Lade-Bericht beschriftet JEDE Art einzeln — die Liste kommt aus dem Typ', () => {
     // Bis hierher stand fuer JEDEN Fall „Signalquelle" — auch fuer ein
     // verworfenes Ausspielziel aus Initiative 9.
-    expect(appQuelle).toContain("d.kind === 'delivery-destination'")
-    expect(appQuelle).toContain("d.kind === 'venue-answer'")
+    //
+    // Und bis hierher pruefte diese Zusicherung ZWEI Sorten namentlich. Das
+    // war dieselbe Bauform wie der Fehler, den sie bewacht: eine Hand
+    // gepflegte Liste, die eine neue Sorte nicht kennt. Jetzt kommt die Liste
+    // aus `LoadDropKind` selbst, und die Tabelle in `App.tsx` muss jede davon
+    // beschriften.
+    const block = typQuelle.slice(
+      typQuelle.indexOf('export type LoadDropKind'),
+      typQuelle.indexOf('export interface LoadDrop'),
+    )
+    const arten = [...block.matchAll(/\|\s*'([a-z-]+)'/g)].map((m) => m[1])
+    expect(arten.length).toBeGreaterThanOrEqual(10)
+    const tabelle = appQuelle.slice(
+      appQuelle.indexOf('const DROP_ART'),
+      appQuelle.indexOf('const DROP_GRUND'),
+    )
+    for (const art of arten) expect(tabelle).toContain(`'${art}':`)
+    // Und die erste Sorte, die kein `|` vor sich hat, darf nicht durchrutschen.
+    expect(tabelle).toContain("'source-identity':")
   })
 })


### PR DESCRIPTION
ADR-005 nennt unter **„Was daraus als Nächstes zu bauen ist"** genau diese Arbeit — und dazu die Bedingung, unter der sie zu tun ist:

> Damit ist der Weg für jeden weiteren Fund in `healProjectPositions` offen. Die übrigen Heilungsschritte sind aber **nicht** blind anzuschliessen — erst ist je Schritt zu prüfen, ob er überhaupt etwas verwirft. Ein Kanal, der Meldungen über Nicht-Verluste trägt, ist so schädlich wie gar keiner: er gewöhnt den Nutzer daran, das Banner wegzuklicken.

Durchgegangen. **Zwei** Schritte verwarfen ganze Datensätze, und zwar wortlos.

### 1. Tally-Positionen (Bedarf 105)

`normaliseTallyPositions` warf einen Datensatz **ohne** Rolle und einen mit **doppelter** Rolle still weg; `healProjectPositions` zusätzlich einen, dessen Rolle es nicht mehr gibt.

Der Datensatz trägt die `checks` — die Beobachtungen, die **jemand an der Kamera aufgenommen hat**. Nach dem stillen Wegfall steht die Position auf dem Vor-Show-Blatt als „nie geprüft", und jemand läuft denselben Weg noch einmal. Oder eben nicht, weil er sich erinnert, dort schon gewesen zu sein.

### 2. Adressbereiche (Bedarf 20)

`normaliseAddressLayers` warf einen Bereich mit unlesbarem CIDR still weg — und eine Ebene ohne Id nahm **alle** ihre Bereiche mit.

Ein Bereich ist der Vorrat, aus dem jede Geräte-Adresse kommt. Fällt er beim Laden still weg, vergibt der nächste Adresslauf aus einem Plan, in dem dieses Netz nie stand, und der Widerspruch fällt erst auf, wenn zwei Geräte im Rack dieselbe Adresse tragen.

### Was ausdrücklich NICHT angeschlossen wurde

| Schritt | Warum nicht |
| --- | --- |
| Gateway-Zeiger eines Segments | Ein **Feld** an einem Datensatz, der überlebt |
| Gateway eines Adressbereichs | Dasselbe — der Bereich bleibt stehen |
| `normaliseNamingScheme` / `normaliseRecordNaming` | Eine Einstellung, kein Nutzer-Datensatz (steht so im Quelltext) |

Eine Zusicherung hält diese Grenze fest (`meldet NICHT, wenn nur das Gateway ausserhalb liegt`) — sonst wandert der Kanal beim nächsten Durchgang genau dorthin, wovor der ADR warnt.

## Ein neuer Grund: `dangling-ref`

„Pflichtfeld fehlt" schickt jemanden in seine Datei, um einen Namen nachzutragen. „Der Verweis zeigt ins Leere" sagt ihm, dass das **Ziel gelöscht** wurde und der Datensatz mit ihm. Wer das Erste liest und das Zweite braucht, sucht am falschen Ende.

Gilt nur, wo das Verwerfen selbst richtig ist. Wo ein Datensatz ohne sein Ziel noch etwas aussagt, bleibt er stehen und bekommt einen Befund — `override-orphan`, `anchor-orphan`, `rate-missing`.

## Die Bauform, die den nächsten Fall dieser Art verhindert

In `App.tsx` stand eine Kette aus **zwölf verschachtelten Ternäroperatoren**, deren letzter Zweig `'Signalquelle'` war — der Fall-Through als Default. Wer eine Sorte an `LoadDropKind` hängte und die Kette vergaß, bekam keinen Fehler, sondern eine Zeile, die den Nutzer die **falsche Sorte** Datensatz in seiner Datei suchen lässt. Genau davor warnte der Kommentar an der Kette; die Kette selbst war die Bauform, die es zulässt.

Jetzt zwei Tabellen mit `satisfies Record<LoadDropKind, …>` bzw. `Record<LoadDropReason, …>`. Eine vergessene Beschriftung ist ein **Typfehler**.

## Zwei Wächter, die an der Verbesserung rot wurden

Beide pinnten die alte Form statt der Zusicherung — dieselbe Lehre wie zuletzt: *ein Wächter, der an einer richtigen Änderung rot wird, wird geändert statt gelesen.*

- `tallyPosition.test.ts` pinnte den Einzeiler `normaliseTallyPositions(project.tallyPositions).filter` → prüft jetzt die Stelle auf beide Zusicherungen (Filter **und** Meldung).
- `venueAnswers.test.ts` kannte **zwei** Sorten namentlich — dieselbe handgepflegte Liste, deren Fehler es bewachte. Zählt jetzt aus `LoadDropKind` selbst auf.

## Prüfung

`tests/ladeberichtStilleVerluste.test.ts` — 15 Tests. **Fünf Gegenproben, alle rot:**

| # | Injizierter Defekt | Rot |
| --- | --- | --- |
| A | Tally-Datensatz ohne Rolle fällt wieder stumm weg | 2 |
| B | doppelte Rolle fällt wieder stumm weg | 1 |
| C | Position auf gelöschte Rolle fällt wieder stumm weg | 1 |
| D | unlesbarer CIDR fällt wieder stumm weg | 2 |
| E | Beschriftung einer Sorte vergessen | 2 — **und schon `tsc` (TS2741 + TS1360)** |

`npx tsc -p tsconfig.app.json --noEmit` 0 Errors · `npm run lint` 0 Errors · `npx vitest run` 200 Dateien, 3097 Tests grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_