### PR TITLE
i18n: die Plan-Prüfung spricht die Sprache des Nutzers (#837)

### DIFF
--- a/src/renderer/components/Cable/CableDialog.tsx
+++ b/src/renderer/components/Cable/CableDialog.tsx
@@ -5,7 +5,8 @@ import { useUiStore } from '../../store/uiStore'
 import { confirmDialog } from '../../lib/confirmDialog'
 import { promptDialog } from '../../lib/promptDialog'
 import { AlertTriangle, Check, XCircle } from 'lucide-react'
-import { format, useTranslation } from '../../lib/i18n'
+import { format, tr, useTranslation } from '../../lib/i18n'
+import { einsetzen } from '../../lib/platzhalter'
 import { Icon } from '../shared/Icon'
 import { connectorToCableType } from '../../lib/cableInheritance'
 import { ALL_CONNECTOR_TYPES } from '../../types/equipment'
@@ -22,6 +23,7 @@ import {
   pickHighestSdiStandard,
   type CableSpec,
   type SignalStandard,
+  type CompatibilityResult,
 } from '../../types/cableSpec'
 import {
   DEFAULT_VIDEO_FORMAT,
@@ -94,9 +96,15 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
     [customSignalStandards],
   )
   // Build list of cables ranked by compatibility with the two ports.
-  const ranked = useMemo((): Array<{ cable: CableSpec; level: 'ok' | 'warn' | 'error'; message: string }> => {
+  const ranked = useMemo((): Array<{ cable: CableSpec } & CompatibilityResult> => {
     if (!fromPort || !toPort) {
-      return fullCableCatalog.map((cable) => ({ cable, level: 'ok' as const, message: '' }))
+      return fullCableCatalog.map((cable) => ({
+        cable,
+        level: 'ok' as const,
+        schluessel: '',
+        werte: {},
+        message: '',
+      }))
     }
     return fullCableCatalog
       .map((cable) => ({
@@ -141,7 +149,13 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
   const [customStandard, setCustomStandard] = useState<SignalStandard>('Generic')
   const [customMaxLength, setCustomMaxLength] = useState<number | ''>('')
   const selectedEntry = specId === CUSTOM_CABLE_SPEC_ID
-    ? { cable: makeCustomCableSpec(customConnectorType, '#64748b'), level: 'ok' as const, message: '' }
+    ? {
+        cable: makeCustomCableSpec(customConnectorType, '#64748b'),
+        level: 'ok' as const,
+        schluessel: '',
+        werte: {},
+        message: '',
+      }
     : (ranked.find((item) => item.cable.id === specId) ?? ranked[0])
   const selected: CableSpec = selectedEntry.cable
 
@@ -203,13 +217,14 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
       balanceForConnector(selected.connectorType) === 'unbalanced' &&
       length > 10
     ) {
+      // Dieselbe Form wie die Urteile aus `types/cableSpec.ts`, damit die
+      // Anzeige unten EINEN Weg hat und keinen Sonderfall (#837).
       return {
         level: 'warn' as const,
-        message: format(
-          t(
-            'cable.balance.longUnbalanced',
-            'Long unbalanced analog audio run ({length} m). Hum/interference risk — prefer balanced (XLR) or keep under ~10 m.',
-          ),
+        schluessel: 'cable.balance.longUnbalanced',
+        werte: { length },
+        message: einsetzen(
+          'Long unbalanced analog audio run ({length} m). Hum/interference risk - prefer balanced (XLR) or keep under ~10 m.',
           { length },
         ),
       }
@@ -219,7 +234,12 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
 
   const connectorMismatch: 'ok' | 'warn' | 'error' =
     specId === CUSTOM_CABLE_SPEC_ID ? 'ok' : selectedEntry.level
-  const connectorMessage = specId === CUSTOM_CABLE_SPEC_ID ? '' : selectedEntry.message
+  // Die Urteile aus `types/cableSpec.ts` sind sprachfrei: sie tragen
+  // Schluessel und Werte, der englische Satz ist der Fallback (#837).
+  const connectorMessage =
+    specId === CUSTOM_CABLE_SPEC_ID
+      ? ''
+      : format(tr(selectedEntry.schluessel, selectedEntry.message), selectedEntry.werte)
 
   const needsConverter =
     connectorMismatch === 'warn' || sdiMismatch?.level === 'warn' || connectorMismatch === 'error'
@@ -524,19 +544,22 @@ export const CableDialog = ({ fromPort, toPort, fromDev, toDev, defaultVideoForm
           {sdiMismatch?.level === 'warn' && (
             <div className="flex items-center gap-1.5 rounded bg-amber-900/50 p-2 text-amber-100">
               <Icon icon={AlertTriangle} size="sm" />
-              {sdiMismatch.message}
+              {format(tr(sdiMismatch.schluessel, sdiMismatch.message), sdiMismatch.werte)}
             </div>
           )}
           {impedanceMismatch?.level === 'warn' && (
             <div className="flex items-center gap-1.5 rounded bg-amber-900/50 p-2 text-amber-100">
               <Icon icon={AlertTriangle} size="sm" />
-              {impedanceMismatch.message}
+              {format(
+                tr(impedanceMismatch.schluessel, impedanceMismatch.message),
+                impedanceMismatch.werte,
+              )}
             </div>
           )}
           {balanceWarning?.level === 'warn' && (
             <div className="flex items-center gap-1.5 rounded bg-amber-900/50 p-2 text-amber-100">
               <Icon icon={AlertTriangle} size="sm" />
-              {balanceWarning.message}
+              {format(tr(balanceWarning.schluessel, balanceWarning.message), balanceWarning.werte)}
             </div>
           )}
           {lengthWarning && (

--- a/src/renderer/lib/drawingChecks.ts
+++ b/src/renderer/lib/drawingChecks.ts
@@ -25,21 +25,10 @@ import { labelTargetIssues } from './labelDerivation'
 import { beurteileAdapter } from '../types/adapter'
 import { anschlussBefunde, type AnschlussLeitung } from '../types/conductor'
 import { beurteileBild } from '../types/displayCapability'
+import { tr, format } from './i18n'
+export type { CheckSeverity, CheckFinding } from '../types/checkFinding'
+import type { CheckSeverity, CheckFinding } from '../types/checkFinding'
 
-export type CheckSeverity = 'error' | 'warning' | 'info'
-
-export interface CheckFinding {
-  /** Stabile ID (Check-Typ + betroffenes Element) — als React-key nutzbar. */
-  id: string
-  severity: CheckSeverity
-  /** Kurzer Check-Typ als Gruppen-Label, z.B. "Doppelte IP". */
-  category: string
-  /** Menschlich lesbare Beschreibung des konkreten Fundes. */
-  message: string
-  /** Klick-Ziel: selektiert dieses Gerät bzw. Kabel auf dem Canvas. */
-  equipmentId?: string
-  cableId?: string
-}
 
 /** Frequenz-String („5.8 GHz", „600 MHz", „614") → MHz (oder null). */
 const parseFreqMHz = (s: string | undefined): number | null => {
@@ -139,10 +128,15 @@ export const runDrawingChecks = (
         id: `open-ports:${e.id}`,
         severity: 'info',
         category: 'Open ports',
-        message: `${e.name}: ${open.length} unverbundene Ports (${open
-          .slice(0, 4)
-          .map((p) => p.name)
-          .join(', ')}${open.length > 4 ? ' …' : ''})`,
+        message: format(tr('check.openPorts', '{name}: {n} unconnected ports ({ports})'), {
+          name: e.name,
+          n: open.length,
+          ports:
+            open
+              .slice(0, 4)
+              .map((p) => p.name)
+              .join(', ') + (open.length > 4 ? ' …' : ''),
+        }),
         equipmentId: e.id,
       })
     }
@@ -160,9 +154,14 @@ export const runDrawingChecks = (
         id: `connector-mismatch:${c.id}`,
         severity: 'warning',
         category: 'Connector mismatch',
-        message: `${c.cableNumber ? c.cableNumber + ' · ' : ''}${eqName(
-          c.fromEquipmentId,
-        )} (${from.connectorType}) → ${eqName(c.toEquipmentId)} (${to.connectorType})`,
+        message:
+          (c.cableNumber ? c.cableNumber + ' · ' : '') +
+          format(tr('check.connectorMismatch', '{from} ({fromType}) → {to} ({toType})'), {
+            from: eqName(c.fromEquipmentId),
+            fromType: from.connectorType,
+            to: eqName(c.toEquipmentId),
+            toType: to.connectorType,
+          }),
         cableId: c.id,
       })
     }
@@ -184,9 +183,15 @@ export const runDrawingChecks = (
           id: `dup-number:${c.id}`,
           severity: 'error',
           category: 'Duplicate cable number',
-          message: `Kabelnummer „${num}" ${group.length}× vergeben: ${eqName(
-            c.fromEquipmentId,
-          )} → ${eqName(c.toEquipmentId)}`,
+          message: format(
+            tr('check.duplicateCableNumber', 'Cable number "{num}" used {n}×: {from} → {to}'),
+            {
+              num,
+              n: group.length,
+              from: eqName(c.fromEquipmentId),
+              to: eqName(c.toEquipmentId),
+            },
+          ),
           cableId: c.id,
         })
       }
@@ -201,9 +206,12 @@ export const runDrawingChecks = (
         id: `missing-length:${c.id}`,
         severity: 'warning',
         category: 'Missing length',
-        message: `${c.cableNumber ? c.cableNumber + ' · ' : ''}${eqName(
-          c.fromEquipmentId,
-        )} → ${eqName(c.toEquipmentId)}: keine Länge gesetzt`,
+        message:
+          (c.cableNumber ? c.cableNumber + ' · ' : '') +
+          format(tr('check.missingLength', '{from} → {to}: no length set'), {
+            from: eqName(c.fromEquipmentId),
+            to: eqName(c.toEquipmentId),
+          }),
         cableId: c.id,
       })
     }
@@ -225,7 +233,10 @@ export const runDrawingChecks = (
           id: `dup-ip:${e.id}`,
           severity: 'error',
           category: 'Duplicate IP',
-          message: `IP ${ip} mehrfach: ${group.map((g) => g.name).join(', ')}`,
+          message: format(tr('check.duplicateIp', 'IP {ip} used more than once: {names}'), {
+            ip,
+            names: group.map((g) => g.name).join(', '),
+          }),
           equipmentId: e.id,
         })
       }
@@ -245,15 +256,19 @@ export const runDrawingChecks = (
         a.mhz != null && b.mhz != null && Math.abs(a.mhz - b.mhz) < RF_MIN_SPACING_MHZ
       if (sameChannel || closeFreq) {
         const why = sameChannel
-          ? `gleicher Kanal ${a.channel}`
-          : `Frequenzabstand < ${RF_MIN_SPACING_MHZ} MHz`
+          ? format(tr('check.rf.sameChannel', 'same channel {channel}'), { channel: a.channel ?? '' })
+          : format(tr('check.rf.tooClose', 'frequency spacing < {mhz} MHz'), {
+              mhz: RF_MIN_SPACING_MHZ,
+            })
         findings.push({
           id: `rf-conflict:${a.cable.id}:${b.cable.id}`,
           severity: 'warning',
           category: 'RF conflict',
-          message: `${eqName(a.cable.fromEquipmentId)} ⟷ ${eqName(
-            b.cable.fromEquipmentId,
-          )}: ${why}`,
+          message: format(tr('check.rfConflict', '{a} ⟷ {b}: {why}'), {
+            a: eqName(a.cable.fromEquipmentId),
+            b: eqName(b.cable.fromEquipmentId),
+            why,
+          }),
           cableId: a.cable.id,
         })
       }
@@ -274,7 +289,10 @@ export const runDrawingChecks = (
         id: `single-power:${e.id}`,
         severity: 'info',
         category: 'Single power',
-        message: `${e.name}: nur eine Strom-Anbindung (kein redundantes Netzteil)`,
+        message: format(
+          tr('check.singlePower', '{name}: only one power feed (no redundant PSU)'),
+          { name: e.name },
+        ),
         equipmentId: e.id,
       })
     }
@@ -288,7 +306,10 @@ export const runDrawingChecks = (
         id: `tc-no-source:${e.id}`,
         severity: 'warning',
         category: 'Timecode',
-        message: `${e.name}: TC-Senke, aber keine TC-Quelle (Generator) im Plan`,
+        message: format(
+          tr('check.tcNoSource', '{name}: timecode sink, but no timecode source (generator) in the plan'),
+          { name: e.name },
+        ),
         equipmentId: e.id,
       })
     }
@@ -302,7 +323,13 @@ export const runDrawingChecks = (
         id: `tally-no-source:${e.id}`,
         severity: 'warning',
         category: 'Tally',
-        message: `${e.name}: Tally-Senke, aber keine Tally-Quelle (Mischer/Tally-Hub) im Plan`,
+        message: format(
+          tr(
+            'check.tallyNoSource',
+            '{name}: tally sink, but no tally source (switcher/tally hub) in the plan',
+          ),
+          { name: e.name },
+        ),
         equipmentId: e.id,
       })
     }
@@ -315,7 +342,13 @@ export const runDrawingChecks = (
         id: `da-no-fanout:${e.id}`,
         severity: 'info',
         category: 'Distribution amplifier',
-        message: `${e.name}: als Verteilverstärker markiert, aber nur ${e.outputs.length} Ausgang/Ausgänge (1→N erwartet)`,
+        message: format(
+          tr(
+            'check.daNoFanout',
+            '{name}: marked as a distribution amplifier, but has only {n} output(s) (1→N expected)',
+          ),
+          { name: e.name, n: e.outputs.length },
+        ),
         equipmentId: e.id,
       })
     }
@@ -338,7 +371,11 @@ export const runDrawingChecks = (
         id: `impedance-mismatch:${c.id}`,
         severity: 'warning',
         category: 'Impedance mismatch',
-        message: `${eqName(c.fromEquipmentId)} → ${eqName(c.toEquipmentId)}: ${mismatch.message}`,
+        message: format(tr('check.onLink', '{from} → {to}: {what}'), {
+          from: eqName(c.fromEquipmentId),
+          to: eqName(c.toEquipmentId),
+          what: format(tr(mismatch.schluessel, mismatch.message), mismatch.werte),
+        }),
         cableId: c.id,
       })
     }
@@ -360,12 +397,26 @@ export const runDrawingChecks = (
     const a = fiberKind(from?.fiberClass)
     const b = fiberKind(to?.fiberClass)
     if (a && b && a !== b) {
-      const lbl = (k: 'mm' | 'sm') => (k === 'mm' ? 'Multimode' : 'Singlemode')
+      const lbl = (k: 'mm' | 'sm') =>
+        k === 'mm' ? tr('check.fibre.multimode', 'multimode') : tr('check.fibre.singlemode', 'singlemode')
       findings.push({
         id: `fiber-mismatch:${c.id}`,
         severity: 'warning',
         category: 'Fibre mismatch',
-        message: `${eqName(c.fromEquipmentId)} → ${eqName(c.toEquipmentId)}: ${from?.fiberClass} (${lbl(a)}) ↔ ${to?.fiberClass} (${lbl(b)}) — optisch inkompatibel`,
+        message: format(
+          tr(
+            'check.fibreMismatch',
+            '{from} → {to}: {aClass} ({aKind}) ↔ {bClass} ({bKind}) - optically incompatible',
+          ),
+          {
+            from: eqName(c.fromEquipmentId),
+            to: eqName(c.toEquipmentId),
+            aClass: from?.fiberClass ?? '',
+            aKind: lbl(a),
+            bClass: to?.fiberClass ?? '',
+            bKind: lbl(b),
+          },
+        ),
         cableId: c.id,
       })
     }
@@ -383,8 +434,10 @@ export const runDrawingChecks = (
       id: 'st2110-no-ptp',
       severity: 'info',
       category: 'Sync / PTP',
-      message:
-        'ST 2110 im Plan, aber kein PTP-Signal — PTP-Grandmaster (IEEE 1588) als Referenz nicht vergessen.',
+      message: tr(
+        'check.st2110NoPtp',
+        'ST 2110 is in the plan, but there is no PTP signal - do not forget a PTP grandmaster (IEEE 1588) as the reference.',
+      ),
     })
   }
   // #365 — ST 2110 braucht eine NMOS-Registry (IS-04 Discovery + IS-05
