### PR TITLE
lager: avplan-inventory v5 trägt die Mindestmenge (B-65)

### DIFF
--- a/src/renderer/lager/lib/inventoryPortable.ts
+++ b/src/renderer/lager/lib/inventoryPortable.ts
@@ -44,7 +44,21 @@ export const INVENTORY_FORMAT = 'avplan-inventory'
 // Version weigert sich ein aelterer Stand stattdessen zu lesen. Aeltere
 // Dateien (v1-v3) lesen wir unveraendert weiter; ihre Einheiten haben schlicht
 // keine Werte.
-export const INVENTORY_FORMAT_VERSION = 4
+// Version 5 (B-65): `InventoryItem.mindestmenge` -- ab wann das Haus
+// nachbestellt oder sub-hired. Gepflegt wird sie im Lager-Werkzeug
+// (`inventory-planner`); hier steht sie, damit der Planer sie nicht
+// wegwirft. Dieselbe Begruendung wie bei 2, 3 und 4: `healItem` baut JEDEN
+// Artikel Feld fuer Feld neu auf, ein Stand ohne dieses Feld laese eine
+// Datei mit gepflegten Mindestmengen ein und schriebe sie still ohne sie
+// zurueck. Die Kachel „Unter Ziel" im Lager stuende danach auf 0 und haette
+// ueber nichts recht -- die teuerste Form des Verlusts: keine Fehlermeldung,
+// sondern eine gruene Zahl.
+//
+// Mit der erhoehten Version weigert sich ein aelterer Stand stattdessen zu
+// lesen. Aeltere Dateien (v1-v4) lesen wir unveraendert weiter; ihre Artikel
+// haben schlicht keine Mindestmenge, und das ist nicht 0, sondern
+// UNBEWERTET.
+export const INVENTORY_FORMAT_VERSION = 5
 
 export interface InventorySnapshot {
   items: InventoryItem[]

--- a/src/renderer/lager/store/inventoryStore.ts
+++ b/src/renderer/lager/store/inventoryStore.ts
@@ -121,6 +121,14 @@ const healItem = (raw: unknown): InventoryItem | null => {
     deviceTypeId:
       typeof r.deviceTypeId === 'string' && r.deviceTypeId.trim() ? r.deviceTypeId : undefined,
     quantity: typeof r.quantity === 'number' && r.quantity >= 0 ? Math.round(r.quantity) : 0,
+    // B-65 -- die Mindestmenge des Lager-Werkzeugs muss die Heilung
+    // ueberleben. Der Planer bearbeitet sie nicht, aber er darf sie auch
+    // nicht wegwerfen: genau hier ginge sie sonst still verloren, und ein
+    // Export aus dem Planer kaeme im Lager ohne Mindestmengen an.
+    mindestmenge:
+      typeof r.mindestmenge === 'number' && r.mindestmenge >= 0
+        ? Math.round(r.mindestmenge)
+        : undefined,
     rentPricePerDay:
       typeof r.rentPricePerDay === 'number' && r.rentPricePerDay >= 0 ? r.rentPricePerDay : undefined,
     stockLocation: typeof r.stockLocation === 'string' ? r.stockLocation : undefined,

--- a/src/renderer/lager/types/inventory.ts
+++ b/src/renderer/lager/types/inventory.ts
@@ -123,6 +123,23 @@ export interface InventoryItem {
   deviceTypeId?: string
   /** Gesamtmenge im Bestand. */
   quantity: number
+  /**
+   * Mindestmenge -- ab wann das Haus nachbestellt oder sub-hired (B-65).
+   *
+   * GEPFLEGT WIRD SIE IM LAGER-WERKZEUG (`inventory-planner`), nicht hier.
+   * Sie steht trotzdem in diesem Typ, und der Grund ist der einzige, der
+   * zaehlt: `healItem` weiter unten baut jeden Artikel Feld fuer Feld neu
+   * auf. Ein Feld, das dieser Typ nicht kennt, laese der Planer aus einer
+   * `avplan-inventory`-Datei ein und schriebe sie beim Export STILL ohne es
+   * zurueck. Der Lagerist saehe danach eine Kachel „Unter Ziel" auf 0 --
+   * ohne Fehlermeldung, ohne Anlass zur Nachfrage, und ohne dass jemals
+   * jemand seine Mindestmengen geloescht haette.
+   *
+   * OPTIONAL, UND DAS IST DER PUNKT. Fehlt die Angabe, ist der Artikel
+   * UNBEWERTET und nicht „bei null". Eine 0 waere die Aussage „darf leer
+   * sein", und die trifft jemand ausdruecklich.
+   */
+  mindestmenge?: number
   /** Mietpreis pro Tag (Kalkulation, Phase 5). */
   rentPricePerDay?: number
   /** Lagerort (z. B. "Regal A3"). */

--- a/tests/inventoryContract.test.ts
+++ b/tests/inventoryContract.test.ts
@@ -1,16 +1,28 @@
 // ───────────────────────────────────────────────────────────────────────────
 // Drift-Guard fuer das portable Lager-Format `avplan-inventory`.
 //
-// Das Format ist in ALLEN DREI Apps (cable / multicam / light) byte-identisch
+// Das Format ist in JEDEM Repo, das ein Lager anfasst, byte-identisch
 // dupliziert, damit ein Lager app-uebergreifend importierbar bleibt. Diese
 // Datei friert den Wire-Contract ein: Format-Marker, Versionsnummer, Envelope-
 // Shape und die Feld-Namen jeder Entitaet. Aendert jemand das Schema in EINEM
 // Repo, schlaegt dessen Guard fehl.
 //
+// ES SIND NICHT MEHR DREI (korrigiert 2026-09-09). Hier stand „in ALLEN DREI
+// Apps (cable / multicam / light)", und die Liste ist seit dem Lager-Schnitt
+// (ADR-006) unvollstaendig: `inventory-planner` ist dazugekommen und ist
+// inzwischen das Werkzeug, in dem der Bestand WIRKLICH gepflegt wird. Eine
+// Liste, die genau das Repo auslaesst, in dem die Aenderung entsteht, schickt
+// den naechsten Mitwirkenden an drei Stellen und an der vierten vorbei.
+//
 // !!! Wenn dieser Contract bewusst geaendert wird:
 //   1. INVENTORY_FORMAT_VERSION erhoehen (Abwaertskompatibilitaet beachten),
-//   2. die identische Aenderung in ALLEN DREI Repos nachziehen
-//      (cable tests/, multicam src/__tests__/, light scripts/),
+//   2. die identische Aenderung in ALLEN VIER Repos nachziehen:
+//        cable-planner      tests/inventoryContract.test.ts
+//        multicam-planner   src/__tests__/inventoryContract.test.ts
+//        light-planner      scripts/inventory-contract-check.ts
+//        inventory-planner  src/domain/lib/inventoryPortable.ts
+//                           (dort friert bisher nur die Version ein, nicht
+//                            die Feldliste -- eigener Vorgang)
 //   3. die eingefrorenen Key-Listen unten anpassen.
 // ───────────────────────────────────────────────────────────────────────────
 import { describe, it, expect } from 'vitest'
@@ -28,9 +40,9 @@ import type { InventoryItem, StorageNode, InventorySet, InventoryUnit } from '..
 // Eingefrorener Contract — MUSS in allen drei Repos identisch sein.
 const CONTRACT = {
   format: 'avplan-inventory',
-  version: 4,
+  version: 5,
   envelopeKeys: ['app', 'exportedAt', 'format', 'items', 'nodes', 'sets', 'units', 'version'],
-  itemKeys: ['category', 'code', 'codeType', 'createdAt', 'deviceTypeId', 'dimensions', 'id', 'locationId', 'manufacturer', 'materialKinds', 'model', 'notes', 'ownership', 'quantity', 'rentPricePerDay', 'returnDue', 'stockLocation', 'supplier', 'updatedAt', 'ursprungsland'],
+  itemKeys: ['category', 'code', 'codeType', 'createdAt', 'deviceTypeId', 'dimensions', 'id', 'locationId', 'manufacturer', 'materialKinds', 'mindestmenge', 'model', 'notes', 'ownership', 'quantity', 'rentPricePerDay', 'returnDue', 'stockLocation', 'supplier', 'updatedAt', 'ursprungsland'],
   nodeKeys: ['code', 'codeType', 'createdAt', 'dimensions', 'id', 'kind', 'name', 'notes', 'parentId', 'updatedAt'],
   setKeys: ['components', 'createdAt', 'id', 'name', 'notes', 'updatedAt'],
   unitKeys: ['anschaffung', 'code', 'codeType', 'condition', 'createdAt', 'history', 'houseRef', 'id', 'itemId', 'locationId', 'notes', 'serial', 'updatedAt', 'versicherungswert'],
@@ -53,6 +65,10 @@ const item: InventoryItem = {
   dimensions: { widthMm: 50, heightMm: 20, depthMm: 200, weightKg: 0.3 },
   // Bedarf 118 — fuers Carnet-Datenblatt.
   ursprungsland: 'JP',
+  // B-65 — die Mindestmenge des Hauses. Sie MUSS den Round-Trip ueberleben:
+  // eine Datei, die sie unterwegs verliert, laesst das Lager wie eines
+  // aussehen, in dem alles reicht.
+  mindestmenge: 20,
   materialKinds: ['rental'], notes: 'x', createdAt: 't', updatedAt: 't',
 }
 const node: StorageNode = {


### PR DESCRIPTION
Der Nachzug zu [larszu/inventory-planner#5](https://github.com/larszu/inventory-planner/pull/5). Das Lager-Werkzeug bekommt mit B-65 eine Mindestmenge je Artikel — „ab wann bestellen wir nach". **Dieses Repo pflegt sie nicht, und genau deshalb muss es sie kennen.**

## Warum ein Feld, das dieser Planer gar nicht bearbeitet

`healItem` baut hier **jeden** Artikel Feld für Feld neu auf. Ein Feld, das der Typ nicht kennt, überlebt das Laden nicht.

Der Planer läse also eine `avplan-inventory`-Datei mit gepflegten Mindestmengen ein und schriebe sie beim Export still ohne sie zurück. Der Lagerist sähe danach seine Kachel „Unter Ziel" auf 0 — ohne Fehlermeldung, ohne Anlass zur Nachfrage, und ohne dass jemals jemand etwas gelöscht hätte. Das ist die teuerste Form des Verlusts: keine Meldung, sondern eine grüne Zahl.

Dasselbe Argument steht wörtlich in den Begründungen für v2, v3 und v4 in `inventoryPortable.ts` — es ist nicht neu, nur wieder anwendbar.

## Was sich ändert

- `InventoryItem.mindestmenge?: number` im Lager-Typ, mit dem Grund an Ort und Stelle. Optional heißt **UNBEWERTET**, nicht 0 — eine 0 wäre die Aussage „darf leer sein", und die trifft jemand ausdrücklich.
- `healItem` trägt das Feld mit.
- `INVENTORY_FORMAT_VERSION` 4 → 5. Ältere Dateien (v1–v4) lesen wir unverändert weiter; eine v5-Datei weist ein älterer Stand ab, statt sie halb zu lesen.
- Der Wire-Contract friert Version, Feldliste und Round-Trip neu ein.

## Eine Korrektur im Kopf des Contract-Guards

Dort stand, das Format liege „in **ALLEN DREI** Apps (cable / multicam / light)" — und die Anleitung darunter schickte den nächsten Mitwirkenden an genau diese drei Stellen.

Seit dem Lager-Schnitt (ADR-006) stimmt das nicht mehr: `inventory-planner` ist dazugekommen und ist inzwischen das Werkzeug, in dem der Bestand *wirklich* gepflegt wird. Eine Liste, die ausgerechnet das Repo ausläßt, in dem die Änderung entsteht, führt zu drei angepassten Guards und einem vierten Repo, das die neuen Dateien ablehnt. Die Liste nennt jetzt alle vier, mit Dateipfad und mit dem Hinweis, dass im Lager-Repo bisher nur die Version eingefroren ist und nicht die Feldliste.

## Nachgeprüft

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 244 Dateien, 3842 Tests grün (2 skipped)
- `npm run lint` — 0 Fehler (12 vorbestehende Warnungen)

## Reihenfolge

Dieser PR und [inventory-planner#5](https://github.com/larszu/inventory-planner/pull/5) gehören zusammen und sollten zeitnah hintereinander gemergt werden. Zwischen den beiden Merges gilt: eine v5-Datei aus dem Lager kann der Planer noch nicht lesen — er weist sie ab, statt sie zu kürzen, was die richtige der beiden Verhaltensweisen ist. Die Nachzüge für `multicam-planner` und `light-planner` folgen in eigenen PRs; dort reichen die Planer Felder unverändert durch, die Version muss aber trotzdem mit, sonst weisen sie ab sofort jede Datei ab, die von hier kommt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_