### PR TITLE
ui: Fließtext-Untergrenze 12px ist erreicht — aus der Ratsche wird eine Regel

### DIFF
--- a/docs/ui-audit.md
+++ b/docs/ui-audit.md
@@ -171,10 +171,10 @@ Hartkodierte Pixel-Schriftgrößen (Tailwind-Arbitrary-Values):
 
 | Klasse        | Audit-Start<br>2026-06-15 | vor der Migration<br>2026-09-10 | heute |
 | ------------- | ------------------------: | ------------------------------: | ----: |
-| `text-[10px]` |                       336 |                             423 |   252 |
-| `text-[11px]` |                       256 |                             390 |   255 |
-| `text-[9px]`  |                        43 |                              10 |     6 |
-| `text-[8px]`  |                         5 |                               5 |     2 |
+| `text-[10px]` |                       336 |                             423 |     0 |
+| `text-[11px]` |                       256 |                             390 |     4 |
+| `text-[9px]`  |                        43 |                              10 |     2 |
+| `text-[8px]`  |                         5 |                               5 |     0 |
 | `text-[12px]` |                         4 |                              20 |    20 |
 | `text-[13px]` |                         2 |                               2 |     2 |
 
@@ -186,14 +186,24 @@ Das ist keine Nachlaessigkeit einzelner Aenderungen, sondern die vorhersehbare
 Folge davon, dass die Grenze nur in Prosa stand: ein TODO in einer Datei
 bremst nichts, weil niemand es beim Schreiben einer neuen Komponente liest.
 Seit `tests/schriftgroesseUntergrenze.test.ts` ist es eine Ratsche — die Zahl
-darf sinken, nie steigen. Stand heute: **515**, in drei Schritten von 881
-(erst `src/mobile`, dann die drei groessten Einzeldateien, dann die naechsten
-neun).
+darf sinken, nie steigen. Der Weg zurück lief in vier Schritten:
+**881 → 828** (`src/mobile`) **→ 705** (die drei größten Einzeldateien)
+**→ 515** (die nächsten neun) **→ 0**.
 
-Was noch offen ist, hat keinen grossen Posten mehr: der Rest verteilt sich auf
-rund hundert Dateien mit einstelligen bis niedrig zweistelligen Zahlen
-(`RentmanCableExportDialog` 18, `AtemMvConfigDialog` 16, `EquipmentChecklist`
-15, `VideohubExportDialog` 14, `IntegrationsTab` 13, dann der lange Schwanz).
+**Die sechs verbliebenen Stellen sind genau die Ausnahme, die dieses TODO
+selbst nennt** — rein dekorative Micro-Glyphen: vier Carets (`▾`/`▴` in
+`MenuBar`, `LibraryMenus` ×2, `PanelWindowMenu`), ein Sortier-Dreieck (`▲` in
+`PatchListDialog`) und die Pin-Markierung (`📌` im Rechner). Ein Pfeil hat
+keine Lesbarkeitsuntergrenze, ein Wort hat eine.
+
+**Damit ist aus der Ratsche eine Regel geworden.** Solange hunderte Stellen
+offen waren, stand im Wächter eine Zahl — die richtige Form für eine laufende
+Migration und die falsche für eine fertige: eine Zahl sagt nicht, *warum* eine
+Stelle bleiben darf, und wer eine neue anlegt, könnte sie mit einer Migration
+anderswo verrechnen. Geprüft wird jetzt, dass **jede** Stelle unter 12px ein
+Glyph ist: der sichtbare Text der Zeile darf keinen Buchstaben und keine
+Ziffer tragen. Wer morgen einen Caret braucht, bleibt grün; wer eine
+Beschriftung auf 10px setzt, wird sofort rot.
 
 **Theming-Schuld:** `index.css` remappt die komplette Tailwind-Slate-Rampe
 (+ Dutzende Opacity-Varianten einzeln) für `[data-theme="light"]`. Fragil,
@@ -219,27 +229,17 @@ Inline-Fallback in `ErrorBoundary`). → Token-Schicht einführen.
 
 ### TODO (großflächiger Rest, NICHT Big-Bang)
 
-- [ ] `text-[10px]`/`text-[11px]`/`text-[9px]` flächendeckend auf
-      Typo-Skala migrieren. Fließtext-Mindestgröße 12px. (Rein
-      dekorative Micro-Glyphen wie MenuBar-Caret `▾` und die
-      Pin-Markierung im Rechner bleiben.)
-      **Erledigt:** zentrale Shells (Phase 2), `src/mobile` komplett,
-      `GreenGoExportDialog`, `CalculatorsDialog`, `CableProperties`,
-      `RackBuilderDialog`, `RentmanTab`, `RackPlacementProperties`,
-      `CableLibraryPanel`, `PortList`, `MobileShareDialog`, `App.tsx`,
-      `ExportDialog`, `AnalysisDialog`.
-      **Offen:** der lange Schwanz, Reihenfolge nach Größe.
-      **Gedeckelt** durch `tests/schriftgroesseUntergrenze.test.ts`:
-      Barriere 515, sinken erlaubt, steigen nicht.
-      `src/mobile` steht dort zusätzlich auf 0 und muss es bleiben —
-      eine reine Gesamtzahl saehe nicht, wenn ein migrierter Ordner
-      zurueckfaellt, waehrend anderswo etwas migriert wird.
-      **Im echten Fenster nachgemessen** (Electron unter xvfb, 1280x800):
-      Bandbreiten-Rechner 66 sichtbare Elemente, Leistungs-Rechner 112,
-      Kabel-Eigenschaften 125, GreenGo-Dialog 49 — kein Überlauf, nichts
-      mehr unter 12px. Der Sprung 10 → 12px in dichten Tabellen ist der
-      Punkt, an dem eine Migration Layout brechen kann; `npm test` sieht
-      das nicht, `ui:overflow` öffnet diese Dialoge nicht.
+- [x] `text-[10px]`/`text-[11px]`/`text-[9px]` flächendeckend auf
+      Typo-Skala migrieren. Fließtext-Mindestgröße 12px. **Erledigt
+      2026-09-10** in vier Schritten (881 → 828 → 705 → 515 → 0);
+      die sechs verbliebenen Stellen sind dekorative Micro-Glyphen,
+      siehe oben. **Gehalten** von
+      `tests/schriftgroesseUntergrenze.test.ts` — nicht mehr als Zahl,
+      sondern als Regel: jede Stelle unter 12px muss ein Glyph sein.
+      **Im echten Fenster nachgemessen** (Electron unter xvfb): alle vier
+      UI-Skripte grün, `ui:overflow` prüft dabei 15 Dialoge. Der Sprung
+      10 → 12px in dichten Tabellen ist der Punkt, an dem eine Migration
+      Layout bricht — `npm test` sieht das nicht.
 - [ ] Translucente Glas-Flächen (`bg-slate-950/95`, `bg-slate-900/80`,
       `bg-slate-950/40`) auf Alpha-Tokens (z. B. `color-mix`) heben —
       aktuell bewusst als slate-Klassen belassen (Remap deckt Light ab).

