### PR TITLE
i18n: Mobile-Ansicht und Viewer übersetzt, lang:check deckt alle drei Browser-Ordner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,18 @@ Pfad-Validierung passiert **immer in main**, nie im Renderer.
   Sätze NIE aus mehreren `t()`-Aufrufen zusammensetzen: die Wortstellung
   gehört zur Sprache. Ein Schlüssel, ein ganzer Satz, Platzhalter über
   `format()`.
+  **`src/mobile` und `src/viewer` haben ein EIGENES, kleines Wörterbuch**
+  (`src/mobile/i18n.ts`, `src/viewer/i18n.ts`) über dem gemeinsamen Werk in
+  `src/renderer/lib/i18nLite.ts`. Grund ist die Größe: `lib/i18n.ts`
+  importiert `de.ts` statisch (316 KB), der Mobile-Chunk ist 72 kB und wird
+  über das Hallen-WLAN auf ein Telefon geladen. Wer dort `lib/i18n`
+  importiert — auch mittelbar über ein Hilfsmodul — vervierfacht die Seite;
+  `tests/i18nEintrittspunkte.test.ts` folgt dem Importgraphen und sagt es.
+  Die Sprache kommt dort aus `navigator.language`, nicht aus dem
+  `uiStore` des Desktops.
+  **`npm run lang:check` deckt alle drei Browser-Ordner ab.** Der Umfang ist
+  keine Liste: derselbe Test liest die Ordner aus `tsconfig.app.json` und
+  besteht darauf, dass jeder im Skript vorkommt.
 - **Theming (#449):** neue Komponenten nutzen die semantischen Farb-Utilities
   (`bg-cp-surface-1/2/3`, `bg-cp-bg`, `border-cp-border(-muted)`,
   `text-cp-text/-secondary/-muted/-faint`, `(bg|text|border)-cp-accent/-warn/-danger`),

--- a/docs/ui-audit.md
+++ b/docs/ui-audit.md
@@ -439,12 +439,22 @@ Begründung. Wer hier nachschlug, hätte deutsche Fallbacks eingetragen und
 den Wächter gegen sich gehabt, ohne zu verstehen warum. Begründungen, die
 auf eine andere Datei zeigen, gehören deshalb datiert.
 
-**Offen und ausdrücklich nicht in diesem Schritt erledigt:** `lang:check`
-prüft nur `src/renderer` (siehe `package.json`). `src/mobile` ist
-durchgehend deutsch beschriftet („Nur lesen · Häkchen bleiben auf diesem
-Gerät…") und wird von keiner Sprachprüfung angefasst — dieselbe Ordner-Lücke
-wie bei der Typprüfung, nur für Sprache. Das ist ein eigener Schnitt (die
-Mobile-Ansicht hat keine `t()`-Verdrahtung), kein Nebenbei.
+**Erledigt am 2026-09-10:** `lang:check` prüft jetzt alle drei Ordner, die
+im Browser laufen — `src/renderer`, `src/mobile`, `src/viewer`. Gemessen:
+0 deutsche Fallbacks, 0 ungewickelte Zeichenketten in der jeweils anderen
+Sprache, in allen dreien.
+
+Die Lücke war real und groß: **63 deutsche Zeichenketten in `src/mobile`,
+12 in `src/viewer`** — beide Ordner ohne jede `t()`-Verdrahtung, beide von
+keiner Prüfung angefasst. Der Wächter stand an einer Tür von dreien und
+meldete „0 Verstöße"; dieselbe Form wie bei der Typprüfung, die `src/mobile`
+nicht ansah.
+
+**Der Umfang ist jetzt keine Liste mehr, sondern eine Regel.**
+`tests/i18nEintrittspunkte.test.ts` liest die Browser-Ordner aus
+`tsconfig.app.json` und besteht darauf, dass jeder davon im `lang:check`-
+Skript vorkommt. Wer einen vierten Eintrittspunkt anlegt, wird dort rot —
+nicht erst, wenn jemand eine halb übersetzte Seite meldet.
 
 ### Phase 4 — erledigt
 
@@ -461,7 +471,7 @@ Mobile-Ansicht hat keine `t()`-Verdrahtung), kein Nebenbei.
 
 ### TODO (großflächiger Rest)
 
-- [ ] Flächendeckende Suche nach restlichen hartkodierten JSX-Texten /
+- [x] Flächendeckende Suche nach restlichen hartkodierten JSX-Texten /
       `placeholder` / `title` ohne `t()`.
       **2026-09-10, erster Schnitt: `src/renderer` ist sauber.** Der
       CableDialog trug fünf deutsche Roh-Beschriftungen („Kabel bearbeiten",
@@ -474,11 +484,37 @@ Mobile-Ansicht hat keine `t()`-Verdrahtung), kein Nebenbei.
       hatte die Zeilen gesehen und als „unklar" abgelegt. Die Liste trägt
       jetzt auch Inhaltswörter, gemessen gegen alle 4622 englischen Fallbacks:
       **kein einziger** würde durch sie fälschlich als deutsch gelten.
-      **Offen:** `src/viewer` (7 Stellen) und `src/mobile` (34) — beide haben
-      gar keine `t()`-Verdrahtung, und `lang:check` läuft nur auf
-      `src/renderer`. Jeder Ordner ist ein eigener Schnitt: erst verdrahten,
-      dann in den Prüfumfang aufnehmen. Der Umfang wächst mit der Migration
-      mit, statt eine Deckung zu behaupten, die es nicht gibt.
+      **2026-09-10, zweiter Schnitt: `src/mobile` und `src/viewer` sind
+      ebenfalls sauber.** Gemessen waren es nicht 34 und 7, sondern **63 und
+      12** — die frühere Zahl stammte aus einer Suche über Umlaute, die
+      kurze Beschriftungen ohne Umlaut („Von Port", „Plan read-only") nicht
+      sah. Beide Ordner sind verdrahtet und übersetzt; `lang:check` deckt sie
+      jetzt ab (siehe Phase 3).
+
+      **Sie bekommen ein eigenes, kleines Wörterbuch — mit Grund.**
+      `renderer/lib/i18n.ts` importiert `de.ts` statisch: 316 KB, 5276
+      Schlüssel. Der Mobile-Chunk ist 57 KB groß und wird über das
+      Hallen-WLAN auf ein Telefon geladen. Ein Import von dort hätte die
+      Seite vervierfacht, damit ein Handy Zeichenketten lädt, die es nie
+      zeigt. Das Werk (`spracheAusBrowser`, `format`) steht deshalb einmal in
+      `renderer/lib/i18nLite.ts`, die Wörterbücher je Seite in
+      `src/mobile/i18n.ts` (169 Schlüssel) und `src/viewer/i18n.ts` (33).
+      Gemessene Kosten: Mobile-Chunk 57 → 72 kB, Viewer 15,8 kB.
+      `tests/i18nEintrittspunkte.test.ts` folgt den Importen beider Seiten
+      durch den ganzen Baum und fällt, wenn `lib/i18n` wieder hereinkommt —
+      auch mittelbar über ein Hilfsmodul.
+
+      **Was `lang:check` NICHT sehen kann, und was deshalb dazukam:** ein
+      fehlender Schlüssel im Wörterbuch zeigt den englischen Fallback, und
+      der ist eine regelkonforme Zeichenkette. Gefunden wurde genau so ein
+      Fall nur, weil die gebaute Seite mit deutscher Spracheinstellung im
+      Browser offen war: „.cpviewer or .json" zwischen lauter deutschen
+      Zeilen, weil ich beim Eintragen geschätzt hatte, die Zeile sei in
+      beiden Sprachen gleich. Derselbe Test besteht jetzt darauf, dass jeder
+      benutzte Schlüssel entweder übersetzt oder in einer kurzen Liste
+      ausdrücklich als „in beiden Sprachen gleich" erklärt ist (heute sechs
+      Einträge: „Plan", „Name", „Problem", „optional…", „Name (optional)",
+      „📶 Remote").
 - [ ] In-`t()`-String-Glyphen aus Phase 1 (`⚠`/`✓`/`✕` in `cable.warn.*`,
       `bom.cable.missingTypes`, „✕ Reset" etc.) extrahieren + Icon im JSX.
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "build:preload": "tsc -p tsconfig.preload.json",
     "build:renderer": "vite build",
     "lint": "eslint .",
-    "lang:check": "node scripts/quellsprache.mjs src/renderer en",
+    "lang:check": "node scripts/quellsprache.mjs src/renderer en && node scripts/quellsprache.mjs src/mobile en && node scripts/quellsprache.mjs src/viewer en",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src/mobile/MobileApp.tsx
+++ b/src/mobile/MobileApp.tsx
@@ -43,12 +43,18 @@ import { portDisplayLabel } from '../renderer/lib/portLabel'
 import { keepScreenAwake } from '../renderer/lib/wakeLock'
 import type { CablePlannerProject } from '../renderer/types/project'
 import { PatternWalk } from './PatternWalk'
+import { format, uebersetzer } from './i18n'
 import { aenderungen, positionsKarte } from '../renderer/lib/rundownCard'
 import type { RundownPlan } from '../renderer/types/rundown'
 
 /** Deep-Link beim Laden: `?lookup=cable/C-0001` oder `#cable/C-0001` /
  *  `#C-0001`. Wird einmalig nach dem Projekt-Load aufgelöst und springt
  *  zum Element. Leerstring = kein Deep-Link. */
+// Ein Uebersetzer je Modul. Die Sprache kommt aus dem Telefon und wechselt
+// waehrend einer Sitzung nicht — ein Hook waere hier nur Zeremonie, und die
+// Klassen-freien Helfer weiter unten koennten ihn gar nicht rufen.
+const t = uebersetzer()
+
 const INITIAL_LOOKUP =
   typeof window !== 'undefined'
     ? window.location.hash.replace(/^#/, '') ||
@@ -311,13 +317,13 @@ const ProjectPicker = ({
       if (!info.ok) throw new Error(`share-info ${info.status}`)
       const meta = (await info.json()) as { ok: boolean; hasProject: boolean }
       if (!meta.ok || !meta.hasProject) {
-        throw new Error('Desktop teilt aktuell kein Projekt.')
+        throw new Error(t('mobile.err.noProject', 'The desktop is not sharing a project right now.'))
       }
       const res = await apiFetch('/project.json', { cache: 'no-store' })
       if (!res.ok) throw new Error(`project ${res.status}`)
       const data = (await res.json()) as CablePlannerProject
       if (!data || !Array.isArray(data.equipment)) {
-        throw new Error('Antwort hat falsches Format.')
+        throw new Error(t('mobile.err.badFormat', 'The response has the wrong format.'))
       }
       cacheProject(data)
       onLoad(data)
@@ -328,8 +334,14 @@ const ProjectPicker = ({
       } else {
         setReloadError(
           e instanceof Error
-            ? `Host nicht erreichbar (${e.message}). Datei wählen oder JSON einfügen.`
-            : 'Host nicht erreichbar.',
+            ? format(
+                t(
+                  'mobile.err.hostUnreachable',
+                  'Host unreachable ({error}). Choose a file or paste JSON.',
+                ),
+                { error: e.message },
+              )
+            : t('mobile.err.hostUnreachableShort', 'Host unreachable.'),
         )
       }
     } finally {
@@ -341,7 +353,12 @@ const ProjectPicker = ({
     try {
       const data = JSON.parse(text) as CablePlannerProject
       if (!data || !Array.isArray(data.equipment) || !Array.isArray(data.cables)) {
-        setError('Datei sieht nicht wie ein Cable-Planner-Projekt aus (fehlende equipment/cables).')
+        setError(
+          t(
+            'mobile.err.notAProject',
+            'This file does not look like a Cable Planner project (equipment/cables missing).',
+          ),
+        )
         return
       }
       onLoad(data)
@@ -355,7 +372,7 @@ const ProjectPicker = ({
     if (!file) return
     const reader = new FileReader()
     reader.onload = () => tryParse(typeof reader.result === 'string' ? reader.result : '')
-    reader.onerror = () => setError('Datei konnte nicht gelesen werden.')
+    reader.onerror = () => setError(t('mobile.err.fileUnreadable', 'The file could not be read.'))
     reader.readAsText(file)
     e.target.value = ''
   }
@@ -368,9 +385,12 @@ const ProjectPicker = ({
           Cable Planner — Mobile
         </h1>
         <p className="mt-1 text-xs text-cp-text-muted">
-          Hak Ports und Kabel ab während du sie steckst, oder trage fehlende
-          Patches direkt vor Ort nach. Alles syncht live zum Desktop. Offline
-          funktioniert auch — Häkchen werden beim Re-Connect übertragen.
+          {t(
+            'mobile.intro',
+            'Tick off ports and cables while you patch them, or add missing patches right ' +
+              'on site. Everything syncs live to the desktop. Offline works too — ticks are ' +
+              'transferred on reconnect.',
+          )}
         </p>
       </header>
       <button
@@ -380,15 +400,23 @@ const ProjectPicker = ({
         className="w-full rounded bg-emerald-700 px-3 py-3 text-sm font-semibold text-white hover:bg-emerald-600 disabled:opacity-50"
         title={
           cached
-            ? `Letztes Projekt vom Host laden — fallback auf Cache vom ${new Date(cached.cachedAt).toLocaleString()}`
-            : 'Aktuell auf dem Desktop geöffnetes Projekt laden'
+            ? format(
+                t(
+                  'mobile.reload.titleCached',
+                  'Load the latest project from the host — falls back to the cache from {time}',
+                ),
+                { time: new Date(cached.cachedAt).toLocaleString() },
+              )
+            : t('mobile.reload.title', 'Load the project currently open on the desktop')
         }
       >
         {reloading
-          ? '⏳ Lade…'
+          ? t('mobile.reload.busy', '⏳ Loading…')
           : cached
-            ? `↻ Projekt erneut laden (Cache: ${new Date(cached.cachedAt).toLocaleString()})`
-            : '↻ Projekt vom Desktop laden'}
+            ? format(t('mobile.reload.cached', '↻ Reload project (cache: {time})'), {
+                time: new Date(cached.cachedAt).toLocaleString(),
+              })
+            : t('mobile.reload.fresh', '↻ Load project from the desktop')}
       </button>
       {reloadError && (
         <div className="flex items-center gap-1.5 rounded border border-amber-700 bg-amber-900/30 p-2 text-cp-xs text-amber-200">
@@ -397,7 +425,7 @@ const ProjectPicker = ({
         </div>
       )}
       <div className="text-center text-cp-xs uppercase tracking-wider text-cp-text-faint">
-        oder
+        {t('mobile.or', 'or')}
       </div>
       <label className="block rounded border border-dashed border-cp-border bg-cp-surface-1 p-4 text-center text-sm text-cp-text-secondary">
         <input
@@ -406,7 +434,9 @@ const ProjectPicker = ({
           className="hidden"
           onChange={onFile}
         />
-        <span className="cursor-pointer">📂 Cable-Planner-Datei (.json) wählen…</span>
+        <span className="cursor-pointer">
+          {t('mobile.file.pick', '📂 Choose a Cable Planner file (.json)…')}
+        </span>
       </label>
       <div className="text-center">
         <button
@@ -414,7 +444,9 @@ const ProjectPicker = ({
           onClick={() => setPasteOpen((v) => !v)}
           className="text-xs text-cp-text-muted underline hover:text-cp-text"
         >
-          {pasteOpen ? 'Einfügen abbrechen' : 'Oder JSON einfügen…'}
+          {pasteOpen
+            ? t('mobile.paste.cancel', 'Cancel pasting')
+            : t('mobile.paste.open', 'Or paste JSON…')}
         </button>
       </div>
       {pasteOpen && (
@@ -431,7 +463,7 @@ const ProjectPicker = ({
             onClick={() => tryParse(pasted)}
             className="w-full rounded bg-cp-accent px-3 py-2 text-sm text-white hover:opacity-90"
           >
-            Projekt laden
+            {t('mobile.paste.load', 'Load project')}
           </button>
         </div>
       )}
@@ -778,9 +810,9 @@ const MobilePlanSvg = ({
       </svg>
       {/* #504 — Zoom-Buttons (für Geräte ohne Pinch und als sichtbarer Hinweis). */}
       <div className="absolute bottom-2 right-2 flex flex-col gap-1">
-        <button type="button" aria-label="Vergrößern" onClick={() => zoomButton(1.4)} className="h-9 w-9 rounded-full bg-cp-surface-3/90 text-lg font-bold text-cp-text shadow ring-1 ring-cp-border active:bg-cp-surface-4">+</button>
-        <button type="button" aria-label="Verkleinern" onClick={() => zoomButton(1 / 1.4)} className="h-9 w-9 rounded-full bg-cp-surface-3/90 text-lg font-bold text-cp-text shadow ring-1 ring-cp-border active:bg-cp-surface-4">−</button>
-        <button type="button" aria-label="Einpassen" onClick={() => zoomButton('fit')} className="h-9 w-9 rounded-full bg-cp-surface-3/90 text-base text-cp-text shadow ring-1 ring-cp-border active:bg-cp-surface-4">⤢</button>
+        <button type="button" aria-label={t('mobile.zoom.in', 'Zoom in')} onClick={() => zoomButton(1.4)} className="h-9 w-9 rounded-full bg-cp-surface-3/90 text-lg font-bold text-cp-text shadow ring-1 ring-cp-border active:bg-cp-surface-4">+</button>
+        <button type="button" aria-label={t('mobile.zoom.out', 'Zoom out')} onClick={() => zoomButton(1 / 1.4)} className="h-9 w-9 rounded-full bg-cp-surface-3/90 text-lg font-bold text-cp-text shadow ring-1 ring-cp-border active:bg-cp-surface-4">−</button>
+        <button type="button" aria-label={t('mobile.zoom.fit', 'Fit')} onClick={() => zoomButton('fit')} className="h-9 w-9 rounded-full bg-cp-surface-3/90 text-base text-cp-text shadow ring-1 ring-cp-border active:bg-cp-surface-4">⤢</button>
       </div>
     </div>
   )
@@ -899,7 +931,7 @@ const PortList = ({
                   {cable && otherDevice && (
                     <span className="mt-1 block rounded bg-cp-accent/60 px-2 py-1 text-xs text-cp-accent">
                       <span className="text-cp-xs uppercase tracking-wide text-cp-accent/80">
-                        → geht zu
+                        {t('mobile.port.goesTo', '→ goes to')}
                       </span>
                       <span className="ml-1 font-semibold text-white">
                         {otherDevice.name}
@@ -917,14 +949,16 @@ const PortList = ({
                       )}
                       {bridgeNames.length > 0 && (
                         <span className="mt-0.5 block text-cp-xs text-cp-accent/80">
-                          via {bridgeNames.join(' → ')}
+                          {format(t('mobile.port.via', 'via {path}'), {
+                            path: bridgeNames.join(' → '),
+                          })}
                         </span>
                       )}
                     </span>
                   )}
                   {cable && !otherDevice && (
                     <span className="mt-1 block text-cp-xs italic text-cp-text-faint">
-                      Offenes Ende
+                      {t('mobile.port.openEnd', 'Open end')}
                     </span>
                   )}
                 </span>
@@ -1011,7 +1045,7 @@ const QrFindOverlay = ({
         await v.play()
         raf = requestAnimationFrame(() => void tick())
       } catch (e) {
-        setCamError((e as Error).message || 'Kamera nicht verfügbar')
+        setCamError((e as Error).message || t('mobile.qr.camUnavailable', 'Camera unavailable'))
       }
     }
     void start()
@@ -1033,13 +1067,13 @@ const QrFindOverlay = ({
     <div className="fixed inset-0 z-50 flex flex-col bg-cp-bg/95 p-4">
       <div className="mb-3 flex items-center justify-between">
         <h2 className="flex items-center gap-2 text-sm font-semibold text-cp-text">
-          <Icon icon={QrCode} size="sm" /> QR / ID finden
+          <Icon icon={QrCode} size="sm" /> {t('mobile.qr.title', 'Find QR / ID')}
         </h2>
         <button
           type="button"
           onClick={onClose}
           className="rounded bg-cp-surface-3 p-1.5 text-cp-text-secondary hover:bg-cp-surface-4"
-          aria-label="Schließen"
+          aria-label={t('mobile.close', 'Close')}
         >
           <Icon icon={X} size="sm" />
         </button>
@@ -1057,9 +1091,11 @@ const QrFindOverlay = ({
         </div>
       ) : (
         <div className="mb-3 rounded border border-cp-border bg-cp-surface-1 px-3 py-2 text-cp-xs text-cp-text-muted">
-          Kamera-Scan hier nicht verfügbar (kein HTTPS/Secure-Context). Scanne das
-          Etikett mit der Kamera-App deines Geräts und füge den Code unten ein —
-          oder tippe die Kabel-/Asset-ID.
+          {t(
+            'mobile.qr.noScan',
+            'Camera scanning is unavailable here (no HTTPS/secure context). Scan the label ' +
+              'with your phone camera app and paste the code below — or type the cable/asset ID.',
+          )}
         </div>
       )}
 
@@ -1072,7 +1108,7 @@ const QrFindOverlay = ({
             if (e.key === 'Enter') submitText()
           }}
           autoFocus={!canScan}
-          placeholder="z.B. C-0001, A-0007 oder cableplanner://…"
+          placeholder={t('mobile.lookup.placeholder', 'e.g. C-0001, A-0007 or cableplanner://…')}
           className="flex-1 rounded border border-cp-border bg-cp-surface-1 px-2 py-2 text-sm text-cp-text"
         />
         <button
@@ -1080,7 +1116,7 @@ const QrFindOverlay = ({
           onClick={submitText}
           className="flex items-center gap-1 rounded bg-cp-accent px-3 py-2 text-xs text-white hover:opacity-90"
         >
-          <Icon icon={Search} size="sm" /> Finden
+          <Icon icon={Search} size="sm" /> {t('mobile.qr.find', 'Find')}
         </button>
       </div>
     </div>
@@ -1144,13 +1180,13 @@ const AblaufKarte = ({
   return (
     <div className="mt-2 space-y-2">
       <label className="block text-cp-xs text-cp-text-secondary">
-        <span className="mb-1 block">Mein Platz</span>
+        <span className="mb-1 block">{t('mobile.rundown.myPlace', 'My position')}</span>
         <select
           value={sourceId ?? ''}
           onChange={(e) => waehle(e.target.value || null)}
           className="w-full rounded border border-cp-border bg-cp-surface-1 px-2 py-1 text-xs text-cp-text"
         >
-          <option value="">— Position wählen —</option>
+          <option value="">{t('mobile.pos.choose', '— choose position —')}</option>
           {identities.map((i) => (
             <option key={i.id} value={i.id}>
               {i.name}
@@ -1161,8 +1197,11 @@ const AblaufKarte = ({
 
       {!sourceId && (
         <p className="text-cp-xs text-cp-text-muted">
-          Wähle deine Kameraposition. Ohne sie kann diese Ansicht nicht sagen, was DIR aufgetragen
-          ist — und eine Liste aller Aufträge wäre am Platz unbrauchbar.
+          {t(
+            'mobile.rundown.pickHint',
+            'Choose your camera position. Without it this view cannot say what YOU are ' +
+              'assigned — and a list of everyone else\'s assignments is useless on the floor.',
+          )}
         </p>
       )}
 
@@ -1170,20 +1209,29 @@ const AblaufKarte = ({
         <>
           <div className="rounded border border-cp-border-muted bg-cp-surface-1 px-2 py-1 text-cp-xs text-cp-text-muted">
             {karte.source}
-            {karte.revision ? ` · ${karte.revision}` : ''} · {karte.mitAuftrag}/
-            {karte.zeilen.length} mit Auftrag
+            {karte.revision ? ` · ${karte.revision}` : ''} ·{' '}
+            {format(t('mobile.rundown.withAssignment', '{done}/{total} with assignment'), {
+              done: karte.mitAuftrag,
+              total: karte.zeilen.length,
+            })}
           </div>
 
           {/* Der Balken. Er steht NUR da, wenn es einen Vergleichsstand gibt
               und wirklich etwas anders ist. */}
           {diff && !diff.unveraendert && (
             <div className="rounded border border-amber-500/50 bg-amber-500/10 px-2 py-1 text-cp-xs text-amber-200">
-              Seit deinem letzten Blick:{' '}
+              {t('mobile.rundown.sinceLast', 'Since your last look:')}{' '}
               {[
-                diff.geaendert > 0 ? `${diff.geaendert} geändert` : null,
-                diff.neu > 0 ? `${diff.neu} neu` : null,
-                diff.entfallen > 0 ? `${diff.entfallen} entfallen` : null,
-                diff.verschoben > 0 ? `${diff.verschoben} verschoben` : null,
+                diff.geaendert > 0
+                  ? format(t('mobile.rundown.changed', '{n} changed'), { n: diff.geaendert })
+                  : null,
+                diff.neu > 0 ? format(t('mobile.rundown.new', '{n} new'), { n: diff.neu }) : null,
+                diff.entfallen > 0
+                  ? format(t('mobile.rundown.dropped', '{n} dropped'), { n: diff.entfallen })
+                  : null,
+                diff.verschoben > 0
+                  ? format(t('mobile.rundown.moved', '{n} moved'), { n: diff.verschoben })
+                  : null,
               ]
                 .filter(Boolean)
                 .join(' · ')}
@@ -1195,14 +1243,16 @@ const AblaufKarte = ({
                 }}
                 className="ml-2 rounded bg-cp-surface-3 px-2 py-0.5 text-cp-text"
               >
-                gesehen
+                {t('mobile.rundown.seen', 'seen')}
               </button>
             </div>
           )}
           {!gesehen && (
             <p className="text-cp-xs text-cp-text-muted">
-              Noch kein Vergleichsstand auf diesem Gerät — beim ersten Blick gibt es nichts zu
-              markieren.{' '}
+              {t(
+                'mobile.rundown.noBaseline',
+                'No baseline on this device yet — there is nothing to mark on the first look.',
+              )}{' '}
               <button
                 type="button"
                 onClick={() => {
@@ -1211,7 +1261,7 @@ const AblaufKarte = ({
                 }}
                 className="rounded bg-cp-surface-3 px-2 py-0.5 text-cp-text"
               >
-                Diesen Stand merken
+                {t('mobile.rundown.rememberBaseline', 'Remember this revision')}
               </button>
             </p>
           )}
@@ -1233,9 +1283,15 @@ const AblaufKarte = ({
                       {z.segment.number ?? z.position}
                     </span>
                     <span className="text-xs text-cp-text">{z.segment.title}</span>
-                    {art === 'neu' && <span className="text-cp-xs text-amber-300">neu</span>}
+                    {art === 'neu' && (
+                      <span className="text-cp-xs text-amber-300">
+                        {t('mobile.rundown.tagNew', 'new')}
+                      </span>
+                    )}
                     {art === 'anders' && (
-                      <span className="text-cp-xs text-amber-300">geändert</span>
+                      <span className="text-cp-xs text-amber-300">
+                        {t('mobile.rundown.tagChanged', 'changed')}
+                      </span>
                     )}
                   </div>
                   {/* Kein Auftrag heisst NICHT „frei" — siehe
@@ -1244,7 +1300,9 @@ const AblaufKarte = ({
                   <div
                     className={`text-xs ${z.coverage ? 'text-cp-text' : 'text-cp-text-faint italic'}`}
                   >
-                    {z.coverage ? z.coverage.shot : 'kein Auftrag eingetragen'}
+                    {z.coverage
+                      ? z.coverage.shot
+                      : t('mobile.rundown.noShot', 'no assignment entered')}
                   </div>
                   {z.coverage?.note && (
                     <div className="text-cp-xs text-cp-text-muted">{z.coverage.note}</div>
@@ -1261,7 +1319,10 @@ const AblaufKarte = ({
                   key={`weg-${z.segmentId}`}
                   className="rounded border border-cp-danger/40 bg-cp-surface-1 px-2 py-1 text-cp-xs text-cp-danger line-through"
                 >
-                  entfallen: {gesehen?.segments.find((s) => s.id === z.segmentId)?.title ?? z.segmentId}
+                  {format(t('mobile.rundown.droppedItem', 'dropped: {title}'), {
+                    title:
+                      gesehen?.segments.find((s) => s.id === z.segmentId)?.title ?? z.segmentId,
+                  })}
                 </li>
               ))}
           </ul>
@@ -1412,24 +1473,50 @@ const ProjectView = ({
       setFocus(null)
       setLookupMsg(
         status === 'current'
-          ? { ok: true, text: `${label}: aktueller Stand` }
+          ? {
+              ok: true,
+              text: format(t('mobile.lookup.docCurrent', '{label}: current revision'), { label }),
+            }
           : status === 'stale'
-            ? { ok: false, text: `${label}: VERALTET — aktueller Stand #${now}` }
-            : { ok: false, text: `${label}: Stand nicht prüfbar` },
+            ? {
+                ok: false,
+                text: format(
+                  t('mobile.lookup.docStale', '{label}: OUTDATED — current revision #{stand}'),
+                  { label, stand: now ?? '?' },
+                ),
+              }
+            : {
+                ok: false,
+                text: format(
+                  t('mobile.lookup.docUnknown', '{label}: revision cannot be checked'),
+                  { label },
+                ),
+              },
       )
       return
     }
     const typed = findByStand(raw, project)
     if (typed) {
       setFocus(null)
-      setLookupMsg({ ok: true, text: `${typed.label}: aktueller Stand` })
+      setLookupMsg({
+        ok: true,
+        text: format(t('mobile.lookup.docCurrent', '{label}: current revision'), {
+          label: typed.label,
+        }),
+      })
       return
     }
     if (/^#?[0-9a-f]{8}$/i.test(raw.trim())) {
       // Acht Hex-Zeichen, aber kein Dokument passt: das Blatt ist veraltet.
       // Das ist eine Aussage und kein "nicht gefunden" — deshalb eigener Fall.
       setFocus(null)
-      setLookupMsg({ ok: false, text: `Stand ${raw.trim()} gehört zu keinem aktuellen Blatt` })
+      setLookupMsg({
+        ok: false,
+        text: format(
+          t('mobile.lookup.standOrphan', 'Revision {stand} does not belong to any current sheet'),
+          { stand: raw.trim() },
+        ),
+      })
       return
     }
 
@@ -1437,18 +1524,32 @@ const ProjectView = ({
     const match = ref ? lookupQrRef(ref, project.cables, project.equipment) : null
     if (!match) {
       setFocus(null)
-      setLookupMsg({ ok: false, text: `Kein Treffer für „${raw.slice(0, 40)}"` })
+      setLookupMsg({
+        ok: false,
+        text: format(t('mobile.lookup.noMatch', 'No match for "{raw}"'), {
+          raw: raw.slice(0, 40),
+        }),
+      })
       return
     }
     setViewMode('list')
     setFilter('')
     if (match.kind === 'equipment') {
       setFocus({ deviceId: match.item.id, nonce: Date.now() })
-      setLookupMsg({ ok: true, text: `Gerät: ${match.item.name}` })
+      setLookupMsg({
+        ok: true,
+        text: format(t('mobile.lookup.device', 'Device: {name}'), { name: match.item.name }),
+      })
     } else {
       const c = match.item
       setFocus({ deviceId: c.fromEquipmentId, portId: c.fromPortId, nonce: Date.now() })
-      setLookupMsg({ ok: true, text: `Kabel ${cableLabelId(c)}: ${c.name || c.type}` })
+      setLookupMsg({
+        ok: true,
+        text: format(t('mobile.lookup.cable', 'Cable {id}: {name}'), {
+          id: cableLabelId(c),
+          name: c.name || c.type,
+        }),
+      })
     }
   }
 
@@ -1536,14 +1637,18 @@ const ProjectView = ({
             type="button"
             onClick={onUnload}
             className="rounded bg-cp-surface-3 px-2 py-1 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-4"
-            title="Anderes Projekt laden"
+            title={t('mobile.header.otherProject', 'Load a different project')}
           >
             ◀
           </button>
           <div className="min-w-0 flex-1">
             <h1 className="truncate text-sm font-semibold text-cp-text">{projectName}</h1>
             <div className="text-cp-xs text-cp-text-muted">
-              {project.equipment.length} Geräte · {project.cables.length} Kabel ·{' '}
+              {format(t('mobile.header.counts', '{devices} devices · {cables} cables'), {
+                devices: project.equipment.length,
+                cables: project.cables.length,
+              })}{' '}
+              ·{' '}
               <span
                 className={
                   checkedPorts === totalPorts
@@ -1553,7 +1658,10 @@ const ProjectView = ({
                       : 'text-cp-text-faint'
                 }
               >
-                {checkedPorts}/{totalPorts} Ports gesteckt
+                {format(t('mobile.header.portsDone', '{done}/{total} ports patched'), {
+                  done: checkedPorts,
+                  total: totalPorts,
+                })}
               </span>
             </div>
           </div>
@@ -1574,7 +1682,11 @@ const ProjectView = ({
                   viewMode === m ? 'bg-cp-accent text-white' : 'text-cp-text-secondary hover:bg-cp-surface-3'
                 }`}
               >
-                {m === 'list' ? 'Patchliste' : m === 'plan' ? 'Plan' : 'Ablauf'}
+                {m === 'list'
+                  ? t('mobile.view.list', 'Patch list')
+                  : m === 'plan'
+                    ? t('mobile.view.plan', 'Plan')
+                    : t('mobile.view.rundown', 'Rundown')}
               </button>
             ),
           )}
@@ -1584,7 +1696,7 @@ const ProjectView = ({
           <input
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
-            placeholder="Suchen…"
+            placeholder={t('mobile.search', 'Search…')}
             className="flex-1 rounded border border-cp-border bg-cp-surface-1 px-2 py-1 text-xs text-cp-text"
           />
           <label className="flex items-center gap-1 text-cp-xs text-cp-text-secondary">
@@ -1593,13 +1705,13 @@ const ProjectView = ({
               checked={onlyOpen}
               onChange={(e) => setOnlyOpen(e.target.checked)}
             />
-            offen
+            {t('mobile.filter.open', 'open')}
           </label>
           <button
             type="button"
             onClick={() => setFindOpen(true)}
             className="flex items-center rounded bg-cp-surface-3 px-2 py-1 text-cp-xs text-cp-text hover:bg-cp-surface-4"
-            title="Per QR-Scan oder ID zu Kabel/Gerät springen"
+            title={t('mobile.find.title', 'Jump to a cable or device by QR scan or ID')}
           >
             <Icon icon={QrCode} size="xs" />
           </button>
@@ -1610,18 +1722,18 @@ const ProjectView = ({
             type="button"
             onClick={() => setWalkOpen(true)}
             className="rounded bg-cp-surface-3 px-2 py-1 text-cp-xs text-cp-text hover:bg-cp-surface-4"
-            title="Prüfbild-Rundgang: wo müsste welches Bild ankommen"
+            title={t('mobile.walk.title', 'Test-pattern walk: which image should arrive where')}
           >
-            Prüfbild
+            {t('mobile.walk.button', 'Pattern')}
           </button>
           {writeMode === 'contribute' && (
             <button
               type="button"
               onClick={() => setShowReport(true)}
               className="rounded bg-cp-surface-3 px-2 py-1 text-cp-xs text-amber-300 hover:bg-cp-surface-4"
-              title="Korrektur/Problem melden (Feld-Rückkanal)"
+              title={t('mobile.report.title', 'Report a correction or problem (field feedback)')}
             >
-              Meldung
+              {t('mobile.report.button', 'Report')}
             </button>
           )}
           {writeMode === 'contribute' && (
@@ -1629,9 +1741,9 @@ const ProjectView = ({
             type="button"
             onClick={() => setShowAddCable(true)}
             className="rounded bg-cp-accent px-2 py-1 text-cp-xs text-white hover:opacity-90"
-            title="Kabel vor Ort hinzufügen (Dropdowns)"
+            title={t('mobile.addCable.title', 'Add a cable on site (dropdowns)')}
           >
-            + Kabel
+            {t('mobile.addCable.button', '+ Cable')}
           </button>
           )}
         </div>
@@ -1656,8 +1768,13 @@ const ProjectView = ({
           <div className="mt-2 flex items-start gap-1.5 rounded border border-amber-700/60 bg-amber-900/30 px-2 py-1 text-cp-xs text-amber-200">
             <Icon icon={AlertTriangle} size="xs" className="mt-0.5 shrink-0" />
             <span>
-              Offline · Cache vom {cachedAt ? new Date(cachedAt).toLocaleString() : '?'} · Checks
-              werden bei Re-Connect synchronisiert
+              {format(
+                t(
+                  'mobile.offline.banner',
+                  'Offline · cache from {time} · ticks are synced on reconnect',
+                ),
+                { time: cachedAt ? new Date(cachedAt).toLocaleString() : '?' },
+              )}
             </span>
           </div>
         )}
@@ -1670,8 +1787,11 @@ const ProjectView = ({
           <div className="mt-2 flex items-start gap-1.5 rounded border border-cp-border bg-cp-surface-2 px-2 py-1 text-cp-xs text-cp-text-secondary">
             <Icon icon={AlertTriangle} size="xs" className="mt-0.5 shrink-0" />
             <span>
-              Nur lesen · Häkchen bleiben auf diesem Gerät und erreichen den Plan nicht · den Plan
-              ändert die Person am Rechner
+              {t(
+                'mobile.readonly.banner',
+                'Read only · ticks stay on this device and do not reach the plan · the person ' +
+                  'at the computer changes the plan',
+              )}
             </span>
           </div>
         )}
@@ -1705,7 +1825,7 @@ const ProjectView = ({
         <div className="space-y-2 pb-8">
           {filteredDevices.length === 0 ? (
             <div className="rounded border border-dashed border-cp-border bg-cp-surface-1 p-6 text-center text-xs text-cp-text-faint">
-              Keine Geräte passen zum Filter.
+              {t('mobile.list.noMatch', 'No devices match the filter.')}
             </div>
           ) : (
             filteredDevices.map((d) => (
@@ -1772,7 +1892,7 @@ const PlanModeView = ({
       <div className="min-h-0 flex-1 overflow-auto px-3 pb-8 pt-2">
         {!selected ? (
           <div className="rounded border border-dashed border-cp-border bg-cp-surface-1 p-5 text-center text-xs text-cp-text-faint">
-            Tippe ein Gerät im Plan an, um seine Patchliste zu sehen.
+            {t('mobile.plan.tapHint', 'Tap a device in the plan to see its patch list.')}
           </div>
         ) : (
           <div className="rounded border border-cp-border bg-cp-surface-1">
@@ -1841,21 +1961,26 @@ const Zugangscodes = () => {
     try {
       const r = await apiFetch('/pincodes', { headers: { 'X-CP-Pin-Token': code.trim() } })
       if (r.status === 404) {
-        setFehler('Nicht freigegeben. Am Planer muss jemand die Zugangscodes freigeben.')
+        setFehler(
+          t(
+            'mobile.pin.notShared',
+            'Not shared. Someone at the planner has to release the access codes.',
+          ),
+        )
         return
       }
       if (r.status === 403) {
-        setFehler('Falscher Code.')
+        setFehler(t('mobile.pin.wrongCode', 'Wrong code.'))
         return
       }
       if (!r.ok) {
-        setFehler(`Fehler ${r.status}.`)
+        setFehler(format(t('mobile.pin.error', 'Error {status}.'), { status: r.status }))
         return
       }
       const daten = (await r.json()) as { codes?: { label: string; value: string }[] }
       setCodes(daten.codes ?? [])
     } catch {
-      setFehler('Keine Verbindung zum Planer.')
+      setFehler(t('mobile.pin.noConnection', 'No connection to the planner.'))
     } finally {
       setLaeuft(false)
     }
@@ -1867,9 +1992,9 @@ const Zugangscodes = () => {
         type="button"
         onClick={() => setOffen(true)}
         className="fixed right-3 top-12 z-[300] flex items-center gap-1 rounded-full border border-cp-border bg-cp-surface-3/90 px-2.5 py-1 text-cp-xs text-cp-text shadow-lg backdrop-blur"
-        title="Anlagen-Zugangscodes"
+        title={t('mobile.pin.title', 'System access codes')}
       >
-        Zugangscodes
+        {t('mobile.pin.button', 'Access codes')}
       </button>
       {offen && (
         <div className="fixed inset-0 z-[301] flex items-end justify-center bg-black/60 p-3" onClick={schliessen}>
@@ -1877,12 +2002,17 @@ const Zugangscodes = () => {
             className="w-full max-w-md rounded-lg border border-cp-border bg-cp-surface-1 p-3 text-cp-text shadow-2xl"
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="mb-2 text-sm font-semibold">Anlagen-Zugangscodes</div>
+            <div className="mb-2 text-sm font-semibold">
+              {t('mobile.pin.title', 'System access codes')}
+            </div>
             {codes === null ? (
               <>
                 <p className="mb-2 text-cp-xs text-cp-text-muted">
-                  Der Code steht nicht im QR-Link. Er wird am Planer ausgegeben und einzeln
-                  weitergegeben.
+                  {t(
+                    'mobile.pin.hint',
+                    'The code is not in the QR link. It is issued at the planner and handed ' +
+                      'over separately.',
+                  )}
                 </p>
                 <input
                   type="text"
@@ -1892,13 +2022,13 @@ const Zugangscodes = () => {
                   spellCheck={false}
                   value={code}
                   onChange={(e) => setCode(e.target.value)}
-                  placeholder="Code vom Planer"
+                  placeholder={t('mobile.pin.placeholder', 'Code from the planner')}
                   className="mb-2 w-full rounded border border-cp-border bg-cp-surface-2 px-2 py-1.5 font-mono text-sm tracking-widest"
                 />
                 {fehler && <div className="mb-2 text-cp-xs text-red-300">{fehler}</div>}
                 <div className="flex justify-end gap-2">
                   <button type="button" onClick={schliessen} className="rounded px-3 py-1.5 text-sm">
-                    Abbrechen
+                    {t('mobile.cancel', 'Cancel')}
                   </button>
                   <button
                     type="button"
@@ -1906,7 +2036,7 @@ const Zugangscodes = () => {
                     disabled={laeuft || code.trim() === ''}
                     className="rounded bg-sky-700 px-3 py-1.5 text-sm text-white disabled:opacity-50"
                   >
-                    {laeuft ? 'Hole…' : 'Anzeigen'}
+                    {laeuft ? t('mobile.pin.fetching', 'Fetching…') : t('mobile.pin.show', 'Show')}
                   </button>
                 </div>
               </>
@@ -1915,7 +2045,7 @@ const Zugangscodes = () => {
                 <ul className="mb-2 space-y-1.5">
                   {codes.length === 0 && (
                     <li className="text-cp-xs text-cp-text-muted">
-                      Freigegeben, aber es sind keine Codes hinterlegt.
+                      {t('mobile.pin.empty', 'Shared, but no codes are stored.')}
                     </li>
                   )}
                   {codes.map((c) => (
@@ -1926,11 +2056,14 @@ const Zugangscodes = () => {
                   ))}
                 </ul>
                 <p className="mb-2 text-cp-xs text-cp-text-muted">
-                  Dieser Abruf steht im Dokument-Register des Planers.
+                  {t(
+                    'mobile.pin.logged',
+                    'This retrieval is recorded in the planner document register.',
+                  )}
                 </p>
                 <div className="flex justify-end">
                   <button type="button" onClick={schliessen} className="rounded px-3 py-1.5 text-sm">
-                    Schließen
+                    {t('mobile.close', 'Close')}
                   </button>
                 </div>
               </>
@@ -1961,51 +2094,61 @@ const ConnectionSettings = () => {
         type="button"
         onClick={() => setOpen(true)}
         className="fixed right-3 top-3 z-[300] flex items-center gap-1 rounded-full border border-cp-border bg-cp-surface-3/90 px-2.5 py-1 text-cp-xs text-cp-text shadow-lg backdrop-blur"
-        title="Verbindung"
+        title={t('mobile.connection', 'Connection')}
       >
-        {cfg.mode === 'remote' ? '📶 Remote' : '🏠 Lokal'}
+        {cfg.mode === 'remote'
+          ? t('mobile.conn.remote', '📶 Remote')
+          : t('mobile.conn.local', '🏠 Local')}
       </button>
       {open && (
         <div className="fixed inset-0 z-[301] flex items-end justify-center bg-black/60 p-3" onClick={() => setOpen(false)}>
           <div className="w-full max-w-md rounded-lg border border-cp-border bg-cp-surface-1 p-3 text-cp-text shadow-2xl" onClick={(e) => e.stopPropagation()}>
-            <div className="mb-2 text-sm font-semibold">Verbindung</div>
+            <div className="mb-2 text-sm font-semibold">
+              {t('mobile.connection', 'Connection')}
+            </div>
             <div className="mb-3 grid grid-cols-2 gap-1 rounded bg-cp-bg p-0.5">
               <button
                 type="button"
                 onClick={() => setCfg({ ...cfg, mode: 'local' })}
                 className={`rounded px-2 py-1.5 text-xs font-medium ${cfg.mode === 'local' ? 'bg-cp-accent text-white' : 'text-cp-text-secondary hover:bg-cp-surface-3'}`}
               >
-                🏠 Lokal (LAN)
+                {t('mobile.conn.localFull', '🏠 Local (LAN)')}
               </button>
               <button
                 type="button"
                 onClick={() => setCfg({ ...cfg, mode: 'remote' })}
                 className={`rounded px-2 py-1.5 text-xs font-medium ${cfg.mode === 'remote' ? 'bg-cp-accent text-white' : 'text-cp-text-secondary hover:bg-cp-surface-3'}`}
               >
-                📶 Remote (Mobilfunk)
+                {t('mobile.conn.remoteFull', '📶 Remote (mobile data)')}
               </button>
             </div>
             {cfg.mode === 'remote' && (
               <label className="block text-xs text-cp-text-secondary">
-                Server-URL (dein Tunnel/Relay auf den Desktop, inkl. ?t=Token)
+                {t(
+                  'mobile.conn.urlLabel',
+                  'Server URL (your tunnel/relay to the desktop, including ?t=token)',
+                )}
                 <input
                   value={cfg.remoteUrl}
                   onChange={(e) => setCfg({ ...cfg, remoteUrl: e.target.value })}
-                  placeholder="https://mein-desktop.example.com/?t=…"
+                  placeholder={t('mobile.host.placeholder', 'https://my-desktop.example.com/?t=…')}
                   className="mt-1 w-full rounded border border-cp-border bg-cp-bg p-2 text-xs"
                 />
               </label>
             )}
             <p className="mt-2 text-cp-xs text-cp-text-faint">
-              Lokal: nur im selben WLAN. Remote: über mobile Daten via eigenem Tunnel/Relay
-              (siehe docs/self-hosted-relay.md). Nichts läuft über fremde Server.
+              {t(
+                'mobile.conn.hint',
+                'Local: same Wi-Fi only. Remote: over mobile data via your own tunnel/relay ' +
+                  '(see docs/self-hosted-relay.md). Nothing goes through third-party servers.',
+              )}
             </p>
             <div className="mt-3 flex justify-end gap-2">
               <button type="button" onClick={() => setOpen(false)} className="rounded bg-cp-surface-3 px-3 py-1 text-xs hover:bg-cp-surface-4">
-                Abbrechen
+                {t('mobile.cancel', 'Cancel')}
               </button>
               <button type="button" onClick={apply} className="rounded bg-emerald-700 px-3 py-1 text-xs hover:bg-emerald-600">
-                Übernehmen
+                {t('mobile.apply', 'Apply')}
               </button>
             </div>
           </div>
@@ -2146,22 +2289,27 @@ export const MobileApp = () => {
       {showSwitched && (
         <div className="mx-auto max-w-md p-2">
           <div className="rounded border border-amber-600 bg-amber-950/60 p-2 text-cp-xs text-amber-100">
-            <b>Am Desktop ist jetzt eine andere Show offen.</b> Dieser Plan bleibt
-            stehen — er gehört zu der Show, mit der diese Seite geladen wurde.
-            Häkchen und Meldungen gehen bis zum Neuladen nicht mehr durch.
+            <b>{t('mobile.showSwitched', 'A different show is now open on the desktop.')}</b>{' '}
+            {t(
+              'mobile.showSwitched.body',
+              'This plan stays as it is — it belongs to the show this page was loaded with. ' +
+                'Ticks and reports no longer get through until you reload.',
+            )}
             <button
               type="button"
               className="mt-1 block rounded border border-amber-500 px-2 py-0.5 text-cp-xs"
               onClick={() => window.location.reload()}
             >
-              Zur neuen Show wechseln (neu laden)
+              {t('mobile.showSwitched.reload', 'Switch to the new show (reload)')}
             </button>
           </div>
         </div>
       )}
       {!autoLoadAttempted ? (
         <div className="grid min-h-screen place-items-center p-4 text-xs text-cp-text-muted">
-          <div className="animate-pulse">Lade Projekt vom Desktop…</div>
+          <div className="animate-pulse">
+            {t('mobile.loading', 'Loading project from the desktop…')}
+          </div>
         </div>
       ) : project ? (
         <ProjectView
@@ -2176,8 +2324,13 @@ export const MobileApp = () => {
           <ProjectPicker onLoad={setProject} />
           {autoLoadError && (
             <div className="mx-auto mt-2 max-w-md rounded border border-amber-700 bg-amber-950 p-2 text-cp-xs text-amber-200">
-              Hinweis: Es lief offenbar ein Desktop-Share-Server, aber das Laden ist
-              fehlgeschlagen ({autoLoadError}).
+              {format(
+                t(
+                  'mobile.autoLoadError',
+                  'Note: a desktop share server appears to be running, but loading failed ({error}).',
+                ),
+                { error: autoLoadError },
+              )}
             </div>
           )}
         </>
@@ -2309,8 +2462,14 @@ const AddCableModal = ({
     } catch (e) {
       setErr(
         e instanceof Error
-          ? `Konnte Kabel nicht senden: ${e.message}. Verbindung zum Desktop prüfen.`
-          : 'Konnte Kabel nicht senden.',
+          ? format(
+              t(
+                'mobile.addCable.sendFailed',
+                'Could not send the cable: {error}. Check the connection to the desktop.',
+              ),
+              { error: e.message },
+            )
+          : t('mobile.addCable.sendFailedShort', 'Could not send the cable.'),
       )
     } finally {
       setBusy(false)
@@ -2326,7 +2485,9 @@ const AddCableModal = ({
     >
       <div className="w-full max-w-md rounded-t-lg border border-cp-border bg-cp-surface-1 text-cp-text shadow-2xl">
         <header className="flex items-center justify-between border-b border-cp-border px-3 py-2">
-          <h2 className="text-sm font-semibold">📱 Kabel hinzufügen</h2>
+          <h2 className="text-sm font-semibold">
+            {t('mobile.addCable.heading', '📱 Add cable')}
+          </h2>
           <button
             type="button"
             onClick={onClose}
@@ -2345,20 +2506,28 @@ const AddCableModal = ({
                   (Plan gesperrt, Gerät oder Port weg, Dublette). Ein
                   Versprechen im Futur von der Seite, die es nicht einlösen
                   kann. Jetzt steht hier nur, was tatsächlich passiert ist. */}
-              ✓ An den Desktop gesendet
+              {t('mobile.addCable.sent', '✓ Sent to the desktop')}
               <div className="mt-1 text-cp-xs font-normal text-emerald-300/80">
-                Ob es im Plan landet, entscheidet der Desktop — dort steht es
-                dann mit 📱-Marker.
+                {t(
+                  'mobile.addCable.sentHint',
+                  'Whether it lands in the plan is the desktop\'s decision — it then shows ' +
+                    'there with a 📱 marker.',
+                )}
               </div>
             </div>
           ) : (
             <>
               <p className="text-cp-xs italic text-cp-text-muted">
-                Wird im Plan mit 📱-Badge markiert, damit der Planer sieht dass das
-                Kabel vor Ort nachgepflegt wurde.
+                {t(
+                  'mobile.addCable.badgeHint',
+                  'Marked in the plan with a 📱 badge so the planner sees that this cable was ' +
+                    'added on site.',
+                )}
               </p>
               <label className="block">
-                <span className="mb-1 block text-cp-text-secondary">Von Gerät</span>
+                <span className="mb-1 block text-cp-text-secondary">
+                  {t('mobile.fromDevice', 'From device')}
+                </span>
                 <select
                   value={fromEqId}
                   onChange={(e) => {
@@ -2367,7 +2536,7 @@ const AddCableModal = ({
                   }}
                   className="w-full rounded border border-cp-border bg-cp-bg p-2"
                 >
-                  <option value="">— wählen —</option>
+                  <option value="">{t('mobile.choose', '— choose —')}</option>
                   {sortedEquipment.map((eq) => (
                     <option key={eq.id} value={eq.id}>
                       {eq.name}
@@ -2376,23 +2545,27 @@ const AddCableModal = ({
                 </select>
               </label>
               <label className="block">
-                <span className="mb-1 block text-cp-text-secondary">Von Port</span>
+                <span className="mb-1 block text-cp-text-secondary">
+                  {t('mobile.fromPort', 'From port')}
+                </span>
                 <select
                   value={fromPortId}
                   onChange={(e) => setFromPortId(e.target.value)}
                   disabled={!fromEq}
                   className="w-full rounded border border-cp-border bg-cp-bg p-2 disabled:opacity-40"
                 >
-                  <option value="">— wählen —</option>
+                  <option value="">{t('mobile.choose', '— choose —')}</option>
                   {fromPorts.map((p) => (
                     <option key={p.id} value={p.id}>
-                      {portDisplayLabel(p)} ({p.connectorType}){occupiedPortIds.has(p.id) ? ' • belegt' : ''}
+                      {portDisplayLabel(p)} ({p.connectorType}){occupiedPortIds.has(p.id) ? t('mobile.port.occupied', ' • occupied') : ''}
                     </option>
                   ))}
                 </select>
               </label>
               <label className="block">
-                <span className="mb-1 block text-cp-text-secondary">Zu Gerät</span>
+                <span className="mb-1 block text-cp-text-secondary">
+                  {t('mobile.toDevice', 'To device')}
+                </span>
                 <select
                   value={toEqId}
                   onChange={(e) => {
@@ -2401,7 +2574,7 @@ const AddCableModal = ({
                   }}
                   className="w-full rounded border border-cp-border bg-cp-bg p-2"
                 >
-                  <option value="">— wählen —</option>
+                  <option value="">{t('mobile.choose', '— choose —')}</option>
                   {sortedEquipment.map((eq) => (
                     <option key={eq.id} value={eq.id}>
                       {eq.name}
@@ -2410,30 +2583,34 @@ const AddCableModal = ({
                 </select>
               </label>
               <label className="block">
-                <span className="mb-1 block text-cp-text-secondary">Zu Port</span>
+                <span className="mb-1 block text-cp-text-secondary">
+                  {t('mobile.toPort', 'To port')}
+                </span>
                 <select
                   value={toPortId}
                   onChange={(e) => setToPortId(e.target.value)}
                   disabled={!toEq}
                   className="w-full rounded border border-cp-border bg-cp-bg p-2 disabled:opacity-40"
                 >
-                  <option value="">— wählen —</option>
+                  <option value="">{t('mobile.choose', '— choose —')}</option>
                   {toPorts.map((p) => (
                     <option key={p.id} value={p.id}>
-                      {portDisplayLabel(p)} ({p.connectorType}){occupiedPortIds.has(p.id) ? ' • belegt' : ''}
+                      {portDisplayLabel(p)} ({p.connectorType}){occupiedPortIds.has(p.id) ? t('mobile.port.occupied', ' • occupied') : ''}
                     </option>
                   ))}
                 </select>
               </label>
               <div className="grid grid-cols-2 gap-2">
                 <label className="block">
-                  <span className="mb-1 block text-cp-text-secondary">Typ</span>
+                  <span className="mb-1 block text-cp-text-secondary">
+                    {t('mobile.type', 'Type')}
+                  </span>
                   <select
                     value={cableType}
                     onChange={(e) => setCableType(e.target.value)}
                     className="w-full rounded border border-cp-border bg-cp-bg p-2"
                   >
-                    <option value="">— wählen —</option>
+                    <option value="">{t('mobile.choose', '— choose —')}</option>
                     {cableTypeOptions.map((t) => (
                       <option key={t} value={t}>
                         {t}
@@ -2442,13 +2619,15 @@ const AddCableModal = ({
                   </select>
                 </label>
                 <label className="block">
-                  <span className="mb-1 block text-cp-text-secondary">Länge (m)</span>
+                  <span className="mb-1 block text-cp-text-secondary">
+                    {t('mobile.length', 'Length (m)')}
+                  </span>
                   <select
                     value={length}
                     onChange={(e) => setLength(e.target.value)}
                     className="w-full rounded border border-cp-border bg-cp-bg p-2"
                   >
-                    <option value="">— wählen —</option>
+                    <option value="">{t('mobile.choose', '— choose —')}</option>
                     {lengthOptions.map((l) => (
                       <option key={l} value={l}>
                         {l} m
@@ -2458,14 +2637,16 @@ const AddCableModal = ({
                 </label>
               </div>
               <label className="block">
-                <span className="mb-1 block text-cp-text-secondary">Name</span>
+                <span className="mb-1 block text-cp-text-secondary">
+                  {t('mobile.name', 'Name')}
+                </span>
                 <input
                   value={name}
                   onChange={(e) => {
                     setName(e.target.value)
                     setNameDirty(true)
                   }}
-                  placeholder="Auto: '<Typ> Gerät A → Gerät B'"
+                  placeholder={t('mobile.name.placeholder', "Auto: '<type> device A → device B'")}
                   className="w-full rounded border border-cp-border bg-cp-bg p-2"
                 />
                 {nameDirty && (
@@ -2475,19 +2656,27 @@ const AddCableModal = ({
                       setNameDirty(false)
                     }}
                     className="mt-1 text-cp-xs text-cp-accent hover:underline"
-                    title="Wieder automatisch aus Typ + Geräten generieren"
+                    title={t(
+                      'mobile.name.regenerate',
+                      'Generate again automatically from type + devices',
+                    )}
                   >
-                    ↺ Auto-Name zurücksetzen
+                    {t('mobile.name.reset', '↺ Reset auto name')}
                   </button>
                 )}
               </label>
               <label className="block">
-                <span className="mb-1 block text-cp-text-secondary">Notizen (opt.)</span>
+                <span className="mb-1 block text-cp-text-secondary">
+                  {t('mobile.notes', 'Notes (opt.)')}
+                </span>
                 <textarea
                   value={notes}
                   onChange={(e) => setNotes(e.target.value)}
                   rows={2}
-                  placeholder="Z.B. 'Notfall-Patch — bitte später ordentlich verlegen'"
+                  placeholder={t(
+                    'mobile.notes.placeholder',
+                    "e.g. 'Emergency patch — please route it properly later'",
+                  )}
                   className="w-full resize-none rounded border border-cp-border bg-cp-bg p-2"
                 />
               </label>
@@ -2503,7 +2692,7 @@ const AddCableModal = ({
                   onClick={onClose}
                   className="rounded bg-cp-surface-4 px-3 py-1.5 text-xs text-cp-text hover:bg-cp-surface-5"
                 >
-                  Abbrechen
+                  {t('mobile.cancel', 'Cancel')}
                 </button>
                 <button
                   type="button"
@@ -2511,7 +2700,9 @@ const AddCableModal = ({
                   disabled={!canSubmit}
                   className="rounded bg-cp-accent px-3 py-1.5 text-xs font-medium text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
                 >
-                  {busy ? 'Sende…' : '📤 An Desktop senden'}
+                  {busy
+                    ? t('mobile.sending', 'Sending…')
+                    : t('mobile.addCable.send', '📤 Send to the desktop')}
                 </button>
               </div>
             </>
@@ -2584,10 +2775,12 @@ const MobileReportModal = ({
         const parts: string[] = []
         if (lengthVal) {
           patch = { length: Number(lengthVal) }
-          parts.push(`Länge → ${Number(lengthVal)} m`)
+          parts.push(
+            format(t('mobile.report.lengthPart', 'length → {n} m'), { n: Number(lengthVal) }),
+          )
         }
         if (note.trim()) parts.push(note.trim())
-        summary = parts.join(' · ') || 'Kabel-Korrektur'
+        summary = parts.join(' · ') || t('mobile.report.cableEdit', 'Cable correction')
       } else {
         const dev = project.equipment.find((e) => e.id === deviceId)
         if (dev) target = { type: 'equipment', id: dev.id, name: dev.name }
@@ -2617,8 +2810,14 @@ const MobileReportModal = ({
     } catch (e) {
       setErr(
         e instanceof Error
-          ? `Konnte Meldung nicht senden: ${e.message}. Verbindung zum Desktop prüfen.`
-          : 'Konnte Meldung nicht senden.',
+          ? format(
+              t(
+                'mobile.report.sendFailed',
+                'Could not send the report: {error}. Check the connection to the desktop.',
+              ),
+              { error: e.message },
+            )
+          : t('mobile.report.sendFailedShort', 'Could not send the report.'),
       )
     } finally {
       setBusy(false)
@@ -2634,7 +2833,9 @@ const MobileReportModal = ({
     >
       <div className="w-full max-w-md rounded-t-lg border border-cp-border bg-cp-surface-1 text-cp-text shadow-2xl">
         <header className="flex items-center justify-between border-b border-cp-border px-3 py-2">
-          <h2 className="text-sm font-semibold">⚠ Meldung an Planer</h2>
+          <h2 className="text-sm font-semibold">
+            {t('mobile.report.heading', '⚠ Report to the planner')}
+          </h2>
           <button
             type="button"
             onClick={onClose}
@@ -2646,21 +2847,27 @@ const MobileReportModal = ({
         <div className="space-y-3 p-3 text-xs">
           {done ? (
             <div className="rounded border border-emerald-700 bg-emerald-900/30 p-3 text-center text-emerald-200">
-              ✓ Meldung gesendet — erscheint am Desktop unter „Feld-Rückmeldungen"
+              {t(
+                'mobile.report.sent',
+                '✓ Report sent — appears on the desktop under "Field feedback"',
+              )}
             </div>
           ) : (
             <>
               <p className="text-cp-xs italic text-cp-text-muted">
-                Wird NICHT direkt geändert — der Planer übernimmt oder verwirft deine
-                Meldung am Desktop (landet dann im Änderungsprotokoll).
+                {t(
+                  'mobile.report.hint',
+                  'Nothing is changed directly — the planner accepts or discards your report ' +
+                    'on the desktop (it then goes into the change log).',
+                )}
               </p>
 
               <div className="grid grid-cols-3 gap-1 rounded bg-cp-bg p-0.5">
                 {(
                   [
-                    ['cable-edit', 'Kabel-Korrektur'],
-                    ['issue', 'Problem'],
-                    ['note', 'Notiz'],
+                    ['cable-edit', t('mobile.report.cableEdit', 'Cable correction')],
+                    ['issue', t('mobile.report.kindIssue', 'Problem')],
+                    ['note', t('mobile.report.kindNote', 'Note')],
                   ] as const
                 ).map(([k, label]) => (
                   <button
@@ -2677,7 +2884,9 @@ const MobileReportModal = ({
               </div>
 
               <label className="block">
-                <span className="mb-1 block text-cp-text-secondary">Gerät (Kontext)</span>
+                <span className="mb-1 block text-cp-text-secondary">
+                  {t('mobile.device.context', 'Device (context)')}
+                </span>
                 <select
                   value={deviceId}
                   onChange={(e) => {
@@ -2686,7 +2895,7 @@ const MobileReportModal = ({
                   }}
                   className="w-full rounded border border-cp-border bg-cp-bg px-2 py-2 text-cp-text"
                 >
-                  <option value="">— wählen —</option>
+                  <option value="">{t('mobile.choose', '— choose —')}</option>
                   {project.equipment.map((d) => (
                     <option key={d.id} value={d.id}>
                       {d.name}
@@ -2698,13 +2907,15 @@ const MobileReportModal = ({
               {kind === 'cable-edit' && (
                 <>
                   <label className="block">
-                    <span className="mb-1 block text-cp-text-secondary">Kabel</span>
+                    <span className="mb-1 block text-cp-text-secondary">
+                      {t('mobile.cable', 'Cable')}
+                    </span>
                     <select
                       value={cableId}
                       onChange={(e) => setCableId(e.target.value)}
                       className="w-full rounded border border-cp-border bg-cp-bg px-2 py-2 text-cp-text"
                     >
-                      <option value="">— wählen —</option>
+                      <option value="">{t('mobile.choose', '— choose —')}</option>
                       {cablesForDevice.map((c) => (
                         <option key={c.id} value={c.id}>
                           {cableLabelId(c)} · {c.name || c.type}
@@ -2714,14 +2925,19 @@ const MobileReportModal = ({
                   </label>
                   <label className="block">
                     <span className="mb-1 block text-cp-text-secondary">
-                      Korrigierte Länge (m){selCable ? ` · aktuell ${selCable.length} m` : ''}
+                      {t('mobile.report.correctedLength', 'Corrected length (m)')}
+                      {selCable
+                        ? format(t('mobile.report.currentLength', ' · currently {n} m'), {
+                            n: selCable.length ?? '?',
+                          })
+                        : ''}
                     </span>
                     <input
                       type="number"
                       inputMode="decimal"
                       value={lengthVal}
                       onChange={(e) => setLengthVal(e.target.value)}
-                      placeholder="z.B. 7.5"
+                      placeholder={t('mobile.report.lengthPlaceholder', 'e.g. 7.5')}
                       className="w-full rounded border border-cp-border bg-cp-bg px-2 py-2 text-cp-text"
                     />
                   </label>
@@ -2730,7 +2946,9 @@ const MobileReportModal = ({
 
               <label className="block">
                 <span className="mb-1 block text-cp-text-secondary">
-                  {kind === 'cable-edit' ? 'Bemerkung (optional)' : 'Beschreibung'}
+                  {kind === 'cable-edit'
+                    ? t('mobile.report.remark', 'Remark (optional)')
+                    : t('mobile.report.description', 'Description')}
                 </span>
                 <textarea
                   value={note}
@@ -2738,21 +2956,23 @@ const MobileReportModal = ({
                   rows={3}
                   placeholder={
                     kind === 'issue'
-                      ? 'Was ist das Problem?'
+                      ? t('mobile.report.issuePlaceholder', 'What is the problem?')
                       : kind === 'note'
-                        ? 'Notiz für den Planer…'
-                        : 'optional…'
+                        ? t('mobile.report.notePlaceholder', 'Note for the planner…')
+                        : t('mobile.report.optionalPlaceholder', 'optional…')
                   }
                   className="w-full rounded border border-cp-border bg-cp-bg px-2 py-2 text-cp-text"
                 />
               </label>
 
               <label className="block">
-                <span className="mb-1 block text-cp-text-secondary">Dein Name (optional)</span>
+                <span className="mb-1 block text-cp-text-secondary">
+                  {t('mobile.report.yourName', 'Your name (optional)')}
+                </span>
                 <input
                   value={reporter}
                   onChange={(e) => setReporter(e.target.value)}
-                  placeholder="für die Protokoll-Zuordnung"
+                  placeholder={t('mobile.report.placeholder', 'for attributing the log entry')}
                   className="w-full rounded border border-cp-border bg-cp-bg px-2 py-2 text-cp-text"
                 />
               </label>
@@ -2769,7 +2989,7 @@ const MobileReportModal = ({
                   onClick={onClose}
                   className="rounded bg-cp-surface-4 px-3 py-1.5 text-xs text-cp-text hover:bg-cp-surface-5"
                 >
-                  Abbrechen
+                  {t('mobile.cancel', 'Cancel')}
                 </button>
                 <button
                   type="button"
@@ -2777,7 +2997,9 @@ const MobileReportModal = ({
                   disabled={!canSubmit}
                   className="rounded bg-amber-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-40"
                 >
-                  {busy ? 'Sende…' : '📤 Meldung senden'}
+                  {busy
+                    ? t('mobile.sending', 'Sending…')
+                    : t('mobile.report.send', '📤 Send report')}
                 </button>
               </div>
             </>

--- a/src/mobile/PatternWalk.tsx
+++ b/src/mobile/PatternWalk.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { format, uebersetzer } from './i18n'
 
 /**
  * Der Prüfbild-Rundgang am Telefon (B-42, Inkrement 2b).
@@ -37,6 +38,8 @@ import { useCallback, useEffect, useState } from 'react'
  * kein Bild kommt.
  */
 
+const t = uebersetzer()
+
 export interface PatternShareStop {
   id: string
   equipmentId: string
@@ -58,12 +61,20 @@ export interface PatternSharePlan {
   offen: PatternShareStop[]
 }
 
-/** Die vier Beobachtungen — dieselben wie am Rechner. */
+/**
+ * Die vier Beobachtungen — dieselben wie am Rechner.
+ *
+ * `wert` ist die Angabe, die ueber die Leitung geht, und bleibt deshalb
+ * deutsch: der Server und `lib/patternDiagnose.ts` kennen genau diese vier
+ * Zeichenketten. `schluessel`/`label` sind die Beschriftung und werden
+ * uebersetzt. Die beiden zu vermischen hiesse, eine Sprachumstellung zu einer
+ * Protokolländerung zu machen.
+ */
 export const BEOBACHTUNGEN = [
-  { wert: 'stimmt', label: 'stimmt' },
-  { wert: 'falsches-bild', label: 'anderes Bild…' },
-  { wert: 'kein-bild', label: 'kein Bild' },
-  { wert: 'kein-monitor', label: 'kein Monitor' },
+  { wert: 'stimmt', schluessel: 'mobile.walk.obsOk', label: 'matches' },
+  { wert: 'falsches-bild', schluessel: 'mobile.walk.obsOther', label: 'different image…' },
+  { wert: 'kein-bild', schluessel: 'mobile.walk.obsNone', label: 'no image' },
+  { wert: 'kein-monitor', schluessel: 'mobile.walk.obsNoMonitor', label: 'no monitor' },
 ] as const
 
 export type Beobachtung = (typeof BEOBACHTUNGEN)[number]['wert']
@@ -101,16 +112,22 @@ export function PatternWalk({ apiFetch, showId, schreibbar, onClose }: Props) {
         // Die beiden zu verwechseln schickte jemanden auf einen Rundgang
         // ohne Ziel.
         setPlan(null)
-        setFehler('Am Rechner ist keine Prüfquelle gewählt.')
+        setFehler(t('mobile.walk.noSource', 'No test source is selected at the computer.'))
         return
       }
       if (!res.ok) {
-        setFehler(`Der Plan liess sich nicht laden (${res.status}).`)
+        setFehler(
+          format(t('mobile.walk.loadFailedStatus', 'The plan could not be loaded ({status}).'), {
+            status: res.status,
+          }),
+        )
         return
       }
       setPlan((await res.json()) as PatternSharePlan)
     } catch (e) {
-      setFehler(e instanceof Error ? e.message : 'Der Plan liess sich nicht laden.')
+      setFehler(
+        e instanceof Error ? e.message : t('mobile.walk.loadFailed', 'The plan could not be loaded.'),
+      )
     } finally {
       setLaedt(false)
     }
@@ -127,7 +144,7 @@ export function PatternWalk({ apiFetch, showId, schreibbar, onClose }: Props) {
     // und geht weiter, sobald er den Knopf gedrückt hat. Scheitert es, wird
     // die Anzeige unten wieder korrigiert; ein stiller Fehlschlag wäre
     // schlimmer als ein lauter.
-    setGemeldet((v) => ({ ...v, [stop.id]: 'sendet …' }))
+    setGemeldet((v) => ({ ...v, [stop.id]: t('mobile.walk.sending', 'sending …') }))
     try {
       const res = await apiFetch('/pattern-checks', {
         method: 'POST',
@@ -144,14 +161,25 @@ export function PatternWalk({ apiFetch, showId, schreibbar, onClose }: Props) {
       })
       if (!res.ok) {
         const text = await res.text().catch(() => '')
-        setGemeldet((v) => ({ ...v, [stop.id]: `nicht angekommen (${res.status}) ${text}`.trim() }))
+        setGemeldet((v) => ({
+          ...v,
+          [stop.id]: format(
+            t('mobile.walk.notArrivedStatus', 'did not arrive ({status}) {text}'),
+            { status: res.status, text },
+          ).trim(),
+        }))
         return
       }
-      setGemeldet((v) => ({ ...v, [stop.id]: 'gemeldet' }))
+      setGemeldet((v) => ({ ...v, [stop.id]: t('mobile.walk.reported', 'reported') }))
     } catch (e) {
       setGemeldet((v) => ({
         ...v,
-        [stop.id]: e instanceof Error ? `nicht angekommen: ${e.message}` : 'nicht angekommen',
+        [stop.id]:
+          e instanceof Error
+            ? format(t('mobile.walk.notArrivedError', 'did not arrive: {error}'), {
+                error: e.message,
+              })
+            : t('mobile.walk.notArrived', 'did not arrive'),
       }))
     }
   }
@@ -175,13 +203,15 @@ export function PatternWalk({ apiFetch, showId, schreibbar, onClose }: Props) {
           <div className="mt-1 text-xs text-cp-warn">{stop.hinweis}</div>
         ) : (
           <div className="mt-1 text-xs text-cp-text-secondary">
-            Laut Plan müsste hier stehen:{' '}
+            {t('mobile.walk.expected', 'According to the plan this should read:')}{' '}
             <span className="font-semibold text-cp-text">{stop.erwartung}</span>
           </div>
         )}
         <div className="mt-1 text-cp-xs text-cp-text-faint">{stop.weg}</div>
         {stop.befund && (
-          <div className="mt-1 text-cp-xs text-cp-text-muted">Zuletzt: {stop.befund}</div>
+          <div className="mt-1 text-cp-xs text-cp-text-muted">
+            {format(t('mobile.walk.last', 'Last: {befund}'), { befund: stop.befund })}
+          </div>
         )}
         {schreibbar ? (
           <>
@@ -197,7 +227,7 @@ export function PatternWalk({ apiFetch, showId, schreibbar, onClose }: Props) {
                   }
                   className="rounded border border-cp-border px-2 py-1 text-xs text-cp-text-secondary active:bg-cp-surface-3"
                 >
-                  {b.label}
+                  {t(b.schluessel, b.label)}
                 </button>
               ))}
             </div>
@@ -207,7 +237,7 @@ export function PatternWalk({ apiFetch, showId, schreibbar, onClose }: Props) {
                   autoFocus
                   value={gesehenerName}
                   onChange={(e) => setGesehenerName(e.target.value)}
-                  placeholder="Welcher Name steht drauf?"
+                  placeholder={t('mobile.walk.seenNamePlaceholder', 'Which name is on it?')}
                   className="min-w-0 flex-1 rounded border border-cp-border bg-cp-surface-2 px-2 py-1 text-xs text-cp-text"
                 />
                 <button
@@ -216,14 +246,17 @@ export function PatternWalk({ apiFetch, showId, schreibbar, onClose }: Props) {
                   onClick={() => void melde(stop, 'falsches-bild', gesehenerName.trim())}
                   className="rounded border border-cp-border px-2 py-1 text-xs disabled:opacity-40"
                 >
-                  merken
+                  {t('mobile.walk.remember', 'remember')}
                 </button>
               </div>
             )}
           </>
         ) : (
           <div className="mt-2 text-cp-xs text-cp-text-faint">
-            Der Rückweg ist zu — am Rechner unter „Freigabe" auf Mitschreiben stellen.
+            {t(
+              'mobile.walk.readOnly',
+              'The return path is closed — set "Sharing" to contribute at the computer.',
+            )}
           </div>
         )}
         {status && <div className="mt-1 text-cp-xs text-cp-text-muted">{status}</div>}
@@ -234,56 +267,65 @@ export function PatternWalk({ apiFetch, showId, schreibbar, onClose }: Props) {
   return (
     <div className="fixed inset-0 z-50 flex flex-col bg-cp-bg p-3">
       <div className="mb-2 flex items-center justify-between">
-        <div className="text-sm font-semibold text-cp-text">Prüfbild-Rundgang</div>
+        <div className="text-sm font-semibold text-cp-text">
+          {t('mobile.walk.heading', 'Test-pattern walk')}
+        </div>
         <button
           type="button"
           onClick={onClose}
           className="rounded border border-cp-border px-2 py-1 text-xs text-cp-text-secondary"
         >
-          Schliessen
+          {t('mobile.close', 'Close')}
         </button>
       </div>
 
       {/* PFLICHT-BESCHRIFTUNG, nicht Zierde: was unten steht, ist der PLAN.
           Diese App sieht nicht, was auf dem Monitor steht (Invariante 16). */}
       <p className="mb-2 rounded border border-cp-border bg-cp-surface-2 p-2 text-cp-xs text-cp-text-secondary">
-        Unten steht, was laut Plan ankommen müsste — nicht, was ankommt. Diese
-        App sieht kein Bild. Was Sie melden, ist das, was Sie auf dem Monitor
-        sehen.
+        {t(
+          'mobile.walk.disclaimer',
+          'Below is what should arrive according to the plan — not what does arrive. ' +
+            'This app sees no image. What you report is what you see on the monitor.',
+        )}
       </p>
 
       <label className="mb-2 block text-xs text-cp-text-muted">
-        Wer prüft
+        {t('mobile.walk.who', 'Who is checking')}
         <input
           value={wer}
           onChange={(e) => merkeWer(e.target.value)}
-          placeholder="Name (optional)"
+          placeholder={t('mobile.walk.namePlaceholder', 'Name (optional)')}
           className="mt-1 w-full rounded border border-cp-border bg-cp-surface-2 px-2 py-1 text-cp-text"
         />
       </label>
 
       <div className="flex-1 space-y-2 overflow-auto pb-6">
-        {laedt && <div className="text-xs text-cp-text-faint">lädt …</div>}
+        {laedt && (
+          <div className="text-xs text-cp-text-faint">{t('mobile.loadingShort', 'loading …')}</div>
+        )}
         {fehler && (
           <div className="rounded border border-cp-warn/50 p-2 text-xs text-cp-warn">
             {fehler}{' '}
             <button type="button" onClick={() => void laden()} className="underline">
-              noch einmal
+              {t('mobile.walk.retry', 'try again')}
             </button>
           </div>
         )}
         {plan && (
           <>
             <div className="text-xs text-cp-text-secondary">
-              Quelle: <span className="font-semibold text-cp-text">{plan.quellName}</span> ·{' '}
-              {plan.ziele.length} Ankunftsorte
-              {plan.offen.length > 0 ? ` · ${plan.offen.length} offen` : ''}
+              {t('mobile.walk.source', 'Source:')}{' '}
+              <span className="font-semibold text-cp-text">{plan.quellName}</span> ·{' '}
+              {format(t('mobile.walk.stops', '{n} arrival points'), { n: plan.ziele.length })}
+              {plan.offen.length > 0
+                ? format(t('mobile.walk.openCount', ' · {n} open'), { n: plan.offen.length })
+                : ''}
             </div>
             {plan.ziele.map((z) => karte(z, false))}
             {plan.offen.length > 0 && (
               <>
                 <div className="pt-2 text-xs font-semibold text-cp-warn">
-                  Wege, die der Plan nicht zu Ende kennt
+                  {t('mobile.walk.openHeading', 'Paths the plan does not follow to the end')}
                 </div>
                 {plan.offen.map((o) => karte(o, true))}
               </>

--- a/src/mobile/i18n.ts
+++ b/src/mobile/i18n.ts
@@ -1,0 +1,243 @@
+// ---------------------------------------------------------------------------
+// Das Woerterbuch der Mobile-Ansicht.
+//
+// ─── WARUM EIN EIGENES UND NICHT DAS DES RENDERERS ─────────────────────────
+//
+// Weil das des Renderers 316 KB gross ist und diese Seite 57 KB.
+//
+// `src/renderer/lib/i18n.ts` importiert `de.ts` STATISCH — wer von dort auch
+// nur `translate` oder `format` holt, bekommt alle 5276 Schluessel der
+// Desktop-App mit. Die Mobile-Ansicht wird ueber das Hallen-WLAN auf ein
+// Telefon geladen und braucht davon keinen einzigen: ihre Oberflaeche ist
+// eine andere. Das Woerterbuch der App mitzuschicken hiesse, die Seite zu
+// vervierfachen, damit ein Handy Zeichenketten laedt, die es nie zeigt.
+//
+// Das ist KEIN zweites System: es ist dieselbe Form, die `CLAUDE.md` fuer
+// jede Sprache beschreibt — ein Woerterbuch als Datei, ein `t(key, fallback)`
+// darueber, keine Zeile Logik. Das Werk dazu (`spracheAusBrowser`, `format`)
+// steht in `renderer/lib/i18nLite.ts` und wird mit dem Viewer geteilt; hier
+// steht nur, was dieser Seite gehoert.
+//
+// ─── WAS HIER NICHT STEHT ──────────────────────────────────────────────────
+//
+// Zeichenketten, die in beiden Sprachen gleich lauten („Plan", „Name",
+// „Problem", „Code / ID"). Ein Eintrag, der die Quelle wiederholt, ist keine
+// Uebersetzung: er sieht beim Lesen aus wie eine und macht die Liste laenger,
+// ohne dass sich etwas aendert, wenn man ihn loescht. Der Fallback im Aufruf
+// liefert dasselbe.
+// ---------------------------------------------------------------------------
+
+import { macheUebersetzer, type Sprache } from '../renderer/lib/i18nLite'
+
+const de: Record<string, string> = {
+  // ── Projekt laden ───────────────────────────────────────────────────────
+  'mobile.err.noProject': 'Desktop teilt aktuell kein Projekt.',
+  'mobile.err.badFormat': 'Antwort hat falsches Format.',
+  'mobile.err.hostUnreachable': 'Host nicht erreichbar ({error}). Datei wählen oder JSON einfügen.',
+  'mobile.err.hostUnreachableShort': 'Host nicht erreichbar.',
+  'mobile.err.notAProject':
+    'Datei sieht nicht wie ein Cable-Planner-Projekt aus (fehlende equipment/cables).',
+  'mobile.err.fileUnreadable': 'Datei konnte nicht gelesen werden.',
+  'mobile.intro':
+    'Hak Ports und Kabel ab während du sie steckst, oder trage fehlende Patches direkt vor Ort nach. Alles syncht live zum Desktop. Offline funktioniert auch — Häkchen werden beim Re-Connect übertragen.',
+  'mobile.reload.titleCached': 'Letztes Projekt vom Host laden — Rückfall auf Cache vom {time}',
+  'mobile.reload.title': 'Aktuell auf dem Desktop geöffnetes Projekt laden',
+  'mobile.reload.busy': '⏳ Lade…',
+  'mobile.reload.cached': '↻ Projekt erneut laden (Cache: {time})',
+  'mobile.reload.fresh': '↻ Projekt vom Desktop laden',
+  'mobile.or': 'oder',
+  'mobile.file.pick': '📂 Cable-Planner-Datei (.json) wählen…',
+  'mobile.paste.cancel': 'Einfügen abbrechen',
+  'mobile.paste.open': 'Oder JSON einfügen…',
+  'mobile.paste.load': 'Projekt laden',
+
+  // ── Port-Liste ──────────────────────────────────────────────────────────
+  'mobile.port.goesTo': '→ geht zu',
+  'mobile.port.via': 'über {path}',
+  'mobile.port.openEnd': 'Offenes Ende',
+  'mobile.port.occupied': ' • belegt',
+
+  // ── Plan-Ansicht ────────────────────────────────────────────────────────
+  'mobile.zoom.in': 'Vergrößern',
+  'mobile.zoom.out': 'Verkleinern',
+  'mobile.zoom.fit': 'Einpassen',
+  'mobile.plan.tapHint': 'Tippe ein Gerät im Plan an, um seine Patchliste zu sehen.',
+
+  // ── QR-/ID-Suche ────────────────────────────────────────────────────────
+  'mobile.qr.title': 'QR / ID finden',
+  'mobile.close': 'Schließen',
+  'mobile.qr.camUnavailable': 'Kamera nicht verfügbar',
+  'mobile.qr.noScan':
+    'Kamera-Scan hier nicht verfügbar (kein HTTPS/Secure-Context). Scanne das Etikett mit der Kamera-App deines Geräts und füge den Code unten ein — oder tippe die Kabel-/Asset-ID.',
+  'mobile.lookup.placeholder': 'z.B. C-0001, A-0007 oder cableplanner://…',
+  'mobile.qr.find': 'Finden',
+  'mobile.lookup.docCurrent': '{label}: aktueller Stand',
+  'mobile.lookup.docStale': '{label}: VERALTET — aktueller Stand #{stand}',
+  'mobile.lookup.docUnknown': '{label}: Stand nicht prüfbar',
+  'mobile.lookup.standOrphan': 'Stand {stand} gehört zu keinem aktuellen Blatt',
+  'mobile.lookup.noMatch': 'Kein Treffer für „{raw}"',
+  'mobile.lookup.device': 'Gerät: {name}',
+  'mobile.lookup.cable': 'Kabel {id}: {name}',
+
+  // ── Ablauf an der eigenen Position (Bedarf 10/11) ───────────────────────
+  'mobile.rundown.myPlace': 'Mein Platz',
+  'mobile.pos.choose': '— Position wählen —',
+  'mobile.rundown.pickHint':
+    'Wähle deine Kameraposition. Ohne sie kann diese Ansicht nicht sagen, was DIR aufgetragen ist — und eine Liste aller Aufträge wäre am Platz unbrauchbar.',
+  'mobile.rundown.withAssignment': '{done}/{total} mit Auftrag',
+  'mobile.rundown.sinceLast': 'Seit deinem letzten Blick:',
+  'mobile.rundown.changed': '{n} geändert',
+  'mobile.rundown.new': '{n} neu',
+  'mobile.rundown.dropped': '{n} entfallen',
+  'mobile.rundown.moved': '{n} verschoben',
+  'mobile.rundown.seen': 'gesehen',
+  'mobile.rundown.noBaseline':
+    'Noch kein Vergleichsstand auf diesem Gerät — beim ersten Blick gibt es nichts zu markieren.',
+  'mobile.rundown.rememberBaseline': 'Diesen Stand merken',
+  'mobile.rundown.tagNew': 'neu',
+  'mobile.rundown.tagChanged': 'geändert',
+  'mobile.rundown.noShot': 'kein Auftrag eingetragen',
+  'mobile.rundown.droppedItem': 'entfallen: {title}',
+
+  // ── Kopfzeile der Projektansicht ────────────────────────────────────────
+  'mobile.header.otherProject': 'Anderes Projekt laden',
+  'mobile.header.counts': '{devices} Geräte · {cables} Kabel',
+  'mobile.header.portsDone': '{done}/{total} Ports gesteckt',
+  'mobile.view.list': 'Patchliste',
+  'mobile.view.rundown': 'Ablauf',
+  'mobile.search': 'Suchen…',
+  'mobile.filter.open': 'offen',
+  'mobile.find.title': 'Per QR-Scan oder ID zu Kabel/Gerät springen',
+  'mobile.walk.title': 'Prüfbild-Rundgang: wo müsste welches Bild ankommen',
+  'mobile.walk.button': 'Prüfbild',
+  'mobile.report.title': 'Korrektur/Problem melden (Feld-Rückkanal)',
+  'mobile.report.button': 'Meldung',
+  'mobile.addCable.title': 'Kabel vor Ort hinzufügen (Dropdowns)',
+  'mobile.addCable.button': '+ Kabel',
+  'mobile.offline.banner':
+    'Offline · Cache vom {time} · Checks werden bei Re-Connect synchronisiert',
+  'mobile.readonly.banner':
+    'Nur lesen · Häkchen bleiben auf diesem Gerät und erreichen den Plan nicht · den Plan ändert die Person am Rechner',
+  'mobile.list.noMatch': 'Keine Geräte passen zum Filter.',
+
+  // ── Anlagen-Zugangscodes (E-3) ──────────────────────────────────────────
+  'mobile.pin.notShared': 'Nicht freigegeben. Am Planer muss jemand die Zugangscodes freigeben.',
+  'mobile.pin.wrongCode': 'Falscher Code.',
+  'mobile.pin.error': 'Fehler {status}.',
+  'mobile.pin.noConnection': 'Keine Verbindung zum Planer.',
+  'mobile.pin.title': 'Anlagen-Zugangscodes',
+  'mobile.pin.button': 'Zugangscodes',
+  'mobile.pin.hint':
+    'Der Code steht nicht im QR-Link. Er wird am Planer ausgegeben und einzeln weitergegeben.',
+  'mobile.pin.placeholder': 'Code vom Planer',
+  'mobile.pin.fetching': 'Hole…',
+  'mobile.pin.show': 'Anzeigen',
+  'mobile.pin.empty': 'Freigegeben, aber es sind keine Codes hinterlegt.',
+  'mobile.pin.logged': 'Dieser Abruf steht im Dokument-Register des Planers.',
+
+  // ── Verbindung (lokal / remote) ─────────────────────────────────────────
+  'mobile.connection': 'Verbindung',
+  'mobile.conn.local': '🏠 Lokal',
+  'mobile.conn.localFull': '🏠 Lokal (LAN)',
+  'mobile.conn.remoteFull': '📶 Remote (Mobilfunk)',
+  'mobile.conn.urlLabel': 'Server-URL (dein Tunnel/Relay auf den Desktop, inkl. ?t=Token)',
+  'mobile.host.placeholder': 'https://mein-desktop.example.com/?t=…',
+  'mobile.conn.hint':
+    'Lokal: nur im selben WLAN. Remote: über mobile Daten via eigenem Tunnel/Relay (siehe docs/self-hosted-relay.md). Nichts läuft über fremde Server.',
+  'mobile.apply': 'Übernehmen',
+
+  // ── Show-Wechsel und Laden (Bedarf 127) ─────────────────────────────────
+  'mobile.showSwitched': 'Am Desktop ist jetzt eine andere Show offen.',
+  'mobile.showSwitched.body':
+    'Dieser Plan bleibt stehen — er gehört zu der Show, mit der diese Seite geladen wurde. Häkchen und Meldungen gehen bis zum Neuladen nicht mehr durch.',
+  'mobile.showSwitched.reload': 'Zur neuen Show wechseln (neu laden)',
+  'mobile.loading': 'Lade Projekt vom Desktop…',
+  'mobile.autoLoadError':
+    'Hinweis: Es lief offenbar ein Desktop-Share-Server, aber das Laden ist fehlgeschlagen ({error}).',
+
+  // ── Kabel vor Ort hinzufuegen ────────────────────────────────────────────
+  'mobile.addCable.sendFailed': 'Konnte Kabel nicht senden: {error}. Verbindung zum Desktop prüfen.',
+  'mobile.addCable.sendFailedShort': 'Konnte Kabel nicht senden.',
+  'mobile.addCable.heading': '📱 Kabel hinzufügen',
+  'mobile.addCable.sent': '✓ An den Desktop gesendet',
+  'mobile.addCable.sentHint':
+    'Ob es im Plan landet, entscheidet der Desktop — dort steht es dann mit 📱-Marker.',
+  'mobile.addCable.badgeHint':
+    'Wird im Plan mit 📱-Badge markiert, damit der Planer sieht dass das Kabel vor Ort nachgepflegt wurde.',
+  'mobile.addCable.send': '📤 An Desktop senden',
+  'mobile.fromDevice': 'Von Gerät',
+  'mobile.fromPort': 'Von Port',
+  'mobile.toDevice': 'Zu Gerät',
+  'mobile.toPort': 'Zu Port',
+  'mobile.choose': '— wählen —',
+  'mobile.type': 'Typ',
+  'mobile.length': 'Länge (m)',
+  'mobile.name.placeholder': "Auto: '<Typ> Gerät A → Gerät B'",
+  'mobile.name.regenerate': 'Wieder automatisch aus Typ + Geräten generieren',
+  'mobile.name.reset': '↺ Auto-Name zurücksetzen',
+  'mobile.notes': 'Notizen (opt.)',
+  'mobile.notes.placeholder': "Z.B. 'Notfall-Patch — bitte später ordentlich verlegen'",
+  'mobile.cancel': 'Abbrechen',
+  'mobile.sending': 'Sende…',
+
+  // ── Meldung an den Planer (Feld-Rueckkanal) ──────────────────────────────
+  'mobile.report.lengthPart': 'Länge → {n} m',
+  'mobile.report.cableEdit': 'Kabel-Korrektur',
+  'mobile.report.sendFailed':
+    'Konnte Meldung nicht senden: {error}. Verbindung zum Desktop prüfen.',
+  'mobile.report.sendFailedShort': 'Konnte Meldung nicht senden.',
+  'mobile.report.heading': '⚠ Meldung an Planer',
+  'mobile.report.sent': '✓ Meldung gesendet — erscheint am Desktop unter „Feld-Rückmeldungen"',
+  'mobile.report.hint':
+    'Wird NICHT direkt geändert — der Planer übernimmt oder verwirft deine Meldung am Desktop (landet dann im Änderungsprotokoll).',
+  'mobile.report.kindNote': 'Notiz',
+  'mobile.device.context': 'Gerät (Kontext)',
+  'mobile.cable': 'Kabel',
+  'mobile.report.correctedLength': 'Korrigierte Länge (m)',
+  'mobile.report.currentLength': ' · aktuell {n} m',
+  'mobile.report.lengthPlaceholder': 'z.B. 7.5',
+  'mobile.report.remark': 'Bemerkung (optional)',
+  'mobile.report.description': 'Beschreibung',
+  'mobile.report.issuePlaceholder': 'Was ist das Problem?',
+  'mobile.report.notePlaceholder': 'Notiz für den Planer…',
+  'mobile.report.yourName': 'Dein Name (optional)',
+  'mobile.report.placeholder': 'für die Protokoll-Zuordnung',
+  'mobile.report.send': '📤 Meldung senden',
+
+  // ── Pruefbild-Rundgang (B-42) ────────────────────────────────────────────
+  'mobile.walk.obsOk': 'stimmt',
+  'mobile.walk.obsOther': 'anderes Bild…',
+  'mobile.walk.obsNone': 'kein Bild',
+  'mobile.walk.obsNoMonitor': 'kein Monitor',
+  'mobile.walk.noSource': 'Am Rechner ist keine Prüfquelle gewählt.',
+  'mobile.walk.loadFailedStatus': 'Der Plan liess sich nicht laden ({status}).',
+  'mobile.walk.loadFailed': 'Der Plan liess sich nicht laden.',
+  'mobile.walk.sending': 'sendet …',
+  'mobile.walk.notArrivedStatus': 'nicht angekommen ({status}) {text}',
+  'mobile.walk.reported': 'gemeldet',
+  'mobile.walk.notArrivedError': 'nicht angekommen: {error}',
+  'mobile.walk.notArrived': 'nicht angekommen',
+  'mobile.walk.expected': 'Laut Plan müsste hier stehen:',
+  'mobile.walk.last': 'Zuletzt: {befund}',
+  'mobile.walk.seenNamePlaceholder': 'Welcher Name steht drauf?',
+  'mobile.walk.remember': 'merken',
+  'mobile.walk.readOnly':
+    'Der Rückweg ist zu — am Rechner unter „Freigabe" auf Mitschreiben stellen.',
+  'mobile.walk.heading': 'Prüfbild-Rundgang',
+  'mobile.walk.disclaimer':
+    'Unten steht, was laut Plan ankommen müsste — nicht, was ankommt. Diese App sieht kein Bild. Was Sie melden, ist das, was Sie auf dem Monitor sehen.',
+  'mobile.walk.who': 'Wer prüft',
+  'mobile.loadingShort': 'lädt …',
+  'mobile.walk.retry': 'noch einmal',
+  'mobile.walk.source': 'Quelle:',
+  'mobile.walk.stops': '{n} Ankunftsorte',
+  'mobile.walk.openCount': ' · {n} offen',
+  'mobile.walk.openHeading': 'Wege, die der Plan nicht zu Ende kennt',
+}
+
+const woerterbuecher: Partial<Record<Sprache, Record<string, string>>> = { de }
+
+/** `t(key, 'English source')` fuer die Mobile-Ansicht. */
+export const uebersetzer = macheUebersetzer(woerterbuecher)
+
+export { format } from '../renderer/lib/i18nLite'

--- a/src/renderer/lib/i18nLite.ts
+++ b/src/renderer/lib/i18nLite.ts
@@ -1,0 +1,80 @@
+// ---------------------------------------------------------------------------
+// Das Uebersetzer-Werk fuer die NEBEN-Eintrittspunkte (`src/mobile`,
+// `src/viewer`) — ohne Woerterbuch, ohne Store, ohne einen einzigen Import.
+//
+// ─── WOFUER DAS DA IST, UND WOFUER NICHT ───────────────────────────────────
+//
+// NICHT fuer die Desktop-App. Die nutzt `lib/i18n.ts`: Registry, `de.ts`,
+// `useTranslation()` am Zustand-Store. Wer im Renderer diese Datei hier
+// importiert, umgeht das Woerterbuch der App und bekommt fuer jeden
+// Schluessel den Fallback — `tests/i18nEintrittspunkte.test.ts` sagt es ihm.
+//
+// SONDERN fuer die beiden Seiten, die ueber einen eigenen Vite-Entry laufen
+// und ihr eigenes, kleines Woerterbuch haben: die Mobile-Ansicht am Telefon
+// im Hallen-WLAN und den read-only Viewer auf GitHub Pages. Beide koennen
+// `lib/i18n.ts` nicht nutzen, weil die Datei `de.ts` STATISCH importiert —
+// 316 KB und 5276 Schluessel, von denen keiner auf diesen Seiten vorkommt.
+// Gemessen: der Mobile-Chunk ist 57 KB gross.
+//
+// ─── WARUM DAS WERK HIER STEHT UND NICHT ZWEIMAL ───────────────────────────
+//
+// Weil `spracheAusBrowser()` und `format()` in beiden Seiten dieselbe Frage
+// beantworten — und zwei Fassungen derselben Regel sind die Defektform, die
+// `scripts/quellsprache.mjs` in ihrem Kopf beschreibt: die eine wird
+// nachgezogen, die andere nicht, und ab da messen sie Verschiedenes.
+//
+// Was NICHT hierher gehoert, sind die Woerterbuecher. Die sind je Seite
+// verschieden (das ist der ganze Punkt) und stehen bei ihr: `mobile/i18n.ts`,
+// `viewer/i18n.ts`.
+// ---------------------------------------------------------------------------
+
+/** Quellsprache ist `en` (E-28); jede weitere Sprache ist ein Eintrag mehr. */
+export type Sprache = 'en' | 'de'
+
+/**
+ * Die Sprache des GERAETS, auf zwei Buchstaben gekuerzt.
+ *
+ * Nicht die des Desktops. Wer eine dieser Seiten liest, steht mit seinem
+ * eigenen Geraet im Aufbau oder sitzt an einem fremden Rechner; welche
+ * Sprache in der Regie eingestellt ist, sagt darueber nichts.
+ * `navigator.language` ist die einzige Angabe, die wirklich der Person
+ * gehoert, die auf den Schirm schaut.
+ *
+ * Faellt sie aus (aeltere WebViews liefern `undefined`), bleibt es bei der
+ * Quellsprache.
+ */
+export const spracheAusBrowser = (): Sprache => {
+  const roh = typeof navigator === 'undefined' ? '' : (navigator.language ?? '')
+  return roh.slice(0, 2).toLowerCase() === 'de' ? 'de' : 'en'
+}
+
+/**
+ * Baut `t(key, 'English source')` ueber einem Satz Woerterbuecher.
+ *
+ * Die englische Quelle steht im Aufruf und ist zugleich der Fallback: ein
+ * fehlender Schluessel zeigt sie an, statt die Oberflaeche leer zu lassen.
+ * Eine Luecke im Woerterbuch kann hier also nie einen leeren Knopf ergeben —
+ * hoechstens einen englischen.
+ */
+export const macheUebersetzer =
+  (woerterbuecher: Partial<Record<Sprache, Record<string, string>>>) =>
+  (sprache: Sprache = spracheAusBrowser()) => {
+    const dict = woerterbuecher[sprache]
+    return (key: string, quelle: string): string => dict?.[key] ?? quelle
+  }
+
+/**
+ * Werte in einen uebersetzten Satz einsetzen: `format(t('k', '{n} m'), {n: 5})`.
+ *
+ * Dieselbe Form wie `format()` in `lib/i18n.ts` — und absichtlich eine eigene
+ * Zeile statt eines Imports von dort: der Import zoege `de.ts` nach und
+ * braechte das ganze Desktop-Woerterbuch auf ein Telefon im Hallen-WLAN.
+ *
+ * Ein unbekannter Platzhalter bleibt sichtbar stehen (`{foo}`) statt leer zu
+ * werden. Eine Uebersetzung, die einen Platzhalter falsch schreibt, faellt
+ * damit im Bild auf, statt still ein Wort zu verschlucken.
+ */
+export const format = (
+  template: string,
+  values: Record<string, string | number>,
+): string => template.replace(/\{(\w+)\}/g, (_, k) => (k in values ? String(values[k]) : `{${k}}`))

--- a/src/viewer/ViewerApp.tsx
+++ b/src/viewer/ViewerApp.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import type { CablePlannerProject, ProjectAnnotation } from '../renderer/types/project'
 import { styleForLayer } from '../renderer/lib/cableLayers'
 import { stampForPlan } from '../renderer/lib/documentStamp'
+import { format, uebersetzer } from './i18n'
 
 // #143 — Zero-Install-Web-Viewer (Stage 1). Lädt eine .cpviewer/.json und
 // rendert den Plan read-only als SVG plus die Anmerkungen. Der Reviewer kann
@@ -32,6 +33,10 @@ import { stampForPlan } from '../renderer/lib/documentStamp'
 // mit dem Bildschirm vergleichen" — genau der Rückweg, den ein Freelancer
 // ohne Konto braucht. Er stand nur nicht auf dem, was er bekommt.
 
+// Ein Uebersetzer je Modul: die Sprache kommt aus dem Browser, der diese
+// Seite geoeffnet hat, und wechselt waehrend einer Sitzung nicht.
+const t = uebersetzer()
+
 const REVIEWER_KEY = 'cable-planner.viewer.reviewer'
 const annKey = (p: CablePlannerProject): string =>
   `cable-planner.viewer.ann::${p.metadata?.name ?? 'plan'}::${p.metadata?.createdAt ?? ''}`
@@ -40,7 +45,11 @@ const uid = (): string =>
   crypto.randomUUID?.() ?? `ann-${Date.now()}-${Math.random().toString(36).slice(2)}`
 
 const STATUS_ORDER: ProjectAnnotation['status'][] = ['open', 'built', 'resolved']
-const STATUS_LABEL: Record<string, string> = { open: 'Offen', built: 'Aufgebaut', resolved: 'Erledigt' }
+const STATUS_LABEL: Record<string, string> = {
+  open: t('viewer.status.open', 'Open'),
+  built: t('viewer.status.built', 'Built'),
+  resolved: t('viewer.status.resolved', 'Resolved'),
+}
 const STATUS_COLOR: Record<string, string> = { open: '#f59e0b', built: '#3b82f6', resolved: '#22c55e' }
 
 interface BBox { x: number; y: number; w: number; h: number }
@@ -213,16 +222,22 @@ export const ViewerApp = () => {
         u.hash = ''
         base = u.toString().replace(/\/$/, '')
       } catch {
-        throw new Error('Ungültige URL.')
+        throw new Error(t('viewer.err.badUrl', 'Invalid URL.'))
       }
       try { localStorage.setItem(REMOTE_KEY, raw) } catch { /* ignore */ }
       const sep = '?'
       const url = `${base}/project.json${token ? `${sep}t=${encodeURIComponent(token)}` : ''}`
       const res = await fetch(url, { cache: 'no-store', headers: token ? { 'X-CP-Token': token } : undefined })
-      if (!res.ok) throw new Error(`Server antwortete ${res.status}.`)
+      if (!res.ok) {
+        throw new Error(
+          format(t('viewer.err.serverStatus', 'The server answered {status}.'), {
+            status: res.status,
+          }),
+        )
+      }
       const parsed = (await res.json()) as CablePlannerProject
       if (!parsed || !Array.isArray(parsed.equipment) || !Array.isArray(parsed.cables)) {
-        throw new Error('Keine gültigen Plandaten empfangen.')
+        throw new Error(t('viewer.err.noPlanData', 'No valid plan data received.'))
       }
       let stored: ProjectAnnotation[] = []
       try {
@@ -232,7 +247,9 @@ export const ViewerApp = () => {
       setProject(parsed)
       setAnnotations(mergeAnn(parsed.annotations ?? [], stored))
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Remote-Laden fehlgeschlagen.')
+      setError(
+        e instanceof Error ? e.message : t('viewer.err.remoteFailed', 'Remote loading failed.'),
+      )
     } finally {
       setLoadingRemote(false)
     }
@@ -243,7 +260,9 @@ export const ViewerApp = () => {
       const text = await file.text()
       const parsed = JSON.parse(text) as CablePlannerProject
       if (!parsed || !Array.isArray(parsed.equipment) || !Array.isArray(parsed.cables)) {
-        throw new Error('Keine gültige Cable-Planner-Datei (.cpviewer / .json).')
+        throw new Error(
+          t('viewer.err.notAFile', 'Not a valid Cable Planner file (.cpviewer / .json).'),
+        )
       }
       let stored: ProjectAnnotation[] = []
       try {
@@ -254,7 +273,9 @@ export const ViewerApp = () => {
       setAnnotations(mergeAnn(parsed.annotations ?? [], stored))
       setError(null)
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Datei konnte nicht gelesen werden.')
+      setError(
+        e instanceof Error ? e.message : t('viewer.err.fileUnreadable', 'The file could not be read.'),
+      )
     }
   }
 
@@ -293,9 +314,11 @@ export const ViewerApp = () => {
     () => (project ? stampForPlan(project, new Date()) : null),
     [project],
   )
-  const standHinweis =
-    'Diese Ansicht ist eine Momentaufnahme. Ob sie noch gilt, beantwortet der ' +
-    'Planer: dort „Analyse → Blatt prüfen" mit dieser Zeichenfolge.'
+  const standHinweis = t(
+    'viewer.stampHint',
+    'This view is a snapshot. Whether it still applies is answered by the planner: ' +
+      'there, use "Analysis → Check sheet" with this string.',
+  )
 
   const downloadAnnotated = (): void => {
     // `stamp` statt einer zweiten Berechnung: eine zweite Ableitung derselben
@@ -321,22 +344,35 @@ export const ViewerApp = () => {
       <div className="flex min-h-screen items-center justify-center bg-cp-bg p-4 text-cp-text">
         <div className="w-full max-w-md rounded-lg border border-cp-border bg-cp-surface-1 p-6 shadow-2xl" onDragOver={(e) => e.preventDefault()} onDrop={onDrop}>
           <h1 className="mb-1 text-lg font-semibold">Cable Planner — Viewer</h1>
-          <p className="mb-4 text-sm text-cp-text-muted">Read-only-Ansicht eines Plans. Keine Installation nötig — Datei laden, prüfen und Anmerkungen setzen.</p>
-          <label className="mb-1 block text-xs text-cp-text-muted">Dein Name (für Anmerkungen)</label>
-          <input value={reviewer} onChange={(e) => setReviewerPersisted(e.target.value)} placeholder="z. B. Jan (Freelance-Cam)" className="mb-4 w-full rounded border border-cp-border bg-cp-surface-2 p-2 text-sm" />
+          <p className="mb-4 text-sm text-cp-text-muted">
+            {t(
+              'viewer.intro',
+              'Read-only view of a plan. No installation needed — load a file, review it and ' +
+                'add annotations.',
+            )}
+          </p>
+          <label className="mb-1 block text-xs text-cp-text-muted">
+            {t('viewer.yourName', 'Your name (for annotations)')}
+          </label>
+          <input value={reviewer} onChange={(e) => setReviewerPersisted(e.target.value)} placeholder={t('viewer.yourName.placeholder', 'e.g. Jan (freelance cam)')} className="mb-4 w-full rounded border border-cp-border bg-cp-surface-2 p-2 text-sm" />
           <label className="flex cursor-pointer flex-col items-center justify-center gap-2 rounded border border-dashed border-cp-border bg-cp-surface-2/40 p-6 text-center text-sm text-cp-text-muted hover:border-cp-accent hover:text-cp-text">
-            <span className="font-medium">Plan-Datei hierher ziehen oder klicken</span>
-            <span className="text-xs">.cpviewer oder .json</span>
+            <span className="font-medium">{t('viewer.drop', 'Drag a plan file here or click')}</span>
+            <span className="text-xs">{t('viewer.drop.kinds', '.cpviewer or .json')}</span>
             <input type="file" accept=".cpviewer,.json,application/json" className="hidden" onChange={(e) => { const f = e.target.files?.[0]; if (f) void loadFile(f) }} />
           </label>
 
           {/* Umschaltbar: Live vom Desktop laden (lokal ODER über Mobilfunk) */}
           <div className="mt-4 border-t border-cp-border-muted pt-3">
-            <div className="mb-1 text-xs font-medium text-cp-text-secondary">— oder live vom Desktop —</div>
+            <div className="mb-1 text-xs font-medium text-cp-text-secondary">
+              {t('viewer.orLive', '— or live from the desktop —')}
+            </div>
             <input
               value={remoteUrl}
               onChange={(e) => setRemoteUrl(e.target.value)}
-              placeholder="http://192.168.1.10:PORT/?t=…  (LAN)  ·  https://…  (Mobilfunk-Tunnel)"
+              placeholder={t(
+                'viewer.remote.placeholder',
+                'http://192.168.1.10:PORT/?t=…  (LAN)  ·  https://…  (mobile tunnel)',
+              )}
               className="w-full rounded border border-cp-border bg-cp-surface-2 p-2 text-xs"
             />
             <button
@@ -345,11 +381,17 @@ export const ViewerApp = () => {
               onClick={() => void loadRemote()}
               className="mt-2 w-full rounded bg-cp-accent px-3 py-1.5 text-xs font-medium text-white enabled:hover:opacity-90 disabled:opacity-50"
             >
-              {loadingRemote ? 'Lade…' : 'Live laden'}
+              {loadingRemote
+                ? t('viewer.remote.loading', 'Loading…')
+                : t('viewer.remote.load', 'Load live')}
             </button>
             <p className="mt-1 text-cp-xs text-cp-text-faint">
-              LAN: die vom Desktop angezeigte Adresse. Mobilfunk: deine öffentliche Tunnel-/Relay-URL
-              (siehe docs/self-hosted-relay.md). Nichts läuft über fremde Server.
+              {t(
+                'viewer.remote.hint',
+                'LAN: the address shown on the desktop. Mobile data: your own public ' +
+                  'tunnel/relay URL (see docs/self-hosted-relay.md). Nothing goes through ' +
+                  'third-party servers.',
+              )}
             </p>
           </div>
 
@@ -368,17 +410,31 @@ export const ViewerApp = () => {
           {/* Bedarf 1: der Stand des Geteilten. Ohne ihn ist diese Ansicht
               eine Momentaufnahme, die nicht sagt, welche. */}
           <p className="truncate text-cp-xs text-cp-text-faint" title={standHinweis}>
-            Stand <span className="font-mono">#{stamp.fingerprint}</span>
-            {stamp.revision && <> · {stamp.revision}{stamp.drifted && ' + Änderungen'}</>}
+            {t('viewer.stamp', 'Revision')} <span className="font-mono">#{stamp.fingerprint}</span>
+            {stamp.revision && (
+              <>
+                {' '}
+                · {stamp.revision}
+                {stamp.drifted && t('viewer.stamp.drifted', ' + changes')}
+              </>
+            )}
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-2 text-xs text-cp-text-muted">
-          <span className="rounded bg-cp-surface-3 px-2 py-1">Plan read-only</span>
+          <span className="rounded bg-cp-surface-3 px-2 py-1">
+            {t('viewer.readOnly', 'Plan read-only')}
+          </span>
           {reviewer && <span className="hidden sm:inline">👤 {reviewer}</span>}
-          <button onClick={() => downloadAnnotated()} className="rounded bg-cp-accent px-2 py-1 font-medium text-white hover:opacity-90" title="Annotierte Datei (.cpviewer) herunterladen — im Hauptprogramm über „Annotierte Viewer-Datei zurücklesen…“ einlesen">
-            Annotierte Datei ↓
+          <button onClick={() => downloadAnnotated()} className="rounded bg-cp-accent px-2 py-1 font-medium text-white hover:opacity-90" title={t(
+            'viewer.download.title',
+            'Download the annotated file (.cpviewer) — read it back in the main program via ' +
+              '"Read back annotated viewer file…"',
+          )}>
+            {t('viewer.download', 'Annotated file ↓')}
           </button>
-          <button onClick={() => setProject(null)} className="rounded border border-cp-border px-2 py-1 hover:bg-cp-surface-3">Andere Datei…</button>
+          <button onClick={() => setProject(null)} className="rounded border border-cp-border px-2 py-1 hover:bg-cp-surface-3">
+            {t('viewer.otherFile', 'Other file…')}
+          </button>
         </div>
       </header>
       <div className="flex min-h-0 flex-1">
@@ -388,16 +444,25 @@ export const ViewerApp = () => {
             onClick={() => setAddMode((v) => !v)}
             className={`absolute left-3 top-3 rounded px-3 py-1.5 text-xs font-medium shadow-lg ${addMode ? 'bg-cp-accent text-white ring-2 ring-cp-accent/50' : 'bg-cp-surface-3 text-cp-text hover:bg-cp-surface-4'}`}
           >
-            {addMode ? 'Klicke in den Plan…' : '+ Anmerkung'}
+            {addMode
+              ? t('viewer.ann.clickPlan', 'Click in the plan…')
+              : t('viewer.ann.add', '+ Annotation')}
           </button>
         </div>
         <aside className="flex w-80 shrink-0 flex-col border-l border-cp-border bg-cp-surface-1">
           <div className="flex items-center justify-between border-b border-cp-border px-3 py-2 text-xs font-semibold uppercase tracking-wide text-cp-text-muted">
-            <span>Anmerkungen ({annotations.length})</span>
+            <span>
+              {format(t('viewer.ann.heading', 'Annotations ({n})'), { n: annotations.length })}
+            </span>
           </div>
           <div className="flex-1 overflow-auto p-2">
             {annotations.length === 0 ? (
-              <p className="p-2 text-xs text-cp-text-faint">Noch keine Anmerkungen. Klicke „+ Anmerkung" und dann in den Plan.</p>
+              <p className="p-2 text-xs text-cp-text-faint">
+                {t(
+                  'viewer.ann.empty',
+                  'No annotations yet. Click "+ Annotation" and then into the plan.',
+                )}
+              </p>
             ) : (
               <ul className="space-y-2">
                 {annotations.map((a, i) => {
@@ -422,14 +487,16 @@ export const ViewerApp = () => {
                       <textarea
                         value={a.text}
                         onChange={(e) => patchAnnotation(a.id, { text: e.target.value })}
-                        placeholder="Anmerkung…"
+                        placeholder={t('viewer.ann.placeholder', 'Annotation…')}
                         rows={2}
                         className="w-full resize-y rounded border border-cp-border-muted bg-cp-surface-1 p-1.5 text-xs text-cp-text"
                         onClick={(e) => e.stopPropagation()}
                       />
                       {mine && (
                         <div className="mt-1 flex justify-end">
-                          <button onClick={(e) => { e.stopPropagation(); removeAnnotation(a.id) }} className="rounded px-1.5 py-0.5 text-cp-xs text-cp-danger hover:bg-cp-danger/20">Löschen</button>
+                          <button onClick={(e) => { e.stopPropagation(); removeAnnotation(a.id) }} className="rounded px-1.5 py-0.5 text-cp-xs text-cp-danger hover:bg-cp-danger/20">
+                            {t('viewer.ann.delete', 'Delete')}
+                          </button>
                         </div>
                       )}
                     </li>
@@ -439,7 +506,11 @@ export const ViewerApp = () => {
             )}
           </div>
           <div className="border-t border-cp-border p-2 text-cp-xs text-cp-text-faint">
-            {project.equipment.length} Geräte · {project.cables.length} Kabel · {(project.locations ?? []).length} Standorte
+            {format(t('viewer.counts', '{devices} devices · {cables} cables · {locations} locations'), {
+              devices: project.equipment.length,
+              cables: project.cables.length,
+              locations: (project.locations ?? []).length,
+            })}
           </div>
         </aside>
       </div>

--- a/src/viewer/i18n.ts
+++ b/src/viewer/i18n.ts
@@ -1,0 +1,90 @@
+// ---------------------------------------------------------------------------
+// Das Woerterbuch des read-only Viewers.
+//
+// ─── WARUM EIN EIGENES UND NICHT DAS DES RENDERERS ─────────────────────────
+//
+// Aus demselben Grund wie bei `mobile/i18n.ts`: `renderer/lib/i18n.ts`
+// importiert `de.ts` STATISCH (316 KB, 5276 Schluessel). Der Viewer ist ein
+// eigener Vite-Entry (`viewer.html`) und liegt auf GitHub Pages — er wird von
+// Leuten geoeffnet, die das Programm gar nicht haben, oft unterwegs. Ihm das
+// Desktop-Woerterbuch mitzugeben hiesse, den ganzen Wortschatz einer App
+// auszuliefern, von der diese Seite 30 Zeichenketten zeigt.
+//
+// Das Werk (`spracheAusBrowser`, `format`) steht in
+// `renderer/lib/i18nLite.ts` und wird mit der Mobile-Ansicht geteilt; hier
+// steht nur, was diesem Eintrittspunkt gehoert.
+//
+// ─── WAS HIER NICHT STEHT ──────────────────────────────────────────────────
+//
+// Zeichenketten, die in beiden Sprachen wirklich gleich lauten („Plan",
+// „Viewer"). Ein Eintrag, der die Quelle wiederholt, sieht beim Lesen aus wie
+// eine Uebersetzung und ist keine; der Fallback im Aufruf liefert dasselbe.
+//
+// „WIRKLICH GLEICH" HEISST: NACHGESEHEN, NICHT GESCHAETZT. `.cpviewer or
+// .json` stand beim ersten Durchgang aus genau diesem Grund nicht in der
+// Liste — bis die Seite im Browser mit deutscher Spracheinstellung offen war
+// und dort „.cpviewer or .json" zwischen lauter deutschen Zeilen stand. Ein
+// Wort Unterschied, und es ist genau die Sorte halbe Uebersetzung, die E-17
+// im `sony-camera-bridge` als Fehler benannt hat. Wer hier einen Eintrag
+// weglaesst, macht die Seite in einer Sprache auf, in der er ihn weglassen
+// will.
+// ---------------------------------------------------------------------------
+
+import { macheUebersetzer, type Sprache } from '../renderer/lib/i18nLite'
+
+const de: Record<string, string> = {
+  // ── Anmerkungs-Status ───────────────────────────────────────────────────
+  'viewer.status.open': 'Offen',
+  'viewer.status.built': 'Aufgebaut',
+  'viewer.status.resolved': 'Erledigt',
+
+  // ── Laden ───────────────────────────────────────────────────────────────
+  'viewer.err.badUrl': 'Ungültige URL.',
+  'viewer.err.serverStatus': 'Server antwortete {status}.',
+  'viewer.err.noPlanData': 'Keine gültigen Plandaten empfangen.',
+  'viewer.err.remoteFailed': 'Remote-Laden fehlgeschlagen.',
+  'viewer.err.notAFile': 'Keine gültige Cable-Planner-Datei (.cpviewer / .json).',
+  'viewer.err.fileUnreadable': 'Datei konnte nicht gelesen werden.',
+
+  // ── Startseite ──────────────────────────────────────────────────────────
+  'viewer.intro':
+    'Read-only-Ansicht eines Plans. Keine Installation nötig — Datei laden, prüfen und Anmerkungen setzen.',
+  'viewer.yourName': 'Dein Name (für Anmerkungen)',
+  'viewer.yourName.placeholder': 'z. B. Jan (Freelance-Cam)',
+  'viewer.drop': 'Plan-Datei hierher ziehen oder klicken',
+  'viewer.drop.kinds': '.cpviewer oder .json',
+  'viewer.orLive': '— oder live vom Desktop —',
+  'viewer.remote.placeholder':
+    'http://192.168.1.10:PORT/?t=…  (LAN)  ·  https://…  (Mobilfunk-Tunnel)',
+  'viewer.remote.loading': 'Lade…',
+  'viewer.remote.load': 'Live laden',
+  'viewer.remote.hint':
+    'LAN: die vom Desktop angezeigte Adresse. Mobilfunk: deine öffentliche Tunnel-/Relay-URL (siehe docs/self-hosted-relay.md). Nichts läuft über fremde Server.',
+
+  // ── Kopfzeile des geladenen Plans ───────────────────────────────────────
+  'viewer.stampHint':
+    'Diese Ansicht ist eine Momentaufnahme. Ob sie noch gilt, beantwortet der Planer: dort „Analyse → Blatt prüfen" mit dieser Zeichenfolge.',
+  'viewer.stamp': 'Stand',
+  'viewer.stamp.drifted': ' + Änderungen',
+  'viewer.readOnly': 'Plan read-only',
+  'viewer.download.title':
+    'Annotierte Datei (.cpviewer) herunterladen — im Hauptprogramm über „Annotierte Viewer-Datei zurücklesen…" einlesen',
+  'viewer.download': 'Annotierte Datei ↓',
+  'viewer.otherFile': 'Andere Datei…',
+
+  // ── Anmerkungen ─────────────────────────────────────────────────────────
+  'viewer.ann.clickPlan': 'Klicke in den Plan…',
+  'viewer.ann.add': '+ Anmerkung',
+  'viewer.ann.heading': 'Anmerkungen ({n})',
+  'viewer.ann.empty': 'Noch keine Anmerkungen. Klicke „+ Anmerkung" und dann in den Plan.',
+  'viewer.ann.placeholder': 'Anmerkung…',
+  'viewer.ann.delete': 'Löschen',
+  'viewer.counts': '{devices} Geräte · {cables} Kabel · {locations} Standorte',
+}
+
+const woerterbuecher: Partial<Record<Sprache, Record<string, string>>> = { de }
+
+/** `t(key, 'English source')` fuer den Viewer. */
+export const uebersetzer = macheUebersetzer(woerterbuecher)
+
+export { format } from '../renderer/lib/i18nLite'

--- a/tests/asciiDrift.test.ts
+++ b/tests/asciiDrift.test.ts
@@ -40,7 +40,16 @@ const roh = {
     import: 'default',
     eager: true,
   }) as Record<string, string>),
-  ...(import.meta.glob('../src/mobile/**/*.ts', {
+  // `.tsx` GEHOERT DAZU, und zwar seit dem 2026-09-10 auch wirklich.
+  //
+  // Bis dahin stand hier `**/*.ts` — und die gesamte Oberflaeche der
+  // Mobile-Ansicht liegt in `.tsx` (`MobileApp.tsx`, `PatternWalk.tsx`).
+  // Der Guard sah von diesem Ordner also die Hilfsmodule und keinen einzigen
+  // Text, den jemand liest. Aufgefallen ist es erst, als die Beschriftungen
+  // ins Woerterbuch `mobile/i18n.ts` wanderten: dieselben Saetze, dieselbe
+  // Schreibweise, ploetzlich geprueft. Ein Glob, der die Endung der
+  // interessanten Dateien nicht kennt, ist die leiseste Form von blind.
+  ...(import.meta.glob('../src/mobile/**/*.{ts,tsx}', {
     query: '?raw',
     import: 'default',
     eager: true,
@@ -116,7 +125,7 @@ const HARMLOS = new Set(
     // Deutsch, und richtig geschrieben — „ue"/„ae"/„oe" ueber eine Silben-
     // oder Wortgrenze hinweg.
     'zuerst', 'neuere', 'neueren', 'neueste', 'querschnitt', 'dauer',
-    'störquelle', 'signalquelle', 'signalquellen', 'frequenzbänder',
+    'störquelle', 'signalquelle', 'signalquellen', 'prüfquelle', 'frequenzbänder',
     'frequenzregulierung', 'koexistieren', 'graues', 'visuell', 'visuelle',
     'virtuelle', 'individuelle', 'aktuellem', 'nachbauen', 'zuerste',
     'queueconnection', 'venuescopedialog', 'catalogueevidence',

--- a/tests/i18nEintrittspunkte.test.ts
+++ b/tests/i18nEintrittspunkte.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join, relative, resolve, sep } from 'node:path'
+
+// ---------------------------------------------------------------------------
+// Jeder Eintrittspunkt, der Oberflaeche rendert, wird auf seine Sprache
+// geprueft — und keiner von ihnen schleppt das Desktop-Woerterbuch mit.
+//
+// ─── DER BEFUND ────────────────────────────────────────────────────────────
+//
+// `lang:check` lief bis 2026-09-10 nur auf `src/renderer`. Es gibt aber drei
+// Ordner, die im Browser laufen — `renderer`, `mobile`, `viewer`; sie stehen
+// so in `tsconfig.app.json` und in `CLAUDE.md`. Die beiden ungeprueften waren
+// vollstaendig deutsch beschriftet: 63 Zeichenketten in `src/mobile`, 12 in
+// `src/viewer`, mitten in einem Repo, dessen Quellsprache seit E-28 `en` ist.
+//
+// Der Waechter stand also an EINER Tuer von dreien und meldete „0 Verstoesse".
+// Das ist dieselbe Form wie beim Typ-Check, der `src/mobile` nicht ansah
+// (siehe `typpruefungDecktSrc.test.ts`): eine Pruefung, die nur einen Teil
+// des Baums sieht, ist auf dem Rest nicht etwa weniger streng — sie ist blind
+// und sagt es nicht.
+//
+// Geprueft wird deshalb nicht „steht `src/mobile` im Skript" (das waere die
+// Liste, die beim naechsten Ordner wieder fehlt), sondern: JEDER Ordner, den
+// `tsconfig.app.json` als Browser-Code fuehrt, kommt im `lang:check`-Skript
+// vor. Wer einen vierten Eintrittspunkt anlegt, wird hier rot.
+//
+// ─── UND DIE ZWEITE HAELFTE: DAS WOERTERBUCH BLEIBT AM DESKTOP ─────────────
+//
+// `renderer/lib/i18n.ts` importiert `de.ts` STATISCH — 316 KB, 5276
+// Schluessel. Der Mobile-Chunk ist 72 KB gross (57 KB davor, +15 KB fuer
+// sein eigenes Woerterbuch — gemessen am 2026-09-10). Ein einziger Import von
+// `lib/i18n` in `src/mobile` oder `src/viewer` (auch ein mittelbarer, ueber
+// irgendein Helfer-Modul) vervierfacht die Seite, die ein Telefon im
+// Hallen-WLAN laedt — und zwar unbemerkt, weil nichts kaputtgeht.
+//
+// Genau deshalb gibt es `lib/i18nLite.ts` und die zwei kleinen
+// Woerterbuecher. Diese Pruefung haelt die Grenze: sie folgt den Importen
+// beider Eintrittspunkte durch den ganzen Baum und faellt, wenn `lib/i18n`
+// oder `lib/i18n/de` darin auftaucht.
+// ---------------------------------------------------------------------------
+
+const WURZEL = process.cwd()
+
+const lies = (pfad: string): string => readFileSync(join(WURZEL, pfad), 'utf8')
+
+/** Die Ordner unter `src/`, die `tsconfig.app.json` als Browser-Code fuehrt. */
+const browserOrdner = (): string[] => {
+  const konfig = JSON.parse(lies('tsconfig.app.json')) as { include: string[] }
+  return konfig.include.filter((e) => e.startsWith('src/') && !e.endsWith('.ts'))
+}
+
+describe('lang:check deckt jeden Browser-Eintrittspunkt', () => {
+  it('kennt ueberhaupt Ordner — sonst prueft der Test nichts', () => {
+    // Eine leere Liste erfuellt die Regel unten muehelos. Ein Waechter, der
+    // bei kaputtem Muster gruen wird, behauptet eine Deckung, die es nicht
+    // gibt — dieselbe Zusicherung wie in den anderen Waechtern dieses Repos.
+    expect(browserOrdner().length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('nennt jeden davon im npm-Skript', () => {
+    const pkg = JSON.parse(lies('package.json')) as { scripts: Record<string, string> }
+    const skript = pkg.scripts['lang:check'] ?? ''
+    const fehlend = browserOrdner().filter((o) => !skript.includes(o))
+    expect(
+      fehlend,
+      `Diese Ordner rendern Oberflaeche, werden aber nicht auf ihre Sprache ` +
+        `geprueft — der Waechter waere dort blind und meldete trotzdem 0:\n  ` +
+        `${fehlend.join('\n  ')}\n(Skript: ${skript})`,
+    ).toEqual([])
+  })
+})
+
+/**
+ * Jedes Modul, das von `start` aus ueber relative Importe erreichbar ist.
+ *
+ * Bewusst der ganze Graph und nicht nur die erste Zeile der Datei: der teure
+ * Import kommt selten direkt: er kommt ueber ein Helfer-Modul, das jemand
+ * arglos mitnimmt. `src/mobile` importiert heute schon sechs Module aus
+ * `renderer/lib` — genau der Weg, auf dem `lib/i18n` hereinkaeme.
+ */
+const erreichbar = (start: string): Set<string> => {
+  const gesehen = new Set<string>()
+  const offen = [resolve(WURZEL, start)]
+  const aufloesen = (basis: string, spez: string): string | null => {
+    const roh = resolve(dirname(basis), spez)
+    for (const kandidat of [roh, `${roh}.ts`, `${roh}.tsx`, join(roh, 'index.ts')]) {
+      if (existsSync(kandidat) && /\.tsx?$/.test(kandidat)) return kandidat
+    }
+    return null
+  }
+  while (offen.length > 0) {
+    const pfad = offen.pop()!
+    if (gesehen.has(pfad)) continue
+    gesehen.add(pfad)
+    const quelle = readFileSync(pfad, 'utf8')
+    for (const m of quelle.matchAll(/(?:from|import)\s*['"](\.[^'"]+)['"]/g)) {
+      const ziel = aufloesen(pfad, m[1])
+      if (ziel) offen.push(ziel)
+    }
+  }
+  return gesehen
+}
+
+describe('Die kleinen Eintrittspunkte tragen kein Desktop-Woerterbuch', () => {
+  /**
+   * Die Registry und der Ordner mit den Woerterbuechern — und NICHT
+   * `i18nLite.ts`.
+   *
+   * Die erste Fassung prueft auf den Praefix `src/renderer/lib/i18n` und
+   * meldete damit `i18nLite.ts` als Verstoss: also genau das Modul, das die
+   * Grenze herstellt. Ein Waechter, der die Loesung fuer den Defekt haelt,
+   * bringt den naechsten Leser dazu, sie wieder auszubauen.
+   */
+  const schwer = (pfad: string): boolean =>
+    pfad === 'src/renderer/lib/i18n.ts' || pfad.startsWith('src/renderer/lib/i18n/')
+
+  for (const [name, start] of [
+    ['Mobile-Ansicht', 'src/mobile/main.tsx'],
+    ['Viewer', 'src/viewer/main.tsx'],
+  ] as const) {
+    it(`${name}: kein Weg nach lib/i18n`, () => {
+      const module = erreichbar(start)
+      // Zusicherung gegen die eigene Aufloesung: findet sie nichts, ist die
+      // Regel darunter leer erfuellt.
+      expect(module.size, `${start} erreicht keine Module — Aufloesung kaputt?`).toBeGreaterThan(5)
+
+      const treffer = [...module]
+        .map((p) => relative(WURZEL, p).split(sep).join('/'))
+        .filter(schwer)
+      expect(
+        treffer,
+        `Diese Seite laedt damit das ganze Desktop-Woerterbuch (de.ts, 316 KB) ` +
+          `auf ein Geraet, das davon keinen Schluessel zeigt. Das kleine Werk ` +
+          `steht in renderer/lib/i18nLite.ts:\n  ${treffer.join('\n  ')}`,
+      ).toEqual([])
+    })
+  }
+
+  it('der Renderer dagegen nutzt das echte Woerterbuch, nicht das kleine Werk', () => {
+    // Die Gegenrichtung, und sie ist kein Zierrat: `i18nLite` liefert fuer
+    // jeden Schluessel den Fallback. Wer es im Renderer benutzt, bekommt eine
+    // Oberflaeche, die beim Sprachwechsel STEHENBLEIBT — und nichts wird rot,
+    // weil der Fallback ja ein gueltiger Text ist.
+    const module = [...erreichbar('src/renderer/main.tsx')]
+      .map((p) => relative(WURZEL, p).split(sep).join('/'))
+      .filter((p) => p.endsWith('i18nLite.ts'))
+    expect(
+      module,
+      `i18nLite ist fuer mobile/viewer da. Im Renderer gehoert lib/i18n hin — ` +
+        `sonst zeigt die Stelle immer den englischen Fallback, egal welche ` +
+        `Sprache eingestellt ist.`,
+    ).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Jeder Schluessel hat eine deutsche Fassung — oder ist ausdruecklich als
+// „in beiden Sprachen gleich" erklaert.
+//
+// ─── WARUM DAS EINE EIGENE PRUEFUNG BRAUCHT ────────────────────────────────
+//
+// Weil `lang:check` diese Luecke NICHT sehen kann. Fehlt ein Schluessel im
+// Woerterbuch, zeigt die Seite den englischen Fallback — und der ist eine
+// voellig regelkonforme Zeichenkette. Der Sprachmix-Zaehler misst den
+// Quelltext, nicht das, was ein deutsches Telefon anzeigt.
+//
+// Gefunden wurde es genau so, wie es sich sonst nicht finden laesst: die
+// gebaute Seite im Browser mit deutscher Spracheinstellung. Zwischen lauter
+// deutschen Zeilen stand „.cpviewer or .json" — ein Wort, weil ich beim
+// Eintragen geschaetzt hatte, die Zeile sei in beiden Sprachen gleich. Sie
+// ist es nicht.
+//
+// Die Liste unten ist die Umkehr davon: was hier steht, ist eine ERKLAERUNG
+// („dieses Wort ist im Deutschen dasselbe"), kein Freibrief. Wer einen
+// Schluessel ohne deutsche Fassung anlegt, muss ihn hier hinschreiben und
+// dabei hinsehen — dieselbe Form wie die `HARMLOS`-Liste in
+// `asciiDrift.test.ts`.
+// ---------------------------------------------------------------------------
+
+/** Schluessel, deren deutsche Fassung Wort fuer Wort die englische ist. */
+const GLEICH_IN_BEIDEN: Record<string, string> = {
+  'mobile.view.plan': 'Plan',
+  'mobile.conn.remote': '📶 Remote',
+  'mobile.name': 'Name',
+  'mobile.report.kindIssue': 'Problem',
+  'mobile.report.optionalPlaceholder': 'optional…',
+  'mobile.walk.namePlaceholder': 'Name (optional)',
+}
+
+describe('Die Woerterbuecher haben keine stillen Luecken', () => {
+  const EINTRITTE = [
+    { ordner: 'src/mobile', quellen: ['MobileApp.tsx', 'PatternWalk.tsx'] },
+    { ordner: 'src/viewer', quellen: ['ViewerApp.tsx'] },
+  ]
+
+  /** Jeder `t('key', 'Source')`-Aufruf einer Seite — Schluessel auf Quelle. */
+  const benutzteSchluessel = (ordner: string, quellen: string[]): Map<string, string> => {
+    const gefunden = new Map<string, string>()
+    for (const datei of quellen) {
+      const quelle = lies(`${ordner}/${datei}`)
+      for (const m of quelle.matchAll(/\bt\(\s*'([\w.]+)'\s*,\s*(['"])((?:[^\\]|\\.)*?)\2/g)) {
+        gefunden.set(m[1], m[3])
+      }
+      // `BEOBACHTUNGEN` traegt Schluessel und Quelle als Datenfelder, weil der
+      // `wert` ueber die Leitung geht und die Beschriftung nicht.
+      for (const m of quelle.matchAll(/schluessel:\s*'([\w.]+)',\s*label:\s*'([^']*)'/g)) {
+        gefunden.set(m[1], m[2])
+      }
+    }
+    return gefunden
+  }
+
+  const uebersetzteSchluessel = (ordner: string): Set<string> =>
+    new Set([...lies(`${ordner}/i18n.ts`).matchAll(/^\s*'([\w.]+)':/gm)].map((m) => m[1]))
+
+  for (const { ordner, quellen } of EINTRITTE) {
+    it(`${ordner}: findet ueberhaupt Aufrufe — sonst prueft der Test nichts`, () => {
+      expect(benutzteSchluessel(ordner, quellen).size).toBeGreaterThan(20)
+    })
+
+    it(`${ordner}: jeder Schluessel ist uebersetzt oder erklaert`, () => {
+      const uebersetzt = uebersetzteSchluessel(ordner)
+      const offen = [...benutzteSchluessel(ordner, quellen)]
+        .filter(([k]) => !uebersetzt.has(k) && !(k in GLEICH_IN_BEIDEN))
+        .map(([k, quelle]) => `${k} = ${JSON.stringify(quelle)}`)
+      expect(
+        offen,
+        `Ohne deutsche Fassung zeigt die Seite hier den englischen Fallback — ` +
+          `mitten in einer sonst deutschen Oberflaeche, und kein Waechter sieht ` +
+          `es. Entweder uebersetzen oder in GLEICH_IN_BEIDEN erklaeren:\n  ` +
+          `${offen.join('\n  ')}`,
+      ).toEqual([])
+    })
+
+    it(`${ordner}: kein Eintrag ohne Nutzer`, () => {
+      // Ein verwaister Eintrag ist keine Uebersetzung mehr, sondern ein Rest:
+      // er sieht beim Lesen aus wie Deckung fuer eine Stelle, die es nicht
+      // mehr gibt — dieselbe Regel wie beim Light-Theme-Remap.
+      const benutzt = benutzteSchluessel(ordner, quellen)
+      const verwaist = [...uebersetzteSchluessel(ordner)].filter((k) => !benutzt.has(k))
+      expect(verwaist, `Schluessel im Woerterbuch, die niemand ruft: ${verwaist.join(', ')}`)
+        .toEqual([])
+    })
+  }
+
+  it('die Erklaerungen stimmen mit der Quelle ueberein', () => {
+    // GEGENPROBE. Ein Eintrag in GLEICH_IN_BEIDEN behauptet etwas ueber den
+    // Quelltext („diese Zeile lautet so"). Aendert jemand die Quelle, ist die
+    // Behauptung still falsch — und der Schluessel bliebe unuebersetzt, ohne
+    // dass die Pruefung oben etwas merkt.
+    const alle = new Map<string, string>()
+    for (const { ordner, quellen } of EINTRITTE) {
+      for (const [k, v] of benutzteSchluessel(ordner, quellen)) alle.set(k, v)
+    }
+    const falsch = Object.entries(GLEICH_IN_BEIDEN)
+      .filter(([k, text]) => alle.get(k) !== text)
+      .map(([k, text]) => `${k}: erklaert ${JSON.stringify(text)}, Quelle ${JSON.stringify(alle.get(k))}`)
+    expect(falsch, `Erklaerung passt nicht mehr zur Quelle:\n  ${falsch.join('\n  ')}`).toEqual([])
+  })
+})

--- a/tests/mobileCableDrop.test.ts
+++ b/tests/mobileCableDrop.test.ts
@@ -117,6 +117,7 @@ describe('das Handy verspricht nicht mehr, was es nicht wissen kann', () => {
   })
 
   it('sagt stattdessen, was tatsaechlich passiert ist', () => {
-    expect(mobile).toContain('An den Desktop gesendet')
+    // Englische Quelle im Aufruf, deutsche Fassung im Woerterbuch (E-28).
+    expect(mobile).toContain('Sent to the desktop')
   })
 })

--- a/tests/mobilePatternCheck.test.ts
+++ b/tests/mobilePatternCheck.test.ts
@@ -10,6 +10,7 @@ import type { EquipmentItem, Port } from '../src/renderer/types/equipment'
 import type { PatternCheck } from '../src/renderer/types/patternCheck'
 import serverSrc from '../src/main/services/mobileShareServer.ts?raw'
 import walkSrc from '../src/mobile/PatternWalk.tsx?raw'
+import mobileWoerterbuch from '../src/mobile/i18n.ts?raw'
 import appSrc from '../src/renderer/App.tsx?raw'
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -255,36 +256,54 @@ describe('Beide Listen der Beobachtungen bleiben gleich', () => {
   })
 })
 
+// ─── WAS HIER GEPRUEFT WIRD, SEIT DIE SEITE UEBERSETZT IST ────────────────
+//
+// Die Saetze standen bis 2026-09-10 als deutscher Text im Bauteil und wurden
+// hier woertlich gesucht. Seit E-28 laeuft die Mobile-Ansicht durch `t()`:
+// im Bauteil steht die englische Quelle, die deutsche Fassung in
+// `src/mobile/i18n.ts`.
+//
+// Gesucht wird deshalb der SCHLUESSEL im Bauteil und der SATZ im
+// Woerterbuch — beides, und mit Absicht. Nur den Schluessel zu pruefen
+// hiesse: es gibt eine Stelle, die irgendetwas anzeigt. Was dort steht, ist
+// aber der ganze Punkt dieser Datei (Invariante 16), und deshalb muss der
+// Satz weiter nachweisbar sein.
 describe('Das Telefon zeigt die Erwartung ALS Erwartung', () => {
   const src = ohneKommentare(walkSrc)
+  const woerterbuch = ohneKommentare(mobileWoerterbuch)
 
   it('der Satz steht ueber der Liste und nicht nur im Kommentar', () => {
     // Invariante 16: ein Telefon, das eine Erwartung wie eine Rueckmeldung
     // darstellt, ist die gefaehrlichste Sorte Anzeige — man liest „KAMERA 1",
     // haelt es fuer bestaetigt und hat den Plan zweimal gelesen.
-    expect(src).toMatch(/was laut Plan ankommen müsste/)
-    expect(src).toMatch(/sieht kein Bild/)
+    expect(src).toContain("'mobile.walk.disclaimer'")
+    expect(woerterbuch).toMatch(/was laut Plan ankommen müsste/)
+    expect(woerterbuch).toMatch(/sieht kein Bild/)
   })
 
   it('je Ankunftsort steht „laut Plan", nicht ein blosser Name', () => {
-    expect(src).toMatch(/Laut Plan müsste hier stehen/)
+    expect(src).toContain("'mobile.walk.expected'")
+    expect(woerterbuch).toMatch(/Laut Plan müsste hier stehen/)
   })
 
   it('der gesehene Name wird gefragt, nicht freigestellt', () => {
     // „Falsches Bild" allein ist ein Symptom; der Name macht daraus den Befund.
-    expect(src).toMatch(/Welcher Name steht drauf\?/)
+    expect(src).toContain("'mobile.walk.seenNamePlaceholder'")
+    expect(woerterbuch).toMatch(/Welcher Name steht drauf\?/)
     expect(src).toMatch(/melde\(stop, 'falsches-bild', gesehenerName\.trim\(\)\)/)
   })
 
   it('ein gescheiterter Versuch bleibt sichtbar', () => {
     // Der Techniker geht weiter, sobald er gedrueckt hat. Ein stiller
     // Fehlschlag hiesse: er glaubt, gemeldet zu haben.
-    expect(src).toMatch(/nicht angekommen/)
+    expect(src).toContain("'mobile.walk.notArrived'")
+    expect(woerterbuch).toMatch(/nicht angekommen/)
   })
 
   it('im Nur-Lesen-Modus sagt die Seite es, statt Knoepfe wegzulassen', () => {
     // Ein fehlender Knopf ohne Grund laesst den Nutzer die App fuer kaputt
     // halten (dieselbe Regel wie bei Bedarf 109 auf der Patchliste).
-    expect(src).toMatch(/Der Rückweg ist zu/)
+    expect(src).toContain("'mobile.walk.readOnly'")
+    expect(woerterbuch).toMatch(/Der Rückweg ist zu/)
   })
 })

--- a/tests/mobileShareWriteBack.test.ts
+++ b/tests/mobileShareWriteBack.test.ts
@@ -212,7 +212,9 @@ describe('mobileShare: Dialog und Handy sagen dasselbe wie der Server', () => {
     const mob = read('src/mobile/MobileApp.tsx')
     expect(mob).toContain("writeMode === 'contribute' &&")
     // Und sagt es auch: die Häkchen bleiben dann lokal.
-    expect(mob).toContain('Nur lesen · Häkchen bleiben auf diesem Gerät')
+    // Der Schluessel, nicht der Satz: die deutsche Fassung steht seit E-28
+    // in `mobile/i18n.ts`, im Bauteil steht die englische Quelle.
+    expect(mob).toContain("'mobile.readonly.banner'")
   })
 
   it('das Handy fällt bei unbekanntem Wert auf „nur lesen" zurück', () => {

--- a/tests/scanNieAllein.test.ts
+++ b/tests/scanNieAllein.test.ts
@@ -98,9 +98,15 @@ describe('die Handeingabe haengt an keiner Kamera-Bedingung', () => {
     // Dort steht die Kamera in einem `canScan ? … : …`. Das Eingabefeld muss
     // DANEBEN stehen und nicht im Ja-Zweig — sonst ist der Hinweis „füge den
     // Code unten ein" eine Anleitung zu einem Feld, das es nicht gibt.
+    //
+    // GEPRUEFT WIRD DER SCHLUESSEL, NICHT DER TEXT. Die erste Fassung suchte
+    // die deutsche Zeichenkette; seit die Mobile-Ansicht durch `t()` laeuft
+    // (E-28), steht dort die englische Quelle und die deutsche Fassung im
+    // Woerterbuch. Ein Waechter, der an einer Uebersetzung rot wird, prueft
+    // die Sprache und nicht das, was er meint.
     const src = lies('src/mobile/MobileApp.tsx')
-    expect(src).toContain('placeholder="z.B. C-0001, A-0007 oder cableplanner://…"')
-    expect(regionHinter(src, '{canScan ? ')).not.toContain('placeholder="z.B. C-0001')
+    expect(src).toContain("t('mobile.lookup.placeholder'")
+    expect(regionHinter(src, '{canScan ? ')).not.toContain("t('mobile.lookup.placeholder'")
   })
 
   it('haelt sich das Scan-Overlay nicht ohne Kamera heraus', () => {
@@ -125,6 +131,8 @@ describe('die Handeingabe haengt an keiner Kamera-Bedingung', () => {
     // stattdessen geht — eine Fehlermeldung ohne Ausweg schickt den Nutzer
     // zurueck an den Anfang.
     expect(lies('src/renderer/lager/ui/ScannerModal.tsx')).toContain('Use manual entry')
-    expect(lies('src/mobile/MobileApp.tsx')).toContain('füge den Code unten ein')
+    // Auch hier der englische Quelltext statt der deutschen Uebersetzung:
+    // er steht im `t()`-Aufruf, die deutsche Fassung in `mobile/i18n.ts`.
+    expect(lies('src/mobile/MobileApp.tsx')).toContain('paste the code below')
   })
 })

--- a/tests/viewerStand.test.ts
+++ b/tests/viewerStand.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import viewerQuelle from '../src/viewer/ViewerApp.tsx?raw'
+import viewerWoerterbuch from '../src/viewer/i18n.ts?raw'
 import { planFingerprint, stampForPlan } from '../src/renderer/lib/documentStamp'
 import type { CablePlannerProject, ProjectAnnotation } from '../src/renderer/types/project'
 
@@ -53,7 +54,11 @@ describe('der Stand steht auf dem, was geteilt wird', () => {
     // ab, muss es dabeistehen — sonst behauptet die Ansicht einen Stand, den
     // sie nicht hat. Dieselbe Regel wie in `stampLine`.
     expect(viewerQuelle).toContain('{stamp.revision}')
-    expect(viewerQuelle).toContain("stamp.drifted && ' + Änderungen'")
+    // Der Zusatz laeuft seit E-28 durch `t()`; der deutsche Text steht in
+    // `src/viewer/i18n.ts`. Geprueft wird beides — die Stelle im Bauteil und
+    // der Satz im Woerterbuch.
+    expect(viewerQuelle).toContain("stamp.drifted && t('viewer.stamp.drifted'")
+    expect(viewerWoerterbuch).toContain('+ Änderungen')
   })
 
   it('zeigt KEIN Druckdatum', () => {
@@ -74,7 +79,8 @@ describe('der Stand steht auf dem, was geteilt wird', () => {
     // Acht Hex-Zeichen ohne Hinweis sind ein Rätsel. Der Bedarf will, dass
     // jemand OHNE Konto feststellen kann, ob sein Plan noch gilt.
     expect(viewerQuelle).toContain('standHinweis')
-    expect(viewerQuelle).toMatch(/Blatt prüfen/)
+    expect(viewerQuelle).toContain("'viewer.stampHint'")
+    expect(viewerWoerterbuch).toMatch(/Blatt prüfen/)
   })
 })
 


### PR DESCRIPTION
## Der Befund

Die Sprachprüfung stand an **einer Tür von dreien**. `npm run lang:check` lief nur auf `src/renderer`; `src/mobile` und `src/viewer` waren durchgehend deutsch beschriftet und ohne jede `t()`-Verdrahtung — in einem Repo, dessen Quellsprache seit E-28 `en` ist.

Gemessen: **63 Zeichenketten** im Mobile-Teil, **12** im Viewer. Der Wächter meldete dabei 0 Verstöße, weil er die Ordner gar nicht ansah — dieselbe Form wie beim Typ-Check, der `src/mobile` in keinem tsconfig hatte (siehe `docs/ui-audit.md`, Phase 0).

Die Zahl im Audit war übrigens auch falsch (34 statt 63): sie stammte aus einer Umlaut-Suche, die kurze Beschriftungen ohne Umlaut („Von Port", „Plan read-only") nicht sah. Im Audit korrigiert.

## Was sich ändert

**Beide Ordner sind gewickelt und übersetzt** — englische Quelle im Aufruf, deutsche Fassung im Wörterbuch (169 bzw. 33 Schlüssel).

**Eigenes, kleines Wörterbuch je Seite statt des Renderer-Wörterbuchs.** `renderer/lib/i18n.ts` importiert `de.ts` **statisch** (316 KB, 5276 Schlüssel); der Mobile-Chunk ist 57 kB und wird über das Hallen-WLAN auf ein Telefon geladen. Ein Import von dort hätte die Seite vervierfacht, damit ein Handy Zeichenketten lädt, die es nie zeigt.

Das gemeinsame Werk (`spracheAusBrowser`, `format`) steht deshalb **einmal** in `renderer/lib/i18nLite.ts` — zwei Fassungen derselben Regel sind die Defektform, die `scripts/quellsprache.mjs` in ihrem eigenen Kopf beschreibt.

| | vorher | nachher |
|---|---|---|
| `mobile-*.js` | 57,4 kB | 72,2 kB (gzip 20,0 kB) |
| `viewer-*.js` | 15,6 kB | 15,8 kB (gzip 5,8 kB) |
| bei Import von `lib/i18n` | — | +316 kB |

**Die Sprache kommt aus `navigator.language`**, nicht aus dem `uiStore`: wer die Mobile-Ansicht liest, steht mit dem eigenen Gerät im Aufbau, und was am Rechner in der Regie eingestellt ist, sagt darüber nichts.

## Die Wächter

`lang:check` prüft jetzt alle drei Browser-Ordner. **Der Umfang ist keine Liste:** `tests/i18nEintrittspunkte.test.ts` liest sie aus `tsconfig.app.json` und besteht darauf, dass jeder im Skript vorkommt. Wer einen vierten Eintrittspunkt anlegt, wird dort rot — nicht erst, wenn jemand eine halb übersetzte Seite meldet.

Derselbe Test folgt den Importen beider Seiten durch den **ganzen Baum** und fällt, wenn `lib/i18n` wieder hereinkommt — auch mittelbar über ein Hilfsmodul (`src/mobile` importiert heute schon sechs Module aus `renderer/lib`, genau der Weg). Gegenprobe gelaufen: ein eingesetzter Import macht ihn rot.

## Zwei Lücken, die kein Wächter sehen konnte

**Ein fehlender Schlüssel** zeigt den englischen Fallback — und der ist eine regelkonforme Zeichenkette. Der Sprachmix-Zähler misst den Quelltext, nicht das, was ein deutsches Telefon anzeigt. Gefunden nur, weil die gebaute Seite mit deutscher Spracheinstellung im Browser offen war: „.cpviewer **or** .json" zwischen lauter deutschen Zeilen, weil beim Eintragen geschätzt statt nachgesehen wurde. Der Test besteht jetzt darauf, dass jeder benutzte Schlüssel übersetzt **oder** ausdrücklich als „in beiden Sprachen gleich" erklärt ist (heute sechs), und prüft die Erklärungen gegen den Quelltext gegen.

**`tests/asciiDrift.test.ts` globte `src/mobile/**/*.ts`** — und die gesamte Oberfläche dieses Ordners liegt in `.tsx`. Der Guard sah von dort die Hilfsmodule und keinen einzigen Text, den jemand liest. Aufgefallen erst, als die Beschriftungen ins Wörterbuch `mobile/i18n.ts` wanderten: dieselben Sätze, plötzlich geprüft. Jetzt `{ts,tsx}`; „Prüfquelle" ist als richtiges Deutsch in die `HARMLOS`-Liste aufgenommen.

## Angepasste Tests

Sechs Wächter hingen am deutschen Quelltext. Sie prüfen jetzt **den Schlüssel im Bauteil UND den Satz im Wörterbuch**. Nur den Schlüssel zu prüfen hieße: es gibt eine Stelle, die irgendetwas anzeigt — was dort steht, ist bei Invariante 16 (`PatternWalk`) der ganze Punkt.

## Verifiziert

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npm run lint` — 0 Fehler (12 vorbestehende Warnungen)
- `npm test` — 3866 grün, 2 übersprungen
- `npm run lang:check` — 0 deutsche Fallbacks, 0 Sprachmix in allen drei Ordnern
- `npm run build` grün; beide Seiten anschließend im Browser mit `de-DE` und `en-US` gerendert, Konsole sauber

Setzt `docs/ui-audit.md` Phase 4 fort (der offene Punkt „flächendeckende Suche nach hartkodierten JSX-Texten" ist damit durch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_