### PR TITLE
feat(check): Port-Gruppen im Plan-Check, getippte Port-Namen bleiben (#838)

### DIFF
--- a/src/renderer/components/Properties/PortList.tsx
+++ b/src/renderer/components/Properties/PortList.tsx
@@ -30,6 +30,7 @@ import { effectivePortNumber, findDuplicatePortNumbers } from '../../lib/portNum
 import { format, useTranslation } from '../../lib/i18n'
 import { Icon } from '../shared/Icon'
 import { PORT_GROUP_INFO, gruppenBefunde, naechsteGruppenId, portGruppen } from '../../lib/portGroups'
+import { vorschlagBeiVorgabename } from '../../lib/portDefaultName'
 
 /**
  * #306 — PortList + SortablePortItem + makePort aus EquipmentProperties
@@ -191,17 +192,12 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
   // ein passender Name vorgeschlagen (z.B. "SDI 1" statt "Input 1").
   // Hat der User schon einen Custom-Namen vergeben, wird er nicht
   // überschrieben.
-  const DEFAULT_NAME_PATTERN = /^(input|output|in|out)\s*\d*$/i
-  const isDefaultName = (name: string): boolean =>
-    DEFAULT_NAME_PATTERN.test(name.trim())
-  const renameIfDefault = (portId: string, prefix: string) => {
-    const port = ports.find((p) => p.id === portId)
-    if (!port || !isDefaultName(port.name)) return null
-    // Index aus dem aktuellen Default-Namen ziehen, sonst Index im Array.
-    const numMatch = port.name.match(/\d+/)
-    const idx = numMatch ? numMatch[0] : String(ports.indexOf(port) + 1)
-    return `${prefix} ${idx}`.trim()
-  }
+  // #838 — Die Regel steht jetzt in `lib/portDefaultName.ts`. Sie stand hier
+  // als Closure und war damit von keinem Test erreichbar — bei einer
+  // Entscheidung, die einem Nutzer seinen getippten Namen nehmen kann, ist
+  // das die falsche Stelle.
+  const renameIfDefault = (portId: string, prefix: string) =>
+    vorschlagBeiVorgabename(ports, portId, prefix)
 
   const updatePort = (portId: string, patch: Partial<Port>) => {
     // v7.9.63 / #175 — Auto-Rename ankoppeln. Wenn der User connectorType
@@ -527,30 +523,14 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
           key={`${f.art}:${f.gruppe}:${i}`}
           className="mb-2 rounded border border-amber-700 bg-amber-950/40 px-2 py-1 text-cp-xs text-amber-200"
         >
-          {f.art === 'groesse' &&
-            format(
-              t(
-                'ports.group.sizeMismatch',
-                'Group "{group}": {is} of {expected} ports — the group says one connector, the plan shows another number.',
-              ),
-              { group: f.gruppe, is: String(f.ist), expected: String(f.erwartet) },
-            )}
-          {f.art === 'artenmix' &&
-            format(
-              t(
-                'ports.group.kindMismatch',
-                'Group "{group}" is declared as {kinds} at the same time — only one of them can be true.',
-              ),
-              { group: f.gruppe, kinds: f.arten.join(' / ') },
-            )}
-          {f.art === 'rolle-doppelt' &&
-            format(
-              t(
-                'ports.group.roleTwice',
-                'Group "{group}" has "{role}" twice — two left channels are not a stereo pair.',
-              ),
-              { group: f.gruppe, role: f.rolle },
-            )}
+          {/*
+            #838 — EIN Satz, zwei Anzeigen. Er stand bis hierher dreimal als
+            `t(key, en)` in diesem JSX; der Plan-Check haette ihn ein viertes
+            Mal formuliert. Jetzt kommt er aus `portGroups.ts` und traegt
+            Schluessel, englischen Text und Werte mit sich — uebersetzt wird
+            dort, wo jemand hinsieht.
+          */}
+          {format(t(f.schluessel, f.text), f.werte)}
         </div>
       ))}
       <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
@@ -576,7 +556,19 @@ export const PortList = ({ title, ports, onChange, hideTitle, showAtemSourceId }
               />
               <input
                 value={port.name}
-                onChange={(event) => updatePort(port.id, { name: event.target.value })}
+                onChange={(event) => {
+                  // #838 — Ein Name, den jemand tippt, ist ab hier seiner.
+                  //
+                  // Ein LEERES Feld setzt das Merkmal NICHT: wer alles
+                  // loescht, hat keinen Namen gewaehlt, sondern den alten
+                  // weggenommen — und stuende sonst mit einem geschuetzten
+                  // leeren Port da, den die Automatik nie wieder fuellt.
+                  const name = event.target.value
+                  updatePort(port.id, {
+                    name,
+                    ...(name.trim() ? { nameFromUser: true } : {}),
+                  })
+                }}
                 placeholder={t('ports.namePlaceholder', 'Port name')}
                 className="flex-1 rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
               />

--- a/src/renderer/lib/drawingChecks.ts
+++ b/src/renderer/lib/drawingChecks.ts
@@ -25,6 +25,7 @@ import { labelTargetIssues } from './labelDerivation'
 import { beurteileAdapter } from '../types/adapter'
 import { anschlussBefunde, type AnschlussLeitung } from '../types/conductor'
 import { beurteileBild } from '../types/displayCapability'
+import { gruppenBefunde } from './portGroups'
 import { tr, format } from './i18n'
 export type { CheckSeverity, CheckFinding } from '../types/checkFinding'
 import type { CheckSeverity, CheckFinding } from '../types/checkFinding'
@@ -1006,6 +1007,43 @@ export const runDrawingChecks = (
       equipmentId: senke.id,
       cableId: c.id,
     })
