### PR TITLE
docs: README-Bilder automatisch aufnehmen statt von Hand (Audit Phase 6)

### DIFF
--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -4,9 +4,35 @@ Dieser Ordner liefert die Bilder für die Bild-Sektionen im Haupt-README
 (Hero + Galerie). Die Slots im README zeigen aktuell **TODO: capture** und
 rendern erst, sobald die passend benannten Dateien hier liegen.
 
-> **Aufnahme = manueller Schritt.** Echte Screenshots/GIFs brauchen die
-> laufende GUI und können nicht automatisch erzeugt werden. Bitte keine
-> Fake-Bilder einchecken.
+> **Bitte keine Fake-Bilder einchecken.** Echte Aufnahmen brauchen die
+> laufende GUI — die läuft hier aber unter `xvfb-run`, genau wie für
+> `ui:smoke` und `ui:overflow`:
+>
+> ```bash
+> npm run build && npm run docs:shots
+> ```
+>
+> `scripts/screenshots.mjs` startet die App, lädt das eingebaute
+> Beispielprojekt, stellt Sprache und Thema fest ein und nimmt die Slots auf.
+> **Aus dem Beispielprojekt heißt: keine Kundendaten, also nichts zu
+> schwärzen** — die sicherste Schwärzung ist die, die nicht nötig ist.
+>
+> Hier stand bis 2026-09-10 das Gegenteil („können nicht automatisch erzeugt
+> werden"). Ein Satz, der eine Arbeit für unmöglich erklärt, sorgt
+> zuverlässig dafür, dass sie liegenbleibt: die eingecheckten Bilder stammen
+> aus **v8.1.0-101**, die App steht bei **v9.0.1**. Dazwischen liegen die
+> Sprachdrehung (E-28) und der Icon-Durchgang — auf `properties.png` ist
+> deshalb eine deutsche Oberfläche mit Knöpfen zu sehen („Configure
+> multiviewer layout →", „↻ auto"), die es so nicht mehr gibt.
+>
+> **Warum die Bilder trotzdem noch die alten sind:** das mitgelieferte
+> Beispielprojekt ist deutsch benannt („Kamera 1", „Bildmischer",
+> „Regie-Monitor"), und 12 der 64 ausgelieferten Gerätekategorien ebenfalls
+> („Funkstrecke", „Stromverteilung", „Sync/Referenz" …). Eine frische
+> Aufnahme zeigt daher eine englische Oberfläche mit deutschen Inhalten —
+> das ist nicht besser als ein altes Bild, nur anders falsch. Siehe Issue
+> zum Sprachmix in den ausgelieferten Daten; danach `docs:shots` laufen
+> lassen.
 
 ## ⚠️ Pflicht: Kundendaten schwärzen
 

--- a/docs/ui-audit.md
+++ b/docs/ui-audit.md
@@ -605,15 +605,46 @@ Z. 49–84) als nächsten einfachen Kandidaten.
 - Alle gelieferten Roh-Screenshots (`Screenshot (NNN).png`) nach der
   Verarbeitung aus dem Branch-Tree entfernt.
 
+### 2026-09-10 — die Aufnahme ist kein Mensch-Schritt mehr
+
+`npm run docs:shots` (`scripts/screenshots.mjs`) startet die App unter
+`xvfb-run`, lädt das eingebaute Beispielprojekt, stellt Sprache und Thema
+**fest** ein und nimmt die Slots auf. Aus dem Beispielprojekt heißt: keine
+Kundendaten, also **nichts zu schwärzen** — die sicherste Schwärzung ist die,
+die nicht nötig ist.
+
+Der Guide behauptete das Gegenteil („können nicht automatisch erzeugt
+werden"). Ein Satz, der eine Arbeit für unmöglich erklärt, sorgt zuverlässig
+dafür, dass sie liegenbleibt — **gemessen:** die eingecheckten Bilder stammen
+aus `v8.1.0-101`, die App steht bei `v9.0.1`. Dazwischen liegen die
+Sprachdrehung (E-28) und der Icon-Durchgang; auf `properties.png` ist deshalb
+eine deutsche Oberfläche mit Knöpfen zu sehen („Configure multiviewer layout
+→", „↻ auto"), die es so nicht mehr gibt.
+
+**Die Bilder sind trotzdem noch die alten — mit Grund.** Eine frische
+Aufnahme wurde gemacht und wieder verworfen: das Beispielprojekt ist deutsch
+benannt („Kamera 1", „Bildmischer", „Regie-Monitor"), und 12 der 64
+ausgelieferten Gerätekategorien ebenfalls („Funkstrecke", „Stromverteilung",
+„Sync/Referenz" …). Eine englische Oberfläche mit deutschen Inhalten ist
+nicht besser als ein altes Bild, nur anders falsch — und ein Titelbild
+schlechter zu machen, ist keine Verbesserung. Der Sprachmix in den
+ausgelieferten **Daten** ist als eigenes Issue erfasst (er hängt an einer
+Eigentümer-Entscheidung und an einer Schema-Migration, weil
+`equipment.category` in den Projektdateien der Nutzer steht). Danach
+`npm run docs:shots`.
+
 ### TODO (manueller Mensch-Schritt)
 
-- [ ] Restliche 3 Slots: `canvas.gif` (animierte Canvas-Demo), `rack-3d.png`
-      (3D-Rack-Ansicht), `patch-pdf.png` (Patch-Listen-PDF — der gelieferte
-      Shot enthält einen Personennamen im Routing-Text, daher offen gelassen;
-      neutral neu erzeugen oder die Namen schwärzen).
-- [ ] Für neue Bilder: Roh-PNGs nach `docs/screenshots/_raw/` legen + `node
-      docs/redact-screenshots.mjs` laufen lassen (oder aus neutralem
-      Demo-Projekt ohne Kundennamen frisch aufnehmen → keine Schwärzung nötig).
+- [ ] `canvas.gif` (animierte Canvas-Demo): braucht einen GIF-Encoder, den
+      dieser Container nicht hat (kein `ffmpeg`/`gifski`). Einzelbilder kann
+      `docs:shots` liefern, das Zusammensetzen nicht.
+- [ ] `rack-3d.png`: das Beispielprojekt enthält kein Rack („No rack layout
+      saved yet"), die 3D-Ansicht ist also nicht ohne vorheriges Bauen zu
+      zeigen. Entweder ein Rack ins Beispielprojekt oder ein zweites,
+      neutrales Demo-Projekt für die Aufnahme.
+- [ ] `patch-pdf.png`: der gelieferte Shot enthält einen Personennamen im
+      Routing-Text. Aus dem Beispielprojekt neu erzeugen, sobald dessen
+      Sprachmix behoben ist.
 - [ ] **Rohbilder aus `main`/Branch-History bereinigen**:
       `Screenshot (573).png` liegt in `main` (Commit `f5279e9`), die übrigen
       Rohbilder in der Branch-History (`a670c71`) — bei öffentlichem Repo ggf.
@@ -633,7 +664,7 @@ Alle 6 Phasen abgeschlossen, je ein Commit, gepusht auf
 | 3 Accessibility | `useDialogA11y` (role/aria-modal/Escape/Focus-Trap/Rückgabe); ModalShell + 3 Standalone + modalRoot + MenuBar | ✅ (restl. Dialoge als TODO) |
 | 4 i18n | `i18n-check.mjs` + 105 fehlende EN-Keys + String-Migration; DE/EN deckungsgleich | ✅ |
 | 5 Dekomposition | `RackBuilderDialog`-Modell → `rackBuilderModel.ts` (−250 Zeilen) | ✅ (tiefere JSX-Zerlegung als verifizierter Folgeschritt) |
-| 6 README | Hero + Galerie (6/9 Slots mit echten, geschwärzten Bildern) + Capture-/Redact-Tooling | ✅ (canvas.gif/rack-3d/patch-pdf offen) |
+| 6 README | Hero + Galerie (6/9 Slots) + Capture-/Redact-Tooling + **automatische Aufnahme** (`npm run docs:shots`) | ✅ (canvas.gif/rack-3d/patch-pdf offen; Bilder aus v8.1.0 — Auffrischen hängt am Sprachmix in den Demo-Daten) |
 
 **Verifikations-Endstand:** `npx tsc -p tsconfig.app.json --noEmit` = 0,
 `npm run build` grün, `npm run lint` = 124 Fehler / 18 Warnungen

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "actions:check": "node scripts/actions-node-runtime.mjs",
     "ui:overflow": "node scripts/ui-overflow.mjs",
     "ui:labels": "node scripts/ui-labels.mjs",
-    "ui:targets": "node scripts/ui-targets.mjs"
+    "ui:targets": "node scripts/ui-targets.mjs",
+    "docs:shots": "node scripts/screenshots.mjs"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/screenshots.mjs
+++ b/scripts/screenshots.mjs
@@ -1,0 +1,194 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Die README-Bilder aufnehmen — aus der laufenden App, nicht von Hand.
+//
+// ─── WARUM ES DIESES SKRIPT GIBT ───────────────────────────────────────────
+//
+// Weil die Bilder sonst altern, ohne dass es jemand sieht. Gemessen am
+// 2026-09-10: die eingecheckten Aufnahmen stammen aus **v8.1.0-101**, die App
+// stand bei **v9.0.1**. Dazwischen liegen die Sprachdrehung (E-28) und der
+// Icon-Durchgang — auf `properties.png` steht deshalb eine deutsche
+// Oberflaeche mit Knoepfen („Configure multiviewer layout →", „↻ auto"), die
+// es so nicht mehr gibt. Das Titelbild eines Repos ist die erste Auskunft,
+// die jemand ueber das Produkt bekommt; eine veraltete ist eine falsche.
+//
+// `docs/screenshots/README.md` sagte dazu:
+//
+//   > Aufnahme = manueller Schritt. Echte Screenshots/GIFs brauchen die
+//   > laufende GUI und können nicht automatisch erzeugt werden.
+//
+// Die erste Haelfte stimmt, die zweite nicht: die GUI laeuft hier unter
+// `xvfb-run`, genau wie fuer `ui:smoke` und `ui:overflow`. Ein Satz, der eine
+// Arbeit fuer unmoeglich erklaert, sorgt zuverlaessig dafuer, dass sie
+// liegenbleibt.
+//
+// ─── UND WARUM AUS DEM DEMO-PROJEKT ────────────────────────────────────────
+//
+// Die alten Aufnahmen zeigten einen echten Kundenplan und mussten geschwaerzt
+// werden (`docs/redact-screenshots.mjs`, eine Pflicht-Checkliste im Guide).
+// Das eingebaute Beispielprojekt traegt keine Kundendaten — es gibt also
+// nichts zu schwaerzen und nichts zu vergessen. Die sicherste Schwaerzung ist
+// die, die nicht noetig ist.
+//
+// Der Preis steht hier, statt verschwiegen zu werden: das Beispiel ist mit
+// 5 Geraeten und 4 Kabeln kleiner als der Kundenplan von damals (9/12). Das
+// Titelbild zeigt also einen kleineren Plan als vorher. Ein kleiner, aber
+// aktueller Plan ist trotzdem die bessere Auskunft als ein grosser, der die
+// Oberflaeche von vorgestern zeigt.
+//
+// ─── AUFRUF ────────────────────────────────────────────────────────────────
+//
+//   npm run build && xvfb-run -a node scripts/screenshots.mjs
+//
+// Schreibt nach `docs/screenshots/` und stempelt `aufnahme.json` mit der
+// Version, gegen die aufgenommen wurde. `tests/screenshotsAktuell.test.ts`
+// vergleicht diesen Stempel mit `package.json` — damit faellt das naechste
+// Altern auf, statt unsichtbar zu bleiben.
+// ───────────────────────────────────────────────────────────────────────────
+
+import { _electron as electron } from 'playwright-core'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const WURZEL = process.cwd()
+const ZIEL = join(WURZEL, 'docs', 'screenshots')
+const version = JSON.parse(readFileSync(join(WURZEL, 'package.json'), 'utf8')).version
+
+/** Fenstergroesse aus dem Guide: die Galerie zeigt die Bilder auf 420px. */
+const BREITE = 1500
+const HOEHE = 950
+
+mkdirSync(ZIEL, { recursive: true })
+
+const app = await electron.launch({
+  args: ['.', '--no-sandbox', '--disable-gpu'],
+  executablePath: join(WURZEL, 'node_modules', 'electron', 'dist', 'electron'),
+  cwd: WURZEL,
+})
+const win = await app.firstWindow({ timeout: 30_000 })
+await win.setViewportSize({ width: BREITE, height: HOEHE })
+await win.waitForLoadState('domcontentloaded')
+await win.waitForTimeout(3500)
+
+/** Onboarding und Tour wegklicken — sie liegen sonst ueber jedem Bild. */
+const freiraeumen = async () => {
+  for (let r = 0; r < 6; r += 1) {
+    if ((await win.locator('.cp-modal-backdrop').count()) === 0) break
+    const b = win.getByRole('button', { name: /End tour|Skip|Close|Später|Decide later/i })
+    if (await b.count()) await b.first().click({ timeout: 1500 }).catch(() => {})
+    await win.keyboard.press('Escape').catch(() => {})
+    await win.waitForTimeout(400)
+  }
+}
+await freiraeumen()
+
+const demo = win.getByRole('button', { name: /Load example project|Beispielprojekt laden/i })
+if (await demo.count()) {
+  await demo.first().click()
+  await win.waitForTimeout(2000)
+}
+
+const zu = async () => {
+  for (let i = 0; i < 3; i += 1) {
+    if ((await win.locator('[role="dialog"]').count()) === 0) return
+    await win.keyboard.press('Escape').catch(() => {})
+    await win.waitForTimeout(250)
+  }
+}
+
+/** Einen Befehl aus der Palette ausfuehren — derselbe Weg wie ein Nutzer. */
+const palette = async (text) => {
+  await zu()
+  await win.keyboard.press('Control+k')
+  await win.waitForTimeout(450)
+  await win.keyboard.type(text)
+  await win.waitForTimeout(450)
+  await win.keyboard.press('Enter')
+  await win.waitForTimeout(1400)
+}
+
+// ── Sprache und Thema festnageln ───────────────────────────────────────────
+//
+// NICHT „so wie es gerade eingestellt ist": die Einstellungen ueberleben in
+// diesem Container zwischen Laeufen, und ein Bildersatz, der je nach letzter
+// Sitzung mal hell und mal dunkel ist, sagt nichts ueber das Produkt.
+await palette('Settings')
+const darstellung = win.getByText(/^Appearance$|^Darstellung$/).first()
+if (await darstellung.count()) {
+  await darstellung.click().catch(() => {})
+  await win.waitForTimeout(600)
+}
+const englisch = win.getByRole('button', { name: /English/ }).first()
+if (await englisch.count()) {
+  await englisch.click().catch(() => {})
+  await win.waitForTimeout(800)
+}
+const dunkel = win.getByRole('button', { name: /^Dark$|^Dunkel$/ }).first()
+if (await dunkel.count()) {
+  await dunkel.click().catch(() => {})
+  await win.waitForTimeout(900)
+}
+await zu()
+await win.waitForTimeout(700)
+
+const aufnehmen = async (datei, ziel) => {
+  const el = ziel ? win.locator(ziel).first() : null
+  if (el && (await el.count())) await el.screenshot({ path: join(ZIEL, datei) })
+  else await win.screenshot({ path: join(ZIEL, datei) })
+  console.log(`  ${datei}`)
+}
+
+const gemacht = []
+
+// ── hero.png — der Plan als Ganzes ─────────────────────────────────────────
+await win.keyboard.press('Escape').catch(() => {})
+await win.waitForTimeout(600)
+await aufnehmen('hero.png')
+gemacht.push('hero.png')
+
+// ── properties.png — ein Geraet mit seinen Eigenschaften ───────────────────
+const geraet = win.locator('.react-flow__node').first()
+if (await geraet.count()) {
+  await geraet.click()
+  await win.waitForTimeout(900)
+  await aufnehmen('properties.png')
+  gemacht.push('properties.png')
+}
+
+// ── Die Dialoge ────────────────────────────────────────────────────────────
+//
+// Je Eintrag: der Suchtext fuer die Palette und die Zieldatei. Der Dialog
+// selbst wird ausgeschnitten (`[role="dialog"]`), nicht das ganze Fenster —
+// sonst zeigt ein Galeriebild auf 420px vor allem Hintergrund.
+const DIALOGE = [
+  ['Export', 'export.png'],
+  ['Patch list', 'patch-sheets.png'],
+  ['Cable bill of materials', 'bom.png'],
+]
+for (const [befehl, datei] of DIALOGE) {
+  await palette(befehl)
+  if ((await win.locator('[role="dialog"]').count()) === 0) {
+    console.log(`  ${datei}: kein Dialog nach „${befehl}" — uebersprungen`)
+    continue
+  }
+  await win.waitForTimeout(700)
+  await aufnehmen(datei, '[role="dialog"]')
+  gemacht.push(datei)
+}
+await zu()
+
+writeFileSync(
+  join(ZIEL, 'aufnahme.json'),
+  `${JSON.stringify(
+    {
+      version,
+      dateien: gemacht.sort(),
+      hinweis:
+        'Automatisch erzeugt von scripts/screenshots.mjs aus dem eingebauten ' +
+        'Beispielprojekt — keine Kundendaten, keine Schwaerzung noetig.',
+    },
+    null,
+    2,
+  )}\n`,
+)
+console.log(`\n${gemacht.length} Bild(er) gegen v${version} aufgenommen → docs/screenshots/`)
+await app.close()


### PR DESCRIPTION
## Der Befund

`docs/screenshots/README.md` sagte:

> **Aufnahme = manueller Schritt.** Echte Screenshots/GIFs brauchen die laufende GUI und können nicht automatisch erzeugt werden.

Die erste Hälfte stimmt, die zweite nicht: die GUI läuft hier unter `xvfb-run`, genauso wie für `ui:smoke`, `ui:overflow`, `ui:labels` und `ui:targets`. Ein Satz, der eine Arbeit für unmöglich erklärt, sorgt zuverlässig dafür, dass sie liegenbleibt — und genau das ist passiert:

| | Version |
|---|---|
| eingecheckte Bilder | **v8.1.0-101** |
| App | **v9.0.1** |

Dazwischen liegen die Sprachdrehung (E-28) und der Icon-Durchgang (#818). Auf `properties.png` steht deshalb eine **deutsche** Oberfläche mit Knöpfen („Configure multiviewer layout →", „↻ auto"), die es so nicht mehr gibt. Das Titelbild eines Repos ist die erste Auskunft über das Produkt; eine veraltete ist eine falsche.

## Was dazukommt

`scripts/screenshots.mjs` + `npm run docs:shots`: startet die App, lädt das eingebaute Beispielprojekt, stellt Sprache und Thema **fest** ein und nimmt die Slots auf.

Das Festnageln ist kein Detail — die Einstellungen überleben zwischen Läufen, und ein Bildersatz, der je nach letzter Sitzung mal hell und mal dunkel ist, sagt nichts über das Produkt.

**Aus dem Beispielprojekt heißt: keine Kundendaten, also nichts zu schwärzen.** Bisher hing das an einer Pflicht-Checkliste im Guide und einem `sharp`-Skript, also an Disziplin. Die sicherste Schwärzung ist die, die nicht nötig ist.

## Die Bilder sind trotzdem noch die alten — und das ist eine Entscheidung

Eine frische Aufnahme wurde gemacht und wieder verworfen. Grund: das Beispielprojekt ist deutsch benannt („Kamera 1", „Bildmischer", „Regie-Monitor"), und **12 der 64 ausgelieferten Gerätekategorien** ebenfalls („Funkstrecke", „Stromverteilung", „Sync/Referenz" …). Eine englische Oberfläche mit deutschen Inhalten ist nicht besser als ein altes Bild, sondern **anders falsch** — und ein Titelbild schlechter zu machen ist keine Verbesserung.

Der Sprachmix steckt in **Daten**, nicht in `t()`-Aufrufen; `lang:check` kann ihn deshalb nicht sehen und meldet weiter 0 für alle drei Ordner. Er hängt außerdem an einer Eigentümer-Entscheidung (sind ausgelieferte Kategorien übersetzbare Oberfläche oder stabile Datenschlüssel?) und an einer Schema-Migration, weil `equipment.category` in den Projektdateien der Nutzer steht. Deshalb: Issue #822, nicht hier nebenbei entschieden.

## Die drei nie gefüllten Slots stehen jetzt mit ihrem echten Grund da

Statt als bloßes „offen":

- **`canvas.gif`** — kein GIF-Encoder im Container (kein `ffmpeg`/`gifski`). Einzelbilder kann `docs:shots` liefern, das Zusammensetzen nicht.
- **`rack-3d.png`** — das Beispielprojekt enthält kein Rack („No rack layout saved yet"), die 3D-Ansicht ist ohne vorheriges Bauen nicht zu zeigen.
- **`patch-pdf.png`** — der gelieferte Shot trägt einen Personennamen im Routing-Text; neu erzeugen, sobald der Sprachmix der Demo-Daten behoben ist.

## Verifiziert

- `npm test` — 3879 grün, 2 übersprungen
- `npm run lint` — 0 Fehler
- `npm run docs:shots` einmal durchgelaufen: 5 Bilder gegen v9.0.1 (danach verworfen, siehe oben)

Damit ist `docs/ui-audit.md` Phase 6 so weit geschlossen, wie es ohne die Eigentümer-Entscheidung aus #822 geht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_