### PR TITLE
lager: avplan-inventory v6 trägt die Prüf-Fristen (B-65)

### DIFF
--- a/src/renderer/lager/lib/inventoryPortable.ts
+++ b/src/renderer/lager/lib/inventoryPortable.ts
@@ -58,7 +58,21 @@ export const INVENTORY_FORMAT = 'avplan-inventory'
 // lesen. Aeltere Dateien (v1-v4) lesen wir unveraendert weiter; ihre Artikel
 // haben schlicht keine Mindestmenge, und das ist nicht 0, sondern
 // UNBEWERTET.
-export const INVENTORY_FORMAT_VERSION = 5
+// Version 6 (B-65): `InventoryUnit.fristen` -- was an einer Einheit
+// turnusmaessig faellig ist (DGUV-V3-Pruefung, Kalibrierung, Wartung,
+// Akku). Gepflegt und ausgewertet wird das im Lager-Werkzeug; hier steht
+// es, damit der Planer es nicht wegwirft. `healUnit` baut JEDE Einheit
+// Feld fuer Feld neu auf.
+//
+// Das wiegt mehr als jedes Feld davor. Eine verlorene Mindestmenge kostet
+// eine Nachbestellung; eine verlorene DGUV-V3-Frist stellt ein
+// ungeprueftes Geraet auf eine Veranstaltung -- und die Ampel im Lager
+// wuerde dabei nicht schweigen, sondern „nichts faellig" melden.
+//
+// Aeltere Dateien (v1-v5) lesen wir unveraendert weiter; ihre Einheiten
+// haben schlicht keine Fristen, und das ist nicht „geprueft", sondern
+// UNBEWERTET.
+export const INVENTORY_FORMAT_VERSION = 6
 
 export interface InventorySnapshot {
   items: InventoryItem[]

--- a/src/renderer/lager/store/inventoryStore.ts
+++ b/src/renderer/lager/store/inventoryStore.ts
@@ -22,6 +22,8 @@ import type {
   Geldbetrag,
   Anschaffung,
   Versicherungswert,
+  Frist,
+  FristArt,
 } from '../types/inventory'
 import { normaliseFaultEvent } from '../lib/faultHistory'
 import { deriveDemand } from '../lib/inventoryCoverage'
@@ -295,6 +297,45 @@ const healVersicherungswert = (raw: unknown): Versicherungswert | undefined => {
   return { betrag, ...(typeof r.stand === 'string' && r.stand.trim() ? { stand: r.stand.trim() } : {}) }
 }
 
+const FRIST_ARTEN: FristArt[] = ['dguv-v3', 'kalibrierung', 'wartung', 'akku', 'sonstige']
+
+/**
+ * Fristen heilen (B-65). Dieselbe Regel wie im Lager-Werkzeug: ein Termin
+ * ohne jede Zeitangabe ist kein Termin und faellt weg; eine unbekannte
+ * `art` wird `sonstige` und wird NICHT verworfen — dass ein neuerer Stand
+ * eine Sorte kennt, die dieser nicht kennt, ist kein Grund, einen
+ * eingetragenen Prueftermin zu loeschen.
+ */
+const healFristen = (raw: unknown): Frist[] | undefined => {
+  if (!Array.isArray(raw)) return undefined
+  const out: Frist[] = []
+  for (const e of raw) {
+    if (!e || typeof e !== 'object') continue
+    const f = e as Partial<Frist>
+    const faellig = typeof f.faellig === 'string' && f.faellig.trim() ? f.faellig.trim() : undefined
+    const zuletzt = typeof f.zuletzt === 'string' && f.zuletzt.trim() ? f.zuletzt.trim() : undefined
+    const intervallMonate =
+      typeof f.intervallMonate === 'number' && f.intervallMonate > 0
+        ? Math.round(f.intervallMonate)
+        : undefined
+    if (!faellig && !(zuletzt && intervallMonate)) continue
+    const art: FristArt =
+      typeof f.art === 'string' && (FRIST_ARTEN as string[]).includes(f.art)
+        ? (f.art as FristArt)
+        : 'sonstige'
+    out.push({
+      art,
+      ...(typeof f.bezeichnung === 'string' && f.bezeichnung.trim()
+        ? { bezeichnung: f.bezeichnung.trim() }
+        : {}),
+      ...(zuletzt ? { zuletzt } : {}),
+      ...(intervallMonate ? { intervallMonate } : {}),
+      ...(faellig ? { faellig } : {}),
+    })
+  }
+  return out.length > 0 ? out : undefined
+}
+
 const healUnit = (raw: unknown): InventoryUnit | null => {
   if (!raw || typeof raw !== 'object') return null
   const r = raw as Partial<InventoryUnit>
@@ -350,6 +391,11 @@ const healUnit = (raw: unknown): InventoryUnit | null => {
     // (siehe `inventoryPortable.ts`).
     anschaffung: healAnschaffung(r.anschaffung),
     versicherungswert: healVersicherungswert(r.versicherungswert),
+    // B-65 — die Pruef-Fristen des Lager-Werkzeugs. Der Planer bearbeitet
+    // sie nicht, darf sie aber auch nicht wegwerfen: genau hier ginge sie
+    // sonst still verloren, und ein Export aus dem Planer kaeme im Lager
+    // ohne eine einzige Frist an.
+    fristen: healFristen(r.fristen),
     history,
     createdAt: typeof r.createdAt === 'string' ? r.createdAt : now,
     updatedAt: typeof r.updatedAt === 'string' ? r.updatedAt : now,

--- a/src/renderer/lager/types/inventory.ts
+++ b/src/renderer/lager/types/inventory.ts
@@ -101,6 +101,43 @@ export interface Versicherungswert {
   stand?: string
 }
 
+/**
+ * Was an einer Einheit turnusmaessig faellig ist (B-65).
+ *
+ * GEPFLEGT WIRD DAS IM LAGER-WERKZEUG (`inventory-planner`, Block
+ * „Fristen"), nicht hier. Der Typ steht trotzdem in diesem Repo, und der
+ * Grund ist derselbe wie bei `mindestmenge`: `healUnit` weiter unten baut
+ * jede Einheit Feld fuer Feld neu auf. Ein Feld, das der Typ nicht kennt,
+ * laese der Planer aus einer `avplan-inventory`-Datei ein und schriebe es
+ * beim Export STILL weg — und die Fristen-Ampel im Lager saehe danach ein
+ * Lager ohne eine einzige Pruef-Frist. Sie wuerde dabei nicht schweigen,
+ * sondern das Gegenteil sagen: „nichts faellig".
+ *
+ * Ein generischer Termin und nicht drei Felder: ein Termin ist immer
+ * dieselbe Sache — ein Datum, ab dem etwas nicht mehr gilt. Woran es
+ * haengt, sagt `art`.
+ */
+export type FristArt = 'dguv-v3' | 'kalibrierung' | 'wartung' | 'akku' | 'sonstige'
+
+export interface Frist {
+  art: FristArt
+  /** Freitext, wenn `art` es nicht sagt (bei `sonstige` das Einzige). */
+  bezeichnung?: string
+  /** Wann sie zuletzt erledigt wurde (ISO-Datum). */
+  zuletzt?: string
+  /** Abstand bis zur naechsten, in Monaten. */
+  intervallMonate?: number
+  /**
+   * Der naechste Termin (ISO-Datum).
+   *
+   * Steht hier eines, gilt es. Steht keines, leitet das Lager-Werkzeug aus
+   * `zuletzt` + `intervallMonate` eines ab und sagt in der Zeile, dass es
+   * gerechnet ist. Fehlt beides, gibt es keinen Termin — und es wird
+   * keiner geraten.
+   */
+  faellig?: string
+}
+
 export interface InventoryItem {
   id: string
   /** Modell-/Artikelname (Pflicht, Anzeigename). */
@@ -414,6 +451,13 @@ export interface InventoryUnit {
   anschaffung?: Anschaffung
   /** Bedarf 118 — wofür sie versichert ist. Siehe `Versicherungswert`. */
   versicherungswert?: Versicherungswert
+  /**
+   * B-65 — was an dieser Einheit turnusmaessig faellig ist. Siehe `Frist`.
+   *
+   * An der EINHEIT und nicht am Artikel: geprueft, kalibriert und mit einer
+   * Plakette beklebt wird das einzelne Geraet.
+   */
+  fristen?: Frist[]
   /** Freie Notiz. */
   notes?: string
   /** Append-only Historie (Bewegungen, Zustandswechsel). */

--- a/tests/inventoryContract.test.ts
+++ b/tests/inventoryContract.test.ts
@@ -40,12 +40,12 @@ import type { InventoryItem, StorageNode, InventorySet, InventoryUnit } from '..
 // Eingefrorener Contract — MUSS in allen drei Repos identisch sein.
 const CONTRACT = {
   format: 'avplan-inventory',
-  version: 5,
+  version: 6,
   envelopeKeys: ['app', 'exportedAt', 'format', 'items', 'nodes', 'sets', 'units', 'version'],
   itemKeys: ['category', 'code', 'codeType', 'createdAt', 'deviceTypeId', 'dimensions', 'id', 'locationId', 'manufacturer', 'materialKinds', 'mindestmenge', 'model', 'notes', 'ownership', 'quantity', 'rentPricePerDay', 'returnDue', 'stockLocation', 'supplier', 'updatedAt', 'ursprungsland'],
   nodeKeys: ['code', 'codeType', 'createdAt', 'dimensions', 'id', 'kind', 'name', 'notes', 'parentId', 'updatedAt'],
   setKeys: ['components', 'createdAt', 'id', 'name', 'notes', 'updatedAt'],
-  unitKeys: ['anschaffung', 'code', 'codeType', 'condition', 'createdAt', 'history', 'houseRef', 'id', 'itemId', 'locationId', 'notes', 'serial', 'updatedAt', 'versicherungswert'],
+  unitKeys: ['anschaffung', 'code', 'codeType', 'condition', 'createdAt', 'fristen', 'history', 'houseRef', 'id', 'itemId', 'locationId', 'notes', 'serial', 'updatedAt', 'versicherungswert'],
 } as const
 
 // Voll besetzte Muster-Entitaeten (jedes Feld gesetzt). Sie halten die
@@ -89,6 +89,10 @@ const unit: InventoryUnit = {
   // Unterversicherung.
   anschaffung: { betrag: { cent: 249900, waehrung: 'EUR' }, am: '2024-03-12' },
   versicherungswert: { betrag: { cent: 180000, waehrung: 'EUR' }, stand: '2026-01-02' },
+  // B-65 — die Pruef-Fristen. Sie MUESSEN den Round-Trip ueberleben: eine
+  // Datei, die sie unterwegs verliert, laesst das Lager wie eines aussehen,
+  // in dem alles geprueft ist.
+  fristen: [{ art: 'dguv-v3', zuletzt: '2026-03-09', intervallMonate: 12 }],
   createdAt: 't', updatedAt: 't',
 }
 const snapshot: InventorySnapshot = { items: [item], nodes: [node], sets: [set], units: [unit] }


### PR DESCRIPTION
Nachzug zu [larszu/inventory-planner#6](https://github.com/larszu/inventory-planner/pull/6). Das Lager-Werkzeug bekommt mit B-65 eine Fristen-Ampel: DGUV-V3-Prüfung, Kalibrierung, Wartung, Akku. **Dieses Repo pflegt sie nicht, und genau deshalb muss es sie kennen.**

## Warum, und warum es diesmal schwerer wiegt

`healUnit` baut hier **jede** Einheit Feld für Feld neu auf. Ein Feld, das der Typ nicht kennt, überlebt das Laden nicht — der Planer läse also eine `avplan-inventory`-Datei mit gepflegten Prüfterminen ein und schriebe sie beim Export still ohne sie zurück.

Die Ampel im Lager würde danach nicht schweigen, sondern **das Gegenteil sagen: „nichts fällig"** — über ein Lager, in dem keine einzige Frist mehr steht. Das ist ein anderer Preis als bei den Feldern davor: eine verlorene Mindestmenge kostet eine Nachbestellung, eine verlorene DGUV-V3-Frist stellt ein ungeprüftes Gerät auf eine Veranstaltung.

## Was sich ändert

- **`Frist` / `FristArt`** im Lager-Typ, mit dem Grund an Ort und Stelle. Ein generischer Termin statt drei Felder: ein Termin ist immer dieselbe Sache — ein Datum, ab dem etwas nicht mehr gilt. Woran es hängt, sagt `art`.
- **`InventoryUnit.fristen?: Frist[]`** — an der *Einheit* und nicht am Artikel: geprüft, kalibriert und mit einer Plakette beklebt wird das einzelne Gerät. „Die ULXD2 sind im März geprüft" ist eine Aussage über zwölf Geräte, von denen zwei in der Werkstatt standen — und genau die zwei nimmt jemand mit.
- **`healFristen`** in `healUnit`. Ein Termin ohne jede Zeitangabe fällt weg (er stünde in der Liste und sähe aus wie eine Zusage, dass jemand ihn im Blick hat); eine unbekannte `art` wird `sonstige` und wird **nicht** verworfen — dass ein neuerer Stand eine Sorte kennt, die dieser nicht kennt, ist kein Grund, einen eingetragenen Prüftermin zu löschen.
- **`INVENTORY_FORMAT_VERSION` 5 → 6.** Ältere Dateien (v1–v5) lesen wir unverändert weiter; ihre Einheiten haben schlicht keine Fristen, und das ist nicht „geprüft", sondern UNBEWERTET.
- Der Wire-Contract friert Version, Feldliste und Muster-Einheit neu ein.

## Nachgeprüft

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 244 Dateien, 3842 Tests grün (2 skipped)
- `npm run lint` — 0 Fehler (12 vorbestehende Warnungen)

## Reihenfolge

Gehört zu [inventory-planner#6](https://github.com/larszu/inventory-planner/pull/6), [multicam-planner#125](https://github.com/larszu/multicam-planner/pull/125) und [light-planner#112](https://github.com/larszu/light-planner/pull/112) — zeitnah hintereinander mergen. Zwischen den Merges weist ein noch nicht nachgezogener Stand eine v6-Datei ab, statt sie zu kürzen; das ist die richtige der beiden Verhaltensweisen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_