+  }
+
+  // — Check 24: Port-Gruppen, die sich widersprechen (#838) ------------------
+  //
+  // Der Rechner steht seit #832 in `lib/portGroups.ts` und meldete bis hierher
+  // NUR in die Eigenschaften-Leiste. Das ist die wichtigere Haelfte — wer eine
+  // halb markierte Stereo-Gruppe beim Eintragen sieht, korrigiert sie sofort.
+  // Sie erwischt aber nicht den Fall, der zaehlt: EINE GRUPPE, DIE VOR WOCHEN
+  // HALB ANGELEGT WURDE UND DEREN GERAET NIEMAND MEHR OEFFNET. Ein
+  // Powerlock-Satz ohne PE (`erwartet 5, ist 4`) ist genau so einer, und er
+  // gehoert auf das Blatt.
+  //
+  // JEDE SEITE FUER SICH. Eine Gruppe ueber Ein- und Ausgaenge hinweg waere
+  // kein Anschluss, sondern eine Durchschleife — dasselbe Argument wie in
+  // `portGruppen()` selbst, und es steht hier in der Aufrufform: zwei Laeufe,
+  // kein zusammengeschuetteter Array.
+  //
+  // DER SATZ KOMMT AUS DEM RECHNER, nicht von hier. Der Geraetename steht
+  // davor und nicht darin — genau wie bei Check 2 die Kabelnummer. So gibt es
+  // ihn einmal statt einmal je Anzeige, und `Eingaenge`/`Ausgaenge` bleiben
+  // Kennungen der Seite statt Satzteile, die eine Uebersetzung umstellen
+  // muesste.
+  for (const e of equipment) {
+    for (const seite of ['inputs', 'outputs'] as const) {
+      const vorsatz = `${e.name} · ${seite === 'inputs' ? 'IN' : 'OUT'} · `
+      for (const b of gruppenBefunde(e[seite])) {
+        findings.push({
+          id: `port-group-${b.art}:${e.id}:${seite}:${b.gruppe}${
+            b.art === 'rolle-doppelt' ? `:${b.rolle}` : ''
+          }`,
+          severity: 'warning',
+          category: 'Port group',
+          message: vorsatz + format(tr(b.schluessel, b.text), b.werte),
+          equipmentId: e.id,
+        })
+      }
+    }
   }
 
   // Sortierung: error → warning → info, innerhalb stabil nach category.

