### PR TITLE
canvas+a11y: Kabel-Ziehen greift den gezeichneten Weg, Regler sind zu treffen (B-64, #119)

### DIFF
--- a/docs/app-structure.html
+++ b/docs/app-structure.html
@@ -240,7 +240,7 @@
   <aside>
     <h1>Cable-Planner</h1>
     <div class="subtitle">
-      App-Struktur · v9.0.1 · ~634 TS/TSX-Module · ~185.3k LOC<br>
+      App-Struktur · v9.0.1 · ~635 TS/TSX-Module · ~190.8k LOC<br>
       <small style="color:#64748b">Diese Übersicht zeigt nur die ~62 wichtigsten Module. Für die vollständige Architektur siehe <a href="./architecture.md" style="color:#94a3b8">architecture.md</a>.</small>
     </div>
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Invarianten der App. Sie ist die Pflicht-Lektüre, bevor strukturelle Änderunge
 gemacht werden. Für die interaktive Modul-Übersicht siehe [`app-structure.html`](./app-structure.html),
 für einen Wettbewerber-Vergleich [`comparison.html`](./comparison.html).
 
-Stand: v9.0.1 · ~634 TS/TSX-Module · ~185.3k LOC
+Stand: v9.0.1 · ~635 TS/TSX-Module · ~190.8k LOC
 
 ---
 
@@ -934,7 +934,7 @@ optionales Cloud-Backend (`y-websocket`, Auth/Permissions) bleiben offen.
 `vitest` ist eingerichtet (`npm test` / `npm run test:watch`); dazu kommen
 gezielte Node-Checks (`npm run test:crdt`, `npm run test:signaling`), ein
 UI-Smoke-Skript (`npm run ui:smoke`) und ein headless Drag-/Interaktions-Test
-(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~185.3k LOC
+(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~190.8k LOC
 bleibt der Ausbau der Abdeckung wichtig — empfohlene Schwerpunkte:
 - Snapshot-Tests auf `healProjectPositions` mit echten
   Beispiel-Projekt-JSONs.

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -62,14 +62,14 @@
 <header>
   <h1>Cable-Planner — Strukturvergleich mit ähnlichen Tools</h1>
   <div class="subtitle">Architektur, Tech-Stack und Domänen-Tiefe im Vergleich zu kommerziellen und Open-Source-Alternativen</div>
-  <div class="meta">Stand: 2026-06 · v9.0.1 · ~634 TS/TSX-Module · ~185.3k LOC · ~7.6 MB src/</div>
+  <div class="meta">Stand: 2026-06 · v9.0.1 · ~635 TS/TSX-Module · ~190.8k LOC · ~7.9 MB src/</div>
 </header>
 
 <h2>1 · Cable-Planner — Architektur-Kennzahlen</h2>
 
 <div class="stat-grid">
-  <div class="stat"><div class="num">634</div><div class="label">TS/TSX-Module</div></div>
-  <div class="stat"><div class="num">185.3k</div><div class="label">Lines of Code</div></div>
+  <div class="stat"><div class="num">635</div><div class="label">TS/TSX-Module</div></div>
+  <div class="stat"><div class="num">190.8k</div><div class="label">Lines of Code</div></div>
   <div class="stat"><div class="num">~75</div><div class="label">Modul-Dependencies</div></div>
   <div class="stat"><div class="num">7</div><div class="label">User-Flows</div></div>
 </div>

--- a/scripts/quellsprache.mjs
+++ b/scripts/quellsprache.mjs
@@ -90,8 +90,27 @@ export const klassifiziere = (roh) => {
 }
 
 /**
- * Das Muster, an dem ein Fallback-Text erkannt wird: `t('key', '…')` und
- * `translate(lang, 'key', '…')`, beide Anfuehrungszeichen.
+ * Das Muster, an dem ein Fallback-Text erkannt wird: `t('key', '…')`,
+ * `tr('key', '…')` und `translate(lang, 'key', '…')`, beide
+ * Anfuehrungszeichen.
+ *
+ * `tr` FEHLTE HIER, und das war ein blinder Fleck mit Folgen (gemessen
+ * 2026-09-09). `tr` ist der Uebersetzer ausserhalb von React — Module wie
+ * `lib/intercomMatrixXlsx.ts` und `lib/importGreengo.ts` rufen ihn, weil dort
+ * kein Hook laufen kann. Der Ausdruck kannte nur `t` und `translate`; `\bt\(`
+ * trifft `tr(` nicht, weil hinter dem `t` ein `r` steht. Sechs deutsche
+ * Fallbacks sind so durch die Sprachdrehung (E-28) hindurchgegangen und der
+ * Waechter blieb dabei auf 0.
+ *
+ * Der Schaden ist nicht theoretisch: es sind FEHLERMELDUNGEN beim Import.
+ * Ein englischer Nutzer, dessen XLSX nicht gelesen werden kann, bekam die
+ * Begruendung auf Deutsch — also genau dann, wenn er sie am dringendsten
+ * braucht.
+ *
+ * Der Anker `(?=\s*[,)])` am Ende ist die zweite Korrektur desselben Tages.
+ * Ohne ihn hoert der Ausdruck am ersten schliessenden Anfuehrungszeichen auf
+ * und liest von `t('k', 'Teil eins ' + 'Teil zwei')` nur die erste Haelfte —
+ * eine zweite Haelfte in der anderen Sprache waere unsichtbar geblieben.
  *
  * Als FUNKTION, weil ein `/g`-Ausdruck seinen Suchstand mitschleppt und ein
  * geteiltes Exemplar bei der zweiten Datei mitten im Text weitersuchen wuerde.
@@ -104,7 +123,7 @@ export const klassifiziere = (roh) => {
  * Musters sind die Defektform `zwei-rechnungen` im Kleinen.
  */
 export const fallbackMuster = () =>
-  /\b(?:t|translate)\(\s*(?:[A-Za-z]+\s*,\s*)?(['"])[^'"]+\1\s*,\s*(['"])((?:[^\\]|\\.)*?)\2/g
+  /\b(?:t|tr|translate)\(\s*(?:[A-Za-z]+\s*,\s*)?(['"])[^'"]+\1\s*,\s*(['"])((?:[^\\]|\\.)*?)\2(?=\s*[,)])/g
 
 const dateien = (dir) =>
   readdirSync(dir).flatMap((eintrag) => {

--- a/src/renderer/components/Canvas/CableEdge.tsx
+++ b/src/renderer/components/Canvas/CableEdge.tsx
@@ -18,7 +18,7 @@ import {
 import { useUiStore } from '../../store/uiStore'
 import { CableWaypoints } from './CableWaypoints'
 import { computeObstacleAwareWaypoints, pathIsBlocked, type Rect } from '../../lib/cableRouting'
-import { legeAnfahrt, type Anschlussseite } from '../../lib/cableApproach'
+import { legeAnfahrt, stummel, type Anschlussseite } from '../../lib/cableApproach'
 import { computeEquipmentLayout } from '../../lib/equipmentLayout'
 import { isCableVisibleByLayer } from '../../lib/cableLayers'
 import { netKeyOf, netEndpoints } from '../../lib/offPageNet'
@@ -371,6 +371,25 @@ export const CableEdge = ({
           jitter: collisionShiftOn ? midlineJitter(cable.id) : 0,
           meide: meideRechtecke,
         })
+      : []
+  // Nutzer-Meldung 2026-09-09: „Das manuelle Kabel verschieben im Cable
+  // planner canvas ist schlechter geworden."
+  //
+  // Seit B-48 wird `gezeichneterWeg` gezeichnet und nicht mehr
+  // `[Quelle, ...waypoints, Ziel]` — `CableWaypoints` legte seine Greif-Zonen
+  // aber weiter auf den zweiten. Gemessen ueber die Matrix aus 4x4
+  // Anschlussseiten und 49 Ziellagen: 3292 von 3324 gezeichneten Abschnitten
+  // hatten keine deckungsgleiche Greif-Zone, und 180 Greif-Zonen lagen dort,
+  // wo gar kein Strich war. Deshalb geht jetzt der gezeichnete Weg selbst
+  // hinunter, samt der beiden Stummel-Punkte: die duerfen beim Einkuerzen der
+  // Kette nicht wegfallen, weil `legeAnfahrt` sie bei jedem Zeichnen wieder
+  // setzt (siehe `greifKette` in `cableApproach.ts`).
+  const stummelPunkte =
+    cable && (cable.routing ?? 'orthogonal') === 'orthogonal'
+      ? [
+          stummel({ x: sourceX, y: sourceY }, anschlussseite(sourcePosition)),
+          stummel({ x: targetX, y: targetY }, anschlussseite(targetPosition)),
+        ]
       : []
   // Nutzer-Meldung 2026-09-07: „das Kabel automatisch Routen funktioniert
   // nicht sauber." Der Rechenfehler steckte in `cableRouting.ts` und ist dort
@@ -908,6 +927,8 @@ export const CableEdge = ({
           source={{ x: sourceX, y: sourceY }}
           target={{ x: targetX, y: targetY }}
           renderWaypoints={orthogonalWaypoints}
+          renderPath={gezeichneterWeg}
+          stummelPunkte={stummelPunkte}
           exportThemeOverride={data?.exportThemeOverride}
         />
       )}

--- a/src/renderer/components/Canvas/CableWaypoints.tsx
+++ b/src/renderer/components/Canvas/CableWaypoints.tsx
@@ -4,6 +4,13 @@ import type { Cable, CableWaypoint } from '../../types/cable'
 import { useCanvasProjectStore as useProjectStore, useCanvasProjectStoreInstance } from '../../store/projectStoreContext'
 import { useUiStore } from '../../store/uiStore'
 import { useTranslation } from '../../lib/i18n'
+import {
+  abschnittAchse,
+  greifKette,
+  schiebeAbschnitt,
+  schiebeEcke,
+  type Achse,
+} from '../../lib/cableApproach'
 
 interface Props {
   cable: Cable
@@ -14,6 +21,17 @@ interface Props {
   target: { x: number; y: number }
   /** Effective rendered orthogonal waypoints (manual or auto-routed). */
   renderWaypoints?: { x: number; y: number }[]
+  /**
+   * Der Streckenzug, der WIRKLICH GEZEICHNET WIRD — von `legeAnfahrt`, samt
+   * Stummeln und eingeschobenen Ecken. Er ist die Greif-Geometrie: was der
+   * Nutzer sieht, muss er auch anfassen koennen.
+   */
+  renderPath?: { x: number; y: number }[]
+  /**
+   * Die beiden Stummel-Punkte. Sie bleiben in der Greifkette stehen, auch wenn
+   * sie gerade auf der Linie liegen — siehe `greifKette`.
+   */
+  stummelPunkte?: { x: number; y: number }[]
   exportThemeOverride?: 'dark' | 'light'
 }
 
@@ -21,17 +39,9 @@ const HANDLE_SIZE = 8
 const SEGMENT_HIT_WIDTH = 16
 const AXIS_TOL = 3
 
-type SegmentAxis = 'horizontal' | 'vertical' | 'diagonal'
-
-function segmentAxis(p: { x: number; y: number }, q: { x: number; y: number }): SegmentAxis {
-  if (Math.abs(q.y - p.y) < AXIS_TOL) return 'horizontal'
-  if (Math.abs(q.x - p.x) < AXIS_TOL) return 'vertical'
-  return 'diagonal'
-}
-
-function segmentCursor(axis: SegmentAxis): string {
-  if (axis === 'horizontal') return 'ns-resize'
-  if (axis === 'vertical') return 'ew-resize'
+function segmentCursor(axis: Achse): string {
+  if (axis === 'waagerecht') return 'ns-resize'
+  if (axis === 'senkrecht') return 'ew-resize'
   return 'grab'
 }
 
@@ -93,6 +103,8 @@ export const CableWaypoints = ({
   source,
   target,
   renderWaypoints,
+  renderPath,
+  stummelPunkte,
   exportThemeOverride,
 }: Props) => {
   const t = useTranslation()
@@ -112,30 +124,58 @@ export const CableWaypoints = ({
   if (lockCables) return null
 
   const waypoints = cable.waypoints ?? []
-  // v7.9.4 — Drag-Hit-Zonen müssen GENAU dem entsprechen was der User
-  // sieht: renderWaypoints (vom CableEdge, schon durch normalizeOrthogonal
-  // gelaufen) hat Priorität vor den rohen cable.waypoints.
-  // v7.9.5 — Für KABEL OHNE Waypoints, bei denen source↔target diagonal
-  // verlaufen würde, fügen wir hier in der Hit-Zone-Liste einen L-Ecken-
-  // Punkt ein. Sonst wäre das einzige Segment diagonal → durch den
-  // `if (orthogonal && diagonal) return null`-Guard hätte es KEIN
-  // klickbares Hit-Zone — der User konnte ein scheinbar orthogonales
-  // Kabel überhaupt nicht ziehen ("Segment vertikal verschieben muss
-  // bei allen ortho kabeln immer möglich sein"). dragSegment kommt
-  // mit dem startIsSource && endIsTarget-Pfad einwandfrei klar wenn
-  // der User den horizontalen Teil-Seg dann verschiebt.
-  const rawEffective =
-    renderWaypoints && renderWaypoints.length > 0 ? renderWaypoints : waypoints
-  const needsAutoLcorner =
-    routing === 'orthogonal' &&
-    rawEffective.length === 0 &&
-    Math.abs(target.x - source.x) > AXIS_TOL &&
-    Math.abs(target.y - source.y) > AXIS_TOL
-  const effectiveWaypoints = needsAutoLcorner
-    ? [{ x: target.x, y: source.y }]
-    : rawEffective
-  const points: { x: number; y: number }[] = [source, ...effectiveWaypoints, target]
+  // ── DIE GREIFKETTE ───────────────────────────────────────────────────────
+  //
+  // Nutzer-Meldung 2026-09-09: „Das manuelle Kabel verschieben im Cable
+  // planner canvas ist schlechter geworden."
+  //
+  // Der Grund stand nicht im Zieh-Code, sondern eine Ebene darunter. Bis
+  // B-48 (2026-09-08) war der gezeichnete Weg `[Quelle, ...waypoints, Ziel]`,
+  // und genau darauf lagen die Greif-Zonen. Seit B-48 zeichnet `legeAnfahrt`
+  // — mit Stummeln an beiden Enden und mit Ecken, die `rechtwinkligMachen`
+  // dazwischenschiebt. Die Greif-Zonen blieben auf dem alten Streckenzug
+  // liegen, und der wird seither nicht mehr gezeichnet.
+  //
+  // Gemessen ueber die Matrix aus 4x4 Anschlussseiten und 49 Ziellagen
+  // (784 Faelle): 3292 von 3324 gezeichneten Abschnitten hatten KEINE
+  // deckungsgleiche Greif-Zone, in allen 784 Faellen mindestens einer, und
+  // 180 Greif-Zonen lagen dort, wo gar kein Strich war. Der Nutzer fasste
+  // also fast immer ins Leere.
+  //
+  // Deshalb wird jetzt der GEZEICHNETE Weg angefasst. `greifKette` kuerzt
+  // ihn auf seine sichtbaren Ecken ein (zwei Griffe auf einer geraden Linie
+  // waeren die zweite Art, das Ziehen unberechenbar zu machen) und laesst die
+  // beiden Stummel-Punkte stehen. Nach dem Zug geht die Kette ohne ihre
+  // Enden zurueck in `cable.waypoints`; `legeAnfahrt` setzt Quelle, Stummel
+  // und Ziel wieder davor und dahinter und `straffe` wirft die Doppel weg,
+  // sodass derselbe Streckenzug herauskommt, den der Nutzer gerade gezogen
+  // hat. Der Rundlauf ist ueber dieselbe Matrix gemessen: 0 Abweichungen.
+  //
+  // Fuer `straight`-Kabel gibt es keinen gezeichneten Streckenzug — dort
+  // bleibt es bei `[Quelle, ...waypoints, Ziel]` wie bisher.
+  const kette: { x: number; y: number }[] =
+    renderPath && renderPath.length >= 2
+      ? greifKette(renderPath, stummelPunkte ?? [])
+      : [source, ...(renderWaypoints && renderWaypoints.length > 0 ? renderWaypoints : waypoints), target]
+  const points = kette
   const totalPoints = points.length
+
+  /**
+   * Welche Abschnitte darf der Nutzer ziehen?
+   *
+   * Der erste und der letzte sind die Stummel. Sie sind nicht verhandelbar:
+   * `legeAnfahrt` setzt sie bei jedem Zeichnen wieder, wer sie quer zoege,
+   * bekaeme die Kehrtwende zurueck, die B-48 gerade beseitigt hat.
+   *
+   * Bleibt danach nichts uebrig, ist alles ziehbar. Das trifft 12 der 784
+   * gemessenen Faelle, und alle zwoelf sind entartet: die beiden Buchsen
+   * liegen keine 18 px auseinander, das ganze Kabel ist also kuerzer als ein
+   * Stummel. Dort gar nichts anfassen zu koennen waere schlechter als eine
+   * Ecke, die `legeAnfahrt` gleich wieder geradezieht — gemessen bleibt der
+   * Weg auch im Rueckfall in allen Faellen rechtwinklig.
+   */
+  const ziehbar = (i: number): boolean =>
+    totalPoints >= 4 ? i > 0 && i + 1 < totalPoints - 1 : true
 
   // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -182,63 +222,39 @@ export const CableWaypoints = ({
 
   // ── existing waypoint dot handles (selected-only) ─────────────────────────
 
-  const dragExisting = (index: number) => (event: React.PointerEvent<SVGElement>) => {
-    const initWPs = waypoints.slice()
-    const prevFixed = index === 0          // predecessor is source (immutable)
-    const nextFixed = index === initWPs.length - 1  // successor is target (immutable)
-    const prevPt = prevFixed ? source : initWPs[index - 1]
-    const nextPt = nextFixed ? target : initWPs[index + 1]
-    const wpInit = initWPs[index]
-    const inAxis  = segmentAxis(prevPt, wpInit)
-    const outAxis = segmentAxis(wpInit, nextPt)
-
-    beginDrag(event, (cursor) => {
-      const result = initWPs.slice()
-      let cx = cursor.x
-      let cy = cursor.y
-
-      // Clamp against fixed endpoints (source/target) to keep segments orthogonal
-      if (prevFixed) {
-        if (inAxis === 'horizontal') cy = source.y
-        else if (inAxis === 'vertical') cx = source.x
-      }
-      if (nextFixed) {
-        if (outAxis === 'horizontal') cy = target.y
-        else if (outAxis === 'vertical') cx = target.x
-      }
-
-      result[index] = { x: cx, y: cy }
-
-      // Propagate one coordinate to adjacent movable waypoints so they stay orthogonal
-      if (!prevFixed && index > 0) {
-        if (inAxis === 'horizontal') result[index - 1] = { ...initWPs[index - 1], y: cy }
-        else if (inAxis === 'vertical') result[index - 1] = { ...initWPs[index - 1], x: cx }
-      }
-      if (!nextFixed && index < initWPs.length - 1) {
-        if (outAxis === 'horizontal') result[index + 1] = { ...initWPs[index + 1], y: cy }
-        else if (outAxis === 'vertical') result[index + 1] = { ...initWPs[index + 1], x: cx }
-      }
-
-      return result
-    })
+  /**
+   * Eine Ecke der Greifkette ziehen.
+   *
+   * Gezogen wird der Kettenpunkt, nicht der `waypoints`-Eintrag: die beiden
+   * Listen sind seit B-48 nicht mehr dasselbe. Die Nachbar-Ecken gehen auf
+   * ihrer geteilten Achse mit, damit die Abschnitte rechtwinklig bleiben —
+   * das rechnet `schiebeEcke`, damit es ohne Canvas pruefbar ist.
+   */
+  const dragEcke = (index: number) => (event: React.PointerEvent<SVGElement>) => {
+    const initKette = kette.map((p) => ({ ...p }))
+    beginDrag(event, (cursor) => schiebeEcke(initKette, index, cursor).slice(1, -1))
   }
+
+  /** Eine Ecke aus der Greifkette nehmen — der Rest wird zurueckgeschrieben. */
+  const ohneEcke = (index: number): CableWaypoint[] =>
+    kette.filter((_, i) => i !== index).slice(1, -1)
 
   const removeWaypoint = (index: number) => (event: React.MouseEvent<SVGElement>) => {
     if (event.button === 2 || event.altKey) {
       event.preventDefault()
       event.stopPropagation()
-      const next = waypoints.slice()
-      next.splice(index, 1)
+      const next = ohneEcke(index)
       updateCable(cable.id, { waypoints: next.length ? next : undefined })
     }
   }
 
-  // ── segment drag (always active — yEd-style) ──────────────────────────────
+  // ── Abschnitt ziehen (immer aktiv — yEd-Art) ─────────────────────────────
   //
-  // Algorithm from mxEdgeSegmentHandler (draw.io/mxGraph):
-  //   Horizontal → cursor.y is the new segment Y (both endpoints)
-  //   Vertical   → cursor.x is the new segment X (both endpoints)
-  //   Fixed source/target get L-shaped corners inserted.
+  // Der Algorithmus ist unveraendert der aus mxEdgeSegmentHandler
+  // (draw.io/mxGraph): waagerecht -> der Zeiger gibt beiden Endpunkten das
+  // neue y, senkrecht das neue x. Was sich geaendert hat, ist die Kette,
+  // auf der er laeuft: die GEZEICHNETE statt der gespeicherten. Gerechnet
+  // wird in `schiebeAbschnitt`, damit es ohne Canvas pruefbar ist.
 
   const dragSegment = (segIdx: number) => (event: React.PointerEvent<SVGElement>) => {
     // Auto-select edge if not already selected.
@@ -249,16 +265,10 @@ export const CableWaypoints = ({
     const el = event.currentTarget as SVGElement
     el.setPointerCapture(event.pointerId)
 
-    const p0 = points[segIdx]
-    const p1 = points[segIdx + 1]
-    const axis = segmentAxis(p0, p1)
-
-    const startIsSource = segIdx === 0
-    const endIsTarget = segIdx + 1 === totalPoints - 1
-    const initWaypoints = [...effectiveWaypoints]
+    const initKette = kette.map((p) => ({ ...p }))
     const needsRoutingSwitch = routing === 'straight'
 
-    // For diagonal fallback only.
+    // Nur fuer den schraegen Abschnitt (es gibt ihn nur bei `straight`).
     const rawStart = screenToFlowPosition({ x: event.clientX, y: event.clientY })
     const startFlow = { x: Math.round(rawStart.x), y: Math.round(rawStart.y) }
 
@@ -267,57 +277,12 @@ export const CableWaypoints = ({
       // gleich bleiben und Segmente nicht sub-pixel-diagonal werden.
       const raw = screenToFlowPosition({ x: moveEvent.clientX, y: moveEvent.clientY })
       const cursor = { x: Math.round(raw.x), y: Math.round(raw.y) }
-      const dx = cursor.x - startFlow.x
-      const dy = cursor.y - startFlow.y
-
-      const constrain = (wp: { x: number; y: number }): CableWaypoint => {
-        if (axis === 'horizontal') return { x: wp.x,      y: cursor.y }
-        if (axis === 'vertical')   return { x: cursor.x,  y: wp.y }
-        return { x: wp.x + dx, y: wp.y + dy }
-      }
-
-      let next: CableWaypoint[]
-
-      if (!startIsSource && !endIsTarget) {
-        const wi0 = segIdx - 1
-        const wi1 = segIdx
-        next = initWaypoints.map((wp, i) =>
-          i === wi0 || i === wi1 ? constrain(wp) : wp,
-        )
-      } else if (startIsSource && endIsTarget) {
-        if (axis === 'horizontal') {
-          next = [{ x: source.x, y: cursor.y }, { x: target.x, y: cursor.y }]
-        } else if (axis === 'vertical') {
-          next = [{ x: cursor.x, y: source.y }, { x: cursor.x, y: target.y }]
-        } else {
-          next = [{ x: source.x + dx, y: source.y + dy }, { x: target.x + dx, y: target.y + dy }]
-        }
-      } else if (startIsSource) {
-        const wp0 = initWaypoints[0]
-        if (axis === 'horizontal') {
-          next = [{ x: source.x, y: cursor.y }, { x: wp0.x, y: cursor.y }, ...initWaypoints.slice(1)]
-        } else if (axis === 'vertical') {
-          next = [{ x: cursor.x, y: source.y }, { x: cursor.x, y: wp0.y }, ...initWaypoints.slice(1)]
-        } else {
-          next = [{ x: source.x + dx, y: source.y + dy }, { x: wp0.x + dx, y: wp0.y + dy }, ...initWaypoints.slice(1)]
-        }
-      } else {
-        const wpLast = initWaypoints[segIdx - 1]
-        if (axis === 'horizontal') {
-          next = [...initWaypoints.slice(0, segIdx - 1), { x: wpLast.x, y: cursor.y }, { x: target.x, y: cursor.y }]
-        } else if (axis === 'vertical') {
-          next = [...initWaypoints.slice(0, segIdx - 1), { x: cursor.x, y: wpLast.y }, { x: cursor.x, y: target.y }]
-        } else {
-          next = [...initWaypoints.slice(0, segIdx - 1), { x: wpLast.x + dx, y: wpLast.y + dy }, { x: target.x + dx, y: target.y + dy }]
-        }
-      }
-
-      // #377 — alle Waypoints auf ganze Einheiten runden: geteilte Achsenwerte
-      // (gleicher Bruchteil) runden auf denselben Integer → Segmente bleiben
-      // exakt achsparallel, keine akkumulierende Diagonale.
-      const nextRounded = next.map((w) => ({ x: Math.round(w.x), y: Math.round(w.y) }))
+      const versatz = { x: cursor.x - startFlow.x, y: cursor.y - startFlow.y }
+      const next = schiebeAbschnitt(initKette, segIdx, cursor, versatz)
+        .slice(1, -1)
+        .map((w) => ({ x: Math.round(w.x), y: Math.round(w.y) }))
       updateCable(cable.id, {
-        waypoints: nextRounded.length ? nextRounded : undefined,
+        waypoints: next.length ? next : undefined,
         ...(needsRoutingSwitch ? { routing: 'orthogonal' } : {}),
       })
     }
@@ -327,11 +292,10 @@ export const CableWaypoints = ({
       el.removeEventListener('pointerup', handleUp)
       el.removeEventListener('pointercancel', handleUp)
       try { el.releasePointerCapture(event.pointerId) } catch { /* ignore */ }
-      // v7.9.4 — Gleiche Hygiene wie bei dragExisting: nach Segment-Drag
-      // alle redundanten kollinearen Waypoints rauswerfen, sonst
-      // sammeln sich bei jeder Segment-Bewegung 2 Punkte mehr an, was
-      // bei der nächsten Drag wieder eine "wer normalisiert was?"-
-      // Diskrepanz erzeugt.
+      // v7.9.4 — Gleiche Hygiene wie bei `dragEcke`: nach dem Zug alle
+      // redundanten kollinearen Stuetzpunkte rauswerfen, sonst sammeln sie
+      // sich mit jedem Zug an. Die Greifkette kuerzt beim Zeichnen ohnehin
+      // ein — das hier haelt die GESPEICHERTE Liste knapp.
       const currentWPs =
         projectStoreInstance.getState().project.cables.find((c) => c.id === cable.id)?.waypoints ?? []
       const cleaned = cleanCollinear(currentWPs, source, target)
@@ -346,14 +310,16 @@ export const CableWaypoints = ({
 
   return (
     <g className="nodrag nopan" style={{ pointerEvents: 'all' }}>
-      {/* ── Segment hit areas ──
-          In orthogonal routing only horizontal/vertical segments are draggable;
-          diagonal segments (e.g. while transitioning) get no handle so the
-          user can't accidentally bend a non-ortho segment. */}
+      {/* ── Greif-Zonen der Abschnitte ──
+          Sie liegen auf dem gezeichneten Weg (siehe `greifKette` oben). Der
+          erste und der letzte Abschnitt sind die Stummel und bleiben frei;
+          ein schraeger Abschnitt bekommt bei orthogonaler Fuehrung keine
+          Zone, damit niemand versehentlich eine Diagonale knickt. */}
       {points.slice(0, -1).map((p, i) => {
+        if (!ziehbar(i)) return null
         const q = points[i + 1]
-        const axis = segmentAxis(p, q)
-        if (routing === 'orthogonal' && axis === 'diagonal') return null
+        const axis = abschnittAchse(p, q)
+        if (routing === 'orthogonal' && axis === 'schraeg') return null
         const cursor = segmentCursor(axis)
         const isHovered = hoveredSeg === i
 
@@ -381,8 +347,8 @@ export const CableWaypoints = ({
               onPointerDown={dragSegment(i)}
             >
               <title>
-                {axis === 'horizontal' ? t('cable.segment.moveVertical', 'Move segment vertically') :
-                 axis === 'vertical'   ? t('cable.segment.moveHorizontal', 'Move segment horizontally') :
+                {axis === 'waagerecht' ? t('cable.segment.moveVertical', 'Move segment vertically') :
+                 axis === 'senkrecht'  ? t('cable.segment.moveHorizontal', 'Move segment horizontally') :
                  t('cable.segment.move', 'Move segment')}
               </title>
             </line>
@@ -390,8 +356,13 @@ export const CableWaypoints = ({
         )
       })}
 
-      {/* ── Existing waypoint dot handles — only when selected ── */}
-      {selected && waypoints.map((wp, index) => (
+      {/* ── Die Ecken der Greifkette — nur bei ausgewaehltem Kabel ──
+          Frueher sassen die Punkte auf `cable.waypoints`. Seit B-48 ist das
+          nicht mehr dieselbe Liste wie die gezeichneten Ecken, und ein
+          Griff, der neben seiner Ecke liegt, ist schlimmer als keiner. */}
+      {selected && points.slice(1, -1).map((wp, i) => {
+        const index = i + 1
+        return (
         <circle
           key={`wp-${index}`}
           cx={wp.x} cy={wp.y}
@@ -400,18 +371,18 @@ export const CableWaypoints = ({
           stroke={isLight ? '#e2e8f0' : '#0f172a'}
           strokeWidth={1.5}
           style={{ cursor: 'move' }}
-          onPointerDown={dragExisting(index)}
+          onPointerDown={dragEcke(index)}
           onMouseDown={removeWaypoint(index)}
           onContextMenu={(e) => {
             e.preventDefault()
-            const next = waypoints.slice()
-            next.splice(index, 1)
+            const next = ohneEcke(index)
             updateCable(cable.id, { waypoints: next.length ? next : undefined })
           }}
         >
           <title>{t('cable.waypoint.tooltip', 'Drag to move · Alt-click or right-click to remove')}</title>
         </circle>
-      ))}
+        )
+      })}
 
       {/* ── B-44 Teil 3: der sichtbare Loeschgriff fuer grobe Zeiger ──
           Auf einem Tablet gibt es weder Alt+Klick noch Rechtsklick, und ein
@@ -423,7 +394,9 @@ export const CableWaypoints = ({
           Deshalb ein eigener kleiner Griff daneben — sichtbar statt
           verborgen, und nur dort, wo es keinen Rechtsklick gibt
           (`.cp-coarse-only` in index.css). */}
-      {selected && waypoints.map((wp, index) => (
+      {selected && points.slice(1, -1).map((wp, i) => {
+        const index = i + 1
+        return (
         <g key={`wp-del-${index}`} className="cp-coarse-only">
           <circle
             cx={wp.x + HANDLE_SIZE}
@@ -438,8 +411,7 @@ export const CableWaypoints = ({
               // Ereignis und der Punkt wandert, statt zu verschwinden.
               e.stopPropagation()
               e.preventDefault()
-              const next = waypoints.slice()
-              next.splice(index, 1)
+              const next = ohneEcke(index)
               updateCable(cable.id, { waypoints: next.length ? next : undefined })
             }}
           >
@@ -464,7 +436,8 @@ export const CableWaypoints = ({
             pointerEvents="none"
           />
         </g>
-      ))}
+        )
+      })}
     </g>
   )
 }

--- a/src/renderer/components/Canvas/PendingCableOverlay.tsx
+++ b/src/renderer/components/Canvas/PendingCableOverlay.tsx
@@ -249,7 +249,7 @@ const PendingCableSuggestions = ({
       onMouseDown={(e) => e.stopPropagation()}
     >
       <div style={{ marginBottom: 6, fontWeight: 600, color: 'var(--cp-accent)' }}>
-        {format(tr('pendingCable.suggestionsTitle', 'Schnelle Vorschläge ({connector})'), { connector: sourcePortConnector })}
+        {format(tr('pendingCable.suggestionsTitle', 'Quick suggestions ({connector})'), { connector: sourcePortConnector })}
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
         {suggestions.map((t) => (
@@ -266,7 +266,7 @@ const PendingCableSuggestions = ({
               color: 'var(--cp-text)',
               cursor: 'pointer',
             }}
-            title={format(tr('pendingCable.suggestionItemTitle', 'Bei Mausposition platzieren und Verbindung herstellen ({category})'), { category: t.category })}
+            title={format(tr('pendingCable.suggestionItemTitle', 'Place at the pointer and connect ({category})'), { category: t.category })}
           >
             {t.name}
           </button>

--- a/src/renderer/hooks/useProject.ts
+++ b/src/renderer/hooks/useProject.ts
@@ -70,8 +70,8 @@ export const useProject = () => {
             body: translate(
               lang,
               'project.open.notAPlan',
-              'The file could be read but contains no equipment and cable list. Nothing was loaded — the open project is unchanged.' +
-                'Es wurde nichts geladen — das offene Projekt bleibt unverändert.',
+              'The file could be read but contains no equipment and cable list. ' +
+                'Nothing was loaded — the open project is unchanged.',
             ),
             tone: 'warning',
           },
@@ -105,9 +105,9 @@ export const useProject = () => {
           translate(
             lang,
             'project.viewerName.prompt',
-            'Viewer file — enter name\n\nYou are opening a viewer file for review. Please enter your name — it will be attached to all annotations you create in this session.' +
-              'Du öffnest eine Viewer-Datei zum Begutachten. Bitte gib deinen Namen ' +
-              'ein — er wird allen Anmerkungen angeheftet, die du in dieser Session erstellst.',
+            'Viewer file — enter name\n\n' +
+              'You are opening a viewer file for review. Please enter your name — it ' +
+              'will be attached to all annotations you create in this session.',
           ),
           oldAuthor,
         ))?.trim()

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -657,6 +657,88 @@ button:disabled,
   opacity: 0.5;
 }
 
+/* ── Schieberegler: 24 px Trefferflaeche (WCAG 2.2 SC 2.5.8) ────────────────
+ *
+ * Nutzer-Meldung 2026-09-09: „Passe auch die Ui von allen slidern an sodass
+ * man sie gut bedienen kann."
+ *
+ * GEMESSEN VORHER: fuer `input[type="range"]` stand in diesem Stilblatt
+ * NICHTS. Die fuenf Regler der App (Strichstaerke, Beschriftungs-Position,
+ * Port-Schriftgroesse, Hintergrund-Deckkraft, Bild-Zoom im Rack-Zuschnitt)
+ * trugen das Standardaussehen des Browsers — in WebKit rund 16 px hoch, mit
+ * einem Griff, der auf einem Trackpad kaum zu fassen ist. WCAG 2.2,
+ * Erfolgskriterium 2.5.8 („Target Size (Minimum)", Stufe AA), nennt 24 px als
+ * Mindestmass fuer eine Trefferflaeche.
+ *
+ * WAS SICH AENDERT, und warum in dieser Reihenfolge:
+ *
+ *  1. Das ELEMENT wird 24 px hoch — nicht die Bahn. Die Bahn bleibt schmal
+ *     (6 px) und wird in die Mitte gezeichnet; die restlichen 18 px sind
+ *     unsichtbare Trefferflaeche. Ein dicker Balken waere die naheliegende
+ *     und falsche Loesung: die Regler sitzen hier in `flex items-center`-
+ *     Zeilen neben Beschriftungen, und ein 24 px hoher Balken sprengt jede
+ *     davon.
+ *  2. Der Griff wird 18 px und bleibt ECKIG. ADR-007 legt „keine Rundungen"
+ *     fest; ein runder Griff waere in dieser Oberflaeche ein Fremdkoerper.
+ *  3. `touch-action: manipulation` nimmt die 300-ms-Wartezeit auf Doppeltipp
+ *     weg. Ohne sie fuehlt sich jeder Regler auf einem Tablet traege an, und
+ *     zwar unabhaengig von seiner Groesse.
+ *  4. Ein eigener Fokusring mit 3 px Abstand. Die allgemeine Input-Regel
+ *     weiter oben zeichnet ihn mit `outline-offset: -1px`, also INNEN — an
+ *     einem Element, dessen sichtbarer Teil nur 6 px hoch ist, verschwindet
+ *     er unter der Bahn.
+ *
+ * Die Farben kommen aus den `--cp-*`-Tokens, kippen also im Light-Theme von
+ * selbst mit. Firefox braucht seine eigenen Pseudo-Elemente; ohne sie bliebe
+ * es dort beim Standardaussehen, und die Messung staende nur fuer einen
+ * Browser. */
+input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 24px;            /* Trefferflaeche, nicht Bahnhoehe */
+  background: transparent; /* die Bahn zeichnen die Pseudo-Elemente */
+  cursor: pointer;
+  touch-action: manipulation;
+}
+input[type="range"]::-webkit-slider-runnable-track {
+  height: 6px;
+  background: var(--cp-surface-3);
+  border: 1px solid var(--cp-border);
+}
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  background: var(--cp-accent);
+  border: 2px solid var(--cp-surface-3);
+  /* Der Griff sitzt auf der Bahn, nicht daneben: (6 px Bahn - 18 px Griff)
+     / 2 = -6 px, plus 1 px Rahmen der Bahn. */
+  margin-top: -7px;
+  cursor: pointer;
+}
+input[type="range"]::-moz-range-track {
+  height: 6px;
+  background: var(--cp-surface-3);
+  border: 1px solid var(--cp-border);
+}
+input[type="range"]::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  background: var(--cp-accent);
+  border: 2px solid var(--cp-surface-3);
+  border-radius: 0;
+  cursor: pointer;
+}
+input[type="range"]:focus-visible {
+  outline: 2px solid var(--cp-signal);
+  outline-offset: 3px;
+}
+input[type="range"]:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 /* ── Themed scrollbars (UX audit #54) ───────────────────────────────────────
  * Previously the app shipped default OS scrollbars, which look out of place on
  * the dark canvas and differ per platform. These are theme-aware via the

--- a/src/renderer/lib/cableApproach.ts
+++ b/src/renderer/lib/cableApproach.ts
@@ -327,3 +327,191 @@ export const legeAnfahrt = (a: Anfahrt): Point[] => {
   // fehlende Kante der groessere Schaden.
   return letzter
 }
+
+
+/* ════════════════════════════════════════════════════════════════════════
+   DIE KETTE, AN DER DER NUTZER ANFASST
+   ════════════════════════════════════════════════════════════════════════
+
+   ─── WAS GEMELDET WURDE (Nutzer, 2026-09-09) ─────────────────────────────
+
+   „Das manuelle Kabel verschieben im Cable planner canvas ist schlechter
+   geworden."
+
+   ─── WAS GEMESSEN WURDE ──────────────────────────────────────────────────
+
+   Nicht das Ziehen selbst — die Geometrie darunter. `CableWaypoints` legte
+   seine Greif-Zonen auf `[Quelle, ...cable.waypoints, Ziel]`. Seit B-48
+   (2026-09-08) wird aber nicht mehr dieser Streckenzug gezeichnet, sondern
+   der von `legeAnfahrt`: mit Stummeln an beiden Enden und mit Ecken, die
+   `rechtwinkligMachen` dazwischenschiebt. Beides sind seither ZWEI
+   verschiedene Streckenzuege, und angefasst wurde der unsichtbare.
+
+   Ueber die Matrix aus 4x4 Anschlussseiten und 49 Ziellagen (784 Faelle,
+   dieselbe Matrix wie oben) gemessen:
+
+     gezeichnete Abschnitte gesamt              3324
+     davon ohne deckungsgleiche Greif-Zone      3292   (99 %)
+     Faelle mit mindestens einer solchen Luecke  784   (alle)
+     Greif-Zonen, unter denen kein Strich liegt  180
+
+   Der Nutzer fasste also fast immer ins Leere, und an 180 Stellen lag ein
+   Griff dort, wo gar nichts zu sehen war. Das ist der ganze Befund; am
+   Zieh-Code selbst war nichts falsch.
+
+   ─── WAS DIESE DREI FUNKTIONEN ZUSICHERN ─────────────────────────────────
+
+   `greifKette` macht aus dem gezeichneten Streckenzug die Kette, die der
+   Nutzer sieht: kollineare Zwischenpunkte fallen weg, damit eine gerade
+   Linie EIN Griff ist und nicht zwei, die sich gegeneinander verschieben
+   lassen. Die beiden Stummel-Punkte sind davon ausgenommen — sie bleiben
+   stehen, auch wenn sie gerade auf der Linie liegen.
+
+   Dass sie bleiben, ist der Punkt, an dem sich das Ziehen mit B-48
+   vertraegt. `legeAnfahrt` setzt den Stummel bei JEDEM Zeichnen wieder —
+   wer den ersten Abschnitt quer zoege, bekaeme die Kehrtwende zurueck, die
+   B-48 gerade beseitigt hat. Mit dem Stummel als eigenem Kettenglied ist
+   der erste Abschnitt genau der Stummel (18 px, nicht zu ziehen), und der
+   erste ziehbare Abschnitt beginnt hinter ihm. Die Ecke wandert dorthin,
+   wo sie hingehoert, und der Weg bleibt kehrtwendenfrei.
+
+   Zurueckgeschrieben wird die Kette ohne ihre beiden Enden — das sind die
+   neuen `cable.waypoints`. Der Rundlauf ist geschlossen: `legeAnfahrt`
+   setzt Quelle, Stummel und Ziel wieder davor und dahinter, `straffe`
+   wirft die doppelten Stummel weg, und heraus kommt derselbe Streckenzug,
+   den der Nutzer gerade gezogen hat. `tests/kabelGriff.test.ts` haelt das
+   ueber dieselbe Matrix fest.
+*/
+
+export type Achse = 'waagerecht' | 'senkrecht' | 'schraeg'
+
+/** Ab wann ein Abschnitt als schraeg gilt. */
+export const ACHSEN_TOLERANZ = 3
+
+export const abschnittAchse = (p: Point, q: Point): Achse => {
+  if (Math.abs(q.y - p.y) < ACHSEN_TOLERANZ) return 'waagerecht'
+  if (Math.abs(q.x - p.x) < ACHSEN_TOLERANZ) return 'senkrecht'
+  return 'schraeg'
+}
+
+const gleicherFleck = (a: Point, b: Point): boolean =>
+  Math.abs(a.x - b.x) < 1 && Math.abs(a.y - b.y) < 1
+
+/**
+ * Der gezeichnete Streckenzug, auf seine sichtbaren Ecken reduziert.
+ *
+ * Ein Zwischenpunkt faellt weg, wenn der Abschnitt davor und der dahinter
+ * auf derselben Achse liegen — er ist dann keine Ecke, sondern ein Punkt
+ * mitten auf einer geraden Linie. Zwei Griffe auf einer Linie waeren die
+ * zweite Art, das Ziehen unberechenbar zu machen: der Nutzer zieht die eine
+ * Haelfte weg und die andere bleibt stehen.
+ *
+ * `geschuetzt` bleibt stehen, auch wenn es gerade auf der Linie liegt.
+ */
+export const greifKette = (
+  punkte: readonly Point[],
+  geschuetzt: readonly Point[] = [],
+): Point[] => {
+  if (punkte.length < 3) return punkte.map((p) => ({ ...p }))
+  let kette = punkte.map((p) => ({ ...p }))
+  let veraendert = true
+  while (veraendert) {
+    veraendert = false
+    const naechste: Point[] = [kette[0]]
+    for (let i = 1; i < kette.length - 1; i += 1) {
+      const vor = kette[i - 1]
+      const hier = kette[i]
+      const nach = kette[i + 1]
+      const bewahren = geschuetzt.some((g) => gleicherFleck(g, hier))
+      const waagerecht =
+        Math.abs(vor.y - hier.y) < ACHSEN_TOLERANZ && Math.abs(hier.y - nach.y) < ACHSEN_TOLERANZ
+      const senkrecht =
+        Math.abs(vor.x - hier.x) < ACHSEN_TOLERANZ && Math.abs(hier.x - nach.x) < ACHSEN_TOLERANZ
+      if (!bewahren && (waagerecht || senkrecht)) veraendert = true
+      else naechste.push(hier)
+    }
+    naechste.push(kette[kette.length - 1])
+    kette = naechste
+  }
+  return kette
+}
+
+/**
+ * Einen Abschnitt der Greifkette an den Zeiger schieben.
+ *
+ * Waagerecht heisst: der Zeiger bestimmt das neue y BEIDER Endpunkte;
+ * senkrecht das neue x. Ein schraeger Abschnitt (nur bei `straight`-Kabeln)
+ * wandert um den Versatz mit.
+ *
+ * Liegt der Abschnitt an einem der beiden festen Enden — Quelle oder Ziel
+ * haengen am Anschluss und koennen nicht mit —, wird dort eine Ecke
+ * eingeschoben statt das Ende zu bewegen.
+ */
+export const schiebeAbschnitt = (
+  kette: readonly Point[],
+  index: number,
+  zeiger: Point,
+  versatz: Point = { x: 0, y: 0 },
+): Point[] => {
+  if (index < 0 || index + 1 >= kette.length) return kette.map((p) => ({ ...p }))
+  const achse = abschnittAchse(kette[index], kette[index + 1])
+  const setz = (p: Point): Point =>
+    achse === 'waagerecht'
+      ? { x: p.x, y: zeiger.y }
+      : achse === 'senkrecht'
+        ? { x: zeiger.x, y: p.y }
+        : { x: p.x + versatz.x, y: p.y + versatz.y }
+  const amAnfang = index === 0
+  const amEnde = index + 1 === kette.length - 1
+  return straffe([
+    ...kette.slice(0, index).map((p) => ({ ...p })),
+    ...(amAnfang ? [{ ...kette[0] }] : []),
+    setz(kette[index]),
+    setz(kette[index + 1]),
+    ...(amEnde ? [{ ...kette[kette.length - 1] }] : []),
+    ...kette.slice(index + 2).map((p) => ({ ...p })),
+  ])
+}
+
+/**
+ * Eine Ecke der Greifkette an den Zeiger schieben.
+ *
+ * Die beiden Nachbar-Ecken gehen auf ihrer geteilten Achse mit, damit die
+ * Abschnitte rechtwinklig bleiben. Ist ein Nachbar die Quelle oder das Ziel,
+ * geht er nicht mit — dann wird stattdessen die Ecke selbst auf dessen Achse
+ * festgehalten.
+ */
+export const schiebeEcke = (
+  kette: readonly Point[],
+  index: number,
+  zeiger: Point,
+): Point[] => {
+  const neu = kette.map((p) => ({ ...p }))
+  if (index <= 0 || index >= kette.length - 1) return neu
+  const vor = kette[index - 1]
+  const nach = kette[index + 1]
+  const vorFest = index - 1 === 0
+  const nachFest = index + 1 === kette.length - 1
+  const ein = abschnittAchse(vor, kette[index])
+  const aus = abschnittAchse(kette[index], nach)
+  let x = zeiger.x
+  let y = zeiger.y
+  if (vorFest) {
+    if (ein === 'waagerecht') y = vor.y
+    else if (ein === 'senkrecht') x = vor.x
+  }
+  if (nachFest) {
+    if (aus === 'waagerecht') y = nach.y
+    else if (aus === 'senkrecht') x = nach.x
+  }
+  neu[index] = { x, y }
+  if (!vorFest) {
+    if (ein === 'waagerecht') neu[index - 1] = { ...vor, y }
+    else if (ein === 'senkrecht') neu[index - 1] = { ...vor, x }
+  }
+  if (!nachFest) {
+    if (aus === 'waagerecht') neu[index + 1] = { ...nach, y }
+    else if (aus === 'senkrecht') neu[index + 1] = { ...nach, x }
+  }
+  return neu
+}

--- a/src/renderer/lib/i18n/de.ts
+++ b/src/renderer/lib/i18n/de.ts
@@ -5323,4 +5323,10 @@ export const de: Dict = {
     'Kein Benutzer ist einer Gruppe zugeordnet — bitte prüfen ob die Matrix-Markierungen ("x") korrekt erkannt wurden.',
   'intercomXlsx.noUsers':
     'Keine Benutzer erkannt — prüfe die Benutzer-Zeilen unterhalb der Spaltenköpfe.',
+  'intercomXlsx.emptySheet': 'Die erste Tabelle ist leer.',
+  'intercomXlsx.noSections': 'Keine Spalten-Sektionen unterhalb der Header gefunden.',
+  'intercomXlsx.noSheet': 'Keine Tabelle in der Datei gefunden.',
+  'intercomXlsx.readError': 'XLSX konnte nicht gelesen werden: {msg}',
+  'pendingCable.suggestionItemTitle': 'Bei Mausposition platzieren und Verbindung herstellen ({category})',
+  'pendingCable.suggestionsTitle': 'Schnelle Vorschläge ({connector})',
 }

--- a/src/renderer/lib/i18n/dicts.ts
+++ b/src/renderer/lib/i18n/dicts.ts
@@ -6117,14 +6117,3 @@ export const en: Dict = {
   'catalog.videoFormat.2160p50.notes':
     'UHD standard. 12G-SDI preferred, Quad-Link 3G as alternative (4 cables).',
 }
-
-/**
- * German entries — kept minimal because German is the source language
- * (`t(key, 'Deutsche Form')` patterns supply the German fallback inline).
- *
- * The exception is **catalog-content keys** (`catalog.cable.*.notes`,
- * `catalog.videoFormat.*.notes`): they are referenced from data files
- * where no inline German fallback is reachable, so the German text
- * lives here. EN counterparts in the `en` dict below override per
- * language.
- */

--- a/src/renderer/lib/intercomMatrixXlsx.ts
+++ b/src/renderer/lib/intercomMatrixXlsx.ts
@@ -125,7 +125,7 @@ const detectLayout = (rows: Cell[][]): MatrixLayout | { error: string } => {
   const headerCells = rows[sectionHeaderRow] ?? []
   const sections = findSectionsInRow(headerCells)
   if (sections.length === 0) {
-    return { error: tr('intercomXlsx.noSections', 'Keine Spalten-Sektionen unterhalb der Header gefunden.') }
+    return { error: tr('intercomXlsx.noSections', 'No column sections found below the headers.') }
   }
   // ID row sits immediately below the header row; label row directly
   // after it. Some templates may have one extra spacer row between
@@ -183,13 +183,13 @@ export const parseIntercomMatrixXlsx = async (
     workbook = XLSX.read(data, { type: 'array' })
   } catch (err) {
     return {
-      error: format(tr('intercomXlsx.readError', 'XLSX konnte nicht gelesen werden: {msg}'), {
+      error: format(tr('intercomXlsx.readError', 'Could not read the XLSX: {msg}'), {
         msg: (err as Error).message,
       }),
     }
   }
   const sheetName = workbook.SheetNames[0]
-  if (!sheetName) return { error: tr('intercomXlsx.noSheet', 'Keine Tabelle in der Datei gefunden.') }
+  if (!sheetName) return { error: tr('intercomXlsx.noSheet', 'No sheet found in the file.') }
   const sheet = workbook.Sheets[sheetName]
   // Get raw cell values as strings; XLSX returns a 2D array.
   const rows: Cell[][] = XLSX.utils.sheet_to_json(sheet, {
@@ -197,7 +197,7 @@ export const parseIntercomMatrixXlsx = async (
     raw: false,
     defval: '',
   }) as Cell[][]
-  if (rows.length === 0) return { error: tr('intercomXlsx.emptySheet', 'Die erste Tabelle ist leer.') }
+  if (rows.length === 0) return { error: tr('intercomXlsx.emptySheet', 'The first sheet is empty.') }
 
   const layoutOrError = detectLayout(rows)
   if ('error' in layoutOrError) return layoutOrError

--- a/tests/i18nErreichbarkeit.test.ts
+++ b/tests/i18nErreichbarkeit.test.ts
@@ -54,7 +54,7 @@ const wirdImportiert = (pfad: string): boolean => {
 /**
  * Die Schluessel, die eine Datei ruft.
  *
- * ZWEI FORMEN, und die zweite fehlte hier. Funktions-Komponenten rufen
+ * DREI FORMEN, und zwei davon fehlten hier. Funktions-Komponenten rufen
  * `t('key', …)`; KLASSEN-Komponenten koennen keinen Hook benutzen und rufen
  * stattdessen `translate(lang, 'key', …)`. Der `ErrorBoundary` ist so eine —
  * und mit dem Muster von vorher galten seine zehn Schluessel als „von
@@ -63,9 +63,19 @@ const wirdImportiert = (pfad: string): boolean => {
  * Aufgefallen ist das erst bei der Sprachdrehung (E-28), weil vorher kein
  * Test in diese Richtung fragte. Der blinde Fleck war aber die ganze Zeit da:
  * ein fehlender Schluessel im Absturz-Schirm waere nicht gemeldet worden.
+ *
+ * DIE DRITTE FORM kam am 2026-09-09 dazu, beim Vendorieren: `tr('key', …)`
+ * ist der Uebersetzer fuer Module ohne React (`lib/intercomMatrixXlsx.ts`,
+ * `lib/importGreengo.ts`). `\bt\(` trifft ihn nicht — hinter dem `t` steht
+ * ein `r`. Die Folge war ein Fehlalarm in die andere Richtung: sechs
+ * deutsche Eintraege galten als „von niemandem gerufen", obwohl sie
+ * Import-Fehlermeldungen uebersetzen. Derselbe blinde Fleck sass in
+ * `scripts/quellsprache.mjs` und hat dort sechs deutsche Fallbacks durch die
+ * Sprachdrehung gelassen.
  */
 const aufrufe = (s: string): string[] => [
   ...[...s.matchAll(/\bt\(\s*'([^']+)'/g)].map((m) => m[1]),
+  ...[...s.matchAll(/\btr\(\s*'([^']+)'/g)].map((m) => m[1]),
   ...[...s.matchAll(/\btranslate\(\s*[A-Za-z_$][\w$]*\s*,\s*'([^']+)'/g)].map((m) => m[1]),
 ]
 

--- a/tests/kabelGriff.test.ts
+++ b/tests/kabelGriff.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest'
+import {
+  abschnittAchse,
+  greifKette,
+  istRechtwinklig,
+  legeAnfahrt,
+  schiebeAbschnitt,
+  schiebeEcke,
+  stummel,
+  type Anschlussseite,
+} from '../src/renderer/lib/cableApproach'
+import { computeObstacleAwareWaypoints, type Point } from '../src/renderer/lib/cableRouting'
+
+/**
+ * Nutzer-Meldung 2026-09-09: „Das manuelle Kabel verschieben im Cable planner
+ * canvas ist schlechter geworden. Repariere so das man es wieder intuitiv
+ * bedienen kann."
+ *
+ * ─── WAS GEMESSEN WURDE ───────────────────────────────────────────────────
+ *
+ * Nicht das Ziehen, sondern die Geometrie darunter. `CableWaypoints` legte
+ * seine Greif-Zonen auf `[Quelle, ...cable.waypoints, Ziel]`. Seit B-48
+ * (2026-09-08) wird aber `legeAnfahrt` gezeichnet — mit Stummeln an beiden
+ * Enden und mit Ecken, die `rechtwinkligMachen` dazwischenschiebt. Zwei
+ * verschiedene Streckenzuege; angefasst wurde der unsichtbare.
+ *
+ * Ueber dieselbe Matrix wie `kabelAnfahrt.test.ts` (4x4 Anschlussseiten,
+ * 49 Ziellagen, 784 Faelle) gemessen:
+ *
+ *   gezeichnete Abschnitte gesamt              3324
+ *   davon ohne deckungsgleiche Greif-Zone      3292   (99 %)
+ *   Faelle mit mindestens einer solchen Luecke  784   (alle)
+ *   Greif-Zonen, unter denen kein Strich liegt  180
+ *
+ * ─── WAS DIESER WAECHTER HAELT ────────────────────────────────────────────
+ *
+ * Die vier Zusicherungen, aus denen „intuitiv" hier besteht:
+ *
+ *  1. Jeder Griff liegt auf dem Strich, den der Nutzer sieht.
+ *  2. Jeder sichtbare Abschnitt zwischen den Stummeln hat einen Griff.
+ *  3. Der Rundlauf schliesst: Kette ohne Enden -> `cable.waypoints` ->
+ *     `legeAnfahrt` -> derselbe Streckenzug. Ohne das wanderte das Kabel
+ *     unter der Hand des Nutzers weg.
+ *  4. Nach einem Zug liegt der gezogene Abschnitt dort, wo der Zeiger ist,
+ *     und der Weg ist noch rechtwinklig.
+ */
+
+const SEITEN: Anschlussseite[] = ['links', 'rechts', 'oben', 'unten']
+const QUELLE: Point = { x: 400, y: 300 }
+
+const LAGEN: Array<[number, number]> = []
+for (const dx of [-300, -120, -18, 0, 18, 120, 300]) {
+  for (const dy of [-220, -80, -18, 0, 18, 80, 220]) LAGEN.push([dx, dy])
+}
+
+/** Liegt der Punkt (auf Zeichen-Genauigkeit) auf dem Streckenzug? */
+const liegtAufWeg = (p: Point, weg: readonly Point[]): boolean => {
+  const eps = 1.5
+  for (let i = 0; i < weg.length - 1; i += 1) {
+    const a = weg[i]
+    const b = weg[i + 1]
+    if (p.x < Math.min(a.x, b.x) - eps || p.x > Math.max(a.x, b.x) + eps) continue
+    if (p.y < Math.min(a.y, b.y) - eps || p.y > Math.max(a.y, b.y) + eps) continue
+    const kreuz = (b.x - a.x) * (p.y - a.y) - (b.y - a.y) * (p.x - a.x)
+    const laenge = Math.hypot(b.x - a.x, b.y - a.y) || 1
+    if (Math.abs(kreuz) / laenge < eps) return true
+  }
+  return false
+}
+
+const gleich = (a: readonly Point[], b: readonly Point[]): boolean =>
+  a.length === b.length &&
+  a.every((p, i) => Math.abs(p.x - b[i].x) < 1 && Math.abs(p.y - b[i].y) < 1)
+
+interface Fall {
+  name: string
+  quelleSeite: Anschlussseite
+  zielSeite: Anschlussseite
+  ziel: Point
+  weg: Point[]
+  kette: Point[]
+  /** Die Abschnitte, die `CableWaypoints` mit einer Greif-Zone belegt. */
+  griffe: number[]
+}
+
+const faelle: Fall[] = []
+for (const quelleSeite of SEITEN) {
+  for (const zielSeite of SEITEN) {
+    for (const [dx, dy] of LAGEN) {
+      const ziel = { x: QUELLE.x + dx, y: QUELLE.y + dy }
+      const zwischen = computeObstacleAwareWaypoints(QUELLE, ziel, [], undefined, [])
+      const weg = legeAnfahrt({ quelle: QUELLE, quelleSeite, ziel, zielSeite, zwischen })
+      const kette = greifKette(weg, [stummel(QUELLE, quelleSeite), stummel(ziel, zielSeite)])
+      // Dieselbe Regel wie `ziehbar` in `CableWaypoints`: erster und letzter
+      // Abschnitt sind die Stummel; bleibt nichts uebrig, ist alles ziehbar.
+      const alle = kette.length - 1
+      const innen: number[] = []
+      for (let i = 0; i < alle; i += 1) if (i > 0 && i + 1 < kette.length - 1) innen.push(i)
+      const griffe = kette.length >= 4 ? innen : Array.from({ length: alle }, (_, i) => i)
+      faelle.push({
+        name: `${quelleSeite}->${zielSeite} d=(${dx},${dy})`,
+        quelleSeite,
+        zielSeite,
+        ziel,
+        weg,
+        kette,
+        griffe,
+      })
+    }
+  }
+}
+
+describe('Der Griff liegt auf dem Strich', () => {
+  it('hat ueberhaupt eine Matrix', () => {
+    expect(faelle.length).toBe(SEITEN.length * SEITEN.length * LAGEN.length)
+    expect(faelle.length).toBe(784)
+  })
+
+  it('legt jede Ecke der Greifkette auf den gezeichneten Weg', () => {
+    // Das ist der gemessene Befund, umgedreht: 3292 von 3324 Abschnitten
+    // hatten keine deckungsgleiche Zone. Hier muss jeder Punkt sitzen.
+    const daneben = faelle.filter((f) => f.kette.some((p) => !liegtAufWeg(p, f.weg)))
+    expect(daneben.map((f) => f.name)).toEqual([])
+  })
+
+  it('laesst keinen sichtbaren Abschnitt ohne Griff', () => {
+    // Ein Abschnitt zwischen den beiden Stummeln, den man nicht anfassen
+    // kann, ist genau die Beschwerde. Die Stummel selbst sind ausgenommen —
+    // sie gehoeren `legeAnfahrt`, nicht dem Nutzer.
+    const ohne = faelle.filter((f) => f.griffe.length === 0 && f.kette.length > 3)
+    expect(ohne.map((f) => f.name)).toEqual([])
+  })
+
+  it('nennt die entarteten Faelle, in denen alles Stummel ist', () => {
+    // Zwoelf Faelle: die beiden Buchsen liegen keine 18 px auseinander, das
+    // ganze Kabel ist kuerzer als ein Stummel. Dort greift der Rueckfall
+    // („alles ziehbar"). Die Zahl steht hier, damit auffaellt, wenn sie
+    // waechst — dann waere der Rueckfall keine Ausnahme mehr.
+    const entartet = faelle.filter((f) => f.kette.length <= 3)
+    expect(entartet.length).toBe(12)
+    for (const f of entartet) expect(f.griffe.length).toBeGreaterThan(0)
+  })
+})
+
+describe('Der Rundlauf schliesst', () => {
+  it('zeichnet aus der zurueckgeschriebenen Kette denselben Weg', () => {
+    // Ohne das wanderte das Kabel beim Loslassen weg: gezogen wird die
+    // Kette, gespeichert werden ihre inneren Punkte, gezeichnet wird wieder
+    // aus ihnen. Nur wenn das dasselbe ergibt, ist das Ziehen berechenbar.
+    const abweichend = faelle.filter((f) => {
+      const zurueck = legeAnfahrt({
+        quelle: QUELLE,
+        quelleSeite: f.quelleSeite,
+        ziel: f.ziel,
+        zielSeite: f.zielSeite,
+        zwischen: f.kette.slice(1, -1),
+      })
+      return !gleich(zurueck, f.weg)
+    })
+    expect(abweichend.map((f) => f.name)).toEqual([])
+  })
+})
+
+describe('Was der Zug bewirkt', () => {
+  it('legt den gezogenen Abschnitt an den Zeiger und laesst den Weg rechtwinklig', () => {
+    const fehler: string[] = []
+    for (const f of faelle) {
+      for (const i of f.griffe) {
+        for (const d of [-60, 45]) {
+          const achse = abschnittAchse(f.kette[i], f.kette[i + 1])
+          const zeiger =
+            achse === 'waagerecht'
+              ? { x: f.kette[i].x, y: f.kette[i].y + d }
+              : { x: f.kette[i].x + d, y: f.kette[i].y }
+          const neu = schiebeAbschnitt(f.kette, i, zeiger, { x: d, y: d })
+          const gezeichnet = legeAnfahrt({
+            quelle: QUELLE,
+            quelleSeite: f.quelleSeite,
+            ziel: f.ziel,
+            zielSeite: f.zielSeite,
+            zwischen: neu.slice(1, -1),
+          })
+          if (!istRechtwinklig(gezeichnet)) fehler.push(`${f.name} Abschnitt ${i} d=${d}: schraeg`)
+          // Der verschobene Abschnitt muss danach auch wirklich dort liegen.
+          const versetzt = neu[i === 0 ? 1 : i]
+          if (!liegtAufWeg(versetzt, gezeichnet)) {
+            fehler.push(`${f.name} Abschnitt ${i} d=${d}: nicht am Zeiger`)
+          }
+        }
+      }
+    }
+    expect(fehler.slice(0, 12)).toEqual([])
+  })
+
+  it('haelt die Ecke am Anschluss fest, statt sie vom Geraet zu loesen', () => {
+    // `schiebeEcke` darf Quelle und Ziel nicht bewegen — die haengen an der
+    // Buchse. Statt den Nachbarn mitzunehmen wird die Ecke auf dessen Achse
+    // festgehalten.
+    const fehler: string[] = []
+    for (const f of faelle) {
+      for (let i = 1; i < f.kette.length - 1; i += 1) {
+        const neu = schiebeEcke(f.kette, i, { x: 900, y: 900 })
+        if (!gleich([neu[0]], [f.kette[0]])) fehler.push(`${f.name}: Quelle bewegt`)
+        if (!gleich([neu[neu.length - 1]], [f.kette[f.kette.length - 1]])) {
+          fehler.push(`${f.name}: Ziel bewegt`)
+        }
+        if (neu.length !== f.kette.length) fehler.push(`${f.name}: Kette geaendert`)
+      }
+    }
+    expect(fehler.slice(0, 12)).toEqual([])
+  })
+
+  it('nimmt eine Ecke heraus, ohne die Enden anzutasten', () => {
+    for (const f of faelle) {
+      if (f.kette.length < 3) continue
+      const ohne = f.kette.filter((_, i) => i !== 1).slice(1, -1)
+      expect(ohne.length).toBe(f.kette.length - 3)
+    }
+  })
+})

--- a/tests/schiebereglerGroesse.test.ts
+++ b/tests/schiebereglerGroesse.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+// ---------------------------------------------------------------------------
+// Sind die Schieberegler zu treffen?
+//
+// Nutzer-Meldung 2026-09-09: „Passe auch die Ui von allen slidern an sodass
+// man sie gut bedienen kann."
+//
+// GEMESSEN VORHER: fuer `input[type="range"]` stand in `index.css` NICHTS. Es
+// blieb also beim Standardaussehen des Browsers, und dessen Regler ist in
+// WebKit rund 16 px hoch. WCAG 2.2, Erfolgskriterium 2.5.8 („Target Size
+// (Minimum)", Stufe AA), nennt 24 px als Mindestmass fuer eine
+// Trefferflaeche — eine Norm mit einer Zahl, deshalb steht sie hier und nicht
+// Apples Richtlinie von 44 pt (die ist eine Herstellerempfehlung).
+//
+// WAS DIESE PRUEFUNG NICHT KANN, und das gehoert hierher statt in eine
+// Fussnote: sie liest das Stilblatt und die Klassen an den Reglern. Das ist
+// WENIGER als eine Messung am gerenderten Fenster — was `gap`, Zeilenhoehe
+// und ein umgebendes `transform` daraus machen, sieht sie nicht.
+// `scripts/ui-targets.mjs` misst so etwas richtig, mit einem echten Browser
+// und `getBoundingClientRect()`.
+//
+// Warum sie trotzdem steht: die beiden Wege, auf denen ein Regler wieder
+// schrumpft, sind BEIDE textlich sichtbar — jemand dreht die Zahl im
+// Stilblatt zurueck, oder jemand haengt an einen einzelnen Regler eine
+// Utility-Klasse wie `h-1`, die das Stilblatt ueberschreibt. Genau diese zwei
+// prueft sie, und sie sagt von sich aus, dass sie nur diese zwei kennt. Eine
+// Pruefung, die ihre Grenze verschweigt, ist die gefaehrlichere.
+// ---------------------------------------------------------------------------
+
+/** WCAG 2.2 SC 2.5.8, Stufe AA. */
+const MINDESTHOEHE = 24
+/** Der sichtbare Griff. Kleiner als das findet der Daumen die Bahn nicht. */
+const MINDESTGRIFF = 18
+
+const WURZEL = resolve(__dirname, '..')
+/** Kommentare RAUS: sie erklaeren die Regeln und wuerden sonst als Regel
+ *  gelesen. Ohne diesen Schritt findet die Pruefung ihre eigene Begruendung
+ *  wieder und ist gruen, nachdem die Regel geloescht wurde. */
+const css = readFileSync(join(WURZEL, 'src/renderer/index.css'), 'utf8').replace(
+  /\/\*[\s\S]*?\*\//g,
+  '',
+)
+
+const block = (selektor: string): string | null => {
+  const i = css.indexOf(selektor)
+  if (i < 0) return null
+  const auf = css.indexOf('{', i)
+  const zu = css.indexOf('}', auf)
+  return auf < 0 || zu < 0 ? null : css.slice(auf + 1, zu)
+}
+
+const px = (rumpf: string | null, eigenschaft: string): number | null => {
+  if (!rumpf) return null
+  const m = new RegExp(`${eigenschaft}\\s*:\\s*(\\d+(?:\\.\\d+)?)px`).exec(rumpf)
+  return m ? Number(m[1]) : null
+}
+
+const tsxDateien = (): string[] => {
+  const out: string[] = []
+  const gehe = (d: string) => {
+    for (const e of readdirSync(d)) {
+      const p = join(d, e)
+      if (statSync(p).isDirectory()) {
+        if (e !== 'node_modules') gehe(p)
+      } else if (/\.tsx$/.test(e)) out.push(p)
+    }
+  }
+  gehe(join(WURZEL, 'src'))
+  return out
+}
+
+describe('Schieberegler-Trefferflaeche (WCAG 2.2 SC 2.5.8)', () => {
+  it('das Element ist mindestens 24 px hoch — die Bahn darf schmal bleiben', () => {
+    const hoehe = px(block('input[type="range"] {'), 'height')
+    expect(hoehe, 'input[type="range"] hat keine Hoehe in px').not.toBeNull()
+    expect(hoehe!).toBeGreaterThanOrEqual(MINDESTHOEHE)
+  })
+
+  it('der Griff ist in BEIDEN Browser-Familien mindestens 18 px', () => {
+    // Ohne den Firefox-Zweig bliebe es dort beim Standardaussehen, und die
+    // Messung stuende nur fuer einen Browser.
+    for (const selektor of [
+      'input[type="range"]::-webkit-slider-thumb {',
+      'input[type="range"]::-moz-range-thumb {',
+    ]) {
+      const rumpf = block(selektor)
+      expect(rumpf, `${selektor} fehlt`).not.toBeNull()
+      const breite = px(rumpf, 'width')
+      expect(breite, `${selektor} hat keine Breite in px`).not.toBeNull()
+      expect(breite!).toBeGreaterThanOrEqual(MINDESTGRIFF)
+    }
+  })
+
+  it('der Fokusring liegt AUSSEN, nicht unter der Bahn', () => {
+    // Die allgemeine Input-Regel zeichnet ihn mit `outline-offset: -1px`. An
+    // einem Element, dessen sichtbarer Teil 6 px hoch ist, verschwindet er
+    // damit unter der Bahn.
+    const rumpf = block('input[type="range"]:focus-visible {')
+    expect(rumpf, 'kein eigener Fokusring fuer den Regler').not.toBeNull()
+    expect(px(rumpf, 'outline-offset')).toBeGreaterThan(0)
+  })
+
+  it('kein einzelner Regler schrumpft sich per Inline-Stil zurueck', () => {
+    // Der zweite Weg, und der leisere: das Stilblatt bleibt richtig, aber an
+    // EINEM Regler haengt `style={{ height: 4 }}`. Ein Inline-Stil gewinnt
+    // gegen jeden Selektor — nur faellt es niemandem auf, weil die anderen
+    // stimmen.
+    const treffer: string[] = []
+    let gefunden = 0
+    for (const datei of tsxDateien()) {
+      const quelle = readFileSync(datei, 'utf8')
+      for (const m of quelle.matchAll(/<input\b[^>]*type="range"[^>]*>/g)) {
+        gefunden += 1
+        const stil = /style=\{\{([^}]*)\}\}/.exec(m[0])?.[1] ?? ''
+        const h = /height:\s*'?(\d+)/.exec(stil)
+        if (h && Number(h[1]) < MINDESTHOEHE) {
+          treffer.push(`${datei.replace(WURZEL + '/', '')} — ${h[0]}`)
+        }
+      }
+    }
+    // Die Gegenprobe zur Pruefung selbst: ein Lauf, der KEINEN Regler findet,
+    // waere sonst gruen — und genau so sieht ein kaputtes Muster aus.
+    expect(gefunden, 'kein einziger `type="range"` gefunden').toBeGreaterThan(0)
+    expect(treffer).toEqual([])
+  })
+})


### PR DESCRIPTION
Zwei Nutzer-Meldungen vom 2026-09-09 und zwei Nachträge zu E-28.

## 1. Das Kabel-Ziehen greift wieder den gezeichneten Weg (B-64)

> „Das manuelle Kabel verschieben im Cable planner canvas ist schlechter
> geworden. Repariere so das man es wieder intuitiv bedienen kann"

Die Griffe saßen auf den **Wegpunkten**, gezeichnet wurde aber der
orthogonale Pfad daraus — zwei Rechnungen für dieselbe Frage, und sie liefen
auseinander. Wer eine sichtbare Ecke anfasste, griff ins Leere; wer einen
Griff traf, verschob eine Stelle, die woanders lag.

Jetzt ist die Greif-Geometrie **derselbe Pfad, der gezeichnet wird**
(`greifKette` in `lib/cableApproach.ts`). Kollineare Zwischenpunkte fallen
weg — außer sie liegen auf einer Stummel-Position, denn das ist die Ecke, die
B-48 dort absichtlich hingesetzt hat.

**Gemessen:** 3292 von 3324 Fällen hatten vorher einen Griff ohne Ecke oder
eine Ecke ohne Griff. Jetzt 0. `tests/kabelGriff.test.ts` hält es fest: jede
Ecke der Kette liegt auf dem gezeichneten Weg, kein sichtbares Segment bleibt
ohne Griff, der Rundlauf schließt, und ein Zug landet unter dem Zeiger, ohne
die Orthogonalität zu verlieren.

## 2. Schieberegler sind zu treffen — 24 px statt 16 (#119)

> „Passe auch die Ui von allen slidern an sodass man sie gut bedienen kann"

Für `input[type="range"]` stand in `index.css` **nichts** — die fünf Regler
der App trugen das Standardaussehen des Browsers, in WebKit rund 16 px hoch.
WCAG 2.2 SC 2.5.8 (Stufe AA) nennt 24 px.

Das **Element** wird 24 px hoch, nicht die Bahn (die Regler sitzen in
`flex items-center`-Zeilen neben Beschriftungen; ein 24 px hoher Balken
sprengt jede davon). Der Griff wird 18 px und bleibt eckig (ADR-007). Dazu
ein **eigener** Fokusring mit 3 px Abstand: die allgemeine Input-Regel zeichnet
ihn mit `outline-offset: -1px`, also innen — an einem Element, dessen sichtbarer
Teil 6 px hoch ist, verschwindet er unter der Bahn. Farben aus den
`--cp-*`-Tokens, kippen also im Light-Theme mit.

`tests/schiebereglerGroesse.test.ts` entfernt die Kommentare, **bevor** es das
Stilblatt liest — sonst findet die Prüfung ihre eigene Begründung wieder und
ist grün, nachdem die Regel gelöscht wurde. Genau das ist der Schwester-Prüfung
im light-planner passiert und dort aufgefallen.

## 3. Nachträge zu E-28

* Acht Fallbacks sind durch die Sprachdrehung gerutscht — die Module, die den
  Übersetzer `tr` statt `t` nennen, hat das Tausch-Werkzeug nicht gesehen
  (`\bt\(` trifft `tr(` nicht).
* Ein Kommentar behauptete noch die alte, von E-28 aufgehobene Regel.

## Prüfungen

* `npm test` — 3838 grün, 2 übersprungen (243 Dateien)
* `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
* `npm run lint` — 0 Fehler
* Gegengeprobt, jeweils rot: Slider-Höhe entfernt, Firefox-Griff entfernt

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT