### PR TITLE
ui: Zustands-Symbole werden Icons (138 → 111 rohe Stellen)

### DIFF
--- a/docs/ui-audit.md
+++ b/docs/ui-audit.md
@@ -639,7 +639,18 @@ nicht erst, wenn jemand eine halb übersetzte Seite meldet.
       Fund verloren: „keine Stelle unter 12px" wäre ab dann auch bei kaputtem
       Muster erfüllt. Sie steht jetzt auf einer **festen Probe** — dieselbe
       Form wie im Sprachmix-Zähler.
-- [ ] **Offen: 138 Stellen in 50 Dateien**, und der Rest ist keine
+- [x] **Dritter Schnitt: die Zustands-Symbole, 138 → 111 Stellen**
+      (2026-09-10). 26 weitere Stellen sind Icons: `↺` (sechs Zurücksetzen-
+      Knöpfe, `RotateCcw`), `✕` (vier Entfernen/Schließen, `X`), `✓` (elf
+      Bestätigungen, `Check`), `●`/`○` (vier Auswahlpunkte, `CircleDot`/
+      `Circle` bzw. `Dot`), `▦` (`Grid3x3`) und `⬆` (`Upload`).
+
+      **Ein Fund nebenbei:** `IntegrationsTab` zeigte „✓ Key" als **rohen
+      englischen Text** — kein `t()`, also auch keine Übersetzung. Der
+      Sprachmix-Zähler sah ihn nicht (er meldet nur die jeweils **andere**
+      Sprache), der Glyph-Durchgang schon. Jetzt
+      `settings.integrations.keyStored`.
+- [ ] **Offen: 111 Stellen in 42 Dateien**, und der Rest ist keine
       Fleißarbeit mehr, sondern Urteilsarbeit — drei Gruppen mit je eigenem
       Grund:
 
@@ -658,9 +669,12 @@ nicht erst, wenn jemand eine halb übersetzte Seite meldet.
       elf `ICON_GLYPHS` in `OptionalFieldsSection` — Letztere stehen **im
       Projekt-File**, sind also Nutzerdaten und nicht Darstellung.
 
-      Was danach noch bleibt (`✓ ✕ ✗ ⚠ ● ○ ↺`, ~40 Stellen), ist echter
-      Kandidat für Icons, aber jeweils mit Zustandsbedeutung im umgebenden
-      Markup — das ist der nächste Schnitt, nicht dieser.
+      Was danach noch bleibt, ist im Wesentlichen Gruppe (1): Pfeile in
+      Datensätzen und Exportzeilen. Von den Zustands-Symbolen sind noch die
+      übrig, die in einer **Zeichenkette** stecken statt im JSX
+      (`⚠ ${e.message}`, `level === 'ok' ? '✓' : …`, `' · ✓'`) — dort ist
+      ein Icon erst möglich, wenn der Aufrufer einen ReactNode annimmt, und
+      das ist eine Änderung an der Schnittstelle, nicht am Symbol.
 
 ## Phase 5 — Komponenten-Dekomposition (RISIKO)
 

--- a/src/renderer/components/Atem/AtemAudioRouterDialog.tsx
+++ b/src/renderer/components/Atem/AtemAudioRouterDialog.tsx
@@ -27,8 +27,7 @@ import {
 } from '../../lib/atemLiveCompare'
 import {
   AlertTriangle, FolderOpen, Save, Plug, Upload, SlidersHorizontal,
-  Square, SquareCheck, SquareMinus,
-} from 'lucide-react'
+  Square, SquareCheck, SquareMinus, Dot} from 'lucide-react'
 import { format, useTranslation } from '../../lib/i18n'
 import { Icon } from '../shared/Icon'
 import { getEquipmentById } from '../../lib/equipmentSelectors'
@@ -1292,7 +1291,7 @@ const MatrixView = ({ config, setConfig }: ViewProps) => {
                                 fontSize: 11,
                               }}
                             >
