### PR TITLE
feat(showcontrol): Companion-Variablenstand als zweite Quelle — E-23 ist damit ganz durch

### DIFF
--- a/src/renderer/components/Delivery/DeliveryDialog.tsx
+++ b/src/renderer/components/Delivery/DeliveryDialog.tsx
@@ -8,6 +8,7 @@ import { downloadBlob } from '../../lib/downloadBlob'
 import { buildExportFilenameWithSuffix } from '../../lib/exportFilename'
 import { csvFromTable, stampForRows } from '../../lib/documentStamp'
 import { checkDelivery, deliveryTable, deliveryTableForProject, type DeliveryIssue } from '../../lib/deliveryParity'
+import { COMPANION_SCHNITTSTELLE_HINWEIS } from '../../lib/companionVariablen'
 import { srtLatencyAdvice, uplinkBudget } from '../../lib/transportParams'
 import {
   ENCODERS,
@@ -1523,10 +1524,7 @@ export const DeliveryDialog = () => {
                     </div>
                     {d.showControl?.companionSeite !== undefined && (
                       <div className="mt-1 text-cp-xs text-cp-text-muted">
-                        {t(
-                          'delivery.osc.companionOptIn',
-                          'Companions Schnittstelle ist ab Werk aus — sie muss dort eingeschaltet werden. Ohne diesen Hinweis zeigt das Blatt einen Weg, den es beim Kunden nicht gibt.',
-                        )}
+                        {t('delivery.osc.companionOptIn', COMPANION_SCHNITTSTELLE_HINWEIS)}
                       </div>
                     )}
 

--- a/src/renderer/components/ShowControl/CompanionStandSection.tsx
+++ b/src/renderer/components/ShowControl/CompanionStandSection.tsx
@@ -1,0 +1,166 @@
+import { useMemo, useState } from 'react'
+import { useProjectStore } from '../../store/projectStore'
+import { useTranslation } from '../../lib/i18n'
+import { PanelHint } from '../shared/PanelHint'
+import {
+  COMPANION_API,
+  COMPANION_SCHNITTSTELLE_HINWEIS,
+  companionAbfrage,
+  leseCompanionStand,
+  type CompanionAblesung,
+} from '../../lib/companionVariablen'
+
+/**
+ * Der Companion-Variablenstand als ZWEITE Quelle (E-23, letzter offener Punkt).
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * WARUM HIER EIN TEXTFELD STEHT UND KEIN „JETZT ABFRAGEN"-KNOPF
+ * ═══════════════════════════════════════════════════════════════════════
+ *
+ * Ein Knopf, der Companion befragt und das Ergebnis anzeigt, wäre der
+ * Anfang des Monitors, den die Bedarfs-Datenbank ausdrücklich verbietet
+ * („a live monitoring dashboard, which would make the suite responsible
+ * for a false all-clear"). Der zweite Schritt wäre ein Intervall, der
+ * dritte eine Farbe, und dann steht dort ein Anlagenzustand.
+ *
+ * Deshalb dieselbe Bauform wie im übrigen Plan: **er benennt den Weg, er
+ * geht ihn nicht.** Links stehen die Befehlszeilen zum Mitnehmen, rechts
+ * kommt zurück, was jemand aus der Sitzung kopiert hat. Was dabei
+ * herauskommt, trägt den Zeitpunkt des ABLESENS und behauptet nichts über
+ * jetzt.
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * WAS DIESER SCHRITT NOCH NICHT KANN — UND WARUM DAS SO DASTEHT
+ * ═══════════════════════════════════════════════════════════════════════
+ *
+ * Es fehlt die PLAN-SEITE. `companionAsBuilt` kann eine Ablesung gegen
+ * einen erwarteten Wert stellen, aber der Plan hält nirgends fest, welchen
+ * Kreuzpunkt er zuletzt über welche Variable gefahren hat — `controlCompanion`
+ * trägt die Variablen-NAMEN, nicht ihre Werte. Diesen Wert hier zu raten
+ * hiesse, eine Abweichung zu behaupten, die niemand gemessen hat.
+ *
+ * Die Zeile sagt das lieber, als es zu verschweigen: eine Ablesung ohne
+ * Plan-Seite ist im As-built-Sinn `unexpected` („vorgefunden, nicht im
+ * Plan") und kein Fehler.
+ */
+export const CompanionStandSection = () => {
+  const t = useTranslation()
+  const equipment = useProjectStore((s) => s.project.equipment)
+
+  // Die Variablennamen kommen aus dem Plan, nicht aus einer Eingabe: nur was
+  // dort steht, kann der Plan hinterher auch zuordnen.
+  const namen = useMemo(() => {
+    const raus: string[] = []
+    for (const item of equipment) {
+      const c = item.controlCompanion
+      if (!c) continue
+      if (c.varOut.trim()) raus.push(c.varOut.trim())
+      if (c.varIn.trim()) raus.push(c.varIn.trim())
+    }
+    return [...new Set(raus)]
+  }, [equipment])
+
+  const zeilen = useMemo(() => companionAbfrage(namen), [namen])
+  const [antwort, setAntwort] = useState('')
+  const [ablesungen, setAblesungen] = useState<CompanionAblesung[]>([])
+  const [problem, setProblem] = useState<string | undefined>()
+
+  const lesen = () => {
+    // Die Uhr steht HIER und nicht im Baustein: der Zeitpunkt des Ablesens
+    // ist eine Beobachtung dieses Augenblicks, und der Baustein bleibt rein.
+    const erg = leseCompanionStand(antwort, namen, new Date().toISOString())
+    setAblesungen(erg.ablesungen)
+    setProblem(erg.problem)
+  }
+
+  return (
+    <div className="mt-5 border-t border-cp-border-muted pt-3">
+      <div className="mb-1 text-cp-xs font-semibold text-cp-text">
+        {t('companion.title', 'Companion-Variablenstand zurücklesen')}
+      </div>
+      <PanelHint
+        className="mb-2 text-cp-xs text-cp-text-muted"
+        text={t('companion.optIn', COMPANION_SCHNITTSTELLE_HINWEIS)}
+      />
+
+      {namen.length === 0 ? (
+        <div className="rounded border border-cp-border-muted bg-cp-surface-2 p-3 text-cp-xs text-cp-text-muted">
+          {t(
+            'companion.noVars',
+            'Kein Gerät im Plan wird über Companion geschaltet — es gibt keine Variable, die sich zurücklesen liesse.',
+          )}
+        </div>
+      ) : (
+        <>
+          <div className="mb-1 text-cp-xs text-cp-text-muted">
+            {t(
+              'companion.commandsHint',
+              'Diese Zeilen in die Companion-Steuerung tippen (TCP, eine Zeile je Befehl) und die Antworten zurückbringen:',
+            )}
+          </div>
+          <pre className="mb-2 max-h-32 overflow-auto rounded border border-cp-border bg-cp-surface-2 p-2 text-cp-xs text-cp-text-secondary">
+            {zeilen.join('\n')}
+          </pre>
+
+          <label className="block text-cp-xs">
+            <span className="mb-1 block text-cp-text-muted">
+              {t('companion.paste', 'Antworten hier einfügen')}
+            </span>
+            <textarea
+              className="h-20 w-full rounded border border-cp-border bg-cp-surface-2 px-2 py-1 font-mono text-cp-xs"
+              value={antwort}
+              placeholder={'+OK "3"\n+OK "5"'}
+              onChange={(e) => setAntwort(e.target.value)}
+            />
+          </label>
+          <button
+            type="button"
+            className="mt-1 rounded bg-cp-surface-3 px-2 py-1 text-cp-xs hover:bg-cp-surface-4"
+            onClick={lesen}
+          >
+            {t('companion.read', 'Als Ablesung übernehmen')}
+          </button>
+
+          {problem && (
+            <div className="mt-2 rounded border border-cp-warn bg-cp-warn/10 p-2 text-cp-xs text-cp-warn">
+              {problem}
+            </div>
+          )}
+
+          {ablesungen.length > 0 && (
+            <>
+              <ul className="mt-2 max-h-40 overflow-y-auto text-cp-xs">
+                {ablesungen.map((a) => (
+                  <li
+                    key={a.variable}
+                    className="border-b border-cp-border-muted py-1 text-cp-text-secondary last:border-b-0"
+                  >
+                    <span className="font-mono">{a.variable}</span>
+                    {' — '}
+                    {a.antwort.fehler
+                      ? t('companion.notRead', 'nicht abgelesen') + `: ${a.antwort.fehler}`
+                      : (a.antwort.wert ?? t('companion.noValue', 'ohne Wert'))}
+                    <span className="text-cp-text-faint">
+                      {' '}
+                      · {t('companion.readAt', 'abgelesen')} {a.gelesenAm.slice(11, 19)}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+              <PanelHint
+                className="mt-1 text-cp-xs text-cp-text-muted"
+                text={t(
+                  'companion.noPlanSide',
+                  'Das ist eine Ablesung von eben, kein Zustand von jetzt — und sie steht ohne Plan-Seite da: der Plan hält nicht fest, welchen Wert er zuletzt in diese Variable geschrieben hat.',
+                )}
+              />
+            </>
+          )}
+        </>
+      )}
+      <div className="mt-1 text-cp-xs text-cp-text-faint">
+        {t('companion.source', 'Protokoll-Angaben nachgesehen in')} {COMPANION_API.gelesen}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/ShowControl/OscEmpfangPanel.tsx
+++ b/src/renderer/components/ShowControl/OscEmpfangPanel.tsx
@@ -6,6 +6,7 @@ import { useProjectStore } from '../../store/projectStore'
 import { useTranslation } from '../../lib/i18n'
 import { ModalShell } from '../shared/ModalShell'
 import { PanelHint } from '../shared/PanelHint'
+import { CompanionStandSection } from './CompanionStandSection'
 import { Icon } from '../shared/Icon'
 import {
   LAUSCHER_LAGE_LABEL,
@@ -207,6 +208,12 @@ export const OscEmpfangPanel = () => {
           ))}
         </ul>
       )}
+
+      {/* Die ZWEITE Quelle (E-23). Sie steht bewusst unter der Mitschrift und
+          nicht daneben: sie kommt nicht ueber den Draht, sondern aus einer
+          Sitzung, die jemand gefuehrt hat — und traegt deshalb den Zeitpunkt
+          des ABLESENS statt den des Empfangs. */}
+      <CompanionStandSection />
     </ModalShell>
   )
 }

--- a/src/renderer/lib/asBuilt.ts
+++ b/src/renderer/lib/asBuilt.ts
@@ -89,6 +89,15 @@ export type ReadingSource =
   | 'field-check'
   /** Von Hand eingetragen, weil niemand das Gerät befragen kann. */
   | 'manual'
+  /**
+   * E-23 — der zurückgelesene Companion-Variablenstand.
+   *
+   * Sechste Quelle für dieses Blatt statt sechstes Blatt: was aus Companion
+   * zurückkommt, ist eine Ablesung wie jede andere hier und gehört in
+   * dieselbe Spur. Der Weg dorthin steht in `lib/companionVariablen.ts` —
+   * ein Import, ausdrücklich kein Poller.
+   */
+  | 'companion'
 
 export const READING_SOURCE_LABEL: Readonly<Record<ReadingSource, string>> = {
   'network-scan': 'Netz-Scan',
@@ -97,6 +106,7 @@ export const READING_SOURCE_LABEL: Readonly<Record<ReadingSource, string>> = {
   erp: 'Vermietung',
   'field-check': 'Aufbau vor Ort',
   manual: 'von Hand',
+  companion: 'Companion-Variable',
 }
 
 /** Das Urteil einer Zeile. */

--- a/src/renderer/lib/companionVariablen.ts
+++ b/src/renderer/lib/companionVariablen.ts
@@ -1,0 +1,274 @@
+// ───────────────────────────────────────────────────────────────────────────
+// DER COMPANION-VARIABLENSTAND ALS ZWEITE QUELLE (E-23, letzter offener Punkt)
+//
+// E-23 hat den eingehenden Show-Control-Weg entschieden und gebaut: der
+// OSC-Lauscher (`main/services/oscListener.ts`) schreibt EMPFANGSMELDUNGEN
+// mit, nie Anlagenzustand. Was der Eintrag ausdrücklich offen gelassen hat,
+// steht hier:
+//
+//   > Offen bleibt der Import eines Companion-Variablenstands als zweite
+//   > Quelle.
+//
+// ═══════════════════════════════════════════════════════════════════════════
+// WARUM DAS EIN IMPORT IST UND KEIN ZWEITER SOCKET
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Ein Poller, der Companion im Sekundentakt nach seinen Variablen fragt und
+// das Ergebnis anzeigt, ist genau das, was die Bedarfs-Datenbank verbietet:
+// „a live monitoring dashboard, which would make the suite responsible for a
+// false all-clear". Der Unterschied zwischen Mitschrift und Monitor liegt
+// nicht in der Technik, sondern darin, ob die Anzeige behauptet, JETZT zu
+// gelten.
+//
+// Deshalb dieselbe Bauform wie beim Rest dieses Plans: **der Plan benennt den
+// Weg, er geht ihn nicht.** Er schreibt die Befehlszeilen auf, die jemand in
+// eine Companion-Sitzung tippt, und liest die Antwort zurück, die derjenige
+// zurückbringt. Was dabei herauskommt, ist eine ABLESUNG mit Zeitpunkt —
+// dieselbe Spur wie beim As-built (`lib/asBuilt.ts`), die ausdrücklich nichts
+// in den Plan zurückschreibt: „was der Hub gerade tut, ist eine Beobachtung,
+// was im Plan steht, eine Absicht."
+//
+// Das ist zugleich der Grund, warum das hier eine ReadingSource bekommt und
+// keinen eigenen Anzeige-Begriff: eine sechste Quelle für ein vorhandenes
+// Blatt ist billiger und ehrlicher als ein sechstes Blatt.
+//
+// ═══════════════════════════════════════════════════════════════════════════
+// DIE PROTOKOLL-ANGABEN — NACHGESEHEN, NICHT ERINNERT
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Gelesen am 2026-09-09 in `bitfocus/companion@main`. Jede Zeile unten steht
+// so im Quelltext; wo etwas NICHT nachgesehen ist, sagt der Kommentar es.
+//
+//   `companion/lib/Service/TcpUdpApi.ts`
+//     • Route:   `custom-variable :name get-value`      (Zeile 266)
+//     • Handler: wirft `Variable not found`, sonst `JSON.stringify(result)`
+//     • Der Befehl wird nur getrimmt, sonst nicht angefasst (Zeile 521)
+//
+//   `companion/lib/Service/Tcp.ts`
+//     • Zeilentrenner ist `\n`; die Zeile wird getrimmt
+//     • Erfolg: `+OK`, bei Rückgabewert `+OK <wert>` — dann `\n`
+//     • Fehler: `-ERR <meldung>` — dann `\n`
+//     • Vorgabe-Port: 16759
+//
+//   `companion/lib/Data/UserConfig.ts`
+//     • Neuinstallation: `tcp_enabled: false`, `udp_enabled: false`,
+//       `osc_enabled: false` — aber `http_api_enabled: true`
+//     • Bestehende Installation (`#populateMissingForExistingDb`): TCP, UDP
+//       und OSC werden EINGESCHALTET, auf den alten Ports 51234 / 51235 /
+//       12321
+//
+// ─── WAS DIESE MESSUNG AN EINER VORHANDENEN ZEILE SCHÄRFT ──────────────────
+//
+// Das Ausspiel-Blatt schreibt heute an jede Companion-Position „Schnittstelle
+// dort einschalten — sie ist ab Werk aus" (`lib/deliveryParity.ts`). Das ist
+// für den LESE-Weg richtig und für den SCHALT-Weg falsch: S-4 schaltet über
+// die HTTP-API, und die ist ab Werk AN. Und „ab Werk aus" gilt nur für eine
+// Neuinstallation — eine hochgezogene Installation hat TCP an, nur auf einem
+// anderen Port. Beides steht jetzt an der Zeile, statt dass es jemand vor Ort
+// herausfindet.
+//
+// ─── EINE ANGABE, DIE HIER AUSDRÜCKLICH NICHT BEHAUPTET WIRD ───────────────
+//
+// Ob der Router Gross- und Kleinschreibung unterscheidet. `RegexRouter.addPath`
+// baut das Muster mit `pathToRegexp(path)` ohne Optionen; welche Vorgabe diese
+// Fassung für `sensitive` hat, ist NICHT nachgesehen worden. Deshalb schreibt
+// dieser Baustein die Befehlszeilen klein — so, wie die Route sie deklariert.
+// Klein passt unter beiden Auslegungen; gross nur unter einer.
+//
+// REIN: keine Uhr, kein Store, kein IO. Der Zeitpunkt kommt von aussen.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { AsBuiltEntry } from './asBuilt'
+
+/** Die nachgesehenen Vorgaben, an einer Stelle statt in drei Kommentaren. */
+export const COMPANION_API = {
+  /** Vorgabe-Port der TCP-Steuerung bei einer NEUINSTALLATION. */
+  tcpPortNeu: 16759,
+  /** Derselbe Port bei einer hochgezogenen Installation. */
+  tcpPortAlt: 51234,
+  /** Quelle und Stand der Angaben oben. */
+  gelesen: 'bitfocus/companion@main, 2026-09-09',
+} as const
+
+/**
+ * Der Satz, der an einer Companion-Position auf dem Blatt steht.
+ *
+ * EINE Stelle, damit die Auflage aus E-23 nicht in zwei Formulierungen
+ * auseinanderläuft — dieselbe Überlegung wie bei `empfangsText`.
+ */
+export const COMPANION_SCHNITTSTELLE_HINWEIS =
+  'Companion: der SCHALT-Weg läuft über die HTTP-API (ab Werk an), das ' +
+  'ZURÜCKLESEN über die TCP-Steuerung (bei einer Neuinstallation ab Werk aus, ' +
+  `Port ${COMPANION_API.tcpPortNeu}; eine hochgezogene Installation hat sie an, ` +
+  `auf Port ${COMPANION_API.tcpPortAlt}). Vor Ort nachsehen, nicht annehmen.`
+
+/**
+ * Die Befehlszeilen, die jemand in die Companion-Sitzung tippt.
+ *
+ * Klein geschrieben, siehe Kopf. Leere und doppelte Namen fallen weg: ein
+ * doppelter Name brächte zwei Antwortzeilen für einen Eintrag und verschöbe
+ * die Zuordnung unten um eins.
+ */
+export const companionAbfrage = (namen: readonly string[]): string[] => {
+  const gesehen = new Set<string>()
+  const raus: string[] = []
+  for (const roh of namen) {
+    const name = roh.trim()
+    if (!name || gesehen.has(name)) continue
+    gesehen.add(name)
+    raus.push(`custom-variable ${name} get-value`)
+  }
+  return raus
+}
+
+/** Eine gelesene Antwortzeile. */
+export interface CompanionAntwort {
+  /** Die Zeile, wie sie ankam — ungedeutet, für die Anzeige im Zweifel. */
+  roh: string
+  /** Der Wert, wenn die Zeile ein `+OK` mit Inhalt war. */
+  wert?: string
+  /** Die Fehlermeldung, wenn die Zeile ein `-ERR` war. */
+  fehler?: string
+}
+
+/**
+ * Eine einzelne Antwortzeile deuten.
+ *
+ * `+OK` ohne Inhalt ist KEIN leerer Wert, sondern gar keiner: Companion
+ * hängt den Wert nur an, wenn der Handler einen zurückgibt. Ein `+OK` allein
+ * kommt von den Befehlen ohne Rückgabe (`press`, `style`) — wer es als
+ * leeren Variablenwert läse, machte aus einem Tastendruck eine Ablesung.
+ *
+ * Der Wert kommt als `JSON.stringify(result)` zurück. Ist er lesbar, wird er
+ * ausgepackt (`"12"` -> `12`); ist er es nicht, bleibt die Rohform stehen.
+ * Raten wird hier nichts: eine unlesbare Antwort ist eine unlesbare Antwort.
+ */
+export const leseCompanionZeile = (zeile: string): CompanionAntwort | undefined => {
+  const z = zeile.trim()
+  if (!z) return undefined
+  if (z.startsWith('-ERR')) {
+    return { roh: z, fehler: z.slice(4).trim() || 'ohne Meldung' }
+  }
+  if (z === '+OK') return { roh: z }
+  if (z.startsWith('+OK ')) {
+    const rest = z.slice(4).trim()
+    let wert = rest
+    try {
+      const geparst: unknown = JSON.parse(rest)
+      if (typeof geparst === 'string' || typeof geparst === 'number' || typeof geparst === 'boolean') {
+        wert = String(geparst)
+      }
+    } catch {
+      // Rohform behalten — siehe oben.
+    }
+    return { roh: z, wert }
+  }
+  return undefined
+}
+
+/** Eine Ablesung: ein Variablenname, eine Antwort, ein Zeitpunkt. */
+export interface CompanionAblesung {
+  variable: string
+  antwort: CompanionAntwort
+  /** ISO-Zeitpunkt, von aussen gesetzt. */
+  gelesenAm: string
+}
+
+export interface CompanionStandErgebnis {
+  ablesungen: CompanionAblesung[]
+  /**
+   * Warum GAR NICHTS zugeordnet wurde. Gesetzt heisst: `ablesungen` ist leer.
+   *
+   * Kein Feld für Randfälle, sondern die Engstelle dieses Bausteins — siehe
+   * `leseCompanionStand`.
+   */
+  problem?: string
+}
+
+/**
+ * Den zurückgebrachten Antwortblock den abgefragten Namen zuordnen.
+ *
+ * ═══ DIE ENGSTELLE, UND WARUM SIE LIEBER NICHTS LIEFERT ═══════════════════
+ *
+ * Die Antwort trägt den Variablennamen NICHT — `+OK "12"` sagt nicht, wozu
+ * die 12 gehört. Zugeordnet werden kann also nur über die REIHENFOLGE, und
+ * die stimmt genau so lange, wie keine Zeile fehlt.
+ *
+ * Fehlt eine, verschiebt sich alles danach um eins: der Wert der einen
+ * Variablen erscheint unter dem Namen der nächsten. Das Ergebnis sieht
+ * vollständig aus, ist plausibel und ist falsch — und es ginge als Ablesung
+ * in ein As-built-Blatt, aus dem später jemand einen Kreuzpunkt liest.
+ *
+ * Deshalb ordnet dieser Baustein NUR bei exakter Übereinstimmung zu und
+ * liefert sonst nichts ausser dem Grund. Eine halbe Zuordnung wäre hier
+ * schlimmer als keine — dieselbe Haltung wie bei Invariante 23 (eine falsch
+ * gelesene Zahl sieht aus wie eine Messung).
+ *
+ * Nicht deutbare Zeilen (die getippten Befehle selbst, Begrüssungen, leere
+ * Zeilen) fallen vorher weg — sonst müsste jeder eine saubere Zwischenablage
+ * liefern, und das tut niemand.
+ */
+export const leseCompanionStand = (
+  text: string,
+  namen: readonly string[],
+  gelesenAm: string,
+): CompanionStandErgebnis => {
+  const gefragt = [...new Set(namen.map((n) => n.trim()).filter(Boolean))]
+  if (gefragt.length === 0) {
+    return { ablesungen: [], problem: 'Keine Variablennamen im Plan — es gibt nichts abzufragen.' }
+  }
+  const antworten = text
+    .split('\n')
+    .map(leseCompanionZeile)
+    .filter((a): a is CompanionAntwort => a !== undefined)
+
+  if (antworten.length === 0) {
+    return {
+      ablesungen: [],
+      problem:
+        'Keine Antwortzeile erkannt. Companion antwortet je Befehl mit einer Zeile, ' +
+        'die mit „+OK" oder „-ERR" beginnt — der eingefügte Text enthält keine solche.',
+    }
+  }
+  if (antworten.length !== gefragt.length) {
+    return {
+      ablesungen: [],
+      problem:
+        `${gefragt.length} Variable(n) abgefragt, ${antworten.length} Antwortzeile(n) erkannt. ` +
+        'Die Antwort trägt den Namen nicht mit — zugeordnet wird über die Reihenfolge, und ' +
+        'die stimmt nur bei gleicher Anzahl. Bei einer fehlenden Zeile stünde jeder Wert ' +
+        'unter dem falschen Namen. Alle Antworten vollständig einfügen, dann erneut.',
+    }
+  }
+  return {
+    ablesungen: gefragt.map((variable, i) => ({ variable, antwort: antworten[i], gelesenAm })),
+  }
+}
+
+/**
+ * Aus Ablesungen As-built-Zeilen machen.
+ *
+ * `planned` ist, was der Plan zuletzt über diese Variable gesetzt HÄTTE —
+ * übergeben wird es, nicht geraten: dieser Baustein kennt die Kreuzpunkte
+ * nicht. Wer nichts übergibt, bekommt eine Zeile ohne Plan-Seite, und
+ * `asBuiltVerdict` nennt sie `unexpected` — „vorgefunden, nicht im Plan".
+ *
+ * Eine `-ERR`-Antwort liefert AUSDRÜCKLICH KEINE Ablesung (`actual` bleibt
+ * leer). „Variable not found" heisst nicht „der Wert ist leer", sondern „es
+ * wurde nichts abgelesen" — und das Urteil dafür heisst `missing` und nicht
+ * `differs`. Der Fehlertext steht im Gegenstand, damit er nicht verlorengeht.
+ */
+export const companionAsBuilt = (
+  ablesungen: readonly CompanionAblesung[],
+  geplant: Readonly<Record<string, string>> = {},
+): AsBuiltEntry[] =>
+  ablesungen.map((a) => ({
+    subject: a.antwort.fehler
+      ? `Companion · ${a.variable} (${a.antwort.fehler})`
+      : `Companion · ${a.variable}`,
+    field: 'Custom-Variable',
+    planned: geplant[a.variable],
+    actual: a.antwort.fehler ? undefined : a.antwort.wert,
+    source: 'companion' as const,
+    at: a.gelesenAm,
+  }))

--- a/src/renderer/lib/deliveryParity.ts
+++ b/src/renderer/lib/deliveryParity.ts
@@ -29,6 +29,7 @@
 import type { CsvCell, CsvTable } from './csv'
 import type { DeliveryDestination, EncodingProfile } from '../types/delivery'
 import { platformByKey } from '../types/delivery'
+import { COMPANION_SCHNITTSTELLE_HINWEIS } from './companionVariablen'
 
 export type DeliveryIssueKind =
   /** Backup weicht in einem der sechs Pflichtfelder ab. */
@@ -225,10 +226,25 @@ export const deliveryIssueText = (i: DeliveryIssue): string => {
  * Die Show-Control-Zelle fuer das Blatt (E-23).
  *
  * ZWEI DINGE STEHEN HIER, UND DAS ZWEITE IST EINE AUFLAGE AUS DER RECHERCHE:
- * wo eine COMPANION-Position steht, schreibt das Blatt dazu, dass deren
- * Schnittstelle opt-in ist. Ohne diesen Zusatz zeigt der Plan einen Weg, den
- * es beim Kunden nicht gibt — die Schnittstelle ist in Companion
- * standardmaessig aus, und niemand sieht das der Positionsangabe an.
+ * wo eine COMPANION-Position steht, schreibt das Blatt dazu, wie es um deren
+ * Schnittstelle steht. Ohne diesen Zusatz zeigt der Plan einen Weg, den es
+ * beim Kunden vielleicht nicht gibt, und niemand sieht das der
+ * Positionsangabe an.
+ *
+ * DIE ERSTE FASSUNG DIESES ZUSATZES WAR ZU GROB. Sie sagte „die
+ * Schnittstelle ist ab Werk aus" — pauschal. Nachgesehen am 2026-09-09 in
+ * `companion/lib/Data/UserConfig.ts` stimmt das nur zur Haelfte:
+ *
+ *   • `http_api_enabled: true`   — der SCHALT-Weg aus S-4 ist ab Werk AN
+ *   • `tcp_enabled: false`       — der LESE-Weg ist ab Werk aus
+ *   • und eine hochgezogene Installation bekommt TCP EINGESCHALTET, nur auf
+ *     dem alten Port 51234 statt 16759
+ *
+ * Wer den Satz auf „ist aus" zurueckkuerzt, schickt jemanden an den falschen
+ * Schalter — und wer „ab Werk an" daraus macht, an gar keinen. Der Text steht
+ * deshalb an EINER Stelle (`lib/companionVariablen.ts`) und wird hier nur
+ * eingesetzt; `tests/companionVariablen.test.ts` haelt fest, dass beide Ports
+ * und beide Wege darin vorkommen.
  */
 export const showControlText = (
   sc: DeliveryDestination['showControl'],
@@ -239,7 +255,7 @@ export const showControlText = (
   if (sc.companionSeite !== undefined && sc.companionPlatz !== undefined) {
     teile.push(
       `Companion Seite ${sc.companionSeite} Platz ${sc.companionPlatz} ` +
-        '(Schnittstelle dort einschalten — sie ist ab Werk aus)',
+        `(${COMPANION_SCHNITTSTELLE_HINWEIS})`,
     )
   }
   return teile.join(' · ')

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -3609,7 +3609,25 @@ export const en: Dict = {
   'delivery.osc.page': 'Companion page',
   'delivery.osc.bank': 'Companion bank',
   'delivery.osc.companionOptIn':
-    "Companion's interface is off by default — it has to be switched on there. Without this note the sheet shows a path that does not exist at the customer.",
+    'Companion: switching goes through the HTTP API (on by default); reading values back goes through the TCP control API (off by default on a fresh install, port 16759; an upgraded install has it on, port 51234). Check on site, do not assume.',
+  // E-23, zweite Quelle: der zurueckgelesene Companion-Variablenstand. Die
+  // Woerter halten dieselbe Grenze wie die OSC-Mitschrift — „read back",
+  // „reading", „at 14:22:07", nirgends „status" oder „current".
+  'companion.title': 'Read back Companion variable values',
+  'companion.optIn':
+    'Companion: switching goes through the HTTP API (on by default); reading values back goes through the TCP control API (off by default on a fresh install, port 16759; an upgraded install has it on, port 51234). Check on site, do not assume.',
+  'companion.noVars':
+    'No device in the plan is switched through Companion — there is no variable to read back.',
+  'companion.commandsHint':
+    'Type these lines into the Companion control API (TCP, one line per command) and bring the answers back:',
+  'companion.paste': 'Paste the answers here',
+  'companion.read': 'Take as a reading',
+  'companion.notRead': 'not read',
+  'companion.noValue': 'no value',
+  'companion.readAt': 'read at',
+  'companion.noPlanSide':
+    'This is a reading from a moment ago, not a state right now — and it stands without a plan side: the plan does not record which value it last wrote into this variable.',
+  'companion.source': 'Protocol details looked up in',
   'app.menu.tools.osc': 'Received show-control messages…',
   'app.menu.tools.osc.note': 'What came in — a transcript, not a system state',
   'osc.title': 'Received show-control messages',

--- a/tests/companionVariablen.test.ts
+++ b/tests/companionVariablen.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COMPANION_API,
+  COMPANION_SCHNITTSTELLE_HINWEIS,
+  companionAbfrage,
+  companionAsBuilt,
+  leseCompanionStand,
+  leseCompanionZeile,
+} from '../src/renderer/lib/companionVariablen'
+import { asBuiltVerdict } from '../src/renderer/lib/asBuilt'
+
+/**
+ * Der Companion-Variablenstand als zweite Quelle (E-23).
+ *
+ * Die Gegenproben stehen bei ihrem jeweiligen Satz, nicht gesammelt am Ende —
+ * wer eine Zusicherung ändert, soll die Probe daneben sehen und nicht suchen
+ * müssen.
+ */
+
+const JETZT = '2026-09-09T14:22:07.000Z'
+
+describe('companionAbfrage', () => {
+  it('schreibt die Befehlszeile so, wie die Route sie deklariert — klein', () => {
+    expect(companionAbfrage(['videohub_out'])).toEqual([
+      'custom-variable videohub_out get-value',
+    ])
+  })
+
+  it('wirft doppelte und leere Namen weg', () => {
+    // Ein doppelter Name braechte zwei Antwortzeilen fuer einen Eintrag und
+    // verschoebe damit die Zuordnung um eins — genau der Fehler, den
+    // `leseCompanionStand` unten verweigert.
+    expect(companionAbfrage(['a', ' a ', '', '  ', 'b'])).toEqual([
+      'custom-variable a get-value',
+      'custom-variable b get-value',
+    ])
+  })
+})
+
+describe('leseCompanionZeile', () => {
+  it('packt den Wert aus, den Companion als JSON zurueckgibt', () => {
+    expect(leseCompanionZeile('+OK "12"')).toEqual({ roh: '+OK "12"', wert: '12' })
+    expect(leseCompanionZeile('+OK 7')).toEqual({ roh: '+OK 7', wert: '7' })
+  })
+
+  it('behaelt die Rohform, wenn die Antwort kein lesbares JSON ist', () => {
+    // Raten wird nichts: eine unlesbare Antwort ist eine unlesbare Antwort.
+    const a = leseCompanionZeile('+OK nicht{json')
+    expect(a?.wert).toBe('nicht{json')
+  })
+
+  it('macht aus einem nackten +OK KEINEN leeren Wert', () => {
+    // Companion haengt den Wert nur an, wenn der Handler einen zurueckgibt.
+    // Ein `+OK` allein kommt von `press`/`style` — wer es als leeren
+    // Variablenwert laese, machte aus einem Tastendruck eine Ablesung.
+    const a = leseCompanionZeile('+OK')
+    expect(a).toEqual({ roh: '+OK' })
+    expect(a?.wert).toBeUndefined()
+  })
+
+  it('liest den Fehler als Fehler und nicht als Wert', () => {
+    expect(leseCompanionZeile('-ERR Variable not found')).toEqual({
+      roh: '-ERR Variable not found',
+      fehler: 'Variable not found',
+    })
+  })
+
+  it('ueberspringt, was keine Antwortzeile ist', () => {
+    // Der getippte Befehl steht in einer kopierten Sitzung mit drin.
+    expect(leseCompanionZeile('custom-variable a get-value')).toBeUndefined()
+    expect(leseCompanionZeile('')).toBeUndefined()
+  })
+})
+
+describe('leseCompanionStand — die Engstelle', () => {
+  it('ordnet der Reihe nach zu, wenn die Anzahl stimmt', () => {
+    const { ablesungen, problem } = leseCompanionStand(
+      'custom-variable out get-value\n+OK "3"\ncustom-variable in get-value\n+OK "5"',
+      ['out', 'in'],
+      JETZT,
+    )
+    expect(problem).toBeUndefined()
+    expect(ablesungen.map((a) => [a.variable, a.antwort.wert])).toEqual([
+      ['out', '3'],
+      ['in', '5'],
+    ])
+  })
+
+  it('liefert NICHTS, wenn eine Antwortzeile fehlt', () => {
+    // DIE Gegenprobe dieses Bausteins. Ohne sie stuende der Wert der einen
+    // Variablen unter dem Namen der naechsten: vollstaendig aussehend,
+    // plausibel und falsch — und er ginge als Ablesung in ein As-built-Blatt,
+    // aus dem spaeter jemand einen Kreuzpunkt liest.
+    const { ablesungen, problem } = leseCompanionStand('+OK "3"', ['out', 'in'], JETZT)
+    expect(ablesungen).toEqual([])
+    expect(problem).toMatch(/2 Variable\(n\) abgefragt, 1 Antwortzeile/)
+  })
+
+  it('liefert auch bei einer Antwortzeile ZU VIEL nichts', () => {
+    const { ablesungen } = leseCompanionStand('+OK "3"\n+OK "5"\n+OK "9"', ['out', 'in'], JETZT)
+    expect(ablesungen).toEqual([])
+  })
+
+  it('nennt den Grund, wenn gar keine Antwortzeile erkennbar ist', () => {
+    const { problem } = leseCompanionStand('irgendein Text', ['out'], JETZT)
+    expect(problem).toMatch(/Keine Antwortzeile erkannt/)
+  })
+
+  it('nennt den Grund, wenn der Plan keine Variablen kennt', () => {
+    const { problem } = leseCompanionStand('+OK "3"', [], JETZT)
+    expect(problem).toMatch(/Keine Variablennamen im Plan/)
+  })
+})
+
+describe('companionAsBuilt', () => {
+  const stand = (text: string, namen: string[]) =>
+    leseCompanionStand(text, namen, JETZT).ablesungen
+
+  it('vergleicht die Ablesung gegen den Plan', () => {
+    const [zeile] = companionAsBuilt(stand('+OK "3"', ['out']), { out: '3' })
+    expect(zeile.source).toBe('companion')
+    expect(zeile.at).toBe(JETZT)
+    expect(asBuiltVerdict(zeile)).toBe('match')
+  })
+
+  it('meldet eine Abweichung als Abweichung', () => {
+    const [zeile] = companionAsBuilt(stand('+OK "9"', ['out']), { out: '3' })
+    expect(asBuiltVerdict(zeile)).toBe('differs')
+  })
+
+  it('macht aus „Variable not found" KEINE Ablesung', () => {
+    // „nicht gefunden" heisst nicht „der Wert ist leer", sondern „es wurde
+    // nichts abgelesen". Das Urteil dafuer ist `missing` und nicht `differs`:
+    // sonst stuende auf dem Blatt eine Abweichung, die niemand gemessen hat.
+    const [zeile] = companionAsBuilt(stand('-ERR Variable not found', ['out']), { out: '3' })
+    expect(zeile.actual).toBeUndefined()
+    expect(zeile.subject).toContain('Variable not found')
+    expect(asBuiltVerdict(zeile)).toBe('missing')
+  })
+
+  it('ohne Plan-Seite: vorgefunden, nicht im Plan', () => {
+    const [zeile] = companionAsBuilt(stand('+OK "3"', ['out']))
+    expect(asBuiltVerdict(zeile)).toBe('unexpected')
+  })
+})
+
+describe('die nachgesehenen Angaben stehen im Hinweis', () => {
+  it('nennt beide Ports und trennt Schalt- von Lese-Weg', () => {
+    // Die Auflage aus E-23 lautete „deren Schnittstelle ist opt-in". Gemessen
+    // gilt das fuer den LESE-Weg (TCP, ab Werk aus) und NICHT fuer den
+    // SCHALT-Weg (HTTP, ab Werk an) — und eine hochgezogene Installation hat
+    // TCP an, nur auf einem anderen Port. Wer den Satz auf „ist aus"
+    // zurueckkuerzt, schickt jemanden an den falschen Schalter.
+    expect(COMPANION_SCHNITTSTELLE_HINWEIS).toContain(String(COMPANION_API.tcpPortNeu))
+    expect(COMPANION_SCHNITTSTELLE_HINWEIS).toContain(String(COMPANION_API.tcpPortAlt))
+    expect(COMPANION_SCHNITTSTELLE_HINWEIS).toMatch(/HTTP-API \(ab Werk an\)/)
+  })
+
+  it('die beiden Ports sind verschieden', () => {
+    expect(COMPANION_API.tcpPortNeu).not.toBe(COMPANION_API.tcpPortAlt)
+  })
+})


### PR DESCRIPTION
## Der letzte offene Punkt aus E-23

E-23 hat den eingehenden Show-Control-Weg entschieden und in #785 gebaut. Ein Punkt blieb ausdrücklich stehen:

> **Offen bleibt** der Import eines Companion-Variablenstands als zweite Quelle.

Der steht jetzt.

## Warum ein Import und kein Poller

Ein Knopf, der Companion befragt und das Ergebnis anzeigt, wäre der erste Schritt zu genau dem Monitor, den die Bedarfs-Datenbank verbietet — *„a live monitoring dashboard, which would make the suite responsible for a false all-clear"*. Der zweite Schritt wäre ein Intervall, der dritte eine Farbe, und dann steht dort ein Anlagenzustand.

Deshalb dieselbe Bauform wie beim ausgehenden Teil: **der Plan benennt den Weg, er geht ihn nicht.** Links stehen die Befehlszeilen zum Mitnehmen, rechts kommt zurück, was jemand aus der Sitzung kopiert hat. Was dabei herauskommt, trägt den Zeitpunkt des **Ablesens** und behauptet nichts über jetzt.

## Wo die Ablesung hingeht

In die vorhandene As-built-Spur. `ReadingSource` bekommt `'companion'` als sechsten Wert — eine sechste Quelle für ein vorhandenes Blatt ist billiger und ehrlicher als ein sechstes Blatt, und diese Spur schreibt ausdrücklich nichts in den Plan zurück (*„was der Hub gerade tut, ist eine Beobachtung, was im Plan steht, eine Absicht"*).

## Die Engstelle — und warum sie lieber nichts liefert

Die Antwort trägt den Variablennamen **nicht**: `+OK "12"` sagt nicht, wozu die 12 gehört. Zugeordnet werden kann also nur über die **Reihenfolge**, und die stimmt genau so lange, wie keine Zeile fehlt.

Fehlt eine, verschiebt sich alles danach um eins: der Wert der einen Variablen erscheint unter dem Namen der nächsten. Das Ergebnis sähe vollständig aus, wäre plausibel und wäre falsch — und es ginge als Ablesung in ein As-built-Blatt, aus dem später jemand einen Kreuzpunkt liest.

`leseCompanionStand` ordnet deshalb **nur bei exakt gleicher Anzahl** zu und liefert sonst nichts ausser dem Grund. Zwei Geschwister derselben Haltung:

| Fall | falsche Lesart | was gebaut ist |
|---|---|---|
| `-ERR Variable not found` | leerer Wert → Urteil `differs` | keine Ablesung → Urteil `missing` |
| nacktes `+OK` | leerer Variablenwert | gar kein Wert — es kommt von `press`/`style` |

Wer das nackte `+OK` als leeren Variablenwert läse, machte aus einem **Tastendruck** eine Ablesung.

## Die Auflage aus der Recherche war zu grob — jetzt ist sie gemessen

Das Ausspiel-Blatt schrieb bisher pauschal „die Schnittstelle ist ab Werk aus". Nachgesehen in `companion/lib/Data/UserConfig.ts` (2026-09-09) stimmt das nur zur Hälfte:

| Einstellung | Wert bei Neuinstallation | betrifft |
|---|---|---|
| `http_api_enabled` | **`true`** | der SCHALT-Weg aus S-4 — ab Werk **an** |
| `tcp_enabled` | `false` | der LESE-Weg — ab Werk aus, Port 16759 |
| bei hochgezogener DB | TCP wird **eingeschaltet** | aber auf dem alten Port **51234** |

Wer den Satz auf „ist aus" zurückkürzt, schickt jemanden an den falschen Schalter; wer „ist an" daraus macht, an gar keinen. Der Text steht jetzt an **einer** Stelle (`COMPANION_SCHNITTSTELLE_HINWEIS`) und wird im Blatt wie im Dialog nur eingesetzt; ein Test hält fest, dass beide Ports und beide Wege darin vorkommen.

## Was ausdrücklich fehlt — und im Panel dasteht

Die **Plan-Seite**. `controlCompanion` trägt die Variablen-*Namen*, nicht ihre Werte; der Plan hält nirgends fest, welchen Kreuzpunkt er zuletzt über welche Variable gefahren hat. Diesen Wert zu raten hiesse, eine Abweichung zu behaupten, die niemand gemessen hat. Die Ablesung steht deshalb als `unexpected` da („vorgefunden, nicht im Plan"), und die Zeile sagt warum.

## Belegkette

Alle Protokoll-Angaben sind in `bitfocus/companion@main` nachgesehen und mit Datei und Zeile im Kopf notiert:

* `Service/TcpUdpApi.ts` — Route `custom-variable :name get-value` (Z. 266); Handler wirft `Variable not found`, sonst `JSON.stringify(result)`; der Befehl wird nur getrimmt (Z. 521)
* `Service/Tcp.ts` — Zeilentrenner `\n`; `+OK` / `+OK <wert>` / `-ERR <meldung>`; Vorgabe-Port 16759
* `Data/UserConfig.ts` — die Tabelle oben

**Eine Angabe ist ausdrücklich NICHT nachgesehen** und steht als Nicht-Wissen im Kopf: ob `pathToRegexp` hier Gross- und Kleinschreibung unterscheidet. Genau deshalb werden die Befehlszeilen klein geschrieben — klein passt unter beiden Auslegungen, gross nur unter einer.

## Prüfungen

18 neue Tests, jede Zusicherung mit ihrer Gegenprobe daneben (die verschobene Zuordnung, das nackte `+OK`, `-ERR` als Nicht-Ablesung, die unlesbare JSON-Antwort). 3826 Tests grün (2 übersprungen), `npx tsc -p tsconfig.app.json --noEmit` 0 Fehler, `npm run lint` 0 Errors, `npm run lang:check` 0 Sprachmix, Build grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_