### PR TITLE
feat: Zugangscodes hinter eigenem Token (E-3) + animierter Signalfluss, Tally, Gewerk-Farben, Schaltbild-Rechner

### DIFF
--- a/docs/app-structure.html
+++ b/docs/app-structure.html
@@ -240,7 +240,7 @@
   <aside>
     <h1>Cable-Planner</h1>
     <div class="subtitle">
-      App-Struktur · v9.0.1 · ~555 TS/TSX-Module · ~165.6k LOC<br>
+      App-Struktur · v9.0.1 · ~566 TS/TSX-Module · ~167.5k LOC<br>
       <small style="color:#64748b">Diese Übersicht zeigt nur die ~62 wichtigsten Module. Für die vollständige Architektur siehe <a href="./architecture.md" style="color:#94a3b8">architecture.md</a>.</small>
     </div>
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Invarianten der App. Sie ist die Pflicht-Lektüre, bevor strukturelle Änderunge
 gemacht werden. Für die interaktive Modul-Übersicht siehe [`app-structure.html`](./app-structure.html),
 für einen Wettbewerber-Vergleich [`comparison.html`](./comparison.html).
 
-Stand: v9.0.1 · ~555 TS/TSX-Module · ~165.6k LOC
+Stand: v9.0.1 · ~566 TS/TSX-Module · ~167.5k LOC
 
 ---
 
@@ -122,6 +122,51 @@ isoliert testbar ist.
    (Multi-Delete, Paste, Drag-End-Batch) gibt es `projectHistory.transact(fn)`.
 5. **Slices mutieren über `set(state => ...)`** — niemals lokal cachen oder
    Side-Effects am Render-Pfad triggern.
+
+#### 3.1b · `liveStore` — die BEOBACHTUNGS-Spur des Canvas
+
+Seit 2026-09-08 gibt es neben `projectStore` (Absicht) einen zweiten,
+**nicht persistierten** Store für das, was Mischer und Router gerade tun.
+Er ist die Renderer-Seite derselben Trennung, die `lib/asBuilt.ts` seit E-4
+für die Dokumente führt.
+
+**Warum nicht im `projectStore`.** Dort liefe eine Ablesung durch Undo/Redo,
+durch die Autospeicherung und in die `.cableplan`-Datei. Eine Beobachtung,
+die als Absicht gespeichert wird, ist genau der Fehler, den ADR-003 benennt
+— und `cable#647` hat gezeigt, wie er sich anfühlt: ein Status-Read hat die
+geplante Kreuzschiene still durch das ersetzt, was der Hub im Moment tat.
+
+**Die Regel, die daran hängt** (`lib/signalAnimation.ts`): der Canvas kennt
+zwei Betriebsarten und keine dritte.
+
+| Lage | Anzeige |
+|---|---|
+| kein Kontakt | Schema |
+| Kontakt älter als 5 s | Schema |
+| Kontakt frisch, über DIESE Strecke nichts bekannt | Schema — **nicht** „aus" |
+| Meldung frisch | der gemeldete Zustand |
+
+Der dritte Fall ist der, den man beim Bauen übersieht. Eine Kante als tot zu
+zeichnen, weil niemand sie gemessen hat, ist eine Aussage über ein
+ungemessenes Kabel.
+
+**Was die Bewegung bedeutet, und was nicht.** Der Zustand ändert nicht die
+Farbe — die gehört dem Layer und ist die Legende, nach der der Plan gedruckt
+wird. Der Zustand trägt die Bewegung. Einzige Ausnahme ist `down`
+(gedämpft), und die gibt es nur mit Beleg.
+
+**Zwei Einspeiser, zwei Hälften.** `useAtemTallyFeed` meldet Tally (1 s,
+über die offene IPC-Verbindung), `useVideohubLinkFeed` meldet Kreuzpunkte
+(2 s, weil `videohub:read-state` je Aufruf eine TCP-Verbindung zu einem
+Gerät im Signalweg öffnet). Fällt einer aus, räumt er **nur seine eigene
+Hälfte** — ein toter Router ist kein toter Mischer, und wer alles leerte,
+schickte den Nutzer zum falschen Gerät.
+
+**Die Grenze des Routers, ausdrücklich:** ein Videohub meldet Kreuzpunkte
+und **nichts** über anliegendes Signal. Deshalb gibt es `routed` als eigenen
+Zustand neben `carrying`. Der Kreuzpunkt steht auch dann, wenn upstream die
+Kamera aus ist; ihn als „Signal liegt an" zu zeigen machte aus einer
+Router-Einstellung eine Aussage über die Anlage.
 
 ### 3.2 · Komponenten
 
@@ -325,6 +370,12 @@ gehören hier rein, nicht in einzelne Komponenten.
 | Stream-Keys der Ausspielziele | OS-Credential-Store via `keytar`, Account `stream-key:<ziel-id>` | OS-eigen |
 | Sync-Lock | `<shared-pfad>/.cable-planner-sync.lock` | JSON (TTL 2h) |
 | Kategorie-Übersetzungen | `localStorage[categoryTranslations]` | JSON-Map |
+| **Beobachtungen (Tally, Kreuzpunkte)** | **nirgends — `liveStore`, nur im Speicher** | — |
+
+Die letzte Zeile steht hier, weil sie eine Entscheidung ist und kein
+Versäumnis: was die Anlage vor einer Stunde tat, weiß diese App nach einem
+Neustart nicht mehr, und das ist die richtige Aussage. Ein persistierter
+Beobachtungsstand sähe beim nächsten Öffnen aus wie ein aktueller.
 
 ---
 
@@ -531,6 +582,15 @@ Das Wichtigste in Listenform. Niemals brechen ohne expliziten Architektur-Review
     beim Laden wird sie nachgefragt, nicht aus der Datei geglaubt. Der Grund
     ist der Weg der Datei — eine `.avplan` wandert per Mail, liegt in Dropbox
     und geht in den Mobile- wie in den Web-Viewer.
+14. **Der Canvas behauptet keinen Anlagenzustand ohne frischen Beleg.** Eine
+    Animation, die aussieht wie fließendes Signal, IST eine Aussage über die
+    Anlage; niemand liest daneben eine Zahl. Ohne frische Beobachtung zeigt
+    der Canvas das **Schema** und sagt das auch (`FlowModeChip`) — und
+    „nichts bekannt" ist ausdrücklich nicht dasselbe wie „aus". Beobachtungen
+    liegen im `liveStore` und nie im Projekt. Wer eine dritte Quelle
+    anschließt, hält sich an dieselbe Grenze: melden, was das Gerät WIRKLICH
+    sagt (`routed` ist nicht `carrying`), mit Zeitstempel, und beim Ausfall
+    nur die eigene Hälfte räumen.
 
 ---
 
@@ -594,7 +654,7 @@ optionales Cloud-Backend (`y-websocket`, Auth/Permissions) bleiben offen.
 `vitest` ist eingerichtet (`npm test` / `npm run test:watch`); dazu kommen
 gezielte Node-Checks (`npm run test:crdt`, `npm run test:signaling`), ein
 UI-Smoke-Skript (`npm run ui:smoke`) und ein headless Drag-/Interaktions-Test
-(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~165.6k LOC
+(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~167.5k LOC
 bleibt der Ausbau der Abdeckung wichtig — empfohlene Schwerpunkte:
 - Snapshot-Tests auf `healProjectPositions` mit echten
   Beispiel-Projekt-JSONs.

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -62,14 +62,14 @@
 <header>
   <h1>Cable-Planner — Strukturvergleich mit ähnlichen Tools</h1>
   <div class="subtitle">Architektur, Tech-Stack und Domänen-Tiefe im Vergleich zu kommerziellen und Open-Source-Alternativen</div>
-  <div class="meta">Stand: 2026-06 · v9.0.1 · ~555 TS/TSX-Module · ~165.6k LOC · ~6.7 MB src/</div>
+  <div class="meta">Stand: 2026-06 · v9.0.1 · ~566 TS/TSX-Module · ~167.5k LOC · ~6.8 MB src/</div>
 </header>
 
 <h2>1 · Cable-Planner — Architektur-Kennzahlen</h2>
 
 <div class="stat-grid">
-  <div class="stat"><div class="num">555</div><div class="label">TS/TSX-Module</div></div>
-  <div class="stat"><div class="num">165.6k</div><div class="label">Lines of Code</div></div>
+  <div class="stat"><div class="num">566</div><div class="label">TS/TSX-Module</div></div>
+  <div class="stat"><div class="num">167.5k</div><div class="label">Lines of Code</div></div>
   <div class="stat"><div class="num">~75</div><div class="label">Modul-Dependencies</div></div>
   <div class="stat"><div class="num">7</div><div class="label">User-Flows</div></div>
 </div>

--- a/src/main/ipc/atemIpc.ts
+++ b/src/main/ipc/atemIpc.ts
@@ -97,6 +97,22 @@ const summarizeState = () => {
     }
   })
 
+  // Was gerade auf Sendung ist — je Mix-Effect. Bis 2026-09-08 stand das hier
+  // nicht: der Renderer konnte den Mischer nach Namen, Multiviewer und
+  // Audio fragen, aber nicht danach, WELCHE Quelle er zeigt. Genau das
+  // braucht die Tally-Anzeige im Canvas.
+  //
+  // Als LISTE je ME und nicht als ein Paar: ein Mischer mit zwei ME hat zwei
+  // Programme, und eines davon zum "dem" Programm zu erklaeren waere eine
+  // Behauptung darueber, welches der Regie wichtig ist. Wer nur eines
+  // braucht, nimmt Index 0 — das ist dann seine Entscheidung.
+  const mixEffectStates = (state.video?.mixEffects ?? []).map((me, index) => ({
+    index,
+    programInput: me?.programInput,
+    previewInput: me?.previewInput,
+    inTransition: me?.transitionPosition?.inTransition ?? false,
+  }))
+
   return {
     productIdentifier: state.info?.productIdentifier ?? '',
     model: state.info?.model,
@@ -105,6 +121,7 @@ const summarizeState = () => {
     auxiliaries: state.info?.capabilities?.auxilliaries,
     inputs,
     multiViewers,
+    mixEffectStates,
   }
 }
 

--- a/src/main/ipc/mobileShareIpc.ts
+++ b/src/main/ipc/mobileShareIpc.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, ipcMain } from 'electron'
+import { appendDocumentLog } from '../services/documentLog.js'
 import path from 'node:path'
 import { existsSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
@@ -12,6 +13,10 @@ import {
   setMobileShareChecksHandler,
   setMobileShareCableAddedHandler,
   setMobileSharePendingChangeHandler,
+  setMobileSharePincodeAccess,
+  setMobileSharePincodeReadHandler,
+  setMobileSharePincodes,
+  mobileSharePincodeStatus,
   startMobileShareServer,
   stopMobileShareServer,
 } from '../services/mobileShareServer.js'
@@ -117,4 +122,54 @@ export const registerMobileShareIpc = () => {
     writeMode: setMobileShareWriteMode(mode),
   }))
   ipcMain.handle('mobileShare:getWriteMode', () => ({ writeMode: mobileShareWriteMode() }))
+
+  /**
+   * E-3 — Zugriff auf die Anlagen-Zugangscodes.
+   *
+   * Der Token kommt hier EINMAL im Klartext zurueck, direkt beim Einschalten,
+   * damit die Oberflaeche ihn anzeigen kann. Es gibt bewusst keinen
+   * „gib mir den aktuellen Token"-Aufruf: ein Geheimnis, das man jederzeit
+   * nachschlagen kann, wandert in jeden Screenshot des Dialogs. Wer ihn
+   * verliert, schaltet aus und wieder ein — und macht damit zugleich den
+   * alten ungueltig, was richtig ist.
+   */
+  ipcMain.handle('mobileShare:setPincodeAccess', (_event, on: unknown) => ({
+    ok: true,
+    token: setMobileSharePincodeAccess(on === true),
+  }))
+
+  ipcMain.handle('mobileShare:setPincodes', (_event, codes: unknown) => {
+    // Formpruefung in main, nicht im Renderer: was hier ankommt, geht ueber
+    // eine Netzroute wieder hinaus.
+    const clean = Array.isArray(codes)
+      ? codes
+          .map((c) => (c && typeof c === 'object' ? (c as Record<string, unknown>) : null))
+          .filter((c): c is Record<string, unknown> => c !== null)
+          .filter((c) => typeof c.label === 'string' && typeof c.value === 'string')
+          .map((c) => ({ label: String(c.label), value: String(c.value) }))
+      : null
+    setMobileSharePincodes(clean && clean.length ? clean : null)
+    return { ok: true, ...mobileSharePincodeStatus() }
+  })
+
+  ipcMain.handle('mobileShare:pincodeStatus', () => mobileSharePincodeStatus())
+
+  /**
+   * Jeder Abruf ins Dokument-Register. Der Eintrag traegt den Zeitpunkt und
+   * die ersten sechs Zeichen des Tokens als `stand` — genug, um zwei
+   * Ausgaben auseinanderzuhalten, und zu wenig, um damit etwas zu oeffnen.
+   *
+   * Der Fehlerfall wird verschluckt: ein Register, das nicht schreiben kann,
+   * darf den Abruf nicht auch noch zum Absturz bringen. Der Abruf ist
+   * bereits beantwortet, wenn dieser Rueckruf laeuft.
+   */
+  setMobileSharePincodeReadHandler((info) => {
+    void appendDocumentLog({
+      docId: 'mobile-pincode',
+      label: `Zugangscodes abgerufen (${info.count})`,
+      stand: info.tokenPrefix,
+      emittedAt: info.at,
+      project: '',
+    }).catch(() => {})
+  })
 }

