### PR TITLE
feat(lager): Barcode-Scan läuft auch am Desktop (zxing-wasm)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,8 @@
         "y-webrtc": "^10.3.0",
         "yaml": "^2.9.0",
         "yjs": "^13.6.31",
-        "zustand": "^5.0.14"
+        "zustand": "^5.0.14",
+        "zxing-wasm": "^3.1.3"
       },
       "devDependencies": {
         "@electron/rebuild": "^4.0.4",
@@ -3133,6 +3134,12 @@
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
       "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.6",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.6.tgz",
+      "integrity": "sha512-uN+9i8bFT5CUcZfyIEYDrSueACEyKGbUs5kC/72DGlZZoinh84sJfVV0i8UOJD1asdzkvLPBRrKs41kZ8MdEXg==",
       "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
@@ -9728,6 +9735,18 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
@@ -10961,6 +10980,34 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zxing-wasm": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/zxing-wasm/-/zxing-wasm-3.1.3.tgz",
+      "integrity": "sha512-3lC9BJk4fR5ZJxcGjb0hVnDFOW7KpLXHIebiBmVd4FDRQZVeObztoTKxRUPxlWwSgxrMRONK0u50hBD1aTYEKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "^1.41.5",
+        "type-fest": "^5.8.0"
+      },
+      "peerDependencies": {
+        "@types/emscripten": ">=1.39.6"
+      }
+    },
+    "node_modules/zxing-wasm/node_modules/type-fest": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.9.0.tgz",
+      "integrity": "sha512-yANm3Jr3GiJ1qgJlxGAVxTOIcEOk1rhQHamlXtnrCK7EHP4HeM9OGxtMg/W7HFdrVzw/ZWJKGVIJusVH85sLtw==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "y-webrtc": "^10.3.0",
     "yaml": "^2.9.0",
     "yjs": "^13.6.31",