--- a/src/renderer/lib/i18n/de.ts
+++ b/src/renderer/lib/i18n/de.ts
@@ -1499,6 +1499,7 @@ export const de: Dict = {
   'check.category.single-power': 'Single-Power',
   'check.category.sync-genlock': 'Sync / Genlock',
   'check.category.sync-ptp': 'Sync / PTP',
+  'check.category.port-group': 'Port-Gruppe',
   'check.category.tally': 'Tally',
   'check.category.timecode': 'Timecode',
   'check.category.video-format': 'Bildformat',

--- a/src/renderer/lib/portDefaultName.ts
+++ b/src/renderer/lib/portDefaultName.ts
@@ -1,0 +1,66 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Wem der Name eines Ports gehoert (#175, #838).
+//
+// ─── DIE REGEL AUS #175, UNVERAENDERT ──────────────────────────────────────
+//
+// Wechselt am Port der Steckertyp oder der Standard und traegt er noch einen
+// VORGABENAMEN (`Input 1`, `In 3`, `Out 4`), dann wird er mit umbenannt: aus
+// `Input 1` wird `SDI 1`. Das erspart das Umbenennen bei jedem Typwechsel und
+// ist ausdruecklich gewollt.
+//
+// ─── WAS #838 DARAN AENDERT, UND WARUM ES NICHT DIE REGEL IST ──────────────
+//
+// Ihr Preis faellt an genau einer Stelle an: WER EINEN PORT BEWUSST `In 5`
+// NENNT, IST VON EINEM VORGABENAMEN NICHT ZU UNTERSCHEIDEN — der Name passt
+// auf das Muster, und beim naechsten Steckertyp-Wechsel ist er weg.
+//
+// Die Loesung ist nicht „Regel weg" (dann kaeme das Umbenennen bei jedem
+// Typwechsel zurueck, und das war die Beschwerde, aus der #175 entstand),
+// sondern die fehlende Angabe: `port.nameFromUser`. Gesetzt, sobald jemand
+// das Namensfeld anfasst; hier wird es gefragt, bevor zugegriffen wird.
+//
+// ─── WARUM DAS EIN MODUL IST UND KEINE ZWEI ZEILEN IN DER KOMPONENTE ───────
+//
+// Weil es genau dort stand — als Closure in `PortList.tsx`, unerreichbar fuer
+// jeden Test. Eine Entscheidung, die einem Nutzer seine Eingabe nehmen kann,
+// gehoert an eine Stelle, an der man sie befragen kann.
+// ───────────────────────────────────────────────────────────────────────────
+import type { Port } from '../types/equipment'
+
+/**
+ * Namen, die von uns stammen koennten: `Input`, `Output`, `In`, `Out`,
+ * wahlweise mit Nummer.
+ *
+ * KOENNTEN — das Muster sagt nicht, wer sie geschrieben hat. Genau diese
+ * Luecke schliesst `nameFromUser`.
+ */
+const VORGABE_MUSTER = /^(input|output|in|out)\s*\d*$/i
+
+export const istVorgabename = (name: string): boolean =>
+  VORGABE_MUSTER.test(name.trim())
+
+/**
+ * Der Name, auf den dieser Port beim Typwechsel gehen soll — oder `null`,
+ * wenn er seinen behalten muss.
+ *
+ * `null` in drei Faellen, und die Reihenfolge ist der Punkt:
+ *   1. den Port gibt es nicht
+ *   2. sein Name kommt vom Nutzer  (#838)
+ *   3. sein Name ist kein Vorgabename
+ */
+export const vorschlagBeiVorgabename = (
+  ports: readonly Port[],
+  portId: string,
+  praefix: string,
+): string | null => {
+  const port = ports.find((p) => p.id === portId)
+  if (!port) return null
+  if (port.nameFromUser) return null
+  if (!istVorgabename(port.name)) return null
+  // Nummer aus dem heutigen Vorgabenamen ziehen, sonst die Position in der
+  // Liste. `Input 3` wird zu `SDI 3` und nicht zu `SDI 1`, nur weil der Port
+  // vorne steht.
+  const nummer = port.name.match(/\d+/)
+  const idx = nummer ? nummer[0] : String(ports.indexOf(port) + 1)
+  return `${praefix} ${idx}`.trim()
+}

--- a/src/renderer/lib/portGroups.ts
+++ b/src/renderer/lib/portGroups.ts
@@ -19,6 +19,7 @@
 // dasselbe meinen, laufen auseinander.
 // ───────────────────────────────────────────────────────────────────────────
 import type { Port, PortGroupKind } from '../types/equipment'
+import { einsetzen, type Platzhalterwerte } from './platzhalter'
 
 /**
  * Wie viele Ports eine Gruppe dieser Art hat — und welche Rollen sie kennt.
@@ -74,10 +75,38 @@ export const portGruppen = (ports: readonly Port[]): PortGruppe[] => {
   return [...nachId.values()]
 }
 
-export type GruppenBefund =
-  | { art: 'groesse'; gruppe: string; erwartet: number; ist: number }
-  | { art: 'artenmix'; gruppe: string; arten: PortGroupKind[] }
-  | { art: 'rolle-doppelt'; gruppe: string; rolle: string }
+/**
+ * Der Satz zum Befund — sprachfrei, wie in `types/adapter.ts` und den anderen
+ * Urteils-Modulen seit #837.
+ *
+ * WARUM DAS MODUL NICHT SELBST UEBERSETZT: es wird an ZWEI Stellen gelesen —
+ * in der Eigenschaften-Leiste, wo `t()` aus dem Hook kommt, und im Plan-Check
+ * auf dem gedruckten Blatt. Ein `tr()` hier drin haette beide an die
+ * eingestellte Sprache gehaengt und jeden Test, der den Text prueft, auf einem
+ * deutschen Rechner rot gemacht — dasselbe Argument wie in
+ * `lib/checkCategoryLabel.ts`.
+ *
+ * ES IST AUCH DER GRUND, WARUM ES NUR EINE FASSUNG DES SATZES GIBT. Vorher
+ * stand er in `PortList.tsx` und sonst nirgends; der Plan-Check haette ihn
+ * zwangslaeufig ein zweites Mal formuliert, und zwei Fassungen desselben
+ * Befundes waeren beim naechsten Umbau auseinandergelaufen.
+ */
+export interface GruppenSatz {
+  /** Woerterbuch-Schluessel. */
+  schluessel: string
+  /** Der englische Satz mit eingesetzten Werten — Quelle und Fallback. */
+  text: string
+  /** Die Werte einzeln, damit die Uebersetzung sie neu einsetzen kann. */
+  werte: Platzhalterwerte
+}
+
+export type GruppenBefund = GruppenSatz &
+  (
+    | { art: 'groesse'; gruppe: string; erwartet: number; ist: number }
+    | { art: 'artenmix'; gruppe: string; arten: PortGroupKind[] }
+    | { art: 'rolle-doppelt'; gruppe: string; rolle: string }
+  )
+
 
 /**
  * Was an den Gruppen NICHT stimmen kann.
@@ -96,18 +125,56 @@ export const gruppenBefunde = (ports: readonly Port[]): GruppenBefund[] => {
   const befunde: GruppenBefund[] = []
   for (const g of portGruppen(ports)) {
     const arten = [...new Set(g.ports.map((p) => p.portGroupKind).filter(Boolean))] as PortGroupKind[]
-    if (arten.length > 1) befunde.push({ art: 'artenmix', gruppe: g.id, arten })
+    if (arten.length > 1) {
+      const werte = { group: g.id, kinds: arten.join(' / ') }
+      befunde.push({
+        art: 'artenmix',
+        gruppe: g.id,
+        arten,
+        schluessel: 'ports.group.kindMismatch',
+        text: einsetzen(
+          'Group "{group}" is declared as {kinds} at the same time — only one of them can be true.',
+          werte,
+        ),
+        werte,
+      })
+    }
 
     const erwartet = g.art ? PORT_GROUP_INFO[g.art].groesse : undefined
     if (erwartet !== undefined && g.ports.length !== erwartet) {
-      befunde.push({ art: 'groesse', gruppe: g.id, erwartet, ist: g.ports.length })
+      const werte = { group: g.id, is: g.ports.length, expected: erwartet }
+      befunde.push({
+        art: 'groesse',
+        gruppe: g.id,
+        erwartet,
+        ist: g.ports.length,
+        schluessel: 'ports.group.sizeMismatch',
+        text: einsetzen(
+          'Group "{group}": {is} of {expected} ports — the group says one connector, the plan shows another number.',
+          werte,
+        ),
+        werte,
+      })
     }
 
     const gesehen = new Set<string>()
     for (const p of g.ports) {
       const r = p.portGroupRole?.trim()
       if (!r) continue
-      if (gesehen.has(r)) befunde.push({ art: 'rolle-doppelt', gruppe: g.id, rolle: r })
+      if (gesehen.has(r)) {
+        const werte = { group: g.id, role: r }
+        befunde.push({
+          art: 'rolle-doppelt',
+          gruppe: g.id,
+          rolle: r,
+          schluessel: 'ports.group.roleTwice',
+          text: einsetzen(
+            'Group "{group}" has "{role}" twice — two left channels are not a stereo pair.',
+            werte,
+          ),
+          werte,
+        })
+      }
       gesehen.add(r)
     }
   }

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -288,6 +288,37 @@ export interface Port {
    *  `+`, `-`. Leer heisst „nicht gesagt" und ist erlaubt: eine Gruppe zu
    *  benennen ist schon eine Angabe, auch ohne die Rollen. */
   portGroupRole?: string
+  /**
+   * #838 — Dieser Name kommt vom Nutzer und wird nicht ueberschrieben.
+   *
+   * ─── WOGEGEN ER SCHUETZT ─────────────────────────────────────────────────
+   *
+   * `PortList.renameIfDefault` benennt einen Port um, sobald Steckertyp oder
+   * Standard wechseln UND der Name noch dem Vorgabe-Muster entspricht
+   * (`Input 1`, `In 3`, `Out 4`): aus `Input 1` wird `SDI 1`. Das ist die
+   * ausdrueckliche Entscheidung aus #175 und erspart das Umbenennen bei
+   * jedem Typwechsel.
+   *
+   * Ihr Preis faellt an genau einer Stelle an: WER EINEN PORT BEWUSST `In 5`
+   * NENNT, IST VON EINEM VORGABENAMEN NICHT ZU UNTERSCHEIDEN — und verliert
+   * ihn beim naechsten Steckertyp-Wechsel. Die Loesung war nicht, die Regel
+   * zu kippen (dann kaeme das Umbenennen bei jedem Typwechsel zurueck),
+   * sondern die fehlende Angabe nachzureichen: woher der Name stammt.
+   *
+   * ─── WARUM ES KEINE MIGRATION DAZU GIBT ──────────────────────────────────
+   *
+   * Weil sie luegen muesste. In einem alten Projekt steht am Port nur der
+   * Name, und ihm sieht niemand an, wer ihn geschrieben hat: `SDI 1` kann
+   * getippt sein ODER von `renameIfDefault` stammen — das Muster erzeugt
+   * genau solche Namen. Ein Migrationslauf, der jeden Nicht-Vorgabenamen als
+   * „vom Nutzer" markierte, traege eine Behauptung ins Projekt-File, die es
+   * nicht belegen kann.
+   *
+   * Fehlt das Feld, entscheidet weiter `isDefaultName` allein — also genau
+   * das Verhalten von vorher. Alte Projekte werden dadurch nicht schlechter,
+   * und der erste getippte Name setzt das Merkmal.
+   */
+  nameFromUser?: boolean
   /** v7.9.14 — Wenn dieses Equipment ein Black-Box-Rack ist, markiert
    *  jeder externe Port aus welchem internen Rack-Gerät er stammt
    *  (Index in rackInternalSnapshot.items). EquipmentNode nutzt diese

--- a/tests/portGruppen.test.ts
+++ b/tests/portGruppen.test.ts
@@ -52,12 +52,9 @@ describe('Was an einer Gruppe nicht stimmen kann', () => {
     const ports = ['a', 'b', 'c'].map((id) =>
       port({ id, portGroup: 'SP-1', portGroupKind: 'stereo' }),
     )
-    expect(gruppenBefunde(ports)).toContainEqual({
-      art: 'groesse',
-      gruppe: 'SP-1',
-      erwartet: 2,
-      ist: 3,
-    })
+    expect(gruppenBefunde(ports)).toContainEqual(
+      expect.objectContaining({ art: 'groesse', gruppe: 'SP-1', erwartet: 2, ist: 3 }),
+    )
   })
 
   it('meldet auch die Gruppe, der ein Mitglied FEHLT', () => {
@@ -65,12 +62,9 @@ describe('Was an einer Gruppe nicht stimmen kann', () => {
     // und wird unterbrochen. Auf dem Blatt steht danach ein Stereo-Anschluss
     // mit einem Kabel.
     const ports = [port({ id: 'a', portGroup: 'SP-1', portGroupKind: 'stereo' })]
-    expect(gruppenBefunde(ports)).toContainEqual({
-      art: 'groesse',
-      gruppe: 'SP-1',
-      erwartet: 2,
-      ist: 1,
-    })
+    expect(gruppenBefunde(ports)).toContainEqual(
+      expect.objectContaining({ art: 'groesse', gruppe: 'SP-1', erwartet: 2, ist: 1 }),
+    )
   })
 
   it('meldet zwei verschiedene Arten in derselben Gruppe', () => {
@@ -89,11 +83,9 @@ describe('Was an einer Gruppe nicht stimmen kann', () => {
       port({ id: 'a', portGroup: 'SP-1', portGroupKind: 'stereo', portGroupRole: 'L' }),
       port({ id: 'b', portGroup: 'SP-1', portGroupKind: 'stereo', portGroupRole: 'L' }),
     ]
-    expect(gruppenBefunde(ports)).toContainEqual({
-      art: 'rolle-doppelt',
-      gruppe: 'SP-1',
-      rolle: 'L',
-    })
+    expect(gruppenBefunde(ports)).toContainEqual(
+      expect.objectContaining({ art: 'rolle-doppelt', gruppe: 'SP-1', rolle: 'L' }),
+    )
   })
 
   it('schweigt bei einer vollständigen Stereo-Gruppe', () => {
@@ -168,12 +160,9 @@ describe('Der Powerlock-Satz (#665)', () => {
   it('ein Satz OHNE PE fällt auf', () => {
     // Der Fall, um den es geht. Vier zu stecken und den fünften zu vergessen
     // ist kein halber Anschluss.
-    expect(gruppenBefunde(satz(['L1', 'L2', 'L3', 'N']))).toContainEqual({
-      art: 'groesse',
-      gruppe: 'PL-IN',
-      erwartet: 5,
-      ist: 4,
-    })
+    expect(gruppenBefunde(satz(['L1', 'L2', 'L3', 'N']))).toContainEqual(
+      expect.objectContaining({ art: 'groesse', gruppe: 'PL-IN', erwartet: 5, ist: 4 }),
+    )
   })
 })
 

--- a/tests/portGruppenImPlanCheck.test.ts
+++ b/tests/portGruppenImPlanCheck.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+import { runDrawingChecks } from '../src/renderer/lib/drawingChecks'
+import { gruppenBefunde } from '../src/renderer/lib/portGroups'
+import {
+  istVorgabename,
+  vorschlagBeiVorgabename,
+} from '../src/renderer/lib/portDefaultName'
+import type { EquipmentItem, Port } from '../src/renderer/types/equipment'
+
+// ---------------------------------------------------------------------------
+// #838 — Zwei Folgearbeiten aus #832, und beide haben dieselbe Form: eine
+// Angabe, die es gibt, wird an der Stelle nicht gelesen, an der sie zaehlt.
+//
+// ─── 1 · DIE GRUPPE, DIE NIEMAND MEHR OEFFNET ──────────────────────────────
+//
+// `gruppenBefunde()` rechnet seit #832 richtig — angezeigt wurde das Ergebnis
+// aber NUR in der Eigenschaften-Leiste, also nur solange jemand genau dieses
+// Geraet offen hat. Der teure Fall ist der andere: eine Gruppe, die vor
+// Wochen halb angelegt wurde. Ein Powerlock-Satz ohne PE (`erwartet 5, ist
+// 4`) faellt so bis in den Saal nicht auf.
+//
+// ─── 2 · `In 5` IST EIN NAME UND KEINE VORGABE ─────────────────────────────
+//
+// `renameIfDefault` (#175) benennt beim Steckertyp-Wechsel um, solange der
+// Name auf `Input 1` / `In 3` / `Out 4` passt. Wer einen Port BEWUSST `In 5`
+// nennt, ist davon nicht zu unterscheiden und verliert ihn. Die Regel bleibt
+// — sie fragt jetzt zuerst `nameFromUser`.
+//
+// Die Regel stand als Closure in `PortList.tsx` und war von hier aus
+// unerreichbar. Dass dieser Test existiert, ist der halbe Fix.
+// ---------------------------------------------------------------------------
+
+const port = (teil: Partial<Port> & { id: string }): Port =>
+  ({ name: teil.id, connectorType: 'BNC', ...teil }) as Port
+
+const geraet = (teil: Partial<EquipmentItem> & { id: string }): EquipmentItem =>
+  ({
+    name: teil.id,
+    type: 'other',
+    category: 'Sonstiges',
+    x: 0,
+    y: 0,
+    inputs: [],
+    outputs: [],
+    ...teil,
+  }) as EquipmentItem
+
+const powerlock = (rollen: string[]): Port[] =>
+  rollen.map((r, i) =>
+    port({
+      id: `pl-${i}`,
+      portGroup: 'PL-IN',
+      portGroupKind: 'powerlock',
+      portGroupRole: r,
+    }),
+  )
+
+describe('Port-Gruppen stehen im Plan-Check', () => {
+  it('meldet den Powerlock-Satz ohne PE — der Fall, um den es geht', () => {
+    const e = geraet({ id: 'v1', name: 'Verteiler A', inputs: powerlock(['L1', 'L2', 'L3', 'N']) })
+    const befunde = runDrawingChecks({ equipment: [e], cables: [] }).findings
+    const treffer = befunde.filter((f) => f.category === 'Port group')
+    expect(treffer).toHaveLength(1)
+    expect(treffer[0].severity).toBe('warning')
+    // Der Geraetename steht davor: auf dem Blatt liegen die Befunde aller
+    // Geraete nebeneinander, und `Gruppe PL-IN` allein sagt nicht, welches.
+    expect(treffer[0].message).toContain('Verteiler A')
+    expect(treffer[0].message).toContain('4 of 5')
+    expect(treffer[0].equipmentId).toBe('v1')
+  })
+
+  it('schweigt beim vollstaendigen Satz — die Gegenprobe', () => {
+    const e = geraet({
+      id: 'v1',
+      inputs: powerlock(['L1', 'L2', 'L3', 'N', 'PE']),
+    })
+    const befunde = runDrawingChecks({ equipment: [e], cables: [] }).findings
+    expect(befunde.filter((f) => f.category === 'Port group')).toEqual([])
+  })
+
+  it('prueft jede Seite fuer sich — zwei halbe Gruppen sind zwei Befunde', () => {
+    // Zusammengeschuettet waeren `SP-1` auf beiden Seiten EINE Gruppe mit zwei
+    // Mitgliedern, also vollstaendig — und der Plan meldete nichts, obwohl
+    // links wie rechts ein Kanal fehlt. Eine Gruppe ueber Ein- und Ausgaenge
+    // hinweg waere ohnehin keine Gruppe, sondern eine Durchschleife.
+    const halb = (id: string) => [port({ id, portGroup: 'SP-1', portGroupKind: 'stereo' })]
+    const e = geraet({ id: 'm1', name: 'Mischer', inputs: halb('a'), outputs: halb('b') })
+    const treffer = runDrawingChecks({ equipment: [e], cables: [] }).findings.filter(
+      (f) => f.category === 'Port group',
+    )
+    expect(treffer).toHaveLength(2)
+    expect(treffer.map((f) => f.id)).toEqual([
+      'port-group-groesse:m1:inputs:SP-1',
+      'port-group-groesse:m1:outputs:SP-1',
+    ])
+    expect(treffer.filter((f) => f.message.includes(' IN ·'))).toHaveLength(1)
+    expect(treffer.filter((f) => f.message.includes(' OUT ·'))).toHaveLength(1)
+  })
+
+  it('der Satz steht EINMAL — der Plan-Check formuliert ihn nicht neu', () => {
+    // Die Eigenschaften-Leiste und das gedruckte Blatt zeigen denselben
+    // Befund. Formulierte ihn jede Seite selbst, liefen die beiden Fassungen
+    // beim naechsten Umbau auseinander — deshalb traegt der Befund seinen
+    // Satz mit sich, und der Plan-Check setzt nur den Geraetenamen davor.
+    const ports = powerlock(['L1', 'L2', 'L3', 'N'])
+    const [b] = gruppenBefunde(ports)
+    expect(b.schluessel).toBe('ports.group.sizeMismatch')
+    expect(b.werte).toEqual({ group: 'PL-IN', is: 4, expected: 5 })
+
+    const e = geraet({ id: 'v1', name: 'Verteiler A', inputs: ports })
+    const [f] = runDrawingChecks({ equipment: [e], cables: [] }).findings.filter(
+      (x) => x.category === 'Port group',
+    )
+    expect(f.message.endsWith(b.text)).toBe(true)
+  })
+})
+
+describe('Ein getippter Port-Name gehoert dem Nutzer', () => {
+  it('benennt einen Vorgabenamen weiter um — die Regel aus #175 bleibt', () => {
+    const ports = [port({ id: 'p1', name: 'Input 1' })]
+    expect(vorschlagBeiVorgabename(ports, 'p1', 'SDI')).toBe('SDI 1')
+  })
+
+  it('behaelt `In 5`, wenn es jemand selbst getippt hat', () => {
+    // DER FALL AUS DEM ISSUE. Ohne das Merkmal ist `In 5` von einem
+    // Vorgabenamen nicht zu unterscheiden — beides passt auf dasselbe Muster.
+    const ports = [port({ id: 'p1', name: 'In 5', nameFromUser: true })]
+    expect(vorschlagBeiVorgabename(ports, 'p1', 'SDI')).toBeNull()
+    // Und die Gegenprobe: OHNE das Merkmal verliert er ihn weiter. Der Test
+    // haelt damit fest, dass das Merkmal die Entscheidung traegt und nicht
+    // etwa das Muster nebenher aufgeweicht wurde.
+    expect(vorschlagBeiVorgabename([port({ id: 'p1', name: 'In 5' })], 'p1', 'SDI')).toBe(
+      'SDI 5',
+    )
+  })
+
+  it('nimmt die Nummer aus dem Namen und nicht aus der Position', () => {
+    const ports = [port({ id: 'a', name: 'Camera' }), port({ id: 'p1', name: 'Input 3' })]
+    expect(vorschlagBeiVorgabename(ports, 'p1', 'SDI')).toBe('SDI 3')
+  })
+
+  it('faellt auf die Position zurueck, wo der Name keine Nummer traegt', () => {
+    const ports = [port({ id: 'a', name: 'Camera' }), port({ id: 'p1', name: 'In' })]
+    expect(vorschlagBeiVorgabename(ports, 'p1', 'SDI')).toBe('SDI 2')
+  })
+
+  it('laesst einen echten Namen unangetastet, auch ohne Merkmal', () => {
+    const ports = [port({ id: 'p1', name: 'Kamera links' })]
+    expect(vorschlagBeiVorgabename(ports, 'p1', 'SDI')).toBeNull()
+  })
+
+  it('kennt die vier Vorgabeformen und sonst nichts', () => {
+    for (const n of ['Input 1', 'Output 2', 'In 3', 'Out 4', 'in', 'OUT']) {
+      expect(istVorgabename(n)).toBe(true)
+    }
+    for (const n of ['Kamera 1', 'SDI 1', 'Intercom In', 'In-Ear 2']) {
+      expect(istVorgabename(n)).toBe(false)
+    }
+  })
+})

--- a/tests/pruefMeldungenGewickelt.test.ts
+++ b/tests/pruefMeldungenGewickelt.test.ts
@@ -132,6 +132,10 @@ const BESTAND: Record<string, number> = {
  */
 const GEWICKELT = [
   'lib/drawingChecks.ts',
+  // #838 — kam mit dem Plan-Check fuer Port-Gruppen dazu. Der Satz zum Befund
+  // steht seither in `portGroups.ts` statt dreimal im JSX der
+  // Eigenschaften-Leiste; er traegt `schluessel` und `werte` wie die anderen.
+  'lib/portGroups.ts',
   'lib/labelDerivation.ts',
   'lib/exportPdfVector.ts',
   'types/cableSpec.ts',

--- a/tests/quellsaetzeDerUrteilsModule.test.ts
+++ b/tests/quellsaetzeDerUrteilsModule.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { klassifiziere } from '../scripts/quellsprache.mjs'
+
+// ---------------------------------------------------------------------------
+// Die Saetze der sprachfreien Module stehen in der Quellsprache (#837, #838).
+//
+// ─── DIE LUECKE, GEMESSEN ──────────────────────────────────────────────────
+//
+// Seit #837 rechnen `types/adapter.ts`, `types/conductor.ts`,
+// `types/displayCapability.ts`, `types/cableSpec.ts`, `lib/labelDerivation.ts`
+// und `lib/portGroups.ts` sprachfrei: sie liefern `schluessel`, `werte` und
+// einen englischen `text`, den `einsetzen(...)` zusammensetzt. Uebersetzt wird
+// beim Anzeigen.
+//
+// Das ist richtig — es haelt `lib/i18n.ts` (mit `de.ts`, 316 KB) aus dem
+// Importgraphen der Mobile-Ansicht. Es hat aber einen Preis, und der wurde am
+// 2026-09-10 nachgemessen: DER SPRACH-WAECHTER SIEHT DIESE SAETZE NICHT.
+// `npm run lang:check` liest `t()`- und `tr()`-Aufrufe; ein Argument von
+// `einsetzen(...)` ist keiner. Zur Gegenprobe wurde ein Satz in
+// `portGroups.ts` versuchsweise auf Deutsch gesetzt — `lang:check` meldete
+// weiterhin „0 deutsch".
+//
+// Es ist dieselbe Form wie bei den Kategorie-Werten (#822) und den
+// Vorlagen-Namen (#837): der Waechter steht an der Tuer, und die Sprache kommt
+// durchs Fenster.
+//
+// ─── WARUM HIER `klassifiziere()` TRAEGT, WO ES DAS SONST NICHT TUT ────────
+//
+// `tests/pruefMeldungenGewickelt.test.ts` sagt ausdruecklich, dass
+// `klassifiziere()` fuer seine Frage untauglich ist — es haelt
+// „Allen & Heath SQ-5" fuer deutsch und „Steckdosenleiste 6-fach" fuer
+// merkmalslos. Beide Fehler betreffen KURZE Bezeichner: Produkt- und
+// Herstellernamen.
+//
+// Hier geht es um etwas anderes. Geprueft wird das erste Argument von
+// `einsetzen(...)` — und das ist nie ein Bezeichner, sondern immer ein ganzer
+// Satz mit Funktionswoertern („the", „does not", „is not stated"). Genau
+// darauf ist die Wortliste ausgelegt. Deshalb ist die Frage hier entscheidbar,
+// und deshalb steht sie in einem eigenen Test statt im anderen.
+//
+// Gemeldet wird nur `de` — nicht „ohne Merkmal". Ein Satz ohne deutsche
+// Marker ist kein Verstoss, sondern ein Satz aus Fachbegriffen, und wer ihn
+// meldete, brauchte eine Ausnahmeliste, die niemand pflegt.
+// ---------------------------------------------------------------------------
+
+const WURZEL = join(process.cwd(), 'src', 'renderer')
+
+const dateien = (dir: string): string[] =>
+  readdirSync(dir).flatMap((eintrag) => {
+    const voll = join(dir, eintrag)
+    if (statSync(voll).isDirectory()) return dateien(voll)
+    return /\.tsx?$/.test(eintrag) ? [voll] : []
+  })
+
+/**
+ * Das erste Argument von `einsetzen(` — die Vorlage, in die die Werte gehen.
+ *
+ * Einfache und doppelte Anfuehrungszeichen sowie Template-Literale, jeweils
+ * auch nach einem Zeilenumbruch: der Formatierer bricht genau dort um, und
+ * eine Vorlage, die dem Umbruch entkommt, waere die naechste stille Luecke.
+ */
+const VORLAGE =
+  /\beinsetzen\(\s*(?:\n\s*)?(?:'((?:[^'\\]|\\.)+?)'|"((?:[^"\\]|\\.)+?)"|`((?:[^`\\]|\\.)+?)`)/g
+
+const ohneKommentare = (text: string) =>
+  text.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/^\s*\/\/.*$/gm, ' ')
+
+interface Fund {
+  datei: string
+  satz: string
+}
+
+const saetze = (): Fund[] => {
+  const gefunden: Fund[] = []
+  for (const datei of dateien(WURZEL)) {
+    const rel = relative(WURZEL, datei).split('\\').join('/')
+    // Das Woerterbuch IST die Uebersetzung — dort steht Deutsch mit Absicht.
+    if (rel.includes('i18n')) continue
+    const quelle = ohneKommentare(readFileSync(datei, 'utf8'))
+    for (const m of quelle.matchAll(VORLAGE)) {
+      gefunden.push({ datei: rel, satz: m[1] ?? m[2] ?? m[3] ?? '' })
+    }
+  }
+  return gefunden
+}
+
+describe('Die Saetze der sprachfreien Urteils-Module', () => {
+  it('keiner von ihnen ist deutsch', () => {
+    const deutsch = saetze()
+      .filter((f) => klassifiziere(f.satz) === 'de')
+      .map((f) => `${f.datei}: ${f.satz.slice(0, 70)}`)
+    expect(
+      deutsch,
+      'Eine deutsche Vorlage in einem sprachfreien Modul. Sie erscheint im ' +
+        'Plan-Check-Panel und auf gedruckten Blaettern, und `npm run lang:check` ' +
+        'sieht sie NICHT — das Argument von `einsetzen(...)` ist kein ' +
+        '`t()`-Aufruf. Den englischen Satz hier eintragen und die deutsche ' +
+        'Fassung unter dem `schluessel` in `lib/i18n/de.ts`.',
+    ).toEqual([])
+  })
+
+  it('die Pruefung sieht ueberhaupt etwas — Gegenprobe zum Muster', () => {
+    // Ohne sie waere ein kaputtes Muster die gefaehrlichste Art gruen: es
+    // findet nichts, und Nichts sieht hier aus wie ein Ergebnis.
+    const gefunden = saetze()
+    expect(gefunden.length).toBeGreaterThan(30)
+    // Und die Module, um die es geht, sind wirklich dabei.
+    const dateienMitSatz = new Set(gefunden.map((f) => f.datei))
+    for (const modul of [
+      'types/adapter.ts',
+      'types/conductor.ts',
+      'types/displayCapability.ts',
+      'lib/labelDerivation.ts',
+      'lib/portGroups.ts',
+    ]) {
+      expect(dateienMitSatz.has(modul), `${modul} liefert keinen Satz mehr`).toBe(true)
+    }
+  })
+
+  it('und sie erkennt einen deutschen Satz, wenn einer kaeme', () => {
+    // Der Beweis, dass die erste Pruefung nicht nur deshalb gruen ist, weil
+    // `klassifiziere()` hier grundsaetzlich schweigt.
+    expect(
+      klassifiziere(
+        'Die Gruppe hat zweimal dieselbe Rolle und ist deshalb kein Stereo-Paar.',
+      ),
+    ).toBe('de')
+  })
+})


### PR DESCRIPTION
Zwei Folgearbeiten aus #832/#835, die dort mit Begruendung liegengeblieben waren. Beide haben dieselbe Form: eine Angabe, die es gibt, wird an der Stelle nicht gelesen, an der sie zaehlt.

## 1 · Die Gruppe, die niemand mehr oeffnet

`gruppenBefunde()` rechnet seit #832 richtig — angezeigt wurde das Ergebnis aber nur in der Eigenschaften-Leiste, also nur solange jemand genau dieses Geraet offen hat. Das ist die wichtigere Haelfte und bleibt. Sie erwischt nur den teuren Fall nicht: **eine Gruppe, die vor Wochen halb angelegt wurde.** Ein Powerlock-Satz ohne PE (`erwartet 5, ist 4`) faellt so bis in den Saal nicht auf.

- Check 24 in `drawingChecks.ts`, Kategorie `Port group`, Schwere `warning` — dieselbe Schwere wie in der Leiste. Zwei Anzeigen mit zwei Antworten auf denselben Befund waeren die Defektform `zwei-rechnungen`.
- **Jede Seite fuer sich.** Zusammengeschuettet waere `SP-1` auf Ein- UND Ausgang eine vollstaendige Zweiergruppe, und der Plan schwiege, obwohl links wie rechts ein Kanal fehlt.
- **Der Satz steht jetzt einmal.** Er lag als drei `t()`-Aufrufe im JSX von `PortList.tsx`; der Plan-Check haette ihn zwangslaeufig ein zweites Mal formuliert. `portGroups.ts` liefert ihn deshalb mit `schluessel`, `werte` und englischem `text` — die Bauform der Urteils-Module aus #837. Der Geraetename steht davor und nicht darin, wie bei Check 2 die Kabelnummer: so bleiben `IN`/`OUT` Kennungen der Seite und keine Satzteile, die eine Uebersetzung umstellen muesste.

## 2 · `In 5` ist ein Name und keine Vorgabe

`renameIfDefault` (#175) benennt beim Steckertyp-Wechsel um, solange der Name auf `Input 1` / `In 3` / `Out 4` passt. Wer einen Port bewusst `In 5` nennt, ist davon nicht zu unterscheiden und verliert ihn.

Die Regel bleibt — sie zu kippen hiesse, das Umbenennen bei jedem Typwechsel zurueckzuholen, und das war die Beschwerde, aus der #175 entstand. Nachgereicht wird die fehlende Angabe: `Port.nameFromUser`, gesetzt sobald jemand das Namensfeld anfasst. Ein LEERES Feld setzt es nicht — wer alles loescht, hat keinen Namen gewaehlt und stuende sonst mit einem geschuetzten leeren Port da.

**Keine Schema-Migration, und das ist Absicht: sie muesste luegen.** In einem alten Projekt sieht dem Namen niemand an, wer ihn geschrieben hat — `SDI 1` kann getippt sein ODER von `renameIfDefault` stammen, das Muster erzeugt genau solche Namen. Fehlt das Feld, entscheidet weiter `istVorgabename` allein, also genau das Verhalten von vorher; der erste getippte Name setzt das Merkmal.

Die Regel zog dabei aus der Komponente nach `lib/portDefaultName.ts`. Sie stand als Closure in `PortList.tsx` und war von keinem Test erreichbar — bei einer Entscheidung, die einem Nutzer seine Eingabe nehmen kann, ist das die falsche Stelle.

## 3 · Der Waechter sah die Saetze nicht

Beim Verschieben nachgemessen: `npm run lang:check` liest `t()`- und `tr()`-Aufrufe, und das Argument von `einsetzen(...)` ist keiner. Zur Gegenprobe wurde ein Satz in `portGroups.ts` versuchsweise auf Deutsch gesetzt — der Waechter meldete weiterhin „0 deutsch". Das gilt fuer **alle** sprachfreien Module aus #837, nicht nur fuer das neue.

`tests/quellsaetzeDerUrteilsModule.test.ts` schliesst das: es liest jedes erste Argument von `einsetzen(` unter `src/renderer` und meldet, was `klassifiziere()` fuer deutsch haelt. Hier traegt die Funktion, wo sie es sonst nicht tut (siehe `pruefMeldungenGewickelt.test.ts`): ihre bekannten Fehlgriffe sind kurze Produkt- und Herstellernamen, geprueft werden aber ganze Saetze mit Funktionswoertern. Gemeldet wird nur `de`, nicht „ohne Merkmal" — sonst braeuchte es eine Ausnahmeliste, die niemand pflegt.

## Geprueft
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 263 Test-Dateien, 3994 Tests gruen
- `npm run lint` — 0 Errors
- `npm run lang:check` — 0 Verstoesse in `src/renderer`, `src/mobile`, `src/viewer`
- `npm run ui:smoke` — gruen (5 Menues, 0 ohne Eintraege)

Closes #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_