### PR TITLE
mobile: die Kneif-Geste gehört dem Plan, nicht dem Browser (B-66)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,21 @@ jobs:
       # allein fuer den groben Zeiger gibt.
       - name: Trefferflaechen sind gross genug fuer einen Finger
         run: xvfb-run -a npm run ui:targets
+      # Fuenfter Lauf im selben Job, wieder aus demselben Grund: dieselbe
+      # gebaute Seite (`dist/renderer`). Er braucht KEINEN X-Server -- er
+      # startet ein eigenes Chromium headless in einem 390x844 grossen
+      # Fenster mit Fingerbedienung und misst, was ein Mensch am 2026-09-10
+      # gemeldet hat: „Man kann das gesamte Fenster aus Versehen
+      # verschieben." Die Elektron-Laeufe darueber sehen das nicht, weil sie
+      # im Schreibtisch-Format messen; genau dort war der Fehler unsichtbar.
+      #
+      # Gerufen wird der npm-Lauf und nicht das Skript direkt: er baut den
+      # Renderer vorher noch einmal. Das kostet drei Sekunden und macht den
+      # Schritt hier identisch mit dem, was ein Mensch am eigenen Rechner
+      # tippt -- ein Lauf, der in CI anders heisst als daheim, wird daheim
+      # nicht gefahren.
+      - name: Die App bleibt auf dem Telefon im Fenster
+        run: npm run mobil:check
       - name: Screenshots bei Fehlschlag
         if: failure()
         uses: actions/upload-artifact@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ npx vitest run -t "Teil des Test-Namens"      # einzelner Test per Name
 npm run test:crdt                        # CRDT-Konvergenz (scripts/crdt-convergence-check.mjs)
 npm run test:signaling                   # Signaling-Relay (baut main vorher)
 npm run ui:smoke                         # UI-Smoke (scripts/ui-smoke.mjs)
