### PR TITLE
ui: drei Reiter fielen aus dem Analysen-Dialog — und der Wächter geht jetzt durch die Tür

### DIFF
--- a/docs/ui-audit.md
+++ b/docs/ui-audit.md
@@ -33,6 +33,31 @@ lag falsch (`src/main*.ts` deckt entgegen der Dokumentation auch
 `src/main/ipc/*.ts` mit ab, nachgemessen mit einer Wegwerfdatei). Wer die
 Regel nachbaut, prueft am Ende seine eigene Lesart.
 
+## Nebenbefund 2026-09-10 (zweiter): drei Reiter fielen aus dem Analysen-Dialog
+
+Der Analysen-Dialog legt **dreizehn Reiter** in eine `flex`-Zeile, die nicht
+umbricht. Die letzten drei — „Kabelwege", „Signalwege", „Blatt prüfen" — lagen
+**164 px, 98 px und 5 px über der rechten Kante**, bei 1280×800 wie bei
+1500×950. Nicht sichtbar, nicht anklickbar: drei Auswertungen, die es für den
+Nutzer nicht gab.
+
+Das ist wörtlich derselbe Befund, aus dem `scripts/ui-overflow.mjs` entstanden
+ist („da kann man Equipment lesen, aber Cable schon nicht mehr") — nur eine
+Ebene tiefer. **Der Wächter stand an der Tür:** er misst die stehende
+Oberfläche und die Menüs, aber ein Dialog ist zu, bis jemand ihn öffnet. Der
+Defekt war Monate alt (nachgemessen gegen `776ed7c`, identische Zahlen) und
+hat jede CI-Runde überlebt.
+
+Behoben mit `flex-wrap` — und nicht mit `overflow-x-auto`: eine waagerecht
+scrollende Reiterleiste versteckt die hinteren Reiter hinter einer Geste, die
+niemand sucht.
+
+**Der Wächter geht jetzt durch die Tür.** `ui-overflow.mjs` läuft die
+Befehlspalette Eintrag für Eintrag durch, öffnet jeden Dialog und misst ihn
+(heute 15 Dialoge, 0 Befunde). Die Liste führt die App: wer einen Dialog anlegt
+und in die Palette hängt, wird gemessen, ohne dass jemand eine zweite Liste
+pflegt — dieselbe Lehre wie bei `tests/dialogTastaturbedienung.test.ts`.
+
 ## Baseline (vor Phase 0)
 
 | Check         | Ergebnis                                   |
@@ -146,10 +171,10 @@ Hartkodierte Pixel-Schriftgrößen (Tailwind-Arbitrary-Values):
 
 | Klasse        | Audit-Start<br>2026-06-15 | vor der Migration<br>2026-09-10 | heute |
 | ------------- | ------------------------: | ------------------------------: | ----: |
-| `text-[10px]` |                       336 |                             423 |   352 |
-| `text-[11px]` |                       256 |                             390 |   338 |
-| `text-[9px]`  |                        43 |                              10 |    10 |
-| `text-[8px]`  |                         5 |                               5 |     5 |
+| `text-[10px]` |                       336 |                             423 |   252 |
+| `text-[11px]` |                       256 |                             390 |   255 |
+| `text-[9px]`  |                        43 |                              10 |     6 |
+| `text-[8px]`  |                         5 |                               5 |     2 |
 | `text-[12px]` |                         4 |                              20 |    20 |
 | `text-[13px]` |                         2 |                               2 |     2 |
 
@@ -161,13 +186,14 @@ Das ist keine Nachlaessigkeit einzelner Aenderungen, sondern die vorhersehbare
 Folge davon, dass die Grenze nur in Prosa stand: ein TODO in einer Datei
 bremst nichts, weil niemand es beim Schreiben einer neuen Komponente liest.
 Seit `tests/schriftgroesseUntergrenze.test.ts` ist es eine Ratsche — die Zahl
-darf sinken, nie steigen. Stand heute: **705**, in zwei Schritten von 881
-(erst `src/mobile`, dann die drei groessten Einzeldateien).
+darf sinken, nie steigen. Stand heute: **515**, in drei Schritten von 881
+(erst `src/mobile`, dann die drei groessten Einzeldateien, dann die naechsten
+neun).
 
-Top-Dateien mit Sub-12px-Schrift, was noch offen ist:
-`RentmanTab` (24), `RackPlacementProperties` (22), `RackBuilderDialog` (22),
-`CableLibraryPanel` (21), `PortList` / `MobileShareDialog` / `App.tsx` (je 20),
-`ExportDialog` / `AnalysisDialog` (je 19).
+Was noch offen ist, hat keinen grossen Posten mehr: der Rest verteilt sich auf
+rund hundert Dateien mit einstelligen bis niedrig zweistelligen Zahlen
+(`RentmanCableExportDialog` 18, `AtemMvConfigDialog` 16, `EquipmentChecklist`
+15, `VideohubExportDialog` 14, `IntegrationsTab` 13, dann der lange Schwanz).
 
 **Theming-Schuld:** `index.css` remappt die komplette Tailwind-Slate-Rampe
 (+ Dutzende Opacity-Varianten einzeln) für `[data-theme="light"]`. Fragil,
@@ -198,10 +224,13 @@ Inline-Fallback in `ErrorBoundary`). → Token-Schicht einführen.
       dekorative Micro-Glyphen wie MenuBar-Caret `▾` und die
       Pin-Markierung im Rechner bleiben.)
       **Erledigt:** zentrale Shells (Phase 2), `src/mobile` komplett,
-      `GreenGoExportDialog`, `CalculatorsDialog`, `CableProperties`.
-      **Offen:** die Liste über der Tabelle, Reihenfolge nach Größe.
+      `GreenGoExportDialog`, `CalculatorsDialog`, `CableProperties`,
+      `RackBuilderDialog`, `RentmanTab`, `RackPlacementProperties`,
+      `CableLibraryPanel`, `PortList`, `MobileShareDialog`, `App.tsx`,
+      `ExportDialog`, `AnalysisDialog`.
+      **Offen:** der lange Schwanz, Reihenfolge nach Größe.
       **Gedeckelt** durch `tests/schriftgroesseUntergrenze.test.ts`:
-      Barriere 705, sinken erlaubt, steigen nicht.
+      Barriere 515, sinken erlaubt, steigen nicht.
       `src/mobile` steht dort zusätzlich auf 0 und muss es bleiben —
       eine reine Gesamtzahl saehe nicht, wenn ein migrierter Ordner
       zurueckfaellt, waehrend anderswo etwas migriert wird.

--- a/scripts/ui-overflow.mjs
+++ b/scripts/ui-overflow.mjs
@@ -360,6 +360,118 @@ for (let i = 0; i < kopfAnzahl; i++) {
 }
 console.log(`${kopfAnzahl} Menue(s) der Kopfleiste geprueft`)
 
