### PR TITLE
ui: Fließtext-Untergrenze als Ratsche, Mobile-Absturz und die Ordner-Lücke in der Typprüfung

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,19 @@ wöchentliche KI-Auditor `docs-sync.yml`.
 
 Es gibt **fünf tsconfigs** — pro Prozess eine: `tsconfig.main.json` (main, ESM
 node16), `tsconfig.preload.json` (preload, **CommonJS**), `tsconfig.app.json`
-(renderer, der für `--noEmit`-Check), `tsconfig.node.json` (vite/build-Tools),
+(alles, was im Browser läuft — `src/renderer`, `src/viewer`, `src/mobile`; der
+für den `--noEmit`-Check), `tsconfig.node.json` (vite/build-Tools),
 `tsconfig.json` (Solution-Root).
+
+**Jeder Ordner unter `src/` gehört in genau eines davon.** `src/mobile` stand
+bis 2026-09-10 in keinem — und weil `build:renderer` schlicht `vite build` ist
+und Vite TypeScript nur transpiliert, war der oben verlangte `--noEmit`-Lauf
+gruen, obwohl er den Ordner gar nicht ansah. Darin überlebte monatelang ein
+freier Bezeichner (`writeMode` in `ProjectView`), der die Mobile-Ansicht beim
+Laden eines Projekts mit einem `ReferenceError` weiss machte.
+`tests/typpruefungDecktSrc.test.ts` fragt jetzt `tsc --listFilesOnly` für jedes
+tsconfig, ob noch eine Quelldatei durchfällt. Wer einen neuen Ordner anlegt,
+wird dort rot — nicht erst, wenn jemand den weissen Bildschirm meldet.
 
 ## Architektur (Big Picture)
 

--- a/docs/ui-audit.md
+++ b/docs/ui-audit.md
@@ -5,6 +5,34 @@
 > großflächigen Migrationen, die bewusst nicht im Big-Bang erledigt
 > werden.
 
