### PR TITLE
canvas: Werkzeugleiste und Kabel-Label auf die Marken-Palette — und ein TODO, das ein Feature gelöscht hätte

### DIFF
--- a/docs/ui-audit.md
+++ b/docs/ui-audit.md
@@ -295,8 +295,34 @@ Inline-Fallback in `ErrorBoundary`). → Token-Schicht einführen.
       Theme **manuell** unterschiedliche Shades wählen und sich deshalb
       nicht auf einen auto-kippenden Token abbilden lassen. Das ist derselbe
       Umbau wie der nächste Punkt und gehört mit ihm zusammen gemacht.
-- [ ] Inline-Style-Komponenten (`CableEdge`, `CanvasToolbar`,
-      `EquipmentNode`) auf `var(--cp-*)` statt `canvasTheme`-Branching.
+- [x] Inline-Style-Komponenten auf `var(--cp-*)` statt
+      `canvasTheme`-Branching — **erledigt 2026-09-10 für `CanvasToolbar`
+      und `CableEdge`.** Die Werkzeugleiste lief als einzige Fläche noch auf
+      Tailwind-Schiefer (`#0f172a`, `#1e293b`, `#cbd5e1`), während die App
+      seit ADR-007 auf Zumpe Navy läuft; jede Farbänderung am Haus ging an
+      ihr vorbei. `isLight`-Verzweigungen: `CanvasToolbar` 18 → 2 (Deklaration
+      + Schlagschatten, der pro Theme legitim anders ist), `CableEdge` 11 → 5
+      (nur noch Durchreichen an Unterkomponenten).
+      Nachgemessen im echten Fenster in **beiden** Themes: dunkel
+      `#182948`/92 % auf `#e1ecef`, hell `#ffffff`/92 % auf `#1d324f`.
+      `color-mix` löst in Electron 42 (Chromium 140) auf, und `var(--cp-*)`
+      gilt auch beim PDF-Export, weil `App.tsx`
+      `document.documentElement.dataset.theme` auf
+      `pdfExportThemeOverride ?? canvasTheme` setzt.
+      **Zwei Sorten Farbe bleiben fest, und das ist keine Restarbeit:**
+      Zustands-Farben (`btnActiveBg` blau, der Lila-Rand „vom Handy
+      dazugekommen") sagen *was ist*, nicht *worauf es liegt* — sie dürfen
+      mit dem Theme nicht kippen. `--cp-accent` ist im Dunkel-Theme
+      Off-White; ein aktiver Knopf würde damit weiß statt blau.
+
+      **`EquipmentNode` gehört NICHT auf diese Liste — der TODO war falsch.**
+      Seine Farben sind keine Theme-Tokens, sondern **Nutzer-Daten**: #307
+      gibt in Einstellungen → Darstellung je Theme Body/Header/Border/Text/
+      Subtext frei, `uiStore.equipmentColors.{light,dark}` hält sie, und
+      einzelne Geräte haben zusätzlich ihre eigene Farbe aus den Properties.
+      `var(--cp-*)` kann das nicht ausdrücken; wer diesen Punkt „abarbeitet",
+      löscht ein Feature. Dass die Zeile hier als offenes Kästchen stand,
+      hat genau diesen Griff eingeladen.
 
 ## Phase 3 — Accessibility
 

--- a/src/renderer/components/Canvas/CableEdge.tsx
+++ b/src/renderer/components/Canvas/CableEdge.tsx
@@ -978,18 +978,18 @@ export const CableEdge = ({
             style={{
               position: 'absolute',
               transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
-              background: isLight ? 'rgba(241,245,249,0.92)' : 'rgba(15,23,42,0.85)',
-              color: isLight ? '#1e293b' : '#e2e8f0',
+              // Marken-Palette statt Schiefer (Phase 2, 2026-09-10): die
+              // Kabel-Beschriftung schwimmt auf der Zeichenflaeche und war
+              // die letzte Stelle, die ihr eigenes Grau mitbrachte.
+              background: 'color-mix(in srgb, var(--cp-surface-1) 90%, transparent)',
+              color: 'var(--cp-text)',
               // v7.9.56 — Mobil-hinzugefügte Kabel kriegen einen lila
               // Border statt slate, damit der Planer sie schon ohne das
               // 📱-Symbol im Text auf den ersten Blick erkennt.
-              border: `1px solid ${
-                cable?.addedFromMobile
-                  ? '#a855f7'
-                  : isLight
-                    ? '#94a3b8'
-                    : '#475569'
-              }`,
+              // Das Lila bleibt eine ZUSTANDS-Farbe und keine Flaeche: es
+              // sagt „vom Handy dazugekommen" und darf mit dem Theme nicht
+              // kippen. Nur der Normalfall geht auf die Palette.
+              border: `1px solid ${cable?.addedFromMobile ? '#a855f7' : 'var(--cp-text-faint)'}`,
               boxShadow: cable?.addedFromMobile
                 ? '0 0 0 1px rgba(168,85,247,0.25)'
                 : undefined,
@@ -1059,9 +1059,9 @@ export const CableEdge = ({
           const targetEndLabel = `← ${effectiveShortName(fromEq)} · ${fromPort.name}`
           const endpointStyle = {
             position: 'absolute' as const,
-            background: isLight ? 'rgba(241,245,249,0.85)' : 'rgba(15,23,42,0.78)',
-            color: isLight ? '#475569' : '#94a3b8',
-            border: `1px dashed ${isLight ? '#cbd5e1' : '#475569'}`,
+            background: 'color-mix(in srgb, var(--cp-surface-1) 85%, transparent)',
+            color: 'var(--cp-text-muted)',
+            border: '1px dashed var(--cp-border)',
             padding: '1px 4px',
             borderRadius: 3,
             fontSize: 9,

--- a/src/renderer/components/Canvas/CanvasToolbar.tsx
+++ b/src/renderer/components/Canvas/CanvasToolbar.tsx
@@ -264,19 +264,41 @@ export const CanvasToolbar = ({ mode = 'main' }: { mode?: CanvasToolbarMode } = 
     commitPositions(newPositionById)
   }
 
-  // v7.9.5 — Unified design tokens für die Toolbar.
+  /**
+   * v7.9.5 — Unified design tokens fuer die Toolbar.
+   *
+   * SEIT 2026-09-10 AUF DER MARKEN-PALETTE statt auf Schiefer (Phase 2 der
+   * UI-Pruefung). Die Werte standen vorher als Paare hier, je einer pro
+   * Theme, und waren Tailwind-Slate: `#0f172a`, `#1e293b`, `#cbd5e1`. Die
+   * uebrige App laeuft seit ADR-007 auf Zumpe Navy — die Werkzeugleiste war
+   * damit die einzige Flaeche, die sichtbar aus der Palette fiel, und jede
+   * Farbaenderung am Haus ging an ihr vorbei.
+   *
+   * `var(--cp-*)` loest hier richtig auf, auch beim PDF-Export: `App.tsx`
+   * setzt `document.documentElement.dataset.theme` auf
+   * `pdfExportThemeOverride ?? canvasTheme`, das Attribut traegt also
+   * waehrend des Exports das Export-Theme. Nachgemessen in beiden Themes im
+   * echten Fenster.
+   *
+   * ZWEI STELLEN BLEIBEN ABSICHTLICH FEST:
+   *   `btnActiveBg`/`btnActiveText` sind eine ZUSTANDS-Farbe, keine
+   *   Flaeche — sie sagen „dieser Knopf ist an". `--cp-accent` ist im
+   *   Dunkel-Theme Off-White (#F6F5F0); ein aktiver Knopf wuerde damit
+   *   weiss statt blau, und das ist eine andere Entscheidung als „auf die
+   *   Palette heben".
+   */
   const T: ToolbarTokens = {
     // #463 — groessere Touch-/Klick-Ziele (war 28px, < komfortable Zielgroesse).
     iconBtnSize: 32,
-    bg: isLight ? 'rgba(248,250,252,0.92)' : 'rgba(15,23,42,0.92)',
-    border: isLight ? '#cbd5e1' : '#1f2937',
-    text: isLight ? '#1e293b' : '#e2e8f0',
-    textMuted: isLight ? '#64748b' : '#94a3b8',
+    bg: 'color-mix(in srgb, var(--cp-surface-1) 92%, transparent)',
+    border: 'var(--cp-border)',
+    text: 'var(--cp-text)',
+    textMuted: 'var(--cp-text-muted)',
     btnBg: 'transparent',
-    btnBgHover: isLight ? 'rgba(15,23,42,0.06)' : 'rgba(148,163,184,0.12)',
+    btnBgHover: 'color-mix(in srgb, var(--cp-text) 8%, transparent)',
     btnActiveBg: '#0284c7',
     btnActiveText: '#ffffff',
-    dividerColor: isLight ? '#e2e8f0' : '#1f2937',
+    dividerColor: 'var(--cp-border-muted)',
   }
   const dividerStyle: React.CSSProperties = {
     width: 1,
@@ -412,7 +434,6 @@ export const CanvasToolbar = ({ mode = 'main' }: { mode?: CanvasToolbarMode } = 
         setCableColorMode={setCableColorMode}
         showLengthLegend={showLengthLegend}
         setShowLengthLegend={setShowLengthLegend}
-        isLight={isLight}
       />
 
       <span style={dividerStyle} />
@@ -590,7 +611,7 @@ export const CanvasToolbar = ({ mode = 'main' }: { mode?: CanvasToolbarMode } = 
             style={{
               width: 140,
               height: T.iconBtnSize - 4,
-              background: isLight ? '#ffffff' : '#0f172a',
+              background: 'var(--cp-surface-3)',
               border: `1px solid ${T.border}`,
               color: T.text,
               padding: '0 6px',
@@ -828,7 +849,7 @@ export const CanvasToolbar = ({ mode = 'main' }: { mode?: CanvasToolbarMode } = 
           padding: '0 10px',
           background:
             projectMode === 'viewer'
-              ? (isLight ? '#e2e8f0' : '#1e293b')
+              ? 'var(--cp-surface-2)'
               : projectMode === 'finalized'
                 ? '#0e7490'
                 : T.btnBg,
@@ -972,7 +993,7 @@ export const CanvasToolbar = ({ mode = 'main' }: { mode?: CanvasToolbarMode } = 
                   height: 3,
                   background: r.color,
                   borderRadius: 2,
-                  border: `1px solid ${isLight ? '#94a3b8' : '#475569'}`,
+                  border: '1px solid var(--cp-text-faint)',
                   ...(r.dashArray
                     ? { backgroundImage: `repeating-linear-gradient(90deg,${r.color} 0 6px,transparent 6px 10px)`, backgroundColor: 'transparent' }
                     : {}),
@@ -1025,7 +1046,6 @@ const DefaultsMenu = ({
   setCableColorMode,
   showLengthLegend,
   setShowLengthLegend,
-  isLight,
 }: {
   T: {
     iconBtnSize: number
@@ -1055,7 +1075,6 @@ const DefaultsMenu = ({
   setCableColorMode: (v: 'manual' | 'byLength' | 'byLayer') => void
   showLengthLegend: boolean
   setShowLengthLegend: (v: boolean) => void
-  isLight: boolean
 }) => {
   const t = useTranslation()
   const [open, setOpen] = useState(false)
@@ -1151,7 +1170,7 @@ const DefaultsMenu = ({
                 style={{
                   flex: 1,
                   padding: 4,
-                  background: defaultRouting === opt.value ? T.btnActiveBg : (isLight ? '#f1f5f9' : '#1e293b'),
+                  background: defaultRouting === opt.value ? T.btnActiveBg : 'var(--cp-surface-2)',
                   color: defaultRouting === opt.value ? T.btnActiveText : T.text,
                   border: '1px solid transparent',
                   borderRadius: 4,
@@ -1174,7 +1193,7 @@ const DefaultsMenu = ({
               style={{
                 flex: 1,
                 padding: 4,
-                background: cableColorMode === 'manual' ? T.btnActiveBg : (isLight ? '#f1f5f9' : '#1e293b'),
+                background: cableColorMode === 'manual' ? T.btnActiveBg : 'var(--cp-surface-2)',
                 color: cableColorMode === 'manual' ? T.btnActiveText : T.text,
                 border: '1px solid transparent',
                 borderRadius: 4,
@@ -1190,7 +1209,7 @@ const DefaultsMenu = ({
               style={{
                 flex: 1,
                 padding: 4,
-                background: cableColorMode === 'byLength' ? T.btnActiveBg : (isLight ? '#f1f5f9' : '#1e293b'),
+                background: cableColorMode === 'byLength' ? T.btnActiveBg : 'var(--cp-surface-2)',
                 color: cableColorMode === 'byLength' ? T.btnActiveText : T.text,
                 border: '1px solid transparent',
                 borderRadius: 4,
@@ -1207,7 +1226,7 @@ const DefaultsMenu = ({
                 title={t('toolbar.defaults.cableColor.legend', 'Show length-colour legend')}
                 style={{
                   padding: '4px 6px',
-                  background: isLight ? '#f1f5f9' : '#1e293b',
+                  background: 'var(--cp-surface-2)',
                   color: T.textMuted,
                   border: '1px solid transparent',
                   borderRadius: 4,


### PR DESCRIPTION
Letzter offener Phase-2-Punkt aus `docs/ui-audit.md` — teils erledigt, teils als **falsch** benannt.

## Was umgestellt ist

Die Werkzeugleiste lief als einzige Fläche noch auf Tailwind-Schiefer (`#0f172a`, `#1e293b`, `#cbd5e1`), während die App seit ADR-007 auf Zumpe Navy läuft. Sie fiel damit sichtbar aus der Palette, und **jede Farbänderung am Haus ging an ihr vorbei**. Dasselbe bei der Kabel-Beschriftung auf der Zeichenfläche.

| Datei | `isLight`-Verzweigungen |
| --- | --- |
| `CanvasToolbar` | 18 → **2** |
| `CableEdge` | 11 → **5** |

Die zwei in der Toolbar sind die Deklaration und der Schlagschatten, der pro Theme legitim anders ist (es gibt keinen Schatten-Token). Die fünf in `CableEdge` sind nur noch Durchreichen an Unterkomponenten.

Dabei fiel ein Prop weg, den die Unterkomponente nach der Umstellung nicht mehr liest — `noUnusedParameters` hat ihn gemeldet.

## Zwei Sorten Farbe bleiben fest, und das ist keine Restarbeit

Zustands-Farben sagen **was ist**, nicht **worauf es liegt**: das Blau des aktiven Knopfs und der lila Rand „vom Handy dazugekommen" dürfen mit dem Theme nicht kippen. `--cp-accent` ist im Dunkel-Theme Off-White — ein aktiver Knopf würde damit weiß statt blau, und das wäre eine andere Entscheidung als „auf die Palette heben".

## `EquipmentNode` gehört nicht auf diese Liste — der TODO war falsch

Seine Farben sind **keine Theme-Tokens, sondern Nutzer-Daten**: #307 gibt in Einstellungen → Darstellung je Theme Body/Header/Border/Text/Subtext frei, `uiStore.equipmentColors.{light,dark}` hält sie, und einzelne Geräte haben zusätzlich ihre eigene Farbe aus den Properties.

`var(--cp-*)` kann das nicht ausdrücken. **Wer diesen Punkt „abarbeitet", löscht ein Feature** — und dass die Zeile als offenes Kästchen dastand, hat genau diesen Griff eingeladen. Der Grund steht jetzt im Audit, nicht bloß der Haken.

## Verifikation im echten Fenster, in beiden Themes

Über die Einstellungen umgeschaltet wie ein Nutzer, dann die gerechneten Farben ausgelesen:

| Theme | Leiste | Text | Rand |
| --- | --- | --- | --- |
| dunkel | `color(srgb .094 .161 .282 / .92)` = `#182948` | `#e1ecef` | `rgba(246,245,240,0.14)` |
| hell | `color(srgb 1 1 1 / .92)` | `#1d324f` | `rgba(29,50,79,0.16)` |

`color-mix` löst in Electron 42 (Chromium 140) auf. Und `var(--cp-*)` gilt auch **beim PDF-Export**: `App.tsx` setzt `document.documentElement.dataset.theme` auf `pdfExportThemeOverride ?? canvasTheme`, das Attribut trägt während des Exports also das Export-Theme — die Tokens folgen dorthin, wo `isLight` vorher hinschaute.

- `npx tsc -p tsconfig.app.json --noEmit` → 0
- `npm run lint` → 0 Errors (12 Warnungen, alle pre-existing)
- `npm test` → 3854 grün, 2 skipped
- `ui:smoke` / `ui:overflow` / `ui:labels` / `ui:targets` → je 0 Befunde
- `npm run build` → grün

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_