### PR TITLE
fix(i18n): Katalog-Notizen kamen außerhalb von Deutsch leer in der Projektdatei an

### DIFF
--- a/src/renderer/components/Cable/CableDialog.tsx
+++ b/src/renderer/components/Cable/CableDialog.tsx
@@ -172,7 +172,10 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
     setColor(spec.color)
     // Catalog entries use notesKey (language-aware via i18n). User-supplied
     // custom CableSpecs use the legacy `notes` literal which stays as-is.
-    setNotes(spec.notesKey ? t(spec.notesKey, '') : (spec.notes ?? ''))
+    // Der Fallback ist `spec.notesSource` und NICHT der leere String: der
+    // Text landet unten in `Cable.notes`, also in der Projektdatei. Mit
+    // leerem Fallback bekam jede Sprache ausser Deutsch dort nichts.
+    setNotes(spec.notesKey ? t(spec.notesKey, spec.notesSource ?? '') : (spec.notes ?? ''))
     setStandard(pickHighestSdiStandard(spec.standards))
   }
 

--- a/src/renderer/types/cableSpec.ts
+++ b/src/renderer/types/cableSpec.ts
@@ -147,11 +147,37 @@ export interface CableSpec {
   notes?: string
   /**
    * Built-in catalog entries use a translation key instead of an inline
-   * `notes` string. Consumers should resolve it via `t(spec.notesKey, '')`
-   * so the description follows the active UI language without changing the
-   * underlying portable spec definition.
+   * `notes` string, so the description follows the active UI language
+   * without changing the underlying portable spec definition.
+   *
+   * Always resolve it together with `notesSource` — see below.
    */
   notesKey?: string
+  /**
+   * The ENGLISH source text for `notesKey`, right next to the key.
+   *
+   * ─── WARUM DAS FELD UEBERHAUPT EXISTIERT ─────────────────────────────
+   *
+   * Weil der Aufruf sonst keinen Rueckfall hat. Bis 2026-09-10 stand in
+   * `CableDialog` woertlich `t(spec.notesKey, '')` — ein LEERER Fallback.
+   * Seit E-28 ist Englisch die Quellsprache und steht deshalb NICHT mehr
+   * als Woerterbuch in der Registry (`lib/i18n.ts` sagt das ausdruecklich).
+   * Fuer jede Sprache ausser Deutsch lieferte der Aufruf damit den leeren
+   * String.
+   *
+   * Das blieb nicht in der Anzeige: `CableDialog` schreibt das Ergebnis in
+   * `Cable.notes`, also in die PROJEKTDATEI. Ein englischer Nutzer bekam
+   * also nicht bloss eine leere Beschreibung zu sehen — er bekam sie leer
+   * in seine eigenen Daten geschrieben, waehrend ein deutscher Nutzer den
+   * Text hatte.
+   *
+   * Der uebliche Weg dieses Repos (`t(key, 'English text')`) war hier nicht
+   * gangbar: der Schluessel ist DYNAMISCH (`t(spec.notesKey, …)`), der Text
+   * kann also nicht an der Aufrufstelle stehen. Er steht deshalb hier, wo
+   * der Schluessel steht — dieselbe Zeile, dasselbe Objekt, und damit kann
+   * das eine nicht mehr ohne das andere wandern.
+   */
+  notesSource?: string
 }
 
 /**
@@ -168,6 +194,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 100,
     color: '#38bdf8',
     notesKey: 'catalog.cable.xlr-3pin-audio.notes',
+    notesSource:
+      'Balanced analog audio or AES3 (digital). Gender: male → female.',
   },
   {
     id: 'sdi-3g',
@@ -177,6 +205,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 100,
     color: '#f59e0b',
     notesKey: 'catalog.cable.sdi-3g.notes',
+    notesSource:
+      'Works for SD/HD/3G. Use 75Ω coax (Belden 1694A or similar).',
   },
   {
     id: 'sdi-6g',
@@ -186,6 +216,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 70,
     color: '#f97316',
     notesKey: 'catalog.cable.sdi-6g.notes',
+    notesSource:
+      '6G needs higher-quality coax; mix with 3G only via down-converter.',
   },
   {
     id: 'sdi-12g',
@@ -195,6 +227,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 50,
     color: '#ef4444',
     notesKey: 'catalog.cable.sdi-12g.notes',
+    notesSource:
+      'Use 4K-rated 12G coax (e.g. Belden 4694R). Downscale to 3G requires a scaler/converter.',
   },
   {
     id: 'hdmi-2.0',
@@ -204,6 +238,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 10,
     color: '#a855f7',
     notesKey: 'catalog.cable.hdmi-2.0.notes',
+    notesSource:
+      'Passive copper limited to ~10 m; use optical HDMI for longer runs.',
   },
   {
     id: 'hdmi-2.1',
@@ -213,6 +249,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 5,
     color: '#c084fc',
     notesKey: 'catalog.cable.hdmi-2.1.notes',
+    notesSource:
+      'Ultra-high speed cables required; pairing with HDMI 1.4 device limits to 1.4.',
   },
   {
     id: 'dp-1.4',
@@ -238,6 +276,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 100,
     color: '#16a34a',
     notesKey: 'catalog.cable.cat6a.notes',
+    notesSource:
+      'Required for 10GBASE-T over full 100 m runs.',
   },
   {
     id: 'ndi-cat6a',
@@ -247,6 +287,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 100,
     color: '#22c55e',
     notesKey: 'catalog.cable.ndi-cat6a.notes',
+    notesSource:
+      'NDI / NDI-HX over standard Gigabit Ethernet. Keep NDI and Dante on separate VLANs/links to avoid congestion.',
   },
   {
     id: 'dante-cat6',
@@ -256,6 +298,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 100,
     color: '#14b8a6',
     notesKey: 'catalog.cable.dante-cat6.notes',
+    notesSource:
+      'Dante / AES67 audio-over-IP. Requires PTP clocking; QoS/DSCP recommended on managed switches.',
   },
   {
     // B-10 — die Ausspiel-Haelfte. Physisch dasselbe Cat6-Kabel wie
@@ -268,6 +312,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 100,
     color: '#a855f7',
     notesKey: 'catalog.cable.stream-uplink-cat6.notes',
+    notesSource:
+      'Outbound stream leg: SRT (contribution, with retransmit reserve), RTMP (platform ingest) or HLS (delivery ladder). Physically the same Cat6 as any other link — kept separate so the network budget shows the uplink as delivery, not as another production source. The budget figures are guide values for one 1080p50 path.',
   },
   {
     id: 'st2110-fiber',
@@ -277,6 +323,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 300,
     color: '#0ea5e9',
     notesKey: 'catalog.cable.st2110-fiber.notes',
+    notesSource:
+      'SMPTE ST 2110 (-20 video / -30 audio / -40 ANC) over fiber. Needs a PTP grandmaster; typically 10/25/100 GbE.',
   },
   {
     id: 'blackburst-bnc',
@@ -286,6 +334,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 100,
     color: '#64748b',
     notesKey: 'catalog.cable.blackburst-bnc.notes',
+    notesSource:
+      'Reference sync (black burst / tri-level) over 75Ω coax. Distribute from one sync generator; feed every genlock-capable device.',
   },
   {
     id: 'wordclock-bnc',
@@ -295,6 +345,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 50,
     color: '#94a3b8',
     notesKey: 'catalog.cable.wordclock-bnc.notes',
+    notesSource:
+      'Word clock for digital audio. Daisy-chain with 75Ω termination at the end; one master clock per domain.',
   },
   {
     id: 'ltc-bnc',
@@ -304,6 +356,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 100,
     color: '#94a3b8',
     notesKey: 'catalog.cable.ltc-bnc.notes',
+    notesSource:
+      'LTC longitudinal timecode (SMPTE 12M): an audio-band signal distributed over 75Ω coax (BNC), or via balanced XLR / LEMO into cameras and recorders. A master clock or sync generator typically feeds genlock and timecode together.',
   },
   {
     id: 'ptp-cat6',
@@ -313,6 +367,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 100,
     color: '#0891b2',
     notesKey: 'catalog.cable.ptp-cat6.notes',
+    notesSource:
+      'PTP (IEEE 1588) timing for ST 2110 / AES67. One grandmaster per PTP domain; enable boundary clocks on switches.',
   },
   {
     id: 'fiber-sm-lc',
@@ -322,6 +378,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 10000,
     color: '#eab308',
     notesKey: 'catalog.cable.fiber-sm-lc.notes',
+    notesSource:
+      'Single-mode (yellow jacket). Long distance (>300 m).',
   },
   {
     id: 'fiber-mm-lc',
@@ -331,6 +389,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 400,
     color: '#facc15',
     notesKey: 'catalog.cable.fiber-mm-lc.notes',
+    notesSource:
+      'Multi-mode (aqua jacket). Short haul in racks/venue.',
   },
   {
     id: 'usb3',
@@ -348,6 +408,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 5,
     color: '#475569',
     notesKey: 'catalog.cable.iec-230v.notes',
+    notesSource:
+      'Standard device power cable ("kettle lead").',
   },
   {
     id: 'powercon-tru1',
@@ -357,6 +419,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 25,
     color: '#0ea5e9',
     notesKey: 'catalog.cable.powercon-tru1.notes',
+    notesSource:
+      'Locking, touring-grade power. Do not mix with classic powerCON (grey/blue).',
   },
   {
     id: 'schuko-230v',
@@ -374,6 +438,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 2,
     color: '#7c3aed',
     notesKey: 'catalog.cable.thunderbolt-3.notes',
+    notesSource:
+      'USB-C connector, passive up to 2 m. Active TB3 cable up to ~50 cm. Forward-compatible with Thunderbolt 4.',
   },
   {
     id: 'thunderbolt-4',
@@ -383,6 +449,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 2,
     color: '#6d28d9',
     notesKey: 'catalog.cable.thunderbolt-4.notes',
+    notesSource:
+      'Same bandwidth as TB3 but stricter certification (2× DP 1.4, 40 Gbps, 100 W PD).',
   },
   {
     id: 'madi-bnc',
@@ -392,6 +460,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 200,
     color: '#0891b2',
     notesKey: 'catalog.cable.madi-bnc.notes',
+    notesSource:
+      'MADI AES10 over 75Ω coax. Up to 64 ch at 48 kHz or 56 ch at 96 kHz.',
   },
   {
     id: 'aes3id-bnc',
@@ -401,6 +471,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 100,
     color: '#0891b2',
     notesKey: 'catalog.cable.aes3id-bnc.notes',
+    notesSource:
+      'AES3id: AES3 digital audio over 75Ω unbalanced coax (BNC) — the BNC variant of AES/EBU. One stereo pair per coax, with longer reach than balanced AES3 over XLR. Common on routers and broadcast gear.',
   },
   {
     id: 'dvb-asi',
@@ -410,6 +482,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 100,
     color: '#2563eb',
     notesKey: 'catalog.cable.dvb-asi.notes',
+    notesSource:
+      'DVB-ASI: MPEG transport stream over 75Ω coax (BNC), up to 270 Mbit/s. Encoder/mux/modulator/playout interconnect in headends and OB trucks.',
   },
   {
     id: 'madi-optical',
@@ -419,6 +493,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 2000,
     color: '#06b6d4',
     notesKey: 'catalog.cable.madi-optical.notes',
+    notesSource:
+      'MADI AES10 over optical fibre. Long reach, galvanically isolated.',
   },
   {
     id: 'smpte-297',
@@ -428,6 +504,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 10000,
     color: '#f59e0b',
     notesKey: 'catalog.cable.smpte-297.notes',
+    notesSource:
+      'SMPTE ST 297: serial digital video (SDI) transported optically over fibre. No power — a pure optical SDI link with long reach.',
   },
   // #376 — SMPTE 304M (Hybrid-Fiber-Kamerakabel) ist KEIN Triax. Triax ist
   // ein analog-orientiertes Single-Coax-System (Damar & Hagen, Fischer),
@@ -442,6 +520,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 2000,
     color: '#d97706',
     notesKey: 'catalog.cable.smpte-304m-lemo.notes',
+    notesSource:
+      'SMPTE 304M hybrid camera cable with LEMO 3K.93C (also called LEMO 311) connector — EBU/broadcast-standard fibre + copper hybrid for studio cameras.',
   },
   {
     id: 'smpte-304m-dragonfly',
@@ -451,6 +531,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 2000,
     color: '#b45309',
     notesKey: 'catalog.cable.smpte-304m-dragonfly.notes',
+    notesSource:
+      'SMPTE 304M hybrid camera cable with Neutrik opticalCON Dragonfly connector — ruggedised touring/stage variant compatible with LEMO 3K.93C via adapter.',
   },
   {
     id: 'triax-dh',
@@ -460,6 +542,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 1500,
     color: '#a16207',
     notesKey: 'catalog.cable.triax-dh.notes',
+    notesSource:
+      'Damar & Hagen triax — analog single-coax for HDTV cameras. Carries video, intercom, talkback, power. Mechanically incompatible with Fischer triax.',
   },
   {
     id: 'triax-fischer',
@@ -469,6 +553,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 1500,
     color: '#854d0e',
     notesKey: 'catalog.cable.triax-fischer.notes',
+    notesSource:
+      'Fischer triax — analog single-coax for HDTV cameras (alternative to Damar & Hagen). Same signals; different connector.',
   },
   {
     id: 'triax-camera',
@@ -478,6 +564,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 300,
     color: '#b45309',
     notesKey: 'catalog.cable.triax-camera.notes',
+    notesSource:
+      'Triaxial (coaxial) camera cable for studio/OB cameras: carries video, return, intercom/talkback, genlock and power over one triax — analogue, distinct from the SMPTE fibre camera cables.',
   },
   {
     id: 'serial-rs422',
@@ -487,6 +575,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 1200,
     color: '#fbbf24',
     notesKey: 'catalog.cable.serial-rs422.notes',
+    notesSource:
+      'Serial device control. RS-232 ~15 m point-to-point; RS-422/485 differential up to ~1200 m (VTR Sony 9-pin, PTZ/VISCA, router/matrix control).',
   },
   {
     id: 'vga-de15',
@@ -496,6 +586,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 15,
     color: '#6366f1',
     notesKey: 'catalog.cable.vga-de15.notes',
+    notesSource:
+      'Analog RGBHV computer/projector video over 15-pin D-Sub. Keep runs short; quality drops past ~10-15 m.',
   },
   {
     id: 'dvi-cable',
@@ -505,6 +597,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 5,
     color: '#818cf8',
     notesKey: 'catalog.cable.dvi-cable.notes',
+    notesSource:
+      'DVI-D (digital), DVI-A (analog) or DVI-I (both). Passive copper limited to ~5 m; single vs dual-link sets the max resolution.',
   },
   {
     id: 'dsub-db25-audio',
@@ -514,6 +608,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 30,
     color: '#fb7185',
     notesKey: 'catalog.cable.dsub-db25-audio.notes',
+    notesSource:
+      'DB25 multi-channel audio per AES59 ("TASCAM" pinout): 8 balanced analog or 4 AES3 pairs on one connector.',
   },
   {
     id: 'dmx-5pin',
@@ -524,6 +620,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 300,
     color: '#fb923c',
     notesKey: 'catalog.cable.dmx-5pin.notes',
+    notesSource:
+      'DMX512-A / RDM lighting control, 512 channels per universe. 5-pin XLR is the standard; terminate the last fixture with 120Ω.',
   },
   {
     id: 'artnet-sacn',
@@ -533,6 +631,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 100,
     color: '#fdba74',
     notesKey: 'catalog.cable.artnet-sacn.notes',
+    notesSource:
+      'Art-Net / sACN (E1.31): many DMX universes over Ethernet. Use a dedicated/managed network; multicast for sACN.',
   },
   {
     id: 'composite-cinch',
@@ -543,6 +643,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 50,
     color: '#eab308',
     notesKey: 'catalog.cable.composite-cinch.notes',
+    notesSource:
+      'Composite video (CVBS/FBAS) over one line — Cinch/RCA or 75Ω BNC. Legacy/consumer, single picture.',
   },
   {
     id: 's-video',
@@ -552,6 +654,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 10,
     color: '#ca8a04',
     notesKey: 'catalog.cable.s-video.notes',
+    notesSource:
+      'S-Video (Y/C): separate luma and chroma over a mini-DIN-4 — better than composite, legacy.',
   },
   {
     id: 'component-ypbpr',
@@ -562,6 +666,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 30,
     color: '#a16207',
     notesKey: 'catalog.cable.component-ypbpr.notes',
+    notesSource:
+      'Analog component YPbPr over three lines (Cinch or BNC). Carries HD analog; legacy in modern plants.',
   },
   {
     id: 'tally-gpi',
@@ -571,6 +677,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 100,
     color: '#f59e0b',
     notesKey: 'catalog.cable.tally-gpi.notes',
+    notesSource:
+      'Tally (red = on-air/PGM, green = preview) and GPI/GPO contact closures for record triggers, cues, lamps. Often D-Sub or terminal blocks.',
   },
   {
     id: 'hdbaset-cat6a',
@@ -580,6 +688,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 100,
     color: '#2dd4bf',
     notesKey: 'catalog.cable.hdbaset-cat6a.notes',
+    notesSource:
+      'HDBaseT: video (up to 4K), audio, control (RS-232/IR), Ethernet and power (PoH) over one Cat6/6a run up to ~100 m.',
   },
   {
     id: 'hdmi-aoc',
@@ -589,6 +699,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 100,
     color: '#a855f7',
     notesKey: 'catalog.cable.hdmi-aoc.notes',
+    notesSource:
+      'Active Optical HDMI: integrated fibre carries HDMI far beyond passive copper (~100 m). Directional (source → sink); not bidirectional.',
   },
   {
     id: 'dp-aoc',
@@ -598,6 +710,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 50,
     color: '#8b5cf6',
     notesKey: 'catalog.cable.dp-aoc.notes',
+    notesSource:
+      'Active Optical DisplayPort for long runs (~50 m) past the ~3 m passive limit. Directional, source → sink.',
   },
   {
     id: 'usbc-aoc',
@@ -607,6 +721,8 @@ export const cableCatalog: CableSpec[] = [
     maxLengthMeters: 30,
     color: '#7c3aed',
     notesKey: 'catalog.cable.usbc-aoc.notes',
+    notesSource:
+      'Active Optical USB-C (USB 3.x / DP-Alt-Mode video) for ~30 m runs. Directional; bus power is limited on AOC.',
   },
 ]
 

--- a/src/renderer/types/videoFormat.ts
+++ b/src/renderer/types/videoFormat.ts
@@ -55,9 +55,14 @@ export interface VideoFormat {
   preferredCable: SignalStandard
   /** Free-text notes (legacy / user-supplied). Built-in entries use `notesKey`. */
   notes?: string