--- a/src/renderer/components/About/AboutDialog.tsx
+++ b/src/renderer/components/About/AboutDialog.tsx
@@ -50,7 +50,7 @@ export const AboutDialog = () => {
           <Icon icon={Cable} size={28} className="text-cp-accent" />
           <div className="min-w-0">
             <div className="font-semibold text-cp-text">{t('app.title', 'Cable Planner')}</div>
-            <div className="text-[11px] text-cp-text-muted">{APP_DESCRIPTION}</div>
+            <div className="text-cp-xs text-cp-text-muted">{APP_DESCRIPTION}</div>
           </div>
           <div className="ml-auto shrink-0 rounded bg-emerald-700 px-2 py-1 font-mono text-cp-xs text-white">
             v{APP_VERSION}
@@ -85,7 +85,7 @@ export const AboutDialog = () => {
           </dd>
         </dl>
 
-        <div className="rounded border border-cp-border-muted bg-cp-surface-3/40 p-3 text-[11px] text-cp-text-muted">
+        <div className="rounded border border-cp-border-muted bg-cp-surface-3/40 p-3 text-cp-xs text-cp-text-muted">
           {t('about.issueHint', 'Please report issues + feature requests directly on GitHub.')}
         </div>
       </div>

--- a/src/renderer/components/Analysis/PlanCheckPanel.tsx
+++ b/src/renderer/components/Analysis/PlanCheckPanel.tsx
@@ -132,7 +132,7 @@ export const PlanCheckPanel = () => {
             </ul>
           )}
         </div>
-        <p className="border-t border-cp-border-muted py-1.5 text-[10px] text-cp-text-muted">
+        <p className="border-t border-cp-border-muted py-1.5 text-cp-xs text-cp-text-muted">
           {t(
             'planCheck.footerHint',
             'Live plan validation. Click a finding to select the affected element.',

--- a/src/renderer/components/Annotations/AnnotationsPanel.tsx
+++ b/src/renderer/components/Annotations/AnnotationsPanel.tsx
@@ -168,7 +168,7 @@ export const AnnotationsPanel = ({
               key={s}
               type="button"
               onClick={() => setStatusFilter(s)}
-              className={`rounded px-2 py-0.5 text-[10px] ${
+              className={`rounded px-2 py-0.5 text-cp-xs ${
                 statusFilter === s
                   ? 'bg-sky-700 text-white'
                   : 'bg-cp-surface-2 text-cp-text-muted hover:bg-cp-surface-4'
@@ -243,7 +243,7 @@ export const AnnotationsPanel = ({
 
       <div className="flex-1 overflow-y-auto p-3">
         {grouped.length === 0 ? (
-          <p className="text-[11px] text-cp-text-muted">
+          <p className="text-cp-xs text-cp-text-muted">
             {t(
               'annotations.empty',
               'No annotations yet. Click “+ New annotation” or right-click a device / cable.',
@@ -252,7 +252,7 @@ export const AnnotationsPanel = ({
         ) : (
           grouped.map(([authorName, items]) => (
             <div key={authorName} className="mb-3">
-              <h4 className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-cp-text-muted">
+              <h4 className="mb-1 text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">
                 {authorName} ({items.length})
               </h4>
               <ul className="space-y-1">
@@ -303,7 +303,7 @@ export const AnnotationsPanel = ({
                     >
                       <div className="mb-1 flex items-center justify-between gap-2">
                         <span
-                          className="rounded px-1 py-0.5 text-[11px] font-semibold"
+                          className="rounded px-1 py-0.5 text-cp-xs font-semibold"
                           style={{
                             background: STATUS_COLOR[a.status],
                             // #451 — Textfarbe luminanzbasiert: dunkler Text auf
@@ -315,7 +315,7 @@ export const AnnotationsPanel = ({
                         >
                           {t(`annotations.status.${a.status}`, STATUS_LABEL[a.status])}
                         </span>
-                        <span className="truncate text-[10px] text-cp-text-muted" title={a.createdAt}>
+                        <span className="truncate text-cp-xs text-cp-text-muted" title={a.createdAt}>
                           {new Date(a.createdAt).toLocaleString()}
                         </span>
                       </div>
@@ -337,7 +337,7 @@ export const AnnotationsPanel = ({
                           {a.text}
                         </p>
                       )}
-                      <div className="mt-1 text-[10px] text-cp-text-muted">
+                      <div className="mt-1 text-cp-xs text-cp-text-muted">
                         {ANCHOR_LABEL(a, deviceNames, cableNames)}
                       </div>
                       <div className="mt-1 flex gap-1">
@@ -348,7 +348,7 @@ export const AnnotationsPanel = ({
                               status: e.target.value as ProjectAnnotation['status'],
                             })
                           }
-                          className="rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-[10px]"
+                          className="rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-cp-xs"
                         >
                           <option value="open">{t('annotations.status.open', 'open')}</option>
                           <option value="built">{t('annotations.status.built', 'built')}</option>
@@ -369,7 +369,7 @@ export const AnnotationsPanel = ({
                                 setAnnotationsVisible(true)
                               }
                             }}
-                            className="inline-flex items-center gap-1 rounded bg-cp-surface-2 px-1.5 py-0.5 text-[10px] text-cp-text-bright hover:bg-cp-surface-4"
+                            className="inline-flex items-center gap-1 rounded bg-cp-surface-2 px-1.5 py-0.5 text-cp-xs text-cp-text-bright hover:bg-cp-surface-4"
                             aria-label={t('annotations.placeCenter', 'Place at canvas centre (keyboard alternative to dragging)')}
                           >
                             <Icon icon={MapPin} size="xs" />
@@ -384,7 +384,7 @@ export const AnnotationsPanel = ({
                                 destructive: true,
                               })) removeAnnotation(a.id)
                             }}
-                            className="rounded bg-red-900/60 px-1 py-0.5 text-[10px] text-red-200 hover:bg-red-800"
+                            className="rounded bg-red-900/60 px-1 py-0.5 text-cp-xs text-red-200 hover:bg-red-800"
                             aria-label={t('annotations.delete', 'Delete annotation')}
                           >
                             ×
@@ -408,7 +408,7 @@ export const AnnotationsPanel = ({
         <Icon icon={MessageSquare} size="sm" /> {t('annotations.title', 'Annotations')} ({annotations.length})
       </span>
       {viewerSession && (
-        <span className="text-[10px] text-cp-text-muted">
+        <span className="text-cp-xs text-cp-text-muted">
           {format(t('annotations.reviewer', 'Reviewer: {name}'), { name: viewerSession.author })}
         </span>
       )}
@@ -450,7 +450,7 @@ export const AnnotationsPanel = ({
             <Icon icon={MessageSquare} size="sm" /> {t('annotations.title', 'Annotations')} ({annotations.length})
           </h3>
           {viewerSession && (
-            <span className="text-[10px] text-cp-text-muted">
+            <span className="text-cp-xs text-cp-text-muted">
               {format(t('annotations.reviewer', 'Reviewer: {name}'), { name: viewerSession.author })}
             </span>
           )}

--- a/src/renderer/components/Atem/AtemAudioRouterDialog.tsx
+++ b/src/renderer/components/Atem/AtemAudioRouterDialog.tsx
@@ -451,7 +451,7 @@ export const AtemAudioRouterDialog = () => {
             <h2 id={titleId} className="text-cp-xl font-semibold">
               {t('atem.audio.title', 'ATEM audio configuration')} — {equipment.name}
             </h2>
-            <div className="text-[11px] text-slate-400">
+            <div className="text-cp-xs text-slate-400">
               {summarise(draft, t)}
             </div>
           </div>
@@ -532,7 +532,7 @@ export const AtemAudioRouterDialog = () => {
               </span>
               {draft.classicMixer && (
                 <span
-                  className="text-[10px] text-slate-400"
+                  className="text-cp-xs text-slate-400"
                   title={t('atem.audio.classicReadOnly', 'The loaded XML also contains a classic AudioMixer section. It is round-tripped on save but is not editable here.')}
                 >
                   {t('atem.audio.classicSectionBadge', '+ AudioMixer section (read-only, round-trip)')}
@@ -601,7 +601,7 @@ export const AtemAudioRouterDialog = () => {
               </button>
             </div>
             {hasDifference(comparison) && (
-              <ul className="mt-1.5 max-h-24 space-y-0.5 overflow-y-auto font-mono text-[10px] text-slate-300">
+              <ul className="mt-1.5 max-h-24 space-y-0.5 overflow-y-auto font-mono text-cp-xs text-slate-300">
                 {allDeltas(comparison).map((d) => (
                   <li key={d.key}>
                     <span className="text-slate-400">{d.label}:</span>{' '}
@@ -770,7 +770,7 @@ const EmptyState = ({
         <Icon icon={SlidersHorizontal} size="xs" className="mr-1 inline-block align-text-bottom" />{t('atem.audio.matrixManual', 'Matrix manual')}
       </button>
     </div>
-    <p className="mt-3 text-[10px] text-slate-400">
+    <p className="mt-3 text-cp-xs text-slate-400">
       {format(
         t(
           'atem.audio.welcomeFooter',
@@ -846,14 +846,14 @@ const ChannelPicker = ({
           <button
             type="button"
             onClick={() => onSetAll([])}
-            className="rounded bg-slate-800 px-2 py-0.5 text-[11px] hover:bg-slate-700"
+            className="rounded bg-slate-800 px-2 py-0.5 text-cp-xs hover:bg-slate-700"
           >
             {t('atem.audio.picker.showAll', 'Show all')}
           </button>
           <button
             type="button"
             onClick={() => onSetAll(items.map((i) => i.id))}
-            className="rounded bg-slate-800 px-2 py-0.5 text-[11px] hover:bg-slate-700"
+            className="rounded bg-slate-800 px-2 py-0.5 text-cp-xs hover:bg-slate-700"
             disabled={allExcluded}
           >
             {t('atem.audio.picker.hideAll', 'Hide all')}
@@ -861,7 +861,7 @@ const ChannelPicker = ({
           <button
             type="button"
             onClick={onClose}
-            className="rounded bg-slate-800 px-2 py-0.5 text-[11px] hover:bg-slate-700"
+            className="rounded bg-slate-800 px-2 py-0.5 text-cp-xs hover:bg-slate-700"
           >
             {t('common.close', 'Close')}
           </button>
@@ -884,7 +884,7 @@ const ChannelPicker = ({
                   }
                   onSetAll(Array.from(next))
                 }}
-                className={`mb-0.5 rounded px-2 py-0.5 text-left text-[11px] font-semibold ${
+                className={`mb-0.5 rounded px-2 py-0.5 text-left text-cp-xs font-semibold ${
                   allHidden
                     ? 'bg-slate-800 text-slate-500'
                     : someHidden
@@ -898,7 +898,7 @@ const ChannelPicker = ({
               {members.map((m) => (
                 <label
                   key={m.id}
-                  className="flex items-center gap-1 pl-2 text-[10px] text-slate-300"
+                  className="flex items-center gap-1 pl-2 text-cp-xs text-slate-300"
                 >
                   <input
                     type="checkbox"
@@ -1063,7 +1063,7 @@ const MatrixView = ({ config, setConfig }: ViewProps) => {
         >
           {t('atem.audio.sourcePicker', 'Source picker')}
           {excludedSourceIds.size > 0 && (
-            <span className="ml-1 text-[10px] text-sky-300">
+            <span className="ml-1 text-cp-xs text-sky-300">
               ({excludedSourceIds.size} {t('atem.audio.hidden', 'hidden')})
             </span>
           )}
@@ -1080,7 +1080,7 @@ const MatrixView = ({ config, setConfig }: ViewProps) => {
         >
           {t('atem.audio.outputPicker', 'Output picker')}
           {excludedOutputIds.size > 0 && (
-            <span className="ml-1 text-[10px] text-sky-300">
+            <span className="ml-1 text-cp-xs text-sky-300">
               ({excludedOutputIds.size} {t('atem.audio.hidden', 'hidden')})
             </span>
           )}

--- a/src/renderer/components/Atem/AtemDialog.tsx
+++ b/src/renderer/components/Atem/AtemDialog.tsx
@@ -383,7 +383,7 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
           {discoveryDone && status !== 'connected' && (
             <div className="mt-2">
               {discovered.length === 0 ? (
-                <div className="rounded border border-dashed border-cp-border bg-cp-surface-3/40 p-2 text-[11px] text-cp-text-muted">
+                <div className="rounded border border-dashed border-cp-border bg-cp-surface-3/40 p-2 text-cp-xs text-cp-text-muted">
                   {t(
                     'atem.dialog.noneFound',
                     'No ATEM switcher found via mDNS on the local network. (Some models / firewall setups block mDNS — enter the IP manually then.)',
@@ -391,7 +391,7 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
                 </div>
               ) : (
                 <div className="space-y-1">
-                  <div className="text-[10px] uppercase tracking-wide text-cp-text-muted">
+                  <div className="text-cp-xs uppercase tracking-wide text-cp-text-muted">
                     {format(t('atem.dialog.foundCount', 'Found ({n}) — click to take the IP:'), {
                       n: discovered.length,
                     })}
@@ -406,12 +406,12 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
                       <span className="font-medium text-cp-text">
                         {dev.name}
                         {dev.model && (
-                          <span className="ml-2 text-[10px] text-cp-text-muted">
+                          <span className="ml-2 text-cp-xs text-cp-text-muted">
                             ({dev.model})
                           </span>
                         )}
                       </span>
-                      <span className="font-mono text-[11px] text-purple-300">{dev.ip}</span>
+                      <span className="font-mono text-cp-xs text-purple-300">{dev.ip}</span>
                     </button>
                   ))}
                 </div>
@@ -419,7 +419,7 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
             </div>
           )}
           {status === 'connected' && state && (
-            <div className="mt-2 text-[11px] text-cp-text-muted">
+            <div className="mt-2 text-cp-xs text-cp-text-muted">
               {state.productIdentifier}
               {state.apiVersion ? ` · API ${state.apiVersion.major}.${state.apiVersion.minor}` : ''}
               {state.mixEffects ? ` · ${state.mixEffects} M/E` : ''}
@@ -468,7 +468,7 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
                     }`}
                   >
                     <td className="py-1 font-mono text-cp-text-muted">{row.inputId}</td>
-                    <td className="py-1 text-[10px] uppercase tracking-wide">
+                    <td className="py-1 text-cp-xs uppercase tracking-wide">
                       <span
                         className={
                           row.category === 'video-input'
@@ -530,7 +530,7 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
               </tbody>
             </table>
             <PanelHint
-              className="mt-3 text-[11px] text-cp-text-muted"
+              className="mt-3 text-cp-xs text-cp-text-muted"
               text={t(
                 'atem.dialog.changesNote',
                 'Heads-up: changes go directly to the switcher (RAM). To survive a reboot, trigger "Save Startup State" in the Blackmagic ATEM Software. Audio inputs (XLR/RJ45 talkback), media players and internal sources are locked — the ATEM manages those itself.',
@@ -539,9 +539,9 @@ export const AtemDialog = ({ onClose, preselectedDeviceId }: AtemDialogProps) =>
           </div>
         )}
 
-        <details className="border-t border-cp-border px-4 py-2 text-[11px]">
+        <details className="border-t border-cp-border px-4 py-2 text-cp-xs">
           <summary className="cursor-pointer text-cp-text-muted">{t('atem.eventLog', 'Event log')} ({events.length})</summary>
-          <pre className="mt-2 max-h-40 overflow-auto rounded bg-cp-surface-3 p-2 font-mono text-[10px] text-cp-text-secondary">
+          <pre className="mt-2 max-h-40 overflow-auto rounded bg-cp-surface-3 p-2 font-mono text-cp-xs text-cp-text-secondary">
             {events.join('\n') || t('atem.dialog.noEvents', '(no events yet)')}
           </pre>
         </details>

--- a/src/renderer/components/Atem/AtemMvConfigDialog.tsx
+++ b/src/renderer/components/Atem/AtemMvConfigDialog.tsx
@@ -192,7 +192,7 @@ const MvLayoutPicker = ({
             left: q.col === 1 ? 0 : '50%',
           }}
         >
-          <span className="pointer-events-none absolute inset-x-0 top-1/2 -translate-y-1/2 text-center text-[10px] font-bold uppercase tracking-wider text-sky-100 opacity-60 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+          <span className="pointer-events-none absolute inset-x-0 top-1/2 -translate-y-1/2 text-center text-cp-xs font-bold uppercase tracking-wider text-sky-100 opacity-60 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
             {quadrants[q.idx] === 'big' ? '1 → 4' : '4 → 1'}
           </span>
         </button>
@@ -491,7 +491,7 @@ const SourcePicker = ({
       <div className="p-1 text-cp-xs">
         {grouped.map(([group, items]) => (
           <div key={group} className="mb-1">
-            <div className="px-1 py-0.5 text-[10px] uppercase tracking-wider text-cp-text-muted">
+            <div className="px-1 py-0.5 text-cp-xs uppercase tracking-wider text-cp-text-muted">
               {group}
             </div>
             {items.map((item) => (
@@ -504,7 +504,7 @@ const SourcePicker = ({
                 }`}
               >
                 <span className="truncate">{item.label}</span>
-                <span className="ml-2 text-[10px] text-cp-text-muted">{item.id}</span>
+                <span className="ml-2 text-cp-xs text-cp-text-muted">{item.id}</span>
               </button>
             ))}
           </div>
@@ -550,7 +550,7 @@ const CapabilitiesPanel = ({
     onOverride({ ...caps, supportedLayouts: Array.from(set).sort((a, b) => a - b) })
   }
   return (
-    <div className="border-t border-cp-border-muted bg-cp-surface-3/40 px-3 py-1.5 text-[10px] text-cp-text-muted">
+    <div className="border-t border-cp-border-muted bg-cp-surface-3/40 px-3 py-1.5 text-cp-xs text-cp-text-muted">
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
@@ -583,7 +583,7 @@ const CapabilitiesPanel = ({
                   key={l.value}
                   type="button"
                   onClick={() => toggleLayout(l.value)}
-                  className={`rounded px-2 py-0.5 text-[10px] ${
+                  className={`rounded px-2 py-0.5 text-cp-xs ${
                     on
                       ? 'bg-sky-900 text-sky-200'
                       : 'bg-cp-surface-2 text-cp-text-faint hover:bg-cp-surface-4'
@@ -696,7 +696,7 @@ const AtemMvDevicePicker = () => {
             </p>
           ) : (
             <>
-              <p className="mb-2 text-[11px] text-cp-text-muted">
+              <p className="mb-2 text-cp-xs text-cp-text-muted">
                 {t('atemMv.picker.intro', 'Which ATEM mixer multiviewer do you want to configure?')}
               </p>
               <ul className="space-y-1">
@@ -1127,12 +1127,12 @@ export const AtemMvConfigDialog = () => {
         title={`${quad.name} groß: ${label} (ID ${sid}) — klicken zum Ändern`}
       >
         {role !== 'other' && (
-          <div className="absolute left-1 top-0 text-[11px] font-semibold uppercase tracking-wider opacity-70">
+          <div className="absolute left-1 top-0 text-cp-xs font-semibold uppercase tracking-wider opacity-70">
             {role.toUpperCase()}
           </div>
         )}
-        <div className="truncate px-1 text-[11px] font-medium leading-tight">{label}</div>
-        <div className="truncate px-1 text-[11px] opacity-60">ID {sid}</div>
+        <div className="truncate px-1 text-cp-xs font-medium leading-tight">{label}</div>
+        <div className="truncate px-1 text-cp-xs opacity-60">ID {sid}</div>
       </button>
     )
   }
@@ -1168,8 +1168,8 @@ export const AtemMvConfigDialog = () => {
         className="group relative flex flex-col items-center justify-center overflow-hidden border border-cp-surface-1/40 text-center hover:brightness-95"
         title={`${quad.name} klein #${cellIdx + 1}: ${label} (ID ${sid}) — klicken zum Ändern`}
       >
-        <div className="truncate px-1 text-[10px] font-medium leading-tight">{label}</div>
-        <div className="truncate px-1 text-[8px] opacity-60">{sid}</div>
+        <div className="truncate px-1 text-cp-xs font-medium leading-tight">{label}</div>
+        <div className="truncate px-1 text-cp-xs opacity-60">{sid}</div>
       </button>
     )
   }
@@ -1234,7 +1234,7 @@ export const AtemMvConfigDialog = () => {
               −
             </button>
           </div>
-          <span className="ml-auto text-[10px] text-cp-text-muted">
+          <span className="ml-auto text-cp-xs text-cp-text-muted">
             {format(t('atem.mv.windowHint', '{n} MV — click a window to change its source.'), { n: config.multiViewers.length })}
           </span>
         </div>
@@ -1281,7 +1281,7 @@ export const AtemMvConfigDialog = () => {
               </button>
             </div>
             {hasDifference(comparison) && (
-              <ul className="mt-1.5 max-h-20 space-y-0.5 overflow-y-auto font-mono text-[10px] text-cp-text-secondary">
+              <ul className="mt-1.5 max-h-20 space-y-0.5 overflow-y-auto font-mono text-cp-xs text-cp-text-secondary">
                 {allDeltas(comparison).map((d) => (
                   <li key={d.key}>
                     <span className="text-cp-text-muted">{d.label}:</span>{' '}
@@ -1309,7 +1309,7 @@ export const AtemMvConfigDialog = () => {
         {mv && (
           <div className="flex flex-wrap items-center gap-4 border-b border-cp-border-muted px-3 py-2">
             <div className="flex items-center gap-2">
-              <span className="text-[11px] text-cp-text-secondary">{t('atem.mv.layoutLabel', 'Layout')}</span>
+              <span className="text-cp-xs text-cp-text-secondary">{t('atem.mv.layoutLabel', 'Layout')}</span>
               <MvLayoutPicker
                 quadrants={quadrants}
                 windows={Array.isArray(mv.windows) ? mv.windows : []}
@@ -1317,7 +1317,7 @@ export const AtemMvConfigDialog = () => {
                 onToggleQuadrant={toggleQuadrant}
                 canvasPortNames={canvasPortNames}
               />
-              <span className="text-[10px] text-cp-text-muted">
+              <span className="text-cp-xs text-cp-text-muted">
                 {t('atem.mv.quadrantHint1', 'Click on a quadrant:')}<br />
                 {t('atem.mv.quadrantHint2', 'big ↔ 4 small')}
               </span>
@@ -1362,7 +1362,7 @@ export const AtemMvConfigDialog = () => {
         />
 
         <div className="flex items-center justify-between border-t border-cp-border px-4 py-2">
-          <span className="text-[11px] text-cp-text-muted">
+          <span className="text-cp-xs text-cp-text-muted">
             {savedFlash ? (
               <span className="font-semibold text-emerald-400">✓ {t('atem.mv.saved', 'Saved')}</span>
             ) : (

--- a/src/renderer/components/Atem/MultiviewerLayoutView.tsx
+++ b/src/renderer/components/Atem/MultiviewerLayoutView.tsx
@@ -170,13 +170,13 @@ const SourceTile = ({ long, short, category, highlight }: TileProps) => {
       className="flex h-full w-full flex-col items-center justify-center overflow-hidden px-1 text-center"
     >
       {highlight && (
-        <div className="text-[11px] font-semibold uppercase tracking-widest opacity-70">
+        <div className="text-cp-xs font-semibold uppercase tracking-widest opacity-70">
           {highlight === 'pgm' ? 'PGM' : 'PRV'}
         </div>
       )}
-      <div className="truncate text-[11px] font-medium leading-tight">{long}</div>
+      <div className="truncate text-cp-xs font-medium leading-tight">{long}</div>
       {short && long !== short && (
-        <div className="truncate text-[11px] opacity-60">{short}</div>
+        <div className="truncate text-cp-xs opacity-60">{short}</div>
       )}
     </div>
   )
@@ -188,7 +188,7 @@ const MultiviewerPanel = ({ mv }: { mv: AtemMultiviewer }) => {
   const prvIndex = mv.programPreviewSwapped ? 1 : 0
   return (
     <div className="rounded border border-cp-surface-5 bg-cp-surface-3 p-2">
-      <div className="mb-1 text-center text-[11px] font-semibold uppercase tracking-wider text-cp-text-secondary">
+      <div className="mb-1 text-center text-cp-xs font-semibold uppercase tracking-wider text-cp-text-secondary">
         MV {mv.index + 1}
       </div>
       <div
@@ -305,7 +305,7 @@ export const MultiviewerLayoutView = ({ onClose }: MultiviewerLayoutViewProps) =
               {t('atem.mvLayout.title', 'Multiviewer layout (live)')}
             </h2>
             {state && (
-              <p className="text-[11px] text-cp-text-muted">
+              <p className="text-cp-xs text-cp-text-muted">
                 {state.productIdentifier} · {mvs.length} MV
                 {mvs.length === 1 ? '' : 's'}
               </p>
@@ -362,7 +362,7 @@ export const MultiviewerLayoutView = ({ onClose }: MultiviewerLayoutViewProps) =
           )}
         </div>
 
-        <footer className="flex flex-wrap items-center gap-4 border-t border-cp-border px-4 py-2 text-[11px] text-cp-text-secondary">
+        <footer className="flex flex-wrap items-center gap-4 border-t border-cp-border px-4 py-2 text-cp-xs text-cp-text-secondary">
           <span className="font-semibold uppercase tracking-wider text-cp-text-muted">
             {t('atem.mvLayout.legend', 'Legend')}
           </span>

--- a/src/renderer/components/Cable/CableDialog.tsx
+++ b/src/renderer/components/Cable/CableDialog.tsx
@@ -333,7 +333,7 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
 
           {specId === CUSTOM_CABLE_SPEC_ID && (
             <div className="rounded border border-cp-border bg-cp-surface-3/60 p-2">
-              <div className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-cp-text-muted">
+              <div className="mb-2 text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">
                 {t('cable.customDefinition', 'Custom Cable Definition')}
               </div>
               <div className="grid grid-cols-2 gap-2">

--- a/src/renderer/components/Calculators/ProjectionCalculatorDialog.tsx
+++ b/src/renderer/components/Calculators/ProjectionCalculatorDialog.tsx
@@ -179,7 +179,7 @@ const ProjectionCalcCore = () => {
             <Result label={t('calc.projection.viewThx', 'Min. viewing distance (THX 36°)')} value={`${screen.thx.toFixed(2)} m`} />
             <Result label={t('calc.projection.viewSmpte', 'Optimal viewing distance (SMPTE 30°)')} value={`${screen.smpte.toFixed(2)} m`} />
           </div>
-          <p className="text-[11px] text-cp-text-muted">
+          <p className="text-cp-xs text-cp-text-muted">
             {t('calc.projection.screen.note', 'Viewing distances by horizontal field of view: THX recommends max. 36°, SMPTE EG-18 about 30°.')}
           </p>
         </div>
@@ -199,7 +199,7 @@ const ProjectionCalcCore = () => {
             <Result label={t('calc.projection.resolution', 'Resolution')} value={`${led.pxW} × ${led.pxH} px`} />
             <Result label={t('calc.projection.totalPixels', 'Total pixels')} value={`${led.total.toLocaleString()} (${led.mp.toFixed(1)} MP)`} />
           </div>
-          <p className="text-[11px] text-cp-text-muted">
+          <p className="text-cp-xs text-cp-text-muted">
             {t('calc.projection.led.note', 'Rule of thumb min. viewing distance (m) ≈ pixel pitch (mm). At 2.6 mm, ~2.6 m before the pixel grid shows.')}
           </p>
         </div>

--- a/src/renderer/components/Calculators/RecordingStorageCalculatorDialog.tsx
+++ b/src/renderer/components/Calculators/RecordingStorageCalculatorDialog.tsx
@@ -102,7 +102,7 @@ export const RecordingStorageCalcCore = ({
 
   return (
     <div className="space-y-3 p-4 text-cp-base">
-      <p className="text-[11px] text-cp-text-muted">
+      <p className="text-cp-xs text-cp-text-muted">
         {t(
           'recStorage.intro',
           'Calculates the storage required for a recording: codec bitrate × duration × channels. Values are approximate without filesystem overhead.',
@@ -174,7 +174,7 @@ export const RecordingStorageCalcCore = ({
             className="w-full rounded border border-cp-border bg-cp-surface-3 p-2 disabled:opacity-50"
           />
           {fixedChannels !== undefined && (
-            <span className="mt-0.5 block text-[10px] text-cp-text-muted">
+            <span className="mt-0.5 block text-cp-xs text-cp-text-muted">
               {t('recStorage.fixedFromDevice', 'taken from device')}
             </span>
           )}
@@ -199,7 +199,7 @@ export const RecordingStorageCalcCore = ({
           <dt className="text-cp-text-faint">{t('recStorage.throughput', 'Write rate')}</dt>
           <dd className="font-mono text-cp-text-bright">
             {((effectiveMbps * channels) / 8).toFixed(0)} MB/s
-            <span className="ml-2 text-[10px] text-cp-text-muted">
+            <span className="ml-2 text-cp-xs text-cp-text-muted">
               {(effectiveMbps * channels) / 8 > 2000
                 ? t('recStorage.tpNvmeArray', '→ needs NVMe RAID')
                 : (effectiveMbps * channels) / 8 > 450
@@ -214,12 +214,12 @@ export const RecordingStorageCalcCore = ({
 
       {/* Array-Dimensionierung: wie viele Laufwerke brauche ich? */}
       <div className="rounded border border-sky-700 bg-sky-950/20 p-3">
-        <div className="mb-2 text-[11px] uppercase tracking-wide text-cp-text-secondary">
+        <div className="mb-2 text-cp-xs uppercase tracking-wide text-cp-text-secondary">
           {t('recStorage.sizing', 'Array sizing')}
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
           <label className="block">
-            <span className="mb-1 block text-[10px] text-cp-text-muted">{t('recStorage.redundancy', 'Redundancy')}</span>
+            <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('recStorage.redundancy', 'Redundancy')}</span>
             <select
               value={redundancy}
               onChange={(e) => setRedundancy(e.target.value as typeof redundancy)}
@@ -232,7 +232,7 @@ export const RecordingStorageCalcCore = ({
             </select>
           </label>
           <label className="block">
-            <span className="mb-1 block text-[10px] text-cp-text-muted">{t('recStorage.headroom', 'Headroom (%)')}</span>
+            <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('recStorage.headroom', 'Headroom (%)')}</span>
             <input
               type="number"
               min={0}
@@ -243,7 +243,7 @@ export const RecordingStorageCalcCore = ({
             />
           </label>
           <label className="block">
-            <span className="mb-1 block text-[10px] text-cp-text-muted">{t('recStorage.driveTb', 'Drive (TB)')}</span>
+            <span className="mb-1 block text-cp-xs text-cp-text-muted">{t('recStorage.driveTb', 'Drive (TB)')}</span>
             <input
               type="number"
               min={0.5}
@@ -260,7 +260,7 @@ export const RecordingStorageCalcCore = ({
           <dt className="text-cp-text-faint font-semibold">{t('recStorage.drivesNeeded', 'Drives needed')}</dt>
           <dd className="font-mono text-cp-xl text-sky-200">
             {sizing.totalDrives} × {driveTb} TB
-            <span className="ml-2 text-[10px] text-cp-text-muted">
+            <span className="ml-2 text-cp-xs text-cp-text-muted">
               ({t('recStorage.rawCapacity', 'raw')} {sizing.rawTb.toFixed(1)} TB)
             </span>
           </dd>
@@ -268,10 +268,10 @@ export const RecordingStorageCalcCore = ({
       </div>
 
       <details className="rounded border border-cp-border-muted bg-cp-surface-3/40">
-        <summary className="cursor-pointer px-3 py-1.5 text-[11px] uppercase tracking-wide text-cp-text-muted">
+        <summary className="cursor-pointer px-3 py-1.5 text-cp-xs uppercase tracking-wide text-cp-text-muted">
           {t('recStorage.formulaHeader', 'Formula')}
         </summary>
-        <code className="block px-3 py-2 text-[11px] text-cp-text-secondary">
+        <code className="block px-3 py-2 text-cp-xs text-cp-text-secondary">
           {t('recStorage.formulaLine1', '(Mbps × 3600 s × hours) ÷ 8 ÷ 1024 = GB per channel')}
           <br />
           {t('recStorage.formulaLine2', 'GB per channel × channels = total')}

--- a/src/renderer/components/Canvas/BulkConnectDialog.tsx
+++ b/src/renderer/components/Canvas/BulkConnectDialog.tsx
@@ -157,7 +157,7 @@ const BulkConnectDialogInner = () => {
       }
     >
       <div className="space-y-3 p-4 text-cp-base">
-        <p className="text-[11px] text-cp-text-muted">
+        <p className="text-cp-xs text-cp-text-muted">
           {t(
             'bulk.intro',
             'Creates N cables at once: source port i → target port i. Occupied target ports are skipped.',
@@ -167,7 +167,7 @@ const BulkConnectDialogInner = () => {
         <div className="grid grid-cols-2 gap-3">
           {/* Quelle */}
           <fieldset className="rounded border border-cp-border p-2">
-            <legend className="px-1 text-[11px] uppercase tracking-wide text-cp-text-muted">
+            <legend className="px-1 text-cp-xs uppercase tracking-wide text-cp-text-muted">
               {t('bulk.source', 'Source')}
             </legend>
             <label className="block">
@@ -216,7 +216,7 @@ const BulkConnectDialogInner = () => {
 
           {/* Ziel */}
           <fieldset className="rounded border border-cp-border p-2">
-            <legend className="px-1 text-[11px] uppercase tracking-wide text-cp-text-muted">
+            <legend className="px-1 text-cp-xs uppercase tracking-wide text-cp-text-muted">
               {t('bulk.target', 'Target')}
             </legend>
             <label className="block">
@@ -307,18 +307,18 @@ const BulkConnectDialogInner = () => {
 
         {/* Preview */}
         <div className="rounded border border-cp-border bg-cp-surface-3/40 p-2">
-          <div className="mb-1 text-[10px] uppercase tracking-wide text-cp-text-muted">
+          <div className="mb-1 text-cp-xs uppercase tracking-wide text-cp-text-muted">
             {format(t('bulk.preview', 'Preview ({n}/{plan} cables)'), {
               n: planned.length,
               plan: count,
             })}
           </div>
           {planned.length === 0 ? (
-            <p className="text-[11px] text-cp-text-muted">
+            <p className="text-cp-xs text-cp-text-muted">
               {t('bulk.previewEmpty', 'Pick source/target and port range.')}
             </p>
           ) : (
-            <ul className="max-h-32 space-y-0.5 overflow-auto text-[11px] text-cp-text-secondary">
+            <ul className="max-h-32 space-y-0.5 overflow-auto text-cp-xs text-cp-text-secondary">
               {planned.slice(0, 12).map((p, i) => (
                 <li key={i} className="font-mono">
                   {p.from} → {p.to}
@@ -330,7 +330,7 @@ const BulkConnectDialogInner = () => {
             </ul>
           )}
           {planWillSkip && (
-            <p className="mt-1 text-[10px] text-amber-400">
+            <p className="mt-1 text-cp-xs text-amber-400">
               {t('bulk.willSkip', '⚠ Count exceeds available ports — extras are skipped.')}
             </p>
           )}

--- a/src/renderer/components/Canvas/CableContextMenu.tsx
+++ b/src/renderer/components/Canvas/CableContextMenu.tsx
@@ -270,7 +270,7 @@ export const CableContextMenu = () => {
       onContextMenu={(e) => e.preventDefault()}
     >
       <div
-        className={`border-b px-3 py-1.5 text-[10px] uppercase tracking-wide ${
+        className={`border-b px-3 py-1.5 text-cp-xs uppercase tracking-wide ${
           isLight ? 'border-slate-200 text-slate-500' : 'border-slate-800 text-slate-400'
         }`}
       >
@@ -356,7 +356,7 @@ export const CableContextMenu = () => {
       <Item onClick={toggleBumpForThisCable} icon={effectiveBumps ? <Icon icon={Check} size="xs" /> : null}>
         {t('canvas.cableMenu.bumps', 'Cable jumps for this cable')}
         {bumpStyle == null && (
-          <span className="ml-auto text-[10px] text-slate-400">
+          <span className="ml-auto text-cp-xs text-slate-400">
             {t('canvas.cableMenu.global', 'global')}
           </span>
         )}
@@ -366,7 +366,7 @@ export const CableContextMenu = () => {
           onClick={() => doUpdate({ bumpStyle: undefined })}
           icon=" "
         >
-          <span className="text-[11px] text-slate-400">
+          <span className="text-cp-xs text-slate-400">
             {t('canvas.cableMenu.removeOverride', 'Remove override (follow global)')}
           </span>
         </Item>

--- a/src/renderer/components/Canvas/CircuitChip.tsx
+++ b/src/renderer/components/Canvas/CircuitChip.tsx
@@ -50,7 +50,7 @@ export function CircuitChip() {
         onClick={() => setAn(!an)}
         title={titel}
         aria-pressed={an}
-        className={`av-focus flex items-center gap-1.5 rounded-full border border-cp-border px-2 py-0.5 text-[11px] ${
+        className={`av-focus flex items-center gap-1.5 rounded-full border border-cp-border px-2 py-0.5 text-cp-xs ${
           an ? 'bg-cp-surface-3 text-cp-text' : 'text-cp-text-secondary hover:bg-cp-surface-3'
         }`}
       >
@@ -78,7 +78,7 @@ export function CircuitChip() {
             'canvas.circuit.resetTitle',
             'All switches back to their default. The plan does not change — it never carried the positions.',
           )}
-          className="av-focus rounded-full border border-cp-border px-2 py-0.5 text-[11px] text-cp-text-secondary hover:bg-cp-surface-3"
+          className="av-focus rounded-full border border-cp-border px-2 py-0.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-3"
         >
           {t('canvas.circuit.reset', 'Reset switches')}
         </button>
@@ -91,7 +91,7 @@ export function CircuitChip() {
             'canvas.circuit.suggestTitle',
             'Why the circuit does not do what it should — and which wire would change that. Every suggestion is computed through and brings its own truth table; nothing is entered without a click.',
           )}
-          className="av-focus rounded-full border border-cp-border px-2 py-0.5 text-[11px] text-cp-text-secondary hover:bg-cp-surface-3"
+          className="av-focus rounded-full border border-cp-border px-2 py-0.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-3"
         >
           {t('canvas.circuit.suggest', 'Suggestions')}
         </button>

--- a/src/renderer/components/Canvas/CircuitSuggestDialog.tsx
+++ b/src/renderer/components/Canvas/CircuitSuggestDialog.tsx
@@ -40,7 +40,7 @@ const Tafel = ({ zeilen }: { zeilen: readonly TafelZeile[] }) => {
   if (schalter.length === 0) return null
   return (
     <div className="mt-1 overflow-x-auto">
-      <table className="text-[11px] tabular-nums">
+      <table className="text-cp-xs tabular-nums">
         <thead>
           <tr className="text-cp-text-muted">
             {schalter.map((id) => (
@@ -197,7 +197,7 @@ export function CircuitSuggestDialog({ open, onClose }: Props) {
                     {t('canvas.circuit.suggest.apply', 'Add wire')}
                   </button>
                 ) : (
-                  <span className="text-[11px] text-cp-warn">
+                  <span className="text-cp-xs text-cp-warn">
                     {t('canvas.circuit.suggest.blocked', 'cannot be added')}
                   </span>
                 )}
@@ -208,7 +208,7 @@ export function CircuitSuggestDialog({ open, onClose }: Props) {
               <button
                 type="button"
                 onClick={() => setOffen(offen === i ? null : i)}
-                className="av-focus mt-1 text-[11px] text-cp-text-muted underline"
+                className="av-focus mt-1 text-cp-xs text-cp-text-muted underline"
               >
                 {offen === i
                   ? t('canvas.circuit.suggest.hideTable', 'Hide truth table')

--- a/src/renderer/components/Canvas/FlowModeChip.tsx
+++ b/src/renderer/components/Canvas/FlowModeChip.tsx
@@ -49,7 +49,7 @@ export function FlowModeChip() {
             ? t('canvas.flow.toggleOff', 'Click: turn motion off.')
             : t('canvas.flow.toggleOn', 'Click: turn motion on.')
       }`}
-      className="av-focus flex items-center gap-1.5 rounded-full border border-cp-border px-2 py-0.5 text-[11px] text-cp-text-secondary hover:bg-cp-surface-3"
+      className="av-focus flex items-center gap-1.5 rounded-full border border-cp-border px-2 py-0.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-3"
     >
       <span
         aria-hidden

--- a/src/renderer/components/Canvas/HubSwitchDialog.tsx
+++ b/src/renderer/components/Canvas/HubSwitchDialog.tsx
@@ -204,7 +204,7 @@ export function HubSwitchDialog({ onClose }: { onClose: () => void }) {
 
             {gewaehlt && (
               <div className="mt-3 space-y-3">
-                <div className="text-[11px] text-cp-text-muted">{gewaehlt.weg}</div>
+                <div className="text-cp-xs text-cp-text-muted">{gewaehlt.weg}</div>
                 {plan.actions.map((a) => (
                   <div key={a.equipmentId} className="rounded border border-cp-border p-2">
                     <div className="text-[12px] font-semibold">{a.equipmentName}</div>
@@ -217,7 +217,7 @@ export function HubSwitchDialog({ onClose }: { onClose: () => void }) {
                         es der wortwoertlich gesendete Text, beim ATEM sind es
                         die Aufrufe — ein erfundener Textblock fuer ein
                         Binaerprotokoll waere eine Behauptung. */}
-                    <div className="mt-2 text-[11px] text-cp-text-muted">
+                    <div className="mt-2 text-cp-xs text-cp-text-muted">
                       {a.art === 'text'
                         ? t('canvas.hubSwitch.sentText', 'Sent verbatim:')
                         : a.art === 'text-vorlage'
@@ -232,10 +232,10 @@ export function HubSwitchDialog({ onClose }: { onClose: () => void }) {
                               )
                             : t('canvas.hubSwitch.sentCalls', 'Commands sent (not a text protocol):')}
                     </div>
-                    <pre className="mt-1 overflow-x-auto rounded bg-cp-surface-3 p-2 text-[11px] leading-tight">
+                    <pre className="mt-1 overflow-x-auto rounded bg-cp-surface-3 p-2 text-cp-xs leading-tight">
                       {a.vorschau}
                     </pre>
-                    <div className="mt-1 text-[11px] text-cp-text-muted">
+                    <div className="mt-1 text-cp-xs text-cp-text-muted">
                       {a.art === 'aufruf' ? a.host : `${a.host}:${a.port}`}
                     </div>
                   </div>

--- a/src/renderer/components/Canvas/LayerVisibilityChips.tsx
+++ b/src/renderer/components/Canvas/LayerVisibilityChips.tsx
@@ -89,7 +89,7 @@ export const LayerVisibilityChips = () => {
   return (
     <div className="relative flex items-center gap-1">
       <span
-        className={`select-none text-[9px] uppercase tracking-wider ${isLight ? 'text-slate-400' : 'text-slate-400'}`}
+        className={`select-none text-cp-xs uppercase tracking-wider ${isLight ? 'text-slate-400' : 'text-slate-400'}`}
         title={t(
           'canvas.layerChips.layerStripTitle',
           'Layer visibility (only cables are filtered, devices stay)',
@@ -119,7 +119,7 @@ export const LayerVisibilityChips = () => {
                   : t('canvas.layerChips.hiddenShow', 'hidden (click to show)'),
               },
             )}
-            className="inline-flex h-6 items-center gap-1 rounded-full border px-2 text-[10px] font-medium transition"
+            className="inline-flex h-6 items-center gap-1 rounded-full border px-2 text-cp-xs font-medium transition"
             style={{
               borderColor: visible ? style.color : isLight ? '#cbd5e1' : '#334155',
               background: visible
@@ -132,11 +132,11 @@ export const LayerVisibilityChips = () => {
               textDecoration: visible ? 'none' : 'line-through',
             }}
           >
-            <span className="text-[11px]">{style.icon}</span>
+            <span className="text-cp-xs">{style.icon}</span>
             <span>{style.label}</span>
             {count > 0 && (
               <span
-                className="rounded-full px-1 text-[8px] font-semibold"
+                className="rounded-full px-1 text-cp-xs font-semibold"
                 style={{
                   background: visible ? `${style.color}55` : isLight ? '#cbd5e1' : '#334155',
                   color: visible ? '#fff' : isLight ? '#475569' : '#94a3b8',
@@ -166,7 +166,7 @@ export const LayerVisibilityChips = () => {
               t('canvas.layerChips.customTitle', '{layer} (custom) — right-click to remove'),
               { layer },
             )}
-            className="inline-flex h-6 items-center gap-1 rounded-full border px-2 text-[10px] font-medium transition"
+            className="inline-flex h-6 items-center gap-1 rounded-full border px-2 text-cp-xs font-medium transition"
             style={{
               borderColor: visible ? '#94a3b8' : isLight ? '#cbd5e1' : '#334155',
               background: visible
@@ -193,7 +193,7 @@ export const LayerVisibilityChips = () => {
         title={t('canvas.layerChips.menuTitle', 'Layer management (create custom / reset all)')}
         aria-haspopup="menu"
         aria-expanded={menuOpen}
-        className={`inline-flex h-6 items-center gap-1 rounded-full border px-2 text-[11px] transition ${
+        className={`inline-flex h-6 items-center gap-1 rounded-full border px-2 text-cp-xs transition ${
           isLight
             ? 'border-slate-300 bg-slate-100 text-slate-600 hover:bg-slate-200'
             : 'border-slate-700 bg-slate-800 text-slate-300 hover:bg-slate-700'

--- a/src/renderer/components/Canvas/PatternChip.tsx
+++ b/src/renderer/components/Canvas/PatternChip.tsx
@@ -123,7 +123,7 @@ export function PatternChip() {
 
   return (
     <span className="flex items-center gap-1">
-      <label className="flex items-center gap-1.5 rounded-full border border-cp-border px-2 py-0.5 text-[11px] text-cp-text-secondary">
+      <label className="flex items-center gap-1.5 rounded-full border border-cp-border px-2 py-0.5 text-cp-xs text-cp-text-secondary">
         <span
           aria-hidden
           className="inline-block h-1.5 w-1.5 rounded-full"
@@ -176,7 +176,7 @@ export function PatternChip() {
               'canvas.pattern.saveImageTitle',
               'Save the image as SVG — for a media player, the switcher stills store, or a laptop on an output. This app feeds nothing in.',
             )}
-            className="av-focus rounded-full border border-cp-border px-2 py-0.5 text-[11px] text-cp-text-secondary hover:bg-cp-surface-3"
+            className="av-focus rounded-full border border-cp-border px-2 py-0.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-3"
           >
             {t('canvas.pattern.saveImage', 'Save image')}
           </button>
@@ -187,7 +187,7 @@ export function PatternChip() {
               'canvas.pattern.saveSheetTitle',
               'The walk-around list — including the paths the plan cannot follow to the end, and why.',
             )}
-            className="av-focus rounded-full border border-cp-border px-2 py-0.5 text-[11px] text-cp-text-secondary hover:bg-cp-surface-3"
+            className="av-focus rounded-full border border-cp-border px-2 py-0.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-3"
           >
             {t('canvas.pattern.saveSheet', 'Check sheet')}
           </button>
@@ -198,7 +198,7 @@ export function PatternChip() {
               'canvas.pattern.saveAcceptanceTitle',
               'What was actually seen, with timestamps — and the places nobody has looked at yet.',
             )}
-            className="av-focus rounded-full border border-cp-border px-2 py-0.5 text-[11px] text-cp-text-secondary hover:bg-cp-surface-3"
+            className="av-focus rounded-full border border-cp-border px-2 py-0.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-3"
           >
             {t('canvas.pattern.saveAcceptance', 'Sign-off')}
           </button>
@@ -210,7 +210,7 @@ export function PatternChip() {
                 'canvas.pattern.switchTitle',
                 'Set the crosspoints the plan foresees for one path — an intervention in the live installation. Only that path\u2019s outputs are switched; the plan itself stays unchanged.',
               )}
-              className="av-focus rounded-full border border-cp-danger/60 px-2 py-0.5 text-[11px] text-cp-danger hover:bg-cp-surface-3"
+              className="av-focus rounded-full border border-cp-danger/60 px-2 py-0.5 text-cp-xs text-cp-danger hover:bg-cp-surface-3"
             >
               {t('canvas.pattern.switch', 'Switch path…')}
             </button>

--- a/src/renderer/components/DrumMicing/DrumMicingDialog.tsx
+++ b/src/renderer/components/DrumMicing/DrumMicingDialog.tsx
@@ -308,11 +308,11 @@ export const DrumMicingDialog = () => {
                       strokeWidth={selected ? 3 : 1.5}
                       strokeDasharray={count > 0 ? undefined : '4 3'}
                     />
-                    <text x={cx} y={cy - r - 4} textAnchor="middle" className="fill-cp-text-secondary text-[9px]">
+                    <text x={cx} y={cy - r - 4} textAnchor="middle" className="fill-cp-text-secondary text-cp-xs">
                       {z.label}
                     </text>
                     {count > 0 && (
-                      <text x={cx} y={cy + 4} textAnchor="middle" className="fill-cp-text text-[11px] font-semibold">
+                      <text x={cx} y={cy + 4} textAnchor="middle" className="fill-cp-text text-cp-xs font-semibold">
                         {count > 1 ? `${count}×` : '●'}
                       </text>
                     )}
@@ -339,7 +339,7 @@ export const DrumMicingDialog = () => {
                 <div className="mb-2 space-y-1">
                   {plan.zones.map((z) => (
                     <div key={z.id} className="flex items-center gap-1">
-                      <span className="w-14 shrink-0 text-[10px] text-cp-text-faint">{ZONE_KIND_LABEL[z.kind]}</span>
+                      <span className="w-14 shrink-0 text-cp-xs text-cp-text-faint">{ZONE_KIND_LABEL[z.kind]}</span>
                       <input
                         value={z.label}
                         onChange={(e) => renameZone(z.id, e.target.value)}
@@ -418,7 +418,7 @@ export const DrumMicingDialog = () => {
                           </button>
                         </div>
                         {phantom && (
-                          <div className="mt-1 flex items-center gap-1 text-[10px] text-amber-500">
+                          <div className="mt-1 flex items-center gap-1 text-cp-xs text-amber-500">
                             <Zap size={10} /> {t('drum.phantom', '48V phantom required')}
                           </div>
                         )}
@@ -493,7 +493,7 @@ export const DrumMicingDialog = () => {
                     <button
                       type="button"
                       onClick={copyBom}
-                      className="rounded border border-cp-border-muted px-2 py-0.5 text-[10px] text-cp-text-secondary hover:bg-cp-surface-2"
+                      className="rounded border border-cp-border-muted px-2 py-0.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-2"
                     >
                       {copied ? t('drum.copied', 'copied ✓') : t('drum.copy', 'copy')}
                     </button>

--- a/src/renderer/components/Export/InstallationDocsDialog.tsx
+++ b/src/renderer/components/Export/InstallationDocsDialog.tsx
@@ -500,7 +500,7 @@ export const InstallationDocsDialog = () => {
                   key={p.id}
                   className="flex items-start gap-2 rounded border border-cp-border-muted bg-cp-surface-1 px-2 py-1.5"
                 >
-                  <span className="mt-0.5 shrink-0 rounded bg-cp-surface-3 px-1.5 py-0.5 text-[10px] uppercase text-cp-text-secondary">
+                  <span className="mt-0.5 shrink-0 rounded bg-cp-surface-3 px-1.5 py-0.5 text-cp-xs uppercase text-cp-text-secondary">
                     {p.target?.type === 'cable'
                       ? t('docs.pending.cable', 'Cable')
                       : p.target?.type === 'equipment'

--- a/src/renderer/components/Export/VideohubExportDialog.tsx
+++ b/src/renderer/components/Export/VideohubExportDialog.tsx
@@ -136,11 +136,11 @@ const ChangeoverSheet = ({
   }
 
   const selCls =
-    'rounded border border-cyan-800/60 bg-cyan-950/40 px-1 py-0.5 text-[11px] text-cyan-100'
+    'rounded border border-cyan-800/60 bg-cyan-950/40 px-1 py-0.5 text-cp-xs text-cyan-100'
 
   return (
     <div className="mb-2 rounded border border-cyan-800/40 bg-cp-surface-2/40 p-2">
-      <div className="mb-1 flex flex-wrap items-center gap-1 text-[11px]">
+      <div className="mb-1 flex flex-wrap items-center gap-1 text-cp-xs">
         <span className="text-cyan-300">{t('salvo.changeover', 'Changeover from')}</span>
         <select value={vonId} onChange={(e) => setVonId(e.target.value)} className={selCls}>
           <option value="">{t('salvo.pick', '\u2014 pick a set \u2014')}</option>
@@ -184,7 +184,7 @@ const ChangeoverSheet = ({
       </div>
 
       {von && nach && (
-        <div className="text-[11px]">
+        <div className="text-cp-xs">
           {aenderungen.length === 0 ? (
             /* Ein leeres Blatt ist hier eine ANTWORT und kein Fehler: die
                beiden Saetze sind gleich, es ist nichts umzustecken. */
@@ -203,7 +203,7 @@ const ChangeoverSheet = ({
       )}
 
       {befunde.length > 0 && (
-        <ul className="mt-1 flex flex-col gap-0.5 text-[11px]">
+        <ul className="mt-1 flex flex-col gap-0.5 text-cp-xs">
           {befunde.map((b, idx) => (
             <li
               key={`${b.kind}:${b.subject}:${idx}`}
@@ -1301,13 +1301,13 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
             abhaengig). */}
         <div className="mb-3 rounded border border-cyan-700/40 bg-cyan-950/20 p-2">
           <div className="mb-2 flex items-center justify-between">
-            <div className="text-[10px] uppercase tracking-wide text-cyan-300">
+            <div className="text-cp-xs uppercase tracking-wide text-cyan-300">
               {t('export.salvosHeader', 'Salvos (routing snapshots)')}
             </div>
             <button
               type="button"
               onClick={() => void saveSalvo()}
-              className="rounded bg-cyan-700 px-2 py-0.5 text-[11px] text-white hover:bg-cyan-600"
+              className="rounded bg-cyan-700 px-2 py-0.5 text-cp-xs text-white hover:bg-cyan-600"
               title={t('videohub.saveSalvo', 'Save current routing as named snapshot')}
             >
               + {t('export.saveCurrentRouting', 'Save current routing')}
@@ -1328,7 +1328,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
             />
           )}
           {salvos.length === 0 ? (
-            <div className="text-[11px] text-cp-text-muted">
+            <div className="text-cp-xs text-cp-text-muted">
               {t('export.noSalvos', 'No salvos yet. Save the current crosspoint distribution and recall it later with one click.')}
             </div>
           ) : (
@@ -1336,7 +1336,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
               {salvos.map((s) => (
                 <div
                   key={s.id}
-                  className="flex items-center gap-1 rounded border border-cyan-800/60 bg-cyan-950/40 px-1.5 py-0.5 text-[11px]"
+                  className="flex items-center gap-1 rounded border border-cyan-800/60 bg-cyan-950/40 px-1.5 py-0.5 text-cp-xs"
                 >
                   <button
                     type="button"
@@ -1367,7 +1367,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
             Teilmengen (z.B. nur Labels nach Re-Labelling, ohne Routing
             zu touchen). */}
         <div className="mb-3 rounded border border-cp-surface-5 bg-cp-surface-2/60 p-2">
-          <div className="mb-2 text-[10px] uppercase tracking-wide text-cp-text-muted">
+          <div className="mb-2 text-cp-xs uppercase tracking-wide text-cp-text-muted">
             An Videohub senden (TCP) — offline editieren, hier pushen wenn online
             {!hasDesktopBridge && (
               <span className="ml-2 text-amber-400">{t('vhx.desktopOnly', '· desktop app only')}</span>
@@ -1459,7 +1459,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                 </div>
               ) : (
                 <div className="flex flex-col gap-1">
-                  <div className="mb-1 text-[10px] uppercase tracking-wide text-teal-300">
+                  <div className="mb-1 text-cp-xs uppercase tracking-wide text-teal-300">
                     Gefunden ({discovered.length}) — Klick übernimmt IP/Port
                   </div>
                   {discovered.map((d) => (
@@ -1476,7 +1476,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                       <span className="truncate font-semibold text-cp-text">
                         {d.name}
                         {d.model && (
-                          <span className="ml-1 text-[10px] font-normal text-cp-text-muted">
+                          <span className="ml-1 text-cp-xs font-normal text-cp-text-muted">
                             · {d.model}
                           </span>
                         )}
@@ -1522,7 +1522,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
             </button>
           </div>
           {hubState && (
-            <div className="mt-1.5 rounded border border-sky-700/40 bg-sky-950/30 p-1.5 text-[11px] text-sky-100">
+            <div className="mt-1.5 rounded border border-sky-700/40 bg-sky-950/30 p-1.5 text-cp-xs text-sky-100">
               <span className="font-semibold">{t('videohub.hubStatus', 'Hub status:')}</span>{' '}
               {hubState.modelName ?? t('export.unknown', 'Unknown')}{' '}
               {hubState.friendlyName && `("${hubState.friendlyName}")`}
@@ -1601,7 +1601,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
               Wechsel). Hilft beim Debuggen ("warum sagt Hub jetzt
               NAK"). Wird beim Dialog-Close vergessen. */}
           {activityLog.length > 0 && (
-            <details className="mt-2 text-[11px]">
+            <details className="mt-2 text-cp-xs">
               <summary className="cursor-pointer text-cp-text-muted hover:text-cp-text-bright">
                 Activity-Log ({activityLog.length})
               </summary>
@@ -1628,7 +1628,7 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
         <textarea
           readOnly
           value={preview}
-          className="flex-1 min-h-[150px] rounded border border-cp-border bg-cp-surface-3 p-2 font-mono text-[11px] text-cp-text-bright"
+          className="flex-1 min-h-[150px] rounded border border-cp-border bg-cp-surface-3 p-2 font-mono text-cp-xs text-cp-text-bright"
         />
 
         <div className="mt-3 flex justify-end gap-2">

--- a/src/renderer/components/Export/VideohubRoutingList.tsx
+++ b/src/renderer/components/Export/VideohubRoutingList.tsx
@@ -40,7 +40,7 @@ export const VideohubRoutingList = ({
   const t = useTranslation()
   return (
     <div className="rounded-cp-control border border-cp-border bg-cp-surface-3">
-      <div className="border-b border-cp-border-muted bg-cp-surface-1 px-3 py-2 text-[11px] uppercase tracking-wide text-cp-text-muted">
+      <div className="border-b border-cp-border-muted bg-cp-surface-1 px-3 py-2 text-cp-xs uppercase tracking-wide text-cp-text-muted">
         {t('export.routingListHeader', 'Routing list')} · {totalOutputs} Outputs · {totalInputs} {t('export.inputsAvailable', 'inputs available')}
       </div>
       <div

--- a/src/renderer/components/Export/VideohubRoutingMatrix.tsx
+++ b/src/renderer/components/Export/VideohubRoutingMatrix.tsx
@@ -208,7 +208,7 @@ export const VideohubRoutingMatrix = ({
   if (!useGrid) {
     return (
       <div className="overflow-auto max-h-64 rounded border border-cp-border bg-cp-surface-3 p-2">
-        <div className="mb-2 text-[10px] text-amber-300">
+        <div className="mb-2 text-cp-xs text-amber-300">
           {totalInputs}×{totalOutputs} ({cellCount.toLocaleString()} Crosspoints) —{' '}
           {t('export.listModeOverload', 'List mode, because at this size the crosspoint matrix overloads browser rendering.')}
         </div>
@@ -332,7 +332,7 @@ export const VideohubRoutingMatrix = ({
 
   return (
     <div className="space-y-1">
-      <div className="flex items-center justify-between text-[11px] text-cp-text-muted">
+      <div className="flex items-center justify-between text-cp-xs text-cp-text-muted">
         <span>
           {t('export.resizeTip', 'Tip: drag the right edge of a column / bottom edge of a row like in Excel.')}
         </span>
@@ -342,7 +342,7 @@ export const VideohubRoutingMatrix = ({
           <button
             type="button"
             onClick={resetLayout}
-            className="rounded bg-cp-surface-2 px-2 py-0.5 text-[11px] text-cp-text-secondary hover:bg-cp-surface-4"
+            className="rounded bg-cp-surface-2 px-2 py-0.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-4"
           >
             ↺ {t('export.resetLayout', 'Reset layout')}
           </button>

--- a/src/renderer/components/Import/GraphmlImportDialog.tsx
+++ b/src/renderer/components/Import/GraphmlImportDialog.tsx
@@ -65,7 +65,7 @@ const confidenceBadge = (conf: ResolvedDevice['confidence']) => {
   const c = colors[conf]
   return (
     <span
-      className="rounded px-1 text-[10px] font-bold"
+      className="rounded px-1 text-cp-xs font-bold"
       style={{ background: c.bg, color: c.fg }}
     >
       {c.label}
@@ -449,7 +449,7 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
 
         {/* Library-mode hint: cables are dropped (templates carry no cabling). */}
         {destination === 'library' && (
-          <div className="border-b border-violet-800/60 bg-violet-950/40 px-4 py-2 text-[11px] text-violet-200">
+          <div className="border-b border-violet-800/60 bg-violet-950/40 px-4 py-2 text-cp-xs text-violet-200">
             {t('graphml.dialog.libraryHint', 'Library mode: devices are saved as reusable templates into the local library. Cables are not adopted (templates carry no cabling).')}
           </div>
         )}
@@ -532,7 +532,7 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
                           className="w-full rounded border border-cp-border bg-cp-surface-3 px-1.5 py-0.5 text-cp-text"
                         />
                         {dev.subtitle && (
-                          <div className="px-1.5 text-[10px] text-cp-text-muted">{dev.subtitle}</div>
+                          <div className="px-1.5 text-cp-xs text-cp-text-muted">{dev.subtitle}</div>
                         )}
                       </td>
                       <td className="px-3 py-1">
@@ -552,7 +552,7 @@ export const GraphmlImportDialog = ({ open, onClose }: GraphmlImportDialogProps)
                       <td className="px-3 py-1">
                         {confidenceBadge(dev.confidence)}
                         {dev.notes[0] && (
-                          <span className="ml-1 text-[10px] text-cp-text-muted" title={dev.notes.join('\n')}>
+                          <span className="ml-1 text-cp-xs text-cp-text-muted" title={dev.notes.join('\n')}>
                             {dev.notes[0].length > 50 ? `${dev.notes[0].slice(0, 47)}…` : dev.notes[0]}
                           </span>
                         )}

--- a/src/renderer/components/Import/GraphmlViewer.tsx
+++ b/src/renderer/components/Import/GraphmlViewer.tsx
@@ -282,14 +282,14 @@ export const GraphmlViewer = ({ document, highlightNodes, className }: GraphmlVi
         <button
           type="button"
           onClick={resetView}
-          className="rounded px-1.5 text-[10px] hover:bg-cp-surface-4"
+          className="rounded px-1.5 text-cp-xs hover:bg-cp-surface-4"
           aria-label={t('graphmlViewer.reset', 'Reset')}
         >
           {t('graphmlViewer.reset', 'Reset')}
         </button>
-        <span className="ml-1 text-[10px] text-cp-text-muted">{Math.round(view.zoom * 100)}%</span>
+        <span className="ml-1 text-cp-xs text-cp-text-muted">{Math.round(view.zoom * 100)}%</span>
       </div>
-      <div className="pointer-events-none absolute bottom-2 left-3 text-[10px] text-cp-text-muted">
+      <div className="pointer-events-none absolute bottom-2 left-3 text-cp-xs text-cp-text-muted">
         {format(
           t(
             'graphmlViewer.statusBar',

--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -1328,7 +1328,7 @@ const MenuItem = ({ onClick, icon, shortcut, disabled, note, children }: MenuIte
       <span className="min-w-0 flex-1">
         <span className="block truncate">{children}</span>
         {note && (
-          <span className="block truncate text-[11px] text-[var(--cp-text-faint)]">{note}</span>
+          <span className="block truncate text-cp-xs text-[var(--cp-text-faint)]">{note}</span>
         )}
       </span>
       {shortcut && (
@@ -1345,7 +1345,7 @@ const MenuSep = () => <div className="my-1 border-t border-cp-border" />
 /** Kleiner, nicht-interaktiver Gruppen-Titel innerhalb eines Menüs. Gliedert
  *  lange Menüs (z. B. Werkzeuge) optisch, ohne echte Flyout-Submenüs. */
 const MenuSectionHeader = ({ children }: { children: React.ReactNode }) => (
-  <div className="px-3 pb-0.5 pt-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--cp-text-faint)] select-none">
+  <div className="px-3 pb-0.5 pt-1.5 text-cp-xs font-semibold uppercase tracking-[0.14em] text-[var(--cp-text-faint)] select-none">
     {children}
   </div>
 )

--- a/src/renderer/components/Library/LibraryItem.tsx
+++ b/src/renderer/components/Library/LibraryItem.tsx
@@ -120,7 +120,7 @@ export const LibraryItem = ({
           )}
           {isFromActiveRentman && (
             <span
-              className="mr-1 rounded bg-orange-600 px-1 text-[11px] font-bold text-white"
+              className="mr-1 rounded bg-orange-600 px-1 text-cp-xs font-bold text-white"
               title={format(
                 t('library.item.badgeActiveRentman', 'From active Rentman project{suffix}'),
                 { suffix: item.rentmanProjectName ? `: ${item.rentmanProjectName}` : '' },
@@ -131,7 +131,7 @@ export const LibraryItem = ({
           )}
           {isFromOtherRentman && (
             <span
-              className="mr-1 rounded bg-cp-surface-5 px-1 text-[11px] font-bold text-cp-text-bright"
+              className="mr-1 rounded bg-cp-surface-5 px-1 text-cp-xs font-bold text-cp-text-bright"
               title={format(
                 t('library.item.badgeOtherRentman', 'From Rentman project{suffix}'),
                 { suffix: item.rentmanProjectName ? `: ${item.rentmanProjectName}` : '' },
@@ -142,7 +142,7 @@ export const LibraryItem = ({
           )}
           {!item.rentmanSource && (
             <span
-              className="mr-1 rounded bg-sky-800/80 px-1 text-[11px] font-bold text-sky-100"
+              className="mr-1 rounded bg-sky-800/80 px-1 text-cp-xs font-bold text-sky-100"
               title={t('library.item.badgeLocal', 'Local device (not from Rentman)')}
             >
               L
@@ -172,7 +172,7 @@ export const LibraryItem = ({
                 event.stopPropagation()
                 onToggleFavorite()
               }}
-              className={`rounded px-1 text-[11px] ${
+              className={`rounded px-1 text-cp-xs ${
                 item.favorite
                   ? 'bg-amber-700 text-amber-100 hover:bg-amber-600'
                   : 'bg-cp-surface-4 text-cp-text-secondary hover:bg-cp-surface-5'
@@ -201,7 +201,7 @@ export const LibraryItem = ({
                 event.stopPropagation()
                 onToggleHidden()
               }}
-              className={`rounded px-1 text-[11px] ${
+              className={`rounded px-1 text-cp-xs ${
                 item.hidden
                   ? 'bg-cp-surface-5 text-cp-text-bright hover:bg-slate-500'
                   : 'bg-cp-surface-4 text-cp-text-secondary hover:bg-cp-surface-5'
@@ -229,7 +229,7 @@ export const LibraryItem = ({
                 event.stopPropagation()
                 onExport()
               }}
-              className="rounded bg-cp-surface-4 px-1 text-[11px] text-cp-text-secondary hover:bg-cp-surface-5"
+              className="rounded bg-cp-surface-4 px-1 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-5"
               aria-label={t('library.item.exportAria', 'Export')}
             >
               <Icon icon={Download} size="xs" />
@@ -259,7 +259,7 @@ export const LibraryItem = ({
                 event.stopPropagation()
                 onLinkPorts()
               }}
-              className="rounded bg-emerald-700 px-1 text-[11px] text-emerald-100 hover:bg-emerald-600"
+              className="rounded bg-emerald-700 px-1 text-cp-xs text-emerald-100 hover:bg-emerald-600"
               aria-label={t('library.item.linkAria', 'Link')}
             >
               <Icon icon={Link} size="xs" />
@@ -274,7 +274,7 @@ export const LibraryItem = ({
                 event.stopPropagation()
                 onRemove()
               }}
-              className="rounded bg-red-700 px-1 text-[10px] hover:bg-red-600"
+              className="rounded bg-red-700 px-1 text-cp-xs hover:bg-red-600"
               aria-label={t('library.item.removeTitle', 'Remove from library')}
             >
               ×

--- a/src/renderer/components/Library/LibraryMenus.tsx
+++ b/src/renderer/components/Library/LibraryMenus.tsx
@@ -192,7 +192,7 @@ export const LibraryFiltersMenu = ({
               : t('library.menus.collapseAll', 'Collapse all categories')}
           </button>
           <div className="my-1 border-t border-cp-border-muted" />
-          <div className="px-3 py-1 text-[10px] uppercase tracking-wider text-cp-text-muted">
+          <div className="px-3 py-1 text-cp-xs uppercase tracking-wider text-cp-text-muted">
             {t('library.menus.sorting', 'Sorting')}
           </div>
           {(

--- a/src/renderer/components/Library/LibraryPanel.tsx
+++ b/src/renderer/components/Library/LibraryPanel.tsx
@@ -720,7 +720,7 @@ export const LibraryPanel = () => {
           type="button"
           onClick={toggleCollapsed}
           aria-label={t('library.show', 'Show library')}
-          className="mt-3 flex-1 self-stretch text-[10px] font-semibold uppercase tracking-[0.18em] text-cp-text-muted transition-colors hover:text-cp-text-secondary focus-visible:outline-none focus-visible:text-sky-300"
+          className="mt-3 flex-1 self-stretch text-cp-xs font-semibold uppercase tracking-[0.18em] text-cp-text-muted transition-colors hover:text-cp-text-secondary focus-visible:outline-none focus-visible:text-sky-300"
           style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}
         >
           {t('library.title', 'Library')}
@@ -855,9 +855,9 @@ export const LibraryPanel = () => {
               }`}
               title={t('library.section.localTitle', 'Custom and imported templates, local to this installation')}
             >
-              <span className="mr-1 rounded bg-sky-900/80 px-1 text-[11px] font-bold text-sky-100">L</span>
+              <span className="mr-1 rounded bg-sky-900/80 px-1 text-cp-xs font-bold text-sky-100">L</span>
               {t('library.section.local', 'Local')}
-              <span className="ml-1 text-[10px] text-cp-text-muted">
+              <span className="ml-1 text-cp-xs text-cp-text-muted">
                 ({customLibrary.filter((t) => !t.rentmanSource).length})
               </span>
             </button>
@@ -871,9 +871,9 @@ export const LibraryPanel = () => {
               }`}
               title={t('library.section.rentmanTitle', 'Rentman-imported devices and account catalog')}
             >
-              <span className="mr-1 rounded bg-orange-900/80 px-1 text-[11px] font-bold text-orange-100">R</span>
+              <span className="mr-1 rounded bg-orange-900/80 px-1 text-cp-xs font-bold text-orange-100">R</span>
               Rentman
-              <span className="ml-1 text-[10px] text-cp-text-muted">
+              <span className="ml-1 text-cp-xs text-cp-text-muted">
                 ({customLibrary.filter((t) => t.rentmanSource).length})
               </span>
             </button>
@@ -977,7 +977,7 @@ export const LibraryPanel = () => {
               </div>
             )}
 
-            <div className="mb-2 text-[11px] uppercase tracking-wide text-cp-text-muted">
+            <div className="mb-2 text-cp-xs uppercase tracking-wide text-cp-text-muted">
               {t('library.netbox.hits', 'Hits')} {netBoxResults.length > 0 ? `(${netBoxResults.length})` : ''}
             </div>
             <div className="space-y-2">
@@ -997,9 +997,9 @@ export const LibraryPanel = () => {
                         <div className="truncate font-medium text-cp-text">
                           {item.manufacturer} {item.model}
                         </div>
-                        <div className="truncate text-[11px] text-cp-text-muted">{item.path}</div>
+                        <div className="truncate text-cp-xs text-cp-text-muted">{item.path}</div>
                         <div className="mt-2 flex max-w-[340px] items-center gap-2">
-                          <span className="text-[11px] text-cp-text-muted">{t('library.netbox.categoryLabel', 'Category:')}</span>
+                          <span className="text-cp-xs text-cp-text-muted">{t('library.netbox.categoryLabel', 'Category:')}</span>
                           <select
                             value={netBoxCategoryByPath[item.path] ?? ''}
                             onChange={(event) =>
@@ -1102,7 +1102,7 @@ export const LibraryPanel = () => {
                     setAiKeyDraft(getGeminiApiKey())
                     setAiSettingsOpen(true)
                   }}
-                  className="text-[10px] text-violet-300 hover:underline"
+                  className="text-cp-xs text-violet-300 hover:underline"
                   title={t('library.create.aiSettings', 'AI settings')}
                 >
                   <Icon icon={Settings} size="xs" className="mr-1 inline-block align-text-bottom" />{t('library.create.aiSettingsLabel', 'AI settings')}
@@ -1174,7 +1174,7 @@ export const LibraryPanel = () => {
                     {t('common.cancel', 'Cancel')}
                   </button>
                 </div>
-                <div className="mt-1 text-[10px] text-cp-text-muted">
+                <div className="mt-1 text-cp-xs text-cp-text-muted">
                   {t('library.create.aiKey.hintPrefix', 'Stored locally in localStorage only. Create a key at')}{' '}
                   <a
                     href="https://aistudio.google.com/app/apikey"

--- a/src/renderer/components/Library/TabButton.tsx
+++ b/src/renderer/components/Library/TabButton.tsx
@@ -36,7 +36,7 @@ export const TabButton = ({
     <span className="truncate">{label}</span>
     {count != null && count > 0 && (
       <span
-        className={`ml-1 rounded-full px-1 text-[10px] ${
+        className={`ml-1 rounded-full px-1 text-cp-xs ${
           active ? 'bg-sky-900/70 text-sky-100' : 'bg-cp-surface-1 text-cp-text-muted'
         }`}
       >

--- a/src/renderer/components/Library/TemplateMergeDialog.tsx
+++ b/src/renderer/components/Library/TemplateMergeDialog.tsx
@@ -198,10 +198,10 @@ export const TemplateMergeDialog = ({
             <div className="mb-2 text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">
               {t('templateMerge.local', 'Local')}
             </div>
-            <div className="mb-1 text-[11px] text-cp-text-muted">{localTemplate.name}</div>
+            <div className="mb-1 text-cp-xs text-cp-text-muted">{localTemplate.name}</div>
             <div className="space-y-2">
               <div>
-                <div className="mb-1 text-[11px] font-semibold text-cp-text-secondary">{t('templateMerge.inputs', 'Inputs')}</div>
+                <div className="mb-1 text-cp-xs font-semibold text-cp-text-secondary">{t('templateMerge.inputs', 'Inputs')}</div>
                 <div className="space-y-1">
                   {localTemplate.inputs.map((port) => {
                     const key = makePortKey('local', 'in', port.id)
@@ -209,14 +209,14 @@ export const TemplateMergeDialog = ({
                       <label key={key} className="flex items-center gap-2 rounded px-1 py-0.5 text-cp-xs hover:bg-cp-surface-1">
                         <input type="checkbox" checked={selectedKeys.has(key)} onChange={() => toggle(key)} />
                         <span className="truncate">{port.name}</span>
-                        <span className="ml-auto text-[10px] text-cp-text-muted">{port.connectorType}</span>
+                        <span className="ml-auto text-cp-xs text-cp-text-muted">{port.connectorType}</span>
                       </label>
                     )
                   })}
                 </div>
               </div>
               <div>
-                <div className="mb-1 text-[11px] font-semibold text-cp-text-secondary">{t('templateMerge.outputs', 'Outputs')}</div>
+                <div className="mb-1 text-cp-xs font-semibold text-cp-text-secondary">{t('templateMerge.outputs', 'Outputs')}</div>
                 <div className="space-y-1">
                   {localTemplate.outputs.map((port) => {
                     const key = makePortKey('local', 'out', port.id)
@@ -224,7 +224,7 @@ export const TemplateMergeDialog = ({
                       <label key={key} className="flex items-center gap-2 rounded px-1 py-0.5 text-cp-xs hover:bg-cp-surface-1">
                         <input type="checkbox" checked={selectedKeys.has(key)} onChange={() => toggle(key)} />
                         <span className="truncate">{port.name}</span>
-                        <span className="ml-auto text-[10px] text-cp-text-muted">{port.connectorType}</span>
+                        <span className="ml-auto text-cp-xs text-cp-text-muted">{port.connectorType}</span>
                       </label>
                     )
                   })}
@@ -235,10 +235,10 @@ export const TemplateMergeDialog = ({
 
           <div className="rounded border border-cp-border bg-cp-surface-3/50 p-2">
             <div className="mb-2 text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">{incomingLabel}</div>
-            <div className="mb-1 text-[11px] text-cp-text-muted">{incomingTemplate.name}</div>
+            <div className="mb-1 text-cp-xs text-cp-text-muted">{incomingTemplate.name}</div>
             <div className="space-y-2">
               <div>
-                <div className="mb-1 text-[11px] font-semibold text-cp-text-secondary">{t('templateMerge.inputs', 'Inputs')}</div>
+                <div className="mb-1 text-cp-xs font-semibold text-cp-text-secondary">{t('templateMerge.inputs', 'Inputs')}</div>
                 <div className="space-y-1">
                   {incomingTemplate.inputs.map((port) => {
                     const key = makePortKey('incoming', 'in', port.id)
@@ -246,14 +246,14 @@ export const TemplateMergeDialog = ({
                       <label key={key} className="flex items-center gap-2 rounded px-1 py-0.5 text-cp-xs hover:bg-cp-surface-1">
                         <input type="checkbox" checked={selectedKeys.has(key)} onChange={() => toggle(key)} />
                         <span className="truncate">{port.name}</span>
-                        <span className="ml-auto text-[10px] text-cp-text-muted">{port.connectorType}</span>
+                        <span className="ml-auto text-cp-xs text-cp-text-muted">{port.connectorType}</span>
                       </label>
                     )
                   })}
                 </div>
               </div>
               <div>
-                <div className="mb-1 text-[11px] font-semibold text-cp-text-secondary">{t('templateMerge.outputs', 'Outputs')}</div>
+                <div className="mb-1 text-cp-xs font-semibold text-cp-text-secondary">{t('templateMerge.outputs', 'Outputs')}</div>
                 <div className="space-y-1">
                   {incomingTemplate.outputs.map((port) => {
                     const key = makePortKey('incoming', 'out', port.id)
@@ -261,7 +261,7 @@ export const TemplateMergeDialog = ({
                       <label key={key} className="flex items-center gap-2 rounded px-1 py-0.5 text-cp-xs hover:bg-cp-surface-1">
                         <input type="checkbox" checked={selectedKeys.has(key)} onChange={() => toggle(key)} />
                         <span className="truncate">{port.name}</span>
-                        <span className="ml-auto text-[10px] text-cp-text-muted">{port.connectorType}</span>
+                        <span className="ml-auto text-cp-xs text-cp-text-muted">{port.connectorType}</span>
                       </label>
                     )
                   })}

--- a/src/renderer/components/Library/tabs/GroupsTab.tsx
+++ b/src/renderer/components/Library/tabs/GroupsTab.tsx
@@ -27,7 +27,7 @@ export const GroupsTab = () => {
     <div className="flex flex-1 min-h-0 flex-col">
       <div className="mb-2 flex flex-wrap items-center justify-between gap-y-1 gap-x-2">
         <h2 className="text-cp-base font-semibold">{t('library.tabs.groups.title', 'Device groups')}</h2>
-        <span className="text-[10px] text-cp-text-muted">
+        <span className="text-cp-xs text-cp-text-muted">
           {t('library.tabs.groups.subtitle', 'Multiple devices + cables as a template')}
         </span>
       </div>
@@ -79,7 +79,7 @@ export const GroupsTab = () => {
                       <div className="flex items-start justify-between gap-2">
                         <div className="min-w-0 flex-1">
                           <div className="truncate font-medium text-cp-text">{preset.name}</div>
-                          <div className="mt-0.5 text-[10px] text-cp-text-muted">
+                          <div className="mt-0.5 text-cp-xs text-cp-text-muted">
                             {format(t('library.tabs.groups.counts', '{items} devices · {cables} cables'), {
                               items: preset.items.length,
                               cables: preset.cables.length,
@@ -90,7 +90,7 @@ export const GroupsTab = () => {
                                 })
                               : ''}
                           </div>
-                          <div className="mt-0.5 truncate text-[10px] text-cp-text-muted">
+                          <div className="mt-0.5 truncate text-cp-xs text-cp-text-muted">
                             {preset.items.map((i) => i.name).join(', ')}
                           </div>
                         </div>
@@ -129,7 +129,7 @@ export const GroupsTab = () => {
                               }
                               renameGroupPreset(preset.id, trimmed)
                             }}
-                            className="rounded bg-cp-surface-4 px-1 text-[11px] text-cp-text-secondary hover:bg-cp-surface-5"
+                            className="rounded bg-cp-surface-4 px-1 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-5"
                             title={t('library.tabs.groups.renameTitle', 'Rename template')}
                             aria-label={t('library.tabs.groups.renameAria', 'Rename')}
                           >
@@ -141,7 +141,7 @@ export const GroupsTab = () => {
                               event.stopPropagation()
                               void exportPresetToFile(preset)
                             }}
-                            className="rounded bg-cp-surface-4 px-1 text-[11px] text-cp-text-secondary hover:bg-cp-surface-5"
+                            className="rounded bg-cp-surface-4 px-1 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-5"
                             title={t(
                               'library.tabs.groups.exportTitle',
                               'Export as file (copy to Downloads folder)',
@@ -168,7 +168,7 @@ export const GroupsTab = () => {
                                 deleteGroupPreset(preset.id)
                               }
                             }}
-                            className="rounded bg-red-700 px-1 text-[10px] hover:bg-red-600"
+                            className="rounded bg-red-700 px-1 text-cp-xs hover:bg-red-600"
                             title={t('library.tabs.groups.deleteTitle', 'Remove group from library')}
                             aria-label={t('common.delete', 'Delete')}
                           >

--- a/src/renderer/components/Library/tabs/LocalEquipmentTab.tsx
+++ b/src/renderer/components/Library/tabs/LocalEquipmentTab.tsx
@@ -156,7 +156,7 @@ export const LocalEquipmentTab = ({
               <Icon icon={X} size="sm" />
             </button>
           ) : (
-            <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[11px] uppercase tracking-wider text-cp-text-muted">
+            <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-cp-xs uppercase tracking-wider text-cp-text-muted">
               {t('library.search.shortcut', 'Ctrl+F')}
             </span>
           )}
@@ -276,7 +276,7 @@ export const LocalEquipmentTab = ({
                   <div className="mb-2 font-semibold text-cp-text-secondary">
                     {t('library.empty.title', 'No devices found')}
                   </div>
-                  <div className="mb-3 text-[11px] text-cp-text-muted">
+                  <div className="mb-3 text-cp-xs text-cp-text-muted">
                     {format(
                       t(
                         'library.empty.body',
@@ -288,7 +288,7 @@ export const LocalEquipmentTab = ({
                   <button
                     type="button"
                     onClick={() => setLibrarySearch('')}
-                    className="rounded bg-cp-surface-4 px-3 py-1 text-[11px] text-cp-text hover:bg-cp-surface-5"
+                    className="rounded bg-cp-surface-4 px-3 py-1 text-cp-xs text-cp-text hover:bg-cp-surface-5"
                   >
                     {t('library.empty.clearSearch', 'Clear search')}
                   </button>
@@ -334,7 +334,7 @@ export const LocalEquipmentTab = ({
                   } catch { /* ignore */ }
                 }}
               >
-                <div className="group/cat flex items-center gap-1.5 rounded-t bg-cp-surface-1/60 px-2 py-1.5 text-left text-[11px] font-semibold uppercase tracking-wide text-cp-text-secondary hover:bg-cp-surface-2/80 hover:text-cp-text">
+                <div className="group/cat flex items-center gap-1.5 rounded-t bg-cp-surface-1/60 px-2 py-1.5 text-left text-cp-xs font-semibold uppercase tracking-wide text-cp-text-secondary hover:bg-cp-surface-2/80 hover:text-cp-text">
                   <button
                     type="button"
                     onClick={() =>
@@ -375,13 +375,13 @@ export const LocalEquipmentTab = ({
                         setCategoryTranslation(cat, { de: result.de, en: result.en })
                       }
                     }}
-                    className="hidden rounded bg-cp-surface-4/80 px-1.5 py-0.5 text-[10px] font-normal normal-case text-cp-text-bright hover:bg-cp-surface-5 group-hover/cat:block"
+                    className="hidden rounded bg-cp-surface-4/80 px-1.5 py-0.5 text-cp-xs font-normal normal-case text-cp-text-bright hover:bg-cp-surface-5 group-hover/cat:block"
                     title={t('library.renameCategory', 'Rename category')}
                     aria-label={t('library.renameCategory', 'Rename category')}
                   >
                     <Icon icon={Pencil} size="xs" />
                   </button>
-                  <span className="rounded bg-cp-surface-2 px-1.5 py-0.5 text-[10px] font-normal text-cp-text-muted">
+                  <span className="rounded bg-cp-surface-2 px-1.5 py-0.5 text-cp-xs font-normal text-cp-text-muted">
                     {items.length}
                   </span>
                 </div>
@@ -390,7 +390,7 @@ export const LocalEquipmentTab = ({
                 {!collapsed && (
                   <div className="space-y-1 px-1 pb-1">
                     {visibleItems.length === 0 ? (
-                      <div className="px-1 py-1 text-[11px] italic text-cp-text-muted">
+                      <div className="px-1 py-1 text-cp-xs italic text-cp-text-muted">
                         {searchQuery
                           ? format(t('library.empty.search', 'No matches for "{query}"'), { query: librarySearch })
                           : t('library.empty.dragHere', 'Drag a device here to move it')}
@@ -418,7 +418,7 @@ export const LocalEquipmentTab = ({
                           <button
                             type="button"
                             onClick={() => setSelectedTemplateName(item.name)}
-                            className="absolute right-7 top-1 hidden rounded bg-cp-surface-5 px-1 py-0.5 text-[10px] hover:bg-slate-500 group-hover/item:block"
+                            className="absolute right-7 top-1 hidden rounded bg-cp-surface-5 px-1 py-0.5 text-cp-xs hover:bg-slate-500 group-hover/item:block"
                             title={t('library.template.editTitle', 'Edit template (name, category)')}
                             aria-label={t('library.template.editTitle', 'Edit template (name, category)')}
                           >

--- a/src/renderer/components/Library/tabs/RacksTab.tsx
+++ b/src/renderer/components/Library/tabs/RacksTab.tsx
@@ -32,7 +32,7 @@ export const RacksTab = ({ onCreateRack, onEditRack }: RacksTabProps) => {
       <div className="mb-2 flex flex-wrap items-center justify-between gap-y-1 gap-x-2">
         <div className="min-w-0">
           <h2 className="text-cp-base font-semibold">{t('library.tabs.racks.title', '2D Rack Builder')}</h2>
-          <div className="text-[10px] text-cp-text-muted">
+          <div className="text-cp-xs text-cp-text-muted">
             {t('library.tabs.racks.subtitle', 'Rack slots in RU, saved as a placeable group')}
           </div>
         </div>
@@ -87,14 +87,14 @@ export const RacksTab = ({ onCreateRack, onEditRack }: RacksTabProps) => {
                       <div className="flex items-start justify-between gap-2">
                         <div className="min-w-0 flex-1">
                           <div className="truncate font-medium text-cp-text">{preset.name}</div>
-                          <div className="mt-0.5 text-[10px] text-cp-text-muted">
+                          <div className="mt-0.5 text-cp-xs text-cp-text-muted">
                             {format(t('library.tabs.racks.counts', '{items} devices · {units} RU · {cables} cables'), {
                               items: preset.items.length,
                               units: totalUnits,
                               cables: preset.cables.length,
                             })}
                           </div>
-                          <div className="mt-0.5 truncate text-[10px] text-cp-text-muted">
+                          <div className="mt-0.5 truncate text-cp-xs text-cp-text-muted">
                             {preset.items.map((i) => i.name).join(', ')}
                           </div>
                         </div>
@@ -109,7 +109,7 @@ export const RacksTab = ({ onCreateRack, onEditRack }: RacksTabProps) => {
                               event.stopPropagation()
                               onEditRack(preset.id)
                             }}
-                            className="rounded bg-cp-surface-4 px-1 py-0.5 text-[11px] hover:bg-cp-surface-5"
+                            className="rounded bg-cp-surface-4 px-1 py-0.5 text-cp-xs hover:bg-cp-surface-5"
                             title={t('library.tabs.racks.editTitle', 'Edit in the 2D rack builder')}
                             aria-label={t('library.tabs.racks.editAria', 'Edit')}
                           >
@@ -121,7 +121,7 @@ export const RacksTab = ({ onCreateRack, onEditRack }: RacksTabProps) => {
                               event.stopPropagation()
                               void exportPresetToFile(preset)
                             }}
-                            className="rounded bg-cp-surface-4 px-1 py-0.5 text-[11px] text-cp-text-secondary hover:bg-cp-surface-5"
+                            className="rounded bg-cp-surface-4 px-1 py-0.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-5"
                             title={t(
                               'library.tabs.racks.exportTitle',
                               'Export as file (copy to Downloads folder)',
@@ -148,7 +148,7 @@ export const RacksTab = ({ onCreateRack, onEditRack }: RacksTabProps) => {
                                 deleteGroupPreset(preset.id)
                               }
                             }}
-                            className="rounded bg-red-700 px-1 text-[10px] hover:bg-red-600"
+                            className="rounded bg-red-700 px-1 text-cp-xs hover:bg-red-600"
                             title={t('library.tabs.racks.deleteTitle', 'Remove rack from library')}
                             aria-label={t('common.delete', 'Delete')}
                           >

--- a/src/renderer/components/Netbox/NetboxImportDialog.tsx
+++ b/src/renderer/components/Netbox/NetboxImportDialog.tsx
@@ -487,6 +487,6 @@ const PreviewStat = ({
     }`}
   >
     <div className="text-cp-xl font-semibold">{value}</div>
-    <div className="text-[10px] leading-tight">{label}</div>
+    <div className="text-cp-xs leading-tight">{label}</div>
   </div>
 )

--- a/src/renderer/components/Network/ReconcileDialog.tsx
+++ b/src/renderer/components/Network/ReconcileDialog.tsx
@@ -293,7 +293,7 @@ export const ReconcileDialog = () => {
                       <span className="font-mono text-amber-300/90">{r.foundIp}</span>
                     )}
                     {r.matchedBy && (
-                      <span className="ml-auto text-[10px] text-cp-text-faint">
+                      <span className="ml-auto text-cp-xs text-cp-text-faint">
                         {format(t('reconcile.matchedBy', 'via {basis}'), { basis: r.matchedBy.toUpperCase() })}
                       </span>
                     )}

--- a/src/renderer/components/Onboarding/ModuleOnboardingDialog.tsx
+++ b/src/renderer/components/Onboarding/ModuleOnboardingDialog.tsx
@@ -88,7 +88,7 @@ export const ModuleOnboardingDialog = () => {
               >
                 <div className="mb-1 flex items-center gap-2 font-semibold text-cp-text-bright">
                   <span
-                    className={`flex h-4 w-4 items-center justify-center rounded-sm border text-[10px] ${
+                    className={`flex h-4 w-4 items-center justify-center rounded-sm border text-cp-xs ${
                       on ? 'border-emerald-500 bg-emerald-600 text-white' : 'border-cp-border'
                     }`}
                   >

--- a/src/renderer/components/Onboarding/OnboardingTour.tsx
+++ b/src/renderer/components/Onboarding/OnboardingTour.tsx
@@ -107,7 +107,7 @@ export const OnboardingTour = ({ open, onClose }: OnboardingTourProps) => {
       open={open}
       onClose={finish}
       title={
-        <span className="text-[11px] uppercase tracking-wider text-cp-text-muted">
+        <span className="text-cp-xs uppercase tracking-wider text-cp-text-muted">
           {format(t('onboarding.header', 'Getting-started tour · step {step} / {total}'), {
             step: step + 1,
             total: STEPS.length,
@@ -172,7 +172,7 @@ export const OnboardingTour = ({ open, onClose }: OnboardingTourProps) => {
         <h2 className="text-cp-xl font-semibold text-cp-text">{current.title}</h2>
         <p className="text-cp-base leading-relaxed text-cp-text-secondary">{current.body}</p>
         {current.hint && (
-          <div className="rounded border border-cp-border-muted bg-cp-surface-3/40 px-2 py-1 text-[11px] text-cp-text-muted">
+          <div className="rounded border border-cp-border-muted bg-cp-surface-3/40 px-2 py-1 text-cp-xs text-cp-text-muted">
             {t('onboarding.tip', 'Tip:')} {current.hint}
           </div>
         )}

--- a/src/renderer/components/Patch/PatchListDialog.tsx
+++ b/src/renderer/components/Patch/PatchListDialog.tsx
@@ -558,7 +558,7 @@ export const PatchListDialog = () => {
       footer={
         <div className="flex items-center justify-between">
           <PanelHint
-            className="text-[10px] text-cp-text-muted"
+            className="text-cp-xs text-cp-text-muted"
             text={t(
               'patchList.footerHint',
               'Each cable as its own row, sorted for patching order on set. CSV export for Excel/print contains the currently filtered rows.',
@@ -827,7 +827,7 @@ export const PatchListDialog = () => {
               ))}
             </select>
           )}
-          <span className="text-[11px] text-cp-text-muted">
+          <span className="text-cp-xs text-cp-text-muted">
             {filtered.length} / {rows.length}
           </span>
         </div>
@@ -859,19 +859,19 @@ export const PatchListDialog = () => {
             <tbody>
               {filtered.map((r) => (
                 <tr key={r.cableId} className="border-t border-cp-border-muted hover:bg-cp-surface-1">
-                  <td className="px-2 py-1 font-mono text-[11px] text-sky-300">{r.cableNumber}</td>
+                  <td className="px-2 py-1 font-mono text-cp-xs text-sky-300">{r.cableNumber}</td>
                   <td className="px-2 py-1 font-medium text-cp-text">{r.fromDevice}</td>
                   <td className="px-2 py-1 text-cp-text-secondary">
                     {r.fromPort}
                     {r.fromPortSub && (
-                      <div className="text-[10px] text-cp-text-muted">{r.fromPortSub}</div>
+                      <div className="text-cp-xs text-cp-text-muted">{r.fromPortSub}</div>
                     )}
                   </td>
                   <td className="px-2 py-1 font-medium text-cp-text">{r.toDevice}</td>
                   <td className="px-2 py-1 text-cp-text-secondary">
                     {r.toPort}
                     {r.toPortSub && (
-                      <div className="text-[10px] text-cp-text-muted">{r.toPortSub}</div>
+                      <div className="text-cp-xs text-cp-text-muted">{r.toPortSub}</div>
                     )}
                   </td>
                   <td className="px-2 py-1 text-cp-text-secondary">{r.type}</td>

--- a/src/renderer/components/Project/AiPlanGenDialog.tsx
+++ b/src/renderer/components/Project/AiPlanGenDialog.tsx
@@ -85,7 +85,7 @@ export const AiPlanGenDialog = () => {
           />
         </label>
         <div className="flex items-center justify-between gap-2">
-          <span className="text-[10px] text-cp-text-muted">
+          <span className="text-cp-xs text-cp-text-muted">
             {t('aiPlan.reviewHint', 'A preview is shown — nothing is inserted without confirmation.')}
           </span>
           <button
@@ -114,7 +114,7 @@ export const AiPlanGenDialog = () => {
                 c: plan.cables.length,
               })}
             </div>
-            <ul className="max-h-40 overflow-auto text-[11px] text-cp-text-secondary">
+            <ul className="max-h-40 overflow-auto text-cp-xs text-cp-text-secondary">
               {plan.equipment.map((e) => (
                 <li key={e.id}>
                   • {e.name} <span className="text-cp-text-faint">[{e.category}]</span>
@@ -122,7 +122,7 @@ export const AiPlanGenDialog = () => {
               ))}
             </ul>
             {plan.warnings.length > 0 && (
-              <ul className="mt-1 list-inside list-disc text-[10px] text-amber-300">
+              <ul className="mt-1 list-inside list-disc text-cp-xs text-amber-300">
                 {plan.warnings.map((w, i) => (
                   <li key={i}>{w}</li>
                 ))}

--- a/src/renderer/components/Project/CableBomDialog.tsx
+++ b/src/renderer/components/Project/CableBomDialog.tsx
@@ -305,7 +305,7 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
       draggableKey="cable-planner:modal-pos:cable-bom"
       scrollBody={false}
       footer={
-        <div className="flex items-center justify-between text-[11px]">
+        <div className="flex items-center justify-between text-cp-xs">
           <span className="text-cp-text-muted">
             {draftPlan
               ? t('bom.cable.draftPending', 'Unsaved changes to the Rentman plan.')
@@ -350,7 +350,7 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
       }
     >
       <div className="flex h-full min-h-0 flex-col -mx-4 -my-3">
-        <div className="flex items-center gap-2 border-b border-cp-border-muted px-4 py-2 text-[11px] text-cp-text-muted">
+        <div className="flex items-center gap-2 border-b border-cp-border-muted px-4 py-2 text-cp-xs text-cp-text-muted">
           <span>{t('bom.cable.groupedNote', 'Grouped by type & length.')}</span>
           <span>
             {t('bom.cable.builtCables', 'Built cables:')} <b className="text-cp-text-bright">{project.cables.length}</b>
@@ -413,7 +413,7 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
                     <div className="font-medium text-cp-text">
                       {r.type}
                       {r.sample && (
-                        <span className="ml-1 text-[10px] text-cp-text-muted">
+                        <span className="ml-1 text-cp-xs text-cp-text-muted">
                           ({r.sample.name})
                         </span>
                       )}
@@ -422,9 +422,9 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
                         Abgleich klar wenn Rentman das gleiche Kabel
                         unter anderem Namen fuehrt. */}
                     {r.rentmanName && (
-                      <div className="mt-0.5 text-[10px] text-orange-300/80">
+                      <div className="mt-0.5 text-cp-xs text-orange-300/80">
                         <span
-                          className="rounded bg-orange-700/30 px-1 py-0 font-mono text-[11px] text-orange-200"
+                          className="rounded bg-orange-700/30 px-1 py-0 font-mono text-cp-xs text-orange-200"
                           title={t('bom.cable.rentmanLinkedTitle', 'Linked Rentman equipment name')}
                         >
                           R
@@ -434,7 +434,7 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
                     )}
                     {!r.rentmanName && r.rentmanId && (
                       <div
-                        className="mt-0.5 text-[10px] text-cp-text-muted"
+                        className="mt-0.5 text-cp-xs text-cp-text-muted"
                         title={t('bom.cable.rentmanMissingTitle', 'Linked, but Rentman template not found locally')}
                       >
                         R #{r.rentmanId}
@@ -477,19 +477,19 @@ export const CableBomDialog = ({ open, onClose }: CableBomDialogProps) => {
                   </td>
                   {/* #292 — Wege-Spalte: max 3 Pfade sichtbar, alle weiteren
                       als Tooltip ("+N weitere"). */}
-                  <td className="px-3 py-1 align-top text-[11px] text-cp-text-secondary">
+                  <td className="px-3 py-1 align-top text-cp-xs text-cp-text-secondary">
                     {r.paths.length === 0 ? (
                       <span className="text-cp-text-dim">—</span>
                     ) : (
                       <div className="flex flex-col gap-0.5">
                         {r.paths.slice(0, 3).map((p, i) => (
-                          <div key={i} className="font-mono text-[10px]">
+                          <div key={i} className="font-mono text-cp-xs">
                             {p}
                           </div>
                         ))}
                         {r.paths.length > 3 && (
                           <div
-                            className="cursor-help text-[10px] text-cp-text-muted"
+                            className="cursor-help text-cp-xs text-cp-text-muted"
                             title={r.paths.slice(3).join('\n')}
                           >
                             {format(t('bom.cable.morePaths', '+{count} more'), { count: r.paths.length - 3 })}

--- a/src/renderer/components/Project/DocumentLogDialog.tsx
+++ b/src/renderer/components/Project/DocumentLogDialog.tsx
@@ -159,7 +159,7 @@ export const DocumentLogDialog = ({ open, onClose }: DocumentLogDialogProps) => 
       maxWidth="4xl"
       draggableKey="cable-planner:modal-pos:document-log"
       footer={
-        <div className="flex items-center justify-between gap-3 text-[11px]">
+        <div className="flex items-center justify-between gap-3 text-cp-xs">
           <span className="text-cp-text-muted">
             {t(
               'doclog.footer',

--- a/src/renderer/components/Project/LocationBomDialog.tsx
+++ b/src/renderer/components/Project/LocationBomDialog.tsx
@@ -340,7 +340,7 @@ export const LocationBomDialog = () => {
       draggableKey="cable-planner:modal-pos:location-bom"
     >
         <div className="text-cp-xs">
-          <div className="mb-3 flex flex-wrap items-center gap-2 text-[11px] text-cp-text-muted">
+          <div className="mb-3 flex flex-wrap items-center gap-2 text-cp-xs text-cp-text-muted">
             <span>
               {t('locbom.devices', 'Devices')}: <b className="text-cp-text-bright">{devices.length}</b>
             </span>
@@ -365,7 +365,7 @@ export const LocationBomDialog = () => {
               </span>
             )}
             <label
-              className="ml-auto flex items-center gap-1.5 text-[11px] text-cp-text-secondary"
+              className="ml-auto flex items-center gap-1.5 text-cp-xs text-cp-text-secondary"
               title={t('locbom.groupTitle', 'Groups identical cables (same type + length) on one row with a quantity — default for the parts list.')}
             >
               <input
@@ -376,7 +376,7 @@ export const LocationBomDialog = () => {
               {t('locbom.groupCables', 'Group cables')}
             </label>
             <label
-              className="flex items-center gap-1.5 text-[11px] text-cp-text-secondary"
+              className="flex items-center gap-1.5 text-cp-xs text-cp-text-secondary"
               title={t('locbom.includePlanTitle', 'Prepends a JPEG plan snippet of the location before the device list — recipients get the parts list and the plan in one document.')}
             >
               <input

--- a/src/renderer/components/Project/PlanCompareDialog.tsx
+++ b/src/renderer/components/Project/PlanCompareDialog.tsx
@@ -141,7 +141,7 @@ export const PlanCompareDialog = ({ open, onClose }: PlanCompareDialogProps) => 
       maxWidth="4xl"
       draggableKey="cable-planner:modal-pos:plan-compare"
       footer={
-        <div className="flex items-center justify-between gap-3 text-[11px]">
+        <div className="flex items-center justify-between gap-3 text-cp-xs">
           <span className="text-cp-text-muted">
             {t(
               'compare.footer',

--- a/src/renderer/components/Project/ProjectMetaDialog.tsx
+++ b/src/renderer/components/Project/ProjectMetaDialog.tsx
@@ -203,7 +203,7 @@ export const ProjectMetaDialog = ({
 
           <div className="grid grid-cols-2 gap-2">
             <div>
-              <div className="mb-1 text-[11px] text-cp-text-muted">
+              <div className="mb-1 text-cp-xs text-cp-text-muted">
                 {t('project.meta.companyLogo', 'Company logo')}
               </div>
               {companyLogo ? (
@@ -216,7 +216,7 @@ export const ProjectMetaDialog = ({
                   <button
                     type="button"
                     onClick={() => setCompanyLogo(undefined)}
-                    className="rounded bg-red-900/60 px-2 py-1 text-[11px] hover:bg-red-800"
+                    className="rounded bg-red-900/60 px-2 py-1 text-cp-xs hover:bg-red-800"
                   >
                     {t('project.meta.removeLogo', 'Remove')}
                   </button>
@@ -237,13 +237,13 @@ export const ProjectMetaDialog = ({
               <button
                 type="button"
                 onClick={() => companyInputRef.current?.click()}
-                className="mt-1 rounded bg-cp-surface-4 px-2 py-1 text-[11px] hover:bg-cp-surface-5"
+                className="mt-1 rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
               >
                 {t('project.meta.chooseLogo', 'Choose logo…')}
               </button>
             </div>
             <div>
-              <div className="mb-1 text-[11px] text-cp-text-muted">
+              <div className="mb-1 text-cp-xs text-cp-text-muted">
                 {t('project.meta.clientLogo', 'Client logo')}
               </div>
               {clientLogo ? (
@@ -256,7 +256,7 @@ export const ProjectMetaDialog = ({
                   <button
                     type="button"
                     onClick={() => setClientLogo(undefined)}
-                    className="rounded bg-red-900/60 px-2 py-1 text-[11px] hover:bg-red-800"
+                    className="rounded bg-red-900/60 px-2 py-1 text-cp-xs hover:bg-red-800"
                   >
                     {t('project.meta.removeLogo', 'Remove')}
                   </button>
@@ -277,7 +277,7 @@ export const ProjectMetaDialog = ({
               <button
                 type="button"
                 onClick={() => clientInputRef.current?.click()}
-                className="mt-1 rounded bg-cp-surface-4 px-2 py-1 text-[11px] hover:bg-cp-surface-5"
+                className="mt-1 rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
               >
                 {t('project.meta.chooseLogo', 'Choose logo…')}
               </button>
@@ -285,7 +285,7 @@ export const ProjectMetaDialog = ({
           </div>
 
           <PanelHint
-            className="text-[10px] italic text-cp-text-muted"
+            className="text-cp-xs italic text-cp-text-muted"
             text={t(
               'project.meta.footnote',
               'These fields appear in the plan footer when exporting to PDF. Every save updates the "last modified" date automatically.',

--- a/src/renderer/components/Project/RevisionsDialog.tsx
+++ b/src/renderer/components/Project/RevisionsDialog.tsx
@@ -169,7 +169,7 @@ export const RevisionsDialog = () => {
             ))}
           </ul>
         )}
-        <p className="text-[10px] text-cp-text-muted">
+        <p className="text-cp-xs text-cp-text-muted">
           {t(
             'revisions.footerHint',
             'A revision stores a full snapshot of the plan. Restoring keeps the history.',

--- a/src/renderer/components/Project/TemplatesDialog.tsx
+++ b/src/renderer/components/Project/TemplatesDialog.tsx
@@ -204,12 +204,12 @@ export const TemplatesDialog = () => {
           <div className="text-cp-xs text-[var(--cp-text-muted)]">{desc(tpl)}</div>
         </div>
       </div>
-      <div className="text-[10px] text-[var(--cp-text-faint)]">{stats(tpl)}</div>
+      <div className="text-cp-xs text-[var(--cp-text-faint)]">{stats(tpl)}</div>
       {/* BEDARF 91 — aus welchem Haus. Steht auf der Karte, weil die
           Entscheidung „diese Vorlage oder die neutrale" hier faellt und nicht
           erst nach dem Laden. */}
       {tpl.venue && (
-        <div className="text-[10px] text-[var(--cp-text-muted)]">
+        <div className="text-cp-xs text-[var(--cp-text-muted)]">
           {format(t('templates.venue', 'Venue template: {venue} \u00b7 {n} answers'), {
             venue: tpl.venue,
             n: tpl.project.metadata?.venueAnswers?.length ?? 0,
@@ -222,7 +222,7 @@ export const TemplatesDialog = () => {
           derentwillen jemand sie aufmacht. */}
       {tpl.basis && (
         <div
-          className={`text-[10px] ${
+          className={`text-cp-xs ${
             tpl.basis === 'as-built'
               ? 'text-[var(--cp-text-muted)]'
               : 'text-amber-300/90'
@@ -298,7 +298,7 @@ export const TemplatesDialog = () => {
         </div>
 
         <div>
-          <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--cp-text-faint)]">
+          <div className="mb-1 text-cp-xs font-semibold uppercase tracking-wider text-[var(--cp-text-faint)]">
             {t('templates.builtinHeading', 'Bundled templates')}
           </div>
           <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
@@ -307,7 +307,7 @@ export const TemplatesDialog = () => {
         </div>
 
         <div>
-          <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--cp-text-faint)]">
+          <div className="mb-1 text-cp-xs font-semibold uppercase tracking-wider text-[var(--cp-text-faint)]">
             {t('templates.userHeading', 'My templates')}
           </div>
           {userTemplates.length === 0 ? (

--- a/src/renderer/components/Project/WelcomeDialog.tsx
+++ b/src/renderer/components/Project/WelcomeDialog.tsx
@@ -84,7 +84,7 @@ export const WelcomeDialog = ({ open, onNew, onOpen, onClose }: WelcomeDialogPro
             <span className="block text-cp-base font-semibold">
               {t('project.welcome.newTitle', 'New project')}
             </span>
-            <span className="block text-[11px] text-cp-text-muted">
+            <span className="block text-cp-xs text-cp-text-muted">
               {t('project.welcome.newSubtitle', 'Start with project name, client and planner.')}
             </span>
           </span>
@@ -103,7 +103,7 @@ export const WelcomeDialog = ({ open, onNew, onOpen, onClose }: WelcomeDialogPro
             <span className="block text-cp-base font-semibold">
               {t('project.welcome.openTitle', 'Open project…')}
             </span>
-            <span className="block text-[11px] text-cp-text-muted">
+            <span className="block text-cp-xs text-cp-text-muted">
               {t('project.welcome.openSubtitle1', 'Load an existing')}{' '}
               <code className="rounded bg-cp-surface-3 px-1">.cableplan</code>
               {t('project.welcome.openSubtitle2', ' file.')}
@@ -113,14 +113,14 @@ export const WelcomeDialog = ({ open, onNew, onOpen, onClose }: WelcomeDialogPro
 
         {recents.length > 0 && (
           <div className="pt-2">
-            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-cp-text-muted">
+            <div className="mb-1 text-cp-xs font-semibold uppercase tracking-wider text-cp-text-muted">
               {t('project.welcome.recents', 'Recently used')}
             </div>
             <div className="max-h-32 space-y-1 overflow-auto">
               {recents.slice(0, 6).map((path) => (
                 <div
                   key={path}
-                  className="flex items-center gap-2 rounded border border-cp-border-muted bg-cp-surface-3/40 px-2 py-1 text-[11px] text-cp-text-muted"
+                  className="flex items-center gap-2 rounded border border-cp-border-muted bg-cp-surface-3/40 px-2 py-1 text-cp-xs text-cp-text-muted"
                   title={path}
                 >
                   <Icon icon={Clock} size="sm" />
@@ -128,7 +128,7 @@ export const WelcomeDialog = ({ open, onNew, onOpen, onClose }: WelcomeDialogPro
                 </div>
               ))}
             </div>
-            <p className="mt-1 text-[10px] text-cp-text-muted">
+            <p className="mt-1 text-cp-xs text-cp-text-muted">
               {t(
                 'project.welcome.recentsHint',
                 'Click "Open project…" and choose one of the files in the file picker.',

--- a/src/renderer/components/Properties/EquipmentProperties.tsx
+++ b/src/renderer/components/Properties/EquipmentProperties.tsx
@@ -121,7 +121,7 @@ export const EquipmentProperties = () => {
       style={{ border: 0, padding: 0, margin: 0, minWidth: 0 }}
     >
       {projectIsLocked && (
-        <div className="rounded border border-amber-700/60 bg-amber-900/30 px-2 py-1.5 text-[11px] text-amber-200">
+        <div className="rounded border border-amber-700/60 bg-amber-900/30 px-2 py-1.5 text-cp-xs text-amber-200">
           {projectMode === 'viewer'
             ? t('inspector.viewerLocked', 'Viewer mode — fields cannot be edited.')
             : t('inspector.finalizedLocked', 'Plan finalised — fields locked. Click "Re-enable editing" in the canvas banner.')}

--- a/src/renderer/components/Properties/LocationProperties.tsx
+++ b/src/renderer/components/Properties/LocationProperties.tsx
@@ -25,7 +25,7 @@ export const LocationProperties = () => {
   return (
     <div className="space-y-3 text-cp-xs">
       <div>
-        <div className="mb-1 text-[11px] uppercase tracking-wide text-cp-text-muted">
+        <div className="mb-1 text-cp-xs uppercase tracking-wide text-cp-text-muted">
           {t('location.title', 'Location')}
         </div>
         <label className="block">
@@ -167,7 +167,7 @@ export const LocationProperties = () => {
       </div>
 
       <PanelHint
-        className="text-[10px] italic text-cp-text-muted"
+        className="text-cp-xs italic text-cp-text-muted"
         text={t(
           'location.tip',
           'Tip: the frame moves independently by default. Enable "Take devices along" to move all contained devices with the frame.',

--- a/src/renderer/components/Properties/ModeEditorDialog.tsx
+++ b/src/renderer/components/Properties/ModeEditorDialog.tsx
@@ -192,7 +192,7 @@ export const ModeEditorDialog = ({
                 className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-3 px-2 py-1 text-cp-text"
               />
               {nameConflict && (
-                <span className="mt-0.5 flex items-center gap-1 text-[10px] text-amber-400">
+                <span className="mt-0.5 flex items-center gap-1 text-cp-xs text-amber-400">
                   <Icon icon={AlertTriangle} size="xs" />
                   {t('modeEditor.nameConflict', 'A mode with this name already exists.')}
                 </span>
@@ -238,7 +238,7 @@ export const ModeEditorDialog = ({
           </div>
 
           <div className="mt-4 flex items-center justify-between">
-            <div className="text-[10px] text-cp-text-muted">
+            <div className="text-cp-xs text-cp-text-muted">
               {format(
                 t('modeEditor.portCount', '{count} port(s) in this mode'),
                 { count: totalPortCount },
@@ -247,7 +247,7 @@ export const ModeEditorDialog = ({
             <button
               type="button"
               onClick={seedFromCurrent}
-              className="rounded bg-cp-surface-4 px-2 py-1 text-[11px] hover:bg-cp-surface-5"
+              className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
               title={t('modeEditor.seedTitle', "Adopt the device's CURRENT port layout as a starting point.")}
             >
               <Icon icon={Download} size="xs" className="mr-1 inline-block align-text-bottom" />{t('modeEditor.seedBtn', 'Adopt current device layout')}
@@ -267,7 +267,7 @@ export const ModeEditorDialog = ({
                 className="rounded border border-cp-border-muted bg-cp-surface-3/40 p-2"
               >
                 <div className="mb-2 flex items-center justify-between">
-                  <span className={`text-[11px] font-semibold ${
+                  <span className={`text-cp-xs font-semibold ${
                     accent === 'cyan' ? 'text-cyan-300' : 'text-emerald-300'
                   }`}>
                     {label} ({list.length})
@@ -275,13 +275,13 @@ export const ModeEditorDialog = ({
                   <button
                     type="button"
                     onClick={() => addPort(side)}
-                    className="rounded bg-cp-surface-2 px-2 py-0.5 text-[10px] text-cp-text-secondary hover:bg-cp-surface-4"
+                    className="rounded bg-cp-surface-2 px-2 py-0.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-4"
                   >
                     + {t('modeEditor.addPort', 'Port')}
                   </button>
                 </div>
                 {list.length === 0 ? (
-                  <div className="rounded border border-dashed border-cp-border p-3 text-center text-[10px] text-cp-text-muted">
+                  <div className="rounded border border-dashed border-cp-border p-3 text-center text-cp-xs text-cp-text-muted">
                     {format(t('modeEditor.emptySide', 'No {kind} in this mode.'), { kind: label.toLowerCase() })}
                   </div>
                 ) : (
@@ -296,7 +296,7 @@ export const ModeEditorDialog = ({
                           value={p.name}
                           onChange={(e) => updatePort(side, p.id, { name: e.target.value })}
                           placeholder={t('ports.namePlaceholder', 'Port name')}
-                          className="flex-1 rounded border border-cp-border bg-cp-surface-3 px-1.5 py-0.5 text-[11px]"
+                          className="flex-1 rounded border border-cp-border bg-cp-surface-3 px-1.5 py-0.5 text-cp-xs"
                         />
                         <select
                           value={p.connectorType}
@@ -305,7 +305,7 @@ export const ModeEditorDialog = ({
                               connectorType: e.target.value as ConnectorType,
                             })
                           }
-                          className="w-28 rounded border border-cp-border bg-cp-surface-3 px-1 py-0.5 text-[10px]"
+                          className="w-28 rounded border border-cp-border bg-cp-surface-3 px-1 py-0.5 text-cp-xs"
                         >
                           {ALL_CONNECTOR_TYPES.map((c) => (
                             <option key={c} value={c}>
@@ -316,7 +316,7 @@ export const ModeEditorDialog = ({
                         <button
                           type="button"
                           onClick={() => removePort(side, p.id)}
-                          className="rounded px-1 py-0.5 text-[11px] text-red-400 hover:bg-red-900/40"
+                          className="rounded px-1 py-0.5 text-cp-xs text-red-400 hover:bg-red-900/40"
                           title={t('modeEditor.removePort', 'Remove port')}
                           aria-label={t('modeEditor.removePort', 'Remove port')}
                         >

--- a/src/renderer/components/Properties/PropertiesPanel.tsx
+++ b/src/renderer/components/Properties/PropertiesPanel.tsx
@@ -78,7 +78,7 @@ export const PropertiesPanel = () => {
               </div>
             </div>
             <div className="rounded border border-cp-border-muted bg-cp-surface-1/40 p-3">
-              <div className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-cp-text-muted">
+              <div className="mb-2 text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">
                 {t('inspector.hints.title', 'Quick orientation')}
               </div>
               <div className="space-y-1">
@@ -126,7 +126,7 @@ export const PropertiesPanel = () => {
         title={
           <span className="flex flex-col">
             <span className="text-cp-base font-semibold text-cp-text">{title}</span>
-            <span className="text-[10px] uppercase tracking-wide text-cp-text-muted">
+            <span className="text-cp-xs uppercase tracking-wide text-cp-text-muted">
               {t('inspector.subtitle', 'Properties')}
             </span>
           </span>
@@ -163,7 +163,7 @@ export const PropertiesPanel = () => {
           type="button"
           onClick={toggle}
           aria-label={t('inspector.collapse.show', 'Show properties')}
-          className="mt-3 flex-1 self-stretch text-[10px] font-semibold uppercase tracking-[0.18em] text-cp-text-muted transition-colors hover:text-cp-text-secondary focus-visible:outline-none focus-visible:text-sky-300"
+          className="mt-3 flex-1 self-stretch text-cp-xs font-semibold uppercase tracking-[0.18em] text-cp-text-muted transition-colors hover:text-cp-text-secondary focus-visible:outline-none focus-visible:text-sky-300"
           style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}
         >
           {t('inspector.subtitle', 'Properties')}
@@ -177,7 +177,7 @@ export const PropertiesPanel = () => {
       <div className="flex items-start justify-between gap-2 border-b border-cp-border-muted px-3 py-2.5">
         <div className="min-w-0">
           <h2 className="truncate text-cp-base font-semibold">{title}</h2>
-          <div className="mt-0.5 text-[10px] uppercase tracking-wide text-cp-text-muted">
+          <div className="mt-0.5 text-cp-xs uppercase tracking-wide text-cp-text-muted">
             {t('inspector.subtitle', 'Properties')}
           </div>
         </div>

--- a/src/renderer/components/Properties/SortableSection.tsx
+++ b/src/renderer/components/Properties/SortableSection.tsx
@@ -38,7 +38,7 @@ export const SortableSection = ({
         transition,
       }}
     >
-      <summary className="flex items-center gap-2 px-2 py-1.5 text-[11px] uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright">
+      <summary className="flex items-center gap-2 px-2 py-1.5 text-cp-xs uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright">
         {/* #421 — Drag-Handle deutlicher: groesseres ⠿-Glyph, hellere Farbe,
             breitere Klickflaeche; sichtbar auf jeder Sektion damit klar ist,
             dass die Reihenfolge per Drag&Drop am Handle aenderbar ist. */}
@@ -55,7 +55,7 @@ export const SortableSection = ({
         </span>
         <span className="flex-1">{title}</span>
         {subtitle && (
-          <span className="normal-case text-[10px] text-cp-text-muted">{subtitle}</span>
+          <span className="normal-case text-cp-xs text-cp-text-muted">{subtitle}</span>
         )}
       </summary>
       <div className="border-t border-cp-border-muted p-2">{children}</div>

--- a/src/renderer/components/Properties/TemplateProperties.tsx
+++ b/src/renderer/components/Properties/TemplateProperties.tsx
@@ -67,12 +67,12 @@ export const TemplateProperties = () => {
   return (
     <div className="space-y-3 text-cp-xs">
       <div className="flex items-center justify-between">
-        <span className="text-cp-text-muted text-[10px] uppercase tracking-wide">
+        <span className="text-cp-text-muted text-cp-xs uppercase tracking-wide">
           {t('template.title', 'Template')}
         </span>
         {template.rentmanSource && (
           <span
-            className="rounded bg-orange-700 px-1.5 py-0.5 text-[10px] font-bold text-white"
+            className="rounded bg-orange-700 px-1.5 py-0.5 text-cp-xs font-bold text-white"
             title={format(t('template.rentmanSourceTitle', 'Imported from Rentman project {source}'), { source: template.rentmanSource })}
           >
             R

--- a/src/renderer/components/Properties/sections/CategoryPropsSection.tsx
+++ b/src/renderer/components/Properties/sections/CategoryPropsSection.tsx
@@ -147,7 +147,7 @@ export const CategoryPropsSection = ({ equipment }: { equipment: EquipmentItem }
       onToggle={(e) => setOpen(e.currentTarget.open)}
       className="rounded border border-cp-border [&_summary]:cursor-pointer"
     >
-      <summary className="flex items-center gap-1 px-2 py-1.5 text-[11px] uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright [&::-webkit-details-marker]:hidden">
+      <summary className="flex items-center gap-1 px-2 py-1.5 text-cp-xs uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright [&::-webkit-details-marker]:hidden">
         <span className="text-cp-text-faint">{open ? '▾' : '▸'}</span>
         <span className="flex-1">
           {t('catprops.title', 'Specs')} — {equipment.category}

--- a/src/renderer/components/Properties/sections/DeviceConfigsBlock.tsx
+++ b/src/renderer/components/Properties/sections/DeviceConfigsBlock.tsx
@@ -25,32 +25,32 @@ export const DeviceConfigsBlock = ({ equipmentId }: { equipmentId: string }) => 
       onToggle={(e) => setOpen(e.currentTarget.open)}
       className="rounded border border-cp-border bg-cp-surface-1/40 [&_summary]:cursor-pointer"
     >
-      <summary className="flex items-center gap-1 px-2 py-1.5 text-[10px] uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright [&::-webkit-details-marker]:hidden">
+      <summary className="flex items-center gap-1 px-2 py-1.5 text-cp-xs uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright [&::-webkit-details-marker]:hidden">
         <span className="text-cp-text-faint">{open ? '▾' : '▸'}</span>
         <span className="flex-1">{t('props.deviceConfigs.title', 'Configurations')}</span>
         {!open && assigned.length > 0 && (
-          <span className="rounded bg-cp-surface-4/60 px-1 text-[11px] normal-case text-cp-text-bright">
+          <span className="rounded bg-cp-surface-4/60 px-1 text-cp-xs normal-case text-cp-text-bright">
             {assigned.length}
           </span>
         )}
       </summary>
       <div className="px-2 pb-2">
       {assigned.length === 0 ? (
-        <div className="text-[11px] text-cp-text-muted">
+        <div className="text-cp-xs text-cp-text-muted">
           {t('props.deviceConfigs.none', 'No configuration assigned.')}
         </div>
       ) : (
         <ul className="mb-2 space-y-1">
           {assigned.map((e) => (
-            <li key={e.id} className="flex items-center gap-2 rounded bg-cp-surface-3 px-2 py-1 text-[11px]">
+            <li key={e.id} className="flex items-center gap-2 rounded bg-cp-surface-3 px-2 py-1 text-cp-xs">
               <span className="flex-1 truncate" title={`${e.fileName} (${e.kind})`}>
                 {e.name}
               </span>
-              <span className="shrink-0 text-[10px] text-cp-text-muted">{e.kind}</span>
+              <span className="shrink-0 text-cp-xs text-cp-text-muted">{e.kind}</span>
               <button
                 type="button"
                 onClick={() => updateDeviceConfig(e.id, { equipmentId: undefined })}
-                className="rounded bg-cp-surface-2 px-1.5 py-0.5 text-[10px] text-cp-text-secondary hover:bg-red-700 hover:text-white"
+                className="rounded bg-cp-surface-2 px-1.5 py-0.5 text-cp-xs text-cp-text-secondary hover:bg-red-700 hover:text-white"
                 title={t('props.deviceConfigs.unassignTitle', 'Detach assignment (file remains in library)')}
               >
                 {t('props.deviceConfigs.unassign', 'Detach')}
@@ -65,7 +65,7 @@ export const DeviceConfigsBlock = ({ equipmentId }: { equipmentId: string }) => 
           onChange={(e) => {
             if (e.target.value) updateDeviceConfig(e.target.value, { equipmentId })
           }}
-          className="w-full rounded border border-cp-border bg-cp-surface-3 p-1 text-[11px]"
+          className="w-full rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
         >
           <option value="">
             {t('props.deviceConfigs.assignExisting', '+ Assign existing configuration…')}
@@ -77,7 +77,7 @@ export const DeviceConfigsBlock = ({ equipmentId }: { equipmentId: string }) => 
           ))}
         </select>
       )}
-      <div className="mt-1 text-[10px] text-cp-text-muted">
+      <div className="mt-1 text-cp-xs text-cp-text-muted">
         {t(
           'props.deviceConfigs.hint',
           'Upload new configurations in Settings → Configurations.',

--- a/src/renderer/components/Properties/sections/DeviceKindCards.tsx
+++ b/src/renderer/components/Properties/sections/DeviceKindCards.tsx
@@ -27,7 +27,7 @@ export const DeviceKindCards = ({ equipment }: { equipment: EquipmentItem }) => 
   if (deviceKind === 'greengo') {
     return (
       <div className="rounded border border-emerald-700 bg-emerald-900/30 p-2">
-        <div className="mb-1 text-[10px] uppercase tracking-wide text-emerald-300">
+        <div className="mb-1 text-cp-xs uppercase tracking-wide text-emerald-300">
           {t('props.deviceKind.greengo', 'GreenGo Intercom detected')}
         </div>
         <GreenGoBeltpackSection equipmentId={equipment.id} />
@@ -45,7 +45,7 @@ export const DeviceKindCards = ({ equipment }: { equipment: EquipmentItem }) => 
   if (deviceKind === 'videohub') {
     return (
       <div className="rounded border border-purple-700 bg-purple-900/30 p-2">
-        <div className="mb-1 text-[10px] uppercase tracking-wide text-purple-300">
+        <div className="mb-1 text-cp-xs uppercase tracking-wide text-purple-300">
           {t('props.deviceKind.videohub', 'Blackmagic Videohub detected')}
         </div>
         <div className="flex flex-col gap-1">
@@ -70,7 +70,7 @@ export const DeviceKindCards = ({ equipment }: { equipment: EquipmentItem }) => 
   if (deviceKind === 'atem') {
     return (
       <div className="rounded border border-sky-700 bg-sky-900/30 p-2">
-        <div className="mb-1 text-[10px] uppercase tracking-wide text-sky-300">
+        <div className="mb-1 text-cp-xs uppercase tracking-wide text-sky-300">
           {t('props.deviceKind.atem', 'Blackmagic ATEM detected')}
         </div>
         <div className="flex flex-col gap-1">
@@ -112,7 +112,7 @@ export const DeviceKindCards = ({ equipment }: { equipment: EquipmentItem }) => 
   if (deviceKind === 'multiviewer') {
     return (
       <div className="rounded border border-emerald-700 bg-emerald-900/30 p-2">
-        <div className="mb-1 text-[10px] uppercase tracking-wide text-emerald-300">
+        <div className="mb-1 text-cp-xs uppercase tracking-wide text-emerald-300">
           {t('props.deviceKind.multiviewer', 'Multiviewer detected')}
         </div>
         <button

--- a/src/renderer/components/Properties/sections/DeviceModePicker.tsx
+++ b/src/renderer/components/Properties/sections/DeviceModePicker.tsx
@@ -141,7 +141,7 @@ export const DeviceModePicker = ({
   return (
     <div className="space-y-2 text-cp-xs">
       <PanelHint
-        className="text-[10px] text-cp-text-muted"
+        className="text-cp-xs text-cp-text-muted"
         text={t(
           'modes.intro',
           "Switches the device's port layout. Cables on ports that don't exist in the new mode stay in the project but need to be re-plugged.",
@@ -149,7 +149,7 @@ export const DeviceModePicker = ({
       />
       <div className="grid grid-cols-1 gap-1">
         {modes.length === 0 && (
-          <div className="rounded border border-dashed border-cp-border p-3 text-center text-[11px] text-cp-text-muted">
+          <div className="rounded border border-dashed border-cp-border p-3 text-center text-cp-xs text-cp-text-muted">
             {t(
               'modes.emptyState',
               'No modes defined yet. Edit ports above, then save the current layout via "+ from current layout".',
@@ -174,13 +174,13 @@ export const DeviceModePicker = ({
                 {m.name}
               </span>
               {m.description && (
-                <span className="text-[10px] text-cp-text-muted">{m.description}</span>
+                <span className="text-cp-xs text-cp-text-muted">{m.description}</span>
               )}
-              <span className="mt-1 text-[10px] text-cp-text-muted">
+              <span className="mt-1 text-cp-xs text-cp-text-muted">
                 {m.inputs.length} {t('modes.inShort', 'In')} · {m.outputs.length} {t('modes.outShort', 'Out')}
               </span>
             </button>
-            <div className="flex gap-1 border-t border-cp-border-muted bg-cp-surface-3/40 px-1 py-1 text-[10px]">
+            <div className="flex gap-1 border-t border-cp-border-muted bg-cp-surface-3/40 px-1 py-1 text-cp-xs">
               <button
                 type="button"
                 onClick={() => setEditorState({ mode: 'edit', modeId: m.id })}
@@ -232,7 +232,7 @@ export const DeviceModePicker = ({
         <button
           type="button"
           onClick={() => setEditorState({ mode: 'create' })}
-          className="w-full rounded border border-sky-700 bg-sky-900/30 px-2 py-1 text-[11px] text-sky-100 hover:bg-sky-800/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+          className="w-full rounded border border-sky-700 bg-sky-900/30 px-2 py-1 text-cp-xs text-sky-100 hover:bg-sky-800/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
           title={t(
             'modes.newEditorTitle',
             'Opens an editor where name, description and ports of the new mode can be configured (Issue #113).',
@@ -243,7 +243,7 @@ export const DeviceModePicker = ({
         <button
           type="button"
           onClick={createModeFromPorts}
-          className="w-full rounded border border-dashed border-emerald-700 bg-emerald-950/30 px-2 py-1 text-[11px] text-emerald-200 hover:bg-emerald-900/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+          className="w-full rounded border border-dashed border-emerald-700 bg-emerald-950/30 px-2 py-1 text-cp-xs text-emerald-200 hover:bg-emerald-900/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
           title={t(
             'modes.quickSaveTitle',
             "Saves the device's current port layout as a new mode (quick-save).",

--- a/src/renderer/components/Properties/sections/DimensionsSection.tsx
+++ b/src/renderer/components/Properties/sections/DimensionsSection.tsx
@@ -72,7 +72,7 @@ export const DimensionsSection = ({ equipment }: { equipment: EquipmentItem }) =
         </label>
       </div>
       <PanelHint
-        className="mt-2 text-[10px] text-cp-text-muted"
+        className="mt-2 text-cp-xs text-cp-text-muted"
         text={t(
           'dims.hint',
           'Physical outer dimensions. 19" rack device: 1 U = 44.45 mm, standard width 482 mm, typical depth 400-600 mm. Used by the 3D rack renderer + logistics tools.',

--- a/src/renderer/components/Properties/sections/DisplayFlagsSection.tsx
+++ b/src/renderer/components/Properties/sections/DisplayFlagsSection.tsx
@@ -53,7 +53,7 @@ export const DisplayFlagsSection = ({ equipment }: { equipment: EquipmentItem })
         {/* #419 — "Ports spiegeln" gehoert zur Inputs-&-Outputs-Sektion
             (siehe PortsSection); nicht mehr hier. */}
         <label
-          className="flex items-center gap-2 text-[11px] text-cp-text-secondary"
+          className="flex items-center gap-2 text-cp-xs text-cp-text-secondary"
           title={t('flags.packedTitle', 'Marks the device as packed. Shown as ✓ on the canvas and as a column in the device BOM.')}
         >
           <input
@@ -69,7 +69,7 @@ export const DisplayFlagsSection = ({ equipment }: { equipment: EquipmentItem })
             eindeutige 1-In/1-Out-Wandler relevant; bei mehrdeutigen
             Geraeten wird trotzdem ohne Pass-Through angezeigt. */}
         <label
-          className="flex items-center gap-2 text-[11px] text-cp-text-secondary"
+          className="flex items-center gap-2 text-cp-xs text-cp-text-secondary"
           title={t('flags.converterTitle', 'Converter marker: the patch list skips this device and shows the next real target directly. Useful for SDI-HDMI converters, format converters, embedders/de-embedders.')}
         >
           <input
@@ -87,7 +87,7 @@ export const DisplayFlagsSection = ({ equipment }: { equipment: EquipmentItem })
             (Buchse n hinten auf Buchse n vorn), dem Patchliste, Signalweg
             und Namens-Ableitung folgen. */}
         <label
-          className="flex items-center gap-2 text-[11px] text-cp-text-secondary"
+          className="flex items-center gap-2 text-cp-xs text-cp-text-secondary"
           title={
             ausKategorie
               ? t(
@@ -113,7 +113,7 @@ export const DisplayFlagsSection = ({ equipment }: { equipment: EquipmentItem })
           {t('flags.patchPanel', 'Patch panel (through-path follows the position)')}
         </label>
         <label
-          className="flex items-center gap-2 text-[11px] text-cp-text-secondary"
+          className="flex items-center gap-2 text-cp-xs text-cp-text-secondary"
           title={t('flags.daTitle', 'Distribution amplifier: one input is actively split to several outputs of the same source (1→N).')}
         >
           <input
@@ -129,7 +129,7 @@ export const DisplayFlagsSection = ({ equipment }: { equipment: EquipmentItem })
         </label>
         {/* #359/#360/#366 — Signal-Flow-Rollen (Timecode / Tally / Embedding). */}
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-1 border-t border-cp-border-muted pt-2">
-          <label className="block text-[10px]">
+          <label className="block text-cp-xs">
             <span className="mb-0.5 block text-cp-text-muted">{t('roles.tc', 'Timecode')}</span>
             <select
               value={equipment.tcRole ?? ''}
@@ -145,7 +145,7 @@ export const DisplayFlagsSection = ({ equipment }: { equipment: EquipmentItem })
               <option value="sink">{t('roles.sink', 'Sink')}</option>
             </select>
           </label>
-          <label className="block text-[10px]">
+          <label className="block text-cp-xs">
             <span className="mb-0.5 block text-cp-text-muted">{t('roles.tally', 'Tally')}</span>
             <select
               value={equipment.tallyRole ?? ''}
@@ -161,7 +161,7 @@ export const DisplayFlagsSection = ({ equipment }: { equipment: EquipmentItem })
               <option value="sink">{t('roles.sink', 'Sink')}</option>
             </select>
           </label>
-          <label className="block text-[10px]">
+          <label className="block text-cp-xs">
             <span className="mb-0.5 block text-cp-text-muted">{t('roles.embed', 'Embedding')}</span>
             <select
               value={equipment.embedderRole ?? ''}

--- a/src/renderer/components/Properties/sections/DisplayPropertiesBlock.tsx
+++ b/src/renderer/components/Properties/sections/DisplayPropertiesBlock.tsx
@@ -45,7 +45,7 @@ export const DisplayPropertiesBlock = ({ equipment }: { equipment: EquipmentItem
       onToggle={(e) => setOpen(e.currentTarget.open)}
       className="rounded border border-cp-border [&_summary]:cursor-pointer"
     >
-      <summary className="flex items-center gap-1 px-2 py-1.5 text-[11px] uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright [&::-webkit-details-marker]:hidden">
+      <summary className="flex items-center gap-1 px-2 py-1.5 text-cp-xs uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright [&::-webkit-details-marker]:hidden">
         <span className="text-cp-text-faint">{open ? '▾' : '▸'}</span>
         <span className="flex-1">{t('display.title', 'Display')}</span>
       </summary>

--- a/src/renderer/components/Properties/sections/GreenGoBeltpackSection.tsx
+++ b/src/renderer/components/Properties/sections/GreenGoBeltpackSection.tsx
@@ -19,7 +19,7 @@ export const GreenGoBeltpackSection = ({ equipmentId }: { equipmentId: string })
   const [open, setOpen] = useState(!!info)
   if (!config || config.users.length === 0) {
     return (
-      <div className="mb-2 text-[10px] text-emerald-300/60">
+      <div className="mb-2 text-cp-xs text-emerald-300/60">
         {t(
           'props.greengo.noConfig',
           'No GreenGo configuration in the project. Open the Intercom planner or load a preset to define beltpacks.',
@@ -36,7 +36,7 @@ export const GreenGoBeltpackSection = ({ equipmentId }: { equipmentId: string })
       onToggle={(e) => setOpen(e.currentTarget.open)}
       className="mb-2 rounded bg-emerald-950/40 [&_summary]:cursor-pointer"
     >
-      <summary className="flex items-center gap-1 px-2 py-1.5 text-[10px] uppercase tracking-wide text-emerald-300 hover:text-emerald-200 [&::-webkit-details-marker]:hidden">
+      <summary className="flex items-center gap-1 px-2 py-1.5 text-cp-xs uppercase tracking-wide text-emerald-300 hover:text-emerald-200 [&::-webkit-details-marker]:hidden">
         <span className="text-emerald-400/70">{open ? '▾' : '▸'}</span>
         <span className="flex-1">{t('props.greengo.beltpack', 'Beltpack')}</span>
         {info?.channelNames && info.channelNames.length > 0 && (
@@ -96,7 +96,7 @@ export const GreenGoBeltpackSection = ({ equipmentId }: { equipmentId: string })
         </select>
       </label>
       {info?.channelNames && info.channelNames.length > 0 && (
-        <div className="mt-2 flex flex-wrap gap-1 text-[10px]">
+        <div className="mt-2 flex flex-wrap gap-1 text-cp-xs">
           {info.channelNames.map((g) => (
             <span
               key={g}

--- a/src/renderer/components/Properties/sections/IdentityBlock.tsx
+++ b/src/renderer/components/Properties/sections/IdentityBlock.tsx
@@ -79,7 +79,7 @@ export const IdentityBlock = ({ equipment }: { equipment: EquipmentItem }) => {
           </button>
         </div>
         {!equipment.shortName?.trim() && autoSuggestion && (
-          <p className="mt-1 text-[10px] text-cp-text-muted">
+          <p className="mt-1 text-cp-xs text-cp-text-muted">
             {t('eq.field.shortNameAutoUsed', 'Automatically using:')}{' '}
             <span className="font-mono text-cp-text-muted">{autoSuggestion}</span>
           </p>

--- a/src/renderer/components/Properties/sections/LifecycleSection.tsx
+++ b/src/renderer/components/Properties/sections/LifecycleSection.tsx
@@ -72,7 +72,7 @@ export const LifecycleSection = ({ equipment }: { equipment: EquipmentItem }) =>
 
   return (
     <details className="rounded border border-cp-border bg-cp-surface-3/40">
-      <summary className="flex cursor-pointer select-none items-center gap-1.5 px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-cp-text-muted hover:bg-cp-surface-2/40">
+      <summary className="flex cursor-pointer select-none items-center gap-1.5 px-2 py-1.5 text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted hover:bg-cp-surface-2/40">
         <Icon icon={Wrench} size="xs" />
         {t('lifecycle.section', 'Lifecycle / maintenance')}
       </summary>
@@ -205,7 +205,7 @@ export const LifecycleSection = ({ equipment }: { equipment: EquipmentItem }) =>
         {/* Service-Historie — nur bei aktivem Festinstallations-Modul. */}
         {festinstallationModule && (
         <div>
-          <div className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-cp-text-muted">
+          <div className="mb-1 text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">
             {t('lifecycle.history', 'Service history')} ({history.length})
           </div>
           {history.length > 0 && (
@@ -213,7 +213,7 @@ export const LifecycleSection = ({ equipment }: { equipment: EquipmentItem }) =>
               {[...history]
                 .sort((a, b) => b.date.localeCompare(a.date))
                 .map((r) => (
-                  <li key={r.id} className="flex items-start gap-1.5 rounded bg-cp-surface-1 px-2 py-1 text-[11px]">
+                  <li key={r.id} className="flex items-start gap-1.5 rounded bg-cp-surface-1 px-2 py-1 text-cp-xs">
                     <span className="shrink-0 font-mono text-cp-text-faint">
                       {new Date(r.date).toLocaleDateString('de-DE')}
                     </span>
@@ -237,7 +237,7 @@ export const LifecycleSection = ({ equipment }: { equipment: EquipmentItem }) =>
             <select
               value={kind}
               onChange={(e) => setKind(e.target.value as ServiceRecord['kind'])}
-              className="rounded border border-cp-border bg-cp-surface-1 p-1.5 text-[11px]"
+              className="rounded border border-cp-border bg-cp-surface-1 p-1.5 text-cp-xs"
             >
               {SERVICE_KINDS.map((k) => (
                 <option key={k} value={k}>
@@ -252,12 +252,12 @@ export const LifecycleSection = ({ equipment }: { equipment: EquipmentItem }) =>
                 if (e.key === 'Enter') onAdd()
               }}
               placeholder={t('lifecycle.history.placeholder', 'What was done?')}
-              className="min-w-0 flex-1 rounded border border-cp-border bg-cp-surface-1 p-1.5 text-[11px]"
+              className="min-w-0 flex-1 rounded border border-cp-border bg-cp-surface-1 p-1.5 text-cp-xs"
             />
             <button
               type="button"
               onClick={onAdd}
-              className="inline-flex shrink-0 items-center gap-1 rounded bg-cp-surface-4 px-2 py-1.5 text-[11px] hover:bg-cp-surface-5"
+              className="inline-flex shrink-0 items-center gap-1 rounded bg-cp-surface-4 px-2 py-1.5 text-cp-xs hover:bg-cp-surface-5"
             >
               <Icon icon={Plus} size="xs" /> {t('common.add', 'Add')}
             </button>

--- a/src/renderer/components/Properties/sections/NetworkConfig.tsx
+++ b/src/renderer/components/Properties/sections/NetworkConfig.tsx
@@ -58,7 +58,7 @@ export const NetworkConfig = ({ equipmentId, item, allPorts, kind }: NetworkConf
   return (
     <>
       <fieldset className="rounded border border-cyan-700 bg-cyan-950/30 p-2">
-        <legend className="px-1 text-[11px] uppercase tracking-wide text-cyan-300">
+        <legend className="px-1 text-cp-xs uppercase tracking-wide text-cyan-300">
           {kind === 'router' ? t('net.routerConfig', 'Router config') : t('net.switchConfig', 'Switch config')}
         </legend>
         <div className="grid grid-cols-2 gap-2">
@@ -119,17 +119,17 @@ export const NetworkConfig = ({ equipmentId, item, allPorts, kind }: NetworkConf
 
       <fieldset className="rounded border border-cyan-700 bg-cyan-950/20 p-2">
         <div className="mb-2 flex items-center justify-between">
-          <span className="text-[11px] uppercase tracking-wide text-cyan-300">{t('net.vlans', 'VLANs')}</span>
+          <span className="text-cp-xs uppercase tracking-wide text-cyan-300">{t('net.vlans', 'VLANs')}</span>
           <button
             type="button"
             onClick={addVlan}
-            className="rounded bg-cyan-700 px-2 py-0.5 text-[11px] hover:bg-cyan-600"
+            className="rounded bg-cyan-700 px-2 py-0.5 text-cp-xs hover:bg-cyan-600"
           >
             {t('net.addVlan', '+ VLAN')}
           </button>
         </div>
         {vlans.length === 0 && (
-          <div className="text-[11px] text-cp-text-muted">{t('net.noVlans', 'No VLANs defined.')}</div>
+          <div className="text-cp-xs text-cp-text-muted">{t('net.noVlans', 'No VLANs defined.')}</div>
         )}
         <ul className="space-y-1">
           {vlans.map((v, i) => (
@@ -156,7 +156,7 @@ export const NetworkConfig = ({ equipmentId, item, allPorts, kind }: NetworkConf
               <button
                 type="button"
                 onClick={() => removeVlan(i)}
-                className="rounded bg-red-900/60 px-2 py-0.5 text-[11px] hover:bg-red-800"
+                className="rounded bg-red-900/60 px-2 py-0.5 text-cp-xs hover:bg-red-800"
               >
                 ×
               </button>
@@ -167,10 +167,10 @@ export const NetworkConfig = ({ equipmentId, item, allPorts, kind }: NetworkConf
 
       {kind === 'switch' && allPorts.length > 0 && (
         <fieldset className="rounded border border-cyan-700 bg-cyan-950/20 p-2">
-          <legend className="px-1 text-[11px] uppercase tracking-wide text-cyan-300">
+          <legend className="px-1 text-cp-xs uppercase tracking-wide text-cyan-300">
             {t('net.portToVlan', 'Port → VLAN')}
           </legend>
-          <div className="mb-1 grid grid-cols-[1fr_70px_120px] gap-1 text-[10px] text-cp-text-muted">
+          <div className="mb-1 grid grid-cols-[1fr_70px_120px] gap-1 text-cp-xs text-cp-text-muted">
             <span>{t('net.col.port', 'Port')}</span>
             <span>{t('net.col.untagged', 'Untagged')}</span>
             <span>{t('net.col.tagged', 'Tagged')}</span>
@@ -180,7 +180,7 @@ export const NetworkConfig = ({ equipmentId, item, allPorts, kind }: NetworkConf
               const assign = portVlans[p.id] ?? {}
               return (
                 <li key={p.id} className="grid grid-cols-[1fr_70px_120px] items-center gap-1">
-                  <span className="truncate text-[11px] text-cp-text-secondary" title={p.name}>
+                  <span className="truncate text-cp-xs text-cp-text-secondary" title={p.name}>
                     {p.name}
                   </span>
                   <input

--- a/src/renderer/components/Properties/sections/OptionalFieldsSection.tsx
+++ b/src/renderer/components/Properties/sections/OptionalFieldsSection.tsx
@@ -55,7 +55,7 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
             <span className="flex items-center gap-1.5 text-cp-text-secondary">
               {verifiedBy.length > 0 && (
                 <span
-                  className="inline-flex items-center gap-1 rounded bg-emerald-900/60 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-200"
+                  className="inline-flex items-center gap-1 rounded bg-emerald-900/60 px-1.5 py-0.5 text-cp-xs font-semibold text-emerald-200"
                   title={format(
                     t('verify.byTitle', 'Verified by: {names}'),
                     { names: verifiedBy.join(', ') },
@@ -65,7 +65,7 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
                 </span>
               )}
               {verifiedBy.length === 0 && (
-                <span className="text-[11px] text-cp-text-muted">
+                <span className="text-cp-xs text-cp-text-muted">
                   {t('verify.none', 'Not verified yet')}
                 </span>
               )}
@@ -79,7 +79,7 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
               {t('verify.button', 'Verify as correct')}
             </button>
           </div>
-          <p className="text-[10px] text-cp-text-faint">
+          <p className="text-cp-xs text-cp-text-faint">
             {t('verify.hint', 'Confirms the ports are correct. When sharing libraries, confirmations from multiple users add up.')}
           </p>
         </div>
@@ -91,7 +91,7 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
             <span className="mb-1 block text-cp-text-secondary">
               {t('eq.field.rentPrice', 'Rental price / day')}
               {equipment.rentmanId && (
-                <span className="ml-1 rounded bg-emerald-900/60 px-1 text-[10px] text-emerald-200">
+                <span className="ml-1 rounded bg-emerald-900/60 px-1 text-cp-xs text-emerald-200">
                   {t('eq.field.rentPriceRentman', 'from Rentman')}
                 </span>
               )}
@@ -243,7 +243,7 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
                 <img src={equipment.imageUrl} alt="" className="max-h-24 max-w-[120px] object-contain" />
               </a>
             ) : (
-              <div className="flex h-24 w-[120px] items-center justify-center rounded border border-dashed border-cp-border text-[10px] text-cp-text-muted">
+              <div className="flex h-24 w-[120px] items-center justify-center rounded border border-dashed border-cp-border text-cp-xs text-cp-text-muted">
                 {t('eq.field.refImageNone', 'No image')}
               </div>
             )}
@@ -310,7 +310,7 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
               <button
                 type="button"
                 onClick={() => updateEquipment(equipment.id, { icon: undefined })}
-                className="rounded bg-cp-surface-4 px-1.5 py-1 text-[10px] hover:bg-cp-surface-5"
+                className="rounded bg-cp-surface-4 px-1.5 py-1 text-cp-xs hover:bg-cp-surface-5"
                 title={t('opt.iconAutoTitle', 'Reset to automatic')}
               >
                 auto

--- a/src/renderer/components/Properties/sections/PortAiSuggestButton.tsx
+++ b/src/renderer/components/Properties/sections/PortAiSuggestButton.tsx
@@ -80,14 +80,14 @@ export const PortAiSuggestButton = ({
   return (
     <div className="rounded border border-purple-700/50 bg-purple-950/20 p-2">
       <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-1 text-[11px] font-semibold text-purple-200">
+        <div className="flex items-center gap-1 text-cp-xs font-semibold text-purple-200">
           <Icon icon={Sparkles} size="xs" /> {t('props.aiPorts.label', 'AI port suggestion')}
         </div>
         <button
           type="button"
           onClick={handleAsk}
           disabled={busy}
-          className="rounded bg-purple-700 px-2 py-0.5 text-[11px] font-medium text-white hover:bg-purple-600 disabled:opacity-50"
+          className="rounded bg-purple-700 px-2 py-0.5 text-cp-xs font-medium text-white hover:bg-purple-600 disabled:opacity-50"
           title={format(
             t(
               'props.aiPorts.btnTitle',
@@ -100,17 +100,17 @@ export const PortAiSuggestButton = ({
         </button>
       </div>
       {error && (
-        <div className="mt-1 rounded bg-red-900/50 p-1.5 text-[10px] text-red-100">{error}</div>
+        <div className="mt-1 rounded bg-red-900/50 p-1.5 text-cp-xs text-red-100">{error}</div>
       )}
       {hints && hints.length > 0 && (
         <div className="mt-2 space-y-1">
-          <div className="text-[10px] text-purple-100/80">
+          <div className="text-cp-xs text-purple-100/80">
             {format(t('props.aiPorts.summary', '{groups} group(s) / {ports} ports suggested:'), {
               groups: hints.length,
               ports: totalSuggested,
             })}
           </div>
-          <ul className="ml-3 list-disc text-[10px] text-purple-100">
+          <ul className="ml-3 list-disc text-cp-xs text-purple-100">
             {hints.map((h, idx) => (
               <li key={idx}>
                 {h.count}× {h.connectorType} (
@@ -135,7 +135,7 @@ export const PortAiSuggestButton = ({
                   )
                   if (ok) apply('replace')
                 }}
-                className="rounded bg-amber-700 px-2 py-0.5 text-[10px] text-amber-100 hover:bg-amber-600"
+                className="rounded bg-amber-700 px-2 py-0.5 text-cp-xs text-amber-100 hover:bg-amber-600"
                 title={t('props.aiPorts.replaceTitle', 'Removes current ports and applies the AI suggestion')}
               >
                 {t('props.aiPorts.replace', 'Replace')}
@@ -144,7 +144,7 @@ export const PortAiSuggestButton = ({
             <button
               type="button"
               onClick={() => apply('append')}
-              className="rounded bg-emerald-700 px-2 py-0.5 text-[10px] text-emerald-100 hover:bg-emerald-600"
+              className="rounded bg-emerald-700 px-2 py-0.5 text-cp-xs text-emerald-100 hover:bg-emerald-600"
               title={t('props.aiPorts.appendTitle', 'Appends the AI suggestion to the existing ports')}
             >
               {hasExisting
@@ -154,7 +154,7 @@ export const PortAiSuggestButton = ({
             <button
               type="button"
               onClick={() => setHints(null)}
-              className="rounded bg-cp-surface-4 px-2 py-0.5 text-[10px] text-cp-text-bright hover:bg-cp-surface-5"
+              className="rounded bg-cp-surface-4 px-2 py-0.5 text-cp-xs text-cp-text-bright hover:bg-cp-surface-5"
             >
               {t('props.aiPorts.discard', 'Discard')}
             </button>

--- a/src/renderer/components/Properties/sections/PortsSection.tsx
+++ b/src/renderer/components/Properties/sections/PortsSection.tsx
@@ -58,7 +58,7 @@ export const PortsSection = ({ equipment }: { equipment: EquipmentItem }) => {
     >
       <div className="space-y-2">
         {equipment.portsUnknown && equipment.inputs.length === 0 && equipment.outputs.length === 0 && (
-          <div className="rounded border border-cp-warn/40 bg-cp-warn/10 px-2 py-1.5 text-[11px] text-cp-text-secondary">
+          <div className="rounded border border-cp-warn/40 bg-cp-warn/10 px-2 py-1.5 text-cp-xs text-cp-text-secondary">
             {t(
               'ports.unknown',
               'Port layout unknown (no datasheet match on import). Add the real connectors below — none were fabricated.',
@@ -82,7 +82,7 @@ export const PortsSection = ({ equipment }: { equipment: EquipmentItem }) => {
             mehr zu "Darstellung & Flags"), weil es die Seiten-Zuordnung der
             Inputs/Outputs am Canvas-Knoten umdreht. */}
         <label
-          className="flex items-center gap-2 px-1 text-[11px] text-cp-text-secondary"
+          className="flex items-center gap-2 px-1 text-cp-xs text-cp-text-secondary"
           title={t(
             'ports.flipTitle',
             'Inputs render on the right, outputs on the left of the device node.',

--- a/src/renderer/components/Properties/sections/PowerConsumptionSection.tsx
+++ b/src/renderer/components/Properties/sections/PowerConsumptionSection.tsx
@@ -116,7 +116,7 @@ export const PowerConsumptionSection = ({ equipment }: { equipment: EquipmentIte
         </label>
       </div>
       <PanelHint
-        className="mt-2 text-[10px] text-cp-text-muted"
+        className="mt-2 text-cp-xs text-cp-text-muted"
         text={t(
           'power.formulaHint',
           'When voltage and current are set, power is computed automatically (P = U × I). Tools → power consumption sums the power field across all devices.',

--- a/src/renderer/components/Properties/sections/RackFacePreview.tsx
+++ b/src/renderer/components/Properties/sections/RackFacePreview.tsx
@@ -22,17 +22,17 @@ export const RackFacePreview = ({
 
   return (
     <fieldset className="rounded border border-cp-border p-2">
-      <legend className="px-1 text-[11px] uppercase tracking-wide text-cp-text-muted">
+      <legend className="px-1 text-cp-xs uppercase tracking-wide text-cp-text-muted">
         {t('rackFace.title', '2D rack preview')}
       </legend>
-      <div className="mb-2 text-[11px] text-cp-text-muted">{format(t('rackFace.subtitle', '19" rack · {he} U · front/rear with port markers'), { he: equipment.rackUnits })}</div>
+      <div className="mb-2 text-cp-xs text-cp-text-muted">{format(t('rackFace.subtitle', '19" rack · {he} U · front/rear with port markers'), { he: equipment.rackUnits })}</div>
       <div className="rounded border border-cp-border bg-cp-surface-3 p-3">
         <div className={`mx-auto grid w-full max-w-[760px] gap-2 ${viewMode === 'both' ? 'grid-cols-2' : 'grid-cols-1'}`}>
           {(viewMode === 'both' ? ['front', 'rear'] : [viewMode]).map((side) => {
             const imageUrl = side === 'front' ? equipment.frontPanelImageUrl : equipment.rearPanelImageUrl
             return (
               <div key={side} className="rounded border border-cp-surface-5 bg-gradient-to-b from-cp-surface-2 to-cp-surface-1 px-4 py-3 shadow-inner">
-                <div className="mb-3 flex items-center justify-between text-[10px] uppercase tracking-[0.2em] text-cp-text-muted">
+                <div className="mb-3 flex items-center justify-between text-cp-xs uppercase tracking-[0.2em] text-cp-text-muted">
                   <span>{side === 'front' ? t('rackFace.front', 'Front') : t('rackFace.rear', 'Rear')}</span>
                   <span>{equipment.rackUnits} HE</span>
                 </div>
@@ -47,7 +47,7 @@ export const RackFacePreview = ({
                   ) : (
                     <>
                       <div className="truncate text-cp-base font-semibold text-cp-text">{equipment.name}</div>
-                      <div className="truncate text-[11px] text-cp-text-muted">{equipment.category}</div>
+                      <div className="truncate text-cp-xs text-cp-text-muted">{equipment.category}</div>
                     </>
                   )}
                 </div>
@@ -56,7 +56,7 @@ export const RackFacePreview = ({
                     const input = equipment.inputs[index]
                     const output = equipment.outputs[index]
                     return (
-                      <div key={`${equipment.id}-${side}-rack-row-${index}`} className="grid grid-cols-[1fr_auto_1fr] items-center gap-3 text-[11px]">
+                      <div key={`${equipment.id}-${side}-rack-row-${index}`} className="grid grid-cols-[1fr_auto_1fr] items-center gap-3 text-cp-xs">
                         <div className="min-w-0 rounded border border-cp-border bg-cp-surface-1/70 px-2 py-1 text-right text-cp-text-bright">
                           {input ? (
                             <span className="block truncate">

--- a/src/renderer/components/Properties/sections/RackInstanceCard.tsx
+++ b/src/renderer/components/Properties/sections/RackInstanceCard.tsx
@@ -18,11 +18,11 @@ export const RackInstanceCard = ({ equipment }: { equipment: EquipmentItem }) =>
 
   return (
     <div className="rounded border border-cyan-700 bg-cyan-950/30 p-2">
-      <div className="mb-1 text-[10px] uppercase tracking-wide text-cyan-300">
+      <div className="mb-1 text-cp-xs uppercase tracking-wide text-cyan-300">
         {t('rackInstance.label', 'Rack instance')} · {equipment.rackInstanceLabel ?? t('rackInstance.fallback', 'Rack')}
       </div>
       <PanelHint
-        className="mb-2 text-[10px] text-cp-text-muted"
+        className="mb-2 text-cp-xs text-cp-text-muted"
         text={t(
           'rackInstance.intro',
           'This device belongs to a rack instance. The rack editor shows a filtered sub-canvas with this rack only — position changes are rounded to whole U on release.',
@@ -36,7 +36,7 @@ export const RackInstanceCard = ({ equipment }: { equipment: EquipmentItem }) =>
         <Icon icon={Server} size="xs" /> {t('rackInstance.openEditor', 'Open rack editor')}
       </button>
       {typeof equipment.rackInstanceStartUnit === 'number' && (
-        <div className="mt-1 text-[10px] text-cp-text-muted">
+        <div className="mt-1 text-cp-xs text-cp-text-muted">
           {format(t('rackInstance.position', 'Position: from U {start}'), {
             start: equipment.rackInstanceStartUnit + 1,
           })}

--- a/src/renderer/components/Properties/sections/RackSection.tsx
+++ b/src/renderer/components/Properties/sections/RackSection.tsx
@@ -53,7 +53,7 @@ export const RackSection = ({ equipment }: { equipment: EquipmentItem }) => {
           </label>
 
           {!equipment.isRackDevice && (
-            <div className="rounded border border-cp-border-muted bg-cp-surface-1/50 p-2 text-[11px] text-cp-text-muted">
+            <div className="rounded border border-cp-border-muted bg-cp-surface-1/50 p-2 text-cp-xs text-cp-text-muted">
               {t(
                 'props.rack.disabledHint',
                 'Rack fields only appear when the device is marked as a 19" rack device.',
@@ -139,7 +139,7 @@ export const RackSection = ({ equipment }: { equipment: EquipmentItem }) => {
               )}
 
               {equipment.netboxPath && (
-                <div className="mt-2 text-[10px] text-cp-text-muted">
+                <div className="mt-2 text-cp-xs text-cp-text-muted">
                   {format(t('props.rack.netboxSource', 'Source: NetBox device-type-library · {path}'), {
                     path: equipment.netboxPath,
                   })}

--- a/src/renderer/components/Properties/sections/RentmanSyncBadge.tsx
+++ b/src/renderer/components/Properties/sections/RentmanSyncBadge.tsx
@@ -21,7 +21,7 @@ export const RentmanSyncBadge = ({ equipment }: { equipment: EquipmentItem }) =>
 
   if (equipment.rentmanRemoved) {
     return (
-      <div className="flex items-center gap-1.5 rounded border border-red-700/50 bg-red-900/20 px-2 py-1 text-[11px] text-red-300">
+      <div className="flex items-center gap-1.5 rounded border border-red-700/50 bg-red-900/20 px-2 py-1 text-cp-xs text-red-300">
         <Icon icon={AlertTriangle} size="sm" />
         <span>{t('props.rentmanBadge.removed', 'No longer present in Rentman!')}</span>
       </div>
@@ -29,14 +29,14 @@ export const RentmanSyncBadge = ({ equipment }: { equipment: EquipmentItem }) =>
   }
   if (equipment.rentmanId) {
     return (
-      <div className="flex items-center gap-1.5 rounded border border-orange-700/50 bg-orange-900/20 px-2 py-1 text-[11px] text-orange-300">
+      <div className="flex items-center gap-1.5 rounded border border-orange-700/50 bg-orange-900/20 px-2 py-1 text-cp-xs text-orange-300">
         <span className="rounded bg-orange-700 px-1 font-bold text-white">R</span>
         {format(t('props.rentmanBadge.id', 'Rentman ID: {id}'), { id: equipment.rentmanId })}
       </div>
     )
   }
   return (
-    <div className="flex items-center gap-1.5 rounded border border-amber-700/40 bg-amber-900/10 px-2 py-1 text-[11px] text-amber-400">
+    <div className="flex items-center gap-1.5 rounded border border-amber-700/40 bg-amber-900/10 px-2 py-1 text-cp-xs text-amber-400">
       <Icon icon={AlertTriangle} size="sm" />
       <span>{t('props.rentmanBadge.notTracked', 'Not tracked in Rentman plan')}</span>
     </div>

--- a/src/renderer/components/Properties/sections/ReplaceDeviceSection.tsx
+++ b/src/renderer/components/Properties/sections/ReplaceDeviceSection.tsx
@@ -174,7 +174,7 @@ export const ReplaceDeviceSection = ({ equipment }: { equipment: EquipmentItem }
             <button
               type="button"
               onClick={() => setOpen(false)}
-              className="rounded bg-cp-surface-4 px-2 py-1 text-[11px] hover:bg-cp-surface-5"
+              className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
             >
               ✕
             </button>
@@ -193,7 +193,7 @@ export const ReplaceDeviceSection = ({ equipment }: { equipment: EquipmentItem }
           </select>
           <div className="max-h-56 overflow-auto rounded border border-cp-border-muted">
             {filtered.length === 0 ? (
-              <div className="px-2 py-3 text-center text-[11px] text-cp-text-muted">
+              <div className="px-2 py-3 text-center text-cp-xs text-cp-text-muted">
                 {t('replaceDevice.noMatches', 'No matches.')}
               </div>
             ) : (
@@ -213,19 +213,19 @@ export const ReplaceDeviceSection = ({ equipment }: { equipment: EquipmentItem }
                           <span className="block text-cp-xs font-medium text-cp-text">
                             {tpl.name}
                           </span>
-                          <span className="block text-[10px] text-cp-text-muted">
+                          <span className="block text-cp-xs text-cp-text-muted">
                             {categoryDisplay(tpl.category ?? '', lang, categoryTranslations)} · {tpl.inputs.length} in / {tpl.outputs.length} out
                           </span>
                         </span>
                         {lost > 0 ? (
                           <span
-                            className="rounded bg-amber-900/60 px-1.5 py-0.5 text-[11px] font-bold text-amber-200"
+                            className="rounded bg-amber-900/60 px-1.5 py-0.5 text-cp-xs font-bold text-amber-200"
                             title={format(t('replaceDevice.lostBadgeTitle', '{n} connection(s) would be lost'), { n: lost })}
                           >
                             -{lost}
                           </span>
                         ) : (
-                          <span className="rounded bg-emerald-900/60 px-1.5 py-0.5 text-[11px] font-bold text-emerald-200">
+                          <span className="rounded bg-emerald-900/60 px-1.5 py-0.5 text-cp-xs font-bold text-emerald-200">
                             ✓
                           </span>
                         )}

--- a/src/renderer/components/Properties/sections/SinkProfileSection.tsx
+++ b/src/renderer/components/Properties/sections/SinkProfileSection.tsx
@@ -127,7 +127,7 @@ export const SinkProfileSection = ({ equipment }: { equipment: EquipmentItem }) 
                   </select>
                   <button
                     type="button"
-                    className="rounded bg-red-700 px-1.5 py-1 text-[10px] hover:bg-red-600"
+                    className="rounded bg-red-700 px-1.5 py-1 text-cp-xs hover:bg-red-600"
                     onClick={() =>
                       setze({ formate: profil.formate.filter((_, j) => j !== i) })
                     }

--- a/src/renderer/components/Rack/NonRackAddDialog.tsx
+++ b/src/renderer/components/Rack/NonRackAddDialog.tsx
@@ -92,7 +92,7 @@ export const NonRackAddDialog = ({
         </div>
       }
     >
-        <div className="mb-3 text-[11px] text-cp-text-muted">
+        <div className="mb-3 text-cp-xs text-cp-text-muted">
           {t('rack.nonRack.intro', 'The device is not marked as a 19″ rack device. Pick how it should be placed in the rack:')}
         </div>
 
@@ -107,7 +107,7 @@ export const NonRackAddDialog = ({
             }`}
           >
             <div className="flex items-center gap-1.5 font-semibold"><Icon icon={Ruler} size="xs" /> {t('rack.nonRack.option.rack', 'As 19″ device')}</div>
-            <div className="mt-0.5 text-[10px] text-cp-text-muted">
+            <div className="mt-0.5 text-cp-xs text-cp-text-muted">
               {t('rack.nonRack.option.rackHint', 'Occupies N U on the rack rails')}
             </div>
           </button>
@@ -121,7 +121,7 @@ export const NonRackAddDialog = ({
             }`}
           >
             <div className="flex items-center gap-1.5 font-semibold"><Icon icon={Armchair} size="xs" /> {t('rack.nonRack.option.shelf', 'On a shelf')}</div>
-            <div className="mt-0.5 text-[10px] text-cp-text-muted">
+            <div className="mt-0.5 text-cp-xs text-cp-text-muted">
               {t('rack.nonRack.option.shelfHint', 'Custom dimensions in mm, sits on a rack shelf')}
             </div>
           </button>
@@ -165,7 +165,7 @@ export const NonRackAddDialog = ({
                   <button
                     type="button"
                     onClick={() => setWidthMm(150)}
-                    className="flex-1 rounded bg-cp-surface-2 px-1 py-0.5 text-[10px] text-cp-text-muted hover:bg-cp-surface-4"
+                    className="flex-1 rounded bg-cp-surface-2 px-1 py-0.5 text-cp-xs text-cp-text-muted hover:bg-cp-surface-4"
                     title={t('rack.nonRack.widthPreset.third', '1/3 rack-mount width ≈ 150 mm')}
                   >
                     1/3
@@ -173,7 +173,7 @@ export const NonRackAddDialog = ({
                   <button
                     type="button"
                     onClick={() => setWidthMm(225)}
-                    className="flex-1 rounded bg-cp-surface-2 px-1 py-0.5 text-[10px] text-cp-text-muted hover:bg-cp-surface-4"
+                    className="flex-1 rounded bg-cp-surface-2 px-1 py-0.5 text-cp-xs text-cp-text-muted hover:bg-cp-surface-4"
                     title={t('rack.nonRack.widthPreset.half', '1/2 rack-mount width ≈ 225 mm')}
                   >
                     1/2
@@ -181,7 +181,7 @@ export const NonRackAddDialog = ({
                   <button
                     type="button"
                     onClick={() => setWidthMm(300)}
-                    className="flex-1 rounded bg-cp-surface-2 px-1 py-0.5 text-[10px] text-cp-text-muted hover:bg-cp-surface-4"
+                    className="flex-1 rounded bg-cp-surface-2 px-1 py-0.5 text-cp-xs text-cp-text-muted hover:bg-cp-surface-4"
                     title={t('rack.nonRack.widthPreset.twoThirds', '2/3 rack-mount width ≈ 300 mm')}
                   >
                     2/3
@@ -213,13 +213,13 @@ export const NonRackAddDialog = ({
                 />
               </label>
             </div>
-            <div className="rounded border border-cp-border-muted bg-cp-surface-3/50 p-2 text-[10px] text-cp-text-muted">
+            <div className="rounded border border-cp-border-muted bg-cp-surface-3/50 p-2 text-cp-xs text-cp-text-muted">
               {t('rack.nonRack.shelfTip', 'Place the device on an existing rack shelf by adding it at the same starting U. Dimensions are visualized in the 3D tab as real box size.')}
             </div>
           </div>
         )}
 
-        <label className="mb-3 flex items-start gap-2 rounded border border-cp-border-muted bg-cp-surface-3/40 p-2 text-[11px]">
+        <label className="mb-3 flex items-start gap-2 rounded border border-cp-border-muted bg-cp-surface-3/40 p-2 text-cp-xs">
           <input
             type="checkbox"
             checked={persistFlag}

--- a/src/renderer/components/Rack/PatchPanelCreateDialog.tsx
+++ b/src/renderer/components/Rack/PatchPanelCreateDialog.tsx
@@ -219,7 +219,7 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
                       key={n}
                       type="button"
                       onClick={() => setPortCount(n)}
-                      className={`rounded px-2 py-0.5 text-[10px] ${
+                      className={`rounded px-2 py-0.5 text-cp-xs ${
                         portCount === n
                           ? 'bg-sky-700 text-white'
                           : 'bg-cp-surface-2 text-cp-text-muted hover:bg-cp-surface-4'
@@ -245,7 +245,7 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
               />
               <span className="flex-1">
                 <span className="font-medium text-cp-text-bright">{t('rack.patchPanel.adapter', 'Adapter patch panel')}</span>
-                <span className="ml-1 text-[10px] text-cp-text-muted">
+                <span className="ml-1 text-cp-xs text-cp-text-muted">
                   {t('rack.patchPanel.adapterHint', '(front ≠ rear connector, with internal adapter cable)')}
                 </span>
               </span>
@@ -278,7 +278,7 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
                 </label>
               )}
             </div>
-            <span className="block text-[10px] text-cp-text-muted">
+            <span className="block text-cp-xs text-cp-text-muted">
               {format(t('rack.patchPanel.appliesToAllPorts', 'Applies to all {count} ports. Adjust individually in the "Per-port detail" tab.'), { count: portCount })}
               {adapterMode
                 ? ` ${t('rack.patchPanel.adapterCouplingNote', 'Each front port couples internally via an adapter cable to the matching rear port.')}`
@@ -289,7 +289,7 @@ export const PatchPanelCreateDialog = ({ open, onClose, onCreated }: PatchPanelC
 
         {tab === 'ports' && (
           <div className="space-y-2">
-            <div className="text-[10px] text-cp-text-muted">
+            <div className="text-cp-xs text-cp-text-muted">
               {t('rack.patchPanel.perPortNote', 'Per port label and connector type are overridable. Leave empty for default.')}
               {adapterMode && ` ${t('rack.patchPanel.perPortAdapterNote', 'In adapter mode the front and rear connectors are chosen independently.')}`}
             </div>

--- a/src/renderer/components/Rack/RackAddSplitButton.tsx
+++ b/src/renderer/components/Rack/RackAddSplitButton.tsx
@@ -57,7 +57,7 @@ export const RackAddSplitButton = ({
         <button
           type="button"
           onClick={onAddFull}
-          className="bg-emerald-600 px-2.5 py-1.5 text-[11px] font-semibold text-white transition hover:bg-emerald-500"
+          className="bg-emerald-600 px-2.5 py-1.5 text-cp-xs font-semibold text-white transition hover:bg-emerald-500"
           title={t('rackAdd.fullDepthTitle', 'Add device full-depth (front + rear) to the rack')}
         >
           {resolvedLabel}
@@ -65,7 +65,7 @@ export const RackAddSplitButton = ({
         <button
           type="button"
           onClick={() => setOpen((v) => !v)}
-          className={`border-l border-emerald-700/60 px-1.5 py-1.5 text-[10px] font-bold text-white transition ${
+          className={`border-l border-emerald-700/60 px-1.5 py-1.5 text-cp-xs font-bold text-white transition ${
             open ? 'bg-emerald-700' : 'bg-emerald-600 hover:bg-emerald-500'
           }`}
           aria-expanded={open}
@@ -78,7 +78,7 @@ export const RackAddSplitButton = ({
       {open && (
         <div
           role="menu"
-          className="absolute right-0 z-30 mt-1 w-44 overflow-hidden rounded-cp-control border border-cp-border bg-cp-surface-1 text-[11px] shadow-2xl"
+          className="absolute right-0 z-30 mt-1 w-44 overflow-hidden rounded-cp-control border border-cp-border bg-cp-surface-1 text-cp-xs shadow-2xl"
         >
           <button
             type="button"
@@ -95,7 +95,7 @@ export const RackAddSplitButton = ({
             </svg>
             <div className="flex flex-col">
               <span className="font-semibold text-emerald-300">{t('rackAdd.frontOnly', 'Front only')}</span>
-              <span className="text-[11px] text-cp-text-muted">{t('rackAdd.frontMount', 'Front-mount')}</span>
+              <span className="text-cp-xs text-cp-text-muted">{t('rackAdd.frontMount', 'Front-mount')}</span>
             </div>
           </button>
           <button
@@ -112,7 +112,7 @@ export const RackAddSplitButton = ({
             </svg>
             <div className="flex flex-col">
               <span className="font-semibold text-cp-text">{t('rackAdd.fullDepth', 'Full-depth')}</span>
-              <span className="text-[11px] text-cp-text-muted">{t('rackAdd.fullDepthSub', 'front + rear (default)')}</span>
+              <span className="text-cp-xs text-cp-text-muted">{t('rackAdd.fullDepthSub', 'front + rear (default)')}</span>
             </div>
           </button>
           <button
@@ -130,7 +130,7 @@ export const RackAddSplitButton = ({
             </svg>
             <div className="flex flex-col">
               <span className="font-semibold text-purple-300">{t('rackAdd.rearOnly', 'Rear only')}</span>
-              <span className="text-[11px] text-cp-text-muted">{t('rackAdd.rearMount', 'Rear-mount (e.g. patch panel)')}</span>
+              <span className="text-cp-xs text-cp-text-muted">{t('rackAdd.rearMount', 'Rear-mount (e.g. patch panel)')}</span>
             </div>
           </button>
         </div>

--- a/src/renderer/components/Rack/RackBuilder3DTab.tsx
+++ b/src/renderer/components/Rack/RackBuilder3DTab.tsx
@@ -62,7 +62,7 @@ export const RackBuilder3DTab = ({
 
   return (
     <>
-      <div className="mb-2 flex items-center gap-1 text-[10px]">
+      <div className="mb-2 flex items-center gap-1 text-cp-xs">
         <span className="text-cp-text-faint">{t('rack.view.label', 'View:')}</span>
         {(['all', 'free', 'released'] as const).map((m) => (
           <button

--- a/src/renderer/components/Rack/RackBuilderDialogExportMenu.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialogExportMenu.tsx
@@ -91,7 +91,7 @@ export const RackBuilderDialogExportMenu = ({
             className="flex w-full flex-col items-start gap-0.5 border-b border-cp-border-muted px-3 py-2 text-left text-cp-text-bright hover:bg-cp-surface-2"
           >
             <span className="font-semibold"><Icon icon={Camera} size="xs" className="mr-1 inline-block align-text-bottom" />{t('rack.export.png2d', '2D as PNG')}</span>
-            <span className="text-[10px] text-cp-text-muted">
+            <span className="text-cp-xs text-cp-text-muted">
               {t('rack.export.png2dDesc', 'Current front/rear/both view as image')}
             </span>
           </button>
@@ -114,7 +114,7 @@ export const RackBuilderDialogExportMenu = ({
             className="flex w-full flex-col items-start gap-0.5 border-b border-cp-border-muted px-3 py-2 text-left text-cp-text-bright hover:bg-cp-surface-2"
           >
             <span className="font-semibold"><Icon icon={Camera} size="xs" className="mr-1 inline-block align-text-bottom" />{t('rack.export.png3d', '3D from 4 perspectives')}</span>
-            <span className="text-[10px] text-cp-text-muted">
+            <span className="text-cp-xs text-cp-text-muted">
               {t('rack.export.png3dDesc', 'PNG: front · rear · iso · top (1× per file)')}
             </span>
           </button>
@@ -133,7 +133,7 @@ export const RackBuilderDialogExportMenu = ({
             className="flex w-full flex-col items-start gap-0.5 border-b border-cp-border-muted px-3 py-2 text-left text-cp-text-bright hover:bg-cp-surface-2"
           >
             <span className="font-semibold"><Icon icon={Box} size="xs" className="mr-1 inline-block align-text-bottom" />{t('rack.export.stl', '3D as STL')}</span>
-            <span className="text-[10px] text-cp-text-muted">
+            <span className="text-cp-xs text-cp-text-muted">
               {t('rack.export.stlDesc', 'Complete rack as binary STL (3D printing, CAD)')}
             </span>
           </button>
@@ -154,7 +154,7 @@ export const RackBuilderDialogExportMenu = ({
             className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left text-cp-text-bright hover:bg-cp-surface-2"
           >
             <span className="font-semibold"><Icon icon={Save} size="xs" className="mr-1 inline-block align-text-bottom" />{t('rack.export.cpgroup', 'Download .cpgroup')}</span>
-            <span className="text-[10px] text-cp-text-muted">
+            <span className="text-cp-xs text-cp-text-muted">
               {t('rack.export.cpgroupDesc', 'Complete rack incl. STL + photos for cross-PC transfer')}
             </span>
           </button>

--- a/src/renderer/components/Rack/RackBuilderFooter.tsx
+++ b/src/renderer/components/Rack/RackBuilderFooter.tsx
@@ -40,7 +40,7 @@ export const RackBuilderFooter = ({
   const t = useTranslation()
   return (
     <div className="mt-3 flex flex-wrap items-center justify-between gap-3 border-t border-cp-border-muted pt-3">
-      <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
+      <div className="flex flex-wrap items-center gap-1.5 text-cp-xs">
         <span className="inline-flex items-center gap-1 rounded bg-cp-surface-2 px-2 py-0.5 text-cp-text-secondary">
           <span className="text-cp-text-faint">{t('rack.devicesLabel', 'Devices:')}</span>
           <strong className="text-cp-text">{devicesCount}</strong>
@@ -72,7 +72,7 @@ export const RackBuilderFooter = ({
       </div>
 
       <div
-        className="flex items-center gap-1.5 text-[10px] text-cp-text-muted"
+        className="flex items-center gap-1.5 text-cp-xs text-cp-text-muted"
         title={
           dirty
             ? t('rack.autosaveActive', 'Autosave runs every few seconds')

--- a/src/renderer/components/Rack/RackBuilderHeader.tsx
+++ b/src/renderer/components/Rack/RackBuilderHeader.tsx
@@ -40,7 +40,7 @@ export const RackBuilderHeader = ({
             {editingId ? rackName || t('rack.unnamedRack', '(unnamed rack)') : t('rack.newRack', 'New rack')}
           </h3>
           <span
-            className={`shrink-0 rounded px-1.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${
+            className={`shrink-0 rounded px-1.5 py-0.5 text-cp-xs font-semibold uppercase tracking-wide ${
               editingId
                 ? 'bg-sky-900/60 text-sky-200'
                 : 'bg-emerald-900/60 text-emerald-200'
@@ -50,7 +50,7 @@ export const RackBuilderHeader = ({
           </span>
           {dirty && (
             <span
-              className="flex shrink-0 items-center gap-1 rounded bg-amber-900/40 px-1.5 py-0.5 text-[11px] font-semibold text-amber-200"
+              className="flex shrink-0 items-center gap-1 rounded bg-amber-900/40 px-1.5 py-0.5 text-cp-xs font-semibold text-amber-200"
               title={t('rack.unsavedTitle', 'Unsaved changes')}
             >
               <span className="inline-block h-1.5 w-1.5 rounded-full bg-amber-400" />
@@ -58,13 +58,13 @@ export const RackBuilderHeader = ({
             </span>
           )}
         </div>
-        <p className="mt-0.5 text-[11px] text-cp-text-muted">
+        <p className="mt-0.5 text-cp-xs text-cp-text-muted">
           {t(
             'rack.subtitle',
             '2D rack builder · Add devices from the library, drag for U position, internal cabling',
           )}
           <span className="ml-2 hidden sm:inline">
-            <kbd className="rounded border border-cp-border bg-cp-surface-2 px-1 text-[10px]">Esc</kbd>{' '}
+            <kbd className="rounded border border-cp-border bg-cp-surface-2 px-1 text-cp-xs">Esc</kbd>{' '}
             {t('rack.closeShortcut', 'close')}
           </span>
         </p>

--- a/src/renderer/components/Rack/RackConflictBadges.tsx
+++ b/src/renderer/components/Rack/RackConflictBadges.tsx
@@ -29,7 +29,7 @@ export const RackConflictBadges = ({
           <button
             type="button"
             onClick={onDismissSaveError}
-            className="rounded bg-red-800/80 px-1.5 text-[10px] hover:bg-red-700"
+            className="rounded bg-red-800/80 px-1.5 text-cp-xs hover:bg-red-700"
             title={t('common.hide', 'Hide')}
           >
             ×

--- a/src/renderer/components/Rack/RackEditorDialog.tsx
+++ b/src/renderer/components/Rack/RackEditorDialog.tsx
@@ -251,7 +251,7 @@ export const RackEditorDialog = () => {
           <div>
             <h2 id={titleId} className="text-cp-base font-semibold">{t('rackEditor.title', 'Rack editor')}</h2>
             <PanelHint
-              className="text-[10px] text-cp-text-muted"
+              className="text-cp-xs text-cp-text-muted"
               text={t(
                 'rackEditor.intro',
                 'Sub-canvas per rack — devices live in the main project, the editor only shows this rack instance. Vertical dragging snaps to U lines.',
@@ -271,7 +271,7 @@ export const RackEditorDialog = () => {
             <RackEditorContent rackInstanceId={slot.rackInstanceId} />
           </ReactFlowProvider>
         </div>
-        <footer className="border-t border-cp-border px-4 py-2 text-[11px] text-cp-text-muted">
+        <footer className="border-t border-cp-border px-4 py-2 text-cp-xs text-cp-text-muted">
           {t(
             'rackEditor.footer',
             'Tip: U position is rounded to the next whole U on release. Changes apply to the main canvas instantly.',

--- a/src/renderer/components/Rack/RackImageCropDialog.tsx
+++ b/src/renderer/components/Rack/RackImageCropDialog.tsx
@@ -376,7 +376,7 @@ export const RackImageCropDialog = ({
                 title={t('rackCrop.scrollHint', 'Scroll wheel or + / - do the same')}
               />
               <span className="w-12 text-right tabular-nums">{zoom.toFixed(2)}x</span>
-              <label className="ml-2 flex items-center gap-1 text-[11px]">
+              <label className="ml-2 flex items-center gap-1 text-cp-xs">
                 <input
                   type="checkbox"
                   checked={aspectLock}
@@ -434,7 +434,7 @@ export const RackImageCropDialog = ({
                     onPointerDown={(e) => handlePointerDown('move', e)}
                   >
                     {/* Live HE badge inside the crop box */}
-                    <div className="pointer-events-none absolute right-1 top-1 rounded bg-cyan-600/90 px-1.5 py-0.5 text-[10px] font-semibold text-white shadow">
+                    <div className="pointer-events-none absolute right-1 top-1 rounded bg-cyan-600/90 px-1.5 py-0.5 text-cp-xs font-semibold text-white shadow">
                       {aspectLock ? `${rackUnits} HE` : `\u2248 ${liveHe.toFixed(1)} HE`}
                     </div>
                     {/* Resize handles */}
@@ -457,7 +457,7 @@ export const RackImageCropDialog = ({
 
           <div className="space-y-2 rounded border border-cp-border bg-cp-surface-3/40 p-2 text-cp-xs">
             <div className="flex items-center justify-between">
-              <span className="text-[11px] uppercase tracking-wide text-cp-text-muted">
+              <span className="text-cp-xs uppercase tracking-wide text-cp-text-muted">
                 {t('rackCrop.presets', 'Crop presets')}
               </span>
               <button
@@ -466,7 +466,7 @@ export const RackImageCropDialog = ({
                   setCrop(defaultCrop(rackUnits, imgAspect))
                   setZoom(1)
                 }}
-                className="rounded bg-cp-surface-4 px-2 py-0.5 text-[10px] hover:bg-cp-surface-5"
+                className="rounded bg-cp-surface-4 px-2 py-0.5 text-cp-xs hover:bg-cp-surface-5"
                 title={t('rackCrop.resetTitle', 'Reset crop and zoom (R)')}
               >
                 {t('rackCrop.reset', '⟲ Reset')}
@@ -487,11 +487,11 @@ export const RackImageCropDialog = ({
             </div>
 
             <div className="mt-3 rounded border border-cp-border-muted bg-cp-surface-1/60 p-2">
-              <div className="mb-1 text-[10px] uppercase tracking-wide text-cp-text-muted">
+              <div className="mb-1 text-cp-xs uppercase tracking-wide text-cp-text-muted">
                 {t('rackCrop.manualValues', 'Manual values (0–1)')}
               </div>
               <div className="grid grid-cols-2 gap-1.5">
-                <label className="block text-[11px]">
+                <label className="block text-cp-xs">
                   X
                   <input
                     type="number"
@@ -506,7 +506,7 @@ export const RackImageCropDialog = ({
                     className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-1 p-1 tabular-nums"
                   />
                 </label>
-                <label className="block text-[11px]">
+                <label className="block text-cp-xs">
                   Y
                   <input
                     type="number"
@@ -521,7 +521,7 @@ export const RackImageCropDialog = ({
                     className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-1 p-1 tabular-nums"
                   />
                 </label>
-                <label className="block text-[11px]">
+                <label className="block text-cp-xs">
                   {t('rackCrop.width', 'Width')}
                   <input
                     type="number"
@@ -536,7 +536,7 @@ export const RackImageCropDialog = ({
                     className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-1 p-1 tabular-nums"
                   />
                 </label>
-                <label className="block text-[11px]">
+                <label className="block text-cp-xs">
                   {t('rackCrop.height', 'Height')}
                   <input
                     type="number"
@@ -554,7 +554,7 @@ export const RackImageCropDialog = ({
               </div>
             </div>
 
-            <div className="rounded border border-cp-border-muted bg-cp-surface-1/60 p-2 text-[11px] text-cp-text-muted">
+            <div className="rounded border border-cp-border-muted bg-cp-surface-1/60 p-2 text-cp-xs text-cp-text-muted">
               <div>
                 {t('rackCrop.targetAspect', 'Target aspect:')}{' '}
                 <span className="tabular-nums text-cp-text-bright">{targetAspect.toFixed(2)}:1</span>

--- a/src/renderer/components/Rack/RackInternalCanvas.tsx
+++ b/src/renderer/components/Rack/RackInternalCanvas.tsx
@@ -466,7 +466,7 @@ const RackSidePropertiesPane = () => {
     <aside className="flex h-full min-h-0 flex-col rounded border border-cp-border bg-cp-surface-3">
       <div className="border-b border-cp-border-muted px-3 py-2">
         <h3 className="truncate text-cp-xs font-semibold text-cp-text">{title}</h3>
-        <div className="mt-0.5 text-[9px] uppercase tracking-wide text-cp-text-muted">
+        <div className="mt-0.5 text-cp-xs uppercase tracking-wide text-cp-text-muted">
           {t('rack.inspector.scope', 'Properties (rack scope)')}
         </div>
       </div>
@@ -474,7 +474,7 @@ const RackSidePropertiesPane = () => {
         {selectedEquipmentId && <EquipmentProperties />}
         {selectedCableId && <CableProperties />}
         {!selectedEquipmentId && !selectedCableId && (
-          <div className="rounded border border-cp-border-muted bg-cp-surface-1/40 p-3 text-[11px] text-cp-text-muted">
+          <div className="rounded border border-cp-border-muted bg-cp-surface-1/40 p-3 text-cp-xs text-cp-text-muted">
             {t('rack.inspector.empty', 'Click a rack device or a connection in the canvas — its properties appear here.')}
           </div>
         )}

--- a/src/renderer/components/Rack/RackLivePreview.tsx
+++ b/src/renderer/components/Rack/RackLivePreview.tsx
@@ -183,7 +183,7 @@ export const RackLivePreview = ({
 
   if (placements.length === 0) {
     return (
-      <div className="rounded border border-dashed border-slate-700 bg-slate-950/40 p-3 text-center text-[10px] text-slate-400">
+      <div className="rounded border border-dashed border-slate-700 bg-slate-950/40 p-3 text-center text-cp-xs text-slate-400">
         {t(
           'rackPreview.empty',
           'No devices in rack — preview appears once the first device is assigned.',
@@ -202,10 +202,10 @@ export const RackLivePreview = ({
   return (
     <div>
       <div className="mb-1 flex items-center justify-between">
-        <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+        <div className="text-cp-xs font-semibold uppercase tracking-wide text-slate-400">
           {t('rackPreview.headerLabel', 'Black box on canvas')}
         </div>
-        <div className="text-[10px] text-slate-400">
+        <div className="text-cp-xs text-slate-400">
           {format(t('rackPreview.counts', '{devices} devices · {cables} internal cables'), {
             devices: placements.length,
             cables: cables.length,
@@ -219,7 +219,7 @@ export const RackLivePreview = ({
         >
           {/* Header — gleicher Look wie EquipmentNode-Card-Header */}
           <div
-            className="border-b border-slate-700 bg-slate-800/90 px-2 text-[11px] font-semibold text-slate-100"
+            className="border-b border-slate-700 bg-slate-800/90 px-2 text-cp-xs font-semibold text-slate-100"
             style={{
               lineHeight: `${HEADER_HEIGHT - 6}px`,
               height: HEADER_HEIGHT,

--- a/src/renderer/components/Rack/RackShelfCreateDialog.tsx
+++ b/src/renderer/components/Rack/RackShelfCreateDialog.tsx
@@ -99,7 +99,7 @@ export const RackShelfCreateDialog = ({ open, onClose, onCreated }: Props) => {
               />
             </label>
           </div>
-          <div className="rounded border border-cp-border-muted bg-cp-surface-3/50 p-2 text-[11px] text-cp-text-muted">
+          <div className="rounded border border-cp-border-muted bg-cp-surface-3/50 p-2 text-cp-xs text-cp-text-muted">
             {t('rack.shelf.tip', 'Tip: place the shelf at the desired U slot, then put non-19" items at the same starting U — they appear visually on the shelf.')}
           </div>
         </div>

--- a/src/renderer/components/Rentman/EquipmentChecklist.tsx
+++ b/src/renderer/components/Rentman/EquipmentChecklist.tsx
@@ -129,7 +129,7 @@ export const EquipmentChecklist = ({
       )
     }
     return (
-      <span className="rounded bg-cp-surface-4/60 px-1.5 py-0.5 text-[10px] text-cp-text-muted" title={tBadge('rentman.checklist.qtyInProject', 'Stückzahl im Rentman-Projekt')}>
+      <span className="rounded bg-cp-surface-4/60 px-1.5 py-0.5 text-cp-xs text-cp-text-muted" title={tBadge('rentman.checklist.qtyInProject', 'Stückzahl im Rentman-Projekt')}>
         ×{item.qty}
       </span>
     )
@@ -198,7 +198,7 @@ export const EquipmentChecklist = ({
                 return (
                   <div key={item.id} className="flex items-center gap-2 rounded bg-cp-surface-1/30 px-2 py-1 text-cp-xs">
                     <span className="w-5" />
-                    <span className="shrink-0 rounded bg-cp-surface-2 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-cp-text-muted">
+                    <span className="shrink-0 rounded bg-cp-surface-2 px-1.5 py-0.5 text-cp-xs font-medium uppercase tracking-wide text-cp-text-muted">
                       {t('rentman.checklist.kind.comment', 'Comment')}
                     </span>
                     <span className="flex-1 italic text-cp-text-muted">{item.name}</span>
@@ -212,7 +212,7 @@ export const EquipmentChecklist = ({
                       <button
                         type="button"
                         onClick={() => toggleExpand(item.id)}
-                        className="w-5 rounded bg-cp-surface-2 text-[10px] leading-none hover:bg-cp-surface-4"
+                        className="w-5 rounded bg-cp-surface-2 text-cp-xs leading-none hover:bg-cp-surface-4"
                         aria-label={isOpen ? t('rentman.checklist.setCollapse', 'Collapse set') : t('rentman.checklist.setExpand', 'Expand set')}
                         title={isOpen ? t('rentman.checklist.setCollapse', 'Collapse set') : t('rentman.checklist.setExpand', 'Expand set')}
                       >
@@ -233,18 +233,18 @@ export const EquipmentChecklist = ({
                           const n = children!.length
                           if (item.kind === 'physical')
                             return (
-                              <span className="ml-2 rounded bg-amber-900/60 px-1.5 py-0.5 text-[10px] font-medium text-amber-200" title={t('rentman.checklist.kind.physicalTitle', 'Physical combination — one stock unit. Default: as 1 device (or rack).')}>
+                              <span className="ml-2 rounded bg-amber-900/60 px-1.5 py-0.5 text-cp-xs font-medium text-amber-200" title={t('rentman.checklist.kind.physicalTitle', 'Physical combination — one stock unit. Default: as 1 device (or rack).')}>
                                 {format(t('rentman.checklist.kind.physical', 'Physical combi · {n}'), { n })}
                               </span>
                             )
                           if (item.kind === 'virtual')
                             return (
-                              <span className="ml-2 rounded bg-violet-900/60 px-1.5 py-0.5 text-[10px] font-medium text-violet-200" title={t('rentman.checklist.kind.virtualTitle', 'Virtual combination — loose bundle; usually only the main device matters.')}>
+                              <span className="ml-2 rounded bg-violet-900/60 px-1.5 py-0.5 text-cp-xs font-medium text-violet-200" title={t('rentman.checklist.kind.virtualTitle', 'Virtual combination — loose bundle; usually only the main device matters.')}>
                                 {format(t('rentman.checklist.kind.virtual', 'Virtual combi · {n}'), { n })}
                               </span>
                             )
                           return (
-                            <span className="ml-2 rounded bg-cp-surface-4/60 px-1.5 py-0.5 text-[10px] text-cp-text-secondary">
+                            <span className="ml-2 rounded bg-cp-surface-4/60 px-1.5 py-0.5 text-cp-xs text-cp-text-secondary">
                               {format(t('rentman.checklist.kind.set', 'Set · {n}'), { n })}
                             </span>
                           )
@@ -257,7 +257,7 @@ export const EquipmentChecklist = ({
                               e.stopPropagation()
                               onSetMainOnly(item.id)
                             }}
-                            className="ml-2 rounded bg-sky-700/60 px-1.5 py-0.5 text-[10px] font-medium text-sky-100 hover:bg-sky-600/60"
+                            className="ml-2 rounded bg-sky-700/60 px-1.5 py-0.5 text-cp-xs font-medium text-sky-100 hover:bg-sky-600/60"
                             title={t('rentman.checklist.mainOnlyTitle', 'Import only the main device of this combination — accessories (cables/battery/tripod …) are skipped.')}
                           >
                             {t('rentman.checklist.mainOnly', '+ main device only')}
@@ -271,7 +271,7 @@ export const EquipmentChecklist = ({
                               e.stopPropagation()
                               onSetAsRack(item.id, !rackSetIds?.has(item.id))
                             }}
-                            className={`ml-2 rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                            className={`ml-2 rounded px-1.5 py-0.5 text-cp-xs font-medium ${
                               rackSetIds?.has(item.id)
                                 ? 'bg-sky-700/70 text-sky-100'
                                 : 'bg-cp-surface-4/60 text-cp-text-secondary hover:bg-cp-surface-5/60'
@@ -302,7 +302,7 @@ export const EquipmentChecklist = ({
                           if (kind === 'rentmanId') {
                             return (
                               <span
-                                className="ml-2 rounded bg-emerald-800/60 px-1.5 py-0.5 text-[10px] font-medium text-emerald-200"
+                                className="ml-2 rounded bg-emerald-800/60 px-1.5 py-0.5 text-cp-xs font-medium text-emerald-200"
                                 title={format(t('rentman.checklist.badge.linkedTitle', 'Already linked in the local library via Rentman ID to "{name}". Re-import only refreshes metadata (category, project link) — the local port configuration is preserved.'), { name: item.templateMatch })}
                               >
                                 {t('rentman.checklist.badge.linked', '✓ linked')}
@@ -312,7 +312,7 @@ export const EquipmentChecklist = ({
                           if (kind === 'nameOnly') {
                             return (
                               <span
-                                className="ml-2 rounded bg-amber-800/60 px-1.5 py-0.5 text-[10px] font-medium text-amber-100"
+                                className="ml-2 rounded bg-amber-800/60 px-1.5 py-0.5 text-cp-xs font-medium text-amber-100"
                                 title={format(t('rentman.checklist.badge.nameOnlyTitle', 'Local template "{name}" has the same name but no Rentman ID. On import a conflict dialog appears — default is to keep the local version (with ports) and only attach the Rentman ID.'), { name: item.templateMatch })}
                               >
                                 <><Icon icon={Zap} size="xs" className="mr-1 inline-block align-text-bottom" />{t('rentman.checklist.badge.nameOnly', 'in library')}</>
@@ -322,7 +322,7 @@ export const EquipmentChecklist = ({
                           if (kind === 'catalog') {
                             return (
                               <span
-                                className="ml-2 rounded bg-cp-surface-4/60 px-1.5 py-0.5 text-[10px] font-medium text-cp-text-bright"
+                                className="ml-2 rounded bg-cp-surface-4/60 px-1.5 py-0.5 text-cp-xs font-medium text-cp-text-bright"
                                 title={format(t('rentman.checklist.badge.catalogTitle', 'Match from built-in catalog ("{name}"). Will be adopted as a template automatically on import.'), { name: item.templateMatch })}
                               >
                                 {t('rentman.checklist.badge.catalog', '⊕ catalog')}
@@ -332,7 +332,7 @@ export const EquipmentChecklist = ({
                           // Fallback (alte Variante ohne kind-Feld)
                           return (
                             <span
-                              className="ml-2 rounded bg-emerald-800/60 px-1.5 py-0.5 text-[10px] font-medium text-emerald-200"
+                              className="ml-2 rounded bg-emerald-800/60 px-1.5 py-0.5 text-cp-xs font-medium text-emerald-200"
                               title={format(t('rentman.checklist.badge.fallbackTitle', 'Auto-filled with template "{name}"'), { name: item.templateMatch })}
                             >
                               ✓ {item.templateMatch}
@@ -351,7 +351,7 @@ export const EquipmentChecklist = ({
                         if (linkedDevice) {
                           return (
                             <span
-                              className="rounded bg-sky-800/60 px-1.5 py-0.5 text-[10px] text-sky-100"
+                              className="rounded bg-sky-800/60 px-1.5 py-0.5 text-cp-xs text-sky-100"
                               title={t('rentman.checklist.linkedTitle', 'Linked to a local device — will not be created as a duplicate on import')}
                             >
                               <Icon icon={Link} size="xs" className="mr-1 inline-block align-text-bottom" />{linkedDevice.name}
@@ -364,7 +364,7 @@ export const EquipmentChecklist = ({
                             onChange={(e) => {
                               if (e.target.value) onLinkExisting(item.id, e.target.value)
                             }}
-                            className="rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-[10px] text-cp-text-secondary"
+                            className="rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-cp-xs text-cp-text-secondary"
                             title={t('rentman.checklist.linkSelectTitle', 'Link to an existing local device')}
                           >
                             <option value="">{t('rentman.checklist.linkPlaceholder', 'Link…')}</option>
@@ -379,7 +379,7 @@ export const EquipmentChecklist = ({
                       <button
                         type="button"
                         onClick={() => onSetAllChildren(item.id, !allChildrenChecked)}
-                        className="rounded bg-cp-surface-4 px-1.5 py-0.5 text-[10px] hover:bg-cp-surface-5"
+                        className="rounded bg-cp-surface-4 px-1.5 py-0.5 text-cp-xs hover:bg-cp-surface-5"
                         title={allChildrenChecked ? t('rentman.checklist.deselectChildren', 'Deselect all children') : t('rentman.checklist.selectChildren', 'Select all children')}
                       >
                         <span className="inline-flex items-center gap-1"><Icon icon={allChildrenChecked ? Square : SquareCheck} size="xs" />{allChildrenChecked ? t('rentman.checklist.childrenAllOff', 'all') : t('rentman.checklist.childrenAllOn', 'all')}</span>

--- a/src/renderer/components/Rentman/NewRentmanDeviceWizard.tsx
+++ b/src/renderer/components/Rentman/NewRentmanDeviceWizard.tsx
@@ -310,7 +310,7 @@ export const NewRentmanDeviceWizard = ({
         {aiSettingsOpen && (
           <div className="mb-3 rounded border border-purple-700 bg-purple-950/40 p-3">
             <div className="mb-2 text-cp-xs font-semibold text-purple-200">{t('rentman.wizard.geminiKeyHeading', 'Gemini API key')}</div>
-            <p className="mb-2 text-[11px] text-cp-text-secondary">
+            <p className="mb-2 text-cp-xs text-cp-text-secondary">
               {t('rentman.wizard.geminiKeyHintPre', 'Free at')}{' '}
               <span className="font-mono text-cp-text-bright">aistudio.google.com/apikey</span>{' '}
               {t('rentman.wizard.geminiKeyHintPost', '(15 requests/min). Stored locally in browser storage.')}

--- a/src/renderer/components/Rentman/ProjectSelector.tsx
+++ b/src/renderer/components/Rentman/ProjectSelector.tsx
@@ -73,7 +73,7 @@ export const ProjectSelector = ({ projects, selectedProjectId, onSelect }: Proje
               })()}
             </span>
             {project.status && (
-              <span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] ${active ? 'bg-sky-700 text-sky-50' : 'bg-cp-surface-2 text-cp-text-muted'}`}>
+              <span className={`shrink-0 rounded px-1.5 py-0.5 text-cp-xs ${active ? 'bg-sky-700 text-sky-50' : 'bg-cp-surface-2 text-cp-text-muted'}`}>
                 {project.status}
               </span>
             )}

--- a/src/renderer/components/Rentman/RentmanCableExportDialog.tsx
+++ b/src/renderer/components/Rentman/RentmanCableExportDialog.tsx
@@ -312,12 +312,12 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
       scrollBody={false}
     >
       <div className="flex h-full min-h-0 flex-col -mx-4 -my-3">
-        <div className="border-b border-cp-border-muted px-4 py-1.5 text-[10px] text-cp-text-muted">
+        <div className="border-b border-cp-border-muted px-4 py-1.5 text-cp-xs text-cp-text-muted">
           {linkedProjectName
             ? format(t('rentman.cableExport.target', 'Target: {name}'), { name: linkedProjectName })
             : t('rentman.cableExport.noLink', 'No Rentman project linked.')}
         </div>
-        <div className="flex flex-wrap items-center gap-2 border-b border-cp-border-muted px-4 py-2 text-[11px] text-cp-text-muted">
+        <div className="flex flex-wrap items-center gap-2 border-b border-cp-border-muted px-4 py-2 text-cp-xs text-cp-text-muted">
           {(() => {
             const totalBuilt = buckets.reduce((sum, b) => sum + b.built, 0)
             const totalSent = buckets.reduce((sum, b) => sum + b.sentQty, 0)
@@ -346,7 +346,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
                   type="button"
                   onClick={() => void sendAll()}
                   disabled={!linkedProjectId || sendableCount === 0 || busyKey !== null}
-                  className="ml-auto rounded bg-emerald-700 px-3 py-1 text-[11px] font-semibold text-white hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="ml-auto rounded bg-emerald-700 px-3 py-1 text-cp-xs font-semibold text-white hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-50"
                   title={
                     !linkedProjectId
                       ? t('rentman.cableExport.noLink', 'No Rentman project linked.')
@@ -361,7 +361,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
                   type="button"
                   onClick={() => void fetchCatalog()}
                   disabled={catalogLoading}
-                  className="rounded bg-orange-700 px-2 py-1 text-[11px] font-semibold text-white hover:bg-orange-600 disabled:opacity-50"
+                  className="rounded bg-orange-700 px-2 py-1 text-cp-xs font-semibold text-white hover:bg-orange-600 disabled:opacity-50"
                 >
                   {catalogLoading
                     ? t('rentman.cableExport.loading', 'Loading…')
@@ -375,7 +375,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
         </div>
 
         {catalogError && (
-          <div className="border-b border-red-700/60 bg-red-900/30 px-4 py-1.5 text-[11px] text-red-200">
+          <div className="border-b border-red-700/60 bg-red-900/30 px-4 py-1.5 text-cp-xs text-red-200">
             {catalogError}
           </div>
         )}
@@ -422,7 +422,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
                   <tr key={bucket.key} className="border-t border-cp-border-muted align-top">
                     <td className="px-3 py-1.5">
                       <div className="font-medium text-cp-text">{bucket.type}</div>
-                      <div className="text-[10px] text-cp-text-muted">
+                      <div className="text-cp-xs text-cp-text-muted">
                         {bucket.length} m
                         {bucket.sample ? ` · ${bucket.sample.name}` : ''}
                       </div>
@@ -455,7 +455,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
                             <div className="truncate text-cp-text-bright">
                               {bucket.mappedName ?? format(t('rentman.cableExport.rentmanId', 'Rentman ID {id}'), { id: bucket.mappedId })}
                             </div>
-                            <div className="text-[10px] text-cp-text-muted">
+                            <div className="text-cp-xs text-cp-text-muted">
                               ID {bucket.mappedId}
                             </div>
                             {/* ADR-005 — Der Import hat mehrere Rentman-
@@ -465,7 +465,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
                                 fuer den ganzen Bestand. */}
                             {(bucket.mergedCount ?? 0) > 1 && (
                               <div
-                                className="text-[10px] text-cp-warn"
+                                className="text-cp-xs text-cp-warn"
                                 title={t(
                                   'rentman.cableExport.mergedTitle',
                                   'Import and export group cables by type and length. The quantity is booked onto the item mapped above; splitting it across several items is only possible in Rentman.',
@@ -484,7 +484,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
                           <button
                             type="button"
                             onClick={() => clearMapping(bucket.key)}
-                            className="rounded bg-cp-surface-4 px-1.5 py-0.5 text-[10px] hover:bg-cp-surface-5"
+                            className="rounded bg-cp-surface-4 px-1.5 py-0.5 text-cp-xs hover:bg-cp-surface-5"
                             title={t('rentman.cableExport.removeMapping', 'Remove mapping')}
                             aria-label={t('rentman.cableExport.removeMapping', 'Remove mapping')}
                           >
@@ -499,7 +499,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
                             setPickerKey(bucket.key)
                             setPickerQuery(`${bucket.type}`)
                           }}
-                          className="rounded bg-cp-surface-4 px-2 py-0.5 text-[10px] hover:bg-cp-surface-5"
+                          className="rounded bg-cp-surface-4 px-2 py-0.5 text-cp-xs hover:bg-cp-surface-5"
                         >
                           {t('rentman.cableExport.pickEquipment', 'Pick Rentman equipment…')}
                         </button>
@@ -512,16 +512,16 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
                             onChange={(event) => setPickerQuery(event.target.value)}
                             placeholder={t('rentman.cableExport.searchPlaceholder', 'Search…')}
                             aria-label={t('rentman.cableExport.searchPlaceholder', 'Search…')}
-                            className="mb-1 w-full rounded border border-cp-border bg-cp-surface-1 px-2 py-0.5 text-[11px]"
+                            className="mb-1 w-full rounded border border-cp-border bg-cp-surface-1 px-2 py-0.5 text-cp-xs"
                           />
                           <div className="max-h-40 space-y-0.5 overflow-auto">
                             {!catalogLoaded && !catalogLoading && (
-                              <div className="px-1 py-0.5 text-[10px] italic text-cp-text-muted">
+                              <div className="px-1 py-0.5 text-cp-xs italic text-cp-text-muted">
                                 {t('rentman.cableExport.loadCatalogFirst', 'Please load the catalog first.')}
                               </div>
                             )}
                             {catalogLoading && (
-                              <div className="px-1 py-0.5 text-[10px] italic text-cp-text-muted">
+                              <div className="px-1 py-0.5 text-cp-xs italic text-cp-text-muted">
                                 {t('rentman.cableExport.loading', 'Loading…')}
                               </div>
                             )}
@@ -533,12 +533,12 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
                                   setMapping(bucket.key, item.id, { resetSync: true })
                                   setPickerKey(null)
                                 }}
-                                className="flex w-full items-start justify-between gap-2 rounded px-1 py-0.5 text-left text-[11px] hover:bg-cp-surface-2"
+                                className="flex w-full items-start justify-between gap-2 rounded px-1 py-0.5 text-left text-cp-xs hover:bg-cp-surface-2"
                               >
                                 <span className="min-w-0 flex-1 truncate text-cp-text-bright">
                                   {item.name}
                                 </span>
-                                <span className="shrink-0 text-[10px] text-cp-text-muted">
+                                <span className="shrink-0 text-cp-xs text-cp-text-muted">
                                   {item.category}
                                 </span>
                               </button>
@@ -548,7 +548,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
                             <button
                               type="button"
                               onClick={() => setPickerKey(null)}
-                              className="rounded bg-cp-surface-4 px-2 py-0.5 text-[10px] hover:bg-cp-surface-5"
+                              className="rounded bg-cp-surface-4 px-2 py-0.5 text-cp-xs hover:bg-cp-surface-5"
                             >
                               {t('common.cancel', 'Cancel')}
                             </button>
@@ -557,7 +557,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
                       )}
                       {status && (
                         <div
-                          className={`mt-1 text-[10px] ${
+                          className={`mt-1 text-cp-xs ${
                             status.startsWith('Fehler') ? 'text-red-400' : 'text-cp-text-muted'
                           }`}
                         >
@@ -570,7 +570,7 @@ export const RentmanCableExportDialog = ({ open, onClose }: RentmanCableExportDi
                         type="button"
                         onClick={() => void sendBucket(bucket)}
                         disabled={!canSend}
-                        className="rounded bg-orange-700 px-2 py-1 text-[11px] font-semibold text-white hover:bg-orange-600 disabled:cursor-not-allowed disabled:opacity-50"
+                        className="rounded bg-orange-700 px-2 py-1 text-cp-xs font-semibold text-white hover:bg-orange-600 disabled:cursor-not-allowed disabled:opacity-50"
                         title={
                           !linkedProjectId
                             ? t('rentman.cableExport.noLink', 'No Rentman project linked.')

--- a/src/renderer/components/Rentman/RentmanImportDialog.tsx
+++ b/src/renderer/components/Rentman/RentmanImportDialog.tsx
@@ -1111,7 +1111,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
           />
           <div className="mb-3 max-h-[55vh] overflow-auto rounded border border-cp-border-muted">
             <table className="w-full text-cp-xs">
-              <thead className="sticky top-0 bg-cp-surface-3 text-left text-[11px] uppercase tracking-wide text-cp-text-muted">
+              <thead className="sticky top-0 bg-cp-surface-3 text-left text-cp-xs uppercase tracking-wide text-cp-text-muted">
                 <tr>
                   <th className="px-2 py-1">{t('rentman.import.col.device', 'Device')}</th>
                   <th className="px-2 py-1">{t('rentman.import.col.action', 'Action')}</th>
@@ -1122,7 +1122,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                   <tr key={c.name} className="border-t border-cp-border-muted align-top">
                     <td className="px-2 py-1.5">
                       <div className="font-medium">{c.name}</div>
-                      <div className="text-[11px] text-cp-text-muted">{c.category}</div>
+                      <div className="text-cp-xs text-cp-text-muted">{c.category}</div>
                     </td>
                     <td className="px-2 py-1.5">
                       <div className="flex flex-col gap-0.5">
@@ -1190,7 +1190,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
               </tbody>
             </table>
           </div>
-          <div className="mb-3 flex items-center gap-2 text-[11px] text-cp-text-muted">
+          <div className="mb-3 flex items-center gap-2 text-cp-xs text-cp-text-muted">
             <span>{t('rentman.import.setAll', 'Set all:')}</span>
             {(
               [
@@ -1287,7 +1287,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
           />
           <div className="mb-3 max-h-[55vh] overflow-auto rounded border border-cp-border-muted">
             <table className="w-full text-cp-xs">
-              <thead className="sticky top-0 bg-cp-surface-3 text-left text-[11px] uppercase tracking-wide text-cp-text-muted">
+              <thead className="sticky top-0 bg-cp-surface-3 text-left text-cp-xs uppercase tracking-wide text-cp-text-muted">
                 <tr>
                   <th className="px-2 py-1">{t('rentman.import.col.device', 'Device')}</th>
                   <th className="px-2 py-1">{t('rentman.import.col.rentman', 'Rentman')}</th>
@@ -1507,7 +1507,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
             }}
           />
           {selectedProjectId && selectedProjectId === linkedProjectId && (
-            <div className="mt-1 inline-flex items-center gap-1 text-[11px] font-medium text-emerald-400">
+            <div className="mt-1 inline-flex items-center gap-1 text-cp-xs font-medium text-emerald-400">
               <Icon icon={Check} size="xs" /> {t('rentman.import.linkedBadge', 'Linked to this plan')}
             </div>
           )}
@@ -1647,7 +1647,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
               }
               if (linked + conflicts === 0) return null
               return (
-                <div className="mb-2 flex flex-wrap items-center gap-1.5 text-[11px]">
+                <div className="mb-2 flex flex-wrap items-center gap-1.5 text-cp-xs">
                   {linked > 0 && (
                     <span
                       className="rounded bg-emerald-900/40 px-1.5 py-0.5 text-emerald-200"
@@ -1780,13 +1780,13 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                     {cablePlanOpen ? '▾ ' : '▸ '}
                     {format(t('rentman.import.cablePlan.headingN', 'Cable quantities from Rentman ({count})'), { count: cableBuckets.length })}
                   </span>
-                  <span className="text-[11px] text-orange-300/70">
+                  <span className="text-cp-xs text-orange-300/70">
                     {cablePlanOpen ? t('rentman.import.cablePlan.collapse', 'collapse') : t('rentman.import.cablePlan.expand', 'open')}
                   </span>
                 </button>
                 {cablePlanOpen && (<>
                 <div className="mb-2 mt-2 flex items-center justify-end">
-                  <div className="flex gap-1 text-[11px]">
+                  <div className="flex gap-1 text-cp-xs">
                     {(() => {
                       const allSelected =
                         cableBuckets.length > 0 &&
@@ -1833,7 +1833,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                           }
                           className="w-16 rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-right"
                         />
-                        <span className="text-[10px] text-cp-text-muted">
+                        <span className="text-cp-xs text-cp-text-muted">
                           {bucket.rows.length === 1
                             ? bucket.rows[0].name
                             : format(t('rentman.import.cablePlan.entryCount', '{count} entries'), { count: bucket.rows.length })}
@@ -1842,7 +1842,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                     )
                   })}
                 </div>
-                <div className="mt-2 flex items-center justify-between text-[11px]">
+                <div className="mt-2 flex items-center justify-between text-cp-xs">
                   <span
                     className={`inline-flex items-center gap-1 ${
                       cablePlanResult?.kind === 'ok'

--- a/src/renderer/components/Settings/EquipmentColorsSection.tsx
+++ b/src/renderer/components/Settings/EquipmentColorsSection.tsx
@@ -43,7 +43,7 @@ export const EquipmentColorsSection = () => {
               <button
                 type="button"
                 onClick={() => resetEquipmentColors(theme)}
-                className="rounded bg-cp-surface-4 px-2 py-0.5 text-[10px] hover:bg-cp-surface-5"
+                className="rounded bg-cp-surface-4 px-2 py-0.5 text-cp-xs hover:bg-cp-surface-5"
                 title={t('settings.eqColors.resetTitle', 'Reset to default')}
               >
                 {t('settings.eqColors.reset', '↺ Reset')}
@@ -61,7 +61,7 @@ export const EquipmentColorsSection = () => {
                       className="h-6 w-10 cursor-pointer rounded border border-cp-border bg-cp-surface-1 p-0.5"
                       title={r.hint}
                     />
-                    <span className="font-mono text-[10px] text-cp-text-muted">
+                    <span className="font-mono text-cp-xs text-cp-text-muted">
                       {equipmentColors[theme][r.key]}
                     </span>
                   </div>
@@ -71,7 +71,7 @@ export const EquipmentColorsSection = () => {
           </div>
         ))}
       </div>
-      <div className="mt-2 text-[10px] text-cp-text-muted">
+      <div className="mt-2 text-cp-xs text-cp-text-muted">
         {t(
           'settings.eqColors.note',
           'Note: Devices with their own color (Properties → device color) still override the body value individually.',
@@ -83,7 +83,7 @@ export const EquipmentColorsSection = () => {
           <div className="text-cp-xs font-semibold text-cp-text-bright">
             {t('settings.eqColors.defaultDeviceColor', 'Default device color')}
           </div>
-          <div className="text-[10px] text-cp-text-muted">
+          <div className="text-cp-xs text-cp-text-muted">
             {t(
               'settings.eqColors.defaultDeviceColorHint',
               'Newly added devices start with this color (Properties → device color can change it individually). Empty: uses the theme body color.',
@@ -101,7 +101,7 @@ export const EquipmentColorsSection = () => {
             <button
               type="button"
               onClick={() => setDefaultDeviceColor(undefined)}
-              className="rounded bg-cp-surface-4 px-2 py-0.5 text-[10px] hover:bg-cp-surface-5"
+              className="rounded bg-cp-surface-4 px-2 py-0.5 text-cp-xs hover:bg-cp-surface-5"
             >
               {t('settings.eqColors.resetX', '✕ Reset')}
             </button>

--- a/src/renderer/components/Settings/tabs/AdvancedTab.tsx
+++ b/src/renderer/components/Settings/tabs/AdvancedTab.tsx
@@ -179,7 +179,7 @@ export const AdvancedTab = () => {
                     <td className="px-2 py-1 text-cp-text">
                       {display}
                       {showCanonical && (
-                        <span className="ml-1 text-[10px] text-cp-text-muted">({cat})</span>
+                        <span className="ml-1 text-cp-xs text-cp-text-muted">({cat})</span>
                       )}
                     </td>
                     <td className="px-2 py-1 text-right text-cp-text-muted">{usageCount(cat)}</td>
@@ -187,7 +187,7 @@ export const AdvancedTab = () => {
                       <button
                         type="button"
                         onClick={() => handleRename(cat)}
-                        className="rounded bg-cp-surface-4 px-2 py-0.5 text-[10px] hover:bg-cp-surface-5"
+                        className="rounded bg-cp-surface-4 px-2 py-0.5 text-cp-xs hover:bg-cp-surface-5"
                       >
                         {t('common.rename', 'Rename')}
                       </button>

--- a/src/renderer/components/Settings/tabs/AppearanceTab.tsx
+++ b/src/renderer/components/Settings/tabs/AppearanceTab.tsx
@@ -81,7 +81,7 @@ const CustomPaletteCard = () => {
                 }
                 className="h-10 w-full cursor-pointer rounded border border-cp-border bg-cp-surface-1 p-1"
               />
-              <code className="mt-1 block text-[10px] text-cp-text-muted">
+              <code className="mt-1 block text-cp-xs text-cp-text-muted">
                 {current[field.key]}
               </code>
             </label>
@@ -190,7 +190,7 @@ export const AppearanceTab = () => {
           ))}
         </div>
         <PanelHint
-          className="mt-2 text-[10px] text-cp-text-muted"
+          className="mt-2 text-cp-xs text-cp-text-muted"
           text={t(
             'settings.appearance.coverage',
             'Translation coverage: comprehensive (1650+ keys). All menus, toolbars, properties panels (incl. PortList, all 17 sub-sections), library, all dialogs (Cable, ATEM ×3, Videohub, GreenGo, Rentman ×5, Rack builder + sub-dialogs, Print, Export, Mobile share, GraphML import, Onboarding tour, About) and shared widgets are language-aware. Strings not yet translated fall through to the German source.',
@@ -258,7 +258,7 @@ export const AppearanceTab = () => {
             type="button"
             onClick={() => setPortLabelFontSize(11)}
             disabled={portLabelFontSize === 11}
-            className="rounded bg-cp-surface-2 px-2 py-0.5 text-[11px] text-cp-text-secondary hover:bg-cp-surface-4 disabled:opacity-50"
+            className="rounded bg-cp-surface-2 px-2 py-0.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-4 disabled:opacity-50"
             title={t('settings.fontSize.reset', 'Reset to default 11 px')}
           >
             ↺
@@ -438,7 +438,7 @@ export const AppearanceTab = () => {
           <div className="mb-2 text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted">
             {t('settings.canvasBg.imageTitle', 'Custom background image')}
           </div>
-          <div className="mb-2 text-[11px] text-cp-text-muted">
+          <div className="mb-2 text-cp-xs text-cp-text-muted">
             {t(
               'settings.canvasBg.imageDesc',
               'Load your own image as the canvas background — separately for dark and light mode. The grid pattern (dots/lines/crosses) is drawn on top.',
@@ -450,7 +450,7 @@ export const AppearanceTab = () => {
               ['light', t('settings.canvasBg.lightImage', 'Light-mode image'), canvasBgImageLight] as const,
             ]).map(([theme, label, current]) => (
               <div key={theme} className="rounded border border-cp-border-muted bg-cp-surface-3/40 p-2">
-                <div className="mb-1 text-[11px] font-semibold text-cp-text-secondary">{label}</div>
+                <div className="mb-1 text-cp-xs font-semibold text-cp-text-secondary">{label}</div>
                 {current ? (
                   <>
                     <img
@@ -465,14 +465,14 @@ export const AppearanceTab = () => {
                           const dataUri = await pickImageAsDataUri()
                           if (dataUri) setCanvasBgImage(theme, dataUri)
                         }}
-                        className="flex-1 rounded bg-cp-surface-4 px-2 py-1 text-[11px] hover:bg-cp-surface-5"
+                        className="flex-1 rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
                       >
                         {t('settings.canvasBg.replace', 'Replace…')}
                       </button>
                       <button
                         type="button"
                         onClick={() => setCanvasBgImage(theme, null)}
-                        className="rounded bg-red-900/60 px-2 py-1 text-[11px] text-red-200 hover:bg-red-800"
+                        className="rounded bg-red-900/60 px-2 py-1 text-cp-xs text-red-200 hover:bg-red-800"
                         title={t('settings.canvasBg.remove', 'Remove image')}
                         aria-label={t('settings.canvasBg.remove', 'Remove image')}
                       >
@@ -487,7 +487,7 @@ export const AppearanceTab = () => {
                       const dataUri = await pickImageAsDataUri()
                       if (dataUri) setCanvasBgImage(theme, dataUri)
                     }}
-                    className="w-full rounded border border-dashed border-cp-border bg-cp-surface-1 px-2 py-4 text-[11px] text-cp-text-muted hover:border-cp-surface-5 hover:text-cp-text-bright"
+                    className="w-full rounded border border-dashed border-cp-border bg-cp-surface-1 px-2 py-4 text-cp-xs text-cp-text-muted hover:border-cp-surface-5 hover:text-cp-text-bright"
                   >
                     {t('settings.canvasBg.upload', '+ Upload image…')}
                   </button>
@@ -537,13 +537,13 @@ export const AppearanceTab = () => {
                 />
                 <span className="flex-1 truncate text-cp-xs">
                   {name}
-                  {isCustom && <span className="ml-1 text-[11px] text-cp-text-muted">(custom)</span>}
+                  {isCustom && <span className="ml-1 text-cp-xs text-cp-text-muted">(custom)</span>}
                 </span>
                 {override && (
                   <button
                     type="button"
                     onClick={() => setConnectorTypeColor(name, null)}
-                    className="rounded bg-cp-surface-4 px-1 py-0.5 text-[10px] text-cp-text-secondary hover:bg-cp-surface-5"
+                    className="rounded bg-cp-surface-4 px-1 py-0.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-5"
                     title={t('settings.colors.resetDefault', 'Reset to default')}
                   >
                     ↺
@@ -572,7 +572,7 @@ export const AppearanceTab = () => {
         )}
       >
         {allKnownCategories.length === 0 ? (
-          <div className="text-[11px] text-cp-text-muted">
+          <div className="text-cp-xs text-cp-text-muted">
             {t('settings.categoryColors.empty', 'No categories known yet. Populated as soon as devices in the plan or library have categories.')}
           </div>
         ) : (
@@ -593,7 +593,7 @@ export const AppearanceTab = () => {
                     <button
                       type="button"
                       onClick={() => setCategoryColor(cat, null)}
-                      className="rounded bg-cp-surface-4 px-1 py-0.5 text-[10px] text-cp-text-secondary hover:bg-cp-surface-5"
+                      className="rounded bg-cp-surface-4 px-1 py-0.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-5"
                       title={t('settings.colors.resetDefault', 'Reset to default')}
                     >
                       ↺

--- a/src/renderer/components/Settings/tabs/ConfigsTab.tsx
+++ b/src/renderer/components/Settings/tabs/ConfigsTab.tsx
@@ -211,7 +211,7 @@ export const ConfigsTab = () => {
                 key={k}
                 type="button"
                 onClick={() => setFilter(k)}
-                className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-[11px] ${
+                className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-cp-xs ${
                   filter === k
                     ? 'bg-sky-700 text-white'
                     : 'bg-cp-surface-2 text-cp-text-secondary hover:bg-cp-surface-4'
@@ -232,21 +232,21 @@ export const ConfigsTab = () => {
         </div>
 
         {library.length === 0 ? (
-          <div className="rounded border border-dashed border-cp-border p-4 text-center text-[11px] text-cp-text-muted">
+          <div className="rounded border border-dashed border-cp-border p-4 text-center text-cp-xs text-cp-text-muted">
             {t(
               'settings.configs.emptyHint',
               'Upload your first configuration file — it will be listed here and can then be assigned to a device on the canvas.',
             )}
           </div>
         ) : grouped.size === 0 ? (
-          <div className="rounded border border-dashed border-cp-border p-4 text-center text-[11px] text-cp-text-muted">
+          <div className="rounded border border-dashed border-cp-border p-4 text-center text-cp-xs text-cp-text-muted">
             {t('settings.configs.noFilterMatch', 'No entry matches the selected filter.')}
           </div>
         ) : (
           <ul className="space-y-2">
             {Array.from(grouped.entries()).map(([kind, entries]) => (
               <li key={kind}>
-                <div className="mb-1 flex items-center gap-1 text-[10px] uppercase tracking-wide text-cp-text-muted">
+                <div className="mb-1 flex items-center gap-1 text-cp-xs uppercase tracking-wide text-cp-text-muted">
                   <Icon icon={CONFIG_KIND_ICON[kind]} size="xs" />
                   {t(`settings.configs.kind.${kind}`, CONFIG_KIND_LABEL[kind])}
                 </div>
@@ -273,7 +273,7 @@ export const ConfigsTab = () => {
                               kind: e.target.value as DeviceConfigKind,
                             })
                           }
-                          className="rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-[11px] text-cp-text-bright"
+                          className="rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-cp-xs text-cp-text-bright"
                         >
                           {(Object.keys(CONFIG_KIND_LABEL) as DeviceConfigKind[]).map((k) => (
                             <option key={k} value={k}>
@@ -288,7 +288,7 @@ export const ConfigsTab = () => {
                               equipmentId: e.target.value || undefined,
                             })
                           }
-                          className="rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-[11px] text-cp-text-bright"
+                          className="rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-cp-xs text-cp-text-bright"
                           title={t(
                             'settings.configs.assignTitle',
                             'Device on the canvas this configuration is assigned to',
@@ -302,7 +302,7 @@ export const ConfigsTab = () => {
                           ))}
                         </select>
                         <span
-                          className="hidden text-[10px] text-cp-text-muted sm:inline"
+                          className="hidden text-cp-xs text-cp-text-muted sm:inline"
                           title={format(
                             t(
                               'settings.configs.fileMeta',
@@ -321,7 +321,7 @@ export const ConfigsTab = () => {
                           <button
                             type="button"
                             onClick={() => downloadConfig(entry)}
-                            className="rounded bg-cp-surface-4 px-2 py-0.5 text-[11px] text-cp-text hover:bg-cp-surface-5"
+                            className="rounded bg-cp-surface-4 px-2 py-0.5 text-cp-xs text-cp-text hover:bg-cp-surface-5"
                             title={t('settings.configs.downloadTitle', 'Download original file')}
                           >
                             <Icon icon={Download} size="xs" />
@@ -347,7 +347,7 @@ export const ConfigsTab = () => {
                                 removeDeviceConfig(entry.id)
                               }
                             }}
-                            className="rounded bg-cp-surface-2 px-2 py-0.5 text-[11px] text-cp-text-secondary hover:bg-red-700 hover:text-white"
+                            className="rounded bg-cp-surface-2 px-2 py-0.5 text-cp-xs text-cp-text-secondary hover:bg-red-700 hover:text-white"
                             title={t('settings.configs.removeTitle', 'Remove from library')}
                           >
                             <Icon icon={X} size="sm" />

--- a/src/renderer/components/Settings/tabs/EditingTab.tsx
+++ b/src/renderer/components/Settings/tabs/EditingTab.tsx
@@ -37,7 +37,7 @@ const CableEndpointLabelsCard = () => {
         {t('settings.editing.endpointLabelsLabel', 'Show endpoint labels')}
       </label>
       <PanelHint
-        className="mt-2 text-[11px] text-cp-text-muted"
+        className="mt-2 text-cp-xs text-cp-text-muted"
         text={t('settings.editing.endpointLabelsNote', 'Off by default — adds extra visual noise. Works together with the global "Hide all labels" toggle and respects per-cable labelPosition=\'none\'.')}
       />
     </SettingsCard>
@@ -70,7 +70,7 @@ const CableInheritTypeCard = () => {
         {t('settings.editing.cableInheritLabel', 'Derive cable type from port connector')}
       </label>
       <PanelHint
-        className="mt-2 text-[11px] text-cp-text-muted"
+        className="mt-2 text-cp-xs text-cp-text-muted"
         text={t(
           'settings.editing.cableInheritNote',
           'On by default: cables should usually reflect the physical connector type of their ports. Turn off if cable types are managed independently of port types.',
@@ -105,7 +105,7 @@ const CableReconnectOptionsCard = () => {
         {t('settings.editing.labelSwapLabel', 'Swap port labels on reconnect')}
       </label>
       <PanelHint
-        className="mt-2 text-[11px] text-cp-text-muted"
+        className="mt-2 text-cp-xs text-cp-text-muted"
         text={t(
           'settings.editing.labelSwapNote',
           'Off by default for safety — otherwise test re-plugging would unintentionally rename labels. Only affects ports with a user-edited name (nothing to swap otherwise).',
@@ -203,7 +203,7 @@ export const EditingTab = () => {
               if (c.routing !== defaultRouting) updateCable(c.id, { routing: defaultRouting })
             })
           }}
-          className="mt-2 w-full rounded bg-cp-surface-2 px-2 py-1 text-[11px] text-cp-text-secondary hover:bg-cp-surface-4 disabled:opacity-50"
+          className="mt-2 w-full rounded bg-cp-surface-2 px-2 py-1 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-4 disabled:opacity-50"
         >
           {format(
             t('settings.editing.routing.applyAll', 'Apply to all existing cables ({count})'),

--- a/src/renderer/components/Settings/tabs/HotkeysTab.tsx
+++ b/src/renderer/components/Settings/tabs/HotkeysTab.tsx
@@ -39,7 +39,7 @@ const HotkeyRow = ({
             setCapturing(false)
           }
         }}
-        className={`min-w-[120px] rounded border px-2 py-1 text-center font-mono text-[11px] ${
+        className={`min-w-[120px] rounded border px-2 py-1 text-center font-mono text-cp-xs ${
           capturing
             ? 'border-sky-500 bg-sky-950/60 text-sky-200'
             : 'border-cp-border bg-cp-surface-1 text-cp-text-secondary hover:border-cp-surface-5'
@@ -55,7 +55,7 @@ const HotkeyRow = ({
       <button
         type="button"
         onClick={() => onChange('')}
-        className="rounded bg-cp-surface-2 px-1.5 py-0.5 text-[10px] text-cp-text-muted hover:bg-red-700 hover:text-white"
+        className="rounded bg-cp-surface-2 px-1.5 py-0.5 text-cp-xs text-cp-text-muted hover:bg-red-700 hover:text-white"
         title={t('settings.hotkeys.clear', 'Clear hotkey')}
         aria-label={t('settings.hotkeys.clear', 'Clear hotkey')}
       >

--- a/src/renderer/components/Settings/tabs/IntegrationsTab.tsx
+++ b/src/renderer/components/Settings/tabs/IntegrationsTab.tsx
@@ -95,12 +95,12 @@ const AiProvidersCard = () => {
                 />
                 <span className="font-semibold">{config.label}</span>
                 {hasKey && (
-                  <span className="rounded bg-emerald-900/40 px-1.5 py-0.5 text-[10px] text-emerald-300">
+                  <span className="rounded bg-emerald-900/40 px-1.5 py-0.5 text-cp-xs text-emerald-300">
                     ✓ Key
                   </span>
                 )}
                 {isSelected && (
-                  <span className="ml-auto rounded bg-sky-900/40 px-1.5 py-0.5 text-[10px] text-sky-300">
+                  <span className="ml-auto rounded bg-sky-900/40 px-1.5 py-0.5 text-cp-xs text-sky-300">
                     {t('settings.integrations.ai.active', 'Active')}
                   </span>
                 )}
@@ -147,7 +147,7 @@ const AiProvidersCard = () => {
                   </button>
                 )}
               </div>
-              <div className="mt-1 flex items-center justify-between text-[10px] text-cp-text-muted">
+              <div className="mt-1 flex items-center justify-between text-cp-xs text-cp-text-muted">
                 <span>
                   Model: <span className="font-mono">{config.defaultModel}</span>
                 </span>
@@ -161,7 +161,7 @@ const AiProvidersCard = () => {
                 </a>
               </div>
               {saved[id] && (
-                <div className="mt-1 text-[10px] text-emerald-300">
+                <div className="mt-1 text-cp-xs text-emerald-300">
                   ✓ {t('settings.integrations.ai.saved', 'saved')}
                 </div>
               )}
@@ -229,7 +229,7 @@ const GreenGoPresetsCard = () => {
         </button>
       </div>
       {presets.length === 0 ? (
-        <div className="mt-2 text-[11px] text-cp-text-muted">
+        <div className="mt-2 text-cp-xs text-cp-text-muted">
           {t('settings.greengo.empty', 'No presets saved yet.')}
         </div>
       ) : (
@@ -241,7 +241,7 @@ const GreenGoPresetsCard = () => {
             >
               <div className="min-w-0 flex-1 truncate">
                 <span className="font-medium text-emerald-100">{p.name}</span>
-                <span className="ml-2 text-[10px] text-emerald-400/60">
+                <span className="ml-2 text-cp-xs text-emerald-400/60">
                   {p.config.users.length} {t('settings.greengo.usersWord', 'users')} · {p.config.groups.length} {t('settings.greengo.groupsWord', 'groups')} ·{' '}
                   {new Date(p.savedAt).toLocaleDateString()}
                 </span>
@@ -263,7 +263,7 @@ const GreenGoPresetsCard = () => {
                     if (!ok) return
                     updateGreenGoConfig(p.config)
                   }}
-                  className="rounded bg-emerald-700 px-2 py-0.5 text-[11px] text-white hover:bg-emerald-600"
+                  className="rounded bg-emerald-700 px-2 py-0.5 text-cp-xs text-white hover:bg-emerald-600"
                 >
                   {t('settings.greengo.apply', 'Load')}
                 </button>
@@ -285,7 +285,7 @@ const GreenGoPresetsCard = () => {
                     deleteGreenGoPreset(p.id)
                     refreshPresets()
                   }}
-                  className="rounded bg-cp-surface-2 px-2 py-0.5 text-[11px] text-cp-text-secondary hover:bg-red-700 hover:text-white"
+                  className="rounded bg-cp-surface-2 px-2 py-0.5 text-cp-xs text-cp-text-secondary hover:bg-red-700 hover:text-white"
                 >
                   {t('settings.greengo.delete', 'Delete')}
                 </button>
@@ -360,7 +360,7 @@ const TallyPiCard = () => {
         />
         <span>
           {t('settings.integrations.tallyPi.enable', 'Allow the direct path to the tally-pi')}{' '}
-          <span className="text-[10px] text-cp-text-muted">
+          <span className="text-cp-xs text-cp-text-muted">
             ({tallyPiDirekt ? t('common.on', 'on') : t('common.off', 'off')})
           </span>
         </span>
@@ -509,7 +509,7 @@ const NetboxCard = ({ onClose }: { onClose: () => void }) => {
           />
           <span>
             {t('settings.integrations.netboxToggle.label', 'Enable NetBox integration')}{' '}
-            <span className="text-[10px] text-cp-text-muted">
+            <span className="text-cp-xs text-cp-text-muted">
               ({netboxEnabled ? t('common.on', 'on') : t('common.off', 'off')})
             </span>
           </span>
@@ -620,7 +620,7 @@ const NetboxCard = ({ onClose }: { onClose: () => void }) => {
             </button>
           </div>
 
-          <div className="mt-2 text-[11px] text-cp-text-muted">
+          <div className="mt-2 text-cp-xs text-cp-text-muted">
             {t('settings.integrations.netbox.apiHint', 'API used:')}{' '}
             <code>/api/dcim/…</code>{' '}
             {t(
@@ -720,7 +720,7 @@ export const IntegrationsTab = ({ onClose }: { onClose: () => void }) => {
           />
           <span>
             {t('settings.integrations.rentmanToggle.label', 'Enable Rentman integration')}{' '}
-            <span className="text-[10px] text-cp-text-muted">
+            <span className="text-cp-xs text-cp-text-muted">
               ({rentmanEnabled ? t('common.on', 'on') : t('common.off', 'off')})
             </span>
           </span>
@@ -794,7 +794,7 @@ export const IntegrationsTab = ({ onClose }: { onClose: () => void }) => {
             {t('settings.integrations.rentman.delete', 'Delete token')}
           </button>
         </div>
-        <div className="mt-2 text-[11px] text-cp-text-muted">
+        <div className="mt-2 text-cp-xs text-cp-text-muted">
           {t('settings.integrations.rentman.endpoint', 'Endpoint:')}{' '}
           <code>https://api.rentman.net</code>
         </div>

--- a/src/renderer/components/Settings/tabs/ProjectTab.tsx
+++ b/src/renderer/components/Settings/tabs/ProjectTab.tsx
@@ -291,7 +291,7 @@ const CableNumberingSection = () => {
           </button>
         </div>
         {doneCount !== null && (
-          <p className="text-[11px] text-emerald-400">
+          <p className="text-cp-xs text-emerald-400">
             {format(t('settings.project.numbering.done', '{n} cables renumbered.'), { n: doneCount })}
           </p>
         )}
@@ -379,7 +379,7 @@ const LengthEstimationSection = () => {
           </button>
         </div>
         {doneCount !== null && (
-          <p className="text-[11px] text-emerald-400">
+          <p className="text-cp-xs text-emerald-400">
             {format(t('settings.project.lengthEst.done', '{n} cable lengths updated.'), { n: doneCount })}
           </p>
         )}
@@ -587,7 +587,7 @@ export const ProjectTab = ({ onClose: _onClose }: { onClose: () => void }) => {
                   {current ? (
                     <img src={current} alt={label} className="max-h-16 max-w-full object-contain" />
                   ) : (
-                    <span className="text-[10px] text-cp-text-muted">{label}</span>
+                    <span className="text-cp-xs text-cp-text-muted">{label}</span>
                   )}
                 </div>
                 <div className="flex w-full gap-1">

--- a/src/renderer/components/Settings/tabs/SchemaBuilderTab.tsx
+++ b/src/renderer/components/Settings/tabs/SchemaBuilderTab.tsx
@@ -213,7 +213,7 @@ export const SchemaBuilderTab = () => {
               <span className="flex-1">{f.label[lang] ?? f.label.de}</span>
               <span className="text-cp-text-faint">{typeLabel(f.type)}</span>
               {f.unit ? <span className="text-cp-text-faint">· {f.unit}</span> : null}
-              <span className="rounded bg-cp-surface-2 px-1 text-[10px] text-cp-text-faint">built-in</span>
+              <span className="rounded bg-cp-surface-2 px-1 text-cp-xs text-cp-text-faint">built-in</span>
             </div>
           ))}
           {userFields.map((f) => (
@@ -221,7 +221,7 @@ export const SchemaBuilderTab = () => {
               <span className="flex-1 text-cp-text">{f.label[lang] ?? f.label.de}</span>
               <span className="text-cp-text-faint">{typeLabel(f.type)}</span>
               {f.unit ? <span className="text-cp-text-faint">· {f.unit}</span> : null}
-              <span className="font-mono text-[10px] text-cp-text-faint">{f.key}</span>
+              <span className="font-mono text-cp-xs text-cp-text-faint">{f.key}</span>
               <button type="button" onClick={() => removeField(f.key)} className="text-cp-danger hover:text-cp-danger/80" title={t('common.delete', 'Delete')}>
                 <Trash2 size={13} />
               </button>

--- a/src/renderer/components/Settings/tabs/SyncTab.tsx
+++ b/src/renderer/components/Settings/tabs/SyncTab.tsx
@@ -77,13 +77,13 @@ const SharedLibrarySyncSection = ({ syncPath }: { syncPath: string }) => {
             : t('settings.sharedLib.syncNow', 'Sync library now')}
         </button>
         {!syncPath.trim() && (
-          <span className="text-[11px] text-cp-text-muted">
+          <span className="text-cp-xs text-cp-text-muted">
             {t('settings.sharedLib.needPath', 'Set a sync directory above first.')}
           </span>
         )}
       </div>
       {res && (
-        <div className="mt-2 text-[11px]">
+        <div className="mt-2 text-cp-xs">
           {res.ok ? (
             <div className="space-y-0.5">
               <p className="text-emerald-400">

--- a/src/renderer/components/Sync/CollabPanel.tsx
+++ b/src/renderer/components/Sync/CollabPanel.tsx
@@ -300,7 +300,7 @@ export const CollabPanel = () => {
             </button>
           </div>
 
-          <p className="text-[11px] text-[var(--cp-text-muted)]">
+          <p className="text-cp-xs text-[var(--cp-text-muted)]">
             {t(
               'collab.discover.adoptHint',
               'Joining adopts the host’s plan (replaces your current plan).',
@@ -356,7 +356,7 @@ export const CollabPanel = () => {
                 <span
                   key={p.id}
                   title={p.self ? `${p.name} (${t('collab.peers.you', 'you')})` : p.name}
-                  className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-[var(--cp-surface-3)] text-[11px] font-bold text-white"
+                  className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-[var(--cp-surface-3)] text-cp-xs font-bold text-white"
                   style={{ backgroundColor: p.color }}
                 >
                   {initials(p.name)}
@@ -365,7 +365,7 @@ export const CollabPanel = () => {
             </div>
           </div>
           {peers.length === 1 && (
-            <p className="text-[11px] text-[var(--cp-text-muted)]">
+            <p className="text-cp-xs text-[var(--cp-text-muted)]">
               {t(
                 'collab.peers.aloneHint',
                 'Others join by using the same room name:',

--- a/src/renderer/components/Wireless/WirelessRigDialog.tsx
+++ b/src/renderer/components/Wireless/WirelessRigDialog.tsx
@@ -262,7 +262,7 @@ export const WirelessRigDialog = () => {
               <ul className="space-y-1 rounded border border-cp-warn/40 bg-cp-warn/5 p-2 text-cp-xs">
                 {derivation.rfConflicts.map((c, i) => (
                   <li key={i} className="flex gap-2">
-                    <span className="rounded bg-cp-surface-3 px-1.5 py-0.5 text-[10px] text-cp-text-muted">
+                    <span className="rounded bg-cp-surface-3 px-1.5 py-0.5 text-cp-xs text-cp-text-muted">
                       {c.kind === 'spacing' ? t('wireless.kindSpacing', 'spacing') : c.kind === 'imd3-2tx' ? 'IMD3·2' : 'IMD3·3'}
                     </span>
                     <span className="text-cp-text-secondary">{c.message}</span>
@@ -270,7 +270,7 @@ export const WirelessRigDialog = () => {
                 ))}
               </ul>
               <PanelHint
-                className="mt-1 text-[11px] text-cp-text-muted"
+                className="mt-1 text-cp-xs text-cp-text-muted"
                 text={t('wireless.rfHint', 'Checked: carrier spacing + 3rd-order intermodulation (2- and 3-transmitter). Basic coordination like Wireless Workbench — not a substitute for an on-site spectrum scan.')}
               />
             </div>

--- a/src/renderer/components/shared/ColorField.tsx
+++ b/src/renderer/components/shared/ColorField.tsx
@@ -53,7 +53,7 @@ export const ColorField = ({
             <button
               type="button"
               onClick={onReset}
-              className="rounded bg-cp-surface-4 px-1.5 py-0.5 text-[10px] hover:bg-cp-surface-5"
+              className="rounded bg-cp-surface-4 px-1.5 py-0.5 text-cp-xs hover:bg-cp-surface-5"
               title={t('colorField.resetTitle', 'Reset colour')}
             >
               {t('colorField.resetBtn', '✕ Reset')}

--- a/src/renderer/components/shared/ConnectorPicker.tsx
+++ b/src/renderer/components/shared/ConnectorPicker.tsx
@@ -153,7 +153,7 @@ export const ConnectorPicker = ({
             <ConnectorSymbol symbol="generic" size={size === 'sm' ? 22 : 28} />
           )}
         </span>
-        <span className={`flex-1 truncate ${size === 'sm' ? 'text-[11px]' : 'text-cp-base'}`}>
+        <span className={`flex-1 truncate ${size === 'sm' ? 'text-cp-xs' : 'text-cp-base'}`}>
           {connectorLabel(value)}
         </span>
         <ChevronDown size={14} className="shrink-0 text-cp-text-faint" />
@@ -188,7 +188,7 @@ export const ConnectorPicker = ({
               {filteredGroups.map((g) => (
                 <div key={g.category.id} className="mb-2 last:mb-0">
                   <div
-                    className="mb-1 flex items-center gap-1.5 px-1 text-[10px] font-semibold tracking-wide uppercase"
+                    className="mb-1 flex items-center gap-1.5 px-1 text-cp-xs font-semibold tracking-wide uppercase"
                     style={{ color: g.category.color }}
                   >
                     <span
@@ -213,7 +213,7 @@ export const ConnectorPicker = ({
                           }`}
                         >
                           <span style={{ color: connectorColor(e) }}>{tileSymbolFor(e)}</span>
-                          <span className="w-full truncate text-[11px] leading-tight text-cp-text-secondary">
+                          <span className="w-full truncate text-cp-xs leading-tight text-cp-text-secondary">
                             {e.label}
                           </span>
                         </button>

--- a/src/renderer/components/shared/PanelWindowMenu.tsx
+++ b/src/renderer/components/shared/PanelWindowMenu.tsx
@@ -120,7 +120,7 @@ export const PanelWindowMenu = ({
           {/* Der dritte Weg steht nur da, weil er sonst unauffindbar waere:
               den Knopf selbst kann man ziehen. Das ist keine Wiederholung des
               ersten Eintrags — es ist die Bedienung, die niemand raet. */}
-          <p className="mt-1 border-t border-cp-border-muted px-2 pt-1.5 text-[10px] text-cp-text-muted">
+          <p className="mt-1 border-t border-cp-border-muted px-2 pt-1.5 text-cp-xs text-cp-text-muted">
             {t('panel.window.dragHint', 'The button can also be dragged.')}
           </p>
         </div>

--- a/src/renderer/components/shared/ProvenanceBadge.tsx
+++ b/src/renderer/components/shared/ProvenanceBadge.tsx
@@ -46,7 +46,7 @@ export const ProvenanceBadge = ({ provenance, field, title }: ProvenanceBadgePro
   return (
     <span
       title={reason}
-      className={`ml-1 inline-block rounded border px-1 text-[10px] leading-4 align-middle ${STYLE[provenance]}`}
+      className={`ml-1 inline-block rounded border px-1 text-cp-xs leading-4 align-middle ${STYLE[provenance]}`}
     >
       {label}
     </span>

--- a/src/renderer/lager/ui/InventoryDialog.tsx
+++ b/src/renderer/lager/ui/InventoryDialog.tsx
@@ -1050,7 +1050,7 @@ const LocationsTab = ({ dimsEditor, formatDims, codeCell }: LocationsTabProps) =
         >
           {container ? <Package size={13} className="shrink-0 text-cp-accent" /> : <Warehouse size={13} className="shrink-0 text-cp-text-muted" />}
           <span className="font-medium">{node.name}</span>
-          <span className="rounded bg-cp-surface-4 px-1.5 py-0.5 text-[10px] text-cp-text-muted">{kindLabel(node.kind)}</span>
+          <span className="rounded bg-cp-surface-4 px-1.5 py-0.5 text-cp-xs text-cp-text-muted">{kindLabel(node.kind)}</span>
           {node.code && codeCell(node.code, node.codeType)}
           {directItems.length > 0 && (
             <span className="text-cp-text-muted">
@@ -1247,7 +1247,7 @@ const LocationsTab = ({ dimsEditor, formatDims, codeCell }: LocationsTabProps) =
         {directItems.length > 0 && (
           <div style={{ marginLeft: depth * 16 + 22 }} className="mt-0.5 mb-0.5 flex flex-wrap gap-1">
             {directItems.map((it) => (
-              <span key={it.id} className="flex items-center gap-1 rounded bg-cp-surface-3 px-1.5 py-0.5 text-[10px] text-cp-text-secondary">
+              <span key={it.id} className="flex items-center gap-1 rounded bg-cp-surface-3 px-1.5 py-0.5 text-cp-xs text-cp-text-secondary">
                 <ChevronRight size={9} />
                 {it.quantity}× {it.model}
               </span>
@@ -1479,7 +1479,7 @@ const SetsTab = () => {
                   <div className="flex items-center gap-2 font-medium">
                     <Layers size={14} className="text-cp-text-muted" />
                     {s.name}
-                    <span className={`rounded px-1.5 py-0.5 text-[10px] ${avail > 0 ? 'bg-emerald-700/30 text-emerald-400' : 'bg-red-700/30 text-red-400'}`}>
+                    <span className={`rounded px-1.5 py-0.5 text-cp-xs ${avail > 0 ? 'bg-emerald-700/30 text-emerald-400' : 'bg-red-700/30 text-red-400'}`}>
                       {format(t('inventory.setAvailable', '{n}× buildable'), { n: avail })}
                     </span>
                   </div>
@@ -1817,14 +1817,14 @@ const UnitsTab = ({ codeCell }: UnitsTabProps) => {
                 {u.serial && <span className="text-cp-text-secondary">SN {u.serial}</span>}
                 {u.houseRef && <span className="text-cp-text-secondary">#{u.houseRef}</span>}
                 {u.code && codeCell(u.code, u.codeType)}
-                <span className={`rounded px-1.5 py-0.5 text-[10px] ${CONDITION_TONE[u.condition]}`}>{conditionLabel(u.condition)}</span>
+                <span className={`rounded px-1.5 py-0.5 text-cp-xs ${CONDITION_TONE[u.condition]}`}>{conditionLabel(u.condition)}</span>
                 {/* BEDARF 52 — der Verdacht steht NEBEN dem Zustand, nicht
                     darin. „defekt" ist eine Entscheidung, die jemand getroffen
                     hat; „3 offene Fehler" ist eine Zählung, und genau die lebte
                     bisher nur im Gedächtnis der Crew. */}
                 {openFaultsOf(u).length > 0 && (
                   <span
-                    className="rounded bg-amber-900/50 px-1.5 py-0.5 text-[10px] text-amber-200"
+                    className="rounded bg-amber-900/50 px-1.5 py-0.5 text-cp-xs text-amber-200"
                     title={affectedServices(u)
                       .map((x) => FAULT_SERVICE_LABEL[x])
                       .join(', ')}
@@ -1839,7 +1839,7 @@ const UnitsTab = ({ codeCell }: UnitsTabProps) => {
                 <select
                   value={u.condition}
                   onChange={(e) => setUnitCondition(u.id, e.target.value as UnitCondition)}
-                  className="rounded border border-cp-border bg-cp-surface-3 p-0.5 text-[10px]"
+                  className="rounded border border-cp-border bg-cp-surface-3 p-0.5 text-cp-xs"
                   title={t('inventory.setCondition', 'Change condition')}
                 >
                   {(['ok', 'defect', 'inRepair', 'retired'] as UnitCondition[]).map((c) => (
@@ -1855,7 +1855,7 @@ const UnitsTab = ({ codeCell }: UnitsTabProps) => {
                     const id = e.target.value || undefined
                     moveUnit(u.id, id, id ? nodePathLabel(nodes, id) : '')
                   }}
-                  className="min-w-0 flex-1 rounded border border-cp-border bg-cp-surface-3 p-0.5 text-[10px]"
+                  className="min-w-0 flex-1 rounded border border-cp-border bg-cp-surface-3 p-0.5 text-cp-xs"
                   title={t('inventory.moveUnit', 'Change location')}
                 >
                   <option value="">{t('inventory.noLocation', '— no location —')}</option>
@@ -1891,7 +1891,7 @@ const UnitsTab = ({ codeCell }: UnitsTabProps) => {
                 </div>
               </div>
               {openHistory === u.id && (
-                <ul className="border-t border-cp-border-muted px-3 py-1.5 text-[10px] text-cp-text-secondary">
+                <ul className="border-t border-cp-border-muted px-3 py-1.5 text-cp-xs text-cp-text-secondary">
                   {u.history.map((e, i) => (
                     <li key={i} className="flex gap-2">
                       <span className="tabular-nums text-cp-text-faint">{e.at.slice(0, 10)}</span>
@@ -1925,7 +1925,7 @@ const UnitsTab = ({ codeCell }: UnitsTabProps) => {
                 </ul>
               )}
               {faultFor === u.id && (
-                <div className="flex flex-wrap items-center gap-1.5 border-t border-cp-border-muted px-3 py-1.5 text-[10px]">
+                <div className="flex flex-wrap items-center gap-1.5 border-t border-cp-border-muted px-3 py-1.5 text-cp-xs">
                   <input
                     value={faultText}
                     onChange={(e) => setFaultText(e.target.value)}
@@ -2864,7 +2864,7 @@ const ReportsTab = () => {
 
   const kpi = (label: string, value: string | number) => (
     <div className="rounded border border-cp-border-muted bg-cp-surface-2 px-3 py-2">
-      <div className="text-[10px] uppercase tracking-wide text-cp-text-muted">{label}</div>
+      <div className="text-cp-xs uppercase tracking-wide text-cp-text-muted">{label}</div>
       <div className="text-cp-sm font-semibold tabular-nums text-cp-text">{value}</div>
     </div>
   )

--- a/src/viewer/ViewerApp.tsx
+++ b/src/viewer/ViewerApp.tsx
@@ -347,7 +347,7 @@ export const ViewerApp = () => {
             >
               {loadingRemote ? 'Lade…' : 'Live laden'}
             </button>
-            <p className="mt-1 text-[11px] text-cp-text-faint">
+            <p className="mt-1 text-cp-xs text-cp-text-faint">
               LAN: die vom Desktop angezeigte Adresse. Mobilfunk: deine öffentliche Tunnel-/Relay-URL
               (siehe docs/self-hosted-relay.md). Nichts läuft über fremde Server.
             </p>
@@ -367,7 +367,7 @@ export const ViewerApp = () => {
           {project.metadata?.description && <p className="truncate text-xs text-cp-text-muted">{project.metadata.description}</p>}
           {/* Bedarf 1: der Stand des Geteilten. Ohne ihn ist diese Ansicht
               eine Momentaufnahme, die nicht sagt, welche. */}
-          <p className="truncate text-[11px] text-cp-text-faint" title={standHinweis}>
+          <p className="truncate text-cp-xs text-cp-text-faint" title={standHinweis}>
             Stand <span className="font-mono">#{stamp.fingerprint}</span>
             {stamp.revision && <> · {stamp.revision}{stamp.drifted && ' + Änderungen'}</>}
           </p>
@@ -407,13 +407,13 @@ export const ViewerApp = () => {
                     <li key={a.id} className={`rounded border p-2 text-xs ${sel ? 'border-cp-accent bg-cp-surface-2' : 'border-cp-border-muted bg-cp-surface-2/40'}`} onClick={() => setSelectedId(a.id)}>
                       <div className="mb-1 flex items-center justify-between gap-2">
                         <span className="flex items-center gap-1.5 font-medium text-cp-text-secondary">
-                          <span className="inline-flex h-4 w-4 items-center justify-center rounded-full text-[9px] font-bold text-slate-900" style={{ backgroundColor: STATUS_COLOR[a.status] ?? '#64748b' }}>{i + 1}</span>
+                          <span className="inline-flex h-4 w-4 items-center justify-center rounded-full text-cp-xs font-bold text-slate-900" style={{ backgroundColor: STATUS_COLOR[a.status] ?? '#64748b' }}>{i + 1}</span>
                           {a.author || '—'}
                         </span>
                         <select
                           value={a.status}
                           onChange={(e) => patchAnnotation(a.id, { status: e.target.value as ProjectAnnotation['status'] })}
-                          className="rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-[10px]"
+                          className="rounded border border-cp-border bg-cp-surface-1 px-1 py-0.5 text-cp-xs"
                           onClick={(e) => e.stopPropagation()}
                         >
                           {STATUS_ORDER.map((s) => <option key={s} value={s}>{STATUS_LABEL[s]}</option>)}
@@ -429,7 +429,7 @@ export const ViewerApp = () => {
                       />
                       {mine && (
                         <div className="mt-1 flex justify-end">
-                          <button onClick={(e) => { e.stopPropagation(); removeAnnotation(a.id) }} className="rounded px-1.5 py-0.5 text-[10px] text-cp-danger hover:bg-cp-danger/20">Löschen</button>
+                          <button onClick={(e) => { e.stopPropagation(); removeAnnotation(a.id) }} className="rounded px-1.5 py-0.5 text-cp-xs text-cp-danger hover:bg-cp-danger/20">Löschen</button>
                         </div>
                       )}
                     </li>
@@ -438,7 +438,7 @@ export const ViewerApp = () => {
               </ul>
             )}
           </div>
-          <div className="border-t border-cp-border p-2 text-[10px] text-cp-text-faint">
+          <div className="border-t border-cp-border p-2 text-cp-xs text-cp-text-faint">
             {project.equipment.length} Geräte · {project.cables.length} Kabel · {(project.locations ?? []).length} Standorte
           </div>
         </aside>

--- a/tests/schriftgroesseUntergrenze.test.ts
+++ b/tests/schriftgroesseUntergrenze.test.ts
@@ -5,10 +5,11 @@ import { join, relative, sep } from 'node:path'
 // ---------------------------------------------------------------------------
 // Fliesstext faellt nicht unter 12px (UI-Pruefung, Phase 2).
 //
-// Der Befund steht in `docs/ui-audit.md` und ist als TODO formuliert:
+// Der Befund stand in `docs/ui-audit.md` und war als TODO formuliert:
 //
 //   > `text-[10px]`/`text-[11px]`/`text-[9px]` flaechendeckend auf Typo-Skala
-//   > migrieren … Fliesstext-Mindestgroesse 12px.
+//   > migrieren … Fliesstext-Mindestgroesse 12px. (Rein dekorative
+//   > Micro-Glyphen wie MenuBar-Caret `▾` bleiben.)
 //
 // ─── WARUM DIESER WAECHTER UEBERHAUPT EXISTIERT ────────────────────────────
 //
@@ -16,7 +17,7 @@ import { join, relative, sep } from 'node:path'
 // dieselbe Baumsuche, die hier laeuft:
 //
 //   * 743 Stellen beim ersten Commit des Audits (955da7e, 2026-06-15)
-//   * 881 Stellen bei HEAD dieses Zweiges (2026-09-10)
+//   * 881 Stellen drei Monate spaeter (2026-09-10)
 //
 // Also 138 Stellen MEHR, nachdem jemand aufgeschrieben hatte, dass es weniger
 // werden sollen. Ein TODO in einer Datei bremst nichts; niemand liest es beim
@@ -24,48 +25,44 @@ import { join, relative, sep } from 'node:path'
 // Aenderungen, sondern die vorhersehbare Folge davon, dass die Grenze nur in
 // Prosa stand.
 //
-// Dieser Test macht daraus eine Ratsche: die Zahl darf sinken, nie steigen.
-// Er ersetzt das TODO nicht, er traegt es — der Rest der Migration bleibt
-// Arbeit, aber sie kann nicht mehr lautlos zunichte gemacht werden.
+// Der Weg zurueck lief in vier Schritten — 881 → 828 (`src/mobile`) → 705
+// (die drei groessten Einzeldateien) → 515 (die naechsten neun) → 0.
+//
+// ─── VON DER RATSCHE ZUR REGEL ─────────────────────────────────────────────
+//
+// Solange noch hunderte Stellen offen waren, stand hier eine Zahl: die
+// Barriere durfte sinken, nie steigen. Das war die richtige Form fuer eine
+// laufende Migration und die falsche fuer eine fertige — eine Zahl sagt
+// nicht, WARUM eine Stelle bleiben darf, und wer eine neue anlegt, koennte
+// sie mit einer Migration anderswo verrechnen.
+//
+// Geprueft wird deshalb jetzt eine REGEL: jede verbliebene Stelle unter 12px
+// muss ein rein dekorativer Micro-Glyph sein. Das ist die Ausnahme, die das
+// Audit selbst nennt (MenuBar-Caret `▾`), und sie ist nachpruefbar statt
+// ermessensabhaengig — der sichtbare Text der Zeile darf keinen Buchstaben
+// und keine Ziffer enthalten. Ein Pfeil hat keine Lesbarkeitsuntergrenze,
+// ein Wort hat eine.
+//
+// Wer morgen einen neuen Caret braucht, bleibt gruen. Wer eine Beschriftung
+// auf 10px setzt, wird rot — und zwar sofort und ohne Verrechnung.
 //
 // ─── WAS GEMESSEN WIRD, UND WAS NICHT ──────────────────────────────────────
 //
-// Gemessen wird `text-[<n>px]` mit n < 12, ueber den GANZEN `src`-Baum. Nicht
+// Gemessen wird `text-[<n>px]` mit n < 12 ueber den GANZEN `src`-Baum. Nicht
 // ueber eine Liste von Dateien: dieselbe Lehre wie bei den Dialogen
-// (`dialogTastaturbedienung.test.ts`) — DIE DOMAENE IST DER ORDNER, NICHT EINE
-// LISTE IM WAECHTER. Wer morgen eine Komponente anlegt, faellt hier auf, ohne
-// dass jemand eine Liste pflegt.
+// (`dialogTastaturbedienung.test.ts`) — DIE DOMAENE IST DER ORDNER, NICHT
+// EINE LISTE IM WAECHTER.
 //
 // NICHT gemessen werden relative Groessen (`text-[0.85em]`, zwei Stellen).
 // Ob ein `em` unter 12px landet, haengt am Elternknoten und ist per Textsuche
-// nicht entscheidbar. Das hier ehrlich zu benennen ist besser, als eine
-// Zahl zu melden, die zwei Faelle stillschweigend auslaesst.
-//
-// Das Audit nimmt rein dekorative Micro-Glyphen (MenuBar-Caret `▾`) aus der
-// Migration aus — zu Recht, ein Pfeil hat keine Lesbarkeitsuntergrenze. Die
-// Ratsche zaehlt sie trotzdem mit, denn „ist das dekorativ?" laesst sich nicht
-// suchen, und ein Waechter mit einer Ermessensklausel prueft am Ende nichts.
-// Wer einen neuen Glyph braucht, migriert im selben Schritt eine Textstelle:
-// die Zahl bleibt dann gleich, und die Untergrenze bleibt gedeckt.
+// nicht entscheidbar. Das hier ehrlich zu benennen ist besser, als eine Zahl
+// zu melden, die zwei Faelle stillschweigend auslaesst.
 // ---------------------------------------------------------------------------
 
 const WURZEL = join(process.cwd(), 'src')
 
 /** Fliesstext-Untergrenze aus dem Audit. Was darunter liegt, zaehlt. */
 const UNTERGRENZE_PX = 12
-
-/**
- * Stand 2026-09-10, gemessen mit genau der Suche unten. Sinken darf die Zahl —
- * dann ist die rote Zeile die Erinnerung, sie hier nachzuziehen.
- *
- * Bisherige Staende: 828 (nach `src/mobile`), 705 (nach GreenGoExportDialog,
- * CalculatorsDialog, CableProperties), 515 (nach den naechsten neun:
- * RackBuilderDialog, RentmanTab, RackPlacementProperties, CableLibraryPanel,
- * PortList, MobileShareDialog, App.tsx, ExportDialog, AnalysisDialog). Die
- * Reihenfolge ist die nach Groesse: die dichten Tabellen und Rechner-Raster
- * zuerst, weil dort die kleinste Schrift und die meiste Zahl zusammenkommen.
- */
-const BARRIERE = 515
 
 const dateien = (dir: string): string[] =>
   readdirSync(dir).flatMap((eintrag) => {
@@ -76,63 +73,92 @@ const dateien = (dir: string): string[] =>
 
 const GROESSE = /text-\[(\d+(?:\.\d+)?)px\]/g
 
-/** Alle Fundstellen unter der Untergrenze, nach Datei. */
-const zuKlein = (): Map<string, number> => {
-  const treffer = new Map<string, number>()
-  for (const pfad of dateien(WURZEL)) {
-    const src = readFileSync(pfad, 'utf8')
-    let n = 0
-    for (const m of src.matchAll(GROESSE)) {
-      if (Number(m[1]) < UNTERGRENZE_PX) n += 1
-    }
-    if (n > 0) treffer.set(relative(WURZEL, pfad), n)
-  }
-  return treffer
+interface Fund {
+  datei: string
+  zeile: number
+  text: string
 }
 
-const summe = (m: Map<string, number>): number =>
-  [...m.values()].reduce((s, n) => s + n, 0)
+/**
+ * Eine reine Kommentarzeile ist keine Klasse.
+ *
+ * `index.css` erklaert in ihrem Kopf, wozu die Typo-Skala da ist, und nennt
+ * dabei `text-[10px]`/`text-[11px]` beim Namen — die erste Fassung dieses
+ * Waechters meldete genau diesen Satz als Verstoss. Wer eine Regel
+ * aufschreibt, soll sie nicht dadurch brechen, dass er sie aufschreibt.
+ */
+const nurKommentar = (z: string): boolean => /^\s*(\/\/|\/\*|\*)/.test(z)
+
+/** Jede Stelle unter der Untergrenze, mit ihrer Zeile. */
+const zuKlein = (): Fund[] => {
+  const funde: Fund[] = []
+  for (const pfad of dateien(WURZEL)) {
+    const zeilen = readFileSync(pfad, 'utf8').split('\n')
+    zeilen.forEach((z, i) => {
+      if (nurKommentar(z)) return
+      for (const m of z.matchAll(GROESSE)) {
+        if (Number(m[1]) < UNTERGRENZE_PX) {
+          funde.push({ datei: relative(WURZEL, pfad).split(sep).join('/'), zeile: i + 1, text: z })
+        }
+      }
+    })
+  }
+  return funde
+}
+
+/**
+ * Der sichtbare Text einer JSX-Zeile: erst die Laeufe zwischen `>` und `<`,
+ * und wenn die leer sind (weil dort ein Ausdruck steht), die Zeichenketten
+ * aus den geschweiften Klammern.
+ *
+ * Attribute bleiben aussen vor — `className="…"` und `title={t('…','Pinned')}`
+ * sind nichts, was jemand LIEST; sie wuerden jede Zeile mit Buchstaben
+ * fuellen und die Regel unbrauchbar machen.
+ */
+const sichtbarerText = (zeile: string): string[] => {
+  const laeufe = [...zeile.matchAll(/>([^<>{}]*)</g)].map((m) => m[1].trim()).filter(Boolean)
+  if (laeufe.length > 0) return laeufe
+  const inKlammern = [...zeile.matchAll(/\{[^}]*\}/g)].map((m) => m[0]).join(' ')
+  return [...inKlammern.matchAll(/'([^']*)'|"([^"]*)"/g)]
+    .map((m) => (m[1] ?? m[2] ?? '').trim())
+    .filter(Boolean)
+}
+
+/** Ein Glyph traegt keine Buchstaben und keine Ziffern. */
+const nurGlyph = (s: string): boolean => !/[\p{L}\p{N}]/u.test(s)
 
 describe('Fliesstext-Untergrenze 12px', () => {
   it('sieht ueberhaupt Dateien — sonst prueft der Test nichts', () => {
-    // Ohne diese Zusicherung waere die Ratsche auch dann gruen, wenn die
-    // Baumsuche nichts mehr findet: 0 <= 828 ist wahr. Ein Waechter, der bei
-    // kaputtem Muster gruen wird, ist schlechter als keiner — er behauptet
-    // eine Deckung, die es nicht gibt.
+    // Ohne diese Zusicherung waere die Regel auch dann erfuellt, wenn die
+    // Baumsuche nichts mehr findet: eine leere Menge erfuellt jede Regel.
+    // Ein Waechter, der bei kaputtem Muster gruen wird, ist schlechter als
+    // keiner — er behauptet eine Deckung, die es nicht gibt.
     expect(dateien(WURZEL).length).toBeGreaterThan(150)
   })
 
-  it('findet die bekannten Fundstellen — sonst passt das Muster nicht mehr', () => {
+  it('findet die bekannten Glyph-Stellen — sonst passt das Muster nicht mehr', () => {
     // Zweite Haelfte derselben Zusicherung: Dateien zu finden reicht nicht,
-    // das Muster muss auch greifen. Faellt der Wert auf 0, ist die Migration
-    // entweder fertig (dann darf diese Zeile weg) oder das Muster ist tot.
-    expect(summe(zuKlein())).toBeGreaterThan(0)
+    // das Muster muss auch greifen. Sechs dekorative Stellen sind heute da
+    // (vier Carets, ein Sortier-Dreieck, eine Pin-Markierung). Faellt der
+    // Wert auf 0, ist entweder auch die letzte Ausnahme weg — dann darf diese
+    // Zeile gehen — oder `GROESSE` trifft nicht mehr.
+    expect(zuKlein().length).toBeGreaterThan(0)
   })
 
-  it('die Ratsche: die Zahl steigt nicht', () => {
-    const treffer = zuKlein()
-    const jetzt = summe(treffer)
-    const groesste = [...treffer.entries()]
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 5)
-      .map(([datei, n]) => `${datei} (${n})`)
-      .join(', ')
+  it('jede Stelle unter 12px ist ein rein dekorativer Glyph', () => {
+    const mitText = zuKlein().filter((f) => {
+      const sichtbar = sichtbarerText(f.text)
+      if (sichtbar.length === 0) return true
+      return !sichtbar.every(nurGlyph)
+    })
+    const liste = mitText
+      .map((f) => `${f.datei}:${f.zeile} „${sichtbarerText(f.text).join(' ')}"`)
+      .join('\n  ')
     expect(
-      jetzt,
-      `Schriftgroessen unter ${UNTERGRENZE_PX}px: ${jetzt} statt hoechstens ${BARRIERE}. ` +
-        `Groesste Posten: ${groesste}. Neue Stellen nutzen die Typo-Skala ` +
-        `(text-cp-xs/-sm/-base/-lg) statt einer eigenen px-Angabe.`,
-    ).toBeLessThanOrEqual(BARRIERE)
-  })
-
-  it('die Mobile-Ansicht bleibt sauber', () => {
-    // Sie ist migriert (58 Stellen) und wird auf einem Telefon im dunklen
-    // Truck gelesen — dort tut die Untergrenze am meisten. Ohne diese Zeile
-    // koennte sie zurueckfallen, waehrend anderswo etwas migriert wird, und
-    // die Gesamtzahl bliebe gleich. Die Ratsche allein sieht das nicht.
-    const rueckfall = [...zuKlein().keys()].filter((d) => d.startsWith(`mobile${sep}`))
-    expect(rueckfall, `Mobile-Ansicht wieder unter der Untergrenze: ${rueckfall.join(', ')}`)
-      .toEqual([])
+      mitText,
+      `Text unter ${UNTERGRENZE_PX}px — die Typo-Skala nutzen ` +
+        `(text-cp-xs/-sm/-base/-lg) statt einer eigenen px-Angabe:\n  ${liste}`,
+    ).toEqual([])
   })
 })
 
@@ -142,11 +168,11 @@ describe('die Skala selbst', () => {
   it('faengt bei genau der Untergrenze an', () => {
     // WICHTIG, UND NICHT NUR EINE VERDOPPLUNG DES CSS.
     //
-    // Die Ratsche zaehlt nur eigene px-Angaben. Setzte jemand
+    // Die Regel oben prueft nur eigene px-Angaben. Setzte jemand
     // `--text-cp-xs` auf 0.625rem, waere jede Migration nach `text-cp-xs`
-    // ein Schritt UNTER die Untergrenze — und die Ratsche saehe dabei zu,
-    // wie ihre Zahl sinkt. Ein Waechter, der denselben Defekt hat wie das
-    // Gepruefte, ist auf diesem Defekt gruen.
+    // ein Schritt UNTER die Untergrenze — und der Waechter saehe zu, weil
+    // dort gar keine px-Angabe mehr steht. Ein Waechter, der denselben
+    // Defekt hat wie das Gepruefte, ist auf diesem Defekt gruen.
     const m = /--text-cp-xs:\s*([\d.]+)rem/.exec(css)
     expect(m, '--text-cp-xs nicht in index.css gefunden').not.toBeNull()
     expect(Number(m![1]) * 16).toBe(UNTERGRENZE_PX)


### PR DESCRIPTION
Vierter und letzter Schnitt der Schriftgrößen-TODO aus `docs/ui-audit.md`. **507 Stellen in 111 Dateien** `text-[8|9|10|11px]` → `text-cp-xs`.

Der Weg zurück, gemessen über dieselbe Baumsuche:

**743** (Audit-Start, 2026-06-15) → **881** (drei Monate später, +138 statt −) → **828** (`src/mobile`) → **705** (die drei größten Einzeldateien) → **515** (die nächsten neun) → **0**.

## Die sechs, die bleiben

Vier Carets (`MenuBar`, `LibraryMenus` ×2, `PanelWindowMenu`), ein Sortier-Dreieck (`PatchListDialog`) und die Pin-Markierung im Rechner. Das ist genau die Ausnahme, die das TODO selbst nennt: **ein Pfeil hat keine Lesbarkeitsuntergrenze, ein Wort hat eine.**

## Aus der Ratsche wird eine Regel

Solange hunderte Stellen offen waren, stand im Wächter eine Zahl — die richtige Form für eine laufende Migration und die falsche für eine fertige. **Eine Zahl sagt nicht, *warum* eine Stelle bleiben darf**, und wer eine neue anlegt, könnte sie mit einer Migration anderswo verrechnen.

Geprüft wird jetzt: *jede* Stelle unter 12px muss ein rein dekorativer Glyph sein — der sichtbare Text der Zeile darf keinen Buchstaben und keine Ziffer tragen. Nachprüfbar statt ermessensabhängig.

Attribute bleiben dabei außen vor: `className` und `title={t('…','Pinned')}` liest niemand, sie würden jede Zeile mit Buchstaben füllen und die Regel unbrauchbar machen.

**Gegenproben gefahren:**
- eine Beschriftung auf 10px → **rot**
- ein neuer dekorativer Caret → **grün**

Beides ist die Absicht.

**Und eine Selbstkorrektur:** die erste Fassung meldete den Kopf von `index.css` als Verstoß — dort steht in Prosa, wozu die Typo-Skala da ist, und dabei stehen `text-[10px]`/`text-[11px]` im Klartext. Wer eine Regel aufschreibt, soll sie nicht dadurch brechen, dass er sie aufschreibt; reine Kommentarzeilen zählen nicht mehr.

## Verifikation im echten Fenster

507 Stellen auf einmal ist genau der Punkt, an dem eine Migration Layout bricht — und `npm test` sieht das nicht: kein Rendering, keine Schriftbreiten. Alle vier UI-Skripte deshalb gegen die gebaute App unter `xvfb` gefahren:

| Prüfung | Ergebnis |
| --- | --- |
| `ui:smoke` | 5 Menüs, 0 ohne Einträge |
| `ui:overflow` | **0 Befunde bei 15 geprüften Dialogen** |
| `ui:labels` | 0 Befunde (118 Bedienelemente) |
| `ui:targets` | 0 Befunde |

Dazu `tsc` 0 · `lint` 0 Errors · **3850 Tests grün** · `npm run build` grün.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_