@@ -399,8 +452,10 @@ export const runDrawingChecks = (
         id: 'st2110-no-nmos',
         severity: 'info',
         category: 'NMOS',
-        message:
-          'ST 2110 im Plan — NMOS-Registry (IS-04 Discovery / IS-05 Connection Management) für Auffindbarkeit + Routing einplanen.',
+        message: tr(
+          'check.st2110NoNmos',
+          'ST 2110 is in the plan - plan an NMOS registry (IS-04 discovery / IS-05 connection management) for findability and routing.',
+        ),
       })
     }
   }
@@ -417,7 +472,13 @@ export const runDrawingChecks = (
       id: 'sdi-no-genlock',
       severity: 'info',
       category: 'Sync / Genlock',
-      message: `${sdiCount} SDI-Signale, aber keine Genlock-/Referenz-Verteilung (Blackburst/Tri-Level) — Sync prüfen.`,
+      message: format(
+        tr(
+          'check.sdiNoGenlock',
+          '{n} SDI signals, but no genlock/reference distribution (blackburst/tri-level) - check the sync.',
+        ),
+        { n: sdiCount },
+      ),
     })
   }
 
@@ -432,7 +493,19 @@ export const runDrawingChecks = (
         id: `cable-too-long:${c.id}`,
         severity: 'warning',
         category: 'Cable length',
-        message: `${eqName(c.fromEquipmentId)} → ${eqName(c.toEquipmentId)}: ${c.length} m überschreitet die passive ${c.standard}-Grenze (~${limit} m) — aktive Lösung (AOC/HDBaseT/Extender/LWL) nötig`,
+        message: format(
+          tr(
+            'check.cableTooLong',
+            '{from} → {to}: {len} m exceeds the passive {standard} limit (~{limit} m) - an active solution (AOC/HDBaseT/extender/fibre) is needed',
+          ),
+          {
+            from: eqName(c.fromEquipmentId),
+            to: eqName(c.toEquipmentId),
+            len: c.length,
+            standard: c.standard ?? '',
+            limit,
+          },
+        ),
         cableId: c.id,
       })
     }
@@ -457,8 +530,19 @@ export const runDrawingChecks = (
   }
   if (dmxLines > 0 || artnetLinks > 0) {
     const parts: string[] = []
-    if (dmxLines > 0) parts.push(`${dmxLines} DMX-Linien (≈ ${dmxLines} Universen, ${dmxLines * 512} Kanäle)`)
-    if (artnetLinks > 0) parts.push(`${artnetLinks} Art-Net/sACN-Links (mehrere Universen je Link)`)
+    if (dmxLines > 0)
+      parts.push(
+        format(tr('check.dmxLines', '{n} DMX lines (≈ {n} universes, {ch} channels)'), {
+          n: dmxLines,
+          ch: dmxLines * 512,
+        }),
+      )
+    if (artnetLinks > 0)
+      parts.push(
+        format(tr('check.artnetLinks', '{n} Art-Net/sACN links (several universes per link)'), {
+          n: artnetLinks,
+        }),
+      )
     findings.push({
       id: 'dmx-summary',
       severity: 'info',
@@ -507,7 +591,13 @@ export const runDrawingChecks = (
         id: `poe-over:${sw.id}`,
         severity: 'warning',
         category: 'PoE-Budget',
-        message: `${sw.name}: PoE-Last ${Math.round(load)} W an ${count} Geräten übersteigt das Budget (${budget} W)`,
+        message: format(
+          tr(
+            'check.poeOverBudget',
+            '{name}: a PoE load of {load} W across {count} devices exceeds the budget ({budget} W)',
+          ),
+          { name: sw.name, load: Math.round(load), count, budget },
+        ),
         equipmentId: sw.id,
       })
     }
@@ -525,7 +615,11 @@ export const runDrawingChecks = (
         id: `balance-mismatch:${c.id}`,
         severity: 'warning',
         category: 'Audio balanced/unbalanced',
-        message: `${eqName(c.fromEquipmentId)} → ${eqName(c.toEquipmentId)}: ${bal.message}`,
+        message: format(tr('check.onLink', '{from} → {to}: {what}'), {
+          from: eqName(c.fromEquipmentId),
+          to: eqName(c.toEquipmentId),
+          what: format(tr(bal.schluessel, bal.message), bal.werte),
+        }),
         cableId: c.id,
       })
     }
@@ -550,7 +644,19 @@ export const runDrawingChecks = (
           id: `dual-link:${e.id}:${grp}`,
           severity: 'warning',
           category: 'Dual-Link',
-          message: `${e.name}: Dual-Link-Set „${grp}" unvollständig — ${g.connected}/${g.total} Links verbunden (${g.names.join(', ')})`,
+          message: format(
+            tr(
+              'check.dualLinkIncomplete',
+              '{name}: dual-link set "{group}" incomplete - {connected}/{total} links connected ({ports})',
+            ),
+            {
+              name: e.name,
+              group: grp,
+              connected: g.connected,
+              total: g.total,
+              ports: g.names.join(', '),
+            },
+          ),
           equipmentId: e.id,
         })
       }
@@ -570,7 +676,13 @@ export const runDrawingChecks = (
         id: `fiber-conn:${c.id}`,
         severity: 'warning',
         category: 'Fibre connector',
-        message: `${eqName(c.fromEquipmentId)} → ${eqName(c.toEquipmentId)}: ${a} ↔ ${b} — optischer Steckertyp ungleich (Adapter/Hybrid-Patch nötig)`,
+        message: format(
+          tr(
+            'check.fibreConnectorMismatch',
+            '{from} → {to}: {a} ↔ {b} - different optical connector types (an adapter/hybrid patch is needed)',
+          ),
+          { from: eqName(c.fromEquipmentId), to: eqName(c.toEquipmentId), a, b },
+        ),
         cableId: c.id,
       })
     }
@@ -587,7 +699,13 @@ export const runDrawingChecks = (
         id: `ports-unknown:${e.id}`,
         severity: 'warning',
         category: 'Ports unknown',
-        message: `${e.name}: Port-Belegung unbekannt (kein Datenblatt-Match) — reale Anschlüsse aus dem Datenblatt ergänzen`,
+        message: format(
+          tr(
+            'check.portsUnknown',
+            '{name}: the port layout is unknown (no data-sheet match) - add the real connectors from the data sheet',
+          ),
+          { name: e.name },
+        ),
         equipmentId: e.id,
       })
     }
@@ -613,7 +731,16 @@ export const runDrawingChecks = (
         id: `ports-guessed:${e.id}`,
         severity: 'warning',
         category: 'Ports guessed',
-        message: `${e.name}: Ports stammen aus ${beleg ?? 'einer Quelle ohne Datenblatt'} — gegen die realen Anschlüsse prüfen`,
+        message: format(
+          tr(
+            'check.portsGuessed',
+            '{name}: the ports come from {source} - check them against the real connectors',
+          ),
+          {
+            name: e.name,
+            source: beleg ?? tr('check.portsGuessed.noSource', 'a source without a data sheet'),
+          },
+        ),
         equipmentId: e.id,
       })
     }
@@ -632,7 +759,13 @@ export const runDrawingChecks = (
         id: `gw-subnet:${e.id}`,
         severity: 'warning',
         category: 'Gateway/subnet',
-        message: `${e.name}: Gateway ${e.gateway} liegt nicht im Subnetz von ${e.ipAddress} (${mask}) — nicht erreichbar`,
+        message: format(
+          tr(
+            'check.gatewaySubnet',
+            '{name}: gateway {gateway} is not in the subnet of {ip} ({mask}) - unreachable',
+          ),
+          { name: e.name, gateway: e.gateway, ip: e.ipAddress, mask },
+        ),
         equipmentId: e.id,
       })
     }
@@ -657,7 +790,13 @@ export const runDrawingChecks = (
         id: 'drum-mic-inputs',
         severity: 'warning',
         category: 'Drum micing',
-        message: `Drum-Kit braucht ${d.channelCount} Mic-Inputs, aber nur ${micInputs} XLR-Eingänge im Plan — fehlende ${d.channelCount - micInputs} Kanäle einplanen (Stagebox/Preamps).`,
+        message: format(
+          tr(
+            'check.drumMicInputs',
+            'The drum kit needs {need} mic inputs, but the plan has only {have} XLR inputs - plan the missing {missing} channels (stagebox/preamps).',
+          ),
+          { need: d.channelCount, have: micInputs, missing: d.channelCount - micInputs },
+        ),
       })
     }
     if (d.phantomCount > 0) {
@@ -665,7 +804,13 @@ export const runDrawingChecks = (
         id: 'drum-phantom',
         severity: 'info',
         category: 'Drum micing',
-        message: `${d.phantomCount} Drum-Mic(s) brauchen 48V-Phantom — Preamps/Pult mit schaltbarer Phantomspeisung sicherstellen.`,
+        message: format(
+          tr(
+            'check.drumPhantom',
+            '{n} drum mic(s) need 48 V phantom - make sure the preamps/console can switch phantom power.',
+          ),
+          { n: d.phantomCount },
+        ),
       })
     }
     if (d.unknownCount > 0) {
@@ -673,7 +818,13 @@ export const runDrawingChecks = (
         id: 'drum-unknown-mics',
         severity: 'warning',
         category: 'Drum micing',
-        message: `${d.unknownCount} Drum-Kanal/Kanäle ohne zugeordnetes Mic-Modell — Phantom-/SPL-Bedarf nicht prüfbar, Modell zuweisen.`,
+        message: format(
+          tr(
+            'check.drumUnknownMics',
+            '{n} drum channel(s) without an assigned mic model - phantom/SPL needs cannot be checked, assign a model.',
+          ),
+          { n: d.unknownCount },
+        ),
       })
     }
     if (d.splRiskCount > 0) {
@@ -681,7 +832,13 @@ export const runDrawingChecks = (
         id: 'drum-spl-risk',
         severity: 'warning',
         category: 'Drum micing',
-        message: `${d.splRiskCount} Mic(s) an lauter Zone (Kick/Snare) mit grenzwertigem Max SPL (< ${140} dB) — Verzerrungsrisiko, Pad/robusteres Mic prüfen.`,
+        message: format(
+          tr(
+            'check.drumSplRisk',
+            '{n} mic(s) in a loud zone (kick/snare) with a marginal max SPL (< {db} dB) - risk of distortion, check a pad or a tougher mic.',
+          ),
+          { n: d.splRiskCount, db: 140 },
+        ),
       })
     }
   }
@@ -691,7 +848,15 @@ export const runDrawingChecks = (
   // Feldlaengen zugeschnitten. Zwei Namen, die danach gleich sind, faellt
   // sonst erst auf dem Multiviewer auf. Die Ableitung liegt in
   // `labelDerivation.ts` und ist ohne Store/React testbar.
-  findings.push(...labelTargetIssues({ equipment, cables, sourceIdentities }))
+  // Uebersetzt wird HIER und nicht drueben: `labelDerivation` ist sprachfrei,
+  // weil es im Importgraphen der Mobile-Ansicht liegt (#837).
+  for (const befund of labelTargetIssues({ equipment, cables, sourceIdentities })) {
+    findings.push(
+      befund.schluessel
+        ? { ...befund, message: format(tr(befund.schluessel, befund.message), befund.werte ?? {}) }
+        : befund,
+    )
+  }
 
   // — Check 21: Adapter — passt er an dieser Stelle? (B-46) ------------------
   //
@@ -718,7 +883,13 @@ export const runDrawingChecks = (
         id: `adapter-unverkabelt:${geraet.id}`,
         severity: 'warning',
         category: 'Adapter',
-        message: `${geraet.name}: Adapter ${geraet.adapter.von} ↔ ${geraet.adapter.nach} hängt nur an einer Seite — der Weg geht hier nicht weiter.`,
+        message: format(
+          tr(
+            'check.adapterHalfWired',
+            '{name}: the adapter {from} ↔ {to} is connected on one side only - the path stops here.',
+          ),
+          { name: geraet.name, from: geraet.adapter.von, to: geraet.adapter.nach },
+        ),
         equipmentId: geraet.id,
       })
       continue
@@ -741,7 +912,10 @@ export const runDrawingChecks = (
           id: `adapter-${urteil.art}:${geraet.id}:${rein.id}:${raus.id}`,
           severity: urteil.art === 'passt-nicht' ? 'error' : 'info',
           category: 'Adapter',
-          message: `${geraet.name}: ${urteil.text}`,
+          message: format(tr('check.onDevice', '{name}: {what}'), {
+            name: geraet.name,
+            what: format(tr(urteil.schluessel, urteil.text), urteil.werte),
+          }),
           equipmentId: geraet.id,
           cableId: rein.id,
         })
@@ -780,7 +954,7 @@ export const runDrawingChecks = (
         id: `anschluss-${b.art}:${b.anschlussId}${b.cableId ? `:${b.cableId}` : ''}:${b.text.length}`,
         severity: SCHWERE[b.art] ?? 'info',
         category: 'Wire bundle',
-        message: b.text,
+        message: format(tr(b.schluessel, b.text), b.werte),
         ...(b.cableId ? { cableId: b.cableId } : {}),
       })
     }
@@ -828,7 +1002,7 @@ export const runDrawingChecks = (
       id: `bild-${urteil.art}:${c.id}`,
       severity: urteil.art === 'passt-nicht' ? 'error' : 'info',
       category: 'Video format',
-      message: urteil.text,
+      message: format(tr(urteil.schluessel, urteil.text), urteil.werte),
       equipmentId: senke.id,
       cableId: c.id,
     })

--- a/src/renderer/lib/exportPdfVector.ts
+++ b/src/renderer/lib/exportPdfVector.ts
@@ -22,8 +22,7 @@
 import type { ProjectMetadata } from '../types/project'
 import { composeExportBackground, type ExportBgVariant } from './exportBackground'
 import { buildExportFilename } from './exportFilename'
