### PR TITLE
i18n: das JSX-Fragment ist auch ein Tag — deutscher Absturz-Text gefunden

### DIFF
--- a/docs/ui-audit.md
+++ b/docs/ui-audit.md
@@ -573,6 +573,19 @@ nicht erst, wenn jemand eine halb übersetzte Seite meldet.
       jetzt `JSX_LITERAL`, und zwar nur für die **reine** Form: was um die
       Zeichenkette herum noch gerechnet wird, ist Code.
 
+      **Nachtrag desselben Tages: das Fragment ist auch ein Tag.**
+      `[^\s=<!>]` verbot vor dem `>` ausdrücklich ein `<` — damit `<=` und
+      `<Foo>` nicht als Tag-Ende durchgehen. Es verbot damit aber auch `<>`,
+      und das ist das **JSX-Fragment**: ein vollwertiges Element, dessen
+      Kinder auf dem Bildschirm stehen wie die jedes anderen. Gefunden an der
+      Stelle, an der es am meisten weh tut — `ErrorBoundary`, der Text, den
+      jemand liest, wenn die App schon abgestürzt ist: „Zusätzlich wurde eine
+      Sicherheitskopie des Autosaves angelegt (…)". `<>` kommt in TypeScript
+      sonst nicht vor (`=>` fängt das `=`, ein Generic trägt vor dem `>`
+      einen Bezeichner, `a < b > c` hat Leerzeichen), die Öffnung ist also
+      eng. Der Satz ist jetzt **ein** Schlüssel mit Platzhalter statt eines
+      Satzes plus eingebettetem `<code>`.
+
       **Der Preis ist benannt:** ein Lauf, der über `{` hinweggeht, endet öfter
       mitten im Ausdruck. `NACH_CODE` hat deshalb `return`, `null`, `typeof`,
       `??` und `if (` dazubekommen — `if` steht auf der **englischen**

--- a/scripts/quellsprache.mjs
+++ b/scripts/quellsprache.mjs
@@ -262,8 +262,22 @@ const SICHTBARE_ATTRIBUTE =
  * abbrach, bevor das schliessende `<` erreicht war, fiel der ganze Satz
  * heraus. Ein Waechter, der an der Klammer HINTER dem Text scheitert, ist
  * schlimmer als keiner: die Null, die er meldet, liest sich wie ein Beleg.
+ *
+ * ─── UND DAS FRAGMENT IST AUCH EIN TAG (2026-09-10) ────────────────────────
+ *
+ * `[^\s=<!>]` verbot vor dem `>` ausdruecklich ein `<` — damit `<=` und
+ * `<Foo>` nicht als Tag-Ende durchgehen. Es verbot damit aber auch `<>`, und
+ * das ist das JSX-FRAGMENT: ein vollwertiges Element, dessen Kinder auf dem
+ * Bildschirm stehen wie die jedes anderen. Gefunden an einer Stelle, an der
+ * es besonders weh tut — `ErrorBoundary`, der Text, den jemand liest, wenn
+ * die App schon abgestuerzt ist:
+ *
+ *     <> Zusaetzlich wurde eine Sicherheitskopie des Autosaves angelegt
+ *
+ * `<>` kommt in TypeScript sonst nicht vor: `=>` faengt das `=`, ein Generic
+ * traegt vor dem `>` einen Bezeichner, und `a < b > c` hat Leerzeichen.
  */
-const JSX_TEXT = /[^\s=<!>]>([^<>]{4,})<[/A-Za-z]/g
+const JSX_TEXT = /(?:[^\s=<!>]|<)>([^<>]{4,})<[/A-Za-z]/g
 
 /**
  * Ein JSX-Ausdruck, der NUR aus einer Zeichenkette besteht: `{'…'}` oder
@@ -280,7 +294,7 @@ const JSX_TEXT = /[^\s=<!>]>([^<>]{4,})<[/A-Za-z]/g
  * Zaehler teuer gelernt nicht zu lesen.
  */
 const JSX_LITERAL =
