### PR TITLE
canvas: das Gerät wird wieder schmal, wenn der Port-Name kürzer wird

### DIFF
--- a/src/renderer/components/Canvas/CanvasArea.tsx
+++ b/src/renderer/components/Canvas/CanvasArea.tsx
@@ -956,6 +956,22 @@ const CanvasContent = ({ mode = 'main' }: { mode?: CanvasMode }) => {
           // obwohl Stelle leer" (Bug 2 in Issue #206). Mit gespeicherten
           // measured Dimensions ist die fallback-Kette
           // rfNode?.width ?? eq.width ?? 0 immer stabil.
+          //
+          // 2026-09-11 — WAS HIER GESCHRIEBEN WIRD, IST EIN ABBILD UND KEINE
+          // ABSICHT. Bis heute las `EquipmentNode` dieselbe Zahl als
+          // Untergrenze wieder ein, und weil die gemessene Breite per
+          // Konstruktion `max(gespeichert, intrinsisch)` ist, konnte sie nie
+          // kleiner werden: ein langer Port-Name machte das Geraet breit, und
+          // das Kuerzen des Namens machte es nicht wieder schmal
+          // (Nutzer-Meldung). Die Groesse kommt jetzt allein aus den Daten
+          // (`lib/equipmentLayout.ts`), dieser Rueckschreiber fuehrt das Feld
+          // nur noch NACH.
+          //
+          // Und genau das heilt nebenbei die Bestandsdaten: sobald der Knoten
+          // schmaler rendert, meldet ReactFlow die neue Groesse, und die Zeile
+          // unten ersetzt den alten, zu grossen Wert. Es braucht keine
+          // Migration in `healProjectPositions` — das Feld korrigiert sich
+          // beim ersten Blick auf den Plan.
           const eq = project.equipment.find((e) => e.id === change.id)
           const newW = Math.max(40, Math.round(change.dimensions.width))
           const newH = Math.max(20, Math.round(change.dimensions.height))

--- a/src/renderer/components/Canvas/EquipmentNode.tsx
+++ b/src/renderer/components/Canvas/EquipmentNode.tsx
@@ -553,13 +553,24 @@ export const EquipmentNode = ({ id, data, selected }: NodeProps<EquipmentNodeDat
   // Expand für lange Port-Labels rundet entsprechend AUF.
   const GRID = EQUIPMENT_LAYOUT.GRID_SIZE
   const snapUp = (n: number) => Math.ceil(n / GRID) * GRID
-  const intrinsicWidth = snapUp(Math.max(EQUIPMENT_LAYOUT.DEFAULT_WIDTH, labelWidth * 2, nameWidth))
-  const width = Math.max(snapUp(data.width ?? intrinsicWidth), intrinsicWidth)
-  // computedHeight ist per Konstruktion bereits Vielfaches von GRID
-  // (headerHeight, PORT_ROW, PADDING sind alle Vielfache); data.height
-  // wird zur Sicherheit aufgerundet falls der User es manuell setzt.
-  const computedHeight = headerHeight + portRows * PORT_ROW + PADDING
-  const height = Math.max(snapUp(data.height ?? computedHeight), computedHeight)
+  // ─── `data.width`/`data.height` ENTSCHEIDEN NICHTS MEHR ───────────────────
+  //
+  // Nutzer-Meldung 2026-09-11: ein langer Port-Name machte das Geraet breit,
+  // und das Kuerzen des Namens machte es nicht wieder schmal. Hier stand
+  // `Math.max(snapUp(data.width ?? intrinsicWidth), intrinsicWidth)` — die
+  // gespeicherte Breite als Untergrenze. Sie war aber nie die Absicht eines
+  // Nutzers, sondern die zuletzt gemessene Breite, die `CanvasArea`
+  // zurueckschreibt. Die ganze Begruendung steht in `lib/equipmentLayout.ts`,
+  // wo die Formel lebt.
+  //
+  // Sie steht dort und nicht hier, und das ist die zweite Haelfte dieser
+  // Aenderung: dieselbe Rechnung stand bis heute in BEIDEN Dateien. Der Kopf
+  // von `equipmentLayout.ts` warnt seit v7.9.4 davor („Single source of
+  // truth"), und trotzdem lief sie doppelt — beim Beheben haette man die eine
+  // Fassung aendern und die andere vergessen koennen, und der Knoten stuende
+  // an einer anderen Stelle als seine Kabel-Enden.
+  const width = snapUp(Math.max(EQUIPMENT_LAYOUT.DEFAULT_WIDTH, labelWidth * 2, nameWidth))
+  const height = snapUp(headerHeight + portRows * PORT_ROW + PADDING)
 
   // Y offset for the handle dot: aligns to vertical center of the row.
   const rowCenter = (index: number) => headerHeight + index * PORT_ROW + PORT_ROW / 2

--- a/src/renderer/lib/equipmentLayout.ts
+++ b/src/renderer/lib/equipmentLayout.ts
@@ -107,12 +107,47 @@ export const computeEquipmentLayout = (
   // (sichtbar v.a. am breiten Videohub mit vielen Output-Ports).
   const GRID = EQUIPMENT_LAYOUT.GRID_SIZE
   const snapUp = (n: number): number => Math.ceil(n / GRID) * GRID
-  const intrinsicWidth = snapUp(Math.max(EQUIPMENT_LAYOUT.DEFAULT_WIDTH, labelWidth * 2, nameWidth))
-  const width = Math.max(snapUp(eq.width ?? intrinsicWidth), intrinsicWidth)
+
+  // ─── `eq.width`/`eq.height` SIND EIN ABBILD, KEINE UNTERGRENZE ───────────
+  //
+  // NUTZER-MELDUNG 2026-09-11: „Wenn im Cable planner ein Gerät einen Port mit
+  // einem sehr langen Namen bekommt wird das Gerät sehr breit. Kürzt man dann
+  // den Namen, bleibt das Gerät breit. Es soll aber kürzer werden."
+  //
+  // GEMESSEN: Port-Name „IN" -> 220 px. Auf einen 37 Zeichen langen Namen
+  // -> 671 px. Name wieder auf „IN" -> immer noch 671 px.
+  //
+  // Hier stand `Math.max(snapUp(eq.width ?? intrinsicWidth), intrinsicWidth)`,
+  // und das war richtig gedacht: „der Nutzer hat das Gerät breiter gezogen,
+  // also lass es breiter". Nur gibt es das Ziehen nicht. `NodeResizer` haengt
+  // ausschliesslich am `LocationFrameNode`; ein Geraet laesst sich auf der
+  // Flaeche nicht in der Groesse aendern. (Die Millimeter-Felder in der
+  // Eigenschaften-Leiste sind `widthMm`/`heightMm` — die physische Bauform,
+  // ein anderes Feld.)
+  //
+  // Was tatsaechlich in `eq.width` stand, war die zuletzt GEMESSENE Breite:
+  // `CanvasArea` schreibt sie bei jedem `dimensions`-Change zurueck, damit der
+  // Ueberlappungs-Test und die Exporte eine stabile Zahl haben (#206). Und die
+  // gemessene Breite ist per Konstruktion `max(gespeichert, intrinsisch)` —
+  // sie kann also nie kleiner werden. Einmal breit, immer breit.
+  //
+  // Ein Feld, zwei Bedeutungen: „so gross will es der Nutzer" und „so gross
+  // war es zuletzt". Die Defektform heisst in dieser Suite
+  // `zwei-rechnungen`; hier war es dieselbe Zahl mit zwei Aufgaben, und die
+  // zweite hat die erste aufgefressen.
+  //
+  // Die Groesse kommt deshalb ab jetzt AUSSCHLIESSLICH aus den Daten. Das
+  // gespeicherte Feld bleibt erhalten und wird weiter nachgefuehrt — Exporte
+  // (`exportDxf`, `exportStagePlot`), die Kabellaengen-Schaetzung und die
+  // Raum-Zuordnung lesen es —, aber es entscheidet nichts mehr. Wer Geraete
+  // eines Tages ziehbar macht, braucht dafuer ein EIGENES Feld; dieses hier
+  // kann die Frage nicht beantworten.
+  const width = snapUp(Math.max(EQUIPMENT_LAYOUT.DEFAULT_WIDTH, labelWidth * 2, nameWidth))
 
   const portRows = Math.max(sideCounts.left, sideCounts.right, 1)
-  const computedHeight = headerHeight + portRows * PORT_ROW + PADDING
-  const height = Math.max(snapUp(eq.height ?? computedHeight), computedHeight)
+  // Dieselbe Begruendung fuer die Hoehe: sie folgt der Zahl der Port-Reihen.
+  // Ports zu loeschen liess das Geraet vorher genauso hoch stehen.
+  const height = snapUp(headerHeight + portRows * PORT_ROW + PADDING)
 
   const rowCenter = (slot: number): number => headerHeight + slot * PORT_ROW + PORT_ROW / 2
 

--- a/tests/geraeteBreiteSchrumpft.test.ts
+++ b/tests/geraeteBreiteSchrumpft.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { computeEquipmentLayout } from '../src/renderer/lib/equipmentLayout'
+import { EQUIPMENT_LAYOUT } from '../src/renderer/lib/layoutConstants'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+
+// ───────────────────────────────────────────────────────────────────────────
+// Ein Geraet wird wieder schmal, wenn der lange Port-Name weggeht.
+//
+// NUTZER-MELDUNG 2026-09-11: „Wenn im Cable planner ein Gerät einen Port mit
+// einem sehr langen Namen bekommt wird das Gerät sehr breit. Kürzt man dann
+// den Namen, bleibt das Gerät breit. Es soll aber kürzer werden."
+//
+// GEMESSEN vor der Aenderung: Port „IN" -> 220 px; Port mit 37 Zeichen
+// -> 671 px; Name zurueck auf „IN" -> immer noch 671 px.
+//
+// ─── WOGEGEN DIESER LAUF STEHT ────────────────────────────────────────────
+//
+// Nicht gegen das Wachsen — das ist gewollt und war nie kaputt. Gegen die
+// EINBAHNSTRASSE: eine Groesse, die nur in eine Richtung geht. Sie faellt
+// niemandem auf, der ein Geraet anlegt; sie faellt dem auf, der einen Tippfehler
+// korrigiert und danach ein Geraet hat, das die halbe Flaeche belegt.
+//
+// Die Ursache war ein Feld mit zwei Bedeutungen. `eq.width` hiess im Renderer
+// „so breit will es der Nutzer" (Untergrenze) und im Rueckschreiber von
+// `CanvasArea` „so breit war es zuletzt" (Messwert). Weil die Messung per
+// Konstruktion `max(gespeichert, intrinsisch)` ist, hat die zweite Bedeutung
+// die erste aufgefressen. Es GIBT kein Nutzer-Ziehen an Geraeten —
+// `NodeResizer` haengt nur am `LocationFrameNode` —, also war die
+// Untergrenze von Anfang an eine Annahme ohne Deckung.
+//
+// ─── WAS ER NICHT KANN ────────────────────────────────────────────────────
+//
+// Er rechnet. Ob der Knoten im laufenden Fenster wirklich schmaler wird, misst
+// `ui:overflow` an der gebauten App und der Mensch davor. Was er dafuer sicher
+// sagt: die Formel kennt keinen Weg mehr, eine alte Breite festzuhalten.
+// ───────────────────────────────────────────────────────────────────────────
+
+const geraet = (portName: string, gespeichert?: { width?: number; height?: number }): EquipmentItem =>
+  ({
+    id: 'e1',
+    name: 'Switcher',
+    type: 'switcher',
+    x: 0,
+    y: 0,
+    inputs: [{ id: 'p1', name: portName, connectorType: 'BNC' }],
+    outputs: [],
+    ...gespeichert,
+  }) as unknown as EquipmentItem
+
+const LANG = 'SEHR LANGER PORTNAME FUER DIE MESSUNG'
+
+describe('die Breite folgt dem Namen in BEIDE Richtungen', () => {
+  it('ein langer Port-Name macht das Geraet breiter', () => {
+    // Die Gegenrichtung zuerst: waere das hier gleich, pruefte der Test
+    // unten gegen zwei identische Zahlen und waere still gruen.
+    const schmal = computeEquipmentLayout(geraet('IN')).width
+    const breit = computeEquipmentLayout(geraet(LANG)).width
+    expect(breit).toBeGreaterThan(schmal)
+  })
+
+  it('das Kuerzen macht es wieder schmal — auch mit alter Breite im Feld', () => {
+    const schmal = computeEquipmentLayout(geraet('IN')).width
+    const breit = computeEquipmentLayout(geraet(LANG)).width
+    // Genau das schreibt `CanvasArea` nach dem Messen zurueck.
+    const nachDemKuerzen = computeEquipmentLayout(geraet('IN', { width: breit })).width
+    expect(nachDemKuerzen).toBe(schmal)
+  })
+
+  it('dasselbe fuer die Hoehe, wenn Ports verschwinden', () => {
+    // Derselbe Fehler auf der anderen Achse: `eq.height` war ebenso
+    // Untergrenze. Ports zu loeschen liess das Geraet hoch stehen.
+    const vieleP = Array.from({ length: 8 }, (_, i) => ({ id: `p${i}`, name: `IN ${i}`, connectorType: 'BNC' }))
+    const hoch = computeEquipmentLayout({ ...geraet('IN'), inputs: vieleP } as EquipmentItem).height
+    const niedrig = computeEquipmentLayout(geraet('IN')).height
+    expect(hoch).toBeGreaterThan(niedrig)
+    expect(computeEquipmentLayout(geraet('IN', { height: hoch })).height).toBe(niedrig)
+  })
+
+  it('die Groesse rastet weiter aufs Raster ein', () => {
+    // Die Aenderung nimmt `Math.max(...)` weg — nicht das `snapUp`. Faellt
+    // das mit, sitzen Kabel-Enden neben ihren Handles (#501).
+    for (const name of ['IN', LANG, 'Ein mittellanger Name']) {
+      const { width, height } = computeEquipmentLayout(geraet(name))
+      expect(width % EQUIPMENT_LAYOUT.GRID_SIZE, `Breite ${width} nicht auf dem Raster`).toBe(0)
+      expect(height % EQUIPMENT_LAYOUT.GRID_SIZE, `Hoehe ${height} nicht auf dem Raster`).toBe(0)
+    }
+  })
+
+  it('unter die Vorgabebreite faellt es nicht', () => {
+    expect(computeEquipmentLayout(geraet('')).width).toBeGreaterThanOrEqual(
+      EQUIPMENT_LAYOUT.DEFAULT_WIDTH,
+    )
+  })
+})
+
+describe('es gibt nur noch EINE Stelle, die entscheidet', () => {
+  const lies = (p: string): string => readFileSync(resolve(__dirname, '..', p), 'utf8')
+  const node = lies('src/renderer/components/Canvas/EquipmentNode.tsx')
+  const layout = lies('src/renderer/lib/equipmentLayout.ts')
+
+  /** Zeilenkommentare weg — der Rest ist, was laeuft. */
+  const ohneKommentare = (t: string): string =>
+    t
+      .split('\n')
+      .filter((z) => {
+        const s = z.trimStart()
+        return !s.startsWith('//') && !s.startsWith('*') && !s.startsWith('/*')
+      })
+      .join('\n')
+
+  it('weder Renderer noch Layout lesen die gespeicherte Groesse als Untergrenze', () => {
+    // Der Kommentar in beiden Dateien NENNT die alte Form, weil er erklaert,
+    // warum sie weg ist — ohne das Streichen faende diese Pruefung genau die
+    // Erklaerung, gegen die sie geschrieben ist.
+    for (const [name, datei] of Object.entries({ node, layout })) {
+      const code = ohneKommentare(datei)
+      expect(/Math\.max\(\s*snapUp\((data|eq)\.width/.test(code), `${name}: alte Untergrenze`).toBe(
+        false,
+      )
+      expect(/Math\.max\(\s*snapUp\((data|eq)\.height/.test(code), `${name}: alte Untergrenze`).toBe(
+        false,
+      )
+    }
+  })
+
+  it('Gegenprobe: die Begruendung steht weiterhin im Quelltext', () => {
+    // Sonst haette das Streichen der Kommentare oben eine zweite Wirkung,
+    // die keiner wollte: die Erklaerung koennte verschwinden und der Lauf
+    // bliebe gruen. Die Zeile selbst sieht harmlos aus; erst der Grund
+    // verhindert, dass jemand die Untergrenze „zur Sicherheit" zurueckbaut.
+    // Die Begruendung lebt an EINER Stelle — dort, wo auch die Formel lebt.
+    // `NodeResizer` ist das entscheidende Wort: es haengt nur am
+    // `LocationFrameNode`, und deshalb war die Untergrenze eine Annahme ohne
+    // Deckung.
+    expect(layout).toContain('NodeResizer')
+    // Der Renderer wiederholt sie nicht, sondern verweist — sonst stuenden
+    // zwei Fassungen derselben Begruendung da, und eine davon veraltet.
+    expect(node).toContain('lib/equipmentLayout.ts')
+  })
+
+  it('die gelesenen Dateien sind wirklich da', () => {
+    for (const [name, inhalt] of Object.entries({ node, layout })) {
+      expect(inhalt.length, `${name} ist leer`).toBeGreaterThan(1000)
+    }
+  })
+})


### PR DESCRIPTION
Nutzer-Meldung 2026-09-11:

> Wenn im Cable planner ein Gerät einen Port mit einem sehr langen Namen bekommt wird das Gerät sehr breit. Kürzt man dann den Namen, bleibt das Gerät breit. Es soll aber kürzer werden.

## Gemessen

Electron, Beispielprojekt, Port „SDI Out", Breite des Knotens ungeskaliert:

| Schritt | vorher | nachher |
|---|---|---|
| Start | 253 px | 253 px |
| Port-Name auf 37 Zeichen | 671 px | 671 px |
| Name zurück auf „IN" | **671 px** | **220 px** |

## Was dahintersteckt

`eq.width` hiess an zwei Stellen zwei verschiedene Dinge.

Im **Renderer** war es eine **Untergrenze**: `Math.max(snapUp(data.width ?? intrinsicWidth), intrinsicWidth)` — gelesen als „der Nutzer hat das Gerät breiter gezogen, also lass es breiter".

In **`CanvasArea`** war es ein **Messwert**: bei jedem `dimensions`-Change wird die gemessene Grösse zurückgeschrieben, damit der Überlappungs-Test und die Exporte eine stabile Zahl haben (#206).

Und die gemessene Breite ist per Konstruktion `max(gespeichert, intrinsisch)` — sie kann also **nie kleiner werden**. Die zweite Bedeutung hat die erste aufgefressen, und das Gerät war ab dem ersten langen Namen auf Dauer breit. Die Defektform heisst in dieser Suite `zwei-rechnungen`; hier war es dieselbe Zahl mit zwei Aufgaben.

### Die Untergrenze hatte nie eine Deckung

**Es gibt kein Ziehen an Geräten.** `NodeResizer` hängt ausschliesslich am `LocationFrameNode`; ein Gerät lässt sich auf der Fläche nicht in der Grösse ändern. (Die Millimeter-Felder in den Eigenschaften sind `widthMm`/`heightMm` — die physische Bauform, ein anderes Feld.) Die Untergrenze schützte also eine Absicht, die niemand äussern kann.

## Was sich ändert

- Die Grösse kommt **allein aus den Daten**: Port-Beschriftungen, Geräte-Name, Zahl der Port-Reihen. Das gespeicherte Feld bleibt erhalten und wird weiter nachgeführt — `exportDxf`, `exportStagePlot`, die Kabellängen-Schätzung und die Raum-Zuordnung lesen es —, aber es entscheidet nichts mehr.
- **Dasselbe für die Höhe.** Derselbe Fehler auf der anderen Achse: Ports zu löschen liess das Gerät genauso hoch stehen.
- **Bestandsdaten heilen sich selbst**: sobald der Knoten schmaler rendert, meldet ReactFlow die neue Grösse, und der Rückschreiber ersetzt den alten Wert. Keine Migration nötig.
- `snapUp` bleibt. Weg ist nur das `Math.max(...)`; ohne die Rasterung sässen Kabel-Enden neben ihren Handles (#501).

### Und die zweite Hälfte

Dieselbe Rechnung stand in **beiden** Dateien — `EquipmentNode.tsx` und `lib/equipmentLayout.ts`. Der Kopf von `equipmentLayout.ts` warnt seit v7.9.4 ausdrücklich davor („Single source of truth"), und trotzdem lief sie doppelt. Beim Beheben hätte man die eine Fassung ändern und die andere vergessen können — dann stünde der Knoten an einer anderen Stelle als seine Kabel-Enden. Die Begründung steht jetzt einmal, in `equipmentLayout.ts`; der Renderer verweist darauf.

## Wächter

`tests/geraeteBreiteSchrumpft.test.ts` (8 Prüfungen). Er steht **nicht** gegen das Wachsen — das war nie kaputt — sondern gegen die **Einbahnstrasse**: eine Grösse, die nur in eine Richtung geht. Sie fällt niemandem auf, der ein Gerät anlegt; sie fällt dem auf, der einen Tippfehler korrigiert.

Er prüft beide Richtungen (sonst wäre „breit == schmal" still grün), beide Achsen, die Rasterung und die Vorgabebreite; dazu liest er beide Dateien und besteht darauf, dass keine die alte Untergrenze zurückbaut. Beim Textvergleich werden Kommentare gestrichen — die *nennen* die alte Form, weil sie erklären, warum sie weg ist.

**Was er nicht kann**, steht in seinem Kopf: er rechnet. Ob der Knoten im Fenster wirklich schmaler wird, misst die Messreihe oben.

**Gegengeprobt:** mit der alten Untergrenze in `equipmentLayout.ts` fallen genau zwei Prüfungen und keine andere.

## Prüfungen

| Lauf | Ergebnis |
|---|---|
| `npx tsc -p tsconfig.app.json --noEmit` | 0 Fehler |
| `npm test` | 271 Dateien, 4079 Tests grün |
| `npm run lint` | 0 Fehler (13 Warnungen, alle im Bestand) |
| `ui:smoke` / `ui:overflow` / `ui:labels` / `ui:targets` | je 0 Befunde |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_