-import { translate } from './i18n'
-import { useUiStore } from '../store/uiStore'
+import { tr, format } from './i18n'
 
 /** v7.9.103 — Standard-Page-Sizes fuer Plotter-/Print-Workflows. 'auto'
  *  kappt auf A0-Landscape (Default, max. Viewer-Kompatibilitaet). 'original'
@@ -103,11 +102,7 @@ const computeNaturalBbox = (viewportEl: HTMLElement): BoundingBox => {
   )
   if (nodeEls.length === 0) {
     throw new Error(
-      translate(
-        useUiStore.getState().language,
-        'export.pdf.errNoDevices',
-        'Keine Geräte zum Exportieren vorhanden',
-      ),
+      tr('export.pdf.errNoDevices', 'No devices to export'),
     )
   }
   const parseTranslate = (el: HTMLElement): { x: number; y: number } => {
@@ -168,11 +163,7 @@ const computeNaturalBbox = (viewportEl: HTMLElement): BoundingBox => {
   }
   if (!isFinite(minX) || !isFinite(minY) || !isFinite(maxX) || !isFinite(maxY)) {
     throw new Error(
-      translate(
-        useUiStore.getState().language,
-        'export.errMeasureCanvas',
-        'Konnte den Inhalt des Canvas nicht vermessen',
-      ),
+      tr('export.errMeasureCanvas', 'The canvas content could not be measured'),
     )
   }
   const padding = 200
@@ -453,19 +444,15 @@ export const exportCanvasToPdfVector = async (
   const canvasEl = document.getElementById('cable-planner-canvas') as HTMLElement | null
   if (!canvasEl)
     throw new Error(
-      translate(useUiStore.getState().language, 'export.errCanvasNotFound', 'Canvas nicht gefunden'),
+      tr('export.errCanvasNotFound', 'Canvas not found'),
     )
   const viewportEl = canvasEl.querySelector('.react-flow__viewport') as HTMLElement | null
   if (!viewportEl)
     throw new Error(
-      translate(
-        useUiStore.getState().language,
-        'export.errViewportNotFound',
-        'ReactFlow-Viewport nicht gefunden',
-      ),
+      tr('export.errViewportNotFound', 'ReactFlow viewport not found'),
     )
 
-  onProgress('measure', 'Inhalt vermessen…')
+  onProgress('measure', tr('export.pdf.measuring', 'Measuring the content…'))
   const bbox = computeNaturalBbox(viewportEl)
 
   const themeDark = options?.backgroundTheme !== 'light'
@@ -479,7 +466,7 @@ export const exportCanvasToPdfVector = async (
   const bgFallback = composed.bgFallback
   const textColor = themeDark ? '#e2e8f0' : '#0f172a'
 
-  onProgress('styles', 'Stylesheets sammeln…')
+  onProgress('styles', tr('export.pdf.collectingStyles', 'Collecting stylesheets…'))
   const appCss = collectAllCss()
   if (appCss.length < 1000) {
     console.warn(
@@ -531,19 +518,30 @@ export const exportCanvasToPdfVector = async (
 
   onProgress(
     'capture',
-    `Canvas-DOM klonen (zoom ${(canvasScale * 100).toFixed(0)}%, Body ${bodyWidthPx}×${bodyHeightPx}px)…`,
+    format(
+      tr('export.pdf.cloning', 'Cloning the canvas DOM (zoom {zoom}%, body {w}×{h} px)…'),
+      { zoom: (canvasScale * 100).toFixed(0), w: bodyWidthPx, h: bodyHeightPx },
+    ),
   )
   const canvasClone = cloneCanvasForPrint(canvasEl, bbox)
   const canvasOuterHtml = canvasClone.outerHTML
   if (canvasOuterHtml.length < 1000) {
     throw new Error(
-      `Canvas-Clone ist verdächtig klein (${canvasOuterHtml.length} bytes) — Export abgebrochen.`,
+      format(
+        tr(
+          'export.pdf.cloneTooSmall',
+          'The canvas clone is suspiciously small ({bytes} bytes) - the export was aborted.',
+        ),
+        { bytes: canvasOuterHtml.length },
+      ),
     )
   }
 
   onProgress(
     'compose',
-    `Print-HTML bauen (${Math.round((appCss.length + canvasOuterHtml.length) / 1024)} KB)…`,
+    format(tr('export.pdf.composing', 'Building the print HTML ({kb} KB)…'), {
+      kb: Math.round((appCss.length + canvasOuterHtml.length) / 1024),
+    }),
   )
   const html = buildPrintHtml({
     appCss,
@@ -564,12 +562,12 @@ export const exportCanvasToPdfVector = async (
     themeDark,
   })
 
-  onProgress('render', `Chromium printToPDF…`)
+  onProgress('render', tr('export.pdf.rendering', 'Chromium printToPDF…'))
   const widthMicrons = Math.round(bodyWidthPx * PX_TO_MICRONS)
   const heightMicrons = Math.round(bodyHeightPx * PX_TO_MICRONS)
   const bytes = await handler({ html, widthMicrons, heightMicrons })
 
-  onProgress('save', 'Datei speichern…')
+  onProgress('save', tr('export.pdf.saving', 'Saving the file…'))
   if (!bytes || bytes.byteLength < 1000) {
     throw new Error(
       `printToPDF lieferte verdächtig wenig zurück (${bytes?.byteLength ?? 0} bytes).`,
@@ -585,5 +583,5 @@ export const exportCanvasToPdfVector = async (
   a.click()
   a.remove()
   URL.revokeObjectURL(url)
-  onProgress('done', 'Fertig.')
+  onProgress('done', tr('export.pdf.done', 'Done.'))
 }

--- a/src/renderer/lib/i18n.ts
+++ b/src/renderer/lib/i18n.ts
@@ -54,6 +54,7 @@ import { useUiStore, type Language } from '../store/uiStore'
 
 import { type Dict } from './i18n/dict'
 import { de } from './i18n/de'
+import { einsetzen } from './platzhalter'
 
 /**
  * Die Woerterbuecher — eine REGISTRY, keine Verzweigung.
@@ -93,10 +94,36 @@ export function useTranslation() {
   return (key: string, fallback?: string) => translate(lang, key, fallback)
 }
 
-/** Convenience: inject runtime values into a translated string.
- *  e.g. format(t('foo', '{n} cables'), { n: 5 }) → '5 cables'. */
-export function format(template: string, values: Record<string, string | number>): string {
-  return template.replace(/\{(\w+)\}/g, (_, k) =>
-    k in values ? String(values[k]) : `{${k}}`,
-  )
+/**
+ * Der Uebersetzer AUSSERHALB von React — eine Kopie, nicht vier.
+ *
+ * Module wie `drawingChecks`, `importGreengo` oder `intercomMatrixXlsx` laufen
+ * ohne Komponente; dort gibt es keinen Hook. Bis 2026-09-10 half sich jedes
+ * mit denselben zwei Zeilen selbst:
+ *
+ *     const tr = (key, fallback) =>
+ *       translate(useUiStore.getState().language, key, fallback)
+ *
+ * Vier Kopien derselben Zeile sind fuer sich schon die Defektform
+ * `zwei-rechnungen` im Kleinen. Teuer wurde es aber an einer anderen Stelle:
+ * WER DIE SPRACHE INLINE HOLT, WIRD VOM SPRACH-WAECHTER NICHT GESEHEN.
+ * `fallbackMuster` in `scripts/quellsprache.mjs` erkennt `translate(lang, k,
+ * f)` nur, wenn das erste Argument ein BEZEICHNER ist; bei
+ * `translate(useUiStore.getState().language, …)` greift es nicht. Gemessen:
+ * `exportPdfVector.ts` trug so den deutschen Fallback „Canvas nicht gefunden"
+ * durch die Sprachdrehung E-28, und `lang:check` meldete daneben 0 Verstoesse.
+ *
+ * Mit dieser Fassung steht an jeder Aufrufstelle `tr('key', 'English')` —
+ * genau die Form, die der Waechter liest.
+ */
+export function tr(key: string, fallback: string): string {
+  return translate(useUiStore.getState().language, key, fallback)
 }
+
+/** Convenience: inject runtime values into a translated string.
+ *  e.g. format(t('foo', '{n} cables'), { n: 5 }) → '5 cables'.
+ *
+ *  Die Regel selbst steht in `lib/platzhalter.ts` — sie ist dieselbe fuer
+ *  Desktop, Mobile-Ansicht, Viewer und die Urteils-Module unter `types/`, und
+ *  seit 2026-09-10 steht sie deshalb nur noch einmal. */
+export const format = einsetzen

--- a/src/renderer/lib/i18n/de.ts
+++ b/src/renderer/lib/i18n/de.ts
@@ -5427,4 +5427,132 @@ export const de: Dict = {
   'intercomXlsx.readError': 'XLSX konnte nicht gelesen werden: {msg}',
   'pendingCable.suggestionItemTitle': 'Bei Mausposition platzieren und Verbindung herstellen ({category})',
   'pendingCable.suggestionsTitle': 'Schnelle Vorschläge ({connector})',
+
+  // ── 2026-09-10: die Plan-Pruefung und der PDF-Export (#837) ───────────────
+  //
+  // Diese 69 Zeichenketten standen als ROHE deutsche Literale in `lib/` und
+  // `types/` — Meldungen des Plan-Checks, Urteile ueber Adapter, Adern und
+  // Bildformate, und die Fortschritts-Texte des Vektor-Exports. Sie erscheinen
+  // im Plan-Check-Panel UND auf gedruckten Blaettern; ein englischsprachiger
+  // Nutzer las neben einer englischen Spalte einen deutschen Satz.
+  //
+  // Der Sprach-Waechter sah davon nichts: er liest `t()`-Aufrufe, und das
+  // waren keine. Der deutsche Text hier ist Zeichen fuer Zeichen der, der
+  // vorher im Quelltext stand.
+  'adapter.directionUnknown':
+    'Hier steckt der Adapter umgekehrt ({nach} nach {von}). Ob er das kann, ist nicht eingetragen — die Richtung gehört ans Gerät.',
+  'adapter.doesNotFit': 'Adapter {von} ↔ {nach} passt nicht zwischen {quelle} und {senke}.',
+  'adapter.fits': 'Adapter {von} nach {nach} trägt an dieser Stelle.',
+  'adapter.noDirection':
+    'Die Richtung dieses Adapters ist nicht eingetragen. Der Plan sagt deshalb nicht, dass er hier trägt.',
+  'adapter.overStandard': 'Der Adapter lässt höchstens {max} durch; hier läuft {wanted}.',
+  'adapter.sourceRequirementUnknown':
+    'Dieser Adapter setzt „{needs}" an der Quelle voraus. Am Quellgerät ist das nicht eingetragen — ob es das kann, weiss der Plan nicht.',
+  'adapter.standardsIncomparable':
+    'Der Adapter ist mit {max} angegeben, hier läuft {wanted} — die beiden sind nicht gegeneinander zu messen.',
+  'adapter.wrongDirection':
+    'Dieser Adapter wandelt nur {von} nach {nach}. Hier steckt er umgekehrt und überträgt nichts.',
+  'bundle.colourContradiction':
+    '{name} · „{cable}": {role} ist {colour}, die Norm „{norm}" sagt {expected}. Ohne Grund ist das ein Widerspruch, kein Sonderfall.',
+  'bundle.noColourStandard':
+    '{name}: keine Farbnorm gewählt — die Adernfarben sind nicht geprüft. Welche Zuordnung für diese Anlage gilt, steht nicht im Programm.',
+  'bundle.wireDuplicate': '{name}: {role} liegt {n}-mal im Bündel. Welche Leitung gilt?',
+  'bundle.wireMissing': '{name}: {role} ist geplant, aber in keiner Leitung dieses Bündels eingetragen.',
+  'bundle.wireMute': '{name}: „{cable}" gehört zum Bündel, trägt aber keine Ader-Angabe.',
+  'cableSpec.balanceMismatch':
+    'Symmetrisch ↔ unsymmetrisch ({from} ↔ {to}). DI-Box / Übertrager verwenden, sonst Brummen und Pegelverlust.',
+  'cableSpec.cannotConnect': 'Kabel „{cable}" ({connector}) verbindet {from} nicht mit {to}.',
+  'cableSpec.impedanceMismatch':
+    'Impedanz-Sprung: {a}Ω ↔ {b}Ω. Reflexionen/Return-Loss — passendes Kabel oder Adapter verwenden.',
+  'cableSpec.matches': '{cable} passt zu {from} ↔ {to}.',
+  'cableSpec.needsAdapter': '{from} und {to} sind ähnlich, brauchen aber einen Adapter.',
+  'cableSpec.sdiSpeedMismatch':
+    'SDI-Geschwindigkeit passt nicht ({from} ↔ {to}). Ein Scaler/Konverter ist nötig.',
+  'cableSpec.standardMatched': '{standard} passt.',
+  // Drei Satz-Geruste ohne eigene Woerter: sie setzen Namen und ein bereits
+  // uebersetztes Urteil zusammen. Sie stehen trotzdem im Woerterbuch, weil die
+  // WORTSTELLUNG zur Sprache gehoert — eine Sprache, die den Namen hinten
+  // fuehrt, braucht hier eine andere Zeile und keine Code-Aenderung.
+  'check.connectorMismatch': '{from} ({fromType}) → {to} ({toType})',
+  'check.onDevice': '{name}: {what}',
+  'check.onLink': '{from} → {to}: {what}',
+  'check.rfConflict': '{a} ⟷ {b}: {why}',
+  'check.adapterHalfWired':
+    '{name}: Adapter {from} ↔ {to} hängt nur an einer Seite — der Weg geht hier nicht weiter.',
+  'check.artnetLinks': '{n} Art-Net/sACN-Links (mehrere Universen je Link)',
+  'check.cableTooLong':
+    '{from} → {to}: {len} m überschreitet die passive {standard}-Grenze (~{limit} m) — aktive Lösung (AOC/HDBaseT/Extender/LWL) nötig',
+  'check.daNoFanout':
+    '{name}: als Verteilverstärker markiert, aber nur {n} Ausgang/Ausgänge (1→N erwartet)',
+  'check.dmxLines': '{n} DMX-Linien (≈ {n} Universen, {ch} Kanäle)',
+  'check.drumMicInputs':
+    'Drum-Kit braucht {need} Mic-Inputs, aber nur {have} XLR-Eingänge im Plan — fehlende {missing} Kanäle einplanen (Stagebox/Preamps).',
+  'check.drumPhantom':
+    '{n} Drum-Mic(s) brauchen 48V-Phantom — Preamps/Pult mit schaltbarer Phantomspeisung sicherstellen.',
+  'check.drumSplRisk':
+    '{n} Mic(s) an lauter Zone (Kick/Snare) mit grenzwertigem Max SPL (< {db} dB) — Verzerrungsrisiko, Pad/robusteres Mic prüfen.',
+  'check.drumUnknownMics':
+    '{n} Drum-Kanal/Kanäle ohne zugeordnetes Mic-Modell — Phantom-/SPL-Bedarf nicht prüfbar, Modell zuweisen.',
+  'check.dualLinkIncomplete':
+    '{name}: Dual-Link-Set „{group}" unvollständig — {connected}/{total} Links verbunden ({ports})',
+  'check.duplicateCableNumber': 'Kabelnummer „{num}" {n}× vergeben: {from} → {to}',
+  'check.duplicateIp': 'IP {ip} mehrfach: {names}',
+  'check.fibre.multimode': 'Multimode',
+  'check.fibre.singlemode': 'Singlemode',
+  'check.fibreConnectorMismatch':
+    '{from} → {to}: {a} ↔ {b} — optischer Steckertyp ungleich (Adapter/Hybrid-Patch nötig)',
+  'check.fibreMismatch':
+    '{from} → {to}: {aClass} ({aKind}) ↔ {bClass} ({bKind}) — optisch inkompatibel',
+  'check.gatewaySubnet':
+    '{name}: Gateway {gateway} liegt nicht im Subnetz von {ip} ({mask}) — nicht erreichbar',
+  'check.missingLength': '{from} → {to}: keine Länge gesetzt',
+  'check.openPorts': '{name}: {n} unverbundene Ports ({ports})',
+  'check.poeOverBudget':
+    '{name}: PoE-Last {load} W an {count} Geräten übersteigt das Budget ({budget} W)',
+  'check.portsGuessed': '{name}: Ports stammen aus {source} — gegen die realen Anschlüsse prüfen',
+  'check.portsGuessed.noSource': 'einer Quelle ohne Datenblatt',
+  'check.portsUnknown':
+    '{name}: Port-Belegung unbekannt (kein Datenblatt-Match) — reale Anschlüsse aus dem Datenblatt ergänzen',
+  'check.rf.sameChannel': 'gleicher Kanal {channel}',
+  'check.rf.tooClose': 'Frequenzabstand < {mhz} MHz',
+  'check.sdiNoGenlock':
+    '{n} SDI-Signale, aber keine Genlock-/Referenz-Verteilung (Blackburst/Tri-Level) — Sync prüfen.',
+  'check.singlePower': '{name}: nur eine Strom-Anbindung (kein redundantes Netzteil)',
+  'check.st2110NoNmos':
+    'ST 2110 im Plan — NMOS-Registry (IS-04 Discovery / IS-05 Connection Management) für Auffindbarkeit + Routing einplanen.',
+  'check.st2110NoPtp':
+    'ST 2110 im Plan, aber kein PTP-Signal — PTP-Grandmaster (IEEE 1588) als Referenz nicht vergessen.',
+  'check.tallyNoSource': '{name}: Tally-Senke, aber keine Tally-Quelle (Mischer/Tally-Hub) im Plan',
+  'check.tcNoSource': '{name}: TC-Senke, aber keine TC-Quelle (Generator) im Plan',
+  'display.accepted': '{sink} nimmt {format} an.',
+  'display.formatRejected':
+    '{sink} nimmt {format} nicht an — im erklärten Profil steht es nicht ({n} Format(e) erklärt).',
+  'display.noProfile':
+    '{sink}: es ist nicht erklärt, welche Formate dieses Gerät annimmt. Ob {format} ankommt, weiss der Plan nicht.',
+  'display.propertyRejected':
+    '{sink} nimmt {format} an, aber nicht mit {property} {wanted} — erklärt sind: {stated}.',
+  'display.propertyUnknown':
+    '{sink} nimmt {format} an, aber zur {property} ist nichts erklärt. Ob {wanted} ankommt, weiss der Plan nicht.',
+  'export.errCanvasNotFound': 'Canvas nicht gefunden',
+  'export.errMeasureCanvas': 'Konnte den Inhalt des Canvas nicht vermessen',
+  'export.errViewportNotFound': 'ReactFlow-Viewport nicht gefunden',
+  'export.pdf.cloneTooSmall':
+    'Canvas-Clone ist verdächtig klein ({bytes} bytes) — Export abgebrochen.',
+  'export.pdf.cloning': 'Canvas-DOM klonen (zoom {zoom}%, Body {w}×{h} px)…',
+  'export.pdf.collectingStyles': 'Stylesheets sammeln…',
+  'export.pdf.composing': 'Print-HTML bauen ({kb} KB)…',
+  'export.pdf.done': 'Fertig.',
+  'export.pdf.errNoDevices': 'Keine Geräte zum Exportieren vorhanden',
+  'export.pdf.measuring': 'Inhalt vermessen…',
+  'export.pdf.rendering': 'Chromium printToPDF…',
+  'export.pdf.saving': 'Datei speichern…',
+  'label.affected': ' — betroffen: {where}.',
+  'label.category.charset': '{system}-Zeichensatz',
+  'label.category.nameCollision': '{system}-Namenskollision',
+  'label.charset': '„{raw}" enthält {chars} — im {system}-{field} nicht darstellbar ({where}).',
+  'label.nameCollision': '{names} werden im {system}-{field} beide zu „{value}"',
+  'label.umdAddressClash':
+    '{names} liegen beide auf UMD-Adresse {address} — die Displays zeigen denselben Text, welcher gewinnt entscheidet die Paketreihenfolge.',
+  'label.unit.bytes': 'Byte',
+  'label.unit.chars': 'Zeichen',
 }

--- a/src/renderer/lib/i18nLite.ts
+++ b/src/renderer/lib/i18nLite.ts
@@ -1,6 +1,12 @@
 // ---------------------------------------------------------------------------
 // Das Uebersetzer-Werk fuer die NEBEN-Eintrittspunkte (`src/mobile`,
-// `src/viewer`) — ohne Woerterbuch, ohne Store, ohne einen einzigen Import.
+// `src/viewer`) — ohne Woerterbuch und ohne Store.
+//
+// Ein einziger Import steht seit 2026-09-10 doch hier: `lib/platzhalter.ts`.
+// Die Datei hat selbst keine Importe und kein Woerterbuch — sie traegt nur die
+// Einsetz-Regel, die vorher zweimal dastand (hier und in `lib/i18n.ts`). Der
+// Grund fuer die Trennung der beiden Werke bleibt unberuehrt: `lib/i18n.ts`
+// zoege `de.ts` nach (316 KB), `platzhalter.ts` zieht gar nichts nach.
 //
 // ─── WOFUER DAS DA IST, UND WOFUER NICHT ───────────────────────────────────
 //
@@ -29,6 +35,8 @@
 // ---------------------------------------------------------------------------
 
 /** Quellsprache ist `en` (E-28); jede weitere Sprache ist ein Eintrag mehr. */
+import { einsetzen } from './platzhalter'
+
 export type Sprache = 'en' | 'de'
 
 /**
@@ -67,14 +75,12 @@ export const macheUebersetzer =
  * Werte in einen uebersetzten Satz einsetzen: `format(t('k', '{n} m'), {n: 5})`.
  *
  * Dieselbe Form wie `format()` in `lib/i18n.ts` — und absichtlich eine eigene
- * Zeile statt eines Imports von dort: der Import zoege `de.ts` nach und
- * braechte das ganze Desktop-Woerterbuch auf ein Telefon im Hallen-WLAN.
+ * Die Regel selbst steht in `lib/platzhalter.ts` und wird von dort geholt —
+ * NICHT aus `lib/i18n.ts`: der Import zoege `de.ts` nach und braechte das
+ * ganze Desktop-Woerterbuch auf ein Telefon im Hallen-WLAN.
  *
  * Ein unbekannter Platzhalter bleibt sichtbar stehen (`{foo}`) statt leer zu
  * werden. Eine Uebersetzung, die einen Platzhalter falsch schreibt, faellt
  * damit im Bild auf, statt still ein Wort zu verschlucken.
  */
-export const format = (
-  template: string,
-  values: Record<string, string | number>,
-): string => template.replace(/\{(\w+)\}/g, (_, k) => (k in values ? String(values[k]) : `{${k}}`))
+export const format = einsetzen

--- a/src/renderer/lib/importGreengo.ts
+++ b/src/renderer/lib/importGreengo.ts
@@ -9,11 +9,7 @@
  */
 
 import type { GreenGoConfig, GreenGoGroup, GreenGoUser, GreenGoKey } from '../types/greengo'
-import { translate } from './i18n'
-import { useUiStore } from '../store/uiStore'
-
-const tr = (key: string, fallback: string) =>
-  translate(useUiStore.getState().language, key, fallback)
+import { tr } from './i18n'
 
 // ── Result types ─────────────────────────────────────────────────────────────
 

--- a/src/renderer/lib/intercomMatrixXlsx.ts
+++ b/src/renderer/lib/intercomMatrixXlsx.ts
@@ -38,11 +38,7 @@
 // "stream has been externalized"-Dev-Warnung.
 import type * as XLSXNs from 'xlsx-js-style'
 import type { GreenGoConfig, GreenGoGroup, GreenGoUser } from '../types/greengo'
-import { translate, format } from './i18n'
-import { useUiStore } from '../store/uiStore'
-
-const tr = (key: string, fallback: string) =>
-  translate(useUiStore.getState().language, key, fallback)
+import { tr, format } from './i18n'
 
 /** What a single cell can contain after we've stringified it. */
 type Cell = string

--- a/src/renderer/lib/itemExport.ts
+++ b/src/renderer/lib/itemExport.ts
@@ -43,13 +43,13 @@ import { useUiStore } from '../store/uiStore'
 const nachZugangsdatenFragen = async <T>(
   werte: readonly T[],
   zielKey: string,
-  zielDe: string,
+  zielEn: string,
 ): Promise<'ab' | 'roh' | 'strip'> => {
   const traeger = countCredentialBearers(werte)
   if (traeger === 0) return 'roh'
   const antwort = await credentialChoiceDialog(
     traeger,
-    translate(useUiStore.getState().language, zielKey, zielDe),
+    translate(useUiStore.getState().language, zielKey, zielEn),
   )
   if (antwort === null) return 'ab'
   return antwort === 'strip' ? 'strip' : 'roh'

--- a/src/renderer/lib/labelDerivation.ts
+++ b/src/renderer/lib/labelDerivation.ts
@@ -31,7 +31,7 @@
 import type { Cable } from '../types/cable'
 import type { EquipmentItem, Port } from '../types/equipment'
 import type { SourceIdentity } from '../types/sourceIdentity'
-import type { CheckFinding } from './drawingChecks'
+import type { CheckFinding } from '../types/checkFinding'
 import { detectDeviceKind, type DeviceKind } from './deviceKind'
 import { patchPanelCounterpart } from './patchPanel'
 import {
@@ -42,6 +42,12 @@ import {
 import { effectiveShortName } from './shortName'
 import { suggestDanteName } from './danteNaming'
 import { umdAddressClashes } from './sourceIdentity'
+// Sprachfrei mit Absicht: dieses Modul liegt ueber `postHandover` und
+// `documentRegistry` im Importgraphen der MOBILE-Ansicht. Ein Import von
+// `lib/i18n.ts` zoege `de.ts` (316 KB) auf ein Telefon im Hallen-WLAN —
+// `tests/i18nEintrittspunkte.test.ts` hat genau das gemeldet (#837). Die
+// Befunde tragen `schluessel` und `werte`; `drawingChecks.ts` uebersetzt.
+import { einsetzen } from './platzhalter'
 import {
   LABEL_TARGETS,
   collisionsForTarget,
@@ -641,10 +647,18 @@ export const labelTargetIssues = (input: LabelDerivationInput): CheckFinding[] =
       id: `umd-address-clash:${clash.address}`,
       severity: 'error',
       category: 'Duplicate UMD address',
-      message:
-        `${clash.identities.map((i) => `"${i.name}"`).join(' und ')} liegen ` +
-        `beide auf UMD-Adresse ${clash.address} — die Displays zeigen ` +
-        'denselben Text, welcher gewinnt entscheidet die Paketreihenfolge.',
+      schluessel: 'label.umdAddressClash',
+      werte: {
+        names: clash.identities.map((i) => `"${i.name}"`).join(' & '),
+        address: clash.address,
+      },
+      message: einsetzen(
+        '{names} both sit on UMD address {address} - the displays show the same text, and the packet order decides which one wins.',
+        {
+          names: clash.identities.map((i) => `"${i.name}"`).join(' & '),
+          address: clash.address,
+        },
+      ),
     })
   }
 
@@ -674,12 +688,36 @@ export const labelTargetIssues = (input: LabelDerivationInput): CheckFinding[] =
       issues.push({
         id: `label-collision:${targetId}:${collision.value}`,
         severity: 'error',
-        category: `${spec.system}-Namenskollision`,
-        message:
-          `${members.map((m) => `"${m.sourceText}"`).join(' und ')} werden im ` +
-          `${spec.system}-${spec.field} beide zu "${collision.value}"` +
-          (budget !== null ? ` (${budget} ${spec.budgetUnit === 'bytes' ? 'Byte' : 'Zeichen'})` : '') +
-          ` — betroffen: ${members.map((m) => m.where).join(', ')}.`,
+        category: einsetzen('{system} name collision', { system: spec.system }),
+        schluessel: 'label.nameCollision',
+        werte: {
+          names: members.map((m) => `"${m.sourceText}"`).join(' & '),
+          value: collision.value,
+          system: spec.system,
+          field: spec.field,
+          // Das Budget steht als FERTIGES Stueck in den Werten und nicht als
+          // zweiter Satz daneben: eine Sprache, die Zahl und Einheit anders
+          // stellt, aendert dann eine Woerterbuch-Zeile und keine Code-Zeile.
+          budget:
+            budget !== null
+              ? ` (${budget} ${spec.budgetUnit === 'bytes' ? 'bytes' : 'characters'})`
+              : '',
+          where: members.map((m) => m.where).join(', '),
+        },
+        message: einsetzen(
+          '{names} both become "{value}" in {system} {field}{budget} - affected: {where}.',
+          {
+            names: members.map((m) => `"${m.sourceText}"`).join(' & '),
+            value: collision.value,
+            system: spec.system,
+            field: spec.field,
+            budget:
+              budget !== null
+                ? ` (${budget} ${spec.budgetUnit === 'bytes' ? 'bytes' : 'characters'})`
+                : '',
+            where: members.map((m) => m.where).join(', '),
+          },
+        ),
         equipmentId: members[0].equipmentId,
       })
     }
@@ -691,10 +729,25 @@ export const labelTargetIssues = (input: LabelDerivationInput): CheckFinding[] =
       issues.push({
         id: `label-charset:${targetId}:${c.key}`,
         severity: 'warning',
-        category: `${spec.system}-Zeichensatz`,
-        message:
-          `"${f.raw}" enthält ${f.invalidChars.map((ch) => `"${ch}"`).join(', ')} — ` +
-          `im ${spec.system}-${spec.field} nicht darstellbar (${c.where}).`,
+        category: einsetzen('{system} character set', { system: spec.system }),
+        schluessel: 'label.charset',
+        werte: {
+          raw: f.raw,
+          chars: f.invalidChars.map((ch) => `"${ch}"`).join(', '),
+          system: spec.system,
+          field: spec.field,
+          where: c.where,
+        },
+        message: einsetzen(
+          '"{raw}" contains {chars} - not representable in {system} {field} ({where}).',
+          {
+            raw: f.raw,
+            chars: f.invalidChars.map((ch) => `"${ch}"`).join(', '),
+            system: spec.system,
+            field: spec.field,
+            where: c.where,
+          },
+        ),
         equipmentId: c.equipmentId,
       })
     }