+npm run mobil:check                      # 390x844 mit Finger: nichts ragt hinaus, das Fenster laesst sich nicht schieben
 npm run test:drag                        # Headless Drag-/Interaktions-Test (scripts/drag-test.mjs, braucht laufenden dev:renderer)
 npm run docs:stats                       # Doku-Kennzahlen (Version/Module/LOC/Slices/Subdomänen) neu berechnen + in Doku schreiben
 ```

--- a/index.html
+++ b/index.html
@@ -1,5 +1,11 @@
 <!doctype html>
-<html lang="en">
+<!-- `data-cp-shell="app"`: NUR dieser Einstieg ist die Vollbild-Anwendung.
+     Sie fuellt das Fenster genau aus und scrollt nicht — die Sperre dagegen
+     steht in `src/renderer/index.css` und haengt an dieser Marke.
+     `mobile.html` und `viewer.html` teilen sich dasselbe Stilblatt, sind aber
+     scrollende SEITEN; ohne die Marke waere ihre Liste nach dem ersten Bild
+     zu Ende, und zwar lautlos. -->
+<html lang="en" data-cp-shell="app">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "ui:smoke": "node scripts/ui-smoke.mjs",
+    "mobil:check": "npm run build:renderer && node scripts/mobil-grenze-check.mjs",
     "test:drag": "node scripts/drag-test.mjs",
     "docs:stats": "node scripts/update-doc-stats.mjs",
     "test:crdt": "node scripts/crdt-convergence-check.mjs",

--- a/scripts/mobil-grenze-check.mjs
+++ b/scripts/mobil-grenze-check.mjs
@@ -1,0 +1,394 @@
+#!/usr/bin/env node
+/**
+ * Bleibt die App im Fenster? — Lauf: `npm run mobil:check`
+ *
+ * ─── DIE MELDUNG ─────────────────────────────────────────────────────────
+ *
+ * Nutzer-Meldung 2026-09-10, mit einem Schirmbild der GitHub-Seite auf einem
+ * iPhone: „Man kann das gesamte Fenster aus Versehen verschieben." Auf dem
+ * Bild war der Inhalt nach links geschoben, rechts stand ein schwarzer
+ * Streifen, die Reihe der Ebenen-Chips endete mitten im Wort „Control", und
+ * die Statuszeile war unten abgeschnitten.
+ *
+ * ─── WAS GEMESSEN WAR (390x844, Fingerbedienung) ─────────────────────────
+ *
+ *   · 18 Elemente ragten ueber den rechten Rand hinaus, der Chip-Streifen
+ *     bis Pixel 726 auf einer 390 Pixel breiten Anzeige.
+ *   · Das Haupt-Raster stand auf 129 | 125 | 129 Pixel: der PLAN war der
+ *     schmalste Teil der Planungs-App. Die Einklappung fuer schmale Fenster
+ *     gab es laengst (#444) — sie sprang nur beim UEBERSCHREITEN der
+ *     Schwelle an, und wer die Seite auf einem Telefon oeffnet, ueberschreitet
+ *     nichts.
+ *   · `html`/`body` trugen weder `overflow` noch `overscroll-behavior`.
+ *   · Ein Kneifen mitten auf dem Plan vergroesserte die SEITE
+ *     (`visualViewport.scale` 1 -> 2, Versatz 98/250 Pixel) statt des Plans.
+ *
+ * ─── WAS DIESER LAUF MISST UND WAS NICHT ─────────────────────────────────
+ *
+ * Er misst im echten Browser, in einem 390x844 grossen Fenster mit
+ * Fingerbedienung, an der GEBAUTEN Seite (`dist/renderer`):
+ *
+ *   1. kein Element ragt ueber den sichtbaren Bereich hinaus,
+ *   2. das Dokument selbst hat nichts zu scrollen,
+ *   3. `overflow: hidden` und `overscroll-behavior: none` stehen wirklich
+ *      im berechneten Stil von `html`/`body`,
+ *   4. `.react-flow__renderer` traegt `touch-action: none`,
+ *   5. die Statuszeile steht vollstaendig im Bild,
+ *   6. die Seiten-Panels sind beim LADEN eingeklappt, der Plan bekommt den
+ *      Platz.
+ *
+ * Er misst NICHT, ob eine echte Kneif-Geste am Ende die Seite in Ruhe
+ * laesst. Das wurde versucht und verworfen: der Kneif-Ersatz der
+ * Fernsteuerung (CDP `Input.synthesizePinchGesture` wie auch
+ * `Input.dispatchTouchEvent`) vergroessert die Seite unter headless-Chromium
+ * AUCH DANN, wenn `touch-action: none` gesetzt ist — die Gegenprobe mit und
+ * ohne die Regel lieferte denselben Wert. Eine Messung, die den Unterschied
+ * nicht sieht, waere ein Waechter, der immer gruen ist. Punkt 4 prueft
+ * deshalb die VORAUSSETZUNG, ohne die es sicher falsch ist, und sagt genau
+ * das. Die zweite Haelfte — Safaris `gesture*`-Ereignisse — steht in
+ * `CanvasArea.tsx` und wird hier im Quelltext nachgesehen (Punkt 7).
+ *
+ * Voraussetzung: `npm run build:renderer` lief vorher.
+ */
+import { chromium } from 'playwright-core'
+import { createServer } from 'node:http'
+import { readFile, access } from 'node:fs/promises'
+import { readFileSync } from 'node:fs'
+import { join, extname, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const WURZEL = join(dirname(fileURLToPath(import.meta.url)), '..')
+const SEITE = join(WURZEL, 'dist/renderer')
+const BREITE = 390
+const HOEHE = 844
+
+try {
+  await access(join(SEITE, 'index.html'))
+} catch {
+  console.error(
+    'FEHLER: dist/renderer/index.html fehlt. Erst `npm run build:renderer`, dann dieser Lauf.',
+  )
+  process.exit(1)
+}
+
+const TYPEN = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.svg': 'image/svg+xml',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.woff2': 'font/woff2',
+  '.wasm': 'application/wasm',
+}
+const server = createServer(async (req, res) => {
+  const pfad = decodeURIComponent((req.url || '/').split('?')[0])
+  const datei = pfad === '/' ? '/index.html' : pfad
+  try {
+    const inhalt = await readFile(join(SEITE, datei))
+    res.writeHead(200, { 'content-type': TYPEN[extname(datei)] ?? 'application/octet-stream' })
+    res.end(inhalt)
+  } catch {
+    res.writeHead(404).end('nicht da')
+  }
+})
+await new Promise((r) => server.listen(0, '127.0.0.1', r))
+const port = server.address().port
+
+/**
+ * Einen Browser finden, ohne einen mitzuliefern.
+ *
+ * `playwright-core` laedt bewusst keinen herunter (deshalb heisst es `-core`).
+ * Gesucht wird deshalb der Reihe nach: was der Aufrufer vorgibt, was
+ * Playwright selbst abgelegt hat (`PLAYWRIGHT_BROWSERS_PATH`), und zuletzt
+ * die ueblichen Systempfade — auf den GitHub-Laeufern liegt dort Chrome.
+ * Findet sich keiner, sagt der Lauf WELCHE Pfade er abgesucht hat; ein
+ * blosses „Browser nicht gefunden" schickt den naechsten auf die Suche.
+ */
+const browserPfad = async () => {
+  const kandidaten = []
+  if (process.env.CP_CHROMIUM) kandidaten.push(process.env.CP_CHROMIUM)
+  try {
+    const eigen = await chromium.executablePath()
+    if (eigen) kandidaten.push(eigen)
+  } catch {
+    /* playwright-core ohne abgelegten Browser — dann eben die Systempfade */
+  }
+  kandidaten.push(
+    '/opt/pw-browsers/chromium',
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+  )
+  for (const k of kandidaten) {
+    try {
+      await access(k)
+      return k
+    } catch {
+      /* weiter */
+    }
+  }
+  console.error(
+    'FEHLER: kein Chromium gefunden. Abgesucht:\n' +
+      kandidaten.map((k) => `  · ${k}`).join('\n') +
+      '\nEinen Pfad in CP_CHROMIUM setzen oder einen Browser installieren.',
+  )
+  server.close()
+  process.exit(1)
+}
+
+const browser = await chromium.launch({
+  executablePath: await browserPfad(),
+  args: ['--no-sandbox', '--use-gl=swiftshader', '--enable-unsafe-swiftshader', '--use-angle=swiftshader'],
+})
+
+/** Eine frische Seite im Telefon-Format, Erststart-Dialoge weggeraeumt. */
+const oeffnen = async (einstieg = '/') => {
+  const ctx = await browser.newContext({
+    viewport: { width: BREITE, height: HOEHE },
+    deviceScaleFactor: 3,
+    isMobile: true,
+    hasTouch: true,
+    userAgent:
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 ' +
+      '(KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+  })
+  // Die Erststart-Dialoge legen sich sonst ueber die Messung. Sie werden
+  // NICHT weggeklickt, sondern vorher als „schon gesehen" hinterlegt: ein
+  // Klick misst die Dialoge, und gemessen werden soll die App.
+  await ctx.addInitScript(() => {
+    try {
+      localStorage.setItem('cable-planner:welcomed', '1')
+      localStorage.setItem('cable-planner.tour.seen.v1', '1')
+      localStorage.setItem(
+        'cable-planner:settings',
+        JSON.stringify({ onboardingDone: true }),
+      )
+    } catch {
+      /* ein Browser ohne Speicher zeigt die Dialoge — dann misst der Lauf sie mit */
+    }
+  })
+  const seite = await ctx.newPage()
+  await seite.goto(`http://127.0.0.1:${port}${einstieg}`, { waitUntil: 'domcontentloaded' })
+  await seite.waitForTimeout(4000)
+  for (let i = 0; i < 6; i++) {
+    if (!(await seite.$('.cp-modal-backdrop'))) break
+    await seite.keyboard.press('Escape').catch(() => {})
+    await seite.waitForTimeout(300)
+  }
+  return { ctx, seite }
+}
+
+const messen = (seite) =>
+  seite.evaluate(() => {
+    const de = document.documentElement
+    const raus = []
+    for (const el of document.querySelectorAll('body *')) {
+      const r = el.getBoundingClientRect()
+      if (r.width === 0 || r.height === 0) continue
+      if (r.right > window.innerWidth + 1 || r.left < -1) {
+        raus.push({
+          tag: el.tagName.toLowerCase(),
+          cls: (el.className || '').toString().slice(0, 70),
+          links: Math.round(r.left),
+          rechts: Math.round(r.right),
+        })
+      }
+    }
+    const renderer = document.querySelector('.react-flow__renderer')
+    const statusbar = document.querySelector('.cp-statusbar')
+    const haupt = document.querySelector('main')
+    const spalten = haupt ? getComputedStyle(haupt).gridTemplateColumns : ''
+    const planBreite = spalten
+      ? Math.round(parseFloat(spalten.split(' ')[2] ?? '0'))
+      : 0
+    return {
+      innerWidth: window.innerWidth,
+      innerHeight: window.innerHeight,
+      docScrollWidth: de.scrollWidth,
+      docScrollHeight: de.scrollHeight,
+      htmlOverflowX: getComputedStyle(de).overflowX,
+      htmlOverflowY: getComputedStyle(de).overflowY,
+      bodyOverflowX: getComputedStyle(document.body).overflowX,
+      htmlOverscroll: getComputedStyle(de).overscrollBehavior,
+      rendererTouchAction: renderer ? getComputedStyle(renderer).touchAction : null,
+      statusUnten: statusbar ? Math.round(statusbar.getBoundingClientRect().bottom) : null,
+      planBreite,
+      raus,
+    }
+  })
+
+const fehler = []
+const { ctx, seite } = await oeffnen()
+const m = await messen(seite)
+
+// ── 1. Nichts ragt hinaus ────────────────────────────────────────────────
+if (m.raus.length > 0) {
+  fehler.push(
+    `${m.raus.length} Element(e) ragen ueber die ${m.innerWidth} Pixel breite Anzeige hinaus:\n` +
+      m.raus
+        .slice(0, 8)
+        .map((r) => `      <${r.tag} class="${r.cls}"> ${r.links}..${r.rechts}`)
+        .join('\n'),
+  )
+}
+
+// ── 2. Das Dokument hat nichts zu scrollen ───────────────────────────────
+if (m.docScrollWidth > m.innerWidth) {
+  fehler.push(
+    `Das Dokument ist ${m.docScrollWidth} Pixel breit bei ${m.innerWidth} Pixel Anzeige — ` +
+      'die Seite laesst sich waagerecht schieben.',
+  )
+}
+if (m.docScrollHeight > m.innerHeight) {
+  fehler.push(
+    `Das Dokument ist ${m.docScrollHeight} Pixel hoch bei ${m.innerHeight} Pixel Anzeige — ` +
+      'die Seite laesst sich senkrecht schieben, und die Statuszeile rutscht darunter.',
+  )
+}
+
+// ── 3. Die Sperre steht wirklich im berechneten Stil ─────────────────────
+if (m.htmlOverflowX !== 'hidden' || m.bodyOverflowX !== 'hidden') {
+  fehler.push(
+    `\`overflow\` fehlt: html=${m.htmlOverflowX}, body=${m.bodyOverflowX}. ` +
+      'Ein Pixel Ueberhang genuegt dann, damit die ganze Seite wandert.',
+  )
+}
+if (m.htmlOverscroll !== 'none') {
+  fehler.push(
+    `\`overscroll-behavior\` steht auf "${m.htmlOverscroll}" statt "none" — ` +
+      'ein Zug, den kein Scrollbereich aufnimmt, verschiebt die Seite gummibandartig.',
+  )
+}
+
+// ── 4. Die Kneif-Geste gehoert dem Plan ──────────────────────────────────
+if (m.rendererTouchAction === null) {
+  fehler.push('`.react-flow__renderer` steht nicht im Dokument — dann misst Regel 4 nichts.')
+} else if (m.rendererTouchAction !== 'none') {
+  fehler.push(
+    `\`.react-flow__renderer\` hat \`touch-action: ${m.rendererTouchAction}\` statt \`none\`. ` +
+      'Der Browser nimmt die Zwei-Finger-Geste dann vorweg und vergroessert die SEITE; ' +
+      'ReactFlows eigener Zoom kommt gar nicht erst dran.',
+  )
+}
+
+// ── 5. Die Statuszeile steht im Bild ─────────────────────────────────────
+if (m.statusUnten === null) {
+  fehler.push('`.cp-statusbar` steht nicht im Dokument — dann misst Regel 5 nichts.')
+} else if (m.statusUnten > m.innerHeight + 1) {
+  fehler.push(
+    `Die Statuszeile endet bei ${m.statusUnten} Pixel, das Fenster bei ${m.innerHeight} — ` +
+      'sie ist abgeschnitten.',
+  )
+}
+
+// ── 6. Der Plan bekommt den Platz ────────────────────────────────────────
+//
+// Die Zahl ist kein Schoenheitswert: bei 129 Pixel Plan zwischen zwei
+// gleich breiten Panels ist die Planungs-App auf dem Telefon unbenutzbar,
+// und genau so lag sie vor dem 2026-09-10. Die Haelfte der Anzeige ist die
+// unterste Schwelle, die noch etwas anderes heisst als „drei gleich breite
+// Spalten".
+const MINDEST_PLAN = Math.round(BREITE / 2)
+if (m.planBreite < MINDEST_PLAN) {
+  fehler.push(
+    `Der Plan bekommt nur ${m.planBreite} von ${m.innerWidth} Pixel (Mindestmass ` +
+      `${MINDEST_PLAN}). Die Seiten-Panels klappen beim LADEN nicht ein — die ` +
+      'Einklappung reagiert dann nur auf das Ueberschreiten der Schwelle, und wer ' +
+      'die Seite auf einem Telefon oeffnet, ueberschreitet nichts.',
+  )
+}
+
+// ── 7. Safaris `gesture*` (Quelltext, nicht Messung) ─────────────────────
+//
+// Ausdruecklich gelesen und nicht gemessen: diese Ereignisse gibt es nur in
+// Safari, und Safari laeuft hier nicht. Ohne sie vergroessert Safari auf dem
+// Trackpad weiter die Seite, auch mit `touch-action`.
+const canvasArea = readFileSync(join(WURZEL, 'src/renderer/components/Canvas/CanvasArea.tsx'), 'utf8')
+for (const g of ['gesturestart', 'gesturechange', 'gestureend']) {
+  if (!canvasArea.includes(`'${g}'`)) {
+    fehler.push(`src/renderer/components/Canvas/CanvasArea.tsx faengt \`${g}\` nicht ab (Safari).`)
+  }
+}
+
+// ── 8. Die anderen beiden Einstiege scrollen weiterhin ───────────────────
+//
+// `mobile.html` und `viewer.html` laden DASSELBE Stilblatt wie die
+// Vollbild-Anwendung, sind aber scrollende Seiten. Beim ersten Anlauf am
+// 2026-09-10 stand die Sperre aus Regel 3 global — und die Mobil-Liste blieb
+// bei 3000 Pixel Inhalt auf `scrollY = 0` stehen: die Seite war nach dem
+// ersten Bild zu Ende, lautlos. Deshalb haengt die Sperre an der Marke
+// `data-cp-shell="app"` in `index.html`, und deshalb steht diese Regel hier:
+// sie misst die Kehrseite derselben Entscheidung.
+for (const einstieg of ['/mobile.html', '/viewer.html']) {
+  const auf = await oeffnen(einstieg)
+  const gescrollt = await auf.seite.evaluate(() => {
+    const ziel = document.querySelector('#root > div') ?? document.body
+    const lang = document.createElement('div')
+    lang.style.height = '3000px'
+    ziel.appendChild(lang)
+    window.scrollTo(0, 1500)
+    return { y: window.scrollY, hoehe: document.documentElement.scrollHeight }
+  })
+  await auf.ctx.close()
+  if (gescrollt.y <= 0) {
+    fehler.push(
+      `${einstieg} laesst sich mit 3000 Pixel Inhalt nicht scrollen ` +
+        `(Dokument ${gescrollt.hoehe} Pixel hoch, scrollY bleibt ${gescrollt.y}). ` +
+        'Die Sperre aus Regel 3 gilt fuer die Vollbild-Anwendung, nicht fuer die ' +
+        'scrollenden Seiten — sie gehoert hinter `html[data-cp-shell="app"]`.',
+    )
+  }
+}
+
+// ── Die Gegenprobe zum Lauf selbst ───────────────────────────────────────
+//
+// Eine Pruefung, die nicht fehlschlagen KANN, ist keine. Zwei der Regeln
+// werden an einem absichtlich kaputten Zustand vorgefuehrt; erkennt eine
+// davon ihren eigenen Defekt nicht mehr, faellt der Lauf hier — nicht erst
+// beim naechsten Nutzer.
+await seite.addStyleTag({
+  content:
+    '#cp-gegenprobe{position:fixed;top:0;left:0;width:900px;height:10px;background:red}' +
+    '.react-flow__renderer{touch-action:auto !important}',
+})
+await seite.evaluate(() => {
+  const d = document.createElement('div')
+  d.id = 'cp-gegenprobe'
+  document.body.appendChild(d)
+})
+await seite.waitForTimeout(200)
+const probe = await messen(seite)
+if (!probe.raus.some((r) => r.cls === '' && r.rechts >= 900)) {
+  fehler.push('Gegenprobe: ein 900 Pixel breites Element wird von Regel 1 nicht mehr gemeldet.')
+}
+if (probe.rendererTouchAction === 'none') {
+  fehler.push('Gegenprobe: `touch-action` wird nicht wirklich am Element gelesen (Regel 4).')
+}
+await ctx.close()
+await browser.close()
+server.close()
+
+if (fehler.length > 0) {
+  console.error(
+    `FEHLER: die App bleibt auf ${BREITE}x${HOEHE} nicht im Fenster:\n` +
+      fehler.map((f) => `  · ${f}`).join('\n'),
+  )
+  process.exit(1)
+}
+
+console.log(
+  `OK (${BREITE}x${HOEHE}, Fingerbedienung): kein Ueberhang, Dokument ` +
+    `${m.docScrollWidth}x${m.docScrollHeight} = Fenster, \`overflow: hidden\` + ` +
+    '`overscroll-behavior: none` gesetzt, `touch-action: none` am Plan-Renderer, ' +
+    `Statuszeile bei ${m.statusUnten}, Plan ${m.planBreite} Pixel breit; ` +
+    'mobile.html und viewer.html scrollen weiterhin.',
+)
+console.log(
+  'NICHT gemessen: ob eine echte Kneif-Geste die Seite in Ruhe laesst. Der ' +
+    'Kneif-Ersatz der Fernsteuerung vergroessert die Seite auch mit ' +
+    '`touch-action: none` — geprueft ist die Voraussetzung, nicht die Wirkung. ' +
+    'Safaris `gesture*` sind gelesen, nicht gemessen.',
+)

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -366,7 +366,24 @@ export default function App() {
   // was wir selbst eingeklappt haben — vom User manuell Eingeklapptes
   // bleibt unangetastet. Floating-Panels sind nie betroffen.
   const isNarrow = useIsNarrow()
-  const prevNarrowRef = useRef(isNarrow)
+  // ─── WARUM HIER `false` UND NICHT `isNarrow` STEHT ────────────────────
+  //
+  // Bis zum 2026-09-10 stand hier `useRef(isNarrow)`. Zusammen mit dem
+  // `if (isNarrow === prevNarrowRef.current) return` weiter unten hiess das:
+  // die Einklappung greift NUR beim Ueberschreiten der Schwelle — und beim
+  // ersten Rendern gibt es kein Ueberschreiten. Wer das Fenster auf dem
+  // Schreibtisch schmal zog, sah die Panels zusammenklappen; wer die Seite
+  // auf einem Telefon OEFFNETE, sah sie nicht.
+  //
+  // GEMESSEN (390x844, GitHub-Seite): das Haupt-Raster stand auf
+  // 129px Bibliothek | 125px Plan | 129px Eigenschaften. Der Plan war der
+  // schmalste Teil der Planungs-App, und die Kopfzeile der Eigenschaften
+  // ragte 17px ueber den rechten Rand hinaus.
+  //
+  // `false` als Startwert heisst: „zuletzt war es breit". Laedt die Seite
+  // schmal, ist das ein Uebergang und die Panels klappen ein. Laedt sie
+  // breit, ist es keiner und es passiert nichts — genau wie vorher.
+  const prevNarrowRef = useRef(false)
   const autoCollapsedRef = useRef({ library: false, properties: false })
   useEffect(() => {
     if (isNarrow === prevNarrowRef.current) return
@@ -1311,7 +1328,7 @@ export default function App() {
   }, [pendingConnection, project.equipment])
 
   return (
-    <div className="flex h-screen flex-col bg-cp-surface-1 text-cp-text">
+    <div className="flex h-dvh flex-col bg-cp-surface-1 text-cp-text">
       <MenuBar
         onNewProject={handleNewProject}
         onOpenProject={() => void openProject()}

--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -218,6 +218,41 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
     return () => setViewportCenterGetter(null)
   }, [screenToFlowPosition])
 
+  // ═════════════════════════════════════════════════════════════════════
+  // Die Kneif-Geste gehoert dem Plan, nicht dem Browser (Nutzer-Meldung
+  // 2026-09-10: „Man kann das gesamte Fenster aus Versehen verschieben").
+  //
+  // Zwei Haelften, und nur zusammen halten sie:
+  //
+  //  1. `touch-action: none` am `.react-flow__renderer` (im Stilblatt).
+  //     Das deckt Chrome, Firefox und den Fingerbetrieb auf iOS ab. Ohne
+  //     es nimmt der Browser die Zwei-Finger-Geste VORWEG — ReactFlows
+  //     eigener Zeiger-Handler kommt dann gar nicht erst dran.
+  //  2. Safaris `gesture*`-Ereignisse. Die gibt es sonst nirgends, und ohne
+  //     sie vergroessert Safari auf dem Trackpad weiter die Seite — auch
+  //     dann, wenn `touch-action` steht: die Geste kommt dort nicht als
+  //     Beruehrung an. Dieselbe Stelle steht im light-planner und in
+  //     `src/mobile/MobileApp.tsx`; sie fehlte nur hier.
+  //
+  // Der Hoerer haengt am WRAPPER, nicht am Fenster: der Seiten-Zoom des
+  // Browsers wird NICHT global abgeschaltet (kein `user-scalable=no`). Er
+  // ist ein Zugaenglichkeits-Werkzeug und soll ueberall dort weiter
+  // funktionieren, wo Text steht — nur nicht ueber dem Plan, der seinen
+  // eigenen Zoom hat.
+  useEffect(() => {
+    const el = wrapperRef.current
+    if (!el) return
+    const stoppen = (e: Event) => e.preventDefault()
+    el.addEventListener('gesturestart', stoppen)
+    el.addEventListener('gesturechange', stoppen)
+    el.addEventListener('gestureend', stoppen)
+    return () => {
+      el.removeEventListener('gesturestart', stoppen)
+      el.removeEventListener('gesturechange', stoppen)
+      el.removeEventListener('gestureend', stoppen)
+    }
+  }, [])
+
   // Gemessene Canvas-Groesse fuer Zoom-to-fit nach Importen bereitstellen.
   // Lazy Getter statt ResizeObserver: der Wert wird nur beim Import gebraucht
   // und ist so garantiert frisch (inkl. aktueller Panel-Breiten), ohne bei

--- a/src/renderer/components/Canvas/LayerVisibilityChips.tsx
+++ b/src/renderer/components/Canvas/LayerVisibilityChips.tsx
@@ -87,7 +87,16 @@ export const LayerVisibilityChips = () => {
     })()
   }
   return (
-    <div className="relative flex items-center gap-1">
+    /* GEMESSEN am 2026-09-10 (390x844): dieser Streifen lief ohne
+       `flex-wrap` bis Pixel 726 auf einer 390 Pixel breiten Anzeige — er
+       hing weit ueber die Werkzeugleiste hinaus, und die Leiste selbst
+       konnte nichts dagegen tun: SIE bricht um (`flexWrap` in
+       `CanvasToolbar.tsx`), aber ein einzelnes Flex-Kind bricht nicht von
+       allein. Auf dem Schirmbild des Nutzers endete die Reihe mitten im
+       Wort „Control". `min-w-0` gehoert dazu: ohne das darf das Kind unter
+       seine Inhaltsbreite gar nicht erst schrumpfen.
+       Der Ausdruck-Dialog setzt denselben Umbruch schon aussen herum. */
+    <div className="relative flex min-w-0 flex-wrap items-center gap-1">
       <span
         className={`select-none text-cp-xs uppercase tracking-wider ${isLight ? 'text-slate-400' : 'text-slate-400'}`}
         title={t(

--- a/src/renderer/components/Properties/PropertiesPanel.tsx
+++ b/src/renderer/components/Properties/PropertiesPanel.tsx
@@ -174,7 +174,12 @@ export const PropertiesPanel = () => {
 
   return (
     <aside className="flex h-full min-h-0 flex-col border-l border-cp-border bg-cp-surface-3 text-cp-text">
-      <div className="flex items-start justify-between gap-2 border-b border-cp-border-muted px-3 py-2.5">
+      {/* `flex-wrap`: die Knopfgruppe rechts ist `shrink-0` (sie darf nicht
+          schmaler werden, sonst ueberlappen die Symbole). Auf einem schmalen
+          Panel — gemessen 129px auf einem 390px breiten Telefon — passt sie
+          dann nicht mehr neben den Titel und stand 17px ueber dem rechten
+          Bildrand. Mit Umbruch rutscht sie unter den Titel statt hinaus. */}
+      <div className="flex flex-wrap items-start justify-between gap-2 border-b border-cp-border-muted px-3 py-2.5">
         <div className="min-w-0">
           <h2 className="truncate text-cp-base font-semibold">{title}</h2>
           <div className="mt-0.5 text-cp-xs uppercase tracking-wide text-cp-text-muted">

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -174,12 +174,91 @@ body,
   margin: 0;
 }
 
+/* ═══════════════════════════════════════════════════════════════════════
+ * Das Fenster selbst ist kein Scrollbereich (Nutzer-Meldung 2026-09-10:
+ * „Man kann das gesamte Fenster aus Versehen verschieben", zum Schirmbild
+ * der GitHub-Seite auf einem iPhone).
+ *
+ * Hier stand bis dahin NUR `height: 100%; margin: 0`. Auf dem Schreibtisch
+ * faellt das nicht auf: dort gibt es kein Gummiband und keine Kneif-Geste.
+ * Auf dem Telefon schon — und dann verschiebt sich die ganze Seite, waehrend
+ * die Anwendung selbst gar nichts davon mitbekommt. Zwei Dinge halten sie
+ * fest:
+ *
+ *  · `overflow: hidden` — die Anwendung ist so gross wie das Fenster, ein
+ *    Rest zum Scrollen darf gar nicht erst entstehen. Ohne das genuegt EIN
+ *    Pixel Ueberhang irgendwo, damit die Seite waagerecht wandert; genau so
+ *    sah das Schirmbild aus (Inhalt nach links geschoben, rechts schwarz).
+ *  · `overscroll-behavior: none` — nimmt das Gummiband weg. Ein Zug, den
+ *    kein Scrollbereich aufnimmt, endet damit im Nichts statt in einer
+ *    Verschiebung der ganzen Seite.
+ *
+ * WAS DAS NICHT LEISTET: die Kneif-Vergroesserung. Die haengt nicht am
+ * Ueberlauf, sondern an `touch-action` — siehe `.react-flow__renderer`
+ * weiter unten. Beide Haelften zusammen misst `npm run mobil:check`.
+ * ═══════════════════════════════════════════════════════════════════════ */
+/* Das Gummiband gilt fuer ALLE drei Einstiege: es nimmt nur das Ueberziehen
+ * am Ende weg (und das versehentliche Neuladen per Zug von oben), nicht das
+ * Scrollen selbst. Ein Rundgang, der seine Haken gesetzt hat, verliert sie
+ * damit nicht mehr an eine Handbewegung. */
+html,
+body {
+  overscroll-behavior: none;
+}
+
+/* Die Sperre selbst haengt an der Marke aus `index.html` — sie gilt NUR fuer
+ * die Vollbild-Anwendung. `mobile.html` und `viewer.html` laden dasselbe
+ * Stilblatt und sind scrollende Seiten; GEMESSEN am 2026-09-10: ohne diese
+ * Einschraenkung blieb die Mobil-Liste bei 3000 Pixel Inhalt auf
+ * `scrollY = 0` stehen — die Seite war nach dem ersten Bild zu Ende, ohne
+ * dass irgendetwas es gesagt haette. */
+html[data-cp-shell='app'],
+html[data-cp-shell='app'] body {
+  overflow: hidden;
+}
+
+/* Auf dem Telefon ist die sichtbare Hoehe nicht `100vh`: die Adressleiste
+ * faehrt ein und aus. `100vh` ist die GROSSE Fassung (Leiste weg) — mit ihr
+ * ragt die Fusszeile unter die eingeblendete Leiste, und genau das war auf
+ * dem Schirmbild die abgeschnittene Statuszeile. `100dvh` ist die jeweils
+ * geltende. Auf dem Schreibtisch sind beide dasselbe. */
+html[data-cp-shell='app'] #root {
+  height: 100dvh;
+}
+
 /* Safety net: ensure React Flow viewport has a concrete size so nodes are visible */
 .react-flow,
 .react-flow__renderer,
 .react-flow__viewport {
   width: 100%;
   height: 100%;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ * Die Kneif-Geste gehoert dem Plan, nicht dem Browser.
+ *
+ * GEMESSEN am 2026-09-10 (390x844, Fingerbedienung, `mobil:check`): ein
+ * Kneifen mitten auf dem Plan vergroesserte die SEITE — `visualViewport`
+ * ging von 1.0 auf 2.0, der sichtbare Ausschnitt sprang um 98/250 Pixel
+ * zur Seite. Der Plan blieb, wie er war. Das ist die Nutzer-Meldung „man
+ * kann das gesamte Fenster aus Versehen verschieben", und sie hat nichts
+ * mit dem Scrollen zu tun: eine einmal vergroesserte Seite laesst sich
+ * danach mit einem Finger beliebig herumschieben.
+ *
+ * ReactFlow bringt fuer `zoomOnPinch` seinen eigenen Zeiger-Handler mit,
+ * aber sein Stilblatt setzt KEIN `touch-action`. Ohne das nimmt der
+ * Browser die Zwei-Finger-Geste vorweg — der Handler kommt gar nicht erst
+ * dran. Dieselbe Lehre steht im light-planner an `.plan-canvas`.
+ *
+ * WARUM `.react-flow__renderer` UND NICHT `.react-flow`: `touch-action`
+ * schneidet sich ueber die Vorfahren; ein Nachfahre kann nicht wieder
+ * aufmachen, was ein Vorfahre zugemacht hat. An `.react-flow` laegen
+ * Minimap und Steuerkreuz mit darunter (sie sind Geschwister des
+ * Renderers), und die brauchen ihre eigenen Gesten. Der Renderer traegt
+ * genau die Flaeche des Plans: Pane, Hintergrund, Knoten, Kanten.
+ * ═══════════════════════════════════════════════════════════════════════ */
+.react-flow__renderer {
+  touch-action: none;
 }
 
 /* v7.7.1 — Gradient lives on the canvas container itself, NOT on
@@ -866,9 +945,15 @@ input[type="range"]:disabled {
 .cp-statusbar {
   display: flex;
   align-items: center;
-  height: 24px;
+  /* `viewport-fit=cover` in der index.html laesst die Seite bis unter den
+   * Rundungs-/Griffbereich des Telefons laufen. Die Statuszeile ist das
+   * unterste Element — ohne die sichere Zone liegt ihre Schrift unter dem
+   * Home-Balken. Auf dem Schreibtisch ist `env(...)` schlicht 0. */
+  height: calc(24px + env(safe-area-inset-bottom));
+  padding-bottom: env(safe-area-inset-bottom);
   flex: none;
-  padding: 0 12px;
+  padding-left: 12px;
+  padding-right: 12px;
   background: var(--cp-surface-3);
   border-top: 1px solid var(--cp-border);
   font-size: 12px;

--- a/tests/rahmenMasse.test.ts
+++ b/tests/rahmenMasse.test.ts
@@ -42,8 +42,26 @@ describe('ADR-007 Abschnitt 6: der Rahmen steht fest', () => {
     expect(regel('cp-topbar')).toMatch(/height:\s*40px/)
   })
 
-  it('die Statusleiste ist 24 px hoch', () => {
-    expect(regel('cp-statusbar')).toMatch(/height:\s*24px/)
+  it('die Statusleiste ist 24 px hoch — plus die sichere Zone des Geraets', () => {
+    // ERWEITERT am 2026-09-10, nicht gelockert: geprueft werden jetzt ZWEI
+    // Dinge statt einem.
+    //
+    // Die Zahl aus ADR-007 steht unveraendert da. Dazu kommt die sichere
+    // Zone: `index.html` sagt `viewport-fit=cover`, die Seite laeuft also
+    // bis unter den Griffbereich des Telefons, und die Statusleiste ist das
+    // unterste Element. Mit flachen 24 px lag ihre Schrift dort unter dem
+    // Home-Balken — gemeldet am 2026-09-10 als „die Statuszeile ist
+    // abgeschnitten".
+    //
+    // `env(safe-area-inset-bottom)` ist ueberall dort 0, wo das Geraet
+    // nichts fuer sich beansprucht: auf dem Schreibtisch bleibt die Leiste
+    // also exakt 24 px, und das Rahmenmass von ADR-007 gilt unveraendert.
+    // Der zweite Ausdruck haelt fest, dass die Zone auch wirklich
+    // freigehalten und nicht nur dazugerechnet wird.
+    expect(regel('cp-statusbar')).toMatch(
+      /height:\s*calc\(24px \+ env\(safe-area-inset-bottom\)\)/,
+    )
+    expect(regel('cp-statusbar')).toMatch(/padding-bottom:\s*env\(safe-area-inset-bottom\)/)
   })
 
   it('beide sind unnachgiebig — sie schrumpfen nicht mit', () => {


### PR DESCRIPTION
## Die Meldung

Nutzer, 2026-09-10, mit einem Schirmbild der GitHub-Seite auf einem iPhone:

> Verbessere die mobile Ansicht. Der Screenshot ist von der GitHub Page. Man kann das gesamte Fenster aus Versehen verschieben.

Auf dem Bild war der Inhalt nach links geschoben, rechts stand ein schwarzer Streifen, die Reihe der Ebenen-Chips endete mitten im Wort „Control", und die Statuszeile war unten abgeschnitten.

## Gemessen

Im echten Browser, 390×844, Fingerbedienung, gegen `dist/renderer` — also gegen genau die Seite, die GitHub Pages ausliefert:

| | vorher | nachher |
|---|---|---|
| Elemente über den rechten Rand hinaus | **18** (Chip-Streifen bis Pixel 726) | **0** |
| Breite des Plans im Haupt-Raster | **125 px** (zwischen 129 px Bibliothek und 129 px Eigenschaften) | **318 px** |
| `overflow` an `html`/`body` | `visible` | `hidden` (nur die Vollbild-Anwendung) |
| `overscroll-behavior` | `auto` | `none` |
| `touch-action` am Plan-Renderer | `auto` | `none` |
| `visualViewport.scale` nach einem Kneifen auf dem Plan | **1 → 2**, Versatz 98/250 px | siehe „nicht gemessen" |

## Vier Ursachen, drei davon im Quelltext unauffällig

* **Die Kneif-Geste.** Eine einmal vergrößerte Seite lässt sich danach mit einem Finger beliebig herumschieben — das ist die Meldung. ReactFlow bringt für `zoomOnPinch` seinen eigenen Handler mit, aber sein Stilblatt setzt **kein `touch-action`**; ohne das nimmt der Browser die Zwei-Finger-Geste vorweg, und der Handler kommt gar nicht erst dran. Die Regel sitzt an `.react-flow__renderer` und **nicht** an `.react-flow`: `touch-action` schneidet sich über die Vorfahren, an `.react-flow` lägen Minimap und Steuerkreuz mit darunter. Dazu Safaris `gesture*`-Hörer am Canvas-Wrapper — dieselbe Stelle wie im `light-planner` (`light#108`) und in `src/mobile`, sie fehlte nur hier.
* **Die Einklappung für schmale Fenster gab es längst — sie sprang nur nie an.** `App.tsx` klappt die Seiten-Panels unter 1024 px ein (#444), aber `useRef(isNarrow)` plus `if (isNarrow === prevNarrowRef.current) return` heißt: nur beim **Überschreiten** der Schwelle. Beim ersten Rendern gibt es kein Überschreiten. Wer das Fenster am Schreibtisch schmal zog, sah die Panels zusammenklappen; wer die Seite auf einem Telefon **öffnete**, sah sie nicht.
* **Der Chip-Streifen konnte nicht umbrechen, obwohl die Werkzeugleiste es kann.** Sie hat `flexWrap` — aber ein einzelnes Flex-Kind bricht nicht von allein. `flex-wrap` + `min-w-0`, wie es der Ausdruck-Dialog schon außen herum tut.
* **`100vh` ist auf dem Telefon die große Fassung** (Adressleiste weg), damit ragte die Fußzeile unter die eingeblendete Leiste. Jetzt `h-dvh`; die Statuszeile hält zusätzlich die sichere Zone frei, weil `viewport-fit=cover` die Seite unter den Home-Balken laufen lässt.

## Der erste Anlauf hat die Mobil-Ansicht kaputtgemacht

`html, body { overflow: hidden }` stand zunächst global — `mobile.html` und `viewer.html` laden aber **dasselbe** Stilblatt und sind scrollende Seiten. Gemessen: die Mobil-Liste blieb bei 3000 px Inhalt auf `scrollY = 0` stehen, die Seite war nach dem ersten Bild zu Ende, und zwar lautlos. Die Sperre hängt deshalb an der Marke `data-cp-shell="app"` in `index.html`, und **Regel 8** des Wächters misst die Kehrseite derselben Entscheidung.

## Der Wächter, und was er nicht kann

`npm run mobil:check` (`scripts/mobil-grenze-check.mjs`, in CI im `ui-smoke`-Job) misst im echten Browser: Überhang, Dokumentgröße, die berechneten `overflow`- und `overscroll-behavior`-Werte, `touch-action` am Plan-Renderer, die Lage der Statuszeile, die Breite des Plans und das Scrollen der beiden anderen Einstiege.

Er misst **nicht**, ob eine echte Kneif-Geste am Ende die Seite in Ruhe lässt. Das wurde versucht und verworfen: der Kneif-Ersatz der Fernsteuerung (CDP `Input.synthesizePinchGesture` wie auch `Input.dispatchTouchEvent`) vergrößert die Seite unter headless-Chromium **auch mit** `touch-action: none` — die Gegenprobe mit und ohne die Regel lieferte denselben Wert. Eine Messung, die den Unterschied nicht sieht, wäre ein Wächter, der immer grün ist; geprüft wird deshalb die Voraussetzung, ohne die es sicher falsch ist, und der Lauf sagt das in seiner Ausgabe. Safaris `gesture*` werden im Quelltext nachgesehen — Safari läuft in CI nicht.

**Gegengeprobt:** gegen den Stand vor der Änderung meldet der Lauf alle acht Befunde (18 Überhänge, `overflow` fehlt, `overscroll-behavior` auto, `touch-action` auto, 125 px Plan, drei fehlende `gesture*`-Hörer); mit global gesetzter Sperre meldet er die beiden nicht mehr scrollenden Einstiege.

## `tests/rahmenMasse.test.ts` wurde erweitert, nicht gelockert

Die 24 px aus ADR-007 stehen unverändert da; dazu kommt die sichere Zone. `env(safe-area-inset-bottom)` ist überall 0, wo das Gerät nichts für sich beansprucht — auf dem Schreibtisch bleibt die Leiste also exakt 24 px, und das Rahmenmaß gilt unverändert.

Backlog: **B-66** in `av-planner-suite/docs/IMPLEMENTATION_BACKLOG.md` (eigener PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT


---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_