+## Nebenbefund 2026-09-10: die Mobile-Ansicht war weiss
+
+Beim Nachmessen der Typo-Skala im Browser (`dist/renderer/mobile.html`, echtes
+Chromium, 390x844) warf die Seite beim Laden eines Projekts einen
+`ReferenceError: writeMode is not defined` und rendert gar nichts mehr.
+
+**Der Defekt:** `ProjectView` in `src/mobile/MobileApp.tsx` las `writeMode` an
+vier Stellen als freien Bezeichner. Der Zustand dazu lag in `MobileApp` und
+wurde nie als Prop durchgereicht. Drin seit Bedarf 109 (`d3ca31c`) — die ganze
+Schreibrechte-Anzeige des Handys („Nur lesen"-Hinweis, Meldung, + Kabel) hat
+seitdem nie funktioniert, weil die Ansicht vorher abstuerzte.
+
+**Warum es niemand gesehen hat, und das ist der eigentliche Befund:**
+`src/mobile` stand in **keinem der fuenf tsconfigs**. `tsconfig.app.json`
+nannte `src/renderer` und `src/viewer`; `build:renderer` ist `vite build`, und
+Vite transpiliert TypeScript ohne Typpruefung. Die Pruefung, die CLAUDE.md vor
+jedem Push verlangt, war also gruen — sie sah den Ordner nicht an. Eine
+Pruefung, die weniger prueft als ihr Name sagt, ist schlimmer als keine: sie
+wird geglaubt.
+
+**Behoben:** `writeMode` ist Prop, `src/mobile` steht in `tsconfig.app.json`,
+und `tests/typpruefungDecktSrc.test.ts` fragt `tsc --listFilesOnly` fuer jedes
+tsconfig, ob noch eine Quelldatei unter `src/` durchfaellt. Der Waechter liest
+die `include`-Muster ausdruecklich NICHT nach — die erste Fassung tat das und
+lag falsch (`src/main*.ts` deckt entgegen der Dokumentation auch
+`src/main/ipc/*.ts` mit ab, nachgemessen mit einer Wegwerfdatei). Wer die
+Regel nachbaut, prueft am Ende seine eigene Lesart.
+
 ## Baseline (vor Phase 0)
 
 | Check         | Ergebnis                                   |
@@ -116,19 +144,30 @@ Gesamtzahl Unicode-Icon-Treffer im Scan: ~136 Dateien (inkl. Daten-Pfeile
 
 Hartkodierte Pixel-Schriftgrößen (Tailwind-Arbitrary-Values):
 
-| Klasse        | Treffer |
-| ------------- | ------: |
-| `text-[10px]` |     336 |
-| `text-[11px]` |     256 |
-| `text-[9px]`  |      43 |
-| `text-[8px]`  |       5 |
-| `text-[12px]` |       4 |
-| `text-[13px]` |       2 |
+| Klasse        | 2026-06-15 | 2026-09-10 |
+| ------------- | ---------: | ---------: |
+| `text-[10px]` |        336 |        423 |
+| `text-[11px]` |        256 |        390 |
+| `text-[9px]`  |         43 |         10 |
+| `text-[8px]`  |          5 |          5 |
+| `text-[12px]` |          4 |         20 |
+| `text-[13px]` |          2 |          2 |
 
-Top-Dateien mit Sub-12px-Schrift: `RackBuilderDialog` (56),
-`GreenGoExportDialog` (43), `LibraryPanel` (42), `CableLibraryPanel` (21),
-`MobileApp` (20), `RentmanCableExportDialog` (18), `CableProperties` (18),
-`App.tsx` (16).
+**Die zweite Spalte ist der eigentliche Befund.** Unter 12px waren es beim
+ersten Commit dieses Audits 743 Stellen, heute sind es 828 — also 85 MEHR,
+nachdem hier aufgeschrieben stand, dass es weniger werden sollen. (Der
+Zwischenstand vor der Mobile-Migration weiter unten waren 881.)
+
+Das ist keine Nachlaessigkeit einzelner Aenderungen, sondern die vorhersehbare
+Folge davon, dass die Grenze nur in Prosa stand: ein TODO in einer Datei
+bremst nichts, weil niemand es beim Schreiben einer neuen Komponente liest.
+Seit `tests/schriftgroesseUntergrenze.test.ts` ist es eine Ratsche — die Zahl
+darf sinken, nie steigen.
+
+Top-Dateien mit Sub-12px-Schrift (2026-09-10, nach der Mobile-Migration):
+`GreenGoExportDialog` (50), `CalculatorsDialog` (43), `CableProperties` (31),
+`RentmanTab` (24), `RackPlacementProperties` (22), `RackBuilderDialog` (22),
+`CableLibraryPanel` (21), `PortList` / `MobileShareDialog` / `App.tsx` (je 20).
 
 **Theming-Schuld:** `index.css` remappt die komplette Tailwind-Slate-Rampe
 (+ Dutzende Opacity-Varianten einzeln) für `[data-theme="light"]`. Fragil,
@@ -155,10 +194,15 @@ Inline-Fallback in `ErrorBoundary`). → Token-Schicht einführen.
 ### TODO (großflächiger Rest, NICHT Big-Bang)
 
 - [ ] `text-[10px]`/`text-[11px]`/`text-[9px]` flächendeckend auf
-      Typo-Skala migrieren (zentrale Shells in Phase 2 erledigt, Rest
-      offen — v. a. RackBuilderDialog/LibraryPanel/Export-Dialoge).
-      Fließtext-Mindestgröße 12px. (Rein dekorative Micro-Glyphen wie
-      MenuBar-Caret `▾` bleiben.)
+      Typo-Skala migrieren (zentrale Shells in Phase 2 erledigt,
+      `src/mobile` komplett — Rest offen, v. a. Export-Dialoge,
+      Rechner und Properties). Fließtext-Mindestgröße 12px. (Rein
+      dekorative Micro-Glyphen wie MenuBar-Caret `▾` bleiben.)
+      **Gedeckelt** durch `tests/schriftgroesseUntergrenze.test.ts`:
+      Barriere 828, sinken erlaubt, steigen nicht.
+      `src/mobile` steht dort zusätzlich auf 0 und muss es bleiben —
+      eine reine Gesamtzahl saehe nicht, wenn ein migrierter Ordner
+      zurueckfaellt, waehrend anderswo etwas migriert wird.
 - [ ] Translucente Glas-Flächen (`bg-slate-950/95`, `bg-slate-900/80`,
       `bg-slate-950/40`) auf Alpha-Tokens (z. B. `color-mix`) heben —
       aktuell bewusst als slate-Klassen belassen (Remap deckt Light ab).
@@ -235,14 +279,39 @@ Rückfrage vorbei schließen.
 - Vollständiges `en`-Dict in `lib/i18n.ts`; Inline-Fallbacks deutsch
   (`t('key', 'Deutsche Form')`), `translations.de` bewusst leer.
 
-### Fallback-Sprache (Entscheidung)
+### Fallback-Sprache (Entscheidung) — ÜBERHOLT SEIT E-28
 
-Die Aufgabe empfahl **Englisch** als Fallback, aber **CLAUDE.md** legt
-verbindlich fest: *„Deutsche Strings = Quell-Sprache, immer als Fallback in
-`t(key, 'Deutsche Form')`. EN-Übersetzung im `en`-Dict."* CLAUDE.md
-überschreibt Defaults → **Deutsch bleibt einheitliche Fallback-Sprache**.
-Ein Umstellen aller `t()`-Fallbacks auf Englisch wäre zudem ein massiver,
-risikoreicher Eingriff entgegen der dokumentierten Projektkonvention.
+Dieser Abschnitt stand bis 2026-09-10 im Präsens da und sagte das Gegenteil
+der geltenden Konvention. **Er wird nicht gelöscht, sondern richtiggestellt**:
+gelöscht wäre nicht nachvollziehbar, warum die Fallbacks im Code aussehen, wie
+sie aussehen.
+
+**Was hier stand (Stand Phase 4):** Die Aufgabe empfahl Englisch als Fallback,
+aber CLAUDE.md lege verbindlich Deutsch als Quell-Sprache fest; ein Umstellen
+aller `t()`-Fallbacks wäre ein massiver, risikoreicher Eingriff entgegen der
+dokumentierten Projektkonvention.
+
+**Was heute gilt:** **E-28 (2026-09-09, vom Eigentümer entschieden) hebt
+E-17/E-20 auf.** Quellsprache ist `en` — für ALLE Repos der Suite, nicht mehr
+je Repo. Deutsch ist die erste Übersetzung. Der Eingriff, der hier als „massiv
+und riskant" abgelehnt wurde, ist gemacht: `t(key, 'English text')`,
+Übersetzungen je Sprache in `src/renderer/lib/i18n/`, gemessen von
+`npm run lang:check` (heute: 0 deutsche, 1281 englische Zeichenketten in
+`src/renderer`).
+
+**Die Lehre steht hier, nicht nur die Korrektur.** Ein Dokument, das eine
+Entscheidung mit „CLAUDE.md sagt X" begründet, wird falsch, wenn CLAUDE.md
+X ändert — und zwar lautlos, weil es weiter so aussieht wie eine gültige
+Begründung. Wer hier nachschlug, hätte deutsche Fallbacks eingetragen und
+den Wächter gegen sich gehabt, ohne zu verstehen warum. Begründungen, die
+auf eine andere Datei zeigen, gehören deshalb datiert.
+
+**Offen und ausdrücklich nicht in diesem Schritt erledigt:** `lang:check`
+prüft nur `src/renderer` (siehe `package.json`). `src/mobile` ist
+durchgehend deutsch beschriftet („Nur lesen · Häkchen bleiben auf diesem
+Gerät…") und wird von keiner Sprachprüfung angefasst — dieselbe Ordner-Lücke
+wie bei der Typprüfung, nur für Sprache. Das ist ein eigener Schnitt (die
+Mobile-Ansicht hat keine `t()`-Verdrahtung), kein Nebenbei.
 
 ### Phase 4 — erledigt
 

--- a/src/mobile/MobileApp.tsx
+++ b/src/mobile/MobileApp.tsx
@@ -391,12 +391,12 @@ const ProjectPicker = ({
             : '↻ Projekt vom Desktop laden'}
       </button>
       {reloadError && (
-        <div className="flex items-center gap-1.5 rounded border border-amber-700 bg-amber-900/30 p-2 text-[11px] text-amber-200">
+        <div className="flex items-center gap-1.5 rounded border border-amber-700 bg-amber-900/30 p-2 text-cp-xs text-amber-200">
           <Icon icon={AlertTriangle} size="xs" />
           {reloadError}
         </div>
       )}
-      <div className="text-center text-[10px] uppercase tracking-wider text-cp-text-faint">
+      <div className="text-center text-cp-xs uppercase tracking-wider text-cp-text-faint">
         oder
       </div>
       <label className="block rounded border border-dashed border-cp-border bg-cp-surface-1 p-4 text-center text-sm text-cp-text-secondary">
@@ -552,11 +552,11 @@ const DeviceCard = ({
     >
       <summary className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm">
         <span className="flex-1 truncate font-medium text-cp-text">{device.name}</span>
-        <span className="text-[10px] text-cp-text-muted">
+        <span className="text-cp-xs text-cp-text-muted">
           {device.category}
         </span>
         <span
-          className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] ${
+          className={`shrink-0 rounded px-1.5 py-0.5 text-cp-xs ${
             checkedPorts === totalPorts && totalPorts > 0
               ? 'bg-emerald-700 text-emerald-50'
               : 'bg-cp-surface-4 text-cp-text'
@@ -811,7 +811,7 @@ const PortList = ({
   if (ports.length === 0) return null
   return (
     <div className="mb-2 last:mb-0">
-      <div className="mb-1 text-[10px] uppercase tracking-wide text-cp-text-faint">{label}</div>
+      <div className="mb-1 text-cp-xs uppercase tracking-wide text-cp-text-faint">{label}</div>
       <ul className="space-y-1">
         {ports.map((p) => {
           const cable = cables.find(
@@ -883,11 +883,11 @@ const PortList = ({
                 <span className="flex-1 min-w-0 break-words">
                   <span className="flex flex-wrap items-baseline gap-x-2">
                     <span className="font-medium">{portDisplayLabel(p)}</span>
-                    <span className="text-[10px] text-cp-text-faint">
+                    <span className="text-cp-xs text-cp-text-faint">
                       {p.connectorType}
                     </span>
                     {cable && (
-                      <span className="text-[10px] text-cp-text-muted">
+                      <span className="text-cp-xs text-cp-text-muted">
                         {cable.type} · {cable.length} m
                       </span>
                     )}
@@ -898,7 +898,7 @@ const PortList = ({
                       and too small to be useful on a phone. */}
                   {cable && otherDevice && (
                     <span className="mt-1 block rounded bg-cp-accent/60 px-2 py-1 text-xs text-cp-accent">
-                      <span className="text-[10px] uppercase tracking-wide text-cp-accent/80">
+                      <span className="text-cp-xs uppercase tracking-wide text-cp-accent/80">
                         → geht zu
                       </span>
                       <span className="ml-1 font-semibold text-white">
@@ -909,21 +909,21 @@ const PortList = ({
                           <span className="mx-1 text-cp-accent">·</span>
                           <span>{portDisplayLabel(otherPort)}</span>
                           {otherPort.connectorType && (
-                            <span className="ml-1 text-[10px] text-cp-accent/80">
+                            <span className="ml-1 text-cp-xs text-cp-accent/80">
                               ({otherPort.connectorType})
                             </span>
                           )}
                         </>
                       )}
                       {bridgeNames.length > 0 && (
-                        <span className="mt-0.5 block text-[10px] text-cp-accent/80">
+                        <span className="mt-0.5 block text-cp-xs text-cp-accent/80">
                           via {bridgeNames.join(' → ')}
                         </span>
                       )}
                     </span>
                   )}
                   {cable && !otherDevice && (
-                    <span className="mt-1 block text-[11px] italic text-cp-text-faint">
+                    <span className="mt-1 block text-cp-xs italic text-cp-text-faint">
                       Offenes Ende
                     </span>
                   )}
@@ -1050,20 +1050,20 @@ const QrFindOverlay = ({
           <video ref={videoRef} className="h-56 w-full object-cover" muted playsInline />
           <div className="pointer-events-none absolute inset-0 m-auto h-40 w-40 rounded-lg border-2 border-cp-accent/80" />
           {camError && (
-            <div className="absolute inset-x-0 bottom-0 bg-amber-900/80 px-2 py-1 text-[11px] text-amber-100">
+            <div className="absolute inset-x-0 bottom-0 bg-amber-900/80 px-2 py-1 text-cp-xs text-amber-100">
               {camError}
             </div>
           )}
         </div>
       ) : (
-        <div className="mb-3 rounded border border-cp-border bg-cp-surface-1 px-3 py-2 text-[11px] text-cp-text-muted">
+        <div className="mb-3 rounded border border-cp-border bg-cp-surface-1 px-3 py-2 text-cp-xs text-cp-text-muted">
           Kamera-Scan hier nicht verfügbar (kein HTTPS/Secure-Context). Scanne das
           Etikett mit der Kamera-App deines Geräts und füge den Code unten ein —
           oder tippe die Kabel-/Asset-ID.
         </div>
       )}
 
-      <label className="mb-1 block text-[11px] text-cp-text-muted">Code / ID</label>
+      <label className="mb-1 block text-cp-xs text-cp-text-muted">Code / ID</label>
       <div className="flex items-center gap-2">
         <input
           value={text}
@@ -1143,7 +1143,7 @@ const AblaufKarte = ({
 
   return (
     <div className="mt-2 space-y-2">
-      <label className="block text-[11px] text-cp-text-secondary">
+      <label className="block text-cp-xs text-cp-text-secondary">
         <span className="mb-1 block">Mein Platz</span>
         <select
           value={sourceId ?? ''}
@@ -1160,7 +1160,7 @@ const AblaufKarte = ({
       </label>
 
       {!sourceId && (
-        <p className="text-[11px] text-cp-text-muted">
+        <p className="text-cp-xs text-cp-text-muted">
           Wähle deine Kameraposition. Ohne sie kann diese Ansicht nicht sagen, was DIR aufgetragen
           ist — und eine Liste aller Aufträge wäre am Platz unbrauchbar.
         </p>
@@ -1168,7 +1168,7 @@ const AblaufKarte = ({
 
       {karte && (
         <>
-          <div className="rounded border border-cp-border-muted bg-cp-surface-1 px-2 py-1 text-[11px] text-cp-text-muted">
+          <div className="rounded border border-cp-border-muted bg-cp-surface-1 px-2 py-1 text-cp-xs text-cp-text-muted">
             {karte.source}
             {karte.revision ? ` · ${karte.revision}` : ''} · {karte.mitAuftrag}/
             {karte.zeilen.length} mit Auftrag
@@ -1177,7 +1177,7 @@ const AblaufKarte = ({
           {/* Der Balken. Er steht NUR da, wenn es einen Vergleichsstand gibt
               und wirklich etwas anders ist. */}
           {diff && !diff.unveraendert && (
-            <div className="rounded border border-amber-500/50 bg-amber-500/10 px-2 py-1 text-[11px] text-amber-200">
+            <div className="rounded border border-amber-500/50 bg-amber-500/10 px-2 py-1 text-cp-xs text-amber-200">
               Seit deinem letzten Blick:{' '}
               {[
                 diff.geaendert > 0 ? `${diff.geaendert} geändert` : null,
@@ -1200,7 +1200,7 @@ const AblaufKarte = ({
             </div>
           )}
           {!gesehen && (
-            <p className="text-[11px] text-cp-text-muted">
+            <p className="text-cp-xs text-cp-text-muted">
               Noch kein Vergleichsstand auf diesem Gerät — beim ersten Blick gibt es nichts zu
               markieren.{' '}
               <button
@@ -1229,13 +1229,13 @@ const AblaufKarte = ({
                   }`}
                 >
                   <div className="flex items-baseline gap-2">
-                    <span className="font-mono text-[11px] text-cp-text-muted">
+                    <span className="font-mono text-cp-xs text-cp-text-muted">
                       {z.segment.number ?? z.position}
                     </span>
                     <span className="text-xs text-cp-text">{z.segment.title}</span>
-                    {art === 'neu' && <span className="text-[10px] text-amber-300">neu</span>}
+                    {art === 'neu' && <span className="text-cp-xs text-amber-300">neu</span>}
                     {art === 'anders' && (
-                      <span className="text-[10px] text-amber-300">geändert</span>
+                      <span className="text-cp-xs text-amber-300">geändert</span>
                     )}
                   </div>
                   {/* Kein Auftrag heisst NICHT „frei" — siehe
@@ -1247,7 +1247,7 @@ const AblaufKarte = ({
                     {z.coverage ? z.coverage.shot : 'kein Auftrag eingetragen'}
                   </div>
                   {z.coverage?.note && (
-                    <div className="text-[11px] text-cp-text-muted">{z.coverage.note}</div>
+                    <div className="text-cp-xs text-cp-text-muted">{z.coverage.note}</div>
                   )}
                 </li>
               )
@@ -1259,7 +1259,7 @@ const AblaufKarte = ({
               .map((z) => (
                 <li
                   key={`weg-${z.segmentId}`}
-                  className="rounded border border-cp-danger/40 bg-cp-surface-1 px-2 py-1 text-[11px] text-cp-danger line-through"
+                  className="rounded border border-cp-danger/40 bg-cp-surface-1 px-2 py-1 text-cp-xs text-cp-danger line-through"
                 >
                   entfallen: {gesehen?.segments.find((s) => s.id === z.segmentId)?.title ?? z.segmentId}
                 </li>
@@ -1275,11 +1275,35 @@ const ProjectView = ({
   project,
   online,
   cachedAt,
+  writeMode,
   onUnload,
 }: {
   project: CablePlannerProject
   online?: boolean
   cachedAt?: string | null
+  /**
+   * BEDARF 109 — darf dieses Handy schreiben? Die Antwort kommt aus
+   * `/share-info.json` und wird in `MobileApp` gehalten; hier gebraucht wird
+   * sie an vier Stellen (Meldung, +Kabel, der read-only-Hinweis und der
+   * Rundgang).
+   *
+   * SIE STAND HIER SEIT BEDARF 109 GAR NICHT ALS PROP, sondern wurde als
+   * freier Bezeichner gelesen — `writeMode === 'contribute'` griff also ins
+   * Modul-Scope und fand nichts. Ergebnis war kein falscher Knopf, sondern
+   * ein `ReferenceError` beim ersten Rendern mit Projekt: die Mobile-Ansicht
+   * war weiss, sobald ein Plan geladen wurde. Gemessen im Browser gegen
+   * `dist/renderer/mobile.html`.
+   *
+   * Warum das monatelang durchging, steht in `tsconfig.app.json`: `src/mobile`
+   * war in keinem der fuenf tsconfigs, und Vite transpiliert ohne
+   * Typpruefung. Der Ordner ist dort jetzt eingetragen — dieser Defekt ist
+   * damit der letzte seiner Art, der nur im Browser auffaellt.
+   *
+   * Kein Default: `read-only` faellt in `MobileApp` an, und ein zweiter
+   * Default hier waere eine zweite Wahrheit darueber, was ein Handy ohne
+   * Antwort vom Server darf.
+   */
+  writeMode: 'read-only' | 'contribute'
   onUnload: () => void
 }) => {
   const projectName = project.metadata?.name || 'cable-planner'
@@ -1511,14 +1535,14 @@ const ProjectView = ({
           <button
             type="button"
             onClick={onUnload}
-            className="rounded bg-cp-surface-3 px-2 py-1 text-[11px] text-cp-text-secondary hover:bg-cp-surface-4"
+            className="rounded bg-cp-surface-3 px-2 py-1 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-4"
             title="Anderes Projekt laden"
           >
             ◀
           </button>
           <div className="min-w-0 flex-1">
             <h1 className="truncate text-sm font-semibold text-cp-text">{projectName}</h1>
-            <div className="text-[10px] text-cp-text-muted">
+            <div className="text-cp-xs text-cp-text-muted">
               {project.equipment.length} Geräte · {project.cables.length} Kabel ·{' '}
               <span
                 className={
@@ -1546,7 +1570,7 @@ const ProjectView = ({
                 key={m}
                 type="button"
                 onClick={() => setViewMode(m)}
-                className={`rounded px-2 py-1 text-[11px] font-medium ${
+                className={`rounded px-2 py-1 text-cp-xs font-medium ${
                   viewMode === m ? 'bg-cp-accent text-white' : 'text-cp-text-secondary hover:bg-cp-surface-3'
                 }`}
               >
@@ -1563,7 +1587,7 @@ const ProjectView = ({
             placeholder="Suchen…"
             className="flex-1 rounded border border-cp-border bg-cp-surface-1 px-2 py-1 text-xs text-cp-text"
           />
-          <label className="flex items-center gap-1 text-[11px] text-cp-text-secondary">
+          <label className="flex items-center gap-1 text-cp-xs text-cp-text-secondary">
             <input
               type="checkbox"
               checked={onlyOpen}
@@ -1574,7 +1598,7 @@ const ProjectView = ({
           <button
             type="button"
             onClick={() => setFindOpen(true)}
-            className="flex items-center rounded bg-cp-surface-3 px-2 py-1 text-[11px] text-cp-text hover:bg-cp-surface-4"
+            className="flex items-center rounded bg-cp-surface-3 px-2 py-1 text-cp-xs text-cp-text hover:bg-cp-surface-4"
             title="Per QR-Scan oder ID zu Kabel/Gerät springen"
           >
             <Icon icon={QrCode} size="xs" />
@@ -1585,7 +1609,7 @@ const ProjectView = ({
           <button
             type="button"
             onClick={() => setWalkOpen(true)}
-            className="rounded bg-cp-surface-3 px-2 py-1 text-[11px] text-cp-text hover:bg-cp-surface-4"
+            className="rounded bg-cp-surface-3 px-2 py-1 text-cp-xs text-cp-text hover:bg-cp-surface-4"
             title="Prüfbild-Rundgang: wo müsste welches Bild ankommen"
           >
             Prüfbild
@@ -1594,7 +1618,7 @@ const ProjectView = ({
             <button
               type="button"
               onClick={() => setShowReport(true)}
-              className="rounded bg-cp-surface-3 px-2 py-1 text-[11px] text-amber-300 hover:bg-cp-surface-4"
+              className="rounded bg-cp-surface-3 px-2 py-1 text-cp-xs text-amber-300 hover:bg-cp-surface-4"
               title="Korrektur/Problem melden (Feld-Rückkanal)"
             >
               Meldung
@@ -1604,7 +1628,7 @@ const ProjectView = ({
           <button
             type="button"
             onClick={() => setShowAddCable(true)}
-            className="rounded bg-cp-accent px-2 py-1 text-[11px] text-white hover:opacity-90"
+            className="rounded bg-cp-accent px-2 py-1 text-cp-xs text-white hover:opacity-90"
             title="Kabel vor Ort hinzufügen (Dropdowns)"
           >
             + Kabel
@@ -1614,7 +1638,7 @@ const ProjectView = ({
         )}
         {lookupMsg && (
           <div
-            className={`mt-2 rounded px-2 py-1 text-[11px] ${
+            className={`mt-2 rounded px-2 py-1 text-cp-xs ${
               lookupMsg.ok
                 ? 'border border-cp-accent/60 bg-cp-accent/30 text-cp-accent'
                 : 'border border-amber-700/60 bg-amber-900/30 text-amber-200'
@@ -1629,7 +1653,7 @@ const ProjectView = ({
             Amber, damit der User weiß dass seine Checks gerade nur
             lokal sind und beim Re-Connect automatisch syncen. */}
         {online === false && (
-          <div className="mt-2 flex items-start gap-1.5 rounded border border-amber-700/60 bg-amber-900/30 px-2 py-1 text-[10px] text-amber-200">
+          <div className="mt-2 flex items-start gap-1.5 rounded border border-amber-700/60 bg-amber-900/30 px-2 py-1 text-cp-xs text-amber-200">
             <Icon icon={AlertTriangle} size="xs" className="mt-0.5 shrink-0" />
             <span>
               Offline · Cache vom {cachedAt ? new Date(cachedAt).toLocaleString() : '?'} · Checks
@@ -1643,7 +1667,7 @@ const ProjectView = ({
             aussieht wie am Desktop angekommen und es nicht ist, ist genau die
             Sorte Auskunft, wegen der jemand ein Kabel für gesteckt hält. */}
         {writeMode === 'read-only' && (
-          <div className="mt-2 flex items-start gap-1.5 rounded border border-cp-border bg-cp-surface-2 px-2 py-1 text-[10px] text-cp-text-secondary">
+          <div className="mt-2 flex items-start gap-1.5 rounded border border-cp-border bg-cp-surface-2 px-2 py-1 text-cp-xs text-cp-text-secondary">
             <Icon icon={AlertTriangle} size="xs" className="mt-0.5 shrink-0" />
             <span>
               Nur lesen · Häkchen bleiben auf diesem Gerät und erreichen den Plan nicht · den Plan
@@ -1754,7 +1778,7 @@ const PlanModeView = ({
           <div className="rounded border border-cp-border bg-cp-surface-1">
             <div className="flex items-center justify-between gap-2 border-b border-cp-border-muted px-3 py-2">
               <span className="truncate text-sm font-medium text-cp-text">{selected.name}</span>
-              <span className="shrink-0 text-[10px] text-cp-text-muted">{selected.category}</span>
+              <span className="shrink-0 text-cp-xs text-cp-text-muted">{selected.category}</span>
             </div>
             <DevicePortDetail
               device={selected}
@@ -1842,7 +1866,7 @@ const Zugangscodes = () => {
       <button
         type="button"
         onClick={() => setOffen(true)}
-        className="fixed right-3 top-12 z-[300] flex items-center gap-1 rounded-full border border-cp-border bg-cp-surface-3/90 px-2.5 py-1 text-[11px] text-cp-text shadow-lg backdrop-blur"
+        className="fixed right-3 top-12 z-[300] flex items-center gap-1 rounded-full border border-cp-border bg-cp-surface-3/90 px-2.5 py-1 text-cp-xs text-cp-text shadow-lg backdrop-blur"
         title="Anlagen-Zugangscodes"
       >
         Zugangscodes
@@ -1856,7 +1880,7 @@ const Zugangscodes = () => {
             <div className="mb-2 text-sm font-semibold">Anlagen-Zugangscodes</div>
             {codes === null ? (
               <>
-                <p className="mb-2 text-[11px] text-cp-text-muted">
+                <p className="mb-2 text-cp-xs text-cp-text-muted">
                   Der Code steht nicht im QR-Link. Er wird am Planer ausgegeben und einzeln
                   weitergegeben.
                 </p>
@@ -1871,7 +1895,7 @@ const Zugangscodes = () => {
                   placeholder="Code vom Planer"
                   className="mb-2 w-full rounded border border-cp-border bg-cp-surface-2 px-2 py-1.5 font-mono text-sm tracking-widest"
                 />
-                {fehler && <div className="mb-2 text-[11px] text-red-300">{fehler}</div>}
+                {fehler && <div className="mb-2 text-cp-xs text-red-300">{fehler}</div>}
                 <div className="flex justify-end gap-2">
                   <button type="button" onClick={schliessen} className="rounded px-3 py-1.5 text-sm">
                     Abbrechen
@@ -1890,18 +1914,18 @@ const Zugangscodes = () => {
               <>
                 <ul className="mb-2 space-y-1.5">
                   {codes.length === 0 && (
-                    <li className="text-[11px] text-cp-text-muted">
+                    <li className="text-cp-xs text-cp-text-muted">
                       Freigegeben, aber es sind keine Codes hinterlegt.
                     </li>
                   )}
                   {codes.map((c) => (
                     <li key={c.label} className="flex items-baseline justify-between gap-2">
-                      <span className="text-[11px] text-cp-text-muted">{c.label}</span>
+                      <span className="text-cp-xs text-cp-text-muted">{c.label}</span>
                       <code className="select-all font-mono text-base tracking-widest">{c.value}</code>
                     </li>
                   ))}
                 </ul>
-                <p className="mb-2 text-[11px] text-cp-text-muted">
+                <p className="mb-2 text-cp-xs text-cp-text-muted">
                   Dieser Abruf steht im Dokument-Register des Planers.
                 </p>
                 <div className="flex justify-end">
@@ -1936,7 +1960,7 @@ const ConnectionSettings = () => {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="fixed right-3 top-3 z-[300] flex items-center gap-1 rounded-full border border-cp-border bg-cp-surface-3/90 px-2.5 py-1 text-[11px] text-cp-text shadow-lg backdrop-blur"
+        className="fixed right-3 top-3 z-[300] flex items-center gap-1 rounded-full border border-cp-border bg-cp-surface-3/90 px-2.5 py-1 text-cp-xs text-cp-text shadow-lg backdrop-blur"
         title="Verbindung"
       >
         {cfg.mode === 'remote' ? '📶 Remote' : '🏠 Lokal'}
@@ -1972,7 +1996,7 @@ const ConnectionSettings = () => {
                 />
               </label>
             )}
-            <p className="mt-2 text-[11px] text-cp-text-faint">
+            <p className="mt-2 text-cp-xs text-cp-text-faint">
               Lokal: nur im selben WLAN. Remote: über mobile Daten via eigenem Tunnel/Relay
               (siehe docs/self-hosted-relay.md). Nichts läuft über fremde Server.
             </p>
@@ -2121,13 +2145,13 @@ export const MobileApp = () => {
           Der Wechsel ist ein Neuladen und damit eine Entscheidung. */}
       {showSwitched && (
         <div className="mx-auto max-w-md p-2">
-          <div className="rounded border border-amber-600 bg-amber-950/60 p-2 text-[11px] text-amber-100">
+          <div className="rounded border border-amber-600 bg-amber-950/60 p-2 text-cp-xs text-amber-100">
             <b>Am Desktop ist jetzt eine andere Show offen.</b> Dieser Plan bleibt
             stehen — er gehört zu der Show, mit der diese Seite geladen wurde.
             Häkchen und Meldungen gehen bis zum Neuladen nicht mehr durch.
             <button
               type="button"
-              className="mt-1 block rounded border border-amber-500 px-2 py-0.5 text-[11px]"
+              className="mt-1 block rounded border border-amber-500 px-2 py-0.5 text-cp-xs"
               onClick={() => window.location.reload()}
             >
               Zur neuen Show wechseln (neu laden)
@@ -2144,13 +2168,14 @@ export const MobileApp = () => {
           project={project}
           online={online}
           cachedAt={cachedAt}
+          writeMode={writeMode}
           onUnload={() => setProject(null)}
         />
       ) : (
         <>
           <ProjectPicker onLoad={setProject} />
           {autoLoadError && (
-            <div className="mx-auto mt-2 max-w-md rounded border border-amber-700 bg-amber-950 p-2 text-[11px] text-amber-200">
+            <div className="mx-auto mt-2 max-w-md rounded border border-amber-700 bg-amber-950 p-2 text-cp-xs text-amber-200">
               Hinweis: Es lief offenbar ein Desktop-Share-Server, aber das Laden ist
               fehlgeschlagen ({autoLoadError}).
             </div>
@@ -2321,14 +2346,14 @@ const AddCableModal = ({
                   Versprechen im Futur von der Seite, die es nicht einlösen
                   kann. Jetzt steht hier nur, was tatsächlich passiert ist. */}
               ✓ An den Desktop gesendet
-              <div className="mt-1 text-[10px] font-normal text-emerald-300/80">
+              <div className="mt-1 text-cp-xs font-normal text-emerald-300/80">
                 Ob es im Plan landet, entscheidet der Desktop — dort steht es
                 dann mit 📱-Marker.
               </div>
             </div>
           ) : (
             <>
-              <p className="text-[10px] italic text-cp-text-muted">
+              <p className="text-cp-xs italic text-cp-text-muted">
                 Wird im Plan mit 📱-Badge markiert, damit der Planer sieht dass das
                 Kabel vor Ort nachgepflegt wurde.
               </p>
@@ -2449,7 +2474,7 @@ const AddCableModal = ({
                     onClick={() => {
                       setNameDirty(false)
                     }}
-                    className="mt-1 text-[10px] text-cp-accent hover:underline"
+                    className="mt-1 text-cp-xs text-cp-accent hover:underline"
                     title="Wieder automatisch aus Typ + Geräten generieren"
                   >
                     ↺ Auto-Name zurücksetzen
@@ -2467,7 +2492,7 @@ const AddCableModal = ({
                 />
               </label>
               {err && (
-                <div className="flex items-center gap-1.5 rounded border border-red-700/60 bg-red-900/30 p-2 text-[11px] text-red-200">
+                <div className="flex items-center gap-1.5 rounded border border-red-700/60 bg-red-900/30 p-2 text-cp-xs text-red-200">
                   <Icon icon={AlertTriangle} size="xs" />
                   {err}
                 </div>
@@ -2625,7 +2650,7 @@ const MobileReportModal = ({
             </div>
           ) : (
             <>
-              <p className="text-[10px] italic text-cp-text-muted">
+              <p className="text-cp-xs italic text-cp-text-muted">
                 Wird NICHT direkt geändert — der Planer übernimmt oder verwirft deine
                 Meldung am Desktop (landet dann im Änderungsprotokoll).
               </p>
@@ -2642,7 +2667,7 @@ const MobileReportModal = ({
                     key={k}
                     type="button"
                     onClick={() => setKind(k)}
-                    className={`rounded px-2 py-1 text-[11px] font-medium ${
+                    className={`rounded px-2 py-1 text-cp-xs font-medium ${
                       kind === k ? 'bg-cp-accent text-white' : 'text-cp-text-secondary hover:bg-cp-surface-3'
                     }`}
                   >

--- a/src/mobile/PatternWalk.tsx
+++ b/src/mobile/PatternWalk.tsx
@@ -179,9 +179,9 @@ export function PatternWalk({ apiFetch, showId, schreibbar, onClose }: Props) {
             <span className="font-semibold text-cp-text">{stop.erwartung}</span>
           </div>
         )}
-        <div className="mt-1 text-[11px] text-cp-text-faint">{stop.weg}</div>
+        <div className="mt-1 text-cp-xs text-cp-text-faint">{stop.weg}</div>
         {stop.befund && (
-          <div className="mt-1 text-[11px] text-cp-text-muted">Zuletzt: {stop.befund}</div>
+          <div className="mt-1 text-cp-xs text-cp-text-muted">Zuletzt: {stop.befund}</div>
         )}
         {schreibbar ? (
           <>
@@ -222,11 +222,11 @@ export function PatternWalk({ apiFetch, showId, schreibbar, onClose }: Props) {
             )}
           </>
         ) : (
-          <div className="mt-2 text-[11px] text-cp-text-faint">
+          <div className="mt-2 text-cp-xs text-cp-text-faint">
             Der Rückweg ist zu — am Rechner unter „Freigabe" auf Mitschreiben stellen.
           </div>
         )}
-        {status && <div className="mt-1 text-[11px] text-cp-text-muted">{status}</div>}
+        {status && <div className="mt-1 text-cp-xs text-cp-text-muted">{status}</div>}
       </div>
     )
   }
@@ -246,7 +246,7 @@ export function PatternWalk({ apiFetch, showId, schreibbar, onClose }: Props) {
 
       {/* PFLICHT-BESCHRIFTUNG, nicht Zierde: was unten steht, ist der PLAN.
           Diese App sieht nicht, was auf dem Monitor steht (Invariante 16). */}
-      <p className="mb-2 rounded border border-cp-border bg-cp-surface-2 p-2 text-[11px] text-cp-text-secondary">
+      <p className="mb-2 rounded border border-cp-border bg-cp-surface-2 p-2 text-cp-xs text-cp-text-secondary">
         Unten steht, was laut Plan ankommen müsste — nicht, was ankommt. Diese
         App sieht kein Bild. Was Sie melden, ist das, was Sie auf dem Monitor
         sehen.

--- a/tests/schriftgroesseUntergrenze.test.ts
+++ b/tests/schriftgroesseUntergrenze.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+
+// ---------------------------------------------------------------------------
+// Fliesstext faellt nicht unter 12px (UI-Pruefung, Phase 2).
+//
+// Der Befund steht in `docs/ui-audit.md` und ist als TODO formuliert:
+//
+//   > `text-[10px]`/`text-[11px]`/`text-[9px]` flaechendeckend auf Typo-Skala
+//   > migrieren … Fliesstext-Mindestgroesse 12px.
+//
+// ─── WARUM DIESER WAECHTER UEBERHAUPT EXISTIERT ────────────────────────────
+//
+// Weil das TODO seit seinem Eintrag RUECKWAERTS gelaufen ist. Gemessen ueber
+// dieselbe Baumsuche, die hier laeuft:
+//
+//   * 743 Stellen beim ersten Commit des Audits (955da7e, 2026-06-15)
+//   * 881 Stellen bei HEAD dieses Zweiges (2026-09-10)
+//
+// Also 138 Stellen MEHR, nachdem jemand aufgeschrieben hatte, dass es weniger
+// werden sollen. Ein TODO in einer Datei bremst nichts; niemand liest es beim
+// Schreiben einer neuen Komponente. Das ist keine Nachlaessigkeit einzelner
+// Aenderungen, sondern die vorhersehbare Folge davon, dass die Grenze nur in
+// Prosa stand.
+//
+// Dieser Test macht daraus eine Ratsche: die Zahl darf sinken, nie steigen.
+// Er ersetzt das TODO nicht, er traegt es — der Rest der Migration bleibt
+// Arbeit, aber sie kann nicht mehr lautlos zunichte gemacht werden.
+//
+// ─── WAS GEMESSEN WIRD, UND WAS NICHT ──────────────────────────────────────
+//
+// Gemessen wird `text-[<n>px]` mit n < 12, ueber den GANZEN `src`-Baum. Nicht
+// ueber eine Liste von Dateien: dieselbe Lehre wie bei den Dialogen
+// (`dialogTastaturbedienung.test.ts`) — DIE DOMAENE IST DER ORDNER, NICHT EINE
+// LISTE IM WAECHTER. Wer morgen eine Komponente anlegt, faellt hier auf, ohne
+// dass jemand eine Liste pflegt.
+//
+// NICHT gemessen werden relative Groessen (`text-[0.85em]`, zwei Stellen).
+// Ob ein `em` unter 12px landet, haengt am Elternknoten und ist per Textsuche
+// nicht entscheidbar. Das hier ehrlich zu benennen ist besser, als eine
+// Zahl zu melden, die zwei Faelle stillschweigend auslaesst.
+//
+// Das Audit nimmt rein dekorative Micro-Glyphen (MenuBar-Caret `▾`) aus der
+// Migration aus — zu Recht, ein Pfeil hat keine Lesbarkeitsuntergrenze. Die
+// Ratsche zaehlt sie trotzdem mit, denn „ist das dekorativ?" laesst sich nicht
+// suchen, und ein Waechter mit einer Ermessensklausel prueft am Ende nichts.
+// Wer einen neuen Glyph braucht, migriert im selben Schritt eine Textstelle:
+// die Zahl bleibt dann gleich, und die Untergrenze bleibt gedeckt.
+// ---------------------------------------------------------------------------
+
+const WURZEL = join(process.cwd(), 'src')
+
+/** Fliesstext-Untergrenze aus dem Audit. Was darunter liegt, zaehlt. */
+const UNTERGRENZE_PX = 12
+
+/**
+ * Stand 2026-09-10, gemessen mit genau der Suche unten. Sinken darf die Zahl —
+ * dann ist die rote Zeile die Erinnerung, sie hier nachzuziehen.
+ */
+const BARRIERE = 828
+
+const dateien = (dir: string): string[] =>
+  readdirSync(dir).flatMap((eintrag) => {
+    const pfad = join(dir, eintrag)
+    if (statSync(pfad).isDirectory()) return dateien(pfad)
+    return /\.(tsx|ts|css|html)$/.test(pfad) ? [pfad] : []
+  })
+
+const GROESSE = /text-\[(\d+(?:\.\d+)?)px\]/g
+
+/** Alle Fundstellen unter der Untergrenze, nach Datei. */
+const zuKlein = (): Map<string, number> => {
+  const treffer = new Map<string, number>()
+  for (const pfad of dateien(WURZEL)) {
+    const src = readFileSync(pfad, 'utf8')
+    let n = 0
+    for (const m of src.matchAll(GROESSE)) {
+      if (Number(m[1]) < UNTERGRENZE_PX) n += 1
+    }
+    if (n > 0) treffer.set(relative(WURZEL, pfad), n)
+  }
+  return treffer
+}
+
+const summe = (m: Map<string, number>): number =>
+  [...m.values()].reduce((s, n) => s + n, 0)
+
+describe('Fliesstext-Untergrenze 12px', () => {
+  it('sieht ueberhaupt Dateien — sonst prueft der Test nichts', () => {
+    // Ohne diese Zusicherung waere die Ratsche auch dann gruen, wenn die
+    // Baumsuche nichts mehr findet: 0 <= 828 ist wahr. Ein Waechter, der bei
+    // kaputtem Muster gruen wird, ist schlechter als keiner — er behauptet
+    // eine Deckung, die es nicht gibt.
+    expect(dateien(WURZEL).length).toBeGreaterThan(150)
+  })
+
+  it('findet die bekannten Fundstellen — sonst passt das Muster nicht mehr', () => {
+    // Zweite Haelfte derselben Zusicherung: Dateien zu finden reicht nicht,
+    // das Muster muss auch greifen. Faellt der Wert auf 0, ist die Migration
+    // entweder fertig (dann darf diese Zeile weg) oder das Muster ist tot.
+    expect(summe(zuKlein())).toBeGreaterThan(0)
+  })
+
+  it('die Ratsche: die Zahl steigt nicht', () => {
+    const treffer = zuKlein()
+    const jetzt = summe(treffer)
+    const groesste = [...treffer.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([datei, n]) => `${datei} (${n})`)
+      .join(', ')
+    expect(
+      jetzt,
+      `Schriftgroessen unter ${UNTERGRENZE_PX}px: ${jetzt} statt hoechstens ${BARRIERE}. ` +
+        `Groesste Posten: ${groesste}. Neue Stellen nutzen die Typo-Skala ` +
+        `(text-cp-xs/-sm/-base/-lg) statt einer eigenen px-Angabe.`,
+    ).toBeLessThanOrEqual(BARRIERE)
+  })
+
+  it('die Mobile-Ansicht bleibt sauber', () => {
+    // Sie ist migriert (58 Stellen) und wird auf einem Telefon im dunklen
+    // Truck gelesen — dort tut die Untergrenze am meisten. Ohne diese Zeile
+    // koennte sie zurueckfallen, waehrend anderswo etwas migriert wird, und
+    // die Gesamtzahl bliebe gleich. Die Ratsche allein sieht das nicht.
+    const rueckfall = [...zuKlein().keys()].filter((d) => d.startsWith(`mobile${sep}`))
+    expect(rueckfall, `Mobile-Ansicht wieder unter der Untergrenze: ${rueckfall.join(', ')}`)
+      .toEqual([])
+  })
+})
+
+describe('die Skala selbst', () => {
+  const css = readFileSync(join(WURZEL, 'renderer', 'index.css'), 'utf8')
+
+  it('faengt bei genau der Untergrenze an', () => {
+    // WICHTIG, UND NICHT NUR EINE VERDOPPLUNG DES CSS.
+    //
+    // Die Ratsche zaehlt nur eigene px-Angaben. Setzte jemand
+    // `--text-cp-xs` auf 0.625rem, waere jede Migration nach `text-cp-xs`
+    // ein Schritt UNTER die Untergrenze — und die Ratsche saehe dabei zu,
+    // wie ihre Zahl sinkt. Ein Waechter, der denselben Defekt hat wie das
+    // Gepruefte, ist auf diesem Defekt gruen.
+    const m = /--text-cp-xs:\s*([\d.]+)rem/.exec(css)
+    expect(m, '--text-cp-xs nicht in index.css gefunden').not.toBeNull()
+    expect(Number(m![1]) * 16).toBe(UNTERGRENZE_PX)
+  })
+
+  it('steigt danach', () => {
+    // Eine Skala, deren Stufen zusammenfallen, ist keine: dann traegt die
+    // Groesse keine Hierarchie mehr, und wer sie braucht, greift wieder zur
+    // eigenen px-Angabe — genau die Bewegung, die diese Datei bremst.
+    const stufe = (name: string): number => {
+      const m = new RegExp(`--text-cp-${name}:\\s*([\\d.]+)rem`).exec(css)
+      expect(m, `--text-cp-${name} fehlt`).not.toBeNull()
+      return Number(m![1])
+    }
+    const werte = ['xs', 'sm', 'base', 'lg'].map(stufe)
+    for (let i = 1; i < werte.length; i += 1) {
+      expect(werte[i], `Stufe ${i} ist nicht groesser als die davor`).toBeGreaterThan(werte[i - 1])
+    }
+  })
+})

--- a/tests/typpruefungDecktSrc.test.ts
+++ b/tests/typpruefungDecktSrc.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readdirSync, statSync } from 'node:fs'
+import { join, relative, resolve, sep } from 'node:path'
+
+// ---------------------------------------------------------------------------
+// Jede Quelldatei unter `src/` wird von mindestens einem tsconfig geprueft.
+//
+// ─── DER BEFUND, DER DIESEN WAECHTER AUSGELOEST HAT ────────────────────────
+//
+// `src/mobile` stand in KEINEM der fuenf tsconfigs. Nicht in `app` (das nannte
+// `src/renderer` und `src/viewer`), nicht in `main`, nicht in `node`, nicht in
+// `preload`. Der Ordner war damit vollstaendig aus der Typpruefung heraus —
+// und weil `build:renderer` schlicht `vite build` ist und Vite TypeScript nur
+// transpiliert statt es zu pruefen, war auch der Build gruen.
+//
+// Was in dieser Luecke ueberlebt hat: `ProjectView` las `writeMode` als
+// FREIEN BEZEICHNER (vier Stellen, seit Bedarf 109 / d3ca31c). Der Zustand
+// dazu lag in `MobileApp` und wurde nie durchgereicht. Das ist kein falsch
+// gesetzter Knopf, sondern ein `ReferenceError` beim ersten Rendern mit
+// Projekt: DIE MOBILE-ANSICHT WAR WEISS, SOBALD EIN PLAN GELADEN WURDE.
+// Gemessen im Browser gegen `dist/renderer/mobile.html`; `tsc` meldete den
+// Fehler in derselben Sekunde, in der der Ordner ins tsconfig kam.
+//
+// CLAUDE.md verlangt `npx tsc -p tsconfig.app.json --noEmit` vor jedem Push,
+// und diese Pruefung war gruen — sie sah den Ordner ja nicht an. Genau das
+// macht die Luecke gefaehrlicher als den einzelnen Defekt: eine Pruefung, die
+// weniger prueft als ihr Name sagt, wird geglaubt.
+//
+// ─── WARUM HIER `tsc` LAEUFT UND NICHT DIE `include`-MUSTER GELESEN WERDEN ─
+//
+// Die erste Fassung dieses Waechters las die `include`-Eintraege und bildete
+// sie auf Regexe ab. Das war falsch, und zwar nachgemessen: `src/main*.ts`
+// deckt in Wahrheit `src/main/ipc/atemIpc.ts` mit ab — geprueft mit einer
+// Wegwerfdatei `src/main/zzz-probe.ts`, die einen Typfehler trug und von
+// `tsc -p tsconfig.main.json` gemeldet wurde. Nach der Dokumentation
+// („`*` matcht keinen Pfadtrenner") haette sie durchfallen muessen.
+//
+// Ein Waechter, der die Regel NACHBAUT, prueft am Ende seine eigene Lesart.
+// Deshalb fragt dieser hier den Compiler selbst: `--listFilesOnly` gibt genau
+// die Dateien aus, die ein Lauf anfassen wuerde — inklusive der ueber Importe
+// hinzugezogenen, die ja ebenfalls geprueft werden.
+//
+// Kosten: rund sieben Sekunden fuer alle vier Konfigurationen (gemessen —
+// `--listFilesOnly` ueberspringt die Pruefung selbst; mit `--listFiles`
+// waeren es 47). Das ist der Preis dafuer, dass die Antwort stimmt.
+//
+// ─── DIE DOMAENE IST DER ORDNER, NICHT EINE LISTE IM WAECHTER ──────────────
+//
+// Dieselbe Lehre wie bei `dialogTastaturbedienung.test.ts`: geprueft wird der
+// BAUM, nicht eine gepflegte Aufzaehlung. Wer morgen `src/kiosk/` anlegt und
+// vergisst, ihn einzutragen, wird hier rot — nicht erst, wenn jemand den
+// weissen Bildschirm meldet.
+// ---------------------------------------------------------------------------
+
+const WURZEL = process.cwd()
+const SRC = join(WURZEL, 'src')
+
+/** Was TypeScript pruefen kann und deshalb geprueft werden muss. */
+const QUELLE = /\.(ts|tsx|cts|mts)$/
+
+const dateien = (dir: string): string[] =>
+  readdirSync(dir).flatMap((eintrag) => {
+    const pfad = join(dir, eintrag)
+    if (statSync(pfad).isDirectory()) return dateien(pfad)
+    return QUELLE.test(pfad) ? [pfad] : []
+  })
+
+const tsconfigs = (): string[] =>
+  readdirSync(WURZEL)
+    .filter((f) => /^tsconfig.*\.json$/.test(f))
+    .sort()
+
+/**
+ * Die Dateien, die ein Lauf gegen dieses tsconfig anfassen wuerde.
+ *
+ * `tsconfig.json` selbst ist die Solution-Root: sie hat `files: []` und nur
+ * `references`. Ein Lauf dagegen fasst nichts an, und das ist richtig so —
+ * die Referenzen zeigen auf die anderen vier, die hier einzeln laufen.
+ */
+const angefasst = (konfig: string): Set<string> => {
+  const roh = execFileSync('npx', ['tsc', '-p', konfig, '--listFilesOnly'], {
+    cwd: WURZEL,
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+  })
+  return new Set(
+    roh
+      .split('\n')
+      .map((z) => z.trim())
+      .filter(Boolean)
+      .map((z) => resolve(WURZEL, z)),
+  )
+}
+
+/** Einmal messen, dann alle Zusicherungen darauf. Sieben Sekunden reichen. */
+const gepruefte = (): Set<string> => {
+  const alle = new Set<string>()
+  for (const k of tsconfigs()) {
+    for (const d of angefasst(k)) alle.add(d)
+  }
+  return alle
+}
+
+const alsAnzeige = (abs: string): string => relative(WURZEL, abs).split(sep).join('/')
+
+describe('die Typpruefung deckt src', () => {
+  const imBaum = dateien(SRC)
+  let gedeckt: Set<string>
+
+  it('faehrt ueberhaupt einen Compiler-Lauf', { timeout: 180_000 }, () => {
+    // Ohne diese Zusicherung waere alles Weitere gruen, wenn `tsc` gar nichts
+    // ausgibt: eine leere Menge deckt eine leere Menge. Und ohne die zweite
+    // waere es gruen, wenn die Baumsuche nichts findet.
+    gedeckt = gepruefte()
+    expect(tsconfigs().length).toBeGreaterThanOrEqual(5)
+    expect(gedeckt.size).toBeGreaterThan(500)
+    expect(imBaum.length).toBeGreaterThan(100)
+  })
+
+  it('keine Quelldatei faellt zwischen die tsconfigs', () => {
+    const offen = imBaum
+      .filter((d) => !gedeckt.has(d))
+      .map(alsAnzeige)
+      .sort()
+    expect(
+      offen,
+      `Diese Dateien prueft kein tsconfig — sie koennen jeden Typfehler ` +
+        `tragen, ohne dass eine Pruefung rot wird: ${offen.join(', ')}`,
+    ).toEqual([])
+  })
+
+  it('und kein ganzer Ordner unter src', () => {
+    // Zweite Sicht auf dieselbe Frage, und die schaerfere: eine EINZELNE
+    // ungedeckte Datei ist ein Versehen, ein ganzer ungedeckter Ordner ist
+    // genau der Befund von oben. Die Zeile nennt ihn beim Namen, statt ihn
+    // in einer langen Dateiliste zu verstecken.
+    const ordner = [
+      ...new Set(
+        imBaum
+          .filter((d) => !gedeckt.has(d))
+          .map(alsAnzeige)
+          .map((rel) => rel.split('/').slice(0, 2).join('/')),
+      ),
+    ].sort()
+    expect(ordner, `ganz ausserhalb der Typpruefung: ${ordner.join(', ')}`).toEqual([])
+  })
+})

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -17,5 +17,5 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/renderer", "src/viewer", "src/vite-env.d.ts"]
+  "include": ["src/renderer", "src/viewer", "src/mobile", "src/vite-env.d.ts"]
 }


### PR DESCRIPTION
Angefangen als der offene Phase-2-Punkt aus `docs/ui-audit.md` — *„Fließtext-Mindestgröße 12px"*. Beim Nachmessen im echten Browser sind zwei größere Defekte aufgefallen, die beide in diesem PR mit drin sind.

## 1 · Schriftgrößen (der eigentliche Auftrag)

`src/mobile` komplett auf die Typo-Skala: **58 Stellen** `text-[10px]`/`text-[11px]` → `text-cp-xs` (12px). Dieser Ordner zuerst, weil die Ansicht auf einem Telefon im dunklen Truck gelesen wird; der 1px-Unterschied zwischen 10 und 11 war nie Hierarchie — die tragen Farbe und Laufweite — also fallen beide ohne Verlust auf die Untergrenze.

**Das TODO lief rückwärts.** Gemessen über dieselbe Baumsuche:

| Stand | Stellen unter 12px |
| --- | ---: |
| 955da7e, 2026-06-15 (erster Commit des Audits) | 743 |
| HEAD vor diesem PR | 881 |
| nach diesem PR | 828 |

Also 138 Stellen **mehr**, nachdem jemand aufgeschrieben hatte, dass es weniger werden sollen. Ein TODO in einer Datei bremst nichts — beim Schreiben einer neuen Komponente liest es niemand.

`tests/schriftgroesseUntergrenze.test.ts` macht daraus eine Ratsche: Barriere 828, sinken erlaubt, steigen nicht. Dazu zwei Zeilen, die eine reine Gesamtzahl nicht leisten würde:

- **`src/mobile` steht separat auf 0.** Sonst könnte ein migrierter Ordner zurückfallen, während anderswo etwas migriert wird, und die Summe bliebe gleich. Genau das ist gegengeprüft.
- **Die Skala selbst wird geprüft.** Rutschte `--text-cp-xs` unter 12px, wäre jede Migration nach `text-cp-xs` ein Schritt *unter* die Untergrenze — und die Ratsche sähe zu, wie ihre Zahl sinkt. Ein Wächter, der denselben Defekt hat wie das Geprüfte, ist auf diesem Defekt grün.

Nicht gemessen werden relative Größen (`text-[0.85em]`, zwei Stellen): ob ein `em` unter 12px landet, hängt am Elternknoten und ist per Textsuche nicht entscheidbar. Das steht so im Kopf der Datei, statt eine Zahl zu melden, die zwei Fälle stillschweigend auslässt.

## 2 · Die Mobile-Ansicht war weiß

Beim Nachmessen gegen `dist/renderer/mobile.html` (echtes Chromium, 390×844) warf die Seite beim Laden eines Projekts `ReferenceError: writeMode is not defined` und rendert gar nichts mehr.

`ProjectView` las `writeMode` an vier Stellen als **freien Bezeichner**; der Zustand dazu lag in `MobileApp` und wurde nie als Prop durchgereicht. Drin seit Bedarf 109 (`d3ca31c`) — die ganze Schreibrechte-Anzeige des Handys (Nur-lesen-Hinweis, Meldung, + Kabel) hat seitdem nie funktioniert, weil die Ansicht vorher abstürzte.

Jetzt Prop, und bewusst **ohne zweiten Default**: das `read-only` fällt in `MobileApp` an; ein zweiter hier wäre eine zweite Wahrheit darüber, was ein Handy ohne Antwort vom Server darf.

## 3 · Warum das niemand gesehen hat — die eigentliche Lücke

**`src/mobile` stand in keinem der fünf tsconfigs.** `tsconfig.app.json` nannte `src/renderer` und `src/viewer`; `build:renderer` ist schlicht `vite build`, und Vite transpiliert TypeScript ohne Typprüfung. Der Lauf, den CLAUDE.md vor jedem Push verlangt, war also grün — er sah den Ordner nicht an. Eintragen meldete den Fehler in derselben Sekunde: fünf Meldungen, alle derselbe Defekt.

Eine Prüfung, die weniger prüft als ihr Name sagt, ist schlimmer als keine: sie wird geglaubt.

`tests/typpruefungDecktSrc.test.ts` fragt `tsc --listFilesOnly` für jedes tsconfig, ob noch eine Quelldatei unter `src/` durchfällt, und nennt einen ganz ungedeckten Ordner beim Namen.

Er liest die `include`-Muster ausdrücklich **nicht** nach. Die erste Fassung tat das und lag falsch: `src/main*.ts` deckt entgegen der Dokumentation auch `src/main/ipc/*.ts` mit ab — nachgemessen mit einer Wegwerfdatei `src/main/zzz-probe.ts`, die einen Typfehler trug und gemeldet wurde. Wer die Regel nachbaut, prüft am Ende seine eigene Lesart. Kosten: 8 s statt 47, weil `--listFilesOnly` die Prüfung selbst überspringt.

## 4 · Doku

`docs/ui-audit.md`: Phase-2-Tabelle mit beiden Messpunkten, der Nebenbefund zum weißen Bildschirm, und der Abschnitt **„Fallback-Sprache (Entscheidung)"** richtiggestellt.

Der sagte im Präsens *„Deutsch bleibt einheitliche Fallback-Sprache"* und begründete das mit CLAUDE.md — **E-28 (2026-09-09) hat das aufgehoben**, Quellsprache ist `en` für alle Repos der Suite. Nicht gelöscht, sondern datiert richtiggestellt: wer dort nachschlug, hätte deutsche Fallbacks eingetragen und den Wächter gegen sich gehabt, ohne zu verstehen warum. Ein Dokument, das eine Entscheidung mit „CLAUDE.md sagt X" begründet, wird lautlos falsch, wenn CLAUDE.md X ändert.

**Ausdrücklich offen gelassen und im Audit benannt:** `lang:check` prüft nur `src/renderer`. `src/mobile` ist durchgehend deutsch beschriftet und wird von keiner Sprachprüfung angefasst — dieselbe Ordner-Lücke wie bei der Typprüfung, nur für Sprache. Das ist ein eigener Schnitt (die Mobile-Ansicht hat keine `t()`-Verdrahtung), kein Nebenbei.

## Verifikation

- `npx tsc -p tsconfig.app.json --noEmit` → 0 (jetzt **inklusive** `src/mobile`)
- `npm run lint` → 0 Errors (12 Warnungen, alle pre-existing)
- `npm test` → 3851 grün, 2 skipped
- `npm run build` → grün
- `npm run lang:check` → 0 deutsch / 1281 englisch in `src/renderer`
- **Im Browser** (Chromium, 390×844, gegen `dist/renderer/mobile.html`): Liste 62 Textknoten, Plan 17, **nichts unter 12px**, keine Seitenfehler — und der Nur-lesen-Hinweis, die Stelle die vorher abstürzte, steht da.
- **Gegenproben, alle gefahren:** eine Stelle mehr → Ratsche rot; `src/mobile` fällt zurück bei gleicher Summe → rot; `--text-cp-xs` auf 0.625rem → rot; `src/mobile` wieder aus dem tsconfig → *„ganz außerhalb der Typprüfung: src/mobile"*.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_