--- a/src/renderer/lib/passiveCatalog.ts
+++ b/src/renderer/lib/passiveCatalog.ts
@@ -85,8 +85,8 @@ const blende = (name: string, n: number, connectorType: ConnectorType): Equipmen
   isPatchPanel: true,
   width: 240,
   height: 80,
-  inputs: ports('Rückseite', n, connectorType),
-  outputs: ports('Frontseite', n, connectorType),
+  inputs: ports('Rear', n, connectorType),
+  outputs: ports('Front', n, connectorType),
 })
 
 /** Eine Durchgangsbuchse: die Blende der Groesse 1. */
@@ -104,8 +104,8 @@ const leiste = (
   category: 'Power distribution',
   width: 240,
   height: 80,
-  inputs: ports('Einspeisung', 1, ein),
-  outputs: ports('Abgang', n, aus),
+  inputs: ports('Feed', 1, ein),
+  outputs: ports('Outlet', n, aus),
 })
 
 /**
@@ -124,7 +124,7 @@ const verteiler = (
   category: 'Power distribution',
   width: 240,
   height: 80,
-  inputs: ports('Einspeisung', 1, ein),
+  inputs: ports('Feed', 1, ein),
   outputs: abgaenge.flatMap((a) =>
     ports(a.name, a.n, a.connectorType, { absicherungA: a.absicherungA }),
   ),
@@ -178,9 +178,13 @@ export const passiveTemplates: EquipmentTemplate[] = [
   durchgang('Feed-through XLR', 'XLR'),
   durchgang('Feed-through RJ45', 'Ethernet/RJ45'),
 
-  leiste('Steckdosenleiste 6-fach', 6, 'Schuko 230V', 'Schuko 230V'),
-  leiste('Steckdosenleiste 8-fach', 8, 'Schuko 230V', 'Schuko 230V'),
-  leiste('IEC-Leiste 8-fach', 8, 'IEC 230V', 'IEC 230V'),
+  // Die Namen stehen in der QUELLSPRACHE (E-28) und sind zugleich die
+  // Kennung der Vorlage in der Bibliothek — wer sie aendert, traegt die alte
+  // Schreibweise in `lib/templateRenames.ts` nach, sonst steht sie beim
+  // naechsten Start doppelt in der Seitenleiste (#837).
+  leiste('Power strip 6-way', 6, 'Schuko 230V', 'Schuko 230V'),
+  leiste('Power strip 8-way', 8, 'Schuko 230V', 'Schuko 230V'),
+  leiste('IEC strip 8-way', 8, 'IEC 230V', 'IEC 230V'),
 
   powerlockSatz('Powerlock set 5x (L1/L2/L3/N/PE)'),
 

--- a/src/renderer/lib/platzhalter.ts
+++ b/src/renderer/lib/platzhalter.ts
@@ -1,0 +1,38 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Platzhalter einsetzen — EINMAL, fuer alle drei Seiten.
+//
+// ─── WOFUER ────────────────────────────────────────────────────────────────
+//
+// `{n} cables` + `{ n: 5 }` -> `5 cables`. Mehr macht diese Datei nicht, und
+// mehr darf sie auch nicht: sie hat KEINE Importe und haengt an keinem Store,
+// keinem Woerterbuch, keinem React.
+//
+// ─── WARUM SIE EIGEN STEHT (2026-09-10, #837) ──────────────────────────────
+//
+// Es gab die Regel bis heute zweimal — in `lib/i18n.ts` fuer den Desktop und
+// in `lib/i18nLite.ts` fuer Mobile-Ansicht und Viewer. Der zweite Ort ist
+// ausdruecklich begruendet: `lib/i18n.ts` importiert `de.ts` statisch (316 KB),
+// und das gehoert nicht auf ein Telefon im Hallen-WLAN.
+//
+// Der Grund war richtig, die Folge nicht: zwei Fassungen derselben Regel sind
+// die Defektform `zwei-rechnungen`, die dieses Repo an mehreren Stellen teuer
+// bezahlt hat. Beim naechsten Randfall — ein Platzhalter mit Punkt, eine
+// doppelte Klammer — waere die eine nachgezogen worden und die andere nicht.
+//
+// Mit dieser Datei bleibt der Grund erhalten und die Doppelung faellt weg:
+// beide Werke rufen `einsetzen`, und keines von beiden schleppt dabei ein
+// Woerterbuch mit. Sie ist ausserdem das Stueck, das die URTEILS-Module unter
+// `types/` brauchen (`adapter`, `conductor`, `displayCapability`): die duerfen
+// `lib/i18n.ts` nicht anfassen, weil ein Typ-Modul im Importgraphen JEDER
+// Seite liegt.
+//
+// Ein unbekannter Platzhalter bleibt sichtbar stehen (`{foo}`) statt leer zu
+// werden. Eine Uebersetzung, die einen Platzhalter falsch schreibt, faellt
+// damit im Bild auf, statt still ein Wort zu verschlucken.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Die Werte, die in eine Vorlage eingesetzt werden. */
+export type Platzhalterwerte = Record<string, string | number>
+
+export const einsetzen = (vorlage: string, werte: Platzhalterwerte): string =>
+  vorlage.replace(/\{(\w+)\}/g, (_, k) => (k in werte ? String(werte[k]) : `{${k}}`))