+// ── 6. Die Dialoge ────────────────────────────────────────────────────────
+// WARUM ERST JETZT, UND WAS DAS GEKOSTET HAT. Die Punkte 1 bis 5 messen die
+// stehende Oberflaeche und die Menues. Ein Dialog ist beides nicht: er ist zu,
+// bis jemand ihn oeffnet, und deshalb hat dieser Guard ihn nie gesehen.
+//
+// Nachgemessen 2026-09-10: der Analysen-Dialog legt DREIZEHN Reiter in eine
+// flex-Zeile, die nicht umbricht. Die letzten drei — „Kabelwege",
+// „Signalwege", „Blatt pruefen" — lagen 164 px, 98 px und 5 px ueber der
+// rechten Kante, bei 1280x800 wie bei 1500x950. Nicht sichtbar, nicht
+// anklickbar. Genau der Befund, aus dem dieser Guard entstanden ist, nur eine
+// Ebene tiefer: er war seit Monaten da und niemand hat ihn gesehen, weil die
+// Messung an der Tuer stehen blieb.
+//
+// DIE LISTE DER DIALOGE FUEHRT DIE APP, NICHT DER WAECHTER. Durchgegangen
+// wird die Befehlspalette, Eintrag fuer Eintrag ueber die Pfeiltaste — sie
+// ist die Registratur, die ohnehin gepflegt wird. Wer morgen einen Dialog
+// anlegt und in die Palette haengt, wird hier gemessen, ohne dass jemand eine
+// zweite Liste nachzieht. (Dieselbe Lehre wie bei den Dialog-Tests in
+// `tests/dialogTastaturbedienung.test.ts`: die Domaene ist die Registratur,
+// nicht eine Aufzaehlung im Pruefer.)
+//
+// Eintraege, die keinen Dialog oeffnen — rueckgaengig, Zoom, Auswahl — fallen
+// von selbst heraus: dann steht danach kein zweiter Dialog offen. Die Palette
+// selbst wird markiert und ausgenommen; sie traegt `role="dialog"` und waere
+// sonst das, was gemessen wird.
+await win.setViewportSize(groessen[groessen.length - 1])
+await win.waitForTimeout(400)
+
+const paletteAuf = async () => {
+  await win.keyboard.press('Control+k')
+  await win.waitForTimeout(450)
+  return win.evaluate(() => {
+    const p = document.querySelector('[role="dialog"]')
+    if (!p) return 0
+    p.setAttribute('data-cp-palette', '1')
+    return p.querySelectorAll('ul > li > button').length
+  })
+}
+
+const zu = async () => {
+  for (let i = 0; i < 3; i++) {
+    if ((await win.locator('[role="dialog"]').count()) === 0) return
+    await win.keyboard.press('Escape').catch(() => {})
+    await win.waitForTimeout(250)
+  }
+}
+
+await zu()
+const befehle = await paletteAuf()
+await zu()
+if (befehle === 0) {
+  throw new Error(
+    'Befehlspalette liefert keine Eintraege — die Dialog-Messung waere leer und ' +
+      'damit gruen, ohne einen einzigen Dialog angesehen zu haben.',
+  )
+}
+
+let dialoge = 0
+for (let i = 0; i < befehle; i++) {
+  const gefunden = await paletteAuf()
+  if (gefunden === 0) { await zu(); continue }
+  for (let k = 0; k < i; k++) await win.keyboard.press('ArrowDown')
+  await win.waitForTimeout(120)
+  const name = await win.evaluate((idx) => {
+    const p = document.querySelector('[data-cp-palette]')
+    const b = p?.querySelectorAll('ul > li > button')[idx]
+    return b ? (b.textContent || '').trim().slice(0, 44) : `Eintrag ${idx + 1}`
+  }, i)
+  await win.keyboard.press('Enter')
+  await win.waitForTimeout(1100)
+
+  const d = await win.evaluate(() => {
+    const el = document.querySelector('[role="dialog"]:not([data-cp-palette])')
+    if (!el) return null
+    const kannScrollen = (x) => {
+      const st = getComputedStyle(x)
+      return /(auto|scroll)/.test(st.overflowX) || /(auto|scroll)/.test(st.overflowY)
+    }
+    const raus = []
+    let sichtbar = 0
+    for (const x of el.querySelectorAll('*')) {
+      const r = x.getBoundingClientRect()
+      if (r.width < 4 || r.height < 4) continue
+      sichtbar += 1
+      const p = x.parentElement
+      if (!p || kannScrollen(p)) continue
+      const pr = p.getBoundingClientRect()
+      if (pr.width < 40) continue
+      const ueber = Math.round(Math.max(r.right - pr.right, pr.left - r.left))
+      if (ueber > 2) {
+        raus.push({ ueber, text: (x.textContent || '').trim().slice(0, 24) || x.tagName.toLowerCase() })
+      }
+    }
+    return { sichtbar, raus: raus.sort((a, b) => b.ueber - a.ueber).slice(0, 5) }
+  })
+  await zu()
+  if (!d) continue
+  dialoge += 1
+  // Ein Dialog mit einer Handvoll Elementen ist eine Bestaetigungsfrage und
+  // kein Formular; dort ist nichts zu messen, und ihn mitzuzaehlen wuerde die
+  // Zahl unten aufblaehen.
+  if (d.sichtbar < 12) continue
+  for (const x of d.raus) {
+    console.error(
+      `✗ Dialog „${name}": „${x.text}" ragt ${x.ueber}px aus seinem Rahmen — ` +
+        'nicht sichtbar und nicht anklickbar',
+    )
+    befunde += 1
+  }
+}
+console.log(`${dialoge} Dialog(e) aus der Befehlspalette geprueft`)
+
 await app.close()
 console.log(`UI-Overflow fertig → ${OUT} (${befunde} Befund(e))`)
 process.exit(befunde > 0 ? 1 : 0)

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1611,7 +1611,7 @@ export default function App() {
               {t('common.ok', 'OK')}
             </button>
           </div>
-          <ul className="max-h-40 space-y-0.5 overflow-y-auto text-[11px] text-cp-text-secondary">
+          <ul className="max-h-40 space-y-0.5 overflow-y-auto text-cp-xs text-cp-text-secondary">
             {lastLoadReport.drops.slice(0, 20).map((d, i) => (
               <li key={`${d.kind}-${d.label}-${i}`}>
                 {dropArtLabel(t, d.kind)}
@@ -1621,7 +1621,7 @@ export default function App() {
               </li>
             ))}
           </ul>
-          <div className="mt-2 text-[11px] text-cp-text-muted">
+          <div className="mt-2 text-cp-xs text-cp-text-muted">
             {t(
               'app.loadReport.hint',
               'Devices that pointed at these roles lost their assignment — including the TSL address used for tally. Saving overwrites the file with this state.',
@@ -1654,7 +1654,7 @@ export default function App() {
               {t('common.ok', 'OK')}
             </button>
           </div>
-          <ul className="max-h-40 space-y-0.5 overflow-y-auto text-[11px] text-cp-text-secondary">
+          <ul className="max-h-40 space-y-0.5 overflow-y-auto text-cp-xs text-cp-text-secondary">
             {lastMobileDrop.drops.slice(0, 20).map((d, i) => (
               <li key={`${d.reason}-${d.label}-${i}`}>
                 {t('app.mobileDrop.cable', 'Cable')}
@@ -1670,7 +1670,7 @@ export default function App() {
               </li>
             ))}
           </ul>
-          <div className="mt-2 text-[11px] text-cp-text-muted">
+          <div className="mt-2 text-cp-xs text-cp-text-muted">
             {t(
               'app.mobileDrop.hint',
               'The phone only reported "sent" to the technician — it cannot know about the rejection. Someone out on site may be waiting for a cable that never reaches the plan.',
@@ -1690,9 +1690,9 @@ export default function App() {
             </div>
             <div className="text-cp-xs text-cp-text-secondary">{pdfProgress.phase}</div>
             {pdfProgress.detail && (
-              <div className="mt-1 text-[11px] text-cp-text-muted">{pdfProgress.detail}</div>
+              <div className="mt-1 text-cp-xs text-cp-text-muted">{pdfProgress.detail}</div>
             )}
-            <div className="mt-3 text-[10px] text-cp-text-muted">
+            <div className="mt-3 text-cp-xs text-cp-text-muted">
               {t('app.pdfProgress.hint', 'Large plans may take a few seconds. Please do not cancel.')}
             </div>
           </div>
@@ -1734,13 +1734,13 @@ const PdfExportDialog = ({
               User z.B. nur die Video-Ebene drucken indem er alle
               anderen Chips deaktiviert. */}
           <fieldset className="rounded border border-cp-border p-3">
-            <legend className="px-1 text-[11px] uppercase tracking-wide text-cp-text-muted">
+            <legend className="px-1 text-cp-xs uppercase tracking-wide text-cp-text-muted">
               {t('pdfExport.layers.title', 'Layers (included in PDF)')}
             </legend>
             <div className="-mx-1 flex flex-wrap gap-1">
               <LayerVisibilityChips />
             </div>
-            <p className="mt-2 text-[10px] text-cp-text-muted">
+            <p className="mt-2 text-cp-xs text-cp-text-muted">
               {t(
                 'pdfExport.layers.hint',
                 'Click on a chip to toggle the layer for canvas AND PDF. Example: only print video ⇒ disable all other chips.',
@@ -1748,7 +1748,7 @@ const PdfExportDialog = ({
             </p>
           </fieldset>
           <fieldset className="rounded border border-cp-border p-3">
-            <legend className="px-1 text-[11px] uppercase tracking-wide text-cp-text-muted">
+            <legend className="px-1 text-cp-xs uppercase tracking-wide text-cp-text-muted">
               {t('pdfExport.bg.title', 'Background')}
             </legend>
             <label className="mb-2 flex cursor-pointer items-center gap-2 text-cp-xs text-cp-text-bright">
@@ -1775,7 +1775,7 @@ const PdfExportDialog = ({
               nutzen. Wenn an: Text bleibt im PDF als echter Text,
               keine Pixelung beim Zoom. */}
           <fieldset className="rounded border border-cp-border p-3">
-            <legend className="px-1 text-[11px] uppercase tracking-wide text-cp-text-muted">
+            <legend className="px-1 text-cp-xs uppercase tracking-wide text-cp-text-muted">
               {t('pdfExport.render.title', 'Render mode')}
             </legend>
             <label className="mb-2 flex cursor-pointer items-start gap-2 text-cp-xs text-cp-text-bright">
@@ -1787,7 +1787,7 @@ const PdfExportDialog = ({
               />
               <span>
                 {t('pdfExport.render.raster', 'Raster (classic)')}
-                <span className="block text-[10px] text-cp-text-muted">
+                <span className="block text-cp-xs text-cp-text-muted">
                   {t(
                     'pdfExport.render.rasterHint',
                     'JPEG snapshot of the canvas. Reliable, but blurry at high zoom in the PDF.',
@@ -1804,7 +1804,7 @@ const PdfExportDialog = ({
               />
               <span>
                 {t('pdfExport.render.vector', 'Vector')}
-                <span className="block text-[10px] text-cp-text-muted">
+                <span className="block text-cp-xs text-cp-text-muted">
                   {t(
                     'pdfExport.render.vectorHint',
                     'Chromium printToPDF. Text stays selectable & sharp at any zoom. Smaller file size.',
@@ -2161,7 +2161,7 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
               summary always visible (current routing); expand to change
               device/port on either side. */}
           <details open className="rounded border border-cp-border bg-cp-surface-3/50">
-            <summary className="cursor-pointer select-none px-2 py-1.5 text-[11px] text-cp-text-secondary hover:bg-cp-surface-2/40">
+            <summary className="cursor-pointer select-none px-2 py-1.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-2/40">
               <span className="font-semibold uppercase tracking-wide text-cp-text-muted">Verbindung</span>
               <span className="ml-2 text-cp-text-secondary">
                 {fromDev?.name ?? '?'} · {fromPort?.name ?? cable.fromPortId}
@@ -2172,7 +2172,7 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
             <div className="border-t border-cp-border p-2">
               <div className="grid grid-cols-2 gap-2">
                 <div>
-                  <div className="mb-0.5 text-[10px] text-cp-text-muted">{t('cable.fromDeviceShort', 'From device')}</div>
+                  <div className="mb-0.5 text-cp-xs text-cp-text-muted">{t('cable.fromDeviceShort', 'From device')}</div>
                   <select
                     aria-label={t('cable.aria.fromDevice', 'Source device')}
                     value={fromEquipmentId}
@@ -2185,7 +2185,7 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
                       </option>
                     ))}
                   </select>
-                  <div className="mt-1 text-[10px] text-cp-text-muted">Port</div>
+                  <div className="mt-1 text-cp-xs text-cp-text-muted">Port</div>
                   <select
                     aria-label={t('cable.aria.fromPort', 'Source port')}
                     value={fromPortId}
@@ -2204,7 +2204,7 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
                   </select>
                 </div>
                 <div>
-                  <div className="mb-0.5 text-[10px] text-cp-text-muted">{t('cable.toDeviceShort', 'To device')}</div>
+                  <div className="mb-0.5 text-cp-xs text-cp-text-muted">{t('cable.toDeviceShort', 'To device')}</div>
                   <select
                     aria-label={t('cable.aria.toDevice', 'Target device')}
                     value={toEquipmentId}
@@ -2217,7 +2217,7 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
                       </option>
                     ))}
                   </select>
-                  <div className="mt-1 text-[10px] text-cp-text-muted">Port</div>
+                  <div className="mt-1 text-cp-xs text-cp-text-muted">Port</div>
                   <select
                     aria-label={t('cable.aria.toPort', 'Target port')}
                     value={toPortId}
@@ -2238,19 +2238,19 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
               </div>
 
               {fromConflict && (
-                <div className="mt-2 flex items-center gap-1.5 rounded bg-amber-900/50 px-2 py-1 text-[11px] text-amber-100">
+                <div className="mt-2 flex items-center gap-1.5 rounded bg-amber-900/50 px-2 py-1 text-cp-xs text-amber-100">
                   <Icon icon={AlertTriangle} size="xs" />
                   {format(t('cable.create.warn.fromBusy', 'Source port is already in use by cable "{name}".'), { name: fromConflict.name })}
                 </div>
               )}
               {toConflict && (
-                <div className="mt-1 flex items-center gap-1.5 rounded bg-amber-900/50 px-2 py-1 text-[11px] text-amber-100">
+                <div className="mt-1 flex items-center gap-1.5 rounded bg-amber-900/50 px-2 py-1 text-cp-xs text-amber-100">
                   <Icon icon={AlertTriangle} size="xs" />
                   {format(t('cable.create.warn.toBusy', 'Target port is already in use by cable "{name}".'), { name: toConflict.name })}
                 </div>
               )}
               {sameEndpoints && (
-                <div className="mt-1 flex items-center gap-1.5 rounded bg-red-900/50 px-2 py-1 text-[11px] text-red-100">
+                <div className="mt-1 flex items-center gap-1.5 rounded bg-red-900/50 px-2 py-1 text-cp-xs text-red-100">
                   <Icon icon={AlertTriangle} size="xs" />
                   {t('cable.create.warn.samePort', 'Source and target point to the same port.')}
                 </div>

--- a/src/renderer/components/Analysis/AnalysisDialog.tsx
+++ b/src/renderer/components/Analysis/AnalysisDialog.tsx
@@ -801,11 +801,11 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
                   {format(t('analysis.network.subnetCount', '{n} devices'), { n: s.names.length })}
                 </span>
                 {s.assumed && (
-                  <span className="text-[10px] text-amber-300/80" title={t('analysis.network.subnetAssumedTitle', 'No mask set — /24 assumed')}>
+                  <span className="text-cp-xs text-amber-300/80" title={t('analysis.network.subnetAssumedTitle', 'No mask set — /24 assumed')}>
                     {t('analysis.network.subnetAssumed', '(/24 assumed)')}
                   </span>
                 )}
-                <span className="text-[10px] text-[var(--cp-text-faint)]">
+                <span className="text-cp-xs text-[var(--cp-text-faint)]">
                   {s.names.slice(0, 6).join(', ')}
                   {s.names.length > 6 ? ` +${s.names.length - 6}` : ''}
                 </span>
@@ -847,7 +847,7 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
                   {/* Der Beleg. Wer die Zeile fuer falsch haelt, soll sehen,
                       welcher Port sie ausgeloest hat. */}
                   {r.evidence && (
-                    <span className="text-[10px] text-[var(--cp-text-faint)]">{r.evidence}</span>
+                    <span className="text-cp-xs text-[var(--cp-text-faint)]">{r.evidence}</span>
                   )}
                 </li>
               ))}
@@ -871,7 +871,7 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
               <div className="mb-1 flex items-center justify-between">
                 <span className="text-cp-xs font-medium">{m.switchName}</span>
                 <div className="flex items-center gap-1">
-                  <span className="text-[10px] text-[var(--cp-text-faint)]">
+                  <span className="text-cp-xs text-[var(--cp-text-faint)]">
                     {format(t('analysis.switchPorts.used', '{u} of {n} occupied'), {
                       u: m.usedCount,
                       n: m.rows.length,
@@ -880,7 +880,7 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
                   <button
                     type="button"
                     onClick={() => exportPortMap(m)}
-                    className="inline-flex items-center gap-1 rounded border border-[var(--cp-border)] px-1.5 py-0.5 text-[10px] hover:bg-[var(--cp-surface-2)]"
+                    className="inline-flex items-center gap-1 rounded border border-[var(--cp-border)] px-1.5 py-0.5 text-cp-xs hover:bg-[var(--cp-surface-2)]"
                   >
                     <Icon icon={Download} size="xs" /> CSV
                   </button>
@@ -891,7 +891,7 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
                       'analysis.switchPorts.descHint',
                       'Vendor-neutral text to paste. The plan sends nothing to the switch \u2014 read what you paste.',
                     )}
-                    className="inline-flex items-center gap-1 rounded border border-[var(--cp-border)] px-1.5 py-0.5 text-[10px] hover:bg-[var(--cp-surface-2)]"
+                    className="inline-flex items-center gap-1 rounded border border-[var(--cp-border)] px-1.5 py-0.5 text-cp-xs hover:bg-[var(--cp-surface-2)]"
                   >
                     <Icon icon={Download} size="xs" />{' '}
                     {t('analysis.switchPorts.descriptions', 'Descriptions')}
@@ -906,14 +906,14 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
                       {r.device ?? t('analysis.switchPorts.free', 'free')}
                     </span>
                     {r.nicLabel && (
-                      <span className="text-[10px] text-[var(--cp-text-faint)]">{r.nicLabel}</span>
+                      <span className="text-cp-xs text-[var(--cp-text-faint)]">{r.nicLabel}</span>
                     )}
-                    {r.ipAddress && <span className="font-mono text-[10px]">{r.ipAddress}</span>}
+                    {r.ipAddress && <span className="font-mono text-cp-xs">{r.ipAddress}</span>}
                     {r.vlanId !== undefined && (
-                      <span className="text-[10px] text-[var(--cp-text-muted)]">VLAN {r.vlanId}</span>
+                      <span className="text-cp-xs text-[var(--cp-text-muted)]">VLAN {r.vlanId}</span>
                     )}
                     {r.source && (
-                      <span className="text-[10px] text-[var(--cp-text-faint)]">
+                      <span className="text-cp-xs text-[var(--cp-text-faint)]">
                         {r.source === 'interface'
                           ? t('analysis.switchPorts.fromNic', 'interface')
                           : t('analysis.switchPorts.fromCable', 'cable')}
@@ -975,7 +975,7 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
                   <span className="flex-1 text-amber-300/90">{i.why}</span>
                 )}
                 {i.source && (
-                  <span className="w-full pl-52 text-[10px] text-[var(--cp-text-faint)]">{i.source}</span>
+                  <span className="w-full pl-52 text-cp-xs text-[var(--cp-text-faint)]">{i.source}</span>
                 )}
                 {/* BEDARF 85 — die Antwort direkt an der Frage. Vier Knoepfe, weil
                     „mit Auflage" der haeufigste Ausgang ist und ein Ja/Nein-Kreuz
@@ -986,7 +986,7 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
                       key={st}
                       type="button"
                       onClick={() => setzeAntwort(i.key, st)}
-                      className={`rounded border px-1.5 py-0.5 text-[10px] ${
+                      className={`rounded border px-1.5 py-0.5 text-cp-xs ${
                         antwort?.answered === st || (st === 'pending' && !antwort?.answered)
                           ? 'border-[var(--cp-accent)] text-[var(--cp-accent)]'
                           : 'border-[var(--cp-border)] text-[var(--cp-text-faint)] hover:text-[var(--cp-text)]'
@@ -1000,12 +1000,12 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
                       value={antwort.note ?? ''}
                       onChange={(e) => setzeNotiz(i.key, e.target.value)}
                       placeholder={t('analysis.venue.a.notePh', 'condition or workaround, in plain words')}
-                      className="min-w-0 flex-1 rounded border border-[var(--cp-border)] bg-transparent px-1.5 py-0.5 text-[10px] text-[var(--cp-text)] outline-none placeholder:text-[var(--cp-text-faint)]"
+                      className="min-w-0 flex-1 rounded border border-[var(--cp-border)] bg-transparent px-1.5 py-0.5 text-cp-xs text-[var(--cp-text)] outline-none placeholder:text-[var(--cp-text-faint)]"
                     />
                   )}
                 </span>
                 {antwort?.state === 'elsewhere' && (
-                  <span className="w-full pl-52 text-[10px] text-amber-300/90">
+                  <span className="w-full pl-52 text-cp-xs text-amber-300/90">
                     {format(
                       t(
                         'analysis.venue.a.elsewhereHint',
@@ -1020,7 +1020,7 @@ const NetworkTab = ({ projectName }: { projectName: string }) => {
           })}
         </ul>
         {answerRows.some((r) => r.state === 'stale') && (
-          <div className="mt-2 border-t border-[var(--cp-border-muted)] pt-2 text-[10px] text-[var(--cp-text-faint)]">
+          <div className="mt-2 border-t border-[var(--cp-border-muted)] pt-2 text-cp-xs text-[var(--cp-text-faint)]">
             {t(
               'analysis.venue.a.staleHead',
               'Answers to points the plan no longer raises — knowledge about the venue, not rubbish:',
@@ -1773,7 +1773,7 @@ const RfTab = ({ projectName }: { projectName: string }) => {
             ))}
           </div>
         )}
-        <p className="mt-1.5 text-[10px] text-[var(--cp-text-faint)]">
+        <p className="mt-1.5 text-cp-xs text-[var(--cp-text-faint)]">
           {t('analysis.rf.suggestNote', 'Free of occupancy + 3rd-order intermodulation (0.4 MHz guard); suggestions mutually compatible.')}
         </p>
       </div>
@@ -1831,7 +1831,7 @@ const RfTab = ({ projectName }: { projectName: string }) => {
 
       {/* #344 — Referenz: gängige Hersteller-Frequenzbänder. */}
       <details className="rounded border border-[var(--cp-border-muted)] bg-[var(--cp-surface-3)]">
-        <summary className="cursor-pointer px-3 py-1.5 text-[11px] uppercase tracking-wide text-[var(--cp-text-muted)]">
+        <summary className="cursor-pointer px-3 py-1.5 text-cp-xs uppercase tracking-wide text-[var(--cp-text-muted)]">
           {t('analysis.rf.bandRef', 'Frequency bands (Sennheiser / Shure / …)')} ({RF_BANDS.length})
         </summary>
         <div className="px-3 py-2">
@@ -1852,12 +1852,12 @@ const RfTab = ({ projectName }: { projectName: string }) => {
                   <td className="py-0.5 pr-2 text-[var(--cp-text-muted)]">{b.line}</td>
                   <td className="py-0.5 pr-2 font-mono font-semibold">{b.band}</td>
                   <td className="py-0.5 pr-2 text-right font-mono">{b.fromMHz}–{b.toMHz}</td>
-                  <td className="py-0.5 text-[10px] text-[var(--cp-text-faint)]">{b.note ?? ''}</td>
+                  <td className="py-0.5 text-cp-xs text-[var(--cp-text-faint)]">{b.note ?? ''}</td>
                 </tr>
               ))}
             </tbody>
           </table>
-          <PanelHint className="mt-2 text-[10px] text-[var(--cp-text-faint)]" text={t(
+          <PanelHint className="mt-2 text-cp-xs text-[var(--cp-text-faint)]" text={t(
           'analysis.rf.bandDisclaimer',
           'Common nominal ranges — band letters are series/region dependent. Always verify against the current datasheet and local frequency regulations.',
         )} />
@@ -2896,7 +2896,28 @@ const AnalysisDialogInner = () => {
       titleIcon={<Icon icon={BarChart3} size="md" />}
       title={t('analysis.title', 'Analyses')}
     >
-      <div className="mb-3 flex gap-1 border-b border-[var(--cp-border)]">
+      {/*
+        DREIZEHN REITER IN EINER ZEILE, DIE NICHT UMBRICHT — die letzten drei
+        („Kabelwege", „Signalwege", „Blatt pruefen") lagen VOLLSTAENDIG
+        ausserhalb des Dialogs. Gemessen im echten Fenster: 164 px, 98 px und
+        5 px ueber der rechten Kante, bei 1280x800 wie bei 1500x950. Nicht
+        sichtbar, nicht anklickbar — drei Auswertungen, die es fuer den
+        Nutzer nicht gab.
+
+        Derselbe Defekt wie der, aus dem `scripts/ui-overflow.mjs` entstanden
+        ist („Equipment kann man lesen, Cable schon nicht mehr"), nur eine
+        Ebene tiefer: der Waechter oeffnet keine Dialoge und sah ihn deshalb
+        nicht. Aufgefallen ist er beim Nachmessen der Schriftgroessen — und
+        er ist AELTER als diese Migration, nachgemessen gegen 776ed7c mit
+        identischen Zahlen.
+
+        `flex-wrap` und nicht `overflow-x-auto`: eine waagerecht scrollende
+        Reiterleiste versteckt die hinteren Reiter hinter einer Geste, die
+        niemand sucht. Umbrechen zeigt alle dreizehn, kostet eine zweite
+        Zeile und ist das Muster, das die Bibliothek fuer ihre Chip-Reihen
+        ohnehin schon nutzt.
+      */}
+      <div className="mb-3 flex flex-wrap gap-1 border-b border-[var(--cp-border)]">
         {TABS.map((tb) => (
           <button
             key={tb.id}

--- a/src/renderer/components/Export/ExportDialog.tsx
+++ b/src/renderer/components/Export/ExportDialog.tsx
@@ -328,7 +328,7 @@ const PlanSection = ({
               <Icon icon={opt.icon} size="sm" />
               <span className="flex-1">
                 <span className="block font-semibold text-cp-text">{opt.label}</span>
-                <span className="block text-[10px] text-cp-text-muted">{opt.hint}</span>
+                <span className="block text-cp-xs text-cp-text-muted">{opt.hint}</span>
               </span>
             </label>
           )
@@ -393,7 +393,7 @@ const PlanSection = ({
               />
               <span>
                 <span className="flex items-center gap-1"><Icon icon={Camera} size="xs" /> {t('export.render.raster', 'Raster (classic)')}</span>
-                <span className="block text-[10px] text-cp-text-muted">
+                <span className="block text-cp-xs text-cp-text-muted">
                   {t(
                     'export.render.rasterHint',
                     'JPEG snapshot. Reliable, but text blurs at high zoom in the PDF.',
@@ -411,7 +411,7 @@ const PlanSection = ({
               />
               <span>
                 <span className="flex items-center gap-1"><Icon icon={Sparkles} size="xs" /> {t('export.render.vector', 'Vector')}</span>
-                <span className="block text-[10px] text-cp-text-muted">
+                <span className="block text-cp-xs text-cp-text-muted">
                   {/* ADR-005, Regel 4 — hier standen nur die Vorteile. Der
                       Vektor-Pfad klont das Canvas-DOM und druckt es via
                       Chromium; einen Titelblock baut er nicht. Revision,
@@ -447,7 +447,7 @@ const PlanSection = ({
                 <option value="a0plus">A0+ Plotter (1682×1189 mm)</option>
                 <option value="original">{t('export.page.original', 'Original — full canvas size for plotter')}</option>
               </select>
-              <p className="text-[10px] text-cp-text-muted">
+              <p className="text-cp-xs text-cp-text-muted">
                 {pdfPageSize === 'original'
                   ? t('export.page.originalHint', 'Heads-up: Edge / Preview sometimes display pages above A0 as white. Acrobat + plotter software print them anyway.')
                   : t('export.page.scaleHint', 'Canvas is scaled vectorially to the page size. Text stays sharp.')}
@@ -465,14 +465,14 @@ const PlanSection = ({
             <div className="-mx-1 flex flex-wrap gap-1">
               <LayerVisibilityChips />
             </div>
-            <p className="text-[10px] text-cp-text-muted">
+            <p className="text-cp-xs text-cp-text-muted">
               {t('export.layersHint', 'Click a chip to toggle that layer for canvas AND PDF.')}
             </p>
           </fieldset>
         </>
       )}
 
-      <div className="rounded border border-cp-border-muted bg-cp-surface-3/40 p-2 text-[11px] text-cp-text-muted">
+      <div className="rounded border border-cp-border-muted bg-cp-surface-3/40 p-2 text-cp-xs text-cp-text-muted">
         {t('export.savedAs', 'Saved as')} <code className="rounded bg-cp-surface-2 px-1 py-0.5">{projectName || 'cable-planner'}</code>
       </div>
       </div>
@@ -607,7 +607,7 @@ const PatchSheetSection = ({ onClose }: { onClose: () => void }) => {
         <span className="text-emerald-300">→</span>
       </button>
 
-      <div className="mb-1 text-[11px] text-cp-text-muted">
+      <div className="mb-1 text-cp-xs text-cp-text-muted">
         {t('export.patch.perDeviceHint', '— or create one patch sheet per device:')}
       </div>
 
@@ -619,7 +619,7 @@ const PatchSheetSection = ({ onClose }: { onClose: () => void }) => {
           <button
             type="button"
             onClick={toggleAll}
-            className="rounded bg-cp-surface-2 px-2 py-0.5 text-[10px] hover:bg-cp-surface-4"
+            className="rounded bg-cp-surface-2 px-2 py-0.5 text-cp-xs hover:bg-cp-surface-4"
           >
             {selectedIds.size === filtered.length
               ? t('export.patch.deselectAll', 'Deselect all')
@@ -655,12 +655,12 @@ const PatchSheetSection = ({ onClose }: { onClose: () => void }) => {
                   }}
                 />
                 <span className="flex-1 truncate">{d.name}</span>
-                <span className="text-[10px] text-cp-text-muted">{d.category}</span>
+                <span className="text-cp-xs text-cp-text-muted">{d.category}</span>
               </label>
             )
           })}
           {filtered.length === 0 && (
-            <div className="px-2 py-3 text-center text-[11px] text-cp-text-muted">
+            <div className="px-2 py-3 text-center text-cp-xs text-cp-text-muted">
               {t('export.patch.noDevices', 'No devices in the project.')}
             </div>
           )}
@@ -842,7 +842,7 @@ const RackGroupSection = ({ onClose }: { onClose: () => void }) => {
                 type="button"
                 disabled={busy}
                 onClick={() => void run(p, 'pdf')}
-                className="rounded bg-sky-700 px-2 py-1 text-[11px] font-medium text-white hover:bg-sky-600 disabled:opacity-50"
+                className="rounded bg-sky-700 px-2 py-1 text-cp-xs font-medium text-white hover:bg-sky-600 disabled:opacity-50"
               >
                 {t('export.rack.pdf', 'PDF')}
               </button>
@@ -850,7 +850,7 @@ const RackGroupSection = ({ onClose }: { onClose: () => void }) => {
                 type="button"
                 disabled={busy}
                 onClick={() => void run(p, 'print')}
-                className="rounded bg-cp-surface-4 px-2 py-1 text-[11px] hover:bg-cp-surface-5 disabled:opacity-50"
+                className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5 disabled:opacity-50"
               >
                 <Icon icon={Printer} size="xs" className="mr-1 inline-block align-text-bottom" />
                 {t('export.rack.print', 'Print')}
@@ -1136,7 +1136,7 @@ const BomSection = () => {
       {/* v7.9.4 — Status-Zeile oben (shrink-0), Tabelle nimmt flex-1 mit
           eigenem overflow-auto, Footer + Action-Buttons sind shrink-0
           → bleiben IMMER sichtbar, egal wie groß der Dialog ist. */}
-      <div className="flex shrink-0 flex-wrap items-center gap-2 text-[11px] text-cp-text-muted">
+      <div className="flex shrink-0 flex-wrap items-center gap-2 text-cp-xs text-cp-text-muted">
         <span>
           {t('export.installedCables', 'Installed cables:')}{' '}
           <b className="text-cp-text-bright">{project.cables.length}</b>
@@ -1185,7 +1185,7 @@ const BomSection = () => {
                 <td className="px-3 py-1">
                   <span className="font-medium text-cp-text">{r.type}</span>
                   {r.sample && (
-                    <span className="ml-1 text-[10px] text-cp-text-muted">({r.sample.name})</span>
+                    <span className="ml-1 text-cp-xs text-cp-text-muted">({r.sample.name})</span>
                   )}
                 </td>
                 <td className="px-3 py-1 text-right font-mono">{r.length}</td>
@@ -1240,7 +1240,7 @@ const BomSection = () => {
 
       {/* Per-Gewerk-Zusammenfassung (Anzahl + Meter je Layer). */}
       {layerSummary.length > 0 && (
-        <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-cp-text-muted">
+        <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 text-cp-xs text-cp-text-muted">
           <span className="font-semibold uppercase tracking-wide text-cp-text-faint">
             {t('export.bom.byLayer', 'By discipline')}:
           </span>
@@ -1254,7 +1254,7 @@ const BomSection = () => {
         </div>
       )}
       {connectorSummary.length > 0 && (
-        <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-cp-text-muted">
+        <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 text-cp-xs text-cp-text-muted">
           <span className="font-semibold uppercase tracking-wide text-cp-text-faint">
             {t('export.bom.connectors', 'Connectors (ends)')}:
           </span>
@@ -1267,7 +1267,7 @@ const BomSection = () => {
       )}
 
       {/* Rentman-Planung-Save (shrink-0, pinned). */}
-      <div className="flex shrink-0 items-center justify-between text-[11px]">
+      <div className="flex shrink-0 items-center justify-between text-cp-xs">
         <span className="text-cp-text-muted">
           {draftPlan
             ? t('export.bom.rentmanDirty', 'Unsaved changes to the Rentman plan.')
@@ -1807,7 +1807,7 @@ const DeviceBomSection = () => {
                               typZuweisen(row.typeTargetIds, event.target.value)
                             }
                           }}
-                          className="ml-2 max-w-[14rem] rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-[10px] text-cp-text-secondary"
+                          className="ml-2 max-w-[14rem] rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-cp-xs text-cp-text-secondary"
                           title={t(
                             'export.devicebom.assignTitle',
                             'Writes the catalogue type onto every device in this row. Stock coverage then matches on the catalogue identity instead of the name.',
@@ -1841,7 +1841,7 @@ const DeviceBomSection = () => {
                           onClick={() =>
                             typBestaetigen(row.itemId!, row.deviceTypeId!)
                           }
-                          className="ml-2 rounded border border-cp-border px-1.5 py-0.5 text-[10px] font-normal text-cp-text-secondary hover:bg-cp-surface-3"
+                          className="ml-2 rounded border border-cp-border px-1.5 py-0.5 text-cp-xs font-normal text-cp-text-secondary hover:bg-cp-surface-3"
                           title={t(
                             'export.devicebom.confirmTitle',
                             'Writes the catalogue identity permanently onto this inventory position. The coverage is then a fact and never has to be guessed from the name again.',

--- a/src/renderer/components/Library/CableLibraryPanel.tsx
+++ b/src/renderer/components/Library/CableLibraryPanel.tsx
@@ -157,7 +157,7 @@ const CableTypeEditor = ({
               className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-text"
             />
             {conflictsWithExisting && (
-              <span className="mt-0.5 flex items-center gap-1 text-[10px] text-amber-400">
+              <span className="mt-0.5 flex items-center gap-1 text-cp-xs text-amber-400">
                 <Icon icon={AlertTriangle} size="xs" className="shrink-0" />
                 {t('cableLib.nameExists', 'Name already exists — saving overwrites the existing entry.')}
               </span>
@@ -176,7 +176,7 @@ const CableTypeEditor = ({
                       setConnectorType(n as ConnectorType)
                     }
                   }}
-                  className="rounded bg-emerald-700 px-1.5 text-[11px] text-emerald-100 hover:bg-emerald-600"
+                  className="rounded bg-emerald-700 px-1.5 text-cp-xs text-emerald-100 hover:bg-emerald-600"
                   title={t('cableLib.addConnectorTitle', 'Add new connector type')}
                 >
                   +
@@ -219,7 +219,7 @@ const CableTypeEditor = ({
                         on ? prev.filter((x) => x !== c) : [...prev, c],
                       )
                     }
-                    className={`rounded px-1.5 py-0.5 text-[10px] ${
+                    className={`rounded px-1.5 py-0.5 text-cp-xs ${
                       on
                         ? 'bg-emerald-700 text-white'
                         : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
@@ -243,7 +243,7 @@ const CableTypeEditor = ({
                     setStandards((prev) => [...prev, n as SignalStandard])
                   }
                 }}
-                className="rounded bg-sky-700 px-1.5 text-[11px] text-sky-100 hover:bg-sky-600"
+                className="rounded bg-sky-700 px-1.5 text-cp-xs text-sky-100 hover:bg-sky-600"
                 title={t('cableLib.addSignalStandardTitle', 'Add new signal standard')}
               >
                 {t('cableLib.addStandard', '+ Standard')}
@@ -261,7 +261,7 @@ const CableTypeEditor = ({
                         on ? prev.filter((x) => x !== s) : [...prev, s],
                       )
                     }
-                    className={`rounded px-1.5 py-0.5 text-[10px] ${
+                    className={`rounded px-1.5 py-0.5 text-cp-xs ${
                       on
                         ? 'bg-sky-700 text-white'
                         : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
@@ -273,7 +273,7 @@ const CableTypeEditor = ({
               })}
             </div>
             {standards.length === 0 && (
-              <span className="mt-0.5 block text-[10px] text-red-400">
+              <span className="mt-0.5 block text-cp-xs text-red-400">
                 {t('cableLib.pickAtLeastOneStandard', 'Select at least one standard.')}
               </span>
             )}
@@ -518,18 +518,18 @@ export const CableLibraryPanel = () => {
       <div className="mb-2 flex flex-wrap items-center justify-between gap-y-1 gap-x-2">
         <div className="flex items-center gap-2">
           <h2 className="text-cp-base font-semibold">{t('cableLib.title', 'Cable library')}</h2>
-          <span className="text-[10px] text-cp-text-muted">{format(t('cableLib.installedCount', '{n} installed'), { n: cables.length })}</span>
+          <span className="text-cp-xs text-cp-text-muted">{format(t('cableLib.installedCount', '{n} installed'), { n: cables.length })}</span>
         </div>
         <button
           type="button"
           onClick={() => setEditing(undefined)}
-          className="rounded bg-emerald-700 px-2 py-1 text-[11px] text-white hover:bg-emerald-600"
+          className="rounded bg-emerald-700 px-2 py-1 text-cp-xs text-white hover:bg-emerald-600"
           title={t('cableLib.newSpecTitle', 'Create new cable type (custom library preset)')}
         >
           {t('cableLib.newSpec', '+ New cable type')}
         </button>
       </div>
-      <p className="mb-2 text-[11px] text-cp-text-muted">
+      <p className="mb-2 text-cp-xs text-cp-text-muted">
         {t('cableLib.presetsInfo', 'Presets with connector and signal info.')}
         {customCableSpecs.length > 0 && (
           <> {format(
@@ -561,9 +561,9 @@ export const CableLibraryPanel = () => {
               >
                 <span className="flex items-center gap-1.5">
                   {group}
-                  <span className="text-[10px] font-normal text-cp-text-muted">({specs.length})</span>
+                  <span className="text-cp-xs font-normal text-cp-text-muted">({specs.length})</span>
                   {groupBuilt > 0 && (
-                    <span className={`rounded px-1.5 py-0.5 text-[11px] font-bold ${
+                    <span className={`rounded px-1.5 py-0.5 text-cp-xs font-bold ${
                       groupPlanned > 0
                         ? groupBuilt >= groupPlanned
                           ? 'bg-emerald-900/60 text-emerald-300'
@@ -608,7 +608,7 @@ export const CableLibraryPanel = () => {
                           <span className="font-medium flex-1">{cable.name}</span>
                           {isCustom && (
                             <span
-                              className="rounded bg-violet-700/80 px-1 text-[11px] font-semibold uppercase text-violet-100"
+                              className="rounded bg-violet-700/80 px-1 text-cp-xs font-semibold uppercase text-violet-100"
                               title={t('cableLib.customBadge', 'Custom cable type (created locally)')}
                             >
                               {t('cableLib.customBadgeLabel', 'Custom')}
@@ -616,19 +616,19 @@ export const CableLibraryPanel = () => {
                           )}
                           {!isCustom && cableSpecOverrides[cable.id] && (
                             <span
-                              className="rounded bg-amber-700/70 px-1 text-[11px] font-semibold uppercase text-amber-100"
+                              className="rounded bg-amber-700/70 px-1 text-cp-xs font-semibold uppercase text-amber-100"
                               title={t('cableLib.overrideBadge', 'Built-in spec with local override (reset via edit dialog)')}
                             >
                               {t('cableLib.overrideBadgeLabel', 'Modified')}
                             </span>
                           )}
                           {isRecommended && (
-                            <span className="rounded bg-emerald-600 px-1 text-[11px] font-semibold uppercase text-white">
+                            <span className="rounded bg-emerald-600 px-1 text-cp-xs font-semibold uppercase text-white">
                               ✓
                             </span>
                           )}
                           {hasCount && (
-                            <span className={`rounded px-1.5 py-0.5 text-[11px] font-bold tabular-nums ${
+                            <span className={`rounded px-1.5 py-0.5 text-cp-xs font-bold tabular-nums ${
                               planned > 0
                                 ? built >= planned
                                   ? 'bg-emerald-900/60 text-emerald-300'
@@ -643,7 +643,7 @@ export const CableLibraryPanel = () => {
                           <button
                             type="button"
                             onClick={() => setEditing(cable)}
-                            className="rounded bg-cp-surface-4 px-1.5 py-0.5 text-[10px] text-cp-text-bright hover:bg-cp-surface-5"
+                            className="rounded bg-cp-surface-4 px-1.5 py-0.5 text-cp-xs text-cp-text-bright hover:bg-cp-surface-5"
                             title={isCustom
                               ? t('cableLib.edit', 'Edit cable type')
                               : t('cableLib.editOverride', 'Adjust cable type locally (override)')}
@@ -672,7 +672,7 @@ export const CableLibraryPanel = () => {
                                 )
                                 if (ok) clearCableSpecOverride(cable.id)
                               }}
-                              className="rounded bg-amber-800/70 px-1.5 py-0.5 text-[10px] text-amber-100 hover:bg-amber-700"
+                              className="rounded bg-amber-800/70 px-1.5 py-0.5 text-cp-xs text-amber-100 hover:bg-amber-700"
                               title={t('cableLib.removeOverride', 'Remove override (reset to default)')}
                             >
                               ↺
@@ -707,25 +707,25 @@ export const CableLibraryPanel = () => {
                                 )
                                 if (ok) removeCustomCableSpec(cable.id)
                               }}
-                              className="rounded bg-red-900/60 px-1.5 py-0.5 text-[10px] text-red-200 hover:bg-red-800"
+                              className="rounded bg-red-900/60 px-1.5 py-0.5 text-cp-xs text-red-200 hover:bg-red-800"
                               title={t('cableLib.deleteSpec', 'Delete cable type')}
                             >
                               <Icon icon={X} size="sm" />
                             </button>
                           )}
                         </div>
-                        <div className="mt-0.5 text-[11px] text-cp-text-muted">
+                        <div className="mt-0.5 text-cp-xs text-cp-text-muted">
                           {cable.connectorType}
                           {cable.compatibleConnectors?.length
                             ? ` (+ ${cable.compatibleConnectors.join(', ')})`
                             : ''}
                           {cable.maxLengthMeters ? ` · max ${cable.maxLengthMeters} m` : ''}
                         </div>
-                        <div className="text-[11px] text-cp-text-muted">
+                        <div className="text-cp-xs text-cp-text-muted">
                           {cable.standards.join(' · ')}
                         </div>
                         {cable.notes && (
-                          <div className="mt-1 rounded bg-cp-surface-1 p-1 text-[10px] italic text-cp-text-secondary">
+                          <div className="mt-1 rounded bg-cp-surface-1 p-1 text-cp-xs italic text-cp-text-secondary">
                             {cable.notes}
                           </div>
                         )}

--- a/src/renderer/components/Library/tabs/RentmanTab.tsx
+++ b/src/renderer/components/Library/tabs/RentmanTab.tsx
@@ -227,13 +227,13 @@ export const RentmanTab = () => {
     <div className="flex flex-1 min-h-0 flex-col gap-3 overflow-auto">
       {linkedRentmanProjectId ? (
         <div className="rounded border border-orange-600/60 bg-orange-900/20 p-2">
-          <div className="text-[10px] uppercase tracking-wider text-orange-300/80">
+          <div className="text-cp-xs uppercase tracking-wider text-orange-300/80">
             {t('library.rentman.currentLinkedProject', 'Currently linked Rentman project')}
           </div>
           <div className="mt-0.5 truncate text-cp-base font-semibold text-orange-200">
             {linkedRentmanProjectName ?? format(t('library.rentman.projectFallback', 'Project #{id}'), { id: linkedRentmanProjectId })}
           </div>
-          <div className="mt-1 flex flex-wrap gap-1 text-[10px] text-orange-100/80">
+          <div className="mt-1 flex flex-wrap gap-1 text-cp-xs text-orange-100/80">
             <span className="rounded bg-orange-950/50 px-1.5 py-0.5">{format(t('library.rentman.statImported', '{n} imported'), { n: linkedImportedCount })}</span>
             <span className="rounded bg-orange-950/50 px-1.5 py-0.5">{format(t('library.rentman.statNoId', '{n} without Rentman ID'), { n: untracked.length })}</span>
             {removed.length > 0 && (
@@ -274,7 +274,7 @@ export const RentmanTab = () => {
                     )
                   }
                 }}
-                className="mt-2 w-full rounded bg-orange-700/60 px-2 py-1 text-[11px] text-orange-100 hover:bg-orange-700"
+                className="mt-2 w-full rounded bg-orange-700/60 px-2 py-1 text-cp-xs text-orange-100 hover:bg-orange-700"
                 title={format(t('library.rentman.resyncTitle', '{n} Rentman devices on the canvas are not linked to library templates. Click to reconstruct the missing templates from the canvas data.'), { n: missing })}
               >
                 🔄 {format(t('library.rentman.resyncAction', 'Rebuild {n} missing library entries'), { n: missing })}
@@ -296,7 +296,7 @@ export const RentmanTab = () => {
         </div>
       )}
 
-      <div className="grid grid-cols-1 sm:grid-cols-3 rounded border border-cp-border-muted bg-cp-surface-1 p-0.5 text-[11px]">
+      <div className="grid grid-cols-1 sm:grid-cols-3 rounded border border-cp-border-muted bg-cp-surface-1 p-0.5 text-cp-xs">
         {([
           ['imported', t('library.rentman.view.imported', 'Imported')],
           ['catalog', t('library.rentman.view.catalog', 'Catalog')],
@@ -321,7 +321,7 @@ export const RentmanTab = () => {
         <div>
           <div className="mb-2 flex flex-wrap items-center justify-between gap-1">
             <h2 className="text-cp-base font-semibold">{t('library.rentman.imported', 'Imported Rentman devices')}</h2>
-            <div className="flex items-center gap-2 text-[10px] text-cp-text-muted">
+            <div className="flex items-center gap-2 text-cp-xs text-cp-text-muted">
               {(() => {
                 const projectIds = new Set(projectGroups.map((group) => group.id))
                 const categoryKeys = new Set<string>()
@@ -453,16 +453,16 @@ export const RentmanTab = () => {
                         <span className="flex min-w-0 items-center gap-1.5">
                           <span className="text-cp-xs">{projectCollapsed ? '▶' : '▼'}</span>
                           {isLinked && (
-                            <span className="rounded bg-orange-700 px-1 text-[11px] font-bold text-white">AKTIV</span>
+                            <span className="rounded bg-orange-700 px-1 text-cp-xs font-bold text-white">AKTIV</span>
                           )}
                           <span className="truncate text-cp-xs font-semibold">{group.name}</span>
                         </span>
-                        <span className="text-[10px] text-cp-text-muted">{format(t('library.rentman.devicesCount', '{n} devices'), { n: group.items.length })}</span>
+                        <span className="text-cp-xs text-cp-text-muted">{format(t('library.rentman.devicesCount', '{n} devices'), { n: group.items.length })}</span>
                       </button>
                       {!projectCollapsed && (
                         <div className="space-y-1 border-t border-cp-border-muted px-1 py-1">
                           {categories.length === 0 ? (
-                            <div className="px-2 py-1 text-[11px] italic text-cp-text-muted">{t('library.rentman.noneInCategory', 'No devices imported.')}</div>
+                            <div className="px-2 py-1 text-cp-xs italic text-cp-text-muted">{t('library.rentman.noneInCategory', 'No devices imported.')}</div>
                           ) : (
                             categories.map((category) => {
                               const categoryKey = `${group.id}::${category}`
@@ -473,7 +473,7 @@ export const RentmanTab = () => {
                                   <button
                                     type="button"
                                     onClick={() => toggleRentmanCat(categoryKey)}
-                                    className="flex w-full items-center justify-between gap-1 px-2 py-1 text-left text-[11px] font-semibold uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright"
+                                    className="flex w-full items-center justify-between gap-1 px-2 py-1 text-left text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright"
                                   >
                                     <span className="flex items-center gap-1">
                                       <span>{categoryCollapsed ? '▶' : '▼'}</span>
@@ -560,14 +560,14 @@ export const RentmanTab = () => {
               <span className="text-cp-xs">{rentmanCatalogCollapsed ? '▶' : '▼'}</span>
               <span>{t('library.rentman.accountAll', 'All Rentman equipment (account catalog)')}</span>
               {rentmanCatalogLoaded && (
-                <span className="ml-1 rounded-full bg-cp-surface-2 px-1.5 text-[10px] text-cp-text-muted">{rentmanCatalog.length}</span>
+                <span className="ml-1 rounded-full bg-cp-surface-2 px-1.5 text-cp-xs text-cp-text-muted">{rentmanCatalog.length}</span>
               )}
             </button>
             <button
               type="button"
               onClick={fetchRentmanCatalog}
               disabled={rentmanCatalogLoading}
-              className="rounded bg-orange-700 px-2 py-0.5 text-[11px] font-semibold text-white hover:bg-orange-600 disabled:opacity-50"
+              className="rounded bg-orange-700 px-2 py-0.5 text-cp-xs font-semibold text-white hover:bg-orange-600 disabled:opacity-50"
             >
               {rentmanCatalogLoading
                 ? '…'
@@ -580,10 +580,10 @@ export const RentmanTab = () => {
           {!rentmanCatalogCollapsed && (
             <>
               {rentmanCatalogError && (
-                <div className="mb-2 rounded border border-red-700/60 bg-red-900/30 px-2 py-1 text-[11px] text-red-200">{rentmanCatalogError}</div>
+                <div className="mb-2 rounded border border-red-700/60 bg-red-900/30 px-2 py-1 text-cp-xs text-red-200">{rentmanCatalogError}</div>
               )}
               {!rentmanCatalogLoaded && !rentmanCatalogLoading && !rentmanCatalogError && (
-                <div className="rounded border border-cp-border/60 bg-cp-surface-1/40 p-2 text-center text-[11px] text-cp-text-muted">
+                <div className="rounded border border-cp-border/60 bg-cp-surface-1/40 p-2 text-center text-cp-xs text-cp-text-muted">
                   {t(
                     'library.rentman.catalogNotLoaded',
                     'Not loaded yet. Click “Load catalog” to show your account’s entire Rentman catalog.',
@@ -614,7 +614,7 @@ export const RentmanTab = () => {
                       )
                     if (filtered.length === 0) {
                       return (
-                        <div className="rounded border border-emerald-700/40 bg-emerald-900/10 p-2 text-center text-[11px] text-emerald-300">
+                        <div className="rounded border border-emerald-700/40 bg-emerald-900/10 p-2 text-center text-cp-xs text-emerald-300">
                           {t('library.rentman.allImported', '✓ All available Rentman devices are already imported.')}
                         </div>
                       )
@@ -642,14 +642,14 @@ export const RentmanTab = () => {
                         >
                           <div className="min-w-0 flex-1">
                             <div className="truncate font-medium text-cp-text-bright">{item.name}</div>
-                            <div className="truncate text-[10px] text-cp-text-muted">{format(t('library.rentman.idLine', 'Rentman ID {id}'), { id: item.id })}</div>
+                            <div className="truncate text-cp-xs text-cp-text-muted">{format(t('library.rentman.idLine', 'Rentman ID {id}'), { id: item.id })}</div>
                           </div>
                           {linkedRentmanProjectId && (
                             <button
                               type="button"
                               onClick={() => handleAddCatalogItemToProject(item)}
                               disabled={busy}
-                              className="rounded bg-orange-700 px-2 py-0.5 text-[10px] font-semibold text-white hover:bg-orange-600 disabled:opacity-50"
+                              className="rounded bg-orange-700 px-2 py-0.5 text-cp-xs font-semibold text-white hover:bg-orange-600 disabled:opacity-50"
                             >
                               {busy ? '…' : t('library.rentman.addToProject', '+ Project')}
                             </button>
@@ -720,7 +720,7 @@ export const RentmanTab = () => {
                           <button
                             type="button"
                             onClick={() => toggleFolder(folderId)}
-                            className="flex w-full items-center justify-between gap-1 px-2 py-1 text-left text-[11px] font-semibold uppercase tracking-wide text-cp-text-secondary hover:text-cp-text"
+                            className="flex w-full items-center justify-between gap-1 px-2 py-1 text-left text-cp-xs font-semibold uppercase tracking-wide text-cp-text-secondary hover:text-cp-text"
                             style={{ paddingLeft: `${0.5 + depth * 0.75}rem` }}
                           >
                             <span className="flex items-center gap-1">
@@ -754,7 +754,7 @@ export const RentmanTab = () => {
                         {rootFolderIds.map((id) => renderFolder(id, 0))}
                         {orphans.length > 0 && (
                           <div className="rounded border border-cp-border-muted/80">
-                            <div className="px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-cp-text-muted">
+                            <div className="px-2 py-1 text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">
                               {t('library.rentman.noFolder', 'No folder')} <span className="font-normal text-cp-text-dim">({orphans.length})</span>
                             </div>
                             <div className="space-y-1 px-2 pb-1">{orphans.map(renderItem)}</div>
@@ -774,7 +774,7 @@ export const RentmanTab = () => {
         <div>
           <div className="mb-2 flex items-center justify-between">
             <h2 className="text-cp-base font-semibold text-amber-300">{t('library.rentman.reconcile', 'Reconcile canvas ↔ Rentman')}</h2>
-            <span className="text-[10px] text-cp-text-muted">{format(t('library.rentman.notTracked', '{n} not tracked'), { n: untracked.length })}</span>
+            <span className="text-cp-xs text-cp-text-muted">{format(t('library.rentman.notTracked', '{n} not tracked'), { n: untracked.length })}</span>
           </div>
           {/* v7.9.128 — Auch im Sync-View ein prominenter Fetch-Knopf. */}
           {linkedRentmanProjectId && (
@@ -789,14 +789,14 @@ export const RentmanTab = () => {
           )}
           {removed.length > 0 && (
             <div className="mb-2 space-y-1">
-              <div className="mb-1 text-[10px] text-red-400">{t('library.rentman.removed', 'No longer in Rentman:')}</div>
+              <div className="mb-1 text-cp-xs text-red-400">{t('library.rentman.removed', 'No longer in Rentman:')}</div>
               {removed.map((equipment) => (
                 <div key={equipment.id} className="flex items-center justify-between rounded border border-red-700/50 bg-red-900/20 px-2 py-1 text-cp-xs">
                   <div>
                     <span className="font-medium text-cp-text">{equipment.name}</span>
-                    <span className="ml-1 text-[10px] text-cp-text-muted">{equipment.category}</span>
+                    <span className="ml-1 text-cp-xs text-cp-text-muted">{equipment.category}</span>
                   </div>
-                  <span className="text-[10px] text-red-400">{t('library.rentman.removedTag', 'removed')}</span>
+                  <span className="text-cp-xs text-red-400">{t('library.rentman.removedTag', 'removed')}</span>
                 </div>
               ))}
             </div>
@@ -811,9 +811,9 @@ export const RentmanTab = () => {
                 <div key={equipment.id} className="flex items-center justify-between rounded border border-amber-700/30 bg-amber-900/10 px-2 py-1 text-cp-xs">
                   <div>
                     <span className="font-medium text-cp-text">{equipment.name}</span>
-                    <span className="ml-1 text-[10px] text-cp-text-muted">{equipment.category}</span>
+                    <span className="ml-1 text-cp-xs text-cp-text-muted">{equipment.category}</span>
                   </div>
-                  <span className="text-[10px] text-amber-500">{t('library.rentman.noIdTag', 'no Rentman ID')}</span>
+                  <span className="text-cp-xs text-amber-500">{t('library.rentman.noIdTag', 'no Rentman ID')}</span>
                 </div>
               ))}
             </div>

--- a/src/renderer/components/MobileShare/MobileShareDialog.tsx
+++ b/src/renderer/components/MobileShare/MobileShareDialog.tsx
@@ -283,20 +283,20 @@ export const MobileShareDialog = () => {
                   <div className="h-[240px] w-[240px] animate-pulse rounded bg-cp-surface-2" />
                 )}
                 <div className="w-full">
-                  <div className="text-[10px] uppercase tracking-wide text-emerald-300">
+                  <div className="text-cp-xs uppercase tracking-wide text-emerald-300">
                     {t('mobile.dialog.activeUrl', 'Active URL')}
                   </div>
                   <div className="flex items-center gap-1">
                     <input
                       readOnly
                       value={selectedUrl}
-                      className="flex-1 rounded border border-cp-border bg-cp-surface-3 px-2 py-1 font-mono text-[11px] text-cp-text"
+                      className="flex-1 rounded border border-cp-border bg-cp-surface-3 px-2 py-1 font-mono text-cp-xs text-cp-text"
                       onFocus={(e) => e.target.select()}
                     />
                     <button
                       type="button"
                       onClick={() => void copyUrl()}
-                      className="rounded bg-cp-surface-4 px-2 py-1 text-[10px] hover:bg-cp-surface-5"
+                      className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
                       title={t('mobile.dialog.copyToClipboard', 'Copy to clipboard')}
                     >
                       <Icon icon={copied ? Check : Clipboard} size="xs" />
@@ -314,26 +314,26 @@ export const MobileShareDialog = () => {
                   ein Feed, der nichts traegt, liest sich als „hat frei". */}
               {crewFeedUrl && (
                 <div className="w-full">
-                  <div className="text-[10px] uppercase tracking-wide text-sky-300">
+                  <div className="text-cp-xs uppercase tracking-wide text-sky-300">
                     {t('mobile.dialog.crewFeed', 'Subscribe to the crew calendar')}
                   </div>
                   <div className="flex items-center gap-1">
                     <input
                       readOnly
                       value={crewFeedUrl}
-                      className="flex-1 rounded border border-cp-border bg-cp-surface-3 px-2 py-1 font-mono text-[11px] text-cp-text"
+                      className="flex-1 rounded border border-cp-border bg-cp-surface-3 px-2 py-1 font-mono text-cp-xs text-cp-text"
                       onFocus={(e) => e.target.select()}
                     />
                     <button
                       type="button"
                       onClick={() => void navigator.clipboard?.writeText(crewFeedUrl)}
-                      className="rounded bg-cp-surface-4 px-2 py-1 text-[10px] hover:bg-cp-surface-5"
+                      className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
                       title={t('mobile.dialog.copyToClipboard', 'Copy to clipboard')}
                     >
                       <Icon icon={Clipboard} size="xs" />
                     </button>
                   </div>
-                  <div className="mt-0.5 text-[10px] text-cp-text-muted">
+                  <div className="mt-0.5 text-cp-xs text-cp-text-muted">
                     {t(
                       'mobile.dialog.crewFeedHint',
                       'Add it to your calendar as a subscription — it fetches the current state instead of going stale.',
@@ -343,7 +343,7 @@ export const MobileShareDialog = () => {
               )}
               {status.urls.length > 1 && (
                 <div>
-                  <div className="mb-1 text-[10px] uppercase tracking-wide text-cp-text-muted">
+                  <div className="mb-1 text-cp-xs uppercase tracking-wide text-cp-text-muted">
                     {t('mobile.dialog.altUrls', 'Alternative LAN addresses (in case one is unreachable)')}
                   </div>
                   <div className="flex flex-wrap gap-1">
@@ -352,7 +352,7 @@ export const MobileShareDialog = () => {
                         key={u}
                         type="button"
                         onClick={() => setSelectedUrl(u)}
-                        className={`rounded border px-2 py-0.5 text-[10px] font-mono ${
+                        className={`rounded border px-2 py-0.5 text-cp-xs font-mono ${
                           u === selectedUrl
                             ? 'border-sky-500 bg-sky-900 text-white'
                             : 'border-cp-border bg-cp-surface-1 text-cp-text-secondary hover:border-sky-700'
@@ -377,34 +377,34 @@ export const MobileShareDialog = () => {
                   liest dabei, was er tut. */}
               {status.withheld.length > 0 && (
                 <div className="rounded border border-amber-700 bg-amber-950/40 p-2">
-                  <div className="mb-1 text-[10px] uppercase tracking-wide text-amber-300">
+                  <div className="mb-1 text-cp-xs uppercase tracking-wide text-amber-300">
                     {t('mobile.dialog.withheldTitle', 'Not shared')}
                   </div>
                   <div className="mb-1 flex flex-wrap gap-1">
                     {status.withheld.map((w) => (
                       <span
                         key={w.address}
-                        className="rounded border border-amber-700 bg-cp-surface-1 px-2 py-0.5 font-mono text-[10px] text-amber-200"
+                        className="rounded border border-amber-700 bg-cp-surface-1 px-2 py-0.5 font-mono text-cp-xs text-amber-200"
                       >
                         {w.address}
                       </span>
                     ))}
                   </div>
-                  <p className="text-[11px] leading-snug text-cp-text-secondary">
+                  <p className="text-cp-xs leading-snug text-cp-text-secondary">
                     {status.withheld[0].reason}
                   </p>
                   <button
                     type="button"
                     disabled={busy}
                     onClick={() => void handleAllowBeyondLan()}
-                    className="mt-1 rounded border border-amber-600 px-2 py-0.5 text-[10px] text-amber-200 hover:bg-amber-900/60"
+                    className="mt-1 rounded border border-amber-600 px-2 py-0.5 text-cp-xs text-amber-200 hover:bg-amber-900/60"
                   >
                     {t('mobile.dialog.allowBeyondLan', 'Share anyway (this session only)')}
                   </button>
                 </div>
               )}
               <div className="flex items-center justify-between">
-                <span className="text-[11px] text-cp-text-muted">
+                <span className="text-cp-xs text-cp-text-muted">
                   {t('mobile.dialog.portLabel', 'Port')} {status.port} ·{' '}
                   {status.hasProject ? (
                     <span className="text-emerald-300">{t('mobile.dialog.projectSynced', 'Project synced')}</span>
@@ -464,7 +464,7 @@ export const MobileShareDialog = () => {
                 </label>
               ))}
             </div>
-            <p className="text-[11px] text-cp-text-muted">
+            <p className="text-cp-xs text-cp-text-muted">
               {writeMode === 'read-only'
                 ? t(
                     'mobile.dialog.writeMode.readHint',
@@ -498,7 +498,7 @@ export const MobileShareDialog = () => {
               {t('mobile.dialog.pincode', 'Make system access codes retrievable')}
             </label>
             {codes.length === 0 ? (
-              <p className="text-[11px] text-cp-text-muted">
+              <p className="text-cp-xs text-cp-text-muted">
                 {t(
                   'mobile.dialog.pincode.none',
                   'This project carries no intercom configuration with access codes.',
@@ -506,7 +506,7 @@ export const MobileShareDialog = () => {
               </p>
             ) : pinAn && pinToken ? (
               <>
-                <p className="text-[11px] text-cp-text-muted">
+                <p className="text-cp-xs text-cp-text-muted">
                   {t(
                     'mobile.dialog.pincode.hint',
                     'Type this code on the phone. It is NOT part of the QR code — whoever only has the link cannot reach the access data.',
@@ -515,7 +515,7 @@ export const MobileShareDialog = () => {
                 <code className="select-all rounded bg-cp-surface-2 px-2 py-1 font-mono text-cp-base tracking-widest text-cp-text">
                   {pinToken}
                 </code>
-                <p className="text-[11px] text-cp-text-muted">
+                <p className="text-cp-xs text-cp-text-muted">
                   {format(
                     t(
                       'mobile.dialog.pincode.count',
@@ -526,7 +526,7 @@ export const MobileShareDialog = () => {
                 </p>
               </>
             ) : (
-              <p className="text-[11px] text-cp-text-muted">
+              <p className="text-cp-xs text-cp-text-muted">
                 {format(
                   t(
                     'mobile.dialog.pincode.offHint',
@@ -538,7 +538,7 @@ export const MobileShareDialog = () => {
             )}
           </div>
 
-          <details className="text-[11px] text-cp-text-muted">
+          <details className="text-cp-xs text-cp-text-muted">
             <summary className="cursor-pointer hover:text-cp-text-secondary">{t('mobile.dialog.securityHeading', 'Security notes')}</summary>
             <ul className="mt-1 list-inside list-disc space-y-1">
               <li>{t('mobile.dialog.security.writeBack', 'Whether the phone may write back is decided by the setting above. If it is set to \u201csend checks and cables back\u201d, anyone with the QR code can change the plan.')}</li>

--- a/src/renderer/components/Properties/PortList.tsx
+++ b/src/renderer/components/Properties/PortList.tsx
@@ -90,7 +90,7 @@ const SortablePortItem = ({ port, children }: SortablePortItemProps) => {
       <div className="flex items-start gap-2">
         <button
           type="button"
-          className="mt-1 cursor-grab rounded border border-cp-border bg-cp-surface-3 px-1.5 py-1 text-[11px] text-cp-text-muted hover:bg-cp-surface-1 active:cursor-grabbing"
+          className="mt-1 cursor-grab rounded border border-cp-border bg-cp-surface-3 px-1.5 py-1 text-cp-xs text-cp-text-muted hover:bg-cp-surface-1 active:cursor-grabbing"
           title={t('ports.dragHandle', 'Reorder port')}
           aria-label={format(t('ports.reorderAria', 'Reorder: {name}'), { name: port.name })}
           {...attributes}
@@ -137,11 +137,11 @@ const CollapsibleSdiCaps = ({
       onToggle={(e) => setOpen(e.currentTarget.open)}
       className="mt-1 rounded border border-amber-900/60 bg-amber-950/20 [&_summary]:cursor-pointer"
     >
-      <summary className="flex items-center gap-1 p-1.5 text-[10px] font-semibold uppercase tracking-wide text-amber-300 hover:text-amber-200 [&::-webkit-details-marker]:hidden">
+      <summary className="flex items-center gap-1 p-1.5 text-cp-xs font-semibold uppercase tracking-wide text-amber-300 hover:text-amber-200 [&::-webkit-details-marker]:hidden">
         <span className="text-amber-400/70">{open ? '▾' : '▸'}</span>
         <span className="flex-1">{t('ports.sdi.caps', 'SDI capabilities (port-specific)')}</span>
         {!open && badge && (
-          <span className="rounded bg-amber-900/50 px-1 text-[11px] normal-case text-amber-200">
+          <span className="rounded bg-amber-900/50 px-1 text-cp-xs normal-case text-amber-200">
             {badge}
           </span>
         )}
@@ -491,14 +491,14 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
         <button
           type="button"
           onClick={addPort}
-          className="rounded bg-cp-surface-4 px-2 py-0.5 text-[11px] hover:bg-cp-surface-5"
+          className="rounded bg-cp-surface-4 px-2 py-0.5 text-cp-xs hover:bg-cp-surface-5"
         >
           {t('ports.add', '+ Port')}
         </button>
       </div>
-      {ports.length === 0 && <div className="text-[11px] text-cp-text-muted">{t('ports.none', 'None')}</div>}
+      {ports.length === 0 && <div className="text-cp-xs text-cp-text-muted">{t('ports.none', 'None')}</div>}
       {duplicatePortNumbers.length > 0 && (
-        <div className="mb-2 rounded border border-amber-700 bg-amber-950/40 px-2 py-1 text-[11px] text-amber-200">
+        <div className="mb-2 rounded border border-amber-700 bg-amber-950/40 px-2 py-1 text-cp-xs text-amber-200">
           {format(t('ports.duplicateNumbers', 'Duplicate port numbers: {nums} — ambiguous for labels / patch list.'), {
             nums: duplicatePortNumbers.join(', '),
           })}
@@ -536,7 +536,7 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                   type="button"
                   onClick={() => removePort(port.id)}
                   aria-label={t('ports.remove', 'Remove port')}
-                  className="rounded bg-red-900/60 px-2 py-1 text-[11px] hover:bg-red-800"
+                  className="rounded bg-red-900/60 px-2 py-1 text-cp-xs hover:bg-red-800"
                 >
                   ×
                 </button>
@@ -679,7 +679,7 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
             </div>
             {showAtemSourceId && (
               <div className="mt-1 flex items-center gap-1.5 rounded border border-emerald-900/60 bg-emerald-950/30 px-1.5 py-1">
-                <span className="text-[10px] font-semibold uppercase tracking-wide text-emerald-300">
+                <span className="text-cp-xs font-semibold uppercase tracking-wide text-emerald-300">
                   ATEM Source-ID
                 </span>
                 <input
@@ -697,14 +697,14 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                   title={t('ports.atemSourceIdTitle', 'Source ID addressed in the MV-Config dialog. AUX = 8001+, PGM = 10010, PVW = 10011, ME 2 PGM = 10020 …. Leave empty on inputs for idx+1 default.')}
                   className="w-32 rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
                 />
-                <span className="text-[10px] text-cp-text-muted">
+                <span className="text-cp-xs text-cp-text-muted">
                   AUX 8001+ · PGM 10010 · PVW 10011
                 </span>
               </div>
             )}
             {(port.connectorType === 'Fiber' || port.connectorType === 'SFP' || port.connectorType === 'SFP+') && (
               <div className="mt-1 rounded border border-sky-900/60 bg-sky-950/30 p-1.5">
-                <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-sky-400">SFP-Modul</div>
+                <div className="mb-1 text-cp-xs font-semibold uppercase tracking-wide text-sky-400">SFP-Modul</div>
                 <div className="grid grid-cols-2 gap-1">
                   <input
                     value={port.sfpType ?? ''}
@@ -775,7 +775,7 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                   .filter(Boolean)
                   .join(' · ')}
               >
-                <div className="grid grid-cols-2 gap-1 text-[10px]">
+                <div className="grid grid-cols-2 gap-1 text-cp-xs">
                   {/* v7.9.63 / #176 — 3G Level A/B nur anzeigen wenn das
                       Port-Max tatsächlich SDI-3G ist. Für 6G/12G/HD sind die
                       Level-Optionen bedeutungslos und nur visueller Lärm. */}
@@ -837,7 +837,7 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                     </select>
                   </label>
                 </div>
-                <div className="mt-1 text-[11px] text-cp-text-muted">
+                <div className="mt-1 text-cp-xs text-cp-text-muted">
                   {t(
                     'ports.sdi.overrideHint',
                     'Overrides the device SDI capabilities for this port. Empty = device default.',
@@ -848,12 +848,12 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                   const count = g ? quadGroupCount(g) : 0
                   const ok = count === 4
                   return (
-                    <div className="mt-1.5 flex items-center gap-1 text-[10px]">
+                    <div className="mt-1.5 flex items-center gap-1 text-cp-xs">
                       <span className="text-cp-text-muted">{t('ports.sdi.quadSet', 'Quad-link set:')}</span>
                       <select
                         value={g ?? ''}
                         onChange={(e) => void assignQuadGroup(port.id, e.target.value)}
-                        className="rounded border border-cp-border bg-cp-surface-3 px-1 py-0.5 text-[10px]"
+                        className="rounded border border-cp-border bg-cp-surface-3 px-1 py-0.5 text-cp-xs"
                       >
                         <option value="">{t('ports.set.none', '— None —')}</option>
                         {existingQuadGroups.map((gid) => (
@@ -864,7 +864,7 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                       {g && (
                         <>
                           <span
-                            className={`rounded px-1 py-0.5 text-[11px] font-bold ${
+                            className={`rounded px-1 py-0.5 text-cp-xs font-bold ${
                               ok
                                 ? 'bg-emerald-900/60 text-emerald-300'
                                 : 'bg-amber-900/60 text-amber-300'
@@ -879,7 +879,7 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                             <button
                               type="button"
                               onClick={() => void autoFillQuadGroup(g, port.id)}
-                              className="rounded bg-sky-800 px-1 py-0.5 text-[11px] text-sky-100 hover:bg-sky-700"
+                              className="rounded bg-sky-800 px-1 py-0.5 text-cp-xs text-sky-100 hover:bg-sky-700"
                               title={t('ports.quadAuto', 'Auto-assign free BNC ports to this set')}
                             >
                               auto-fill
@@ -895,12 +895,12 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                   const count = g ? dualGroupCount(g) : 0
                   const ok = count === 2
                   return (
-                    <div className="mt-1 flex items-center gap-1 text-[10px]">
+                    <div className="mt-1 flex items-center gap-1 text-cp-xs">
                       <span className="text-cp-text-muted">{t('ports.sdi.dualSet', 'Dual-link set:')}</span>
                       <select
                         value={g ?? ''}
                         onChange={(e) => void assignDualGroup(port.id, e.target.value)}
-                        className="rounded border border-cp-border bg-cp-surface-3 px-1 py-0.5 text-[10px]"
+                        className="rounded border border-cp-border bg-cp-surface-3 px-1 py-0.5 text-cp-xs"
                       >
                         <option value="">{t('ports.set.none', '— None —')}</option>
                         {existingDualGroups.map((gid) => (
@@ -911,7 +911,7 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                       {g && (
                         <>
                           <span
-                            className={`rounded px-1 py-0.5 text-[11px] font-bold ${
+                            className={`rounded px-1 py-0.5 text-cp-xs font-bold ${
                               ok
                                 ? 'bg-emerald-900/60 text-emerald-300'
                                 : 'bg-amber-900/60 text-amber-300'
@@ -926,7 +926,7 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
                             <button
                               type="button"
                               onClick={() => void autoFillDualGroup(g, port.id)}
-                              className="rounded bg-sky-800 px-1 py-0.5 text-[11px] text-sky-100 hover:bg-sky-700"
+                              className="rounded bg-sky-800 px-1 py-0.5 text-cp-xs text-sky-100 hover:bg-sky-700"
                               title={t('ports.dualAuto', 'Auto-assign free BNC ports to this set')}
                             >
                               auto-fill

--- a/src/renderer/components/Rack/RackBuilderDialog.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialog.tsx
@@ -736,7 +736,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
               <div className="text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">
                 {t('library.title', 'Library')}
               </div>
-              <span className="rounded bg-cp-surface-2 px-1.5 py-0.5 text-[10px] text-cp-text-muted">
+              <span className="rounded bg-cp-surface-2 px-1.5 py-0.5 text-cp-xs text-cp-text-muted">
                 {filteredTemplates.length} / {templates.length}
               </span>
             </div>
@@ -749,7 +749,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
               <button
                 type="button"
                 onClick={() => setPatchPanelDialogOpen(true)}
-                className="rounded border border-amber-700 bg-amber-900/30 px-2 py-1.5 text-[11px] font-semibold text-amber-200 hover:bg-amber-900/50"
+                className="rounded border border-amber-700 bg-amber-900/30 px-2 py-1.5 text-cp-xs font-semibold text-amber-200 hover:bg-amber-900/50"
                 title={t('rack.patchPanelTitle', 'Create new patch panel: height, port count, connector type')}
               >
                 {t('rack.patchPanelBtn', '+ Patch panel')}
@@ -757,7 +757,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
               <button
                 type="button"
                 onClick={() => setShelfDialogOpen(true)}
-                className="rounded border border-emerald-700 bg-emerald-900/30 px-2 py-1.5 text-[11px] font-semibold text-emerald-200 hover:bg-emerald-900/50"
+                className="rounded border border-emerald-700 bg-emerald-900/30 px-2 py-1.5 text-cp-xs font-semibold text-emerald-200 hover:bg-emerald-900/50"
                 title={t('rack.shelfTitle', 'Create rack shelf for non-19" gear')}
               >
                 {t('rack.shelfBtn', '+ Rack shelf')}
@@ -796,7 +796,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
               )}
             </div>
             <label
-              className="mb-2 flex items-center gap-1.5 text-[10px] text-cp-text-muted"
+              className="mb-2 flex items-center gap-1.5 text-cp-xs text-cp-text-muted"
               title={t(
                 'rack.showNonRackTitle',
                 'When active, templates that are not marked as 19" rack devices are also shown. Adding one will ask for the U height.',
@@ -812,7 +812,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
             </label>
             <div className="max-h-[58vh] space-y-1 overflow-auto">
               {filteredTemplates.length === 0 && (
-                <div className="rounded border border-dashed border-cp-border bg-cp-surface-3/40 p-4 text-center text-[11px] text-cp-text-muted">
+                <div className="rounded border border-dashed border-cp-border bg-cp-surface-3/40 p-4 text-center text-cp-xs text-cp-text-muted">
                   {query ? (
                     <>
                       {t('rack.noMatchesPre', 'No matches for')}{' '}
@@ -869,7 +869,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                           <span className="min-w-0 break-words font-medium leading-snug text-cp-text">{template.name}</span>
                           {placedCount > 0 && (
                             <span
-                              className="shrink-0 rounded bg-emerald-800/70 px-1 text-[8px] font-semibold uppercase text-emerald-200"
+                              className="shrink-0 rounded bg-emerald-800/70 px-1 text-cp-xs font-semibold uppercase text-emerald-200"
                               title={format(t('rack.placedCountTitle', '{count}× placed in rack'), { count: placedCount })}
                             >
                               ✓ {placedCount}×
@@ -877,14 +877,14 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                           )}
                           {!isRack && (
                             <span
-                              className="shrink-0 rounded bg-amber-800/60 px-1 text-[8px] font-semibold uppercase text-amber-200"
+                              className="shrink-0 rounded bg-amber-800/60 px-1 text-cp-xs font-semibold uppercase text-amber-200"
                               title={t('rack.notRackTitle', 'Not marked as 19" rack device — height will be asked on add.')}
                             >
                               No-HE
                             </span>
                           )}
                         </div>
-                        <div className="break-words text-[10px] text-cp-text-muted">{template.category}</div>
+                        <div className="break-words text-cp-xs text-cp-text-muted">{template.category}</div>
                       </div>
                       {/* v7.9.80 / #170 — Split-Button: Hauptaktion
                           "+ Hinzufügen" (Default = full-depth) + kleines
@@ -898,7 +898,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                         primaryLabel={placedCount > 0 ? t('rack.addMore', '+ Add more') : t('rack.addToRack', '+ Into rack')}
                       />
                     </div>
-                    <div className="mt-1 text-[10px] text-cp-text-muted">
+                    <div className="mt-1 text-cp-xs text-cp-text-muted">
                       {isRack ? `${parseUnits(template)} HE · ` : 'HE ? · '}
                       {template.inputs.length} In · {template.outputs.length} Out
                     </div>
@@ -923,7 +923,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                 {/* v7.9.73 / #170 — 2D/3D Tab-Toggle. 2D ist der bestehende
                     Front/Rear-Panel-Editor; 3D ist die neue Orbit-Ansicht
                     auf Basis von react-three-fiber. */}
-                <div className="ml-2 inline-flex overflow-hidden rounded-cp-control border border-cp-border text-[11px] font-medium">
+                <div className="ml-2 inline-flex overflow-hidden rounded-cp-control border border-cp-border text-cp-xs font-medium">
                   <button
                     type="button"
                     onClick={() => setViewTab('2d')}
@@ -968,7 +968,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                     <button
                       type="button"
                       onClick={() => setZoom(1)}
-                      className="min-w-[2.75rem] rounded px-1 text-center text-[11px] tabular-nums hover:bg-cp-surface-2"
+                      className="min-w-[2.75rem] rounded px-1 text-center text-cp-xs tabular-nums hover:bg-cp-surface-2"
                       title={t('rack.zoomFitTitle', 'Back to 100 % (auto-fit)')}
                     >
                       {Math.round(zoom * 100)}%
@@ -993,7 +993,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                     </button>
                   </div>
                 )}
-                <div className="hidden items-center gap-1.5 text-[10px] text-cp-text-muted sm:flex">
+                <div className="hidden items-center gap-1.5 text-cp-xs text-cp-text-muted sm:flex">
                   <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                     <path d="M8 2 L8 14 M5 5 L8 2 L11 5 M5 11 L8 14 L11 11" />
                   </svg>
@@ -1006,7 +1006,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                 <div className="mb-2 text-3xl">▥</div>
                 <div className="mb-1 font-semibold text-cp-text-secondary">{t('rack.empty', 'Rack is empty')}</div>
                 <div>{t('rack.addFromLibraryHint', 'Add devices from the library on the left (button "+ Rack").')}</div>
-                <div className="mt-2 text-[10px]">
+                <div className="mt-2 text-cp-xs">
                   {t('rack.tipPrefix', 'Tip:')}{' '}
                   <span className="text-cp-text-muted">"{t('rack.showNonRack', 'Include non-rack devices')}"</span>{' '}
                   {t('rack.tipBody', 'enable when the desired device is missing.')}
@@ -1059,7 +1059,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
             {/* v7.9.80 / #170 — Front/Rear/Both-Toggle ist jetzt Teil der
                 2D-Rack-Spalte (war vorher als Select im Header). */}
             {viewTab === '2d' && (
-              <div className="mb-2 flex overflow-hidden rounded-cp-control border border-cp-border text-[11px]">
+              <div className="mb-2 flex overflow-hidden rounded-cp-control border border-cp-border text-cp-xs">
                 {([
                   ['front', t('rack.viewMode.front', 'Front'), RectangleVertical],
                   ['rear', t('rack.viewMode.rear', 'Rear'), FlipHorizontal2],
@@ -1086,7 +1086,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
             )}
             {/* #472 — Steckverbinder-Symbole im 2D- UND 3D-Rack ein-/ausblenden. */}
             {(viewTab === '2d' || viewTab === '3d') && (
-              <label className="mb-2 flex cursor-pointer items-center gap-1.5 text-[11px] text-cp-text-secondary">
+              <label className="mb-2 flex cursor-pointer items-center gap-1.5 text-cp-xs text-cp-text-secondary">
                 <input
                   type="checkbox"
                   checked={showConnectorSymbols}
@@ -1111,11 +1111,11 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
               {draft.viewMode === 'side' && (
                 <div className="rounded border border-cp-border-muted bg-cp-surface-3 p-2">
                   <div className="mb-2 flex items-center gap-2">
-                    <span className="inline-flex items-center gap-1 rounded bg-sky-900/50 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-sky-200">
+                    <span className="inline-flex items-center gap-1 rounded bg-sky-900/50 px-1.5 py-0.5 text-cp-xs font-semibold uppercase tracking-wide text-sky-200">
                       <span className="inline-block h-1.5 w-1.5 rounded-full" style={{ background: '#0ea5e9' }} />
                       Seitenansicht (Tiefe)
                     </span>
-                    <span className="text-[10px] text-cp-text-muted">
+                    <span className="text-cp-xs text-cp-text-muted">
                       Vorne ◀ {draft.depthMm ?? 800} mm ▶ Hinten
                     </span>
                   </div>
@@ -1137,7 +1137,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                               className="absolute left-0 right-0 border-t border-cp-border-muted/80"
                               style={{ top: idx * rowHeight, height: rowHeight }}
                             >
-                              <span className="absolute left-1 top-0.5 text-[9px] text-cp-text-muted">U{unit}</span>
+                              <span className="absolute left-1 top-0.5 text-cp-xs text-cp-text-muted">U{unit}</span>
                             </div>
                           )
                         })}
@@ -1167,7 +1167,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                             <div
                               key={`side-block-${item.id}`}
                               onClick={() => setSelectedPlacementId(item.id)}
-                              className={`absolute cursor-pointer overflow-hidden rounded border-2 text-[9px] text-white transition ${
+                              className={`absolute cursor-pointer overflow-hidden rounded border-2 text-cp-xs text-white transition ${
                                 isSelected ? 'border-amber-300 ring-1 ring-amber-400/40' : colorClass
                               }`}
                               style={{ top, height, left: leftPx, width: widthPx }}
@@ -1186,7 +1186,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                 <div key={side} className="rounded border border-cp-border-muted bg-cp-surface-3 p-2">
                   <div className="mb-2 flex items-center gap-2">
                     <span
-                      className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+                      className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-cp-xs font-semibold uppercase tracking-wide ${
                         side === 'front'
                           ? 'bg-sky-900/50 text-sky-200'
                           : 'bg-purple-900/50 text-purple-200'
@@ -1270,7 +1270,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                           className="absolute left-0 right-0 border-t border-cp-border-muted/80"
                           style={{ top: index * rowHeight, height: rowHeight }}
                         >
-                          <span className="absolute left-1 top-0.5 text-[9px] text-cp-text-muted">U{unit}</span>
+                          <span className="absolute left-1 top-0.5 text-cp-xs text-cp-text-muted">U{unit}</span>
                         </div>
                       )
                     })}
@@ -1481,7 +1481,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                               className="pointer-events-none h-full w-full object-contain"
                             />
                           ) : (
-                            <div className="pointer-events-none flex h-full items-center justify-center px-2 text-center text-[10px] font-semibold text-sky-100">{item.name}</div>
+                            <div className="pointer-events-none flex h-full items-center justify-center px-2 text-center text-cp-xs font-semibold text-sky-100">{item.name}</div>
                           )}
                           {/* v7.9.78 / #170 — Port-Dots-Overlay im 2D
                               Rack-Editor. Front-Side zeigt inputs[],
@@ -1510,7 +1510,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                             side={side as 'front' | 'rear'}
                             showSymbols={showConnectorSymbols}
                           />
-                          <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-black/50 px-1 py-0.5 text-[9px] text-white">
+                          <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-black/50 px-1 py-0.5 text-cp-xs text-white">
                             {item.inputs.length} In · {item.outputs.length} Out
                           </div>
                         </div>
@@ -1557,7 +1557,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
               (PlacementPropertiesDialog am Ende der Component), das per
               Doppelklick auf ein Gerät im Rack aufgeht. Hier nur ein
               kleiner Hinweis statt der dauerhaft offenen Sidebar. */}
-          <div className="rounded border border-dashed border-cp-border bg-cp-surface-3/30 px-2 py-3 text-center text-[10px] text-cp-text-muted">
+          <div className="rounded border border-dashed border-cp-border bg-cp-surface-3/30 px-2 py-3 text-center text-cp-xs text-cp-text-muted">
             {t(
               'rack.propsHint',
               'Double-click a device in the rack → opens the properties popup (height, start RU, panel images, remove).',

--- a/src/renderer/components/Rack/RackPlacementProperties.tsx
+++ b/src/renderer/components/Rack/RackPlacementProperties.tsx
@@ -60,7 +60,7 @@ export const RackPlacementProperties = ({
       onClose={onClose}
       title={format(t('rack.props.title', 'Properties · {name}'), { name: selectedPlacement.name })}
       titleIcon={
-        <span className="rounded bg-amber-900/60 px-1.5 py-0.5 text-[11px] font-semibold text-amber-200">
+        <span className="rounded bg-amber-900/60 px-1.5 py-0.5 text-cp-xs font-semibold text-amber-200">
           {heRange}
         </span>
       }
@@ -132,7 +132,7 @@ export const RackPlacementProperties = ({
               }`}
             />
             {heightInvalid && (
-              <span className="mt-0.5 block text-[10px] text-red-400">
+              <span className="mt-0.5 block text-cp-xs text-red-400">
                 {format(
                   t(
                     'rack.props.heightOverflow',
@@ -160,7 +160,7 @@ export const RackPlacementProperties = ({
                 heightInvalid ? 'border-red-600 ring-1 ring-red-600/40' : 'border-cp-border'
               }`}
             />
-            <span className="mt-0.5 block text-[10px] text-cp-text-muted">
+            <span className="mt-0.5 block text-cp-xs text-cp-text-muted">
               {format(
                 t('rack.props.maxHint', 'max {max} (height {he} RU)'),
                 { max: startMax, he: selectedPlacement.rackUnits },
@@ -212,7 +212,7 @@ export const RackPlacementProperties = ({
           <div className="mb-1 text-cp-xs text-cp-text-secondary">{t('rack.stl.header', '3D model (STL, optional)')}</div>
           <div className="mt-1 flex items-center gap-2">
             <label
-              className="inline-flex cursor-pointer items-center gap-1 rounded border border-cp-surface-5 bg-sky-700 px-3 py-1 text-[11px] font-semibold text-white hover:bg-sky-600"
+              className="inline-flex cursor-pointer items-center gap-1 rounded border border-cp-surface-5 bg-sky-700 px-3 py-1 text-cp-xs font-semibold text-white hover:bg-sky-600"
               title={t('rack.stlUploadTitle', 'Upload STL file (.stl, max 5 MB) for this device')}
             >
               <span>📁</span>
@@ -252,7 +252,7 @@ export const RackPlacementProperties = ({
                   const tpl = templates.find((tt) => tt.name === selectedPlacement.templateName)
                   if (tpl && tpl.stlDataUri) onSyncStlToTemplate(selectedPlacement.templateName, undefined)
                 }}
-                className="rounded border border-cp-surface-5 bg-cp-surface-4 px-2 py-1 text-[11px] text-cp-text-bright hover:bg-cp-surface-5"
+                className="rounded border border-cp-surface-5 bg-cp-surface-4 px-2 py-1 text-cp-xs text-cp-text-bright hover:bg-cp-surface-5"
                 title={t('rack.stlRemoveTitle', 'Remove STL — device renders as a box again')}
               >
                 ✕ {t('common.remove', 'Remove')}
@@ -264,7 +264,7 @@ export const RackPlacementProperties = ({
               <StlPreview stlDataUri={selectedPlacement.stlDataUri} size={120} />
             </div>
           )}
-          <span className="mt-1 block text-[10px] text-cp-text-muted">
+          <span className="mt-1 block text-cp-xs text-cp-text-muted">
             {selectedPlacement.stlDataUri
               ? t('rack.stl.loaded', '✓ STL loaded — rendered in the 3D tab and saved permanently with the device (library + project).')
               : t('rack.stl.noStl', 'Without STL the device is rendered as a box with front/rear photo.')}
@@ -282,8 +282,8 @@ export const RackPlacementProperties = ({
           if (!(tpl?.widthMm && tpl?.heightMm)) {
             return (
               <details className="rounded border border-cp-border-muted bg-cp-surface-1/40 p-2" open>
-                <summary className="cursor-pointer text-[11px] font-semibold text-cp-text-secondary">{t('rack.depthPos.title', 'Depth position (Z)')}</summary>
-                <label className="mt-2 block text-[10px]">
+                <summary className="cursor-pointer text-cp-xs font-semibold text-cp-text-secondary">{t('rack.depthPos.title', 'Depth position (Z)')}</summary>
+                <label className="mt-2 block text-cp-xs">
                   <span className="mb-0.5 block text-cp-text-muted">{t('rack.depthPos.depthFromFront', 'Depth (mm from front)')}</span>
                   <input
                     type="number"
@@ -298,7 +298,7 @@ export const RackPlacementProperties = ({
                     }
                     className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1"
                   />
-                  <span className="text-[11px] text-cp-text-muted">{format(t('rack.depthPos.maxFront', 'max {max} mm · 0 = front'), { max: Math.round(maxZ) })}</span>
+                  <span className="text-cp-xs text-cp-text-muted">{format(t('rack.depthPos.maxFront', 'max {max} mm · 0 = front'), { max: Math.round(maxZ) })}</span>
                 </label>
               </details>
             )
@@ -306,14 +306,14 @@ export const RackPlacementProperties = ({
           const maxX = Math.max(0, RACK_MOUNT_WIDTH_MM - tpl.widthMm)
           return (
             <details className="rounded border border-emerald-800 bg-emerald-900/20 p-2" open>
-              <summary className="cursor-pointer text-[11px] font-semibold text-emerald-200">
+              <summary className="cursor-pointer text-cp-xs font-semibold text-emerald-200">
                 🪑 {t('rack.shelfPos.title', 'Shelf position')}
                 <span className="ml-1 text-emerald-400">
                   ({tpl.widthMm}×{tpl.heightMm}×{tpl.depthMm ?? 400} mm)
                 </span>
               </summary>
               <div className="mt-2 grid grid-cols-2 gap-2">
-                <label className="block text-[10px]">
+                <label className="block text-cp-xs">
                   <span className="mb-0.5 block text-emerald-300/80">{t('rack.shelfPos.horizontal', 'Horizontal (mm from left rail)')}</span>
                   <input
                     type="number"
@@ -328,9 +328,9 @@ export const RackPlacementProperties = ({
                     }
                     className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1"
                   />
-                  <span className="text-[11px] text-cp-text-muted">{format(t('rack.shelfPos.maxMm', 'max {max} mm'), { max: Math.round(maxX) })}</span>
+                  <span className="text-cp-xs text-cp-text-muted">{format(t('rack.shelfPos.maxMm', 'max {max} mm'), { max: Math.round(maxX) })}</span>
                 </label>
-                <label className="block text-[10px]">
+                <label className="block text-cp-xs">
                   <span className="mb-0.5 block text-emerald-300/80">{t('rack.depthPos.depthFromFront', 'Depth (mm from front)')}</span>
                   <input
                     type="number"
@@ -345,23 +345,23 @@ export const RackPlacementProperties = ({
                     }
                     className="w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1"
                   />
-                  <span className="text-[11px] text-cp-text-muted">{format(t('rack.shelfPos.maxMm', 'max {max} mm'), { max: Math.round(maxZ) })}</span>
+                  <span className="text-cp-xs text-cp-text-muted">{format(t('rack.shelfPos.maxMm', 'max {max} mm'), { max: Math.round(maxZ) })}</span>
                 </label>
               </div>
-              <div className="mt-1 text-[10px] text-cp-text-muted">
+              <div className="mt-1 text-cp-xs text-cp-text-muted">
                 {t('rack.shelfPos.tip', 'Tip: In the 2D tab you can also drag the device horizontally with the mouse. Depth position is only editable here or in the 3D tab.')}
               </div>
             </details>
           )
         })()}
         <details className="rounded border border-cp-border-muted bg-cp-surface-1/40 p-2" open>
-          <summary className="cursor-pointer text-[11px] font-semibold text-cp-text-secondary">
+          <summary className="cursor-pointer text-cp-xs font-semibold text-cp-text-secondary">
             {t('rack.portSideSection.title', 'Port side (front/rear)')}
             <span className="ml-1 text-cp-text-faint">
               {format(t('rack.portSideSection.counts', '({inputs} inputs / {outputs} outputs)'), { inputs: selectedPlacement.inputs.length, outputs: selectedPlacement.outputs.length })}
             </span>
           </summary>
-          <div className="mt-2 grid grid-cols-1 sm:grid-cols-3 gap-1 text-[10px]">
+          <div className="mt-2 grid grid-cols-1 sm:grid-cols-3 gap-1 text-cp-xs">
             <button
               type="button"
               onClick={() =>
@@ -417,11 +417,11 @@ export const RackPlacementProperties = ({
               return (
                 <div
                   key={port.id}
-                  className="flex items-center justify-between gap-2 border-t border-cp-border-muted/60 px-2 py-0.5 text-[10px] first:border-t-0"
+                  className="flex items-center justify-between gap-2 border-t border-cp-border-muted/60 px-2 py-0.5 text-cp-xs first:border-t-0"
                 >
                   <span className="flex min-w-0 items-center gap-1">
                     <span
-                      className={`shrink-0 rounded px-1 text-[8px] font-bold uppercase ${
+                      className={`shrink-0 rounded px-1 text-cp-xs font-bold uppercase ${
                         dir === 'in' ? 'bg-cyan-900/60 text-cyan-200' : 'bg-emerald-900/60 text-emerald-200'
                       }`}
                       title={dir === 'in' ? t('rack.portDir.input', 'Input (signal in)') : t('rack.portDir.output', 'Output (signal out)')}
@@ -484,7 +484,7 @@ export const RackPlacementProperties = ({
         </details>
         <div className="space-y-2">
           <div className="flex items-center justify-between">
-            <div className="text-[11px] font-semibold text-cp-text-muted">{t('rack.panelImages.header', 'Panel images (import + crop)')}</div>
+            <div className="text-cp-xs font-semibold text-cp-text-muted">{t('rack.panelImages.header', 'Panel images (import + crop)')}</div>
             {(selectedPlacement.frontPanelImageUrl || selectedPlacement.rearPanelImageUrl) && (
               <button
                 type="button"
@@ -496,7 +496,7 @@ export const RackPlacementProperties = ({
                     rearPanelCrop: selectedPlacement.frontPanelCrop,
                   })
                 }
-                className="rounded bg-cp-surface-4 px-2 py-0.5 text-[10px] text-cp-text-bright hover:bg-cp-surface-5"
+                className="rounded bg-cp-surface-4 px-2 py-0.5 text-cp-xs text-cp-text-bright hover:bg-cp-surface-5"
                 title={t('rack.swapPhotos', 'Swap front and rear photo (if the mapping is wrong)')}
               >
                 ↔ {t('rack.swapPhotosBtn', 'Swap front/rear')}
@@ -513,7 +513,7 @@ export const RackPlacementProperties = ({
                 <div key={side} className="space-y-1">
                   <button
                     type="button"
-                    className={`w-full rounded ${btnColor} px-2 py-1 text-[11px]`}
+                    className={`w-full rounded ${btnColor} px-2 py-1 text-cp-xs`}
                     onClick={async () => {
                       const dataUri = await pickImageAsDataUri('image/png,image/jpeg,image/webp')
                       if (dataUri) onPickPanelImage(selectedPlacement.id, side, dataUri)
@@ -529,7 +529,7 @@ export const RackPlacementProperties = ({
                       <button
                         type="button"
                         onClick={() => onUpdate(selectedPlacement.id, { [urlKey]: undefined, [side === 'front' ? 'frontPanelCrop' : 'rearPanelCrop']: undefined })}
-                        className="rounded px-1.5 py-0.5 text-[10px] text-red-400 hover:bg-red-900/40 hover:text-red-300"
+                        className="rounded px-1.5 py-0.5 text-cp-xs text-red-400 hover:bg-red-900/40 hover:text-red-300"
                         title={t('rack.removeImage', 'Remove image')}
                       >
                         ✕

--- a/tests/schriftgroesseUntergrenze.test.ts
+++ b/tests/schriftgroesseUntergrenze.test.ts
@@ -59,11 +59,13 @@ const UNTERGRENZE_PX = 12
  * dann ist die rote Zeile die Erinnerung, sie hier nachzuziehen.
  *
  * Bisherige Staende: 828 (nach `src/mobile`), 705 (nach GreenGoExportDialog,
- * CalculatorsDialog, CableProperties). Die Reihenfolge ist die nach Groesse:
- * die dichten Tabellen und Rechner-Raster zuerst, weil dort die kleinste
- * Schrift und die meiste Zahl zusammenkommen.
+ * CalculatorsDialog, CableProperties), 515 (nach den naechsten neun:
+ * RackBuilderDialog, RentmanTab, RackPlacementProperties, CableLibraryPanel,
+ * PortList, MobileShareDialog, App.tsx, ExportDialog, AnalysisDialog). Die
+ * Reihenfolge ist die nach Groesse: die dichten Tabellen und Rechner-Raster
+ * zuerst, weil dort die kleinste Schrift und die meiste Zahl zusammenkommen.
  */
-const BARRIERE = 705
+const BARRIERE = 515
 
 const dateien = (dir: string): string[] =>
   readdirSync(dir).flatMap((eintrag) => {


### PR DESCRIPTION
Dritter Schnitt der Schriftgrößen-TODO aus `docs/ui-audit.md`. Beim Nachmessen ist ein Defekt aufgefallen, der wichtiger ist als die Migration selbst — und der Grund, warum er so lange leben konnte.

## 1 · Drei Reiter lagen außerhalb des Dialogs

Der Analysen-Dialog legt **dreizehn Reiter** in eine `flex`-Zeile, die nicht umbricht. Die letzten drei lagen über der rechten Kante:

| Reiter | über der Kante |
| --- | ---: |
| „Blatt prüfen" | 164 px |
| „Signalwege" | 98 px |
| „Kabelwege" | 5 px |

Bei 1280×800 wie bei 1500×950. Nicht sichtbar, nicht anklickbar — **drei Auswertungen, die es für den Nutzer nicht gab.**

Das ist wörtlich derselbe Befund, aus dem `scripts/ui-overflow.mjs` entstanden ist (*„da kann man Equipment lesen, aber Cable schon nicht mehr"*), nur eine Ebene tiefer. Er ist **älter als diese Migration** — nachgemessen gegen `776ed7c`, identische Zahlen — und hat jede CI-Runde überlebt.

**Behoben mit `flex-wrap`, nicht mit `overflow-x-auto`:** eine waagerecht scrollende Reiterleiste versteckt die hinteren Reiter hinter einer Geste, die niemand sucht. Umbrechen zeigt alle dreizehn und kostet eine Zeile.

## 2 · Der Wächter stand an der Tür

`ui-overflow.mjs` misst die stehende Oberfläche und die Menüs. Ein Dialog ist beides nicht: **er ist zu, bis jemand ihn öffnet.** Deshalb hat der Guard, der genau für diese Fehlerklasse gebaut wurde, sie in Dialogen nie gesehen.

Punkt 6 läuft jetzt die **Befehlspalette Eintrag für Eintrag** durch, öffnet jeden Dialog und misst ihn — heute **15 Dialoge, 0 Befunde**.

**Die Liste führt die App, nicht der Wächter.** Die Palette ist die Registratur, die ohnehin gepflegt wird; wer morgen einen Dialog anlegt und einhängt, wird gemessen, ohne dass jemand eine zweite Liste nachzieht. Dieselbe Lehre wie in `tests/dialogTastaturbedienung.test.ts`.

Drei Dinge, die der Pass richtig machen muss, damit er nicht still grün ist:
- Einträge ohne Dialog (Zoom, rückgängig, Auswahl) fallen von selbst heraus.
- Die Palette trägt **selbst** `role="dialog"` — sie wird markiert und ausgenommen, sonst wäre sie das, was gemessen wird.
- Liefert sie keine Einträge, **bricht der Lauf ab**, statt grün zu werden.

**Gegenprobe gefahren:** `flex-wrap` wieder entfernt → drei Befunde, jeder mit Reiter-Name und Pixelzahl; wieder eingesetzt → 0.

## 3 · Schriftgrößen

Neun Dateien, **190 Stellen** `text-[10px]`/`text-[11px]` → `text-cp-xs`:

`RackBuilderDialog` 24 · `RentmanTab` 24 · `RackPlacementProperties` 23 · `CableLibraryPanel` 21 · `PortList` 20 · `MobileShareDialog` 20 · `App.tsx` 20 · `ExportDialog` 19 · `AnalysisDialog` 19

Barriere **705 → 515**. Damit ist der letzte große Posten weg; der Rest verteilt sich auf rund hundert Dateien mit einstelligen bis niedrig zweistelligen Zahlen.

Verlauf seit Audit-Start: **743 → 881 → 828 → 705 → 515.**

## Verifikation

- `npx tsc -p tsconfig.app.json --noEmit` → 0
- `npm run lint` → 0 Errors (12 Warnungen, alle pre-existing)
- `npm test` → 3851 grün, 2 skipped
- `xvfb-run -a npm run ui:overflow` → 0 Befunde (15 Dialoge geprüft)
- `xvfb-run -a npm run ui:smoke` → 5 Menüs, 0 ohne Einträge
- `npm run lang:check` → 0 deutsch / 1281 englisch
- `npm run build` → grün

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_