### PR TITLE
feat(demo): das Beispiel bringt ein Rack mit, und es spricht Englisch

### DIFF
--- a/docs/ui-audit.md
+++ b/docs/ui-audit.md
@@ -760,10 +760,30 @@ Eigentümer-Entscheidung und an einer Schema-Migration, weil
 - [ ] `canvas.gif` (animierte Canvas-Demo): braucht einen GIF-Encoder, den
       dieser Container nicht hat (kein `ffmpeg`/`gifski`). Einzelbilder kann
       `docs:shots` liefern, das Zusammensetzen nicht.
-- [ ] `rack-3d.png`: das Beispielprojekt enthält kein Rack („No rack layout
-      saved yet"), die 3D-Ansicht ist also nicht ohne vorheriges Bauen zu
-      zeigen. Entweder ein Rack ins Beispielprojekt oder ein zweites,
-      neutrales Demo-Projekt für die Aufnahme.
+- [x] `rack-3d.png`: **das Beispiel bringt jetzt ein Rack mit** (2026-09-10,
+      `lib/demoRack.ts`) — ein 12-HE-Rack mit Patchblende, Mischer,
+      Multiviewer und IEC-Leiste plus drei internen Verbindungen. Die
+      Aufnahme ist damit ohne vorheriges Bauen möglich.
+
+      **Der Befund war größer als die fehlende Aufnahme.** Rack-Vorlagen
+      kommen ausschliesslich aus `localStorage`
+      (`groupPresetsPersist.loadGroupPresets`: kein Eintrag → `[]`), also hat
+      eine frische Installation keine einzige. An `components/Rack/` hängt
+      aber die gesamte 3D-Ansicht samt `lib/exportRack.ts` — der grösste
+      einzelne Brocken der Anwendung. Wer die App zum ersten Mal öffnete,
+      konnte davon nichts sehen. Dieselbe Form wie B-65 in der Suite:
+      gebaute Rechenwerke ohne einen Weg hinein.
+
+      **Am Beispiel und nicht am Start**, denn eine Vorlage, die beim Start
+      nachwächst, kommt nach dem Löschen wieder. `loadDemoProject()` im
+      Store legt sie an, wenn `DEMO_RACK_PRESET_ID` fehlt; zweimal laden legt
+      nichts doppelt an.
+
+      **Nebenbefund derselben Klasse:** die `description` des
+      Beispielprojekts war deutsch, während der `name` daneben englisch war —
+      Daten, also für `lang:check` unsichtbar. `tests/beispielRack.test.ts`
+      prüft beides jetzt mit `klassifiziere()`, dazu die Kabel-Endpunkte, die
+      HE-Belegung und den Namen der Strom-Leiste gegen `passiveCatalog`.
 - [x] **Die Bilder sind aufgefrischt** (2026-09-10, gegen **v9.0.1** statt
       v8.1.0-101). Möglich wurde das durch #822: Kategorien und Beispielprojekt
       stehen jetzt in der Quellsprache, eine Aufnahme zeigt also nicht mehr

--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -59,7 +59,6 @@ import {
   triggerCanvasFitView,
   setCanvasCenterOnHandler,
 } from '../../lib/canvasViewport'
-import { createDemoProject } from '../../lib/demoProject'
 import { CanvasSearch } from './CanvasSearch'
 import { format, useTranslation } from '../../lib/i18n'
 import { useAtemTallyFeed } from '../../hooks/useAtemTallyFeed'
@@ -117,7 +116,9 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
   const projectVersion = useProjectStore((state) => state.projectVersion)
   const updateEquipment = useProjectStore((state) => state.updateEquipment)
   const addEquipment = useProjectStore((state) => state.addEquipment)
-  const loadProjectIntoStore = useProjectStore((state) => state.loadProject)
+  // #ux — das Beispiel bringt seine Rack-Vorlage mit; sonst steht die
+  // Rack-Karte einer frischen Installation leer (siehe `lib/demoRack.ts`).
+  const loadDemoProjectIntoStore = useProjectStore((state) => state.loadDemoProject)
   const pasteEquipment = useProjectStore((state) => state.pasteEquipment)
   const deleteEquipment = useProjectStore((state) => state.deleteEquipment)
   const deleteLocation = useProjectStore((state) => state.deleteLocation)
@@ -1607,7 +1608,7 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
             className="pointer-events-auto rounded-cp-control border border-cp-border bg-cp-surface-2 px-cp-4 py-cp-2 text-cp-sm font-medium text-cp-text hover:bg-cp-surface-3"
             onClick={() => {
               // Demo nur laden wenn wirklich leer (Empty-State) — kein Überschreiben.
-              loadProjectIntoStore(createDemoProject())
+              loadDemoProjectIntoStore()
               // Nach dem Neu-Mount der Nodes auf den Inhalt zoomen.
               setTimeout(() => triggerCanvasFitView(), 80)
             }}

--- a/src/renderer/components/Layout/CommandPalette.tsx
+++ b/src/renderer/components/Layout/CommandPalette.tsx
@@ -18,7 +18,6 @@ import {
   triggerCanvasSelectAll,
   triggerCanvasDuplicate,
 } from '../../lib/canvasViewport'
-import { createDemoProject } from '../../lib/demoProject'
 import { useTranslation } from '../../lib/i18n'
 import { Icon } from '../shared/Icon'
 import { useDialogA11y } from '../../hooks/useDialogA11y'
@@ -103,7 +102,7 @@ export const CommandPalette = () => {
       { id: 'recStorage', group: gTools, title: t('app.menu.tools.recStorage', 'Calculate recording storage…'), run: () => ui().openRecordingStorageCalc() },
       { id: 'projection', group: gTools, title: t('app.menu.tools.projection', 'Projection & display…'), run: () => ui().openProjectionCalc() },
       { id: 'installDocs', group: gTools, title: t('app.menu.tools.installDocs', 'Fixed install: docs & handover…'), run: () => ui().openInstallDocs() },
-      { id: 'loadDemo', group: gTools, title: t('canvas.empty.loadDemo', 'Load example project'), run: () => { useProjectStore.getState().loadProject(createDemoProject()); setTimeout(() => triggerCanvasFitView(), 80) } },
+      { id: 'loadDemo', group: gTools, title: t('canvas.empty.loadDemo', 'Load example project'), run: () => { useProjectStore.getState().loadDemoProject(); setTimeout(() => triggerCanvasFitView(), 80) } },
       { id: 'settings', group: gHelp, title: t('palette.settings', 'Settings…'), run: () => ui().openSettings() },
       { id: 'shortcuts', group: gHelp, title: t('app.menu.help.shortcuts', 'Keyboard shortcuts…'), run: () => window.dispatchEvent(new CustomEvent('cp:open-shortcuts-help')) },
       { id: 'about', group: gHelp, title: t('app.menu.help.about', 'About Cable Planner…'), run: () => ui().openAboutDialog() },

--- a/src/renderer/lib/demoProject.ts
+++ b/src/renderer/lib/demoProject.ts
@@ -36,9 +36,13 @@ export const createDemoProject = (): CablePlannerProject => {
   return {
     metadata: {
       name: 'Example: small studio setup',
+      // QUELLSPRACHE (E-28). Diese Zeile stand bis 2026-09-10 auf Deutsch,
+      // waehrend `name` daneben schon englisch war — der Sprach-Waechter sieht
+      // sie nicht, weil sie DATEN ist und kein `t()`-Aufruf. Sie ist das
+      // Zweite, was ein neuer Nutzer liest.
       description:
-        'Demo-Plan: 2 Kameras → Bildmischer → Multiviewer & Regie-Monitor. ' +
-        'Zum Ausprobieren — einfach Geräte/Kabel anklicken oder löschen.',
+        'Demo plan: 2 cameras → vision mixer → multiviewer & control room ' +
+        'monitor. Made to be poked at — click or delete any device or cable.',
       createdAt: now,
       updatedAt: now,
       defaultVideoFormat: '1080p50',

--- a/src/renderer/lib/demoRack.ts
+++ b/src/renderer/lib/demoRack.ts
@@ -1,0 +1,208 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Das mitgelieferte Beispiel-Rack.
+//
+// ─── DER BEFUND (gemessen 2026-09-10) ──────────────────────────────────────
+//
+// Rack-Vorlagen leben in `groupPresets`, und die kommen AUSSCHLIESSLICH aus
+// `localStorage` (`store/groupPresetsPersist.ts`: kein Eintrag -> `[]`).
+// Eine frische Installation hat deshalb keine einzige, und die Rack-Karte
+// sagt „No rack layout saved yet".
+//
+// Das trifft nicht nur die Karte. An `components/Rack/` haengt die gesamte
+// 3D-Ansicht samt `lib/exportRack.ts` — der groesste einzelne Brocken der
+// Anwendung, und der Grund fuer die Lazy-Grenze in `CLAUDE.md`. Wer die App
+// zum ersten Mal oeffnet, kann davon nichts sehen, ohne vorher selbst ein Rack
+// zu bauen. Dieselbe Form wie B-65 in der Suite: gebaute Rechenwerke ohne
+// einen Weg hinein.
+//
+// Belegt ist es an einer dritten Stelle: `docs/ui-audit.md` fuehrt
+// `rack-3d.png` als offen, woertlich „das Beispielprojekt enthaelt kein Rack
+// […] die 3D-Ansicht ist also nicht ohne vorheriges Bauen zu zeigen".
+//
+// ─── WARUM ES AM BEISPIELPROJEKT HAENGT UND NICHT AM START ─────────────────
+//
+// Der naheliegende Weg waere, die Vorlage beim Start in die Bibliothek zu
+// setzen, wie `seedBuiltInLibrary` es fuer die Geraete-Vorlagen tut. Das waere
+// hier falsch: eine Vorlage, die beim Start nachwaechst, kommt nach dem
+// Loeschen wieder — und der Nutzer kann sie nicht loswerden, ohne zu wissen,
+// warum sie zurueckkehrt.
+//
+// Sie haengt deshalb am ausdruecklichen „Beispielprojekt laden". Das ist eine
+// Handlung, und wer sie ausloest, erwartet Beispieldaten. Ein zweiter Aufruf
+// legt nichts doppelt an (`DEMO_RACK_PRESET_ID` ist fest), und wer die Vorlage
+// loescht und das Beispiel nicht neu laedt, ist sie los.
+//
+// ─── DIE NAMEN SIND KENNUNGEN ──────────────────────────────────────────────
+//
+// Die Kabel des Racks verweisen ueber `fromPortName`/`toPortName` auf die
+// Ports der Inhalte — nicht ueber einen Index. Wer hier einen Port umbenennt,
+// muss das Kabel mitnehmen; `tests/beispielRack.test.ts` haelt fest, dass
+// jeder Endpunkt einen Port trifft.
+// ───────────────────────────────────────────────────────────────────────────
+import type { GroupPreset } from '../types/equipment'
+
+/**
+ * Feste Kennung — der Wiedererkennungspunkt beim zweiten „Beispielprojekt
+ * laden". Eine frische UUID je Aufruf legte die Vorlage jedes Mal erneut an.
+ */
+export const DEMO_RACK_PRESET_ID = 'demo-rack-ob-van'
+
+/**
+ * Ein 12-HE-Rack, wie es im Beispielprojekt stuende: Mischer, Multiviewer,
+ * Patchblende, Netzteil-Leiste — und die drei Verbindungen dazwischen, die
+ * man im Rack tatsaechlich steckt.
+ *
+ * Absichtlich klein. Es soll zeigen, wie ein Rack aussieht, und nicht, wie
+ * viel hineinpasst.
+ */
+export const createDemoRackPreset = (): GroupPreset => ({
+  id: DEMO_RACK_PRESET_ID,
+  name: 'Example rack: small OB van',
+  rack: {
+    totalUnits: 12,
+    depthMm: 800,
+    placements: [
+      { itemIndex: 0, startUnit: 1, heightUnits: 1, mountSide: 'front' },
+      { itemIndex: 1, startUnit: 3, heightUnits: 2, mountSide: 'full' },
+      { itemIndex: 2, startUnit: 6, heightUnits: 1, mountSide: 'full' },
+      { itemIndex: 3, startUnit: 12, heightUnits: 1, mountSide: 'rear' },
+    ],
+  },
+  items: [
+    {
+      name: 'Patch panel 16x BNC',
+      category: 'Patch panels',
+      rackUnits: 1,
+      offsetX: 0,
+      offsetY: 0,
+      width: 240,
+      height: 120,
+      inputs: Array.from({ length: 8 }, (_, i) => ({
+        id: `demo-rack-pp-in-${i + 1}`,
+        name: `Rear ${i + 1}`,
+        type: 'BNC',
+        connectorType: 'BNC' as const,
+        direction: 'in' as const,
+      })),
+      outputs: Array.from({ length: 8 }, (_, i) => ({
+        id: `demo-rack-pp-out-${i + 1}`,
+        name: `Front ${i + 1}`,
+        type: 'BNC',
+        connectorType: 'BNC' as const,
+        direction: 'out' as const,
+      })),
+    },
+    {
+      name: 'Vision mixer',
+      category: 'Mixer',
+      rackUnits: 2,
+      offsetX: 0,
+      offsetY: 160,
+      width: 240,
+      height: 180,
+      nodeColor: '#7c3aed',
+      inputs: Array.from({ length: 4 }, (_, i) => ({
+        id: `demo-rack-mix-in-${i + 1}`,
+        name: `In ${i + 1}`,
+        type: 'BNC',
+        connectorType: 'BNC' as const,
+        direction: 'in' as const,
+      })),
+      outputs: [
+        {
+          id: 'demo-rack-mix-pgm',
+          name: 'PGM Out',
+          type: 'BNC',
+          connectorType: 'BNC' as const,
+          direction: 'out' as const,
+        },
+        {
+          id: 'demo-rack-mix-mv',
+          name: 'Multiview Out',
+          type: 'BNC',
+          connectorType: 'BNC' as const,
+          direction: 'out' as const,
+        },
+      ],
+    },
+    {
+      name: 'Multiviewer',
+      category: 'Monitors',
+      rackUnits: 1,
+      offsetX: 0,
+      offsetY: 380,
+      width: 240,
+      height: 120,
+      inputs: [
+        {
+          id: 'demo-rack-mv-in',
+          name: 'SDI In',
+          type: 'BNC',
+          connectorType: 'BNC' as const,
+          direction: 'in' as const,
+        },
+      ],
+      outputs: [],
+    },
+    {
+      // Die Leiste sitzt hinten und unten — dort, wo sie im echten Rack sitzt.
+      // Der Name ist zugleich die Kennung der ausgelieferten Vorlage aus
+      // `passiveCatalog.ts` (#837); wer ihn hier aendert, loest ihn von dort.
+      name: 'IEC strip 8-way',
+      category: 'Power',
+      rackUnits: 1,
+      offsetX: 0,
+      offsetY: 540,
+      width: 240,
+      height: 120,
+      inputs: [
+        {
+          id: 'demo-rack-pdu-feed',
+          name: 'Feed',
+          type: 'Schuko 230V',
+          connectorType: 'Schuko 230V' as const,
+          direction: 'in' as const,
+        },
+      ],
+      outputs: Array.from({ length: 8 }, (_, i) => ({
+        id: `demo-rack-pdu-out-${i + 1}`,
+        name: `Outlet ${i + 1}`,
+        type: 'IEC 230V',
+        connectorType: 'IEC 230V' as const,
+        direction: 'out' as const,
+      })),
+    },
+  ],
+  cables: [
+    {
+      fromItemIndex: 0,
+      fromPortName: 'Front 1',
+      toItemIndex: 1,
+      toPortName: 'In 1',
+      name: 'Patch 1 → mixer In 1',
+      type: 'BNC',
+      length: 1,
+      color: '#3b82f6',
+    },
+    {
+      fromItemIndex: 0,
+      fromPortName: 'Front 2',
+      toItemIndex: 1,
+      toPortName: 'In 2',
+      name: 'Patch 2 → mixer In 2',
+      type: 'BNC',
+      length: 1,
+      color: '#3b82f6',
+    },
+    {
+      fromItemIndex: 1,
+      fromPortName: 'Multiview Out',
+      toItemIndex: 2,
+      toPortName: 'SDI In',
+      name: 'Multiview → Multiviewer',
+      type: 'BNC',
+      length: 1,
+      color: '#22c55e',
+    },
+  ],
+})

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -42,6 +42,8 @@ import {
 } from '../lib/categoryTranslations'
 import { heileSteckertyp } from '../lib/connectorRenames'
 import { loadGroupPresets } from './groupPresetsPersist'
+import { createDemoProject } from '../lib/demoProject'
+import { DEMO_RACK_PRESET_ID, createDemoRackPreset } from '../lib/demoRack'
 import { scheduleProjectAutosave } from './projectAutosave'
 import { blackmagicTemplates } from '../lib/blackmagicCatalog'
 import { detectLayerForConnector } from '../lib/cableLayers'
@@ -251,6 +253,11 @@ export interface ProjectState {
   setRecentProjects: (items: string[]) => void
   setFilePath: (path?: string) => void
   loadProject: (project: CablePlannerProject, filePath?: string) => void
+  /**
+   * Das Beispielprojekt UND seine Rack-Vorlage — ein Aufruf, damit die beiden
+   * nicht an zwei Stellen getrennt gepflegt werden (siehe `lib/demoRack.ts`).
+   */
+  loadDemoProject: () => void
   /** #413 — Wendet einen remote (CRDT-)Stand von equipment/cables/locations
    *  auf das aktuelle Projekt an. Anders als loadProject: ersetzt NUR diese
    *  drei Collections (Metadaten, canvasState, Annotationen etc. bleiben),
@@ -1681,6 +1688,15 @@ const buildProjectStore = (
         customLibrary: healedLibrary,
       }
     }),
+  loadDemoProject: () => {
+    get().loadProject(createDemoProject())
+    // Die Rack-Vorlage kommt MIT dem Beispiel und nicht beim Start: eine
+    // Vorlage, die beim Start nachwaechst, kommt nach dem Loeschen wieder.
+    // Zweimal laden legt sie nicht doppelt an — die Kennung ist fest.
+    if (!get().groupPresets.some((p) => p.id === DEMO_RACK_PRESET_ID)) {
+      get().addGroupPreset(createDemoRackPreset())
+    }
+  },
   applyRemoteProject: (slice) =>
     set((state) => ({
       // Nur die drei kollaborativen Collections ersetzen; alles andere am

--- a/tests/beispielRack.test.ts
+++ b/tests/beispielRack.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest'
+import { klassifiziere } from '../scripts/quellsprache.mjs'
+import { createDemoProject } from '../src/renderer/lib/demoProject'
+import { DEMO_RACK_PRESET_ID, createDemoRackPreset } from '../src/renderer/lib/demoRack'
+import { passiveTemplates } from '../src/renderer/lib/passiveCatalog'
+
+// ---------------------------------------------------------------------------
+// Das Beispiel bringt ein Rack mit — und beides steht in der Quellsprache.
+//
+// ─── DER BEFUND (gemessen 2026-09-10) ──────────────────────────────────────
+//
+// Rack-Vorlagen kommen ausschliesslich aus `localStorage`
+// (`groupPresetsPersist.loadGroupPresets`: kein Eintrag -> `[]`). Eine frische
+// Installation hatte deshalb keine, und die Rack-Karte sagte „No rack layout
+// saved yet". An `components/Rack/` haengt die gesamte 3D-Ansicht samt
+// `lib/exportRack.ts` — sichtbar erst, nachdem jemand selbst ein Rack gebaut
+// hat. `docs/ui-audit.md` fuehrt genau das als offenen Punkt (`rack-3d.png`).
+//
+// Nebenbefund derselben Klasse: die `description` des Beispielprojekts war
+// deutsch, waehrend der `name` daneben schon englisch war. Beides sind DATEN,
+// und `npm run lang:check` liest `t()`-Aufrufe — es hat davon nie etwas
+// gesehen. Es ist das Zweite, was ein neuer Nutzer liest.
+//
+// ─── WAS DIESER TEST HAELT ─────────────────────────────────────────────────
+//
+// Nicht „das Rack sieht gut aus" — das ist Geschmack. Sondern die drei
+// Zusagen, die brechen koennen, ohne dass es jemand merkt: die Kabel treffen
+// Ports, die Platzierungen passen ins Rack, und die Texte sind englisch.
+// ---------------------------------------------------------------------------
+
+describe('Das mitgelieferte Beispiel-Rack', () => {
+  it('jeder Kabel-Endpunkt trifft einen Port seines Geraets', () => {
+    // Die Kabel des Racks verweisen ueber NAMEN, nicht ueber Indizes in der
+    // Port-Liste. Ein umbenannter Port laesst das Kabel still ins Leere
+    // laufen — `placeGroupPreset` findet den Namen nicht und legt die
+    // Verbindung gar nicht erst an.
+    const rack = createDemoRackPreset()
+    const fehlend: string[] = []
+    for (const c of rack.cables) {
+      const von = rack.items[c.fromItemIndex]
+      const nach = rack.items[c.toItemIndex]
+      if (!von || !nach) {
+        fehlend.push(`${c.name}: Geraete-Index zeigt ins Leere`)
+        continue
+      }
+      const hat = (item: typeof von, name: string) =>
+        [...item.inputs, ...item.outputs].some((p) => p.name === name)
+      if (!hat(von, c.fromPortName)) fehlend.push(`${c.name}: ${von.name} hat kein "${c.fromPortName}"`)
+      if (!hat(nach, c.toPortName)) fehlend.push(`${c.name}: ${nach.name} hat kein "${c.toPortName}"`)
+    }
+    expect(fehlend).toEqual([])
+  })
+
+  it('jede Platzierung liegt im Rack und keine zwei ueberlappen auf derselben Seite', () => {
+    const rack = createDemoRackPreset()
+    const gesamt = rack.rack?.totalUnits ?? 0
+    expect(gesamt).toBeGreaterThan(0)
+    const belegt = new Map<string, Set<number>>()
+    const fehler: string[] = []
+    for (const p of rack.rack?.placements ?? []) {
+      if (p.startUnit < 1 || p.startUnit + p.heightUnits - 1 > gesamt) {
+        fehler.push(`Index ${p.itemIndex}: HE ${p.startUnit}..${p.startUnit + p.heightUnits - 1} von ${gesamt}`)
+      }
+      // 'full' belegt beide Tiefen; 'front'/'rear' je eine.
+      const seiten = p.mountSide === 'full' || !p.mountSide ? ['front', 'rear'] : [p.mountSide]
+      for (const seite of seiten) {
+        const genommen = belegt.get(seite) ?? new Set<number>()
+        for (let he = p.startUnit; he < p.startUnit + p.heightUnits; he += 1) {
+          if (genommen.has(he)) fehler.push(`HE ${he} (${seite}) doppelt belegt`)
+          genommen.add(he)
+        }
+        belegt.set(seite, genommen)
+      }
+    }
+    expect(fehler).toEqual([])
+  })
+
+  it('jedes Geraet nennt so viele Hoeheneinheiten wie seine Platzierung', () => {
+    // Zwei Zahlen fuer dieselbe Sache — `rackUnits` am Geraet und
+    // `heightUnits` an der Platzierung. Sie laufen auseinander, sobald
+    // jemand nur eine anfasst.
+    const rack = createDemoRackPreset()
+    for (const p of rack.rack?.placements ?? []) {
+      expect(rack.items[p.itemIndex]?.rackUnits, `Index ${p.itemIndex}`).toBe(p.heightUnits)
+    }
+  })
+
+  it('die Kennung ist fest — zweimal laden legt nichts doppelt an', () => {
+    expect(createDemoRackPreset().id).toBe(DEMO_RACK_PRESET_ID)
+    expect(createDemoRackPreset().id).toBe(createDemoRackPreset().id)
+  })
+
+  it('die Strom-Leiste heisst wie die ausgelieferte Vorlage', () => {
+    // Der Name IST die Kennung (#837). Weicht er ab, steht im Rack ein Geraet,
+    // das aussieht wie die Katalog-Vorlage und keine ist.
+    const leiste = createDemoRackPreset().items.find((i) => i.category === 'Power')
+    expect(leiste).toBeDefined()
+    expect(passiveTemplates.some((t) => t.name === leiste?.name)).toBe(true)
+  })
+})
+
+describe('Beispielprojekt und Beispiel-Rack stehen in der Quellsprache', () => {
+  const texte = (): Array<{ wo: string; text: string }> => {
+    const p = createDemoProject()
+    const rack = createDemoRackPreset()
+    return [
+      { wo: 'metadata.name', text: p.metadata.name },
+      { wo: 'metadata.description', text: p.metadata.description ?? '' },
+      ...p.equipment.map((e) => ({ wo: `equipment ${e.id}`, text: e.name })),
+      ...p.cables.map((c) => ({ wo: `cable ${c.id}`, text: c.name })),
+      { wo: 'rack.name', text: rack.name },
+      ...rack.items.map((i) => ({ wo: `rack item`, text: i.name })),
+      ...rack.cables.map((c) => ({ wo: `rack cable`, text: c.name })),
+    ]
+  }
+
+  it('kein Text ist deutsch', () => {
+    const deutsch = texte()
+      .filter((t) => klassifiziere(t.text) === 'de')
+      .map((t) => `${t.wo}: ${t.text}`)
+    expect(
+      deutsch,
+      'Deutscher Text im ausgelieferten Beispiel. Er ist das Erste, was ein ' +
+        'neuer Nutzer sieht, und `npm run lang:check` findet ihn NICHT — er ' +
+        'ist ein Datenwert und kein `t()`-Aufruf.',
+    ).toEqual([])
+  })
+
+  it('die Pruefung sieht ueberhaupt etwas — Gegenprobe', () => {
+    expect(texte().length).toBeGreaterThan(15)
+    expect(klassifiziere('Demo-Plan mit zwei Kameras und einem Bildmischer für die Regie.')).toBe('de')
+  })
+})


### PR DESCRIPTION
## Der Befund

Rack-Vorlagen leben in `groupPresets`, und die kommen **ausschliesslich** aus `localStorage` (`groupPresetsPersist.loadGroupPresets`: kein Eintrag → `[]`). Eine frische Installation hat deshalb keine einzige, und die Rack-Karte sagt „No rack layout saved yet".

Das trifft nicht nur die Karte. An `components/Rack/` haengt die gesamte 3D-Ansicht samt `lib/exportRack.ts` — der groesste einzelne Brocken der Anwendung und der Grund fuer die Lazy-Grenze in `CLAUDE.md`. Wer die App zum ersten Mal oeffnet, sieht davon nichts, ohne vorher selbst ein Rack zu bauen. Dieselbe Form wie B-65 in der Suite: gebaute Rechenwerke ohne einen Weg hinein. `docs/ui-audit.md` fuehrt es seit dem Screenshot-Lauf als offenen Punkt (`rack-3d.png`), dort aber nur als fehlende Aufnahme.

## Was gebaut ist

- **`lib/demoRack.ts`** — ein 12-HE-Rack: Patchblende (front), Mischer (full), Multiviewer (full), IEC-Leiste (rear, ganz unten), plus die drei Verbindungen, die man im Rack tatsaechlich steckt.
- **`projectStore.loadDemoProject()`** — laedt das Beispielprojekt UND legt die Rack-Vorlage an, wenn `DEMO_RACK_PRESET_ID` fehlt. Beide Aufrufer (`CanvasArea`, `CommandPalette`) gehen jetzt darueber, damit die Zusammengehoerigkeit an einer Stelle steht statt an zweien.

**Am Beispiel und nicht am Start, und das ist der Punkt:** eine Vorlage, die beim Start nachwaechst — wie `seedBuiltInLibrary` es fuer die Geraete-Vorlagen tut —, kommt nach dem Loeschen wieder, und der Nutzer wird sie nicht los, ohne zu wissen warum. „Beispielprojekt laden" ist eine Handlung; wer sie ausloest, erwartet Beispieldaten. Zweimal laden legt nichts doppelt an, die Kennung ist fest.

## Nebenbefund derselben Klasse

Die `description` des Beispielprojekts war deutsch („Demo-Plan: 2 Kameras → Bildmischer …"), waehrend der `name` daneben schon englisch war. Sie ist **Daten** und kein `t()`-Aufruf — `npm run lang:check` hat davon nie etwas gesehen, und `ausgelieferteDatenQuellsprache.test.ts` prueft Kategorie-Werte, keine Beschreibungen. Es ist das Zweite, was ein neuer Nutzer liest.

## Der Waechter

`tests/beispielRack.test.ts` haelt nicht „das Rack sieht gut aus" fest — das ist Geschmack —, sondern die Zusagen, die still brechen:

- jeder Kabel-Endpunkt trifft einen Port (die Kabel verweisen ueber **Namen**; ein umbenannter Port laesst `placeGroupPreset` die Verbindung gar nicht erst anlegen)
- jede Platzierung liegt im Rack, und keine zwei ueberlappen auf derselben Seite (`full` belegt front UND rear)
- `rackUnits` am Geraet und `heightUnits` an der Platzierung stimmen ueberein — zwei Zahlen fuer dieselbe Sache
- die Kennung ist fest
- die Strom-Leiste heisst wie die ausgelieferte Vorlage aus `passiveCatalog` (der Name IST die Kennung, #837)
- kein Text im Beispiel ist deutsch, gemessen mit `klassifiziere()`, mit Gegenprobe

## Geprueft
- `npx tsc -p tsconfig.app.json --noEmit` — 0 Fehler
- `npx vitest run` — 264 Test-Dateien, 4001 Tests gruen
- `npm run lint` — 0 Errors
- `npm run lang:check` — 0 Verstoesse in `src/renderer`, `src/mobile`, `src/viewer`
- `npm run ui:smoke` — gruen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_