--- a/src/main/preload.cts
+++ b/src/main/preload.cts
@@ -378,6 +378,25 @@ contextBridge.exposeInMainWorld('cablePlanner', {
       ipcRenderer.invoke('mobileShare:getWriteMode') as Promise<{
         writeMode: 'read-only' | 'contribute'
       }>,
+    /**
+     * E-3 — Zugriff auf die Anlagen-Zugangscodes ein- oder ausschalten.
+     * Gibt beim Einschalten den zweiten Token EINMAL zurueck; es gibt
+     * bewusst keinen Weg, ihn spaeter nachzuschlagen.
+     */
+    setPincodeAccess: (on: boolean) =>
+      ipcRenderer.invoke('mobileShare:setPincodeAccess', on) as Promise<{
+        ok: boolean
+        token: string
+      }>,
+    /** E-3 — die Codes in main hinterlegen. Sie verlassen den Renderer nur hierhin. */
+    setPincodes: (codes: { label: string; value: string }[] | null) =>
+      ipcRenderer.invoke('mobileShare:setPincodes', codes) as Promise<{
+        ok: boolean
+        on: boolean
+        count: number
+      }>,
+    pincodeStatus: () =>
+      ipcRenderer.invoke('mobileShare:pincodeStatus') as Promise<{ on: boolean; count: number }>,
     // v7.9.3 — Subscriber für Mobile-Check-State-Updates. Main schickt
     // 'mobileShare:checksUpdate' wenn POST /checks reinkommt; Renderer
     // updated daraufhin project.checkState im Store.

--- a/src/main/services/mobileShareServer.ts
+++ b/src/main/services/mobileShareServer.ts
@@ -121,6 +121,44 @@ interface MobileShareState {
    */
   writeMode: MobileShareWriteMode
   /**
+   * E-3 — der ZWEITE Token, hinter dem die Anlagen-Zugangscodes liegen.
+   *
+   * Leer heisst: nicht ausgegeben, und dann gibt es die Route nicht, egal
+   * welchen Token jemand mitschickt. Er wird ausdruecklich am Rechner
+   * erzeugt und von Hand weitergegeben — er reist NICHT im QR-Code und
+   * NICHT in der URL.
+   *
+   * WARUM NICHT DER SITZUNGS-TOKEN. Der steckt im QR-Code und liegt damit
+   * auf jedem Telefon im WLAN, das ihn abfotografiert hat. Ihn auch fuer
+   * die Zugangscodes gelten zu lassen hiesse „hinter einem Token" zu sagen
+   * und „hinter dem Link" zu bauen — der Eigentuemer hat am 2026-09-08 das
+   * erste entschieden.
+   */
+  pincodeToken: string
+  /**
+   * E-3 — die Codes selbst. NUR HIER, nur im Speicher von `main`, nie in
+   * `serialized` und nie in einer Datei.
+   *
+   * Der Renderer setzt sie zusammen mit dem Projekt und nur dann, wenn der
+   * Zugriff eingeschaltet ist. `stripSecrets` bleibt unveraendert: das
+   * Roh-Dokument des Herstellers geht weiterhin als Ganzes nicht mit, und
+   * das ausgelieferte Blatt traegt keinen einzigen dieser Werte. Wer sie
+   * will, holt sie ueber eine eigene Route mit dem zweiten Token.
+   */
+  pincodes: { label: string; value: string }[] | null
+  /**
+   * E-3 — wohin der Abruf gemeldet wird.
+   *
+   * Als Rueckruf und nicht als direkter Aufruf des Dokument-Registers: der
+   * Server soll ohne Electron laufen und pruefbar bleiben. Die Verdrahtung
+   * macht `mobileShareIpc`, wie bei den drei Schreibwegen auch.
+   *
+   * Er bekommt den FINGERABDRUCK des Tokens, nie den Token und nie die Codes.
+   * Ein Protokoll, das das Geheimnis mitschreibt, ist die zweite Kopie des
+   * Geheimnisses.
+   */
+  onPincodeRead: ((info: { at: string; tokenPrefix: string; count: number }) => void) | null
+  /**
    * BEDARF 127 — die Show, die gerade freigegeben ist.
    *
    * Steht neben dem Projekt und nicht in ihm, damit die Pruefung des
@@ -193,6 +231,11 @@ const state: MobileShareState = {
   token: '',
   allowBeyondLan: false,
   writeMode: 'read-only',
+  // Vorgabe: kein Zugriff. Wie `writeMode` eine Verhaltensvorgabe und keine
+  // Folge davon, dass die Route existiert.
+  pincodeToken: '',
+  pincodes: null,
+  onPincodeRead: null,
   showId: null,
   project: null,
   serialized: null,
@@ -365,6 +408,63 @@ const handleRequest = (req: IncomingMessage, res: ServerResponse) => {
     res.setHeader('Cache-Control', 'no-store')
     applyCors(req, res)
     res.end(state.serialized ?? '{}')
+    return
+  }
+
+  /**
+   * E-3 — die Anlagen-Zugangscodes, hinter dem ZWEITEN Token.
+   *
+   * DREI SPERREN, und jede fuer sich ist notwendig:
+   *
+   *   1. der Sitzungstoken wie ueberall — wer den Plan nicht sehen darf,
+   *      darf auch die Codes nicht;
+   *   2. der AUSGEGEBENE zweite Token (`X-CP-Pin-Token`). Er steckt nicht im
+   *      QR-Code und nicht in der URL, sondern wird am Rechner angezeigt und
+   *      von Hand weitergegeben. Ohne ihn gibt es die Route nicht — 404 und
+   *      nicht 401, damit ein abgeschalteter Zugriff nicht wie ein falsch
+   *      eingetippter Code aussieht;
+   *   3. der Zugriff muss eingeschaltet sein. Vorgabe ist AUS.
+   *
+   * Er kommt bewusst NICHT als Query-Parameter durch: der Sitzungstoken darf
+   * das, weil er ohnehin im QR-Code steht, aber ein Code in einer URL landet
+   * im Verlauf, im Screenshot und in jedem Server-Log dazwischen. Hier zaehlt
+   * nur der Header.
+   *
+   * Jeder Abruf steht danach im Dokument-Register — mit Zeitpunkt und den
+   * ersten sechs Zeichen des Tokens, NICHT mit dem Wert. Ein Protokoll, das
+   * das Geheimnis mitschreibt, ist die zweite Kopie des Geheimnisses.
+   */
+  if (pathname === '/pincodes') {
+    if (!authed(req, url)) return denyUnauthorized(req, res)
+    // Kein Zugriff eingeschaltet: die Route existiert nicht. Der Unterschied
+    // ist wichtig — 401 hiesse „falscher Code, versuch es nochmal" und
+    // schickte jemanden ans Raten.
+    if (!state.pincodeToken) {
+      applyCors(req, res)
+      res.statusCode = 404
+      res.setHeader('Content-Type', 'application/json; charset=utf-8')
+      res.end('{"error":"not-available"}')
+      return
+    }
+    const pin = req.headers['x-cp-pin-token']
+    if (typeof pin !== 'string' || pin !== state.pincodeToken) {
+      applyCors(req, res)
+      res.statusCode = 403
+      res.setHeader('Content-Type', 'application/json; charset=utf-8')
+      res.end('{"error":"pin-token"}')
+      return
+    }
+    applyCors(req, res)
+    res.statusCode = 200
+    res.setHeader('Content-Type', 'application/json; charset=utf-8')
+    res.setHeader('Cache-Control', 'no-store')
+    const codes = state.pincodes ?? []
+    state.onPincodeRead?.({
+      at: new Date().toISOString(),
+      tokenPrefix: state.pincodeToken.slice(0, 6),
+      count: codes.length,
+    })
+    res.end(JSON.stringify({ codes }))
     return
   }
 
@@ -787,11 +887,65 @@ export const stopMobileShareServer = (): void => {
   // Die Freigabe gilt fuer DIESES Netz und diese Sitzung. Wer den Rechner
   // morgen woanders aufstellt, faengt wieder beim LAN an.
   state.allowBeyondLan = false
+  // E-3: Zugriff und Codes ueberleben das Stoppen nicht. Ein Token, das
+  // eine Sitzung ueberlebt, ist kein ausgegebener Token mehr, sondern ein
+  // hinterlegter — und die Codes haben ohne laufenden Server nichts im
+  // Speicher zu suchen.
+  state.pincodeToken = ''
+  state.pincodes = null
   state.project = null
   state.serialized = null
   state.showId = null
   state.devProxyUrl = undefined
 }
+
+/**
+ * E-3 — den Zugriff auf die Anlagen-Zugangscodes einschalten und dabei einen
+ * frischen zweiten Token ausgeben. `false` schaltet ihn ab und wirft Token
+ * UND Codes weg.
+ *
+ * Der Rueckgabewert ist der Token im Klartext — er wird am Rechner angezeigt
+ * und von Hand weitergegeben. Genau das ist der Unterschied zum Sitzungstoken,
+ * der im QR-Code steht: dieser hier reist nicht.
+ */
+export const setMobileSharePincodeAccess = (on: boolean): string => {
+  if (!on) {
+    state.pincodeToken = ''
+    state.pincodes = null
+    return ''
+  }
+  // Ein neuer Token bei jedem Einschalten. Wer ihn einmal weitergegeben hat,
+  // nimmt ihn durch Aus- und Wiedereinschalten zurueck.
+  state.pincodeToken = randomBytes(6).toString('hex')
+  return state.pincodeToken
+}
+
+/**
+ * E-3 — die Codes hinterlegen. Nur wirksam, solange der Zugriff eingeschaltet
+ * ist: ohne Token gibt es keine Route, und Codes ohne Route waeren ein
+ * Geheimnis im Speicher ohne Zweck.
+ */
+export const setMobileSharePincodes = (
+  codes: { label: string; value: string }[] | null,
+): void => {
+  state.pincodes = state.pincodeToken ? codes : null
+}
+
+/**
+ * E-3 — wohin ein Abruf gemeldet wird. Wie bei den Schreibwegen registriert
+ * der IPC-Anschluss den Rueckruf; der Server selbst kennt das Register nicht.
+ */
+export const setMobileSharePincodeReadHandler = (
+  handler: ((info: { at: string; tokenPrefix: string; count: number }) => void) | null,
+): void => {
+  state.onPincodeRead = handler
+}
+
+/** Ist der Zugriff eingeschaltet, und liegen Codes bereit? Ohne den Token. */
+export const mobileSharePincodeStatus = (): { on: boolean; count: number } => ({
+  on: state.pincodeToken !== '',
+  count: state.pincodes?.length ?? 0,
+})
 
 export const setMobileShareProject = (project: unknown): void => {
   state.project = project

--- a/src/mobile/MobileApp.tsx
+++ b/src/mobile/MobileApp.tsx
@@ -1501,6 +1501,154 @@ const PlanModeView = ({
   )
 }
 
+/**
+ * E-3 — die Anlagen-Zugangscodes, hinter einem EIGENEN Code.
+ *
+ * Der Techniker steht vor der Intercom-Anlage und braucht den Pincode. Bis
+ * `cable#656` stand er im ausgelieferten Blatt und damit auf jedem Telefon im
+ * WLAN, das den QR-Code abfotografiert hatte; seither steht er nirgends. Der
+ * Eigentümer hat am 2026-09-08 den Mittelweg entschieden: abrufbar, aber
+ * hinter einem zweiten Code, den jemand am Rechner ausgibt und von Hand
+ * weitergibt.
+ *
+ * DREI DINGE MACHT DIESE ANSICHT BEWUSST NICHT:
+ *
+ *   * Sie merkt sich den Code nicht. Kein `localStorage`, kein Feld mit
+ *     `autocomplete` — er wird bei jedem Abruf neu eingetippt. Ein
+ *     gespeicherter Zugangscode auf einem Baustellen-Handy ist derselbe
+ *     Fehler wie der Code im Blatt, nur später.
+ *   * Sie hält die Werte nicht. Sie fallen weg, sobald das Feld geschlossen
+ *     wird — nicht als Schutz gegen einen Angreifer, sondern damit der
+ *     nächste Blick aufs Telefon sie nicht mehr zeigt.
+ *   * Sie schickt den Code NICHT in der URL. Der Sitzungstoken darf das (er
+ *     steht ohnehin im QR-Code), dieser hier nicht: eine URL landet im
+ *     Verlauf, im Screenshot und in jedem Server-Log dazwischen.
+ *
+ * Ein 404 heißt „nicht freigegeben", ein 403 „falscher Code". Der
+ * Unterschied steht im Text, weil er entscheidet, was der Techniker als
+ * Nächstes tut: nachfragen oder nochmal tippen.
+ */
+const Zugangscodes = () => {
+  const [offen, setOffen] = useState(false)
+  const [code, setCode] = useState('')
+  const [codes, setCodes] = useState<{ label: string; value: string }[] | null>(null)
+  const [fehler, setFehler] = useState('')
+  const [laeuft, setLaeuft] = useState(false)
+
+  const schliessen = () => {
+    setOffen(false)
+    setCode('')
+    setCodes(null)
+    setFehler('')
+  }
+
+  const hole = async () => {
+    setLaeuft(true)
+    setFehler('')
+    try {
+      const r = await apiFetch('/pincodes', { headers: { 'X-CP-Pin-Token': code.trim() } })
+      if (r.status === 404) {
+        setFehler('Nicht freigegeben. Am Planer muss jemand die Zugangscodes freigeben.')
+        return
+      }
+      if (r.status === 403) {
+        setFehler('Falscher Code.')
+        return
+      }
+      if (!r.ok) {
+        setFehler(`Fehler ${r.status}.`)
+        return
+      }
+      const daten = (await r.json()) as { codes?: { label: string; value: string }[] }
+      setCodes(daten.codes ?? [])
+    } catch {
+      setFehler('Keine Verbindung zum Planer.')
+    } finally {
+      setLaeuft(false)
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOffen(true)}
+        className="fixed right-3 top-12 z-[300] flex items-center gap-1 rounded-full border border-cp-border bg-cp-surface-3/90 px-2.5 py-1 text-[11px] text-cp-text shadow-lg backdrop-blur"
+        title="Anlagen-Zugangscodes"
+      >
+        Zugangscodes
+      </button>
+      {offen && (
+        <div className="fixed inset-0 z-[301] flex items-end justify-center bg-black/60 p-3" onClick={schliessen}>
+          <div
+            className="w-full max-w-md rounded-lg border border-cp-border bg-cp-surface-1 p-3 text-cp-text shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-2 text-sm font-semibold">Anlagen-Zugangscodes</div>
+            {codes === null ? (
+              <>
+                <p className="mb-2 text-[11px] text-cp-text-muted">
+                  Der Code steht nicht im QR-Link. Er wird am Planer ausgegeben und einzeln
+                  weitergegeben.
+                </p>
+                <input
+                  type="text"
+                  inputMode="text"
+                  autoComplete="off"
+                  autoCapitalize="off"
+                  spellCheck={false}
+                  value={code}
+                  onChange={(e) => setCode(e.target.value)}
+                  placeholder="Code vom Planer"
+                  className="mb-2 w-full rounded border border-cp-border bg-cp-surface-2 px-2 py-1.5 font-mono text-sm tracking-widest"
+                />
+                {fehler && <div className="mb-2 text-[11px] text-red-300">{fehler}</div>}
+                <div className="flex justify-end gap-2">
+                  <button type="button" onClick={schliessen} className="rounded px-3 py-1.5 text-sm">
+                    Abbrechen
+                  </button>
+                  <button
+                    type="button"
+                    onClick={hole}
+                    disabled={laeuft || code.trim() === ''}
+                    className="rounded bg-sky-700 px-3 py-1.5 text-sm text-white disabled:opacity-50"
+                  >
+                    {laeuft ? 'Hole…' : 'Anzeigen'}
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <ul className="mb-2 space-y-1.5">
+                  {codes.length === 0 && (
+                    <li className="text-[11px] text-cp-text-muted">
+                      Freigegeben, aber es sind keine Codes hinterlegt.
+                    </li>
+                  )}
+                  {codes.map((c) => (
+                    <li key={c.label} className="flex items-baseline justify-between gap-2">
+                      <span className="text-[11px] text-cp-text-muted">{c.label}</span>
+                      <code className="select-all font-mono text-base tracking-widest">{c.value}</code>
+                    </li>
+                  ))}
+                </ul>
+                <p className="mb-2 text-[11px] text-cp-text-muted">
+                  Dieser Abruf steht im Dokument-Register des Planers.
+                </p>
+                <div className="flex justify-end">
+                  <button type="button" onClick={schliessen} className="rounded px-3 py-1.5 text-sm">
+                    Schließen
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
 // Verbindungs-Umschalter: Lokal (LAN) ↔ Remote (Mobilfunk, eigener Tunnel/Relay).
 // Persistiert; „Übernehmen" lädt die App mit der neuen Verbindung neu.
 const ConnectionSettings = () => {
@@ -1697,6 +1845,7 @@ export const MobileApp = () => {
   return (
     <div className="min-h-screen bg-cp-bg text-cp-text">
       <ConnectionSettings />
+      <Zugangscodes />
       {/* BEDARF 127 — am Desktop steht jetzt eine andere Show. Der Plan auf
           diesem Handy bleibt der, mit dem es geladen wurde: ein stiller Tausch
           mitten im Aufbau ist genau der Schaden, den `ontime#1325` beschreibt.

--- a/src/renderer/components/Canvas/CableEdge.tsx
+++ b/src/renderer/components/Canvas/CableEdge.tsx
@@ -26,6 +26,7 @@ import { OffPageLeaderHandles } from './OffPageLeaderHandles'
 import { effectiveShortName } from '../../lib/shortName'
 import { getEquipmentById } from '../../lib/equipmentSelectors'
 import { useTranslation } from '../../lib/i18n'
+import { useEdgeFlow } from '../../hooks/useCanvasFlow'
 
 interface CableEdgeData {
   cable: Cable
@@ -370,6 +371,9 @@ export const CableEdge = ({
 }: EdgeProps<CableEdgeData>) => {
   const t = useTranslation()
   const cable = data?.cable
+  // Signalfluss dieser Kante. Der Hook laeuft VOR jedem fruehen Ausstieg
+  // (Off-Page, Layer-Filter) — React-Hook-Regeln.
+  const flow = useEdgeFlow(cable)
   const deleteCable = useProjectStore((state) => state.deleteCable)
   const equipment = useProjectStore((state) => state.project.equipment)
   const greengoConfig = useProjectStore((state) => state.project.greengoConfig)
@@ -921,6 +925,25 @@ export const CableEdge = ({
         markerEnd={markerEnd}
         markerStart={markerStart}
       />
+      {/* Signalfluss (Eigentümer-Entscheidung 2026-09-08) — ein zweiter,
+          gestrichelter Pfad ÜBER der Kante, dessen Strichversatz läuft.
+          Die Kante selbst bleibt unangetastet: sie trägt die Layer-Farbe,
+          die Beschriftung und `cable.dashed` für Funkstrecken.
+
+          Was die Bewegung BEDEUTET, entscheidet `useEdgeFlow` und nicht
+          diese Stelle — im Schema „hier ist ein Weg vorgesehen", im
+          Live-Betrieb „hier liegt Signal an". Welche der beiden gilt,
+          steht am Canvas und nicht an der Kante; an dreihundert Kanten
+          wäre es dreihundertmal dasselbe zu lesen. */}
+      {flow?.animate && (
+        <path
+          d={path}
+          className={`cp-flow${flow.direction === -1 ? ' cp-flow--reverse' : ''}`}
+          stroke={(mergedStyle.stroke as string) ?? '#94a3b8'}
+          strokeWidth={strokeWidth + 1}
+          opacity={0.85}
+        />
+      )}
       {cable && (
         <CableWaypoints
           cable={cable}

--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -63,6 +63,7 @@ import { createDemoProject } from '../../lib/demoProject'
 import { CanvasSearch } from './CanvasSearch'
 import { format, useTranslation } from '../../lib/i18n'
 import { useAtemTallyFeed } from '../../hooks/useAtemTallyFeed'
+import { styleForLayer } from '../../lib/cableLayers'
 
 const nodeTypes = { equipment: EquipmentNode, location: LocationFrameNode }
 const edgeTypes = { cable: CableEdge }
@@ -498,10 +499,16 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
         const lengthColor = cableColorMode === 'byLength' ? colorByLength(item.length) : null
         // In byLength mode, cables with no matching length rule get a neutral grey so they're
         // visually distinct from manually-colored cables and easy to spot.
+        // `byLayer` faerbt NUR die Darstellung; `item.color` bleibt
+        // unangetastet. Ein Modus, der die gespeicherte Farbe ueberschreibt,
+        // nimmt dem Nutzer eine Angabe weg, um eine andere zu zeigen — und
+        // beim Zurueckschalten waere sie fort.
         const strokeColor =
           cableColorMode === 'byLength'
             ? (lengthColor ? lengthColor.color : '#64748b')
-            : item.color
+            : cableColorMode === 'byLayer'
+              ? styleForLayer(item.layer).color
+              : item.color
         const dashArray = item.dashed
           ? '6 4'
           : cableColorMode === 'byLength' && lengthColor?.dashArray

--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -63,6 +63,7 @@ import { createDemoProject } from '../../lib/demoProject'
 import { CanvasSearch } from './CanvasSearch'
 import { format, useTranslation } from '../../lib/i18n'
 import { useAtemTallyFeed } from '../../hooks/useAtemTallyFeed'
+import { useVideohubLinkFeed } from '../../hooks/useVideohubLinkFeed'
 import { styleForLayer } from '../../lib/cableLayers'
 
 const nodeTypes = { equipment: EquipmentNode, location: LocationFrameNode }
@@ -101,6 +102,9 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
   // Der Mischer-Zustand als Beobachtung. Er haengt am Canvas, weil der Canvas
   // ihn zeigt — nicht an `App`, wo er auch dann liefe, wenn niemand hinsieht.
   useAtemTallyFeed()
+  // Der Kreuzpunkt-Zustand des Routers. Zweite Quelle neben dem Mischer; sie
+  // meldet ihre eigene Haelfte ab, wenn sie ausfaellt.
+  useVideohubLinkFeed()
   // #515 — stabile ID dieser CanvasArea-Instanz für die A*-Router-Registry.
   // Haupt- und Rack-Canvas teilen die Komponente, aber nicht die Instanz;
   // die ID hält ihre Router im Stack auseinander (siehe setCableRouter).

--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -62,6 +62,7 @@ import {
 import { createDemoProject } from '../../lib/demoProject'
 import { CanvasSearch } from './CanvasSearch'
 import { format, useTranslation } from '../../lib/i18n'
+import { useAtemTallyFeed } from '../../hooks/useAtemTallyFeed'
 
 const nodeTypes = { equipment: EquipmentNode, location: LocationFrameNode }
 const edgeTypes = { cable: CableEdge }
@@ -96,6 +97,9 @@ const ViewportStateSync = ({
 
 const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
   const t = useTranslation()
+  // Der Mischer-Zustand als Beobachtung. Er haengt am Canvas, weil der Canvas
+  // ihn zeigt — nicht an `App`, wo er auch dann liefe, wenn niemand hinsieht.
+  useAtemTallyFeed()
   // #515 — stabile ID dieser CanvasArea-Instanz für die A*-Router-Registry.
   // Haupt- und Rack-Canvas teilen die Komponente, aber nicht die Instanz;
   // die ID hält ihre Router im Stack auseinander (siehe setCableRouter).

--- a/src/renderer/components/Canvas/CanvasToolbar.tsx
+++ b/src/renderer/components/Canvas/CanvasToolbar.tsx
@@ -4,6 +4,7 @@ import { useUiStore } from '../../store/uiStore'
 import { useCanvasProjectStore as useProjectStore } from '../../store/projectStoreContext'
 import { LENGTH_COLOR_RULES } from '../../lib/cableColors'
 import { LayerVisibilityChips } from './LayerVisibilityChips'
+import { FlowModeChip } from './FlowModeChip'
 import { useDraggablePosition } from '../../hooks/useDraggablePosition'
 import { confirmDialog } from '../../lib/confirmDialog'
 import { computeEquipmentLayout } from '../../lib/equipmentLayout'
@@ -748,6 +749,11 @@ export const CanvasToolbar = ({ mode = 'main' }: { mode?: CanvasToolbarMode } = 
           #123). Aus AV-Industrie-Recherche: D-Tools, Stardraw, AVECAV
           nutzen genau diese 5 Top-Level-Layer als Branchenstandard. */}
       <LayerVisibilityChips />
+      <span style={dividerStyle} />
+      {/* Die Betriebsart des Signalflusses. Sie steht neben der
+          Layer-Legende, weil beide dasselbe beantworten: wonach ist dieses
+          Bild zu lesen. */}
+      <FlowModeChip />
       <span style={dividerStyle} />
       {/* v7.9.67 / #177 — der Schutz gegen versehentliches Verschieben, je
           Objektart (Rahmen / Geräte / Kabel).

--- a/src/renderer/components/Canvas/CanvasToolbar.tsx
+++ b/src/renderer/components/Canvas/CanvasToolbar.tsx
@@ -1047,8 +1047,8 @@ const DefaultsMenu = ({
   setCableLabelShortForm: (v: boolean) => void
   colorPortsByType: boolean
   setColorPortsByType: (v: boolean) => void
-  cableColorMode: 'manual' | 'byLength'
-  setCableColorMode: (v: 'manual' | 'byLength') => void
+  cableColorMode: 'manual' | 'byLength' | 'byLayer'
+  setCableColorMode: (v: 'manual' | 'byLength' | 'byLayer') => void
   showLengthLegend: boolean
   setShowLengthLegend: (v: boolean) => void
   isLight: boolean

--- a/src/renderer/components/Canvas/EquipmentNode.tsx
+++ b/src/renderer/components/Canvas/EquipmentNode.tsx
@@ -29,6 +29,7 @@ type EquipmentNodeData = EquipmentItem & {
 // equipmentLayout.ts dupliziert — Bug-Garantie wenn einer der beiden
 // geändert wurde.
 import { EQUIPMENT_LAYOUT } from '../../lib/layoutConstants'
+import { useTally } from '../../hooks/useCanvasFlow'
 const HEADER_HEIGHT = EQUIPMENT_LAYOUT.HEADER_HEIGHT
 const HEADER_HEIGHT_WITH_IP = EQUIPMENT_LAYOUT.HEADER_HEIGHT_WITH_IP
 const PORT_ROW = EQUIPMENT_LAYOUT.PORT_ROW
@@ -49,6 +50,8 @@ const resolvePortSide = (
 }
 
 export const EquipmentNode = ({ id, data, selected }: NodeProps<EquipmentNodeData>) => {
+  // Tally aus dem Mischer — `null`, solange nichts bekannt ist.
+  const tally = useTally(id)
   const t = useTranslation()
   const pendingCable = useUiStore((s) => s.pendingCable)
   const startPendingCable = useUiStore((s) => s.startPendingCable)
@@ -557,9 +560,21 @@ export const EquipmentNode = ({ id, data, selected }: NodeProps<EquipmentNodeDat
         borderRadius: 6,
         color: tokens.text,
         fontSize: 12,
-        boxShadow: isLight
-          ? '0 2px 6px rgba(0,0,0,0.12)'
-          : '0 2px 6px rgba(0,0,0,0.4)',
+        // Tally-Ring (Eigentuemer-Entscheidung 2026-09-08). Als AUSSENRING
+        // und nicht als Rahmenfarbe: der Rahmen traegt bereits die
+        // Geraetefarbe und die Auswahl, und ihn zu ueberschreiben liesse
+        // zwei Aussagen um eine Stelle streiten.
+        //
+        // `null` heisst KEINE Aussage und faerbt nichts. Eine Kamera, die
+        // der Mischer nicht kennt, darf nicht aussehen wie eine, von der
+        // bekannt ist, dass sie frei ist.
+        boxShadow: [
+          isLight ? '0 2px 6px rgba(0,0,0,0.12)' : '0 2px 6px rgba(0,0,0,0.4)',
+          tally === 'program' ? '0 0 0 3px #ef4444' : '',
+          tally === 'preview' ? '0 0 0 3px #22c55e' : '',
+        ]
+          .filter(Boolean)
+          .join(', '),
       }}
     >
       {/* Header */}

--- a/src/renderer/components/Canvas/FlowModeChip.tsx
+++ b/src/renderer/components/Canvas/FlowModeChip.tsx
@@ -1,0 +1,73 @@
+import { useCanvasFlowMode } from '../../hooks/useCanvasFlow'
+import { useSettingsStore } from '../../store/settingsStore'
+import { useReducedMotion } from '../../hooks/useReducedMotion'
+import { useTranslation } from '../../lib/i18n'
+
+/**
+ * Die Betriebsart des Canvas — Schema oder Live.
+ *
+ * SIE IST PFLICHT UND NICHT ZIERDE. Die Bewegung auf den Kanten sieht in
+ * beiden Betriebsarten gleich aus; ohne diese Anzeige gäbe es für den
+ * Betrachter keinen Unterschied zwischen „so ist es geplant" und „so ist es
+ * gerade". Genau das ist die Bedingung, unter der die Animation gebaut werden
+ * durfte (ADR-003, und die Auflage aus E-23).
+ *
+ * SIE STEHT AM CANVAS UND NICHT AN DER KANTE. An dreihundert Kanten wäre es
+ * dreihundertmal dasselbe zu lesen, und der Plan wäre unlesbar. Was eine
+ * EINZELNE Kante gemeldet hat, steht in ihrer Eigenschaften-Ansicht.
+ *
+ * WARUM SIE AUCH DAS ALTER ZEIGT. „Live" ohne Zeitangabe ist dieselbe
+ * Behauptung wie eine laufende Animation ohne Beleg — nur in Textform. Reißt
+ * die Verbindung ab, fällt der Canvas aufs Schema zurück (Eigentümer-
+ * Entscheidung), und dieser Streifen sagt, wie lange das her ist.
+ */
+export function FlowModeChip() {
+  const t = useTranslation()
+  const { live, ageMs, motion } = useCanvasFlowMode()
+  const gewuenscht = useSettingsStore((s) => s.canvasMotion)
+  const setMotion = useSettingsStore((s) => s.setCanvasMotion)
+  const systemReduziert = useReducedMotion()
+
+  const sekunden = ageMs === null ? null : Math.round(ageMs / 1000)
+  const titel = live
+    ? t('canvas.flow.liveTitle', 'Beobachteter Zustand aus Mischer/Router.')
+    : ageMs === null
+      ? t('canvas.flow.schemaTitle', 'Der geplante Weg. Es besteht keine Verbindung zu einer Anlage.')
+      : t(
+          'canvas.flow.fellBackTitle',
+          'Die Live-Verbindung ist abgerissen — gezeigt wird wieder der geplante Weg.',
+        )
+
+  return (
+    <button
+      type="button"
+      onClick={() => setMotion(!gewuenscht)}
+      title={`${titel} ${
+        systemReduziert
+          ? t('canvas.flow.systemReduced', 'Das System hat Bewegung abgestellt; die Anzeige bleibt ruhig.')
+          : gewuenscht
+            ? t('canvas.flow.toggleOff', 'Klick: Bewegung ausschalten.')
+            : t('canvas.flow.toggleOn', 'Klick: Bewegung einschalten.')
+      }`}
+      className="av-focus flex items-center gap-1.5 rounded-full border border-cp-border px-2 py-0.5 text-[11px] text-cp-text-secondary hover:bg-cp-surface-3"
+    >
+      <span
+        aria-hidden
+        className="inline-block h-1.5 w-1.5 rounded-full"
+        style={{ background: live ? 'var(--cp-ok, #22c55e)' : 'var(--cp-text-faint, #64748b)' }}
+      />
+      <span>{live ? t('canvas.flow.live', 'Live') : t('canvas.flow.schema', 'Schema')}</span>
+      {live && sekunden !== null && (
+        <span className="tabular-nums text-cp-text-muted">{`· ${sekunden} s`}</span>
+      )}
+      {!live && sekunden !== null && (
+        <span className="text-cp-text-muted">
+          {t('canvas.flow.lostContact', '· Verbindung weg')}
+        </span>
+      )}
+      {!motion && (
+        <span className="text-cp-text-muted">{t('canvas.flow.still', '· ruhig')}</span>
+      )}
+    </button>
+  )
+}

--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -1019,6 +1019,14 @@ export const MenuBar = ({
           >
             {t('app.menu.view.colorByLength', 'Kabelfarbe nach Länge')}
           </MenuItem>
+          <MenuItem
+            onClick={() =>
+              useUiStore.getState().setCableColorMode(cableColorMode === 'byLayer' ? 'manual' : 'byLayer')
+            }
+            icon={cableColorMode === 'byLayer' ? <Icon icon={Check} size="sm" /> : null}
+          >
+            {t('app.menu.view.colorByLayer', 'Kabelfarbe nach Gewerk')}
+          </MenuItem>
           <MenuSep />
           <MenuItem
             onClick={() => useUiStore.getState().setAnnotationsPanelOpen(!annotationsPanelOpen)}

--- a/src/renderer/components/MobileShare/MobileShareDialog.tsx
+++ b/src/renderer/components/MobileShare/MobileShareDialog.tsx
@@ -27,7 +27,7 @@
  * closes (Electron tears down the http server with the process).
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Smartphone, Clipboard, Check, Radio } from 'lucide-react'
 import QRCode from 'qrcode'
 import { Icon } from '../shared/Icon'
@@ -129,11 +129,13 @@ export const MobileShareDialog = () => {
     void cablePlannerApi.mobileShare.getWriteMode().then((r) => {
       if (lebt) setWriteModeState(r.writeMode)
     })
-    void cablePlannerApi.mobileShare.pincodeStatus().then((r) => {
-      if (!lebt) return
-      setPinAn(r.on)
-      setPinAnzahl(r.count)
-    })
+    if (hasDesktopBridge) {
+      void cablePlannerApi.mobileShare.pincodeStatus().then((r) => {
+        if (!lebt) return
+        setPinAn(r.on)
+        setPinAnzahl(r.count)
+      })
+    }
     return () => {
       lebt = false
     }
@@ -150,7 +152,16 @@ export const MobileShareDialog = () => {
    * IPC-Aufruf in den Hauptprozess und leben dort im Speicher, solange der
    * Schalter an ist.
    */
-  const codes = useProjectStore((st) => anlagenZugangscodes(st.project.greengoConfig?.basePreset))
+  //
+  // Der Selektor gibt das ROH-DOKUMENT zurueck und nicht die fertige Liste:
+  // `anlagenZugangscodes` baut bei jedem Aufruf ein neues Array, und ein
+  // zustand-Selektor mit neuer Identitaet je Aufruf laesst
+  // `useSyncExternalStore` bei JEDEM Render einen neuen Zustand sehen. Dieser
+  // Dialog haengt dauerhaft in `App.tsx` (auch geschlossen), also traf das die
+  // ganze App: der Canvas kam nicht mehr zur Ruhe, und „Beispielprojekt laden"
+  // tat nichts mehr. Gefunden vom UI-Overflow-Lauf, nicht von den Unit-Tests.
+  const basePreset = useProjectStore((st) => st.project.greengoConfig?.basePreset)
+  const codes = useMemo(() => anlagenZugangscodes(basePreset), [basePreset])
 
   const hatSchichten = useProjectStore(
     (st) => (st.project.crewPlan?.entries.length ?? 0) > 0,

--- a/src/renderer/components/MobileShare/MobileShareDialog.tsx
+++ b/src/renderer/components/MobileShare/MobileShareDialog.tsx
@@ -35,7 +35,8 @@ import { ModalShell } from '../shared/ModalShell'
 import { useUiStore } from '../../store/uiStore'
 import { useProjectStore } from '../../store/projectStore'
 import { cablePlannerApi, hasDesktopBridge } from '../../lib/bridge'
-import { useTranslation } from '../../lib/i18n'
+import { format, useTranslation } from '../../lib/i18n'
+import { anlagenZugangscodes } from '../../lib/anlagenZugangscodes'
 import { PanelHint } from '../shared/PanelHint'
 
 interface WithheldAddress {
@@ -109,11 +110,29 @@ export const MobileShareDialog = () => {
    * am Plan mitschreibt.
    */
   const [writeMode, setWriteModeState] = useState<'read-only' | 'contribute'>('read-only')
+  /**
+   * E-3 — der Zugriff auf die Anlagen-Zugangscodes.
+   *
+   * Wie `writeMode` kommt der Zustand VOM SERVER; der Token dagegen kommt
+   * EINMAL beim Einschalten und wird hier gehalten, bis der Dialog schliesst.
+   * Es gibt bewusst keinen Weg, ihn spaeter nachzuschlagen: ein Geheimnis,
+   * das man jederzeit aufrufen kann, wandert in jeden Screenshot dieses
+   * Dialogs. Wer ihn verliert, schaltet aus und wieder ein — und macht damit
+   * zugleich den alten ungueltig, was richtig ist.
+   */
+  const [pinAn, setPinAn] = useState(false)
+  const [pinToken, setPinToken] = useState('')
+  const [pinAnzahl, setPinAnzahl] = useState(0)
 
   useEffect(() => {
     let lebt = true
     void cablePlannerApi.mobileShare.getWriteMode().then((r) => {
       if (lebt) setWriteModeState(r.writeMode)
+    })
+    void cablePlannerApi.mobileShare.pincodeStatus().then((r) => {
+      if (!lebt) return
+      setPinAn(r.on)
+      setPinAnzahl(r.count)
     })
     return () => {
       lebt = false
@@ -125,6 +144,14 @@ export const MobileShareDialog = () => {
   // anders gebildet wird, geht beim naechsten Umbau auseinander. `webcal://`
   // statt `http://`, weil das am Handy das Abo oeffnet statt eine Datei zu
   // laden — genau der Unterschied, den der Bedarf verlangt.
+  /**
+   * E-3 — die Codes aus dem Roh-Dokument des Herstellers. Sie werden hier
+   * GELESEN und nirgends abgelegt: von hier gehen sie ueber genau einen
+   * IPC-Aufruf in den Hauptprozess und leben dort im Speicher, solange der
+   * Schalter an ist.
+   */
+  const codes = useProjectStore((st) => anlagenZugangscodes(st.project.greengoConfig?.basePreset))
+
   const hatSchichten = useProjectStore(
     (st) => (st.project.crewPlan?.entries.length ?? 0) > 0,
   )
@@ -437,11 +464,73 @@ export const MobileShareDialog = () => {
             </p>
           </div>
 
+          {/* E-3 — die Anlagen-Zugangscodes, hinter einem eigenen Token. */}
+          <div className="flex flex-col gap-1 rounded border border-cp-border-muted p-2">
+            <label className="flex items-center gap-2 text-cp-xs font-medium text-cp-text">
+              <input
+                type="checkbox"
+                checked={pinAn}
+                disabled={codes.length === 0}
+                onChange={async () => {
+                  const an = !pinAn
+                  const r = await cablePlannerApi.mobileShare.setPincodeAccess(an)
+                  setPinAn(an)
+                  setPinToken(r.token)
+                  const st = an
+                    ? await cablePlannerApi.mobileShare.setPincodes(codes)
+                    : { count: 0 }
+                  setPinAnzahl(st.count)
+                }}
+              />
+              {t('mobile.dialog.pincode', 'Anlagen-Zugangscodes abrufbar machen')}
+            </label>
+            {codes.length === 0 ? (
+              <p className="text-[11px] text-cp-text-muted">
+                {t(
+                  'mobile.dialog.pincode.none',
+                  'Dieses Projekt trägt keine Intercom-Konfiguration mit Zugangscodes.',
+                )}
+              </p>
+            ) : pinAn && pinToken ? (
+              <>
+                <p className="text-[11px] text-cp-text-muted">
+                  {t(
+                    'mobile.dialog.pincode.hint',
+                    'Diesen Code am Handy eingeben. Er steht NICHT im QR-Code — wer nur den Link hat, kommt nicht an die Zugangsdaten.',
+                  )}
+                </p>
+                <code className="select-all rounded bg-cp-surface-2 px-2 py-1 font-mono text-cp-base tracking-widest text-cp-text">
+                  {pinToken}
+                </code>
+                <p className="text-[11px] text-cp-text-muted">
+                  {format(
+                    t(
+                      'mobile.dialog.pincode.count',
+                      '{n} Code(s) hinterlegt. Jeder Abruf steht im Dokument-Register — mit Zeitpunkt, nicht mit dem Wert.',
+                    ),
+                    { n: pinAnzahl },
+                  )}
+                </p>
+              </>
+            ) : (
+              <p className="text-[11px] text-cp-text-muted">
+                {format(
+                  t(
+                    'mobile.dialog.pincode.offHint',
+                    'Aus. {n} Code(s) stünden bereit — sie verlassen den Rechner erst, wenn der Schalter an ist.',
+                  ),
+                  { n: codes.length },
+                )}
+              </p>
+            )}
+          </div>
+
           <details className="text-[11px] text-cp-text-muted">
             <summary className="cursor-pointer hover:text-cp-text-secondary">{t('mobile.dialog.securityHeading', 'Hinweise zur Sicherheit')}</summary>
             <ul className="mt-1 list-inside list-disc space-y-1">
               <li>{t('mobile.dialog.security.writeBack', 'Ob das Handy zurückschreiben darf, entscheidet die Einstellung darüber. Steht sie auf „Häkchen und Kabel zurückschicken“, kann jeder mit dem QR-Code den Plan ändern.')}</li>
               <li>{t('mobile.dialog.security.token', 'Jeder Schreibweg verlangt das Token aus dem QR-Code. Passwörter und Schlüssel werden aus dem Projekt entfernt, bevor es das Gerät verlässt.')}</li>
+              <li>{t('mobile.dialog.security.pincode', 'Die Anlagen-Zugangscodes gehen NIE im Projekt mit. Sie liegen nur im Speicher der Desktop-App und nur, solange der Schalter oben an ist; abgerufen werden sie über einen zweiten Code, der nicht im QR-Code steht.')}</li>
               <li>{t('mobile.dialog.security.bind', 'Der Server bindet auf das lokale Netzwerk (0.0.0.0). Wenn unklar ist, wer im Netz hängt, lieber stoppen.')}</li>
               <li>{t('mobile.dialog.security.autostop', 'Beim Schließen der Desktop-App stoppt auch der Server automatisch.')}</li>
             </ul>

--- a/src/renderer/components/Settings/tabs/AppearanceTab.tsx
+++ b/src/renderer/components/Settings/tabs/AppearanceTab.tsx
@@ -311,7 +311,7 @@ export const AppearanceTab = () => {
         title={t('settings.appearance.cableColor', 'Kabelfarbe')}
         description={t(
           'settings.appearance.cableColorDesc',
-          'Manuell = pro Kabel im Properties-Panel; nach Länge = Längen-basierte Farbcodierung.',
+          'Manuell = pro Kabel im Properties-Panel; nach Länge = Längen-Farbcodierung; nach Gewerk = die Layer-Legende (Video/Audio/Control/Netz/Strom). Die am Kabel gespeicherte Farbe bleibt in jedem Modus erhalten.',
         )}
       >
         <div className="flex gap-1">
@@ -336,6 +336,21 @@ export const AppearanceTab = () => {
             }`}
           >
             {t('settings.appearance.cableColor.byLength', 'Nach Länge')}
+          </button>
+          {/* Die Layer-Farben gab es bis 2026-09-08 nur an den Legenden-Chips:
+              der Plan versprach eine Codierung, die er nicht einlöste. Als
+              eigener Modus und nicht als Vorgabe — wer Kabel von Hand
+              eingefärbt hat, soll sie nicht beim nächsten Start anders sehen. */}
+          <button
+            type="button"
+            onClick={() => setCableColorMode('byLayer')}
+            className={`flex-1 rounded px-3 py-1 text-cp-xs ${
+              cableColorMode === 'byLayer'
+                ? 'bg-sky-700 text-white'
+                : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
+            }`}
+          >
+            {t('settings.appearance.cableColor.byLayer', 'Nach Gewerk')}
           </button>
         </div>
       </SettingsCard>

--- a/src/renderer/hooks/useAtemTallyFeed.ts
+++ b/src/renderer/hooks/useAtemTallyFeed.ts
@@ -1,0 +1,69 @@
+import { useEffect } from 'react'
+import { cablePlannerApi, hasDesktopBridge } from '../lib/bridge'
+import { useCanvasProjectStore as useProjectStore } from '../store/projectStoreContext'
+import { useLiveStore } from '../store/liveStore'
+import { LIVE_TICK_MS } from '../store/liveStore'
+import { atemTally } from '../lib/atemTally'
+import { buildTallyMap } from '../lib/tallyMap'
+
+/**
+ * Der Mischer-Zustand als Beobachtung — die Live-Hälfte des Canvas-Signalflusses.
+ *
+ * WARUM ABFRAGEN UND NICHT ZUHÖREN. `atem:*` kennt heute nur einen Log-Kanal
+ * (`onEvent` liefert Textzeilen), keinen Zustands-Push. Ein solcher wäre der
+ * bessere Weg und ist eine eigene Arbeit; bis dahin ist eine Abfrage im
+ * Sekundentakt das ehrlichere Provisorium: sie kostet einen IPC-Aufruf pro
+ * Sekunde und liefert einen Zeitstempel, an dem die Rückfall-Regel greifen
+ * kann. Ein Push OHNE Zeitstempel wäre schlechter — dann sähe eine
+ * eingefrorene Verbindung aus wie ein stabiler Zustand.
+ *
+ * WAS BEI EINEM FEHLSCHLAG PASSIERT: `verbindungWeg()`. Nicht „letzten Stand
+ * behalten": ein Mischer, den wir nicht mehr erreichen, ist kein Mischer, der
+ * dasselbe zeigt wie eben. Der Canvas fällt dann aufs Schema zurück, und der
+ * Streifen sagt es (Eigentümer-Entscheidung vom 2026-09-08).
+ *
+ * ER LÄUFT NUR IM DESKTOP-BETRIEB und nur, solange der Mischer verbunden ist.
+ * Im Browser gibt es keine IPC-Brücke, und ein Takt, der jede Sekunde ins
+ * Leere greift, kostet Bildrate für nichts.
+ */
+export const useAtemTallyFeed = (): void => {
+  const project = useProjectStore((s) => s.project)
+  const melde = useLiveStore((s) => s.melde)
+  const verbindungWeg = useLiveStore((s) => s.verbindungWeg)
+
+  useEffect(() => {
+    if (!hasDesktopBridge) return
+    let lebt = true
+
+    const runde = async () => {
+      if (!lebt) return
+      try {
+        const status = await cablePlannerApi.atem.getStatus()
+        if (!lebt) return
+        if (!status.connected) {
+          verbindungWeg()
+          return
+        }
+        const state = await cablePlannerApi.atem.getState()
+        if (!lebt) return
+        // Die Zuordnung Eingang → Geraet kommt aus dem PLAN und wird hier
+        // nicht zweitgefuehrt (ADR-001). Sie neu zu rechnen ist billig genug
+        // und immer aktuell; eine gecachte Karte ginge beim naechsten
+        // Umpatchen auseinander.
+        const rows = buildTallyMap(project).rows
+        melde({ tally: atemTally(state, rows, Date.now()) }, Date.now())
+      } catch {
+        // Erreichbar heisst nicht antwortend. Kein Stand ist besser als ein
+        // alter, der wie ein aktueller aussieht.
+        if (lebt) verbindungWeg()
+      }
+    }
+
+    void runde()
+    const timer = window.setInterval(() => void runde(), LIVE_TICK_MS)
+    return () => {
+      lebt = false
+      window.clearInterval(timer)
+    }
+  }, [project, melde, verbindungWeg])
+}

--- a/src/renderer/hooks/useAtemTallyFeed.ts
+++ b/src/renderer/hooks/useAtemTallyFeed.ts
@@ -17,7 +17,8 @@ import { buildTallyMap } from '../lib/tallyMap'
  * kann. Ein Push OHNE Zeitstempel wäre schlechter — dann sähe eine
  * eingefrorene Verbindung aus wie ein stabiler Zustand.
  *
- * WAS BEI EINEM FEHLSCHLAG PASSIERT: `verbindungWeg()`. Nicht „letzten Stand
+ * WAS BEI EINEM FEHLSCHLAG PASSIERT: er meldet seine eigene Hälfte ab — und
+ * nur die, denn ein toter Mischer ist kein toter Router. Nicht „letzten Stand
  * behalten": ein Mischer, den wir nicht mehr erreichen, ist kein Mischer, der
  * dasselbe zeigt wie eben. Der Canvas fällt dann aufs Schema zurück, und der
  * Streifen sagt es (Eigentümer-Entscheidung vom 2026-09-08).
@@ -41,7 +42,7 @@ export const useAtemTallyFeed = (): void => {
         const status = await cablePlannerApi.atem.getStatus()
         if (!lebt) return
         if (!status.connected) {
-          verbindungWeg()
+          verbindungWeg('tally')
           return
         }
         const state = await cablePlannerApi.atem.getState()
@@ -55,7 +56,7 @@ export const useAtemTallyFeed = (): void => {
       } catch {
         // Erreichbar heisst nicht antwortend. Kein Stand ist besser als ein
         // alter, der wie ein aktueller aussieht.
-        if (lebt) verbindungWeg()
+        if (lebt) verbindungWeg('tally')
       }
     }
 

--- a/src/renderer/hooks/useCanvasFlow.ts
+++ b/src/renderer/hooks/useCanvasFlow.ts
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react'
+import { useSettingsStore } from '../store/settingsStore'
+import { useLiveStore, LIVE_TICK_MS } from '../store/liveStore'
+import { edgeFlow, liveFreshness, tallyOf, type EdgeFlow } from '../lib/signalAnimation'
+import type { Cable } from '../types/cable'
+import { useReducedMotion } from './useReducedMotion'
+
+/**
+ * Darf sich im Canvas etwas bewegen?
+ *
+ * BEIDE müssen zustimmen: die Einstellung des Nutzers (was er will) und die
+ * Systemeinstellung (was er verträgt). Wer `prefers-reduced-motion` gesetzt
+ * hat, hat das aus einem Grund getan, den diese App nicht kennt.
+ */
+export const useCanvasMotion = (): boolean => {
+  const gewuenscht = useSettingsStore((s) => s.canvasMotion)
+  const reduziert = useReducedMotion()
+  return gewuenscht && !reduziert
+}
+
+/**
+ * Ein Takt, der nur läuft, wenn es etwas zu takten gibt.
+ *
+ * WOZU. Ohne ihn bliebe ein abgerissener Live-Kontakt so lange als „live"
+ * stehen, bis irgendetwas anderes ein Rendern auslöst — im Zweifel bis zur
+ * nächsten Mausbewegung. Der Rückfall aufs Schema wäre gebaut und unsichtbar.
+ *
+ * Er läuft NICHT im reinen Schema-Betrieb: dort gibt es nichts, das
+ * veralten könnte, und ein Intervall, das auf einem Plan mit 300 Kabeln
+ * jede Sekunde alles neu rechnet, kostet Bildrate für nichts.
+ */
+export const useLiveTick = (): number => {
+  const hatKontakt = useLiveStore((s) => s.snapshot.lastContactAt !== undefined)
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    if (!hatKontakt) return
+    const id = window.setInterval(() => setNow(Date.now()), LIVE_TICK_MS)
+    return () => window.clearInterval(id)
+  }, [hatKontakt])
+  return now
+}
+
+export interface CanvasFlowMode {
+  /** Gilt Live gerade? */
+  live: boolean
+  /** Alter der letzten Meldung in ms. `null` = nie Kontakt. */
+  ageMs: number | null
+  /** Bewegt sich etwas? */
+  motion: boolean
+}
+
+/**
+ * Die Betriebsart, wie der Canvas sie ANZEIGT.
+ *
+ * Sie ist Pflicht und nicht Zierde: die Animation sieht in beiden Betriebsarten
+ * gleich aus, und ohne diese Anzeige wäre der Unterschied zwischen „so ist es
+ * geplant" und „so ist es gerade" für den Betrachter nicht vorhanden.
+ */
+export const useCanvasFlowMode = (): CanvasFlowMode => {
+  const snapshot = useLiveStore((s) => s.snapshot)
+  const now = useLiveTick()
+  const motion = useCanvasMotion()
+  const { live, ageMs } = liveFreshness(snapshot, now)
+  return { live, ageMs, motion }
+}
+
+/** Wie diese eine Kante zu zeichnen ist. */
+export const useEdgeFlow = (cable: Pick<Cable, 'id' | 'bidirectional'> | undefined): EdgeFlow | null => {
+  const snapshot = useLiveStore((s) => s.snapshot)
+  const now = useLiveTick()
+  const motion = useCanvasMotion()
+  if (!cable) return null
+  return edgeFlow(cable, snapshot, now, { motion })
+}
+
+/** Tally eines Geräts — oder `null`, wenn nichts bekannt ist. */
+export const useTally = (equipmentId: string | undefined) => {
+  const snapshot = useLiveStore((s) => s.snapshot)
+  const now = useLiveTick()
+  if (!equipmentId) return null
+  return tallyOf(equipmentId, snapshot, now)
+}

--- a/src/renderer/hooks/useCanvasFlow.ts
+++ b/src/renderer/hooks/useCanvasFlow.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useSettingsStore } from '../store/settingsStore'
 import { useLiveStore, LIVE_TICK_MS } from '../store/liveStore'
-import { edgeFlow, liveFreshness, tallyOf, type EdgeFlow } from '../lib/signalAnimation'
+import { edgeFlow, liveFreshness, tallyOf, type EdgeFlow, type TallyState } from '../lib/signalAnimation'
 import type { Cable } from '../types/cable'
 import { useReducedMotion } from './useReducedMotion'
 
@@ -73,10 +73,18 @@ export const useEdgeFlow = (cable: Pick<Cable, 'id' | 'bidirectional'> | undefin
   return edgeFlow(cable, snapshot, now, { motion })
 }
 
-/** Tally eines Geräts — oder `null`, wenn nichts bekannt ist. */
-export const useTally = (equipmentId: string | undefined) => {
+/**
+ * Tally eines Geräts — oder `null`, wenn nichts bekannt ist.
+ *
+ * Gibt bewusst nur den ZUSTAND zurück und nicht das Alter: der Wert ist damit
+ * ein einfacher String, und React kann einen Knoten überspringen, dessen
+ * Tally sich nicht geändert hat. Mit einem Objekt wären es bei dreihundert
+ * Geräten dreihundert Neuzeichnungen pro Sekunde für nichts. Das Alter steht
+ * am Canvas-Streifen, wo es einmal hingehört.
+ */
+export const useTally = (equipmentId: string | undefined): TallyState | null => {
   const snapshot = useLiveStore((s) => s.snapshot)
   const now = useLiveTick()
   if (!equipmentId) return null
-  return tallyOf(equipmentId, snapshot, now)
+  return tallyOf(equipmentId, snapshot, now)?.state ?? null
 }

--- a/src/renderer/hooks/useReducedMotion.ts
+++ b/src/renderer/hooks/useReducedMotion.ts
@@ -1,0 +1,44 @@
+import { useSyncExternalStore } from 'react'
+
+/**
+ * Respektiert `prefers-reduced-motion` des Betriebssystems.
+ *
+ * WARUM ALS EIGENER HOOK und nicht als Feld in den Einstellungen: das sind
+ * zwei verschiedene Aussagen. Die Einstellung sagt, was der Nutzer WILL; die
+ * Systemeinstellung, was er VERTRAEGT. Sie in ein Feld zu ziehen hiesse, das
+ * eine mit dem anderen zu ueberschreiben — und zwar in der falschen
+ * Richtung, denn wer Bewegung im System abgestellt hat, hat das aus einem
+ * Grund getan, den diese App nicht kennt.
+ *
+ * Deshalb gilt: Bewegung nur, wenn BEIDES zustimmt (`useCanvasMotion`).
+ *
+ * WARUM `useSyncExternalStore` UND NICHT `useState` + `useEffect`. Die
+ * Media-Query IST ein externer Speicher; sie im Effekt in einen State zu
+ * spiegeln heisst, beim ersten Bild noch den falschen Wert zu zeigen und
+ * dann synchron nachzuziehen — genau das, was `react-hooks` als kaskadierendes
+ * Rendern meldet. Hier liest der erste Render bereits den richtigen Wert.
+ */
+const abonniere = (an: () => void): (() => void) => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return () => {}
+  const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+  // `addEventListener` gibt es auf `MediaQueryList` erst ab Safari 14; der
+  // Fallback kostet drei Zeilen und erspart eine tote Einstellung.
+  if (typeof mq.addEventListener === 'function') {
+    mq.addEventListener('change', an)
+    return () => mq.removeEventListener('change', an)
+  }
+  mq.addListener(an)
+  return () => mq.removeListener(an)
+}
+
+/**
+ * Ohne `matchMedia` (Test-Umgebung, sehr alte Runtime) gilt „keine
+ * Einschraenkung" — die Systemeinstellung ist dann nicht ermittelbar, und die
+ * Vorgabe des Nutzers zu unterschlagen waere die schlechtere Annahme.
+ */
+const lies = (): boolean => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+export const useReducedMotion = (): boolean => useSyncExternalStore(abonniere, lies, () => false)

--- a/src/renderer/hooks/useVideohubLinkFeed.ts
+++ b/src/renderer/hooks/useVideohubLinkFeed.ts
@@ -1,0 +1,74 @@
+import { useEffect } from 'react'
+import { cablePlannerApi, hasDesktopBridge } from '../lib/bridge'
+import { useCanvasProjectStore as useProjectStore } from '../store/projectStoreContext'
+import { useLiveStore } from '../store/liveStore'
+import { videohubLinks } from '../lib/videohubLinks'
+import { detectDeviceKind } from '../lib/deviceKind'
+
+/**
+ * Der Kreuzpunkt-Zustand des Videohubs als Beobachtung.
+ *
+ * WARUM LANGSAMER ALS DER MISCHER. `atem:*` hält eine offene Verbindung; ein
+ * `getState` kostet einen IPC-Aufruf. `videohub:read-state` öffnet dagegen je
+ * Aufruf eine TCP-Verbindung zum Hub. Im Sekundentakt wäre das eine Last, die
+ * niemand bestellt hat — auf einem Gerät, das im Signalweg steht.
+ *
+ * Zwei Sekunden sind trotzdem innerhalb des Frische-Fensters (fünf Sekunden),
+ * also fällt keine Kante zwischen zwei Runden aufs Schema zurück. Der Takt
+ * ist damit eine Frage der Höflichkeit gegenüber dem Gerät und keine der
+ * Korrektheit — genau so soll es sein.
+ *
+ * WELCHER HUB. Der erste im Plan, der als Videohub erkannt wird UND eine
+ * Adresse trägt. Ohne Adresse gibt es nichts zu fragen; eine geratene wäre
+ * ein Verbindungsversuch zu einem fremden Gerät im Kundennetz.
+ *
+ * ER MELDET NUR SEINE EIGENE HÄLFTE ab (`verbindungWeg('links')`). Ein toter
+ * Router ist kein toter Mischer.
+ */
+const HUB_TICK_MS = 2000
+
+export const useVideohubLinkFeed = (): void => {
+  const equipment = useProjectStore((s) => s.project.equipment)
+  const cables = useProjectStore((s) => s.project.cables)
+  const melde = useLiveStore((s) => s.melde)
+  const verbindungWeg = useLiveStore((s) => s.verbindungWeg)
+
+  useEffect(() => {
+    if (!hasDesktopBridge) return
+    const hub = equipment.find(
+      (e) => detectDeviceKind(e) === 'videohub' && (e.ipAddress ?? '').trim() !== '',
+    )
+    if (!hub) {
+      // Kein Hub im Plan oder keiner mit Adresse: nichts zu melden, und
+      // nichts stehen lassen, was von einem frueheren Plan stammt.
+      verbindungWeg('links')
+      return
+    }
+
+    let lebt = true
+    const runde = async () => {
+      if (!lebt) return
+      try {
+        const antwort = await cablePlannerApi.videohub.readState({
+          host: (hub.ipAddress ?? '').trim(),
+          port: 9990,
+        })
+        if (!lebt) return
+        if (!antwort.ok || !antwort.state) {
+          verbindungWeg('links')
+          return
+        }
+        melde({ links: videohubLinks(hub, cables, antwort.state, Date.now()) }, Date.now())
+      } catch {
+        if (lebt) verbindungWeg('links')
+      }
+    }
+
+    void runde()
+    const timer = window.setInterval(() => void runde(), HUB_TICK_MS)
+    return () => {
+      lebt = false
+      window.clearInterval(timer)
+    }
+  }, [equipment, cables, melde, verbindungWeg])
+}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -227,6 +227,39 @@ body,
   animation: overlap-flash 0.5s ease-in-out;
 }
 
+/* ── Signalfluss auf den Kanten (Eigentümer-Entscheidung 2026-09-08) ───────
+ *
+ * Ein zweiter Pfad ÜBER der Kante, gestrichelt, dessen Strichversatz läuft.
+ * Bewusst nicht die Kante selbst animiert: die trägt Farbe (Layer-Legende),
+ * Breite, Auswahl-Schatten und Beschriftung, und ein `stroke-dasharray`
+ * darauf würde mit `cable.dashed` (Funkstrecken) kollidieren.
+ *
+ * `pointer-events: none` ist Pflicht: der Overlay-Pfad liegt genau über der
+ * klickbaren Kante, und ohne die Zeile ließe sich kein Kabel mehr auswählen.
+ *
+ * Die Bewegung wird NICHT hier per Media-Query unterdrückt, sondern in
+ * `useCanvasMotion` — sonst liefe die Klasse weiter und der Code glaubte, es
+ * bewege sich etwas, während es das nicht tut. Ein System, das über seinen
+ * eigenen Zustand irrt, ist schlimmer als eines, das sich bewegt. */
+@keyframes cp-flow {
+  from { stroke-dashoffset: 24; }
+  to   { stroke-dashoffset: 0; }
+}
+@keyframes cp-flow-reverse {
+  from { stroke-dashoffset: 0; }
+  to   { stroke-dashoffset: 24; }
+}
+.cp-flow {
+  pointer-events: none;
+  fill: none;
+  stroke-dasharray: 8 16;
+  stroke-linecap: round;
+  animation: cp-flow 1.1s linear infinite;
+}
+.cp-flow--reverse {
+  animation-name: cp-flow-reverse;
+}
+
 /* ── Light theme: remap dark Tailwind slate classes ────────────────────────
  *
  * GLOBAL THEMING SYSTEM

--- a/src/renderer/lib/anlagenZugangscodes.ts
+++ b/src/renderer/lib/anlagenZugangscodes.ts
@@ -1,0 +1,74 @@
+/**
+ * Die Zugangscodes der Intercom-Anlage aus dem Roh-Dokument des Herstellers
+ * herauslesen (E-3).
+ *
+ * WOZU. `cable#656` hat das Roh-Dokument (`GreenGoConfig.basePreset`) aus
+ * allem herausgenommen, was den Rechner verlaesst: seine Zugangsdaten heissen
+ * `ConfigPassword`, `AdminPassword`, `TechPincode` und `Security.Pincode`,
+ * keiner dieser Namen steht in `SECRET_KEYS`, und deshalb gingen sie vorher in
+ * die Viewer-Datei und an jedes Handy im WLAN.
+ *
+ * Der Eigentuemer hat am 2026-09-08 entschieden, dass der Techniker vor Ort
+ * trotzdem an den Code kommen soll — hinter einem eigenen Token. Diese Datei
+ * liefert dafuer die Werte, und zwar NUR diese: sie liest gezielt vier Pfade
+ * statt das Dokument nach „irgendwas mit Passwort" abzusuchen.
+ *
+ * WARUM GEZIELT UND NICHT SUCHEND. Eine Suche ueber alle Felder faende beim
+ * naechsten Firmware-Stand mehr, als jemand entschieden hat herzugeben — und
+ * das ist die falsche Richtung, um sich zu irren. Ein Feld, das hier fehlt,
+ * fehlt sichtbar (der Techniker fragt nach); eines, das versehentlich
+ * mitgeht, faellt niemandem auf.
+ *
+ * WAS HIER NICHT PASSIERT: nichts wird gespeichert, geloggt oder verschickt.
+ * Die Werte gehen von hier ueber EINEN IPC-Aufruf in den Hauptprozess und
+ * leben dort nur im Speicher, solange der Zugriff eingeschaltet ist.
+ */
+
+/** Ein Code, wie ihn die Mobile-Ansicht anzeigt. */
+export interface AnlagenZugangscode {
+  label: string
+  value: string
+}
+
+/**
+ * Die vier Pfade, die als Zugangsmittel gelten — Pfad, Beschriftung.
+ *
+ * Als Tabelle und nicht als vier `if`: wer einen fuenften Pfad aufnimmt,
+ * schreibt eine Zeile und keine Verzweigung, und die Beschriftung steht
+ * daneben statt in der Oberflaeche.
+ */
+export const ZUGANGSCODE_PFADE: { pfad: string[]; label: string }[] = [
+  { pfad: ['Security', 'Pincode'], label: 'Anlagen-Pincode' },
+  { pfad: ['TechPincode'], label: 'Technik-Pincode' },
+  { pfad: ['AdminPassword'], label: 'Admin-Passwort' },
+  { pfad: ['ConfigPassword'], label: 'Konfigurations-Passwort' },
+]
+
+const lies = (quelle: unknown, pfad: string[]): string | null => {
+  let aktuell: unknown = quelle
+  for (const teil of pfad) {
+    if (!aktuell || typeof aktuell !== 'object') return null
+    aktuell = (aktuell as Record<string, unknown>)[teil]
+  }
+  if (typeof aktuell === 'string' && aktuell.trim() !== '') return aktuell
+  // Zahlen kommen vor: ein Pincode ist im Herstellerdokument gern `4711` ohne
+  // Anfuehrungszeichen. Ihn deshalb zu verschweigen waere die schlechteste
+  // Art, genau zu sein.
+  if (typeof aktuell === 'number' && Number.isFinite(aktuell)) return String(aktuell)
+  return null
+}
+
+/**
+ * Die vorhandenen Zugangscodes, in der Reihenfolge der Tabelle. Leere Felder
+ * fallen weg — ein leerer Pincode ist kein Geheimnis, und ihn als „—" zu
+ * zeigen liesse den Techniker glauben, er habe den richtigen Wert vor sich.
+ */
+export const anlagenZugangscodes = (basePreset: unknown): AnlagenZugangscode[] => {
+  if (!basePreset || typeof basePreset !== 'object') return []
+  const out: AnlagenZugangscode[] = []
+  for (const { pfad, label } of ZUGANGSCODE_PFADE) {
+    const wert = lies(basePreset, pfad)
+    if (wert !== null) out.push({ label, value: wert })
+  }
+  return out
+}

--- a/src/renderer/lib/atemTally.ts
+++ b/src/renderer/lib/atemTally.ts
@@ -1,0 +1,80 @@
+/**
+ * Vom Mischer-Zustand zur Tally-Anzeige im Canvas.
+ *
+ * WAS HIER ÜBERSETZT WIRD. Der Mischer kennt EINGANGSNUMMERN, der Plan kennt
+ * GERÄTE. Die Brücke dazwischen gibt es seit Initiative 2 und wird hier nicht
+ * neu gebaut: `buildTallyMap` leitet aus dem Kabelgraph ab, welche Kamera an
+ * welchem Eingang hängt. Eine zweite Zuordnung daneben wäre die zweite
+ * Wahrheit, gegen die ADR-001 geschrieben ist — und die beiden gingen genau
+ * dann auseinander, wenn jemand umpatcht.
+ *
+ * WAS EIN GERÄT OHNE EINTRAG BEKOMMT: nichts. Kein `off`, kein Eintrag.
+ * `tallyOf` gibt dafür `null` zurück, und die Anzeige lässt es in Ruhe. Eine
+ * Kamera, die der Mischer nicht kennt, darf nicht aussehen wie eine, von der
+ * bekannt ist, dass sie nicht auf Sendung ist — das ist der gefährlichste
+ * Irrtum an einer Tally-Anzeige, weil er in die falsche Richtung beruhigt.
+ *
+ * PROGRAM SCHLÄGT PREVIEW. Steht dieselbe Quelle auf beidem (üblich beim
+ * Vorbereiten eines Schnitts auf sich selbst), gilt Program: rot ist die
+ * Aussage, auf die es ankommt, und ein grüner Ring darüber wäre die
+ * gefährlichere Hälfte der Wahrheit.
+ *
+ * NUR MIX-EFFECT 0, und das ausdrücklich. Ein Mischer mit zwei ME hat zwei
+ * Programme; welches „das" Programm ist, entscheidet die Regie und nicht
+ * diese Datei. Solange der Plan das nicht führt, ist ME 1 die einzige
+ * belegbare Annahme — die Alternative wäre, beide zu verodern und damit eine
+ * Kamera rot zu zeigen, die auf keinem Ausspielweg liegt.
+ */
+
+import type { LiveTally } from './signalAnimation'
+import type { TallyMapRow } from './tallyMap'
+
+/** Der Ausschnitt des Mischer-Zustands, den diese Datei braucht. */
+export interface AtemMixEffectState {
+  index: number
+  programInput?: number
+  previewInput?: number
+  inTransition?: boolean
+}
+
+export interface AtemStateSlice {
+  mixEffectStates?: readonly AtemMixEffectState[]
+}
+
+/**
+ * Die Tally-Meldungen zu einem Mischer-Zustand.
+ *
+ * `at` kommt von aussen, damit die Rechnung rein bleibt — dieselbe Trennung
+ * wie beim Ablauf-Import und beim Seed-Merge.
+ */
+export const atemTally = (
+  state: AtemStateSlice | null | undefined,
+  rows: readonly TallyMapRow[],
+  at: number,
+): LiveTally[] => {
+  const me = state?.mixEffectStates?.find((m) => m.index === 0)
+  if (!me) return []
+
+  const out: LiveTally[] = []
+  const gesehen = new Set<string>()
+
+  const nimm = (input: number | undefined, zustand: 'program' | 'preview') => {
+    if (typeof input !== 'number') return
+    for (const row of rows) {
+      if (row.switcher?.input !== input) continue
+      // ALLE Geraete der Rolle, nicht nur das erste: ein Haupt-/Backup-Paar
+      // haengt an demselben Eingang, und beide sind auf Sendung. Nur eines
+      // rot zu zeigen liesse das andere aussehen, als sei es frei.
+      for (const geraet of row.devices) {
+        // Program zuerst eingesammelt: wer schon drin ist, bleibt.
+        if (gesehen.has(geraet.id)) continue
+        gesehen.add(geraet.id)
+        out.push({ equipmentId: geraet.id, state: zustand, at, source: 'atem' })
+      }
+    }
+  }
+
+  nimm(me.programInput, 'program')
+  nimm(me.previewInput, 'preview')
+  return out
+}

--- a/src/renderer/lib/bridge.ts
+++ b/src/renderer/lib/bridge.ts
@@ -101,6 +101,17 @@ export interface AtemStateSummary {
   auxiliaries?: number
   inputs: AtemInputSummary[]
   multiViewers?: (AtemMultiviewer | null)[]
+  /**
+   * Was gerade auf Sendung ist — je Mix-Effect. Optional, weil eine aeltere
+   * `main`-Fassung (etwa im Browser-Betrieb) das Feld nicht liefert; die
+   * Tally-Anzeige zeigt dann nichts statt etwas Erfundenes.
+   */
+  mixEffectStates?: {
+    index: number
+    programInput?: number
+    previewInput?: number
+    inTransition?: boolean
+  }[]
 }
 
 export interface AtemConnectResult {

--- a/src/renderer/lib/bridge.ts
+++ b/src/renderer/lib/bridge.ts
@@ -391,6 +391,16 @@ type CablePlannerApi = {
     ) => Promise<{ ok: boolean; writeMode: 'read-only' | 'contribute' }>
     getWriteMode: () => Promise<{ writeMode: 'read-only' | 'contribute' }>
     /**
+     * E-3 — Zugriff auf die Anlagen-Zugangscodes. Gibt den zweiten Token
+     * EINMAL beim Einschalten zurueck; nachschlagen kann man ihn nicht.
+     */
+    setPincodeAccess: (on: boolean) => Promise<{ ok: boolean; token: string }>
+    /** E-3 — die Codes im Hauptprozess hinterlegen. Sie gehen nirgends sonst hin. */
+    setPincodes: (
+      codes: { label: string; value: string }[] | null,
+    ) => Promise<{ ok: boolean; on: boolean; count: number }>
+    pincodeStatus: () => Promise<{ on: boolean; count: number }>
+    /**
      * BEDARF 133 — Adressen ueber das LAN hinaus freigeben.
      *
      * Ausdruecklich und nur fuer diese Sitzung: `stop` setzt es im
@@ -995,6 +1005,11 @@ const webFallbackApi: CablePlannerApi = {
     // Im Browser gibt es keinen Server — und damit auch keinen Schreibweg.
     setWriteMode: async () => ({ ok: true, writeMode: 'read-only' as const }),
     getWriteMode: async () => ({ writeMode: 'read-only' as const }),
+    // Ohne Desktop-App gibt es keinen Server, der etwas herausgeben koennte —
+    // und damit auch keinen Zugriff, den man einschalten kann.
+    setPincodeAccess: async () => ({ ok: false, token: '' }),
+    setPincodes: async () => ({ ok: false, on: false, count: 0 }),
+    pincodeStatus: async () => ({ on: false, count: 0 }),
     setAllowBeyondLan: async () => {
       throw new Error('Handy-Zugriff erfordert die Desktop-App.')
     },

--- a/src/renderer/lib/circuitSolver.ts
+++ b/src/renderer/lib/circuitSolver.ts
@@ -1,0 +1,243 @@
+/**
+ * Wer brennt, wenn Strom anliegt — Schaltbilder für Licht-Stromkreise
+ * (Eigentümer-Wunsch vom 2026-09-08: „auch für Strom, Schaltungen darstellen
+ * wo brennt eine Lampe wenn Strom anliegt, auch Wechselschaltungen und
+ * Dimmer").
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * WAS DAS IST — UND VOR ALLEM, WAS ES NICHT IST
+ * ═══════════════════════════════════════════════════════════════════════
+ *
+ * Es ist ein SCHALTBILD-RECHNER: er sagt, welche Leuchte bei welcher
+ * Schalterstellung brennt. Das ist genau die Frage, die ein Wechsel- oder
+ * Kreuzschaltungs-Plan beantworten soll, und sie lässt sich exakt beantworten.
+ *
+ * Es ist **keine** elektrotechnische Berechnung und **kein** Sicherheitsnachweis.
+ * Diese Datei rechnet keine Ströme, keine Leitungsquerschnitte, keine
+ * Selektivität und keine Fehlerschleifenimpedanz. Wer sie dafür hält, hält
+ * ein Übersichtsbild für eine Prüfung.
+ *
+ * DER RÜCKLEITER FEHLT ABSICHTLICH. Ein Schaltbild einer Wechselschaltung
+ * zeigt den geschalteten Außenleiter; N und PE laufen daneben und werden nicht
+ * geschaltet. Sie hier mitzuführen brächte kein anderes Ergebnis und verlangte
+ * vom Nutzer, jede Leuchte doppelt zu verdrahten, bevor das Bild etwas zeigt.
+ * Das ist eine VEREINFACHUNG mit Grund, keine Lücke — und sie steht hier,
+ * damit sie beim nächsten Durchgang nicht als Fehler „behoben" wird.
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * WARUM KLEMMEN UND NICHT „SCHALTER AN/AUS"
+ * ═══════════════════════════════════════════════════════════════════════
+ *
+ * Eine Wechselschaltung lässt sich nicht als Kette von An/Aus beschreiben:
+ * zwei Schalter, und die Leuchte brennt, wenn beide auf DERSELBEN Seite
+ * stehen — bei „Schalter A an, Schalter B an" ebenso wie bei „beide aus".
+ * Wer sie als Kette baut, muss den Sonderfall von Hand einbauen, und der
+ * Kreuzschalter in der Mitte macht daraus drei Sonderfälle.
+ *
+ * Deshalb bekommt jeder Knoten KLEMMEN, und seine Stellung sagt, welche
+ * Klemmen innen miteinander verbunden sind. Der Strom sucht sich seinen Weg;
+ * Wechsel- und Kreuzschaltung fallen dabei heraus, statt aufgezählt zu werden.
+ * Eine vierte Schaltungsart braucht dann eine Zeile in `INNERE_VERBINDUNG`
+ * und keinen neuen Zweig.
+ */
+
+/** Was ein Knoten im Stromkreis ist. */
+export type CircuitKind =
+  /** Einspeisung. Führt Spannung, wenn `on`. */
+  | 'feed'
+  /** Gewöhnlicher Aus-Schalter: Klemme 1 ↔ 2, wenn Stellung 1. */
+  | 'switch'
+  /** Wechselschalter: Klemme 0 (kommend) ↔ 1 oder 2, je nach Stellung. */
+  | 'changeover'
+  /** Kreuzschalter: tauscht die beiden durchlaufenden Adern in Stellung 2. */
+  | 'crossover'
+  /** Dimmer: leitet immer, und bestimmt die Helligkeit dahinter. */
+  | 'dimmer'
+  /** Leuchte. Brennt, wenn Spannung an Klemme 0 ankommt. */
+  | 'lamp'
+  /** Klemmstelle/Dose: alles, was hier ankommt, geht überall weiter. */
+  | 'junction'
+
+export interface CircuitNode {
+  id: string
+  kind: CircuitKind
+  /**
+   * Schalterstellung. `switch`: 1 = ein, sonst aus. `changeover`: 1 oder 2
+   * (welche Korrespondierende). `crossover`: 1 = gerade, 2 = gekreuzt.
+   * Bei `feed`: 1 = Spannung liegt an.
+   */
+  position?: number
+  /** Nur `dimmer`: 0..100. Fehlt er, gilt 100 — ein Dimmer ohne Angabe dunkelt nicht. */
+  levelPct?: number
+}
+
+export interface CircuitEdge {
+  id: string
+  fromNode: string
+  /** Klemme am Quellknoten. Vorgabe 0. */
+  fromTerminal?: number
+  toNode: string
+  toTerminal?: number
+}
+
+/**
+ * Welche Klemmen ein Knoten in seiner Stellung innen verbindet.
+ *
+ * Als TABELLE mit `satisfies Record<CircuitKind, …>`: eine neue Bauart ohne
+ * Eintrag ist ein Typfehler und keine still nicht leitende Stelle. Genau das
+ * wäre der unangenehmste Fehler hier — eine Leuchte, die nicht brennt, sieht
+ * aus wie eine richtige Antwort.
+ *
+ * Jeder Eintrag gibt Klemmen-PAARE zurück. `junction` ist der Sonderfall
+ * „alles mit allem" und wird beim Auflösen gesondert behandelt, weil seine
+ * Klemmenzahl erst aus den Kanten folgt.
+ */
+const INNERE_VERBINDUNG = {
+  feed: () => [] as [number, number][],
+  switch: (n: CircuitNode) => (n.position === 1 ? ([[1, 2]] as [number, number][]) : []),
+  changeover: (n: CircuitNode) =>
+    n.position === 2 ? ([[0, 2]] as [number, number][]) : ([[0, 1]] as [number, number][]),
+  crossover: (n: CircuitNode) =>
+    n.position === 2
+      ? ([
+          [1, 4],
+          [2, 3],
+        ] as [number, number][])
+      : ([
+          [1, 3],
+          [2, 4],
+        ] as [number, number][]),
+  dimmer: () => [[1, 2]] as [number, number][],
+  lamp: () => [] as [number, number][],
+  junction: () => [] as [number, number][],
+} satisfies Record<CircuitKind, (n: CircuitNode) => [number, number][]>
+
+/** Helligkeit hinter einem Dimmer. Ohne Angabe volle Helligkeit. */
+const dimmerPegel = (n: CircuitNode): number => {
+  const roh = n.levelPct
+  if (typeof roh !== 'number' || !Number.isFinite(roh)) return 100
+  return Math.max(0, Math.min(100, roh))
+}
+
+export interface LampState {
+  /** Kommt Spannung an? */
+  lit: boolean
+  /**
+   * Helligkeit 0..100. Ohne Dimmer 100.
+   *
+   * Erreichen MEHRERE Wege die Leuchte, gilt der HELLSTE. Zwei parallele
+   * Dimmer auf einer Leuchte ergeben nicht das Minimum, sondern das, was der
+   * stärkere durchlässt — und `lit: true, levelPct: 0` ist ausdrücklich
+   * erlaubt: ein auf null gefahrener Dimmer ist etwas anderes als ein
+   * offener Schalter, und die Anzeige darf beides nicht verwechseln.
+   */
+  levelPct: number
+}
+
+export interface CircuitResult {
+  lamps: Map<string, LampState>
+  /** Kanten, auf denen Spannung liegt — für die Einfärbung im Canvas. */
+  energisedEdges: Set<string>
+}
+
+const schluessel = (node: string, terminal: number) => `${node}#${terminal}`
+
+/**
+ * Den Stromkreis auflösen: wer brennt, und worüber.
+ *
+ * Ausbreitung von jeder eingeschalteten Einspeisung aus über Kanten und die
+ * inneren Verbindungen der Knoten. Der Pegel wandert mit; ein Dimmer setzt
+ * ihn herab, alles andere reicht ihn durch.
+ *
+ * Ein Knoten wird erneut besucht, wenn ihn ein HELLERER Pegel erreicht —
+ * sonst gewänne bei zwei Wegen der zufällig zuerst gelaufene. Weil der Pegel
+ * dabei nur steigen kann und nach oben begrenzt ist, endet das auch in einem
+ * Netz mit Schleifen; eine Ringleitung ist im Hausnetz nichts Besonderes.
+ */
+export const solveCircuit = (
+  nodes: readonly CircuitNode[],
+  edges: readonly CircuitEdge[],
+): CircuitResult => {
+  const nachId = new Map(nodes.map((n) => [n.id, n]))
+  /** Klemme → Kanten, die dort hängen. */
+  const anKlemme = new Map<string, { edge: CircuitEdge; gegen: string; gegenNode: string }[]>()
+  const haenge = (k: string, wert: { edge: CircuitEdge; gegen: string; gegenNode: string }) => {
+    const liste = anKlemme.get(k)
+    if (liste) liste.push(wert)
+    else anKlemme.set(k, [wert])
+  }
+  for (const e of edges) {
+    const a = schluessel(e.fromNode, e.fromTerminal ?? 0)
+    const b = schluessel(e.toNode, e.toTerminal ?? 0)
+    haenge(a, { edge: e, gegen: b, gegenNode: e.toNode })
+    haenge(b, { edge: e, gegen: a, gegenNode: e.fromNode })
+  }
+
+  /** Klemmen eines Knotens, die in Kanten vorkommen — für `junction`. */
+  const klemmenVon = new Map<string, Set<number>>()
+  for (const e of edges) {
+    const rein = (id: string, t: number) => {
+      const s = klemmenVon.get(id)
+      if (s) s.add(t)
+      else klemmenVon.set(id, new Set([t]))
+    }
+    rein(e.fromNode, e.fromTerminal ?? 0)
+    rein(e.toNode, e.toTerminal ?? 0)
+  }
+
+  const bester = new Map<string, number>()
+  const energisedEdges = new Set<string>()
+  const warteschlange: { klemme: string; pegel: number }[] = []
+
+  const anbieten = (klemme: string, pegel: number) => {
+    const bisher = bester.get(klemme)
+    if (bisher !== undefined && bisher >= pegel) return
+    bester.set(klemme, pegel)
+    warteschlange.push({ klemme, pegel })
+  }
+
+  for (const n of nodes) {
+    if (n.kind !== 'feed') continue
+    if (n.position !== 1) continue
+    // Die Einspeisung fuehrt Spannung an ihrer Klemme 0.
+    anbieten(schluessel(n.id, 0), 100)
+  }
+
+  while (warteschlange.length) {
+    const { klemme, pegel } = warteschlange.shift()!
+    if ((bester.get(klemme) ?? -1) > pegel) continue
+
+    // 1. Ueber die Kanten weiter.
+    for (const { edge, gegen } of anKlemme.get(klemme) ?? []) {
+      energisedEdges.add(edge.id)
+      anbieten(gegen, pegel)
+    }
+
+    // 2. Durch den Knoten hindurch, gemaess seiner Stellung.
+    const [nodeId, terminalRoh] = klemme.split('#')
+    const terminal = Number(terminalRoh)
+    const node = nachId.get(nodeId)
+    if (!node) continue
+
+    if (node.kind === 'junction') {
+      for (const t of klemmenVon.get(nodeId) ?? []) {
+        if (t !== terminal) anbieten(schluessel(nodeId, t), pegel)
+      }
+      continue
+    }
+
+    const durch = node.kind === 'dimmer' ? Math.round((pegel * dimmerPegel(node)) / 100) : pegel
+    for (const [a, b] of INNERE_VERBINDUNG[node.kind](node)) {
+      if (a === terminal) anbieten(schluessel(nodeId, b), durch)
+      else if (b === terminal) anbieten(schluessel(nodeId, a), durch)
+    }
+  }
+
+  const lamps = new Map<string, LampState>()
+  for (const n of nodes) {
+    if (n.kind !== 'lamp') continue
+    const pegel = bester.get(schluessel(n.id, 0))
+    lamps.set(n.id, pegel === undefined ? { lit: false, levelPct: 0 } : { lit: true, levelPct: pegel })
+  }
+  return { lamps, energisedEdges }
+}

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3380,6 +3380,17 @@ export const en: Dict = {
     'The three write routes are closed — the phone is refused on every write attempt. The plan is changed by the person at the desk.',
   'mobile.dialog.writeMode.contributeHint':
     'Ticks, cables added on site and field reports go back into the project. Anyone with the QR code can change the plan.',
+  // Signalfluss im Canvas — Schema vs. Live (Eigentuemer-Entscheidung 2026-09-08).
+  'canvas.flow.live': 'Live',
+  'canvas.flow.schema': 'Schematic',
+  'canvas.flow.lostContact': '· connection lost',
+  'canvas.flow.still': '· still',
+  'canvas.flow.liveTitle': 'Observed state from the switcher/router.',
+  'canvas.flow.schemaTitle': 'The planned path. There is no connection to a live system.',
+  'canvas.flow.fellBackTitle': 'The live connection dropped — showing the planned path again.',
+  'canvas.flow.systemReduced': 'Your system has motion turned off; the view stays still.',
+  'canvas.flow.toggleOff': 'Click: turn motion off.',
+  'canvas.flow.toggleOn': 'Click: turn motion on.',
   // E-3 — die Anlagen-Zugangscodes hinter einem eigenen Code.
   'mobile.dialog.pincode': 'Make system access codes retrievable',
   'mobile.dialog.pincode.none': 'This project carries no intercom configuration with access codes.',

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3380,6 +3380,17 @@ export const en: Dict = {
     'The three write routes are closed — the phone is refused on every write attempt. The plan is changed by the person at the desk.',
   'mobile.dialog.writeMode.contributeHint':
     'Ticks, cables added on site and field reports go back into the project. Anyone with the QR code can change the plan.',
+  // E-3 — die Anlagen-Zugangscodes hinter einem eigenen Code.
+  'mobile.dialog.pincode': 'Make system access codes retrievable',
+  'mobile.dialog.pincode.none': 'This project carries no intercom configuration with access codes.',
+  'mobile.dialog.pincode.hint':
+    'Type this code on the phone. It is NOT part of the QR code — whoever only has the link cannot reach the access data.',
+  'mobile.dialog.pincode.count':
+    '{n} code(s) held. Every retrieval is recorded in the document register — with a timestamp, not with the value.',
+  'mobile.dialog.pincode.offHint':
+    'Off. {n} code(s) would be available — they leave this machine only once the switch is on.',
+  'mobile.dialog.security.pincode':
+    'The system access codes NEVER travel with the project. They live only in the desktop app\'s memory and only while the switch above is on; they are retrieved with a second code that is not part of the QR code.',
   'mobile.dialog.crewFeedHint':
     'Add it to your calendar as a subscription — it fetches the current state instead of going stale.',
   'analysis.crew.planned': '{n} pencilled/held — not in the totals',

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -300,9 +300,10 @@ export const en: Dict = {
     'SDI = amber, HDMI = violet, Ethernet = green, fibre = yellow…',
   'settings.appearance.cableColor': 'Cable colour',
   'settings.appearance.cableColorDesc':
-    'Manual = per cable in the properties panel; by length = length-based colour coding.',
+    'Manual = per cable in the properties panel; by length = length-based colour coding; by discipline = the layer legend (video/audio/control/network/power). The colour stored on the cable is kept in every mode.',
   'settings.appearance.cableColor.manual': 'Manual',
   'settings.appearance.cableColor.byLength': 'By length',
+  'settings.appearance.cableColor.byLayer': 'By discipline',
   'settings.appearance.arrows': 'Arrows on cables',
   'settings.appearance.arrowsDesc':
     'Default for newly drawn cables. Overridable per cable in the properties panel.',
@@ -4549,6 +4550,7 @@ export const en: Dict = {
   'app.menu.view.hideLabels': 'Hide cable labels',
   'app.menu.view.offPageNames': 'Show off-page names',
   'app.menu.view.colorByLength': 'Color cables by length',
+  'app.menu.view.colorByLayer': 'Color cables by discipline',
   'app.menu.view.annotations': 'Annotations panel',
   'app.menu.view.fit': 'Fit to view',
   'app.menu.view.zoom100': 'Zoom 100 %',

--- a/src/renderer/lib/signalAnimation.ts
+++ b/src/renderer/lib/signalAnimation.ts
@@ -57,10 +57,21 @@ import type { ReadingSource } from './asBuilt'
  */
 export const LIVE_STALE_AFTER_MS = 5000
 
-/** Beobachteter Zustand einer Strecke. Nur mit Beleg. */
+/**
+ * Beobachteter Zustand einer Strecke. Nur mit Beleg.
+ *
+ * `carrying` und `routed` sind ausdrücklich ZWEI Aussagen und keine Nuance
+ * derselben. Ein Videohub meldet seine Kreuzpunkte — er sagt, dass er diesen
+ * Eingang auf diesen Ausgang durchschaltet, und NICHTS darüber, ob dort
+ * Signal anliegt. Das als `carrying` zu melden wäre die Falschaussage, gegen
+ * die diese ganze Datei gebaut ist: der Kreuzpunkt steht auch dann, wenn
+ * upstream die Kamera aus ist.
+ */
 export type LinkState =
-  /** Signal liegt an. */
+  /** Signal liegt an — von einer Quelle, die Signal wirklich erkennt. */
   | 'carrying'
+  /** Der Router führt diese Strecke. Über anliegendes Signal sagt er nichts. */
+  | 'routed'
   /** Verbindung steht, es läuft nichts darüber. */
   | 'idle'
   /** Keine Verbindung. */
@@ -131,6 +142,8 @@ export type FlowKind =
   | 'schema'
   /** Beobachtet: Signal liegt an. */
   | 'live-carrying'
+  /** Beobachtet: der Router führt die Strecke — über Signal ist nichts bekannt. */
+  | 'live-routed'
   /** Beobachtet: Verbindung steht, kein Signal. */
   | 'live-idle'
   /** Beobachtet: keine Verbindung. */
@@ -203,6 +216,19 @@ export const edgeFlow = (
     case 'carrying':
       return {
         kind: 'live-carrying',
+        animate: opts.motion,
+        direction,
+        dimmed: false,
+        ageMs,
+        source: eintrag.source,
+      }
+    case 'routed':
+      // Bewegt sich wie `carrying`: der Router SCHALTET diese Strecke durch,
+      // das ist ein Weg und kein Stillstand. Der Unterschied steckt in `kind`
+      // und wird dort gelesen, wo er etwas aendert — nicht in der Bewegung,
+      // die sonst dreierlei bedeutete.
+      return {
+        kind: 'live-routed',
         animate: opts.motion,
         direction,
         dimmed: false,

--- a/src/renderer/lib/signalAnimation.ts
+++ b/src/renderer/lib/signalAnimation.ts
@@ -1,0 +1,290 @@
+/**
+ * Was der Canvas an einer Kante ZEIGEN DARF — Signalfluss, Tally,
+ * Verbindungszustand (Eigentümer-Entscheidung vom 2026-09-08).
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * DIE EINE REGEL, aus der alles andere folgt
+ * ═══════════════════════════════════════════════════════════════════════
+ *
+ * Eine Animation, die aussieht wie fließendes Signal, IST eine Aussage über
+ * die Anlage. Läuft sie ohne Beleg, ist sie die teuerste Sorte Falschaussage:
+ * niemand liest daneben eine Zahl, niemand klickt auf ein Warndreieck, man
+ * sieht nur, dass es fließt — und glaubt es. Genau das verbietet ADR-003 für
+ * unbestätigten Zustand, und genau das ist die Bedingung, unter der E-23 den
+ * eingehenden Weg zulässt.
+ *
+ * Deshalb kennt diese Datei **zwei Betriebsarten und keine dritte**:
+ *
+ *   SCHEMA — der geplante Weg. Sie sagt aus, was gesteckt sein SOLL, und
+ *            behauptet nichts über die Anlage. Sie ist die Vorgabe und der
+ *            Rückfall (Eigentümer: „auf Schema zurückfallen").
+ *
+ *   LIVE   — eine BEOBACHTUNG mit Zeitpunkt und Quelle, aus derselben Spur,
+ *            die `asBuilt.ts` führt (`ReadingSource`). Kein zweites Modell
+ *            neben dem, das E-4 schon entschieden hat.
+ *
+ * Der Wechsel zwischen beiden ist nie stillschweigend: `liveFreshness` sagt,
+ * ob Live gilt, und wie alt die letzte Meldung ist. Wer diese Funktion
+ * umgeht, hat die Regel umgangen.
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * WARUM DER ZUSTAND NICHT DIE FARBE ÄNDERT
+ * ═══════════════════════════════════════════════════════════════════════
+ *
+ * Die Farbe gehört dem LAYER (Video blau, Audio rot, Control gelb, Netz
+ * grün, Strom violett) — das ist die Legende, nach der der Plan gelesen und
+ * gedruckt wird. Würde der Zustand sie überschreiben, hieße dieselbe Farbe
+ * an zwei Kanten zweierlei, und die gedruckte Legende wäre falsch.
+ *
+ * Der Zustand trägt deshalb die BEWEGUNG: es fließt oder es fließt nicht.
+ * Die einzige Ausnahme ist `down` — eine Strecke, die beobachtet AUS ist,
+ * wird gedämpft und gestrichelt gezeichnet, weil „vorhanden, aber tot" sich
+ * von „vorhanden" unterscheiden muss und Stillstand allein dafür zu leise
+ * ist. `down` gibt es nur mit Beleg; im Schema kommt es nie vor.
+ */
+
+import type { Cable } from '../types/cable'
+import type { ReadingSource } from './asBuilt'
+
+/**
+ * Wie frisch eine Beobachtung sein muss, um noch als „jetzt" zu gelten.
+ *
+ * Fünf Sekunden, weil das die Größenordnung ist, in der sich ein
+ * Mischer-Zustand ändert (ein Schnitt dauert Bruchteile davon). Länger
+ * hieße, einen alten Zustand als aktuellen zu zeigen; kürzer hieße, bei
+ * jedem Netz-Schluckauf ins Schema zu fallen und wieder zurück — ein
+ * flackernder Canvas ist unbrauchbarer als ein ehrlich veralteter.
+ */
+export const LIVE_STALE_AFTER_MS = 5000
+
+/** Beobachteter Zustand einer Strecke. Nur mit Beleg. */
+export type LinkState =
+  /** Signal liegt an. */
+  | 'carrying'
+  /** Verbindung steht, es läuft nichts darüber. */
+  | 'idle'
+  /** Keine Verbindung. */
+  | 'down'
+
+export interface LiveLink {
+  cableId: string
+  state: LinkState
+  /** Wann beobachtet (Epoch-Millisekunden). */
+  at: number
+  source: ReadingSource
+}
+
+/** Der Zustand, den jeder auf der Fläche sucht. */
+export type TallyState = 'program' | 'preview' | 'off'
+
+export interface LiveTally {
+  equipmentId: string
+  state: TallyState
+  at: number
+  source: ReadingSource
+}
+
+/**
+ * Was gerade an Beobachtungen vorliegt.
+ *
+ * `lastContactAt` ist bewusst getrennt von den Einträgen: eine Anlage, die
+ * verbunden ist und nichts zu melden hat, unterscheidet sich von einer, zu
+ * der die Verbindung abgerissen ist. Ohne dieses Feld sähen beide gleich
+ * aus — und der Canvas zeigte den letzten Stand als den jetzigen.
+ */
+export interface LiveSnapshot {
+  links: readonly LiveLink[]
+  tally: readonly LiveTally[]
+  lastContactAt?: number
+}
+
+export const EMPTY_LIVE: LiveSnapshot = { links: [], tally: [] }
+
+export interface Freshness {
+  /** Gilt Live gerade? */
+  live: boolean
+  /** Alter der letzten Meldung in Millisekunden. `null` = nie Kontakt. */
+  ageMs: number | null
+}
+
+/**
+ * Gilt Live, und wie alt ist die letzte Meldung?
+ *
+ * DIE EINZIGE STELLE, an der über den Betriebsart-Wechsel entschieden wird.
+ * Ein zweiter Ort mit eigener Frist wäre eine zweite Wahrheit über
+ * „gerade" — und die eine, die am längsten wartet, gewönne still.
+ */
+export const liveFreshness = (
+  snapshot: LiveSnapshot | null | undefined,
+  now: number,
+  staleAfterMs: number = LIVE_STALE_AFTER_MS,
+): Freshness => {
+  const at = snapshot?.lastContactAt
+  if (typeof at !== 'number') return { live: false, ageMs: null }
+  const ageMs = Math.max(0, now - at)
+  return { live: ageMs <= staleAfterMs, ageMs }
+}
+
+/** Woher die Darstellung einer Kante stammt. */
+export type FlowKind =
+  /** Der geplante Weg. Keine Aussage über die Anlage. */
+  | 'schema'
+  /** Beobachtet: Signal liegt an. */
+  | 'live-carrying'
+  /** Beobachtet: Verbindung steht, kein Signal. */
+  | 'live-idle'
+  /** Beobachtet: keine Verbindung. */
+  | 'live-down'
+
+export interface EdgeFlow {
+  kind: FlowKind
+  /** Fließt die Animation? */
+  animate: boolean
+  /** `1` = Quelle → Ziel, `-1` = umgekehrt. */
+  direction: 1 | -1
+  /** Gedämpft und gestrichelt zeichnen (nur `live-down`). */
+  dimmed: boolean
+  /** Alter der Beobachtung in ms. `null` im Schema. */
+  ageMs: number | null
+  /** Woher die Beobachtung kam. Fehlt im Schema. */
+  source?: ReadingSource
+}
+
+export interface FlowOptions {
+  /** Bewegung überhaupt zeigen? Kommt aus Einstellung + `prefers-reduced-motion`. */
+  motion: boolean
+  /** Frist, ab der eine Beobachtung nicht mehr „jetzt" ist. */
+  staleAfterMs?: number
+}
+
+/**
+ * Wie diese Kante zu zeichnen ist.
+ *
+ * SCHEMA ANIMIERT AUCH — aber es behauptet damit nichts: dort bedeutet die
+ * Bewegung „hier ist ein Weg vorgesehen, und er läuft in diese Richtung".
+ * Das ist derselbe Inhalt, den der Pfeil an der Kante schon trägt, nur
+ * lesbarer. Die Unterscheidung zur Live-Aussage macht nicht die Bewegung,
+ * sondern die Betriebsart-Anzeige am Canvas — und die ist Pflicht, nicht
+ * Zierde.
+ */
+export const edgeFlow = (
+  cable: Pick<Cable, 'id' | 'bidirectional'>,
+  snapshot: LiveSnapshot | null | undefined,
+  now: number,
+  opts: FlowOptions,
+): EdgeFlow => {
+  const staleAfterMs = opts.staleAfterMs ?? LIVE_STALE_AFTER_MS
+  // Bidirektionale Strecken haben keine „eine" Richtung; sie laufen in der
+  // Zeichenrichtung, weil eine erfundene Gegenrichtung eine Aussage waere.
+  const direction: 1 | -1 = 1
+
+  const { live } = liveFreshness(snapshot, now, staleAfterMs)
+  if (!live) {
+    return { kind: 'schema', animate: opts.motion, direction, dimmed: false, ageMs: null }
+  }
+
+  const eintrag = snapshot?.links.find((l) => l.cableId === cable.id)
+  if (!eintrag) {
+    // Live gilt, aber ueber DIESE Strecke ist nichts bekannt. Das ist kein
+    // „aus" — es ist keine Aussage, und die richtige Darstellung dafuer ist
+    // das Schema. Sie hier als tot zu zeichnen waere eine Behauptung ueber
+    // ein Kabel, das niemand gemessen hat.
+    return { kind: 'schema', animate: opts.motion, direction, dimmed: false, ageMs: null }
+  }
+
+  const ageMs = Math.max(0, now - eintrag.at)
+  if (ageMs > staleAfterMs) {
+    // Der Gesamtkontakt ist frisch, diese eine Meldung nicht. Auch hier:
+    // Schema, nicht der alte Wert.
+    return { kind: 'schema', animate: opts.motion, direction, dimmed: false, ageMs: null }
+  }
+
+  switch (eintrag.state) {
+    case 'carrying':
+      return {
+        kind: 'live-carrying',
+        animate: opts.motion,
+        direction,
+        dimmed: false,
+        ageMs,
+        source: eintrag.source,
+      }
+    case 'idle':
+      // Steht, fliesst nicht. Bewegung waere hier die Falschaussage.
+      return {
+        kind: 'live-idle',
+        animate: false,
+        direction,
+        dimmed: false,
+        ageMs,
+        source: eintrag.source,
+      }
+    case 'down':
+      return {
+        kind: 'live-down',
+        animate: false,
+        direction,
+        dimmed: true,
+        ageMs,
+        source: eintrag.source,
+      }
+  }
+}
+
+/**
+ * Tally eines Geräts. `null` heißt „keine Aussage" und ist ausdrücklich
+ * NICHT dasselbe wie „aus": eine Kamera ohne Meldung darf nicht wie eine
+ * aussehen, von der bekannt ist, dass sie nicht auf Sendung ist.
+ */
+export const tallyOf = (
+  equipmentId: string,
+  snapshot: LiveSnapshot | null | undefined,
+  now: number,
+  staleAfterMs: number = LIVE_STALE_AFTER_MS,
+): { state: TallyState; ageMs: number } | null => {
+  const { live } = liveFreshness(snapshot, now, staleAfterMs)
+  if (!live) return null
+  const eintrag = snapshot?.tally.find((t) => t.equipmentId === equipmentId)
+  if (!eintrag) return null
+  const ageMs = Math.max(0, now - eintrag.at)
+  if (ageMs > staleAfterMs) return null
+  return { state: eintrag.state, ageMs }
+}
+
+/**
+ * Die Kette vom Tally-Gerät zum Mischer einfärben (Eigentümer-Wunsch:
+ * „Rot/Grün an Kamera-Knoten UND an der Kette bis zum Mischer").
+ *
+ * Nur ÜBER BEKANNTE KABEL, und nur vorwärts: die Kette folgt den Kabeln
+ * ab dem Gerät, dessen Tally gemeldet ist. Ein Weg, den der Plan nicht
+ * kennt, wird nicht erfunden — dann endet die Kette dort, und das ist die
+ * wahrheitsgemäße Darstellung.
+ *
+ * Der Zyklus-Schutz ist kein Luxus: ein Rückweg im Plan (Mischer → Monitor
+ * → Mischer) ist eine gewöhnliche Verkabelung, und ohne `gesehen` liefe das
+ * Einfärben endlos.
+ */
+export const tallyChain = (
+  startEquipmentId: string,
+  cables: readonly Pick<Cable, 'id' | 'fromEquipmentId' | 'toEquipmentId'>[],
+  maxHops = 8,
+): Set<string> => {
+  const kanten = new Set<string>()
+  const gesehen = new Set<string>([startEquipmentId])
+  let front = [startEquipmentId]
+  for (let hop = 0; hop < maxHops && front.length; hop++) {
+    const naechste: string[] = []
+    for (const eq of front) {
+      for (const c of cables) {
+        if (c.fromEquipmentId !== eq) continue
+        kanten.add(c.id)
+        if (!gesehen.has(c.toEquipmentId)) {
+          gesehen.add(c.toEquipmentId)
+          naechste.push(c.toEquipmentId)
+        }
+      }
+    }
+    front = naechste
+  }
+  return kanten
+}

--- a/src/renderer/lib/videohubLinks.ts
+++ b/src/renderer/lib/videohubLinks.ts
@@ -1,0 +1,103 @@
+/**
+ * Vom Kreuzpunkt-Zustand des Videohubs zur Kanten-Anzeige im Canvas.
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * DIE GRENZE, DIE DIESE DATEI EINHÄLT
+ * ═══════════════════════════════════════════════════════════════════════
+ *
+ * Ein Blackmagic-Videohub meldet über sein Protokoll seine KREUZPUNKTE:
+ * welcher Eingang gerade auf welchen Ausgang geschaltet ist. Er meldet
+ * **nicht**, ob dort Signal anliegt — kein Lock, kein Format, keine
+ * Signalerkennung. Genau das steht in `videohub:read-state`: `routing`,
+ * Labels, Locks, sonst nichts.
+ *
+ * Deshalb liefert diese Datei `routed` und niemals `carrying`. Der
+ * Unterschied ist kein Wortspiel: ein Kreuzpunkt steht auch dann, wenn
+ * upstream die Kamera aus ist. Wer ihn als „Signal liegt an" zeigte, machte
+ * aus einer Router-Einstellung eine Aussage über die Anlage — die
+ * Falschaussage, gegen die der ganze Signalfluss-Entwurf gebaut ist.
+ *
+ * Und sie liefert **nie** `down`. Der Hub kann Verbindungsverlust nicht
+ * melden; eine Kante als tot zu zeichnen, weil sie nicht geroutet ist, wäre
+ * derselbe Fehler in klein. Nicht geroutet heisst `idle` — die Strecke ist
+ * da, es läuft nur nichts über sie.
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * WIE DIE KABEL AUF EIN- UND AUSGÄNGE ABGEBILDET WERDEN
+ * ═══════════════════════════════════════════════════════════════════════
+ *
+ * Über die POSITION des Ports in `inputs`/`outputs` des Hub-Geräts, 1-basiert
+ * — dieselbe Zählung, mit der `labelDerivation.inputIndex` arbeitet und mit
+ * der ATEM und Videohub den Eingang auf dem Draht adressieren. Eine zweite
+ * Zählung daneben ginge beim nächsten Umsortieren der Ports auseinander, und
+ * zwar still.
+ */
+
+import type { Cable } from '../types/cable'
+import type { EquipmentItem } from '../types/equipment'
+import type { LiveLink } from './signalAnimation'
+
+/** Der Ausschnitt des Hub-Zustands, den diese Datei braucht. */
+export interface VideohubStateSlice {
+  /** Ausgangsnummer → Eingangsnummer, beide 1-basiert wie auf dem Draht. */
+  routing?: Record<number, number>
+}
+
+/**
+ * Die Kanten-Meldungen zu einem Hub-Zustand.
+ *
+ * `at` kommt von aussen, damit die Rechnung rein bleibt — dieselbe Trennung
+ * wie beim Mischer-Tally und beim Seed-Merge.
+ */
+export const videohubLinks = (
+  hub: Pick<EquipmentItem, 'id' | 'inputs' | 'outputs'> | undefined,
+  cables: readonly Cable[],
+  state: VideohubStateSlice | null | undefined,
+  at: number,
+): LiveLink[] => {
+  const routing = state?.routing
+  if (!hub || !routing) return []
+
+  // Welche Eingangsnummern werden gerade irgendwohin durchgeschaltet?
+  const belegteEingaenge = new Set(Object.values(routing))
+  // Welche Ausgangsnummern fuehren gerade etwas?
+  const belegteAusgaenge = new Set(
+    Object.entries(routing)
+      .filter(([, eingang]) => typeof eingang === 'number')
+      .map(([ausgang]) => Number(ausgang)),
+  )
+
+  const eingangNr = new Map(hub.inputs.map((p, i) => [p.id, i + 1]))
+  const ausgangNr = new Map(hub.outputs.map((p, i) => [p.id, i + 1]))
+
+  const out: LiveLink[] = []
+  for (const cable of cables) {
+    // Ein Kabel IN den Hub: sein Port ist ein Hub-Eingang.
+    if (cable.toEquipmentId === hub.id) {
+      const nr = eingangNr.get(cable.toPortId)
+      if (nr === undefined) continue
+      out.push({
+        cableId: cable.id,
+        state: belegteEingaenge.has(nr) ? 'routed' : 'idle',
+        at,
+        source: 'videohub',
+      })
+      continue
+    }
+    // Ein Kabel AUS dem Hub: sein Port ist ein Hub-Ausgang.
+    if (cable.fromEquipmentId === hub.id) {
+      const nr = ausgangNr.get(cable.fromPortId)
+      if (nr === undefined) continue
+      out.push({
+        cableId: cable.id,
+        state: belegteAusgaenge.has(nr) ? 'routed' : 'idle',
+        at,
+        source: 'videohub',
+      })
+    }
+    // Alles andere: keine Aussage. Der Hub weiss ueber Kabel, die ihn nicht
+    // beruehren, nichts — und `edgeFlow` zeigt fuer eine Kante ohne Eintrag
+    // das Schema, nicht „aus".
+  }
+  return out
+}

--- a/src/renderer/store/liveStore.ts
+++ b/src/renderer/store/liveStore.ts
@@ -37,8 +37,22 @@ interface LiveState {
    * und ein Einspeiser, der sie mitliefert, koennte sie schoenen.
    */
   melde: (teil: { links?: readonly LiveLink[]; tally?: readonly LiveTally[] }, now: number) => void
-  /** Verbindung weg. Der Canvas faellt beim naechsten Takt aufs Schema. */
-  verbindungWeg: () => void
+  /**
+   * Eine QUELLE ist weg. Sie raeumt ihre eigene Haelfte und ruehrt
+   * `lastContactAt` NICHT an.
+   *
+   * WARUM NICHT ALLES. Es gibt zwei Einspeiser — der Mischer meldet Tally,
+   * der Router meldet Kreuzpunkte. Faellt einer aus, faellt nicht der andere
+   * aus; wer hier alles leerte, machte aus einem toten Router einen toten
+   * Mischer. Und `lastContactAt` stehen zu lassen ist richtig, solange die
+   * andere Quelle es weiter hochsetzt: „live" heisst, dass ueberhaupt jemand
+   * meldet. Die Eintraege der toten Quelle altern von selbst aus dem
+   * Frische-Fenster heraus, und ihre Kanten fallen einzeln aufs Schema —
+   * genau die Regel, die `edgeFlow` je Eintrag prueft.
+   *
+   * Ohne Argument: beide Haelften, und dann faellt auch `lastContactAt` weg.
+   */
+  verbindungWeg: (teil?: 'links' | 'tally') => void
 }
 
 export const useLiveStore = create<LiveState>((set) => ({
@@ -51,7 +65,17 @@ export const useLiveStore = create<LiveState>((set) => ({
         lastContactAt: now,
       },
     })),
-  verbindungWeg: () => set({ snapshot: EMPTY_LIVE }),
+  verbindungWeg: (teil) =>
+    set((s) => {
+      if (!teil) return { snapshot: EMPTY_LIVE }
+      return {
+        snapshot: {
+          ...s.snapshot,
+          links: teil === 'links' ? [] : s.snapshot.links,
+          tally: teil === 'tally' ? [] : s.snapshot.tally,
+        },
+      }
+    }),
 }))
 
 /**

--- a/src/renderer/store/liveStore.ts
+++ b/src/renderer/store/liveStore.ts
@@ -1,0 +1,67 @@
+import { create } from 'zustand'
+import {
+  EMPTY_LIVE,
+  LIVE_STALE_AFTER_MS,
+  liveFreshness,
+  type LiveLink,
+  type LiveSnapshot,
+  type LiveTally,
+} from '../lib/signalAnimation'
+
+/**
+ * Die BEOBACHTUNGEN, die der Canvas zeigen darf — und sonst nichts.
+ *
+ * WARUM EIN EIGENER STORE. `projectStore` ist die Wahrheit ueber den PLAN;
+ * was eine Anlage gerade tut, ist keine Plan-Aenderung. Waere es dort drin,
+ * liefe es durch Undo/Redo, durch die Autospeicherung und in die
+ * `.cableplan`-Datei — eine Ablesung, die als Absicht gespeichert wird, ist
+ * genau der Fehler, den ADR-003 und E-4 (`asBuilt.ts`, „eigene Spur")
+ * benennen.
+ *
+ * Deshalb: eigener Store, NICHT persistiert, ohne Historie. Beim Neustart
+ * ist er leer, und das ist die richtige Aussage — was die Anlage vor einer
+ * Stunde tat, weiss diese App nicht mehr.
+ *
+ * ER WIRD HEUTE VON NIEMANDEM GEFUELLT. Das ist kein Versehen: Inkrement 1
+ * baut die Darstellung samt Rueckfall-Regel, das Einspeisen aus Mischer und
+ * Router folgt. Bis dahin zeigt der Canvas ehrlich „Schema" — und die Regel,
+ * die das entscheidet, ist bereits durch Tests gesichert statt spaeter
+ * nachgereicht.
+ */
+interface LiveState {
+  snapshot: LiveSnapshot
+  /**
+   * Eine Runde Beobachtungen uebernehmen. `lastContactAt` wird HIER gesetzt
+   * und nicht vom Einspeiser mitgegeben: „wann haben wir zuletzt etwas
+   * gehoert" ist eine Aussage ueber die Verbindung, nicht ueber die Daten,
+   * und ein Einspeiser, der sie mitliefert, koennte sie schoenen.
+   */
+  melde: (teil: { links?: readonly LiveLink[]; tally?: readonly LiveTally[] }, now: number) => void
+  /** Verbindung weg. Der Canvas faellt beim naechsten Takt aufs Schema. */
+  verbindungWeg: () => void
+}
+
+export const useLiveStore = create<LiveState>((set) => ({
+  snapshot: EMPTY_LIVE,
+  melde: (teil, now) =>
+    set((s) => ({
+      snapshot: {
+        links: teil.links ?? s.snapshot.links,
+        tally: teil.tally ?? s.snapshot.tally,
+        lastContactAt: now,
+      },
+    })),
+  verbindungWeg: () => set({ snapshot: EMPTY_LIVE }),
+}))
+
+/**
+ * Wie oft der Canvas nachrechnen muss, damit ein Rueckfall aufs Schema
+ * SICHTBAR wird, statt bis zur naechsten Maus-Bewegung zu warten.
+ *
+ * Eine Sekunde: fein genug, dass niemand mehrere Sekunden lang eine
+ * Behauptung sieht, fuer die es keinen Beleg mehr gibt, und grob genug, dass
+ * es keine Bildrate kostet.
+ */
+export const LIVE_TICK_MS = 1000
+
+export { LIVE_STALE_AFTER_MS, liveFreshness }

--- a/src/renderer/store/settingsStore.ts
+++ b/src/renderer/store/settingsStore.ts
@@ -86,6 +86,15 @@ interface PersistedSettings {
    *  Projekte. Das zugehörige Token liegt im OS-Schlüsselbund, niemals
    *  hier. Leerer String = NetBox nicht konfiguriert. */
   netboxUrl: string
+  /**
+   * Bewegte Darstellung im Canvas (Signalfluss auf den Kanten).
+   *
+   * Vorgabe AN, aber `prefers-reduced-motion` des Systems gewinnt darueber —
+   * die Auswertung steht in `useReducedMotion`, nicht hier: diese Einstellung
+   * sagt, was der Nutzer WILL, die Systemeinstellung, was er VERTRAEGT. Beides
+   * in ein Feld zu ziehen hiesse, das eine mit dem anderen zu ueberschreiben.
+   */
+  canvasMotion: boolean
 }
 
 const defaults: PersistedSettings = {
@@ -97,6 +106,7 @@ const defaults: PersistedSettings = {
   onboardingDone: false,
   userSchema: {},
   netboxUrl: '',
+  canvasMotion: true,
 }
 
 const load = (): PersistedSettings => {
@@ -127,6 +137,11 @@ const load = (): PersistedSettings => {
         typeof parsed.onboardingDone === 'boolean' ? parsed.onboardingDone : true,
       userSchema: sanitizeUserSchema(parsed.userSchema),
       netboxUrl: typeof parsed.netboxUrl === 'string' ? parsed.netboxUrl : defaults.netboxUrl,
+      // Bestehende Installationen kennen das Feld nicht — sie bekommen die
+      // Vorgabe AN. Das ist keine Aenderung ihrer Entscheidung, sondern die
+      // erste: die Bewegung gab es vorher nicht.
+      canvasMotion:
+        typeof parsed.canvasMotion === 'boolean' ? parsed.canvasMotion : defaults.canvasMotion,
     }
   } catch {
     return defaults
@@ -152,6 +167,7 @@ const snapshot = (s: PersistedSettings): PersistedSettings => ({
   onboardingDone: s.onboardingDone,
   userSchema: s.userSchema,
   netboxUrl: s.netboxUrl,
+  canvasMotion: s.canvasMotion,
 })
 
 interface SettingsState {
@@ -167,6 +183,7 @@ interface SettingsState {
   onboardingDone: boolean
   userSchema: UserSchemaMap
   netboxUrl: string
+  canvasMotion: boolean
   setHasToken: (value: boolean) => void
   setTokenStatus: (value: string) => void
   setAutosaveIntervalMs: (value: number) => void
@@ -183,6 +200,8 @@ interface SettingsState {
   setUserSchema: (map: UserSchemaMap) => void
   /** #597 — Basis-URL der NetBox-Instanz setzen (leer = nicht konfiguriert). */
   setNetboxUrl: (value: string) => void
+  /** Bewegte Darstellung im Canvas ein-/ausschalten. */
+  setCanvasMotion: (value: boolean) => void
 }
 
 const initial = load()
@@ -199,6 +218,7 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   editorName: initial.editorName,
   enabledModules: initial.enabledModules,
   onboardingDone: initial.onboardingDone,
+  canvasMotion: initial.canvasMotion,
   userSchema: initial.userSchema,
   netboxUrl: initial.netboxUrl,
   setHasToken: (value) => set({ hasToken: value }),
@@ -223,6 +243,11 @@ export const useSettingsStore = create<SettingsState>((set) => ({
     set((state) => {
       persist(snapshot({ ...state, editorName: value }))
       return { editorName: value }
+    }),
+  setCanvasMotion: (value) =>
+    set((state) => {
+      persist(snapshot({ ...state, canvasMotion: value }))
+      return { canvasMotion: value }
     }),
   setModuleEnabled: (id, value) =>
     set((state) => {

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -100,7 +100,18 @@ interface PersistedUiState {
   propertiesWidth: number
   /** Whether cable color on the canvas is derived from the manually set color
    * or from the standard length-color coding. */
-  cableColorMode: 'manual' | 'byLength'
+  /**
+   * Woher die Kabelfarbe kommt.
+   *
+   *   manual   — was am Kabel steht (Vorgabe; nichts wird ueberschrieben)
+   *   byLength — Laengen-Farbcodierung fuer die Kommissionierung
+   *   byLayer  — die Layer-Legende (Video/Audio/Control/Netz/Strom), damit
+   *              Steuerpfade auf dem Plan von Video und Audio zu
+   *              unterscheiden sind. Bis 2026-09-08 gab es die Farben nur
+   *              an den Legenden-Chips: der Plan versprach eine Codierung,
+   *              die er nicht einloeste.
+   */
+  cableColorMode: 'manual' | 'byLength' | 'byLayer'
   /** Canvas background theme. */
   canvasTheme: 'dark' | 'light'
   /** #453 — Wenn true, folgt canvasTheme automatisch dem OS-Theme
@@ -629,7 +640,7 @@ interface UiState extends PersistedUiState {
   setDefaultArrow: (value: boolean) => void
   setLibraryWidth: (value: number) => void
   setPropertiesWidth: (value: number) => void
-  setCableColorMode: (value: 'manual' | 'byLength') => void
+  setCableColorMode: (value: 'manual' | 'byLength' | 'byLayer') => void
   setCanvasTheme: (value: 'dark' | 'light') => void
   setFollowSystemTheme: (value: boolean) => void
   setColorPortsByType: (value: boolean) => void

--- a/tests/atemTally.test.ts
+++ b/tests/atemTally.test.ts
@@ -106,16 +106,34 @@ import { resolve } from 'node:path'
 const quelle = (rel: string) => readFileSync(resolve(__dirname, '..', rel), 'utf8')
 
 describe('Der Mischer-Einspeiser', () => {
+  // Ohne Kommentare: der Kopfkommentar der Datei NENNT `verbindungWeg`, um zu
+  // erklaeren, was sie tut. Ein Waechter, der Begruendungen mitliest, macht
+  // die Begruendung zum Fehler — derselbe Griff daneben wie beim Live-Store.
   const feed = quelle('src/renderer/hooks/useAtemTallyFeed.ts')
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1')
 
+  // Die Zusicherung ist „er wirft den Stand weg", nicht „er ruft
+  // `verbindungWeg()` ohne Argument". Der erste Anlauf pinnte die leere
+  // Klammer und wurde rot, als die Funktion ein Argument bekam (welche
+  // Haelfte) — eine RICHTIGE Aenderung. Ein Waechter, der daran rot wird,
+  // wird geaendert statt gelesen.
   it('wirft den Stand weg, sobald der Mischer nicht mehr verbunden ist', () => {
     expect(feed).toContain('if (!status.connected)')
-    expect(feed).toMatch(/if \(!status\.connected\) \{\s*verbindungWeg\(\)/)
+    expect(feed).toMatch(/if \(!status\.connected\) \{\s*verbindungWeg\(/)
   })
 
   it('wirft den Stand auch bei einem Fehlschlag weg', () => {
     // Erreichbar heisst nicht antwortend.
-    expect(feed).toMatch(/catch \{[\s\S]*verbindungWeg\(\)/)
+    expect(feed).toMatch(/catch \{[\s\S]*verbindungWeg\(/)
+  })
+
+  it('raeumt dabei NUR seine eigene Haelfte', () => {
+    // Ein toter Mischer ist kein toter Router. Das ist die Aussage, die das
+    // Argument traegt — deshalb steht sie hier als eigene Zeile und nicht
+    // als Klammerinhalt in den beiden darueber.
+    expect(feed).toContain("verbindungWeg('tally')")
+    expect(feed).not.toMatch(/verbindungWeg\(\)/)
   })
 
   it('stempelt jede Meldung mit der Zeit', () => {

--- a/tests/atemTally.test.ts
+++ b/tests/atemTally.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+import { atemTally, type AtemStateSlice } from '../src/renderer/lib/atemTally'
+import type { TallyMapRow } from '../src/renderer/lib/tallyMap'
+
+// ───────────────────────────────────────────────────────────────────────────
+// Vom Mischer-Zustand zur Tally-Anzeige.
+//
+// Der Mischer kennt Eingangsnummern, der Plan kennt Geräte. Die Brücke gibt
+// es seit Initiative 2 (`buildTallyMap`) und wird hier BENUTZT, nicht neu
+// gebaut — eine zweite Zuordnung ginge genau dann auseinander, wenn jemand
+// umpatcht.
+//
+// Der gefährlichste Irrtum an einer Tally-Anzeige ist nicht „rot statt grün",
+// sondern „gar nichts statt rot": eine Kamera, die der Mischer nicht kennt,
+// darf nicht aussehen wie eine, von der bekannt ist, dass sie frei ist. Diese
+// Datei liefert für sie deshalb KEINEN Eintrag — `tallyOf` macht daraus
+// `null`, und die Anzeige lässt sie in Ruhe.
+// ───────────────────────────────────────────────────────────────────────────
+
+const row = (id: string, input: number | undefined, geraete = [id]): TallyMapRow => ({
+  identityId: `rolle-${id}`,
+  name: id.toUpperCase(),
+  devices: geraete.map((g) => ({ id: g, name: g })),
+  ...(input === undefined
+    ? {}
+    : { switcher: { equipmentId: 'atem', name: 'Mischer', input } }),
+})
+
+const state = (program?: number, preview?: number): AtemStateSlice => ({
+  mixEffectStates: [{ index: 0, programInput: program, previewInput: preview }],
+})
+
+const JETZT = 5000
+
+describe('ATEM → Tally', () => {
+  it('meldet Program als rot und Preview als grün', () => {
+    const t = atemTally(state(1, 2), [row('cam1', 1), row('cam2', 2)], JETZT)
+    expect(t).toEqual([
+      { equipmentId: 'cam1', state: 'program', at: JETZT, source: 'atem' },
+      { equipmentId: 'cam2', state: 'preview', at: JETZT, source: 'atem' },
+    ])
+  })
+
+  it('meldet NICHTS für eine Kamera, die auf keinem der beiden liegt', () => {
+    // Kein `off`-Eintrag. Die Anzeige lässt sie in Ruhe, statt zu behaupten,
+    // sie sei frei.
+    const t = atemTally(state(1, 2), [row('cam1', 1), row('cam3', 3)], JETZT)
+    expect(t.map((x) => x.equipmentId)).toEqual(['cam1'])
+  })
+
+  it('Program schlägt Preview, wenn dieselbe Quelle auf beidem steht', () => {
+    // Üblich beim Vorbereiten eines Schnitts auf sich selbst. Ein grüner Ring
+    // wäre hier die gefährlichere Hälfte der Wahrheit.
+    const t = atemTally(state(1, 1), [row('cam1', 1)], JETZT)
+    expect(t).toEqual([{ equipmentId: 'cam1', state: 'program', at: JETZT, source: 'atem' }])
+  })
+
+  it('nimmt beide Geräte einer Rolle — Haupt und Backup hängen am selben Eingang', () => {
+    const t = atemTally(state(1), [row('rolle', 1, ['haupt', 'backup'])], JETZT)
+    expect(t.map((x) => x.equipmentId).sort()).toEqual(['backup', 'haupt'])
+    expect(t.every((x) => x.state === 'program')).toBe(true)
+  })
+
+  it('überspringt Rollen ohne Mischer-Anschluss', () => {
+    expect(atemTally(state(1), [row('cam1', undefined)], JETZT)).toEqual([])
+  })
+
+  it('meldet nichts ohne Mischer-Zustand', () => {
+    expect(atemTally(null, [row('cam1', 1)], JETZT)).toEqual([])
+    expect(atemTally({}, [row('cam1', 1)], JETZT)).toEqual([])
+    expect(atemTally({ mixEffectStates: [] }, [row('cam1', 1)], JETZT)).toEqual([])
+  })
+
+  it('nimmt nur Mix-Effect 1 und verodert nicht', () => {
+    // Ein Mischer mit zwei ME hat zwei Programme. Beide zu verodern zeigte
+    // eine Kamera rot, die auf keinem Ausspielweg liegt.
+    const zwei: AtemStateSlice = {
+      mixEffectStates: [
+        { index: 0, programInput: 1 },
+        { index: 1, programInput: 2 },
+      ],
+    }
+    const t = atemTally(zwei, [row('cam1', 1), row('cam2', 2)], JETZT)
+    expect(t.map((x) => x.equipmentId)).toEqual(['cam1'])
+  })
+
+  it('stempelt den Zeitpunkt, den der Aufrufer nennt', () => {
+    // Die Rechnung bleibt rein; das Alter entscheidet spaeter ueber den
+    // Rueckfall aufs Schema.
+    expect(atemTally(state(1), [row('cam1', 1)], 12345)[0].at).toBe(12345)
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// Die Verdrahtung — an der Quelle geprüft, weil `vitest` hier nicht rendert.
+//
+// Die Zusicherung ist nicht „der Ring ist rot", sondern die Regel darunter:
+// eine Beobachtung, die wir nicht mehr bekommen, wird nicht als letzter Stand
+// weitergezeigt. Ein eingefrorener Mischer-Zustand sieht aus wie ein stabiler
+// — und das ist die Falschaussage, gegen die der ganze Rückfall gebaut ist.
+// ───────────────────────────────────────────────────────────────────────────
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const quelle = (rel: string) => readFileSync(resolve(__dirname, '..', rel), 'utf8')
+
+describe('Der Mischer-Einspeiser', () => {
+  const feed = quelle('src/renderer/hooks/useAtemTallyFeed.ts')
+
+  it('wirft den Stand weg, sobald der Mischer nicht mehr verbunden ist', () => {
+    expect(feed).toContain('if (!status.connected)')
+    expect(feed).toMatch(/if \(!status\.connected\) \{\s*verbindungWeg\(\)/)
+  })
+
+  it('wirft den Stand auch bei einem Fehlschlag weg', () => {
+    // Erreichbar heisst nicht antwortend.
+    expect(feed).toMatch(/catch \{[\s\S]*verbindungWeg\(\)/)
+  })
+
+  it('stempelt jede Meldung mit der Zeit', () => {
+    // Ohne Zeitstempel koennte die Rueckfall-Regel nicht greifen.
+    expect(feed).toContain('Date.now()')
+  })
+
+  it('rechnet die Zuordnung aus dem Plan und fuehrt keine zweite Karte', () => {
+    expect(feed).toContain('buildTallyMap')
+  })
+
+  it('laeuft nicht ohne Desktop-Bruecke', () => {
+    expect(feed).toContain('if (!hasDesktopBridge) return')
+  })
+})
+
+describe('Der Tally-Ring am Geraet', () => {
+  const node = quelle('src/renderer/components/Canvas/EquipmentNode.tsx')
+
+  it('faerbt nur bei bekanntem Zustand', () => {
+    // Kein Zweig fuer `null`: was nicht gemeldet ist, bleibt ungefaerbt.
+    expect(node).toContain("tally === 'program'")
+    expect(node).toContain("tally === 'preview'")
+    expect(node).not.toContain("tally === 'off'")
+  })
+
+  it('legt den Ring NEBEN die Rahmenfarbe, nicht darueber', () => {
+    // Der Rahmen traegt Geraetefarbe und Auswahl; zwei Aussagen an einer
+    // Stelle streiten sich.
+    expect(node).toContain('boxShadow: [')
+    expect(node).toMatch(/border: `1px solid \$\{selected \? '#38bdf8'/)
+  })
+})

--- a/tests/circuitSolver.test.ts
+++ b/tests/circuitSolver.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest'
+import { solveCircuit, type CircuitEdge, type CircuitNode } from '../src/renderer/lib/circuitSolver'
+
+// ───────────────────────────────────────────────────────────────────────────
+// Wer brennt, wenn Strom anliegt (Eigentümer-Wunsch 2026-09-08).
+//
+// DIE PRÜFUNG, an der sich die Bauform entscheidet, ist die WECHSELSCHALTUNG.
+// Sie lässt sich nicht als Kette von An/Aus beschreiben: die Leuchte brennt,
+// wenn beide Schalter auf DERSELBEN Seite stehen — bei „beide oben" ebenso
+// wie bei „beide unten". Wer das als Kette baut, braucht einen Sonderfall,
+// und der Kreuzschalter macht daraus drei.
+//
+// Deshalb ist die Wahrheitstabelle hier vollständig ausgeschrieben und nicht
+// gerechnet: sie ist die Zusicherung, und eine Zusicherung, die sich derselben
+// Formel bedient wie der Code, prüft nichts.
+// ───────────────────────────────────────────────────────────────────────────
+
+const k = (id: string, from: string, ft: number, to: string, tt: number): CircuitEdge => ({
+  id,
+  fromNode: from,
+  fromTerminal: ft,
+  toNode: to,
+  toTerminal: tt,
+})
+
+describe('Der einfachste Fall', () => {
+  const nodes = (an: boolean, schalter: number): CircuitNode[] => [
+    { id: 'f', kind: 'feed', position: an ? 1 : 0 },
+    { id: 's', kind: 'switch', position: schalter },
+    { id: 'l', kind: 'lamp' },
+  ]
+  const edges = [k('e1', 'f', 0, 's', 1), k('e2', 's', 2, 'l', 0)]
+
+  it('brennt bei Spannung und geschlossenem Schalter', () => {
+    const r = solveCircuit(nodes(true, 1), edges)
+    expect(r.lamps.get('l')).toEqual({ lit: true, levelPct: 100 })
+    expect([...r.energisedEdges].sort()).toEqual(['e1', 'e2'])
+  })
+
+  it('brennt nicht bei offenem Schalter — und die Ader dahinter führt nichts', () => {
+    const r = solveCircuit(nodes(true, 0), edges)
+    expect(r.lamps.get('l')).toEqual({ lit: false, levelPct: 0 })
+    expect([...r.energisedEdges]).toEqual(['e1'])
+  })
+
+  it('brennt nicht ohne Einspeisung', () => {
+    const r = solveCircuit(nodes(false, 1), edges)
+    expect(r.lamps.get('l')?.lit).toBe(false)
+    expect([...r.energisedEdges]).toEqual([])
+  })
+})
+
+describe('Wechselschaltung — die vollständige Wahrheitstabelle', () => {
+  // Einspeisung → Wechselschalter A (Klemme 0), A/1 und A/2 als
+  // Korrespondierende auf B/1 und B/2, B/0 → Leuchte.
+  const bau = (a: number, b: number): CircuitNode[] => [
+    { id: 'f', kind: 'feed', position: 1 },
+    { id: 'a', kind: 'changeover', position: a },
+    { id: 'b', kind: 'changeover', position: b },
+    { id: 'l', kind: 'lamp' },
+  ]
+  const edges = [
+    k('e0', 'f', 0, 'a', 0),
+    k('k1', 'a', 1, 'b', 1),
+    k('k2', 'a', 2, 'b', 2),
+    k('e3', 'b', 0, 'l', 0),
+  ]
+
+  it.each([
+    [1, 1, true],
+    [1, 2, false],
+    [2, 1, false],
+    [2, 2, true],
+  ])('A=%i, B=%i → brennt: %s', (a, b, erwartet) => {
+    expect(solveCircuit(bau(a, b), edges).lamps.get('l')?.lit).toBe(erwartet)
+  })
+
+  it('jeder Schalter allein schaltet um', () => {
+    // Das ist der ZWECK der Wechselschaltung, und er folgt aus der Tabelle:
+    // ein Umlegen auf einer Seite dreht das Ergebnis immer um.
+    for (const b of [1, 2]) {
+      const mit1 = solveCircuit(bau(1, b), edges).lamps.get('l')!.lit
+      const mit2 = solveCircuit(bau(2, b), edges).lamps.get('l')!.lit
+      expect(mit1).not.toBe(mit2)
+    }
+  })
+})
+
+describe('Kreuzschaltung — drei Stellen, jede schaltet um', () => {
+  // A (Wechsel) → Kreuzschalter X → B (Wechsel) → Leuchte.
+  const bau = (a: number, x: number, b: number): CircuitNode[] => [
+    { id: 'f', kind: 'feed', position: 1 },
+    { id: 'a', kind: 'changeover', position: a },
+    { id: 'x', kind: 'crossover', position: x },
+    { id: 'b', kind: 'changeover', position: b },
+    { id: 'l', kind: 'lamp' },
+  ]
+  const edges = [
+    k('e0', 'f', 0, 'a', 0),
+    k('k1', 'a', 1, 'x', 1),
+    k('k2', 'a', 2, 'x', 2),
+    k('k3', 'x', 3, 'b', 1),
+    k('k4', 'x', 4, 'b', 2),
+    k('e5', 'b', 0, 'l', 0),
+  ]
+
+  it('jede der drei Stellen dreht das Ergebnis um', () => {
+    for (const a of [1, 2]) {
+      for (const x of [1, 2]) {
+        for (const b of [1, 2]) {
+          const jetzt = solveCircuit(bau(a, x, b), edges).lamps.get('l')!.lit
+          const andersA = solveCircuit(bau(a === 1 ? 2 : 1, x, b), edges).lamps.get('l')!.lit
+          const andersX = solveCircuit(bau(a, x === 1 ? 2 : 1, b), edges).lamps.get('l')!.lit
+          const andersB = solveCircuit(bau(a, x, b === 1 ? 2 : 1), edges).lamps.get('l')!.lit
+          expect(andersA, `A bei ${a}${x}${b}`).not.toBe(jetzt)
+          expect(andersX, `X bei ${a}${x}${b}`).not.toBe(jetzt)
+          expect(andersB, `B bei ${a}${x}${b}`).not.toBe(jetzt)
+        }
+      }
+    }
+  })
+})
+
+describe('Dimmer', () => {
+  const bau = (pegel: number | undefined): CircuitNode[] => [
+    { id: 'f', kind: 'feed', position: 1 },
+    { id: 'd', kind: 'dimmer', levelPct: pegel },
+    { id: 'l', kind: 'lamp' },
+  ]
+  const edges = [k('e1', 'f', 0, 'd', 1), k('e2', 'd', 2, 'l', 0)]
+
+  it('setzt die Helligkeit herab', () => {
+    expect(solveCircuit(bau(40), edges).lamps.get('l')).toEqual({ lit: true, levelPct: 40 })
+  })
+
+  it('ohne Angabe dunkelt er nicht', () => {
+    expect(solveCircuit(bau(undefined), edges).lamps.get('l')?.levelPct).toBe(100)
+  })
+
+  it('auf null ist NICHT dasselbe wie ein offener Schalter', () => {
+    // Die Anzeige darf beides nicht verwechseln: bei „aus" liegt keine
+    // Spannung an, bei „null" schon — nur eben keine Helligkeit.
+    const r = solveCircuit(bau(0), edges)
+    expect(r.lamps.get('l')).toEqual({ lit: true, levelPct: 0 })
+    expect([...r.energisedEdges].sort()).toEqual(['e1', 'e2'])
+  })
+
+  it('rechnet zwei Dimmer hintereinander multiplikativ', () => {
+    const nodes: CircuitNode[] = [
+      { id: 'f', kind: 'feed', position: 1 },
+      { id: 'd1', kind: 'dimmer', levelPct: 50 },
+      { id: 'd2', kind: 'dimmer', levelPct: 50 },
+      { id: 'l', kind: 'lamp' },
+    ]
+    const e = [k('a', 'f', 0, 'd1', 1), k('b', 'd1', 2, 'd2', 1), k('c', 'd2', 2, 'l', 0)]
+    expect(solveCircuit(nodes, e).lamps.get('l')?.levelPct).toBe(25)
+  })
+
+  it('bei zwei Wegen gewinnt der hellere', () => {
+    // Zwei parallele Dimmer auf einer Leuchte ergeben nicht das Minimum.
+    const nodes: CircuitNode[] = [
+      { id: 'f', kind: 'feed', position: 1 },
+      { id: 'j', kind: 'junction' },
+      { id: 'd1', kind: 'dimmer', levelPct: 20 },
+      { id: 'd2', kind: 'dimmer', levelPct: 80 },
+      { id: 'z', kind: 'junction' },
+      { id: 'l', kind: 'lamp' },
+    ]
+    const e = [
+      k('a', 'f', 0, 'j', 0),
+      k('b', 'j', 1, 'd1', 1),
+      k('c', 'j', 2, 'd2', 1),
+      k('d', 'd1', 2, 'z', 1),
+      k('e', 'd2', 2, 'z', 2),
+      k('f2', 'z', 0, 'l', 0),
+    ]
+    expect(solveCircuit(nodes, e).lamps.get('l')?.levelPct).toBe(80)
+  })
+})
+
+describe('Was der Rechner nicht tut', () => {
+  it('läuft in einer Ringleitung nicht endlos', () => {
+    // Eine Schleife im Hausnetz ist nichts Besonderes.
+    const nodes: CircuitNode[] = [
+      { id: 'f', kind: 'feed', position: 1 },
+      { id: 'j1', kind: 'junction' },
+      { id: 'j2', kind: 'junction' },
+      { id: 'l', kind: 'lamp' },
+    ]
+    const e = [
+      k('a', 'f', 0, 'j1', 0),
+      k('b', 'j1', 1, 'j2', 1),
+      k('c', 'j2', 2, 'j1', 2),
+      k('d', 'j2', 0, 'l', 0),
+    ]
+    expect(solveCircuit(nodes, e).lamps.get('l')?.lit).toBe(true)
+  })
+
+  it('nennt eine Leuchte ohne jede Verbindung als aus, nicht als unbekannt', () => {
+    // Hier ist „aus" die richtige Antwort und keine Behauptung: der PLAN sagt,
+    // dass nichts hinführt. Anders als bei einer Live-Beobachtung fehlt hier
+    // keine Messung, sondern eine Leitung.
+    const r = solveCircuit([{ id: 'l', kind: 'lamp' }], [])
+    expect(r.lamps.get('l')).toEqual({ lit: false, levelPct: 0 })
+  })
+})

--- a/tests/deviceReadSites.test.ts
+++ b/tests/deviceReadSites.test.ts
@@ -134,6 +134,20 @@ const CLASSIFIED: Site[] = [
       'tat.',
   },
   {
+    file: 'hooks/useAtemTallyFeed.ts',
+    verdict: 'getrennt',
+    reason:
+      'Der Mischer-Zustand fuer die Tally-Anzeige im Canvas (2026-09-08). Er ' +
+      'liest den Plan (fuer die Zuordnung Eingang -> Geraet ueber ' +
+      '`buildTallyMap`) und den Mischer — und schreibt in KEINEN von beiden. ' +
+      'Das Ergebnis geht in `liveStore`, einen eigenen, nicht persistierten ' +
+      'Store ohne Historie. Genau darum gibt es ihn: im `projectStore` liefe ' +
+      'eine Ablesung durch Undo/Redo, die Autospeicherung und in die ' +
+      'Projektdatei — eine Beobachtung, die als Absicht gespeichert wird, ist ' +
+      'der Fehler, den ADR-003 und E-4 benennen. Die Trennung ist hier also ' +
+      'nicht nachtraeglich hergestellt, sondern die Bauform.',
+  },
+  {
     file: 'components/Atem/AtemDialog.tsx',
     verdict: 'liest-nur',
     reason:

--- a/tests/deviceReadSites.test.ts
+++ b/tests/deviceReadSites.test.ts
@@ -134,6 +134,20 @@ const CLASSIFIED: Site[] = [
       'tat.',
   },
   {
+    file: 'hooks/useVideohubLinkFeed.ts',
+    verdict: 'getrennt',
+    reason:
+      'Der Kreuzpunkt-Zustand des Routers fuer die Kanten-Anzeige im Canvas ' +
+      '(2026-09-08). Dieselbe Bauform wie `useAtemTallyFeed`: er liest den ' +
+      'Plan (Hub-Geraet, Kabel) und den Router und schreibt in keinen von ' +
+      'beiden — das Ergebnis geht in den nicht persistierten `liveStore`. ' +
+      'Dazu die Grenze, die `videohubLinks` einhaelt: der Hub meldet ' +
+      'Kreuzpunkte und NICHTS ueber anliegendes Signal, also liefert er ' +
+      '`routed` und nie `carrying`. Was der Hub tut, ist eine Beobachtung; ' +
+      'was im Plan steht, eine Absicht — derselbe Satz, den ' +
+      '`VideohubExportDialog` schon traegt.',
+  },
+  {
     file: 'hooks/useAtemTallyFeed.ts',
     verdict: 'getrennt',
     reason:

--- a/tests/kabelfarbeNachGewerk.test.ts
+++ b/tests/kabelfarbeNachGewerk.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { LAYER_STYLES, STANDARD_LAYERS, styleForLayer } from '../src/renderer/lib/cableLayers'
+
+// ───────────────────────────────────────────────────────────────────────────
+// „Steuerpfade getrennt einfärben" (Eigentümer-Wunsch 2026-09-08).
+//
+// DER BEFUND DAHINTER. Die Layer-Farben gab es seit #123 — aber nur an den
+// LEGENDEN-CHIPS. Auf dem Plan selbst kam keine davon vor: die Kanten nahmen
+// `cable.color` oder die Längen-Codierung. Der Plan versprach also eine
+// Farbcodierung, die er nicht einlöste, und wer nach dem gelben Control-Chip
+// suchte, fand auf der Fläche nichts Gelbes.
+//
+// WARUM ALS EIGENER MODUS UND NICHT ALS VORGABE. Wer Kabel von Hand
+// eingefärbt hat, soll sie nicht beim nächsten Start anders sehen. Und
+// entscheidend: der Modus färbt nur die DARSTELLUNG — `cable.color` bleibt
+// stehen. Ein Modus, der die gespeicherte Farbe überschreibt, nimmt dem
+// Nutzer eine Angabe weg, um eine andere zu zeigen, und beim Zurückschalten
+// wäre sie fort.
+// ───────────────────────────────────────────────────────────────────────────
+
+const lies = (rel: string) => readFileSync(resolve(__dirname, '..', rel), 'utf8')
+
+describe('Die Layer-Legende und die Fläche zeigen dieselben Farben', () => {
+  it('jeder Standard-Layer hat eine Farbe, und `styleForLayer` liefert genau die', () => {
+    for (const layer of STANDARD_LAYERS) {
+      expect(styleForLayer(layer).color).toBe(LAYER_STYLES[layer].color)
+    }
+  })
+
+  it('ein Unter-Layer erbt die Farbe seines Gewerks', () => {
+    // `video.backup` ist Video. Sonst hätte ein Plan mit Sub-Layern lauter
+    // graue Kanten, und die Legende stimmte wieder nicht.
+    expect(styleForLayer('video.backup').color).toBe(LAYER_STYLES.video.color)
+    expect(styleForLayer('audio.foh').color).toBe(LAYER_STYLES.audio.color)
+  })
+
+  it('ein Kabel ohne Layer wird wie „other" behandelt, nicht farblos', () => {
+    expect(styleForLayer(undefined).color).toBe(LAYER_STYLES.other.color)
+  })
+
+  it('Control hat eine eigene Farbe — sonst wäre der Wunsch nicht erfüllt', () => {
+    // „Steuerpfade getrennt einfärben" heisst: Control unterscheidet sich von
+    // Video und Audio. Eine Tabelle mit doppelten Farben sähe vollständig aus
+    // und wäre wertlos.
+    const farben = STANDARD_LAYERS.map((l) => LAYER_STYLES[l].color)
+    expect(new Set(farben).size).toBe(STANDARD_LAYERS.length)
+  })
+})
+
+describe('Der Modus färbt, ohne zu überschreiben', () => {
+  const canvas = lies('src/renderer/components/Canvas/CanvasArea.tsx')
+
+  it('nimmt im Gewerk-Modus die Layer-Farbe', () => {
+    expect(canvas).toContain("cableColorMode === 'byLayer'")
+    expect(canvas).toContain('styleForLayer(item.layer).color')
+  })
+
+  it('schreibt dabei NICHT an `cable.color`', () => {
+    // Der Modus lebt in der `edges`-Ableitung. Ein `updateCable(... color ...)`
+    // in derselben Datei waere der Weg, auf dem die gespeicherte Farbe
+    // verlorenginge.
+    const ableitung = canvas.slice(canvas.indexOf('const edges = useMemo'), canvas.indexOf('const edges = useMemo') + 3000)
+    expect(ableitung).not.toContain('updateCable')
+    expect(ableitung).not.toMatch(/color:\s*styleForLayer/)
+  })
+
+  it('ist erreichbar — Einstellungen UND Ansichts-Menü', () => {
+    // Ein Modus, den niemand findet, ist keiner. Dieselbe Form wie B-35.
+    expect(lies('src/renderer/components/Settings/tabs/AppearanceTab.tsx')).toContain(
+      "setCableColorMode('byLayer')",
+    )
+    expect(lies('src/renderer/components/Layout/MenuBar.tsx')).toContain("'byLayer'")
+  })
+
+  it('bleibt NICHT die Vorgabe', () => {
+    // Wer Kabel von Hand eingefaerbt hat, soll sie nicht beim naechsten Start
+    // anders sehen.
+    expect(lies('src/renderer/store/uiStore.ts')).toContain("cableColorMode: 'manual',")
+  })
+})

--- a/tests/mobilePincodeZugang.test.ts
+++ b/tests/mobilePincodeZugang.test.ts
@@ -1,0 +1,284 @@
+// @vitest-environment node
+//
+// Node-Umgebung, nicht happy-dom: dieser Test spricht einen echten
+// HTTP-Server an, und happy-doms `fetch` setzt eine Same-Origin-Regel
+// durch, die es im Hauptprozess nicht gibt. Mit happy-dom pruefte er die
+// CORS-Politik der Testumgebung statt der Route.
+import { afterEach, describe, expect, it } from 'vitest'
+import { Agent, request } from 'node:http'
+import {
+  getMobileShareStatus,
+  setMobileShareProject,
+  setMobileSharePincodeAccess,
+  setMobileSharePincodeReadHandler,
+  setMobileSharePincodes,
+  mobileSharePincodeStatus,
+  startMobileShareServer,
+  stopMobileShareServer,
+} from '../src/main/services/mobileShareServer'
+import { stripSecrets } from '../src/main/util/stripSecrets'
+import { anlagenZugangscodes } from '../src/renderer/lib/anlagenZugangscodes'
+
+// ───────────────────────────────────────────────────────────────────────────
+// E-3 — der Anlagen-Zugangscode ueber die Mobile-Ansicht, hinter einem
+// EIGENEN Token.
+//
+// DIE VORGESCHICHTE. `cable#656` hat die Zugangsdaten der Intercom-Anlage aus
+// dem ausgelieferten Blatt genommen: `TechPincode` und `Security.Pincode`
+// stehen im Roh-Dokument des Herstellers (`basePreset`), keiner ihrer Namen
+// steht in `SECRET_KEYS`, und deshalb gingen sie in die `.cpviewer`-Datei und
+// an jedes Handy im WLAN. Die Antwort war, das Roh-Dokument als Ganzes
+// zurueckzuhalten.
+//
+// Der Eigentuemer hat am 2026-09-08 entschieden, dass der Techniker vor Ort
+// trotzdem an den Code kommen soll — aber hinter einem eigenen Token, nicht
+// hinter dem des QR-Links. Genau diese Unterscheidung ist die Zusicherung,
+// und sie zerfaellt in vier Teile, die alle einzeln pruefbar sind:
+//
+//   1. Der Sitzungstoken aus dem QR-Code reicht NICHT. Sonst hiesse „hinter
+//      einem Token" in der Praxis „hinter dem Link", und die Entscheidung
+//      waere eine andere als die getroffene.
+//   2. Der Wert steht NICHT im ausgelieferten Blatt. `stripSecrets` bleibt,
+//      wie es ist; `/project.json` traegt keinen Code.
+//   3. Vorgabe ist AUS. Ohne ausdrueckliches Einschalten gibt es die Route
+//      nicht — und zwar als 404, nicht als 401: „falscher Code, versuch es
+//      nochmal" schickte jemanden ans Raten.
+//   4. Jeder Abruf wird gemeldet, mit Fingerabdruck statt Wert.
+// ───────────────────────────────────────────────────────────────────────────
+
+const CODES = [
+  { label: 'Technik-Pincode', value: '4711' },
+  { label: 'Admin-Passwort', value: 'geheim' },
+]
+
+interface Lauf {
+  basis: string
+  token: string
+}
+
+/** Server starten und Basis-URL + Sitzungstoken aus der angebotenen URL holen. */
+const starte = async (): Promise<Lauf> => {
+  const info = await startMobileShareServer('/nicht/vorhanden')
+  const url = new URL(info.urls.find((u) => u.includes('127.0.0.1')) ?? info.urls[0])
+  return { basis: `http://127.0.0.1:${info.port}`, token: url.searchParams.get('t') ?? '' }
+}
+
+/**
+ * Ein Aufruf ohne Verbindungs-Wiederverwendung.
+ *
+ * Bewusst `node:http` und nicht `fetch`: die Tests starten je einen Server,
+ * stoppen ihn wieder, und der naechste bekommt vom Betriebssystem oft
+ * DENSELBEN Port. Undicis Verbindungs-Pool haelt dann eine Verbindung zu
+ * einem Server, den es nicht mehr gibt, und der naechste Aufruf scheitert mit
+ * „other side closed" — ein Fehlschlag der Testmechanik, der wie ein
+ * Fehlschlag der Route aussieht.
+ */
+const ruf = (
+  url: string,
+  kopf: Record<string, string> = {},
+): Promise<{ status: number; body: string }> =>
+  new Promise((ok, fail) => {
+    const req = request(url, { agent: new Agent({ keepAlive: false }), headers: kopf }, (res) => {
+      let body = ''
+      res.setEncoding('utf8')
+      res.on('data', (c) => (body += c))
+      res.on('end', () => ok({ status: res.statusCode ?? 0, body }))
+    })
+    req.on('error', fail)
+    req.end()
+  })
+
+const hole = (l: Lauf, kopf: Record<string, string> = {}) =>
+  ruf(`${l.basis}/pincodes`, { 'X-CP-Token': l.token, ...kopf })
+
+afterEach(() => {
+  setMobileSharePincodeReadHandler(null)
+  stopMobileShareServer()
+})
+
+describe('E-3 — Vorgabe ist aus', () => {
+  it('meldet keinen Zugriff, solange niemand ihn einschaltet', async () => {
+    const l = await starte()
+    setMobileSharePincodes(CODES)
+    expect(mobileSharePincodeStatus()).toEqual({ on: false, count: 0 })
+    const r = await hole(l)
+    // 404 und nicht 401: die Route gibt es nicht, es ist nichts falsch
+    // eingetippt.
+    expect(r.status).toBe(404)
+  })
+
+  it('nimmt keine Codes an, solange der Zugriff aus ist', async () => {
+    await starte()
+    setMobileSharePincodes(CODES)
+    expect(mobileSharePincodeStatus().count).toBe(0)
+  })
+})
+
+describe('E-3 — der zweite Token, nicht der des QR-Links', () => {
+  it('weist den Sitzungstoken allein ab', async () => {
+    const l = await starte()
+    setMobileSharePincodeAccess(true)
+    setMobileSharePincodes(CODES)
+    const r = await hole(l)
+    // 403 und nicht 404: die Route gibt es, der zweite Token fehlt.
+    expect(r.status).toBe(403)
+    expect(JSON.parse(r.body)).toEqual({ error: 'pin-token' })
+  })
+
+  it('weist einen falschen zweiten Token ab', async () => {
+    const l = await starte()
+    setMobileSharePincodeAccess(true)
+    setMobileSharePincodes(CODES)
+    expect((await hole(l, { 'X-CP-Pin-Token': 'falsch' })).status).toBe(403)
+  })
+
+  it('gibt die Codes mit dem richtigen zweiten Token heraus', async () => {
+    const l = await starte()
+    const pin = setMobileSharePincodeAccess(true)
+    setMobileSharePincodes(CODES)
+    const r = await hole(l, { 'X-CP-Pin-Token': pin })
+    expect(r.status).toBe(200)
+    expect(JSON.parse(r.body)).toEqual({ codes: CODES })
+  })
+
+  it('laesst den zweiten Token NICHT als Query-Parameter durch', async () => {
+    // Ein Code in einer URL landet im Verlauf, im Screenshot und in jedem
+    // Server-Log dazwischen. Der Sitzungstoken darf das, weil er ohnehin im
+    // QR-Code steht; dieser hier nicht.
+    const l = await starte()
+    const pin = setMobileSharePincodeAccess(true)
+    setMobileSharePincodes(CODES)
+    const r = await ruf(`${l.basis}/pincodes?t=${l.token}&pin=${pin}`)
+    expect(r.status).toBe(403)
+  })
+
+  it('macht den alten Token mit dem Aus- und Wiedereinschalten ungueltig', async () => {
+    const l = await starte()
+    const alt = setMobileSharePincodeAccess(true)
+    setMobileSharePincodes(CODES)
+    const neu = setMobileSharePincodeAccess(true)
+    setMobileSharePincodes(CODES)
+    expect(neu).not.toBe(alt)
+    expect((await hole(l, { 'X-CP-Pin-Token': alt })).status).toBe(403)
+    expect((await hole(l, { 'X-CP-Pin-Token': neu })).status).toBe(200)
+  })
+
+  it('nimmt Zugriff und Codes beim Abschalten weg', async () => {
+    const l = await starte()
+    const pin = setMobileSharePincodeAccess(true)
+    setMobileSharePincodes(CODES)
+    setMobileSharePincodeAccess(false)
+    expect(mobileSharePincodeStatus()).toEqual({ on: false, count: 0 })
+    expect((await hole(l, { 'X-CP-Pin-Token': pin })).status).toBe(404)
+  })
+})
+
+describe('E-3 — der Wert steht nicht im ausgelieferten Blatt', () => {
+  it('haelt `basePreset` weiter ganz zurueck, auch bei eingeschaltetem Zugriff', async () => {
+    const l = await starte()
+    setMobileSharePincodeAccess(true)
+    setMobileSharePincodes(CODES)
+    setMobileShareProject({
+      name: 'Show',
+      intercom: { basePreset: { Security: { Pincode: '4711' } } },
+    })
+    const blatt = (await ruf(`${l.basis}/project.json?t=${l.token}`)).body
+    expect(blatt).not.toContain('4711')
+    expect(blatt).not.toContain('basePreset')
+  })
+
+  it('aendert nichts an der Streich-Regel selbst', () => {
+    // Der Zugriff ist ein zweiter WEG, keine Lockerung des ersten. Ginge das
+    // Roh-Dokument wieder mit, waere die ganze Konstruktion sinnlos.
+    const gestrichen = stripSecrets({ basePreset: { Security: { Pincode: '4711' } } })
+    expect(gestrichen).toEqual({})
+  })
+})
+
+describe('E-3 — jeder Abruf wird gemeldet', () => {
+  it('meldet Zeitpunkt, Fingerabdruck und Anzahl — nicht den Wert', async () => {
+    const l = await starte()
+    const pin = setMobileSharePincodeAccess(true)
+    setMobileSharePincodes(CODES)
+    const gemeldet: { at: string; tokenPrefix: string; count: number }[] = []
+    setMobileSharePincodeReadHandler((info) => gemeldet.push(info))
+
+    await hole(l, { 'X-CP-Pin-Token': pin })
+
+    expect(gemeldet).toHaveLength(1)
+    expect(gemeldet[0].count).toBe(2)
+    expect(gemeldet[0].tokenPrefix).toBe(pin.slice(0, 6))
+    expect(gemeldet[0].tokenPrefix.length).toBeLessThan(pin.length)
+    expect(Number.isNaN(Date.parse(gemeldet[0].at))).toBe(false)
+    // Der Wert taucht nirgends auf.
+    expect(JSON.stringify(gemeldet)).not.toContain('4711')
+    expect(JSON.stringify(gemeldet)).not.toContain('geheim')
+  })
+
+  it('meldet einen abgewiesenen Abruf NICHT als Abruf', async () => {
+    // Sonst stuende im Register ein Abruf, der nie stattgefunden hat — und
+    // jemand suchte nach einem Leck, das es nicht gibt.
+    const l = await starte()
+    setMobileSharePincodeAccess(true)
+    setMobileSharePincodes(CODES)
+    const gemeldet: unknown[] = []
+    setMobileSharePincodeReadHandler((info) => gemeldet.push(info))
+    await hole(l, { 'X-CP-Pin-Token': 'falsch' })
+    expect(gemeldet).toEqual([])
+  })
+})
+
+describe('E-3 — das Aufraeumen', () => {
+  it('vergisst Token und Codes beim Stoppen des Servers', async () => {
+    await starte()
+    setMobileSharePincodeAccess(true)
+    setMobileSharePincodes(CODES)
+    stopMobileShareServer()
+    expect(mobileSharePincodeStatus()).toEqual({ on: false, count: 0 })
+    expect(getMobileShareStatus().running).toBe(false)
+  })
+})
+
+describe('E-3 — welche Felder als Zugangsmittel gelten', () => {
+  it('liest die vier benannten Pfade', () => {
+    expect(
+      anlagenZugangscodes({
+        Security: { Pincode: '1234' },
+        TechPincode: '5678',
+        AdminPassword: 'admin',
+        ConfigPassword: 'config',
+      }),
+    ).toEqual([
+      { label: 'Anlagen-Pincode', value: '1234' },
+      { label: 'Technik-Pincode', value: '5678' },
+      { label: 'Admin-Passwort', value: 'admin' },
+      { label: 'Konfigurations-Passwort', value: 'config' },
+    ])
+  })
+
+  it('nimmt eine Zahl als Pincode an', () => {
+    // Im Herstellerdokument steht ein Pincode gern ohne Anfuehrungszeichen.
+    // Ihn deshalb zu verschweigen waere die schlechteste Art, genau zu sein.
+    expect(anlagenZugangscodes({ TechPincode: 4711 })).toEqual([
+      { label: 'Technik-Pincode', value: '4711' },
+    ])
+  })
+
+  it('laesst leere Felder weg', () => {
+    // Ein leerer Pincode ist kein Geheimnis, und ihn als „—" zu zeigen liesse
+    // den Techniker glauben, er habe den richtigen Wert vor sich.
+    expect(anlagenZugangscodes({ TechPincode: '', Security: { Pincode: '   ' } })).toEqual([])
+  })
+
+  it('sucht NICHT nach anderen Feldern, die nach Geheimnis aussehen', () => {
+    // Eine Suche faende beim naechsten Firmware-Stand mehr, als jemand
+    // entschieden hat herzugeben — die falsche Richtung, um sich zu irren.
+    expect(anlagenZugangscodes({ SuperSecretKey: 'x', wifiPassword: 'y' })).toEqual([])
+  })
+
+  it('kommt mit fehlendem Dokument klar', () => {
+    expect(anlagenZugangscodes(undefined)).toEqual([])
+    expect(anlagenZugangscodes(null)).toEqual([])
+    expect(anlagenZugangscodes('kein Objekt')).toEqual([])
+  })
+})

--- a/tests/signalAnimation.test.ts
+++ b/tests/signalAnimation.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EMPTY_LIVE,
+  LIVE_STALE_AFTER_MS,
+  edgeFlow,
+  liveFreshness,
+  tallyChain,
+  tallyOf,
+  type LiveSnapshot,
+} from '../src/renderer/lib/signalAnimation'
+
+// ───────────────────────────────────────────────────────────────────────────
+// Der animierte Signalfluss im Canvas (Eigentümer-Entscheidung 2026-09-08).
+//
+// DIE ZUSICHERUNG, die hier hängt, ist eine einzige, und sie ist die
+// Bedingung, unter der die Animation überhaupt gebaut werden durfte:
+//
+//   Der Canvas behauptet nie einen Anlagenzustand, für den es keinen
+//   frischen Beleg gibt.
+//
+// Eine laufende Animation IST eine Behauptung. Niemand liest daneben eine
+// Zahl, niemand klickt ein Warndreieck weg — man sieht, dass es fließt, und
+// glaubt es. Das ist ADR-003 an dieser Stelle, und es ist die Auflage aus
+// E-23 („do NOT build a live monitoring dashboard").
+//
+// Die Zusicherung zerfällt in vier Fälle, und der dritte ist der, den man
+// beim Bauen übersieht:
+//
+//   1. kein Kontakt         → Schema
+//   2. Kontakt zu alt       → Schema
+//   3. Kontakt frisch, aber über DIESE Strecke nichts bekannt → Schema
+//      (nicht „aus"! Das wäre eine Aussage über ein ungemessenes Kabel)
+//   4. Meldung frisch       → der gemeldete Zustand
+// ───────────────────────────────────────────────────────────────────────────
+
+const JETZT = 1_000_000
+
+const snap = (over: Partial<LiveSnapshot> = {}): LiveSnapshot => ({
+  links: [],
+  tally: [],
+  lastContactAt: JETZT,
+  ...over,
+})
+
+const kabel = { id: 'c1', bidirectional: false }
+const opts = { motion: true }
+
+describe('Betriebsart — gilt Live?', () => {
+  it('ohne Kontakt gilt Live nicht, und das Alter ist unbekannt', () => {
+    expect(liveFreshness(EMPTY_LIVE, JETZT)).toEqual({ live: false, ageMs: null })
+    expect(liveFreshness(null, JETZT)).toEqual({ live: false, ageMs: null })
+  })
+
+  it('frischer Kontakt gilt, alter nicht — und das Alter steht in beiden Fällen da', () => {
+    expect(liveFreshness(snap(), JETZT)).toEqual({ live: true, ageMs: 0 })
+    const knapp = liveFreshness(snap({ lastContactAt: JETZT - LIVE_STALE_AFTER_MS }), JETZT)
+    expect(knapp.live).toBe(true)
+    const drueber = liveFreshness(snap({ lastContactAt: JETZT - LIVE_STALE_AFTER_MS - 1 }), JETZT)
+    expect(drueber).toEqual({ live: false, ageMs: LIVE_STALE_AFTER_MS + 1 })
+  })
+
+  it('rechnet ein Alter nie negativ', () => {
+    // Uhren laufen auseinander. Eine negative Zahl in der Anzeige („vor -3 s")
+    // sieht aus wie ein Fehler der App und schickt die Suche in die falsche
+    // Richtung.
+    expect(liveFreshness(snap({ lastContactAt: JETZT + 5000 }), JETZT).ageMs).toBe(0)
+  })
+})
+
+describe('Kante — die vier Fälle', () => {
+  it('1. ohne Kontakt: Schema', () => {
+    const f = edgeFlow(kabel, EMPTY_LIVE, JETZT, opts)
+    expect(f.kind).toBe('schema')
+    expect(f.ageMs).toBeNull()
+  })
+
+  it('2. Kontakt zu alt: Schema, auch wenn eine Meldung dasteht', () => {
+    const f = edgeFlow(
+      kabel,
+      snap({
+        lastContactAt: JETZT - 60_000,
+        links: [{ cableId: 'c1', state: 'carrying', at: JETZT - 60_000, source: 'atem' }],
+      }),
+      JETZT,
+      opts,
+    )
+    expect(f.kind).toBe('schema')
+  })
+
+  it('3. Kontakt frisch, diese Strecke unbekannt: Schema — NICHT „aus"', () => {
+    // Der Fall, den man beim Bauen übersieht. Eine Kante als tot zu zeichnen,
+    // weil niemand sie gemessen hat, ist genau die Falschaussage, gegen die
+    // die ganze Konstruktion steht.
+    const f = edgeFlow(kabel, snap({ links: [] }), JETZT, opts)
+    expect(f.kind).toBe('schema')
+    expect(f.dimmed).toBe(false)
+  })
+
+  it('3b. auch eine EINZELNE veraltete Meldung fällt aufs Schema zurück', () => {
+    const f = edgeFlow(
+      kabel,
+      snap({ links: [{ cableId: 'c1', state: 'down', at: JETZT - 60_000, source: 'videohub' }] }),
+      JETZT,
+      opts,
+    )
+    expect(f.kind).toBe('schema')
+    expect(f.dimmed).toBe(false)
+  })
+
+  it('4. frische Meldung: der gemeldete Zustand, mit Alter und Quelle', () => {
+    const f = edgeFlow(
+      kabel,
+      snap({ links: [{ cableId: 'c1', state: 'carrying', at: JETZT - 200, source: 'atem' }] }),
+      JETZT,
+      opts,
+    )
+    expect(f.kind).toBe('live-carrying')
+    expect(f.animate).toBe(true)
+    expect(f.ageMs).toBe(200)
+    expect(f.source).toBe('atem')
+  })
+})
+
+describe('Was Bewegung bedeutet', () => {
+  it('„steht, fließt nicht" bewegt sich NICHT', () => {
+    // Sonst hiesse Bewegung zweierlei, und das Bild ist nur noch Dekoration.
+    const f = edgeFlow(
+      kabel,
+      snap({ links: [{ cableId: 'c1', state: 'idle', at: JETZT, source: 'videohub' }] }),
+      JETZT,
+      opts,
+    )
+    expect(f.kind).toBe('live-idle')
+    expect(f.animate).toBe(false)
+    expect(f.dimmed).toBe(false)
+  })
+
+  it('„keine Verbindung" wird gedämpft, nicht nur stillgestellt', () => {
+    // „Vorhanden, aber tot" muss sich von „vorhanden" unterscheiden, und
+    // Stillstand allein ist dafür zu leise.
+    const f = edgeFlow(
+      kabel,
+      snap({ links: [{ cableId: 'c1', state: 'down', at: JETZT, source: 'videohub' }] }),
+      JETZT,
+      opts,
+    )
+    expect(f.kind).toBe('live-down')
+    expect(f.animate).toBe(false)
+    expect(f.dimmed).toBe(true)
+  })
+
+  it('ohne Bewegungs-Erlaubnis animiert nichts — auch nicht Live', () => {
+    // `prefers-reduced-motion` und der Schalter in den Einstellungen. Die
+    // AUSSAGE bleibt: `kind` ist weiter `live-carrying`, nur ohne Bewegung.
+    const f = edgeFlow(
+      kabel,
+      snap({ links: [{ cableId: 'c1', state: 'carrying', at: JETZT, source: 'atem' }] }),
+      JETZT,
+      { motion: false },
+    )
+    expect(f.kind).toBe('live-carrying')
+    expect(f.animate).toBe(false)
+  })
+
+  it('gedämpft gibt es NUR mit Beleg — nie im Schema', () => {
+    expect(edgeFlow(kabel, EMPTY_LIVE, JETZT, opts).dimmed).toBe(false)
+    expect(edgeFlow(kabel, null, JETZT, opts).dimmed).toBe(false)
+  })
+})
+
+describe('Tally', () => {
+  it('meldet Zustand und Alter, wenn frisch', () => {
+    const t = tallyOf(
+      'cam1',
+      snap({ tally: [{ equipmentId: 'cam1', state: 'program', at: JETZT - 100, source: 'atem' }] }),
+      JETZT,
+    )
+    expect(t).toEqual({ state: 'program', ageMs: 100 })
+  })
+
+  it('gibt null statt „off", wenn nichts bekannt ist', () => {
+    // Eine Kamera ohne Meldung darf nicht wie eine aussehen, von der bekannt
+    // ist, dass sie nicht auf Sendung ist — das ist der gefährlichste Irrtum
+    // an einer Tally-Anzeige.
+    expect(tallyOf('cam1', snap({ tally: [] }), JETZT)).toBeNull()
+    expect(tallyOf('cam1', EMPTY_LIVE, JETZT)).toBeNull()
+  })
+
+  it('gibt null bei veralteter Meldung', () => {
+    expect(
+      tallyOf(
+        'cam1',
+        snap({ tally: [{ equipmentId: 'cam1', state: 'program', at: JETZT - 60_000, source: 'atem' }] }),
+        JETZT,
+      ),
+    ).toBeNull()
+  })
+})
+
+describe('Die Kette bis zum Mischer', () => {
+  const c = (id: string, from: string, to: string) => ({ id, fromEquipmentId: from, toEquipmentId: to })
+
+  it('folgt den Kabeln vorwärts', () => {
+    const kanten = tallyChain('cam1', [c('k1', 'cam1', 'conv'), c('k2', 'conv', 'atem'), c('k3', 'x', 'y')])
+    expect([...kanten].sort()).toEqual(['k1', 'k2'])
+  })
+
+  it('erfindet keinen Weg, den der Plan nicht kennt', () => {
+    // Endet die Verkabelung, endet die Kette. Sie „bis zum Mischer"
+    // weiterzumalen hiesse, eine Strecke zu behaupten.
+    expect([...tallyChain('cam1', [c('k1', 'cam1', 'conv')])]).toEqual(['k1'])
+    expect([...tallyChain('cam1', [])]).toEqual([])
+  })
+
+  it('läuft bei einem Rückweg im Plan nicht endlos', () => {
+    // Mischer → Monitor → Mischer ist eine gewöhnliche Verkabelung.
+    const kanten = tallyChain('a', [c('k1', 'a', 'b'), c('k2', 'b', 'a')])
+    expect([...kanten].sort()).toEqual(['k1', 'k2'])
+  })
+
+  it('hört nach der Sprung-Obergrenze auf', () => {
+    const lang = Array.from({ length: 30 }, (_, i) => c(`k${i}`, `e${i}`, `e${i + 1}`))
+    expect(tallyChain('e0', lang, 3).size).toBe(3)
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// Die Verdrahtung im Canvas — geprüft an der Quelle, weil `vitest` hier nicht
+// rendert.
+//
+// Was hier hängt, ist NICHT „wie sieht die Kante aus" (Farbe, Strichlänge und
+// Anordnung dürfen sich ändern, ohne dass eine Zusicherung fällt), sondern die
+// eine Aussage, ohne die die ganze Konstruktion sinnlos wäre:
+//
+//   Wo sich etwas bewegt, steht auch, WONACH dieses Bild zu lesen ist.
+//
+// Die Animation sieht im Schema und im Live-Betrieb gleich aus. Ein Canvas,
+// der sie zeigt und die Betriebsart verschweigt, behauptet einen Zustand, für
+// den es keinen Beleg gibt — dieselbe Form wie E-13 (die Vorschau, die nicht
+// sagte, dass sie eine ist).
+// ───────────────────────────────────────────────────────────────────────────
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const lies = (rel: string) => readFileSync(resolve(__dirname, '..', rel), 'utf8')
+
+describe('Canvas — wo Bewegung ist, steht die Betriebsart', () => {
+  it('die Kante entscheidet die Bewegung nicht selbst', () => {
+    // `useEdgeFlow` ist die Engstelle: dort steckt die Rückfall-Regel. Eine
+    // Kante, die `cp-flow` an einer eigenen Bedingung aufhängt, umgeht sie.
+    const edge = lies('src/renderer/components/Canvas/CableEdge.tsx')
+    expect(edge).toContain('useEdgeFlow')
+    const flowStellen = [...edge.matchAll(/cp-flow/g)]
+    expect(flowStellen.length, 'cp-flow wird gerendert').toBeGreaterThan(0)
+    // Die Klasse steht nur innerhalb des `flow?.animate`-Zweigs.
+    const abschnitt = edge.slice(edge.indexOf('flow?.animate'), edge.indexOf('flow?.animate') + 600)
+    expect(abschnitt).toContain('cp-flow')
+  })
+
+  it('die Werkzeugleiste zeigt die Betriebsart an', () => {
+    const toolbar = lies('src/renderer/components/Canvas/CanvasToolbar.tsx')
+    expect(toolbar).toContain('<FlowModeChip')
+  })
+
+  it('die Anzeige nennt beide Betriebsarten und das Alter', () => {
+    // „Live" ohne Zeitangabe ist dieselbe Behauptung wie eine laufende
+    // Animation ohne Beleg, nur in Textform.
+    const chip = lies('src/renderer/components/Canvas/FlowModeChip.tsx')
+    expect(chip).toContain("'canvas.flow.live'")
+    expect(chip).toContain("'canvas.flow.schema'")
+    expect(chip).toContain('ageMs')
+  })
+
+  it('Bewegung verlangt die Zustimmung von Nutzer UND System', () => {
+    const hooks = lies('src/renderer/hooks/useCanvasFlow.ts')
+    expect(hooks).toContain('useReducedMotion')
+    expect(hooks).toContain('canvasMotion')
+    // Beide, nicht eines von beiden.
+    expect(hooks).toMatch(/gewuenscht\s*&&\s*!reduziert/)
+  })
+
+  it('die Beobachtungen liegen NICHT im Projekt-Store', () => {
+    // Sonst liefen sie durch Undo/Redo, die Autospeicherung und in die
+    // Projektdatei — eine Ablesung, die als Absicht gespeichert wird, ist der
+    // Fehler, den ADR-003 und E-4 benennen.
+    // Geprueft werden die IMPORTE, nicht der Fliesstext: der Kopfkommentar
+    // des Live-Stores nennt `projectStore` ausdruecklich, um zu sagen, dass er
+    // nicht dorthin gehoert. Ein Waechter, der Begruendungen verbietet, macht
+    // die Begruendung zum Fehler.
+    const store = lies('src/renderer/store/liveStore.ts')
+    const importe = [...store.matchAll(/^import .*$/gm)].map((m) => m[0]).join('\n')
+    expect(importe).not.toContain('projectStore')
+    expect(importe).not.toContain('persist')
+    const projekt = lies('src/renderer/store/projectStore.ts')
+    expect(projekt).not.toContain('LiveSnapshot')
+  })
+})

--- a/tests/videohubLinks.test.ts
+++ b/tests/videohubLinks.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest'
+import { videohubLinks } from '../src/renderer/lib/videohubLinks'
+import { edgeFlow, EMPTY_LIVE } from '../src/renderer/lib/signalAnimation'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+
+// ───────────────────────────────────────────────────────────────────────────
+// Der Kreuzpunkt-Zustand des Videohubs auf den Kanten.
+//
+// DIE GRENZE IST DIE ZUSICHERUNG. Ein Videohub meldet, welchen Eingang er auf
+// welchen Ausgang schaltet — und NICHTS darüber, ob dort Signal anliegt. Kein
+// Lock, kein Format, keine Signalerkennung; das Protokoll kennt sie nicht.
+//
+// Ein Kreuzpunkt steht auch dann, wenn upstream die Kamera aus ist. Ihn als
+// „Signal liegt an" zu zeigen, machte aus einer Router-EINSTELLUNG eine
+// Aussage über die Anlage. Deshalb `routed` und nie `carrying` — und nie
+// `down`, weil der Hub Verbindungsverlust gar nicht melden kann.
+// ───────────────────────────────────────────────────────────────────────────
+
+const port = (id: string) => ({ id, name: id, type: 'port' as const, connectorType: 'BNC' as const })
+
+const hub = {
+  id: 'hub',
+  inputs: [port('in1'), port('in2'), port('in3')],
+  outputs: [port('out1'), port('out2')],
+} as unknown as EquipmentItem
+
+const kabel = (id: string, from: [string, string], to: [string, string]): Cable =>
+  ({
+    id,
+    fromEquipmentId: from[0],
+    fromPortId: from[1],
+    toEquipmentId: to[0],
+    toPortId: to[1],
+  }) as unknown as Cable
+
+const JETZT = 9000
+
+describe('Videohub → Kanten', () => {
+  it('meldet eine geroutete Zuleitung als `routed`, nicht als `carrying`', () => {
+    const c = kabel('k1', ['cam1', 'out'], ['hub', 'in1'])
+    const l = videohubLinks(hub, [c], { routing: { 1: 1 } }, JETZT)
+    expect(l).toEqual([{ cableId: 'k1', state: 'routed', at: JETZT, source: 'videohub' }])
+  })
+
+  it('meldet eine nicht geroutete Zuleitung als `idle`, nicht als `down`', () => {
+    // Die Strecke ist da, es laeuft nur nichts darueber. `down` koennte der
+    // Hub gar nicht belegen.
+    const c = kabel('k1', ['cam1', 'out'], ['hub', 'in2'])
+    const l = videohubLinks(hub, [c], { routing: { 1: 1 } }, JETZT)
+    expect(l[0].state).toBe('idle')
+  })
+
+  it('meldet einen belegten Ausgang als `routed`', () => {
+    const c = kabel('k2', ['hub', 'out1'], ['atem', 'in'])
+    const l = videohubLinks(hub, [c], { routing: { 1: 3 } }, JETZT)
+    expect(l[0].state).toBe('routed')
+  })
+
+  it('meldet einen unbelegten Ausgang als `idle`', () => {
+    const c = kabel('k2', ['hub', 'out2'], ['atem', 'in'])
+    const l = videohubLinks(hub, [c], { routing: { 1: 3 } }, JETZT)
+    expect(l[0].state).toBe('idle')
+  })
+
+  it('meldet NIE `carrying` und NIE `down`', () => {
+    // Die Grenze in einer Zeile. Wer hier eine dritte Sorte einbaut, faellt auf.
+    const cs = [
+      kabel('a', ['cam1', 'o'], ['hub', 'in1']),
+      kabel('b', ['cam2', 'o'], ['hub', 'in2']),
+      kabel('c', ['hub', 'out1'], ['atem', 'i']),
+      kabel('d', ['hub', 'out2'], ['mon', 'i']),
+    ]
+    const l = videohubLinks(hub, cs, { routing: { 1: 1 } }, JETZT)
+    expect(l.length).toBe(4)
+    for (const eintrag of l) {
+      expect(['routed', 'idle']).toContain(eintrag.state)
+    }
+  })
+
+  it('sagt über Kabel, die den Hub nicht berühren, nichts', () => {
+    // Und `edgeFlow` zeigt fuer eine Kante ohne Eintrag das Schema, nicht
+    // „aus" — die beiden Regeln greifen ineinander.
+    const c = kabel('fremd', ['cam1', 'o'], ['atem', 'i'])
+    expect(videohubLinks(hub, [c], { routing: { 1: 1 } }, JETZT)).toEqual([])
+  })
+
+  it('sagt nichts ohne Hub-Zustand oder ohne Hub im Plan', () => {
+    const c = kabel('k1', ['cam1', 'o'], ['hub', 'in1'])
+    expect(videohubLinks(hub, [c], null, JETZT)).toEqual([])
+    expect(videohubLinks(hub, [c], {}, JETZT)).toEqual([])
+    expect(videohubLinks(undefined, [c], { routing: { 1: 1 } }, JETZT)).toEqual([])
+  })
+
+  it('überspringt einen Port, den der Hub nicht führt', () => {
+    // Ein Kabel auf einen Port, den es am Hub nicht (mehr) gibt: keine
+    // Nummer, keine Aussage. Eine geratene Nummer traefe die falsche Kante.
+    const c = kabel('k1', ['cam1', 'o'], ['hub', 'gibtEsNicht'])
+    expect(videohubLinks(hub, [c], { routing: { 1: 1 } }, JETZT)).toEqual([])
+  })
+})
+
+describe('Wie `routed` auf der Kante ankommt', () => {
+  const c = { id: 'k1', bidirectional: false }
+
+  it('bewegt sich wie ein Weg — der Router schaltet ja durch', () => {
+    const f = edgeFlow(
+      c,
+      { links: [{ cableId: 'k1', state: 'routed', at: JETZT, source: 'videohub' }], tally: [], lastContactAt: JETZT },
+      JETZT,
+      { motion: true },
+    )
+    expect(f.kind).toBe('live-routed')
+    expect(f.animate).toBe(true)
+    expect(f.dimmed).toBe(false)
+  })
+
+  it('bleibt als eigene Sorte erkennbar, nicht als `carrying`', () => {
+    // Der Unterschied steckt in `kind` und wird dort gelesen, wo er etwas
+    // aendert. In der Bewegung koennte er nicht stecken: die bedeutete dann
+    // dreierlei.
+    const f = edgeFlow(
+      c,
+      { links: [{ cableId: 'k1', state: 'routed', at: JETZT, source: 'videohub' }], tally: [], lastContactAt: JETZT },
+      JETZT,
+      { motion: true },
+    )
+    expect(f.kind).not.toBe('live-carrying')
+  })
+
+  it('faellt ohne Kontakt weiter aufs Schema zurück', () => {
+    expect(edgeFlow(c, EMPTY_LIVE, JETZT, { motion: true }).kind).toBe('schema')
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// Zwei Quellen, zwei Hälften — und was passiert, wenn eine ausfällt.
+//
+// Der Mischer meldet Tally, der Router meldet Kreuzpunkte. Fällt einer aus,
+// fällt nicht der andere aus. Wer das nicht trennt, macht aus einem toten
+// Router einen toten Mischer — und der Nutzer sucht den Fehler am falschen
+// Gerät.
+// ───────────────────────────────────────────────────────────────────────────
+
+import { readFileSync } from 'node:fs'
+import { useLiveStore } from '../src/renderer/store/liveStore'
+import { resolve } from 'node:path'
+
+const lies = (rel: string) => readFileSync(resolve(__dirname, '..', rel), 'utf8')
+
+describe('Ausfall einer Quelle', () => {
+  it('jeder Einspeiser meldet NUR seine eigene Haelfte ab', () => {
+    expect(lies('src/renderer/hooks/useAtemTallyFeed.ts')).toContain("verbindungWeg('tally')")
+    expect(lies('src/renderer/hooks/useVideohubLinkFeed.ts')).toContain("verbindungWeg('links')")
+  })
+
+  it('der Store raeumt bei einem Teil-Ausfall nur diesen Teil', () => {
+    // VERHALTEN, nicht Quelltext. Der erste Anlauf dieses Tests las die zwei
+    // Zeilen aus `liveStore.ts` — und blieb GRUEN, als eine Gegenprobe ein
+    // `return EMPTY_LIVE` DAVOR setzte: die Zeilen standen weiter da, nur
+    // unerreichbar. Ein Waechter, der die Form liest statt der Wirkung,
+    // bewacht nichts.
+    const s = useLiveStore.getState()
+    s.melde(
+      {
+        links: [{ cableId: 'k1', state: 'routed', at: JETZT, source: 'videohub' }],
+        tally: [{ equipmentId: 'cam1', state: 'program', at: JETZT, source: 'atem' }],
+      },
+      JETZT,
+    )
+
+    useLiveStore.getState().verbindungWeg('links')
+    const nachRouter = useLiveStore.getState().snapshot
+    expect(nachRouter.links).toEqual([])
+    expect(nachRouter.tally).toHaveLength(1)
+    // Und der Gesamtkontakt bleibt: die andere Quelle meldet ja noch.
+    expect(nachRouter.lastContactAt).toBe(JETZT)
+
+    useLiveStore.getState().verbindungWeg('tally')
+    expect(useLiveStore.getState().snapshot.tally).toEqual([])
+
+    // Ohne Argument: alles, samt Gesamtkontakt.
+    useLiveStore.getState().melde({ tally: [{ equipmentId: 'c', state: 'off', at: JETZT, source: 'atem' }] }, JETZT)
+    useLiveStore.getState().verbindungWeg()
+    expect(useLiveStore.getState().snapshot.lastContactAt).toBeUndefined()
+  })
+
+  it('der Router wird langsamer gefragt als der Mischer', () => {
+    // `videohub:read-state` oeffnet je Aufruf eine TCP-Verbindung zu einem
+    // Geraet, das im Signalweg steht. Der Takt bleibt innerhalb des
+    // Frische-Fensters, ist also Hoeflichkeit und keine Korrektheitsfrage.
+    const feed = lies('src/renderer/hooks/useVideohubLinkFeed.ts')
+    const takt = /HUB_TICK_MS = (\d+)/.exec(feed)
+    expect(takt).not.toBeNull()
+    expect(Number(takt![1])).toBeGreaterThan(1000)
+    expect(Number(takt![1])).toBeLessThan(5000)
+  })
+
+  it('fragt keinen Hub ohne Adresse', () => {
+    // Eine geratene Adresse waere ein Verbindungsversuch zu einem fremden
+    // Geraet im Kundennetz.
+    expect(lies('src/renderer/hooks/useVideohubLinkFeed.ts')).toContain("(e.ipAddress ?? '').trim() !== ''")
+  })
+})


### PR DESCRIPTION
Zwei Sachen: die Eigentümer-Entscheidung **E-3**, und der neue Wunsch vom selben Tag — bewegter Signalfluss und Steuerzustände im Canvas, samt Strom-Schaltbildern.

---

## 1 · E-3 · Anlagen-Zugangscodes hinter einem eigenen Token

`cable#656` hat die Zugangsdaten der Intercom-Anlage aus dem ausgelieferten Blatt genommen: `TechPincode`, `Security.Pincode`, `AdminPassword` und `ConfigPassword` stehen im Roh-Dokument des Herstellers, **keiner dieser Namen steht in `SECRET_KEYS`** — deshalb gingen sie vorher in die `.cpviewer`-Datei und an jedes Handy im WLAN.

Der Eigentümer hat entschieden: der Techniker vor Ort soll trotzdem herankommen — **hinter einem eigenen Token, nicht hinter dem des QR-Links**. Die Speicherregel aus `CLAUDE.md` ist unberührt; was sich ändert, ist allein der Abrufweg.

| # | Bedingung | Warum |
| --- | --- | --- |
| 1 | **Zweiter Token, nur als Header** | Der Sitzungstoken steckt im QR-Code und liegt auf jedem Telefon im WLAN. Als Query-Parameter kommt der zweite ausdrücklich **nicht** durch: eine URL landet im Verlauf, im Screenshot und in jedem Server-Log dazwischen |
| 2 | **Nicht im ausgelieferten Blatt** | Die Codes liegen nur im Speicher von `main`. `/project.json` trägt weiterhin kein `basePreset` |
| 3 | **Vorgabe AUS** | Ohne Einschalten gibt es die Route nicht — als **404**, nicht 401: „falscher Code, versuch es nochmal" schickte jemanden ans Raten |
| 4 | **Jeder Abruf ins Dokument-Register** | Mit Zeitpunkt und Token-Fingerabdruck, **nicht** mit dem Wert. Ein *abgewiesener* Abruf wird nicht gemeldet: sonst stünde im Register ein Abruf, den es nie gab |

`renderer/lib/anlagenZugangscodes.ts` liest **gezielt vier Pfade** statt das Dokument nach „irgendwas mit Passwort" abzusuchen — eine Suche fände beim nächsten Firmware-Stand mehr, als jemand entschieden hat herzugeben.

**Ein Defekt aus diesem PR, gefunden und behoben:** der erste Anlauf hängte einen zustand-Selektor an eine Funktion, die bei jedem Aufruf ein neues Array baut. `MobileShareDialog` hängt dauerhaft in `App.tsx` — auch geschlossen —, also traf es die ganze App: `ui-smoke` war rot, „Beispielprojekt laden" tat nichts. Gefunden vom UI-Overflow-Lauf, nicht von den Unit-Tests; gegengeprobt an main, dort grün.

---

## 2 · Animierter Signalfluss und Steuerzustände

**Die eine Regel, aus der alles folgt.** Eine Animation, die aussieht wie fließendes Signal, **ist** eine Aussage über die Anlage. Läuft sie ohne Beleg, ist sie die teuerste Sorte Falschaussage: niemand liest daneben eine Zahl, niemand klickt ein Warndreieck weg — man sieht, dass es fließt, und glaubt es.

Zwei Betriebsarten, keine dritte: **Schema** (der geplante Weg; Vorgabe und Rückfall) und **Live** (eine Beobachtung mit Zeitpunkt und Quelle, aus derselben Spur, die `asBuilt.ts` seit E-4 führt).

| Lage | Anzeige |
| --- | --- |
| kein Kontakt | Schema |
| Kontakt zu alt | Schema |
| Kontakt frisch, über **diese** Strecke nichts bekannt | Schema — **nicht** „aus" |
| Meldung frisch | der gemeldete Zustand |

Der dritte Fall ist der, den man beim Bauen übersieht.

### Die vier Zustände, die der Eigentümer ausgewählt hat

**Signalfluss auf den Kanten** — ein gestrichelter Overlay-Pfad, dessen Strichversatz läuft. Der Zustand ändert **nicht** die Farbe (die gehört dem Layer und ist die gedruckte Legende), er trägt die Bewegung. „Steht, fließt nicht" bewegt sich nicht; „keine Verbindung" wird gedämpft.

**Tally aus dem Mischer** — `atem:state` liefert erstmals `programInput`/`previewInput` je Mix-Effect; das fehlte ganz. Die Übersetzung Eingangsnummer → Gerät läuft über die vorhandene `buildTallyMap` (ADR-001, keine zweite Zuordnung). Ein Gerät ohne Meldung bekommt **keinen** Ring — nicht „aus": das ist der gefährlichste Irrtum an einer Tally-Anzeige, weil er in die falsche Richtung beruhigt. Program schlägt Preview; Haupt und Backup am selben Eingang sind beide rot; nur ME 1, weil beide zu verodern eine Kamera rot zeigte, die auf keinem Ausspielweg liegt.

**Verbindungszustand aus dem Router** — und hier lag die eigentliche Arbeit. Ein Videohub meldet **Kreuzpunkte**, nicht Signal: kein Lock, kein Format, keine Signalerkennung. Der Kreuzpunkt steht auch dann, wenn upstream die Kamera aus ist. Deshalb ein eigener Zustand **`routed`** neben `carrying` — nie `carrying`, und nie `down` (Verbindungsverlust kann der Hub gar nicht melden; nicht geroutet heisst `idle`).

**Steuerpfade getrennt einfärben** — der Wunsch hat einen größeren Befund freigelegt: die Layer-Farben gab es seit #123 nur an den Legenden-Chips, auf dem Plan kam keine davon vor. `cableColorMode` bekommt `byLayer` als dritten Wert. Er färbt **nur die Darstellung**; `cable.color` bleibt stehen, sonst wäre die Handfarbe beim Zurückschalten fort. Nicht Vorgabe, aus demselben Grund.

### Betriebsart-Anzeige, Bewegung, Ausfall

`FlowModeChip` in der Werkzeugleiste ist **Pflicht und nicht Zierde** — die Animation sieht in beiden Betriebsarten gleich aus. Sie nennt das Alter der letzten Meldung („Live" ohne Zeitangabe ist dieselbe Behauptung, nur in Textform) und ist zugleich der Schalter für die Bewegung. Bewegung nur, wenn Nutzer **und** System zustimmen (`prefers-reduced-motion`).

**Zwei Einspeiser, zwei Hälften.** Der Mischer wird im Sekundentakt über die offene IPC-Verbindung gefragt, der Router alle zwei Sekunden — `videohub:read-state` öffnet je Aufruf eine TCP-Verbindung zu einem Gerät im Signalweg. Fällt einer aus, räumt er **nur seine eigene Hälfte**: ein toter Router ist kein toter Mischer, und wer alles leerte, schickte den Nutzer zum falschen Gerät.

Die Beobachtungen liegen in einem eigenen, **nicht persistierten** Store. Im `projectStore` liefen sie durch Undo/Redo, die Autospeicherung und in die Projektdatei — genau der Fehler aus `cable#647`.

---

## 3 · Strom: Schaltbild-Rechner (Wechsel-, Kreuzschaltung, Dimmer)

**Was es ist:** ein Schaltbild-Rechner — welche Leuchte brennt bei welcher Schalterstellung. **Was es nicht ist:** eine elektrotechnische Berechnung oder ein Sicherheitsnachweis. Der Rückleiter fehlt absichtlich (ein Wechselschaltungs-Plan zeigt den geschalteten Außenleiter); die Vereinfachung ist im Quelltext benannt, damit sie nicht als Fehler „behoben" wird.

**Warum Klemmen und nicht „Schalter an/aus":** eine Wechselschaltung ist keine Kette von An/Aus — die Leuchte brennt, wenn beide Schalter auf *derselben* Seite stehen. Als Kette gebaut braucht das einen Sonderfall, der Kreuzschalter macht daraus drei. `INNERE_VERBINDUNG` ist `satisfies Record<CircuitKind, …>` — eine Bauart ohne Eintrag ist ein Typfehler statt einer still nicht leitenden Stelle.

Bei mehreren Wegen gewinnt der **hellste**; `lit: true, levelPct: 0` ist erlaubt (ein auf null gefahrener Dimmer ist etwas anderes als ein offener Schalter); Ringleitungen enden; eine Leuchte ohne Verbindung ist **aus** und nicht „unbekannt" — hier fehlt keine Messung, sondern eine Leitung.

**Offen:** die Schaltbild-Symbole auf dem Canvas. Der Rechner steht und ist geprüft; die Darstellung folgt.

---

## Gegenproben

Alle **22** rot, zurückgebaut grün.

| Bereich | Proben |
| --- | --- |
| E-3 (5) | Sitzungstoken allein reicht · Roh-Dokument geht wieder mit · Vorgabe an statt aus · abgewiesener Abruf wird gemeldet · Token überlebt das Stoppen |
| Signalfluss (6) | ungemessene Strecke wird als tot gezeichnet · veraltete Einzelmeldung gilt als jetzt · „steht, fließt nicht" bewegt sich · negatives Alter · System-Einstellung ignoriert · Bewegung ohne Betriebsart-Anzeige |
| Tally (5) | Preview schlägt Program · alle Mix-Effects verodert · nur das erste Gerät einer Rolle · getrennter Mischer behält den Stand · ungemeldetes Gerät bekommt einen „aus"-Ring |
| Router (6) | Kreuzpunkt als „Signal liegt an" · nicht geroutet gilt als tot · geratene Portnummer · Teil-Ausfall räumt alles · Router so schnell gefragt wie der Mischer · Hub ohne Adresse wird gefragt |
| Gewerk-Farben (4) | Control wie Video · Unter-Layer erbt nicht · `byLayer` als Vorgabe · Modus färbt gar nicht |
| Strom (5) | Wechselschalter als An/Aus · Kreuzschalter kreuzt nicht · erster Weg gewinnt · Dimmer auf null gilt als aus · Dimmer leitet nicht |

Dazu die vollständige Wahrheitstabelle der Wechselschaltung (ausgeschrieben, nicht gerechnet) und für die Kreuzschaltung alle acht Stellungen mit der Probe, dass jede der drei Stellen das Ergebnis umdreht.

## Drei Wächter haben sich dabei selbst blamiert — und sind repariert statt umgangen

1. **`devport`-Wächter** (in light#96): meldete beim ersten CI-Lauf sich selbst — sein Kopfkommentar trug die alte Adresse als wählbares Literal. Lokal war er blind dafür, weil er nur versionierte Dateien liest und selbst noch nicht versioniert war.
2. **„Teil-Ausfall räumt alles"** blieb bei der Gegenprobe **grün**: der Test las zwei Zeilen aus `liveStore.ts`, die hinter einem eingeschleusten `return` weiter dastanden, nur unerreichbar. Er prüft jetzt das Verhalten des Stores.
3. **Zwei Tally-Wächter** pinnten `verbindungWeg()` mit leerer Klammer und wurden rot, als die Funktion ein Argument bekam — eine *richtige* Änderung. Sie prüfen jetzt die Zusicherung, und die neue Aussage („nur die eigene Hälfte") steht als eigene Zeile daneben.

Dazu hat der `deviceReadSites`-Wächter beide neuen Einspeiser erwartungsgemäß gemeldet; beide sind als `getrennt` eingeordnet und begründet.

---

`docs/architecture.md` trägt die Entscheidung jetzt selbst: neuer Abschnitt 3.1b (`liveStore` als Beobachtungs-Spur), die Beobachtungen in den Persistenz-Tiers als bewusstes „nirgends", und **Invariante 14** — der Canvas behauptet keinen Anlagenzustand ohne frischen Beleg, samt Auflage für eine dritte Quelle.

`tsc` app/main/preload je 0 Fehler · `lint` 0 Errors · **3200 Tests grün** · `ui-overflow` 0 Befunde bei beiden Fenstergrößen · `ui:smoke` 5 Menüs.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT