### PR TITLE
haus: der Plan liest die Gebäude-Auskunft und prüft gegen sie

### DIFF
--- a/src/renderer/components/Analysis/PlanCheckPanel.tsx
+++ b/src/renderer/components/Analysis/PlanCheckPanel.tsx
@@ -36,10 +36,13 @@ export const PlanCheckPanel = () => {
   const anschlussListe = useProjectStore((s) => s.project.anschlussListe)
   const farbnormen = useProjectStore((s) => s.project.farbnormen)
   const defaultVideoFormat = useProjectStore((s) => s.project.metadata.defaultVideoFormat)
+  // Die Auskunft des Gebaeudes speist die Haus-Checks (facility Issue #2).
+  // Fehlt sie, schweigen sie vollstaendig.
+  const hausAuskunft = useProjectStore((s) => s.project.hausAuskunft)
   const setSelection = useProjectStore((s) => s.setSelection)
 
   const result = useMemo(
-    () => runDrawingChecks({ equipment, cables, drumKit, sourceIdentities, anschlussListe, farbnormen, defaultVideoFormat }),
+    () => runDrawingChecks({ equipment, cables, drumKit, sourceIdentities, anschlussListe, farbnormen, defaultVideoFormat, hausAuskunft }),
     [equipment, cables, drumKit, sourceIdentities, anschlussListe, farbnormen, defaultVideoFormat],
   )
 

--- a/src/renderer/components/Layout/StatusBar.tsx
+++ b/src/renderer/components/Layout/StatusBar.tsx
@@ -122,6 +122,9 @@ export const StatusBar = ({
   const anschlussListe = useProjectStore((s) => s.project.anschlussListe)
   const farbnormen = useProjectStore((s) => s.project.farbnormen)
   const defaultVideoFormat = useProjectStore((s) => s.project.metadata.defaultVideoFormat)
+  // Die Auskunft des Gebaeudes speist die Haus-Checks (facility Issue #2).
+  // Fehlt sie, schweigen sie vollstaendig.
+  const hausAuskunft = useProjectStore((s) => s.project.hausAuskunft)
   const networkSegments = useProjectStore((s) => s.project.networkSegments)
   const togglePlanCheck = useUiStore((s) => s.togglePlanCheck)
   // Memoisiert, weil die StatusBar bei jeder Viewport-Aenderung rendert, die
@@ -129,7 +132,7 @@ export const StatusBar = ({
   // den Kabelgraph). Abhaengigkeiten sind Store-Referenzen, wechseln also nur
   // bei echter Projekt-Aenderung.
   const { errorCount, warningCount } = useMemo(
-    () => runDrawingChecks({ equipment, cables, drumKit, sourceIdentities, anschlussListe, farbnormen, defaultVideoFormat }),
+    () => runDrawingChecks({ equipment, cables, drumKit, sourceIdentities, anschlussListe, farbnormen, defaultVideoFormat, hausAuskunft }),
     [equipment, cables, drumKit, sourceIdentities, anschlussListe, farbnormen, defaultVideoFormat],
   )
   // ── DIE NETZ-BEFUNDE, NEBEN DEN PLAN-CHECK (2026-09-07) ────────────────

--- a/src/renderer/components/Properties/EquipmentProperties.tsx
+++ b/src/renderer/components/Properties/EquipmentProperties.tsx
@@ -22,6 +22,7 @@ import { PowerConsumptionSection } from './sections/PowerConsumptionSection'
 import { CircuitSection } from './sections/CircuitSection'
 import { AdapterSection } from './sections/AdapterSection'
 import { DmxSection } from './sections/DmxSection'
+import { HausSection } from './sections/HausSection'
 import { SinkProfileSection } from './sections/SinkProfileSection'
 import { SwitchingSection } from './sections/SwitchingSection'
 import { DisplayPropertiesBlock } from './sections/DisplayPropertiesBlock'
@@ -170,6 +171,7 @@ export const EquipmentProperties = () => {
           Namensabgleich liefern kann und die im Aufbau darueber entscheiden,
           ob ueberhaupt etwas ankommt. */}
       <DmxSection equipment={equipment} />
+      <HausSection equipment={equipment} />
       <SinkProfileSection equipment={equipment} />
       <SwitchingSection equipment={equipment} />
 

--- a/src/renderer/components/Properties/sections/HausSection.tsx
+++ b/src/renderer/components/Properties/sections/HausSection.tsx
@@ -1,0 +1,163 @@
+import { useRef, useState } from 'react'
+import { useProjectStore } from '../../../store/projectStore'
+import { format, useTranslation } from '../../../lib/i18n'
+import type { EquipmentItem } from '../../../types/equipment'
+import { hausPunkt, hausRaumLabel } from '../../../types/hausAuskunft'
+import { leseHausDatei } from '../../../lib/hausDatei'
+import { SortableSection } from '../SortableSection'
+import { PanelHint } from '../../shared/PanelHint'
+
+/**
+ * Der Hausanschluss dieses Geraets (larszu-facility-planner Issue #2).
+ *
+ * ─── WARUM DIE DATEI HIER GELADEN WIRD UND NICHT IN DEN EINSTELLUNGEN ──────
+ *
+ * Weil hier die Frage entsteht. Wer ein Geraet setzt und wissen will, woran
+ * es haengt, sucht nicht erst einen Reiter. Der Knopf steht deshalb an der
+ * Stelle, an der die Auskunft gebraucht wird, und verschwindet, sobald eine
+ * hinterlegt ist.
+ *
+ * ─── WAS HIER NICHT PASSIERT ───────────────────────────────────────────────
+ *
+ * Nichts wird abgeschrieben. Absicherung, Dauerleistung und „geschaltet"
+ * stehen als ANZEIGE da und gehen nicht ins Geraet: das Geraet haelt nur die
+ * Id. Waere es anders, haette der Plan beim naechsten Export des Betreibers
+ * Zahlen, die das Haus so nicht mehr sagt — und niemand saehe es.
+ */
+export const HausSection = ({ equipment }: { equipment: EquipmentItem }) => {
+  const t = useTranslation()
+  const auskunft = useProjectStore((s) => s.project.hausAuskunft)
+  const setHausAuskunft = useProjectStore((s) => s.setHausAuskunft)
+  const updateEquipment = useProjectStore((s) => s.updateEquipment)
+  const [fehler, setFehler] = useState<string | null>(null)
+  const feld = useRef<HTMLInputElement>(null)
+
+  const punkt = hausPunkt(auskunft, equipment.hausPunktId)
+  const klinke = auskunft?.klinken.find((k) => k.id === equipment.hausKlinkeId)
+
+  const laden = async (datei: File) => {
+    setFehler(null)
+    const gelesen = leseHausDatei(await datei.text(), {
+      quelle: datei.name,
+      gelesenAm: new Date().toISOString(),
+    })
+    if (!gelesen) {
+      setFehler(
+        t(
+          'haus.dateiUnlesbar',
+          'That is not a building file from the facility planner, or it comes from a newer version. Nothing was taken over.',
+        ),
+      )
+      return
+    }
+    setHausAuskunft(gelesen)
+  }
+
+  const summary = !auskunft
+    ? t('haus.keineAuskunft', 'no building file')
+    : punkt
+      ? punkt.bezeichnung
+      : t('haus.nichtZugeordnet', 'not assigned')
+
+  return (
+    <SortableSection id="haus" title={t('haus.title', 'House connection')} subtitle={summary}>
+      {!auskunft ? (
+        <>
+          <PanelHint
+            text={t(
+              'haus.ladenHinweis',
+              'The facility planner exports the building as an .avfacility file: which outlets exist, what they carry, which of them are switched or dimmed, and which control addresses the show may use. Load it here and the plan check can ask it.',
+            )}
+          />
+          <button
+            type="button"
+            onClick={() => feld.current?.click()}
+            className="mt-2 rounded bg-cp-surface-4 px-2 py-1 text-cp-xs hover:bg-cp-surface-5"
+          >
+            {t('haus.dateiLaden', 'Load building file…')}
+          </button>
+          <input
+            ref={feld}
+            type="file"
+            accept=".avfacility,application/json"
+            className="hidden"
+            onChange={(e) => {
+              const datei = e.target.files?.[0]
+              e.target.value = ''
+              if (datei) void laden(datei)
+            }}
+          />
+          {fehler && <PanelHint text={fehler} />}
+        </>
+      ) : (
+        <div className="space-y-2">
+          {/* Die Abschrift sagt, WANN sie entstanden ist. Zwischen Export und
+              Aufbau kann der Betreiber eine Dose stillgelegt haben. */}
+          <div className="text-cp-xs text-cp-text-muted">
+            {format(t('haus.stand', '{name} · read {stand} from {quelle}'), {
+              name: auskunft.name,
+              stand: auskunft.gelesenAm.slice(0, 10),
+              quelle: auskunft.quelle,
+            })}
+          </div>
+
+          <label className="text-cp-xs">
+            <span className="text-cp-text-muted">{t('haus.punkt', 'House outlet')}</span>
+            <select
+              value={equipment.hausPunktId ?? ''}
+              onChange={(e) => updateEquipment(equipment.id, { hausPunktId: e.target.value || undefined })}
+              className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
+            >
+              <option value="">{t('haus.keinPunkt', '— none —')}</option>
+              {auskunft.punkte.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.bezeichnung} · {hausRaumLabel(auskunft, p.raumId)} · {p.anschlussart} {p.absicherungA} A
+                </option>
+              ))}
+            </select>
+          </label>
+
+          {/* Was das Haus über diesen Punkt sagt — als Anzeige, nicht als
+              Kopie. Was es NICHT sagt, steht auch nicht da. */}
+          {punkt && (
+            <ul className="space-y-0.5 text-cp-xs text-cp-text-muted">
+              <li>
+                {format(t('haus.absicherung', 'Fuse {a} A'), { a: punkt.absicherungA })}
+                {punkt.dauerleistungW
+                  ? ` · ${format(t('haus.dauerleistung', '{w} W continuous'), { w: punkt.dauerleistungW })}`
+                  : ` · ${t('haus.keineDauerleistung', 'continuous rating not stated')}`}
+              </li>
+              {punkt.geschaltet === true && <li className="text-cp-warn">{t('haus.geschaltet', 'switched')}</li>}
+              {punkt.gedimmt === true && <li className="text-cp-danger">{t('haus.gedimmt', 'dimmed')}</li>}
+              {punkt.hinweis && <li>{punkt.hinweis}</li>}
+            </ul>
+          )}
+
+          <label className="text-cp-xs">
+            <span className="text-cp-text-muted">{t('haus.klinke', 'Control address')}</span>
+            <select
+              value={equipment.hausKlinkeId ?? ''}
+              onChange={(e) => updateEquipment(equipment.id, { hausKlinkeId: e.target.value || undefined })}
+              className="mt-0.5 w-full rounded border border-cp-border bg-cp-surface-3 p-1 text-cp-xs"
+            >
+              <option value="">{t('haus.keineKlinke', '— none —')}</option>
+              {auskunft.klinken.map((k) => (
+                <option key={k.id} value={k.id}>
+                  {k.system.toUpperCase()} {k.adresse}
+                  {k.adressart ? ` (${k.adressart})` : ''} · {k.bedeutung}
+                </option>
+              ))}
+            </select>
+          </label>
+          {klinke && (
+            <div className="text-cp-xs text-cp-text-muted">
+              {klinke.richtung === 'lesen'
+                ? t('haus.nurLesen', 'read only — this address reports, it does not switch')
+                : t('haus.schaltet', 'switching — what it does is what the building states')}
+            </div>
+          )}
+        </div>
+      )}
+    </SortableSection>
+  )
+}

--- a/src/renderer/lib/drawingChecks.ts
+++ b/src/renderer/lib/drawingChecks.ts
@@ -79,6 +79,16 @@ export interface DrawingCheckInput {
   farbnormen?: import('../types/conductor').Farbnorm[]
   /** B-47 — das Format, das gilt, wo das Kabel keines nennt. */
   defaultVideoFormat?: import('../types/videoFormat').VideoFormatId
+  /**
+   * Die Auskunft des Gebaeudes, gegen die geplant wurde
+   * (`larszu-facility-planner` Issue #2).
+   *
+   * Fehlt sie, schweigen die Haus-Checks vollstaendig — sie melden dann NICHT
+   * „kein Gebaeude hinterlegt". Die allermeisten Plaene stehen in einer Halle,
+   * ueber die niemand eine Datei hat, und ein Befund, den man nicht beheben
+   * kann, ist die schnellste Art, eine Liste unlesbar zu machen.
+   */
+  hausAuskunft?: import('../types/hausAuskunft').HausAuskunft
 }
 
 export interface DrawingCheckResult {
@@ -101,6 +111,7 @@ export const runDrawingChecks = (
     anschlussListe,
     farbnormen,
     defaultVideoFormat,
+    hausAuskunft,
   }: DrawingCheckInput,
 ): DrawingCheckResult => {
   const findings: CheckFinding[] = []
@@ -1086,6 +1097,126 @@ export const runDrawingChecks = (
       message: format(tr(b.schluessel, b.text), b.werte),
       equipmentId: b.geraetId,
     })
+  }
+
+  // — Check 26: die Auskunft des Gebaeudes (facility-planner Issue #2) -------
+  //
+  // Der Plan verweist auf Anschlusspunkte und Steuerklinken des Hauses und
+  // kopiert deren Angaben NICHT. Diese Pruefungen sind das, was der Verweis
+  // wert ist: sie fragen die Auskunft, statt sich auf eine Abschrift zu
+  // verlassen, die inzwischen falsch sein koennte.
+  //
+  // Ohne hinterlegte Auskunft passiert hier gar nichts — kein „nicht
+  // geprueft", kein Hinweis. Wer in einer Halle plant, ueber die es keine
+  // Datei gibt, soll keine Liste bekommen, die er nicht abarbeiten kann.
+  if (hausAuskunft) {
+    const punktById = new Map(hausAuskunft.punkte.map((p) => [p.id, p]))
+    const klinkeById = new Map(hausAuskunft.klinken.map((k) => [k.id, k]))
+    const lastJePunkt = new Map<string, number>()
+
+    for (const e of equipment) {
+      if (e.hausPunktId) {
+        const punkt = punktById.get(e.hausPunktId)
+        if (!punkt) {
+          // Der teure Fall: das Haus hat eine neue Datei geschickt, und die
+          // Dose von damals steht nicht mehr drin. Stillschweigend weiter zu
+          // planen hiesse, eine Last auf einen Punkt zu legen, den es nicht
+          // mehr gibt.
+          findings.push({
+            id: `haus-punkt-fehlt:${e.id}`,
+            severity: 'error',
+            category: 'House outlet',
+            message: format(
+              tr(
+                'check.haus.punktFehlt',
+                '{name} is planned on a house outlet that the building statement of {stand} no longer lists. Pick a current one.',
+              ),
+              { name: e.name, stand: hausAuskunft.gelesenAm.slice(0, 10) },
+            ),
+            equipmentId: e.id,
+          })
+        } else {
+          if (punkt.gedimmt === true) {
+            findings.push({
+              id: `haus-gedimmt:${e.id}`,
+              severity: 'error',
+              category: 'House outlet',
+              message: format(
+                tr(
+                  'check.haus.gedimmt',
+                  '{name} hangs on {punkt}, and the building states that outlet is dimmed. A switching power supply on a dimmer either fails or burns.',
+                ),
+                { name: e.name, punkt: punkt.bezeichnung },
+              ),
+              equipmentId: e.id,
+            })
+          }
+          if (punkt.geschaltet === true) {
+            // WARNUNG und kein Fehler: geschaltet ist nicht verboten, es ist
+            // nur selten gemeint. Fuer die Saalbeleuchtung ist es richtig,
+            // fuer den Medienserver das Ende der Show.
+            findings.push({
+              id: `haus-geschaltet:${e.id}`,
+              severity: 'warning',
+              category: 'House outlet',
+              message: format(
+                tr(
+                  'check.haus.geschaltet',
+                  '{name} hangs on {punkt}, and the building states that outlet is switched. Whoever flips that switch takes the device with it.',
+                ),
+                { name: e.name, punkt: punkt.bezeichnung },
+              ),
+              equipmentId: e.id,
+            })
+          }
+          const watt = effectiveWatts(e)
+          if (watt > 0) lastJePunkt.set(punkt.id, (lastJePunkt.get(punkt.id) ?? 0) + watt)
+        }
+      }
+
+      if (e.hausKlinkeId && !klinkeById.has(e.hausKlinkeId)) {
+        findings.push({
+          id: `haus-klinke-fehlt:${e.id}`,
+          severity: 'error',
+          category: 'House control',
+          message: format(
+            tr(
+              'check.haus.klinkeFehlt',
+              '{name} uses a control address that the building statement of {stand} no longer lists. What it would switch is unknown.',
+            ),
+            { name: e.name, stand: hausAuskunft.gelesenAm.slice(0, 10) },
+          ),
+          equipmentId: e.id,
+        })
+      }
+    }
+
+    // Die Summe gegen die DAUERLEISTUNG — und nur, wenn das Haus sie angibt.
+    //
+    // Sie aus `absicherungA` zu rechnen waere die naheliegende Ergaenzung und
+    // die falsche: der Nennstrom ist die Ausloeseschwelle, nicht die
+    // Belastbarkeit. Leitungslaenge, Haeufung und Gleichzeitigkeit gehen ein,
+    // und keine dieser Zahlen steht im Plan. Wo das Haus schweigt, schweigt
+    // auch dieser Check — eine erfundene Grenze liest sich auf dem Blatt wie
+    // eine gemessene.
+    for (const [punktId, watt] of lastJePunkt) {
+      const punkt = punktById.get(punktId)
+      if (!punkt?.dauerleistungW) continue
+      if (watt > punkt.dauerleistungW) {
+        findings.push({
+          id: `haus-last:${punktId}`,
+          severity: 'error',
+          category: 'House outlet',
+          message: format(
+            tr(
+              'check.haus.ueberlast',
+              '{punkt} carries {watt} W of plan devices; the building states {grenze} W continuous.',
+            ),
+            { punkt: punkt.bezeichnung, watt: Math.round(watt), grenze: punkt.dauerleistungW },
+          ),
+        })
+      }
+    }
   }
 
   // Sortierung: error → warning → info, innerhalb stabil nach category.

--- a/src/renderer/lib/hausDatei.ts
+++ b/src/renderer/lib/hausDatei.ts
@@ -1,0 +1,160 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Die Gebaeude-Datei lesen (`avplan-facility`)
+//
+// Der Leser zum Format, das der `facility-planner` schreibt. Er nimmt aus der
+// Datei GENAU die vier Auskuenfte, die der Plan braucht (siehe
+// `types/hausAuskunft.ts`), und laesst den Rest liegen: Verteilungen,
+// Stromkreise, Trassen, Maengel gehoeren dem Haus und nicht der Show.
+//
+// ─── WAS DIESER LESER NICHT TUT ────────────────────────────────────────────
+//
+//  1. ER ERFINDET NICHTS. Fehlt `dauerleistungW`, bleibt es leer — es wird
+//     nicht aus `absicherungA` gerechnet. Fehlt `geschaltet`, bleibt es
+//     `undefined` und wird nicht `false`. „Das Haus sagt nichts dazu" ist
+//     eine andere Aussage als „nein", und im Plan-Check entscheidet der
+//     Unterschied zwischen einer Warnung und Schweigen.
+//  2. ER LIEST KEINE FREMDE DATEI HALB. Falscher Marker oder eine neuere
+//     Fassung → `null`. Eine halb gelesene Gebaeude-Auskunft ist gefaehrlicher
+//     als gar keine: die fehlenden Felder sind Angaben ueber Strom.
+//  3. ER SCHREIBT NICHT ZURUECK. Es gibt in diesem Repo keinen Weg zum
+//     Gebaeude; der einzige Rueckweg ist `mangelMelden` im anderen Werkzeug.
+// ───────────────────────────────────────────────────────────────────────────
+import type {
+  HausAdressart,
+  HausAnschlussart,
+  HausAuskunft,
+  HausKlinke,
+  HausPunkt,
+  HausRaum,
+  HausSteuersystem,
+  HausStrecke,
+} from '../types/hausAuskunft'
+
+export const FACILITY_FORMAT = 'avplan-facility'
+
+/**
+ * Die hoechste Fassung, die dieser Leser versteht.
+ *
+ * Sie muss mit `FACILITY_FORMAT_VERSION` im `facility-planner`
+ * uebereinstimmen. Eine neuere Datei wird abgewiesen — nicht aus Strenge,
+ * sondern weil die Felder, die dieser Leser dann nicht kennt, Auskuenfte
+ * ueber Strom sind.
+ */
+export const FACILITY_FORMAT_VERSION = 1
+
+const ANSCHLUSSARTEN: HausAnschlussart[] = ['cee63', 'cee32', 'cee16', 'powerlock', 'klemme', 'schuko']
+const SYSTEME: HausSteuersystem[] = ['knx', 'dali', 'crestron', 'vissonic', 'sonstige']
+const ADRESSARTEN: HausAdressart[] = ['kurz', 'gruppe', 'broadcast']
+
+const text = (v: unknown): string | undefined =>
+  typeof v === 'string' && v.trim() ? v.trim() : undefined
+
+const zahl = (v: unknown): number | undefined =>
+  typeof v === 'number' && Number.isFinite(v) ? v : undefined
+
+/** `undefined` bleibt `undefined` — hier NICHT auf `false` ziehen. */
+const jaNein = (v: unknown): boolean | undefined => (typeof v === 'boolean' ? v : undefined)
+
+const leseRaum = (roh: unknown): HausRaum | null => {
+  if (!roh || typeof roh !== 'object') return null
+  const r = roh as Record<string, unknown>
+  const id = text(r.id)
+  const name = text(r.name)
+  if (!id || !name) return null
+  return { id, name, hausbezeichner: text(r.hausbezeichner) ?? '' }
+}
+
+const lesePunkt = (roh: unknown): HausPunkt | null => {
+  if (!roh || typeof roh !== 'object') return null
+  const p = roh as Record<string, unknown>
+  const id = text(p.id)
+  const bezeichnung = text(p.bezeichnung)
+  const raumId = text(p.raumId)
+  const anschlussart = ANSCHLUSSARTEN.find((a) => a === p.anschlussart)
+  const absicherungA = zahl(p.absicherungA)
+  // Ohne diese fuenf ist es kein Anschlusspunkt, sondern eine Zeile.
+  if (!id || !bezeichnung || !raumId || !anschlussart || absicherungA === undefined) return null
+  const dauerleistungW = zahl(p.dauerleistungW)
+  return {
+    id,
+    bezeichnung,
+    art: p.art === 'dose' ? 'dose' : 'einspeisung',
+    raumId,
+    anschlussart,
+    absicherungA,
+    ...(dauerleistungW !== undefined && dauerleistungW > 0 ? { dauerleistungW } : {}),
+    ...(jaNein(p.geschaltet) !== undefined ? { geschaltet: jaNein(p.geschaltet) } : {}),
+    ...(jaNein(p.gedimmt) !== undefined ? { gedimmt: jaNein(p.gedimmt) } : {}),
+    ...(text(p.hinweis) ? { hinweis: text(p.hinweis) } : {}),
+  }
+}
+
+const leseKlinke = (roh: unknown): HausKlinke | null => {
+  if (!roh || typeof roh !== 'object') return null
+  const k = roh as Record<string, unknown>
+  const id = text(k.id)
+  const adresse = text(k.adresse)
+  const bedeutung = text(k.bedeutung)
+  const system = SYSTEME.find((s) => s === k.system)
+  // Eine Adresse OHNE Bedeutung ist eine Nummer, die jemand schaltet, ohne zu
+  // wissen, was passiert. Sie faellt weg — dieselbe Regel wie drueben, wo
+  // beide Felder Pflicht sind.
+  if (!id || !adresse || !bedeutung || !system) return null
+  const adressart = ADRESSARTEN.find((a) => a === k.adressart)
+  return {
+    id,
+    system,
+    adresse,
+    ...(adressart ? { adressart } : {}),
+    richtung: k.richtung === 'lesen' ? 'lesen' : 'schalten',
+    bedeutung,
+  }
+}
+
+const leseStrecke = (roh: unknown): HausStrecke | null => {
+  if (!roh || typeof roh !== 'object') return null
+  const s = roh as Record<string, unknown>
+  const id = text(s.id)
+  const bezeichnung = text(s.bezeichnung)
+  if (!id || !bezeichnung) return null
+  return { id, bezeichnung }
+}
+
+const liste = <T>(v: unknown, lies: (roh: unknown) => T | null): T[] =>
+  Array.isArray(v) ? v.map(lies).filter((x): x is T => x !== null) : []
+
+/**
+ * Eine `.avfacility`-Datei zu der Auskunft machen, die der Plan fuehrt.
+ *
+ * `quelle` und `gelesenAm` kommen von aussen herein: dieses Modul kennt weder
+ * Uhr noch Dateisystem, und die Abschrift ohne Datum saehe aus wie der
+ * Zustand von heute.
+ */
+export const leseHausDatei = (
+  json: string,
+  meta: { quelle: string; gelesenAm: string },
+): HausAuskunft | null => {
+  let daten: unknown
+  try {
+    daten = JSON.parse(json)
+  } catch {
+    return null
+  }
+  if (!daten || typeof daten !== 'object') return null
+  const f = daten as Record<string, unknown>
+  if (f.format !== FACILITY_FORMAT) return null
+  const version = zahl(f.version)
+  if (version === undefined || version > FACILITY_FORMAT_VERSION) return null
+  const g = f.gebaeude
+  if (!g || typeof g !== 'object') return null
+  const gg = g as Record<string, unknown>
+  return {
+    name: text(gg.name) ?? 'Gebäude',
+    gelesenAm: meta.gelesenAm,
+    quelle: meta.quelle,
+    raeume: liste(gg.raeume, leseRaum),
+    punkte: liste(gg.punkte, lesePunkt),
+    klinken: liste(gg.klinken, leseKlinke),
+    strecken: liste(gg.strecken, leseStrecke),
+  }
+}

--- a/src/renderer/lib/i18n/de.ts
+++ b/src/renderer/lib/i18n/de.ts
@@ -5627,4 +5627,40 @@ export const de: Dict = {
   'palette.dmxPatchSummary':
     '{n} Geräte haben eine Adresse bekommen, {skipped} wurden übersprungen, weil kein Modus gesetzt ist. Jede Überschneidung steht im Plan-Check.',
   'check.category.dmx-address': 'DMX-Adresse',
+
+  // ── Die Auskunft des Gebaeudes (facility Issue #2, 2026-09-10) ────────────
+  'check.haus.punktFehlt':
+    '{name} ist auf einen Hausanschluss geplant, den die Gebäude-Auskunft vom {stand} nicht mehr führt. Bitte einen aktuellen wählen.',
+  'check.haus.gedimmt':
+    '{name} hängt an {punkt}, und das Haus gibt diese Dose als gedimmt an. Ein Schaltnetzteil am Dimmer fällt aus oder brennt.',
+  'check.haus.geschaltet':
+    '{name} hängt an {punkt}, und das Haus gibt diese Dose als geschaltet an. Wer den Schalter umlegt, nimmt das Gerät mit.',
+  'check.haus.klinkeFehlt':
+    '{name} benutzt eine Steueradresse, die die Gebäude-Auskunft vom {stand} nicht mehr führt. Was sie schalten würde, ist unbekannt.',
+  'check.haus.ueberlast':
+    'An {punkt} hängen {watt} W aus dem Plan; das Haus gibt {grenze} W Dauerleistung an.',
+  'check.category.house-outlet': 'Hausanschluss',
+  'check.category.house-control': 'Haussteuerung',
+
+  // ── Hausanschluss am Geraet (facility Issue #2) ───────────────────────────
+  'haus.title': 'Hausanschluss',
+  'haus.keineAuskunft': 'keine Gebäude-Datei',
+  'haus.nichtZugeordnet': 'nicht zugeordnet',
+  'haus.ladenHinweis':
+    'Das Gebäude-Werkzeug gibt das Haus als .avfacility-Datei aus: welche Anschlüsse es gibt, was sie hergeben, welche davon geschaltet oder gedimmt sind und welche Steueradressen der Show offenstehen. Hier geladen, kann der Plan-Check sie fragen.',
+  'haus.dateiLaden': 'Gebäude-Datei laden…',
+  'haus.dateiUnlesbar':
+    'Das ist keine Gebäude-Datei des Gebäude-Werkzeugs, oder sie stammt aus einer neueren Fassung. Es wurde nichts übernommen.',
+  'haus.stand': '{name} · gelesen {stand} aus {quelle}',
+  'haus.punkt': 'Hausanschluss',
+  'haus.keinPunkt': '— keiner —',
+  'haus.absicherung': 'Absicherung {a} A',
+  'haus.dauerleistung': '{w} W Dauerleistung',
+  'haus.keineDauerleistung': 'Dauerleistung nicht angegeben',
+  'haus.geschaltet': 'geschaltet',
+  'haus.gedimmt': 'gedimmt',
+  'haus.klinke': 'Steueradresse',
+  'haus.keineKlinke': '— keine —',
+  'haus.nurLesen': 'nur lesen — diese Adresse meldet, sie schaltet nicht',
+  'haus.schaltet': 'schaltet — was dabei passiert, sagt das Gebäude',
 }

--- a/src/renderer/lib/modelFields.ts
+++ b/src/renderer/lib/modelFields.ts
@@ -163,6 +163,14 @@ export const INSTANCE_FIELDS = [
   'dmxUniverse',
   'dmxAdresse',
   'dmxAdresseFestgesetzt',
+
+  // An WELCHER Dose des Hauses dieses Exemplar haengt, und welche Klinke der
+  // Haussteuerung es benutzt (facility Issue #2). Am Modell waere beides
+  // sinnlos: „der Medienserver" haengt nirgends, DIESER Medienserver haengt
+  // an der Wanddose im Foyer. Wer es ans Modell haengte, zoege beim zweiten
+  // Geraet desselben Typs still die Dose des ersten mit.
+  'hausPunktId',
+  'hausKlinkeId',
   'id',
 
   // Wo dieses Exemplar steht

--- a/src/renderer/lib/planDiff.ts
+++ b/src/renderer/lib/planDiff.ts
@@ -222,6 +222,12 @@ export const EQUIPMENT_FIELD_CLASS: Record<string, FieldClass> = {
   dmxUniverse: 'substantive',
   dmxAdresse: 'substantive',
   dmxAdresseFestgesetzt: 'substantive',
+  // Die Verweise ins Gebaeude (facility Issue #2). `substantive`, weil an
+  // ihnen Befunde haengen: eine andere Dose kann geschaltet oder gedimmt
+  // sein, und die Last verteilt sich anders. Am Aussehen des Plans aendert
+  // sich dabei nichts — genau deshalb waere `cosmetic` hier gefaehrlich.
+  hausPunktId: 'substantive',
+  hausKlinkeId: 'substantive',
   // B-46 — die erklaerten Merkmale. Ebenfalls `substantive`: ob die Quelle den
   // Alternate-Mode kann, entscheidet ueber einen Befund am Adapter. Wer das
   // Merkmal streicht, aendert die Aussage des Plans, nicht sein Aussehen.

--- a/src/renderer/store/projectStore.ts
+++ b/src/renderer/store/projectStore.ts
@@ -361,6 +361,22 @@ export interface ProjectState {
   ) => string[]
   updateEquipment: (id: string, patch: Partial<EquipmentItem>) => void
   /**
+   * Die Auskunft des Gebaeudes uebernehmen (facility Issue #2).
+   *
+   * ERSETZT die bisherige, und zwar ganz. Zwei Gebaeude zusammenzufuehren
+   * waere die naheliegende Bequemlichkeit und die falsche: die Ids sind je
+   * Haus unabhaengig vergeben, und ein `p1` von hier ist nicht das `p1` von
+   * dort. Wer sie mischt, bekommt eine Dose mit der Absicherung einer
+   * anderen — und der Plan-Check schweigt dazu, weil beide Verweise ja
+   * aufloesen.
+   *
+   * `undefined` loescht sie. Die Verweise an den Geraeten bleiben stehen:
+   * sie sind die Absicht des Planers, und die verschwindet nicht, weil
+   * gerade keine Datei hinterlegt ist. Der Plan-Check schweigt dann
+   * vollstaendig (siehe `runDrawingChecks`), statt jedes Geraet zu melden.
+   */
+  setHausAuskunft: (auskunft: import('../types/hausAuskunft').HausAuskunft | undefined) => void
+  /**
    * #314 — Geraet auf dem Canvas durch ein anderes Library-Template
    * ersetzen. Ports werden anhand (connectorType, contentLabel/name,
    * dann positional) gemappt; Kabel die kein Mapping bekommen werden

--- a/src/renderer/store/slices/metaSlice.ts
+++ b/src/renderer/store/slices/metaSlice.ts
@@ -37,6 +37,7 @@ export type MetaSlice = Pick<
   | 'setMulticastConfig'
   | 'setFallbackPlan'
   | 'setEventMetadata'
+  | 'setHausAuskunft'
   | 'setTransmissionRecord'
   | 'setCostPlan'
   | 'setNamingScheme'
@@ -325,6 +326,16 @@ export const createMetaSlice: StateCreator<ProjectState, [], [], MetaSlice> = (s
   setEventMetadata: (plan) =>
     set((state) => {
       const updated = { ...state.project, eventMetadata: plan }
+      scheduleProjectAutosave(updated)
+      return { project: updated }
+    }),
+  // Die Auskunft des GEBAEUDES (facility Issue #2). Ein Setter fuer das ganze
+  // Objekt, aus demselben Grund wie oben: Punkte, Klinken und der Zeitpunkt
+  // gehoeren zusammen. Eine Auskunft, deren Punkte von heute und deren Datum
+  // von letzter Woche ist, waere schlimmer als keine.
+  setHausAuskunft: (auskunft) =>
+    set((state) => {
+      const updated = { ...state.project, hausAuskunft: auskunft }
       scheduleProjectAutosave(updated)
       return { project: updated }
     }),

--- a/src/renderer/types/equipment.ts
+++ b/src/renderer/types/equipment.ts
@@ -679,6 +679,32 @@ export interface EquipmentItem {
    * mit der Herkunft `geschaetzt` — sichtbar als solcher, statt still zu
    * einer belegten Zahl zu werden.
    */
+  /**
+   * An welchem Anschlusspunkt des HAUSES dieses Geraet haengt
+   * (`HausAuskunft.punkte[].id`).
+   *
+   * ─── WARUM EIN VERWEIS UND KEINE KOPIE ──────────────────────────────────
+   *
+   * Absicherung, Dauerleistung und „haengt an einem Lichtschalter" sind
+   * Auskuenfte des Hauses. Sie hier abzuschreiben hiesse, sie im Plan zu
+   * fuehren — und beim naechsten Export des Betreibers haette der Plan eine
+   * Zahl, die das Haus so nicht mehr sagt, ohne dass es jemandem auffaellt.
+   * Der Verweis dagegen zeigt entweder auf eine Auskunft oder ins Leere, und
+   * ins Leere zeigt der Plan-Check an.
+   *
+   * Dieselbe Regel wie bei `deviceTypeId` (ADR-002): eine Zuordnung ist eine
+   * ERKLAERUNG und kein Namensvergleich.
+   */
+  hausPunktId?: string
+  /**
+   * Welche Steuerklinke des Hauses dieses Geraet benutzt
+   * (`HausAuskunft.klinken[].id`).
+   *
+   * Beispiel: ein Medienserver, der zum Showstart ueber KNX das Saallicht
+   * dimmt. Was dabei passiert, steht in der `bedeutung` der Klinke — im Plan
+   * steht nur, DASS sie benutzt wird.
+   */
+  hausKlinkeId?: string
   dmxProfil?: import('../lib/dmx/types').DmxProfil
   /** Welcher Modus gefahren wird (Id aus `dmxProfil.modi`). */
   dmxModusId?: string

--- a/src/renderer/types/hausAuskunft.ts
+++ b/src/renderer/types/hausAuskunft.ts
@@ -1,0 +1,146 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Was das GEBAEUDE ueber sich erklaert — gelesen, nie bearbeitet
+// (larszu-facility-planner Issue #2, letzter offener Haken)
+//
+// ─── WARUM DAS HIER NICHT DAS GEBAEUDE-MODELL IST ──────────────────────────
+//
+// Der `facility-planner` fuehrt ein grosses Modell: Raeume, Verteilungen,
+// Stromkreise, Trassen, Schaltstellen, Maengel. Davon steht hier NICHTS —
+// weder als Kopie noch als Import. Das ist dieselbe Grenze wie beim Lager
+// (ADR-006), nur von der anderen Seite gelesen: der Plan beschreibt eine
+// SHOW, die am Abbautag eingepackt wird, das Gebaeude steht Jahre. Wer das
+// Hausmodell hier hereinzieht, fuehrt die Verwaltung des Hauses in einem
+// Werkzeug, das dafuer nicht gebaut ist — und aendert sie dort, wo sie nicht
+// hingehoert.
+//
+// Was der Plan wirklich braucht, sind vier Auskuenfte:
+//
+//   1. Welche Anschlusspunkte gibt es, und was geben sie her?
+//   2. Haengt der Punkt an einem Schalter oder Dimmer?
+//   3. Welche Steuerklinken stehen der Show offen?
+//   4. Welche festen Strecken gehoeren dem Haus?
+//
+// ─── ES IST EINE ABSCHRIFT MIT DATUM, KEINE LEITUNG ────────────────────────
+//
+// Diese Auskunft kommt als DATEI (`avplan-facility`) und wird im Projekt
+// mitgespeichert. Sie ist damit der Stand, gegen den geplant wurde, und nicht
+// der Stand des Hauses von heute: zwischen Export und Aufbau kann der
+// Betreiber eine Dose stillgelegt haben. Deshalb traegt sie `gelesenAm` und
+// den Namen der Quelle, und der Plan-Check sagt es, wenn ein Verweis ins
+// Leere zeigt.
+//
+// Und sie ist READ-ONLY. Es gibt in diesem Repo keinen Weg, sie zu aendern:
+// der einzige Rueckweg zum Gebaeude ist `mangelMelden` im Vertrag des
+// anderen Werkzeugs, und der laeuft nicht ueber diese Datei.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Wie ein Punkt angeschlossen ist — die Werte des Hauses, unveraendert. */
+export type HausAnschlussart =
+  | 'cee63'
+  | 'cee32'
+  | 'cee16'
+  | 'powerlock'
+  | 'klemme'
+  | 'schuko'
+
+/** Ein Anschlusspunkt des Hauses, so weit der Plan ihn braucht. */
+export interface HausPunkt {
+  id: string
+  bezeichnung: string
+  art: 'einspeisung' | 'dose'
+  /** Verweist auf `HausRaum.id`. */
+  raumId: string
+  anschlussart: HausAnschlussart
+  absicherungA: number
+  /**
+   * Zulaessige Dauerleistung in Watt — NUR wenn das Haus sie angibt.
+   *
+   * Sie ist NICHT `absicherungA x Spannung`. Der Nennstrom ist die
+   * Ausloeseschwelle, nicht die Belastbarkeit; Leitungslaenge, Haeufung und
+   * Gleichzeitigkeit gehen ein. Wer sie rechnet, wo sie fehlt, liefert eine
+   * Vermutung, die als Messung gelesen wird — und der Plan-Check unten
+   * schweigt lieber, als eine erfundene Grenze zu melden.
+   */
+  dauerleistungW?: number
+  /**
+   * Der Punkt haengt an einer Schaltstelle.
+   *
+   * `undefined` heisst „das Haus sagt nichts dazu" und NICHT „nein". Der
+   * Unterschied entscheidet, ob der Plan-Check warnt oder schweigt.
+   */
+  geschaltet?: boolean
+  /** Der Punkt haengt an einem Dimmer. Fuer ein Netzteil unbrauchbar. */
+  gedimmt?: boolean
+  /** Freitext des Betreibers („nur bis 10 A", „nur Reinigung"). */
+  hinweis?: string
+}
+
+export interface HausRaum {
+  id: string
+  name: string
+  /** Der Bezeichner, unter dem das Haus den Raum fuehrt. Der Plan druckt ihn. */
+  hausbezeichner: string
+}
+
+export type HausSteuersystem = 'knx' | 'dali' | 'crestron' | 'vissonic' | 'sonstige'
+
+/**
+ * Art einer Steuer-Adresse.
+ *
+ * Bei DALI heisst „3" je nach Art etwas voellig anderes: Kurzadresse 3 ist
+ * ein Vorschaltgeraet, Gruppe 3 koennen 30 Leuchten sein, Broadcast ist alles
+ * am Bus — auch das Notlicht. Wer eine Gruppenadresse fuer eine Kurzadresse
+ * haelt, schaltet im Zweifel den halben Saal.
+ */
+export type HausAdressart = 'kurz' | 'gruppe' | 'broadcast'
+
+/** Eine Klinke der Haussteuerung, die der Show offensteht. */
+export interface HausKlinke {
+  id: string
+  system: HausSteuersystem
+  adresse: string
+  adressart?: HausAdressart
+  richtung: 'lesen' | 'schalten'
+  /** Was passiert, wenn man sie benutzt. Klartext, vom Betreiber. */
+  bedeutung: string
+}
+
+/** Eine feste Strecke des Hauses (Steigleitung, Leerrohr, verlegte Leitung). */
+export interface HausStrecke {
+  id: string
+  bezeichnung: string
+}
+
+/**
+ * Die Auskunft, wie der Plan sie fuehrt.
+ *
+ * `gelesenAm` und `quelle` sind Pflicht: eine Abschrift ohne Datum sieht aus
+ * wie der Zustand von heute, und genau das ist sie nicht.
+ */
+export interface HausAuskunft {
+  /** Name des Gebaeudes, wie das Haus ihn fuehrt. */
+  name: string
+  /** ISO-Zeitstempel, wann diese Abschrift in den Plan kam. */
+  gelesenAm: string
+  /** Dateiname oder App, aus der sie kam — damit die Herkunft nachvollziehbar ist. */
+  quelle: string
+  raeume: HausRaum[]
+  punkte: HausPunkt[]
+  klinken: HausKlinke[]
+  strecken: HausStrecke[]
+}
+
+/** Der Punkt zu einer Id, oder `undefined`. Kein Namensabgleich (ADR-002). */
+export const hausPunkt = (a: HausAuskunft | undefined, id: string | undefined) =>
+  a && id ? a.punkte.find((p) => p.id === id) : undefined
+
+/** Die Klinke zu einer Id, oder `undefined`. */
+export const hausKlinke = (a: HausAuskunft | undefined, id: string | undefined) =>
+  a && id ? a.klinken.find((k) => k.id === id) : undefined
+
+/** Der Raum-Bezeichner, den das Haus fuehrt — fuer die Anzeige und den Druck. */
+export const hausRaumLabel = (a: HausAuskunft | undefined, raumId: string): string => {
+  const r = a?.raeume.find((x) => x.id === raumId)
+  if (!r) return raumId
+  return r.hausbezeichner ? `${r.name} (${r.hausbezeichner})` : r.name
+}

--- a/src/renderer/types/project.ts
+++ b/src/renderer/types/project.ts
@@ -3,6 +3,7 @@ import type { EquipmentItem } from './equipment'
 import type { IntercomPlan } from './intercomPlan'
 import type { LocationFrame } from './location'
 import type { VenueAnswer } from './venueAnswer'
+import type { HausAuskunft } from './hausAuskunft'
 import type { VideoFormatId } from './videoFormat'
 import type { PowerStandardId } from './powerStandard'
 import type { ChangeLogEntry, PendingChange } from './lifecycle'
@@ -148,6 +149,7 @@ export interface ProjectMetadata {
    * behaupten, die es hier nie gab.
    */
   venueAnswers?: VenueAnswer[]
+
   /** Festinstallation — Übergabe-/Abnahme-Datum (ISO). */
   handoverDate?: string
   /** Festinstallation — wartender Dienstleister / Servicekontakt. */
@@ -201,6 +203,21 @@ export interface CablePlannerProject {
    * (ADR-001).
    */
   intercom?: IntercomPlan
+  /**
+   * Die Auskunft des GEBAEUDES, gegen die geplant wurde
+   * (`larszu-facility-planner` Issue #2).
+   *
+   * Sie kommt als `.avfacility`-Datei herein und wird hier MITGESPEICHERT —
+   * nicht, weil der Plan das Haus verwaltet, sondern damit ein Plan von
+   * gestern noch sagen kann, worauf er sich stuetzte. Zwischen Export und
+   * Aufbau kann der Betreiber eine Dose stillgelegt haben; `gelesenAm` und
+   * `quelle` machen den Stand nachvollziehbar, statt ihn als heutigen
+   * Zustand auszugeben.
+   *
+   * READ-ONLY. Der Planer aendert sie nicht — der einzige Rueckweg zum
+   * Gebaeude ist `mangelMelden` im `facility-planner`.
+   */
+  hausAuskunft?: HausAuskunft
   /** v7.9.3 — Aufbau-Status: welche Ports / Kabel der Field-Tech bereits
    *  physikalisch gesteckt hat. Wird vom Mobile-Viewer (handy.html) via
    *  POST /checks zurückgespielt und im Haupt-Canvas als kleines Häkchen

--- a/tests/asciiDrift.test.ts
+++ b/tests/asciiDrift.test.ts
@@ -109,6 +109,10 @@ const HARMLOS = new Set(
     // gemeldet — die Silbengrenze faellt in „Ste-uer" mitten in ein „ue".
     // Dasselbe gilt fuer die uebrigen Zusammensetzungen mit „Steuer-", die
     // in dieser Liste noch fehlten.
+    // facility Issue #2 (2026-09-10): dieselbe Silbengrenze noch einmal —
+    // „Ste-ueradresse" und „Da-uerleistung". Beide sind richtiges Deutsch und
+    // heissen genau das, was das Gebaeude angibt.
+    'steueradresse', 'steueradressen', 'dauerleistung',
     'steuerzeichen', 'steuerbefehl', 'steuerbefehle', 'steuerprotokoll',
     'steuerprotokolle', 'steuerport', 'steuerweg', 'steuerwege',
     'frequenzen', 'frequenzgang', 'frequenzabstand', 'funkfrequenz',

--- a/tests/hausAuskunft.test.ts
+++ b/tests/hausAuskunft.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest'
+import { leseHausDatei, FACILITY_FORMAT, FACILITY_FORMAT_VERSION } from '../src/renderer/lib/hausDatei'
+import { runDrawingChecks } from '../src/renderer/lib/drawingChecks'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+import type { HausAuskunft } from '../src/renderer/types/hausAuskunft'
+
+// ───────────────────────────────────────────────────────────────────────────
+// Der Weg vom Plan zur Klinke (larszu-facility-planner Issue #2).
+//
+// Bis 2026-09-10 las der Kabelplaner den Vertrag des Gebaeude-Werkzeugs GAR
+// NICHT — weder `facility` noch `Steuerklinke` kamen im Quelltext vor. Der
+// Vertrag war sechs Funktionen ueber einem Objekt, das nur im localStorage
+// der anderen App lebte.
+//
+// Was hier geprueft wird, ist nicht „JSON kommt an", sondern die drei
+// Zusagen, an denen im Aufbau etwas haengt:
+//
+//   1. Der Leser erfindet nichts. „Nicht angegeben" bleibt es.
+//   2. Der Plan haelt einen VERWEIS, keine Abschrift — zeigt er ins Leere,
+//      steht es im Plan-Check.
+//   3. Wo das Haus schweigt, schweigt der Check. Eine erfundene Grenze liest
+//      sich auf dem Blatt wie eine gemessene.
+// ───────────────────────────────────────────────────────────────────────────
+
+const datei = (gebaeude: unknown, version = FACILITY_FORMAT_VERSION) =>
+  JSON.stringify({ format: FACILITY_FORMAT, version, gebaeude })
+
+const HAUS = {
+  id: 'haus-1',
+  name: 'Stadthalle',
+  raeume: [{ id: 'r1', name: 'Saal', hausbezeichner: 'EG.01' }],
+  punkte: [
+    {
+      id: 'p1',
+      bezeichnung: 'Bühne links',
+      art: 'einspeisung',
+      raumId: 'r1',
+      anschlussart: 'cee32',
+      netzform: 'TN-S',
+      absicherungA: 32,
+      charakteristik: 'C',
+      rcdTyp: 'A',
+      dauerleistungW: 3000,
+    },
+    {
+      id: 'p2',
+      bezeichnung: 'Wanddose Foyer',
+      art: 'dose',
+      raumId: 'r1',
+      anschlussart: 'schuko',
+      netzform: 'TN-S',
+      absicherungA: 16,
+      charakteristik: 'B',
+      rcdTyp: 'A',
+      geschaltet: true,
+    },
+    {
+      id: 'p3',
+      bezeichnung: 'Dimmerkreis Saal',
+      art: 'dose',
+      raumId: 'r1',
+      anschlussart: 'schuko',
+      netzform: 'TN-S',
+      absicherungA: 16,
+      charakteristik: 'B',
+      rcdTyp: 'A',
+      gedimmt: true,
+    },
+  ],
+  klinken: [
+    { id: 'k1', system: 'dali', adresse: '7', adressart: 'kurz', richtung: 'schalten', bedeutung: 'Saallicht Reihe 1' },
+    { id: 'k2', system: 'knx', adresse: '1/2/3', richtung: 'lesen', bedeutung: 'Ist die Bühne freigegeben?' },
+  ],
+  strecken: [{ id: 's1', bezeichnung: 'Steigleitung EG-OG' }],
+}
+
+const auskunft = (): HausAuskunft =>
+  leseHausDatei(datei(HAUS), { quelle: 'stadthalle.avfacility', gelesenAm: '2026-09-10T10:00:00.000Z' })!
+
+const geraet = (teil: Partial<EquipmentItem> & { id: string }): EquipmentItem =>
+  ({
+    name: teil.id,
+    category: 'Sonstiges',
+    inputs: [],
+    outputs: [],
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 96,
+    ...teil,
+  }) as unknown as EquipmentItem
+
+const checks = (equipment: EquipmentItem[], hausAuskunft?: HausAuskunft) =>
+  runDrawingChecks({ equipment, cables: [], hausAuskunft })
+
+describe('Die Gebäude-Auskunft kommt an', () => {
+  it('1. Punkte, Klinken und Strecken werden gelesen — mit Adressart', () => {
+    const a = auskunft()
+    expect(a.name).toBe('Stadthalle')
+    expect(a.punkte).toHaveLength(3)
+    expect(a.klinken[0]!.adressart).toBe('kurz')
+    expect(a.strecken[0]!.bezeichnung).toBe('Steigleitung EG-OG')
+    // Die Abschrift trägt ihr Datum und ihre Herkunft — sonst sieht sie aus
+    // wie der Zustand von heute.
+    expect(a.gelesenAm).toBe('2026-09-10T10:00:00.000Z')
+    expect(a.quelle).toBe('stadthalle.avfacility')
+  })
+
+  it('2. „nicht angegeben" wird NICHT zu „nein"', () => {
+    const p1 = auskunft().punkte.find((p) => p.id === 'p1')!
+    expect(p1.geschaltet, 'aus keiner Angabe darf kein „nicht geschaltet" werden').toBeUndefined()
+    expect(p1.gedimmt).toBeUndefined()
+  })
+
+  it('3. keine Dauerleistung wird gerechnet, wo das Haus keine angibt', () => {
+    // `absicherungA x 230` waere die naheliegende Ergänzung und die falsche:
+    // der Nennstrom ist die Auslöseschwelle, nicht die Belastbarkeit.
+    const p2 = auskunft().punkte.find((p) => p.id === 'p2')!
+    expect(p2.dauerleistungW).toBeUndefined()
+  })
+
+  it('4. eine Klinke ohne Bedeutung fällt weg — eine Adresse ohne Sinn ist keine Klinke', () => {
+    const a = leseHausDatei(
+      datei({ ...HAUS, klinken: [{ id: 'kx', system: 'knx', adresse: '1/1/1', richtung: 'schalten' }] }),
+      { quelle: 'x', gelesenAm: 't' },
+    )
+    expect(a?.klinken).toEqual([])
+  })
+
+  it('5. eine fremde oder neuere Datei wird abgewiesen, nicht halb gelesen', () => {
+    expect(leseHausDatei('kein json', { quelle: 'x', gelesenAm: 't' })).toBeNull()
+    expect(leseHausDatei(JSON.stringify({ format: 'anderes', version: 1 }), { quelle: 'x', gelesenAm: 't' })).toBeNull()
+    expect(leseHausDatei(datei(HAUS, FACILITY_FORMAT_VERSION + 1), { quelle: 'x', gelesenAm: 't' })).toBeNull()
+  })
+})
+
+describe('Der Plan-Check fragt die Auskunft', () => {
+  it('1. ein Gerät an einer GESCHALTETEN Dose wird gewarnt', () => {
+    const r = checks([geraet({ id: 'srv', name: 'Medienserver', hausPunktId: 'p2' })], auskunft())
+    const f = r.findings.find((x) => x.id === 'haus-geschaltet:srv')
+    expect(f?.severity).toBe('warning')
+    expect(f?.message).toContain('Wanddose Foyer')
+  })
+
+  it('2. ein Gerät an einer GEDIMMTEN Dose ist ein Fehler', () => {
+    const r = checks([geraet({ id: 'srv', name: 'Medienserver', hausPunktId: 'p3' })], auskunft())
+    expect(r.findings.find((x) => x.id === 'haus-gedimmt:srv')?.severity).toBe('error')
+  })
+
+  it('3. ein Verweis ins Leere fällt auf', () => {
+    // Der teure Fall: das Haus schickt eine neue Datei, und die Dose von
+    // damals steht nicht mehr drin.
+    const r = checks([geraet({ id: 'srv', hausPunktId: 'weg' })], auskunft())
+    expect(r.findings.find((x) => x.id === 'haus-punkt-fehlt:srv')?.severity).toBe('error')
+    const k = checks([geraet({ id: 'srv', hausKlinkeId: 'weg' })], auskunft())
+    expect(k.findings.find((x) => x.id === 'haus-klinke-fehlt:srv')?.severity).toBe('error')
+  })
+
+  it('4. die Summe gegen die angegebene Dauerleistung', () => {
+    const r = checks(
+      [
+        geraet({ id: 'a', hausPunktId: 'p1', powerConsumptionWatts: 2000 }),
+        geraet({ id: 'b', hausPunktId: 'p1', powerConsumptionWatts: 1500 }),
+      ],
+      auskunft(),
+    )
+    const f = r.findings.find((x) => x.id === 'haus-last:p1')
+    expect(f?.severity).toBe('error')
+    expect(f?.message).toContain('3500')
+  })
+
+  it('5. wo das Haus KEINE Dauerleistung angibt, schweigt der Check', () => {
+    // p2 hat nur eine Absicherung. Eine Grenze daraus zu rechnen waere eine
+    // Vermutung, die auf dem Blatt wie eine Messung aussieht.
+    const r = checks([geraet({ id: 'a', hausPunktId: 'p2', powerConsumptionWatts: 5000 })], auskunft())
+    expect(r.findings.some((x) => x.id.startsWith('haus-last'))).toBe(false)
+  })
+
+  it('6. ohne hinterlegte Auskunft schweigen ALLE Haus-Checks', () => {
+    // Kein „nicht geprüft", kein Hinweis. Die meisten Pläne stehen in einer
+    // Halle, über die niemand eine Datei hat — ein Befund, den man nicht
+    // beheben kann, macht die Liste unlesbar.
+    const r = checks([geraet({ id: 'srv', hausPunktId: 'p2', hausKlinkeId: 'weg' })])
+    expect(r.findings.filter((x) => x.category.startsWith('House'))).toEqual([])
+  })
+})


### PR DESCRIPTION
Die Leseseite zu larszu/larszu-facility-planner#5 — zusammen schließen sie den letzten offenen Haken aus larszu/larszu-facility-planner#2: *„der Weg vom Plan zur Klinke — heute liest der `cable-planner` den Vertrag noch gar nicht ab."*

Nachgemessen stimmte das wörtlich: weder `facility` noch `Steuerklinke` kamen im Quelltext vor.

## Die schmale Sicht

`types/hausAuskunft.ts` nimmt vom Gebäude **vier Auskünfte**: Räume, Anschlusspunkte, Steuerklinken, Hausstrecken. Das Hausmodell selbst — Verteilungen, Stromkreise, Trassen, Mängel — kommt nicht mit. Das ist dieselbe Grenze wie beim Lager (ADR-006), von der anderen Seite gelesen: der Plan beschreibt eine Show, die am Abbautag eingepackt wird, das Gebäude steht Jahre. Wer das Hausmodell hier hereinzieht, führt die Verwaltung des Hauses in einem Werkzeug, das dafür nicht gebaut ist.

## Der Leser erfindet nichts

- Fehlt `dauerleistungW`, bleibt es leer — es wird **nicht** aus `absicherungA` gerechnet. Der Nennstrom ist die Auslöseschwelle, nicht die Belastbarkeit; Leitungslänge, Häufung und Gleichzeitigkeit gehen ein, und keine dieser Zahlen steht im Plan.
- Fehlt `geschaltet`, bleibt es `undefined` und wird nicht `false`. Der Unterschied entscheidet, ob der Plan-Check warnt oder schweigt.
- Eine Klinke ohne `bedeutung` fällt weg: eine Adresse ohne Sinn ist eine Nummer, die jemand schaltet, ohne zu wissen, was passiert.
- Fremde oder neuere Datei → `null`, nicht halb gelesen.

## Verweise, keine Abschriften

`EquipmentItem.hausPunktId` und `.hausKlinkeId` halten nur die Id. Wären es Kopien, hätte der Plan beim nächsten Export des Betreibers Zahlen, die das Haus so nicht mehr sagt — und niemand sähe es. Der Verweis dagegen zeigt entweder auf eine Auskunft oder ins Leere, und ins Leere zeigt der Plan-Check an.

`CablePlannerProject.hausAuskunft` trägt die Abschrift mit `gelesenAm` und `quelle`: der Stand, gegen den geplant wurde, ist nicht der Stand des Hauses von heute.

## Vier neue Plan-Checks

| Fall | Schwere |
| --- | --- |
| Gerät an einer Dose, die das Haus als **gedimmt** angibt | Fehler |
| Gerät an einer Dose, die das Haus als **geschaltet** angibt | Warnung |
| Verweis auf einen Punkt / eine Klinke, die die Auskunft nicht mehr führt | Fehler |
| Summe der Plan-Leistung über der **angegebenen** Dauerleistung | Fehler |

**Ohne hinterlegte Auskunft schweigen sie vollständig** — kein „nicht geprüft", kein Hinweis. Die meisten Pläne stehen in einer Halle, über die niemand eine Datei hat, und ein Befund, den man nicht beheben kann, ist die schnellste Art, eine Liste unlesbar zu machen.

Geladen wird die Datei **dort, wo die Frage entsteht**: in den Eigenschaften des Geräts, nicht in einem Einstellungs-Reiter. Wer ein Gerät setzt und wissen will, woran es hängt, sucht nicht erst einen Reiter.

## Nachgewiesen

268 Testdateien, 4043 Tests grün — 11 davon neu in `tests/hausAuskunft.test.ts`, je einer für jede Zusage samt Gegenprobe (u. a. „wo das Haus keine Dauerleistung angibt, schweigt der Check").

Drei Wächter haben Auslassungen gefunden und sind bedient: die Feld-Klassifizierung (`modelFields`), der Plan-Vergleich (`planDiff`, beide Felder `substantive` — an ihnen hängen Befunde, am Aussehen ändert sich nichts) und die deutschen Fassungen der neuen Meldungen. Der ASCII-Wächter hat „Ste-ueradresse" und „Da-uerleistung" gemeldet — dieselbe Silbengrenze wie bei „Ste-uerzeichen", mit derselben Begründung in die Liste aufgenommen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_