### PR TITLE
i18n: die HTML-Entität bricht den Sprachmix-Zähler nicht mehr ab

### DIFF
--- a/scripts/quellsprache.mjs
+++ b/scripts/quellsprache.mjs
@@ -345,7 +345,8 @@ const RUMPF =
   /\bbody:\s*(?:(['"])((?:[^\\]|\\.){4,}?)\1|`((?:[^`\\]|\\.){4,}?)`)/g
 
 /**
- * Die Einsetzungen aus einem Textknoten herausnehmen — und zwar VON INNEN.
+ * Die Einsetzungen und Entitaeten aus einem Textknoten herausnehmen — und zwar
+ * VON INNEN.
  *
  * `{sum.counts.walls}` ist ein Feldname und keine Beschriftung; bliebe er
  * stehen, meldete die Klassifizierung Englisch, wo Deutsch steht. Geschachtelt
@@ -357,7 +358,21 @@ const RUMPF =
  * der Text davor ist echt, alles danach ist Quelltext.
  */
 const ohneAusdruecke = (roh) => {
-  let text = roh
+  // DIE ENTITAET ZUERST, und sie ist der Grund fuer diesen Zusatz.
+  //
+  // `&amp;` traegt ein SEMIKOLON, und `NACH_CODE` haelt ein Semikolon fuer
+  // Quelltext. Ein Textknoten mit einem kaufmaennischen Und darin fiel damit
+  // vollstaendig heraus — nicht das Zeichen, der ganze Satz. Gefunden im
+  // light-planner an der Beschreibung im „Ueber"-Dialog:
+  //
+  //     Planung von Veranstaltungs- und Buehnenbeleuchtung – …, DMX-Patch
+  //     &amp; Export.
+  //
+  // Vier Zeilen deutscher Fliesstext in einem Repo mit Quellsprache `en`, und
+  // der Zaehler meldete daneben eine Null. Es ist dieselbe Bauform wie bei der
+  // geschweiften Klammer: ein Zeichen HINTER dem Text bringt den Lauf zu Fall,
+  // und was er dann nicht sieht, kann er auch nicht falsch nennen.
+  let text = roh.replace(/&(?:[A-Za-z][A-Za-z0-9]{1,9}|#\d{1,6}|#[Xx][0-9A-Fa-f]{1,6});/g, ' ')
   for (let i = 0; i < 8; i += 1) {
     const naechste = text.replace(/\{[^{}]*\}/g, ' ')
     if (naechste === text) break
@@ -487,6 +502,10 @@ if (process.argv[1] && process.argv[1].endsWith('quellsprache.mjs')) {
     '<div>Sentence before the brace\n{!bridge && (\n<span>x</span>)}</div>',
     // Das Fragment ist auch ein Tag — `<>` war bis 2026-09-10 ausgeschlossen.
     '<>Inside a bare fragment<code>x</code></>',
+    // Die HTML-Entitaet. `&amp;` traegt ein SEMIKOLON, und ein Semikolon hielt
+    // `NACH_CODE` fuer Quelltext — der ganze Satz fiel heraus, nicht nur das
+    // Zeichen (2026-09-10, gefunden im light-planner).
+    '<span>Plan &amp; export as PDF</span>',
   ].join('\n')
 
   // Sortiert verglichen: in welcher Reihenfolge Attribute, Rueckfragen und
@@ -502,6 +521,7 @@ if (process.argv[1] && process.argv[1].endsWith('quellsprache.mjs')) {
     'with ${n} of them',
     'Sentence before the brace',
     'Inside a bare fragment',
+    'Plan export as PDF',
     'New connector type, e.g. Speakon NL4:',
     'Beyond the rental plan',
     'More cables built than booked.',


### PR DESCRIPTION
## Der Befund

`&amp;` trägt ein **Semikolon**, und `NACH_CODE` hält ein Semikolon für Quelltext. Ein JSX-Textknoten mit einem kaufmännischen Und darin fiel damit vollständig aus der Messung — nicht das Zeichen, **der ganze Satz**.

Gefunden im `light-planner`, an der Beschreibung im „Über"-Dialog:

```
Planung von Veranstaltungs- und Bühnenbeleuchtung – Grundriss-Import,
Maßstab, Leuchten mit echten photometrischen Daten, …, DMX-Patch
&amp; Export.
```

Vier Zeilen deutscher Fließtext in einem Repo mit Quellsprache `en`, und der Zähler meldete daneben eine Null.

Es ist dieselbe Bauform wie bei der geschweiften Klammer, die in #826 repariert wurde: **ein Zeichen hinter dem Text bringt den Lauf zu Fall**, und was er nicht sieht, kann er auch nicht falsch nennen.

## Was jetzt dasteht

`ohneAusdruecke` entfernt die Entitäten vor allem anderen — benannte (`&amp;`, `&nbsp;`), dezimale (`&#160;`) und hexadezimale (`&#x2014;`). Die feste Probe bekommt eine Zeile dafür; ohne sie fällt die Härte beim nächsten Aufräumen still wieder heraus.

## Und in den beiden anderen Kopien

Dieselbe Änderung geht in `light-planner` und `multicam-planner` — `lang:parity` in der Suite besteht darauf. Der Guard dort vergleicht ab sofort **auch `ohneAusdruecke` selbst**: die Funktion steht im Rumpf von `sichtbareTexte` nur als *Aufruf*, und ein Aufruf sieht in allen drei Kopien gleich aus, auch wenn die gerufene Funktion in einer davon etwas anderes tut. Genau die Sorte Drift, gegen die dieser Vergleich gebaut ist, wäre unter ihm hindurchgelaufen.

## Prüfung

- `npm run lang:check` über alle drei Wurzeln (`renderer` / `mobile` / `viewer`) — Sprachmix 0
- `tests/quellsprache.test.ts` + `tests/ausgelieferteDatenQuellsprache.test.ts` — 19 Tests grün

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_