--- a/src/renderer/lib/projectTemplates.ts
+++ b/src/renderer/lib/projectTemplates.ts
@@ -96,7 +96,7 @@ export const buildBuiltinTemplates = (): ProjectTemplate[] => {
       builtin: true,
       nameKey: 'templates.builtin.obVan.name',
       descKey: 'templates.builtin.obVan.desc',
-      name: 'Ü-Wagen / OB-Van',
+      name: 'OB van',
       description: 'Übertragungswagen mit Bühne und FOH — getrennte Standort-Rahmen.',
       project: base('Ü-Wagen / OB-Van', 'Übertragungswagen-Setup', [
         frame('Ü-Wagen', 40, 40, 520, 360, '#38bdf8'),
@@ -120,7 +120,7 @@ export const buildBuiltinTemplates = (): ProjectTemplate[] => {
       builtin: true,
       nameKey: 'templates.builtin.liveStage.name',
       descKey: 'templates.builtin.liveStage.desc',
-      name: 'Live-Bühne',
+      name: 'Live stage',
       description: 'Bühne, FOH und Monitorwelt für Live-Events.',
       project: base('Live-Bühne', 'Live-Stage-Setup', [
         frame('Bühne', 40, 40, 640, 320, '#34d399'),

--- a/src/renderer/lib/templateRenames.ts
+++ b/src/renderer/lib/templateRenames.ts
@@ -1,0 +1,43 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Ausgelieferte Vorlagen-Namen: alt -> neu (#837).
+//
+// ─── WARUM ES DIE TABELLE BRAUCHT ──────────────────────────────────────────
+//
+// Drei Vorlagen aus `passiveCatalog.ts` trugen deutsche Namen, in einem Repo
+// mit Quellsprache `en` (E-28): `Steckdosenleiste 6-fach`,
+// `Steckdosenleiste 8-fach`, `IEC-Leiste 8-fach`. Der Sprach-Waechter konnte
+// sie nicht sehen — sie sind DATEN und keine `t()`-Aufrufe.
+//
+// Umbenennen allein reicht hier aber nicht, und das ist der eigentliche Punkt:
+// **der Name IST die Kennung.** `projectStore.seedBuiltInLibrary` gleicht die
+// mitgelieferten Vorlagen ueber `byName` gegen die Bibliothek des Nutzers ab,
+// und `LibraryPanel` sucht Konflikte ueber `tpl.name === template.name`. Ohne
+// Migration stuende nach dem Umbenennen die alte deutsche Vorlage NEBEN der
+// neuen englischen — dasselbe Geraet zweimal in der Seitenleiste, und der
+// Nutzer muesste raten, welche seine Plaene benutzen.
+//
+// Es ist dieselbe Bauform wie `LEGACY_CATEGORY_RENAMES` (#822/#835) und
+// `LEGACY_CONNECTOR_RENAMES` (#832), und aus demselben Grund getrennt: die
+// Kategorien stehen an `equipment.category`, die Steckertypen am Port, die
+// Vorlagen-Namen in der Bibliothek. Drei Orte, drei Tabellen — eine gemeinsame
+// waere kuerzer und wuerde beim naechsten Eintrag an der falschen Stelle
+// angewandt.
+//
+// ─── WAS HIER NICHT HINEINGEHOERT ──────────────────────────────────────────
+//
+// Namen, die ein Nutzer selbst vergeben hat. Diese Tabelle gilt fuer
+// AUSGELIEFERTE Vorlagen; eine eigene Vorlage, die zufaellig so heisst, wird
+// mit umbenannt, und das ist der Preis. Er ist klein und die Gegenrichtung
+// waere schlimmer: eine Tabelle, die nur „manchmal" greift, laesst die
+// Doppelung genau dort stehen, wo sie jemanden trifft.
+// ───────────────────────────────────────────────────────────────────────────
+
+export const LEGACY_TEMPLATE_RENAMES: Record<string, string> = {
+  'Steckdosenleiste 6-fach': 'Power strip 6-way',
+  'Steckdosenleiste 8-fach': 'Power strip 8-way',
+  'IEC-Leiste 8-fach': 'IEC strip 8-way',
+}
+
+/** Der heutige Name einer Vorlage — unveraendert, wo nichts umbenannt wurde. */
+export const heileVorlagenName = (name: string): string =>
+  LEGACY_TEMPLATE_RENAMES[name] ?? name

--- a/src/renderer/store/libraryPersist.ts
+++ b/src/renderer/store/libraryPersist.ts
@@ -2,6 +2,7 @@ import type { EquipmentTemplate } from '../types/equipment'
 import { STORAGE_KEYS } from '../lib/storageKeys'
 import { syncDevicesToFolder } from '../lib/librarySync'
 import { LEGACY_CATEGORY_RENAMES } from '../lib/categoryTranslations'
+import { heileVorlagenName } from '../lib/templateRenames'
 import { heileSteckertyp } from '../lib/connectorRenames'
 
 /**
@@ -66,6 +67,11 @@ export const loadCustomLibrary = (): EquipmentTemplate[] => {
       }))
     return items.map((t) => ({
       ...t,
+      // #837 — der Name einer ausgelieferten Vorlage IST ihre Kennung: die
+      // Seed-Stufe in `projectStore` gleicht ueber `byName` ab. Ohne diese
+      // Zeile stuende nach dem Umbenennen die alte deutsche Vorlage neben der
+      // neuen englischen.
+      name: heileVorlagenName(t.name),
       ...(t.category && LEGACY_CATEGORY_RENAMES[t.category]
         ? { category: LEGACY_CATEGORY_RENAMES[t.category] }
         : {}),

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -51,6 +51,7 @@ import { cameraTemplates } from '../lib/cameraCatalog'
 import { miscTemplates } from '../lib/miscCatalog'
 import { mediaStationTemplates } from '../lib/mediaStationCatalog'
 import { passiveTemplates } from '../lib/passiveCatalog'
+import { heileVorlagenName } from '../lib/templateRenames'
 import { greengoTemplates } from '../lib/greengoCatalog'
 import { ajaTemplates } from '../lib/ajaCatalog'
 import { rossTemplates } from '../lib/rossCatalog'
@@ -132,7 +133,16 @@ const runLibraryMigration = () => {
     // migration gate. Entries the user saved under the same name are kept.
     const raw = localStorage.getItem(CUSTOM_LIB_KEY)
     const existing: EquipmentTemplate[] = raw ? JSON.parse(raw) : []
-    const byName = new Map(existing.map((t) => [t.name, t]))
+    // #837 — erst den heutigen Namen herstellen, dann abgleichen. Die
+    // Reihenfolge ist der ganze Punkt: wer zuerst abgleicht, findet die alte
+    // deutsche Vorlage nicht unter dem neuen Namen und legt sie ein zweites
+    // Mal an.
+    const byName = new Map(
+      existing.map((t) => {
+        const name = heileVorlagenName(t.name)
+        return [name, { ...t, name }] as const
+      }),
+    )
     let added = false
     for (const t of [...blackmagicTemplates, ...ubiquitiTemplates, ...monitorTemplates, ...cameraTemplates, ...miscTemplates, ...greengoTemplates, ...ajaTemplates, ...rossTemplates, ...lynxTemplates, ...switcherTemplates, ...avNetworkTemplates, ...broadcastToolsTemplates, ...audioTemplates, ...wirelessAudioTemplates, ...micTemplates, ...mediaStationTemplates, ...passiveTemplates]) {
       if (!byName.has(t.name)) {

--- a/src/renderer/types/adapter.ts
+++ b/src/renderer/types/adapter.ts
@@ -55,6 +55,7 @@
 // ───────────────────────────────────────────────────────────────────────────
 import type { ConnectorType } from './equipment'
 import type { SignalStandard } from './cableSpec'
+import { einsetzen, type Platzhalterwerte } from '../lib/platzhalter'
 
 /** In welche Richtung der Adapter wandelt. */
 export type AdapterRichtung =
@@ -192,6 +193,21 @@ export type AdapterUrteilArt =
 
 export interface AdapterUrteil {
   art: AdapterUrteilArt
+  /**
+   * Der Woerterbuch-Schluessel dieses Satzes und die Werte darin.
+   *
+   * Uebersetzt wird NICHT hier: dieses Modul rechnet, und ein `tr()` haenge
+   * sein Ergebnis an die eingestellte Sprache — jeder Test auf einen Satz
+   * waere auf einem deutschen Rechner rot. Ausserdem zoege `lib/i18n.ts` das
+   * Woerterbuch `de.ts` (316 KB) in den Importgraphen jeder Seite, auch in den
+   * der Mobile-Ansicht.
+   *
+   * Wer anzeigt, schreibt `format(tr(u.schluessel, u.text), u.werte)`. Fehlt
+   * der Schluessel, greift `text` — der englische Satz mit bereits
+   * eingesetzten Werten, den `format` unveraendert laesst.
+   */
+  schluessel: string
+  werte: Platzhalterwerte
   /** Der Satz fuer die Anzeige. Bei 'passt' die Bestaetigung, sonst der Grund. */
   text: string
 }
@@ -231,7 +247,12 @@ export const beurteileAdapter = (spec: AdapterSpec, lage: AdapterLage): AdapterU
   if (!vorwaerts && !rueckwaerts) {
     return {
       art: 'passt-nicht',
-      text: `Adapter ${spec.von} ↔ ${spec.nach} passt nicht zwischen ${quelleSteckt ?? '?'} und ${senkeSteckt ?? '?'}.`,
+      schluessel: 'adapter.doesNotFit',
+      werte: { von: spec.von, nach: spec.nach, quelle: quelleSteckt ?? '?', senke: senkeSteckt ?? '?' },
+      text: einsetzen(
+          'The adapter {von} ↔ {nach} does not fit between {quelle} and {senke}.',
+          { von: spec.von, nach: spec.nach, quelle: quelleSteckt ?? '?', senke: senkeSteckt ?? '?' },
+        ),
     }
   }
 
@@ -240,13 +261,23 @@ export const beurteileAdapter = (spec: AdapterSpec, lage: AdapterLage): AdapterU
     if (spec.richtung === 'einweg') {
       return {
         art: 'passt-nicht',
-        text: `Dieser Adapter wandelt nur ${spec.von} nach ${spec.nach}. Hier steckt er umgekehrt und überträgt nichts.`,
+        schluessel: 'adapter.wrongDirection',
+        werte: { von: spec.von, nach: spec.nach },
+        text: einsetzen(
+            'This adapter only converts {von} to {nach}. Here it is plugged in the other way round and carries nothing.',
+            { von: spec.von, nach: spec.nach },
+          ),
       }
     }
     if (spec.richtung === 'unbekannt') {
       return {
         art: 'offen',
-        text: `Hier steckt der Adapter umgekehrt (${spec.nach} nach ${spec.von}). Ob er das kann, ist nicht eingetragen — die Richtung gehört ans Gerät.`,
+        schluessel: 'adapter.directionUnknown',
+        werte: { von: spec.von, nach: spec.nach },
+        text: einsetzen(
+            'Here the adapter is plugged in the other way round ({nach} to {von}). Whether it can do that is not recorded - the direction belongs on the device.',
+            { von: spec.von, nach: spec.nach },
+          ),
       }
     }
   }
@@ -257,13 +288,23 @@ export const beurteileAdapter = (spec: AdapterSpec, lage: AdapterLage): AdapterU
     if (wie === 'oberhalb') {
       return {
         art: 'passt-nicht',
-        text: `Der Adapter lässt höchstens ${spec.hoechsterStandard} durch; hier läuft ${verlangt}.`,
+        schluessel: 'adapter.overStandard',
+        werte: { max: spec.hoechsterStandard ?? '', wanted: verlangt ?? '' },
+        text: einsetzen(
+            'The adapter carries {max} at most; {wanted} runs here.',
+            { max: spec.hoechsterStandard ?? '', wanted: verlangt ?? '' },
+          ),
       }
     }
     if (wie === 'nicht-vergleichbar') {
       return {
         art: 'offen',
-        text: `Der Adapter ist mit ${spec.hoechsterStandard} angegeben, hier läuft ${verlangt} — die beiden sind nicht gegeneinander zu messen.`,
+        schluessel: 'adapter.standardsIncomparable',
+        werte: { max: spec.hoechsterStandard ?? '', wanted: verlangt ?? '' },
+        text: einsetzen(
+            'The adapter is rated for {max}, {wanted} runs here - the two cannot be measured against each other.',
+            { max: spec.hoechsterStandard ?? '', wanted: verlangt ?? '' },
+          ),
       }
     }
   }
@@ -276,7 +317,12 @@ export const beurteileAdapter = (spec: AdapterSpec, lage: AdapterLage): AdapterU
     if (!erklaert) {
       return {
         art: 'offen',
-        text: `Dieser Adapter setzt „${spec.setztVoraus}" an der Quelle voraus. Am Quellgerät ist das nicht eingetragen — ob es das kann, weiss der Plan nicht.`,
+        schluessel: 'adapter.sourceRequirementUnknown',
+        werte: { needs: spec.setztVoraus ?? '' },
+        text: einsetzen(
+            'This adapter requires "{needs}" at the source. That is not recorded on the source device - the plan does not know whether it can.',
+            { needs: spec.setztVoraus ?? '' },
+          ),
       }
     }
   }
@@ -285,13 +331,20 @@ export const beurteileAdapter = (spec: AdapterSpec, lage: AdapterLage): AdapterU
   if (spec.richtung === 'unbekannt') {
     return {
       art: 'offen',
-      text: 'Die Richtung dieses Adapters ist nicht eingetragen. Der Plan sagt deshalb nicht, dass er hier trägt.',
+      schluessel: 'adapter.noDirection',
+      werte: {},
+      text: 'The direction of this adapter is not recorded. The plan therefore does not claim that it carries here.',
     }
   }
 
   return {
     art: 'passt',
-    text: `Adapter ${spec.von} nach ${spec.nach} trägt an dieser Stelle.`,
+    schluessel: 'adapter.fits',
+    werte: { von: spec.von, nach: spec.nach },
+    text: einsetzen('The adapter {von} to {nach} carries at this point.', {
+      von: spec.von,
+      nach: spec.nach,
+    }),
   }
 }
 

--- a/src/renderer/types/cableSpec.ts
+++ b/src/renderer/types/cableSpec.ts
@@ -1,4 +1,5 @@
 import type { ConnectorType } from './equipment'
+import { einsetzen, type Platzhalterwerte } from '../lib/platzhalter'
 
 /**
  * Signal sub-standards for the same physical connector (e.g. 3G vs 12G SDI on BNC).
@@ -777,6 +778,12 @@ export type CompatibilityLevel = 'ok' | 'warn' | 'error'
 export interface CompatibilityResult {
   level: CompatibilityLevel
   message: string
+  /**
+   * Schluessel und Werte dieses Satzes — uebersetzt wird beim Anzeigen, nicht
+   * hier (siehe Kopf von `types/adapter.ts`): `format(tr(b.schluessel, b.message), b.werte)`.
+   */
+  schluessel: string
+  werte: Platzhalterwerte
 }
 
 /**
@@ -797,18 +804,37 @@ export const checkCableCompatibility = (
   if (!fromOk || !toOk) {
     return {
       level: 'error',
-      message: `Cable "${cable.name}" (${cableConnector}) cannot connect ${from} to ${to}.`,
+      schluessel: 'cableSpec.cannotConnect',
+      werte: { cable: cable.name, connector: cableConnector, from, to },
+      message: einsetzen(
+          'Cable "{cable}" ({connector}) cannot connect {from} to {to}.',
+          { cable: cable.name, connector: cableConnector, from, to },
+        ),
     }
   }
 
   if (!connectorsAreDirectlyMating(from, to)) {
     return {
       level: 'warn',
-      message: `${from} and ${to} use similar signalling but need an adapter.`,
+      schluessel: 'cableSpec.needsAdapter',
+      werte: { from, to },
+      message: einsetzen(
+          '{from} and {to} use similar signalling but need an adapter.',
+          { from, to },
+        ),
     }
   }
 
-  return { level: 'ok', message: `${cable.name} matches ${from} ↔ ${to}.` }
+  return {
+    level: 'ok',
+    schluessel: 'cableSpec.matches',
+    werte: { cable: cable.name, from, to },
+    message: einsetzen('{cable} matches {from} ↔ {to}.', {
+      cable: cable.name,
+      from,
+      to,
+    }),
+  }
 }
 
 /**
@@ -821,7 +847,15 @@ export const checkSdiStandardMismatch = (
   const sdi = new Set<SignalStandard>(['SDI-SD', 'SDI-HD', 'SDI-3G', 'SDI-6G', 'SDI-12G'])
   if (!fromStandard || !toStandard) return null
   if (!sdi.has(fromStandard) || !sdi.has(toStandard)) return null
-  if (fromStandard === toStandard) return { level: 'ok', message: `${fromStandard} matched.` }
+  if (fromStandard === toStandard)
+    return {
+      level: 'ok',
+      schluessel: 'cableSpec.standardMatched',
+      werte: { standard: fromStandard },
+      message: einsetzen('{standard} matched.', {
+        standard: fromStandard,
+      }),
+    }
 
   const rank: Record<string, number> = {
     'SDI-SD': 1,
@@ -835,7 +869,12 @@ export const checkSdiStandardMismatch = (
   if (a !== b) {
     return {
       level: 'warn',
-      message: `SDI speed mismatch (${fromStandard} ↔ ${toStandard}). A scaler/converter is required.`,
+      schluessel: 'cableSpec.sdiSpeedMismatch',
+      werte: { from: fromStandard, to: toStandard },
+      message: einsetzen(
+          'SDI speed mismatch ({from} ↔ {to}). A scaler/converter is required.',
+          { from: fromStandard, to: toStandard },
+        ),
     }
   }
   return null
@@ -1011,7 +1050,12 @@ export const checkImpedanceMismatch = (
   if (a == null || b == null || a === b) return null
   return {
     level: 'warn',
-    message: `Impedance mismatch: ${a}Ω ↔ ${b}Ω. Reflections/return loss — use a matching cable/adapter.`,
+    schluessel: 'cableSpec.impedanceMismatch',
+    werte: { a, b },
+    message: einsetzen(
+        'Impedance mismatch: {a}Ω ↔ {b}Ω. Reflections/return loss - use a matching cable/adapter.',
+        { a, b },
+      ),
   }
 }
 
@@ -1063,6 +1107,11 @@ export const checkBalanceMismatch = (
   if (!a || !b || a === b) return null
   return {
     level: 'warn',
-    message: `Balanced ↔ unbalanced transition (${from} ↔ ${to}). Use a DI box / transformer to avoid hum and level loss.`,
+    schluessel: 'cableSpec.balanceMismatch',
+    werte: { from: from ?? '', to: to ?? '' },
+    message: einsetzen(
+        'Balanced ↔ unbalanced transition ({from} ↔ {to}). Use a DI box / transformer to avoid hum and level loss.',
+        { from: from ?? '', to: to ?? '' },
+      ),
   }
 }

--- a/src/renderer/types/checkFinding.ts
+++ b/src/renderer/types/checkFinding.ts
@@ -1,0 +1,39 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Der Befund der Plan-Pruefung — als TYP, ohne Rechenwerk daneben.
+//
+// Er stand bis 2026-09-10 in `lib/drawingChecks.ts`, und das war eine Zeile zu
+// viel Naehe: `labelDerivation.ts` liefert Befunde und holte den Typ von dort.
+// Ein `import type` ist zur Laufzeit nichts — der IMPORTGRAPH kennt den
+// Unterschied aber nicht, und `tests/i18nEintrittspunkte.test.ts` folgt ihm.
+// Ueber `documentRegistry` -> `postHandover` -> `labelDerivation` haette die
+// MOBILE-Ansicht damit `drawingChecks.ts` und darueber `lib/i18n.ts` mit
+// `de.ts` (316 KB) geladen — auf ein Telefon im Hallen-WLAN, fuer einen Typ.
+//
+// Hier steht deshalb nur die Form. Wer rechnet, ist `drawingChecks.ts`; wer
+// beschriftet, ist die Oberflaeche.
+// ───────────────────────────────────────────────────────────────────────────
+import type { Platzhalterwerte } from '../lib/platzhalter'
+
+export type CheckSeverity = 'error' | 'warning' | 'info'
+
+export interface CheckFinding {
+  /** Stabile ID (Check-Typ + betroffenes Element) — als React-key nutzbar. */
+  id: string
+  severity: CheckSeverity
+  /** Kurzer Check-Typ als Gruppen-Label, z.B. "Doppelte IP". */
+  category: string
+  /** Menschlich lesbare Beschreibung des konkreten Fundes. */
+  message: string
+  /**
+   * Schluessel und Werte, wo der Befund aus einem SPRACHFREIEN Modul kommt
+   * (`labelDerivation`, das ueber `postHandover` im Importgraphen der
+   * Mobile-Ansicht liegt und `lib/i18n.ts` deshalb nicht anfassen darf).
+   * `message` traegt dann den englischen Satz mit eingesetzten Werten; wer
+   * uebersetzen kann, ruft `format(tr(f.schluessel, f.message), f.werte)`.
+   */
+  schluessel?: string
+  werte?: Platzhalterwerte
+  /** Klick-Ziel: selektiert dieses Gerät bzw. Kabel auf dem Canvas. */
+  equipmentId?: string
+  cableId?: string
+}

--- a/src/renderer/types/conductor.ts
+++ b/src/renderer/types/conductor.ts
@@ -60,6 +60,8 @@
 // ───────────────────────────────────────────────────────────────────────────
 
 /** Welchen Leiter eine Ader fuehrt. */
+import { einsetzen, type Platzhalterwerte } from '../lib/platzhalter'
+
 export type LeiterRolle = 'L1' | 'L2' | 'L3' | 'N' | 'PE' | 'frei'
 
 export const LEITER_ROLLE_LABEL = {
@@ -173,6 +175,12 @@ export interface AnschlussBefund {
   /** Die betroffene Leitung, wo es eine gibt. */
   cableId?: string
   text: string
+  /**
+   * Schluessel und Werte dieses Satzes — uebersetzt wird beim Anzeigen, nicht
+   * hier (siehe Kopf von `types/adapter.ts`): `format(tr(b.schluessel, b.text), b.werte)`.
+   */
+  schluessel: string
+  werte: Platzhalterwerte
 }
 
 /** Was eine Leitung an das Anschluss meldet. */
@@ -214,7 +222,12 @@ export const anschlussBefunde = (
       befunde.push({
         art: 'ader-fehlt',
         anschlussId: anschluss.id,
-        text: `${anschluss.name}: ${rolle} ist geplant, aber in keiner Leitung dieses Bündels eingetragen.`,
+        schluessel: 'bundle.wireMissing',
+        werte: { name: anschluss.name, role: rolle },
+        text: einsetzen(
+            '{name}: {role} is planned but recorded in no wire of this bundle.',
+            { name: anschluss.name, role: rolle },
+          ),
       })
     }
   }
@@ -226,7 +239,12 @@ export const anschlussBefunde = (
       befunde.push({
         art: 'ader-doppelt',
         anschlussId: anschluss.id,
-        text: `${anschluss.name}: ${rolle} liegt ${anzahl}-mal im Bündel. Welche Leitung gilt?`,
+        schluessel: 'bundle.wireDuplicate',
+        werte: { name: anschluss.name, role: rolle, n: anzahl },
+        text: einsetzen(
+            '{name}: {role} is in the bundle {n} times. Which wire applies?',
+            { name: anschluss.name, role: rolle, n: anzahl },
+          ),
       })
     }
   }
