### PR TITLE
i18n: der Wächter kennt die eigenen Dialoge — sieben deutsche Meldungen gefunden

### DIFF
--- a/docs/ui-audit.md
+++ b/docs/ui-audit.md
@@ -586,6 +586,25 @@ nicht erst, wenn jemand eine halb übersetzte Seite meldet.
       eng. Der Satz ist jetzt **ein** Schlüssel mit Platzhalter statt eines
       Satzes plus eingebettetem `<code>`.
 
+      **Dritter Nachtrag: die eigenen Dialoge, nicht die des Browsers.**
+      Der Zähler kannte `alert`, `confirm` und `prompt` — Formen, die diese
+      App gar nicht mehr benutzt: der `dialogs:native`-Wächter der Suite
+      verbietet sie, an ihrer Stelle stehen `infoDialog`, `confirmDialog`
+      und `promptDialog` aus `renderer/lib/`. Die Liste war also eine Liste
+      der Formen, die es **nicht mehr gibt**, und ihre Null damit wertlos.
+      Dazu kommt `{ body: '…' }`: der Titel steht im ersten Argument, der
+      längere und wichtigere Fließtext in den Optionen.
+
+      Gemessen nach der Erweiterung: **fünf deutsche Rückfragen in
+      `App.tsx`** — darunter „Neuer Stecker-Typ (z. B. „Speakon NL4"):",
+      also eine **Eingabeaufforderung**, ohne deren Verständnis niemand
+      weitermacht. Zwei weitere fand dabei das Auge in
+      `VideohubExportDialog`: „⚠ {n} Zeilen nicht erkannt" und „{in} Inputs
+      · {out} Outputs neu beschriftet" — keine davon ist JSX-Text, Attribut
+      oder `t()`-Fallback, sondern eine gewöhnliche Zuweisung an eine
+      Variable, die später im Dialog landet. **Diese Form sieht der Zähler
+      weiterhin nicht**, und das steht hier, statt verschwiegen zu werden.
+
       **Der Preis ist benannt:** ein Lauf, der über `{` hinweggeht, endet öfter
       mitten im Ausdruck. `NACH_CODE` hat deshalb `return`, `null`, `typeof`,
       `??` und `if (` dazubekommen — `if` steht auf der **englischen**

--- a/scripts/quellsprache.mjs
+++ b/scripts/quellsprache.mjs
@@ -316,9 +316,33 @@ const NACH_CODE =
  * mit eingesetztem Namen steht praktisch immer im Backtick — ausgerechnet die
  * Form also, die eine erste Fassung nicht kannte (gefunden ueber den
  * `dialogs:native`-Waechter der Suite, nicht ueber diesen Lauf).
+ *
+ * ─── UND DIE EIGENEN DIALOGE, NICHT NUR DIE DES BROWSERS (2026-09-10) ──────
+ *
+ * `alert`, `confirm` und `prompt` benutzt diese App gar nicht mehr: der
+ * `dialogs:native`-Waechter der Suite verbietet sie, und an ihre Stelle sind
+ * `infoDialog`, `confirmDialog` und `promptDialog` aus `renderer/lib/`
+ * getreten. Die Liste hier war also eine Liste der Formen, die es NICHT MEHR
+ * GIBT — sie konnte nichts finden, und ihre Null war deshalb wertlos.
+ *
+ * Gemessen nach der Erweiterung: FUENF deutsche Rueckfragen in `App.tsx`,
+ * mitten in einem Repo mit Quellsprache `en` — darunter „Neuer Stecker-Typ
+ * (z.B. \"Speakon NL4\"):", also eine Eingabeaufforderung, ohne deren
+ * Verstaendnis niemand weitermacht.
  */
 const RUFE =
-  /\b(?:alert|confirm|prompt)\(\s*(?:(['"])((?:[^\\]|\\.){4,}?)\1|`((?:[^`\\]|\\.){4,}?)`)/g
+  /\b(?:alert|confirm|prompt|infoDialog|confirmDialog|promptDialog)\(\s*(?:(['"])((?:[^\\]|\\.){4,}?)\1|`((?:[^`\\]|\\.){4,}?)`)/g
+
+/**
+ * Der Fliesstext eines eigenen Dialogs: `{ body: '…' }`.
+ *
+ * Der Titel steht als erstes Argument (oben), der Rumpf in den Optionen — und
+ * der Rumpf ist der laengere und wichtigere Teil. Ohne diese Zeile faende der
+ * Zaehler die Ueberschrift „Über Rentman-Plan hinaus" und uebersaehe die drei
+ * Saetze darunter, die erklaeren, was zu tun ist.
+ */
+const RUMPF =
+  /\bbody:\s*(?:(['"])((?:[^\\]|\\.){4,}?)\1|`((?:[^`\\]|\\.){4,}?)`)/g
 
 /**
  * Die Einsetzungen aus einem Textknoten herausnehmen — und zwar VON INNEN.
@@ -349,6 +373,7 @@ export const sichtbareTexte = (quelle, jsx) => {
   const raus = []
   for (const m of text.matchAll(SICHTBARE_ATTRIBUTE)) raus.push(m[1] ?? m[2])
   for (const m of text.matchAll(RUFE)) raus.push(m[2] ?? m[3])
+  for (const m of text.matchAll(RUMPF)) raus.push(m[2] ?? m[3])
   if (jsx) {
     for (const m of text.matchAll(JSX_TEXT)) {
       const t = ohneAusdruecke(m[1])
@@ -440,6 +465,9 @@ if (process.argv[1] && process.argv[1].endsWith('quellsprache.mjs')) {
     '<button title="Delete this cable">',
     '<span>Not connected yet</span>',
     'window.confirm(`Delete "${name}" and its ${n} shots?`)',
+    // Die eigenen Dialoge — die einzigen, die es hier noch gibt.
+    "await promptDialog('New connector type, e.g. Speakon NL4:')",
+    "await infoDialog('Beyond the rental plan', { body: 'More cables built than booked.' })",
     // Die beiden Kommentar-Zeilen tragen mit Absicht Muster, die OHNE den
     // Kommentarfilter treffen wuerden — eine ohne waere wirkungslos: was kein
     // `>` und kein `title=` enthaelt, findet der Zaehler ohnehin nicht, und die
@@ -474,6 +502,9 @@ if (process.argv[1] && process.argv[1].endsWith('quellsprache.mjs')) {
     'with ${n} of them',
     'Sentence before the brace',
     'Inside a bare fragment',
+    'New connector type, e.g. Speakon NL4:',
+    'Beyond the rental plan',
+    'More cables built than booked.',
   ].sort()
   if (gefunden.length !== erwartet.length || erwartet.some((e, i) => gefunden[i] !== e)) {
     console.error(

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -916,7 +916,10 @@ export default function App() {
   // Planner und werden beim ersten Mal nach ihrem Namen gefragt.
   const handleExportViewer = async () => {
     if (!hasDesktopBridge) {
-      await infoDialog('Viewer-Export erfordert die Desktop-App.', { tone: 'warning' })
+      await infoDialog(
+        t('app.viewer.desktopOnly', 'Exporting a viewer file needs the desktop app.'),
+        { tone: 'warning' },
+      )
       return
     }
     try {
@@ -1279,11 +1282,14 @@ export default function App() {
       .getState()
       .project.cables.filter((c) => c.type === draft.type && c.length === draft.length).length
     if (built > planned) {
-      await infoDialog('Über Rentman-Plan hinaus', {
-        body:
-          `Es sind jetzt ${built} x ${draft.type} ${draft.length} m verbaut, ` +
-          `aber nur ${planned} laut Rentman-Plan vorhanden. ` +
-          `Bitte zusätzliche Kabel in Rentman buchen oder die Verkabelung anpassen.`,
+      await infoDialog(t('app.rentman.overBuiltTitle', 'Beyond the rental plan'), {
+        body: format(
+          t(
+            'app.rentman.overBuiltBody',
+            '{built} x {type} {length} m are now built, but the rental plan lists only {planned}. Book the extra cables in Rentman or adjust the wiring.',
+          ),
+          { built, type: draft.type, length: draft.length, planned },
+        ),
         tone: 'warning',
       })
     }
@@ -2039,7 +2045,11 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
                   onChange={async (e) => {
                     const v = e.target.value
                     if (v === '__new__') {
-                      const name = (await promptDialog('Neuer Stecker-Typ (z.B. "Speakon NL4"):'))?.trim()
+                      const name = (
+                        await promptDialog(
+                          t('app.connector.newPrompt', 'New connector type (e.g. "Speakon NL4"):'),
+                        )
+                      )?.trim()
                       if (name) {
                         useUiStore.getState().addCustomConnectorType(name)
                         setCustomConnectorType(name as ConnectorType)
@@ -2066,7 +2076,11 @@ const CableEditDialog = ({ cable, onClose, onSave }: CableEditDialogProps) => {
                   onChange={async (e) => {
                     const v = e.target.value
                     if (v === '__new__') {
-                      const name = (await promptDialog('Neuer Signal-Standard (z.B. "Madi 64ch"):'))?.trim()
+                      const name = (
+                        await promptDialog(
+                          t('app.standard.newPrompt', 'New signal standard (e.g. "Madi 64ch"):'),
+                        )
+                      )?.trim()
                       if (name) {
                         useUiStore.getState().addCustomSignalStandard(name)
                         setCustomStandard(name as SignalStandard)

--- a/src/renderer/components/Export/VideohubExportDialog.tsx
+++ b/src/renderer/components/Export/VideohubExportDialog.tsx
@@ -825,12 +825,23 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
     setEquipment(device.id, { inputs: nextInputs, outputs: nextOutputs })
     const updatedIn = parsed.inputs.filter((x) => x).length
     const updatedOut = parsed.outputs.filter((x) => x).length
+    // Beide Saetze standen bis 2026-09-10 roh und auf Deutsch hier — in einem
+    // Repo mit Quellsprache `en`, und kein Waechter sah sie: es ist kein
+    // JSX-Text, kein Attribut und kein `t()`-Fallback, sondern eine ganz
+    // gewoehnliche Zuweisung an eine Variable, die spaeter im Dialog landet.
     const warningSummary =
       parsed.warnings.length > 0
-        ? `\n\n⚠ ${parsed.warnings.length} Zeilen nicht erkannt:\n${parsed.warnings.slice(0, 5).join('\n')}`
+        ? `\n\n${fmt(
+            t('export.labelsImportWarnings', '{n} lines were not recognised:'),
+            { n: parsed.warnings.length },
+          )}\n${parsed.warnings.slice(0, 5).join('\n')}`
         : ''
     await infoDialog(t('export.labelsImported', 'Labels.txt imported'), {
-      body: `${updatedIn} Inputs · ${updatedOut} Outputs neu beschriftet.${warningSummary}`,
+      body:
+        fmt(t('export.labelsImportBody', '{in} inputs and {out} outputs relabelled.'), {
+          in: updatedIn,
+          out: updatedOut,
+        }) + warningSummary,
       tone: 'success',
     })
   }

--- a/src/renderer/lib/i18n/de.ts
+++ b/src/renderer/lib/i18n/de.ts
@@ -575,6 +575,12 @@ export const de: Dict = {
   'app.menu.file.saveAs': 'Speichern unter…',
   'app.menu.file.viewForeign': 'Verknüpfte Venue-Planung ansehen…',
   'app.menu.file.viewForeignRoom': 'Raum',
+  'app.connector.newPrompt': 'Neuer Stecker-Typ (z. B. „Speakon NL4“):',
+  'app.standard.newPrompt': 'Neuer Signal-Standard (z. B. „Madi 64ch“):',
+  'app.rentman.overBuiltTitle': 'Über Rentman-Plan hinaus',
+  'app.rentman.overBuiltBody':
+    'Es sind jetzt {built} x {type} {length} m verbaut, aber nur {planned} laut Rentman-Plan vorhanden. Bitte zusätzliche Kabel in Rentman buchen oder die Verkabelung anpassen.',
+  'app.viewer.desktopOnly': 'Der Viewer-Export braucht die Desktop-App.',
   'app.menu.file.viewForeignCameras': 'Kameras ({n})',
   'app.menu.file.viewForeignCounts': '{walls} Wände · {persons} Personen · {stage} Bühne',
   'app.menu.file.viewForeignFixtures': 'Lampen ({n})',
@@ -5287,6 +5293,8 @@ export const de: Dict = {
   'rundown.pastePh': '1\tBegrüßung\n2\tInterview\tGast kommt von links\n3\tMusik',
   'schema.catPh': 'z. B. Funkstrecken-Zubehör',
   'vhx.desktopOnly': '· nur in Desktop-App verfügbar',
+  'export.labelsImportBody': '{in} Eingänge und {out} Ausgänge neu beschriftet.',
+  'export.labelsImportWarnings': '{n} Zeilen wurden nicht erkannt:',
   'vhx.discover.found': 'Gefunden ({n}) — Klick übernimmt IP/Port',
   'vhx.push.heading':
     'An Videohub senden (TCP) — offline bearbeiten und pushen, sobald das richtige Netz da ist',


### PR DESCRIPTION
Dritter Nachtrag zu #824 / #826.

## Der Befund: eine Liste der Formen, die es nicht mehr gibt

`RUFE` in `scripts/quellsprache.mjs` suchte nach `alert`, `confirm` und `prompt`. **Diese App benutzt keine davon** — der `dialogs:native`-Wächter der Suite verbietet sie, an ihrer Stelle stehen `infoDialog`, `confirmDialog` und `promptDialog` aus `renderer/lib/`.

Die Liste war also eine Liste der Formen, die es nicht mehr gibt. Sie konnte nichts finden, und ihre Null war deshalb wertlos — dieselbe Defektform wie beim Fragment (#826) und bei der geschweiften Klammer (#824): ein Wächter, der auf ein leeres Feld zeigt und „keine Verstöße" meldet.

Dazu `RUMPF` für `{ body: '…' }`: der Titel steht im ersten Argument, der **längere und wichtigere** Fließtext in den Optionen. Ohne ihn fände der Zähler die Überschrift und übersähe die Sätze darunter, die erklären, was zu tun ist.

## Gemessen: fünf deutsche Rückfragen in `App.tsx`

| Text | Art |
|---|---|
| `Viewer-Export erfordert die Desktop-App.` | Hinweis |
| `Über Rentman-Plan hinaus` + der dreisätzige Rumpf darunter | Warnung mit Handlungsanweisung |
| `Neuer Stecker-Typ (z.B. "Speakon NL4"):` | **Eingabeaufforderung** |
| `Neuer Signal-Standard (z.B. "Madi 64ch"):` | **Eingabeaufforderung** |

Die letzten beiden sind der unangenehmste Fall: ohne ihr Verständnis macht niemand weiter — der Dialog wartet auf eine Eingabe.

## Zwei weitere fand das Auge, nicht der Zähler

In `VideohubExportDialog`: „⚠ {n} Zeilen nicht erkannt" und „{in} Inputs · {out} Outputs neu beschriftet". Sie sind hier mit gewickelt, aber **der Zähler sieht ihre Form weiterhin nicht**: das ist kein JSX-Text, kein Attribut und kein `t()`-Fallback, sondern eine gewöhnliche Zuweisung an eine Variable, die später im Dialog landet. Das steht so im Audit, statt verschwiegen zu werden.

## Die Sätze

Alle sieben jetzt `t()` mit englischer Quelle (E-28) und deutschem Wörterbuch-Eintrag. Der Rentman-Satz und die Import-Meldung über `format()` mit Platzhaltern statt Zeichenketten-Addition — die Wortstellung gehört zur Sprache. Die feste Probe im CLI-Teil trägt beide neuen Formen mit.

## Prüfung

- `npm run lang:check` — 0 / 0 / 0, feste Probe grün
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — 250 Testdateien, 3879 Tests grün
- `npm run lint` — 0 Errors (12 vorbestehende Warnings)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_