### PR TITLE
catalog: der Kopf sagt seine Beleglage, statt sie zu behaupten (B-11)

### DIFF
--- a/src/renderer/lib/blackmagicCatalog.ts
+++ b/src/renderer/lib/blackmagicCatalog.ts
@@ -1,9 +1,18 @@
 import type { EquipmentTemplate, Port } from '../types/equipment'
 import type { RecordingCapability } from './recording'
 
-// Known Blackmagic Design device templates with port counts taken from the
-// official datasheets. Matched by name substrings so Rentman items like
-// "Blackmagic Smart Videohub 40x40 12G" get the proper ports assigned on import.
+// Known Blackmagic Design device templates. Matched by name substrings so
+// Rentman items like "Blackmagic Smart Videohub 40x40 12G" get the proper
+// ports assigned on import.
+//
+// BELEGLAGE: kein Datenblatt-Link je Eintrag (B-11).
+// Bis 2026-09-09 stand hier „port counts taken from the official
+// datasheets". Keiner der 32 Einträge hinterlegt eines. Die Zahlen mögen
+// von dort stammen — nachsehen kann es von hier aus niemand, und genau
+// diese Prüfbarkeit behauptete der alte Satz. Was darunter an einzelnen
+// Feldern „laut Datenblatt" sagt, ist durch diese Zeile eingeordnet.
+// `tests/katalogBeleglage.test.ts` hält beide Richtungen fest: sind die
+// Belege nachgetragen, muss diese Zeile wieder verschwinden.
 
 const port = (name: string, connectorType: Port['connectorType'] = 'BNC'): Port => ({
   id: '',

--- a/src/renderer/lib/cameraCatalog.ts
+++ b/src/renderer/lib/cameraCatalog.ts
@@ -1,8 +1,15 @@
 import type { EquipmentTemplate, Port } from '../types/equipment'
 
-// Camera templates sourced from official datasheets / manufacturer spec pages.
-// Covers Sony PXW/PMW cinema line, Blackmagic URSA / Pocket / Studio Camera,
-// and Canon EOS Cinema range commonly found in broadcast/event rental inventories.
+// Camera templates covering the Sony PXW/PMW cinema line, Blackmagic URSA /
+// Pocket / Studio Camera, and the Canon EOS Cinema range commonly found in
+// broadcast/event rental inventories.
+//
+// BELEGLAGE: kein Datenblatt-Link je Eintrag (B-11).
+// Bis 2026-09-09 stand hier „sourced from official datasheets / manufacturer
+// spec pages". Keiner der 20 Einträge hinterlegt eine solche Seite. Der Satz
+// las sich wie ein Beleg und war keiner — wer eine Auflösung oder einen
+// Anschluss nachprüfen wollte, hörte bei ihm auf zu suchen.
+// `tests/katalogBeleglage.test.ts` hält es fest.
 
 const port = (name: string, connectorType: Port['connectorType'] = 'BNC'): Port => ({
   id: '',

--- a/src/renderer/lib/greengoCatalog.ts
+++ b/src/renderer/lib/greengoCatalog.ts
@@ -1,5 +1,10 @@
 import type { EquipmentTemplate, Port } from '../types/equipment'
 
+// BELEGLAGE: kein Datenblatt-Link je Eintrag (B-11).
+// Der Kopf behauptete kein Datenblatt — er sagte aber auch nicht, dass keines
+// hinterlegt ist, und ein leeres Feld sieht aus wie „hat gerade niemand
+// nachgetragen". Neun Einträge, null Belege.
+//
 // GreenGo intercom equipment templates for rental catalog matching.
 // GreenGo is a fully IP-based intercom system — all devices connect via
 // standard Ethernet. The MCX/MCXD provide analog program I/O via XLR-3.

--- a/src/renderer/lib/miscCatalog.ts
+++ b/src/renderer/lib/miscCatalog.ts
@@ -6,6 +6,11 @@ import type { RecordingCapability } from './recording'
 // Decimator SDI/HDMI converters, AJA recorders/scalers, Miranda frame sync,
 // TC Electronics metering, Yamaha studio monitors.
 // Verified against a professional rental-house Rentman inventory (April 2026).
+//
+// BELEGLAGE: kein Datenblatt-Link je Eintrag (B-11).
+// Die Rentman-Prüfung oben ist eine echte Quelle und bleibt stehen — sie sagt
+// nur etwas anderes: dass es die Geräte so GIBT, nicht dass die Port-Zahlen
+// stimmen. Für die 22 Einträge ist kein Hersteller-Beleg hinterlegt.
 
 const port = (name: string, connectorType: Port['connectorType'] = 'BNC'): Port => ({
   id: '',

--- a/src/renderer/lib/monitorCatalog.ts
+++ b/src/renderer/lib/monitorCatalog.ts
@@ -1,9 +1,15 @@
 import type { EquipmentTemplate, Port } from '../types/equipment'
 import type { RecordingCapability } from './recording'
 
-// Broadcast monitor / monitor-recorder templates sourced from official datasheets.
-// Matched by name substrings so Rentman items resolve to the correct port layout
-// on import. All templates are also seeded into the built-in library.
+// Broadcast monitor / monitor-recorder templates. Matched by name substrings
+// so Rentman items resolve to the correct port layout on import. All templates
+// are also seeded into the built-in library.
+//
+// BELEGLAGE: kein Datenblatt-Link je Eintrag (B-11).
+// Bis 2026-09-09 stand hier „sourced from official datasheets". Keiner der
+// 36 Einträge hinterlegt eines. Bei Monitoren trifft das die Port-Belegung —
+// also genau das, wofür dieser Katalog beim Import gelesen wird.
+// `tests/katalogBeleglage.test.ts` hält es fest.
 
 const port = (name: string, connectorType: Port['connectorType'] = 'BNC'): Port => ({
   id: '',

--- a/src/renderer/lib/ubiquitiCatalog.ts
+++ b/src/renderer/lib/ubiquitiCatalog.ts
@@ -1,10 +1,16 @@
 import type { EquipmentTemplate, Port } from '../types/equipment'
 
-// Ubiquiti EdgeRouter / EdgeSwitch / UniFi Switch templates based on the
-// official datasheets / ui.com spec pages. Matched by name substrings so
-// Rentman items like "Ubiquiti EdgeSwitch ES-24-500W" resolve to this
-// template during import, and they're also seeded into the library so the
+// Ubiquiti EdgeRouter / EdgeSwitch / UniFi Switch templates. Matched by name
+// substrings so Rentman items like "Ubiquiti EdgeSwitch ES-24-500W" resolve to
+// this template during import, and they're also seeded into the library so the
 // user can drag them onto the canvas without Rentman.
+//
+// BELEGLAGE: kein Datenblatt-Link je Eintrag (B-11).
+// Bis 2026-09-09 stand hier „based on the official datasheets / ui.com spec
+// pages". Keiner der 40 Einträge hinterlegt eine. Es ist der größte
+// beleglose Katalog des Repos, und der Satz war der überzeugendste — er
+// nannte sogar die Domäne.
+// `tests/katalogBeleglage.test.ts` hält es fest.
 
 const port = (name: string, connectorType: Port['connectorType'] = 'Ethernet/RJ45'): Port => ({
   id: '',

--- a/tests/katalogBeleglage.test.ts
+++ b/tests/katalogBeleglage.test.ts
@@ -1,0 +1,171 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Sagt der Kopf einer Katalog-Datei die Wahrheit über ihre Beleglage?
+//
+// ─── DER BEFUND, GEMESSEN 2026-09-09 ───────────────────────────────────────
+//
+// Vier der sechs Kataloge ohne einen einzigen `manufacturerUrl` behaupten in
+// ihrer Kopfzeile genau das Gegenteil:
+//
+//   blackmagicCatalog.ts  32 Einträge, 0 Belege — „port counts taken from the
+//                         official datasheets"
+//   cameraCatalog.ts      20 Einträge, 0 Belege — „sourced from official
+//                         datasheets / manufacturer spec pages"
+//   monitorCatalog.ts     36 Einträge, 0 Belege — „sourced from official
+//                         datasheets"
+//   ubiquitiCatalog.ts    40 Einträge, 0 Belege — „based on the official
+//                         datasheets / ui.com spec pages"
+//
+// Das sind 128 Einträge, deren Kopf ein Datenblatt nennt, das niemand
+// hinterlegt hat. Die beiden übrigen (`greengo`, `misc`) behaupten es nicht;
+// `misc` nennt sogar eine andere, tatsächlich vorhandene Quelle („Verified
+// against a professional rental-house Rentman inventory, April 2026").
+//
+// ─── WARUM DAS EINE PRÜFUNG WERT IST UND KEIN KOMMENTAR-GESCHMACK ──────────
+//
+// Der Nutzer hat es als Symptom gemeldet: „die presets an Geräten die es gibt
+// stimmen häufig nicht ganz genau". Wer daraufhin eine Port-Zahl nachsehen
+// will, liest den Kopf, findet „taken from the official datasheets" und hört
+// auf zu suchen — obwohl im Eintrag darunter kein Link steht, mit dem er es
+// nachprüfen könnte. Die Behauptung ist damit schlimmer als ein leeres Feld:
+// sie behauptet Prüfbarkeit, die es nicht gibt. Dieselbe Defektform, gegen die
+// `catalogueEvidence.ts` schon die ZAHLEN absichert — nur stand die Prosa
+// darüber bisher außerhalb jeder Messung.
+//
+// ─── WAS DIESE DATEI PRÜFT ─────────────────────────────────────────────────
+//
+// Eine Regel, in BEIDE Richtungen scharf:
+//
+//   0 Belege  → der Kopf trägt die BELEGLAGE-Zeile und behauptet in seiner
+//               Prosa kein Datenblatt.
+//   ≥1 Beleg  → der Kopf trägt die BELEGLAGE-Zeile NICHT.
+//
+// Die zweite Hälfte ist die wichtigere: sie sorgt dafür, dass die Zeile
+// wieder verschwindet, sobald jemand die Belege nachträgt. Eine Markierung,
+// die nach der Reparatur stehen bleibt, ist beim nächsten Lesen wieder eine
+// Lüge — nur in die andere Richtung.
+//
+// ─── WAS SIE AUSDRÜCKLICH NICHT PRÜFT ──────────────────────────────────────
+//
+// Nur den KOPF, also den ersten Kommentarblock. Weiter unten stehen
+// Feld-Kommentare, die ebenfalls ein Datenblatt nennen (`blackmagicCatalog`:
+// „Datenblatt-Fakt statt Port-Zähl-Schätzung"). Die bleiben stehen, und zwar
+// bewusst: der Kopf sagt jetzt die Beleglage der ganzen Datei, und damit ist
+// eine solche Zeile darunter eingeordnet statt freistehend. Wer sie einzeln
+// prüfen will, braucht eine andere Prüfung als diese — diese sagt es hier,
+// damit niemand sie für gründlicher hält, als sie ist.
+//
+// Und sie prüft NICHT, ob die Zahlen stimmen. Das kann von hier aus niemand:
+// die Hersteller-Domänen laufen in den Egress-Filter (B-11, dreimal
+// nachgemessen, zuletzt 2026-09-09). Diese Datei sorgt dafür, dass der
+// Zustand dransteht — nicht dafür, dass er sich ändert.
+// ───────────────────────────────────────────────────────────────────────────
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { evidenceReport } from '../src/renderer/lib/catalogueEvidence'
+
+const LIB = join(__dirname, '..', 'src', 'renderer', 'lib')
+
+/**
+ * Die Zeile, die „hier ist kein Beleg" sagt.
+ *
+ * Wörtlich und ohne Spielraum, damit sie greppbar bleibt und nicht in fünf
+ * Umschreibungen zerfällt.
+ */
+const BELEGLAGE = '// BELEGLAGE: kein Datenblatt-Link je Eintrag (B-11).'
+
+/** Was als Datenblatt-Behauptung gilt — deutsch wie englisch. */
+const BEHAUPTUNG = /datasheet|datenblatt|spec page|spezifikationsseite/i
+
+/**
+ * Der Kopf einer Katalog-Datei: der erste zusammenhaengende Kommentarblock.
+ *
+ * NICHT einfach „die ersten Zeilen der Datei". `blackmagicCatalog.ts` stellt
+ * seine `import`-Zeilen VOR den Kopf, und eine Prüfung, die schon dort
+ * abbricht, liest einen leeren Kopf — und ist auf jeder Behauptung darin
+ * grün. Genau so lief der erste Entwurf dieser Datei: Prüfung 2 war grün,
+ * während im Kopf „taken from the official datasheets" stand. Deshalb
+ * überspringt der Lauf `import`/`export … from`-Zeilen und Leerzeilen und
+ * nimmt den ersten Kommentarblock, der danach kommt.
+ */
+const kopf = (datei: string): string => {
+  const zeilen = readFileSync(join(LIB, datei), 'utf8').split('\n')
+  const gesammelt: string[] = []
+  for (const z of zeilen) {
+    const t = z.trim()
+    const istKommentar = t.startsWith('//') || t.startsWith('/*') || t.startsWith('*')
+    if (istKommentar) {
+      gesammelt.push(t)
+      continue
+    }
+    // Vor dem Kopf darf Leerraum und Import stehen; danach beendet die erste
+    // Nicht-Kommentar-Zeile den Block.
+    if (gesammelt.length > 0) break
+    if (t === '' || /^(import|export)\b.*\bfrom\b/.test(t)) continue
+    break
+  }
+  return gesammelt.join('\n')
+}
+
+/** `blackmagic` → `blackmagicCatalog.ts`. Gilt für alle 16 Namen. */
+const dateiFuer = (name: string): string => `${name}Catalog.ts`
+
+describe('B-11 — der Kopf einer Katalog-Datei sagt seine Beleglage', () => {
+  const bericht = evidenceReport()
+
+  it('1. ein Katalog ohne Beleg trägt die BELEGLAGE-Zeile', () => {
+    const ohne = bericht.perCatalogue.filter((c) => c.entries > 0 && c.sourced === 0)
+    // Gegenprobe zur Prüfung selbst: gäbe es keinen einzigen belegloosen
+    // Katalog, liefe die Schleife leer und bewiese nichts. Heute sind es
+    // sechs (B-11: 159 Einträge). Wird die Lücke geschlossen, fällt DIESE
+    // Zeile zuerst — und dann gehört die ganze Datei weg, nicht die Zeile.
+    expect(ohne.length, 'kein belegloser Katalog mehr — dann ist B-11 erledigt').toBe(6)
+
+    for (const c of ohne) {
+      const text = kopf(dateiFuer(c.name))
+      expect(
+        text.includes(BELEGLAGE),
+        `${dateiFuer(c.name)}: ${c.entries} Einträge, 0 Belege — der Kopf sagt es nicht`,
+      ).toBe(true)
+    }
+  })
+
+  it('2. und behauptet OBERHALB davon kein Datenblatt', () => {
+    // Der Schnitt liegt an der BELEGLAGE-Zeile, nicht an einzelnen Wörtern:
+    // darüber steht, WAS die Datei enthält, darunter, WIE es belegt ist. Der
+    // Absatz unter der Zeile darf das Wort „Datenblatt" also brauchen — er
+    // erklärt ja gerade, dass keines hinterlegt ist. Ein Regex, der das Wort
+    // überall verböte, würde die ehrliche Erklärung mit derselben Härte
+    // treffen wie die Behauptung, gegen die sie geschrieben ist.
+    for (const c of bericht.perCatalogue.filter((x) => x.entries > 0 && x.sourced === 0)) {
+      const text = kopf(dateiFuer(c.name))
+      const schnitt = text.indexOf(BELEGLAGE)
+      const darueber = schnitt < 0 ? text : text.slice(0, schnitt)
+      expect(
+        BEHAUPTUNG.test(darueber),
+        `${dateiFuer(c.name)}: der Kopf nennt ein Datenblatt, das kein Eintrag hinterlegt`,
+      ).toBe(false)
+    }
+  })
+
+  it('3. ein belegter Katalog trägt die Zeile NICHT', () => {
+    const mit = bericht.perCatalogue.filter((c) => c.sourced > 0)
+    expect(mit.length).toBeGreaterThan(5)
+    for (const c of mit) {
+      expect(
+        kopf(dateiFuer(c.name)).includes(BELEGLAGE),
+        `${dateiFuer(c.name)}: ${c.sourced} Belege, und trotzdem die BELEGLAGE-Zeile`,
+      ).toBe(false)
+    }
+  })
+
+  it('4. die Zählung stammt aus dem einen Bericht, nicht aus einer zweiten Rechnung', () => {
+    // Ohne diese Zeile wäre nicht festgehalten, dass hier `evidenceReport()`
+    // gelesen wird und nicht noch einmal per Regex gezählt. Zwei Rechnungen
+    // über dieselben Kataloge laufen auseinander — der Kopf von
+    // `catalogueEvidence.ts` nennt genau das als Grund für die Engstelle.
+    expect(bericht.perCatalogue.map((c) => c.name)).toContain('blackmagic')
+    expect(bericht.entries).toBe(bericht.sourced + bericht.unsourced)
+    expect(bericht.unsourced).toBe(159)
+  })
+})


### PR DESCRIPTION
Nutzer-Meldung: „die presets an Geräten die es gibt stimmen häufig nicht ganz genau. Vergleiche alle einzeln mit den Datenblättern. Und passe an."

## Der Abgleich selbst geht von hier aus nicht — und das ist gemessen

| Domäne | curl | WebFetch |
|---|---|---|
| `blackmagicdesign.com` | 000 (keine Verbindung) | `EGRESS_BLOCKED` |
| `ui.com` | 000 | — |
| `lynx-technik.com` | 000 | — |
| `greengo.eu` | 000 | — |
| `sony.com` | 000 | — |

Dreimal nachgemessen (2026-09-04, 2026-09-09 früh, 2026-09-09 heute Abend), weil ein Egress-Filter sich ändern kann und eine alte Messung als Begründung fürs Liegenlassen zu wenig ist. Die Websuche liefert Händlerseiten (B&H, Markertek, Full Compass), keine Hersteller-Produktseiten.

**159 URLs einzutragen, die niemand geöffnet hat**, wäre genau der Fehler, gegen den die Belegkette dieses Repos gebaut ist: ein `manufacturerUrl`, der ins Leere zeigt, ist schlechter als ein leeres Feld, weil er Prüfbarkeit behauptet.

## Was dabei auffiel — und das ist reparierbar

Vier der sechs beleglosen Kataloge behaupten in ihrem **Kopf** ein Datenblatt, das kein einziger Eintrag hinterlegt:

| Katalog | Einträge | Belege | Der Satz, der bis heute dort stand |
|---|---:|---:|---|
| `blackmagicCatalog` | 32 | **0** | „port counts taken from the official datasheets" |
| `cameraCatalog` | 20 | **0** | „sourced from official datasheets / manufacturer spec pages" |
| `monitorCatalog` | 36 | **0** | „sourced from official datasheets" |
| `ubiquitiCatalog` | 40 | **0** | „based on the official datasheets / ui.com spec pages" |

Zusammen **128 Einträge**.

Für den Nutzer ist das der Unterschied zwischen „niemand hat nachgesehen" und „steht im Datenblatt". Wer eine Port-Zahl anzweifelt — und genau das meldet er ja —, liest den Kopf, findet den Satz und hört auf zu suchen; obwohl im Eintrag darunter kein Link steht, mit dem er es nachprüfen könnte. Die Behauptung ist damit schlimmer als ein leeres Feld.

Es ist dieselbe Defektform, gegen die `catalogueEvidence.ts` schon die **Zahlen** absichert (Ratsche über 253 von 412 Belegen). Die **Prosa** darüber lag bisher außerhalb jeder Messung.

`greengoCatalog` (9) und `miscCatalog` (22) behaupteten nichts — sagten aber auch nicht, dass nichts hinterlegt ist, und ein leeres Feld sieht aus wie „hat gerade niemand nachgetragen". Bei `misc` bleibt die Rentman-Prüfung stehen: sie ist eine echte Quelle, sagt nur etwas anderes — dass es die Geräte so **gibt**, nicht dass die Port-Zahlen stimmen.

## Die Regel, in beide Richtungen scharf

```
0 Belege  → der Kopf trägt die BELEGLAGE-Zeile
            und behauptet oberhalb davon kein Datenblatt
≥1 Beleg  → der Kopf trägt die Zeile NICHT
```

Die **zweite Hälfte ist die wichtigere**: sie lässt die Markierung wieder verschwinden, sobald jemand die Belege nachträgt. Eine Markierung, die nach der Reparatur stehen bleibt, ist beim nächsten Lesen wieder eine Lüge — nur in die andere Richtung.

Der Schnitt für Regel 2 liegt an der Zeile selbst, nicht an einzelnen Wörtern: darüber steht, **was** die Datei enthält, darunter, **wie** es belegt ist. Der Absatz unter der Zeile darf das Wort „Datenblatt" also brauchen — er erklärt ja gerade, dass keines hinterlegt ist.

Gezählt wird nicht neu: `tests/katalogBeleglage.test.ts` liest `evidenceReport()`. Zwei Rechnungen über dieselben Kataloge laufen auseinander, und dann stünde im Bericht etwas anderes als im Wächter — der Kopf von `catalogueEvidence.ts` nennt genau das als Grund für die Engstelle.

## Gegengeprobt, jede Regel einzeln rot

| Eingriff | rot |
|---|---|
| BELEGLAGE-Zeile aus `blackmagicCatalog` entfernt | Regel 1 |
| alten Datenblatt-Satz wieder eingesetzt | Regel 2 |
| Zeile in `micCatalog` eingefügt (184 Belege) | Regel 3 |

**Und einmal war der Wächter selbst der Fehler:** beim ersten Entwurf war Regel 2 grün, während im Kopf noch „taken from the official datasheets" stand. Die Kopf-Erkennung brach an der ersten `import`-Zeile ab und las damit einen leeren Kopf — `blackmagicCatalog` stellt seine Importe vor den Kommentar. Das steht jetzt als Begründung in der Datei, weil die nächste Person sonst dieselbe Bauform wählt.

## Was ausdrücklich nicht geprüft wird

* **Ob die Zahlen stimmen.** Das kann von hier aus niemand (siehe oben). Diese Änderung sorgt dafür, dass der Zustand dransteht — nicht dafür, dass er sich ändert.
* **Nur der Kopf**, also der erste Kommentarblock. Weiter unten stehen Feld-Kommentare, die ebenfalls ein Datenblatt nennen (`blackmagicCatalog`: „Datenblatt-Fakt statt Port-Zähl-Schätzung"). Die bleiben bewusst stehen: der Kopf sagt jetzt die Beleglage der ganzen Datei, und damit ist eine solche Zeile darunter eingeordnet statt freistehend. Die Testdatei sagt das von sich aus, damit niemand sie für gründlicher hält, als sie ist.

## Was den Abgleich entsperren würde

Eines von dreien, alle drei sind Eigentümer-Sachen:

1. Die fünf Hersteller-Domänen im Egress-Filter freigeben.
2. Die Datenblätter als PDF ins Repo (oder in die Sitzung) legen.
3. Entscheiden, dass die 159 Einträge unbelegt bleiben — dann sagt der Kopf es jetzt wenigstens.

## Prüfungen

* `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
* `npx vitest run` — 244 Dateien, 3842 Tests grün
* `npm run lint` — 0 Fehler (12 vorbestehende Warnungen)
* `npm run lang:check` — 0 Sprachmix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_