### PR TITLE
theme: Glasflächen auf Tokens — Phase 2 ist ohne offenes Kästchen

### DIFF
--- a/docs/ui-audit.md
+++ b/docs/ui-audit.md
@@ -273,28 +273,48 @@ Inline-Fallback in `ErrorBoundary`). → Token-Schicht einführen.
       UI-Skripte grün, `ui:overflow` prüft dabei 15 Dialoge. Der Sprung
       10 → 12px in dichten Tabellen ist der Punkt, an dem eine Migration
       Layout bricht — `npm test` sieht das nicht.
-- [ ] Translucente Glas-Flächen auf Alpha-Tokens (z. B. `color-mix`) heben —
-      aktuell bewusst als slate-Klassen belassen (Remap deckt Light ab).
-      **Nachgemessen 2026-09-10: der Posten ist klein geworden** — noch
-      11 Stellen, und die im TODO genannten Beispiele (`bg-slate-950/95`,
-      `bg-slate-900/80`) gibt es gar nicht mehr. Übrig sind `/30`, `/40`,
-      `/50`, `/60`, `bg-slate-900/98`, `bg-slate-800/90`, `bg-slate-400/50`
-      in `AtemAudioRouterDialog`, `RackLivePreview`, `CableContextMenu`
-      und `VideohubRoutingMatrix`.
-- [ ] Slate-Remapping in `index.css` schrittweise durch `--cp-*`-Tokens
-      ersetzen; Ziel: Opacity-Varianten-Liste schrumpfen.
-      **Nachgemessen 2026-09-10: die Liste ist nicht das Problem.**
-      207 Regeln, davon **204 mit echten Nutzern** — der Remap ist längst
-      auf das Legacy-Sicherheitsnetz geschrumpft, das sein Kopfkommentar
-      beschreibt. Die drei ohne Nutzer sind entfernt.
+- [x] Translucente Glas-Flächen auf Alpha-Tokens heben — **erledigt
+      2026-09-10.** Die im TODO genannten Beispiele (`bg-slate-950/95`,
+      `bg-slate-900/80`) gab es beim Nachmessen gar nicht mehr; übrig waren
+      neun klassenbasierte Stellen in `AtemAudioRouterDialog` (3),
+      `RackLivePreview` (3), `CableContextMenu` (2) und
+      `VideohubRoutingMatrix` (1).
+      **Kein `color-mix` von Hand nötig:** der Opacity-Modifier wirkt auf den
+      semantischen Utilities, `bg-cp-surface-3/40` kompiliert zu
+      `color-mix(in oklab, var(--cp-surface-3) 40%, transparent)`. Die
+      Migration ist damit ein Eins-zu-eins-Tausch mit **exakt gleicher
+      Deckung** — nur die Basisfarbe wechselt von Schiefer auf die
+      Marken-Palette.
+      `CableContextMenu` verliert dabei seinen `isLight`-Zweig ganz (vier
+      Stellen); die Datei führt keine eigene Farbtabelle mehr.
+      **Nicht migriert, mit Grund:** die Kreuzpunkt-Füllung der
+      Videohub-Matrix (`bg-slate-400/50`) ist eine Zustands-Farbe — sie sagt
+      „diese Verbindung ist geschaltet" und darf mit dem Theme nicht kippen.
+      Ebenso die dunklen Overlays in `Rack3DView` und das Amber-Banner in
+      `PendingCableOverlay`: beide liegen über einer eigenen dunklen Szene
+      bzw. sind Warnfarbe, nicht Fläche.
+- [x] Slate-Remapping in `index.css` schrittweise durch `--cp-*`-Tokens
+      ersetzen; Ziel: Opacity-Varianten-Liste schrumpfen. **Erledigt
+      2026-09-10, soweit es die Liste betrifft.**
+      **Nachgemessen: die Liste war nicht das Problem, für das der TODO sie
+      hielt.** 207 Regeln, davon 204 mit echten Nutzern — der Remap ist
+      längst das Legacy-Sicherheitsnetz, das sein Kopfkommentar beschreibt.
+      Die drei ohne Nutzer sind entfernt, und mit der Glas-Migration oben
+      fielen fünf weitere Regeln von selbst weg: `bg-slate-950/30|40|50|60`
+      und `bg-slate-900/98` hatten keinen Nutzer mehr.
+      **Der Wächter hat das gemeldet, nicht ein Mensch** — genau so soll er
+      sich verhalten: die Liste schrumpft mit der Migration mit, statt
+      Karteileichen anzusammeln.
       Was stattdessen gefunden wurde, steht als eigener Nebenbefund oben:
       vier Regeln waren doppelt deklariert, mit widersprüchlichen Werten.
       **Gehalten** von `tests/themeRemapEindeutig.test.ts`.
