### PR TITLE
ui: Aufklapp-Carets und freistehende Emojis werden Icons (180 → 138 rohe Symbole)

### DIFF
--- a/docs/ui-audit.md
+++ b/docs/ui-audit.md
@@ -581,14 +581,54 @@ nicht erst, wenn jemand eine halb übersetzte Seite meldet.
       Die feste Probe im CLI-Teil trägt die drei neuen Formen jetzt mit; ohne
       sie fällt genau diese Härte beim nächsten Aufräumen still wieder heraus.
 
-- [ ] **Offen (gemessen, nicht geschätzt): 106 rohe Symbole im JSX in 47
-      Dateien**, außerhalb jedes `t()`-Aufrufs (`<span>🔄</span>`,
-      `★ Custom Cable…`, `{open ? '▾' : '▸'}`). Ein guter Teil davon ist
-      legitim — die Caret-Dreiecke der Menüs, die Richtungspfeile des
-      Off-Page-Symbols, ein Zustandspunkt —, und genau deshalb ist es ein
-      eigener Schnitt mit eigener Urteilsarbeit und keine Fortsetzung dieses
-      hier. Der Wächter sagt in seinem Kopf ausdrücklich, dass er sie nicht
-      sieht.
+- [x] **Rohe Symbole im JSX: 180 → 138 Stellen, 61 → 50 Dateien**
+      (2026-09-10, gemessen über dieselbe Baumsuche wie der Glyph-Wächter).
+      Zwei Klassen sind durch, und zwar die zwei, für die `Icon.tsx` genau
+      seinen Grund nennt („Emojis rendern je Plattform/Font inkonsistent"):
+
+      **(a) Alle 24 Aufklapp-Carets.** `{open ? '▾' : '▸'}`,
+      `{collapsed ? '▶' : '▼'}`, `{offen ? '▴' : '▾'}` und die
+      freistehenden `▾` in `MenuBar`, `LibraryMenus`, `RackAddSplitButton` —
+      jetzt `<Icon icon={open ? ChevronDown : ChevronRight} />`. Es waren
+      **fünf verschiedene Glyph-Paare für dieselbe Geste**; das allein ist der
+      Grund, warum ein Aufklapper je nach Dialog anders aussah.
+
+      **(b) 17 freistehende Emoji/Symbol-Kinder**: `🔄` (drei Mal, dieselbe
+      Aktualisieren-Aktion), `📦`, `🔍`, `📁` (zwei Mal), `▥` (zwei Mal),
+      `🪑`, `⏬`/`⏫` (fünf Mal), `✅`, `📌`, `◆`, `➕`.
+
+      **Ein Wächter ist dabei umgefallen, und das war richtig so.**
+      `tests/schriftgroesseUntergrenze.test.ts` sicherte zu, dass die
+      Baumsuche „mindestens eine" Stelle unter 12px findet — die sechs
+      dekorativen Micro-Glyphen, die es damals noch gab. Die sind jetzt
+      `<Icon />` und tragen ihre Größe als Zahl statt als CSS-Klasse, also
+      fand sie null. Der Kommentar dort hatte den Fall vorhergesehen und
+      benannt. Eine Zusicherung, die am Bestand hängt, geht mit dem letzten
+      Fund verloren: „keine Stelle unter 12px" wäre ab dann auch bei kaputtem
+      Muster erfüllt. Sie steht jetzt auf einer **festen Probe** — dieselbe
+      Form wie im Sprachmix-Zähler.
+- [ ] **Offen: 138 Stellen in 50 Dateien**, und der Rest ist keine
+      Fleißarbeit mehr, sondern Urteilsarbeit — drei Gruppen mit je eigenem
+      Grund:
+
+      **(1) Pfeile im Satz oder im Datensatz** (40× `→`, 11× `←`, 8× `↔`):
+      `${from} → ${to}` in einer Stückliste, ein Achsen-Label der
+      Routing-Matrix, der Zielhinweis einer Zeile. Das sind **Daten**, keine
+      Verzierung, und sie landen in CSV/PDF, wo kein SVG hinkann.
+
+      **(2) `<option>`-Kinder** (`◆ {l}` in `CableProperties`, `📦 ` in
+      `InventoryDialog`, `▼` im Videohub-Dialog): `<option>` nimmt nur Text.
+      Ein Icon dort ist technisch unmöglich, nicht bloß unerwünscht — wer die
+      Zeile „aufräumt", bekommt `[object Object]` in der Auswahlliste.
+
+      **(3) Symbole, die der Wert sind**: `♂`/`♀` an der Steckerbauart,
+      `◄`/`►` in der Pfeilspitzen-Auswahl, `▲` des Polardiagramms und die
+      elf `ICON_GLYPHS` in `OptionalFieldsSection` — Letztere stehen **im
+      Projekt-File**, sind also Nutzerdaten und nicht Darstellung.
+
+      Was danach noch bleibt (`✓ ✕ ✗ ⚠ ● ○ ↺`, ~40 Stellen), ist echter
+      Kandidat für Icons, aber jeweils mit Zustandsbedeutung im umgebenden
+      Markup — das ist der nächste Schnitt, nicht dieser.
 
 ## Phase 5 — Komponenten-Dekomposition (RISIKO)
 

--- a/src/renderer/ErrorBoundary.tsx
+++ b/src/renderer/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react'
-import { ClipboardCopy, RotateCcw, Trash2 } from 'lucide-react'
+import { ClipboardCopy, RotateCcw, Trash2, CircleCheck} from 'lucide-react'
 import { cablePlannerApi } from './lib/bridge'
 import { confirmDialog } from './lib/confirmDialog'
 import { translate } from './lib/i18n'
@@ -300,7 +300,8 @@ export class ErrorBoundary extends Component<Props, State> {
                 {translate(lang, 'errorBoundary.bootLoop', 'Boot loop detected — UI settings were reset automatically.')}
               </div>
               <div style={{ fontSize: 13, lineHeight: 1.5 }}>
-                ✅ <strong>{translate(lang, 'errorBoundary.dataSafeHead', 'Your project data is safe')}</strong>
+                <Icon icon={CircleCheck} size="sm" className="mr-1 inline" />
+                <strong>{translate(lang, 'errorBoundary.dataSafeHead', 'Your project data is safe')}</strong>
                 {translate(lang, 'errorBoundary.dataSafeBody', ': the autosave, the local library, saved groups and rack drafts were NOT deleted.')}
                 {this.state.projectBackedUp && (
                   <> Zusätzlich wurde eine Sicherheitskopie des Autosaves angelegt

--- a/src/renderer/components/Atem/AtemMvConfigDialog.tsx
+++ b/src/renderer/components/Atem/AtemMvConfigDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { toPng } from 'html-to-image'
-import { Download, Square, SquareCheck, Monitor } from 'lucide-react'
+import { Download, Square, SquareCheck, Monitor, ChevronDown, ChevronRight} from 'lucide-react'
 import { Icon } from '../shared/Icon'
 import { useProjectStore } from '../../store/projectStore'
 import { useUiStore } from '../../store/uiStore'
@@ -556,7 +556,7 @@ const CapabilitiesPanel = ({
         onClick={() => setOpen((o) => !o)}
         className="flex w-full items-center gap-2 text-left hover:text-cp-text-bright"
       >
-        <span>{open ? '▾' : '▸'}</span>
+        <Icon icon={open ? ChevronDown : ChevronRight} size="xs" />
         <span>
           {t('atem.mv.capabilities', 'Model capabilities:')} <span className="text-cp-text-secondary">{equipmentName}</span> ·{' '}
           {caps.mvCount} MV{caps.mvCount === 1 ? '' : 's'} ·{' '}

--- a/src/renderer/components/Calculators/CalculatorsDialog.tsx
+++ b/src/renderer/components/Calculators/CalculatorsDialog.tsx
@@ -12,7 +12,7 @@ import { useMemo, useState } from 'react'
 import { useUiStore } from '../../store/uiStore'
 import { useProjectStore } from '../../store/projectStore'
 import { ModalShell } from '../shared/ModalShell'
-import { AlertTriangle, Download, Calculator, BatteryCharging } from 'lucide-react'
+import { AlertTriangle, Download, Calculator, BatteryCharging, Pin} from 'lucide-react'
 import { useTranslation } from '../../lib/i18n'
 import { Icon } from '../shared/Icon'
 import { downloadBlob } from '../../lib/downloadBlob'
@@ -848,7 +848,7 @@ const PowerTab = () => {
                     <td className="truncate py-0.5">
                       {a.name}
                       {a.pinned && (
-                        <span className="ml-1 text-[11px] text-cp-text-muted" title={t('calc.phasePinned', 'Pinned')}>📌</span>
+                        <Icon icon={Pin} size={11} className="ml-1 inline text-cp-text-muted" label={t('calc.phasePinned', 'Pinned')} />
                       )}
                     </td>
                     <td className="text-right font-mono text-cp-text-muted">{a.watts}</td>

--- a/src/renderer/components/Canvas/CableContextMenu.tsx
+++ b/src/renderer/components/Canvas/CableContextMenu.tsx
@@ -22,7 +22,7 @@
 //   • Kabel löschen
 
 import { useEffect, useRef, useState } from 'react'
-import { Pencil, Pin, X, Plus, Minus, RotateCcw, Navigation, CornerDownRight, Check, Milestone } from 'lucide-react'
+import { Pencil, Pin, X, Plus, Minus, RotateCcw, Navigation, CornerDownRight, Check, Milestone, ChevronDown, ChevronRight} from 'lucide-react'
 import { Icon } from '../shared/Icon'
 import { useUiStore } from '../../store/uiStore'
 import { useCanvasProjectStore as useProjectStore } from '../../store/projectStoreContext'
@@ -337,7 +337,11 @@ export const CableContextMenu = () => {
       >
         {t('canvas.cableMenu.routing', 'Routing:')}{' '}
         <strong className="ml-1">{routingLabel(routing, t)}</strong>
-        <span className="ml-auto text-slate-500">{submenu === 'routing' ? '▾' : '▸'}</span>
+        <Icon
+          icon={submenu === 'routing' ? ChevronDown : ChevronRight}
+          size="xs"
+          className="ml-auto text-slate-500"
+        />
       </Item>
       {submenu === 'routing' && (
         <div className="border-l-2 border-sky-700 bg-cp-surface-3/50">

--- a/src/renderer/components/Canvas/CanvasToolbar.tsx
+++ b/src/renderer/components/Canvas/CanvasToolbar.tsx
@@ -11,7 +11,7 @@ import { useDraggablePosition } from '../../hooks/useDraggablePosition'
 import { confirmDialog } from '../../lib/confirmDialog'
 import { computeEquipmentLayout } from '../../lib/equipmentLayout'
 import { computeAlignedPositions, type AlignMode, type AlignItem } from '../../lib/alignEquipment'
-import { Check, X } from 'lucide-react'
+import { Check, X, ChevronUp, ChevronDown} from 'lucide-react'
 import { useTranslation, format } from '../../lib/i18n'
 import { Icon } from '../shared/Icon'
 import { Tooltip } from '../shared/Tooltip'
@@ -1132,7 +1132,7 @@ const DefaultsMenu = ({
             title={t('toolbar.defaults.modified', 'At least one default has been changed')}
           />
         )}
-        <span style={{ fontSize: 9 }}>{open ? '▴' : '▾'}</span>
+        <Icon icon={open ? ChevronUp : ChevronDown} size={9} />
       </button>
       {open && (
         <div
@@ -1400,7 +1400,7 @@ const LockMenu = ({
             Oeffnen beantwortet ist. Bei null wird nichts gezeigt: eine „0"
             waere eine Angabe ueber nichts. */}
         {aktiv > 0 && <span style={{ fontVariantNumeric: 'tabular-nums' }}>{aktiv}/3</span>}
-        <span style={{ fontSize: 9 }}>{open ? '▴' : '▾'}</span>
+        <Icon icon={open ? ChevronUp : ChevronDown} size={9} />
       </button>
       {open && (
         <div

--- a/src/renderer/components/Canvas/LayerVisibilityChips.tsx
+++ b/src/renderer/components/Canvas/LayerVisibilityChips.tsx
@@ -18,7 +18,7 @@
  *  - Tooltip erklärt was passiert
  */
 import { useState } from 'react'
-import { Eye } from 'lucide-react'
+import { Eye, Diamond, Plus} from 'lucide-react'
 import { useUiStore } from '../../store/uiStore'
 import { Icon } from '../shared/Icon'
 import { LAYER_STYLES, STANDARD_LAYERS, topLayer, type StandardLayer } from '../../lib/cableLayers'
@@ -179,7 +179,7 @@ export const LayerVisibilityChips = () => {
               textDecoration: visible ? 'none' : 'line-through',
             }}
           >
-            <span>◆</span>
+            <Icon icon={Diamond} size="xs" />
             <span>{layer}</span>
           </button>
         )
@@ -219,7 +219,7 @@ export const LayerVisibilityChips = () => {
               isLight ? 'border-slate-200 hover:bg-slate-100' : 'border-slate-800 hover:bg-slate-800'
             }`}
           >
-            <span>➕</span>
+            <Icon icon={Plus} size="xs" />
             <span>{t('canvas.layerChips.addCustom', 'Create custom layer…')}</span>
           </button>
           <button

--- a/src/renderer/components/Export/VideohubExportDialog.tsx
+++ b/src/renderer/components/Export/VideohubExportDialog.tsx
@@ -1,5 +1,5 @@
 ﻿import { useEffect, useMemo, useRef, useState } from 'react'
-import { X, SlidersHorizontal, List, Link, Wand2, ClipboardList, Search, Lock, Download, Loader2, Upload, Tag } from 'lucide-react'
+import { X, SlidersHorizontal, List, Link, Wand2, ClipboardList, Search, Lock, Download, Loader2, Upload, Tag, ChevronDown, ChevronRight} from 'lucide-react'
 import { Icon } from '../shared/Icon'
 import { useProjectStore } from '../../store/projectStore'
 import {
@@ -1059,7 +1059,8 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
               onClick={() => setShowMatrix((m) => !m)}
               className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
             >
-              {showMatrix ? '▼' : '▶'} {t('export.routingView', 'Routing view')}
+              <Icon icon={showMatrix ? ChevronDown : ChevronRight} size="xs" className="mr-1 inline" />
+              {t('export.routingView', 'Routing view')}
             </button>
             {/* v7.9.129 — View-Mode-Switch: Matrix oder Liste */}
             {showMatrix && (

--- a/src/renderer/components/Layout/MenuBar.tsx
+++ b/src/renderer/components/Layout/MenuBar.tsx
@@ -53,6 +53,7 @@ import {
   ZoomIn,
   ZoomOut,
   ListOrdered,
+  ChevronDown,
 } from 'lucide-react'
 import { Icon } from '../shared/Icon'
 import {
@@ -1289,7 +1290,7 @@ const Menu = ({ label, children }: MenuProps) => {
         className={`rounded px-2 py-1 text-cp-text-bright hover:bg-cp-surface-2 ${open ? 'bg-cp-surface-2' : ''}`}
       >
         {label}
-        <span className="ml-1 text-[11px] text-cp-text-muted" aria-hidden="true">▾</span>
+        <Icon icon={ChevronDown} size={11} className="ml-1 text-cp-text-muted" />
       </button>
       {open && (
         <div

--- a/src/renderer/components/Library/CableLibraryPanel.tsx
+++ b/src/renderer/components/Library/CableLibraryPanel.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type ReactNode } from 'react'
-import { AlertTriangle, X, Pencil } from 'lucide-react'
+import { AlertTriangle, X, Pencil, ChevronDown, ChevronRight} from 'lucide-react'
 import { Icon } from '../shared/Icon'
 import {
   DndContext,
@@ -574,7 +574,11 @@ export const CableLibraryPanel = () => {
                     </span>
                   )}
                 </span>
-                <span className="text-cp-text-faint">{isOpen ? '▾' : '▸'}</span>
+                <Icon
+                  icon={isOpen ? ChevronDown : ChevronRight}
+                  size="xs"
+                  className="text-cp-text-faint"
+                />
               </button>
               {isOpen && (
                 <div className="space-y-1 border-t border-cp-border-muted p-1.5">

--- a/src/renderer/components/Library/LibraryMenus.tsx
+++ b/src/renderer/components/Library/LibraryMenus.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Square, SquareCheck } from 'lucide-react'
+import { Square, SquareCheck, ChevronDown, ChevronRight} from 'lucide-react'
 import { Icon } from '../shared/Icon'
 import { useTranslation } from '../../lib/i18n'
 
@@ -47,7 +47,7 @@ export const PlusMenu = ({
         aria-expanded={open}
       >
         <span className="text-cp-base leading-none">+</span>
-        <span className="text-[11px] leading-none">▾</span>
+        <Icon icon={ChevronDown} size={11} />
       </button>
       {open && (
         <div
@@ -170,7 +170,7 @@ export const LibraryFiltersMenu = ({
         <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
           <path d="M2 3h12l-4.5 5.5V13l-3-1.5V8.5L2 3z" strokeLinejoin="round" />
         </svg>
-        <span className="text-[9px] leading-none">▾</span>
+        <Icon icon={ChevronDown} size={9} />
       </button>
       {open && (
         <div
@@ -185,7 +185,7 @@ export const LibraryFiltersMenu = ({
             className="block w-full px-3 py-1.5 text-left hover:bg-cp-surface-2"
           >
             <span className="mr-2 inline-block w-4 text-center text-cp-text-muted">
-              {allCollapsed ? '▸' : '▾'}
+              <Icon icon={allCollapsed ? ChevronRight : ChevronDown} size="xs" />
             </span>
             {allCollapsed
               ? t('library.menus.expandAll', 'Expand all categories')

--- a/src/renderer/components/Library/tabs/RacksTab.tsx
+++ b/src/renderer/components/Library/tabs/RacksTab.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Download, X } from 'lucide-react'
+import { Pencil, Download, X, Server} from 'lucide-react'
 import { useProjectStore } from '../../../store/projectStore'
 import { Icon } from '../../shared/Icon'
 import { confirmDialog } from '../../../lib/confirmDialog'
@@ -47,7 +47,7 @@ export const RacksTab = ({ onCreateRack, onEditRack }: RacksTabProps) => {
 
       {groupPresets.filter((preset) => !!preset.rack).length === 0 ? (
         <div className="flex-1 flex flex-col items-center justify-center gap-2 text-cp-xs text-cp-text-faint text-center p-4">
-          <span className="text-2xl">▥</span>
+          <Icon icon={Server} size="xl" />
           <span>{t('library.tabs.racks.empty', 'No rack layout saved yet.')}</span>
         </div>
       ) : (

--- a/src/renderer/components/Library/tabs/RentmanTab.tsx
+++ b/src/renderer/components/Library/tabs/RentmanTab.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from 'react'
-import { Check } from 'lucide-react'
+import { Check, ChevronDown, ChevronRight, RefreshCw, Package, Search, Folder} from 'lucide-react'
 import { Icon } from '../../shared/Icon'
 import { useProjectStore } from '../../../store/projectStore'
 import { useUiStore } from '../../../store/uiStore'
@@ -249,7 +249,8 @@ export const RentmanTab = () => {
             className="mt-2 w-full rounded bg-orange-600 px-2 py-1.5 text-cp-xs font-semibold text-white hover:bg-orange-500"
             title={t('library.rentman.refreshTitle', 'Fetch the current equipment list from the linked Rentman project — new or changed items are shown in the dialog.')}
           >
-            🔄 {t('library.rentman.refreshAction', 'Refresh from Rentman / import new items')}
+            <Icon icon={RefreshCw} size="xs" className="mr-1 inline" />
+            {t('library.rentman.refreshAction', 'Refresh from Rentman / import new items')}
           </button>
           {(() => {
             // v7.9.70 / #171 — Re-Sync Button: zeigt nur wenn Canvas-Equipment
@@ -279,7 +280,8 @@ export const RentmanTab = () => {
                 className="mt-2 w-full rounded bg-orange-700/60 px-2 py-1 text-cp-xs text-orange-100 hover:bg-orange-700"
                 title={format(t('library.rentman.resyncTitle', '{n} Rentman devices on the canvas are not linked to library templates. Click to reconstruct the missing templates from the canvas data.'), { n: missing })}
               >
-                🔄 {format(t('library.rentman.resyncAction', 'Rebuild {n} missing library entries'), { n: missing })}
+                <Icon icon={RefreshCw} size="xs" className="mr-1 inline" />
+                {format(t('library.rentman.resyncAction', 'Rebuild {n} missing library entries'), { n: missing })}
               </button>
             )
           })()}
@@ -413,7 +415,7 @@ export const RentmanTab = () => {
             if (projectGroups.length === 0) {
               return (
                 <div className="flex flex-col items-center gap-2 p-3 text-center text-cp-xs text-cp-text-faint">
-                  <span className="text-2xl">📦</span>
+                  <Icon icon={Package} size="xl" />
                   <span>{t('library.rentman.noneImported', 'No Rentman devices imported yet.')}</span>
                 </div>
               )
@@ -421,7 +423,7 @@ export const RentmanTab = () => {
             if (visibleProjectGroups.length === 0) {
               return (
                 <div className="flex flex-col items-center gap-2 p-3 text-center text-cp-xs text-cp-text-faint">
-                  <span className="text-2xl">🔍</span>
+                  <Icon icon={Search} size="xl" />
                   <span>{format(t('library.rentman.noMatches', 'No matches for "{query}".'), { query: rentmanSearch })}</span>
                 </div>
               )
@@ -453,7 +455,7 @@ export const RentmanTab = () => {
                         }`}
                       >
                         <span className="flex min-w-0 items-center gap-1.5">
-                          <span className="text-cp-xs">{projectCollapsed ? '▶' : '▼'}</span>
+                          <Icon icon={projectCollapsed ? ChevronRight : ChevronDown} size="xs" />
                           {isLinked && (
                             <span className="rounded bg-orange-700 px-1 text-cp-xs font-bold text-white">AKTIV</span>
                           )}
@@ -478,7 +480,7 @@ export const RentmanTab = () => {
                                     className="flex w-full items-center justify-between gap-1 px-2 py-1 text-left text-cp-xs font-semibold uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright"
                                   >
                                     <span className="flex items-center gap-1">
-                                      <span>{categoryCollapsed ? '▶' : '▼'}</span>
+                                      <Icon icon={categoryCollapsed ? ChevronRight : ChevronDown} size="xs" />
                                       <span>{category}</span>
                                     </span>
                                     <span className="font-normal text-cp-text-dim">({categoryItems.length})</span>
@@ -559,7 +561,7 @@ export const RentmanTab = () => {
               className="flex flex-1 items-center gap-1 text-left text-cp-base font-semibold text-cp-text-bright hover:text-white"
               title={t('library.rentman.accountTitle', 'All equipment created in your Rentman account (account catalog), organized by the Rentman folder structure')}
             >
-              <span className="text-cp-xs">{rentmanCatalogCollapsed ? '▶' : '▼'}</span>
+              <Icon icon={rentmanCatalogCollapsed ? ChevronRight : ChevronDown} size="xs" />
               <span>{t('library.rentman.accountAll', 'All Rentman equipment (account catalog)')}</span>
               {rentmanCatalogLoaded && (
                 <span className="ml-1 rounded-full bg-cp-surface-2 px-1.5 text-cp-xs text-cp-text-muted">{rentmanCatalog.length}</span>
@@ -727,8 +729,8 @@ export const RentmanTab = () => {
                             style={{ paddingLeft: `${0.5 + depth * 0.75}rem` }}
                           >
                             <span className="flex items-center gap-1">
-                              <span>{collapsed ? '▶' : '▼'}</span>
-                              <span>📁</span>
+                              <Icon icon={collapsed ? ChevronRight : ChevronDown} size="xs" />
+                              <Icon icon={Folder} size="xs" />
                               <span>{folder.name}</span>
                             </span>
                             <span className="font-normal text-cp-text-faint">({total})</span>
@@ -787,7 +789,8 @@ export const RentmanTab = () => {
               className="mb-3 w-full rounded bg-orange-600 px-2 py-1.5 text-cp-xs font-semibold text-white hover:bg-orange-500"
               title={t('library.rentman.loadProjectTitle', 'Load the equipment list from the linked Rentman project now. New items can be imported directly.')}
             >
-              🔄 {t('library.rentman.refreshAction', 'Refresh from Rentman / import new items')}
+              <Icon icon={RefreshCw} size="xs" className="mr-1 inline" />
+              {t('library.rentman.refreshAction', 'Refresh from Rentman / import new items')}
             </button>
           )}
           {removed.length > 0 && (

--- a/src/renderer/components/Patch/PatchListDialog.tsx
+++ b/src/renderer/components/Patch/PatchListDialog.tsx
@@ -16,7 +16,7 @@ import { downloadBlob } from '../../lib/downloadBlob'
 import { buildExportFilenameWithSuffix } from '../../lib/exportFilename'
 import { sanitizeForPdf } from '../../lib/sanitizeForPdf'
 import { portLabelPair, genderSymbol } from '../../lib/portLabel'
-import { Cable as CableIcon, Tag, Download, SlidersHorizontal } from 'lucide-react'
+import { Cable as CableIcon, Tag, Download, SlidersHorizontal, ChevronUp} from 'lucide-react'
 import { ModalShell } from '../shared/ModalShell'
 import { Icon } from '../shared/Icon'
 import { useTranslation } from '../../lib/i18n'
@@ -854,7 +854,7 @@ export const PatchListDialog = () => {
                     onClick={() => setSortKey(col.k)}
                   >
                     {col.label}
-                    {sortKey === col.k && <span className="ml-1 text-[11px]">▲</span>}
+                    {sortKey === col.k && <Icon icon={ChevronUp} size={11} className="ml-1 inline" />}
                   </th>
                 ))}
               </tr>

--- a/src/renderer/components/Properties/PortList.tsx
+++ b/src/renderer/components/Properties/PortList.tsx
@@ -1,3 +1,4 @@
+import { ChevronDown, ChevronRight } from 'lucide-react'
 import { useMemo, useState, type ReactNode } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import {
@@ -27,6 +28,7 @@ import { infoDialog } from '../../lib/infoDialog'
 import { promptDialog } from '../../lib/promptDialog'
 import { effectivePortNumber, findDuplicatePortNumbers } from '../../lib/portNumbering'
 import { format, useTranslation } from '../../lib/i18n'
+import { Icon } from '../shared/Icon'
 
 /**
  * #306 — PortList + SortablePortItem + makePort aus EquipmentProperties
@@ -138,7 +140,7 @@ const CollapsibleSdiCaps = ({
       className="mt-1 rounded border border-amber-900/60 bg-amber-950/20 [&_summary]:cursor-pointer"
     >
       <summary className="flex items-center gap-1 p-1.5 text-cp-xs font-semibold uppercase tracking-wide text-amber-300 hover:text-amber-200 [&::-webkit-details-marker]:hidden">
-        <span className="text-amber-400/70">{open ? '▾' : '▸'}</span>
+        <Icon icon={open ? ChevronDown : ChevronRight} size="xs" className="text-amber-400/70" />
         <span className="flex-1">{t('ports.sdi.caps', 'SDI capabilities (port-specific)')}</span>
         {!open && badge && (
           <span className="rounded bg-amber-900/50 px-1 text-cp-xs normal-case text-amber-200">

--- a/src/renderer/components/Properties/sections/CategoryPropsSection.tsx
+++ b/src/renderer/components/Properties/sections/CategoryPropsSection.tsx
@@ -1,3 +1,4 @@
+import { ChevronDown, ChevronRight } from 'lucide-react'
 import { useState } from 'react'
 import { useProjectStore } from '../../../store/projectStore'
 import { useUiStore } from '../../../store/uiStore'
@@ -6,6 +7,7 @@ import type { EquipmentItem } from '../../../types/equipment'
 import { schemaForCategory, type CategoryFieldDef } from '../../../lib/categorySchemas'
 import type { Lang } from '../../../lib/categoryTranslations'
 import { PolarPatternDiagram } from '../../shared/PolarPatternDiagram'
+import { Icon } from '../../shared/Icon'
 
 const inputCls = 'w-full rounded border border-cp-border bg-cp-surface-1 p-2'
 
@@ -148,7 +150,7 @@ export const CategoryPropsSection = ({ equipment }: { equipment: EquipmentItem }
       className="rounded border border-cp-border [&_summary]:cursor-pointer"
     >
       <summary className="flex items-center gap-1 px-2 py-1.5 text-cp-xs uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright [&::-webkit-details-marker]:hidden">
-        <span className="text-cp-text-faint">{open ? '▾' : '▸'}</span>
+        <Icon icon={open ? ChevronDown : ChevronRight} size="xs" className="text-cp-text-faint" />
         <span className="flex-1">
           {t('catprops.title', 'Specs')} — {equipment.category}
         </span>

--- a/src/renderer/components/Properties/sections/DeviceConfigsBlock.tsx
+++ b/src/renderer/components/Properties/sections/DeviceConfigsBlock.tsx
@@ -1,6 +1,8 @@
+import { ChevronDown, ChevronRight } from 'lucide-react'
 import { useState } from 'react'
 import { useUiStore } from '../../../store/uiStore'
 import { useTranslation } from '../../../lib/i18n'
+import { Icon } from '../../shared/Icon'
 
 /**
  * #306 — Geräte-Konfigurations-Zuordnung (Issue #80). Liest die
@@ -26,7 +28,7 @@ export const DeviceConfigsBlock = ({ equipmentId }: { equipmentId: string }) => 
       className="rounded border border-cp-border bg-cp-surface-1/40 [&_summary]:cursor-pointer"
     >
       <summary className="flex items-center gap-1 px-2 py-1.5 text-cp-xs uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright [&::-webkit-details-marker]:hidden">
-        <span className="text-cp-text-faint">{open ? '▾' : '▸'}</span>
+        <Icon icon={open ? ChevronDown : ChevronRight} size="xs" className="text-cp-text-faint" />
         <span className="flex-1">{t('props.deviceConfigs.title', 'Configurations')}</span>
         {!open && assigned.length > 0 && (
           <span className="rounded bg-cp-surface-4/60 px-1 text-cp-xs normal-case text-cp-text-bright">

--- a/src/renderer/components/Properties/sections/DisplayPropertiesBlock.tsx
+++ b/src/renderer/components/Properties/sections/DisplayPropertiesBlock.tsx
@@ -1,7 +1,9 @@
+import { ChevronDown, ChevronRight } from 'lucide-react'
 import { useState } from 'react'
 import { useProjectStore } from '../../../store/projectStore'
 import { useTranslation } from '../../../lib/i18n'
 import type { EquipmentItem } from '../../../types/equipment'
+import { Icon } from '../../shared/Icon'
 
 const RESOLUTION_PRESETS = [
   '1280x720',
@@ -46,7 +48,7 @@ export const DisplayPropertiesBlock = ({ equipment }: { equipment: EquipmentItem
       className="rounded border border-cp-border [&_summary]:cursor-pointer"
     >
       <summary className="flex items-center gap-1 px-2 py-1.5 text-cp-xs uppercase tracking-wide text-cp-text-muted hover:text-cp-text-bright [&::-webkit-details-marker]:hidden">
-        <span className="text-cp-text-faint">{open ? '▾' : '▸'}</span>
+        <Icon icon={open ? ChevronDown : ChevronRight} size="xs" className="text-cp-text-faint" />
         <span className="flex-1">{t('display.title', 'Display')}</span>
       </summary>
       <div className="px-2 pb-2">

--- a/src/renderer/components/Properties/sections/GreenGoBeltpackSection.tsx
+++ b/src/renderer/components/Properties/sections/GreenGoBeltpackSection.tsx
@@ -1,6 +1,8 @@
+import { ChevronDown, ChevronRight } from 'lucide-react'
 import { useState } from 'react'
 import { useGreenGoBeltpack } from '../../../lib/greengoSync'
 import { format, useTranslation } from '../../../lib/i18n'
+import { Icon } from '../../shared/Icon'
 
 /**
  * #306 — GreenGo-Beltpack-Konfiguration pro Equipment. Aus
@@ -37,7 +39,7 @@ export const GreenGoBeltpackSection = ({ equipmentId }: { equipmentId: string })
       className="mb-2 rounded bg-emerald-950/40 [&_summary]:cursor-pointer"
     >
       <summary className="flex items-center gap-1 px-2 py-1.5 text-cp-xs uppercase tracking-wide text-emerald-300 hover:text-emerald-200 [&::-webkit-details-marker]:hidden">
-        <span className="text-emerald-400/70">{open ? '▾' : '▸'}</span>
+        <Icon icon={open ? ChevronDown : ChevronRight} size="xs" className="text-emerald-400/70" />
         <span className="flex-1">{t('props.greengo.beltpack', 'Beltpack')}</span>
         {info?.channelNames && info.channelNames.length > 0 && (
           <span

--- a/src/renderer/components/Rack/RackAddSplitButton.tsx
+++ b/src/renderer/components/Rack/RackAddSplitButton.tsx
@@ -1,3 +1,4 @@
+import { ChevronDown } from 'lucide-react'
 /**
  * v7.9.80 / #170 — Split-Button für den Rack-Builder Library-Add.
  *
@@ -14,6 +15,7 @@
  */
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from '../../lib/i18n'
+import { Icon } from '../shared/Icon'
 
 interface Props {
   onAddFull: () => void
@@ -72,7 +74,7 @@ export const RackAddSplitButton = ({
           aria-haspopup="menu"
           title={t('rackAdd.mountOptionsTitle', 'Mount options (front / rear)')}
         >
-          ▾
+          <Icon icon={ChevronDown} size="xs" />
         </button>
       </div>
       {open && (

--- a/src/renderer/components/Rack/RackBuilderDialog.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialog.tsx
@@ -19,7 +19,7 @@ import { RackInternalWireOverlay } from './RackInternalWireOverlay'
 import { RackPlacementProperties } from './RackPlacementProperties'
 import { Splitter } from '../Layout/Splitter'
 import { Icon } from '../shared/Icon'
-import { Box, Columns2, FlipHorizontal2, GalleryVerticalEnd, Maximize2, Minus, Plus, RectangleVertical, Square } from 'lucide-react'
+import { Box, Columns2, FlipHorizontal2, GalleryVerticalEnd, Maximize2, Minus, Plus, RectangleVertical, Square, Server} from 'lucide-react'
 import type {
   RackDraft,
   RackPlacementDraft,
@@ -1003,7 +1003,7 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
             </div>
             {draft.placements.length === 0 && (
               <div className="rounded border border-dashed border-cp-border bg-cp-surface-3/40 p-8 text-center text-cp-xs text-cp-text-faint">
-                <div className="mb-2 text-3xl">▥</div>
+                <div className="mb-2 flex justify-center"><Icon icon={Server} size={28} /></div>
                 <div className="mb-1 font-semibold text-cp-text-secondary">{t('rack.empty', 'Rack is empty')}</div>
                 <div>{t('rack.addFromLibraryHint', 'Add devices from the library on the left (button "+ Rack").')}</div>
                 <div className="mt-2 text-cp-xs">

--- a/src/renderer/components/Rack/RackPlacementProperties.tsx
+++ b/src/renderer/components/Rack/RackPlacementProperties.tsx
@@ -1,4 +1,4 @@
-import { Check } from 'lucide-react'
+import { Check, Folder, Rows3, ArrowDownToLine, ArrowUpToLine} from 'lucide-react'
 import { useTranslation, format } from '../../lib/i18n'
 import { Icon } from '../shared/Icon'
 import { confirmDialog } from '../../lib/confirmDialog'
@@ -217,7 +217,7 @@ export const RackPlacementProperties = ({
               className="inline-flex cursor-pointer items-center gap-1 rounded border border-cp-surface-5 bg-sky-700 px-3 py-1 text-cp-xs font-semibold text-white hover:bg-sky-600"
               title={t('rack.stlUploadTitle', 'Upload STL file (.stl, max 5 MB) for this device')}
             >
-              <span>📁</span>
+              <Icon icon={Folder} size="xs" />
               <span>{selectedPlacement.stlDataUri
                 ? t('rack.stl.replace', 'Replace STL…')
                 : t('rack.stl.pick', 'Pick STL…')}</span>
@@ -314,7 +314,8 @@ export const RackPlacementProperties = ({
           return (
             <details className="rounded border border-emerald-800 bg-emerald-900/20 p-2" open>
               <summary className="cursor-pointer text-cp-xs font-semibold text-emerald-200">
-                🪑 {t('rack.shelfPos.title', 'Shelf position')}
+                <Icon icon={Rows3} size="xs" className="mr-1 inline" />
+                {t('rack.shelfPos.title', 'Shelf position')}
                 <span className="ml-1 text-emerald-400">
                   ({tpl.widthMm}×{tpl.heightMm}×{tpl.depthMm ?? 400} mm)
                 </span>
@@ -380,7 +381,8 @@ export const RackPlacementProperties = ({
               className="rounded bg-purple-900/40 px-2 py-1 text-purple-200 hover:bg-purple-900/60"
               title={t('rack.portsAllRear', 'All ports to the rear (default for classic server gear)')}
             >
-              ⏬ {t('rack.portsAllRearBtn', 'all to rear')}
+              <Icon icon={ArrowDownToLine} size="xs" className="mr-1 inline" />
+              {t('rack.portsAllRearBtn', 'all to rear')}
             </button>
             <button
               type="button"
@@ -412,7 +414,8 @@ export const RackPlacementProperties = ({
               className="rounded bg-green-900/40 px-2 py-1 text-green-200 hover:bg-green-900/60"
               title={t('rack.portsAllFront', 'All ports to the front (e.g. front-panel devices)')}
             >
-              ⏫ {t('rack.portsAllFrontBtn', 'all to front')}
+              <Icon icon={ArrowUpToLine} size="xs" className="mr-1 inline" />
+              {t('rack.portsAllFrontBtn', 'all to front')}
             </button>
           </div>
           <div className="mt-2 max-h-48 overflow-y-auto rounded border border-cp-border-muted">
@@ -480,9 +483,14 @@ export const RackPlacementProperties = ({
                       { side: side === 'front' ? t('rack.portSide.front', 'front') : t('rack.portSide.rear', 'rear') },
                     )}
                   >
+                    <Icon
+                      icon={side === 'front' ? ArrowUpToLine : ArrowDownToLine}
+                      size="xs"
+                      className="mr-1 inline"
+                    />
                     {side === 'front'
-                      ? '⏫ ' + t('rack.portSide.front', 'front')
-                      : '⏬ ' + t('rack.portSide.rear', 'rear')}
+                      ? t('rack.portSide.front', 'front')
+                      : t('rack.portSide.rear', 'rear')}
                   </button>
                 </div>
               )

--- a/src/renderer/components/Rentman/EquipmentChecklist.tsx
+++ b/src/renderer/components/Rentman/EquipmentChecklist.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { Check, Zap, Link, Square, SquareCheck } from 'lucide-react'
+import { Check, Zap, Link, Square, SquareCheck, ChevronDown, ChevronRight} from 'lucide-react'
 import { Icon } from '../shared/Icon'
 import { format, useTranslation } from '../../lib/i18n'
 
@@ -216,7 +216,7 @@ export const EquipmentChecklist = ({
                         aria-label={isOpen ? t('rentman.checklist.setCollapse', 'Collapse set') : t('rentman.checklist.setExpand', 'Expand set')}
                         title={isOpen ? t('rentman.checklist.setCollapse', 'Collapse set') : t('rentman.checklist.setExpand', 'Expand set')}
                       >
-                        {isOpen ? '▾' : '▸'}
+                        <Icon icon={isOpen ? ChevronDown : ChevronRight} size="xs" />
                       </button>
                     ) : (
                       <span className="w-5" />

--- a/src/renderer/components/Rentman/RentmanImportDialog.tsx
+++ b/src/renderer/components/Rentman/RentmanImportDialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Zap, Check, AlertTriangle, RotateCcw } from 'lucide-react'
+import { Zap, Check, AlertTriangle, RotateCcw, ChevronDown, ChevronRight} from 'lucide-react'
 import { Icon } from '../shared/Icon'
 import { format, useTranslation } from '../../lib/i18n'
 import { infoDialog } from '../../lib/infoDialog'
@@ -1781,7 +1781,7 @@ export const RentmanImportDialog = ({ open, onClose }: RentmanImportDialogProps)
                   className="flex w-full items-center justify-between text-left"
                 >
                   <span className="text-cp-base font-semibold text-orange-200">
-                    {cablePlanOpen ? '▾ ' : '▸ '}
+                    <Icon icon={cablePlanOpen ? ChevronDown : ChevronRight} size="xs" className="mr-1 inline" />
                     {format(t('rentman.import.cablePlan.headingN', 'Cable quantities from Rentman ({count})'), { count: cableBuckets.length })}
                   </span>
                   <span className="text-cp-xs text-orange-300/70">

--- a/src/renderer/components/shared/PanelWindowMenu.tsx
+++ b/src/renderer/components/shared/PanelWindowMenu.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from 'react'
-import { ExternalLink, PictureInPicture2 } from 'lucide-react'
+import { ExternalLink, PictureInPicture2, ChevronUp, ChevronDown} from 'lucide-react'
 import { useTranslation } from '../../lib/i18n'
 import { Icon } from './Icon'
 
@@ -86,7 +86,7 @@ export const PanelWindowMenu = ({
       >
         <Icon icon={PictureInPicture2} size="xs" />
         <span>{t('panel.window.button', 'Window')}</span>
-        <span className="text-[9px] leading-none">{offen ? '▴' : '▾'}</span>
+        <Icon icon={offen ? ChevronUp : ChevronDown} size={9} />
       </button>
       {offen && (
         <div

--- a/tests/schriftgroesseUntergrenze.test.ts
+++ b/tests/schriftgroesseUntergrenze.test.ts
@@ -136,13 +136,37 @@ describe('Fliesstext-Untergrenze 12px', () => {
     expect(dateien(WURZEL).length).toBeGreaterThan(150)
   })
 
-  it('findet die bekannten Glyph-Stellen — sonst passt das Muster nicht mehr', () => {
+  it('greift auf eine feste Probe — sonst prueft die Regel nichts', () => {
     // Zweite Haelfte derselben Zusicherung: Dateien zu finden reicht nicht,
-    // das Muster muss auch greifen. Sechs dekorative Stellen sind heute da
-    // (vier Carets, ein Sortier-Dreieck, eine Pin-Markierung). Faellt der
-    // Wert auf 0, ist entweder auch die letzte Ausnahme weg — dann darf diese
-    // Zeile gehen — oder `GROESSE` trifft nicht mehr.
-    expect(zuKlein().length).toBeGreaterThan(0)
+    // das Muster muss auch greifen.
+    //
+    // BIS 2026-09-10 STAND HIER `zuKlein().length > 0` — gemessen am Repo.
+    // Damals waren noch sechs dekorative Stellen uebrig (vier Carets, ein
+    // Sortier-Dreieck, eine Pin-Markierung), und die Zeile darueber sagte
+    // ausdruecklich: faellt der Wert auf null, ist entweder die letzte
+    // Ausnahme weg oder `GROESSE` trifft nicht mehr. Genau das ist
+    // eingetreten — die sechs Stellen sind jetzt `<Icon />` und tragen ihre
+    // Groesse als Zahl, nicht als CSS-Klasse.
+    //
+    // Eine Zusicherung, die am Repo haengt, geht mit dem letzten Fund
+    // verloren: „keine Stelle unter 12px" waere ab dann auch bei kaputtem
+    // Muster erfuellt, und Nichts saehe aus wie ein Ergebnis. Die Probe ist
+    // deshalb FEST und unabhaengig vom Bestand — dieselbe Form wie im
+    // Sprachmix-Zaehler (`scripts/quellsprache.mjs`).
+    const PROBE = [
+      '<span className="text-[9px] leading-none">x</span>',
+      '<div className="text-[11px]">Hinweis</div>',
+      '<div className="text-[12px]">gerade noch erlaubt</div>',
+      '<div className="text-cp-xs">ueber die Skala</div>',
+    ]
+    const getroffen = PROBE.filter((z) =>
+      [...z.matchAll(GROESSE)].some((m) => Number(m[1]) < UNTERGRENZE_PX),
+    )
+    expect(getroffen).toEqual([PROBE[0], PROBE[1]])
+
+    // Und die Urteilsregel selbst: ein Glyph ist ohne Buchstabe und Ziffer.
+    expect(sichtbarerText(PROBE[1]).every(nurGlyph)).toBe(false)
+    expect(sichtbarerText('<span className="text-[9px]">▾</span>').every(nurGlyph)).toBe(true)
   })
 
   it('jede Stelle unter 12px ist ein rein dekorativer Glyph', () => {


### PR DESCRIPTION
Zweiter Schnitt des Symbol-Durchgangs aus `docs/ui-audit.md`. Der erste (#818) nahm die Symbole aus den `t()`-Fallbacks; hier kommen die, die **roh im JSX** standen — genau die, von denen der Glyph-Wächter in seinem Kopf ausdrücklich sagt, dass er sie nicht sieht.

Gemessen über dieselbe Baumsuche wie der Wächter: **180 → 138 Stellen, 61 → 50 Dateien.**

## (a) Alle 24 Aufklapp-Carets

`{open ? '▾' : '▸'}`, `{collapsed ? '▶' : '▼'}`, `{offen ? '▴' : '▾'}` und die freistehenden `▾` in `MenuBar`, `LibraryMenus`, `RackAddSplitButton` — jetzt `<Icon icon={open ? ChevronDown : ChevronRight} />`.

Es waren **fünf verschiedene Glyph-Paare für dieselbe Geste** (`▾/▸`, `▴/▾`, `▶/▼`, `▸/▾`, `▼/▶`). Das allein ist der Grund, warum ein Aufklapper je nach Dialog anders aussah.

## (b) 17 freistehende Emoji-Kinder

`🔄` (drei Mal, dieselbe Aktualisieren-Aktion), `📦`, `🔍`, `📁` (2×), `▥` (2×), `🪑`, `⏬`/`⏫` (5×), `✅`, `📌`, `◆`, `➕`. Der Grund steht in `Icon.tsx` selbst: „Emojis rendern je Plattform/Font inkonsistent."

## Ein Wächter ist dabei umgefallen — und das war richtig so

`tests/schriftgroesseUntergrenze.test.ts` sicherte zu, dass die Baumsuche **mindestens eine** Stelle unter 12px findet: die sechs dekorativen Micro-Glyphen (`text-[9px]`, `text-[11px]`, `fontSize: 9`), die es damals noch gab. Die sind jetzt `<Icon />` und tragen ihre Größe als **Zahl** statt als CSS-Klasse — also fand sie null.

Der Kommentar dort hatte den Fall wörtlich vorhergesehen:

> Fällt der Wert auf 0, ist entweder auch die letzte Ausnahme weg — dann darf diese Zeile gehen — oder `GROESSE` trifft nicht mehr.

Eine Zusicherung, die am **Bestand** hängt, geht mit dem letzten Fund verloren: „keine Stelle unter 12px" wäre ab dann auch bei kaputtem Muster erfüllt, und Nichts sähe aus wie ein Ergebnis. Sie steht jetzt auf einer **festen Probe** — zwei Zeilen, die treffen müssen, zwei, die nicht treffen dürfen, plus eine Probe auf die Urteilsregel selbst („ein Glyph trägt keinen Buchstaben und keine Ziffer"). Dieselbe Form wie im Sprachmix-Zähler.

## Was bewusst stehenbleibt (mit Grund je Gruppe im Audit)

| Gruppe | Warum |
|---|---|
| Pfeile im Satz oder Datensatz (40× `→`, 11× `←`, 8× `↔`) | Sie landen in CSV und PDF, wo kein SVG hinkann |
| `<option>`-Kinder (`◆ {l}`, `📦 `, `▼`) | `<option>` nimmt nur Text — ein Icon dort ergäbe `[object Object]` in der Auswahlliste |
| Symbole, die **der Wert** sind: `♂`/`♀`, `◄`/`►`, das `▲` des Polardiagramms, die elf `ICON_GLYPHS` | Letztere stehen im **Projekt-File** und sind damit Nutzerdaten, nicht Darstellung |

Was danach noch bleibt (`✓ ✕ ✗ ⚠ ● ○ ↺`, ~40 Stellen) ist echter Icon-Kandidat, hängt aber jeweils an Zustandsbedeutung im umgebenden Markup — das ist der nächste Schnitt, nicht dieser. Der Audit-Eintrag sagt das mit denselben Zahlen.

## Prüfung

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — 250 Testdateien, 3879 Tests grün
- `npm run lint` — 0 Errors (12 vorbestehende Warnings)
- `npm run lang:check` — 0 / 0 / 0

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_