### PR TITLE
ui: die drei größten Dialoge auf die 12px-Untergrenze, im echten Fenster nachgemessen

### DIFF
--- a/docs/ui-audit.md
+++ b/docs/ui-audit.md
@@ -144,30 +144,30 @@ Gesamtzahl Unicode-Icon-Treffer im Scan: ~136 Dateien (inkl. Daten-Pfeile
 
 Hartkodierte Pixel-Schriftgrößen (Tailwind-Arbitrary-Values):
 
-| Klasse        | 2026-06-15 | 2026-09-10 |
-| ------------- | ---------: | ---------: |
-| `text-[10px]` |        336 |        423 |
-| `text-[11px]` |        256 |        390 |
-| `text-[9px]`  |         43 |         10 |
-| `text-[8px]`  |          5 |          5 |
-| `text-[12px]` |          4 |         20 |
-| `text-[13px]` |          2 |          2 |
+| Klasse        | Audit-Start<br>2026-06-15 | vor der Migration<br>2026-09-10 | heute |
+| ------------- | ------------------------: | ------------------------------: | ----: |
+| `text-[10px]` |                       336 |                             423 |   352 |
+| `text-[11px]` |                       256 |                             390 |   338 |
+| `text-[9px]`  |                        43 |                              10 |    10 |
+| `text-[8px]`  |                         5 |                               5 |     5 |
+| `text-[12px]` |                         4 |                              20 |    20 |
+| `text-[13px]` |                         2 |                               2 |     2 |
 
-**Die zweite Spalte ist der eigentliche Befund.** Unter 12px waren es beim
-ersten Commit dieses Audits 743 Stellen, heute sind es 828 — also 85 MEHR,
-nachdem hier aufgeschrieben stand, dass es weniger werden sollen. (Der
-Zwischenstand vor der Mobile-Migration weiter unten waren 881.)
+**Die mittlere Spalte ist der eigentliche Befund.** Unter 12px waren es beim
+ersten Commit dieses Audits 743 Stellen — und drei Monate spaeter 881, also
+138 MEHR, nachdem hier aufgeschrieben stand, dass es weniger werden sollen.
 
 Das ist keine Nachlaessigkeit einzelner Aenderungen, sondern die vorhersehbare
 Folge davon, dass die Grenze nur in Prosa stand: ein TODO in einer Datei
 bremst nichts, weil niemand es beim Schreiben einer neuen Komponente liest.
 Seit `tests/schriftgroesseUntergrenze.test.ts` ist es eine Ratsche — die Zahl
-darf sinken, nie steigen.
+darf sinken, nie steigen. Stand heute: **705**, in zwei Schritten von 881
+(erst `src/mobile`, dann die drei groessten Einzeldateien).
 
-Top-Dateien mit Sub-12px-Schrift (2026-09-10, nach der Mobile-Migration):
-`GreenGoExportDialog` (50), `CalculatorsDialog` (43), `CableProperties` (31),
+Top-Dateien mit Sub-12px-Schrift, was noch offen ist:
 `RentmanTab` (24), `RackPlacementProperties` (22), `RackBuilderDialog` (22),
-`CableLibraryPanel` (21), `PortList` / `MobileShareDialog` / `App.tsx` (je 20).
+`CableLibraryPanel` (21), `PortList` / `MobileShareDialog` / `App.tsx` (je 20),
+`ExportDialog` / `AnalysisDialog` (je 19).
 
 **Theming-Schuld:** `index.css` remappt die komplette Tailwind-Slate-Rampe
 (+ Dutzende Opacity-Varianten einzeln) für `[data-theme="light"]`. Fragil,
@@ -194,15 +194,23 @@ Inline-Fallback in `ErrorBoundary`). → Token-Schicht einführen.
 ### TODO (großflächiger Rest, NICHT Big-Bang)
 
 - [ ] `text-[10px]`/`text-[11px]`/`text-[9px]` flächendeckend auf
-      Typo-Skala migrieren (zentrale Shells in Phase 2 erledigt,
-      `src/mobile` komplett — Rest offen, v. a. Export-Dialoge,
-      Rechner und Properties). Fließtext-Mindestgröße 12px. (Rein
-      dekorative Micro-Glyphen wie MenuBar-Caret `▾` bleiben.)
+      Typo-Skala migrieren. Fließtext-Mindestgröße 12px. (Rein
+      dekorative Micro-Glyphen wie MenuBar-Caret `▾` und die
+      Pin-Markierung im Rechner bleiben.)
+      **Erledigt:** zentrale Shells (Phase 2), `src/mobile` komplett,
+      `GreenGoExportDialog`, `CalculatorsDialog`, `CableProperties`.
+      **Offen:** die Liste über der Tabelle, Reihenfolge nach Größe.
       **Gedeckelt** durch `tests/schriftgroesseUntergrenze.test.ts`:
-      Barriere 828, sinken erlaubt, steigen nicht.
+      Barriere 705, sinken erlaubt, steigen nicht.
       `src/mobile` steht dort zusätzlich auf 0 und muss es bleiben —
       eine reine Gesamtzahl saehe nicht, wenn ein migrierter Ordner
       zurueckfaellt, waehrend anderswo etwas migriert wird.
+      **Im echten Fenster nachgemessen** (Electron unter xvfb, 1280x800):
+      Bandbreiten-Rechner 66 sichtbare Elemente, Leistungs-Rechner 112,
+      Kabel-Eigenschaften 125, GreenGo-Dialog 49 — kein Überlauf, nichts
+      mehr unter 12px. Der Sprung 10 → 12px in dichten Tabellen ist der
+      Punkt, an dem eine Migration Layout brechen kann; `npm test` sieht
+      das nicht, `ui:overflow` öffnet diese Dialoge nicht.
 - [ ] Translucente Glas-Flächen (`bg-slate-950/95`, `bg-slate-900/80`,
       `bg-slate-950/40`) auf Alpha-Tokens (z. B. `color-mix`) heben —
       aktuell bewusst als slate-Klassen belassen (Remap deckt Light ab).

