### PR TITLE
fristen: eigene Fristarten im Wire-Contract (avplan-inventory 7)

### DIFF
--- a/src/renderer/lager/lib/inventoryPortable.ts
+++ b/src/renderer/lager/lib/inventoryPortable.ts
@@ -7,7 +7,7 @@
 // werden per Freitext (manufacturer/model) + Label-`code` identifiziert; ein
 // Katalog-GUID-Bezug ist bewusst nicht Teil des Formats.
 // ───────────────────────────────────────────────────────────────────────────
-import type { InventoryItem, StorageNode, InventorySet, InventoryUnit } from '../types/inventory'
+import type { InventoryItem, StorageNode, InventorySet, InventoryUnit, FristArtDef } from '../types/inventory'
 
 export const INVENTORY_FORMAT = 'avplan-inventory'
 // Version 2 (ADR-002): `InventoryItem.deviceTypeId`. Die Erhoehung ist kein
@@ -72,13 +72,40 @@ export const INVENTORY_FORMAT = 'avplan-inventory'
 // Aeltere Dateien (v1-v5) lesen wir unveraendert weiter; ihre Einheiten
 // haben schlicht keine Fristen, und das ist nicht „geprueft", sondern
 // UNBEWERTET.
-export const INVENTORY_FORMAT_VERSION = 6
+// Version 7 (Eigentuemer-Entscheidung 2026-09-10): `fristArten` -- die
+// Fristarten, die das HAUS selbst angelegt hat, und die eingebaute Art
+// `haltbarkeit` fuer Verbrauchsmaterial mit Ablaufdatum.
+//
+// Der Verlust, den diese Version verhindert, ist ein anderer als bei 3 bis 6.
+// Dort ging ein FELD verloren; hier ginge die BEDEUTUNG verloren. `Frist.art`
+// war eine feste Aufzaehlung, und jeder Leser zog eine unbekannte Art auf
+// `sonstige` -- gut gemeint, damit ein Termin nicht verschwindet. Sobald ein
+// Haus eigene Arten fuehrt (Anschlagmittel, Leiterpruefung, Feuerloescher,
+// Nebelfluid-Charge), macht dieselbe Zeile aus jeder davon „Sonstige": der
+// Termin steht noch auf der Liste, aber ohne den Grund, aus dem ihn jemand
+// eingetragen hat. Wer die Liste abarbeitet, weiss nicht mehr, was zu tun ist.
+//
+// Deshalb zwei Dinge zusammen: die Liste reist mit, UND eine unbekannte Art
+// bleibt stehen, wie sie ist. Die Anzeige sagt dann, dass sie die Art nicht
+// kennt -- das ist eine Auskunft, „Sonstige" waere eine Behauptung.
+//
+// Aeltere Dateien (v1-v6) lesen wir unveraendert weiter; ihre Fristen tragen
+// eingebaute Arten, und eine Liste eigener Arten haben sie schlicht nicht.
+export const INVENTORY_FORMAT_VERSION = 7
 
 export interface InventorySnapshot {
   items: InventoryItem[]
   nodes: StorageNode[]
   sets: InventorySet[]
   units: InventoryUnit[]
+  /**
+   * Die selbst angelegten Fristarten des Hauses (Version 7).
+   *
+   * Optional heisst: die Datei stammt aus einem Haus, das keine eigenen
+   * fuehrt -- nicht, dass es keine gibt. Die eingebauten Arten stehen
+   * hier NIE drin; sie kennt jede App.
+   */
+  fristArten?: FristArtDef[]
 }
 
 interface PortableFile extends InventorySnapshot {
@@ -101,11 +128,42 @@ export const serializeInventory = (snap: InventorySnapshot, meta?: { exportedAt?
     nodes: snap.nodes,
     sets: snap.sets,
     units: snap.units,
+    fristArten: snap.fristArten,
   }
   return JSON.stringify(file, null, 2)
 }
 
 const arr = <T>(v: unknown): T[] => (Array.isArray(v) ? (v as T[]) : [])
+
+/**
+ * Die eigenen Fristarten heilen.
+ *
+ * Eine Art ohne Id oder ohne Namen ist keine: unter ihr stuende in der Liste
+ * nichts, und ein Termin, dessen Art nichts sagt, ist ein Termin ohne Grund.
+ * Doppelte Ids fallen weg -- die erste gilt, wie ueberall in diesem Format.
+ */
+const heileFristArten = (raw: unknown): FristArtDef[] | undefined => {
+  if (!Array.isArray(raw)) return undefined
+  const gesehen = new Set<string>()
+  const aus: FristArtDef[] = []
+  for (const e of raw) {
+    if (!e || typeof e !== 'object') continue
+    const d = e as Partial<FristArtDef>
+    const id = typeof d.id === 'string' ? d.id.trim() : ''
+    const name = typeof d.name === 'string' ? d.name.trim() : ''
+    if (!id || !name || gesehen.has(id)) continue
+    gesehen.add(id)
+    aus.push({
+      id,
+      name,
+      ...(typeof d.standardIntervallMonate === 'number' && d.standardIntervallMonate > 0
+        ? { standardIntervallMonate: Math.round(d.standardIntervallMonate) }
+        : {}),
+      ...(typeof d.grundlage === 'string' && d.grundlage.trim() ? { grundlage: d.grundlage.trim() } : {}),
+    })
+  }
+  return aus.length > 0 ? aus : undefined
+}
 
 /**
  * Parst portables JSON zu einem Snapshot. Tolerant gegenüber fehlenden
@@ -129,5 +187,6 @@ export const parseInventory = (json: string): InventorySnapshot | null => {
     nodes: arr<StorageNode>(f.nodes),
     sets: arr<InventorySet>(f.sets),
     units: arr<InventoryUnit>(f.units),
+    ...(heileFristArten(f.fristArten) ? { fristArten: heileFristArten(f.fristArten) } : {}),
   }
 }

--- a/src/renderer/lager/store/inventoryStore.ts
+++ b/src/renderer/lager/store/inventoryStore.ts
@@ -297,7 +297,16 @@ const healVersicherungswert = (raw: unknown): Versicherungswert | undefined => {
   return { betrag, ...(typeof r.stand === 'string' && r.stand.trim() ? { stand: r.stand.trim() } : {}) }
 }
 
-const FRIST_ARTEN: FristArt[] = ['dguv-v3', 'kalibrierung', 'wartung', 'akku', 'sonstige']
+/**
+ * Eine Art ohne Inhalt ist keine.
+ *
+ * Bis 2026-09-10 stand hier eine feste Liste, und alles ausserhalb wurde
+ * `sonstige`. Seit die Haeuser eigene Arten anlegen duerfen (Anschlagmittel,
+ * Leiterpruefung, Nebelfluid-Charge), macht dieselbe Zeile aus JEDER davon
+ * „Sonstige" -- der Termin bleibt auf der Liste, sein Grund nicht. Geprueft
+ * wird deshalb nur noch, ob ueberhaupt etwas dasteht.
+ */
+const istArt = (v: unknown): v is FristArt => typeof v === 'string' && v.trim().length > 0
 
 /**
  * Fristen heilen (B-65). Dieselbe Regel wie im Lager-Werkzeug: ein Termin
@@ -319,10 +328,10 @@ const healFristen = (raw: unknown): Frist[] | undefined => {
         ? Math.round(f.intervallMonate)
         : undefined
     if (!faellig && !(zuletzt && intervallMonate)) continue
-    const art: FristArt =
-      typeof f.art === 'string' && (FRIST_ARTEN as string[]).includes(f.art)
-        ? (f.art as FristArt)
-        : 'sonstige'
+    // Unbekannte Arten bleiben stehen, wie sie sind (Format-Version 7).
+    // Was die Anzeige nicht kennt, sagt sie -- „Sonstige" waere eine
+    // Behauptung an einer Stelle, an der eine Auskunft hingehoert.
+    const art: FristArt = istArt(f.art) ? f.art.trim() : 'sonstige'
     out.push({
       art,
       ...(typeof f.bezeichnung === 'string' && f.bezeichnung.trim()

--- a/src/renderer/lager/types/inventory.ts
+++ b/src/renderer/lager/types/inventory.ts
@@ -117,9 +117,80 @@ export interface Versicherungswert {
  * dieselbe Sache — ein Datum, ab dem etwas nicht mehr gilt. Woran es
  * haengt, sagt `art`.
  */
-export type FristArt = 'dguv-v3' | 'kalibrierung' | 'wartung' | 'akku' | 'sonstige'
+/**
+ * Die Fristarten, die jede App mitbringt.
+ *
+ * `haltbarkeit` ist seit 2026-09-10 dabei (Eigentuemer-Entscheidung):
+ * Verbrauchsmaterial mit Ablaufdatum -- Batterien, Gaffa, Filter,
+ * Nebelfluid -- ist KEIN zweites Modell, sondern eine weitere Art von
+ * Termin. Ein Ablaufdatum und ein Prueftermin sind dieselbe Sache: ein
+ * Datum, ab dem etwas nicht mehr gilt. Zwei Mechaniken dafuer haetten
+ * geheissen, dass jede kuenftige Auswertung beide fragen muss -- und die
+ * naechste fragt dann eine.
+ */
+export const EINGEBAUTE_FRIST_ARTEN = [
+  'dguv-v3',
+  'kalibrierung',
+  'wartung',
+  'akku',
+  'haltbarkeit',
+  'sonstige',
+] as const
+
+export type EingebauteFristArt = (typeof EINGEBAUTE_FRIST_ARTEN)[number]
+
+/**
+ * Die Art einer Frist: eine eingebaute Id oder eine, die das Haus selbst
+ * angelegt hat.
+ *
+ * ─── WARUM DAS KEINE FESTE AUFZAEHLUNG MEHR IST ─────────────────────────
+ *
+ * Sie war eine, und die Liste war die Kenntnis ihres Autors. Was ein Haus
+ * turnusmaessig prueft, weiss aber nur das Haus: Leiter- und
+ * Traversenpruefung, Anschlagmittel, Feuerloescher, Erste-Hilfe-Kasten,
+ * Nebelfluid-Charge, TUeV am Anhaenger. Jede dieser Fristen landete unter
+ * `sonstige`, und damit war die Ampel im Lager fuer alles ausser den vier
+ * eingebauten Arten eine Sammelmeldung ohne Sortierung.
+ *
+ * `(string & {})` statt `string`: der Typ bleibt offen, aber die
+ * eingebauten Ids stehen weiter in der Vervollstaendigung. Ein blankes
+ * `string` haette beides gekostet.
+ */
+export type FristArt = EingebauteFristArt | (string & {})
+
+/**
+ * Eine Fristart, wie das Haus sie fuehrt.
+ *
+ * Reist im Inventar-Datei-Format mit (`fristArten`), und zwar NUR die selbst
+ * angelegten: die eingebauten kennt jede App ohnehin, und sie mitzuschicken
+ * hiesse, ihre Uebersetzung in die Datei zu schreiben.
+ */
+export interface FristArtDef {
+  /** Stabile Id. Unter ihr steht sie in `Frist.art`. */
+  id: string
+  /** Anzeigename, so wie das Haus sie nennt. */
+  name: string
+  /** Vorschlag fuer das Intervall in Monaten, wenn eine neue angelegt wird. */
+  standardIntervallMonate?: number
+  /**
+   * Woran die Frist haengt -- nur zur Anzeige, nicht zur Rechnung.
+   * Freitext: „DGUV V3", „Herstellerangabe", „Hausregel".
+   */
+  grundlage?: string
+}
 
 export interface Frist {
+  /**
+   * Eingebaute Id oder eine aus `fristArten`.
+   *
+   * Eine Id, die WEDER eingebaut ist NOCH in der Liste steht, bleibt
+   * trotzdem stehen. Sie auf `sonstige` zu ziehen war bis 2026-09-10 die
+   * Regel und ist jetzt genau der Verlust, den es zu vermeiden gilt: die
+   * Datei sagt „Anschlagmittel", der Leser macht daraus „Sonstige", und der
+   * Termin steht auf der Liste ohne den Grund, aus dem ihn jemand
+   * eingetragen hat. Die Anzeige sagt stattdessen, dass sie die Art nicht
+   * kennt.
+   */
   art: FristArt
   /** Freitext, wenn `art` es nicht sagt (bei `sonstige` das Einzige). */
   bezeichnung?: string

--- a/tests/inventoryContract.test.ts
+++ b/tests/inventoryContract.test.ts
@@ -40,8 +40,8 @@ import type { InventoryItem, StorageNode, InventorySet, InventoryUnit } from '..
 // Eingefrorener Contract — MUSS in allen drei Repos identisch sein.
 const CONTRACT = {
   format: 'avplan-inventory',
-  version: 6,
-  envelopeKeys: ['app', 'exportedAt', 'format', 'items', 'nodes', 'sets', 'units', 'version'],
+  version: 7,
+  envelopeKeys: ['app', 'exportedAt', 'format', 'fristArten', 'items', 'nodes', 'sets', 'units', 'version'],
   itemKeys: ['category', 'code', 'codeType', 'createdAt', 'deviceTypeId', 'dimensions', 'id', 'locationId', 'manufacturer', 'materialKinds', 'mindestmenge', 'model', 'notes', 'ownership', 'quantity', 'rentPricePerDay', 'returnDue', 'stockLocation', 'supplier', 'updatedAt', 'ursprungsland'],
   nodeKeys: ['code', 'codeType', 'createdAt', 'dimensions', 'id', 'kind', 'name', 'notes', 'parentId', 'updatedAt'],
   setKeys: ['components', 'createdAt', 'id', 'name', 'notes', 'updatedAt'],
@@ -95,7 +95,19 @@ const unit: InventoryUnit = {
   fristen: [{ art: 'dguv-v3', zuletzt: '2026-03-09', intervallMonate: 12 }],
   createdAt: 't', updatedAt: 't',
 }
-const snapshot: InventorySnapshot = { items: [item], nodes: [node], sets: [set], units: [unit] }
+/**
+ * Eine selbst angelegte Fristart (Format-Version 7). Sie MUSS mitreisen:
+ * ohne sie kommt drueben ein Termin an, dessen Art niemand benennen kann.
+ */
+const eigeneArt = { id: 'anschlagmittel', name: 'Anschlagmittel', standardIntervallMonate: 12 }
+
+const snapshot: InventorySnapshot = {
+  items: [item],
+  nodes: [node],
+  sets: [set],
+  units: [unit],
+  fristArten: [eigeneArt],
+}
 
 const sortedKeys = (o: object) => Object.keys(o).sort()
 


### PR DESCRIPTION
Gegenstück zu larszu/inventory-planner#9 — dort werden die Fristarten gepflegt, hier reisen sie durch.

## Warum das hier überhaupt Arbeit ist

`healUnit` baut jede Einheit **Feld für Feld** neu auf. Ein Feld, das der Typ nicht kennt, hätte der Lager-Store eingelesen und beim Export still weggeschrieben — dieselbe Stelle, an der schon `mindestmenge`, `versicherungswert` und `fristen` selbst hängen geblieben wären.

## Was sich ändert

- `EINGEBAUTE_FRIST_ARTEN` (jetzt sechs — `haltbarkeit` ist dazugekommen) und `FristArtDef`. `FristArt` ist `EingebauteFristArt | (string & {})`: offen, aber die eingebauten Ids stehen weiter in der Vervollständigung.
- `InventorySnapshot.fristArten` mit Heilung beim Parsen, Format-Version 7. Eine Art ohne Id oder ohne Namen ist keine; doppelte Ids fallen weg, die erste gilt.
- **Die Heilung im Lager-Store zieht eine unbekannte Art nicht mehr auf `sonstige`.** Das war gut gemeint und benannte um, statt zu bewahren: die Datei sagt „Anschlagmittel", der Leser macht „Sonstige" daraus, und der Termin steht ohne seinen Grund auf der Liste. Geprüft wird jetzt nur noch, ob überhaupt etwas dasteht.
- Der eingefrorene Contract-Test trägt Version 7 und den Envelope-Schlüssel; sein Muster-Snapshot enthält eine selbst angelegte Art, sonst prüfte er die neue Zusage nicht.

Ältere Dateien (v1–v6) bleiben lesbar; ihre Fristen tragen eingebaute Arten, und eine Liste eigener Arten haben sie schlicht nicht — das ist keine leere Liste, sondern keine.

## Nachgewiesen

267 Testdateien, 4032 Tests grün · `tsc -p tsconfig.app.json --noEmit` sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_