-  /[^\s=<!>]>\s*\{\s*(?:`((?:[^`\\]|\\.){4,}?)`|'((?:[^'\\]|\\.){4,}?)')\s*\}/g
+  /(?:[^\s=<!>]|<)>\s*\{\s*(?:`((?:[^`\\]|\\.){4,}?)`|'((?:[^'\\]|\\.){4,}?)')\s*\}/g
 
 /**
  * Was ein JSX-Textknoten NIE enthaelt, ein Code-Schnipsel dagegen fast immer.
@@ -443,6 +457,8 @@ if (process.argv[1] && process.argv[1].endsWith('quellsprache.mjs')) {
     '<span>Front {draft.depthMm} mm rear</span>',
     '<span>{`with ${n} of them`}</span>',
     '<div>Sentence before the brace\n{!bridge && (\n<span>x</span>)}</div>',
+    // Das Fragment ist auch ein Tag — `<>` war bis 2026-09-10 ausgeschlossen.
+    '<>Inside a bare fragment<code>x</code></>',
   ].join('\n')
 
   // Sortiert verglichen: in welcher Reihenfolge Attribute, Rueckfragen und
@@ -457,6 +473,7 @@ if (process.argv[1] && process.argv[1].endsWith('quellsprache.mjs')) {
     'Front mm rear',
     'with ${n} of them',
     'Sentence before the brace',
+    'Inside a bare fragment',
   ].sort()
   if (gefunden.length !== erwartet.length || erwartet.some((e, i) => gefunden[i] !== e)) {
     console.error(

--- a/src/renderer/ErrorBoundary.tsx
+++ b/src/renderer/ErrorBoundary.tsx
@@ -1,8 +1,8 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react'
-import { ClipboardCopy, RotateCcw, Trash2, CircleCheck} from 'lucide-react'
+import { ClipboardCopy, RotateCcw, Trash2, CircleCheck } from 'lucide-react'
 import { cablePlannerApi } from './lib/bridge'
 import { confirmDialog } from './lib/confirmDialog'
-import { translate } from './lib/i18n'
+import { translate, format } from './lib/i18n'
 import { Icon } from './components/shared/Icon'
 import { useUiStore } from './store/uiStore'
 
@@ -304,8 +304,22 @@ export class ErrorBoundary extends Component<Props, State> {
                 <strong>{translate(lang, 'errorBoundary.dataSafeHead', 'Your project data is safe')}</strong>
                 {translate(lang, 'errorBoundary.dataSafeBody', ': the autosave, the local library, saved groups and rack drafts were NOT deleted.')}
                 {this.state.projectBackedUp && (
-                  <> Zusätzlich wurde eine Sicherheitskopie des Autosaves angelegt
-                  (<code>cable-planner:projectBackup:&lt;Zeit&gt;</code> in localStorage).</>
+                  // EIN Schluessel fuer den ganzen Satz. Der Speicher-Schluessel
+                  // steht als Platzhalter darin und nicht als eigenes <code>:
+                  // ein Satz, der aus zwei Bausteinen zusammengesetzt wird,
+                  // laesst sich nicht uebersetzen, ohne die Wortstellung der
+                  // Quellsprache mitzuschleppen.
+                  <>
+                    {' '}
+                    {format(
+                      translate(
+                        lang,
+                        'errorBoundary.projectBackedUp',
+                        'A safety copy of the autosave was also created ({key} in localStorage).',
+                      ),
+                      { key: 'cable-planner:projectBackup:<time>' },
+                    )}
+                  </>
                 )}
                 <br />
                 {translate(lang, 'errorBoundary.reloading', 'The app reloads in 2 s — you land straight back in your project.')}

--- a/src/renderer/lib/i18n/de.ts
+++ b/src/renderer/lib/i18n/de.ts
@@ -5294,6 +5294,8 @@ export const de: Dict = {
   'errorBoundary.bootLoop': 'Boot-Loop erkannt — UI-Einstellungen wurden automatisch zurückgesetzt.',
   'errorBoundary.dataSafeBody': ': das Autosave, die lokale Library, gespeicherte Gruppen und Rack-Entwürfe wurden NICHT gelöscht.',
   'errorBoundary.dataSafeHead': 'Deine Projekt-Daten sind sicher',
+  'errorBoundary.projectBackedUp':
+    'Zusätzlich wurde eine Sicherheitskopie des Autosaves angelegt ({key} in localStorage).',
   'errorBoundary.pleaseCopy': 'Bitte den vollständigen Text unten kopieren und an den Entwickler weitergeben — das hilft, den Bug endgültig zu finden.',
   'errorBoundary.reloadOnly': 'Nur neu laden (nichts löschen)',
   'errorBoundary.reloading': 'Die App lädt in 2 s neu — du landest direkt wieder in deinem Projekt.',


### PR DESCRIPTION
Nachtrag zu #824 vom selben Tag.

## Der Befund

`JSX_TEXT` verlangte vor dem `>` ein Zeichen aus `[^\s=<!>]` — das `<` war **ausdrücklich** verboten, damit `<=` und `<Foo>` nicht als Tag-Ende durchgehen. Damit war aber auch `<>` ausgeschlossen, und das ist das **JSX-Fragment**: ein vollwertiges Element, dessen Kinder auf dem Bildschirm stehen wie die jedes anderen.

Gefunden an der Stelle, an der es am meisten weh tut — `ErrorBoundary`, also der Text, den jemand liest, **wenn die App schon abgestürzt ist**:

```jsx
<> Zusätzlich wurde eine Sicherheitskopie des Autosaves angelegt
(<code>cable-planner:projectBackup:&lt;Zeit&gt;</code> in localStorage).</>
```

Deutsch, roh im JSX, in einem Repo mit Quellsprache `en` (E-28) — und der Zähler meldete 0.

## Die Öffnung ist eng und kostet nichts

`<>` kommt in TypeScript sonst nicht vor: `=>` fängt das `=`, ein Generic trägt vor dem `>` einen Bezeichner, und `a < b > c` hat Leerzeichen. **Gemessen nach der Änderung: eine einzige neue Fundstelle, und die war echt.** `JSX_LITERAL` hat dieselbe Öffnung bekommen; die feste Probe im CLI-Teil trägt den Fall jetzt mit.

## Der Satz

Jetzt **ein** Schlüssel mit Platzhalter (`errorBoundary.projectBackedUp`), EN als Quelle, DE als Übersetzung. Das eingebettete `<code>` ist dabei gefallen: ein Satz, der aus zwei Bausteinen zusammengesetzt wird, lässt sich nicht übersetzen, ohne die Wortstellung der Quellsprache mitzuschleppen — der Speicher-Schlüssel steht deshalb als `{key}` im Satz.

## Prüfung

- `npm run lang:check` — 0 / 0 / 0, feste Probe grün
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — 250 Testdateien, 3879 Tests grün
- `npm run lint` — 0 Errors (12 vorbestehende Warnings)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_