### PR TITLE
tally: der Plan geht direkt an den Pi, ohne Datei-Umweg (B-6)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,6 +15,7 @@ import { registerLogIpc } from './ipc/logIpc.js'
 import { registerDocumentLogIpc } from './ipc/documentLogIpc.js'
 import { registerReceiptIpc } from './ipc/receiptIpc.js'
 import { registerShowControlIpc } from './ipc/showControlIpc.js'
+import { registerTallyIpc } from './ipc/tallyIpc.js'
 import { registerSyncIpc } from './ipc/syncIpc.js'
 import { registerGraphmlIpc } from './ipc/graphmlIpc.js'
 import { registerMobileShareIpc } from './ipc/mobileShareIpc.js'
@@ -349,6 +350,7 @@ app.whenReady().then(async () => {
   registerDocumentLogIpc()
   registerReceiptIpc()
   registerShowControlIpc()
+  registerTallyIpc()
   registerSyncIpc()
   registerGraphmlIpc()
   registerMobileShareIpc()

--- a/src/main/ipc/tallyIpc.ts
+++ b/src/main/ipc/tallyIpc.ts
@@ -1,0 +1,30 @@
+/**
+ * `tally:*` — der Direktweg zum Tally-Pi (B-6, E-7).
+ *
+ * Eigene Domaene nach der Repo-Konvention (ein Channel = eine Domaene). Zwei
+ * Aufrufe, und sie sind absichtlich getrennt:
+ *
+ *   `tally:read`  — was steht gerade auf dem Pi?
+ *   `tally:write` — die Rollenliste aus dem Plan hinschreiben.
+ *
+ * Ein einziger „senden"-Aufruf, der still vorher liest, waere bequemer und
+ * genau deshalb falsch: der Schreibvorgang LOESCHT Rollen, die der Plan nicht
+ * nennt (`merge_tally_config` behaelt Felder, nicht Geraete). Wer das
+ * ausloest, soll vorher gesehen haben, was verschwindet.
+ *
+ * Es gibt keinen Aufruf, der still `undefined` zurueckgibt: aus einem
+ * fehlenden Ergebnis liest jemand „hat wohl geklappt", und das ist die
+ * Entwarnung, die dieser Weg nicht geben darf.
+ */
+import { ipcMain } from 'electron'
+import { lesen, schreiben } from '../services/tallyPushService.js'
+
+export const registerTallyIpc = () => {
+  ipcMain.handle('tally:read', (_e, adresse: unknown) =>
+    lesen(typeof adresse === 'string' ? adresse : ''),
+  )
+
+  ipcMain.handle('tally:write', (_e, adresse: unknown, devices: unknown) =>
+    schreiben(typeof adresse === 'string' ? adresse : '', Array.isArray(devices) ? devices : []),
+  )
+}

--- a/src/main/preload.cts
+++ b/src/main/preload.cts
@@ -283,6 +283,21 @@ contextBridge.exposeInMainWorld('cablePlanner', {
       return () => ipcRenderer.removeListener('showControl:update', handler)
     },
   },
+  /**
+   * B-6 / E-7 — der Direktweg zum Tally-Pi. Lesen und Schreiben getrennt:
+   * der Schreibvorgang loescht Rollen, die der Plan nicht nennt, und wer das
+   * ausloest, soll vorher gesehen haben, was verschwindet.
+   *
+   * Die Adresse wird hier NICHT geprueft — das passiert in main
+   * (`tallyPushService.pruefeZiel`), wie es die Repo-Regel verlangt. Eine
+   * zweite Pruefung hier waere die zweite Wahrheit: sie liefe irgendwann
+   * auseinander, und die im Renderer waere die nachgiebigere.
+   */
+  tally: {
+    read: (adresse: string) => ipcRenderer.invoke('tally:read', adresse) as Promise<unknown>,
+    write: (adresse: string, devices: unknown[]) =>
+      ipcRenderer.invoke('tally:write', adresse, devices) as Promise<unknown>,
+  },
   logs: {
     rendererError: (payload: { message: string; stack?: string; source?: string }) =>
       ipcRenderer.send('logs:renderer-error', payload),

--- a/src/main/services/tallyPushService.ts
+++ b/src/main/services/tallyPushService.ts
@@ -1,0 +1,189 @@
+/**
+ * B-6 / E-7 — DER DIREKTWEG ZUM TALLY-PI.
+ *
+ * Der Befund, gegen den das hier steht: `ExportDialog` erzeugt eine
+ * Download-Datei, die jemand von Hand nach `/opt/pi-guide/tally.json`
+ * kopiert. Genau der Medienbruch, gegen den dieses Programm angetreten ist.
+ *
+ * E-7 (2026-09-08, vom Eigentuemer bestaetigt) sagt BEIDES, mit Rangfolge:
+ * die Datei bleibt der Vorgabeweg, der Direktweg kommt als ausdruecklich
+ * einzuschaltendes Ziel dazu. Wer ohne Netz zum Pi plant — und das ist der
+ * Normalfall im Vorlauf —, merkt von diesem Modul nichts.
+ *
+ * ===========================================================================
+ * WARUM DAS IM MAIN-PROZESS LIEGT
+ * ===========================================================================
+ *
+ * `guide_server.py` schickt keine CORS-Kopfzeilen (nachgesehen: weder
+ * `Access-Control-*` noch ein OPTIONS-Zweig). Ein `fetch` aus dem Renderer
+ * scheiterte am Preflight oder waere — mit `mode: 'no-cors'` — abgeschickt,
+ * aber unlesbar. Ein Schreibvorgang, dessen Ergebnis man nicht erfaehrt, ist
+ * SCHLIMMER als keiner: der Nutzer glaubt, die Karte sei auf dem Pi. Node
+ * kennt keine Same-Origin-Regel und liefert die echte Antwort samt Status.
+ *
+ * Ausserdem gilt die Repo-Regel: Adress- und Pfad-Pruefung passiert immer in
+ * main, nie im Renderer. Die Pruefung steht deshalb HIER und nicht im Dialog.
+ *
+ * ===========================================================================
+ * GESCHICKT WIRD NUR `devices` — UND DAS IST KEIN GEIZ
+ * ===========================================================================
+ *
+ * Der Pi besitzt die VERDRAHTUNG (ATEM-Adresse, GPIO-Pins, Trigger-Modi), der
+ * Plan besitzt die ROLLENLISTE (Id, Name, Mischer-Eingang). `tallyMap.ts`
+ * laesst `out_gpio`, `out_trigger` und `me` ausdruecklich weg — „eine
+ * erfundene Pin-Nummer waere schlimmer als ein fehlendes Feld".
+ * `merge_tally_config` drueben behaelt jedes Feld, das der Post nicht nennt.
+ *
+ * GERAETE dagegen, die der Post nicht nennt, verschwinden — und das ist die
+ * richtige Semantik (der Plan besitzt die Liste) und trotzdem eine Wirkung,
+ * die niemand ungefragt ausloesen soll. Deshalb gibt es `lesen` und
+ * `schreiben` EINZELN: erst lesen und vergleichen, dann schreiben.
+ *
+ * ===========================================================================
+ * KEIN TOKEN — UND DAS STEHT HIER, STATT VORGETAEUSCHT ZU WERDEN
+ * ===========================================================================
+ *
+ * Das DoD zu B-6 nannte „Token-geschuetzt wie der Mobile-Share". Nachgesehen
+ * (2026-09-09): `guide_server.py` prueft NICHTS — kein `Authorization`, kein
+ * eigener Kopf, an keinem seiner Schreib-Endpunkte. Und seine eigene
+ * Bedienseite (`setup-guide.html`, vom selben Server ausgeliefert) schreibt
+ * ueber dieselben offenen Endpunkte.
+ *
+ * Einen Kopf mitzuschicken, den niemand prueft, waere die schlechteste der
+ * moeglichen Antworten: das Feld im Einstellungs-Dialog behauptete einen
+ * Schutz, den es nicht gibt, und wer es ausfuellt, hielte den Weg fuer
+ * gesichert. Deshalb schickt dieses Modul keinen — und der Schutz des Pi ist
+ * als eigener Punkt im Backlog vermerkt, wo er hingehoert: er ist eine
+ * Entscheidung ueber die ganze HTTP-Flaeche des Pi und nicht ueber diesen
+ * einen Aufruf.
+ */
+import http from 'node:http'
+
+/** Nach dieser Zeit ohne Antwort gilt der Pi als nicht erreichbar. */
+const ANFRAGE_FRIST_MS = 6000
+
+/** Groesster Rumpf, den wir lesen — ein Pi antwortet mit wenigen Kilobyte. */
+const RUMPF_GRENZE = 256 * 1024
+
+export interface PiAntwort {
+  ok: boolean
+  status?: number
+  /** Der geparste Rumpf, wenn es JSON war. */
+  json?: unknown
+  /** Der Rumpf als Text, gekuerzt. Bei einem Fehler steht dort die Begruendung des Pi. */
+  text?: string
+  /** Immer gesetzt, wenn `ok` false ist. Nie leer, nie `undefined`. */
+  error?: string
+}
+
+/**
+ * Die Adresse pruefen — in main, wie es die Repo-Regel verlangt.
+ *
+ * `http:` und sonst nichts. Nicht aus Bequemlichkeit: `file:` waere ein
+ * Dateizugriff mit der Adresse als Pfad, und `https:` gaukelte eine
+ * Verschluesselung vor, die `guide_server.py` gar nicht anbietet (er bindet
+ * einen einfachen `HTTPServer` auf Port 8080). Wer `https://` eintraegt,
+ * bekommt hier eine Absage statt einer Zeitueberschreitung ohne Grund.
+ */
+export const pruefeZiel = (adresse: string): { ok: true; url: URL } | { ok: false; error: string } => {
+  const roh = (adresse ?? '').trim()
+  if (!roh) return { ok: false, error: 'Keine Adresse für den Tally-Pi hinterlegt.' }
+  let url: URL
+  try {
+    url = new URL(roh)
+  } catch {
+    return { ok: false, error: `Keine gültige Adresse: ${roh}` }
+  }
+  if (url.protocol !== 'http:') {
+    return {
+      ok: false,
+      error: `Der Tally-Pi spricht http:// — eingetragen ist ${url.protocol}//`,
+    }
+  }
+  if (!url.hostname) return { ok: false, error: `Keine gültige Adresse: ${roh}` }
+  return { ok: true, url }
+}
+
+/** Eine HTTP-Anfrage an den Pi. Antwortet IMMER mit einem Objekt, wirft nie. */
+const anfrage = (ziel: URL, methode: 'GET' | 'POST', koerper?: unknown): Promise<PiAntwort> =>
+  new Promise((resolve) => {
+    const daten = koerper === undefined ? null : Buffer.from(JSON.stringify(koerper), 'utf8')
+    const req = http.request(
+      {
+        hostname: ziel.hostname,
+        port: ziel.port || 80,
+        path: `${ziel.pathname}${ziel.search}`,
+        method: methode,
+        timeout: ANFRAGE_FRIST_MS,
+        headers: daten
+          ? { 'Content-Type': 'application/json', 'Content-Length': String(daten.length) }
+          : {},
+      },
+      (res) => {
+        const stuecke: Buffer[] = []
+        let laenge = 0
+        res.on('data', (c: Buffer) => {
+          laenge += c.length
+          if (laenge <= RUMPF_GRENZE) stuecke.push(c)
+        })
+        res.on('end', () => {
+          const text = Buffer.concat(stuecke).toString('utf8')
+          let json: unknown
+          try {
+            json = JSON.parse(text)
+          } catch {
+            json = undefined
+          }
+          const status = res.statusCode ?? 0
+          const ok = status >= 200 && status < 300
+          const grund =
+            (json && typeof json === 'object' && typeof (json as { error?: unknown }).error === 'string'
+              ? (json as { error: string }).error
+              : '') || `HTTP ${status}`
+          resolve({
+            ok,
+            status,
+            json,
+            // Gekuerzt mitgegeben: bei einem Fehler steht dort die
+            // Begruendung des Pi, und die gehoert vor den Nutzer.
+            text: text.slice(0, 2000),
+            ...(ok ? {} : { error: grund }),
+          })
+        })
+      },
+    )
+    req.on('timeout', () => {
+      req.destroy()
+      resolve({
+        ok: false,
+        error: `Keine Antwort von ${ziel.host} innerhalb von ${ANFRAGE_FRIST_MS / 1000} s`,
+      })
+    })
+    // `error` kann NACH `timeout` noch kommen (das `destroy` loest ihn aus).
+    // `resolve` ist dann wirkungslos — die erste Antwort gilt, und das ist die
+    // mit dem brauchbaren Grund.
+    req.on('error', (err: Error) => resolve({ ok: false, error: err.message }))
+    if (daten) req.write(daten)
+    req.end()
+  })
+
+/** Die aktuelle `tally.json` des Pi lesen — vor dem Schreiben. */
+export const lesen = async (adresse: string): Promise<PiAntwort> => {
+  const ziel = pruefeZiel(adresse)
+  if (!ziel.ok) return { ok: false, error: ziel.error }
+  return anfrage(new URL('/tally-config', ziel.url), 'GET')
+}
+
+/**
+ * Die Rollenliste aus dem Plan schreiben.
+ *
+ * Bewusst NUR `devices`: alles andere gehoert dem Pi und wird drueben aus der
+ * alten Datei ergaenzt. Wer hier ein zweites Feld hinzufuegt, loescht auf dem
+ * Pi das, was er nicht mitschickt.
+ */
+export const schreiben = async (adresse: string, devices: unknown[]): Promise<PiAntwort> => {
+  const ziel = pruefeZiel(adresse)
+  if (!ziel.ok) return { ok: false, error: ziel.error }
+  if (!Array.isArray(devices)) return { ok: false, error: 'Keine Rollenliste zum Senden.' }
+  return anfrage(new URL('/tally-config', ziel.url), 'POST', { devices })
+}

--- a/src/renderer/components/Export/ExportDialog.tsx
+++ b/src/renderer/components/Export/ExportDialog.tsx
@@ -43,7 +43,9 @@ import { printPdfBlob } from '../../lib/printPdfBlob'
 import { sanitizeForPdf } from '../../lib/sanitizeForPdf'
 import { downloadBlob } from '../../lib/downloadBlob'
 import { exportDeviceConfig } from '../../lib/deviceConfigExport'
-import { buildTallyMap, tallyMapCsv, toTallyPiDevices } from '../../lib/tallyMap'
+import { buildTallyMap, tallyMapCsv, toTallyPiDevices, vergleicheMitPi, type PiVergleich } from '../../lib/tallyMap'
+import { cablePlannerApi } from '../../lib/bridge'
+import { useSettingsStore } from '../../store/settingsStore'
 import { TallyPreShowPanel } from '../Tally/TallyPreShowPanel'
 import { toCsv } from '../../lib/csv'
 import {
@@ -1437,6 +1439,47 @@ const TallySection = () => {
       'text/csv;charset=utf-8',
     )
   }
+  // B-6 / E-7 — der Direktweg. Er ist AUSDRUECKLICH einzuschalten und braucht
+  // eine Adresse; ohne beides steht dieser Block gar nicht da. Die Datei
+  // daneben bleibt der Vorgabeweg und verschwindet nicht.
+  const piUrl = useSettingsStore((st) => st.tallyPiUrl)
+  const piDirekt = useSettingsStore((st) => st.tallyPiDirekt)
+  const [piGelesen, setPiGelesen] = useState<{ adresse: string; vergleich: PiVergleich } | null>(null)
+  const [piMeldung, setPiMeldung] = useState<{ ton: 'ok' | 'fehler'; text: string } | null>(null)
+  const [piLaeuft, setPiLaeuft] = useState(false)
+
+  const piLesen = async () => {
+    setPiLaeuft(true)
+    setPiMeldung(null)
+    const antwort = await cablePlannerApi.tally.read(piUrl)
+    setPiLaeuft(false)
+    if (!antwort.ok) {
+      setPiGelesen(null)
+      setPiMeldung({ ton: 'fehler', text: antwort.error ?? 'Der Pi hat nicht geantwortet.' })
+      return
+    }
+    setPiGelesen({ adresse: piUrl, vergleich: vergleicheMitPi(antwort.json, toTallyPiDevices(map)) })
+  }
+
+  const piSenden = async () => {
+    setPiLaeuft(true)
+    setPiMeldung(null)
+    const antwort = await cablePlannerApi.tally.write(piUrl, toTallyPiDevices(map))
+    setPiLaeuft(false)
+    if (!antwort.ok) {
+      setPiMeldung({ ton: 'fehler', text: antwort.error ?? 'Der Pi hat die Karte nicht angenommen.' })
+      return
+    }
+    // Nach dem Schreiben ist der gelesene Stand veraltet. Ihn stehen zu
+    // lassen hiesse, beim naechsten Klick eine Vorschau zu zeigen, die es so
+    // nicht mehr gibt — und der zweite Sendeknopf waere ohne neuen Blick frei.
+    setPiGelesen(null)
+    setPiMeldung({
+      ton: 'ok',
+      text: t('export.tally.piSent', 'Die Tally-Karte steht auf dem Pi.'),
+    })
+  }
+
   const downloadTallyPi = () => {
     // BEDARF 43 — die Geraetedatei fuer den Pi geht mit Herkunfts-Blatt raus.
     exportDeviceConfig(
@@ -1550,6 +1593,78 @@ const TallySection = () => {
           {t('export.tally.pi', 'tally-pi-Geräte (JSON)')}
         </button>
       </div>
+
+      {/* B-6 / E-7 — der Direktweg. Er steht NEBEN der Datei und nicht an
+          ihrer Stelle: die Datei ist der Vorgabeweg und der einzige, der ohne
+          Netz zum Pi funktioniert. Sichtbar wird er nur, wenn er in den
+          Einstellungen eingeschaltet UND eine Adresse hinterlegt ist. */}
+      {piDirekt && piUrl.trim() !== '' && map.rows.length > 0 && (
+        <div className="rounded border border-cp-border bg-cp-surface-2 p-3">
+          <div className="mb-2 flex items-center gap-2 text-cp-xs text-cp-text-secondary">
+            <Icon icon={Lightbulb} size="sm" />
+            {format(t('export.tally.piDirect', 'Direkt an den Pi: {url}'), { url: piUrl })}
+          </div>
+          <PanelHint
+            className="mb-2 text-cp-xs text-cp-text-muted"
+            text={t(
+              'export.tally.piDirect.hint',
+              'Der Pi behält seine Verdrahtung — ATEM-Adresse und GPIO-Pins schickt der Plan nicht mit. Rollen dagegen, die im Plan fehlen, verschwinden dort samt ihrer Pin-Zuordnung. Deshalb erst lesen, dann senden.',
+            )}
+          />
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={piLesen}
+              disabled={piLaeuft}
+              className="rounded border border-cp-border px-3 py-1.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-3 disabled:opacity-40"
+            >
+              {t('export.tally.piRead', 'Pi lesen')}
+            </button>
+            <button
+              type="button"
+              onClick={piSenden}
+              // ERST LESEN, DANN SENDEN — und zwar von DIESER Adresse. Wer
+              // die Adresse nach dem Lesen aendert, hat den Stand eines
+              // anderen Pi gesehen, und die Vorschau gilt nicht mehr.
+              disabled={piLaeuft || piGelesen === null || piGelesen.adresse !== piUrl}
+              className="rounded bg-cp-accent px-3 py-1.5 text-cp-xs text-white disabled:opacity-40"
+            >
+              {t('export.tally.piSend', 'An den Pi senden')}
+            </button>
+            {piLaeuft && <Spinner />}
+          </div>
+          {piGelesen && piGelesen.adresse === piUrl && (
+            <ul className="mt-2 flex flex-col gap-1 text-cp-xs">
+              <li className="text-cp-text-muted">
+                {format(
+                  t('export.tally.piDiff', '{bleiben} bleiben, {neu} kommen dazu'),
+                  { bleiben: piGelesen.vergleich.bleiben, neu: piGelesen.vergleich.neu.length },
+                )}
+              </li>
+              {piGelesen.vergleich.verschwinden.map((v) => (
+                <li key={v.id} className={v.hatVerdrahtung ? 'text-cp-danger' : 'text-cp-warn'}>
+                  {format(
+                    v.hatVerdrahtung
+                      ? t(
+                          'export.tally.piGoneWired',
+                          '{name} verschwindet vom Pi — samt seiner GPIO-Zuordnung',
+                        )
+                      : t('export.tally.piGone', '{name} verschwindet vom Pi'),
+                    { name: v.name },
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+          {piMeldung && (
+            <p
+              className={`mt-2 text-cp-xs ${piMeldung.ton === 'ok' ? 'text-cp-text-secondary' : 'text-cp-danger'}`}
+            >
+              {piMeldung.text}
+            </p>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/components/Settings/tabs/IntegrationsTab.tsx
+++ b/src/renderer/components/Settings/tabs/IntegrationsTab.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { X, Eye, EyeOff } from 'lucide-react'
 import { Icon } from '../../shared/Icon'
+import { PanelHint } from '../../shared/PanelHint'
 import { cablePlannerApi } from '../../../lib/bridge'
 import { useSettingsStore, useModule } from '../../../store/settingsStore'
 import { useProjectStore } from '../../../store/projectStore'
@@ -292,6 +293,112 @@ const GreenGoPresetsCard = () => {
             </li>
           ))}
         </ul>
+      )}
+    </SettingsCard>
+  )
+}
+
+/**
+ * B-6 / E-7 — DAS ZIEL FUER DEN DIREKTWEG ZUM TALLY-PI.
+ *
+ * Die Entscheidung sagt beides, mit Rangfolge: „Die Datei bleibt der
+ * Vorgabeweg; der Direktweg kommt als ausdrücklich einzuschaltendes Ziel
+ * dazu." Deshalb steht der Schalter VOR der Adresse und ist aus, bis jemand
+ * ihn umlegt — auch bei bestehenden Installationen, die schon eine Adresse
+ * haetten.
+ *
+ * WARUM HIER KEIN TOKEN-FELD STEHT. `guide_server.py` prueft an seinen
+ * Schreib-Endpunkten nichts — kein `Authorization`, kein eigener Kopf, und
+ * seine eigene Bedienseite schreibt ueber dieselben offenen Wege. Ein Feld
+ * „Token" behauptete einen Schutz, den es nicht gibt; wer es ausfuellte,
+ * hielte den Weg fuer gesichert. Der Schutz des Pi ist ein eigener Punkt und
+ * eine Entscheidung ueber seine ganze HTTP-Flaeche, nicht ueber diesen einen
+ * Aufruf.
+ *
+ * Die Adresse gehoert der INSTALLATION, nicht dem Projekt: eine `.avplan`
+ * wandert per Mail und geht in den Web-Viewer, und eine LAN-Adresse darin
+ * waere die Anlagenkarte eines fremden Hauses in einer herumgereichten Datei.
+ */
+const TallyPiCard = () => {
+  const t = useTranslation()
+  const tallyPiUrl = useSettingsStore((s) => s.tallyPiUrl)
+  const tallyPiDirekt = useSettingsStore((s) => s.tallyPiDirekt)
+  const setTallyPiUrl = useSettingsStore((s) => s.setTallyPiUrl)
+  const setTallyPiDirekt = useSettingsStore((s) => s.setTallyPiDirekt)
+  const [adresse, setAdresse] = useState(tallyPiUrl)
+  const [probe, setProbe] = useState<string | null>(null)
+  const [laeuft, setLaeuft] = useState(false)
+
+  const pruefen = async () => {
+    setLaeuft(true)
+    setProbe(null)
+    // Geprueft wird durch LESEN, nicht durch Schreiben: ein „Verbindung
+    // testen", das etwas hinterlaesst, ist kein Test.
+    const antwort = await cablePlannerApi.tally.read(adresse.trim())
+    setLaeuft(false)
+    setProbe(
+      antwort.ok
+        ? t('settings.integrations.tallyPi.ok', 'Der Pi antwortet.')
+        : (antwort.error ?? t('settings.integrations.tallyPi.fail', 'Keine Antwort.')),
+    )
+  }
+
+  return (
+    <SettingsCard
+      title={t('settings.integrations.tallyPi.title', 'Tally-Pi (Direktweg)')}
+      description={t(
+        'settings.integrations.tallyPi.desc',
+        'Schickt die Tally-Karte aus dem Export-Dialog direkt an den Pi, statt eine Datei herunterzuladen, die jemand von Hand kopiert. Die Datei bleibt daneben bestehen — sie ist der Weg, der ohne Netz zum Pi funktioniert. Der Pi behält dabei seine Verdrahtung; Rollen, die im Plan fehlen, verschwinden dort.',
+      )}
+    >
+      <label className="flex items-center gap-2 text-cp-base">
+        <input
+          type="checkbox"
+          checked={tallyPiDirekt}
+          onChange={(e) => setTallyPiDirekt(e.target.checked)}
+          className="h-4 w-4 accent-sky-500"
+        />
+        <span>
+          {t('settings.integrations.tallyPi.enable', 'Direktweg zum Tally-Pi erlauben')}{' '}
+          <span className="text-[10px] text-cp-text-muted">
+            ({tallyPiDirekt ? t('common.on', 'ein') : t('common.off', 'aus')})
+          </span>
+        </span>
+      </label>
+
+      {tallyPiDirekt && (
+        <>
+          <label className="mt-3 block text-cp-base">
+            <span className="mb-1 block text-cp-text-secondary">
+              {t('settings.integrations.tallyPi.url', 'Adresse des Pi')}
+            </span>
+            <input
+              value={adresse}
+              onChange={(e) => setAdresse(e.target.value)}
+              onBlur={() => setTallyPiUrl(adresse.trim())}
+              placeholder="http://10.0.0.42:8080"
+              className="w-full rounded border border-cp-border bg-cp-surface-1 p-2"
+            />
+          </label>
+          <div className="mt-2 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={pruefen}
+              disabled={laeuft || adresse.trim() === ''}
+              className="rounded border border-cp-border px-3 py-1.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-3 disabled:opacity-40"
+            >
+              {t('settings.integrations.tallyPi.test', 'Verbindung prüfen')}
+            </button>
+            {probe && <span className="text-cp-xs text-cp-text-muted">{probe}</span>}
+          </div>
+          <PanelHint
+            className="mt-2 text-cp-xs text-cp-text-muted"
+            text={t(
+              'settings.integrations.tallyPi.noToken',
+              'Der Pi verlangt für diesen Weg keinen Nachweis — er prüft an seinen Schreib-Wegen nichts. Wer ihn erreicht, kann ihn beschreiben. Das ist eine Eigenschaft des Pi und keine Einstellung hier; nutze den Direktweg nur in einem Netz, dem du das zutraust.',
+            )}
+          />
+        </>
       )}
     </SettingsCard>
   )
@@ -755,6 +862,9 @@ export const IntegrationsTab = ({ onClose }: { onClose: () => void }) => {
 
       {/* #597 — NetBox-Instanz (Toggle + URL + Token). */}
       <NetboxCard onClose={onClose} />
+
+      {/* B-6 / E-7 — Ziel fuer den Direktweg zum Tally-Pi. */}
+      <TallyPiCard />
 
       {/* v7.9.86 / #197 — Multi-AI-Provider Card (Gemini / Claude / OpenAI). */}
       <AiProvidersCard />

--- a/src/renderer/lib/bridge.ts
+++ b/src/renderer/lib/bridge.ts
@@ -13,6 +13,22 @@ import { downloadBlob } from './downloadBlob'
  * Netzwerktechnik statt in einer Entscheidung, die diese Anwendung getroffen
  * hat.
  */
+/**
+ * B-6 — die Antwort des Tally-Pi, wie sie aus main zurueckkommt.
+ *
+ * `error` ist gesetzt, WANN IMMER `ok` false ist, und nie leer. Ein
+ * Fehlschlag ohne Grund waere fuer den Nutzer dasselbe wie kein Fehlschlag:
+ * er saehe „ging nicht" und wuesste nicht, ob die Adresse falsch ist, der Pi
+ * aus, oder die Karte abgelehnt wurde.
+ */
+export interface PiAntwort {
+  ok: boolean
+  status?: number
+  json?: unknown
+  text?: string
+  error?: string
+}
+
 export interface MobileShareInfo {
   port: number
   urls: string[]
@@ -221,6 +237,21 @@ type CablePlannerApi = {
     onUpdate: (
       cb: (payload: { zustand: LauscherZustand; meldungen: OscEmpfang[] }) => void,
     ) => () => void
+  }
+  /**
+   * B-6 / E-7 — der Direktweg zum Tally-Pi.
+   *
+   * `read` und `write` getrennt: der Schreibvorgang loescht auf dem Pi jede
+   * Rolle, die der Plan nicht nennt. Wer ihn ausloest, soll vorher gesehen
+   * haben, was verschwindet.
+   *
+   * Beide antworten IMMER mit `{ ok }` und im Fehlerfall mit `error` — nie
+   * mit `undefined`. Aus einem stillen Ergebnis liest jemand „ist auf dem
+   * Pi", und das ist der Glaube, gegen den dieser Weg gebaut ist.
+   */
+  tally: {
+    read: (adresse: string) => Promise<PiAntwort>
+    write: (adresse: string, devices: unknown[]) => Promise<PiAntwort>
   }
   project: {
     newProject: () => Promise<void>
@@ -687,6 +718,24 @@ const webFallbackApi: CablePlannerApi = {
     state: async () => ({ zustand: { lage: 'aus' as const }, meldungen: [] }),
     clear: async () => ({ zustand: { lage: 'aus' as const }, meldungen: [] }),
     onUpdate: () => () => {},
+  },
+  /**
+   * B-6 im Browser: kein Weg zum Pi, und das wird GESAGT.
+   *
+   * `guide_server.py` schickt keine CORS-Kopfzeilen — ein `fetch` von hier
+   * scheiterte am Preflight, und mit `no-cors` waere er abgeschickt, aber
+   * unlesbar. Das ist der schlimmste Fall: der Nutzer glaubte, die Karte sei
+   * auf dem Pi. Deshalb wird hier gar nicht erst gesendet, sondern geantwortet.
+   */
+  tally: {
+    read: async () => ({
+      ok: false,
+      error: 'Der Weg zum Tally-Pi braucht die Desktop-App — im Browser lässt der Pi keine Anfrage zu.',
+    }),
+    write: async () => ({
+      ok: false,
+      error: 'Der Weg zum Tally-Pi braucht die Desktop-App — im Browser lässt der Pi keine Anfrage zu.',
+    }),
   },
   streamKey: {
     get: async (id: string) => localStorage.getItem(STREAM_KEY_WEB_PREFIX + id),

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -2365,6 +2365,28 @@ export const en: Dict = {
   'export.tally.piTitle':
     'The part of tally.json the plan owns: id, name, input. ATEM IP and GPIO pins stay with the box.',
 
+  // B-6 / E-7 — the direct path to the tally-pi. The file stays the default
+  // way; this is the target you switch on deliberately.
+  'export.tally.piDirect': 'Straight to the Pi: {url}',
+  'export.tally.piDirect.hint':
+    'The Pi keeps its wiring — the plan does not send the ATEM address or GPIO pins. Roles missing from the plan, however, disappear there along with their pin assignment. So read first, then send.',
+  'export.tally.piRead': 'Read the Pi',
+  'export.tally.piSend': 'Send to the Pi',
+  'export.tally.piSent': 'The tally map is on the Pi.',
+  'export.tally.piDiff': '{bleiben} stay, {neu} are added',
+  'export.tally.piGone': '{name} disappears from the Pi',
+  'export.tally.piGoneWired': '{name} disappears from the Pi — along with its GPIO assignment',
+  'settings.integrations.tallyPi.title': 'Tally-Pi (direct path)',
+  'settings.integrations.tallyPi.desc':
+    'Sends the tally map straight from the export dialog to the Pi instead of downloading a file for someone to copy by hand. The file stays alongside it — it is the way that works without a network path to the Pi. The Pi keeps its wiring; roles missing from the plan disappear there.',
+  'settings.integrations.tallyPi.enable': 'Allow the direct path to the tally-pi',
+  'settings.integrations.tallyPi.url': 'Address of the Pi',
+  'settings.integrations.tallyPi.test': 'Check the connection',
+  'settings.integrations.tallyPi.ok': 'The Pi answers.',
+  'settings.integrations.tallyPi.fail': 'No answer.',
+  'settings.integrations.tallyPi.noToken':
+    'The Pi asks for no credential on this path — it checks nothing on its write endpoints. Whoever can reach it can write to it. That is a property of the Pi and not a setting here; use the direct path only on a network you trust that far.',
+
   // ADR-001 — Identitaets-Karte (.avsourcemap)
   'app.menu.file.exportSourceMap': 'Export identity map (.avsourcemap)…',
   'app.menu.file.importSourceMap': 'Import identity map (.avsourcemap)…',

--- a/src/renderer/lib/tallyMap.ts
+++ b/src/renderer/lib/tallyMap.ts
@@ -312,3 +312,70 @@ export const toTallyPiDevices = (map: TallyMap): TallyPiDevice[] => {
       return { id, name: r.name, input: r.switcher!.input }
     })
 }
+
+// ───────────────────────────────────────────────────────────────────────────
+// B-6 / E-7 — WAS DER DIREKTWEG AUF DEM PI ANRICHTET, BEVOR ER ES TUT.
+//
+// `merge_tally_config` auf dem Pi behaelt jedes FELD, das der Post nicht
+// nennt (ATEM-Adresse, GPIO-Pins) — aber jedes GERAET, das er nicht nennt,
+// verschwindet. Das ist die richtige Semantik: der Plan besitzt die
+// Rollenliste. Es ist trotzdem eine Wirkung, die niemand ungefragt ausloesen
+// soll, denn mit dem Geraet geht auch seine Verdrahtung.
+//
+// Diese Rechnung ist die Vorschau darauf. Sie steht hier und nicht im Dialog,
+// weil eine Rechnung im Knopf niemand nachrechnen kann.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Was ein Schreibvorgang an der Geraeteliste des Pi aendern wuerde. */
+export interface PiVergleich {
+  /** Rollen, die auf dem Pi stehen und im Plan fehlen — die verschwinden. */
+  verschwinden: { id: string; name: string; hatVerdrahtung: boolean }[]
+  /** Rollen, die der Plan mitbringt und der Pi noch nicht hat. */
+  neu: string[]
+  /** Rollen, die es auf beiden Seiten gibt. */
+  bleiben: number
+}
+
+/** Die Felder, die drueben dem Pi gehoeren (`PI_OWNED_DEVICE_FIELDS`). */
+const PI_FELDER = ['out_gpio', 'out_trigger', 'in_gpio', 'in_edge', 'in_action', 'me', 'aux'] as const
+
+/**
+ * Die Geraeteliste des Pi mit der aus dem Plan vergleichen.
+ *
+ * `rohe` ist die Antwort von `GET /tally-config` — ungeprueft, wie sie vom
+ * Netz kommt. Alles, was nicht wie eine Geraeteliste aussieht, ergibt einen
+ * leeren Vergleich statt eines Fehlers: „der Pi hat noch nichts" und „der Pi
+ * hat geantwortet, aber anders" fuehren beide dazu, dass nichts verschwindet,
+ * und genau das ist die Auskunft, auf die es hier ankommt.
+ *
+ * `hatVerdrahtung` unterscheidet die beiden Faelle, die verschieden schwer
+ * wiegen: eine Rolle ohne Pin verschwinden zu lassen kostet einen Eintrag,
+ * eine MIT Pin kostet die Verkabelung einer Lampe.
+ */
+export const vergleicheMitPi = (rohe: unknown, plan: TallyPiDevice[]): PiVergleich => {
+  const roh = rohe as { devices?: unknown } | null | undefined
+  const piListe = Array.isArray(roh?.devices) ? roh.devices : []
+  const imPlan = new Set(plan.map((d) => d.id))
+  const aufPi = new Set<string>()
+  const verschwinden: PiVergleich['verschwinden'] = []
+
+  for (const eintrag of piListe) {
+    if (!eintrag || typeof eintrag !== 'object') continue
+    const d = eintrag as Record<string, unknown>
+    const id = typeof d.id === 'string' ? d.id : ''
+    if (!id) continue
+    aufPi.add(id)
+    if (imPlan.has(id)) continue
+    verschwinden.push({
+      id,
+      name: typeof d.name === 'string' && d.name ? d.name : id,
+      hatVerdrahtung: PI_FELDER.some((f) => d[f] !== undefined && d[f] !== null),
+    })
+  }
+
+  return {
+    verschwinden,
+    neu: plan.filter((d) => !aufPi.has(d.id)).map((d) => d.id),
+    bleiben: plan.filter((d) => aufPi.has(d.id)).length,
+  }
+}

--- a/src/renderer/store/settingsStore.ts
+++ b/src/renderer/store/settingsStore.ts
@@ -95,6 +95,25 @@ interface PersistedSettings {
    * in ein Feld zu ziehen hiesse, das eine mit dem anderen zu ueberschreiben.
    */
   canvasMotion: boolean
+  /**
+   * B-6 / E-7 — Adresse des Tally-Pi (z. B. http://10.0.0.42:8080).
+   *
+   * Pro INSTALLATION, nicht pro Projekt — und das ist keine Formsache: eine
+   * `.avplan` wandert per Mail, liegt in Dropbox und geht in den Web-Viewer.
+   * Eine LAN-Adresse darin waere die Anlagenkarte eines fremden Hauses in
+   * einer Datei, die herumgereicht wird. Leerer String = kein Ziel.
+   */
+  tallyPiUrl: string
+  /**
+   * B-6 / E-7 — der Direktweg ist AUSDRUECKLICH EINZUSCHALTEN.
+   *
+   * Die Entscheidung sagt beides mit Rangfolge: „Die Datei bleibt der
+   * Vorgabeweg; der Direktweg kommt als ausdrücklich einzuschaltendes Ziel
+   * dazu." Deshalb `false` als Vorgabe. Ein Knopf, der ungefragt in ein Geraet
+   * im Produktionsnetz schreibt, waere genau das Gegenteil dessen, was hier
+   * entschieden wurde — und der Schreibvorgang loescht drueben Rollen.
+   */
+  tallyPiDirekt: boolean
 }
 
 const defaults: PersistedSettings = {
@@ -107,6 +126,8 @@ const defaults: PersistedSettings = {
   userSchema: {},
   netboxUrl: '',
   canvasMotion: true,
+  tallyPiUrl: '',
+  tallyPiDirekt: false,
 }
 
 const load = (): PersistedSettings => {
@@ -142,6 +163,13 @@ const load = (): PersistedSettings => {
       // erste: die Bewegung gab es vorher nicht.
       canvasMotion:
         typeof parsed.canvasMotion === 'boolean' ? parsed.canvasMotion : defaults.canvasMotion,
+      tallyPiUrl: typeof parsed.tallyPiUrl === 'string' ? parsed.tallyPiUrl : defaults.tallyPiUrl,
+      // Bestehende Installationen bekommen den Direktweg AUS — auch die, die
+      // eine Adresse eingetragen haetten. Ein gespeichertes Feld, das beim
+      // ersten Start nach dem Update auf AN steht, waere eine Entscheidung,
+      // die niemand getroffen hat, mit Wirkung auf ein Geraet im Netz.
+      tallyPiDirekt:
+        typeof parsed.tallyPiDirekt === 'boolean' ? parsed.tallyPiDirekt : defaults.tallyPiDirekt,
     }
   } catch {
     return defaults
@@ -168,6 +196,8 @@ const snapshot = (s: PersistedSettings): PersistedSettings => ({
   userSchema: s.userSchema,
   netboxUrl: s.netboxUrl,
   canvasMotion: s.canvasMotion,
+  tallyPiUrl: s.tallyPiUrl,
+  tallyPiDirekt: s.tallyPiDirekt,
 })
 
 interface SettingsState {
@@ -184,6 +214,8 @@ interface SettingsState {
   userSchema: UserSchemaMap
   netboxUrl: string
   canvasMotion: boolean
+  tallyPiUrl: string
+  tallyPiDirekt: boolean
   setHasToken: (value: boolean) => void
   setTokenStatus: (value: string) => void
   setAutosaveIntervalMs: (value: number) => void
@@ -202,6 +234,8 @@ interface SettingsState {
   setNetboxUrl: (value: string) => void
   /** Bewegte Darstellung im Canvas ein-/ausschalten. */
   setCanvasMotion: (value: boolean) => void
+  setTallyPiUrl: (value: string) => void
+  setTallyPiDirekt: (value: boolean) => void
 }
 
 const initial = load()
@@ -221,6 +255,8 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   canvasMotion: initial.canvasMotion,
   userSchema: initial.userSchema,
   netboxUrl: initial.netboxUrl,
+  tallyPiUrl: initial.tallyPiUrl,
+  tallyPiDirekt: initial.tallyPiDirekt,
   setHasToken: (value) => set({ hasToken: value }),
   setTokenStatus: (value) => set({ tokenStatus: value }),
   setAutosaveIntervalMs: (value) =>
@@ -248,6 +284,16 @@ export const useSettingsStore = create<SettingsState>((set) => ({
     set((state) => {
       persist(snapshot({ ...state, canvasMotion: value }))
       return { canvasMotion: value }
+    }),
+  setTallyPiUrl: (value) =>
+    set((state) => {
+      persist(snapshot({ ...state, tallyPiUrl: value }))
+      return { tallyPiUrl: value }
+    }),
+  setTallyPiDirekt: (value) =>
+    set((state) => {
+      persist(snapshot({ ...state, tallyPiDirekt: value }))
+      return { tallyPiDirekt: value }
     }),
   setModuleEnabled: (id, value) =>
     set((state) => {

--- a/tests/deviceReadSites.test.ts
+++ b/tests/deviceReadSites.test.ts
@@ -68,7 +68,7 @@ const RENDERER = resolve(__dirname, '..', 'src', 'renderer')
  * eine neue anlegt, muss sie einordnen — zwei Zeilen — statt sie stillschweigend
  * durchrutschen zu lassen.
  */
-const GERAETE_DOMAENEN = ['atem', 'videohub', 'switcher', 'netbox', 'rentman'] as const
+const GERAETE_DOMAENEN = ['atem', 'videohub', 'switcher', 'netbox', 'rentman', 'tally'] as const
 
 /**
  * Die uebrigen Domaenen — ausdruecklich KEINE Geraete-Wege.
@@ -194,6 +194,18 @@ const CLASSIFIED: Site[] = [
       'die Kreuzschiene ein Zustand, und zoege das Senden den Plan mit, gaebe ' +
       'es hinterher keine Abweichung mehr zu sehen (ADR-001). ' +
       '`tests/hubSwitch.test.ts` haelt das als negative Zusicherung fest.',
+  },
+  {
+    file: 'components/Export/ExportDialog.tsx',
+    verdict: 'getrennt',
+    reason:
+      'B-6 / E-7: `tally.read` holt die Geraeteliste, die GERADE auf dem Pi steht — ' +
+      'ausschliesslich, um zu zeigen, welche Rollen ein Schreibvorgang dort ' +
+      'loeschen wuerde. Der gelesene Stand liegt in `piGelesen` (Komponenten-' +
+      'Zustand) und wird nach dem Senden verworfen; kein Zweig schreibt ihn in ' +
+      'den Plan. Die Richtung ist ohnehin die umgekehrte: der Plan besitzt die ' +
+      'Rollenliste, der Pi die Verdrahtung. Ein Weg vom Pi IN den Plan waere ' +
+      'genau der Befund-als-Absicht, gegen den dieser Waechter steht.',
   },
   {
     file: 'components/Export/VideohubExportDialog.tsx',

--- a/tests/tallyDirektweg.test.ts
+++ b/tests/tallyDirektweg.test.ts
@@ -1,0 +1,181 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { pruefeZiel } from '../src/main/services/tallyPushService'
+import { vergleicheMitPi, type TallyPiDevice } from '../src/renderer/lib/tallyMap'
+
+/**
+ * B-6 / E-7 — DER DIREKTWEG ZUM TALLY-PI.
+ *
+ * Der Befund: `ExportDialog` erzeugte eine Download-Datei, die jemand von
+ * Hand nach `/opt/pi-guide/tally.json` kopiert — genau der Medienbruch, gegen
+ * den dieses Programm angetreten ist. E-7 sagt BEIDES mit Rangfolge: die
+ * Datei bleibt der Vorgabeweg, der Direktweg kommt als ausdruecklich
+ * einzuschaltendes Ziel dazu.
+ *
+ * Geprueft ist hier, was daran schiefgehen kann:
+ *
+ *  1. Die Adresse wird in MAIN geprueft, nicht im Renderer (Repo-Regel), und
+ *     `https://` bekommt eine Absage statt einer Zeitueberschreitung.
+ *  2. Der Schreibvorgang LOESCHT auf dem Pi jede Rolle, die der Plan nicht
+ *     nennt — samt ihrer GPIO-Zuordnung. Das muss man vorher sehen.
+ *  3. Der Weg ist aus, bis jemand ihn einschaltet, und die Datei bleibt.
+ */
+
+const lies = (p: string): string => readFileSync(join(__dirname, '..', p), 'utf8')
+
+describe('Die Adresse wird in main geprueft', () => {
+  it('nimmt eine gewoehnliche Pi-Adresse an', () => {
+    const r = pruefeZiel('http://10.0.0.42:8080')
+    expect(r.ok).toBe(true)
+  })
+
+  it('lehnt https ab und sagt warum', () => {
+    // `guide_server.py` bindet einen einfachen HTTPServer auf Port 8080. Wer
+    // `https://` eintraegt, bekaeme sonst eine Zeitueberschreitung ohne Grund
+    // und suchte den Fehler im Netz.
+    const r = pruefeZiel('https://10.0.0.42:8080')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toContain('http://')
+  })
+
+  it('lehnt file: ab', () => {
+    // Eine Adresse, die zum Dateisystem zeigt, ist kein Tally-Pi. Ohne diese
+    // Absage waere die Adresse ein Pfad, und der Pfad kaeme aus dem Renderer.
+    expect(pruefeZiel('file:///etc/passwd').ok).toBe(false)
+  })
+
+  it('lehnt Leeres und Unsinn ab, mit Grund', () => {
+    for (const roh of ['', '   ', 'nicht mal eine URL']) {
+      const r = pruefeZiel(roh)
+      expect(r.ok).toBe(false)
+      if (!r.ok) expect(r.error.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('Was der Schreibvorgang auf dem Pi anrichtet, steht vorher da', () => {
+  const plan: TallyPiDevice[] = [
+    { id: 'cam1', name: 'Kamera 1', input: 1 },
+    { id: 'cam2', name: 'Kamera 2', input: 2 },
+  ]
+
+  it('nennt die Rollen, die verschwinden', () => {
+    const pi = { devices: [{ id: 'cam1', name: 'Kamera 1' }, { id: 'alt', name: 'Alte Rolle' }] }
+    const v = vergleicheMitPi(pi, plan)
+    expect(v.verschwinden.map((x) => x.id)).toEqual(['alt'])
+    expect(v.neu).toEqual(['cam2'])
+    expect(v.bleiben).toBe(1)
+  })
+
+  it('unterscheidet, ob an der verschwindenden Rolle eine Lampe haengt', () => {
+    // Der Unterschied kostet verschieden viel: ein Eintrag ist schnell wieder
+    // eingetragen, eine GPIO-Zuordnung ist Verkabelung, die jemand am Gehaeuse
+    // gemacht hat.
+    const pi = {
+      devices: [
+        { id: 'ohne', name: 'Ohne Pin' },
+        { id: 'mit', name: 'Mit Pin', out_gpio: 17 },
+      ],
+    }
+    const v = vergleicheMitPi(pi, plan)
+    expect(v.verschwinden.find((x) => x.id === 'ohne')?.hatVerdrahtung).toBe(false)
+    expect(v.verschwinden.find((x) => x.id === 'mit')?.hatVerdrahtung).toBe(true)
+  })
+
+  it('zaehlt auch eine Null-Zuordnung als Verdrahtung nicht mit', () => {
+    // `out_gpio: null` heisst „ausdruecklich keiner". Es als Verdrahtung zu
+    // zaehlen faerbte die Warnung rot, wo nichts zu verlieren ist — und eine
+    // Warnung, die zu oft rot ist, wird nicht mehr gelesen.
+    const v = vergleicheMitPi({ devices: [{ id: 'x', name: 'X', out_gpio: null }] }, plan)
+    expect(v.verschwinden[0]?.hatVerdrahtung).toBe(false)
+  })
+
+  it('macht aus einer unbrauchbaren Antwort keinen Fehler, sondern eine leere Liste', () => {
+    // „Der Pi hat noch nichts" und „der Pi hat anders geantwortet" fuehren
+    // beide dazu, dass nichts verschwindet — und genau das ist die Auskunft,
+    // auf die es hier ankommt.
+    // `{ devices: 7 }` steht hier NICHT zur Zierde: es ist der einzige Fall,
+    // der eine fehlende `Array.isArray`-Pruefung zum Werfen bringt. Ohne ihn
+    // blieb diese Regel gruen, wenn man die Pruefung entfernte — eine
+    // Zeichenkette laesst sich durchlaufen, eine Zahl nicht. Gegengeprobt.
+    for (const roh of [null, undefined, {}, { devices: 'nein' }, { devices: 7 }, { devices: [null, 7, {}] }]) {
+      const v = vergleicheMitPi(roh, plan)
+      expect(v.verschwinden).toEqual([])
+      expect(v.neu).toEqual(['cam1', 'cam2'])
+    }
+  })
+})
+
+describe('Der Weg ist aus, bis jemand ihn einschaltet — und die Datei bleibt', () => {
+  it('die Vorgabe ist AUS', () => {
+    const store = lies('src/renderer/store/settingsStore.ts')
+    expect(store).toContain('tallyPiDirekt: false')
+  })
+
+  it('eine bestehende Installation bekommt ihn nicht ungefragt an', () => {
+    // Ein gespeichertes Feld, das nach dem Update auf AN steht, waere eine
+    // Entscheidung, die niemand getroffen hat — mit Wirkung auf ein Geraet im
+    // Netz.
+    const store = lies('src/renderer/store/settingsStore.ts')
+    const stelle = store.slice(store.indexOf('tallyPiDirekt:\n'))
+    expect(store).toMatch(/tallyPiDirekt:\s*\n?\s*typeof parsed\.tallyPiDirekt === 'boolean'/)
+    expect(stelle.slice(0, 200)).toContain('defaults.tallyPiDirekt')
+  })
+
+  it('der Download-Knopf steht weiter da', () => {
+    // E-7: „Die Datei bleibt der Vorgabeweg." Sie ist ausserdem der einzige
+    // Weg, der ohne Netz zum Pi funktioniert.
+    const dialog = lies('src/renderer/components/Export/ExportDialog.tsx')
+    expect(dialog).toContain('onClick={downloadTallyPi}')
+  })
+
+  it('der Sendeknopf ist zu, solange niemand gelesen hat', () => {
+    const dialog = lies('src/renderer/components/Export/ExportDialog.tsx')
+    const stelle = dialog.slice(dialog.indexOf('onClick={piSenden}'))
+    expect(stelle.slice(0, 600)).toContain('piGelesen === null')
+    // Und der gelesene Stand muss zu DIESER Adresse gehoeren: wer sie nach
+    // dem Lesen aendert, hat den Stand eines anderen Pi gesehen.
+    expect(stelle.slice(0, 600)).toContain('piGelesen.adresse !== piUrl')
+  })
+})
+
+describe('Kein Token, wo keiner geprueft wird', () => {
+  it('schickt keinen Nachweis-Kopf mit', () => {
+    // `guide_server.py` prueft an seinen Schreib-Endpunkten nichts. Einen Kopf
+    // mitzuschicken, den niemand liest, waere die schlechteste Antwort: das
+    // Feld im Dialog behauptete einen Schutz, den es nicht gibt.
+    const dienst = lies('src/main/services/tallyPushService.ts')
+    // GEMESSEN WIRD DER CODE, NICHT DER TEXT. Die erste Fassung dieser Regel
+    // suchte „Authorization" in der ganzen Datei — und wurde rot an dem
+    // Kommentar, der ERKLAERT, dass kein solcher Kopf geschickt wird. Ein
+    // Waechter, der die Begruendung fuer den Verstoss haelt, zwingt dazu, die
+    // Begruendung zu loeschen. Also: Kommentare raus, dann messen.
+    const ohneKommentar = dienst
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('\n')
+      .filter((z) => !z.trim().startsWith('//'))
+      .join('\n')
+    expect(ohneKommentar).not.toMatch(/Authorization|X-Token|X-Tally-Token|token/i)
+    // Und der Grund steht in der Datei, statt dass jemand ihn spaeter
+    // „nachruestet", ohne zu wissen, dass niemand ihn prueft.
+    expect(dienst).toContain('KEIN TOKEN')
+  })
+
+  it('sagt es dem Nutzer an der Stelle, wo er das Ziel eintraegt', () => {
+    const tab = lies('src/renderer/components/Settings/tabs/IntegrationsTab.tsx')
+    expect(tab).toContain('settings.integrations.tallyPi.noToken')
+  })
+})
+
+describe('Geschickt wird nur die Rollenliste', () => {
+  it('der Post traegt `devices` und sonst nichts', () => {
+    // `merge_tally_config` drueben behaelt jedes Feld, das der Post nicht
+    // nennt — ATEM-Adresse und GPIO-Verdrahtung. Wer hier ein zweites Feld
+    // mitschickt, loescht auf dem Pi das, was er dabei weglaesst.
+    const dienst = lies('src/main/services/tallyPushService.ts')
+    const stelle = dienst.slice(dienst.indexOf('export const schreiben'))
+    expect(stelle).toContain("anfrage(new URL('/tally-config', ziel.url), 'POST', { devices })")
+    expect(stelle).not.toMatch(/atem_ip|out_gpio/)
+  })
+})


### PR DESCRIPTION
Der Befund, gegen den das steht: `ExportDialog` erzeugte eine Download-Datei, die jemand von Hand nach `/opt/pi-guide/tally.json` kopiert. Genau der Medienbruch, gegen den dieses Programm angetreten ist.

E-7 sagt beides mit Rangfolge — die Datei bleibt der Vorgabeweg, der Direktweg kommt als **ausdrücklich einzuschaltendes** Ziel dazu. Beides ist so gebaut.

## Was gebaut wurde

* **`tally:*` als eigene IPC-Domäne** (`main/services/tallyPushService.ts` + `main/ipc/tallyIpc.ts`), im **Main-Prozess**. `guide_server.py` schickt keine CORS-Kopfzeilen; ein `fetch` aus dem Renderer scheiterte am Preflight oder wäre — mit `no-cors` — abgeschickt, aber unlesbar. Ein Schreibvorgang, dessen Ergebnis man nicht erfährt, ist **schlimmer als keiner**: der Nutzer glaubt, die Karte sei auf dem Pi. Im Browser wird deshalb gar nicht erst gesendet, sondern geantwortet.
* **Die Adresse wird in main geprüft**, wie es die Repo-Regel verlangt. `https://` bekommt eine Absage statt einer Zeitüberschreitung ohne Grund — der Pi bindet einen einfachen HTTPServer auf 8080.
* **Erst lesen, dann senden — erzwungen, nicht empfohlen.** `merge_tally_config` drüben behält jedes *Feld*, das der Post nicht nennt (ATEM-Adresse, GPIO-Pins), aber jedes *Gerät*, das er nicht nennt, verschwindet. `vergleicheMitPi` zeigt vorher, wer verschwindet, und unterscheidet die Rolle **mit** Pin (rot — das ist Verkabelung, die jemand am Gehäuse gemacht hat) von der ohne (gelb). Der Sendeknopf bleibt zu, bis für *diese* Adresse gelesen wurde.
* **Geschickt wird nur `devices`.** Wer hier ein zweites Feld mitschickt, löscht auf dem Pi das, was er dabei weglässt.
* **Der Weg ist AUS, bis jemand ihn einschaltet** — auch für bestehende Installationen mit hinterlegter Adresse. Ein Feld, das nach dem Update auf AN steht, wäre eine Entscheidung, die niemand getroffen hat, mit Wirkung auf ein Gerät im Netz.

## Kein Token — die eine Stelle, an der das DoD absichtlich nicht erfüllt ist

Nachgesehen: `guide_server.py` prüft an seinen Schreib-Endpunkten **nichts** — kein `Authorization`, kein eigener Kopf, an keinem — und seine eigene Bedienseite (`setup-guide.html`, statisch vom selben Server) schreibt über dieselben offenen Wege.

Einen Kopf mitzuschicken, den niemand prüft, wäre die schlechteste der möglichen Antworten: das Feld im Dialog behauptete einen Schutz, den es nicht gibt, und wer es ausfüllt, hielte den Weg für gesichert. Ein Wächter hält fest, dass der Dienst keinen schickt; die Einstellungs-Karte **sagt dem Nutzer**, dass der Pi keinen verlangt. Der Schutz des Pi ist als **B-58** im Suite-Backlog vermerkt — er ist eine Entscheidung über seine ganze HTTP-Fläche, nicht über diesen einen Aufruf.

## Zwei Wächter haben zugeschlagen, beide zu Recht

* `deviceReadSites` verlangte die Einordnung der neuen Brücken-Domäne — `getrennt`: der gelesene Pi-Stand liegt im Komponenten-Zustand und erreicht den Plan nirgends.
* `hinweisLaenge` verlangte den `PanelHint` für den langen Absatz.

## Gegengeprobt (7)

`https://` durchgelassen · `out_gpio: null` als Verdrahtung gezählt · `Array.isArray` entfernt · Direktweg als Vorgabe AN · Senden ohne Lesen frei · der Post trägt ein zweites Feld · ein Nachweis-Kopf wird mitgeschickt.

Die dritte Regel war zuerst **unverdient**: nur `{ devices: 7 }` bringt die fehlende Prüfung zum Werfen, eine Zeichenkette lässt sich durchlaufen. Der Fall steht jetzt im Test, mit dem Grund daneben.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_