### PR TITLE
circuit: nachgerechnete Verdrahtungs-Vorschläge (#666)

### DIFF
--- a/src/renderer/components/Canvas/CircuitChip.tsx
+++ b/src/renderer/components/Canvas/CircuitChip.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react'
 import { useUiStore } from '../../store/uiStore'
 import { useCircuitStore } from '../../store/circuitStore'
 import { useCircuitOverview } from '../../hooks/useCircuit'
 import { useTranslation } from '../../lib/i18n'
+import { CircuitSuggestDialog } from './CircuitSuggestDialog'
 
 /**
  * Das Schaltbild — an oder aus, und was es gerade sagt.
@@ -24,6 +26,7 @@ export function CircuitChip() {
   const setAn = useUiStore((s) => s.setCircuitOverlay)
   const zuruecksetzen = useCircuitStore((s) => s.zuruecksetzen)
   const { brennen, leuchten, ohneBauart, knoten } = useCircuitOverview()
+  const [vorschlaegeOffen, setVorschlaegeOffen] = useState(false)
 
   const titel = !an
     ? t(
@@ -80,6 +83,20 @@ export function CircuitChip() {
           {t('canvas.circuit.reset', 'Schalter zurück')}
         </button>
       )}
+      {an && knoten > 0 && (
+        <button
+          type="button"
+          onClick={() => setVorschlaegeOffen(true)}
+          title={t(
+            'canvas.circuit.suggestTitle',
+            'Warum tut die Schaltung nicht, was sie soll — und welche Ader würde es ändern. Jeder Vorschlag ist durchgerechnet und bringt seine Wahrheitstafel mit; eingetragen wird nur auf Knopfdruck.',
+          )}
+          className="av-focus rounded-full border border-cp-border px-2 py-0.5 text-[11px] text-cp-text-secondary hover:bg-cp-surface-3"
+        >
+          {t('canvas.circuit.suggest', 'Vorschläge')}
+        </button>
+      )}
+      <CircuitSuggestDialog open={vorschlaegeOffen} onClose={() => setVorschlaegeOffen(false)} />
     </span>
   )
 }

--- a/src/renderer/components/Canvas/CircuitSuggestDialog.tsx
+++ b/src/renderer/components/Canvas/CircuitSuggestDialog.tsx
@@ -1,0 +1,226 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Die Verdrahtungs-Vorschläge, sichtbar (#666).
+//
+// Der Rechner dahinter (`lib/circuitSuggest.ts`) und die Rückübersetzung in
+// Geräte und Anschlüsse (`lib/circuitSuggestPlan.ts`) sind rein und geprüft.
+// Diese Datei ist ihre Oberfläche — und sie ist der Ort, an dem die drei
+// Zusagen jener Module beim Nutzer ankommen oder verloren gehen:
+//
+//   1. Der Vorschlag ist NACHGERECHNET. Deshalb steht seine Wahrheitstafel
+//      daneben, aufklappbar, Stellung für Stellung. Wer die Ader einträgt,
+//      kann vorher nachsehen, statt zu vertrauen.
+//   2. Die ANNAHMEN stehen sichtbar oben und nicht im Kleingedruckten. „Alle
+//      Einspeisungen führen Spannung" ist eine Voraussetzung der ganzen
+//      Rechnung; wer sie nicht liest, hält das Ergebnis für eine Messung.
+//   3. Was sich NICHT eintragen lässt, steht trotzdem da — mit dem Grund und
+//      der fehlenden Klemme. Ein verschluckter Vorschlag liest sich wie
+//      „alles in Ordnung".
+//
+// EINGETRAGEN WIRD NUR AUF KNOPFDRUCK, und immer der ganze Vorschlag. Ein
+// halb eingetragener Zwei-Adern-Vorschlag wäre schlimmer als gar keiner: er
+// sieht danach aus wie fertig.
+// ───────────────────────────────────────────────────────────────────────────
+import { useMemo, useState } from 'react'
+import { useCanvasProjectStore as useProjectStore } from '../../store/projectStoreContext'
+import { useCircuitStore } from '../../store/circuitStore'
+import { useDialogA11y } from '../../hooks/useDialogA11y'
+import { useBackdropClose } from '../../hooks/useBackdropClose'
+import { useTranslation } from '../../lib/i18n'
+import { PanelHint } from '../shared/PanelHint'
+import { planVorschlaege, type PlanVorschlag } from '../../lib/circuitSuggestPlan'
+import type { TafelZeile } from '../../lib/circuitSuggest'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+}
+
+const Tafel = ({ zeilen }: { zeilen: readonly TafelZeile[] }) => {
+  const schalter = Object.keys(zeilen[0]?.stellungen ?? {})
+  if (schalter.length === 0) return null
+  return (
+    <div className="mt-1 overflow-x-auto">
+      <table className="text-[11px] tabular-nums">
+        <thead>
+          <tr className="text-cp-text-muted">
+            {schalter.map((id) => (
+              <th key={id} className="px-2 py-0.5 text-left font-normal">
+                {id}
+              </th>
+            ))}
+            <th className="px-2 py-0.5 text-left font-normal">Leuchte</th>
+          </tr>
+        </thead>
+        <tbody>
+          {zeilen.map((z, i) => (
+            <tr key={i} className="border-t border-cp-border-muted">
+              {schalter.map((id) => (
+                <td key={id} className="px-2 py-0.5">
+                  {z.stellungen[id]}
+                </td>
+              ))}
+              <td className={`px-2 py-0.5 ${z.an ? 'text-cp-accent' : 'text-cp-text-muted'}`}>
+                {z.an ? 'an' : 'aus'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export function CircuitSuggestDialog({ open, onClose }: Props) {
+  const t = useTranslation()
+  const project = useProjectStore((s) => s.project)
+  const addCablesBulk = useProjectStore((s) => s.addCablesBulk)
+  const sim = useCircuitStore((s) => s.sim)
+  const [offen, setOffen] = useState<number | null>(null)
+  const [meldung, setMeldung] = useState<string>('')
+
+  const { panelRef, titleId, dialogProps } = useDialogA11y(open, onClose)
+  const backdrop = useBackdropClose(onClose)
+
+  // Gerechnet wird nur, solange der Dialog offen ist. Die Suche probiert
+  // Kombinationen durch; sie bei jedem Zeichenlauf des Canvas mitlaufen zu
+  // lassen waere ein Preis fuer eine Auskunft, die niemand sehen will.
+  const ergebnis = useMemo(
+    () => (open ? planVorschlaege(project, sim) : null),
+    [open, project, sim],
+  )
+
+  if (!open || !ergebnis) return null
+
+  const eintragen = (v: PlanVorschlag) => {
+    const stat = addCablesBulk(
+      v.kanten.map((k) => ({
+        name: t('canvas.circuit.suggest.cableName', 'Ader (Vorschlag)'),
+        type: k.steckertyp,
+        length: 0,
+        color: '#94a3b8',
+        notes: t(
+          'canvas.circuit.suggest.cableNote',
+          'Aus einem nachgerechneten Verdrahtungs-Vorschlag eingetragen.',
+        ),
+        fromEquipmentId: k.fromEquipmentId,
+        fromPortId: k.fromPortId,
+        toEquipmentId: k.toEquipmentId,
+        toPortId: k.toPortId,
+      })),
+    )
+    setMeldung(
+      stat.skipped === 0
+        ? t('canvas.circuit.suggest.done', '{n} Ader(n) eingetragen.').replace(
+            '{n}',
+            String(stat.created),
+          )
+        : `${stat.created} eingetragen, ${stat.skipped} übersprungen: ${stat.skippedReasons.join(' ')}`,
+    )
+  }
+
+  const { befunde, vorschlaege, annahmen, vollstaendig, grund } = ergebnis
+
+  return (
+    <div
+      {...backdrop}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+    >
+      <div
+        ref={panelRef}
+        aria-labelledby={titleId}
+        {...dialogProps}
+        className="flex max-h-[85vh] w-full max-w-[720px] flex-col rounded border border-cp-border bg-cp-surface-1 text-cp-text shadow-2xl"
+      >
+        <header className="flex items-center justify-between border-b border-cp-border px-4 py-2">
+          <h2 id={titleId} className="text-cp-lg font-semibold">
+            {t('canvas.circuit.suggest.title', 'Verdrahtungs-Vorschläge')}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="av-focus rounded bg-cp-surface-3 px-3 py-1 text-cp-xs hover:bg-cp-surface-2"
+          >
+            {t('common.close', 'Schließen')}
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto px-4 py-3 text-cp-sm">
+          <PanelHint
+            text={t(
+              'canvas.circuit.suggest.lead',
+              'GERECHNET, nicht gemessen. Jeder Vorschlag ist durchprobiert worden: er steht hier nur, weil die Schaltung mit ihm in jeder Schalterstellung tut, was sie soll. Die Tafel daneben zeigt es.',
+            )}
+          />
+
+          {annahmen.length > 0 && (
+            <ul className="mb-3 list-disc pl-5 text-[12px] text-cp-text-muted">
+              {annahmen.map((a) => (
+                <li key={a}>{a}</li>
+              ))}
+            </ul>
+          )}
+
+          {befunde.length === 0 && vorschlaege.length === 0 && (
+            <p className="text-cp-text-secondary">
+              {t('canvas.circuit.suggest.nothing', 'Nichts zu beanstanden.')}
+            </p>
+          )}
+
+          {befunde.length > 0 && (
+            <ul className="mb-4 space-y-1">
+              {befunde.map((b, i) => (
+                <li key={i} className="rounded border border-cp-warn/40 bg-cp-surface-2 px-3 py-2">
+                  <span className="text-cp-warn">{b.art}</span>
+                  <span className="text-cp-text-secondary"> — {b.text}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {!vollstaendig && grund && (
+            <p className="mb-4 rounded border border-cp-border bg-cp-surface-2 px-3 py-2 text-[12px] text-cp-text-secondary">
+              {t('canvas.circuit.suggest.capped', 'Die Suche wurde begrenzt: ')}
+              {grund}
+            </p>
+          )}
+
+          {vorschlaege.map((v, i) => (
+            <div key={i} className="mb-2 rounded border border-cp-border px-3 py-2">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <span>{v.text}</span>
+                {v.hindernis === undefined ? (
+                  <button
+                    type="button"
+                    onClick={() => eintragen(v)}
+                    className="av-focus rounded bg-cp-accent px-3 py-1 text-cp-xs text-cp-bg"
+                  >
+                    {t('canvas.circuit.suggest.apply', 'Ader eintragen')}
+                  </button>
+                ) : (
+                  <span className="text-[11px] text-cp-warn">
+                    {t('canvas.circuit.suggest.blocked', 'nicht eintragbar')}
+                  </span>
+                )}
+              </div>
+              {v.hindernis && (
+                <p className="mt-1 text-[12px] text-cp-text-secondary">{v.hindernis}</p>
+              )}
+              <button
+                type="button"
+                onClick={() => setOffen(offen === i ? null : i)}
+                className="av-focus mt-1 text-[11px] text-cp-text-muted underline"
+              >
+                {offen === i
+                  ? t('canvas.circuit.suggest.hideTable', 'Wahrheitstafel ausblenden')
+                  : t('canvas.circuit.suggest.showTable', 'Wahrheitstafel zeigen')}
+              </button>
+              {offen === i && <Tafel zeilen={v.wahrheitstafel} />}
+            </div>
+          ))}
+
+          {meldung && <p className="mt-3 text-[12px] text-cp-accent">{meldung}</p>}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/lib/circuitSuggest.ts
+++ b/src/renderer/lib/circuitSuggest.ts
@@ -1,0 +1,566 @@
+// ───────────────────────────────────────────────────────────────────────────
+// „Automatische Vorschläge machen etc" (#666, dritter Satz).
+//
+// #666 hat drei Sätze. Zwei sind gebaut: Schaltungen mit Prüfung
+// (`circuitSolver`) und die Leuchte, die auf dem Plan bei richtiger Verkabelung
+// angeht. Der dritte war offen — und er ist der heikelste, weil ein Vorschlag
+// zur Verkabelung einer Leuchte wie eine Auskunft aussieht.
+//
+// ═══════════════════════════════════════════════════════════════════════════
+// JEDER VORSCHLAG IST NACHGERECHNET, KEINER IST GERATEN
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Dieses Modul rät nicht, welche Klemme wohin gehört. Es SUCHT: es probiert
+// fehlende Verbindungen durch, lässt `solveCircuit` über alle Schalterstellungen
+// laufen und behält nur, was die Schaltung danach wirklich in Ordnung bringt.
+// Ein Vorschlag, der die Prüfung nicht besteht, wird nicht ausgegeben — es gibt
+// hier keinen Zweig, der eine Verkabelung „nach Erfahrung" empfiehlt.
+//
+// Und jeder Vorschlag bringt seinen Beleg mit: die Wahrheitstafel der Leuchte
+// nach der Änderung, Stellung für Stellung. Wer den Vorschlag übernimmt, kann
+// vorher nachsehen, statt zu vertrauen. Ohne die Tafel wäre das Ergebnis ein
+// Ratschlag; mit ihr ist es ein Nachweis.
+//
+// ═══════════════════════════════════════════════════════════════════════════
+// WAS „IN ORDNUNG" HEISST — UND WARUM „SIE BRENNT" NICHT REICHT
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Die naheliegende Prüfung wäre SCHALTBAR: einmal an, einmal aus. Sie ist zu
+// schwach, und zwar an genau der Stelle, um die es in #666 geht. Eine
+// Wechselschaltung, der die zweite Korrespondierende fehlt, ist schaltbar — sie
+// brennt, wenn beide Schalter auf 1 stehen, und sonst nicht. Im Schaltbild
+// sieht das richtig aus; im Flur tut der zweite Schalter nichts, sobald der
+// erste unten steht.
+//
+// Geprüft wird deshalb die Eigenschaft, die eine Wechselschaltung ausmacht:
+// **jeder Bedienschalter muss die Leuchte in JEDER Stellung der anderen
+// umschalten.** Für einen einzelnen Aus-Schalter ist das dasselbe wie
+// „schaltbar"; für Wechsel- und Kreuzschaltung ist es der Unterschied zwischen
+// „geht" und „geht meistens".
+//
+// ═══════════════════════════════════════════════════════════════════════════
+// WAS DAS MODUL NICHT TUT
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Es ÜBERNIMMT NICHTS. Die Funktion ist rein und gibt Vorschläge zurück; das
+// Eintragen ist ein Griff des Nutzers. Eine Automatik, die selbst verdrahtet,
+// hätte genau die Eigenschaft, die dieser Plan nirgends haben soll: sie sähe
+// hinterher aus wie eine Angabe des Planers.
+//
+// Es NIMMT AUCH NICHTS WEG. Die Suche legt nur Adern dazu. Es gibt deshalb
+// Defekte, für die sie richtigerweise keinen Vorschlag hat — eine Leuchte, die
+// in jeder Stellung brennt, wird von keiner zusätzlichen Ader dunkler. Dass es
+// dafür keinen Vorschlag gibt, wird gesagt, statt als „nichts gefunden"
+// auszugehen.
+//
+// Es rechnet WEITER KEINE Elektrotechnik. `circuitSolver` sagt in seiner
+// eigenen Kopfzeile, dass er ein Schaltbild-Rechner ist und kein
+// Sicherheitsnachweis; dieses Modul erbt das vollständig. Ein Vorschlag heisst
+// „so brennt die Lampe bei der richtigen Stellung" und nicht „so darf gebaut
+// werden".
+//
+// ═══════════════════════════════════════════════════════════════════════════
+// KEINE STILLEN GRENZEN
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Die Suche ist begrenzt — sie muss es sein, sie probiert Kombinationen durch.
+// Wo sie an eine Grenze stösst, sagt das Ergebnis es (`vollstaendig: false` mit
+// Grund). Eine gekappte Suche, die wie eine erschöpfende aussieht, ist die
+// schlechtere Hälfte von „keine Vorschläge gefunden": der Nutzer schliesst
+// daraus, dass es keine Lösung gibt.
+// ───────────────────────────────────────────────────────────────────────────
+import {
+  solveCircuit,
+  type CircuitEdge,
+  type CircuitKind,
+  type CircuitNode,
+} from './circuitSolver'
+import { CIRCUIT_KIND_INFO } from '../types/circuit'
+
+/**
+ * Bauarten, die ein Mensch im Betrieb bedient — und deren Wirkung deshalb
+ * geprüft wird.
+ *
+ * Die fünf anderen Kontakte aus B-52 Teil 2 (FI, LS, Not-Aus, Schütz, Relais)
+ * stehen NICHT hier. Sie sind Betriebsmittel: dass die Leuchte nicht angeht,
+ * wenn der LS ausgelöst hat, ist kein Verdrahtungsfehler. Sie werden für die
+ * Prüfung LEITEND angenommen, und diese Annahme steht im Ergebnis, statt still
+ * eingebaut zu sein — sonst meldete ein Kreis mit ausgelöstem FI jede
+ * Verdrahtung als falsch.
+ */
+const BEDIENSCHALTER: ReadonlySet<CircuitKind> = new Set<CircuitKind>([
+  'switch',
+  'changeover',
+  'crossover',
+  'button',
+])
+
+/** Betriebsmittel: leitend angenommen, nicht durchgespielt. */
+const BETRIEBSMITTEL: ReadonlySet<CircuitKind> = new Set<CircuitKind>([
+  'contactor',
+  'relay',
+  'emergencyStop',
+  'rcd',
+  'mcb',
+])
+
+/** Die zwei Stellungen je Bedienschalter. */
+const STELLUNGEN: Readonly<Record<string, readonly [number, number]>> = {
+  switch: [1, 0],
+  button: [1, 0],
+  changeover: [1, 2],
+  crossover: [1, 2],
+}
+
+/** Bauarten ohne feste Klemmenzahl — ihre Klemmen entstehen aus den Kanten. */
+const KLEMMSTELLEN: ReadonlySet<CircuitKind> = new Set<CircuitKind>(['junction', 'distro'])
+
+/**
+ * Welche Klemmen eine Bauart hat.
+ *
+ * Gelesen aus `CIRCUIT_KIND_INFO` und NICHT hier ein zweites Mal
+ * aufgeschrieben. Eine eigene Klemmen-Tabelle wäre die zweite Wahrheit, gegen
+ * die ADR-001 geschrieben ist — und sie wäre besonders leise falsch: ein
+ * Vorschlag auf eine Klemme, die es an dieser Bauart gar nicht gibt, sähe im
+ * Ergebnis aus wie jeder andere.
+ */
+const klemmenVon = (kind: CircuitKind): readonly number[] => CIRCUIT_KIND_INFO[kind].klemmen
+
+/** Grenzen der Suche. Werden sie überschritten, wird es GESAGT. */
+export const GRENZEN = {
+  /** Höchstzahl durchgespielter Stellungs-Kombinationen. */
+  stellungen: 256,
+  /** Höchstzahl freier Klemmen, aus denen Kandidaten gebildet werden. */
+  klemmen: 40,
+  /** Höchstzahl geprüfter Zwei-Adern-Kombinationen. */
+  paare: 20_000,
+} as const
+
+export type BefundArt =
+  | 'keine-einspeisung'
+  | 'keine-spannung'
+  | 'keine-leuchte'
+  | 'mehrere-leuchten'
+  | 'leuchte-ohne-anschluss'
+  | 'ohne-schalter'
+  | 'nie-an'
+  | 'immer-an'
+  | 'schalter-ohne-wirkung'
+
+export interface Befund {
+  art: BefundArt
+  /** Betroffene Leuchte, wo der Befund eine betrifft. */
+  lampeId?: string
+  /** Betroffener Schalter, bei `schalter-ohne-wirkung`. */
+  knotenId?: string
+  text: string
+}
+
+/** Eine Ader, die der Vorschlag legen würde. */
+export interface VorschlagsKante {
+  fromNode: string
+  fromTerminal: number
+  toNode: string
+  toTerminal: number
+}
+
+/** Eine Zeile der Wahrheitstafel: Stellungen → brennt die Leuchte? */
+export interface TafelZeile {
+  /** Knoten-Id → Stellung. */
+  stellungen: Readonly<Record<string, number>>
+  an: boolean
+}
+
+export interface Vorschlag {
+  kanten: VorschlagsKante[]
+  text: string
+  /** Der Beleg. Ohne ihn wäre der Vorschlag ein Ratschlag. */
+  wahrheitstafel: TafelZeile[]
+}
+
+export interface VorschlagsErgebnis {
+  befunde: Befund[]
+  vorschlaege: Vorschlag[]
+  /** War die Suche erschöpfend? */
+  vollstaendig: boolean
+  /** Warum nicht, falls nicht. */
+  grund?: string
+  /** Annahmen, unter denen gerechnet wurde — immer sichtbar, nie stillschweigend. */
+  annahmen: string[]
+}
+
+const schluessel = (node: string, terminal: number) => `${node}#${terminal}`
+
+/** Alle belegten Klemmen aus den vorhandenen Kanten. */
+const belegteKlemmen = (edges: readonly CircuitEdge[]): Set<string> => {
+  const s = new Set<string>()
+  for (const e of edges) {
+    s.add(schluessel(e.fromNode, e.fromTerminal ?? 0))
+    s.add(schluessel(e.toNode, e.toTerminal ?? 0))
+  }
+  return s
+}
+
+/** Die höchste an einem Knoten benutzte Klemmennummer, oder -1. */
+const hoechsteKlemme = (edges: readonly CircuitEdge[], nodeId: string): number => {
+  let max = -1
+  for (const e of edges) {
+    if (e.fromNode === nodeId) max = Math.max(max, e.fromTerminal ?? 0)
+    if (e.toNode === nodeId) max = Math.max(max, e.toTerminal ?? 0)
+  }
+  return max
+}
+
+/**
+ * Die Klemmen, an denen ein Vorschlag ansetzen darf.
+ *
+ * BELEGTE KLEMMEN BLEIBEN DRAUSSEN. Ein Vorschlag, der eine zweite Ader auf
+ * eine schon belegte Schalterklemme legt, mag rechnerisch ein Ergebnis liefern
+ * — auf der Klemme ist dafür kein Platz, und ein Vorschlag, den man nicht bauen
+ * kann, ist schlimmer als keiner.
+ *
+ * Klemmstellen bekommen GENAU EINE frische Klemme.
+ *
+ * Zwei standen hier zwischendurch, mit der Begründung, an einer Dose dürften
+ * zwei neue Adern zusammenkommen. Das stimmt — nur ändert es an dieser Suche
+ * nichts, und die Gegenprobe hat es gezeigt: mit einer statt zwei Klemmen blieb
+ * jeder Test grün. Der Grund ist die Suchtiefe. Wer zwei neue Adern an
+ * DERSELBEN Dose braucht, verbindet damit zwei Klemmen, die sich genauso
+ * direkt verbinden lassen — und dieser direkte Kandidat steht ohnehin in der
+ * Liste. Nötig wäre die zweite Klemme erst bei drei Adern, und so tief sucht
+ * hier nichts.
+ *
+ * Sie steht deshalb nicht mehr da. Eine Regel, die keine Gegenprobe rot
+ * bekommt, ist keine Regel, sondern eine Vermutung mit Codegewicht.
+ */
+const freieKlemmen = (
+  nodes: readonly CircuitNode[],
+  edges: readonly CircuitEdge[],
+): { nodeId: string; terminal: number }[] => {
+  const belegt = belegteKlemmen(edges)
+  const frei: { nodeId: string; terminal: number }[] = []
+  for (const n of nodes) {
+    if (KLEMMSTELLEN.has(n.kind)) {
+      frei.push({ nodeId: n.id, terminal: hoechsteKlemme(edges, n.id) + 1 })
+      continue
+    }
+    for (const t of klemmenVon(n.kind)) {
+      if (!belegt.has(schluessel(n.id, t))) frei.push({ nodeId: n.id, terminal: t })
+    }
+  }
+  return frei
+}
+
+/** Die Bedienschalter des Kreises, in Reihenfolge der Knotenliste. */
+const bedienschalter = (nodes: readonly CircuitNode[]): CircuitNode[] =>
+  nodes.filter((n) => BEDIENSCHALTER.has(n.kind))
+
+/**
+ * Alle Stellungs-Kombinationen der Bedienschalter.
+ *
+ * Gekappt bei `GRENZEN.stellungen`; der Aufrufer erfährt es über
+ * `vollstaendig: false`, statt eine halbe Tafel für eine ganze zu halten.
+ */
+const stellungsKombinationen = (
+  schalter: readonly CircuitNode[],
+): { kombinationen: Record<string, number>[]; gekappt: boolean } => {
+  let kombinationen: Record<string, number>[] = [{}]
+  for (const s of schalter) {
+    const moeglich = STELLUNGEN[s.kind]
+    const naechste: Record<string, number>[] = []
+    for (const bisher of kombinationen) {
+      for (const p of moeglich) naechste.push({ ...bisher, [s.id]: p })
+    }
+    if (naechste.length > GRENZEN.stellungen) return { kombinationen, gekappt: true }
+    kombinationen = naechste
+  }
+  return { kombinationen, gekappt: false }
+}
+
+/**
+ * Die Knoten mit einer Stellungs-Kombination belegt: Einspeisungen an,
+ * Betriebsmittel leitend, Bedienschalter wie in der Kombination.
+ */
+const mitStellungen = (
+  nodes: readonly CircuitNode[],
+  stellungen: Readonly<Record<string, number>>,
+): CircuitNode[] =>
+  nodes.map((n) => {
+    if (n.kind === 'feed' || BETRIEBSMITTEL.has(n.kind)) return { ...n, position: 1 }
+    const p = stellungen[n.id]
+    return p === undefined ? n : { ...n, position: p }
+  })
+
+/** Die Wahrheitstafel einer Leuchte über alle Stellungen. */
+const wahrheitstafel = (
+  nodes: readonly CircuitNode[],
+  edges: readonly CircuitEdge[],
+  lampeId: string,
+  kombinationen: readonly Record<string, number>[],
+): TafelZeile[] =>
+  kombinationen.map((stellungen) => ({
+    stellungen,
+    an: solveCircuit(mitStellungen(nodes, stellungen), edges).lamps.get(lampeId)?.lit === true,
+  }))
+
+/**
+ * Welche Bedienschalter NICHT in jeder Stellung der anderen umschalten.
+ *
+ * Das ist die Eigenschaft, die eine Wechselschaltung ausmacht. Ein Schalter,
+ * der nur in manchen Stellungen der anderen wirkt, ist der Fall, den ein Blick
+ * aufs Schaltbild nicht findet und ein Griff im Flur sofort.
+ */
+const schalterOhneWirkung = (
+  tafel: readonly TafelZeile[],
+  schalterIds: readonly string[],
+): string[] =>
+  schalterIds.filter((id) =>
+    tafel.some((zeile) => {
+      const gegenstueck = tafel.find(
+        (x) =>
+          x.stellungen[id] !== zeile.stellungen[id] &&
+          schalterIds.every((s) => s === id || x.stellungen[s] === zeile.stellungen[s]),
+      )
+      // Kein Gegenstueck heisst: dieser Schalter hat in der Tafel nur eine
+      // Stellung. Das ist kein Befund, sondern eine Tafel ohne Aussage.
+      return gegenstueck !== undefined && gegenstueck.an === zeile.an
+    }),
+  )
+
+/**
+ * Was „in Ordnung" heisst.
+ *
+ * MIT Bedienschalter: jeder von ihnen schaltet die Leuchte in jeder Stellung
+ * der anderen um. OHNE: die Leuchte muss überhaupt brennen — „schaltbar" wäre
+ * dann unerreichbar, und es als Ziel zu setzen hiesse, jede Suche mit „nichts
+ * gefunden" enden zu lassen.
+ */
+const zielErfuellt = (tafel: readonly TafelZeile[], schalterIds: readonly string[]): boolean =>
+  schalterIds.length === 0
+    ? tafel.some((z) => z.an)
+    : schalterOhneWirkung(tafel, schalterIds).length === 0
+
+const kantenText = (kanten: readonly VorschlagsKante[]): string =>
+  kanten
+    .map((k) => `${k.fromNode} Klemme ${k.fromTerminal} → ${k.toNode} Klemme ${k.toTerminal}`)
+    .join(' und ')
+
+let laufendeNummer = 0
+/** Kanten-Id fuer die Probe. Nur intern; der Vorschlag traegt keine. */
+const probeKante = (k: VorschlagsKante): CircuitEdge => ({
+  id: `probe-${(laufendeNummer += 1)}`,
+  fromNode: k.fromNode,
+  fromTerminal: k.fromTerminal,
+  toNode: k.toNode,
+  toTerminal: k.toTerminal,
+})
+
+/**
+ * Warum tut diese Schaltung nicht, was sie soll — und welche Ader würde es
+ * ändern?
+ *
+ * Gibt Befunde und nachgerechnete Vorschläge zurück. Ohne `lampeId` wird die
+ * einzige Leuchte des Kreises genommen; gibt es mehrere, sagt ein Befund, dass
+ * eine benannt werden muss. Sich eine auszusuchen wäre die Antwort auf eine
+ * andere Frage als die gestellte.
+ */
+export const schaltungsVorschlaege = (
+  nodes: readonly CircuitNode[],
+  edges: readonly CircuitEdge[],
+  lampeId?: string,
+): VorschlagsErgebnis => {
+  const befunde: Befund[] = []
+  const annahmen: string[] = []
+  const fertig = (vorschlaege: Vorschlag[], grund?: string): VorschlagsErgebnis => ({
+    befunde,
+    vorschlaege,
+    vollstaendig: grund === undefined,
+    ...(grund === undefined ? {} : { grund }),
+    annahmen,
+  })
+
+  const leuchten = nodes.filter((n) => n.kind === 'lamp')
+  if (leuchten.length === 0) {
+    befunde.push({ art: 'keine-leuchte', text: 'Der Stromkreis enthält keine Leuchte.' })
+    return fertig([])
+  }
+  const ziel = lampeId ?? (leuchten.length === 1 ? leuchten[0].id : undefined)
+  if (ziel === undefined) {
+    befunde.push({
+      art: 'mehrere-leuchten',
+      text: `Der Stromkreis hat ${leuchten.length} Leuchten — welche geprüft werden soll, muss benannt werden.`,
+    })
+    return fertig([])
+  }
+  if (!leuchten.some((l) => l.id === ziel)) {
+    befunde.push({ art: 'keine-leuchte', text: `Es gibt keine Leuchte „${ziel}".` })
+    return fertig([])
+  }
+
+  const einspeisungen = nodes.filter((n) => n.kind === 'feed')
+  if (einspeisungen.length === 0) {
+    befunde.push({
+      art: 'keine-einspeisung',
+      text: 'Der Stromkreis hat keine Einspeisung — ohne sie brennt keine Leuchte, gleich wie verdrahtet wird.',
+    })
+    return fertig([])
+  }
+  if (!einspeisungen.some((n) => n.position === 1)) {
+    befunde.push({
+      art: 'keine-spannung',
+      text: 'Keine Einspeisung steht auf „an". Für die Prüfung wird angenommen, dass Spannung anliegt.',
+    })
+  }
+  // Immer angenommen und immer genannt: die Verdrahtungsfrage ist von der Frage
+  // „ist eingeschaltet" unabhaengig, und beide zu vermischen hiesse, einen
+  // ausgeschalteten Kreis als Verdrahtungsfehler zu melden.
+  annahmen.push('Alle Einspeisungen führen Spannung.')
+  if (nodes.some((n) => BETRIEBSMITTEL.has(n.kind))) {
+    annahmen.push('FI, LS, Not-Aus, Schütz und Relais sind leitend angenommen.')
+  }
+
+  if (!belegteKlemmen(edges).has(schluessel(ziel, 0))) {
+    befunde.push({
+      art: 'leuchte-ohne-anschluss',
+      lampeId: ziel,
+      text: 'An der Leuchte hängt keine Ader.',
+    })
+  }
+
+  const schalter = bedienschalter(nodes)
+  const schalterIds = schalter.map((s) => s.id)
+  if (schalterIds.length === 0) {
+    befunde.push({
+      art: 'ohne-schalter',
+      text:
+        'Der Stromkreis hat keinen Bedienschalter — eine Leuchte darin ist immer an oder ' +
+        'immer aus. Geprüft wird deshalb nur, ob sie überhaupt brennt.',
+    })
+  }
+
+  const { kombinationen, gekappt } = stellungsKombinationen(schalter)
+  if (gekappt) {
+    return fertig(
+      [],
+      `Mehr als ${GRENZEN.stellungen} Stellungs-Kombinationen — die Tafel wäre nicht mehr durchzurechnen.`,
+    )
+  }
+
+  const tafelJetzt = wahrheitstafel(nodes, edges, ziel, kombinationen)
+  if (zielErfuellt(tafelJetzt, schalterIds)) return fertig([])
+
+  if (tafelJetzt.every((z) => z.an)) {
+    // DIE SUCHE WIRD HIER GAR NICHT ERST GESTARTET, und das ist der Punkt.
+    // Sie legt nur Adern DAZU, und eine zusaetzliche Ader kann eine Leuchte
+    // niemals dunkler machen — jeder zusaetzliche Weg ist ein weiterer Weg, auf
+    // dem Spannung ankommt. Liesse man sie trotzdem laufen, endete sie mit
+    // „keine Vorschlaege gefunden", und das liest sich als „es gibt keine
+    // Loesung". Es gibt eine; sie besteht im Wegnehmen, und das schlaegt dieses
+    // Modul nicht vor.
+    befunde.push({
+      art: 'immer-an',
+      lampeId: ziel,
+      text:
+        'Die Leuchte brennt in jeder Stellung — der Schalter liegt nicht im Weg. Das lässt ' +
+        'sich nur durch Umlegen oder Entfernen einer Ader beheben, nicht durch eine ' +
+        'zusätzliche; deshalb steht hier kein Vorschlag.',
+    })
+    return fertig([])
+  }
+
+  if (tafelJetzt.every((z) => !z.an)) {
+    befunde.push({
+      art: 'nie-an',
+      lampeId: ziel,
+      text:
+        schalterIds.length === 0
+          ? 'Die Leuchte brennt nicht.'
+          : 'Die Leuchte brennt in keiner Stellung.',
+    })
+  } else {
+    for (const id of schalterOhneWirkung(tafelJetzt, schalterIds)) {
+      befunde.push({
+        art: 'schalter-ohne-wirkung',
+        lampeId: ziel,
+        knotenId: id,
+        text: `„${id}" schaltet die Leuchte nicht in jeder Stellung der anderen Schalter — im Flur heisst das: er wirkt manchmal nicht.`,
+      })
+    }
+  }
+
+  const frei = freieKlemmen(nodes, edges)
+  if (frei.length > GRENZEN.klemmen) {
+    return fertig(
+      [],
+      `${frei.length} freie Klemmen — mehr als die ${GRENZEN.klemmen}, die durchprobiert werden.`,
+    )
+  }
+
+  // Kandidaten: jede Verbindung zwischen zwei freien Klemmen VERSCHIEDENER
+  // Knoten. Eine Bruecke innerhalb eines Knotens waere keine Verdrahtung,
+  // sondern eine Behauptung ueber sein Inneres.
+  const kandidaten: VorschlagsKante[] = []
+  for (let i = 0; i < frei.length; i += 1) {
+    for (let j = i + 1; j < frei.length; j += 1) {
+      if (frei[i].nodeId === frei[j].nodeId) continue
+      kandidaten.push({
+        fromNode: frei[i].nodeId,
+        fromTerminal: frei[i].terminal,
+        toNode: frei[j].nodeId,
+        toTerminal: frei[j].terminal,
+      })
+    }
+  }
+
+  const einzeln: Vorschlag[] = []
+  for (const k of kandidaten) {
+    const tafel = wahrheitstafel(nodes, [...edges, probeKante(k)], ziel, kombinationen)
+    if (zielErfuellt(tafel, schalterIds)) {
+      einzeln.push({
+        kanten: [k],
+        text: `Eine Ader legen: ${kantenText([k])}.`,
+        wahrheitstafel: tafel,
+      })
+    }
+  }
+  if (einzeln.length > 0) return fertig(einzeln)
+
+  // Keine einzelne Ader reicht. Zwei — aber nur, solange es zu zaehlen ist.
+  const paare = (kandidaten.length * (kandidaten.length - 1)) / 2
+  if (paare > GRENZEN.paare) {
+    return fertig(
+      [],
+      `Keine einzelne Ader genügt, und ${paare} Zweier-Kombinationen sind mehr als die ${GRENZEN.paare}, die geprüft werden.`,
+    )
+  }
+  const doppelt: Vorschlag[] = []
+  for (let i = 0; i < kandidaten.length; i += 1) {
+    for (let j = i + 1; j < kandidaten.length; j += 1) {
+      const a = kandidaten[i]
+      const b = kandidaten[j]
+      // Zwei Kandidaten, die dieselbe freie Klemme belegen, gehen nicht
+      // zusammen — auf der Klemme ist Platz fuer eine Ader.
+      const klemmen = new Set([
+        schluessel(a.fromNode, a.fromTerminal),
+        schluessel(a.toNode, a.toTerminal),
+        schluessel(b.fromNode, b.fromTerminal),
+        schluessel(b.toNode, b.toTerminal),
+      ])
+      if (klemmen.size < 4) continue
+      const tafel = wahrheitstafel(
+        nodes,
+        [...edges, probeKante(a), probeKante(b)],
+        ziel,
+        kombinationen,
+      )
+      if (zielErfuellt(tafel, schalterIds)) {
+        doppelt.push({
+          kanten: [a, b],
+          text: `Zwei Adern legen: ${kantenText([a, b])}.`,
+          wahrheitstafel: tafel,
+        })
+      }
+    }
+  }
+  return fertig(doppelt)
+}

--- a/src/renderer/lib/circuitSuggestPlan.ts
+++ b/src/renderer/lib/circuitSuggestPlan.ts
@@ -1,0 +1,184 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Vom Vorschlag zum Kabel — die Rückübersetzung (#666).
+//
+// `circuitSuggest` rechnet auf KNOTEN und KLEMMEN. Der Plan kennt GERÄTE und
+// ANSCHLÜSSE. Diese Datei ist die Stelle dazwischen, und sie ist der Grund,
+// warum der Rechner nichts vom Projekt weiss: `circuitFromProject` geht in die
+// eine Richtung, dieses Modul in die andere, und beide teilen sich die einzige
+// Zuordnung, die es gibt — `Port.circuitTerminal`.
+//
+// ═══════════════════════════════════════════════════════════════════════════
+// EIN VORSCHLAG, DER SICH NICHT EINTRAGEN LÄSST, WIRD GESAGT UND NICHT
+// WEGGELASSEN
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Ein Wechselschalter im Plan hat nicht zwingend einen Anschluss mit
+// `circuitTerminal: 2` — vielleicht hat ihn niemand angegeben. Der Rechner
+// findet die Ader trotzdem, denn er rechnet auf der Bauart; eintragen lässt
+// sie sich dann nicht.
+//
+// Solche Vorschläge stillschweigend zu verschlucken wäre die schlechteste der
+// möglichen Antworten: der Nutzer sähe „keine Vorschläge" und schlösse daraus,
+// dass die Verdrahtung in Ordnung ist. Sie stehen deshalb mit `hindernis` in
+// der Liste — mit dem Gerät und der Klemme, die fehlt. Das ist zugleich die
+// Anleitung: wer die Klemme am Anschluss einträgt, bekommt beim nächsten
+// Durchlauf einen Vorschlag, den er anwenden kann.
+// ───────────────────────────────────────────────────────────────────────────
+import type { CablePlannerProject } from '../types/project'
+import type { EquipmentItem, Port } from '../types/equipment'
+import type { CableType } from '../types/cable'
+import { circuitFromProject, istStromKabel, LEERE_SIM, type CircuitSim } from './circuitFromProject'
+import { schaltungsVorschlaege, type Befund, type TafelZeile } from './circuitSuggest'
+import { CIRCUIT_KIND_INFO } from '../types/circuit'
+
+/** Eine Ader, die sich so in den Plan eintragen lässt. */
+export interface PlanKante {
+  fromEquipmentId: string
+  fromPortId: string
+  toEquipmentId: string
+  toPortId: string
+  /**
+   * Der Kabeltyp — GELESEN am Anschluss, nicht ausgedacht.
+   *
+   * Ein Kabel braucht einen Typ, und ihn zu erfinden waere ein Namensabgleich
+   * mit anderen Mitteln (ADR-002). Genommen wird deshalb der Steckertyp des
+   * Anschlusses, an dem die Ader anfaengt — dieselbe Angabe, aus der der Plan
+   * ueberall sonst seinen Layer ableitet. Drei Steckertypen (DIN,
+   * DisplayPort, USB) sind als Kabeltyp nicht vorgesehen; dort steht
+   * `Custom`, also ausdruecklich „nicht aus der Liste" statt eines
+   * naheliegenden Nachbarn.
+   */
+  steckertyp: CableType
+}
+
+export interface PlanVorschlag {
+  text: string
+  wahrheitstafel: TafelZeile[]
+  /** Leer, wenn `hindernis` gesetzt ist. */
+  kanten: PlanKante[]
+  /** Warum sich dieser Vorschlag nicht eintragen lässt. */
+  hindernis?: string
+}
+
+export interface PlanErgebnis {
+  befunde: Befund[]
+  vorschlaege: PlanVorschlag[]
+  vollstaendig: boolean
+  grund?: string
+  annahmen: string[]
+}
+
+/** Bauarten, deren Klemmen erst aus den Kanten entstehen. */
+const KLEMMSTELLEN = new Set(['junction', 'distro'])
+
+/** Alle Anschlüsse eines Geräts, Ein- und Ausgänge in einer Liste. */
+const alleAnschluesse = (eq: EquipmentItem): Port[] => [...eq.inputs, ...eq.outputs]
+
+/** Anschlüsse, an denen schon ein Strom-Kabel hängt. */
+const belegteAnschluesse = (project: CablePlannerProject): Set<string> => {
+  const s = new Set<string>()
+  for (const c of project.cables) {
+    if (!istStromKabel(c.layer)) continue
+    s.add(c.fromPortId)
+    s.add(c.toPortId)
+  }
+  return s
+}
+
+/**
+ * Den Anschluss finden, der diese Klemme trägt.
+ *
+ * Bei einer Klemmstelle zählt die Klemmennummer nicht: dort geht alles nach
+ * überall weiter, und die Nummer aus dem Rechner ist eine frisch vergebene.
+ * Genommen wird der erste freie Anschluss. Bei jeder anderen Bauart muss die
+ * Klemme ANGEGEBEN sein — sich den nächstbesten Anschluss zu greifen, wäre
+ * genau die stille Umverdrahtung, gegen die `circuitTerminal` überhaupt
+ * eingeführt wurde (der Befund aus B-33).
+ */
+const anschlussFuer = (
+  eq: EquipmentItem,
+  klemme: number,
+  belegt: ReadonlySet<string>,
+): Port | undefined => {
+  const frei = alleAnschluesse(eq).filter((p) => !belegt.has(p.id))
+  if (KLEMMSTELLEN.has(eq.circuitKind ?? '')) return frei[0]
+  return frei.find((p) => (p.circuitTerminal ?? 0) === klemme)
+}
+
+const geraetName = (eq: EquipmentItem | undefined, id: string): string => eq?.name ?? id
+
+/** Steckertypen, die es als Kabeltyp nicht gibt (siehe `CableType`). */
+const NICHT_ALS_KABEL = new Set(['DIN', 'DisplayPort', 'USB'])
+
+const kabeltypVon = (p: Port): CableType =>
+  NICHT_ALS_KABEL.has(p.connectorType) ? 'Custom' : (p.connectorType as CableType)
+
+/**
+ * Die Vorschläge zum Stromkreis dieses Plans — schon in Geräten und
+ * Anschlüssen ausgedrückt.
+ *
+ * Die Reihenfolge ist die von `schaltungsVorschlaege`; anwendbare und nicht
+ * anwendbare stehen gemeinsam in der Liste, damit die Oberfläche beide zeigen
+ * kann. Eintragen tut dieses Modul nichts — das ist ein Griff des Nutzers.
+ */
+export const planVorschlaege = (
+  project: CablePlannerProject,
+  sim: CircuitSim = LEERE_SIM,
+  lampeId?: string,
+): PlanErgebnis => {
+  const plan = circuitFromProject(project, sim)
+  const roh = schaltungsVorschlaege(plan.nodes, plan.edges, lampeId)
+  const nachId = new Map(project.equipment.map((e) => [e.id, e]))
+  const belegtImPlan = belegteAnschluesse(project)
+
+  const vorschlaege: PlanVorschlag[] = roh.vorschlaege.map((v) => {
+    // Innerhalb EINES Vorschlags darf kein Anschluss zweimal vergeben werden —
+    // sonst traegt ein Zwei-Adern-Vorschlag beide Adern auf dieselbe Klemme.
+    const belegt = new Set(belegtImPlan)
+    const kanten: PlanKante[] = []
+    let hindernis: string | undefined
+
+    for (const k of v.kanten) {
+      const a = nachId.get(k.fromNode)
+      const b = nachId.get(k.toNode)
+      if (!a || !b) {
+        hindernis = `Gerät „${geraetName(a, k.fromNode)}" oder „${geraetName(b, k.toNode)}" steht nicht mehr im Plan.`
+        break
+      }
+      const pa = anschlussFuer(a, k.fromTerminal, belegt)
+      const pb = anschlussFuer(b, k.toTerminal, belegt)
+      const fehlt = !pa ? { eq: a, klemme: k.fromTerminal } : !pb ? { eq: b, klemme: k.toTerminal } : undefined
+      if (fehlt) {
+        const bauart = fehlt.eq.circuitKind ? CIRCUIT_KIND_INFO[fehlt.eq.circuitKind].label : 'Gerät'
+        hindernis =
+          `${bauart} „${fehlt.eq.name}" hat keinen freien Anschluss mit Klemme ${fehlt.klemme}. ` +
+          'Die Klemme steht in den Eigenschaften am Anschluss — ohne sie lässt sich die Ader nicht eintragen.'
+        break
+      }
+      belegt.add(pa!.id)
+      belegt.add(pb!.id)
+      kanten.push({
+        fromEquipmentId: a.id,
+        fromPortId: pa!.id,
+        toEquipmentId: b.id,
+        toPortId: pb!.id,
+        steckertyp: kabeltypVon(pa!),
+      })
+    }
+
+    return {
+      text: v.text,
+      wahrheitstafel: v.wahrheitstafel,
+      kanten: hindernis === undefined ? kanten : [],
+      ...(hindernis === undefined ? {} : { hindernis }),
+    }
+  })
+
+  return {
+    befunde: roh.befunde,
+    vorschlaege,
+    vollstaendig: roh.vollstaendig,
+    ...(roh.grund === undefined ? {} : { grund: roh.grund }),
+    annahmen: roh.annahmen,
+  }
+}

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3435,6 +3435,22 @@ export const en: Dict = {
     'CALCULATED, not measured: this is how the circuit behaves with the switch positions as set. The positions are not part of the plan.',
   'canvas.circuit.resetTitle':
     'All switches back to their default. The plan does not change — it never carried the positions.',
+  // Verdrahtungs-Vorschlaege (#666).
+  'canvas.circuit.suggest': 'Suggestions',
+  'canvas.circuit.suggestTitle':
+    'Why the circuit does not do what it should — and which wire would change that. Every suggestion is computed through and brings its own truth table; nothing is entered without a click.',
+  'canvas.circuit.suggest.title': 'Wiring suggestions',
+  'canvas.circuit.suggest.lead':
+    'COMPUTED, not measured. Every suggestion has been tried out: it is listed only because the circuit does what it should in every switch position with it. The table beside it shows that.',
+  'canvas.circuit.suggest.nothing': 'Nothing to report.',
+  'canvas.circuit.suggest.capped': 'The search was limited: ',
+  'canvas.circuit.suggest.apply': 'Add wire',
+  'canvas.circuit.suggest.blocked': 'cannot be added',
+  'canvas.circuit.suggest.showTable': 'Show truth table',
+  'canvas.circuit.suggest.hideTable': 'Hide truth table',
+  'canvas.circuit.suggest.cableName': 'Wire (suggested)',
+  'canvas.circuit.suggest.cableNote': 'Added from a computed wiring suggestion.',
+  'canvas.circuit.suggest.done': '{n} wire(s) added.',
   // Pruefbild — die Erwartung aus dem Plan, kein Videobild.
   'canvas.pattern.label': 'Test pattern',
   'canvas.pattern.none': 'none',

--- a/tests/circuitSuggest.test.ts
+++ b/tests/circuitSuggest.test.ts
@@ -1,0 +1,380 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Der Wächter zu den Schaltungs-Vorschlägen (#666, dritter Satz).
+//
+// Die Prüfsteine sind die drei Zusagen aus der Kopfzeile des Moduls:
+//   1. Jeder Vorschlag ist NACHGERECHNET — die mitgelieferte Wahrheitstafel
+//      stimmt mit dem überein, was `solveCircuit` nach der Änderung sagt.
+//   2. „In Ordnung" heisst UNABHÄNGIG, nicht bloss schaltbar — die
+//      Wechselschaltung mit einer fehlenden Korrespondierenden ist der Fall,
+//      an dem sich das entscheidet.
+//   3. Keine stillen Grenzen und keine stillen Annahmen.
+// ───────────────────────────────────────────────────────────────────────────
+import { describe, it, expect } from 'vitest'
+import { solveCircuit, type CircuitEdge, type CircuitNode } from '../src/renderer/lib/circuitSolver'
+import { schaltungsVorschlaege, GRENZEN } from '../src/renderer/lib/circuitSuggest'
+
+const kante = (
+  id: string,
+  fromNode: string,
+  fromTerminal: number,
+  toNode: string,
+  toTerminal: number,
+): CircuitEdge => ({ id, fromNode, fromTerminal, toNode, toTerminal })
+
+/** Wechselschaltung, wie sie sein soll: zwei Korrespondierende. */
+const wechselKnoten: CircuitNode[] = [
+  { id: 'F', kind: 'feed', position: 1 },
+  { id: 'W1', kind: 'changeover', position: 1 },
+  { id: 'W2', kind: 'changeover', position: 1 },
+  { id: 'L', kind: 'lamp' },
+]
+const wechselKanten: CircuitEdge[] = [
+  kante('e1', 'F', 0, 'W1', 0),
+  kante('e2', 'W1', 1, 'W2', 1),
+  kante('e3', 'W1', 2, 'W2', 2),
+  kante('e4', 'W2', 0, 'L', 0),
+]
+
+describe('richtige Wechselschaltung', () => {
+  it('brennt bei gleicher Stellung und ist damit in Ordnung', () => {
+    const r = schaltungsVorschlaege(wechselKnoten, wechselKanten)
+    expect(r.befunde).toEqual([])
+    expect(r.vorschlaege).toEqual([])
+    expect(r.vollstaendig).toBe(true)
+  })
+
+  it('nennt die Annahme, unter der gerechnet wurde', () => {
+    const r = schaltungsVorschlaege(wechselKnoten, wechselKanten)
+    expect(r.annahmen).toContain('Alle Einspeisungen führen Spannung.')
+  })
+})
+
+describe('Wechselschaltung mit fehlender Korrespondierender', () => {
+  // Genau der Fall, den „schaltbar" durchgehen laesst: die Leuchte brennt bei
+  // W1=1 und W2=1, also einmal an und einmal aus — und trotzdem tut W2 nichts,
+  // sobald W1 auf 2 steht.
+  const kanten = wechselKanten.filter((e) => e.id !== 'e3')
+
+  it('ist schaltbar und trotzdem ein Befund', () => {
+    const tafel = [1, 2].flatMap((p1) =>
+      [1, 2].map((p2) =>
+        solveCircuit(
+          wechselKnoten.map((n) =>
+            n.id === 'W1' ? { ...n, position: p1 } : n.id === 'W2' ? { ...n, position: p2 } : n,
+          ),
+          kanten,
+        ).lamps.get('L')?.lit,
+      ),
+    )
+    // einmal an, dreimal aus — „schaltbar" waere erfuellt.
+    expect(tafel.filter(Boolean)).toHaveLength(1)
+
+    const r = schaltungsVorschlaege(wechselKnoten, kanten)
+    expect(r.befunde.map((b) => b.art)).toContain('schalter-ohne-wirkung')
+    expect(r.befunde.filter((b) => b.art === 'schalter-ohne-wirkung').map((b) => b.knotenId).sort())
+      .toEqual(['W1', 'W2'])
+  })
+
+  it('schlägt genau die fehlende Ader vor', () => {
+    const r = schaltungsVorschlaege(wechselKnoten, kanten)
+    expect(r.vorschlaege.length).toBeGreaterThan(0)
+    const gefunden = r.vorschlaege.some((v) =>
+      v.kanten.some(
+        (k) =>
+          (k.fromNode === 'W1' && k.fromTerminal === 2 && k.toNode === 'W2' && k.toTerminal === 2) ||
+          (k.fromNode === 'W2' && k.fromTerminal === 2 && k.toNode === 'W1' && k.toTerminal === 2),
+      ),
+    )
+    expect(gefunden).toBe(true)
+  })
+
+  it('jeder Vorschlag ist einer, der wirklich hilft — nachgerechnet', () => {
+    const r = schaltungsVorschlaege(wechselKnoten, kanten)
+    for (const v of r.vorschlaege) {
+      const mitVorschlag = [
+        ...kanten,
+        ...v.kanten.map((k, i) => kante(`neu-${i}`, k.fromNode, k.fromTerminal, k.toNode, k.toTerminal)),
+      ]
+      const an = [1, 2].flatMap((p1) =>
+        [1, 2].map((p2) =>
+          solveCircuit(
+            wechselKnoten.map((n) =>
+              n.id === 'W1' ? { ...n, position: p1 } : n.id === 'W2' ? { ...n, position: p2 } : n,
+            ),
+            mitVorschlag,
+          ).lamps.get('L')?.lit === true,
+        ),
+      )
+      // Unabhaengig heisst hier: genau zwei der vier Stellungen brennen.
+      expect(an.filter(Boolean), v.text).toHaveLength(2)
+    }
+  })
+
+  it('die mitgelieferte Wahrheitstafel stimmt mit dem Rechner überein', () => {
+    const r = schaltungsVorschlaege(wechselKnoten, kanten)
+    const v = r.vorschlaege[0]
+    expect(v.wahrheitstafel).toHaveLength(4)
+    for (const zeile of v.wahrheitstafel) {
+      const knoten = wechselKnoten.map((n) =>
+        zeile.stellungen[n.id] === undefined ? n : { ...n, position: zeile.stellungen[n.id] },
+      )
+      const mitVorschlag = [
+        ...kanten,
+        ...v.kanten.map((k, i) => kante(`neu-${i}`, k.fromNode, k.fromTerminal, k.toNode, k.toTerminal)),
+      ]
+      expect(solveCircuit(knoten, mitVorschlag).lamps.get('L')?.lit === true).toBe(zeile.an)
+    }
+  })
+})
+
+describe('Leuchte ohne Ader', () => {
+  const knoten: CircuitNode[] = [
+    { id: 'F', kind: 'feed', position: 1 },
+    { id: 'S', kind: 'switch', position: 1 },
+    { id: 'L', kind: 'lamp' },
+  ]
+  const kanten = [kante('e1', 'F', 0, 'S', 1)]
+
+  it('meldet den fehlenden Anschluss und schlägt ihn vor', () => {
+    const r = schaltungsVorschlaege(knoten, kanten)
+    expect(r.befunde.map((b) => b.art)).toContain('leuchte-ohne-anschluss')
+    expect(r.befunde.map((b) => b.art)).toContain('nie-an')
+    const trifft = r.vorschlaege.some((v) =>
+      v.kanten.some(
+        (k) =>
+          (k.fromNode === 'S' && k.fromTerminal === 2 && k.toNode === 'L') ||
+          (k.toNode === 'S' && k.toTerminal === 2 && k.fromNode === 'L'),
+      ),
+    )
+    expect(trifft).toBe(true)
+  })
+
+  it('schlägt keine Ader auf eine schon belegte Klemme vor', () => {
+    const r = schaltungsVorschlaege(knoten, kanten)
+    for (const v of r.vorschlaege) {
+      for (const k of v.kanten) {
+        expect(`${k.fromNode}#${k.fromTerminal}`).not.toBe('F#0')
+        expect(`${k.toNode}#${k.toTerminal}`).not.toBe('F#0')
+        expect(`${k.fromNode}#${k.fromTerminal}`).not.toBe('S#1')
+        expect(`${k.toNode}#${k.toTerminal}`).not.toBe('S#1')
+      }
+    }
+  })
+
+  it('legt keine zweite Ader auf eine schon belegte Klemme', () => {
+    // Der Fall, an dem sich das entscheidet: `S#2` haengt bereits an einer Dose,
+    // die ins Leere geht. Eine Ader von `S#2` zur Leuchte WUERDE die Schaltung
+    // in Ordnung bringen — an der Klemme ist dafuer aber kein Platz. Der Weg
+    // ueber die Dose leistet dasselbe und laesst sich bauen.
+    const knoten: CircuitNode[] = [
+      { id: 'F', kind: 'feed', position: 1 },
+      { id: 'S', kind: 'switch', position: 1 },
+      { id: 'J', kind: 'junction' },
+      { id: 'L', kind: 'lamp' },
+    ]
+    const kanten = [kante('e1', 'F', 0, 'S', 1), kante('e2', 'S', 2, 'J', 0)]
+    const r = schaltungsVorschlaege(knoten, kanten)
+    expect(r.vorschlaege.length).toBeGreaterThan(0)
+    const belegt = new Set(['F#0', 'S#1', 'S#2', 'J#0'])
+    for (const v of r.vorschlaege) {
+      for (const k of v.kanten) {
+        expect(belegt.has(`${k.fromNode}#${k.fromTerminal}`), v.text).toBe(false)
+        expect(belegt.has(`${k.toNode}#${k.toTerminal}`), v.text).toBe(false)
+      }
+    }
+    // Und ueber die Dose wird die Leuchte trotzdem erreicht.
+    expect(r.vorschlaege.some((v) => v.kanten.some((k) => k.fromNode === 'J' && k.toNode === 'L'))).toBe(true)
+  })
+
+  it('schlägt keine Ader von einem Knoten auf sich selbst vor', () => {
+    const r = schaltungsVorschlaege(knoten, kanten)
+    for (const v of r.vorschlaege) {
+      for (const k of v.kanten) expect(k.fromNode).not.toBe(k.toNode)
+    }
+  })
+})
+
+describe('was sich nicht durch Hinzufügen beheben lässt', () => {
+  it('immer an: Befund mit Grund, keine Vorschläge, aber vollständig', () => {
+    // Der Schalter haengt parallel statt in Reihe: die Leuchte haengt direkt
+    // an der Einspeisung.
+    const knoten: CircuitNode[] = [
+      { id: 'F', kind: 'feed', position: 1 },
+      { id: 'S', kind: 'switch', position: 1 },
+      { id: 'L', kind: 'lamp' },
+    ]
+    const kanten = [kante('e1', 'F', 0, 'L', 0), kante('e2', 'F', 0, 'S', 1)]
+    const r = schaltungsVorschlaege(knoten, kanten)
+    const immer = r.befunde.find((b) => b.art === 'immer-an')
+    expect(immer).toBeDefined()
+    expect(immer?.text).toContain('Entfernen')
+    expect(r.vorschlaege).toEqual([])
+    // Und ausdruecklich NICHT als gekappte Suche ausgewiesen.
+    expect(r.vollstaendig).toBe(true)
+    expect(r.grund).toBeUndefined()
+  })
+})
+
+describe('Kreis ohne Bedienschalter', () => {
+  const knoten: CircuitNode[] = [
+    { id: 'F', kind: 'feed', position: 1 },
+    { id: 'L', kind: 'lamp' },
+  ]
+
+  it('prüft dann nur, ob die Leuchte überhaupt brennt', () => {
+    const r = schaltungsVorschlaege(knoten, [])
+    expect(r.befunde.map((b) => b.art)).toContain('ohne-schalter')
+    expect(r.vorschlaege).toHaveLength(1)
+    expect(r.vorschlaege[0].kanten).toEqual([
+      { fromNode: 'F', fromTerminal: 0, toNode: 'L', toTerminal: 0 },
+    ])
+  })
+
+  it('brennt sie schon, gibt es nichts vorzuschlagen', () => {
+    const r = schaltungsVorschlaege(knoten, [kante('e1', 'F', 0, 'L', 0)])
+    expect(r.vorschlaege).toEqual([])
+    expect(r.befunde.map((b) => b.art)).toEqual(['ohne-schalter'])
+  })
+})
+
+describe('Betriebsmittel sind kein Verdrahtungsfehler', () => {
+  it('ein ausgelöster LS macht die Schaltung nicht falsch', () => {
+    const knoten: CircuitNode[] = [
+      { id: 'F', kind: 'feed', position: 1 },
+      // Ausgeloest: Stellung 0. Ohne die Annahme „leitend" waere die Leuchte
+      // nie an und jede Verdrahtung ein Befund.
+      { id: 'LS', kind: 'mcb', position: 0 },
+      { id: 'S', kind: 'switch', position: 1 },
+      { id: 'L', kind: 'lamp' },
+    ]
+    const kanten = [
+      kante('e1', 'F', 0, 'LS', 1),
+      kante('e2', 'LS', 2, 'S', 1),
+      kante('e3', 'S', 2, 'L', 0),
+    ]
+    const r = schaltungsVorschlaege(knoten, kanten)
+    expect(r.befunde).toEqual([])
+    expect(r.vorschlaege).toEqual([])
+    expect(r.annahmen).toContain('FI, LS, Not-Aus, Schütz und Relais sind leitend angenommen.')
+  })
+
+  it('ohne Betriebsmittel steht die Annahme auch nicht da', () => {
+    const r = schaltungsVorschlaege(wechselKnoten, wechselKanten)
+    expect(r.annahmen).toEqual(['Alle Einspeisungen führen Spannung.'])
+  })
+})
+
+describe('ausgeschaltete Einspeisung', () => {
+  it('ist ein eigener Befund und kein Verdrahtungsfehler', () => {
+    const aus = wechselKnoten.map((n) => (n.kind === 'feed' ? { ...n, position: 0 } : n))
+    const r = schaltungsVorschlaege(aus, wechselKanten)
+    expect(r.befunde.map((b) => b.art)).toEqual(['keine-spannung'])
+    expect(r.vorschlaege).toEqual([])
+  })
+
+  it('ohne Einspeisung wird gar nicht erst gesucht', () => {
+    const ohne = wechselKnoten.filter((n) => n.kind !== 'feed')
+    const r = schaltungsVorschlaege(ohne, wechselKanten)
+    expect(r.befunde.map((b) => b.art)).toEqual(['keine-einspeisung'])
+    expect(r.vorschlaege).toEqual([])
+  })
+})
+
+describe('welche Leuchte', () => {
+  const zwei: CircuitNode[] = [
+    { id: 'F', kind: 'feed', position: 1 },
+    { id: 'S', kind: 'switch', position: 1 },
+    { id: 'L1', kind: 'lamp' },
+    { id: 'L2', kind: 'lamp' },
+  ]
+
+  it('sucht sich bei mehreren keine aus', () => {
+    const r = schaltungsVorschlaege(zwei, [kante('e1', 'F', 0, 'S', 1)])
+    expect(r.befunde.map((b) => b.art)).toEqual(['mehrere-leuchten'])
+    expect(r.vorschlaege).toEqual([])
+  })
+
+  it('nimmt die benannte', () => {
+    const r = schaltungsVorschlaege(zwei, [kante('e1', 'F', 0, 'S', 1)], 'L2')
+    expect(r.befunde.every((b) => b.lampeId === undefined || b.lampeId === 'L2')).toBe(true)
+    expect(r.vorschlaege.length).toBeGreaterThan(0)
+    for (const v of r.vorschlaege) {
+      expect(v.kanten.some((k) => k.fromNode === 'L1' || k.toNode === 'L1')).toBe(false)
+    }
+  })
+
+  it('eine benannte Leuchte, die es nicht gibt, ist ein Befund', () => {
+    const r = schaltungsVorschlaege(zwei, [], 'L9')
+    expect(r.befunde.map((b) => b.art)).toEqual(['keine-leuchte'])
+  })
+})
+
+describe('keine stillen Grenzen', () => {
+  it('zu viele Stellungen: gesagt, nicht halb gerechnet', () => {
+    // Neun Aus-Schalter ergeben 512 Kombinationen — mehr als die 256, die
+    // durchgerechnet werden.
+    const knoten: CircuitNode[] = [
+      { id: 'F', kind: 'feed', position: 1 },
+      { id: 'L', kind: 'lamp' },
+      ...Array.from({ length: 9 }, (_, i) => ({ id: `S${i}`, kind: 'switch' as const, position: 1 })),
+    ]
+    const r = schaltungsVorschlaege(knoten, [])
+    expect(r.vollstaendig).toBe(false)
+    expect(r.grund).toContain(String(GRENZEN.stellungen))
+    expect(r.vorschlaege).toEqual([])
+  })
+
+  it('zu viele freie Klemmen: ebenfalls gesagt', () => {
+    // Kein Bedienschalter, damit die Stellungs-Grenze nicht zuerst greift —
+    // dafuer mehr als GRENZEN.klemmen freie Klemmen.
+    const knoten: CircuitNode[] = [
+      { id: 'F', kind: 'feed', position: 1 },
+      { id: 'L', kind: 'lamp' },
+      ...Array.from({ length: 25 }, (_, i) => ({ id: `D${i}`, kind: 'dimmer' as const })),
+    ]
+    const r = schaltungsVorschlaege(knoten, [])
+    expect(r.vollstaendig).toBe(false)
+    expect(r.grund).toContain(String(GRENZEN.klemmen))
+  })
+})
+
+describe('Kreuzschaltung', () => {
+  // Drei Stellen, eine Leuchte: W1 — K — W2.
+  const knoten: CircuitNode[] = [
+    { id: 'F', kind: 'feed', position: 1 },
+    { id: 'W1', kind: 'changeover', position: 1 },
+    { id: 'K', kind: 'crossover', position: 1 },
+    { id: 'W2', kind: 'changeover', position: 1 },
+    { id: 'L', kind: 'lamp' },
+  ]
+  const kanten = [
+    kante('e1', 'F', 0, 'W1', 0),
+    kante('e2', 'W1', 1, 'K', 1),
+    kante('e3', 'W1', 2, 'K', 2),
+    kante('e4', 'K', 3, 'W2', 1),
+    kante('e5', 'K', 4, 'W2', 2),
+    kante('e6', 'W2', 0, 'L', 0),
+  ]
+
+  it('ist in Ordnung, wenn alle drei Stellen wirken', () => {
+    const r = schaltungsVorschlaege(knoten, kanten)
+    expect(r.befunde).toEqual([])
+    expect(r.vorschlaege).toEqual([])
+  })
+
+  it('fehlt eine Ader am Kreuzschalter, wird sie vorgeschlagen', () => {
+    const r = schaltungsVorschlaege(
+      knoten,
+      kanten.filter((e) => e.id !== 'e5'),
+    )
+    expect(r.befunde.map((b) => b.art)).toContain('schalter-ohne-wirkung')
+    const trifft = r.vorschlaege.some((v) =>
+      v.kanten.some(
+        (k) =>
+          (k.fromNode === 'K' && k.fromTerminal === 4 && k.toNode === 'W2' && k.toTerminal === 2) ||
+          (k.toNode === 'K' && k.toTerminal === 4 && k.fromNode === 'W2' && k.fromTerminal === 2),
+      ),
+    )
+    expect(trifft).toBe(true)
+  })
+})

--- a/tests/circuitSuggestPlan.test.ts
+++ b/tests/circuitSuggestPlan.test.ts
@@ -1,0 +1,235 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Der Wächter zur Rückübersetzung: vom Vorschlag zum Kabel (#666).
+//
+// `circuitSuggest` ist in `circuitSuggest.test.ts` geprüft. Hier geht es um
+// die Stelle, an der ein richtiger Vorschlag im Plan trotzdem nicht ankommt:
+// die Zuordnung Klemme → Anschluss. Sie kann fehlen, und dann ist die einzige
+// richtige Antwort, das zu SAGEN — ein verschluckter Vorschlag liest sich wie
+// „alles in Ordnung".
+// ───────────────────────────────────────────────────────────────────────────
+import { describe, expect, it } from 'vitest'
+import { planVorschlaege } from '../src/renderer/lib/circuitSuggestPlan'
+import type { CablePlannerProject } from '../src/renderer/types/project'
+import type { Cable } from '../src/renderer/types/cable'
+import type { EquipmentItem, Port } from '../src/renderer/types/equipment'
+import type { CircuitKind } from '../src/renderer/lib/circuitSolver'
+
+const port = (id: string, terminal?: number): Port =>
+  ({
+    id,
+    name: id,
+    type: 'power',
+    connectorType: 'schuko',
+    ...(terminal === undefined ? {} : { circuitTerminal: terminal }),
+  }) as unknown as Port
+
+const geraet = (id: string, kind: CircuitKind, ports: Port[]): EquipmentItem =>
+  ({
+    id,
+    name: id,
+    category: 'Strom',
+    x: 0,
+    y: 0,
+    inputs: ports,
+    outputs: [],
+    circuitKind: kind,
+  }) as unknown as EquipmentItem
+
+const kabel = (id: string, from: [string, string], to: [string, string], layer = 'power'): Cable =>
+  ({
+    id,
+    fromEquipmentId: from[0],
+    fromPortId: from[1],
+    toEquipmentId: to[0],
+    toPortId: to[1],
+    layer,
+  }) as unknown as Cable
+
+const projekt = (equipment: EquipmentItem[], cables: Cable[]): CablePlannerProject =>
+  ({
+    metadata: { name: 'Test', description: '', createdAt: '', updatedAt: '' },
+    equipment,
+    cables,
+    canvasState: { x: 0, y: 0, zoom: 1 },
+  }) as unknown as CablePlannerProject
+
+/** Wechselschaltung, der die zweite Korrespondierende fehlt. */
+const halbeWechselschaltung = (s2Klemmen: (number | undefined)[] = [0, 1, 2]) =>
+  projekt(
+    [
+      geraet('feed', 'feed', [port('f0', 0)]),
+      geraet('W1', 'changeover', [port('a0', 0), port('a1', 1), port('a2', 2)]),
+      geraet('W2', 'changeover', [
+        port('b0', s2Klemmen[0]),
+        port('b1', s2Klemmen[1]),
+        port('b2', s2Klemmen[2]),
+      ]),
+      geraet('L', 'lamp', [port('l0', 0)]),
+    ],
+    [
+      kabel('k1', ['feed', 'f0'], ['W1', 'a0']),
+      kabel('k2', ['W1', 'a1'], ['W2', 'b1']),
+      kabel('k4', ['W2', 'b0'], ['L', 'l0']),
+    ],
+  )
+
+describe('der anwendbare Vorschlag', () => {
+  it('nennt Geräte und Anschlüsse, nicht Knoten und Klemmen', () => {
+    const r = planVorschlaege(halbeWechselschaltung())
+    const treffer = r.vorschlaege.find((v) =>
+      v.kanten.some(
+        (k) =>
+          (k.fromPortId === 'a2' && k.toPortId === 'b2') ||
+          (k.fromPortId === 'b2' && k.toPortId === 'a2'),
+      ),
+    )
+    expect(treffer).toBeDefined()
+    expect(treffer?.hindernis).toBeUndefined()
+    expect(treffer?.kanten[0].fromEquipmentId === 'W1' || treffer?.kanten[0].fromEquipmentId === 'W2').toBe(
+      true,
+    )
+  })
+
+  // Diese Zusicherung ist heute NICHT gegenprobierbar, und das steht hier statt
+  // es zu verschweigen: der Rechner bietet je Klemme genau einen Kandidaten und
+  // schliesst zwei Adern auf dieselbe Klemme selbst aus. Die Buchfuehrung in
+  // `planVorschlaege` bleibt trotzdem stehen — sie haelt eine Eigenschaft, die
+  // aus einem ANDEREN Modul folgt, und die kann sich aendern. Der Test prueft
+  // also die Ausgabe-Eigenschaft, nicht die Regel dahinter.
+  it('vergibt innerhalb eines Vorschlags keinen Anschluss zweimal', () => {
+    // Beide Korrespondierenden fehlen: der Vorschlag traegt zwei Adern.
+    const p = projekt(
+      [
+        geraet('feed', 'feed', [port('f0', 0)]),
+        geraet('W1', 'changeover', [port('a0', 0), port('a1', 1), port('a2', 2)]),
+        geraet('W2', 'changeover', [port('b0', 0), port('b1', 1), port('b2', 2)]),
+        geraet('L', 'lamp', [port('l0', 0)]),
+      ],
+      [kabel('k1', ['feed', 'f0'], ['W1', 'a0']), kabel('k4', ['W2', 'b0'], ['L', 'l0'])],
+    )
+    const r = planVorschlaege(p)
+    const zwei = r.vorschlaege.filter((v) => v.kanten.length === 2)
+    expect(zwei.length).toBeGreaterThan(0)
+    for (const v of zwei) {
+      const anschluesse = v.kanten.flatMap((k) => [k.fromPortId, k.toPortId])
+      expect(new Set(anschluesse).size, v.text).toBe(anschluesse.length)
+    }
+  })
+
+  it('nimmt keinen Anschluss, an dem schon ein Strom-Kabel hängt', () => {
+    const r = planVorschlaege(halbeWechselschaltung())
+    const belegt = new Set(['f0', 'a0', 'a1', 'b1', 'b0', 'l0'])
+    for (const v of r.vorschlaege) {
+      for (const k of v.kanten) {
+        expect(belegt.has(k.fromPortId), v.text).toBe(false)
+        expect(belegt.has(k.toPortId), v.text).toBe(false)
+      }
+    }
+  })
+})
+
+describe('der Vorschlag, der sich nicht eintragen lässt', () => {
+  it('verschwindet nicht, sondern nennt die fehlende Klemme', () => {
+    // W2 hat keinen Anschluss mit Klemme 2 — niemand hat sie angegeben.
+    const r = planVorschlaege(halbeWechselschaltung([0, 1, undefined]))
+    expect(r.vorschlaege.length).toBeGreaterThan(0)
+    const gehindert = r.vorschlaege.filter((v) => v.hindernis !== undefined)
+    expect(gehindert.length).toBeGreaterThan(0)
+    expect(gehindert.some((v) => v.hindernis?.includes('Klemme 2'))).toBe(true)
+    expect(gehindert.some((v) => v.hindernis?.includes('W2'))).toBe(true)
+    // Und er traegt dann auch keine halbe Kantenliste.
+    for (const v of gehindert) expect(v.kanten).toEqual([])
+  })
+
+  it('trägt auch keine HALBE Kantenliste, wenn erst die zweite Ader scheitert', () => {
+    // Beide Korrespondierenden fehlen — und W2 hat keinen Anschluss mit
+    // Klemme 2. Die erste Ader liesse sich eintragen, die zweite nicht. Eine
+    // halb eingetragene Wechselschaltung waere schlimmer als eine gar nicht
+    // eingetragene: sie sieht danach aus wie fertig.
+    const p = projekt(
+      [
+        geraet('feed', 'feed', [port('f0', 0)]),
+        geraet('W1', 'changeover', [port('a0', 0), port('a1', 1), port('a2', 2)]),
+        geraet('W2', 'changeover', [port('b0', 0), port('b1', 1), port('b2')]),
+        geraet('L', 'lamp', [port('l0', 0)]),
+      ],
+      [kabel('k1', ['feed', 'f0'], ['W1', 'a0']), kabel('k4', ['W2', 'b0'], ['L', 'l0'])],
+    )
+    const r = planVorschlaege(p)
+    const zweiAdrig = r.vorschlaege.filter((v) => v.text.startsWith('Zwei Adern'))
+    expect(zweiAdrig.length).toBeGreaterThan(0)
+    for (const v of zweiAdrig) {
+      // Entweder ganz eintragbar oder gar nicht — nie zur Haelfte.
+      expect(v.kanten.length === 2 || v.kanten.length === 0, v.text).toBe(true)
+      if (v.kanten.length === 0) expect(v.hindernis, v.text).toBeDefined()
+    }
+    expect(zweiAdrig.some((v) => v.hindernis !== undefined)).toBe(true)
+  })
+
+  it('sagt in derselben Zeile, was zu tun ist', () => {
+    const r = planVorschlaege(halbeWechselschaltung([0, 1, undefined]))
+    const g = r.vorschlaege.find((v) => v.hindernis !== undefined)
+    expect(g?.hindernis).toContain('Eigenschaften')
+  })
+
+  it('behält die Wahrheitstafel auch dann', () => {
+    // Der Beleg gehoert zum Vorschlag und nicht zu seiner Anwendbarkeit: wer
+    // die Klemme nachtraegt, will vorher sehen, was es bringt.
+    const r = planVorschlaege(halbeWechselschaltung([0, 1, undefined]))
+    const g = r.vorschlaege.find((v) => v.hindernis !== undefined)
+    expect(g?.wahrheitstafel.length).toBeGreaterThan(0)
+  })
+})
+
+describe('die Klemmstelle ist der Sonderfall', () => {
+  it('nimmt dort den ersten freien Anschluss, ohne Klemmennummer', () => {
+    const p = projekt(
+      [
+        geraet('feed', 'feed', [port('f0', 0)]),
+        geraet('S', 'switch', [port('s1', 1), port('s2', 2)]),
+        // Dose ohne jede Klemmenangabe — bei einer Klemmstelle ist das richtig.
+        geraet('J', 'junction', [port('j1'), port('j2')]),
+        geraet('L', 'lamp', [port('l0', 0)]),
+      ],
+      [kabel('k1', ['feed', 'f0'], ['S', 's1']), kabel('k2', ['S', 's2'], ['J', 'j1'])],
+    )
+    const r = planVorschlaege(p)
+    const ueberDose = r.vorschlaege.find(
+      (v) => v.hindernis === undefined && v.kanten.some((k) => k.fromEquipmentId === 'J' || k.toEquipmentId === 'J'),
+    )
+    expect(ueberDose).toBeDefined()
+    // Der belegte Anschluss der Dose wird nicht noch einmal vergeben.
+    for (const k of ueberDose!.kanten) {
+      expect(k.fromPortId).not.toBe('j1')
+      expect(k.toPortId).not.toBe('j1')
+    }
+  })
+
+  it('bei jeder ANDEREN Bauart wird die Klemme verlangt, nicht der nächstbeste Anschluss', () => {
+    // Der Wechselschalter haette einen freien Anschluss — aber ohne Klemme 2.
+    // Ihn trotzdem zu nehmen waere die stille Umverdrahtung, gegen die
+    // `circuitTerminal` eingefuehrt wurde.
+    const r = planVorschlaege(halbeWechselschaltung([0, 1, undefined]))
+    for (const v of r.vorschlaege) {
+      for (const k of v.kanten) {
+        expect(k.fromPortId).not.toBe('b2')
+        expect(k.toPortId).not.toBe('b2')
+      }
+    }
+  })
+})
+
+describe('Befunde und Annahmen gehen unverändert durch', () => {
+  it('reicht Befunde, Annahmen und die Vollständigkeit weiter', () => {
+    const r = planVorschlaege(halbeWechselschaltung())
+    expect(r.befunde.map((b) => b.art)).toContain('schalter-ohne-wirkung')
+    expect(r.annahmen).toContain('Alle Einspeisungen führen Spannung.')
+    expect(r.vollstaendig).toBe(true)
+  })
+
+  it('ein Plan ohne Schaltbild-Geräte meldet das, statt zu schweigen', () => {
+    const r = planVorschlaege(projekt([], []))
+    expect(r.befunde.map((b) => b.art)).toEqual(['keine-leuchte'])
+    expect(r.vorschlaege).toEqual([])
+  })
+})


### PR DESCRIPTION
Der dritte Satz von #666 („Automatische Vorschläge machen etc") war als einziger offen. Die beiden anderen sind gebaut: Schaltungen mit Prüfung (`circuitSolver`) und die Leuchte, die auf dem Plan bei richtiger Verkabelung angeht.

## Was jetzt geht

Im Schaltbild-Streifen des Canvas gibt es einen Knopf **„Vorschläge"**. Er beantwortet zwei Fragen: *warum tut diese Schaltung nicht, was sie soll* — und *welche Ader würde es ändern*.

## Kein Vorschlag ist geraten

Das Modul rät nicht, welche Klemme wohin gehört. Es **sucht**: es probiert fehlende Verbindungen durch, lässt `solveCircuit` über alle Schalterstellungen laufen und behält nur, was die Schaltung danach wirklich in Ordnung bringt. Es gibt keinen Zweig, der eine Verkabelung „nach Erfahrung" empfiehlt.

Und jeder Vorschlag bringt seinen **Beleg** mit: die Wahrheitstafel der Leuchte nach der Änderung, Stellung für Stellung, im Dialog aufklappbar. Wer den Vorschlag übernimmt, kann vorher nachsehen, statt zu vertrauen. Ohne die Tafel wäre es ein Ratschlag; mit ihr ein Nachweis.

## „In Ordnung" heisst unabhängig, nicht bloss schaltbar

Daran hängt der ganze Nutzen. Eine Wechselschaltung, der die zweite Korrespondierende fehlt, **ist** schaltbar — sie brennt, wenn beide Schalter auf 1 stehen, und sonst nicht. Im Schaltbild sieht das richtig aus; im Flur tut der zweite Schalter nichts, sobald der erste unten steht.

Geprüft wird deshalb die Eigenschaft, die eine Wechselschaltung ausmacht: **jeder Bedienschalter muss die Leuchte in JEDER Stellung der anderen umschalten.** Für einen Aus-Schalter ist das dasselbe wie „schaltbar", für Wechsel- und Kreuzschaltung der Unterschied zwischen „geht" und „geht meistens".

## Entscheidungen mit Grund

* **FI, LS, Not-Aus, Schütz und Relais werden leitend angenommen** und nicht durchgespielt: dass die Leuchte bei ausgelöstem LS nicht angeht, ist kein Verdrahtungsfehler. Die Annahme steht im Ergebnis und im Dialog, statt still eingebaut zu sein.
* **„Immer an" bekommt einen Befund und ausdrücklich keinen Vorschlag.** Die Suche legt nur Adern dazu, und eine zusätzliche Ader macht keine Leuchte dunkler. Liesse man sie laufen, endete sie mit „nichts gefunden" — was sich liest wie „es gibt keine Lösung".
* **Belegte Klemmen bleiben aus den Kandidaten heraus.** An einer Schalterklemme ist Platz für eine Ader; ein Vorschlag, den man nicht bauen kann, ist schlimmer als keiner.
* **Die Klemmenliste kommt aus `CIRCUIT_KIND_INFO`** und wird nicht ein zweites Mal aufgeschrieben (ADR-001). Eine eigene Tabelle wäre leise falsch: ein Vorschlag auf eine Klemme, die es an der Bauart nicht gibt, sähe aus wie jeder andere.
* **Die Grenzen der Suche werden gesagt** (`vollstaendig: false` mit Grund). Eine gekappte Suche, die wie eine erschöpfende aussieht, ist die schlechtere Hälfte von „keine Vorschläge".
* **Was sich nicht eintragen lässt, verschwindet nicht.** Ein Wechselschalter ohne Anschluss mit Klemme 2 bekommt den Vorschlag samt Hindernis und fehlender Klemme — das ist zugleich die Anleitung. Still verschluckt läse es sich als „alles in Ordnung".
* **Eingetragen wird nur auf Knopfdruck, und immer der ganze Vorschlag.** Eine halb eingetragene Wechselschaltung sieht danach aus wie fertig.
* **Der Kabeltyp wird am Anschluss gelesen**, nicht ausgedacht; die drei Steckertypen, die es als Kabeltyp nicht gibt, werden `Custom`.

## Eine Regel ist beim Gegenproben durchgefallen

Die Klemmstelle bekam zwei frische Klemmen statt einer, mit der Begründung, an einer Dose dürften zwei neue Adern zusammenkommen. Das stimmt, ändert an dieser Suchtiefe aber nichts — wer zwei Adern an derselben Dose braucht, verbindet zwei Klemmen, die sich auch direkt verbinden lassen, und dieser Kandidat steht ohnehin in der Liste. Mit einer Klemme blieb jeder Test grün. Der Grund steht jetzt an ihrer Stelle im Code.

Dieselbe Ehrlichkeit an einer zweiten Stelle: „kein Anschluss zweimal je Vorschlag" ist heute **nicht** rot zu bekommen, weil der Rechner je Klemme nur einen Kandidaten anbietet. Die Buchführung bleibt trotzdem stehen — sie hält eine Eigenschaft, die aus einem anderen Modul folgt. Das steht als Kommentar am Test, statt als Zusicherung behauptet zu werden.

## Gegengeprobt

**Rechner (9, alle rot):** Ziel nur „schaltbar" statt unabhängig · „immer an" ohne Begründung · belegte Klemmen als Kandidaten zugelassen · Betriebsmittel nicht leitend angenommen · Annahmen verschwiegen · ungeprüft vorgeschlagen · Wechselschalter ohne Klemme 2 in der Klemmenliste · Stellungs-Kappung still · Klemmen-Kappung still.

**Rückübersetzung (4, alle rot):** gehinderte Vorschläge still weggelassen · nächstbester Anschluss statt der angegebenen Klemme · belegte Anschlüsse mitgenommen · Wahrheitstafel fällt beim Hindernis weg.

## Geprüft

* `npm test` → 3808 grün, 2 skipped
* `npx tsc -p tsconfig.app.json --noEmit` → sauber
* `npm run lint` → 0 Fehler (12 vorbestehende Warnungen)
* `tests/i18nErreichbarkeit.test.ts` war rot (13 fehlende EN-Schlüssel), `tests/hinweisLaenge.test.ts` war rot (langer Absatz ohne `PanelHint`) — beide behoben

Refs #666 (der erste und zweite Satz sind seit #771/#782/#788 gebaut; das Issue bleibt für die Gebäude-Kreise offen, siehe [ADR-006](https://github.com/larszu/av-planner-suite/blob/main/docs/decisions/ADR-006-werkzeug-schnitt.md)).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_