### PR TITLE
docs: die Projektseite steht im README — mit gemessenem Stand

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@
 
 ---
 
+## The web page
+
+Every push to the default branch builds this repo's page from
+`.github/workflows/pages.yml` and publishes it:
+
+**https://larszu.github.io/cable-planner/**
+
+The workflow **asks the Pages API before it configures anything.** With no
+Pages site it still builds — that is a real check — and skips only the
+publishing step, with a warning and the one missing step in the run summary.
+A run that must stay red for a click nobody made teaches people to ignore red.
+
+Measured 2026-09-09: **published** — the `deploy` job ran and succeeded.
+
+---
 ## ✨ Overview
 
 **CablePlanner** is free-to-use **broadcast cable planning software** for designing and visualizing **SDI signal flow**, **ATEM multiviewer** layouts and **Blackmagic Videohub routing** on a node-based canvas. It runs **fully offline** on macOS and Windows, so every audio, video and data run is documented before you ever pull cable on site.


### PR DESCRIPTION
**Nutzer, 2026-09-09:** „Alle Pages sind jetzt über die actions erstellbar. Update auch die readmes erneut."

Das README nannte die Adresse der Seite nur als Badge-Link, ohne zu sagen, wie sie entsteht. Jetzt steht beides da — die Adresse und der Mechanismus: der Lauf **fragt die Pages-API, bevor er konfiguriert**; ohne Site wird trotzdem gebaut (das ist eine echte Prüfung) und nur das Veröffentlichen entfällt, mit Warnung und dem einen fehlenden Schritt in der Lauf-Zusammenfassung.

**Gemessen und nicht behauptet** (`deploy`-Job des letzten Pages-Laufs, 2026-09-09): veröffentlicht. Der Stand steht mit Datum dort, weil er sich ändern kann — ein README, das eine 404 verlinkt, ist schlimmer als eines ohne Link.

### Nebenbefund aus derselben Messung

Von den acht Repos der Suite bauen alle acht ihre Seite; **veröffentlicht sind fünf.** Bei `Broadcast-intercom`, `sony-camera-bridge` und `pi-media-station` ist der `deploy`-Job *skipped* — für diese Repos ist keine Pages-Site angelegt. Das ist der eine Schritt, den kein Workflow tun kann; in den drei READMEs steht er jetzt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_