### PR TITLE
theme: vier Light-Regeln standen doppelt da — die tote Fassung unter ihrer eigenen Begründung

### DIFF
--- a/docs/ui-audit.md
+++ b/docs/ui-audit.md
@@ -33,6 +33,39 @@ lag falsch (`src/main*.ts` deckt entgegen der Dokumentation auch
 `src/main/ipc/*.ts` mit ab, nachgemessen mit einer Wegwerfdatei). Wer die
 Regel nachbaut, prueft am Ende seine eigene Lesart.
 
+## Nebenbefund 2026-09-10 (dritter): vier Light-Regeln standen doppelt da
+
+`index.css` deklarierte vier Regeln **zweimal**, mit unterschiedlichen Werten:
+
+```
+Zeile 333:  .bg-slate-950\/30 { background-color: rgba(240,244,248,0.7); }
+Zeile 480:  .bg-slate-950\/30 { background-color: rgba(240,244,248,0.3); }
+```
+
+dazu `/40`, `/50` und `/60` in derselben Form. Gleiche Spezifität, also gewann
+die spätere; der Minifier hat die frühere aus dem Build sogar ganz entfernt
+(nachgesehen in `dist/renderer/assets/*.css`), und im Fenster gemessen rendert
+`bg-slate-950/50` tatsächlich `rgba(240,244,248,0.5)`.
+
+**Die schlimmere Hälfte war nicht der Wert, sondern wo die tote Fassung
+stand:** genau unter dem Kommentar, der erklärt, *warum* es diese Regeln gibt
+(„damit die Context-Menüs, Modal-Overlays und Sub-Karten im Light-Mode nicht
+dunkel bleiben"). Wer eine Glasfläche nachjustieren wollte, las dort die
+Begründung, änderte die Zeile darunter — und sah nichts passieren.
+
+Behoben: die Regeln stehen jetzt an **einer** Stelle, bei ihrer Begründung.
+Übernommen wurden die **wirksamen** Werte, nicht die kommentierten — was die
+App seit Monaten zeigt, ist der Ist-Zustand; ihn nebenbei zu ändern wäre eine
+unbestellte Änderung am Aussehen. Nachgemessen: die vier Klassen rendern nach
+dem Umbau byte-gleich wie vorher.
+
+Dazu drei Regeln für Klassen, die im ganzen Baum nicht vorkommen
+(`bg-sky-950/50`, `border-amber-400`, `border-orange-700/60`) — jeweils eine
+Ziffer neben einer, die es gibt. Ein Eintrag ohne Nutzer ist nicht bloß
+ungenutzt: er sieht beim Lesen aus wie eine Deckung, die es nicht gibt.
+
+`tests/themeRemapEindeutig.test.ts` hält beides fest.
+
 ## Nebenbefund 2026-09-10 (zweiter): drei Reiter fielen aus dem Analysen-Dialog
 
 Der Analysen-Dialog legt **dreizehn Reiter** in eine `flex`-Zeile, die nicht
@@ -240,11 +273,28 @@ Inline-Fallback in `ErrorBoundary`). → Token-Schicht einführen.
       UI-Skripte grün, `ui:overflow` prüft dabei 15 Dialoge. Der Sprung
       10 → 12px in dichten Tabellen ist der Punkt, an dem eine Migration
       Layout bricht — `npm test` sieht das nicht.
-- [ ] Translucente Glas-Flächen (`bg-slate-950/95`, `bg-slate-900/80`,
-      `bg-slate-950/40`) auf Alpha-Tokens (z. B. `color-mix`) heben —
+- [ ] Translucente Glas-Flächen auf Alpha-Tokens (z. B. `color-mix`) heben —
       aktuell bewusst als slate-Klassen belassen (Remap deckt Light ab).
