### PR TITLE
lang: den Sprachmix zaehlen statt ihn zu vermuten — gemessen null (B-63)

### DIFF
--- a/scripts/quellsprache.mjs
+++ b/scripts/quellsprache.mjs
@@ -164,6 +164,109 @@ export const messeQuellsprache = (wurzel) => {
 export const abweichungen = (messung, quellsprache) =>
   messung.stellen.filter((s) => s.sprache !== quellsprache)
 
+// ── Sprachmix: sichtbarer Text, der GAR NICHT gewickelt ist (B-61/B-63) ────
+//
+// Die Messung oben sieht nur die Fallbacks in `t()`. Beschriftungen, die
+// niemand gewickelt hat, sieht sie nicht — und genau die sind der Sprachmix,
+// den E-17 fuer `sony-camera-bridge` als Fehler benannt hat: wer die andere
+// Sprache waehlt, bekommt eine Oberflaeche, in der ein Teil umschaltet und
+// der Rest stehenbleibt.
+//
+// ZWEI FEHLER DES LAUFS IM `sony-camera-bridge` SIND HIER VERMIEDEN, weil sie
+// drueben Geld gekostet haben:
+//   1. Er sah Kommentare fuer Literale. Kommentare werden vor dem Messen
+//      entfernt.
+//   2. Er sah nur Attribute, nicht den JSX-Text. Hier wird beides gelesen.
+
+/** Kommentare raus — sie folgen der Repo-Konvention, nicht der Oberflaeche. */
+const ohneKommentare = (text) =>
+  text.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/^\s*\/\/.*$/gm, ' ')
+
+const SICHTBARE_ATTRIBUTE =
+  /\b(?:title|aria-label|placeholder|label|alt|summary|submitLabel|hint)=(?:"([^"]{4,})"|\{\s*'((?:[^'\\]|\\.){4,}?)'\s*\})/g
+
+/**
+ * JSX-Textknoten — und zwar NUR die.
+ *
+ * Die erste Fassung war `/>([^<>{}]{4,})</g`. Sie trifft in einer .tsx-Datei
+ * auch CODE: `>` und `<` sind Vergleichsoperatoren, und dazwischen steht dann
+ * ein Stueck Quelltext (`if (clipped.length > 2)`, `arr.filter(n => n.id)`).
+ * Gemessen mit dem lockeren Muster: 35 solche Fehltreffer im cable-planner,
+ * 12 im light-planner — ausnahmslos Code, kein einziger echter Fund.
+ *
+ * ZWEI BEDINGUNGEN MACHEN DARAUS EIN TAG-MUSTER:
+ *   • Das `>` muss ein Tag-Ende sein: davor ein Bezeichner, ein
+ *     Anfuehrungszeichen, eine geschweifte Klammer oder ein Schraegstrich —
+ *     nie ein Leerzeichen, `=`, `<` oder `!`. Damit fallen `a > b`, `=>` und
+ *     `<=` heraus.
+ *   • Das schliessende `<` muss ein Tag beginnen: `</` oder `<Buchstabe`.
+ * Was danach noch durchkommt, sind Generics (`useState<Foo>(null)`); die
+ * faengt `NACH_CODE`.
+ */
+const JSX_TEXT = /[^\s=<!>]>([^<>{}]{4,})<[/A-Za-z]/g
+
+/**
+ * Was ein JSX-Textknoten NIE enthaelt, ein Code-Schnipsel dagegen fast immer.
+ * Greift ausschliesslich auf JSX-Text, nicht auf Attribute: dort steht
+ * durchaus ein `=` in der Oberflaeche („Shift = frei, Mausrad = Stufe").
+ */
+const NACH_CODE = /[;=]|\b(?:const|let|var|function|await|async)\b/
+
+/**
+ * Auch das Template-Literal, nicht nur die Anfuehrungszeichen. Eine Rueckfrage
+ * mit eingesetztem Namen steht praktisch immer im Backtick — ausgerechnet die
+ * Form also, die eine erste Fassung nicht kannte (gefunden ueber den
+ * `dialogs:native`-Waechter der Suite, nicht ueber diesen Lauf).
+ */
+const RUFE =
+  /\b(?:alert|confirm|prompt)\(\s*(?:(['"])((?:[^\\]|\\.){4,}?)\1|`((?:[^`\\]|\\.){4,}?)`)/g
+
+/** Sichtbarer Text einer Datei, der NICHT in einem `t()`-Fallback steht. */
+export const sichtbareTexte = (quelle, jsx) => {
+  const text = ohneKommentare(quelle).replace(fallbackMuster(), ' ')
+  const raus = []
+  for (const m of text.matchAll(SICHTBARE_ATTRIBUTE)) raus.push(m[1] ?? m[2])
+  for (const m of text.matchAll(RUFE)) raus.push(m[2] ?? m[3])
+  if (jsx) {
+    for (const m of text.matchAll(JSX_TEXT)) {
+      const t = m[1].trim()
+      if (t && !t.startsWith('{') && !NACH_CODE.test(t)) raus.push(t)
+    }
+  }
+  return raus
+}
+
+/**
+ * Die Obergrenze, nicht das Ziel.
+ *
+ * GEMESSEN am 2026-09-09 mit dem strengen JSX-Muster: NULL. Das ist ein
+ * Ergebnis und keine Selbstverstaendlichkeit — die offene Frage aus B-63 war
+ * genau diese, und sie war bis dahin nicht gemessen, sondern vermutet.
+ *
+ * Sie darf SINKEN und nicht steigen: wer eine englische Beschriftung
+ * hinzufuegt, faellt durch; wer uebersetzt und die Zahl stehen laesst,
+ * ebenfalls. Auf null bedeutet: JEDE neue Zeichenkette in der anderen
+ * Sprache faellt sofort auf.
+ */
+export const MIX_GRENZE = 0
+
+/** Ungewickelter sichtbarer Text in der jeweils anderen Sprache. */
+export const messeSprachmix = (wurzel, quellsprache) => {
+  const ziel = quellsprache === 'de' ? 'en' : 'de'
+  const funde = []
+  for (const datei of dateien(wurzel)) {
+    const rel = relative(wurzel, datei).split(sep).join('/')
+    // Das Woerterbuch ist per Definition in der anderen Sprache, Tests sind
+    // keine Oberflaeche. Eine Zahl, die niemand auf null bringen kann, liest
+    // niemand.
+    if (rel.includes('i18n') || rel.includes('__tests__') || rel.includes('.test.')) continue
+    for (const roh of sichtbareTexte(readFileSync(datei, 'utf8'), datei.endsWith('.tsx'))) {
+      if (klassifiziere(roh) === ziel) funde.push({ datei: rel, text: roh.slice(0, 100) })
+    }
+  }
+  return funde
+}
+
 // CLI: `node scripts/quellsprache.mjs <wurzel> <sprache>`
 if (process.argv[1] && process.argv[1].endsWith('quellsprache.mjs')) {
   const [, , wurzel, sprache] = process.argv
@@ -182,6 +285,31 @@ if (process.argv[1] && process.argv[1].endsWith('quellsprache.mjs')) {
       `\n${falsch.length} Fallback(s) nicht in der Quellsprache „${sprache}". ` +
         'Entweder die Zeile uebersetzen oder — wenn die Quellsprache wirklich ' +
         'wechseln soll — die Deklaration in package.json UND CLAUDE.md aendern.',
+    )
+    process.exit(1)
+  }
+
+  const mix = messeSprachmix(wurzel, sprache)
+  console.log(
+    `Sprachmix: ${mix.length} ungewickelte Zeichenkette(n) in der anderen Sprache ` +
+      `(Grenze ${MIX_GRENZE}).`,
+  )
+  if (mix.length > MIX_GRENZE) {
+    console.error(`\n${mix.length - MIX_GRENZE} mehr als erlaubt:`)
+    for (const f of mix.slice(0, 40)) console.error(`  ${f.datei}: ${f.text}`)
+    if (mix.length > 40) console.error(`  … und ${mix.length - 40} weitere`)
+    console.error(
+      '\nEntweder wickeln und uebersetzen — oder, wenn es wirklich so bleiben ' +
+        'soll, MIX_GRENZE mit Begruendung anheben. Das Anheben ist die Ausnahme; ' +
+        'das Senken ist der Normalfall.',
+    )
+    process.exit(1)
+  }
+  if (mix.length < MIX_GRENZE) {
+    console.error(
+      `\nDie Grenze steht auf ${MIX_GRENZE}, gemessen sind ${mix.length}. ` +
+        'MIX_GRENZE auf den neuen Wert setzen — eine Grenze ueber dem Ist deckt ' +
+        'ab morgen wieder Zuwachs.',
     )
     process.exit(1)
   }

--- a/scripts/quellsprache.mjs
+++ b/scripts/quellsprache.mjs
@@ -250,10 +250,19 @@ export const sichtbareTexte = (quelle, jsx) => {
  */
 export const MIX_GRENZE = 0
 
-/** Ungewickelter sichtbarer Text in der jeweils anderen Sprache. */
+/**
+ * Ungewickelter sichtbarer Text in der jeweils anderen Sprache.
+ *
+ * Gibt AUSSERDEM zurueck, wie viel sichtbarer Text ueberhaupt geprueft wurde.
+ * Die Zahl steht in der Ausgabe, damit die Null darueber zu deuten ist — als
+ * Angabe, nicht als Schwelle: sie faellt, je mehr gewickelt wird, und waere
+ * als Untergrenze deshalb nach dem zweiten Nachziehen nur noch Zierrat. Dass
+ * das Muster ueberhaupt findet, belegt die feste Probe im CLI-Teil.
+ */
 export const messeSprachmix = (wurzel, quellsprache) => {
   const ziel = quellsprache === 'de' ? 'en' : 'de'
   const funde = []
+  let gesehen = 0
   for (const datei of dateien(wurzel)) {
     const rel = relative(wurzel, datei).split(sep).join('/')
     // Das Woerterbuch ist per Definition in der anderen Sprache, Tests sind
@@ -261,10 +270,11 @@ export const messeSprachmix = (wurzel, quellsprache) => {
     // niemand.
     if (rel.includes('i18n') || rel.includes('__tests__') || rel.includes('.test.')) continue
     for (const roh of sichtbareTexte(readFileSync(datei, 'utf8'), datei.endsWith('.tsx'))) {
+      gesehen += 1
       if (klassifiziere(roh) === ziel) funde.push({ datei: rel, text: roh.slice(0, 100) })
     }
   }
-  return funde
+  return { funde, gesehen }
 }
 
 // CLI: `node scripts/quellsprache.mjs <wurzel> <sprache>`
@@ -289,10 +299,60 @@ if (process.argv[1] && process.argv[1].endsWith('quellsprache.mjs')) {
     process.exit(1)
   }
 
-  const mix = messeSprachmix(wurzel, sprache)
+  // ── Die Gegenprobe zum Messwerkzeug selbst — an fester Probe, nicht am Repo.
+  //
+  // WARUM NICHT AM REPO. Der naheliegende Weg waere eine Untergrenze auf der
+  // Zahl der gefundenen Texte („mindestens N"). Der Wert davon faellt aber
+  // genau dann, wenn die Arbeit gelingt: je mehr gewickelt ist, desto weniger
+  // ungewickelter Text bleibt uebrig. Eine solche Schwelle muesste bei jedem
+  // Fortschritt nachgezogen werden und waere nach dem zweiten Nachziehen nur
+  // noch Zierrat.
+  //
+  // Die Probe dagegen ist unabhaengig von der Repo-Groesse und haelt genau die
+  // Fehlformen fest, die diesen Zaehler Zeit gekostet haben: der Kommentar als
+  // Literal, das Vergleichs-`>` als Tag-Ende, die Rueckfrage im Backtick. Ohne
+  // sie waere ein kaputtes Muster die gefaehrlichste Art gruen: es findet
+  // nichts, und Nichts sieht hier aus wie ein Ergebnis.
+  const PROBE = [
+    '<button title="Delete this cable">',
+    '<span>Not connected yet</span>',
+    'window.confirm(`Delete "${name}" and its ${n} shots?`)',
+    // Die beiden Kommentar-Zeilen tragen mit Absicht Muster, die OHNE den
+    // Kommentarfilter treffen wuerden — eine ohne waere wirkungslos: was kein
+    // `>` und kein `title=` enthaelt, findet der Zaehler ohnehin nicht, und die
+    // Probe belegte dann nichts.
+    '// title="Legacy tooltip, no longer shown"',
+    '/* <b>Old markup left in a comment</b> */',
+    'if (a.length > 2) return b < c',
+    'const n = a>b ? 1 : 2; const m = c<d',
+    "t('cable.remove', 'Delete this cable')",
+  ].join('\n')
+
+  // Sortiert verglichen: in welcher Reihenfolge Attribute, Rueckfragen und
+  // Textknoten herausfallen, ist eine Eigenschaft der Schleifen und keine
+  // Zusicherung — ein Waechter, der bei einer umgestellten Schleife anschlaegt,
+  // meldet Fehlalarme.
+  const gefunden = sichtbareTexte(PROBE, true).slice().sort()
+  const erwartet = [
+    'Delete "${name}" and its ${n} shots?',
+    'Delete this cable',
+    'Not connected yet',
+  ].sort()
+  if (gefunden.length !== erwartet.length || erwartet.some((e, i) => gefunden[i] !== e)) {
+    console.error(
+      '\nDie Probe des Sprachmix-Musters schlaegt fehl.\n' +
+        `  erwartet: ${JSON.stringify(erwartet)}\n` +
+        `  gefunden: ${JSON.stringify(gefunden)}\n` +
+        'Das Muster findet entweder echte Beschriftungen nicht mehr oder wieder ' +
+        'Kommentare und Quelltext. Beides macht die Zahl unten wertlos.',
+    )
+    process.exit(1)
+  }
+
+  const { funde: mix, gesehen } = messeSprachmix(wurzel, sprache)
   console.log(
     `Sprachmix: ${mix.length} ungewickelte Zeichenkette(n) in der anderen Sprache ` +
-      `(Grenze ${MIX_GRENZE}).`,
+      `(Grenze ${MIX_GRENZE}, ${gesehen} sichtbare Texte geprueft).`,
   )
   if (mix.length > MIX_GRENZE) {
     console.error(`\n${mix.length - MIX_GRENZE} mehr als erlaubt:`)


### PR DESCRIPTION
## Worum es geht

Der Quellsprachen-Waechter (`npm run lang:check`) las bisher nur die Fallbacks in `t('key', 'Text')`. Beschriftungen, die **niemand gewickelt hat**, sah er nicht — und genau die sind der Sprachmix, den E-17 im `sony-camera-bridge` als Fehler benannt hat: wer die andere Sprache waehlt, bekommt eine Oberflaeche, in der ein Teil umschaltet und der Rest stehenbleibt.

B-63 hat die Frage fuer die beiden deutsch-quelligen Repos ausdruecklich **offen** gelassen:

> Die eigentliche Frage bleibt offen und ist berechtigt: haben `cable-planner` und `light-planner` denselben blinden Fleck? … Ob dort englische Beschriftungen ungewickelt herumstehen, ist damit **nicht gemessen** — und es als „vermutlich nicht" abzutun waere dieselbe Behauptung ohne Messung, gegen die dieses Backlog sonst schreibt.

Jetzt ist sie gemessen. Das Ergebnis ist **null** — aber das ist ein Messergebnis und keine Selbstverstaendlichkeit, und ab jetzt haelt es ein Waechter fest.

## Was dazukommt

- **`sichtbareTexte(quelle, jsx)`** liest sichtbare Attribute (`title`, `aria-label`, `placeholder`, `label`, `alt`, `summary`, `submitLabel`, `hint`), JSX-Textknoten und die Rueckfragen in `alert`/`confirm`/`prompt` — jeweils **nach** Abzug aller `t()`-Fallbacks, denn die misst bereits die erste Haelfte des Checks.
- **`MIX_GRENZE = 0`**, geprueft in **beide** Richtungen (siehe unten).
- Der CLI-Lauf meldet die Zahl und faellt bei Abweichung; `lang:check` ist im CI.

## Die drei Fallen, die hier vermieden sind

Alle drei haben im `sony-camera-bridge` (B-26) bzw. im `multicam-planner` (B-61) Zeit gekostet und sind deshalb im Datei-Kopf als **Messung** notiert, nicht als Meinung:

1. **Kommentare sind keine Oberflaeche.** Sie werden vor dem Messen entfernt. Ohne diesen Filter zaehlte der Lauf im multicam-planner 47 statt 37 — ein Kommentar folgt der Repo-Konvention (hier: deutsch), nicht der Sprache der Oberflaeche.
2. **Attribute allein reichen nicht.** Ohne die JSX-Messung waeren es 23 statt 37 gewesen; der sichtbarste Text einer React-Oberflaeche steht zwischen den Tags.
3. **Das JSX-Muster muss ein Tag-Muster sein.** Die naheliegende Form `/>([^<>{}]{4,})</g` trifft in einer `.tsx`-Datei auch **Code**, weil `>` und `<` Vergleichsoperatoren sind (`if (clipped.length > 2)`, `arr.filter(n => n.id)`). Gemessen mit dem lockeren Muster: **35 Fehltreffer hier**, 12 im light-planner — ausnahmslos Quelltext, kein einziger echter Fund.

   Dass das im multicam-planner nicht auffiel (dort: 0), war **Zufall der Richtung**: ein Code-Schnipsel traegt `if`, `for`, `const`, `return` und wird vom Klassifizierer als *englisch* eingeordnet. In einem englisch-quelligen Repo sucht die Messung aber Deutsch — die Fehltreffer fielen also durchs Raster, statt zu laermen. In der Gegenrichtung tun sie es nicht.

   Zwei Bedingungen machen daraus ein Tag-Muster: vor dem `>` muss ein Bezeichner, Anfuehrungszeichen, `}` oder `/` stehen (nie Leerzeichen, `=`, `<`, `!` — damit fallen `a > b`, `=>`, `<=` heraus), und das schliessende `<` muss ein Tag beginnen (`</` oder `<Buchstabe`). Was dann noch durchkommt, sind Generics; die faengt `NACH_CODE`.

   `NACH_CODE` greift **nur auf JSX-Text, nie auf Attribute** — in einem Attribut steht durchaus ein `=` als Oberflaeche („Shift = frei, Mausrad = Stufe").

## Warum die Grenze in beide Richtungen faellt

Eine Grenze, die nur nach oben schlaegt, ist ein Deckel: wer uebersetzt und die Zahl stehen laesst, gibt den Platz frei, den der naechste Zuwachs unbemerkt fuellt — und zwar bei gruenem Check. Deshalb faellt der Lauf auch, wenn die Messung **unter** `MIX_GRENZE` liegt, mit der Aufforderung, die Grenze zu senken.

## Gegenprobe

In `StatusBar.tsx`, beide Richtungen rot und danach wiederhergestellt:

| Probe | Erwartet | Gemessen |
|---|---|---|
| englisches `title`-Attribut eingefuegt | rot | 1 Fund, Exit 1 |
| englischer JSX-Text eingefuegt | rot | 1 Fund, Exit 1 |
| unveraendert | gruen | 0 Funde |

## Messung

```
src/renderer: 2324 deutsch, 0 englisch, 2790 ohne Merkmal
Sprachmix: 0 ungewickelte Zeichenkette(n) in der anderen Sprache (Grenze 0)
```

`npx tsc -p tsconfig.app.json --noEmit` 0 Fehler, 3808 Tests gruen (2 uebersprungen).

Teil von B-63. Die andere Haelfte der Frage (light-planner) beantwortet der Schwester-PR — ebenfalls 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_