--- a/src/renderer/components/Calculators/CalculatorsDialog.tsx
+++ b/src/renderer/components/Calculators/CalculatorsDialog.tsx
@@ -136,7 +136,7 @@ const BandwidthTab = () => {
   const fittingTier = SDI_TIERS.find((t) => mbps <= t.mbps)
   return (
     <div className="space-y-3 p-4 text-cp-base">
-      <PanelHint className="mb-2 text-[11px] text-cp-text-muted" text={t(
+      <PanelHint className="mb-2 text-cp-xs text-cp-text-muted" text={t(
           'calc.bandwidth.intro',
           'Gross data rate of a video stream (before compression) and the smallest SDI tier that carries it. Pixels × lines × fps × bits-per-pixel.',
         )} />
@@ -193,7 +193,7 @@ const BandwidthTab = () => {
         </label>
       </div>
       <div className="rounded border border-amber-700 bg-amber-950/30 p-3">
-        <div className="text-[10px] uppercase tracking-wide text-amber-300">{t('calc.dataRate', 'Data rate')}</div>
+        <div className="text-cp-xs uppercase tracking-wide text-amber-300">{t('calc.dataRate', 'Data rate')}</div>
         <div className="font-mono text-cp-xl text-amber-100">{mbps.toLocaleString(undefined, { maximumFractionDigits: 1 })} Mbps</div>
         <div className="mt-1 text-cp-xs text-amber-200">
           {fittingTier
@@ -207,7 +207,7 @@ const BandwidthTab = () => {
         </div>
       </div>
       <details className="rounded border border-cp-border-muted bg-cp-surface-3/40">
-        <summary className="cursor-pointer px-3 py-1.5 text-[11px] uppercase tracking-wide text-cp-text-muted">
+        <summary className="cursor-pointer px-3 py-1.5 text-cp-xs uppercase tracking-wide text-cp-text-muted">
           SDI-Tiers
         </summary>
         <ul className="space-y-0.5 px-3 py-2 text-cp-xs">
@@ -220,7 +220,7 @@ const BandwidthTab = () => {
         </ul>
       </details>
       <details className="rounded border border-cp-border-muted bg-cp-surface-3/40">
-        <summary className="cursor-pointer px-3 py-1.5 text-[11px] uppercase tracking-wide text-cp-text-muted">
+        <summary className="cursor-pointer px-3 py-1.5 text-cp-xs uppercase tracking-wide text-cp-text-muted">
           {t('calc.bandwidth.signalStds', 'IP / digital signal standards')}
         </summary>
         <ul className="space-y-0.5 px-3 py-2 text-cp-xs">
@@ -237,10 +237,10 @@ const BandwidthTab = () => {
       {netBudget.count > 0 && (
         <div className="rounded border border-sky-700 bg-sky-950/20 p-3">
           <div className="mb-2 flex items-center justify-between">
-            <div className="text-[11px] uppercase tracking-wide text-cp-text-secondary">
+            <div className="text-cp-xs uppercase tracking-wide text-cp-text-secondary">
               {t('calc.bandwidth.netBudget', 'Project network budget')}
             </div>
-            <div className="text-[10px] text-cp-text-muted">
+            <div className="text-cp-xs text-cp-text-muted">
               {netBudget.count} {t('calc.bandwidth.netLinks', 'IP signals')}
             </div>
           </div>
@@ -284,7 +284,7 @@ const BandwidthTab = () => {
               </dd>
             </dl>
           )}
-          <PanelHint className="mt-2 text-[10px] text-cp-text-muted" text={t(
+          <PanelHint className="mt-2 text-cp-xs text-cp-text-muted" text={t(
           'calc.bandwidth.netNote',
           'Sum of the gross bandwidths of all cables carrying an IP media signal (NDI, Dante/AES67, ST 2110). Ethernet cables do NOT count as load — what a line can carry is not a load it carries; their capacity is listed separately below. Rough figures; ST 2110-20 heavily format-dependent.',
         )} />
@@ -636,7 +636,7 @@ const PowerTab = () => {
 
   return (
     <div className="space-y-3 p-4 text-cp-base">
-      <p className="text-[11px] text-cp-text-muted">
+      <p className="text-cp-xs text-cp-text-muted">
         {t(
           'calc.power.intro1',
           'Sum of the consumption values in the device properties',
@@ -725,7 +725,7 @@ const PowerTab = () => {
 
       {/* Distro-Vergleich: welcher Anschluss trägt die Last? */}
       {totals.totalW > 0 && (
-        <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
+        <div className="flex flex-wrap items-center gap-1.5 text-cp-xs">
           <span className="font-semibold uppercase tracking-wide text-cp-text-faint">
             {t('calc.power.fitsOn', 'Fits on')}:
           </span>
@@ -752,13 +752,13 @@ const PowerTab = () => {
           } p-3`}
         >
           <div className="mb-2 flex items-center justify-between">
-            <div className="text-[11px] uppercase tracking-wide text-cp-text-secondary">
+            <div className="text-cp-xs uppercase tracking-wide text-cp-text-secondary">
               {t('calc.phaseDistribution', 'Phase distribution')} ({supply.label})
             </div>
-            <div className="text-[10px] text-cp-text-muted">
+            <div className="text-cp-xs text-cp-text-muted">
               {t('calc.imbalance', 'Imbalance')}: {maxImbalancePct}%
               {overloaded && (
-                <span className="ml-2 inline-flex items-center gap-1 rounded bg-red-700 px-1.5 py-0.5 text-[10px] text-white">
+                <span className="ml-2 inline-flex items-center gap-1 rounded bg-red-700 px-1.5 py-0.5 text-cp-xs text-white">
                   <Icon icon={AlertTriangle} size="xs" />
                   {t('calc.phaseOverload', 'Phase overloaded')}
                 </span>
@@ -775,7 +775,7 @@ const PowerTab = () => {
                   className={`rounded border ${PHASE_COLORS[PHASE_KEYS[idx]].border} ${PHASE_COLORS[PHASE_KEYS[idx]].bg} p-2`}
                 >
                   <div
-                    className={`flex items-center gap-1 text-[10px] uppercase tracking-wider ${PHASE_COLORS[PHASE_KEYS[idx]].text}`}
+                    className={`flex items-center gap-1 text-cp-xs uppercase tracking-wider ${PHASE_COLORS[PHASE_KEYS[idx]].text}`}
                   >
                     <span
                       className="inline-block h-2 w-2 rounded-full"
@@ -787,7 +787,7 @@ const PowerTab = () => {
                   <div className="font-mono text-cp-lg text-cp-text">
                     {watts.toFixed(0)} W
                   </div>
-                  <div className="font-mono text-[11px] text-cp-text-secondary">
+                  <div className="font-mono text-cp-xs text-cp-text-secondary">
                     {amps.toFixed(1)} A / {supply.perPhaseAmps} A
                   </div>
                   <div className="mt-1 h-1.5 overflow-hidden rounded bg-cp-surface-2">
@@ -802,7 +802,7 @@ const PowerTab = () => {
                       style={{ width: `${Math.min(100, fraction * 100)}%` }}
                     />
                   </div>
-                  <div className="mt-0.5 text-[10px] text-cp-text-muted">
+                  <div className="mt-0.5 text-cp-xs text-cp-text-muted">
                     {Math.round(fraction * 100)}% {t('calc.load', 'load')}
                   </div>
                 </div>
@@ -810,7 +810,7 @@ const PowerTab = () => {
             })}
           </div>
           {/* #345 — Neutralleiterstrom-Schätzung: klein = gut balanciert. */}
-          <div className="mt-2 flex items-center gap-2 rounded border border-sky-800 bg-sky-950/30 px-2 py-1.5 text-[11px]">
+          <div className="mt-2 flex items-center gap-2 rounded border border-sky-800 bg-sky-950/30 px-2 py-1.5 text-cp-xs">
             <span
               className="inline-block h-2 w-2 shrink-0 rounded-full"
               style={{ background: PHASE_COLORS.N.dot }}
@@ -819,7 +819,7 @@ const PowerTab = () => {
               {t('calc.neutralCurrent', 'Neutral (estimated)')}:
             </span>
             <span className="font-mono text-sky-200">{neutralAmps.toFixed(1)} A</span>
-            <span className="ml-auto text-[10px] text-cp-text-muted">
+            <span className="ml-auto text-cp-xs text-cp-text-muted">
               {neutralAmps < 0.05 * supply.perPhaseAmps
                 ? t('calc.neutralOk', 'well balanced')
                 : neutralAmps > 0.25 * supply.perPhaseAmps
@@ -828,10 +828,10 @@ const PowerTab = () => {
             </span>
           </div>
           <details className="mt-2">
-            <summary className="cursor-pointer text-[11px] uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright">
+            <summary className="cursor-pointer text-cp-xs uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright">
               {t('calc.devicesToPhase', 'Devices → Phase')} ({distribution.assignments.length})
             </summary>
-            <div className="mb-1 mt-1 text-[10px] text-cp-text-muted">
+            <div className="mb-1 mt-1 text-cp-xs text-cp-text-muted">
               {t('calc.phasePinHint', 'Pick a phase to pin a device; "Auto" lets the balancer distribute it.')}
             </div>
             <table className="block overflow-x-auto w-full text-cp-xs">
@@ -881,7 +881,7 @@ const PowerTab = () => {
               </tbody>
             </table>
           </details>
-          <div className="mt-2 flex flex-wrap items-center gap-3 text-[10px] text-cp-text-muted">
+          <div className="mt-2 flex flex-wrap items-center gap-3 text-cp-xs text-cp-text-muted">
             <span className="font-semibold uppercase tracking-wide text-cp-text-faint">
               {t('calc.euColorTitle', 'EU colour code (DIN VDE 0293-308)')}:
             </span>
@@ -896,13 +896,13 @@ const PowerTab = () => {
             ))}
           </div>
           <PanelHint
-            className="mt-2 text-[10px] text-cp-text-muted"
+            className="mt-2 text-cp-xs text-cp-text-muted"
             text={t(
               'calc.greedyExplain',
               'Greedy distribution: sorted by power, each device on the currently least-loaded phase. With symmetric loads three-phase draws only {amps} A per phase; imbalance raises the highest phase current. Target: every phase < 85% load + imbalance < 20%.',
             ).replace('{amps}', ampsThreePhase.toFixed(1))}
           />
-          <div className="mt-3 flex items-center justify-between text-[11px]">
+          <div className="mt-3 flex items-center justify-between text-cp-xs">
             <span className="text-cp-text-muted">
               {t('calc.power.heat', 'Heat (BTU/h)')}:{' '}
               <span className="font-mono text-cp-text-bright">{totalBtu}</span>
@@ -910,14 +910,14 @@ const PowerTab = () => {
             <button
               type="button"
               onClick={exportCsv}
-              className="inline-flex items-center gap-1 rounded bg-emerald-700 px-2 py-1 text-[11px] font-medium text-white hover:bg-emerald-600"
+              className="inline-flex items-center gap-1 rounded bg-emerald-700 px-2 py-1 text-cp-xs font-medium text-white hover:bg-emerald-600"
             >
               <Icon icon={Download} size="xs" /> {t('analysis.exportCsv', 'Export CSV')}
             </button>
             <button
               type="button"
               onClick={exportPdf}
-              className="inline-flex items-center gap-1 rounded bg-amber-700 px-2 py-1 text-[11px] font-medium text-white hover:bg-amber-600"
+              className="inline-flex items-center gap-1 rounded bg-amber-700 px-2 py-1 text-cp-xs font-medium text-white hover:bg-amber-600"
             >
               <Icon icon={Download} size="xs" /> {t('calc.power.exportPdf', 'PDF report')}
             </button>
@@ -928,14 +928,14 @@ const PowerTab = () => {
       {/* #345 ff. — USV / Notstrom-Puffer-Rechner. Nutzt die Gesamtlast der
           Geräte (oben) und schätzt USV-Größe + Pufferzeit. */}
       <details className="rounded border border-cp-border-muted bg-cp-surface-3/40" open={totals.totalW > 0}>
-        <summary className="flex cursor-pointer items-center gap-1.5 px-3 py-1.5 text-[11px] uppercase tracking-wide text-cp-text-muted">
+        <summary className="flex cursor-pointer items-center gap-1.5 px-3 py-1.5 text-cp-xs uppercase tracking-wide text-cp-text-muted">
           <Icon icon={BatteryCharging} size="xs" />
           {t('calc.ups.title', 'UPS / battery backup')}
         </summary>
         <div className="space-y-3 px-3 py-2">
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
             <label className="block">
-              <span className="mb-1 block text-[10px] text-cp-text-muted">
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">
                 {t('calc.ups.va', 'UPS rating (VA)')}
               </span>
               <input
@@ -947,7 +947,7 @@ const PowerTab = () => {
               />
             </label>
             <label className="block">
-              <span className="mb-1 block text-[10px] text-cp-text-muted">
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">
                 {t('calc.ups.pf', 'Power factor')}
               </span>
               <select
@@ -963,7 +963,7 @@ const PowerTab = () => {
               </select>
             </label>
             <div className="block">
-              <span className="mb-1 block text-[10px] text-cp-text-muted">
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">
                 {t('calc.ups.capacity', 'Capacity (W)')}
               </span>
               <div className="rounded border border-cp-border-muted bg-cp-surface-1 px-2 py-1 font-mono text-cp-xs text-cp-text-bright">
@@ -974,7 +974,7 @@ const PowerTab = () => {
 
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
             <label className="block">
-              <span className="mb-1 block text-[10px] text-cp-text-muted">
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">
                 {t('calc.ups.battV', 'Battery (V)')}
               </span>
               <input
@@ -986,7 +986,7 @@ const PowerTab = () => {
               />
             </label>
             <label className="block">
-              <span className="mb-1 block text-[10px] text-cp-text-muted">
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">
                 {t('calc.ups.battAh', 'Capacity (Ah)')}
               </span>
               <input
@@ -998,7 +998,7 @@ const PowerTab = () => {
               />
             </label>
             <label className="block">
-              <span className="mb-1 block text-[10px] text-cp-text-muted">
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">
                 {t('calc.ups.battCount', 'Battery count')}
               </span>
               <input
@@ -1010,7 +1010,7 @@ const PowerTab = () => {
               />
             </label>
             <label className="block">
-              <span className="mb-1 block text-[10px] text-cp-text-muted">
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">
                 {t('calc.ups.usable', 'Usable (%)')}
               </span>
               <input
@@ -1040,7 +1040,7 @@ const PowerTab = () => {
                   {Math.round(upsLoadFraction * 100)}%
                 </span>
                 {upsOverloaded && (
-                  <span className="ml-2 inline-flex items-center gap-1 rounded bg-red-700 px-1.5 py-0.5 text-[10px] text-white">
+                  <span className="ml-2 inline-flex items-center gap-1 rounded bg-red-700 px-1.5 py-0.5 text-cp-xs text-white">
                     <Icon icon={AlertTriangle} size="xs" />
                     {t('calc.ups.overload', 'UPS overloaded')}
                   </span>
@@ -1061,7 +1061,7 @@ const PowerTab = () => {
                     : `${runtimeMin.toFixed(0)} min`}
               </dd>
             </dl>
-            <div className="mt-2 flex items-center gap-2 border-t border-cp-border-muted pt-2 text-[11px]">
+            <div className="mt-2 flex items-center gap-2 border-t border-cp-border-muted pt-2 text-cp-xs">
               <span className="text-cp-text-muted">{t('calc.ups.target', 'Target runtime')}</span>
               <input
                 type="number"
@@ -1076,7 +1076,7 @@ const PowerTab = () => {
               </span>
             </div>
           </div>
-          <PanelHint className="mb-2 text-[10px] text-cp-text-muted" text={t(
+          <PanelHint className="mb-2 text-cp-xs text-cp-text-muted" text={t(
           'calc.ups.note',
           'UPS capacity (W) = VA × power factor. Runtime ≈ usable battery energy / load. Linear approximation — real runtime depends on the discharge curve, battery age and temperature; check the manufacturer runtime chart when in doubt.',
         )} />
@@ -1085,13 +1085,13 @@ const PowerTab = () => {
 
       {/* #345 ff. — Spannungsfall auf der Zuleitung (Distro-Strecke). */}
       <details className="rounded border border-cp-border-muted bg-cp-surface-3/40">
-        <summary className="flex cursor-pointer items-center gap-1.5 px-3 py-1.5 text-[11px] uppercase tracking-wide text-cp-text-muted">
+        <summary className="flex cursor-pointer items-center gap-1.5 px-3 py-1.5 text-cp-xs uppercase tracking-wide text-cp-text-muted">
           {t('calc.vdrop.title', 'Voltage drop (feeder)')}
         </summary>
         <div className="space-y-3 px-3 py-2">
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
             <label className="block">
-              <span className="mb-1 block text-[10px] text-cp-text-muted">
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">
                 {t('calc.vdrop.length', 'Cable length (m)')}
               </span>
               <input
@@ -1103,7 +1103,7 @@ const PowerTab = () => {
               />
             </label>
             <label className="block">
-              <span className="mb-1 block text-[10px] text-cp-text-muted">
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">
                 {t('calc.vdrop.cross', 'Cross-section (mm²)')}
               </span>
               <select
@@ -1119,7 +1119,7 @@ const PowerTab = () => {
               </select>
             </label>
             <div className="block">
-              <span className="mb-1 block text-[10px] text-cp-text-muted">
+              <span className="mb-1 block text-cp-xs text-cp-text-muted">
                 {t('calc.vdrop.current', 'Load current')}
               </span>
               <div className="rounded border border-cp-border-muted bg-cp-surface-1 px-2 py-1 font-mono text-cp-xs text-cp-text-bright">
@@ -1154,7 +1154,7 @@ const PowerTab = () => {
                 >
                   {vdropPercent.toFixed(1)} %
                 </span>
-                <span className="ml-2 text-[10px] text-cp-text-muted">
+                <span className="ml-2 text-cp-xs text-cp-text-muted">
                   {vdropPercent > 5
                     ? t('calc.vdrop.bad', '> 5 % — increase cross-section')
                     : vdropPercent > 3
@@ -1168,7 +1168,7 @@ const PowerTab = () => {
               </dd>
             </dl>
           </div>
-          <PanelHint className="mb-2 text-[10px] text-cp-text-muted" text={t(
+          <PanelHint className="mb-2 text-cp-xs text-cp-text-muted" text={t(
           'calc.vdrop.note',
           'Copper, ρ ≈ 0.0175 Ω·mm²/m. 1-phase ΔU = 2·L·I·ρ/A, 3-phase ΔU = √3·L·I·ρ/A. Rule of thumb: ≤ 3 % at end devices. Load current = symmetric current incl. margin.',
         )} />
@@ -1177,7 +1177,7 @@ const PowerTab = () => {
 
       {totals.devices.length > 0 && (
         <details className="rounded border border-cp-border-muted bg-cp-surface-3/40">
-          <summary className="cursor-pointer px-3 py-1.5 text-[11px] uppercase tracking-wide text-cp-text-muted">
+          <summary className="cursor-pointer px-3 py-1.5 text-cp-xs uppercase tracking-wide text-cp-text-muted">
             {t('calc.topConsumers', 'Top consumers')}
           </summary>
           <ul className="px-3 py-2 text-cp-xs">

--- a/src/renderer/components/Export/GreenGoExportDialog.tsx
+++ b/src/renderer/components/Export/GreenGoExportDialog.tsx
@@ -411,7 +411,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
         <div className="flex items-center justify-between border-b border-cp-border px-4 py-3">
           <div>
             <h3 className="text-cp-xl font-semibold text-emerald-300">{t('greengo.title', 'GreenGo Intercom planning')}</h3>
-            <p className="text-[11px] text-cp-text-muted">{config.systemName}</p>
+            <p className="text-cp-xs text-cp-text-muted">{config.systemName}</p>
           </div>
           <button
             type="button"
@@ -467,12 +467,12 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                   <table className="w-full border-collapse text-cp-xs">
                     <thead>
                       <tr className="bg-cp-surface-2">
-                        <th className="w-8 px-2 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-cp-text-muted">#</th>
-                        <th className="min-w-[130px] px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-cp-text-muted">{t('greengo.col.station', 'Station')}</th>
-                        <th className="min-w-[70px] px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-cp-text-muted">{t('greengo.col.type', 'Type')}</th>
-                        <th className="min-w-[160px] px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-cp-text-muted">{t('greengo.col.deviceCanvas', 'Device (canvas)')}</th>
+                        <th className="w-8 px-2 py-2 text-left text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">#</th>
+                        <th className="min-w-[130px] px-3 py-2 text-left text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">{t('greengo.col.station', 'Station')}</th>
+                        <th className="min-w-[70px] px-3 py-2 text-left text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">{t('greengo.col.type', 'Type')}</th>
+                        <th className="min-w-[160px] px-3 py-2 text-left text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">{t('greengo.col.deviceCanvas', 'Device (canvas)')}</th>
                         {config.groups.map((group) => (
-                          <th key={group.id} className="px-2 py-2 text-center text-[10px] font-semibold uppercase tracking-wide text-emerald-400 whitespace-nowrap">
+                          <th key={group.id} className="px-2 py-2 text-center text-cp-xs font-semibold uppercase tracking-wide text-emerald-400 whitespace-nowrap">
                             {group.name}
                           </th>
                         ))}
@@ -485,7 +485,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                         return (
                           <tr key={user.id}
                             className={`border-t border-cp-border-muted ${idx % 2 === 0 ? 'bg-cp-surface-1' : 'bg-cp-surface-2/30'} hover:bg-cp-surface-2/70`}>
-                            <td className="px-2 py-1.5 text-center text-[10px] text-cp-text-muted font-mono">{user.id}</td>
+                            <td className="px-2 py-1.5 text-center text-cp-xs text-cp-text-muted font-mono">{user.id}</td>
                             <td className="px-2 py-1">
                               <input
                                 value={user.name}
@@ -495,22 +495,22 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                             </td>
                             <td className="px-3 py-1.5 whitespace-nowrap">
                               {deviceType
-                                ? <span className="rounded bg-emerald-900/60 px-1.5 py-0.5 text-[10px] font-mono text-emerald-300">{deviceType}</span>
-                                : <span className="text-[10px] text-cp-text-muted">—</span>}
+                                ? <span className="rounded bg-emerald-900/60 px-1.5 py-0.5 text-cp-xs font-mono text-emerald-300">{deviceType}</span>
+                                : <span className="text-cp-xs text-cp-text-muted">—</span>}
                             </td>
                             <td className="px-2 py-1">
                               {intercomEquipment.length > 0 ? (
                                 <select
                                   value={user.equipmentId ?? ''}
                                   onChange={(e) => updateUser(user.id, { equipmentId: e.target.value || undefined })}
-                                  className="w-full rounded border border-cp-border-muted bg-cp-surface-3 px-1 py-0.5 text-[11px] text-cp-text-secondary hover:border-cp-surface-5 focus:outline-none">
+                                  className="w-full rounded border border-cp-border-muted bg-cp-surface-3 px-1 py-0.5 text-cp-xs text-cp-text-secondary hover:border-cp-surface-5 focus:outline-none">
                                   <option value="">{t('greengo.option.unassigned', '— unassigned —')}</option>
                                   {intercomEquipment.map((eq) => (
                                     <option key={eq.id} value={eq.id}>{eq.name}</option>
                                   ))}
                                 </select>
                               ) : (
-                                <span className="text-[10px] text-cp-text-muted">{t('greengo.noIntercomCanvas', 'no intercom on canvas')}</span>
+                                <span className="text-cp-xs text-cp-text-muted">{t('greengo.noIntercomCanvas', 'no intercom on canvas')}</span>
                               )}
                             </td>
                             {config.groups.map((group) => {
@@ -535,7 +535,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                             })}
                             <td className="px-1 py-1 text-center">
                               <button type="button" onClick={() => removeUser(user.id)}
-                                className="rounded px-1 py-0.5 text-[10px] text-cp-text-muted hover:bg-red-900/60 hover:text-red-300">×</button>
+                                className="rounded px-1 py-0.5 text-cp-xs text-cp-text-muted hover:bg-red-900/60 hover:text-red-300">×</button>
                             </td>
                           </tr>
                         )
@@ -543,9 +543,9 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                     </tbody>
                     <tfoot>
                       <tr className="border-t border-cp-border bg-cp-surface-2/80">
-                        <td colSpan={4} className="px-3 py-1.5 text-[10px] text-cp-text-muted">{t('greengo.members', 'Members')}</td>
+                        <td colSpan={4} className="px-3 py-1.5 text-cp-xs text-cp-text-muted">{t('greengo.members', 'Members')}</td>
                         {config.groups.map((group) => (
-                          <td key={group.id} className="px-2 py-1.5 text-center text-[10px] font-bold text-emerald-400">
+                          <td key={group.id} className="px-2 py-1.5 text-center text-cp-xs font-bold text-emerald-400">
                             {config.users.filter((u) => u.groupIds.includes(group.id)).length}
                           </td>
                         ))}
@@ -567,21 +567,21 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
 
               {intercomEquipment.length > 0 && (
                 <div className="mt-5">
-                  <div className="mb-1.5 text-[10px] uppercase tracking-wide text-cp-text-muted">{t('greengo.devicesOnCanvas', 'GreenGo devices on the canvas')}</div>
+                  <div className="mb-1.5 text-cp-xs uppercase tracking-wide text-cp-text-muted">{t('greengo.devicesOnCanvas', 'GreenGo devices on the canvas')}</div>
                   <div className="flex flex-wrap gap-2">
                     {intercomEquipment.map((eq) => {
                       const assignedTo = config.users.find((u) => u.equipmentId === eq.id)
                       return (
                         <div key={eq.id}
-                          className={`rounded border px-2 py-1 text-[11px] ${
+                          className={`rounded border px-2 py-1 text-cp-xs ${
                             assignedTo
                               ? 'border-emerald-800 bg-emerald-950/40 text-emerald-300'
                               : 'border-cp-border bg-cp-surface-2/60 text-cp-text-muted'
                           }`}>
                           <span className="font-medium">{eq.name}</span>
                           {assignedTo
-                            ? <span className="ml-1.5 text-[10px] text-cp-text-muted">→ {assignedTo.name}</span>
-                            : <span className="ml-1.5 text-[10px] text-cp-text-muted">{t('greengo.unassigned', 'unassigned')}</span>}
+                            ? <span className="ml-1.5 text-cp-xs text-cp-text-muted">→ {assignedTo.name}</span>
+                            : <span className="ml-1.5 text-cp-xs text-cp-text-muted">{t('greengo.unassigned', 'unassigned')}</span>}
                         </div>
                       )
                     })}
@@ -621,7 +621,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                     className="rounded border border-cp-border bg-cp-surface-2/60 p-3"
                   >
                     <div className="mb-2 flex items-center gap-2">
-                      <span className="w-6 text-center text-[10px] font-bold text-cp-text-muted">
+                      <span className="w-6 text-center text-cp-xs font-bold text-cp-text-muted">
                         #{user.id}
                       </span>
                       <input
@@ -650,7 +650,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                       <button
                         type="button"
                         onClick={() => removeUser(user.id)}
-                        className="rounded bg-red-900/60 px-2 py-1 text-[11px] hover:bg-red-800"
+                        className="rounded bg-red-900/60 px-2 py-1 text-cp-xs hover:bg-red-800"
                       >
                         ×
                       </button>
@@ -660,7 +660,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                         {user.groupIds.map((gid) => {
                           const g = config.groups.find((x) => x.id === gid)
                           return g ? (
-                            <span key={gid} className="rounded bg-emerald-900/60 px-1.5 py-0.5 text-[10px] text-emerald-300">
+                            <span key={gid} className="rounded bg-emerald-900/60 px-1.5 py-0.5 text-cp-xs text-emerald-300">
                               {g.name}
                             </span>
                           ) : null
@@ -711,7 +711,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                       className="rounded border border-cp-border bg-cp-surface-2/60 p-3"
                     >
                       <div className="flex items-center gap-2">
-                        <span className="w-6 text-center text-[10px] font-bold text-cp-text-muted">
+                        <span className="w-6 text-center text-cp-xs font-bold text-cp-text-muted">
                           #{group.id}
                         </span>
                         <input
@@ -720,19 +720,19 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                           placeholder={t('greengo.groups.namePlaceholder', 'Group name (e.g. CAM)')}
                           className="flex-1 rounded border border-cp-border bg-cp-surface-3 p-1.5 text-cp-xs"
                         />
-                        <span className="text-[10px] text-cp-text-muted">
+                        <span className="text-cp-xs text-cp-text-muted">
                           {memberCount} {t('greengo.members', 'Members')}
                         </span>
                         <button
                           type="button"
                           onClick={() => removeGroup(group.id)}
-                          className="rounded bg-red-900/60 px-2 py-1 text-[11px] hover:bg-red-800"
+                          className="rounded bg-red-900/60 px-2 py-1 text-cp-xs hover:bg-red-800"
                         >
                           ×
                         </button>
                       </div>
                       {memberNames && (
-                        <p className="mt-1 pl-8 text-[10px] text-cp-text-muted">{memberNames}</p>
+                        <p className="mt-1 pl-8 text-cp-xs text-cp-text-muted">{memberNames}</p>
                       )}
                     </div>
                   )
@@ -774,7 +774,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                   placeholder="239.1.160.1"
                   className="w-full rounded border border-cp-border bg-cp-surface-3 p-2 font-mono text-cp-base"
                 />
-                <span className="mt-0.5 block text-[10px] text-cp-text-muted">
+                <span className="mt-0.5 block text-cp-xs text-cp-text-muted">
                   {t('greengo.system.multicastHint', 'Default: 239.1.160.1 — must be unique on the network.')}
                 </span>
               </label>
@@ -798,7 +798,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
 
         {/* Footer */}
         <div className="flex items-center justify-between border-t border-cp-border px-4 py-3">
-          <span className="text-[11px] text-cp-text-muted">
+          <span className="text-cp-xs text-cp-text-muted">
             {config.users.length} {t('greengo.footer.stations', 'stations')} · {config.groups.length} {t('greengo.footer.groups', 'groups')}
             {intercomEquipment.length > 0 && (
               <span className="ml-2 text-emerald-700">· {intercomEquipment.length} {t('greengo.footer.devicesOnCanvas', 'devices on canvas')}</span>
@@ -909,7 +909,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
           <button
             type="button"
             onClick={() => setXlsxImportNotice(null)}
-            className="mt-2 rounded bg-cyan-800 px-2 py-1 text-[11px] text-white hover:bg-cyan-700"
+            className="mt-2 rounded bg-cyan-800 px-2 py-1 text-cp-xs text-white hover:bg-cyan-700"
           >
             OK
           </button>
@@ -938,7 +938,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                 <h3 className="text-cp-base font-semibold text-emerald-300">
                   {t('greengo.importOverlay.title', 'Import .gg5 — link devices')}
                 </h3>
-                <p className="text-[11px] text-cp-text-muted">
+                <p className="text-cp-xs text-cp-text-muted">
                   {t('greengo.importOverlay.system', 'System:')} <span className="text-cp-text-bright">{importResult.config.systemName}</span>
                   {importResult.config.multicastAddress && (
                     <span className="ml-2 font-mono text-cp-text-faint">{importResult.config.multicastAddress}</span>
@@ -966,7 +966,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                     )}
                   </div>
                   {importResult.unreadSections.length > 0 && (
-                    <div className="font-mono text-[11px] text-cp-text-secondary">
+                    <div className="font-mono text-cp-xs text-cp-text-secondary">
                       {importResult.unreadSections.join(', ')}
                     </div>
                   )}
@@ -978,7 +978,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                       eingemessenen Gains. Der Nutzer las „Devices, Rooms,
                       Templates" und schloss, seine Stationen seien uebernommen. */}
                   {importResult.unreadFields.map((u) => (
-                    <div key={u.section} className="mt-1 text-[11px] text-cp-text-secondary">
+                    <div key={u.section} className="mt-1 text-cp-xs text-cp-text-secondary">
                       <span className="font-semibold">{u.section}</span>
                       {u.section === 'Settings'
                         ? ''
@@ -990,7 +990,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                       <span className="font-mono">{u.fields.join(', ')}</span>
                     </div>
                   ))}
-                  <div className="mt-1.5 text-[11px] text-cp-text-muted">
+                  <div className="mt-1.5 text-cp-xs text-cp-text-muted">
                     {t(
                       'greengo.importOverlay.unreadHint',
                       'Cable Planner does not read these sections and fields — when you export from the loaded file they travel through unchanged. Only without a loaded file are they regenerated with defaults. The export never replaces the original file, but keep it anyway.',
@@ -1017,7 +1017,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                       )}
                     </div>
                     {matchReport.kept.length > 0 && (
-                      <div className="text-[11px] text-cp-text-secondary">
+                      <div className="text-cp-xs text-cp-text-secondary">
                         {format(
                           t(
                             'greengo.importOverlay.matchKept',
@@ -1028,7 +1028,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                       </div>
                     )}
                     {matchReport.renamed.length > 0 && (
-                      <div className="mt-1 text-[11px] text-cp-warn">
+                      <div className="mt-1 text-cp-xs text-cp-warn">
                         {format(
                           t(
                             'greengo.importOverlay.matchRenamed',
@@ -1039,7 +1039,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                       </div>
                     )}
                     {matchReport.stale.length > 0 && (
-                      <div className="mt-1 text-[11px] text-cp-warn">
+                      <div className="mt-1 text-cp-xs text-cp-warn">
                         {format(
                           t(
                             'greengo.importOverlay.matchStale',
@@ -1049,7 +1049,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                         )}
                       </div>
                     )}
-                    <div className="mt-1.5 text-[11px] text-cp-text-muted">
+                    <div className="mt-1.5 text-cp-xs text-cp-text-muted">
                       {t(
                         'greengo.importOverlay.matchHint',
                         'Guessed mappings can be corrected per station below before the import is applied.',
@@ -1061,12 +1061,12 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
               {/* Groups summary */}
               {importResult.config.groups.length > 0 && (
                 <div>
-                  <div className="mb-1.5 text-[10px] uppercase tracking-wide text-cp-text-muted">
+                  <div className="mb-1.5 text-cp-xs uppercase tracking-wide text-cp-text-muted">
                     {t('greengo.importOverlay.importedGroups', 'Imported groups')} ({importResult.config.groups.length})
                   </div>
                   <div className="flex flex-wrap gap-1.5">
                     {importResult.config.groups.map((g) => (
-                      <span key={g.id} className="rounded bg-emerald-900/50 px-2 py-0.5 text-[11px] text-emerald-300">
+                      <span key={g.id} className="rounded bg-emerald-900/50 px-2 py-0.5 text-cp-xs text-emerald-300">
                         {g.name}
                       </span>
                     ))}
@@ -1076,19 +1076,19 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
 
               {/* User → Equipment mapping table */}
               <div>
-                <div className="mb-1.5 text-[10px] uppercase tracking-wide text-cp-text-muted">
+                <div className="mb-1.5 text-cp-xs uppercase tracking-wide text-cp-text-muted">
                   {t('greengo.importOverlay.linkStations', 'Link stations → canvas devices')} ({importResult.config.users.length})
                 </div>
-                <p className="mb-2 text-[11px] text-cp-text-muted">
+                <p className="mb-2 text-cp-xs text-cp-text-muted">
                   {t('greengo.importOverlay.linkHint', 'Pick the matching canvas device for each imported station. Auto-detected matches are pre-filled.')}
                 </p>
                 <table className="w-full border-collapse text-cp-xs">
                   <thead>
                     <tr className="bg-cp-surface-2">
-                      <th className="px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-cp-text-muted">{t('greengo.importOverlay.col.nameFromGg5', 'Name (from .gg5)')}</th>
-                      <th className="px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-cp-text-muted">{t('greengo.col.type', 'Type')}</th>
-                      <th className="px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-cp-text-muted">{t('greengo.importOverlay.col.groups', 'Groups')}</th>
-                      <th className="min-w-[180px] px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wide text-emerald-400">{t('greengo.importOverlay.col.deviceCanvas', 'Device on canvas')}</th>
+                      <th className="px-3 py-2 text-left text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">{t('greengo.importOverlay.col.nameFromGg5', 'Name (from .gg5)')}</th>
+                      <th className="px-3 py-2 text-left text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">{t('greengo.col.type', 'Type')}</th>
+                      <th className="px-3 py-2 text-left text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">{t('greengo.importOverlay.col.groups', 'Groups')}</th>
+                      <th className="min-w-[180px] px-3 py-2 text-left text-cp-xs font-semibold uppercase tracking-wide text-emerald-400">{t('greengo.importOverlay.col.deviceCanvas', 'Device on canvas')}</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -1104,13 +1104,13 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                           <td className="px-3 py-2 font-medium text-cp-text-bright">{user.name}</td>
                           <td className="px-3 py-2">
                             {typeHint
-                              ? <span className="rounded bg-emerald-900/60 px-1.5 py-0.5 text-[10px] font-mono text-emerald-300">{typeHint}</span>
+                              ? <span className="rounded bg-emerald-900/60 px-1.5 py-0.5 text-cp-xs font-mono text-emerald-300">{typeHint}</span>
                               : <span className="text-cp-text-dim">—</span>}
                           </td>
                           <td className="px-3 py-2">
                             {userGroups.length > 0
-                              ? <span className="text-[10px] text-cp-text-muted">{userGroups.join(', ')}</span>
-                              : <span className="text-[10px] text-cp-text-muted">{t('greengo.importOverlay.noGroups', 'none')}</span>}
+                              ? <span className="text-cp-xs text-cp-text-muted">{userGroups.join(', ')}</span>
+                              : <span className="text-cp-xs text-cp-text-muted">{t('greengo.importOverlay.noGroups', 'none')}</span>}
                           </td>
                           <td className="px-3 py-2">
                             {intercomEquipment.length > 0 ? (
@@ -1122,7 +1122,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                                   else next.delete(user.id)
                                   setImportMappings(next)
                                 }}
-                                className={`w-full rounded border px-1.5 py-1 text-[11px] focus:outline-none ${
+                                className={`w-full rounded border px-1.5 py-1 text-cp-xs focus:outline-none ${
                                   assignedId
                                     ? 'border-emerald-800 bg-emerald-950/40 text-emerald-200'
                                     : 'border-cp-border bg-cp-surface-3 text-cp-text-muted'
@@ -1133,7 +1133,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                                 ))}
                               </select>
                             ) : (
-                              <span className="text-[10px] text-cp-text-muted">{t('greengo.importOverlay.noIntercomCanvas', 'No intercom on canvas')}</span>
+                              <span className="text-cp-xs text-cp-text-muted">{t('greengo.importOverlay.noIntercomCanvas', 'No intercom on canvas')}</span>
                             )}
                           </td>
                         </tr>
@@ -1147,7 +1147,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
 
             {/* Footer */}
             <div className="flex items-center justify-between border-t border-cp-border px-4 py-3">
-              <span className="text-[11px] text-cp-text-muted">
+              <span className="text-cp-xs text-cp-text-muted">
                 {t('greengo.importOverlay.linkedCount', '{linked} of {total} stations linked').replace('{linked}', String(importMappings.size)).replace('{total}', String(importResult.config.users.length))}
               </span>
               <div className="flex gap-2">

--- a/src/renderer/components/Properties/CableProperties.tsx
+++ b/src/renderer/components/Properties/CableProperties.tsx
@@ -120,13 +120,13 @@ export const CableProperties = () => {
           <div className="min-w-0 flex-1">
             <div className="font-medium text-cp-text-bright truncate">{spec.name}</div>
             {cable.standard && (
-              <div className="text-[10px] text-cp-text-muted">{cable.standard}</div>
+              <div className="text-cp-xs text-cp-text-muted">{cable.standard}</div>
             )}
           </div>
           <button
             type="button"
             onClick={() => openCableEdit(cable.id)}
-            className="shrink-0 rounded bg-cp-surface-4 px-1.5 py-0.5 text-[10px] hover:bg-cp-surface-5"
+            className="shrink-0 rounded bg-cp-surface-4 px-1.5 py-0.5 text-cp-xs hover:bg-cp-surface-5"
             title={t('cable.edit.typeStandard', 'Edit cable type / standard')}
             aria-label={t('cable.edit.typeStandard', 'Edit cable type / standard')}
           >
@@ -153,7 +153,7 @@ export const CableProperties = () => {
         const typePatch = cableTypePatchFromPorts(cable, equipment)
         if (!typePatch) return null
         return (
-          <div className="flex items-center gap-2 rounded border border-amber-700/50 bg-amber-950/30 px-2 py-1 text-[11px] text-amber-200">
+          <div className="flex items-center gap-2 rounded border border-amber-700/50 bg-amber-950/30 px-2 py-1 text-cp-xs text-amber-200">
             <span className="flex-1 leading-snug">
               {t('cable.typeMismatch.prefix', 'Cable type')} <strong>{cable.type}</strong> {t('cable.typeMismatch.suffix', 'does not match the ports')}
               ({fromPort.connectorType} ↔ {toPort.connectorType}).
@@ -183,7 +183,7 @@ export const CableProperties = () => {
               name: sourceDestLabel(cable, new Map(equipment.map((e) => [e.id, e]))),
             })
           }
-          className="mt-1 text-[10px] text-cp-accent hover:underline"
+          className="mt-1 text-cp-xs text-cp-accent hover:underline"
           title={t('cable.field.sourceDestTitle', 'Generate name from source → destination (AVIXA F501.01)')}
         >
           ↳ {t('cable.field.sourceDest', 'from source → destination')}
@@ -259,7 +259,7 @@ export const CableProperties = () => {
           Terminierung und Mess-/Test-Ergebnis. Nur bei aktivem Modul. */}
       {festinstallationModule && (
       <details className="rounded border border-cp-border bg-cp-surface-3/40">
-        <summary className="cursor-pointer select-none px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-cp-text-muted hover:bg-cp-surface-2/40">
+        <summary className="cursor-pointer select-none px-2 py-1.5 text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted hover:bg-cp-surface-2/40">
           {t('lifecycle.cableSection', 'Fixed install / lifecycle')}
         </summary>
         <div className="space-y-2 border-t border-cp-border p-2">
@@ -323,12 +323,12 @@ export const CableProperties = () => {
           {/* Mess-/Test-Ergebnis */}
           <div className="rounded border border-cp-border-muted bg-cp-surface-1/40 p-1.5">
             <div className="mb-1 flex items-center justify-between">
-              <span className="text-[11px] text-cp-text-secondary">{t('lifecycle.test', 'Measurement/test result')}</span>
+              <span className="text-cp-xs text-cp-text-secondary">{t('lifecycle.test', 'Measurement/test result')}</span>
               {cable.testResult && (
                 <button
                   type="button"
                   onClick={() => setCableTestResult(cable.id, undefined)}
-                  className="rounded px-1 py-0.5 text-[10px] text-cp-text-muted hover:bg-cp-surface-3"
+                  className="rounded px-1 py-0.5 text-cp-xs text-cp-text-muted hover:bg-cp-surface-3"
                 >
                   {t('common.clear', 'Clear')}
                 </button>
@@ -350,7 +350,7 @@ export const CableProperties = () => {
                   }
                   setCableTestResult(cable.id, next)
                 }}
-                className="rounded border border-cp-border bg-cp-surface-1 p-1.5 text-[11px]"
+                className="rounded border border-cp-border bg-cp-surface-1 p-1.5 text-cp-xs"
               >
                 <option value="">{t('lifecycle.testNone', '— not tested —')}</option>
                 <option value="pass">PASS</option>
@@ -369,7 +369,7 @@ export const CableProperties = () => {
                     marginDb: e.target.value === '' ? undefined : Number(e.target.value),
                   })
                 }
-                className="rounded border border-cp-border bg-cp-surface-1 p-1.5 text-[11px] disabled:opacity-40"
+                className="rounded border border-cp-border bg-cp-surface-1 p-1.5 text-cp-xs disabled:opacity-40"
               />
               <input
                 value={cable.testResult?.standard ?? ''}
@@ -382,7 +382,7 @@ export const CableProperties = () => {
                     standard: e.target.value || undefined,
                   })
                 }
-                className="rounded border border-cp-border bg-cp-surface-1 p-1.5 text-[11px] disabled:opacity-40"
+                className="rounded border border-cp-border bg-cp-surface-1 p-1.5 text-cp-xs disabled:opacity-40"
               />
               <input
                 value={cable.testResult?.reportRef ?? ''}
@@ -395,7 +395,7 @@ export const CableProperties = () => {
                     reportRef: e.target.value || undefined,
                   })
                 }
-                className="rounded border border-cp-border bg-cp-surface-1 p-1.5 text-[11px] disabled:opacity-40"
+                className="rounded border border-cp-border bg-cp-surface-1 p-1.5 text-cp-xs disabled:opacity-40"
               />
             </div>
           </div>
@@ -442,7 +442,7 @@ export const CableProperties = () => {
           haben". Nur das Zweite kann merken, dass die vierte von fuenf
           Leitungen fehlt. */}
       <details className="rounded border border-cp-border bg-cp-surface-3/40">
-        <summary className="cursor-pointer select-none px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-cp-text-muted hover:bg-cp-surface-2/40">
+        <summary className="cursor-pointer select-none px-2 py-1.5 text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted hover:bg-cp-surface-2/40">
           {t('adern.cableSection', 'Conductors (power)')}
         </summary>
         <div className="space-y-2 border-t border-cp-border p-2">
@@ -523,7 +523,7 @@ export const CableProperties = () => {
               />
               <button
                 type="button"
-                className="rounded bg-red-700 px-1.5 py-1 text-[10px] hover:bg-red-600"
+                className="rounded bg-red-700 px-1.5 py-1 text-cp-xs hover:bg-red-600"
                 onClick={() =>
                   updateCable(cable.id, {
                     adern:
@@ -575,7 +575,7 @@ export const CableProperties = () => {
           Plan wird an jedem Ende ein benanntes Connector-Symbol gezeichnet.
           Segmente mit gleichem Netznamen bilden ein gemeinsames Netz. */}
       <div className="rounded border border-cp-border bg-cp-surface-3/50 p-2 space-y-2">
-        <label className="flex items-center gap-2 text-[11px] text-cp-text-secondary cursor-pointer">
+        <label className="flex items-center gap-2 text-cp-xs text-cp-text-secondary cursor-pointer">
           <input
             type="checkbox"
             checked={!!cable.offPage}
@@ -594,7 +594,7 @@ export const CableProperties = () => {
         {cable.offPage && (
           <div className="pl-5 space-y-1">
             <label className="block">
-              <span className="mb-0.5 block text-[10px] text-cp-text-muted">
+              <span className="mb-0.5 block text-cp-xs text-cp-text-muted">
                 {t('cable.field.netName', 'Net / signal name')}
               </span>
               <input
@@ -623,7 +623,7 @@ export const CableProperties = () => {
               const peers = netPeerCount(cables, cable)
               const key = netKeyOf(cable)
               return (
-                <p className={`text-[10px] ${peers > 0 ? 'text-amber-300' : 'text-cp-text-muted'}`}>
+                <p className={`text-cp-xs ${peers > 0 ? 'text-amber-300' : 'text-cp-text-muted'}`}>
                   {peers > 0
                     ? format(
                         t(
@@ -646,7 +646,7 @@ export const CableProperties = () => {
       {/* Endpoint editor — inline accordion (open by default) so users can
           re-route a cable from the properties panel without opening a dialog. */}
       <details open className="rounded border border-cp-border bg-cp-surface-3/50">
-        <summary className="cursor-pointer select-none px-2 py-1.5 text-[11px] text-cp-text-secondary hover:bg-cp-surface-2/40">
+        <summary className="cursor-pointer select-none px-2 py-1.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-2/40">
           <span className="font-semibold uppercase tracking-wide text-cp-text-muted">
             {t('cable.field.connection', 'Connection')}
           </span>
@@ -659,7 +659,7 @@ export const CableProperties = () => {
         <div className="border-t border-cp-border p-2">
           <div className="grid grid-cols-2 gap-2">
             <div>
-              <div className="mb-0.5 text-[10px] text-cp-text-muted">{t('cable.fromDeviceShort', 'From device')}</div>
+              <div className="mb-0.5 text-cp-xs text-cp-text-muted">{t('cable.fromDeviceShort', 'From device')}</div>
               <select
                 aria-label={t('cable.aria.fromDevice', 'Source device')}
                 value={cable.fromEquipmentId}
@@ -672,7 +672,7 @@ export const CableProperties = () => {
                   </option>
                 ))}
               </select>
-              <div className="mt-1 text-[10px] text-cp-text-muted">{t('cable.portShort', 'Port')}</div>
+              <div className="mt-1 text-cp-xs text-cp-text-muted">{t('cable.portShort', 'Port')}</div>
               <select
                 aria-label={t('cable.aria.fromPort', 'Source port')}
                 value={cable.fromPortId}
@@ -691,7 +691,7 @@ export const CableProperties = () => {
               </select>
             </div>
             <div>
-              <div className="mb-0.5 text-[10px] text-cp-text-muted">{t('cable.toDeviceShort', 'To device')}</div>
+              <div className="mb-0.5 text-cp-xs text-cp-text-muted">{t('cable.toDeviceShort', 'To device')}</div>
               <select
                 aria-label={t('cable.aria.toDevice', 'Target device')}
                 value={cable.toEquipmentId}
@@ -704,7 +704,7 @@ export const CableProperties = () => {
                   </option>
                 ))}
               </select>
-              <div className="mt-1 text-[10px] text-cp-text-muted">{t('cable.portShort', 'Port')}</div>
+              <div className="mt-1 text-cp-xs text-cp-text-muted">{t('cable.portShort', 'Port')}</div>
               <select
                 aria-label={t('cable.aria.toPort', 'Target port')}
                 value={cable.toPortId}
@@ -724,13 +724,13 @@ export const CableProperties = () => {
             </div>
           </div>
           {fromConflict && (
-            <div className="mt-2 flex items-center gap-1 rounded bg-amber-900/50 px-2 py-1 text-[11px] text-amber-100">
+            <div className="mt-2 flex items-center gap-1 rounded bg-amber-900/50 px-2 py-1 text-cp-xs text-amber-100">
               <Icon icon={AlertTriangle} size="xs" className="shrink-0" />
               {format(t('cable.warn.fromBusy', 'Source port already in use by "{name}".'), { name: fromConflict.name })}
             </div>
           )}
           {toConflict && (
-            <div className="mt-1 flex items-center gap-1 rounded bg-amber-900/50 px-2 py-1 text-[11px] text-amber-100">
+            <div className="mt-1 flex items-center gap-1 rounded bg-amber-900/50 px-2 py-1 text-cp-xs text-amber-100">
               <Icon icon={AlertTriangle} size="xs" className="shrink-0" />
               {format(t('cable.warn.toBusy', 'Target port already in use by "{name}".'), { name: toConflict.name })}
             </div>
@@ -826,11 +826,11 @@ export const CableProperties = () => {
                 })}
               </div>
               {isHidden && (
-                <p className="mt-1 text-[10px] text-cp-text-muted">
+                <p className="mt-1 text-cp-xs text-cp-text-muted">
                   {t('cable.label.hiddenHint', 'Label hidden — click one of the three positions to show it again.')}
                 </p>
               )}
-              <div className={`mt-2 flex items-center gap-2 text-[11px] ${isHidden ? 'opacity-40' : ''}`}>
+              <div className={`mt-2 flex items-center gap-2 text-cp-xs ${isHidden ? 'opacity-40' : ''}`}>
                 <span className="text-cp-text-faint">{t('cable.field.labelSlider', 'Slider:')}</span>
                 <input
                   type="range"
@@ -869,7 +869,7 @@ export const CableProperties = () => {
                   <button
                     type="button"
                     onClick={() => updateCable(cable.id, { labelT: undefined })}
-                    className="rounded bg-cp-surface-2 px-1 py-0.5 text-[10px] text-cp-text-muted hover:bg-cp-surface-4"
+                    className="rounded bg-cp-surface-2 px-1 py-0.5 text-cp-xs text-cp-text-muted hover:bg-cp-surface-4"
                     title={t('cable.field.labelSliderReset', 'Reset slider — preset becomes active again')}
                   >
                     reset
@@ -901,7 +901,7 @@ export const CableProperties = () => {
                 type="button"
                 title={opt.title}
                 onClick={() => updateCable(cable.id, { endpointLabels: opt.id })}
-                className={`flex-1 rounded px-1.5 py-1 text-[11px] ${
+                className={`flex-1 rounded px-1.5 py-1 text-cp-xs ${
                   active
                     ? 'bg-emerald-700/40 text-emerald-100 ring-1 ring-emerald-500'
                     : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
@@ -953,7 +953,7 @@ export const CableProperties = () => {
       </div>
 
       <div className="rounded border border-cp-border bg-cp-surface-3/50 p-2 space-y-2">
-        <label className="flex items-center gap-2 text-[11px] text-cp-text-secondary cursor-pointer">
+        <label className="flex items-center gap-2 text-cp-xs text-cp-text-secondary cursor-pointer">
           <input
             type="checkbox"
             checked={cable.wireless ?? false}
@@ -964,7 +964,7 @@ export const CableProperties = () => {
         {cable.wireless && (
           <div className="grid grid-cols-2 gap-2 pl-5">
             <label className="block">
-              <span className="mb-0.5 block text-[10px] text-cp-text-muted">{t('cable.field.frequencyLabel', 'Frequency (e.g. 5.8 GHz)')}</span>
+              <span className="mb-0.5 block text-cp-xs text-cp-text-muted">{t('cable.field.frequencyLabel', 'Frequency (e.g. 5.8 GHz)')}</span>
               <input
                 value={cable.frequency ?? ''}
                 onChange={(event) => updateCable(cable.id, { frequency: event.target.value || undefined })}
@@ -973,7 +973,7 @@ export const CableProperties = () => {
               />
             </label>
             <label className="block">
-              <span className="mb-0.5 block text-[10px] text-cp-text-muted">{t('cable.field.channelLabel', 'Channel')}</span>
+              <span className="mb-0.5 block text-cp-xs text-cp-text-muted">{t('cable.field.channelLabel', 'Channel')}</span>
               <input
                 value={cable.wifiChannel ?? ''}
                 onChange={(event) => updateCable(cable.id, { wifiChannel: event.target.value || undefined })}
@@ -1049,7 +1049,7 @@ const ConnectorMismatchHint = ({
   const toDev = equipment.find((e) => e.id === toEquipmentId)
 
   return (
-    <div className="mt-2 rounded border border-amber-700/60 bg-amber-900/30 px-2 py-1.5 text-[11px] text-amber-100">
+    <div className="mt-2 rounded border border-amber-700/60 bg-amber-900/30 px-2 py-1.5 text-cp-xs text-amber-100">
       <div className="flex items-center gap-1">
         <Icon icon={AlertTriangle} size="xs" className="shrink-0" />
         {format(

--- a/tests/schriftgroesseUntergrenze.test.ts
+++ b/tests/schriftgroesseUntergrenze.test.ts
@@ -57,8 +57,13 @@ const UNTERGRENZE_PX = 12
 /**
  * Stand 2026-09-10, gemessen mit genau der Suche unten. Sinken darf die Zahl —
  * dann ist die rote Zeile die Erinnerung, sie hier nachzuziehen.
+ *
+ * Bisherige Staende: 828 (nach `src/mobile`), 705 (nach GreenGoExportDialog,
+ * CalculatorsDialog, CableProperties). Die Reihenfolge ist die nach Groesse:
+ * die dichten Tabellen und Rechner-Raster zuerst, weil dort die kleinste
+ * Schrift und die meiste Zahl zusammenkommen.
  */
-const BARRIERE = 828
+const BARRIERE = 705
 
 const dateien = (dir: string): string[] =>
   readdirSync(dir).flatMap((eintrag) => {


### PR DESCRIPTION
Zweiter Schnitt derselben TODO-Zeile aus `docs/ui-audit.md` („Fließtext-Mindestgröße 12px"). Nach `src/mobile` in [#809](https://github.com/larszu/cable-planner/pull/809) jetzt die drei größten Einzeldateien — Reihenfolge nach Anzahl, weil dort die kleinste Schrift und die meiste Zahl zusammenkommen.

## Was migriert wurde

| Datei | Stellen |
| --- | ---: |
| `GreenGoExportDialog` | 50 |
| `CalculatorsDialog` | 42 |
| `CableProperties` | 31 |

`text-[10px]`/`text-[11px]` → `text-cp-xs` (12px). Ratschen-Barriere in `tests/schriftgroesseUntergrenze.test.ts` von **828 auf 705**.

**Eine Stelle bleibt bewusst stehen:** die Pin-Markierung im Rechner (`CalculatorsDialog:851`). Das Audit nimmt rein dekorative Micro-Glyphen aus, und ein Pin hat keine Lesbarkeitsuntergrenze. Die Ratsche zählt sie trotzdem mit — „ist das dekorativ?" lässt sich nicht suchen, und ein Wächter mit Ermessensklausel prüft am Ende nichts.

## Im echten Fenster nachgemessen — und das ist hier nicht Beiwerk

Der Sprung 10 → 12px in dichten Tabellen ist genau der Punkt, an dem eine solche Migration Layout bricht. `npm test` sieht das nicht (kein Rendering, keine Schriftbreiten), und `ui:overflow` öffnet diese Dialoge nicht. Gemessen wurde deshalb einzeln, unter `xvfb` gegen die gebaute App: jedes sichtbare Element unter dem Dialog daraufhin, ob ein Kind aus einem **nicht scrollbaren** Elternteil ragt.

| Fläche | sichtbare Elemente | Überlauf | unter 12px |
| --- | ---: | ---: | --- |
| Bandbreiten-Rechner | 66 | 0 | keine |
| Leistungs-Rechner | 112 | 0 | keine |
| Kabel-Eigenschaften | 125 | 0 | keine |
| GreenGo-Dialog | 49 | 0 | keine |

**Zwei dieser Messungen waren zuerst wertlos** und sind es nicht geblieben — beide Male hätte die Zahl „0 Überlauf" gemeldet, ohne irgendetwas angesehen zu haben:

- **Kabel-Eigenschaften** maßen die Platzhalter-Spalte („Nothing selected"), weil der Klick auf die dünne SVG-Kante nicht traf. Jetzt über die Kabel-Beschriftung — und die Messung prüft selbst, dass wirklich ein Kabel gewählt ist, bevor sie zählt.
- **Der GreenGo-Dialog** ließ sich gar nicht öffnen: das Werkzeuge-Menü blendet ihn ohne Intercom im Plan aus (`toolsInPlan`). Jetzt wird vorher ein Gerät aus der Bibliothek auf die Fläche gezogen.

## Verifikation

- `npx tsc -p tsconfig.app.json --noEmit` → 0
- `npm run lint` → 0 Errors (12 Warnungen, alle pre-existing)
- `npm test` → 3851 grün, 2 skipped
- `xvfb-run -a npm run ui:overflow` → 0 Befunde
- `npm run build` → grün

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_