+      **Nachgemessen 2026-09-10: der Posten ist klein geworden** — noch
+      11 Stellen, und die im TODO genannten Beispiele (`bg-slate-950/95`,
+      `bg-slate-900/80`) gibt es gar nicht mehr. Übrig sind `/30`, `/40`,
+      `/50`, `/60`, `bg-slate-900/98`, `bg-slate-800/90`, `bg-slate-400/50`
+      in `AtemAudioRouterDialog`, `RackLivePreview`, `CableContextMenu`
+      und `VideohubRoutingMatrix`.
 - [ ] Slate-Remapping in `index.css` schrittweise durch `--cp-*`-Tokens
       ersetzen; Ziel: Opacity-Varianten-Liste schrumpfen.
+      **Nachgemessen 2026-09-10: die Liste ist nicht das Problem.**
+      207 Regeln, davon **204 mit echten Nutzern** — der Remap ist längst
+      auf das Legacy-Sicherheitsnetz geschrumpft, das sein Kopfkommentar
+      beschreibt. Die drei ohne Nutzer sind entfernt.
+      Was stattdessen gefunden wurde, steht als eigener Nebenbefund oben:
+      vier Regeln waren doppelt deklariert, mit widersprüchlichen Werten.
+      **Gehalten** von `tests/themeRemapEindeutig.test.ts`.
+      Offen bleibt der eigentliche Umbau auf Tokens — die verbliebenen
+      Regeln decken die `isLight`-Canvas-/Print-Komponenten ab, die pro
+      Theme **manuell** unterschiedliche Shades wählen und sich deshalb
+      nicht auf einen auto-kippenden Token abbilden lassen. Das ist derselbe
+      Umbau wie der nächste Punkt und gehört mit ihm zusammen gemacht.
 - [ ] Inline-Style-Komponenten (`CableEdge`, `CanvasToolbar`,
       `EquipmentNode`) auf `var(--cp-*)` statt `canvasTheme`-Branching.
 

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -329,11 +329,28 @@ body,
  * weil Tailwind sie als eigene Klassen mit rgb()-Werten generiert. Hier
  * explizit für die häufigsten Opacity-Varianten überschreiben damit die
  * Context-Menüs, Modal-Overlays und Sub-Karten im Light-Mode nicht
- * dunkel bleiben. */
-[data-theme="light"] .bg-slate-950\/30   { background-color: rgba(240,244,248,0.7); }
-[data-theme="light"] .bg-slate-950\/40   { background-color: rgba(240,244,248,0.7); }
-[data-theme="light"] .bg-slate-950\/50   { background-color: rgba(240,244,248,0.75); }
-[data-theme="light"] .bg-slate-950\/60   { background-color: rgba(240,244,248,0.8); }
+ * dunkel bleiben.
+ *
+ * DIE VIER `bg-slate-950/NN` STANDEN BIS 2026-09-10 ZWEIMAL HIER — einmal
+ * an dieser Stelle und einmal weiter unten unter „Opacity variants", mit
+ * ANDEREN Werten (0,7/0,7/0,75/0,8 gegen 0,3/0,4/0,5/0,6). Gleiche
+ * Spezifitaet, also gewann die spaetere; der Minifier hat die fruehere aus
+ * dem Build sogar ganz entfernt. Gemessen im Fenster: `bg-slate-950/50`
+ * rendert `rgba(240,244,248,0.5)`.
+ *
+ * Das war die schlimmere Haelfte des Defekts, nicht der Wert: die tote
+ * Fassung stand genau unter DIESER Begruendung. Wer den Light-Mode einer
+ * Glasflaeche nachjustieren wollte, las hier warum es die Regeln gibt,
+ * aenderte die Zeile darunter — und sah nichts passieren.
+ *
+ * Die Regeln stehen jetzt an einer Stelle, und zwar hier: bei ihrer
+ * Begruendung. Die Werte sind die WIRKSAMEN uebernommen, nicht die
+ * kommentierten — was die App seit Monaten zeigt, ist der Ist-Zustand;
+ * ihn nebenbei zu aendern waere eine unbestellte Aenderung am Aussehen. */
+[data-theme="light"] .bg-slate-950\/30   { background-color: rgba(240,244,248,0.3); }
+[data-theme="light"] .bg-slate-950\/40   { background-color: rgba(240,244,248,0.4); }
+[data-theme="light"] .bg-slate-950\/50   { background-color: rgba(240,244,248,0.5); }
+[data-theme="light"] .bg-slate-950\/60   { background-color: rgba(240,244,248,0.6); }
 [data-theme="light"] .bg-slate-900\/98   { background-color: rgba(234,239,245,0.98); }
 /* Modal-Backdrop: im Light-Mode statt schwarz ein helles Grau mit
  * Transparenz, damit Modals "weiches Glas" auf hellem Hintergrund sind. */