-  /** Translation key for the built-in catalog. Resolved via `t(notesKey, '')`
-   *  so the description follows the active UI language. */
+  /**
+   * Translation key for the built-in catalog. Resolve it together with
+   * `notesSource` — der leere Fallback war der Defekt, siehe `cableSpec.ts`.
+   */
   notesKey?: string
+  /** The English source text for `notesKey` — the fallback for every
+   *  language that has no dictionary entry. */
+  notesSource?: string
 }
 
 export const VIDEO_FORMATS: VideoFormat[] = [
@@ -75,6 +80,8 @@ export const VIDEO_FORMATS: VideoFormat[] = [
     carriers: ['SDI-3G-A', 'SDI-3G-B', 'DualLink-HD'],
     preferredCable: 'SDI-3G',
     notesKey: 'catalog.videoFormat.1080p50.notes',
+    notesSource:
+      'Main standard. Level A recommended; Level B for older equipment.',
   },
   {
     id: '1080p60',
@@ -106,6 +113,8 @@ export const VIDEO_FORMATS: VideoFormat[] = [
     carriers: ['SDI-12G', 'QuadLink-3G-2SI', 'QuadLink-3G-SquareDivision'],
     preferredCable: 'SDI-12G',
     notesKey: 'catalog.videoFormat.2160p50.notes',
+    notesSource:
+      'UHD standard. 12G-SDI preferred, Quad-Link 3G as alternative (4 cables).',
   },
   {
     id: '2160p60',

--- a/tests/katalogNotizenHabenQuelle.test.ts
+++ b/tests/katalogNotizenHabenQuelle.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { cableCatalog } from '../src/renderer/types/cableSpec'
+import { VIDEO_FORMATS } from '../src/renderer/types/videoFormat'
+
+// ---------------------------------------------------------------------------
+// Ein `notesKey` ohne `notesSource` schreibt LEERE Notizen in die Projektdatei.
+//
+// ─── DER BEFUND (2026-09-10) ───────────────────────────────────────────────
+//
+// `CableDialog.tsx` loeste die Katalog-Notiz woertlich so auf:
+//
+//     setNotes(spec.notesKey ? t(spec.notesKey, '') : (spec.notes ?? ''))
+//
+// Der zweite Parameter von `t()` ist der Rueckfall, und er war LEER. Seit
+// E-28 (2026-09-09) ist Englisch die Quellsprache und steht deshalb NICHT
+// mehr als Woerterbuch in der Registry — `lib/i18n.ts` sagt das ausdruecklich
+// („Englisch fehlt hier mit Absicht"). Damit gab es fuer jede Sprache ausser
+// Deutsch nichts, worauf `t()` zurueckfallen konnte:
+//
+//     Deutsch    de-Dict trifft zu           -> die uebersetzte Notiz
+//     Englisch   kein Dict, Fallback ''      -> LEER
+//     jede weitere Sprache                   -> LEER
+//
+// ─── WARUM DAS NICHT NUR ANZEIGE IST ───────────────────────────────────────
+//
+// Weil der Wert nicht angezeigt, sondern GESCHRIEBEN wird: `setNotes` fuellt
+// das Notizfeld des Kabels, und das steht in `Cable.notes` — in der
+// Projektdatei des Nutzers. Ein englischer Nutzer bekam die Beschreibung also
+// nicht bloss leer zu sehen; er bekam sie leer in seine eigenen Daten
+// geschrieben, waehrend ein deutscher Nutzer denselben Katalog-Eintrag mit
+// Text bekam. Dieselbe Datei, spaeter geoeffnet, sieht dann je nach Sprache
+// des Erstellers anders aus.
+//
+// Genau diese Richtung hat `tests/deutschesDictIstDeutsch.test.ts` schon
+// einmal benannt — dort ging es um englische Werte im deutschen Woerterbuch,
+// die in die Projektdatei wanderten. Die Leerstelle ist derselbe Weg, nur
+// ohne Text.
+//
+// ─── WAS DIESER TEST FESTHAELT ─────────────────────────────────────────────
+//
+// Der uebliche Weg dieses Repos — `t(key, 'English text')` — war hier nicht
+// gangbar: der Schluessel ist DYNAMISCH (`t(spec.notesKey, …)`), der Text
+// kann also nicht an der Aufrufstelle stehen. Er steht deshalb als
+// `notesSource` im Katalog-Eintrag, neben dem Schluessel.
+//
+// Das Paar kann jetzt nur noch gemeinsam wandern, und dieser Test besteht
+// darauf. Ein neuer Katalog-Eintrag mit `notesKey` und ohne `notesSource`
+// faellt hier durch — nicht erst, wenn jemand mit englischer Oberflaeche
+// eine Projektdatei mit leeren Notizen abgibt.
+// ---------------------------------------------------------------------------
+
+/** Beide Kataloge in einer Liste — die Regel gilt fuer jeden `notesKey`. */
+const EINTRAEGE: Array<{ katalog: string; id: string; notesKey?: string; notesSource?: string }> = [
+  ...cableCatalog.map((c) => ({ katalog: 'cableCatalog', id: c.id, ...c })),
+  ...VIDEO_FORMATS.map((v) => ({ katalog: 'VIDEO_FORMATS', id: v.id, ...v })),
+]
+
+describe('Katalog-Notizen tragen ihre Quellsprache mit', () => {
+  it('sieht ueberhaupt Eintraege — sonst prueft der Test nichts', () => {
+    // Ohne diese Zusicherung waere die Regel unten auch dann erfuellt, wenn
+    // ein Katalog leer importiert wuerde. Eine leere Menge erfuellt jede
+    // Regel; ein Waechter, der daran gruen wird, behauptet eine Deckung,
+    // die es nicht gibt.
+    const mitSchluessel = EINTRAEGE.filter((e) => e.notesKey)
+    expect(mitSchluessel.length).toBeGreaterThan(40)
+  })
+
+  it('jeder notesKey hat einen nicht-leeren notesSource', () => {
+    const ohne = EINTRAEGE.filter((e) => e.notesKey && !e.notesSource?.trim()).map(
+      (e) => `${e.katalog}/${e.id} (${e.notesKey})`,
+    )
+    expect(
+      ohne,
+      'Ein `notesKey` ohne `notesSource` faellt fuer jede Sprache ohne ' +
+        'Woerterbuch-Eintrag auf den leeren String zurueck — und der landet ' +
+        'ueber `CableDialog` in `Cable.notes`, also in der Projektdatei:\n  ' +
+        `${ohne.join('\n  ')}`,
+    ).toEqual([])
+  })
+
+  it('die Aufrufstelle benutzt notesSource als Rueckfall, nicht den leeren String', () => {
+    // DIE ZWEITE HAELFTE DERSELBEN ZUSICHERUNG. Jeder Eintrag koennte seinen
+    // Quelltext tragen und der Aufruf ihn trotzdem ignorieren — das war der
+    // Zustand vorher, nur mit vertauschten Rollen. Die Regel oben prueft die
+    // Daten, diese hier den Weg, auf dem sie gelesen werden.
+    const quelle = readFileSync(
+      join(process.cwd(), 'src', 'renderer', 'components', 'Cable', 'CableDialog.tsx'),
+      'utf8',
+    )
+    expect(quelle).toContain('t(spec.notesKey, spec.notesSource ?? \'\')')
+    expect(quelle).not.toContain("t(spec.notesKey, '')")
+  })
+
+  it('der deutsche Eintrag sagt etwas anderes als die Quelle', () => {
+    // GEGENPROBE gegen die naheliegende Fehlreparatur: `notesSource` mit dem
+    // DEUTSCHEN Text zu fuellen waere gruen und trotzdem falsch — dann saehe
+    // ein englischer Nutzer deutsche Notizen statt gar keiner.
+    //
+    // Geprueft wird gegen das deutsche Woerterbuch: wo es einen Eintrag zu
+    // demselben Schluessel gibt, muss er sich vom Quelltext unterscheiden.
+    // Dieselbe Form wie in `deutschesDictIstDeutsch.test.ts`, nur von der
+    // anderen Seite her gestellt.
+    const de = readFileSync(
+      join(process.cwd(), 'src', 'renderer', 'lib', 'i18n', 'de.ts'),
+      'utf8',
+    )
+    const deWerte = new Map<string, string>()
+    const zeilen = de.split('\n')
+    zeilen.forEach((z, i) => {
+      const m = /^\s*'(catalog\.[^']+)':\s*(.*)$/.exec(z)
+      if (!m) return
+      const roh = (m[2].trim() || (zeilen[i + 1] ?? '').trim()).replace(/,$/, '').trim()
+      if (roh.startsWith("'") && roh.endsWith("'")) deWerte.set(m[1], roh.slice(1, -1))
+    })
+    expect(deWerte.size, 'Kein deutscher Katalog-Eintrag gefunden — Muster passt nicht').toBeGreaterThan(20)
+
+    const gleich = EINTRAEGE.filter(
+      (e) => e.notesKey && e.notesSource && deWerte.get(e.notesKey) === e.notesSource,
+    ).map((e) => `${e.katalog}/${e.id}`)
+    expect(
+      gleich,
+      'Quelltext und deutsche Uebersetzung sind woertlich gleich — entweder ' +
+        `steht Deutsch im Quellfeld oder die Uebersetzung fehlt:\n  ${gleich.join('\n  ')}`,
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
Gefunden beim Aufräumen von #820 — und es ist kein toter Code, sondern ein Datenverlust.

## Der Befund

`CableDialog.tsx` löste die Notiz eines Katalog-Kabels wörtlich so auf:

```ts
setNotes(spec.notesKey ? t(spec.notesKey, '') : (spec.notes ?? ''))
```

Der zweite Parameter von `t()` ist der **Rückfall**, und er war leer. Seit E-28 ist Englisch die Quellsprache und steht deshalb **nicht mehr als Wörterbuch in der Registry** — `lib/i18n.ts` sagt das ausdrücklich („Englisch fehlt hier mit Absicht"). Damit gab es für jede Sprache außer Deutsch nichts, worauf der Aufruf zurückfallen konnte:

| Sprache | Ergebnis |
|---|---|
| Deutsch | de-Dict trifft zu → die übersetzte Notiz |
| Englisch | kein Dict, Fallback `''` → **leer** |
| jede weitere Sprache | → **leer** |

## Warum das nicht nur Anzeige ist

`setNotes` füllt das Notizfeld des Kabels, und das steht in **`Cable.notes` — in der Projektdatei**. Ein englischer Nutzer bekam die Beschreibung also nicht bloß leer zu sehen; er bekam sie **leer in seine eigenen Daten geschrieben**, während ein deutscher Nutzer denselben Katalog-Eintrag mit Text bekam. Dieselbe Datei, später geöffnet, sieht je nach Sprache des Erstellers anders aus.

Genau diese Richtung hat `tests/deutschesDictIstDeutsch.test.ts` schon einmal benannt — dort waren es englische Werte im deutschen Wörterbuch, die in die Projektdatei wanderten. Die Leerstelle ist derselbe Weg, nur ohne Text.

## Der Weg der Reparatur

Der übliche Weg dieses Repos — `t(key, 'English text')` — war hier **nicht gangbar**: der Schlüssel ist dynamisch (`t(spec.notesKey, …)`), der Text kann also nicht an der Aufrufstelle stehen. Er steht deshalb als neues Feld **`notesSource`** im Katalog-Eintrag, neben dem Schlüssel — dieselbe Zeile, dasselbe Objekt. Damit kann das eine nicht mehr ohne das andere wandern.

Übernommen sind die 47 englischen Texte, die bisher **nur im toten `en`-Export** von `i18n/dicts.ts` lagen (45 Kabel, 2 Videoformate). Sie stehen jetzt dort, wo der Schlüssel steht, statt in einer Datei, die niemand lädt.

## Der Wächter

`tests/katalogNotizenHabenQuelle.test.ts` hält vier Dinge fest:

1. dass überhaupt Einträge gesehen werden (sonst erfüllt die leere Menge jede Regel),
2. dass jeder `notesKey` einen nicht-leeren `notesSource` hat,
3. dass die **Aufrufstelle** ihn auch benutzt — die Daten könnten stimmen und der Aufruf sie trotzdem ignorieren,
4. **Gegenprobe:** dass der Quelltext sich vom deutschen Wörterbuch-Eintrag unterscheidet. Wäre Deutsch ins Quellfeld gerutscht, sähe ein englischer Nutzer deutsche Notizen statt gar keiner — auch das wäre grün gewesen.

## Bezug zu #820

Das Issue schlug vor, `export const en` zu löschen. Das ging so **nicht**: für die 48 `catalog.*`-Schlüssel war die tote Datei die einzige Kopie des englischen Textes. Nach diesem PR ist sie es nicht mehr, und der Rest von #820 (Test-Zusicherungen umstellen, `dicts.ts` entfernen) wird möglich.

## Prüfung

- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm test` — 251 Testdateien, 3883 Tests grün
- `npm run lint` — 0 Errors (12 vorbestehende Warnings)
- `npm run lang:check` — 0 / 0 / 0

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_