### PR TITLE
test: der WASM-Pfad wird aufgelöst statt zusammengesetzt

### DIFF
--- a/tests/barcodeDecoder.test.ts
+++ b/tests/barcodeDecoder.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
+import { createRequire } from 'node:module'
 import { prepareZXingModule, readBarcodes } from 'zxing-wasm/reader'
 
 // ---------------------------------------------------------------------------
@@ -74,10 +75,41 @@ const alsBild = (text: string) => {
   return { data, width: breite, height: HOEHE, colorSpace: 'srgb' as const }
 }
 
+/**
+ * Die Paket-Wurzel aus einem aufgeloesten Einstiegspunkt.
+ *
+ * `resolve('zxing-wasm/package.json')` waere der direkte Weg und geht nicht:
+ * das Paket zaehlt in `exports` auf, was es herausgibt, und die
+ * `package.json` steht nicht darin. Aufgeloest wird deshalb der Einstieg, den
+ * der Test ohnehin importiert; von dort geht es aufwaerts bis zum Ordner mit
+ * dem Paketnamen.
+ */
+const paketWurzel = (einstieg: string): string => {
+  let dir = dirname(createRequire(import.meta.url).resolve(einstieg))
+  const name = einstieg.split('/')[0]
+  while (basename(dir) !== name) {
+    const oben = dirname(dir)
+    if (oben === dir) throw new Error(`Paketwurzel von ${einstieg} nicht gefunden`)
+    dir = oben
+  }
+  return dir
+}
+
+/**
+ * Der Pfad zur WASM-Datei wird AUFGELOEST und nicht zusammengesetzt.
+ *
+ * `join(process.cwd(), 'node_modules', …)` stimmt genau dann, wenn das Paket
+ * neben dem Arbeitsverzeichnis liegt. In einem npm-Workspace liegt es das
+ * nicht: dort wird nach oben gehoben, und der Test suchte eine Datei, die es
+ * an dieser Stelle nie gab — mit einer Fehlermeldung ueber einen fehlenden
+ * Pfad statt ueber einen fehlenden Decoder.
+ *
+ * Genau so ist es beim Vendorieren in `av-planner-suite` passiert. `resolve`
+ * beantwortet die Frage, die hier wirklich gestellt ist — „wo liegt das
+ * Paket, das ich gerade importiere" —, und beantwortet sie in beiden Layouts.
+ */
 const WASM = join(
-  process.cwd(),
-  'node_modules',
-  'zxing-wasm',
+  paketWurzel('zxing-wasm/reader'),
   'dist',
   'reader',
   'zxing_reader.wasm',


### PR DESCRIPTION
Gefunden beim Vendorieren nach `av-planner-suite`.

## Der Befund

`tests/barcodeDecoder.test.ts` baute den Pfad zur WASM-Datei zusammen:

```ts
const WASM = join(process.cwd(), 'node_modules', 'zxing-wasm', 'dist', 'reader', 'zxing_reader.wasm')
```

Das stimmt genau dann, wenn das Paket **neben** dem Arbeitsverzeichnis liegt. In einem npm-Workspace liegt es das nicht — dort wird nach oben gehoben. Der Test suchte also eine Datei, die es an dieser Stelle nie gab, und meldete:

> `ENOENT: no such file or directory, open '…/apps/cable-planner/node_modules/zxing-wasm/dist/reader/zxing_reader.wasm'`

**Eine Fehlermeldung über einen fehlenden Pfad statt über einen fehlenden Decoder.** Wer sie liest, sucht am falschen Ende — beim Paket, bei der Installation, beim Vendoring —, und der Decoder war die ganze Zeit da.

## Was jetzt dasteht

`createRequire(import.meta.url).resolve(...)` beantwortet die Frage, die hier wirklich gestellt ist: *wo liegt das Paket, das ich gerade importiere*. Und es beantwortet sie in beiden Layouts.

Aufgelöst wird der **Einstieg** (`zxing-wasm/reader`) und nicht die `package.json`: das Paket zählt in `exports` auf, was es herausgibt, und die `package.json` steht nicht darin — `resolve('zxing-wasm/package.json')` wirft. Von dort geht `paketWurzel()` aufwärts bis zum Ordner mit dem Paketnamen.

Die Zusicherung selbst bleibt unverändert: die WASM-Datei kommt aus dem Paket und nicht aus dem Netz — genauso wie im Browser, wo `barcodeScanner.ts` sie über einen `?url`-Import aus dem Bundle holt. Ein Test, der sie herunterlädt, bewiese das Gegenteil von dem, was hier zugesichert wird.

## Prüfung

- `npm test` — 3972 Tests grün
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Errors
- `npm run lint` — 0 Errors (12 vorbestehende Warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_