@@ -238,7 +256,12 @@ export const anschlussBefunde = (
         art: 'leitung-stumm',
         anschlussId: anschluss.id,
         cableId: l.cableId,
-        text: `${anschluss.name}: „${l.bezeichnung}" gehört zum Bündel, trägt aber keine Ader-Angabe.`,
+        schluessel: 'bundle.wireMute',
+        werte: { name: anschluss.name, cable: l.bezeichnung },
+        text: einsetzen(
+            '{name}: "{cable}" belongs to the bundle but carries no conductor entry.',
+            { name: anschluss.name, cable: l.bezeichnung },
+          ),
       })
     }
   }
@@ -254,7 +277,26 @@ export const anschlussBefunde = (
             art: 'farbe-widerspricht',
             anschlussId: anschluss.id,
             cableId: l.cableId,
-            text: `${anschluss.name} · „${l.bezeichnung}": ${a.rolle} ist ${a.farbe}, die Norm „${norm.name}" sagt ${ausNorm}. Ohne Grund ist das ein Widerspruch, kein Sonderfall.`,
+            schluessel: 'bundle.colourContradiction',
+            werte: {
+                name: anschluss.name,
+                cable: l.bezeichnung,
+                role: a.rolle,
+                colour: a.farbe,
+                norm: norm.name,
+                expected: ausNorm,
+              },
+            text: einsetzen(
+                '{name} · "{cable}": {role} is {colour}, the standard "{norm}" says {expected}. Without a reason that is a contradiction, not a special case.',
+                {
+                name: anschluss.name,
+                cable: l.bezeichnung,
+                role: a.rolle,
+                colour: a.farbe,
+                norm: norm.name,
+                expected: ausNorm,
+              },
+              ),
           })
         }
       }
@@ -266,7 +308,12 @@ export const anschlussBefunde = (
     befunde.push({
       art: 'norm-offen',
       anschlussId: anschluss.id,
-      text: `${anschluss.name}: keine Farbnorm gewählt — die Adernfarben sind nicht geprüft. Welche Zuordnung für diese Anlage gilt, steht nicht im Programm.`,
+      schluessel: 'bundle.noColourStandard',
+      werte: { name: anschluss.name },
+      text: einsetzen(
+          '{name}: no colour standard chosen - the conductor colours are unchecked. Which mapping applies to this installation is not in the program.',
+          { name: anschluss.name },
+        ),
     })
   }
 

--- a/src/renderer/types/displayCapability.ts
+++ b/src/renderer/types/displayCapability.ts
@@ -48,6 +48,7 @@
 // REIN: keine Uhr, kein Store, kein IO.
 // ───────────────────────────────────────────────────────────────────────────
 import { VIDEO_FORMATS, type VideoFormatId } from './videoFormat'
+import { einsetzen, type Platzhalterwerte } from '../lib/platzhalter'
 
 /** Bits je Farbkanal. */
 export type Farbtiefe = 8 | 10 | 12