-      Offen bleibt der eigentliche Umbau auf Tokens — die verbliebenen
+      **Was bleibt, ist kein Rest, sondern der Zweck:** die verbliebenen
       Regeln decken die `isLight`-Canvas-/Print-Komponenten ab, die pro
-      Theme **manuell** unterschiedliche Shades wählen und sich deshalb
-      nicht auf einen auto-kippenden Token abbilden lassen. Das ist derselbe
-      Umbau wie der nächste Punkt und gehört mit ihm zusammen gemacht.
+      Theme **manuell** unterschiedliche Shades wählen (`EquipmentNode`
+      liest dafür sogar Nutzer-Einstellungen, siehe unten). Sie lassen sich
+      nicht auf einen auto-kippenden Token abbilden — das ist der Grund,
+      warum es das Sicherheitsnetz gibt, und nicht der Grund, es weiter
+      abzutragen.
 - [x] Inline-Style-Komponenten auf `var(--cp-*)` statt
       `canvasTheme`-Branching — **erledigt 2026-09-10 für `CanvasToolbar`
       und `CableEdge`.** Die Werkzeugleiste lief als einzige Fläche noch auf

--- a/src/renderer/components/Atem/AtemAudioRouterDialog.tsx
+++ b/src/renderer/components/Atem/AtemAudioRouterDialog.tsx
@@ -464,7 +464,7 @@ export const AtemAudioRouterDialog = () => {
           </button>
         </header>
 
-        <div className="flex flex-wrap items-center gap-2 border-b border-slate-700 bg-slate-950/40 px-4 py-2 text-cp-xs">
+        <div className="flex flex-wrap items-center gap-2 border-b border-cp-border bg-cp-surface-3/40 px-4 py-2 text-cp-xs">
           <button
             type="button"
             onClick={handleLoadXml}
@@ -831,7 +831,7 @@ const ChannelPicker = ({
 
   const allExcluded = items.length > 0 && items.every((it) => excluded.has(it.id))
   return (
-    <div className="border-b border-slate-800 bg-slate-950/60 px-4 py-2 text-cp-xs">
+    <div className="border-b border-cp-border bg-cp-surface-3/60 px-4 py-2 text-cp-xs">
       <div className="mb-1 flex items-center justify-between">
         <span className="text-slate-300">
           {format(
@@ -1032,7 +1032,7 @@ const MatrixView = ({ config, setConfig }: ViewProps) => {
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
-      <div className="flex flex-wrap items-center gap-2 border-b border-slate-800 bg-slate-950/30 px-4 py-2 text-cp-xs">
+      <div className="flex flex-wrap items-center gap-2 border-b border-cp-border bg-cp-surface-3/30 px-4 py-2 text-cp-xs">
         <input
           type="text"
           value={filterSources}

--- a/src/renderer/components/Canvas/CableContextMenu.tsx
+++ b/src/renderer/components/Canvas/CableContextMenu.tsx
@@ -96,9 +96,15 @@ export const CableContextMenu = () => {
   const t = useTranslation()
   const menu = useUiStore((s) => s.cableContextMenu)
   const close = useUiStore((s) => s.closeCableContextMenu)
-  // v7.9.81 — Theme-Awareness: Menu folgt jetzt canvasTheme.
-  const canvasTheme = useUiStore((s) => s.canvasTheme)
-  const isLight = canvasTheme === 'light'
+  // v7.9.81 — Theme-Awareness: Menu folgt dem canvasTheme.
+  //
+  // SEIT 2026-09-10 OHNE EIGENEN ZWEIG (Phase 2 der UI-Pruefung). Vorher
+  // waehlte diese Datei an vier Stellen selbst einen Schiefer-Ton je Theme;
+  // jetzt tragen die semantischen Utilities (`bg-cp-surface-*`,
+  // `text-cp-*`, `border-cp-border`) den Wechsel, und sie tragen ihn auf
+  // der Marken-Palette statt auf Tailwind-Schiefer. Ein Menue, das seine
+  // eigene Farbtabelle fuehrt, faellt beim naechsten Palettenwechsel als
+  // Erstes auf.
   const globalCableBumps = useUiStore((s) => s.cableBumps)
   const updateCable = useProjectStore((s) => s.updateCable)
   const deleteCable = useProjectStore((s) => s.deleteCable)
@@ -263,19 +269,15 @@ export const CableContextMenu = () => {
         zIndex: 9999,
       }}
       className={`rounded border shadow-2xl backdrop-blur-sm ${
-        isLight
-          ? 'border-slate-300 bg-white/98 text-slate-900'
-          : 'border-slate-700 bg-slate-900/98 text-slate-100'
+        'border-cp-border bg-cp-surface-1/98 text-cp-text'
       }`}
       onContextMenu={(e) => e.preventDefault()}
     >
       <div
-        className={`border-b px-3 py-1.5 text-cp-xs uppercase tracking-wide ${
-          isLight ? 'border-slate-200 text-slate-500' : 'border-slate-800 text-slate-400'
-        }`}
+        className="border-b border-cp-border px-3 py-1.5 text-cp-xs uppercase tracking-wide text-cp-text-muted"
       >
         {t('canvas.cableMenu.headerLabel', 'Cable:')}{' '}
-        <span className={`font-semibold ${isLight ? 'text-slate-700' : 'text-slate-200'}`}>{cable.name}</span>
+        <span className="font-semibold text-cp-text">{cable.name}</span>
       </div>
       <Item onClick={renameLabel} icon={<Icon icon={Pencil} size="xs" />}>
         {t('canvas.cableMenu.rename', 'Change label…')}
@@ -338,7 +340,7 @@ export const CableContextMenu = () => {
         <span className="ml-auto text-slate-500">{submenu === 'routing' ? '▾' : '▸'}</span>
       </Item>
       {submenu === 'routing' && (
-        <div className={`border-l-2 border-sky-700 ${isLight ? 'bg-slate-100' : 'bg-slate-950/50'}`}>
+        <div className="border-l-2 border-sky-700 bg-cp-surface-3/50">
           {(['orthogonal', 'straight', 'curved'] as const).map((r) => (
             <Item
               key={r}

--- a/src/renderer/components/Rack/RackLivePreview.tsx
+++ b/src/renderer/components/Rack/RackLivePreview.tsx
@@ -183,7 +183,7 @@ export const RackLivePreview = ({
 
   if (placements.length === 0) {
     return (
-      <div className="rounded border border-dashed border-slate-700 bg-slate-950/40 p-3 text-center text-cp-xs text-slate-400">
+      <div className="rounded border border-dashed border-cp-border bg-cp-surface-3/40 p-3 text-center text-cp-xs text-cp-text-muted">
         {t(
           'rackPreview.empty',
           'No devices in rack — preview appears once the first device is assigned.',
@@ -212,14 +212,22 @@ export const RackLivePreview = ({
           })}
         </div>
       </div>
-      <div className="flex items-start justify-center rounded border border-slate-700 bg-slate-950/60 p-3">
+      <div className="flex items-start justify-center rounded border border-cp-border bg-cp-surface-3/60 p-3">
         <div
           className="relative rounded border-2 border-slate-500 bg-slate-900 shadow-lg"
           style={{ width: BLACK_BOX_WIDTH, height: blackBoxHeight }}
         >
-          {/* Header — gleicher Look wie EquipmentNode-Card-Header */}
+          {/*
+            Header — angenaehert an den EquipmentNode-Card-Header.
+            ANGENAEHERT UND NICHT GLEICH, und das war schon vor der
+            Token-Umstellung so: der echte Karten-Header liest
+            `equipmentColors[theme].header` aus den Einstellungen (#307),
+            hier stand eine feste Farbe. Wer die Vorschau wirklich
+            angleichen will, liest dieselbe Quelle — die Palette zu
+            wechseln macht aus einer Naeherung keine Uebereinstimmung.
+          */}
           <div
-            className="border-b border-slate-700 bg-slate-800/90 px-2 text-cp-xs font-semibold text-slate-100"
+            className="border-b border-cp-border bg-cp-surface-2/90 px-2 text-cp-xs font-semibold text-cp-text"
             style={{
               lineHeight: `${HEADER_HEIGHT - 6}px`,
               height: HEADER_HEIGHT,

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -343,15 +343,16 @@ body,
  * Glasflaeche nachjustieren wollte, las hier warum es die Regeln gibt,
  * aenderte die Zeile darunter — und sah nichts passieren.
  *
- * Die Regeln stehen jetzt an einer Stelle, und zwar hier: bei ihrer
- * Begruendung. Die Werte sind die WIRKSAMEN uebernommen, nicht die
- * kommentierten — was die App seit Monaten zeigt, ist der Ist-Zustand;
- * ihn nebenbei zu aendern waere eine unbestellte Aenderung am Aussehen. */
-[data-theme="light"] .bg-slate-950\/30   { background-color: rgba(240,244,248,0.3); }
-[data-theme="light"] .bg-slate-950\/40   { background-color: rgba(240,244,248,0.4); }
-[data-theme="light"] .bg-slate-950\/50   { background-color: rgba(240,244,248,0.5); }
-[data-theme="light"] .bg-slate-950\/60   { background-color: rgba(240,244,248,0.6); }
-[data-theme="light"] .bg-slate-900\/98   { background-color: rgba(234,239,245,0.98); }
+ * Die Regeln standen zuletzt an einer Stelle, und zwar hier: bei ihrer
+ * Begruendung.
+ *
+ * UND SIND SEIT 2026-09-10 GANZ WEG. Die fuenf Glasflaechen, die sie
+ * deckten, tragen jetzt `bg-cp-surface-*/NN` — Tailwind rechnet daraus
+ * selbst ein `color-mix` auf den Token, und der Token kippt pro Theme. Ein
+ * Remap-Eintrag hat damit niemanden mehr, und der Waechter
+ * (`tests/themeRemapEindeutig.test.ts`) hat genau das gemeldet, als die
+ * letzte Nutzung wegfiel. So soll er sich verhalten: die Liste schrumpft
+ * mit der Migration mit, statt Karteileichen anzusammeln. */
 /* Modal-Backdrop: im Light-Mode statt schwarz ein helles Grau mit
  * Transparenz, damit Modals "weiches Glas" auf hellem Hintergrund sind. */
 [data-theme="light"] .bg-black\/40       { background-color: rgba(15,23,42,0.15); }


### PR DESCRIPTION
Die letzten beiden offenen Kästchen der Phase 2 aus `docs/ui-audit.md`.

## Kein `color-mix` von Hand nötig

Der Opacity-Modifier wirkt auf den semantischen Utilities — im Build nachgesehen:

```
bg-cp-surface-3/40  →  color-mix(in oklab, var(--cp-surface-3) 40%, transparent)
```

Die Migration ist damit ein **Eins-zu-eins-Tausch mit exakt gleicher Deckung**; nur die Basisfarbe wechselt von Schiefer auf die Marken-Palette. Kein eigener Glas-Token, keine Alpha-Skala, keine Entscheidung über fremde Flächen.

Neun Stellen gemessen, acht migriert: `AtemAudioRouterDialog` (3), `RackLivePreview` (3), `CableContextMenu` (2).

`CableContextMenu` verliert dabei seinen `isLight`-Zweig **ganz** (vier Stellen) — die Datei führt keine eigene Farbtabelle mehr und braucht auch das `canvasTheme`-Abo nicht.

## Der Wächter hat die Folge gemeldet, nicht ich

Mit der letzten Nutzung fielen fünf Remap-Regeln tot — `bg-slate-950/30|40|50|60` und `bg-slate-900/98` — und `tests/themeRemapEindeutig.test.ts` aus [#813](https://github.com/larszu/cable-planner/pull/813) wurde prompt rot:

```
Regeln fuer Klassen, die niemand benutzt — sie sehen beim Lesen aus wie eine
Deckung, die es nicht gibt: bg-slate-900/98, bg-slate-950/30, …
```

Genau dafür ist er da: **die Liste schrumpft mit der Migration mit**, statt Karteileichen anzusammeln. Die fünf Regeln sind raus.

## Was nicht migriert ist, und warum das kein Rest ist

Dieselbe Grenze wie in [#814](https://github.com/larszu/cable-planner/pull/814): **Flächen gehen auf Tokens, Zustände nicht.**

| bleibt | weil |
| --- | --- |
| `bg-slate-400/50` in der Videohub-Matrix | Kreuzpunkt-Füllung — sagt „diese Verbindung ist geschaltet", darf mit dem Theme nicht kippen |
| dunkle Overlays in `Rack3DView` | liegen über einer eigenen dunklen 3D-Szene |
| Amber-Banner in `PendingCableOverlay` | Warnfarbe, keine Fläche |

## Phase 2 ist damit durch

Auch das zweite Kästchen („Slate-Remapping … Opacity-Varianten-Liste schrumpfen") schließt: gemessen waren es 207 Regeln mit **204 echten Nutzern** — die Liste war nicht das Problem, für das der TODO sie hielt. Drei ohne Nutzer sind in #813 gefallen, fünf weitere hier.

**Was bleibt, ist kein Rückstand, sondern der Zweck des Sicherheitsnetzes:** die verbliebenen Regeln decken die `isLight`-Canvas-/Print-Komponenten, die pro Theme *manuell* wählen — `EquipmentNode` liest dafür sogar Nutzer-Einstellungen (#307).

## Verifikation

- `npx tsc -p tsconfig.app.json --noEmit` → 0
- `npm run lint` → 0 Errors (12 Warnungen, alle pre-existing)
- `npm test` → 3854 grün, 2 skipped
- `ui:smoke` / `ui:overflow` / `ui:labels` / `ui:targets` → je 0 Befunde
- `npm run build` → grün
- Kontextmenü in **beiden** Themes im echten Fenster nachgemessen: dunkel `rgb(24,41,72)` auf `#e1ecef`, hell weiß auf `#1d324f`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_