-                              ●
+                              <Icon icon={Dot} size="sm" />
                             </span>
                           ) : outputHasOtherSource ? (
                             // #456 — Marker "Output anderweitig belegt": vorher

--- a/src/renderer/components/Atem/AtemMvConfigDialog.tsx
+++ b/src/renderer/components/Atem/AtemMvConfigDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { toPng } from 'html-to-image'
-import { Download, Square, SquareCheck, Monitor, ChevronDown, ChevronRight} from 'lucide-react'
+import { Download, Square, SquareCheck, Monitor, ChevronDown, ChevronRight, Check} from 'lucide-react'
 import { Icon } from '../shared/Icon'
 import { useProjectStore } from '../../store/projectStore'
 import { useUiStore } from '../../store/uiStore'
@@ -1364,7 +1364,10 @@ export const AtemMvConfigDialog = () => {
         <div className="flex items-center justify-between border-t border-cp-border px-4 py-2">
           <span className="text-cp-xs text-cp-text-muted">
             {savedFlash ? (
-              <span className="font-semibold text-emerald-400">✓ {t('atem.mv.saved', 'Saved')}</span>
+              <span className="inline-flex items-center gap-1 font-semibold text-emerald-400">
+                <Icon icon={Check} size="xs" />
+                {t('atem.mv.saved', 'Saved')}
+              </span>
             ) : (
               status ||
               (connected

--- a/src/renderer/components/Export/GreenGoExportDialog.tsx
+++ b/src/renderer/components/Export/GreenGoExportDialog.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react'
-import { ArrowRight, Download, Upload, X, FileSpreadsheet } from 'lucide-react'
+import { ArrowRight, Download, Upload, X, FileSpreadsheet, CircleDot, Circle} from 'lucide-react'
 import { Icon } from '../shared/Icon'
 import { useProjectStore } from '../../store/projectStore'
 import type { GreenGoConfig, GreenGoGroup, GreenGoUser } from '../../types/greengo'
@@ -528,7 +528,7 @@ export const GreenGoExportDialog = ({ onClose }: Props) => {
                                         ? 'bg-emerald-600 text-white hover:bg-emerald-500'
                                         : 'bg-cp-surface-2 text-cp-text-dim hover:bg-cp-surface-4 hover:text-cp-text-secondary'
                                     }`}>
-                                    {active ? '●' : '○'}
+                                    <Icon icon={active ? CircleDot : Circle} size="xs" />
                                   </button>
                                 </td>
                               )

--- a/src/renderer/components/Export/VideohubExportDialog.tsx
+++ b/src/renderer/components/Export/VideohubExportDialog.tsx
@@ -1,5 +1,5 @@
 ﻿import { useEffect, useMemo, useRef, useState } from 'react'
-import { X, SlidersHorizontal, List, Link, Wand2, ClipboardList, Search, Lock, Download, Loader2, Upload, Tag, ChevronDown, ChevronRight} from 'lucide-react'
+import { X, SlidersHorizontal, List, Link, Wand2, ClipboardList, Search, Lock, Download, Loader2, Upload, Tag, ChevronDown, ChevronRight, RotateCcw, Grid3x3} from 'lucide-react'
 import { Icon } from '../shared/Icon'
 import { useProjectStore } from '../../store/projectStore'
 import {
@@ -1086,7 +1086,8 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
                   }`}
                   title={t('videohub.matrixView', 'Crosspoint matrix')}
                 >
-                  ▦ {t('export.matrixToggle', 'Matrix')}
+                  <Icon icon={Grid3x3} size="xs" className="mr-1 inline" />
+                  {t('export.matrixToggle', 'Matrix')}
                 </button>
                 <button
                   type="button"
@@ -1180,7 +1181,8 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
               className="rounded bg-cp-surface-2 px-2 py-1 text-cp-xs hover:bg-cp-surface-4"
               title={t('videohub.resetDiag', 'Reset diagonal routing (output N → input N)')}
             >
-              ↺ {t('export.reset', 'Reset')}
+              <Icon icon={RotateCcw} size="xs" className="mr-1 inline" />
+              {t('export.reset', 'Reset')}
             </button>
           </div>
           {showMatrix && (() => {
@@ -1676,7 +1678,8 @@ export const VideohubExportDialog = ({ onClose, preselectedDeviceId, initialShow
               className="rounded bg-sky-700 px-3 py-1 text-cp-base hover:bg-sky-600"
               title={t('export.importLabelsTitle', 'Import Labels.txt — write port names from a file (e.g. from Videohub Setup) onto this device.')}
             >
-              ⬆ {t('export.importLabels', 'Import Labels.txt')}
+              <Icon icon={Upload} size="xs" className="mr-1 inline" />
+              {t('export.importLabels', 'Import Labels.txt')}
             </button>
           )}
           {/* #502 — Druckbare Beschriftungs-Labels (Smart-Control-Raster) als

--- a/src/renderer/components/Export/VideohubRoutingMatrix.tsx
+++ b/src/renderer/components/Export/VideohubRoutingMatrix.tsx
@@ -1,5 +1,7 @@
+import { RotateCcw } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { format, useTranslation } from '../../lib/i18n'
+import { Icon } from '../shared/Icon'
 
 /** Struktur fuer farb-kodierte Label-Rendering. Wenn ein Eintrag
  *  mehr als nur `port` enthaelt, rendert der Matrix-Header die Teile
@@ -344,7 +346,8 @@ export const VideohubRoutingMatrix = ({
             onClick={resetLayout}
             className="rounded bg-cp-surface-2 px-2 py-0.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-4"
           >
-            ↺ {t('export.resetLayout', 'Reset layout')}
+            <Icon icon={RotateCcw} size="xs" className="mr-1 inline" />
+            {t('export.resetLayout', 'Reset layout')}
           </button>
         )}
       </div>

--- a/src/renderer/components/Library/CableLibraryPanel.tsx
+++ b/src/renderer/components/Library/CableLibraryPanel.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type ReactNode } from 'react'
-import { AlertTriangle, X, Pencil, ChevronDown, ChevronRight} from 'lucide-react'
+import { AlertTriangle, X, Pencil, ChevronDown, ChevronRight, RotateCcw, Check} from 'lucide-react'
 import { Icon } from '../shared/Icon'
 import {
   DndContext,
@@ -628,7 +628,7 @@ export const CableLibraryPanel = () => {
                           )}
                           {isRecommended && (
                             <span className="rounded bg-emerald-600 px-1 text-cp-xs font-semibold uppercase text-white">
-                              ✓
+                              <Icon icon={Check} size="xs" />
                             </span>
                           )}
                           {hasCount && (
@@ -679,7 +679,7 @@ export const CableLibraryPanel = () => {
                               className="rounded bg-amber-800/70 px-1.5 py-0.5 text-cp-xs text-amber-100 hover:bg-amber-700"
                               title={t('cableLib.removeOverride', 'Remove override (reset to default)')}
                             >
-                              ↺
+                              <Icon icon={RotateCcw} size="xs" />
                             </button>
                           )}
                           {isCustom && (

--- a/src/renderer/components/Library/LibraryMenus.tsx
+++ b/src/renderer/components/Library/LibraryMenus.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Square, SquareCheck, ChevronDown, ChevronRight} from 'lucide-react'
+import { Square, SquareCheck, ChevronDown, ChevronRight, CircleDot, Circle} from 'lucide-react'
 import { Icon } from '../shared/Icon'
 import { useTranslation } from '../../lib/i18n'
 
@@ -211,7 +211,7 @@ export const LibraryFiltersMenu = ({
               className="block w-full px-3 py-1.5 text-left hover:bg-cp-surface-2"
             >
               <span className="mr-2 inline-block w-4 text-center">
-                {sortMode === opt.value ? '●' : '○'}
+                <Icon icon={sortMode === opt.value ? CircleDot : Circle} size="xs" />
               </span>
               {opt.label}
             </button>

--- a/src/renderer/components/Library/tabs/RentmanTab.tsx
+++ b/src/renderer/components/Library/tabs/RentmanTab.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from 'react'
-import { Check, ChevronDown, ChevronRight, RefreshCw, Package, Search, Folder} from 'lucide-react'
+import { Check, ChevronDown, ChevronRight, RefreshCw, Package, Search, Folder, X} from 'lucide-react'
 import { Icon } from '../../shared/Icon'
 import { useProjectStore } from '../../../store/projectStore'
 import { useUiStore } from '../../../store/uiStore'
@@ -392,7 +392,7 @@ export const RentmanTab = () => {
                   title={t('library.search.clear', 'Clear search')}
                   className="absolute right-1 top-1/2 -translate-y-1/2 rounded px-1 py-0.5 text-cp-xs text-cp-text-faint hover:bg-cp-surface-4 hover:text-cp-text-bright"
                 >
-                  ✕
+                  <Icon icon={X} size="xs" />
                 </button>
               )}
             </div>

--- a/src/renderer/components/Onboarding/ModuleOnboardingDialog.tsx
+++ b/src/renderer/components/Onboarding/ModuleOnboardingDialog.tsx
@@ -7,7 +7,7 @@
  * Siehe `docs/modular-ui-concept.md`.
  */
 import { useState } from 'react'
-import { Blocks } from 'lucide-react'
+import { Blocks, Check} from 'lucide-react'
 import { useSettingsStore } from '../../store/settingsStore'
 import { useTranslation } from '../../lib/i18n'
 import { PRESETS, type PresetId } from '../../lib/modules'
@@ -92,7 +92,7 @@ export const ModuleOnboardingDialog = () => {
                       on ? 'border-emerald-500 bg-emerald-600 text-white' : 'border-cp-border'
                     }`}
                   >
-                    {on ? '✓' : ''}
+                    {on ? <Icon icon={Check} size="xs" /> : null}
                   </span>
                   {t(`onboarding.preset.${p.id}.label`, p.label)}
                 </div>

--- a/src/renderer/components/Properties/sections/DeviceModePicker.tsx
+++ b/src/renderer/components/Properties/sections/DeviceModePicker.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Pencil, ArrowUp, Trash2 } from 'lucide-react'
+import { Pencil, ArrowUp, Trash2, Dot} from 'lucide-react'
 import { useProjectStore } from '../../../store/projectStore'
 import { Icon } from '../../shared/Icon'
 import { confirmDialog } from '../../../lib/confirmDialog'
@@ -170,7 +170,7 @@ export const DeviceModePicker = ({
               title={active === m.id ? t('modes.active', 'Active') : t('modes.activate', 'Activate')}
             >
               <span className="font-medium">
-                {active === m.id && <span className="mr-1 text-sky-300">●</span>}
+                {active === m.id && <Icon icon={Dot} size="sm" className="text-sky-300" />}
                 {m.name}
               </span>
               {m.description && (

--- a/src/renderer/components/Properties/sections/OptionalFieldsSection.tsx
+++ b/src/renderer/components/Properties/sections/OptionalFieldsSection.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink } from 'lucide-react'
+import { ExternalLink, Check} from 'lucide-react'
 import { useCanvasProjectStore as useProjectStore } from '../../../store/projectStoreContext'
 import { Icon } from '../../shared/Icon'
 import { format, useTranslation } from '../../../lib/i18n'
@@ -63,7 +63,8 @@ export const OptionalFieldsSection = ({ equipment }: { equipment: EquipmentItem 
                     { names: verifiedBy.join(', ') },
                   )}
                 >
-                  ✓ {format(t('verify.count', '{n}× verified'), { n: verifiedBy.length })}
+                  <Icon icon={Check} size="xs" className="mr-1 inline" />
+                  {format(t('verify.count', '{n}× verified'), { n: verifiedBy.length })}
                 </span>
               )}
               {verifiedBy.length === 0 && (

--- a/src/renderer/components/Properties/sections/ReplaceDeviceSection.tsx
+++ b/src/renderer/components/Properties/sections/ReplaceDeviceSection.tsx
@@ -1,3 +1,4 @@
+import { X, Check} from 'lucide-react'
 import { useState, useMemo } from 'react'
 import { useCanvasProjectStore as useProjectStore } from '../../../store/projectStoreContext'
 import { useUiStore } from '../../../store/uiStore'
@@ -11,6 +12,7 @@ import { blackmagicTemplates } from '../../../lib/blackmagicCatalog'
 import { SortableSection } from '../SortableSection'
 import type { EquipmentItem, EquipmentTemplate, Port } from '../../../types/equipment'
 import { resolvePortLabel } from '../../../lib/portLabel'
+import { Icon } from '../../shared/Icon'
 
 /**
  * #314 — "Gerät ersetzen…" — tauscht das aktuell ausgewaehlte Equipment
@@ -176,7 +178,7 @@ export const ReplaceDeviceSection = ({ equipment }: { equipment: EquipmentItem }
               onClick={() => setOpen(false)}
               className="rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
             >
-              ✕
+              <Icon icon={X} size="xs" />
             </button>
           </div>
           <select
@@ -226,7 +228,7 @@ export const ReplaceDeviceSection = ({ equipment }: { equipment: EquipmentItem }
                           </span>
                         ) : (
                           <span className="rounded bg-emerald-900/60 px-1.5 py-0.5 text-cp-xs font-bold text-emerald-200">
-                            ✓
+                            <Icon icon={Check} size="xs" />
                           </span>
                         )}
                       </button>

--- a/src/renderer/components/Rack/RackBuilderDialog.tsx
+++ b/src/renderer/components/Rack/RackBuilderDialog.tsx
@@ -19,7 +19,7 @@ import { RackInternalWireOverlay } from './RackInternalWireOverlay'
 import { RackPlacementProperties } from './RackPlacementProperties'
 import { Splitter } from '../Layout/Splitter'
 import { Icon } from '../shared/Icon'
-import { Box, Columns2, FlipHorizontal2, GalleryVerticalEnd, Maximize2, Minus, Plus, RectangleVertical, Square, Server} from 'lucide-react'
+import { Box, Columns2, FlipHorizontal2, GalleryVerticalEnd, Maximize2, Minus, Plus, RectangleVertical, Square, Server, Check} from 'lucide-react'
 import type {
   RackDraft,
   RackPlacementDraft,
@@ -872,7 +872,8 @@ export const RackBuilderDialog = ({ open, templates, initialPreset, onClose, onS
                               className="shrink-0 rounded bg-emerald-800/70 px-1 text-cp-xs font-semibold uppercase text-emerald-200"
                               title={format(t('rack.placedCountTitle', '{count}× placed in rack'), { count: placedCount })}
                             >
-                              ✓ {placedCount}×
+                              <Icon icon={Check} size="xs" className="mr-1 inline" />
+                              {placedCount}×
                             </span>
                           )}
                           {!isRack && (

--- a/src/renderer/components/Rack/RackPlacementProperties.tsx
+++ b/src/renderer/components/Rack/RackPlacementProperties.tsx
@@ -1,4 +1,4 @@
-import { Check, Folder, Rows3, ArrowDownToLine, ArrowUpToLine} from 'lucide-react'
+import { Check, Folder, Rows3, ArrowDownToLine, ArrowUpToLine, X} from 'lucide-react'
 import { useTranslation, format } from '../../lib/i18n'
 import { Icon } from '../shared/Icon'
 import { confirmDialog } from '../../lib/confirmDialog'
@@ -257,7 +257,8 @@ export const RackPlacementProperties = ({
                 className="rounded border border-cp-surface-5 bg-cp-surface-4 px-2 py-1 text-cp-xs text-cp-text-bright hover:bg-cp-surface-5"
                 title={t('rack.stlRemoveTitle', 'Remove STL — device renders as a box again')}
               >
-                ✕ {t('common.remove', 'Remove')}
+                <Icon icon={X} size="xs" className="mr-1 inline" />
+                {t('common.remove', 'Remove')}
               </button>
             )}
           </div>
@@ -547,7 +548,7 @@ export const RackPlacementProperties = ({
                         className="rounded px-1.5 py-0.5 text-cp-xs text-red-400 hover:bg-red-900/40 hover:text-red-300"
                         title={t('rack.removeImage', 'Remove image')}
                       >
-                        ✕
+                        <Icon icon={X} size="xs" />
                       </button>
                     </div>
                   )}

--- a/src/renderer/components/Rentman/EquipmentChecklist.tsx
+++ b/src/renderer/components/Rentman/EquipmentChecklist.tsx
@@ -341,7 +341,8 @@ export const EquipmentChecklist = ({
                               className="ml-2 rounded bg-emerald-800/60 px-1.5 py-0.5 text-cp-xs font-medium text-emerald-200"
                               title={format(t('rentman.checklist.badge.fallbackTitle', 'Auto-filled with template "{name}"'), { name: item.templateMatch })}
                             >
-                              ✓ {item.templateMatch}
+                              <Icon icon={Check} size="xs" className="mr-1 inline" />
+                              {item.templateMatch}
                             </span>
                           )
                         })()}

--- a/src/renderer/components/Settings/tabs/AppearanceTab.tsx
+++ b/src/renderer/components/Settings/tabs/AppearanceTab.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { X, Moon, Sun } from 'lucide-react'
+import { X, Moon, Sun, RotateCcw} from 'lucide-react'
 import { Icon } from '../../shared/Icon'
 import { useUiStore } from '../../../store/uiStore'
 import { useProjectStore } from '../../../store/projectStore'
@@ -261,7 +261,7 @@ export const AppearanceTab = () => {
             className="rounded bg-cp-surface-2 px-2 py-0.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-4 disabled:opacity-50"
             title={t('settings.fontSize.reset', 'Reset to default 11 px')}
           >
-            ↺
+            <Icon icon={RotateCcw} size="xs" />
           </button>
         </label>
       </SettingsCard>
@@ -546,7 +546,7 @@ export const AppearanceTab = () => {
                     className="rounded bg-cp-surface-4 px-1 py-0.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-5"
                     title={t('settings.colors.resetDefault', 'Reset to default')}
                   >
-                    ↺
+                    <Icon icon={RotateCcw} size="xs" />
                   </button>
                 )}
               </label>
@@ -596,7 +596,7 @@ export const AppearanceTab = () => {
                       className="rounded bg-cp-surface-4 px-1 py-0.5 text-cp-xs text-cp-text-secondary hover:bg-cp-surface-5"
                       title={t('settings.colors.resetDefault', 'Reset to default')}
                     >
-                      ↺
+                      <Icon icon={RotateCcw} size="xs" />
                     </button>
                   )}
                 </label>

--- a/src/renderer/components/Settings/tabs/IntegrationsTab.tsx
+++ b/src/renderer/components/Settings/tabs/IntegrationsTab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { X, Eye, EyeOff } from 'lucide-react'
+import { X, Eye, EyeOff, Check} from 'lucide-react'
 import { Icon } from '../../shared/Icon'
 import { PanelHint } from '../../shared/PanelHint'
 import { cablePlannerApi } from '../../../lib/bridge'
@@ -96,7 +96,8 @@ const AiProvidersCard = () => {
                 <span className="font-semibold">{config.label}</span>
                 {hasKey && (
                   <span className="rounded bg-emerald-900/40 px-1.5 py-0.5 text-cp-xs text-emerald-300">
-                    ✓ Key
+                    <Icon icon={Check} size="xs" className="mr-1 inline" />
+                    {t('settings.integrations.keyStored', 'Key')}
                   </span>
                 )}
                 {isSelected && (
@@ -162,7 +163,8 @@ const AiProvidersCard = () => {
               </div>
               {saved[id] && (
                 <div className="mt-1 text-cp-xs text-emerald-300">
-                  ✓ {t('settings.integrations.ai.saved', 'saved')}
+                  <Icon icon={Check} size="xs" className="mr-1 inline" />
+                  {t('settings.integrations.ai.saved', 'saved')}
                 </div>
               )}
             </div>

--- a/src/renderer/components/Wireless/WirelessRigDialog.tsx
+++ b/src/renderer/components/Wireless/WirelessRigDialog.tsx
@@ -12,6 +12,7 @@ import { MicPlotPanel } from './MicPlotPanel'
 import { PanelHint } from '../shared/PanelHint'
 import { useDialogA11y } from '../../hooks/useDialogA11y'
 import { useBackdropClose } from '../../hooks/useBackdropClose'
+import { Icon } from '../shared/Icon'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Funkstrecken / Gesang — Kanalplan: je Kanal Body + kompatible Kapsel/Headset +
@@ -163,7 +164,9 @@ export const WirelessRigDialog = () => {
                     <th className="px-2 py-1.5 font-medium">{t('wireless.channel', 'Channel')}</th>
                     <th className="px-2 py-1.5 font-medium">{t('wireless.body', 'Transmitter (body)')}</th>
                     <th className="px-2 py-1.5 font-medium">{t('wireless.mic', 'Capsule / headset')}</th>
-                    <th className="px-2 py-1.5 text-center font-medium" title={t('wireless.compat', 'Compatibility')}>✓</th>
+                    <th className="px-2 py-1.5 text-center font-medium" title={t('wireless.compat', 'Compatibility')}>
+                      <Icon icon={Check} size="xs" label={t('wireless.compat', 'Compatibility')} />
+                    </th>
                     <th className="px-2 py-1.5 font-medium">{t('wireless.freq', 'Frequency (MHz)')}</th>
                     <th className="px-2 py-1.5"></th>
                   </tr>

--- a/src/renderer/lib/i18n/de.ts
+++ b/src/renderer/lib/i18n/de.ts
@@ -4607,6 +4607,7 @@ export const de: Dict = {
   'settings.integrations.ai': 'AI-Provider (KI-Port-Vorschläge)',
   'settings.integrations.ai.active': 'Aktiv',
   'settings.integrations.ai.createKey': 'Key erstellen',
+  'settings.integrations.keyStored': 'Schlüssel',
   'settings.integrations.ai.saved': 'gespeichert',
   'settings.integrations.aiDesc':
     'Aktiver Provider für die AI-Buttons im Geräte-Wizard und in der Rentman-Library. Jeder Provider hat seinen eigenen API-Key. Alle Keys werden nur lokal im Browser-localStorage gespeichert.',


### PR DESCRIPTION
Dritter Schnitt des Symbol-Durchgangs aus `docs/ui-audit.md`, nach den Carets und Emojis (#825). **26 weitere Stellen** sind jetzt `<Icon />`:

| Symbol | Icon | Stellen |
|---|---|---|
| `↺` | `RotateCcw` | 6 Zurücksetzen-Knöpfe (AppearanceTab ×3, CableLibraryPanel, VideohubExportDialog, VideohubRoutingMatrix) |
| `✕` | `X` | 4 Entfernen/Schließen (ReplaceDeviceSection, RentmanTab, RackPlacementProperties ×2) |
| `✓` | `Check` | 11 Bestätigungen (EquipmentChecklist, ReplaceDeviceSection, OptionalFieldsSection, ModuleOnboardingDialog, AtemMvConfigDialog, IntegrationsTab ×2, CableLibraryPanel, RackBuilderDialog, WirelessRigDialog) |
| `●`/`○` | `CircleDot`/`Circle`, `Dot` | 4 Auswahlpunkte (DeviceModePicker, AtemAudioRouterDialog, LibraryMenus, GreenGoExportDialog) |
| `▦`, `⬆` | `Grid3x3`, `Upload` | Videohub-Dialog |

## Ein Fund nebenbei

`IntegrationsTab` zeigte **„✓ Key" als rohen englischen Text** — kein `t()`, also auch keine Übersetzung. Der Sprachmix-Zähler sah ihn nicht (er meldet nur die jeweils **andere** Sprache), der Glyph-Durchgang schon. Jetzt `settings.integrations.keyStored` mit deutschem Eintrag.

## Was bewusst bleibt

Die Zustands-Symbole, die in einer **Zeichenkette** stecken statt im JSX: `⚠ ${e.message}`, `level === 'ok' ? '✓' : …`, `' · ✓'`. Dort ist ein Icon erst möglich, wenn der Aufrufer einen `ReactNode` annimmt — das ist eine Änderung an der **Schnittstelle** und nicht am Symbol, und sie gehört nicht in diesen Schnitt. Der Audit-Eintrag sagt das mit denselben Zahlen; offen bleiben 111 Stellen in 42 Dateien, im Wesentlichen Pfeile in Datensätzen und Exportzeilen.

## Prüfung

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — 250 Testdateien, 3879 Tests grün
- `npm run lint` — 0 Errors (12 vorbestehende Warnings)
- `npm run lang:check` — 0 / 0 / 0

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_