@@ -119,6 +120,12 @@ export type BildUrteilArt = 'passt' | 'passt-nicht' | 'offen'
 export interface BildUrteil {
   art: BildUrteilArt
   text: string
+  /**
+   * Schluessel und Werte dieses Satzes — uebersetzt wird beim Anzeigen, nicht
+   * hier (siehe Kopf von `types/adapter.ts`): `format(tr(b.schluessel, b.text), b.werte)`.
+   */
+  schluessel: string
+  werte: Platzhalterwerte
 }
 
 /**
@@ -137,7 +144,12 @@ export const beurteileBild = (
   if (!profil) {
     return {
       art: 'offen',
-      text: `${senkenName}: es ist nicht erklärt, welche Formate dieses Gerät annimmt. Ob ${wunsch.formatId} ankommt, weiss der Plan nicht.`,
+      schluessel: 'display.noProfile',
+      werte: { sink: senkenName, format: wunsch.formatId },
+      text: einsetzen(
+          '{sink}: it is not stated which formats this device accepts. The plan does not know whether {format} arrives.',
+          { sink: senkenName, format: wunsch.formatId },
+        ),
     }
   }
 
@@ -145,7 +157,12 @@ export const beurteileBild = (
   if (!treffer) {
     return {
       art: 'passt-nicht',
-      text: `${senkenName} nimmt ${wunsch.formatId} nicht an — im erklärten Profil steht es nicht (${profil.formate.length} Format(e) erklärt).`,
+      schluessel: 'display.formatRejected',
+      werte: { sink: senkenName, format: wunsch.formatId, n: profil.formate.length },
+      text: einsetzen(
+          '{sink} does not accept {format} - it is not in the stated profile ({n} format(s) stated).',
+          { sink: senkenName, format: wunsch.formatId, n: profil.formate.length },
+        ),
     }
   }
 
@@ -163,7 +180,24 @@ export const beurteileBild = (
     if (!erklaert.includes(gewuenscht)) {
       return {
         art: 'passt-nicht',
-        text: `${senkenName} nimmt ${wunsch.formatId} an, aber nicht mit ${name} ${gewuenscht} — erklärt sind: ${erklaert.join(', ')}.`,
+        schluessel: 'display.propertyRejected',
+        werte: {
+            sink: senkenName,
+            format: wunsch.formatId,
+            property: name,
+            wanted: gewuenscht,
+            stated: erklaert.join(', '),
+          },
+        text: einsetzen(
+            '{sink} accepts {format}, but not with {property} {wanted} - stated are: {stated}.',
+            {
+            sink: senkenName,
+            format: wunsch.formatId,
+            property: name,
+            wanted: gewuenscht,
+            stated: erklaert.join(', '),
+          },
+          ),
       }
     }
   }
@@ -173,12 +207,25 @@ export const beurteileBild = (
     if (erklaert.length === 0) {
       return {
         art: 'offen',
-        text: `${senkenName} nimmt ${wunsch.formatId} an, aber zur ${name} ist nichts erklärt. Ob ${gewuenscht} ankommt, weiss der Plan nicht.`,
+        schluessel: 'display.propertyUnknown',
+        werte: { sink: senkenName, format: wunsch.formatId, property: name, wanted: gewuenscht },
+        text: einsetzen(
+            '{sink} accepts {format}, but nothing is stated about {property}. The plan does not know whether {wanted} arrives.',
+            { sink: senkenName, format: wunsch.formatId, property: name, wanted: gewuenscht },
+          ),
       }
     }
   }
 
-  return { art: 'passt', text: `${senkenName} nimmt ${wunsch.formatId} an.` }
+  return {
+    art: 'passt',
+    schluessel: 'display.accepted',
+    werte: { sink: senkenName, format: wunsch.formatId },
+    text: einsetzen('{sink} accepts {format}.', {
+      sink: senkenName,
+      format: wunsch.formatId,
+    }),
+  }
 }
 
 // ─── SCHEMA-HEILUNG ────────────────────────────────────────────────────────

--- a/tests/edid.test.ts
+++ b/tests/edid.test.ts
@@ -45,7 +45,7 @@ describe('Drei Urteile — und „nicht erklärt" ist keins von beiden anderen',
   it('ohne Profil: offen, nicht passt und nicht passt-nicht', () => {
     const u = beurteileBild(undefined, { formatId: '1080p50' }, 'Monitor 1')
     expect(u.art).toBe('offen')
-    expect(u.text).toContain('nicht erklärt')
+    expect(u.text).toContain('it is not stated')
   })
 
   it('Format im Profil: passt', () => {

--- a/tests/labelDerivation.test.ts
+++ b/tests/labelDerivation.test.ts
@@ -269,7 +269,7 @@ describe('labelTargetIssues', () => {
       ]),
     ]
     const issues = labelTargetIssues({ equipment, cables: [] })
-    const collision = issues.find((i) => i.category === 'ATEM-Namenskollision')
+    const collision = issues.find((i) => i.category === 'ATEM name collision')
     expect(collision?.severity).toBe('error')
     expect(collision?.message).toContain('"Kamera 1"')
     expect(collision?.message).toContain('"Kamera 10"')
@@ -282,7 +282,7 @@ describe('labelTargetIssues', () => {
     // Multiviewer auf.
     const equipment = [atem([port('in1', '1 SDI 3G'), port('in2', '2 SDI 3G')])]
     const issues = labelTargetIssues({ equipment, cables: [] })
-    expect(issues.some((i) => i.category === 'ATEM-Namenskollision')).toBe(true)
+    expect(issues.some((i) => i.category === 'ATEM name collision')).toBe(true)
   })
 
   it('meldet Abschneiden allein NICHT — das ist der Normalfall', () => {
@@ -290,7 +290,7 @@ describe('labelTargetIssues', () => {
       atem([port('in1', 'In 1', { contentLabel: 'Weitwinkel Buehne' })]),
     ]
     const issues = labelTargetIssues({ equipment, cables: [] })
-    expect(issues.some((i) => i.category === 'ATEM-Namenskollision')).toBe(false)
+    expect(issues.some((i) => i.category === 'ATEM name collision')).toBe(false)
   })
 
   it('warnt vor einem Komma im Videohub-Label — es zerlegt die Labels.txt', () => {
@@ -300,7 +300,7 @@ describe('labelTargetIssues', () => {
       inputs: [port('vh-in1', 'In 1', { contentLabel: 'Kamera 1, links' })],
     })
     const issues = labelTargetIssues({ equipment: [vh], cables: [] })
-    const charset = issues.find((i) => i.category === 'Videohub-Zeichensatz')
+    const charset = issues.find((i) => i.category === 'Videohub character set')
     expect(charset?.severity).toBe('warning')
     expect(charset?.message).toContain('","')
   })
@@ -332,7 +332,7 @@ describe('labelTargetIssues — Dante', () => {
       eq({ id: 'b', name: 'pult-regie', ipAddress: '10.0.0.11' }),
     ]
     const issues = labelTargetIssues({ equipment, cables: [] })
-    const collision = issues.find((i) => i.category === 'Dante-Namenskollision')
+    const collision = issues.find((i) => i.category === 'Dante name collision')
     expect(collision?.severity).toBe('error')
     expect(collision?.message).toContain('"Pult Regie"')
   })
@@ -350,7 +350,7 @@ describe('labelTargetIssues — Dante', () => {
     // waere eine Warnung ueber den eigenen Rat.
     const equipment = [eq({ id: 'a', name: 'Pult Bühne 1', ipAddress: '10.0.0.10' })]
     const issues = labelTargetIssues({ equipment, cables: [] })
-    expect(issues.some((i) => i.category === 'Dante-Zeichensatz')).toBe(false)
+    expect(issues.some((i) => i.category === 'Dante character set')).toBe(false)
   })
 })
 
@@ -447,7 +447,7 @@ describe('runDrawingChecks — Verdrahtung', () => {
       ]),
     ]
     const { findings, errorCount } = runDrawingChecks({ equipment, cables: [] })
-    expect(findings.some((f) => f.category === 'ATEM-Namenskollision')).toBe(true)
+    expect(findings.some((f) => f.category === 'ATEM name collision')).toBe(true)
     expect(errorCount).toBeGreaterThan(0)
   })
 })

--- a/tests/passiveTraeger.test.ts
+++ b/tests/passiveTraeger.test.ts
@@ -45,7 +45,7 @@ describe('Formen, keine Produkte', () => {
     const namen = passiveTemplates.map((t) => t.name).join(' | ')
     expect(namen).toMatch(/Patch panel/)
     expect(namen).toMatch(/Feed-through/)
-    expect(namen).toMatch(/Steckdosenleiste/)
+    expect(namen).toMatch(/Power strip/)
     expect(namen).toMatch(/Distro/)
   })
 })

--- a/tests/portsGuessed.test.ts
+++ b/tests/portsGuessed.test.ts
@@ -199,6 +199,6 @@ describe('drawingChecks — die Meldung nennt die aufgezeichnete Quelle', () => 
     eq.specSource = { inputs: { value: '1 In / 0 Out', source: '' } }
     const { findings } = runDrawingChecks({ equipment: [eq], cables: [] })
     const f = findings.find((x) => x.id === 'ports-guessed:e9')
-    expect(f?.message).toContain('ohne Datenblatt')
+    expect(f?.message).toContain('without a data sheet')
   })
 })

--- a/tests/pruefMeldungenGewickelt.test.ts
+++ b/tests/pruefMeldungenGewickelt.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+// ---------------------------------------------------------------------------
+// Eine Meldung ist Oberflaeche, auch wenn sie in `lib/` entsteht (#837).
+//
+// ─── DER BEFUND ────────────────────────────────────────────────────────────
+//
+// `drawingChecks.ts` schrieb seine `message:`-Texte als ROHE Zeichenketten und
+// durchgehend auf Deutsch — in einem Repo, dessen Quellsprache seit E-28 `en`
+// ist. Dieselben Saetze stehen im Plan-Check-Panel UND auf gedruckten
+// Blaettern. Die `category:`-Werte daneben waren laengst englisch
+// (`Open ports`, `Duplicate IP`): wer das Panel oeffnete, las eine englische
+// Spalte neben einem deutschen Satz.
+//
+// `npm run lang:check` meldete dabei 0 Verstoesse, und das war kein Fehler des
+// Waechters, sondern seine Grenze: er liest `t()`-Aufrufe, und das hier waren
+// keine — es waren Daten.
+//
+// ─── WARUM DIESE PRUEFUNG STRUKTURELL IST UND NICHT SPRACHLICH ─────────────
+//
+// Der naheliegende Weg waere, die Meldungen zu klassifizieren. Genau das kann
+// `klassifiziere()` aus `scripts/quellsprache.mjs` hier nicht zuverlaessig,
+// und zwar in BEIDE Richtungen (gemessen 2026-09-10):
+//
+//     'Steckdosenleiste 6-fach'  -> null   (deutsch, nicht erkannt)
+//     'Netzwerk', 'Kameras'      -> null   (deutsch, nicht erkannt)
+//     'Allen & Heath SQ-5'       -> 'de'   (ein Herstellername)
+//     'Jünger Audio DAP8'        -> 'de'   (ein Herstellername)
+//
+// Ein Waechter, der Hersteller meldet und deutsche Produktnamen durchlaesst,
+// wird nach dem zweiten Fehlalarm abgeschaltet statt gelesen. Deshalb fragt
+// dieser Test NICHT nach der Sprache, sondern nach der FORM: steht hinter
+// `message:` / `text:` ein Literal, oder ein Aufruf? Das ist entscheidbar,
+// braucht keine Wortliste und hat keine Fehlalarme.
+//
+// ─── DIE AUSNAHMELISTE IST DER PUNKT, NICHT DER MAKEL ──────────────────────
+//
+// 32 Module tragen heute noch rohe Meldungen. Sie stehen unten mit ihrer
+// gemessenen ANZAHL, und der Test besteht darauf, dass keine davon WAECHST.
+// Eine Liste, die nur „diese Datei ist ausgenommen" sagt, deckt ab morgen auch
+// die naechste neue Meldung darin; eine Liste mit Zahlen deckt genau den
+// Bestand und nichts weiter.
+//
+// Wer eine Datei aufraeumt, zieht ihre Zahl nach unten — der Test verlangt das
+// sogar: eine Zahl ueber dem Ist ist derselbe Deckel wie eine zu hohe
+// MIX_GRENZE und gibt den Platz frei, den der naechste Zuwachs still fuellt.
+// ---------------------------------------------------------------------------
+
+const WURZEL = join(process.cwd(), 'src', 'renderer')
+
+const dateien = (dir: string): string[] =>
+  readdirSync(dir).flatMap((eintrag) => {
+    const voll = join(dir, eintrag)
+    if (statSync(voll).isDirectory()) return dateien(voll)
+    return /\.tsx?$/.test(eintrag) ? [voll] : []
+  })
+
+/**
+ * `message:` oder `text:` mit einem LITERAL dahinter — einfach, doppelt oder
+ * als Template. Ein Zeilenumbruch zwischen Doppelpunkt und Literal zaehlt mit:
+ * der Formatierer bricht lange Zeilen genau dort um, und eine Meldung, die
+ * dem Umbruch entkommt, waere die naechste stille Luecke.
+ */
+const ROHE_MELDUNG = /\b(?:message|text)\s*:\s*(?:\n\s*)?(['"`])/g
+
+/**
+ * Ein Literal ist in Ordnung, wenn im selben Objekt ein `schluessel:` steht.
+ *
+ * Das ist die Form, die `types/adapter.ts` und die anderen Urteils-Module
+ * tragen: der englische Satz IST der Fallback, uebersetzt wird beim Anzeigen
+ * ueber `schluessel` und `werte`. Ohne diese Ausnahme muesste dort ein
+ * `einsetzen('…', {})` ohne Platzhalter stehen — Zierrat, nur damit der Test
+ * schweigt, und ein Test, der zu solchen Zeilen zwingt, wird abgeschaltet.
+ *
+ * Geprueft wird ein Fenster von sechs Zeilen um den Treffer. Objekt-Grenzen
+ * sauber zu bestimmen hiesse, TypeScript zu parsen; das Fenster deckt jede
+ * Form ab, die der Formatierer dieses Repos erzeugt, und ein Literal SECHS
+ * Zeilen von einem fremden `schluessel:` entfernt gibt es hier nicht.
+ */
+const NEBEN_SCHLUESSEL = 6
+
+/** Kommentare raus: sie folgen der Repo-Konvention, nicht der Oberflaeche. */
+const ohneKommentare = (text: string) =>
+  text.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/^\s*\/\/.*$/gm, ' ')
+
+/**
+ * Der gemessene Bestand am 2026-09-10, Datei fuer Datei. Diese Zahlen duerfen
+ * SINKEN und nicht steigen.
+ */
+const BESTAND: Record<string, number> = {
+  'lib/eventMetadata.ts': 11,
+  'lib/circuitSuggest.ts': 11,
+  'lib/transmissionRecord.ts': 10,
+  'lib/bridge.ts': 9,
+  'lib/tallyPosition.ts': 8,
+  'lib/costComparison.ts': 8,
+  'lib/namingScheme.ts': 7,
+  'lib/labourCost.ts': 7,
+  'lib/tallyMap.ts': 6,
+  'lib/multicastPlan.ts': 6,
+  'lib/micAssignment.ts': 6,
+  'lib/graphml/parser.ts': 6,
+  'lib/crewNetworkSheet.ts': 6,
+  'lib/addressTemplate.ts': 6,
+  'lib/textProtocol.ts': 5,
+  'lib/ptpPlan.ts': 5,
+  'lib/networkSegments.ts': 5,
+  'lib/jobHandover.ts': 5,
+  'lib/fallbackPlan.ts': 5,
+  'lib/dantePatch.ts': 5,
+  'lib/spectrumScan.ts': 4,
+  'lib/channelIdentity.ts': 4,
+  'lib/salvoSheet.ts': 3,
+  'lib/rfCoordination.ts': 3,
+  'lib/mvSheet.ts': 3,
+  'lib/clientSummary.ts': 3,
+  'lib/templateScope.ts': 2,
+  'lib/exportPdf.ts': 2,
+  'lib/receiptRead.ts': 1,
+  'lib/portLabel.ts': 1,
+  'lib/patternSharePlan.ts': 1,
+  'lib/exportGreengo.ts': 1,
+}
+
+/**
+ * Die Module, die mit #837 gewickelt wurden. Sie stehen NICHT im Bestand: fuer
+ * sie gilt null, und der Test sagt das ausdruecklich noch einmal. Ohne diese
+ * Liste waere ein Rueckfall dort nur „eine Datei mehr im Bestand" — hier ist
+ * er ein benannter Rueckschritt.
+ */
+const GEWICKELT = [
+  'lib/drawingChecks.ts',
+  'lib/labelDerivation.ts',
+  'lib/exportPdfVector.ts',
+  'types/cableSpec.ts',
+  'types/adapter.ts',
+  'types/conductor.ts',
+  'types/displayCapability.ts',
+]
+
+const zaehle = (): Map<string, number> => {
+  const treffer = new Map<string, number>()
+  for (const datei of dateien(WURZEL)) {
+    const rel = relative(WURZEL, datei).split('\\').join('/')
+    if (!rel.startsWith('lib/') && !rel.startsWith('types/')) continue
+    // Das Woerterbuch IST eine Sammlung von Literalen — das ist sein Zweck.
+    if (rel.includes('i18n')) continue
+    const quelle = ohneKommentare(readFileSync(datei, 'utf8'))
+    const zeilen = quelle.split('\n')
+    let n = 0
+    for (const m of quelle.matchAll(ROHE_MELDUNG)) {
+      const zeile = quelle.slice(0, m.index).split('\n').length - 1
+      const fenster = zeilen
+        .slice(Math.max(0, zeile - NEBEN_SCHLUESSEL), zeile + NEBEN_SCHLUESSEL)
+        .join('\n')
+      if (/\bschluessel:/.test(fenster)) continue
+      n += 1
+    }
+    if (n > 0) treffer.set(rel, n)
+  }
+  return treffer
+}
+
+describe('Meldungen aus lib/ und types/ sind gewickelt', () => {
+  it('kein Modul traegt mehr rohe Meldungen als der eingefrorene Bestand', () => {
+    const ist = zaehle()
+    const zuwachs: string[] = []
+    for (const [datei, n] of ist) {
+      const erlaubt = BESTAND[datei] ?? 0
+      if (n > erlaubt) zuwachs.push(`${datei}: ${n} statt ${erlaubt}`)
+    }
+    expect(
+      zuwachs,
+      'Neue rohe `message:`/`text:`-Literale in lib/ oder types/. Sie erscheinen ' +
+        'im Plan-Check-Panel UND auf gedruckten Blaettern — der Sprach-Waechter ' +
+        'sieht sie nicht, weil sie keine `t()`-Aufrufe sind. Entweder ueber ' +
+        '`tr(key, en)` wickeln (siehe drawingChecks.ts) oder, wenn es wirklich ' +
+        'kein Oberflaechen-Text ist, die Zahl unten mit Begruendung anheben.',
+    ).toEqual([])
+  })
+
+  it('die gewickelten Module bleiben gewickelt', () => {
+    const ist = zaehle()
+    const rueckfall = GEWICKELT.filter((d) => (ist.get(d) ?? 0) > 0).map(
+      (d) => `${d}: ${ist.get(d)}`,
+    )
+    expect(
+      rueckfall,
+      'Ein mit #837 gewickeltes Modul traegt wieder rohe Meldungen. Das ist kein ' +
+        'Zuwachs im Bestand, sondern ein Rueckschritt an einer Stelle, die schon ' +
+        'einmal durchgegangen wurde.',
+    ).toEqual([])
+  })
+
+  it('der Bestand ist nicht ueber dem Ist — sonst deckt er kuenftigen Zuwachs', () => {
+    const ist = zaehle()
+    const zuHoch: string[] = []
+    for (const [datei, erlaubt] of Object.entries(BESTAND)) {
+      const n = ist.get(datei) ?? 0
+      if (n < erlaubt) zuHoch.push(`${datei}: gemessen ${n}, eingetragen ${erlaubt}`)
+    }
+    expect(
+      zuHoch,
+      'Eine Bestandszahl liegt ueber dem gemessenen Ist. Das ist derselbe Deckel ' +
+        'wie eine zu hohe MIX_GRENZE: wer aufraeumt und die Zahl stehen laesst, ' +
+        'gibt den Platz frei, den der naechste Zuwachs still fuellt. Zahl auf den ' +
+        'neuen Wert setzen (oder den Eintrag loeschen, wenn er auf 0 ist).',
+    ).toEqual([])
+  })
+
+  it('die Pruefung sieht ueberhaupt etwas — Gegenprobe zum Muster', () => {
+    // Ohne sie waere ein kaputtes Muster die gefaehrlichste Art gruen: es
+    // findet nichts, und Nichts sieht hier aus wie ein Ergebnis.
+    const gesamt = [...zaehle().values()].reduce((a, b) => a + b, 0)
+    expect(gesamt).toBeGreaterThan(100)
+  })
+})

--- a/tests/vorlagenUmbenennung.test.ts
+++ b/tests/vorlagenUmbenennung.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { LEGACY_TEMPLATE_RENAMES, heileVorlagenName } from '../src/renderer/lib/templateRenames'
+import { passiveTemplates } from '../src/renderer/lib/passiveCatalog'
+import { STORAGE_KEYS } from '../src/renderer/lib/storageKeys'
+
+// ---------------------------------------------------------------------------
+// Der Name einer ausgelieferten Vorlage IST ihre Kennung (#837).
+//
+// Drei Vorlagen aus `passiveCatalog.ts` trugen deutsche Namen in einem Repo mit
+// Quellsprache `en`. Sie umzubenennen ist die eine Haelfte; die andere ist die
+// Migration, und ohne sie waere das Umbenennen ein SCHADEN statt einer
+// Korrektur:
+//
+//   `projectStore.seedBuiltInLibrary` gleicht die mitgelieferten Vorlagen ueber
+//   `byName` gegen die Bibliothek des Nutzers ab. Steht dort die alte deutsche
+//   Vorlage, findet der Abgleich den neuen englischen Namen nicht — und legt
+//   ihn ZUSAETZLICH an. Dasselbe Geraet zweimal in der Seitenleiste, und der
+//   Nutzer muesste raten, welche seine Plaene benutzen.
+//
+// Dieselbe Bauform wie `LEGACY_CATEGORY_RENAMES` (#822/#835) und
+// `LEGACY_CONNECTOR_RENAMES` (#832) — und derselbe Test wie dort: kein
+// AUSGELIEFERTER Name darf ein SCHLUESSEL der Tabelle sein. Das ist
+// entscheidbar, vollstaendig und braucht keine Wortliste: ein Name, der noch
+// umbenannt wird, ist per Definition ein alter.
+// ---------------------------------------------------------------------------
+
+describe('Die Umbenennungstabelle der Vorlagen', () => {
+  it('bildet jeden alten Namen auf einen neuen ab, der nicht selbst alt ist', () => {
+    for (const [alt, neu] of Object.entries(LEGACY_TEMPLATE_RENAMES)) {
+      expect(alt).not.toBe(neu)
+      expect(
+        LEGACY_TEMPLATE_RENAMES[neu],
+        `"${alt}" -> "${neu}", aber "${neu}" wird selbst noch umbenannt — ` +
+          'eine Kette, die nach einem Durchlauf noch nicht fertig ist.',
+      ).toBeUndefined()
+    }
+  })
+
+  it('kein ausgelieferter Vorlagen-Name steht als ALTER Name in der Tabelle', () => {
+    // Die Zusicherung, die keine Sprachkenntnis braucht: was heute
+    // ausgeliefert wird, darf nicht gleichzeitig etwas sein, das noch
+    // umbenannt wird. Wer eine Vorlage umbenennt und den Eintrag vergisst,
+    // faellt hier durch — nicht erst, wenn jemand zwei gleiche Eintraege in
+    // der Seitenleiste meldet.
+    const ausgeliefert = passiveTemplates.map((t) => t.name)
+    const veraltet = ausgeliefert.filter((n) => n in LEGACY_TEMPLATE_RENAMES)
+    expect(
+      veraltet,
+      'Diese ausgelieferten Vorlagen tragen einen Namen, den die Tabelle als ' +
+        'ALT fuehrt. Entweder den Katalog auf den neuen Namen ziehen oder den ' +
+        'Eintrag entfernen.',
+    ).toEqual([])
+  })
+
+  it('laesst einen unbekannten Namen unveraendert', () => {
+    expect(heileVorlagenName('Eigene Patchblende 3HE')).toBe('Eigene Patchblende 3HE')
+  })
+
+  it('zieht die drei umbenannten Leisten auf ihren heutigen Namen', () => {
+    expect(heileVorlagenName('Steckdosenleiste 6-fach')).toBe('Power strip 6-way')
+    expect(heileVorlagenName('Steckdosenleiste 8-fach')).toBe('Power strip 8-way')
+    expect(heileVorlagenName('IEC-Leiste 8-fach')).toBe('IEC strip 8-way')
+  })
+})
+
+describe('Die Bibliothek des Nutzers ueberlebt die Umbenennung', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('legt die umbenannte Vorlage nicht ein zweites Mal an', async () => {
+    // Die Lage, um die es geht: der Nutzer hat die App vor der Umbenennung
+    // benutzt, seine Bibliothek traegt den deutschen Namen — und dazu eine
+    // eigene Aenderung (hier: eine Notiz), die nicht verlorengehen darf.
+    const alt = {
+      ...passiveTemplates.find((t) => t.name === 'Power strip 6-way')!,
+      name: 'Steckdosenleiste 6-fach',
+      notes: 'meine eigene Notiz',
+    }
+    localStorage.setItem(STORAGE_KEYS.customLibrary, JSON.stringify([alt]))
+
+    const { loadCustomLibrary } = await import('../src/renderer/store/libraryPersist')
+    const geladen = loadCustomLibrary()
+
+    const treffer = geladen.filter((t) => t.name === 'Power strip 6-way')
+    expect(treffer, 'genau eine Vorlage, nicht zwei').toHaveLength(1)
+    expect(treffer[0].notes, 'die eigene Aenderung bleibt').toBe('meine eigene Notiz')
+    expect(geladen.some((t) => t.name === 'Steckdosenleiste 6-fach')).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #837

## Der Befund

Die Meldungen des Plan-Checks standen als **rohe deutsche Zeichenketten** in `lib/` und `types/` — in einem Repo, dessen Quellsprache seit E-28 `en` ist. Sie erscheinen im Plan-Check-Panel **und** auf gedruckten Blättern, und die `category:`-Spalte daneben war längst englisch: wer das Panel öffnete, las eine englische Überschrift neben einem deutschen Satz.

`npm run lang:check` meldete dabei 0 Verstöße. Das war kein Fehler des Wächters, sondern seine Grenze — er liest `t()`-Aufrufe, und das hier waren Daten.

## Was gewickelt wurde

| Datei | was |
|---|---|
| `lib/drawingChecks.ts` | alle 33 Meldungen der Plan-Prüfung |
| `types/adapter.ts`, `types/conductor.ts`, `types/displayCapability.ts`, `types/cableSpec.ts` | die Urteile, die drawingChecks in seine Sätze einsetzt |
| `lib/labelDerivation.ts` | Namenskollisionen an ATEM, Videohub, Dante |
| `lib/exportPdfVector.ts` | vier Fehlermeldungen + sieben Fortschritts-Texte |
| `lib/i18n/de.ts` | 80 neue deutsche Einträge |

Die vier Fehlermeldungen im PDF-Export sah der Wächter nicht, **obwohl sie in `translate(...)` standen**: `fallbackMuster` erkennt die Form nur, wenn das erste Argument ein *Bezeichner* ist, und dort stand `useUiStore.getState().language`. Der deutsche Fallback „Canvas nicht gefunden" ist so durch die ganze Sprachdrehung E-28 gegangen.

## Zwei Entscheidungen, die größer sind als die Übersetzung

### Die Urteils-Module übersetzen NICHT selbst

Der erste Versuch tat es, und `tests/i18nEintrittspunkte.test.ts` wurde rot — zu Recht: ein Typ-Modul liegt im Importgraphen **jeder** Seite, auch der Mobile-Ansicht, und `lib/i18n.ts` zieht `de.ts` (316 KB) nach. Auf ein Telefon im Hallen-WLAN, für einen Satz.

Jedes Urteil trägt deshalb `schluessel` und `werte`; wer anzeigt, ruft `format(tr(u.schluessel, u.text), u.werte)`. Fällt der Schlüssel aus, greift `u.text` — der englische Satz mit eingesetzten Werten, den `format` dann unverändert lässt. **Der englische Quelltext steht damit genau einmal.**

Zweitens hänge ein `tr()` im Rechenmodul sein Ergebnis an die eingestellte Sprache: jeder Test, der auf einen Satz prüft, wäre auf einem deutschen Rechner rot. Dieselbe Begründung, aus der `checkCategoryLabel.ts` seit #822 die Kategorien übersetzt und `drawingChecks.ts` sie nur führt.

### `CheckFinding` zieht nach `types/checkFinding.ts`

`labelDerivation` holte den Typ aus `drawingChecks`, und ein `import type` ist zur Laufzeit nichts — der Importgraph kennt den Unterschied aber nicht. Über `documentRegistry` → `postHandover` → `labelDerivation` hätte die Mobile-Ansicht so das ganze Wörterbuch geladen, für einen Typ.

## Ausgelieferte Namen

`Steckdosenleiste 6-fach`, `Steckdosenleiste 8-fach`, `IEC-Leiste 8-fach` → `Power strip 6-way`, `Power strip 8-way`, `IEC strip 8-way`; die Port-Namen der Fabrikfunktionen (`Einspeisung`, `Abgang`, `Rückseite`, `Frontseite`) ebenso; bei den Projekt-Vorlagen `Ü-Wagen / OB-Van` und `Live-Bühne`.

**Umbenennen allein wäre hier ein Schaden gewesen: der Name IST die Kennung.** `seedBuiltInLibrary` gleicht über `byName` ab und hätte die alte deutsche Vorlage nicht wiedererkannt — dasselbe Gerät zweimal in der Seitenleiste. `lib/templateRenames.ts` trägt die Tabelle alt → neu, angewandt in `loadCustomLibrary` und in der Seed-Stufe (dort **vor** dem Abgleich, sonst hilft sie nicht). Dieselbe Bauform wie `LEGACY_CATEGORY_RENAMES` (#822/#835) und `LEGACY_CONNECTOR_RENAMES` (#832).

Die Port-Namen **bestehender** Geräte bleiben unberührt: sie sind vom Nutzer änderbar, und eine Migration würde eine eigene Beschriftung überschreiben.

## Der Wächter, der das hält

`tests/pruefMeldungenGewickelt.test.ts` fragt nicht nach der **Sprache**, sondern nach der **Form**: steht hinter `message:`/`text:` ein Literal oder ein Aufruf? Das ist entscheidbar und hat keine Fehlalarme — anders als `klassifiziere()`, das hier in beide Richtungen unzuverlässig ist (es meldet „Allen & Heath SQ-5" als deutsch und lässt „Steckdosenleiste 6-fach" durch).

32 Module tragen noch rohe Meldungen. Sie stehen mit ihrer gemessenen **Anzahl** im Test, und keine darf wachsen; eine Zahl *über* dem Ist fällt ebenfalls durch, sonst wäre sie ein Deckel für den nächsten Zuwachs.

## Nebenbei

`tr(key, en)` wird aus `lib/i18n.ts` exportiert statt in vier Modulen mit denselben zwei Zeilen nachgebaut, und `format` steht als `einsetzen` in `lib/platzhalter.ts` — vorher zweimal, in `i18n.ts` und `i18nLite.ts`. Die Trennung der beiden Werke bleibt: `platzhalter.ts` hat keine Importe und zieht kein Wörterbuch nach.

## Prüfung

`lang:check` (Sprachmix 0 über renderer/mobile/viewer, **1347** englische Fallbacks statt 1303), **3981 Tests**, `tsc -p tsconfig.app.json --noEmit`, `lint` (0 Fehler), `build`, `actions:check`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_