-    "zustand": "^5.0.14"
+    "zustand": "^5.0.14",
+    "zxing-wasm": "^3.1.3"
   },
   "devDependencies": {
     "@electron/rebuild": "^4.0.4",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -323,7 +323,22 @@ app.whenReady().then(async () => {
           ...details.responseHeaders,
           'Content-Security-Policy': [
             "default-src 'self'; " +
-              "script-src 'self'; " +
+              // `wasm-unsafe-eval` ist NICHT `unsafe-eval`: es erlaubt genau
+              // das Uebersetzen von WebAssembly und weiterhin kein `eval()`
+              // und keinen `new Function()` fuer JavaScript.
+              //
+              // Ohne diese Angabe schlaegt der Barcode-Decoder
+              // (`lib/barcodeScanner.ts`, zxing-wasm) beim ersten Scan fehl —
+              // gemessen im gepackten Fenster am 2026-09-10:
+              //
+              //   WebAssembly.instantiateStreaming(): Compiling or
+              //   instantiating WebAssembly module violates the following
+              //   Content Security policy directive …
+              //
+              // Und zwar erst beim SCAN, nicht beim Start: der Fehler haette
+              // die App durchlaufen und waere jemandem im Lager vor die Fuesse
+              // gefallen, nicht hier.
+              "script-src 'self' 'wasm-unsafe-eval'; " +
               "style-src 'self' 'unsafe-inline'; " +
               "img-src 'self' data: blob:; " +
               "font-src 'self' data:; " +

--- a/src/renderer/lib/barcodeScanner.ts
+++ b/src/renderer/lib/barcodeScanner.ts
@@ -1,34 +1,139 @@
 // ───────────────────────────────────────────────────────────────────────────
-// Kamera-Barcode-/QR-Scanner — dünne Hülle um die Browser-`BarcodeDetector`-API.
+// Kamera-Barcode-/QR-Scanner.
 //
-// Funktioniert im sicheren Kontext (Electron-Renderer, localhost, HTTPS). Über
-// unverschlüsseltes LAN blockieren Browser Kamera-Zugriff — dort greift die
-// manuelle Code-Eingabe. Erkennt QR + gängige 1D-Symbologien (Code128/39,
-// EAN). Ehrlich degradierend: ohne Support liefert `isBarcodeScannerSupported`
-// false und die UI zeigt nur das Eingabefeld.
+// ─── WARUM DAS NICHT MEHR NUR `BarcodeDetector` IST ────────────────────────
+//
+// Weil es diese API auf dem Desktop nicht gibt. Chromium implementiert
+// `BarcodeDetector` nur auf Android, macOS und ChromeOS; unter Windows und
+// Linux fehlt sie. Gemessen im echten Fenster dieses Repos (Electron,
+// Chrome/148, Linux):
+//
+//     { BarcodeDetector: false, getUserMedia: true }
+//
+// Die Kamera war also da, der Decoder nicht. Die Oberflaeche hat das ehrlich
+// gemeldet („Kamera-Scan hier nicht verfuegbar") und auf die Handeingabe
+// zurueckgeschaltet — aber ehrlich zu sein ueber eine Funktion, die auf der
+// haeufigsten Plattform gar nicht laeuft, ist kein Ersatz dafuer, dass sie
+// laeuft. Wer im Lager 200 Etiketten abhaken will, tippt sie sonst ab.
+//
+// ─── DIE ZWEI WEGE, UND WARUM BEIDE ────────────────────────────────────────
+//
+// 1. `BarcodeDetector`, wo es sie gibt. Sie kostet nichts: kein Download,
+//    keine WASM-Instanz, die Dekodierung laeuft im Browser-Prozess.
+// 2. `zxing-wasm` sonst — 1,09 MB WASM, per `import()` NACHGELADEN und nicht
+//    im Haupt-Chunk. Wer nie scannt, laedt es nie.
+//
+// Die Reihenfolge ist Absicht und keine Bequemlichkeit: die native API ist
+// auf einem Telefon spuerbar sparsamer, und die Mobile-Ansicht (die ihren
+// eigenen Scan-Weg hat) laeuft ohnehin auf Geraeten, die sie mitbringen.
+//
+// ─── OFFLINE, UND ZWAR WIRKLICH ────────────────────────────────────────────
+//
+// `zxing-wasm` sucht seine `.wasm` standardmaessig neben dem eigenen Skript.
+// In einem Vite-Bundle waere das `/assets/zxing_reader.wasm` — eine Datei,
+// die dort nicht liegt. Deshalb kommt die Adresse hier aus einem `?url`-
+// Import: Vite legt die Datei mit ins Bundle und setzt den Pfad ein. Die App
+// ist offline-first; ein Decoder, der beim ersten Scan ins Netz greift, ist
+// im Hallen-WLAN genau dann kaputt, wenn er gebraucht wird.
 // ───────────────────────────────────────────────────────────────────────────
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { keepScreenAwake } from './wakeLock'
+import wasmUrl from 'zxing-wasm/reader/zxing_reader.wasm?url'
 
-/** Ist Kamera-Scannen in dieser Umgebung möglich? */
+/**
+ * Ist Kamera-Scannen in dieser Umgebung moeglich?
+ *
+ * Seit dem WASM-Rueckfall haengt das nur noch an der KAMERA. Vorher stand
+ * hier zusaetzlich `'BarcodeDetector' in window`, und das machte die Antwort
+ * auf Windows und Linux zu einem Nein, obwohl die Kamera bereitstand.
+ */
 export const isBarcodeScannerSupported = (): boolean =>
-  typeof window !== 'undefined' &&
-  'BarcodeDetector' in window &&
-  typeof navigator !== 'undefined' &&
-  !!navigator.mediaDevices?.getUserMedia
+  typeof navigator !== 'undefined' && !!navigator.mediaDevices?.getUserMedia
 
 export interface ScannerHandle {
   stop: () => void
 }
 
+/** Die Symbologien, die im Lager und auf den Etiketten vorkommen. */
 const FORMATS = ['qr_code', 'code_128', 'code_39', 'ean_13', 'ean_8', 'upc_a']
 
+/** Dieselbe Liste in der Schreibweise von zxing (`QRCode` statt `qr_code`). */
+const ZXING_FORMATS = ['QRCode', 'Code128', 'Code39', 'EAN-13', 'EAN-8', 'UPC-A']
+
 /**
- * Startet die Kamera im gegebenen <video>, erkennt fortlaufend Codes und ruft
- * `onDetect` mit dem ersten Rohwert je Frame. Rückgabe stoppt Kamera + Loop.
- * Wirft, wenn Kamera/Detector nicht verfügbar sind (Aufrufer fängt das ab).
+ * Ein Decoder: bekommt ein Bild und gibt den ersten gefundenen Rohwert.
+ *
+ * Die beiden Wege unterscheiden sich in ihrer Eingabe — die native API
+ * dekodiert direkt aus dem `<video>`, zxing braucht `ImageData`. Deshalb
+ * nimmt diese Grenze das `<video>` und nicht das Bild: sonst muesste der
+ * native Weg unnoetig ueber ein Canvas gehen.
+ */
+type Decoder = (video: HTMLVideoElement) => Promise<string | null>
+
+const nativerDecoder = (): Decoder | null => {
+  const Detector = typeof window !== 'undefined' ? (window as any).BarcodeDetector : undefined
+  if (!Detector) return null
+  let detector: any = null
+  return async (video) => {
+    if (!detector) {
+      const unterstuetzt: string[] =
+        (await Detector.getSupportedFormats?.().catch(() => FORMATS)) ?? FORMATS
+      detector = new Detector({ formats: FORMATS.filter((f) => unterstuetzt.includes(f)) })
+    }
+    const codes = await detector.detect(video)
+    const wert = codes?.[0]?.rawValue
+    return wert ? String(wert).trim() || null : null
+  }
+}
+
+/**
+ * Das Zwischen-Canvas fuer den WASM-Weg — EINES, nicht eines je Bild.
+ *
+ * Und kleiner als das Kamerabild: zxing dekodiert ein 1920er Bild deutlich
+ * langsamer als ein 640er, und fuer einen Code, der formatfuellend vor der
+ * Linse haengt, aendert die Aufloesung am Ergebnis nichts.
+ */
+const ZIEL_BREITE = 640
+
+const wasmDecoder = async (): Promise<Decoder> => {
+  const { prepareZXingModule, readBarcodes } = await import('zxing-wasm/reader')
+  prepareZXingModule({ overrides: { locateFile: () => wasmUrl } })
+  const canvas = document.createElement('canvas')
+  const ctx = canvas.getContext('2d', { willReadFrequently: true })
+  return async (video) => {
+    if (!ctx || !video.videoWidth) return null
+    const faktor = Math.min(1, ZIEL_BREITE / video.videoWidth)
+    canvas.width = Math.max(1, Math.round(video.videoWidth * faktor))
+    canvas.height = Math.max(1, Math.round(video.videoHeight * faktor))
+    ctx.drawImage(video, 0, 0, canvas.width, canvas.height)
+    const bild = ctx.getImageData(0, 0, canvas.width, canvas.height)
+    const treffer = await readBarcodes(bild, {
+      formats: ZXING_FORMATS as never,
+      tryHarder: true,
+      maxNumberOfSymbols: 1,
+    })
+    const wert = treffer[0]?.text
+    return wert ? wert.trim() || null : null
+  }
+}
+
+/**
+ * Wie oft der WASM-Weg ein Bild ansieht.
+ *
+ * Nicht `requestAnimationFrame`: eine WASM-Dekodierung je Bildwiederholung
+ * laestet einen Laptop-Kern voll aus, waehrend die Kamera daneben laeuft.
+ * Alle 120 ms sind fuer die Hand, die ein Etikett vor die Linse haelt,
+ * ununterscheidbar von „sofort" — der native Weg bleibt bei `rAF`, weil er
+ * fast nichts kostet.
+ */
+const WASM_TAKT_MS = 120
+
+/**
+ * Startet die Kamera im gegebenen `<video>`, erkennt fortlaufend Codes und
+ * ruft `onDetect` mit dem ersten Rohwert. Rueckgabe stoppt Kamera + Schleife.
+ * Wirft, wenn die Kamera nicht verfuegbar ist (Aufrufer faengt das ab).
  */
 export const startCameraScan = async (
   video: HTMLVideoElement,
@@ -47,34 +152,43 @@ export const startCameraScan = async (
   // endet mit ihr, also kann sie nicht versehentlich stehenbleiben.
   const awake = keepScreenAwake()
 
-  const Detector = (window as any).BarcodeDetector
-  const supported: string[] = (await Detector.getSupportedFormats?.().catch(() => FORMATS)) ?? FORMATS
-  const detector = new Detector({ formats: FORMATS.filter((f) => supported.includes(f)) })
-
   let running = true
   let raf = 0
-  const loop = async () => {
+  let timer = 0
+
+  const aufraeumen = () => {
+    running = false
+    cancelAnimationFrame(raf)
+    window.clearTimeout(timer)
+    stream.getTracks().forEach((t) => t.stop())
+    video.srcObject = null
+    awake.release()
+  }
+
+  const nativ = nativerDecoder()
+  // Der WASM-Weg wird ERST HIER geladen, nicht beim Import dieses Moduls:
+  // wer den Scanner nie oeffnet, zieht die 1,09 MB nie.
+  const decoder: Decoder = nativ ?? (await wasmDecoder())
+  // Der Ladevorgang kann laenger dauern als die Geduld des Aufrufers; wurde
+  // in der Zwischenzeit gestoppt, faengt die Schleife gar nicht erst an.
+  if (!running) return { stop: aufraeumen }
+
+  const schritt = async () => {
     if (!running) return
     try {
-      const codes = await detector.detect(video)
-      if (codes && codes.length) {
-        const value = String(codes[0].rawValue ?? '').trim()
-        if (value) onDetect(value)
+      const wert = await decoder(video)
+      if (wert) {
+        onDetect(wert)
+        return
       }
     } catch {
-      /* Frame noch nicht bereit — nächster Versuch */
+      /* Frame noch nicht bereit oder transienter Decode-Fehler — weiter */
     }
-    if (running) raf = requestAnimationFrame(loop)
+    if (!running) return
+    if (nativ) raf = requestAnimationFrame(() => void schritt())
+    else timer = window.setTimeout(() => void schritt(), WASM_TAKT_MS)
   }
-  raf = requestAnimationFrame(loop)
+  void schritt()
 
-  return {
-    stop: () => {
-      running = false
-      cancelAnimationFrame(raf)
-      stream.getTracks().forEach((t) => t.stop())
-      video.srcObject = null
-      awake.release()
-    },
-  }
+  return { stop: aufraeumen }
 }

--- a/tests/barcodeDecoder.test.ts
+++ b/tests/barcodeDecoder.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { prepareZXingModule, readBarcodes } from 'zxing-wasm/reader'
+
+// ---------------------------------------------------------------------------
+// Der Barcode-Decoder liest wirklich — und er liest OHNE Netz.
+//
+// ─── DER BEFUND ────────────────────────────────────────────────────────────
+//
+// `lib/barcodeScanner.ts` hing bis 2026-09-10 allein an `BarcodeDetector`.
+// Chromium implementiert die API nur auf Android, macOS und ChromeOS; unter
+// Windows und Linux gibt es sie nicht. Gemessen im echten Fenster dieses
+// Repos (Electron, Chrome/148, Linux):
+//
+//     { BarcodeDetector: false, getUserMedia: true }
+//
+// Die Kamera war da, der Decoder nicht. Die Oberflaeche meldete das ehrlich
+// und schaltete auf Handeingabe zurueck — auf der haeufigsten Plattform also
+// 200 Etiketten abtippen.
+//
+// ─── WAS DIESER TEST PRUEFT, UND WAS DER ANDERE PRUEFT ─────────────────────
+//
+// Hier: dass der WASM-Decoder aus einem Bild wirklich den richtigen Text
+// holt. Ein Rundlauf mit einem SELBST erzeugten Code — nicht mit dem
+// Writer aus demselben Paket, dessen Dokumentation „subject to change a lot"
+// sagt, und nicht mit einer abgelegten PNG-Datei, der man beim Lesen nicht
+// ansieht, was drinsteht. Code 39 ist einfach genug, um ihn hier
+// hinzuschreiben: neun Elemente je Zeichen, drei davon breit.
+//
+// Ein Test, der nur `typeof readBarcodes === 'function'` prueft, waere gruen,
+// wenn die WASM-Datei fehlt.
+// ---------------------------------------------------------------------------
+
+/**
+ * Code 39, ein Zeichen = 9 Elemente (Strich/Luecke im Wechsel), 3 davon breit.
+ * Hier schon als Bitfolge ausgeschrieben: 1 = schwarzes Modul, 0 = weisses.
+ * Nur die Zeichen, die die Probe unten braucht — eine vollstaendige Tabelle
+ * waere Zierrat.
+ */
+const CODE39: Record<string, string> = {
+  '*': '100101101101',
+  '0': '101001101101',
+  '2': '101100101011',
+  '4': '101001101011',
+  'A': '110101001011',
+  'B': '101101001011',
+  'C': '110110100101',
+  '-': '100101011011',
+}
+
+const MODUL_BREITE = 3
+const HOEHE = 60
+/** Ruhezone. Ohne sie findet kein Leser der Welt den Anfang. */
+const RAND = 30
+
+/** Ein Code-39-Bild als `ImageData`-Form (Node kennt die Klasse nicht). */
+const alsBild = (text: string) => {
+  const bits = ['*', ...text, '*'].map((c) => CODE39[c]).join('0')
+  const breite = RAND * 2 + bits.length * MODUL_BREITE
+  const data = new Uint8ClampedArray(breite * HOEHE * 4).fill(255)
+  for (let x = 0; x < bits.length; x += 1) {
+    if (bits[x] !== '1') continue
+    for (let dx = 0; dx < MODUL_BREITE; dx += 1) {
+      const px = RAND + x * MODUL_BREITE + dx
+      for (let y = 0; y < HOEHE; y += 1) {
+        const i = (y * breite + px) * 4
+        data[i] = 0
+        data[i + 1] = 0
+        data[i + 2] = 0
+      }
+    }
+  }
+  return { data, width: breite, height: HOEHE, colorSpace: 'srgb' as const }
+}
+
+const WASM = join(
+  process.cwd(),
+  'node_modules',
+  'zxing-wasm',
+  'dist',
+  'reader',
+  'zxing_reader.wasm',
+)
+
+describe('Der WASM-Decoder', () => {
+  it('liest einen Code 39 aus einem Bild', async () => {
+    // Die WASM-Datei kommt aus dem Paket, nicht aus dem Netz — genauso wie
+    // im Browser, wo `barcodeScanner.ts` sie ueber einen `?url`-Import aus
+    // dem Bundle holt. Ein Test, der sie herunterlaedt, bewiese das Gegenteil
+    // von dem, was hier zugesichert wird.
+    const wasmBinary = readFileSync(WASM)
+    prepareZXingModule({ overrides: { wasmBinary: wasmBinary.buffer as ArrayBuffer } })
+
+    const probe = 'CAB-0042'
+    const treffer = await readBarcodes(alsBild(probe) as never, {
+      formats: ['Code39'],
+      tryHarder: true,
+    })
+    expect(treffer.map((t) => t.text)).toEqual([probe])
+    expect(treffer[0].format).toBe('Code39')
+  }, 30_000)
+
+  it('meldet nichts, wo nichts ist', async () => {
+    // GEGENPROBE. Ohne sie waere der Test auch dann gruen, wenn der Decoder
+    // auf jedes Bild denselben Wert zurueckgaebe — und genau das ist die Art
+    // Fehler, die man einem Scanner erst im Lager ansieht.
+    const leer = {
+      data: new Uint8ClampedArray(200 * 60 * 4).fill(255),
+      width: 200,
+      height: 60,
+      colorSpace: 'srgb' as const,
+    }
+    const treffer = await readBarcodes(leer as never, { formats: ['Code39'] })
+    expect(treffer).toEqual([])
+  }, 30_000)
+})
+
+describe('Die Verdrahtung im Renderer', () => {
+  const quelle = readFileSync(
+    join(process.cwd(), 'src', 'renderer', 'lib', 'barcodeScanner.ts'),
+    'utf8',
+  )
+
+  it('laedt die WASM-Datei aus dem Bundle, nicht aus dem Netz', () => {
+    // `zxing-wasm` sucht seine `.wasm` sonst neben dem eigenen Skript — in
+    // einem Vite-Bundle also unter `/assets/zxing_reader.wasm`, wo sie nicht
+    // liegt. Der `?url`-Import legt sie mit ins Bundle; `locateFile` zeigt
+    // darauf. Die App ist offline-first: ein Decoder, der beim ersten Scan
+    // ins Netz greift, ist im Hallen-WLAN genau dann kaputt, wenn er
+    // gebraucht wird.
+    expect(quelle).toContain("from 'zxing-wasm/reader/zxing_reader.wasm?url'")
+    expect(quelle).toContain('locateFile: () => wasmUrl')
+  })
+
+  it('laedt den Decoder erst beim Scannen nach', () => {
+    // 1,09 MB WASM im Haupt-Chunk waeren fuer jeden da, der nie scannt.
+    // Ein STATISCHER Import von `zxing-wasm/reader` waere genau das —
+    // gesucht wird deshalb der dynamische.
+    expect(quelle).toContain("await import('zxing-wasm/reader')")
+    expect(quelle).not.toMatch(/^import .*from 'zxing-wasm\/reader'$/m)
+  })
+
+  it('nimmt den nativen Weg, wo es ihn gibt', () => {
+    // Die Reihenfolge ist kein Zufall: `BarcodeDetector` kostet keinen
+    // Download und keine WASM-Instanz. Faellt diese Zeile weg, laedt auch ein
+    // Telefon, das die API mitbringt, das Modul nach.
+    expect(quelle).toContain('const decoder: Decoder = nativ ?? (await wasmDecoder())')
+  })
+
+  it('haengt die Verfuegbarkeit nur noch an der Kamera', () => {
+    // Vorher stand in `isBarcodeScannerSupported` zusaetzlich
+    // `'BarcodeDetector' in window` — und das machte die Antwort auf Windows
+    // und Linux zu einem Nein, obwohl die Kamera bereitstand.
+    const zeile = /export const isBarcodeScannerSupported[\s\S]*?\n\n/.exec(quelle)?.[0] ?? ''
+    expect(zeile).toContain('getUserMedia')
+    expect(zeile).not.toContain('BarcodeDetector')
+  })
+})
+
+describe('Die CSP laesst WebAssembly zu — und sonst nichts dazu', () => {
+  const main = readFileSync(join(process.cwd(), 'src', 'main', 'index.ts'), 'utf8')
+
+  it('erlaubt `wasm-unsafe-eval`', () => {
+    // OHNE DIESE ANGABE IST DER DECODER TOT, und zwar erst beim Scan.
+    // Gemessen im gepackten Fenster am 2026-09-10:
+    //
+    //   WebAssembly.instantiateStreaming(): Compiling or instantiating
+    //   WebAssembly module violates the following Content Security policy
+    //   directive because 'unsafe-eval' is not an allowed source of script
+    //   in the following Content Security Policy directive: "script-src 'self'"
+    //
+    // Die WASM-Datei laedt unter `file://` anstandslos (gemessen: 200,
+    // 1 093 289 B) — sie laesst sich nur nicht uebersetzen. Ein Fehler, der
+    // die ganze Pruefkette durchlaeuft und jemandem im Lager vor die Fuesse
+    // faellt, nicht hier.
+    expect(main).toContain("\"script-src 'self' 'wasm-unsafe-eval'; \"")
+  })
+
+  it('erlaubt NICHT `unsafe-eval` oder `unsafe-inline` im Skript-Teil', () => {
+    // Die beiden sind nicht dasselbe: `wasm-unsafe-eval` erlaubt genau das
+    // Uebersetzen von WebAssembly und weiterhin kein `eval()` und keinen
+    // `new Function()` fuer JavaScript. Wer beim naechsten WASM-Problem zum
+    // breiteren Schalter greift, hebt den Schutz fuer den ganzen Renderer
+    // auf — deshalb steht das hier als eigene Zeile und nicht als Kommentar.
+    const skriptTeil = /"script-src[^"]*"/.exec(main)?.[0] ?? ''
+    expect(skriptTeil).not.toContain("'unsafe-eval'")
+    expect(skriptTeil).not.toContain("'unsafe-inline'")
+  })
+})


### PR DESCRIPTION
## Der Befund

Der Kamera-Scan hing allein an `BarcodeDetector`. Chromium implementiert die API **nur auf Android, macOS und ChromeOS** — unter Windows und Linux gibt es sie nicht. Gemessen im echten Fenster dieses Repos (Electron, Chrome/148, Linux):

```json
{ "BarcodeDetector": false, "getUserMedia": true }
```

Die Kamera war also da, der Decoder nicht. Die Oberfläche hat das ehrlich gemeldet und auf die Handeingabe zurückgeschaltet — aber ehrlich zu sein über eine Funktion, die auf der häufigsten Plattform gar nicht läuft, ist kein Ersatz dafür, dass sie läuft. Wer im Lager 200 Etiketten abhaken will, tippt sie sonst ab.

Das Repo **kann** Codes längst schreiben (`jsbarcode`, `qrcode` stehen seit je in den Abhängigkeiten); nur lesen konnte es sie am Desktop nicht.

## Was sich ändert

- **`zxing-wasm` als Rückfall**, per `import()` nachgeladen: 1,09 MB WASM in einem eigenen Chunk. Gemessen: Haupt-Chunk **3.304,63 → 3.305,22 kB**, also 0,6 kB. Wer nie scannt, lädt den Decoder nie.
- **Die native API bleibt der erste Weg**, wo es sie gibt — sie kostet keinen Download und keine WASM-Instanz. Auf einem Telefon ist das spürbar.
- `isBarcodeScannerSupported()` hängt jetzt **nur noch an der Kamera**. Der zusätzliche Test auf `BarcodeDetector` war genau die Zeile, die auf Windows und Linux Nein sagte, obwohl die Kamera bereitstand.
- Die WASM kommt **aus dem Bundle** (`?url`-Import + `locateFile`), nicht aus dem Netz. Die App ist offline-first; ein Decoder, der beim ersten Scan ins Netz greift, ist im Hallen-WLAN genau dann kaputt, wenn er gebraucht wird.
- Der WASM-Weg dekodiert im **120-ms-Takt auf einem 640px-Bild** statt je Bildwiederholung auf dem vollen Kamerabild: eine WASM-Dekodierung je Frame lastet einen Laptop-Kern voll aus, und für die Hand, die ein Etikett vor die Linse hält, ist der Unterschied nicht wahrnehmbar.

## Die CSP hätte das still zerbrochen

`script-src 'self'` verbietet das Übersetzen von WebAssembly. Gemessen im gepackten Fenster:

```
WebAssembly.instantiateStreaming(): Compiling or instantiating WebAssembly module
violates the following Content Security policy directive because 'unsafe-eval' is
not an allowed source of script in the following CSP directive: "script-src 'self'"
```

Die Datei selbst lädt unter `file://` anstandslos (**200, 1.093.289 B**) — sie ließ sich nur nicht übersetzen. Der Fehler wäre erst **beim Scan** aufgetreten, also nicht in einer Prüfung, sondern im Lager.

`script-src` trägt jetzt zusätzlich `'wasm-unsafe-eval'`. Das ist **nicht** `'unsafe-eval'`: es erlaubt genau das Übersetzen von WebAssembly und weiterhin kein `eval()` und keinen `new Function()` für JavaScript. Ein Test hält beide Hälften fest — die Erlaubnis muss da sein, der breitere Schalter darf nicht dazukommen.

## Belegt statt behauptet

| Beleg | Ergebnis |
|---|---|
| Rundlauf im Test mit einem **selbst erzeugten** Code 39 (nicht mit dem Writer desselben Pakets, dessen Doku „subject to change a lot" sagt) | `CAB-0042` hinein, `CAB-0042` heraus |
| Gegenprobe: leeres Bild | keine Treffer |
| Ende zu Ende im Browser mit dem **gebauten** Chunk + der **gebauten** WASM über ein echtes Canvas | `CAB-0042`, Format `Code39` |
| `WebAssembly.compile` im gepackten Fenster unter der neuen CSP | ok, 21 Exporte |

Dazu: `tsc` (app + main) 0 Fehler, `eslint` 0 Fehler, **3877 Tests grün**.

## Nicht in diesem Schnitt

Die **Mobile-Ansicht** hat ihren eigenen Scan-Weg und bleibt bei `BarcodeDetector`. Android-Chrome bringt die API mit, **iOS Safari nicht** — dort ist der Kamera-Scan also weiter zu. Der Rückfall wäre technisch derselbe, kostet dort aber 1,09 MB über das Hallen-WLAN, und das ist eine Abwägung mit einer Zahl, keine Nebenbei-Entscheidung. Als Issue nachgetragen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_