@@ -451,7 +468,6 @@ body,
 [data-theme="light"] .border-red-700\/60     { border-color: rgba(248,113,113,0.7); }
 [data-theme="light"] .border-orange-600\/60  { border-color: rgba(234,88,12,0.6); }
 [data-theme="light"] .border-orange-700\/50  { border-color: rgba(234,88,12,0.6); }
-[data-theme="light"] .border-orange-700\/60  { border-color: rgba(234,88,12,0.7); }
 [data-theme="light"] .border-orange-800\/60  { border-color: rgba(194,65,12,0.6); }
 [data-theme="light"] .border-orange-900\/40  { border-color: rgba(154,52,18,0.4); }
 [data-theme="light"] .border-sky-700         { border-color: #38bdf8; }
@@ -476,11 +492,9 @@ body,
 
 /* Focus variants */
 
-/* Opacity variants */
-[data-theme="light"] .bg-slate-950\/30  { background-color: rgba(240,244,248,0.3); }
-[data-theme="light"] .bg-slate-950\/40  { background-color: rgba(240,244,248,0.4); }
-[data-theme="light"] .bg-slate-950\/50  { background-color: rgba(240,244,248,0.5); }
-[data-theme="light"] .bg-slate-950\/60  { background-color: rgba(240,244,248,0.6); }
+/* Opacity variants — die `bg-slate-950/NN` stehen oben bei ihrer
+ * Begruendung; sie standen bis 2026-09-10 zusaetzlich hier und haben die
+ * dortigen Werte still ueberschrieben. */
 
 /* Opacity border variants */
 
@@ -504,7 +518,6 @@ body,
 [data-theme="light"] .text-amber-100     { color: #78350f; }
 [data-theme="light"] .text-amber-200     { color: #92400e; }
 [data-theme="light"] .text-amber-200\/70 { color: rgba(146,64,14,0.85); }
-[data-theme="light"] .border-amber-400   { border-color: #fbbf24; }
 [data-theme="light"] .border-amber-600   { border-color: #d97706; }
 [data-theme="light"] .border-amber-700\/60 { border-color: rgba(180,83,9,0.6); }
 [data-theme="light"] .border-amber-900\/60 { border-color: rgba(146,64,14,0.6); }
@@ -585,7 +598,6 @@ body,
 [data-theme="light"] .bg-sky-900\/40     { background-color: rgba(224,242,254,0.6); }
 [data-theme="light"] .bg-sky-950\/20     { background-color: rgba(240,249,255,0.55); }
 [data-theme="light"] .bg-sky-950\/30     { background-color: rgba(240,249,255,0.7); }
-[data-theme="light"] .bg-sky-950\/50     { background-color: rgba(240,249,255,0.85); }
 [data-theme="light"] .bg-sky-950\/60     { background-color: rgba(240,249,255,0.9); }
 [data-theme="light"] .text-sky-50        { color: #0c4a6e; }
 [data-theme="light"] .text-sky-200       { color: #075985; }

--- a/tests/themeRemapEindeutig.test.ts
+++ b/tests/themeRemapEindeutig.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+// ---------------------------------------------------------------------------
+// Der Light-Theme-Remap in `index.css` sagt jede Regel genau einmal — und nur
+// fuer Klassen, die es wirklich gibt (UI-Pruefung, Phase 2).
+//
+// ─── DER BEFUND ────────────────────────────────────────────────────────────
+//
+// Vier Regeln standen ZWEIMAL da, mit unterschiedlichen Werten:
+//
+//   Zeile 333: .bg-slate-950\/30 { background-color: rgba(240,244,248,0.7); }
+//   Zeile 480: .bg-slate-950\/30 { background-color: rgba(240,244,248,0.3); }
+//
+// dazu `/40`, `/50` und `/60` in derselben Form. Gleiche Spezifitaet, also
+// gewann die spaetere; der Minifier hat die fruehere aus dem Build sogar ganz
+// entfernt (nachgesehen in `dist/renderer/assets/*.css`) und im Fenster
+// gemessen rendert `bg-slate-950/50` `rgba(240,244,248,0.5)`.
+//
+// DIE SCHLIMMERE HAELFTE WAR NICHT DER WERT, SONDERN WO DIE TOTE FASSUNG
+// STAND: genau unter dem Kommentar, der erklaert, warum es diese Regeln
+// ueberhaupt gibt („damit die Context-Menues, Modal-Overlays und Sub-Karten
+// im Light-Mode nicht dunkel bleiben"). Wer eine Glasflaeche nachjustieren
+// wollte, las dort die Begruendung, aenderte die Zeile darunter — und sah
+// nichts passieren. Eine Datei, die ihre eigene Begruendung von ihrer
+// Wirkung trennt, kostet jeden, der sie liest, denselben Nachmittag.
+//
+// ─── DAZU: REGELN FUER KLASSEN, DIE NIEMAND BENUTZT ────────────────────────
+//
+// Drei Eintraege deckten Klassen ab, die im ganzen Baum nicht vorkommen
+// (`bg-sky-950/50`, `border-amber-400`, `border-orange-700/60`) — jeweils
+// eine Ziffer neben einer, die es gibt. Das ist die Bewegung, die diese
+// Liste auf ueber 200 Eintraege gebracht hat, und das Audit nennt als Ziel
+// ausdruecklich, sie schrumpfen zu lassen.
+//
+// Ein Eintrag ohne Nutzer ist nicht bloss ungenutzt: er sieht beim Lesen aus
+// wie eine Deckung, die es nicht gibt. Wer prueft, ob `border-amber-400` im
+// Light-Theme behandelt ist, findet eine Zeile und hoert auf zu suchen.
+// ---------------------------------------------------------------------------
+
+const WURZEL = process.cwd()
+const CSS_PFAD = join(WURZEL, 'src', 'renderer', 'index.css')
+const css = readFileSync(CSS_PFAD, 'utf8')
+
+/**
+ * Eine einzeilige Regel `[data-theme="light"] … { … }`.
+ *
+ * Nur einzeilige: die mehrzeiligen Bloecke in dieser Datei sind der
+ * Token-Satz und ein paar ReactFlow-Regeln, die kein Klassen-Remap sind.
+ */
+const REGEL = /^\s*(\[data-theme="light"\][^{]*?)\s*\{\s*([^}]*?)\s*\}\s*$/
+
+interface Regel {
+  selektor: string
+  wert: string
+  zeile: number
+}
+
+const regeln = (): Regel[] =>
+  css.split('\n').flatMap((z, i) => {
+    const m = REGEL.exec(z)
+    return m ? [{ selektor: m[1].trim(), wert: m[2].trim(), zeile: i + 1 }] : []
+  })
+
+/**
+ * Der Klassenname, wie er im JSX steht.
+ *
+ * Im CSS ist er maskiert (`.hover\:bg-slate-700:hover`, `.bg-slate-950\/50`);
+ * gesucht wird bis zum ersten NICHT maskierten `:` — das ist die Pseudoklasse
+ * und gehoert nicht mehr zum Namen.
+ */
+const klasseAus = (selektor: string): string | null => {
+  const m = /\[data-theme="light"\]\s*\.((?:[^\s{:,\\]|\\.)+)/.exec(selektor)
+  return m ? m[1].replace(/\\/g, '') : null
+}
+
+const quelltext = (): string => {
+  const sammeln = (dir: string): string[] =>
+    readdirSync(dir).flatMap((eintrag) => {
+      const pfad = join(dir, eintrag)
+      if (statSync(pfad).isDirectory()) return sammeln(pfad)
+      if (!/\.(tsx|ts|html)$/.test(pfad)) return []
+      return [readFileSync(pfad, 'utf8')]
+    })
+  return sammeln(join(WURZEL, 'src')).join('\n')
+}
+
+describe('Light-Theme-Remap', () => {
+  it('findet ueberhaupt Regeln — sonst prueft der Test nichts', () => {
+    // Ohne diese Zusicherung waeren beide Regeln unten erfuellt, wenn das
+    // Muster nicht mehr passt: eine leere Liste hat keine Doppelten und keine
+    // toten Eintraege. Ein Waechter, der bei kaputtem Muster gruen wird,
+    // behauptet eine Deckung, die es nicht gibt.
+    expect(regeln().length).toBeGreaterThan(150)
+  })
+
+  it('sagt jede Regel genau einmal', () => {
+    const nachSelektor = new Map<string, Regel[]>()
+    for (const r of regeln()) {
+      const bisher = nachSelektor.get(r.selektor) ?? []
+      bisher.push(r)
+      nachSelektor.set(r.selektor, bisher)
+    }
+    const doppelt = [...nachSelektor.entries()]
+      .filter(([, v]) => v.length > 1)
+      .map(([selektor, v]) => {
+        const werte = new Set(v.map((r) => r.wert))
+        const art = werte.size > 1 ? 'WIDERSPRUCH' : 'doppelt'
+        return `${art}: ${selektor} in Zeile ${v.map((r) => r.zeile).join(' und ')}`
+      })
+    expect(
+      doppelt,
+      `Doppelt deklariert — die spaetere gewinnt, die fruehere ist tot ` +
+        `und trotzdem lesbar:\n  ${doppelt.join('\n  ')}`,
+    ).toEqual([])
+  })
+
+  it('remappt nur Klassen, die es im Baum wirklich gibt', () => {
+    const text = quelltext()
+    const ohneNutzer = [
+      ...new Set(
+        regeln()
+          .map((r) => klasseAus(r.selektor))
+          .filter((k): k is string => k !== null)
+          .filter((k) => !text.includes(k)),
+      ),
+    ].sort()
+    expect(
+      ohneNutzer,
+      `Regeln fuer Klassen, die niemand benutzt — sie sehen beim Lesen aus ` +
+        `wie eine Deckung, die es nicht gibt: ${ohneNutzer.join(', ')}`,
+    ).toEqual([])
+  })
+
+  it('das Klassen-Lesen kommt mit Maskierung zurecht', () => {
+    // GEGENPROBE GEGEN DIE EIGENE LESART. Faellt eine dieser Zeilen, zaehlt
+    // die Pruefung oben Klassen, die es so nie gab — und meldet dann entweder
+    // Unsinn oder gar nichts. Beide Formen kommen in dieser Datei vor.
+    expect(klasseAus('[data-theme="light"] .bg-slate-950\\/50')).toBe('bg-slate-950/50')
+    expect(klasseAus('[data-theme="light"] .hover\\:bg-slate-700:hover')).toBe('hover:bg-slate-700')
+    expect(klasseAus('[data-theme="light"] .text-slate-100')).toBe('text-slate-100')
+  })
+})


### PR DESCRIPTION
Phase 2 weiter — und zwar erst gemessen, statt der TODO-Zeile zu glauben.

## Der Defekt

`index.css` deklarierte vier Regeln **zweimal**, mit unterschiedlichen Werten:

```
Zeile 333:  .bg-slate-950\/30 { background-color: rgba(240,244,248,0.7); }
Zeile 480:  .bg-slate-950\/30 { background-color: rgba(240,244,248,0.3); }
```

dazu `/40`, `/50` und `/60` in derselben Form. Gleiche Spezifität, also gewann die spätere; der Minifier hat die frühere aus dem Build sogar **ganz entfernt** (nachgesehen in `dist/renderer/assets/*.css`), und im Fenster gemessen rendert `bg-slate-950/50` tatsächlich `rgba(240,244,248,0.5)`.

**Die schlimmere Hälfte war nicht der Wert, sondern wo die tote Fassung stand:** genau unter dem Kommentar, der erklärt, *warum* es diese Regeln gibt — „damit die Context-Menüs, Modal-Overlays und Sub-Karten im Light-Mode nicht dunkel bleiben". Wer eine Glasfläche nachjustieren wollte, las dort die Begründung, änderte die Zeile darunter, und sah nichts passieren.

Die Regeln stehen jetzt an **einer** Stelle, bei ihrer Begründung.

**Übernommen sind die wirksamen Werte, nicht die kommentierten.** Was die App seit Monaten zeigt, ist der Ist-Zustand; ihn nebenbei zu ändern wäre eine unbestellte Änderung am Aussehen. Nachgemessen im Light-Theme vor und nach dem Umbau — die vier Klassen rendern byte-gleich:

```
bg-slate-950/30 → rgba(240, 244, 248, 0.3)
bg-slate-950/40 → rgba(240, 244, 248, 0.4)
bg-slate-950/50 → rgba(240, 244, 248, 0.5)
bg-slate-950/60 → rgba(240, 244, 248, 0.6)
```

Dazu drei Regeln für Klassen, die im ganzen Baum nicht vorkommen (`bg-sky-950/50`, `border-amber-400`, `border-orange-700/60`) — jeweils *eine Ziffer* neben einer, die es gibt. Ein Eintrag ohne Nutzer ist nicht bloß ungenutzt: er sieht beim Lesen aus wie eine Deckung, die es nicht gibt.

## Der Wächter

`tests/themeRemapEindeutig.test.ts` prüft zweierlei: **keine Regel zweimal**, und **keine Regel für eine Klasse ohne Nutzer**.

Dazu eine Gegenprobe gegen die eigene Lesart: das Klassen-Lesen muss mit der CSS-Maskierung zurechtkommen (`.bg-slate-950\/50`, `.hover\:bg-slate-700:hover`) — sonst zählt es Klassen, die es so nie gab, und meldet dann entweder Unsinn oder gar nichts.

**Gegenproben gefahren:** doppelte Regel → rot · Klasse ohne Nutzer → rot.

## Was die Messung sonst ergab

Beide TODO-Zeilen waren überholt — im Audit nachgetragen statt stehengelassen:

| TODO sagte | Gemessen 2026-09-10 |
| --- | --- |
| Glas-Flächen `bg-slate-950/95`, `bg-slate-900/80`, `bg-slate-950/40` | Die ersten beiden gibt es **gar nicht mehr**; übrig sind 11 Stellen |
| „Opacity-Varianten-Liste schrumpfen" | 207 Regeln, **204 mit echten Nutzern** — die Liste ist nicht das Problem, das sie 2026-06 war |

Offen bleibt der eigentliche Umbau auf Tokens. Die verbliebenen Regeln decken die `isLight`-Canvas-/Print-Komponenten ab, die pro Theme **manuell** unterschiedliche Shades wählen und sich deshalb nicht auf einen auto-kippenden Token abbilden lassen — das ist derselbe Umbau wie der letzte Phase-2-Punkt (`CableEdge`/`CanvasToolbar`/`EquipmentNode`) und gehört mit ihm zusammen gemacht.

## Verifikation

- `npx tsc -p tsconfig.app.json --noEmit` → 0
- `npm run lint` → 0 Errors (12 Warnungen, alle pre-existing)
- `npm test` → **3854 grün**, 2 skipped
- `ui:smoke` / `ui:overflow` / `ui:labels` / `ui:targets` → je **0 Befunde** (`ui:overflow` prüft dabei 15 Dialoge)
- `npm run build` → grün
- Light-Theme im echten Fenster gemessen, vorher/nachher identisch

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_