### PR TITLE
katalog: vier Konverter und vier Monitore tragen den alten Kategorienamen

### DIFF
--- a/src/renderer/lib/miscCatalog.ts
+++ b/src/renderer/lib/miscCatalog.ts
@@ -919,7 +919,7 @@ export const MISC_CATALOG: MiscEntry[] = [
     template: {
       manufacturerUrl: 'https://www.aja.com/products/hi5-12g',
       name: 'AJA Hi5-12G',
-      category: 'Konverter',
+      category: 'Converter',
       inputs: [
         sdiIn('SDI In'),
       ],
@@ -937,7 +937,7 @@ export const MISC_CATALOG: MiscEntry[] = [
     template: {
       manufacturerUrl: 'https://www.aja.com/products/ha5-12g',
       name: 'AJA HA5-12G',
-      category: 'Konverter',
+      category: 'Converter',
       inputs: [
         hdmiIn('HDMI In'),
       ],
@@ -955,7 +955,7 @@ export const MISC_CATALOG: MiscEntry[] = [
     template: {
       manufacturerUrl: 'https://www.aja.com/products/ha5-4k',
       name: 'AJA HA5-4K',
-      category: 'Konverter',
+      category: 'Converter',
       inputs: [
         hdmiIn('HDMI In'),
       ],
@@ -975,7 +975,7 @@ export const MISC_CATALOG: MiscEntry[] = [
     template: {
       manufacturerUrl: 'https://www.aja.com/products/roi-hdmi',
       name: 'AJA ROI-HDMI',
-      category: 'Konverter',
+      category: 'Converter',
       inputs: [
         hdmiIn('HDMI In'),
       ],
@@ -1097,7 +1097,7 @@ export const MISC_CATALOG: MiscEntry[] = [
     template: {
       manufacturerUrl: 'https://decimator.com/Products/MultiViewers/DMON-QUAD%20MultiViewer/DMON-QUAD.html',
       name: 'Decimator DMON-QUAD',
-      category: 'Monitore',
+      category: 'Monitors',
       inputs: [
         sdiIn('SDI In 1'),
         sdiIn('SDI In 2'),
@@ -1118,7 +1118,7 @@ export const MISC_CATALOG: MiscEntry[] = [
     template: {
       manufacturerUrl: 'https://decimator.com/Products/MultiViewers/DMON-4S%20MultiViewer/DMON-4S.html',
       name: 'Decimator DMON-4S',
-      category: 'Monitore',
+      category: 'Monitors',
       inputs: [
         sdiIn('SDI In 1'),
         sdiIn('SDI In 2'),
@@ -1139,7 +1139,7 @@ export const MISC_CATALOG: MiscEntry[] = [
     template: {
       manufacturerUrl: 'https://decimator.com/Products/MultiViewers/DMON-6S%20MultiViewer/DMON-6S.html',
       name: 'Decimator DMON-6S',
-      category: 'Monitore',
+      category: 'Monitors',
       inputs: [
         sdiIn('SDI In 1'),
         sdiIn('SDI In 2'),
@@ -1162,7 +1162,7 @@ export const MISC_CATALOG: MiscEntry[] = [
     template: {
       manufacturerUrl: 'https://decimator.com/Products/MultiViewers/DMON-16S%20MultiViewer/DMON-16S.html',
       name: 'Decimator DMON-16S',
-      category: 'Monitore',
+      category: 'Monitors',
       inputs: [
         sdiIn('SDI In 1'),
         sdiIn('SDI In 2'),


### PR DESCRIPTION
**`main` ist rot.** `tests/ausgelieferteDatenQuellsprache.test.ts` fällt seit dem Katalog-Zuwachs `317d8b79` (Kiloview): acht Einträge in `src/renderer/lib/miscCatalog.ts` liefern eine Kategorie aus, die es als kanonischen Wert nicht mehr gibt.

```
category: 'Konverter'  ->  'Converter'   (4 Einträge)
category: 'Monitore'   ->  'Monitors'    (4 Einträge)
```

## Warum das mehr ist als ein Schönheitsfehler

Der kanonische Kategoriename ist seit E-28 **englisch**; `lib/categoryTranslations.ts` übersetzt ihn für die Anzeige ins Deutsche (`Converter` → „Konverter", `Monitors` → „Monitore"). Wer ein Gerät aus dem Katalog einfügte, bekam bisher den deutschen Wert als **Daten** ins Projekt. Die Migration schreibt ihn beim nächsten Laden auf den englischen um — und der Katalog trägt ihn beim nächsten Einfügen gleich wieder herein. In der Seitenleiste stehen dann zwei Zeilen mit derselben Bedeutung, und man sucht den Unterschied.

Derselbe Katalog benutzt `Converter` an zwei anderen Stellen bereits richtig — es waren also nicht zwei Schreibweisen mit Absicht, sondern acht vergessene.

**Gegengeprobt:** mit den alten Werten fällt genau diese eine Prüfung, mit den neuen ist sie grün. Der Wächter dafür stand schon; er hat gemeldet, wofür er gebaut ist.

Aufgefallen ist es an der CI von [av-planner-suite#234](https://github.com/larszu/av-planner-suite/pull/234): die vendorte Kopie trägt denselben Katalog und denselben Wächter, also erbt die Suite die rote Prüfung, bis sie hier behoben ist.

**Geprüft:** tsc 0 Fehler · npm test 272 Dateien / 4087 Tests grün · lint 0 Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_