### PR TITLE
raster: eine Rastergroesse, aus der Geraete-Layout und A*-Zelle folgen

### DIFF
--- a/docs/app-structure.html
+++ b/docs/app-structure.html
@@ -240,7 +240,7 @@
   <aside>
     <h1>Cable-Planner</h1>
     <div class="subtitle">
-      App-Struktur · v9.0.1 · ~657 TS/TSX-Module · ~193.0k LOC<br>
+      App-Struktur · v9.0.1 · ~659 TS/TSX-Module · ~193.2k LOC<br>
       <small style="color:#64748b">Diese Übersicht zeigt nur die ~62 wichtigsten Module. Für die vollständige Architektur siehe <a href="./architecture.md" style="color:#94a3b8">architecture.md</a>.</small>
     </div>
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Invarianten der App. Sie ist die Pflicht-Lektüre, bevor strukturelle Änderunge
 gemacht werden. Für die interaktive Modul-Übersicht siehe [`app-structure.html`](./app-structure.html),
 für einen Wettbewerber-Vergleich [`comparison.html`](./comparison.html).
 
-Stand: v9.0.1 · ~657 TS/TSX-Module · ~193.0k LOC
+Stand: v9.0.1 · ~659 TS/TSX-Module · ~193.2k LOC
 
 ---
 
@@ -313,7 +313,9 @@ prüfen, ob das gemeinsame Konzept nach `shared/` gehört.
 - `CableEdge.tsx` (Custom-Edge mit Waypoints, Auto-Routing, Label-Slider)
 - `LocationNode.tsx` (Rahmen mit Move-Contents-Logik)
 - `LayerVisibilityChips.tsx` (Layer-Filter mit Count-Badges)
-- `pathfinding.ts` (Orthogonal-Routing zwischen Ports)
+- `pathfinding.ts` (Orthogonal-Routing zwischen Ports). **Das Zellmaß ist ein
+  Parameter, keine Konstante** — es kommt aus `lib/raster.ts` und ist gleich
+  der eingestellten Rastergröße (Invariante 24).
 - `cableApproach.ts` (die Anfahrt an das Geraet: Stummel an beiden Enden,
   Form gewaehlt statt angenommen — der Weg macht nicht kehrt, und der Pfeil
   faehrt gerade in die Buchse). Wer eine zweite Stelle baut, an der ein
@@ -872,6 +874,41 @@ Das Wichtigste in Listenform. Niemals brechen ohne expliziten Architektur-Review
     Aussage über die Schreibweise der Kategorie und nicht über das Gerät
     (ADR-002).
 
+24. **Das Raster ist EINE Zahl.** `uiStore.gridSize` — im Menü unter
+    *Einstellungen → Bearbeiten → Raster* einstellbar — ist die einzige
+    Schrittweite der Fläche. `lib/raster.ts` leitet daraus **alles** ab: die
+    Kopfhöhe der Gerätekarte, die Port-Reihe, das Innenpolster, die
+    Vorgabebreite **und das Zellmaß des Wegfinders**. Niemand schreibt eine
+    dieser Zahlen mehr hin.
+
+    Vorher waren es drei Rechnungen für dieselbe Frage: die eingestellte
+    Rastergröße, die 11er-Vielfachen in `EQUIPMENT_LAYOUT` und `CELL_SIZE = 20`
+    im A*. 20 ist kein Vielfaches von 11 — die Buchsen lagen also **per
+    Konstruktion** zwischen zwei Gitterpunkten des Wegfinders, und der
+    gezeichnete Weg holte den Rest als Stufe kurz vor der Buchse nach
+    (Nutzer-Meldung 2026-09-12: *„die Kabel gehen manchmal noch etwas unterhalb
+    von dem Ziel-Port und dann wieder hoch"*; in engen Szenen als Haken).
+
+    Zwei Regeln tragen die Ausrichtung, beide in `raster.ts` begründet:
+    - **Das Zellmaß teilt die Rastergröße** (es *ist* sie). Ein größeres Maß —
+      auch ein Vielfaches wie 2 g — lässt jede zweite Port-Reihe wieder
+      dazwischenfallen.
+    - **Die Port-Reihe ist ein GERADES Vielfaches** der Rastergröße, weil die
+      Buchse in ihrer Mitte sitzt.
+
+    Die Mindestmaße (44 / 66 / 22 / 11 / 220 px) bleiben als *Lesbarkeits-*
+    grenzen stehen und werden aufs nächste Vielfache gehoben; bei der Vorgabe
+    11 px ergibt das exakt die alten Zahlen. Die Grenzen `RASTER_MIN = 6` und
+    `RASTER_MAX = 60` sind gemessen, nicht geschätzt: eine Zelle je
+    Rasterschritt heißt quadratisch wachsende Suchfläche, und bei 2 px braucht
+    ein Plan mit 300 Kabeln rund sieben Sekunden (Tabelle in `raster.ts`).
+    Bei der Vorgabe ist das eine Raster **schneller** als die alten festen
+    20 px — 0,45 gegen 0,86 ms je Weg —, weil ein feineres Gitter geradere
+    Wege zulässt.
+
+    Wer das Zellmaß wieder von der Rastergröße löst, fällt in
+    `tests/rasterAlsEineZahl.test.ts` und `tests/anfahrtAmPort.test.ts`.
+
 ---
 
 ## 9 · Offene Architektur-Pfade
@@ -934,7 +971,7 @@ optionales Cloud-Backend (`y-websocket`, Auth/Permissions) bleiben offen.
 `vitest` ist eingerichtet (`npm test` / `npm run test:watch`); dazu kommen
 gezielte Node-Checks (`npm run test:crdt`, `npm run test:signaling`), ein
 UI-Smoke-Skript (`npm run ui:smoke`) und ein headless Drag-/Interaktions-Test
-(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~193.0k LOC
+(`npm run test:drag`, treibt den Renderer via Playwright). Bei ~193.2k LOC
 bleibt der Ausbau der Abdeckung wichtig — empfohlene Schwerpunkte:
 - Snapshot-Tests auf `healProjectPositions` mit echten
   Beispiel-Projekt-JSONs.

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -62,14 +62,14 @@
 <header>
   <h1>Cable-Planner — Strukturvergleich mit ähnlichen Tools</h1>
   <div class="subtitle">Architektur, Tech-Stack und Domänen-Tiefe im Vergleich zu kommerziellen und Open-Source-Alternativen</div>
-  <div class="meta">Stand: 2026-06 · v9.0.1 · ~657 TS/TSX-Module · ~193.0k LOC · ~7.9 MB src/</div>
+  <div class="meta">Stand: 2026-06 · v9.0.1 · ~659 TS/TSX-Module · ~193.2k LOC · ~7.9 MB src/</div>
 </header>
 
 <h2>1 · Cable-Planner — Architektur-Kennzahlen</h2>
 
 <div class="stat-grid">
-  <div class="stat"><div class="num">657</div><div class="label">TS/TSX-Module</div></div>
-  <div class="stat"><div class="num">193.0k</div><div class="label">Lines of Code</div></div>
+  <div class="stat"><div class="num">659</div><div class="label">TS/TSX-Module</div></div>
+  <div class="stat"><div class="num">193.2k</div><div class="label">Lines of Code</div></div>
   <div class="stat"><div class="num">~75</div><div class="label">Modul-Dependencies</div></div>
   <div class="stat"><div class="num">7</div><div class="label">User-Flows</div></div>
 </div>

--- a/src/renderer/components/Annotations/AnnotationCanvasOverlay.tsx
+++ b/src/renderer/components/Annotations/AnnotationCanvasOverlay.tsx
@@ -11,6 +11,7 @@ import { useReactFlow, useViewport } from 'reactflow'
 import { useCanvasProjectStore as useProjectStore } from '../../store/projectStoreContext'
 import { useUiStore } from '../../store/uiStore'
 import { computeEquipmentLayout } from '../../lib/equipmentLayout'
+import { useRaster } from '../../lib/aktuellesRaster'
 import { format, useTranslation } from '../../lib/i18n'
 import { getEquipmentById } from '../../lib/equipmentSelectors'
 import { readableTextColor } from '../../lib/contrast'
@@ -56,6 +57,9 @@ type DragState = {
 }
 
 export const AnnotationCanvasOverlay = () => {
+  // Geraete-Geometrie folgt der eingestellten Rastergroesse; mit Abonnement,
+  // damit ein Wechsel im Menue die Flaeche neu zeichnet.
+  const raster = useRaster()
   const t = useTranslation()
   const annotations = useProjectStore((s) => s.project.annotations) ?? EMPTY
   const equipment = useProjectStore((s) => s.project.equipment)
@@ -87,7 +91,7 @@ export const AnnotationCanvasOverlay = () => {
         if (anchor.type === 'device') {
           const eq = getEquipmentById(equipment, anchor.deviceId)
           if (!eq) return null
-          const layout = computeEquipmentLayout(eq, intercom)
+          const layout = computeEquipmentLayout(eq, intercom, raster)
           return {
             annotation: a,
             flow: { x: eq.x + layout.width - 8, y: eq.y + 4 },
@@ -96,7 +100,7 @@ export const AnnotationCanvasOverlay = () => {
         if (anchor.type === 'port') {
           const eq = getEquipmentById(equipment, anchor.deviceId)
           if (!eq) return null
-          const layout = computeEquipmentLayout(eq, intercom)
+          const layout = computeEquipmentLayout(eq, intercom, raster)
           const pos =
             layout.portPos(anchor.portId, 'source') ?? layout.portPos(anchor.portId, 'target')
           if (!pos) return null
@@ -107,7 +111,7 @@ export const AnnotationCanvasOverlay = () => {
       .filter(
         (x): x is { annotation: ProjectAnnotation; flow: { x: number; y: number } } => !!x,
       )
-  }, [annotations, equipment, intercom])
+  }, [annotations, equipment, intercom, raster])
 
   if (positions.length === 0) return null
   if (!annotationsVisible) return null

--- a/src/renderer/components/Canvas/CableEdge.tsx
+++ b/src/renderer/components/Canvas/CableEdge.tsx
@@ -21,6 +21,7 @@ import { computeObstacleAwareWaypoints, pathIsBlocked, type Rect } from '../../l
 import { legeAnfahrt, stummel, type Anschlussseite } from '../../lib/cableApproach'
 import { routeCableWithAStar, type HandleSide } from '../../lib/routeCableWithAStar'
 import { computeEquipmentLayout } from '../../lib/equipmentLayout'
+import { useRaster } from '../../lib/aktuellesRaster'
 import { isCableVisibleByLayer } from '../../lib/cableLayers'
 import { netKeyOf, netEndpoints } from '../../lib/offPageNet'
 import { OffPageConnectorSymbol } from './OffPageConnectorSymbol'
@@ -297,6 +298,9 @@ export const CableEdge = ({
   selected,
   label,
 }: EdgeProps<CableEdgeData>) => {
+  // Geraete-Geometrie folgt der eingestellten Rastergroesse; mit Abonnement,
+  // damit ein Wechsel im Menue die Flaeche neu zeichnet.
+  const raster = useRaster()
   const t = useTranslation()
   const cable = data?.cable
   // Signalfluss dieser Kante. Der Hook laeuft VOR jedem fruehen Ausstieg
@@ -348,7 +352,7 @@ export const CableEdge = ({
       // #501-Folgefix — gleiche Geometrie-Quelle wie der Renderer, damit die
       // Obstacle-Boxen fürs Kabel-Umfahren exakt den gerenderten Geräten
       // entsprechen (vorher veraltete 62/48/8-Kopie ohne snapUp-Breite).
-      const { width, height } = computeEquipmentLayout(item, intercom)
+      const { width, height } = computeEquipmentLayout(item, intercom, raster)
       rects.push({ x: item.x, y: item.y, width, height })
       ids.push(item.id)
     }
@@ -522,6 +526,9 @@ export const CableEdge = ({
       obstacles: obstacles.map((r, i) => ({ ...r, id: obstacleIds[i] })),
       sourceEquipmentId: cable.fromEquipmentId,
       targetEquipmentId: cable.toEquipmentId,
+      // Dasselbe Raster, auf dem die Geraete einrasten und ihre Buchsen
+      // sitzen. Damit ist jede Buchse ein Gitterpunkt des Wegfinders.
+      rasterPx: raster.GRID_SIZE,
     })
     updateCable(cable.id, { waypoints: ausAStern ?? orthogonalWaypoints })
     // `obstacles`/`obstacleIds` werden bei jedem Render neu gebaut und waeren

--- a/src/renderer/components/Canvas/CanvasToolbar.tsx
+++ b/src/renderer/components/Canvas/CanvasToolbar.tsx
@@ -10,6 +10,7 @@ import { PatternChip } from './PatternChip'
 import { useDraggablePosition } from '../../hooks/useDraggablePosition'
 import { confirmDialog } from '../../lib/confirmDialog'
 import { computeEquipmentLayout } from '../../lib/equipmentLayout'
+import { useRaster } from '../../lib/aktuellesRaster'
 import { computeAlignedPositions, type AlignMode, type AlignItem } from '../../lib/alignEquipment'
 import { Check, X, ChevronUp, ChevronDown} from 'lucide-react'
 import { useTranslation, format } from '../../lib/i18n'
@@ -103,6 +104,9 @@ const IconButton = ({
 )
 
 export const CanvasToolbar = ({ mode = 'main' }: { mode?: CanvasToolbarMode } = {}) => {
+  // Geraete-Geometrie folgt der eingestellten Rastergroesse; mit Abonnement,
+  // damit ein Wechsel im Menue die Flaeche neu zeichnet.
+  const raster = useRaster()
   const t = useTranslation()
   // v7.9.5 — Toolbar frei verschiebbar (User-Request: "Mache die
   // toolbar im canvas frei verschiebbar"). useDraggablePosition liefert
@@ -118,9 +122,9 @@ export const CanvasToolbar = ({ mode = 'main' }: { mode?: CanvasToolbarMode } = 
   const triggerRackBuilderEditFromBlackBox = useUiStore(
     (s) => s.triggerRackBuilderEditFromBlackBox,
   )
-  // v7.9.30 — Snap-to-Grid + Grid-Size sind nicht mehr user-konfigurierbar.
-  // Werte kommen jetzt aus dem Store-Default (snapToGrid=true,
-  // gridSize=EQUIPMENT_LAYOUT.GRID_SIZE=11) — siehe uiStore-Migration.
+  // v7.9.30 hatte den Toolbar-Knopf entfernt; die Einstellung selbst gibt es
+  // weiter unter Einstellungen > Bearbeiten > Raster, und seit 2026-09-12
+  // ueberlebt sie auch das Neuladen wieder (siehe uiStore-Hydrate).
   const snapToGrid = useUiStore((state) => state.snapToGrid)
   const gridSize = useUiStore((state) => state.gridSize)
   const defaultRouting = useUiStore((state) => state.defaultRouting)
@@ -212,7 +216,7 @@ export const CanvasToolbar = ({ mode = 'main' }: { mode?: CanvasToolbarMode } = 
   // (snapUp-Breite + Header inkl. Subtitle/Beltpack). Vorher: ungesnappte
   // Store-Breite + vereinfachter Header → Versatz bei breiten Geräten.
   const measuredSize = (item: (typeof equipmentList)[number]) => {
-    const { width, height } = computeEquipmentLayout(item, intercom)
+    const { width, height } = computeEquipmentLayout(item, intercom, raster)
     return { w: width, h: height }
   }
 

--- a/src/renderer/components/Canvas/EquipmentNode.tsx
+++ b/src/renderer/components/Canvas/EquipmentNode.tsx
@@ -28,7 +28,7 @@ type EquipmentNodeData = EquipmentItem & {
 // Vorher waren diese Werte zwischen EquipmentNode.tsx und
 // equipmentLayout.ts dupliziert — Bug-Garantie wenn einer der beiden
 // geändert wurde.
-import { EQUIPMENT_LAYOUT } from '../../lib/layoutConstants'
+import { useRaster } from '../../lib/aktuellesRaster'
 import { useTally } from '../../hooks/useCanvasFlow'
 import { useLampLevel } from '../../hooks/useCircuit'
 import { useErwartetesBild } from '../../hooks/usePattern'
@@ -36,11 +36,11 @@ import { testPatternDataUri } from '../../lib/testPattern'
 import { PatternCheckRow } from './PatternCheckRow'
 import { useCircuitStore, istSchaltbar } from '../../store/circuitStore'
 import { CIRCUIT_KIND_INFO } from '../../types/circuit'
-const HEADER_HEIGHT = EQUIPMENT_LAYOUT.HEADER_HEIGHT
-const HEADER_HEIGHT_WITH_IP = EQUIPMENT_LAYOUT.HEADER_HEIGHT_WITH_IP
-const PORT_ROW = EQUIPMENT_LAYOUT.PORT_ROW
-const HANDLE_SIZE = EQUIPMENT_LAYOUT.HANDLE_SIZE
-const PADDING = EQUIPMENT_LAYOUT.PADDING
+// 2026-09-12 — Diese fuenf Zahlen standen hier als Modul-Konstanten und waren
+// damit fuer die Lebensdauer des Moduls festgenagelt. Sie folgen jetzt der im
+// Menue eingestellten Rastergroesse und werden deshalb IN der Komponente
+// geholt (`useRaster()`), nicht daneben: nur mit Abonnement zeichnet sich die
+// Karte neu, wenn der Nutzer das Raster aendert.
 
 // v7.9.39 — rackBandColor lebt jetzt in '../../lib/rackBandColors' damit
 // die RackLivePreview im 2D Rack Builder identische Band-Farben rendert.
@@ -56,6 +56,15 @@ const resolvePortSide = (
 }
 
 export const EquipmentNode = ({ id, data, selected }: NodeProps<EquipmentNodeData>) => {
+  const {
+    HEADER_HEIGHT,
+    HEADER_HEIGHT_WITH_IP,
+    PORT_ROW,
+    HANDLE_SIZE,
+    PADDING,
+    GRID_SIZE,
+    DEFAULT_WIDTH,
+  } = useRaster()
   // Tally aus dem Mischer — `null`, solange nichts bekannt ist.
   const tally = useTally(id)
   // Schaltbild: Helligkeit dieser Leuchte. `null` = keine Aussage (kein
@@ -328,7 +337,7 @@ export const EquipmentNode = ({ id, data, selected }: NodeProps<EquipmentNodeDat
   // erweitern den Header um 11 px (1 Grid-Step) statt 14, sodass der
   // headerHeight immer ein Vielfaches von gridSize bleibt und die
   // Ports auf Dot-Reihen landen.
-  const EXTRA_HEADER_LINE = EQUIPMENT_LAYOUT.GRID_SIZE
+  const EXTRA_HEADER_LINE = GRID_SIZE
   const beltpackLine = greengoUser ? EXTRA_HEADER_LINE : 0
   const headerHeight = (
     data.ipAddress
@@ -551,8 +560,7 @@ export const EquipmentNode = ({ id, data, selected }: NodeProps<EquipmentNodeDat
   // v7.9.26 — Width rastet auf gridSize-Vielfache (11 px) ein, sodass
   // die Außenkanten der Karte mit Dot-Spalten zusammenfallen. Auto-
   // Expand für lange Port-Labels rundet entsprechend AUF.
-  const GRID = EQUIPMENT_LAYOUT.GRID_SIZE
-  const snapUp = (n: number) => Math.ceil(n / GRID) * GRID
+  const snapUp = (n: number) => Math.ceil(n / GRID_SIZE) * GRID_SIZE
   // ─── `data.width`/`data.height` ENTSCHEIDEN NICHTS MEHR ───────────────────
   //
   // Nutzer-Meldung 2026-09-11: ein langer Port-Name machte das Geraet breit,
@@ -569,7 +577,7 @@ export const EquipmentNode = ({ id, data, selected }: NodeProps<EquipmentNodeDat
   // truth"), und trotzdem lief sie doppelt — beim Beheben haette man die eine
   // Fassung aendern und die andere vergessen koennen, und der Knoten stuende
   // an einer anderen Stelle als seine Kabel-Enden.
-  const width = snapUp(Math.max(EQUIPMENT_LAYOUT.DEFAULT_WIDTH, labelWidth * 2, nameWidth))
+  const width = snapUp(Math.max(DEFAULT_WIDTH, labelWidth * 2, nameWidth))
   const height = snapUp(headerHeight + portRows * PORT_ROW + PADDING)
 
   // Y offset for the handle dot: aligns to vertical center of the row.

--- a/src/renderer/components/Canvas/InlineSelectionToolbar.tsx
+++ b/src/renderer/components/Canvas/InlineSelectionToolbar.tsx
@@ -33,10 +33,14 @@ import { useProjectStore } from '../../store/projectStore'
 import { useUiStore } from '../../store/uiStore'
 import { useTranslation } from '../../lib/i18n'
 import { computeEquipmentLayout } from '../../lib/equipmentLayout'
+import { useRaster } from '../../lib/aktuellesRaster'
 import { computeAlignedPositions, type AlignMode, type AlignItem } from '../../lib/alignEquipment'
 import { triggerCanvasDuplicate } from '../../lib/canvasViewport'
 
 export const InlineSelectionToolbar = () => {
+  // Geraete-Geometrie folgt der eingestellten Rastergroesse; mit Abonnement,
+  // damit ein Wechsel im Menue die Flaeche neu zeichnet.
+  const raster = useRaster()
   const t = useTranslation()
   const enabled = useUiStore((s) => s.inlineToolbarEnabled)
   const snapToGrid = useUiStore((s) => s.snapToGrid)
@@ -87,7 +91,7 @@ export const InlineSelectionToolbar = () => {
     const items: AlignItem[] = equipment
       .filter((e) => ids.includes(e.id))
       .map((item) => {
-        const { width, height } = computeEquipmentLayout(item, intercom)
+        const { width, height } = computeEquipmentLayout(item, intercom, raster)
         return { id: item.id, x: item.x, y: item.y, w: width, h: height }
       })
     const moves = computeAlignedPositions(items, mode, { snap, singleSelectionBounds: null })

--- a/src/renderer/components/Canvas/PendingCableOverlay.tsx
+++ b/src/renderer/components/Canvas/PendingCableOverlay.tsx
@@ -5,6 +5,7 @@ import { useReactFlow, useViewport } from 'reactflow'
 import { useUiStore } from '../../store/uiStore'
 import { useCanvasProjectStore as useProjectStore } from '../../store/projectStoreContext'
 import { computeEquipmentLayout } from '../../lib/equipmentLayout'
+import { useRaster } from '../../lib/aktuellesRaster'
 import { getEquipmentById } from '../../lib/equipmentSelectors'
 import { useTranslation, format } from '../../lib/i18n'
 
@@ -32,6 +33,9 @@ const BANNER_BUTTON: CSSProperties = {
  * source port through all placed waypoints to the current mouse position.
  */
 export const PendingCableOverlay = () => {
+  // Geraete-Geometrie folgt der eingestellten Rastergroesse; mit Abonnement,
+  // damit ein Wechsel im Menue die Flaeche neu zeichnet.
+  const raster = useRaster()
   const t = useTranslation()
   const pendingCable = useUiStore((s) => s.pendingCable)
   const clearPendingCable = useUiStore((s) => s.clearPendingCable)
@@ -77,7 +81,7 @@ export const PendingCableOverlay = () => {
   // bei breiteren Geräten landete der Startpunkt der gestrichelten
   // Linie mitten im Gerät statt am Port (User-Bug "startpunkt der
   // gelben gestrichelten linie ist aktuell immer die geräte mitte").
-  const layout = computeEquipmentLayout(node, project.intercom)
+  const layout = computeEquipmentLayout(node, project.intercom, raster)
   const pos = layout.portPos(
     port.id,
     pendingCable.handleType === 'source' ? 'source' : 'target',

--- a/src/renderer/components/Canvas/useCanvasCableRouter.ts
+++ b/src/renderer/components/Canvas/useCanvasCableRouter.ts
@@ -3,6 +3,8 @@ import type { StoreApi } from 'zustand'
 import { computeEquipmentLayout } from '../../lib/equipmentLayout'
 import { routeCableWithAStar, type HandleSide, type PixelRect } from '../../lib/routeCableWithAStar'
 import { setCableRouter } from '../../lib/canvasViewport'
+import { rasterAus } from '../../lib/raster'
+import { useUiStore } from '../../store/uiStore'
 import type { ProjectState } from '../../store/projectStore'
 import type { Cable } from '../../types/cable'
 import type { EquipmentItem } from '../../types/equipment'
@@ -20,7 +22,12 @@ export function useCanvasCableRouter(
   mode: 'main' | 'rack',
   equipment: EquipmentItem[],
 ): void {
+  const gridSize = useUiStore((s) => s.gridSize)
   useEffect(() => {
+    // Das eingestellte Raster, einmal je Registrierung gelesen. Der Effekt
+    // haengt unten an `gridSize`, damit eine Aenderung im Menue den Router
+    // mit dem neuen Mass neu registriert.
+    const raster = rasterAus(gridSize)
     // Compute the layout geometry of one equipment item, matching the
     // visual rendering in EquipmentNode. Returns the equipment's
     // bounding rect plus precomputed port positions so we can place
@@ -32,7 +39,7 @@ export function useCanvasCableRouter(
       // Kopie (HEADER 62/48, PADDING 8, Port-Y über Array-Index statt Slot),
       // wodurch A*-geroutete Kabel von den echten Handles abwichen.
       const intercom = projectStoreInstance.getState().project.intercom
-      const layout = computeEquipmentLayout(eq, intercom)
+      const layout = computeEquipmentLayout(eq, intercom, raster)
       const handleAt = (
         portId: string,
         type: 'source' | 'target',
@@ -67,6 +74,9 @@ export function useCanvasCableRouter(
         obstacles,
         sourceEquipmentId: cable.fromEquipmentId,
         targetEquipmentId: cable.toEquipmentId,
+        // Dasselbe Raster wie `layoutOf` oben: eine Zelle des Wegfinders ist
+        // ein Rasterschritt, damit die Buchsen auf Gitterpunkten liegen.
+        rasterPx: raster.GRID_SIZE,
         // v7.9.118 / Issue #223 — Im Rack-Mode kleineres Obstacle-
         // Padding, weil Rack-Geraete in 1HE-Schritten direkt aneinander
         // stehen. Default 2 (= 40 px) wuerde den Korridor zwischen
@@ -102,7 +112,9 @@ export function useCanvasCableRouter(
 
     setCableRouter(routerId, { routeOne, routeAll })
     return () => setCableRouter(routerId, null)
-    // projectStoreInstance + mode sind stabil; equipment triggert Re-Routing.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routerId, equipment, updateCable])
+    // `gridSize` steht jetzt mit in der Liste: aendert der Nutzer das Raster,
+    // muss der Router mit dem neuen Zellmass neu registriert werden. Damit
+    // sind alle gelesenen Werte aufgefuehrt und die frueher noetige
+    // eslint-Ausnahme ist weg.
+  }, [routerId, equipment, updateCable, gridSize, projectStoreInstance, mode])
 }

--- a/src/renderer/components/Canvas/useCanvasKeyboardShortcuts.ts
+++ b/src/renderer/components/Canvas/useCanvasKeyboardShortcuts.ts
@@ -4,7 +4,7 @@ import type { Node, Edge } from 'reactflow'
 import { useTranslation } from '../../lib/i18n'
 import { promptDialog } from '../../lib/promptDialog'
 import { projectHistory } from '../../store/projectHistory'
-import { EQUIPMENT_LAYOUT } from '../../lib/layoutConstants'
+import { aktuellesRaster } from '../../lib/aktuellesRaster'
 import type { ProjectState } from '../../store/projectStore'
 import type { EquipmentItem } from '../../types/equipment'
 import type { Cable } from '../../types/cable'
@@ -127,7 +127,10 @@ export function useCanvasKeyboardShortcuts(deps: CanvasKeyboardShortcutsDeps): v
         const ids = getSelectedEquipmentIds()
         if (ids.length === 0) return
         event.preventDefault()
-        const grid = EQUIPMENT_LAYOUT.GRID_SIZE
+        // Ein Pfeiltastendruck ist ein Rasterschritt — der eingestellte, nicht
+        // ein fester. Ausserhalb von React gelesen: der Effekt laeuft beim
+        // Tastendruck, nicht beim Rendern.
+        const grid = aktuellesRaster().GRID_SIZE
         const step = event.shiftKey ? grid * 4 : grid
         const dx = event.key === 'ArrowLeft' ? -step : event.key === 'ArrowRight' ? step : 0
         const dy = event.key === 'ArrowUp' ? -step : event.key === 'ArrowDown' ? step : 0

--- a/src/renderer/components/Rack/RackInternalCanvas.tsx
+++ b/src/renderer/components/Rack/RackInternalCanvas.tsx
@@ -31,6 +31,7 @@ import { ProjectStoreProvider } from '../../store/ProjectStoreProvider'
 import { createProjectStoreInstance } from '../../store/projectStore'
 import { routeCable } from '../../lib/canvasViewport'
 import { computeEquipmentLayout } from '../../lib/equipmentLayout'
+import { aktuellesRaster } from '../../lib/aktuellesRaster'
 import type {
   EquipmentItem,
   EquipmentTemplate,
@@ -161,7 +162,7 @@ const buildScratchEquipment = (
     // Wert stabilisierte. Mit exakter Vorab-Größe ist estimate == measured →
     // der onNodesChange-Diff bleibt unter der 2px-Schwelle, kein Sprung. Hält
     // auch den hasOverlap-Check (#206) von Anfang an stabil.
-    const layout = computeEquipmentLayout(eq)
+    const layout = computeEquipmentLayout(eq, undefined, aktuellesRaster())
     eq.width = layout.width
     eq.height = layout.height
     return eq

--- a/src/renderer/components/Rack/RackLivePreview.tsx
+++ b/src/renderer/components/Rack/RackLivePreview.tsx
@@ -14,7 +14,7 @@
 
 import { useMemo } from 'react'
 import { rackBandColor } from '../../lib/rackBandColors'
-import { EQUIPMENT_LAYOUT } from '../../lib/layoutConstants'
+import { useRaster } from '../../lib/aktuellesRaster'
 import {
   RackBandsOverlay,
   RackInternalCablesOverlay,
@@ -47,9 +47,6 @@ interface RackLivePreviewProps {
   cables: PreviewCable[]
 }
 
-const PORT_ROW = EQUIPMENT_LAYOUT.PORT_ROW
-const HEADER_HEIGHT = EQUIPMENT_LAYOUT.HEADER_HEIGHT
-const PADDING = EQUIPMENT_LAYOUT.PADDING
 const HANDLE_R = 4
 const BAND_HEADER_ROW = 1
 const GAP_BETWEEN_BANDS = 1
@@ -68,6 +65,9 @@ export const RackLivePreview = ({
   placements,
   cables,
 }: RackLivePreviewProps) => {
+  // Folgt der eingestellten Rastergroesse; mit Abonnement, damit die Vorschau
+  // beim Umstellen mitgeht.
+  const { HEADER_HEIGHT, PORT_ROW, PADDING } = useRaster()
   const t = useTranslation()
   void _totalUnits
 
@@ -144,7 +144,7 @@ export const RackLivePreview = ({
       }
     }
     return m
-  }, [bandsComputed])
+  }, [bandsComputed, HEADER_HEIGHT, PORT_ROW])
 
   const placementById = useMemo(
     () => new Map(placements.map((p) => [p.id, p])),

--- a/src/renderer/components/Rack/blackBoxShared.tsx
+++ b/src/renderer/components/Rack/blackBoxShared.tsx
@@ -13,9 +13,8 @@
 // Hooks. EquipmentNode rendert seine Handles separat darüber.
 
 import type { CSSProperties } from 'react'
-import { EQUIPMENT_LAYOUT } from '../../lib/layoutConstants'
+import { useRaster } from '../../lib/aktuellesRaster'
 
-const PORT_ROW = EQUIPMENT_LAYOUT.PORT_ROW
 
 export interface BlackBoxBand {
   /** Stabile Identität (DeviceIndex auf Canvas, Placement-ID in Preview). */
@@ -50,6 +49,7 @@ interface RackBandsOverlayProps {
 /** Bänder-Stripes innerhalb der Black-Box-Card. Position absolut
  *  relativ zur Card. */
 export const RackBandsOverlay = ({ bands, headerHeight, isLight }: RackBandsOverlayProps) => {
+  const { PORT_ROW } = useRaster()
   return (
     <>
       {bands.map((band) => {

--- a/src/renderer/components/Settings/tabs/EditingTab.tsx
+++ b/src/renderer/components/Settings/tabs/EditingTab.tsx
@@ -5,6 +5,8 @@ import { confirmDialog } from '../../../lib/confirmDialog'
 import { RoutingToggle } from '../../shared/RoutingToggle'
 import { SettingsCard } from '../SettingsCard'
 import { PanelHint } from '../../shared/PanelHint'
+import { PANEL_LIMITS } from '../../../lib/layoutConstants'
+import { RASTER_DEFAULT } from '../../../lib/raster'
 
 /**
  * #307 — Editing-Tab aus SettingsDialog ausgelagert. Enthaelt
@@ -214,7 +216,10 @@ export const EditingTab = () => {
 
       <SettingsCard
         title={t('settings.editing.grid', 'Grid')}
-        description={t('settings.editing.gridDesc', 'Snap-to-grid and grid size in pixels.')}
+        description={t(
+          'settings.editing.gridDesc',
+          'One step for everything: equipment snaps to it, port rows sit on it, and automatic cable routing searches on it.',
+        )}
       >
         <label className="flex items-center gap-2 text-cp-base text-cp-text-bright">
           <input
@@ -225,13 +230,20 @@ export const EditingTab = () => {
           {t('settings.editing.snapLabel', 'Snap equipment to grid')}
         </label>
         <label className="mt-2 block text-cp-base text-cp-text-secondary">
-          {t('settings.editing.gridSize', 'Grid size (pixels)')}
+          {format(
+            t('settings.editing.gridSize', 'Grid size in pixels ({min}-{max})'),
+            { min: PANEL_LIMITS.gridSize.MIN, max: PANEL_LIMITS.gridSize.MAX },
+          )}
           <input
             type="number"
-            min={2}
-            max={100}
+            // Grenzen aus einer Quelle: an ihnen haengt seit 2026-09-12 auch
+            // das Zellmass des Wegfinders. Standen sie hier noch einmal als
+            // 2 und 100, koennte das Feld einen Wert anbieten, den der Store
+            // klemmt — und der Nutzer saehe eine andere Zahl als die, die gilt.
+            min={PANEL_LIMITS.gridSize.MIN}
+            max={PANEL_LIMITS.gridSize.MAX}
             value={gridSize}
-            onChange={(e) => setGridSize(Number(e.target.value) || 10)}
+            onChange={(e) => setGridSize(Number(e.target.value) || RASTER_DEFAULT)}
             className="mt-1 w-full border border-cp-border bg-cp-surface-3 p-2"
           />
         </label>

--- a/src/renderer/lib/aktuellesRaster.ts
+++ b/src/renderer/lib/aktuellesRaster.ts
@@ -1,0 +1,26 @@
+// Der Zugang zum EINGESTELLTEN Raster.
+//
+// `raster.ts` bleibt rein — es rechnet, es liest nichts. Diese Datei liest:
+// sie holt die im Menue eingestellte Rastergroesse aus dem uiStore und gibt
+// das daraus abgeleitete Raster zurueck.
+//
+// Warum zwei Dateien: `uiStore` importiert `layoutConstants` (fuer die
+// Vorgabe und die Panel-Grenzen), und `layoutConstants` importiert `raster`.
+// Wuerde `raster` seinerseits den uiStore lesen, waere der Kreis geschlossen
+// und das Modul beim Start halb leer. Die Trennung ist keine Stilfrage.
+
+import { useUiStore } from '../store/uiStore'
+import { rasterAus, type Raster } from './raster'
+
+/** Das aktuelle Raster ausserhalb von React (Router, Exporte, Slices). */
+export const aktuellesRaster = (): Raster => rasterAus(useUiStore.getState().gridSize)
+
+/**
+ * Das aktuelle Raster in einer Komponente — mit Abonnement.
+ *
+ * Wichtig gegenueber `aktuellesRaster()`: nur so zeichnet sich die Flaeche neu,
+ * wenn der Nutzer die Rastergroesse im Menue aendert. Wer in einer Komponente
+ * `aktuellesRaster()` aufruft, bekommt beim naechsten Rendern den neuen Wert —
+ * aber niemand loest dieses Rendern aus.
+ */
+export const useRaster = (): Raster => rasterAus(useUiStore((s) => s.gridSize))

--- a/src/renderer/lib/equipmentLayout.ts
+++ b/src/renderer/lib/equipmentLayout.ts
@@ -10,15 +10,17 @@
 import type { EquipmentItem, Port } from '../types/equipment'
 import type { IntercomPlan } from '../types/intercomPlan'
 import { findIntercomStationForEquipment } from './greengoSync'
-import { EQUIPMENT_LAYOUT } from './layoutConstants'
+import { aktuellesRaster } from './aktuellesRaster'
+import type { Raster } from './raster'
 
 // v7.9.23 — Layout-Konstanten zentralisiert in lib/layoutConstants.ts.
 // Vorher waren diese Werte zwischen EquipmentNode.tsx + equipmentLayout.ts
 // dupliziert — Bug-Garantie wenn einer der beiden geändert wurde.
-const HEADER_HEIGHT = EQUIPMENT_LAYOUT.HEADER_HEIGHT
-const HEADER_HEIGHT_WITH_IP = EQUIPMENT_LAYOUT.HEADER_HEIGHT_WITH_IP
-const PORT_ROW = EQUIPMENT_LAYOUT.PORT_ROW
-const PADDING = EQUIPMENT_LAYOUT.PADDING
+//
+// 2026-09-12 — und seither sind es keine Konstanten mehr, sondern das Ergebnis
+// der eingestellten Rastergroesse. Sie kommen als Parameter herein, damit diese
+// Datei nicht an einer Stelle rechnet, an der der Renderer eine andere Zahl
+// benutzt.
 
 export type PortSide = 'left' | 'right'
 
@@ -52,7 +54,16 @@ const resolveSide = (
 export const computeEquipmentLayout = (
   eq: EquipmentItem,
   intercom?: IntercomPlan,
+  raster: Raster = aktuellesRaster(),
 ): EquipmentLayout => {
+  const {
+    HEADER_HEIGHT,
+    HEADER_HEIGHT_WITH_IP,
+    PORT_ROW,
+    PADDING,
+    GRID_SIZE,
+    DEFAULT_WIDTH,
+  } = raster
   const inputs = eq.inputs ?? []
   const outputs = eq.outputs ?? []
   const portsFlipped = !!eq.portsFlipped
@@ -61,7 +72,7 @@ export const computeEquipmentLayout = (
   // v7.9.26 — Optionale Header-Zeilen sind gridSize-aligned (11 px)
   // statt 14, damit Port-Y-Positionen auf Dot-Reihen landen.
   const greengoUser = findIntercomStationForEquipment(eq.id, intercom)
-  const EXTRA_HEADER_LINE = EQUIPMENT_LAYOUT.GRID_SIZE
+  const EXTRA_HEADER_LINE = GRID_SIZE
   const beltpackLine = greengoUser ? EXTRA_HEADER_LINE : 0
   const headerHeight =
     (eq.ipAddress
@@ -105,8 +116,7 @@ export const computeEquipmentLayout = (
   // Linie an einer UN-gesnappten Außenkante, während der echte Port-Handle
   // an der gesnappten Kante sitzt → rechtsseitiger Versatz von bis zu 10px
   // (sichtbar v.a. am breiten Videohub mit vielen Output-Ports).
-  const GRID = EQUIPMENT_LAYOUT.GRID_SIZE
-  const snapUp = (n: number): number => Math.ceil(n / GRID) * GRID
+  const snapUp = (n: number): number => Math.ceil(n / GRID_SIZE) * GRID_SIZE
 
   // ─── `eq.width`/`eq.height` SIND EIN ABBILD, KEINE UNTERGRENZE ───────────
   //
@@ -142,7 +152,7 @@ export const computeEquipmentLayout = (
   // Raum-Zuordnung lesen es —, aber es entscheidet nichts mehr. Wer Geraete
   // eines Tages ziehbar macht, braucht dafuer ein EIGENES Feld; dieses hier
   // kann die Frage nicht beantworten.
-  const width = snapUp(Math.max(EQUIPMENT_LAYOUT.DEFAULT_WIDTH, labelWidth * 2, nameWidth))
+  const width = snapUp(Math.max(DEFAULT_WIDTH, labelWidth * 2, nameWidth))
 
   const portRows = Math.max(sideCounts.left, sideCounts.right, 1)
   // Dieselbe Begruendung fuer die Hoehe: sie folgt der Zahl der Port-Reihen.

--- a/src/renderer/lib/i18n/de.ts
+++ b/src/renderer/lib/i18n/de.ts
@@ -4591,8 +4591,9 @@ export const de: Dict = {
   'settings.editing.endpointLabelsNote':
     'Default aus — gibt zusätzlichen Visual-Noise. Wirkt zusammen mit dem globalen "Alle Labels ausblenden"-Toggle und respektiert per-Kabel labelPosition=\'none\'.',
   'settings.editing.grid': 'Raster (Grid)',
-  'settings.editing.gridDesc': 'Snap-to-Grid und Rastergröße in Pixeln.',
-  'settings.editing.gridSize': 'Rastergröße (Pixel)',
+  'settings.editing.gridDesc':
+    'Ein Schritt für alles: Geräte rasten darauf ein, Port-Reihen sitzen darauf, und das automatische Routen sucht darauf.',
+  'settings.editing.gridSize': 'Rastergröße in Pixeln ({min}-{max})',
   'settings.editing.inlineToolbar': 'Inline-Auswahl-Toolbar',
   'settings.editing.inlineToolbarDesc':
     'Schwebende Schnellaktionen (Ausrichten, Duplizieren, Rahmen, Löschen) direkt neben der Auswahl auf dem Canvas.',

--- a/src/renderer/lib/layoutConstants.ts
+++ b/src/renderer/lib/layoutConstants.ts
@@ -10,37 +10,24 @@
 // Jetzt: ein zentrales `LAYOUT` + `LIMITS` Objekt. Wer die Werte
 // ändern will fasst genau eine Stelle an.
 
-/** Equipment-Node-Layout (geteilt zwischen EquipmentNode + equipmentLayout.ts).
- *  v7.9.26 — Alle Werte sind Vielfache von 11 px (= gridSize). Dadurch:
- *    - Port-Handle (im Row-Center bei headerHeight + slot*PORT_ROW + 11)
- *      landet exakt auf einer Dot-Reihe → Kabel laufen sichtbar entlang
- *      der Gitter-Linien.
- *    - Geräte-Höhe = headerHeight + N·PORT_ROW + PADDING = mult of 11
- *      → die Karten-Unterkante liegt immer auf einer Dot-Reihe.
- *    - DEFAULT_WIDTH = 220 = 20·11 → Geräte-Außenkanten links/rechts
- *      decken sich mit Dot-Spalten.
- *  Snap der Geräte-Position erfolgt mit gridSize=11 (siehe uiStore-Default). */
-export const EQUIPMENT_LAYOUT = {
-  /** Höhe der Karten-Header-Zone ohne IP-Adresse. 4·11 = 44 px. */
-  HEADER_HEIGHT: 44,
-  /** Höhe wenn die Karte eine IP-Adresse als Subtitle zeigt. 6·11 = 66 px. */
-  HEADER_HEIGHT_WITH_IP: 66,
-  /** Höhe einer Port-Zeile (Input/Output mit Connector-Dot + Label).
-   *  2·11 = 22 px — Port-Handle in der Mitte liegt damit auf jeder
-   *  zweiten Dot-Reihe. */
-  PORT_ROW: 22,
-  /** Größe der ReactFlow-Handle-Hitzone (transparent, click area).
-   *  Nicht grid-gebunden — rein visuelles UX-Element. */
-  HANDLE_SIZE: 16,
-  /** Inner-Padding der Equipment-Karte. 1·11 = 11 px. */
-  PADDING: 11,
-  /** Default-Breite eines Equipment-Items wenn nicht explizit gesetzt.
-   *  20·11 = 220 px. Auto-Expand schnappt ebenfalls auf 11-px-Schritte. */
-  DEFAULT_WIDTH: 220,
-  /** Default-Grid-Step in CSS-Pixeln. Single source of truth — der
-   *  uiStore-Default referenziert diesen Wert. */
-  GRID_SIZE: 11,
-} as const
+import { RASTER_MAX, RASTER_MIN, RASTER_VORGABE } from './raster'
+
+/**
+ * Equipment-Node-Layout der VORGABE-Rastergroesse.
+ *
+ * Hier standen bis 2026-09-12 die Zahlen selbst: 44, 66, 22, 11, 220. Alle
+ * Vielfache von 11, mit genau der Begruendung, die jetzt in `raster.ts` als
+ * Rechnung steht — die Port-Reihe muss auf einer Punktreihe landen, die
+ * Karten-Unterkante auch. Nur liess sich die Rastergroesse im Menue aendern
+ * (Einstellungen > Bearbeiten), und dann stimmte die Begruendung nicht mehr:
+ * die Geraete rasteten auf dem neuen Mass ein, ihr Innenleben blieb auf 11.
+ *
+ * Deshalb wird gerechnet statt geschrieben. Dieses Objekt ist das Ergebnis fuer
+ * die Vorgabe und bleibt exakt wie vorher (44/66/22/11/220) — es ist der
+ * Rueckfall fuer Aufrufer ohne Zugriff auf die Einstellung. Wer die
+ * EINGESTELLTE Groesse braucht, nimmt `aktuellesRaster()` bzw. `useRaster()`.
+ */
+export const EQUIPMENT_LAYOUT = RASTER_VORGABE
 
 /** Default-Werte für Viewport-Berechnungen (zoom-to-fit etc.). */
 export const VIEWPORT_DEFAULTS = {
@@ -79,8 +66,11 @@ export const PANEL_LIMITS = {
   /** Properties-Sidebar (rechts). Min 220px weil Properties-Forms
    *  längere Labels haben als die Library; max 600px Symmetrie. */
   properties: { MIN: 220, MAX: 600 },
-  /** Grid-Size (Snap-Raster) in px. */
-  gridSize: { MIN: 2, MAX: 100 },
+  /** Grid-Size (Snap-Raster) in px. Die Grenzen stehen in `raster.ts`: dort
+   *  haengt an ihnen seit 2026-09-12 auch das Zellmass des Wegfinders, und
+   *  zwei Zahlenpaare fuer dieselbe Grenze waeren genau der Fehler, den diese
+   *  Aenderung behebt. */
+  gridSize: { MIN: RASTER_MIN, MAX: RASTER_MAX },
 } as const
 
 /** Dialog-Drag-Grenzen. */

--- a/src/renderer/lib/pathfinding.ts
+++ b/src/renderer/lib/pathfinding.ts
@@ -54,13 +54,23 @@ interface GridNode {
 
 // ---------- Constants ----------
 
-/** Grid cell size in pixels. All grid coordinates are multiples of this. */
-export const CELL_SIZE = 20;
+// ─── DAS ZELLMASS IST EIN PARAMETER, KEINE KONSTANTE ────────────────────────
+//
+// Hier stand `export const CELL_SIZE = 20`. Das Raster, auf dem die Geraete
+// einrasten, steht aber woanders und ist im Menue einstellbar (Einstellungen >
+// Bearbeiten > Rastergroesse). Zwei Zahlen fuer dieselbe Frage — in dieser
+// Suite heisst die Defektform `zwei-rechnungen` —, und weil 20 kein Vielfaches
+// von 11 ist, lag jeder Stuetzpunkt neben einer Buchse bis zu eine halbe Zelle
+// daneben.
+//
+// Das Zellmass kommt deshalb jetzt von aussen herein. `raster.ts` leitet es aus
+// der eingestellten Rastergroesse ab; `computeEdgePath` verlangt es als Feld,
+// damit niemand versehentlich wieder auf einer stillen 20 landet.
 
 /** Convert pixel coordinate to grid coordinate. */
-export const px2g = (px: number) => Math.round(px / CELL_SIZE);
+export const px2g = (px: number, cellSize: number) => Math.round(px / cellSize);
 /** Convert grid coordinate to pixel coordinate. */
-export const g2px = (g: number) => g * CELL_SIZE;
+export const g2px = (g: number, cellSize: number) => g * cellSize;
 
 /** Default routing parameters. Values are in GRID CELLS unless noted. */
 export const ROUTING_DEFAULTS = {
@@ -114,10 +124,11 @@ export function buildObstacles(
   nodes: readonly { id: string; position: { x: number; y: number }; parentId?: string; measured?: { width?: number; height?: number }; type?: string }[],
   excludeIds: Iterable<string>,
   getAbsPos: (node: typeof nodes[number]) => { x: number; y: number },
+  cellSize: number,
 ): { rects: Rect[] } {
   const excludeSet = excludeIds instanceof Set ? excludeIds : new Set(excludeIds);
   const rects: Rect[] = [];
-  const pad = ROUTING_PARAMS.PAD * CELL_SIZE; // PAD is in grid cells
+  const pad = ROUTING_PARAMS.PAD * cellSize; // PAD is in grid cells
   for (const n of nodes) {
     if (
       n.type === "room" ||
@@ -141,12 +152,12 @@ export function buildObstacles(
 }
 
 /** Convert pixel-coordinate obstacle rects to grid-coordinate rects. */
-export function pixelRectsToGrid(rects: Rect[]): GridRect[] {
+export function pixelRectsToGrid(rects: Rect[], cellSize: number): GridRect[] {
   return rects.map((r) => ({
-    left: Math.floor(r.left / CELL_SIZE),
-    top: Math.floor(r.top / CELL_SIZE),
-    right: Math.ceil(r.right / CELL_SIZE),
-    bottom: Math.ceil(r.bottom / CELL_SIZE),
+    left: Math.floor(r.left / cellSize),
+    top: Math.floor(r.top / cellSize),
+    right: Math.ceil(r.right / cellSize),
+    bottom: Math.ceil(r.bottom / cellSize),
     nodeId: r.nodeId,
   }));
 }
@@ -156,7 +167,7 @@ export function pixelRectsToGrid(rects: Rect[]): GridRect[] {
 export interface IntGrid {
   cols: number;
   rows: number;
-  originX: number; // grid X of column 0 (so pixel X = (originX + col) * CELL_SIZE)
+  originX: number; // grid X of column 0 (so pixel X = (originX + col) * cellSize)
   originY: number; // grid Y of row 0
   blocked: Uint8Array; // flat: blocked[col * rows + row], 1=blocked 0=free
 }
@@ -973,6 +984,9 @@ export interface ComputeEdgePathOptions {
    *  um einen Korridor vom Handle durch die eigene Padding-Zone zu
    *  öffnen. */
   extraForceOpen?: { gx: number; gy: number }[];
+  /** Kantenlaenge einer Gitterzelle in Pixeln. Pflichtfeld: siehe die
+   *  Begruendung oben bei `px2g`. `raster.ts` liefert den Wert. */
+  cellSize: number;
 }
 
 export function computeEdgePath(
@@ -995,13 +1009,14 @@ export function computeEdgePath(
     freeEndDir,
     stubCells,
     extraForceOpen,
+    cellSize,
   } = opts;
 
   // Convert pixel coordinates to grid coordinates
-  const sgx = px2g(sourceX);
-  const sgy = px2g(sourceY);
-  const tgx = px2g(targetX);
-  const tgy = px2g(targetY);
+  const sgx = px2g(sourceX, cellSize);
+  const sgy = px2g(sourceY, cellSize);
+  const tgx = px2g(targetX, cellSize);
+  const tgy = px2g(targetY, cellSize);
 
   // Stub: outward exit from port. Default 1 cell, kann per stubCells
   // erhöht werden wenn Source/Target gepaddete Obstacles sind.
@@ -1037,7 +1052,7 @@ export function computeEdgePath(
       }
     }
   } else {
-    const gridRects = precomputedGridRects ?? pixelRectsToGrid(obstacles);
+    const gridRects = precomputedGridRects ?? pixelRectsToGrid(obstacles, cellSize);
     const forceOpen = [
       { gx: stubSGX, gy: sgy },
       { gx: stubTGX, gy: tgy },
@@ -1063,16 +1078,16 @@ export function computeEdgePath(
   if (!astarResult) return null;
 
   // Convert grid path to pixel waypoints
-  const interiorPixels: Point[] = astarResult.path.map((p) => ({ x: g2px(p.gx), y: g2px(p.gy) }));
+  const interiorPixels: Point[] = astarResult.path.map((p) => ({ x: g2px(p.gx, cellSize), y: g2px(p.gy, cellSize) }));
   const interior = simplifyWaypoints(interiorPixels);
 
   // Build full waypoint list: source handle → A* path → target handle
   const waypoints: Point[] = [];
-  waypoints.push({ x: g2px(sgx), y: g2px(sgy) }); // Source (grid-snapped pixel)
+  waypoints.push({ x: g2px(sgx, cellSize), y: g2px(sgy, cellSize) }); // Source (grid-snapped pixel)
   for (const p of interior) {
     waypoints.push({ x: p.x + offset, y: p.y + offset });
   }
-  waypoints.push({ x: g2px(tgx), y: g2px(tgy) }); // Target (grid-snapped pixel)
+  waypoints.push({ x: g2px(tgx, cellSize), y: g2px(tgy, cellSize) }); // Target (grid-snapped pixel)
 
   const simplified = simplifyWaypoints(waypoints);
   const path = waypointsToSvgPath(simplified);

--- a/src/renderer/lib/raster.ts
+++ b/src/renderer/lib/raster.ts
@@ -1,0 +1,152 @@
+// ─── DAS RASTER IST EINE ZAHL ───────────────────────────────────────────────
+//
+// NUTZER-MELDUNG 2026-09-12: „Stattdessen solltest du besser die
+// Berechnungsgrundlage des A* von dem Raster abhaengig machen. Das Raster kann
+// man doch auch im Menue veraendern. Da ist ein hart kodiertes 20-px-Zellen
+// doch dumm. Ebenso das fest kodierte Raster der Geraete."
+//
+// Bis hierher standen DREI Zahlen fuer dieselbe Frage „wie gross ist ein
+// Schritt":
+//
+//   * `uiStore.gridSize` — was das Menue anbietet (Einstellungen > Bearbeiten >
+//     Rastergroesse), Vorgabe 11.
+//   * `EQUIPMENT_LAYOUT` — Kopfhoehe 44, Port-Reihe 22, Polster 11, Breite 220.
+//     Alles Vielfache von 11, aber als feste Zahlen hingeschrieben.
+//   * `CELL_SIZE = 20` im Wegfinder.
+//
+// 20 ist kein Vielfaches von 11. Die Buchsen sassen also per Konstruktion
+// zwischen zwei Gitterpunkten des Wegfinders, und der gezeichnete Weg holte
+// den Rest als Stufe kurz vor der Buchse nach. Wer im Menue etwas anderes als
+// 11 einstellte, verschob ausserdem nur das Einrasten der Geraete-Position —
+// ihre Kopfhoehe, ihre Port-Reihen und der Wegfinder blieben, wo sie waren.
+//
+// Diese Datei hat deshalb EINEN Eingang: die eingestellte Rastergroesse. Alles
+// andere wird daraus gerechnet.
+//
+// Die Datei bleibt rein — sie liest den Store nicht. Wer den eingestellten Wert
+// braucht, nimmt `aktuellesRaster.ts`; wer nur rechnen will (Tests, Exporte),
+// ruft `rasterAus(n)` mit seiner eigenen Zahl auf.
+
+/**
+ * Untergrenzen in Pixeln. Sie sind KEINE Rasterwerte, sondern Lesbarkeits- und
+ * Bauform-Grenzen: unter 44 px passt die Kopfzeile mit Name und Kategorie
+ * nicht, unter 22 px draengen sich zwei Port-Beschriftungen ineinander. Aus
+ * ihnen wird das naechste Vielfache der Rastergroesse.
+ */
+export const RASTER_MINDEST = {
+  HEADER_HEIGHT: 44,
+  HEADER_HEIGHT_WITH_IP: 66,
+  PORT_ROW: 22,
+  PADDING: 11,
+  DEFAULT_WIDTH: 220,
+} as const
+
+/** Vorgabe-Rastergroesse. Bei ihr ergibt sich exakt das Layout von vorher:
+ *  44 / 66 / 22 / 11 / 220 — die Zahlen, die frueher fest hier standen. */
+export const RASTER_DEFAULT = 11
+
+/**
+ * Kleinstes zulaessiges Raster.
+ *
+ * Eine Zelle des Wegfinders ist ab jetzt ein Rasterschritt. Die Zahl der Zellen
+ * je Suche waechst deshalb quadratisch, wenn das Raster feiner wird — und das
+ * ist der einzige Grund fuer diese Grenze.
+ *
+ * GEMESSEN am 2026-09-12, zwoelf Geraete mit je vier Ein- und Ausgaengen,
+ * 264 Wege, Zeit je Weg:
+ *
+ *     Raster  2 px -> 23.67 ms      Raster 11 px ->  0.45 ms  (Vorgabe)
+ *     Raster  3 px ->  9.47 ms      Raster 16 px ->  0.32 ms
+ *     Raster  4 px ->  4.19 ms      Raster 22 px ->  0.22 ms
+ *     Raster  6 px ->  1.33 ms      Raster 60 px ->  0.13 ms
+ *
+ * Bei 2 px braucht ein Plan mit 300 Kabeln rund sieben Sekunden; das merkt der
+ * Nutzer beim Ziehen. Bei 6 px sind es vier Zehntel. Deshalb 6.
+ *
+ * Zum Vergleich das ALTE Verhalten, feste 20-px-Zellen neben einem 11-px-Raster
+ * derselben Szene: 0.86 ms je Weg. Das eine Raster ist bei der Vorgabe also
+ * nicht nur genauer, sondern auch schneller — ein feineres Gitter laesst A*
+ * geradere Wege finden und spart die Umwege, die der Drehstrafe teuer waren.
+ *
+ * Die Grenze ist bewusst eine PRODUKT-Grenze und keine stille Klemmung im
+ * Wegfinder: wer 6 px einstellt, bekommt 6 px auch im Geraete-Layout — sonst
+ * waere es wieder zweierlei Mass.
+ */
+export const RASTER_MIN = 6
+/** Groesstes zulaessiges Raster. Darueber passt ein Geraet mit vier Ports
+ *  nicht mehr auf einen Bildschirm. */
+export const RASTER_MAX = 60
+
+export interface Raster {
+  /** Schrittweite in Pixeln — die eine Zahl, aus der alles folgt. */
+  GRID_SIZE: number
+  HEADER_HEIGHT: number
+  HEADER_HEIGHT_WITH_IP: number
+  PORT_ROW: number
+  PADDING: number
+  DEFAULT_WIDTH: number
+  /** Klickflaeche des ReactFlow-Handles. Bewusst NICHT rastergebunden — sie
+   *  ist eine Fingerkuppe, kein Layoutmass. */
+  HANDLE_SIZE: number
+  /** Kantenlaenge einer Zelle des Wegfinders. Gleich der Schrittweite: nur
+   *  dann ist jede Buchse ein Gitterpunkt (Begruendung bei `zellenMass`). */
+  CELL_SIZE: number
+}
+
+export const rasterGrenzen = (n: number): number =>
+  Math.min(RASTER_MAX, Math.max(RASTER_MIN, Math.round(n)))
+
+/** Naechstes Vielfaches von `g`, das `mindest` nicht unterschreitet. */
+const aufVielfaches = (mindest: number, g: number): number =>
+  g * Math.max(1, Math.ceil(mindest / g))
+
+/**
+ * Naechstes GERADES Vielfaches von `g`.
+ *
+ * Nur fuer die Port-Reihe. Die Buchse sitzt in deren Mitte
+ * (`kopfhoehe + slot * PORT_ROW + PORT_ROW / 2`); waere PORT_ROW ein ungerades
+ * Vielfaches, laege die halbe Reihe zwischen zwei Rasterpunkten und die Buchse
+ * damit neben dem Gitter — genau der Fehler, den diese Datei abstellt.
+ */
+const aufGeradesVielfaches = (mindest: number, g: number): number =>
+  2 * g * Math.max(1, Math.ceil(mindest / (2 * g)))
+
+/**
+ * Kantenlaenge einer Zelle des Wegfinders.
+ *
+ * Sie ist die Schrittweite selbst, und das ist keine Bequemlichkeit: alle
+ * Buchsen-Koordinaten sind Vielfache von `g` (Geraete-Position eingerastet,
+ * Kopfhoehe Vielfaches, Port-Reihe gerades Vielfaches). Ein Punkt liegt genau
+ * dann auf jedem Gitterpunkt, wenn das Zellmass `g` TEILT. Ein groesseres Mass
+ * — auch ein Vielfaches wie 2g — laesst jede zweite Port-Reihe wieder zwischen
+ * die Zellen fallen. Es bleibt also `g`.
+ */
+const zellenMass = (g: number): number => g
+
+/** Alle Layoutmasse aus einer Rastergroesse. Rein, ohne Store. */
+export const rasterAus = (gridSize: number): Raster => {
+  const g = rasterGrenzen(Number.isFinite(gridSize) ? gridSize : RASTER_DEFAULT)
+  if (zwischenspeicher && zwischenspeicher.GRID_SIZE === g) return zwischenspeicher
+  const raster: Raster = {
+    GRID_SIZE: g,
+    HEADER_HEIGHT: aufVielfaches(RASTER_MINDEST.HEADER_HEIGHT, g),
+    HEADER_HEIGHT_WITH_IP: aufVielfaches(RASTER_MINDEST.HEADER_HEIGHT_WITH_IP, g),
+    PORT_ROW: aufGeradesVielfaches(RASTER_MINDEST.PORT_ROW, g),
+    PADDING: aufVielfaches(RASTER_MINDEST.PADDING, g),
+    DEFAULT_WIDTH: aufVielfaches(RASTER_MINDEST.DEFAULT_WIDTH, g),
+    HANDLE_SIZE: 16,
+    CELL_SIZE: zellenMass(g),
+  }
+  zwischenspeicher = raster
+  return raster
+}
+
+// Ein-Platz-Zwischenspeicher. Nicht fuer die Rechenzeit — die ist
+// vernachlaessigbar —, sondern fuer die Identitaet: React-Komponenten rufen
+// `rasterAus` im Rendern auf, und ein bei jedem Aufruf neues Objekt haette
+// jede `useMemo`-Abhaengigkeit darauf wertlos gemacht.
+let zwischenspeicher: Raster | null = null
+
+/** Das Raster der Vorgabe. Fuer Aufrufer ohne Store-Zugang (Tests, Node-Skripte
+ *  und die Voreinstellung des uiStore selbst). */
+export const RASTER_VORGABE: Raster = rasterAus(RASTER_DEFAULT)

--- a/src/renderer/lib/routeCableWithAStar.ts
+++ b/src/renderer/lib/routeCableWithAStar.ts
@@ -22,10 +22,10 @@
  */
 
 import {
-  CELL_SIZE,
   computeEdgePath,
   type Rect,
 } from './pathfinding'
+import { RASTER_DEFAULT, rasterAus } from './raster'
 
 export type HandleSide = 'left' | 'right' | 'top' | 'bottom'
 
@@ -59,10 +59,36 @@ export interface RouteCableArgs {
    *  komplett → A* loopt um das ganze Rack. Caller darf den Wert
    *  reduzieren (z.B. 0) um dichte Routen zuzulassen. */
   obstaclePadCells?: number
+  /** Rastergroesse in Pixeln — die im Menue eingestellte Schrittweite
+   *  (`uiStore.gridSize`). Daraus folgt das Zellmass des Wegfinders: eine
+   *  Zelle ist ein Rasterschritt, damit jede Buchse auf einem Gitterpunkt
+   *  liegt. Ohne Angabe gilt die Vorgabe — nicht als zweite feste Zahl,
+   *  sondern als derselbe Wert, mit dem der uiStore startet. */
+  rasterPx?: number
 }
 
-/** v7.9.32 — Sichtbare Lücke um jedes Hindernis. 2 Grid-Cells = 40 px. */
-const OBSTACLE_PAD_CELLS = 2
+/**
+ * v7.9.32 — Sichtbare Luecke um jedes Hindernis.
+ *
+ * Sie stand als „2 Grid-Cells" da und war damit an das alte 20-px-Zellmass
+ * gebunden: 40 px. Seit das Zellmass der Rastergroesse folgt, waeren 2 Zellen
+ * bei feinem Raster ploetzlich 12 px und bei grobem 100 — die sichtbare Luecke
+ * haette sich mit einer Einstellung geaendert, die ueber sie nichts sagt. Der
+ * Wunsch steht deshalb in Pixeln und wird in Zellen umgerechnet.
+ */
+const OBSTACLE_PAD_PX = 40
+
+/**
+ * Die oberste Sprosse der Abstands-Leiter, in Zellen.
+ *
+ * EXPORTIERT, obwohl die Anwendung sie nicht ruft: `tests/autoRouteEinRouter`
+ * haelt daneben, was EINE Sprosse allein geschafft haette — und muss dafuer
+ * dieselbe Sprosse nehmen wie der Router. Eine „2" im Test waere seit dem
+ * rasterabhaengigen Zellmass eine andere Luecke als die des Routers, und der
+ * Waechter haette etwas anderes gemessen, als er behauptet.
+ */
+export const obersteSprosse = (rasterPx: number): number =>
+  Math.max(1, Math.round(OBSTACLE_PAD_PX / rasterAus(rasterPx).CELL_SIZE))
 
 // ReactFlow side → outward direction in pixel space (dx, dy).
 const handleOutwardDelta = (side: HandleSide): { dx: number; dy: number } => {
@@ -84,17 +110,18 @@ const inflate = (r: PixelRect, pad: number): Rect => ({
 
 /** Compute force-open cells: ein Korridor vom Handle, einen Cell tief
  *  ins Source-Device hinein (damit der gerenderte erste Segment am
- *  Handle anschließt) PLUS OBSTACLE_PAD_CELLS Cells nach außen durch
+ *  Handle anschließt) PLUS die Abstands-Zellen nach außen durch
  *  das eigene Padding. Ohne den Korridor wäre der Stub-Endpunkt in der
  *  Padding-Zone des Source-Devices selbst gefangen. */
 const handleCorridor = (
   handlePx: { x: number; y: number },
   side: HandleSide,
   outwardCells: number,
+  cellSize: number,
 ): { gx: number; gy: number }[] => {
   const { dx, dy } = handleOutwardDelta(side)
-  const baseGx = Math.round(handlePx.x / CELL_SIZE)
-  const baseGy = Math.round(handlePx.y / CELL_SIZE)
+  const baseGx = Math.round(handlePx.x / cellSize)
+  const baseGy = Math.round(handlePx.y / cellSize)
   const cells: { gx: number; gy: number }[] = []
   for (let i = 0; i <= outwardCells; i++) {
     cells.push({ gx: baseGx + dx * i, gy: baseGy + dy * i })
@@ -122,6 +149,7 @@ export const versuchMitAbstand = (
   // v7.9.37 — ALLE Devices kommen mit Padding als Hard-Obstacles rein,
   // inklusive Source und Target. Damit kann A* den Pfad nicht mehr durch
   // den eigenen Source/Target-Body optimieren.
+  const { CELL_SIZE } = rasterAus(args.rasterPx ?? RASTER_DEFAULT)
   const padPx = padCells * CELL_SIZE
   const obstacles: Rect[] = args.obstacles.map((r) => inflate(r, padPx))
 
@@ -134,8 +162,8 @@ export const versuchMitAbstand = (
   // damit der gerenderte erste Segment (Handle → erstes Waypoint = Stub)
   // einen freien Weg hat und A* den Stub erreichen kann.
   const extraForceOpen = [
-    ...handleCorridor(args.source, args.sourceSide, stubCells),
-    ...handleCorridor(args.target, args.targetSide, stubCells),
+    ...handleCorridor(args.source, args.sourceSide, stubCells, CELL_SIZE),
+    ...handleCorridor(args.target, args.targetSide, stubCells, CELL_SIZE),
   ]
 
   // Bei Top/Bottom-Handles weiß der Pathfinder nicht von "vertical stub" —
@@ -188,45 +216,41 @@ export const versuchMitAbstand = (
     excludeStartDir,
     stubCells,
     extraForceOpen,
+    cellSize: CELL_SIZE,
   })
   if (!result) return null
 
-  // ─── DIE ACHSE DER BUCHSE GEWINNT ──────────────────────────────────────
+  // ─── DIE ACHSE DER BUCHSE, ALS RUECKFALL ───────────────────────────────
   //
   // NUTZER-MELDUNG 2026-09-12: „Es gehen die Kabel manchmal noch etwas
   // unterhalb von dem Ziel-Port und dann wieder hoch, dann erst in den
   // Ziel-Port. Manchmal passieren auch Haken."
   //
-  // BEIDES IST DERSELBE BEFUND. A* rechnet auf einem Gitter aus 20-px-Zellen
-  // (`CELL_SIZE`); die Buchsen sitzen auf dem 11-px-Raster des Geraets
-  // (`EQUIPMENT_LAYOUT.GRID_SIZE`, Port-Reihe 22 px). Die beiden Raster
-  // treffen sich nie. Der Stuetzpunkt neben der Buchse liegt deshalb bis zu
-  // eine halbe Zelle daneben, und der gezeichnete Weg muss den Rest als
-  // kleine Stufe nachholen — unmittelbar vor der Buchse.
+  // URSACHE WAREN ZWEI RASTER. A* rechnete auf festen 20-px-Zellen, die
+  // Buchsen sassen auf dem 11-px-Raster des Geraets. 20 ist kein Vielfaches
+  // von 11, der Stuetzpunkt neben der Buchse lag also bis zu eine halbe Zelle
+  // daneben, und der gezeichnete Weg holte den Rest als Stufe unmittelbar vor
+  // der Buchse nach. Zeigte die Stufe gegen den naechsten Abschnitt, wurde ein
+  // Sporn daraus — der „Haken". GEMESSEN ueber 3300 Wege in 25 Raster-Szenen:
+  // Stufe an beiden Enden in 3300 von 3300 Faellen, Kehrtwende in 1972
+  // (59,8 %).
   //
-  // Zeigt die Stufe in die Gegenrichtung des naechsten Abschnitts, wird aus
-  // ihr ein Sporn, der aus der Linie heraussteht: der „Haken". Beispiel aus
-  // der Messung, Quelle (340, 155) nach rechts:
+  // DIE URSACHE IST SEIT 2026-09-12 WEG: es gibt nur noch EIN Raster. Das
+  // Zellmass ist die eingestellte Rastergroesse selbst (siehe `raster.ts`),
+  // und weil jede Buchsen-Koordinate ein Vielfaches davon ist, liegt jede
+  // Buchse auf einem Gitterpunkt. Die Abweichung, die hier korrigiert wurde,
+  // entsteht gar nicht mehr.
   //
-  //     …(380, 155) -> (380, 160) -> (380, 60)…
-  //                     ^^^^^^^^^^ 5 px hinunter und sofort wieder hinauf
+  // WARUM DIESER ABSCHNITT TROTZDEM STEHT: „eingerastet" gilt fuer Geraete,
+  // die der Editor gesetzt hat. Ein Projekt aus der Zeit vor dem Einrasten
+  // kann `x = 137` tragen, ein Import von aussen auch; `healProjectPositions`
+  // rundet solche Positionen zwar beim Laden, aber nur solange das Einrasten
+  // eingeschaltet ist. Fuer diese Faelle bleibt die Korrektur als Rueckfall —
+  // sie greift nur bei weniger als einer halben Zelle Abweichung, eine echte
+  // senkrechte Anfahrt bleibt unberuehrt.
   //
-  // GEMESSEN ueber 3300 Wege in 25 Raster-Szenen: die Stufe hatten 3300 von
-  // 3300 an BEIDEN Enden (hier immer 3 px, weil alle Ziele dieselbe
-  // Port-Reihe trafen), und 1972 Wege (59,8 %) trugen dadurch eine
-  // Kehrtwende im gezeichneten Streckenzug.
-  //
-  // WAS HIER PASSIERT: der Stuetzpunkt NEBEN der Buchse bekommt deren Achse.
-  // Nur dieser eine, und nur wenn der Abstand die Gitter-Rundung selbst ist
-  // (weniger als eine halbe Zelle) — eine echte senkrechte Anfahrt bleibt
-  // unberuehrt. Der Weg wird dadurch nicht laenger; die Stufe wandert vom
-  // letzten Zentimeter vor der Buchse auf die Ecke davor, wo sie ohnehin
-  // hingehoert.
-  //
-  // Nicht behoben ist damit die URSACHE — zwei Raster, die nicht aufeinander
-  // passen. Das Gitter des Wegfinders auf 11 px zu stellen waere die andere
-  // Antwort; sie kostet die dreifache Zellenzahl je Suche und ist nicht
-  // gemessen.
+  // NICHT GEMESSEN: ob der gezeichnete Weg optisch der kuerzeste ist. Die
+  // Abstands-Leiter oben nimmt die erste haltende Sprosse, nicht die kuerzeste.
   const aufAchse = (
     p: { x: number; y: number },
     buchse: { x: number; y: number },
@@ -304,7 +328,7 @@ export const routeCableWithAStar = (
   const wunsch =
     typeof args.obstaclePadCells === 'number' && args.obstaclePadCells >= 0
       ? Math.floor(args.obstaclePadCells)
-      : OBSTACLE_PAD_CELLS
+      : obersteSprosse(args.rasterPx ?? RASTER_DEFAULT)
 
   for (let padCells = wunsch; padCells >= 0; padCells -= 1) {
     const weg = versuchMitAbstand(args, padCells)
@@ -325,5 +349,6 @@ const handleArriveDir = (side: HandleSide): 0 | 1 | 2 | 3 => {
   }
 }
 
-// Re-exported for callers that previously imported these from cableAStar.
-export { CELL_SIZE }
+// Frueher stand hier `export { CELL_SIZE }`. Es gibt keine feste Zellgroesse
+// mehr; wer das Mass braucht, fragt `rasterAus(gridSize).CELL_SIZE`.
+export { rasterAus, RASTER_DEFAULT }

--- a/src/renderer/store/slices/locationSlice.ts
+++ b/src/renderer/store/slices/locationSlice.ts
@@ -1,7 +1,7 @@
 import type { StateCreator } from 'zustand'
 import { v4 as uuidv4 } from 'uuid'
 import type { LocationFrame } from '../../types/location'
-import { EQUIPMENT_LAYOUT } from '../../lib/layoutConstants'
+import { aktuellesRaster } from '../../lib/aktuellesRaster'
 import { isProjectLocked, touchProject } from '../projectStoreHelpers'
 import type { ProjectState } from '../projectStore'
 
@@ -64,7 +64,7 @@ export const createLocationSlice: StateCreator<ProjectState, [], [], LocationSli
       let maxX = -Infinity
       let maxY = -Infinity
       for (const e of items) {
-        const w = e.width ?? EQUIPMENT_LAYOUT.DEFAULT_WIDTH
+        const w = e.width ?? aktuellesRaster().DEFAULT_WIDTH
         const h = e.height ?? 140
         if (e.x < minX) minX = e.x
         if (e.y < minY) minY = e.y

--- a/src/renderer/store/uiStore.ts
+++ b/src/renderer/store/uiStore.ts
@@ -85,7 +85,8 @@ export interface DeviceConfigEntry {
 }
 
 import { STORAGE_KEYS } from '../lib/storageKeys'
-import { PANEL_LIMITS, EQUIPMENT_LAYOUT } from '../lib/layoutConstants'
+import { PANEL_LIMITS } from '../lib/layoutConstants'
+import { RASTER_DEFAULT, rasterGrenzen } from '../lib/raster'
 
 const KEY = STORAGE_KEYS.ui
 
@@ -354,7 +355,7 @@ const defaults: PersistedUiState = {
   propertiesCollapsed: false,
   libraryCollapsed: false,
   snapToGrid: true,
-  gridSize: EQUIPMENT_LAYOUT.GRID_SIZE,
+  gridSize: RASTER_DEFAULT,
   defaultRouting: 'orthogonal',
   defaultArrow: true,
   libraryWidth: 260,
@@ -622,11 +623,28 @@ const load = (): PersistedUiState => {
     }
     if (typeof merged.bgOpacity !== 'number' || !Number.isFinite(merged.bgOpacity))
       merged.bgOpacity = defaults.bgOpacity
-    // v7.9.30 — Snap-to-Grid und gridSize sind nicht mehr user-konfigurierbar
-    // (Toolbar-Toggle entfernt). Werte werden bei jedem Hydrate auf die
-    // Defaults gezwungen — alte localStorage-Stände werden überschrieben.
-    merged.snapToGrid = defaults.snapToGrid
-    merged.gridSize = defaults.gridSize
+    // ─── DIE RASTERGROESSE UEBERLEBT DAS NEULADEN WIEDER ──────────────────
+    //
+    // Hier stand seit v7.9.30: „Snap-to-Grid und gridSize sind nicht mehr
+    // user-konfigurierbar (Toolbar-Toggle entfernt). Werte werden bei jedem
+    // Hydrate auf die Defaults gezwungen." Der Toolbar-Knopf war weg — die
+    // EINSTELLUNG nicht: `Settings > Editing > Grid` bietet beides bis heute
+    // an, Haken und Zahlenfeld. Wer dort etwas eintrug, sah es wirken und
+    // nach dem naechsten Start wieder auf 11 stehen. Ein Menuepunkt, der
+    // seine Eingabe still wegwirft, ist schlimmer als keiner.
+    //
+    // Seit 2026-09-12 haengt an dieser Zahl ausserdem das Zellmass des
+    // Wegfinders (`lib/raster.ts`). Sie zu verwerfen hiesse jetzt: der Nutzer
+    // stellt das Raster um, die Geraete rasten anders ein, und nach dem
+    // Neustart rechnet wieder alles auf 11.
+    //
+    // Geprueft wird sie statt erzwungen: eine Zahl innerhalb der Grenzen aus
+    // `raster.ts`, sonst die Vorgabe.
+    if (typeof merged.snapToGrid !== 'boolean') merged.snapToGrid = defaults.snapToGrid
+    merged.gridSize =
+      typeof merged.gridSize === 'number' && Number.isFinite(merged.gridSize)
+        ? rasterGrenzen(merged.gridSize)
+        : defaults.gridSize
     if (typeof merged.libraryWidth !== 'number') merged.libraryWidth = defaults.libraryWidth
     if (typeof merged.propertiesWidth !== 'number') merged.propertiesWidth = defaults.propertiesWidth
     if (merged.canvasBgImageDark != null && typeof merged.canvasBgImageDark !== 'string')

--- a/tests/anfahrtAmPort.test.ts
+++ b/tests/anfahrtAmPort.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import { computeEquipmentLayout } from '../src/renderer/lib/equipmentLayout'
-import { routeCableWithAStar, CELL_SIZE } from '../src/renderer/lib/routeCableWithAStar'
+import { routeCableWithAStar } from '../src/renderer/lib/routeCableWithAStar'
 import { legeAnfahrt, hatKehrtwende, type Anschlussseite } from '../src/renderer/lib/cableApproach'
 import { pathIsBlocked } from '../src/renderer/lib/cableRouting'
-import { EQUIPMENT_LAYOUT } from '../src/renderer/lib/layoutConstants'
+import { RASTER_DEFAULT, RASTER_MAX, RASTER_MIN, rasterAus } from '../src/renderer/lib/raster'
 import type { EquipmentItem } from '../src/renderer/types/equipment'
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -13,35 +13,44 @@ import type { EquipmentItem } from '../src/renderer/types/equipment'
 // von dem Ziel-Port und dann wieder hoch, dann erst in den Ziel-Port. Manchmal
 // passieren auch Haken."
 //
-// ─── EIN BEFUND, ZWEI ERSCHEINUNGEN ───────────────────────────────────────
+// ─── WAS DIE URSACHE WAR ──────────────────────────────────────────────────
 //
-// A* rechnet auf einem Gitter aus 20-px-Zellen (`CELL_SIZE`). Die Buchsen
-// sitzen auf dem 11-px-Raster des Geraets (`EQUIPMENT_LAYOUT.GRID_SIZE`,
-// Port-Reihe 22 px). Die beiden Raster treffen sich nie: der Stuetzpunkt neben
-// der Buchse liegt bis zu eine halbe Zelle daneben, und der gezeichnete Weg
-// holt den Rest als kleine Stufe nach — unmittelbar vor der Buchse. Das ist
-// die erste Erscheinung.
-//
-// Zeigt diese Stufe in die Gegenrichtung des naechsten Abschnitts, steht sie
-// als Sporn aus der Linie heraus. Das ist die zweite — der „Haken":
+// Zwei Raster. A* rechnete auf festen 20-px-Zellen, die Buchsen sassen auf dem
+// 11-px-Raster des Geraets. Der Stuetzpunkt neben einer Buchse lag deshalb bis
+// zu eine halbe Zelle daneben, und der gezeichnete Weg holte den Rest als
+// Stufe unmittelbar vor der Buchse nach. Zeigte die Stufe gegen den naechsten
+// Abschnitt, stand sie als Sporn heraus — der „Haken":
 //
 //     …(380, 155) -> (380, 160) -> (380, 60)…
 //                     ^^^^^^^^^^ 5 px hinunter und sofort wieder hinauf
 //
 // GEMESSEN vor der Korrektur, ueber 3300 Wege in 25 Raster-Szenen:
-//   Stufe am Ziel      3300 von 3300      danach 0
-//   Stufe an der Quelle 3300 von 3300     danach 0
-//   Kehrtwende im gezeichneten Weg 1972 (59,8 %)   danach 0
+//   Stufe am Ziel 3300 von 3300, Stufe an der Quelle 3300 von 3300,
+//   Kehrtwende im gezeichneten Weg 1972 (59,8 %).
 //
-// ─── WOGEGEN DIESER LAUF STEHT ────────────────────────────────────────────
+// ─── WAS DIESER LAUF SEIT DEM 2026-09-12 PRUEFT ───────────────────────────
 //
-// Dagegen, dass der letzte Stuetzpunkt vor der Buchse wieder auf das
-// Wegfinder-Gitter zurueckfaellt. Er prueft den Weg, der WIRKLICH GEZEICHNET
-// WIRD (`legeAnfahrt` samt Stummeln und eingeschobenen Ecken) — nicht das
-// Ergebnis des Routers: die Stufe entsteht erst beim Zusammensetzen.
+// Die erste Fassung dieses Waechters verlangte als Vorbedingung, dass die
+// beiden Raster NICHT aufgehen (`CELL_SIZE % GRID_SIZE !== 0`) und dass ueber
+// 100 Buchsen neben dem Gitter liegen — sonst haette er nichts gemessen. Genau
+// diese Vorbedingung ist jetzt falsch, und zwar weil der Defekt behoben ist:
+// es gibt nur noch EIN Raster (`lib/raster.ts`), eine Zelle des Wegfinders ist
+// ein Rasterschritt, und damit liegt JEDE Buchse auf einem Gitterpunkt.
+//
+// Der Waechter behauptet deshalb ab hier etwas anderes — nicht weniger:
+//
+//   1. Die Zusage selbst: bei JEDER zulaessigen Rastergroesse liegt keine
+//      einzige Buchse neben dem Gitter. Das ist die Aussage, die die Stufe
+//      unmoeglich macht.
+//   2. Die Gegenprobe im selben Lauf: auf dem ALTEN festen 20-px-Gitter laegen
+//      dieselben Buchsen hundertfach daneben. Ohne diese Zeile waere Punkt 1
+//      eine Behauptung ueber eine Szene, die die Frage gar nicht stellt.
+//   3. Der gezeichnete Weg (`legeAnfahrt` samt Stummeln und eingeschobenen
+//      Ecken, nicht die rohen Wegpunkte) traegt keine Stufe, keinen Haken und
+//      laeuft durch kein unbeteiligtes Geraet.
 //
 // WAS ER NICHT KANN: er rechnet. Ob der Strich im Fenster schoen liegt, misst
-// er nicht.
+// er nicht. Und er prueft die Rastergroessen unten, nicht jede dazwischen.
 // ───────────────────────────────────────────────────────────────────────────
 
 const seite = (s: 'left' | 'right'): Anschlussseite => (s === 'left' ? 'links' : 'rechts')
@@ -63,23 +72,48 @@ interface Lauf {
   stufeAnDerQuelle: number
   haken: number
   durchEinGeraet: number
-  /** Buchsen, deren Achse NICHT auf dem Wegfinder-Gitter liegt. Ist die Zahl
-   *  null, koennte die Stufe gar nicht entstehen und die drei Pruefungen
-   *  darueber waeren still gruen. */
+  /** Buchsen, deren Achse NICHT auf dem Gitter des Wegfinders liegt. Muss 0
+   *  sein — das ist die Zusage. */
   buchsenNebenDemGitter: number
+  /** Dieselben Buchsen, gemessen gegen das ALTE feste 20-px-Gitter. Muss gross
+   *  sein, sonst stellt die Szene die Frage nicht und die Null darueber
+   *  belegt nichts. */
+  buchsenNebenDemAltenGitter: number
 }
 
-const messe = (): Lauf => {
+/** Das feste Zellmass, mit dem der Wegfinder bis zum 2026-09-12 rechnete. Nur
+ *  fuer die Gegenprobe — im Quelltext gibt es diese Zahl nicht mehr. */
+const ALTES_ZELLMASS = 20
+
+const messe = (rasterPx: number): Lauf => {
+  const raster = rasterAus(rasterPx)
+  const rasten = (n: number) => Math.round(n / raster.GRID_SIZE) * raster.GRID_SIZE
   const lauf: Lauf = {
-    wege: 0, stufeAmZiel: 0, stufeAnDerQuelle: 0, haken: 0, durchEinGeraet: 0, buchsenNebenDemGitter: 0,
+    wege: 0, stufeAmZiel: 0, stufeAnDerQuelle: 0, haken: 0, durchEinGeraet: 0,
+    buchsenNebenDemGitter: 0, buchsenNebenDemAltenGitter: 0,
   }
-  for (const dx of [300, 420, 560]) {
-    for (const dy of [200, 260, 340]) {
+  // ─── DIE SZENE WAECHST MIT DEM RASTER ─────────────────────────────────
+  //
+  // Die Abstaende standen hier als feste Pixelzahlen (300/420/560 mal
+  // 200/260/340). Das ging, solange die Geraete immer gleich gross waren.
+  // Seit ihre Hoehe der Rastergroesse folgt, ist ein Geraet bei 60 px Raster
+  // 600 px hoch — bei 200 px Zeilenabstand stapeln sich die Karten dann
+  // ineinander, und der Waechter meldet nicht den Router, sondern seine
+  // eigene unmoegliche Szene (gemessen: 12 Stufen, 12 Haken, alle aus
+  // ueberlappenden Geraeten).
+  //
+  // Die Abstaende sind deshalb Vielfache der GEMESSENEN Geraetegroesse.
+  const probe = computeEquipmentLayout(geraet('probe', 0, 0), undefined, raster)
+  for (const spaltenLuecke of [0.4, 0.9, 1.6]) {
+    for (const zeilenLuecke of [0.4, 0.8, 1.4]) {
+      const dx = rasten(probe.width * (1 + spaltenLuecke))
+      const dy = rasten(probe.height * (1 + zeilenLuecke))
       const geraete: EquipmentItem[] = []
       for (let c = 0; c < 4; c += 1) {
-        for (let r = 0; r < 3; r += 1) geraete.push(geraet(`d${c}-${r}`, 120 + c * dx, 100 + r * dy))
+        for (let r = 0; r < 3; r += 1)
+          geraete.push(geraet(`d${c}-${r}`, rasten(120) + c * dx, rasten(100) + r * dy))
       }
-      const layouts = new Map(geraete.map((g) => [g.id, computeEquipmentLayout(g)]))
+      const layouts = new Map(geraete.map((g) => [g.id, computeEquipmentLayout(g, undefined, raster)]))
       const hindernisse = geraete.map((g) => ({
         x: g.x, y: g.y, width: layouts.get(g.id)!.width, height: layouts.get(g.id)!.height, id: g.id,
       }))
@@ -95,7 +129,10 @@ const messe = (): Lauf => {
             const quelle = layouts.get(a.id)!.portPos(a.outputs![aus].id, 'source')!
             const ziel = layouts.get(b.id)!.portPos(b.inputs![ein].id, 'target')!
             for (const p of [quelle, ziel]) {
-              if (Math.abs(p.y - Math.round(p.y / CELL_SIZE) * CELL_SIZE) > 0.5) lauf.buchsenNebenDemGitter += 1
+              const z = raster.CELL_SIZE
+              if (Math.abs(p.y - Math.round(p.y / z) * z) > 0.001) lauf.buchsenNebenDemGitter += 1
+              if (Math.abs(p.y - Math.round(p.y / ALTES_ZELLMASS) * ALTES_ZELLMASS) > 0.001)
+                lauf.buchsenNebenDemAltenGitter += 1
             }
             const wp = routeCableWithAStar({
               source: { x: quelle.x, y: quelle.y },
@@ -105,6 +142,7 @@ const messe = (): Lauf => {
               obstacles: hindernisse,
               sourceEquipmentId: a.id,
               targetEquipmentId: b.id,
+              rasterPx: raster.GRID_SIZE,
             })
             if (!wp || wp.length === 0) continue
             lauf.wege += 1
@@ -130,16 +168,34 @@ const messe = (): Lauf => {
   return lauf
 }
 
-describe('Die Anfahrt endet auf der Achse der Buchse', () => {
-  const lauf = messe()
+// Die Vorgabe, die beiden Raender des Erlaubten und ein krummer Wert
+// dazwischen. Mehr waere Rechenzeit ohne neue Aussage: die Regel in
+// `raster.ts` kennt keine Sonderfaelle zwischen diesen Punkten.
+const RASTER_PROBEN = [RASTER_MIN, 13, RASTER_DEFAULT, RASTER_MAX]
 
-  it('die Szene kann die Stufe ueberhaupt erzeugen', () => {
-    // Der Wegfinder rastert auf CELL_SIZE, das Geraet auf GRID_SIZE. Solange
-    // die beiden nicht aufgehen, liegen Buchsen zwangslaeufig neben dem
-    // Gitter — und nur dann pruefen die drei Zeilen darunter etwas.
-    expect(CELL_SIZE % EQUIPMENT_LAYOUT.GRID_SIZE).not.toBe(0)
-    expect(lauf.buchsenNebenDemGitter).toBeGreaterThan(100)
+describe.each(RASTER_PROBEN)('Die Anfahrt endet auf der Achse der Buchse (Raster %i px)', (rasterPx) => {
+  const lauf = messe(rasterPx)
+
+  it('die Szene stellt die Frage ueberhaupt', () => {
     expect(lauf.wege).toBeGreaterThan(500)
+    if (rasterAus(rasterPx).GRID_SIZE % ALTES_ZELLMASS === 0) {
+      // Ein Raster, das ein Vielfaches der alten festen 20 px ist, waere auch
+      // mit dem alten Gitter aufgegangen. Hier gibt es nichts gegenzuproben —
+      // und das steht hier, damit niemand die fehlende Gegenprobe fuer ein
+      // Versehen haelt.
+      expect(lauf.buchsenNebenDemAltenGitter).toBe(0)
+      return
+    }
+    // Sonst: auf dem alten festen 20-px-Gitter laegen diese Buchsen
+    // hundertfach daneben. Ohne diese Zeile waere die Null darunter eine
+    // Aussage ueber eine Szene, in der gar nichts schiefgehen koennte.
+    expect(lauf.buchsenNebenDemAltenGitter).toBeGreaterThan(100)
+  })
+
+  it('keine Buchse liegt neben dem Gitter des Wegfinders', () => {
+    // Die Zusage: ein Raster, und die Buchsen sind Gitterpunkte. Wer das
+    // Zellmass wieder von der Rastergroesse loest, faellt hier zuerst.
+    expect(lauf.buchsenNebenDemGitter).toBe(0)
   })
 
   it('kein Weg endet neben der Buchse und steigt erst davor ein', () => {

--- a/tests/autoRouteEinRouter.test.ts
+++ b/tests/autoRouteEinRouter.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { computeEquipmentLayout } from '../src/renderer/lib/equipmentLayout'
-import { routeCableWithAStar, versuchMitAbstand } from '../src/renderer/lib/routeCableWithAStar'
+import { routeCableWithAStar, versuchMitAbstand, obersteSprosse } from '../src/renderer/lib/routeCableWithAStar'
+import { RASTER_DEFAULT } from '../src/renderer/lib/raster'
 import { pathIsBlocked } from '../src/renderer/lib/cableRouting'
 import type { EquipmentItem } from '../src/renderer/types/equipment'
 
@@ -111,7 +112,11 @@ const messe = (): Lauf => {
           targetEquipmentId: b.id,
         }
         // Die alte Fassung: der Wunsch-Abstand als Bedingung, eine Sprosse.
-        if (!versuchMitAbstand(auftrag, 2)) lauf.ohneWegBeiFestemAbstand += 1
+        // Welche das ist, sagt der Router selbst — seit das Zellmass der
+        // Rastergroesse folgt, waere eine feste Zahl hier eine andere Luecke
+        // als die, gegen die geprueft werden soll.
+        if (!versuchMitAbstand(auftrag, obersteSprosse(RASTER_DEFAULT)))
+          lauf.ohneWegBeiFestemAbstand += 1
         const weg = routeCableWithAStar(auftrag)
         if (!weg) {
           lauf.ohneWeg += 1
@@ -147,6 +152,12 @@ describe('Automatisches Routen: eine Rechnung, und sie gibt nicht zu frueh auf',
     //
     // Gemessen: 342 von 1188 Paaren finden mit dem Wunsch-Abstand als
     // Bedingung KEINEN Weg. Mit der Leiter sind es null.
+    //
+    // Dieselbe Zahl wie vor dem Raster-Umbau, und das ist kein Zufall: der
+    // Wunsch steht in Pixeln. Frueher waren es 2 Zellen a 20 px, jetzt sind es
+    // 4 Zellen a 11 px — 40 gegen 44 px, also dieselbe Luecke und dieselben
+    // Paare, die daran scheitern. Haette hier weiter eine feste „2" gestanden,
+    // waere die Zahl auf 0 gefallen und der Waechter still gruen geworden.
     expect(lauf.ohneWegBeiFestemAbstand).toBeGreaterThan(300)
   })
 })

--- a/tests/rasterAlsEineZahl.test.ts
+++ b/tests/rasterAlsEineZahl.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { computeEquipmentLayout } from '../src/renderer/lib/equipmentLayout'
+import {
+  RASTER_DEFAULT,
+  RASTER_MAX,
+  RASTER_MIN,
+  RASTER_MINDEST,
+  rasterAus,
+} from '../src/renderer/lib/raster'
+import { EQUIPMENT_LAYOUT } from '../src/renderer/lib/layoutConstants'
+import type { EquipmentItem } from '../src/renderer/types/equipment'
+
+// ───────────────────────────────────────────────────────────────────────────
+// EINE ZAHL, AUS DER ALLES FOLGT
+//
+// NUTZER-MELDUNG 2026-09-12: „Stattdessen solltest du besser die
+// Berechnungsgrundlage des A* von dem Raster abhaengig machen. Das Raster kann
+// man doch auch im Menue veraendern. Da ist ein hart kodiertes 20-px-Zellen
+// doch dumm. Ebenso das fest kodierte Raster der Geraete."
+//
+// Vorher gab es drei Zahlen fuer dieselbe Frage: die eingestellte
+// Rastergroesse, die 11-Vielfachen im Geraete-Layout und die 20-px-Zelle des
+// Wegfinders. Dieser Lauf haelt fest, dass es wieder eine ist.
+//
+// WAS ER NICHT KANN: er rechnet. Ob eine Karte bei 60 px Raster im Fenster
+// noch gut aussieht, ist eine Geschmacksfrage und steht hier nicht.
+// ───────────────────────────────────────────────────────────────────────────
+
+const geraet = (id: string, x: number, y: number, ports: number): EquipmentItem =>
+  ({
+    id, name: `Device ${id}`, category: 'Other', x, y,
+    inputs: Array.from({ length: ports }, (_, i) => ({
+      id: `${id}-in${i}`, name: `In ${i + 1}`, type: 'BNC', connectorType: 'BNC', direction: 'in' as const,
+    })),
+    outputs: Array.from({ length: ports }, (_, i) => ({
+      id: `${id}-out${i}`, name: `Out ${i + 1}`, type: 'BNC', connectorType: 'BNC', direction: 'out' as const,
+    })),
+  }) as EquipmentItem
+
+const ALLE_RASTER = Array.from(
+  { length: RASTER_MAX - RASTER_MIN + 1 },
+  (_, i) => RASTER_MIN + i,
+)
+
+describe('Das Raster ist eine Zahl, und alles andere folgt ihr', () => {
+  it('bei der Vorgabe stehen exakt die Zahlen von vorher', () => {
+    // Der Beleg, dass diese Aenderung bei der Vorgabe nichts verschiebt:
+    // 44 / 66 / 22 / 11 / 220 sind die Werte, die bis zum 2026-09-12 als
+    // Konstanten in `layoutConstants.ts` standen.
+    expect(EQUIPMENT_LAYOUT).toMatchObject({
+      GRID_SIZE: 11,
+      HEADER_HEIGHT: 44,
+      HEADER_HEIGHT_WITH_IP: 66,
+      PORT_ROW: 22,
+      PADDING: 11,
+      DEFAULT_WIDTH: 220,
+      CELL_SIZE: 11,
+    })
+    expect(EQUIPMENT_LAYOUT).toEqual(rasterAus(RASTER_DEFAULT))
+  })
+
+  it('layoutConstants schreibt diese Zahlen nicht mehr hin', () => {
+    // Sonst waere die Zeile darueber gruen, waehrend daneben weiter eine
+    // zweite, feste Fassung derselben Masse laege.
+    const quelle = readFileSync(
+      resolve(__dirname, '..', 'src/renderer/lib/layoutConstants.ts'),
+      'utf8',
+    )
+    const codeZeilen = quelle
+      .split('\n')
+      .filter((z) => !z.trimStart().startsWith('*') && !z.trimStart().startsWith('//'))
+      .join('\n')
+    for (const zahl of ['44', '66', '22', '220']) {
+      expect(codeZeilen).not.toMatch(new RegExp(`(HEADER_HEIGHT|PORT_ROW|DEFAULT_WIDTH)[^\\n]*${zahl}`))
+    }
+  })
+
+  it('das Zellmass des Wegfinders teilt die Rastergroesse', () => {
+    // Die Eigenschaft, auf der die ganze Ausrichtung ruht: Buchsen-Koordinaten
+    // sind Vielfache der Rastergroesse, also liegt eine Buchse genau dann auf
+    // jedem Gitterpunkt, wenn das Zellmass die Rastergroesse TEILT. Ein
+    // groesseres Mass — auch ein Vielfaches wie 2g — laesst jede zweite
+    // Port-Reihe wieder dazwischenfallen.
+    for (const g of ALLE_RASTER) {
+      const r = rasterAus(g)
+      expect(r.GRID_SIZE % r.CELL_SIZE).toBe(0)
+    }
+  })
+
+  it('die Port-Reihe ist ein GERADES Vielfaches — ihre Mitte bleibt ein Rasterschritt', () => {
+    for (const g of ALLE_RASTER) {
+      const r = rasterAus(g)
+      expect(r.PORT_ROW % (2 * r.GRID_SIZE)).toBe(0)
+      expect((r.PORT_ROW / 2) % r.GRID_SIZE).toBe(0)
+    }
+  })
+
+  it('kein Mass faellt unter seine Lesbarkeitsgrenze', () => {
+    for (const g of ALLE_RASTER) {
+      const r = rasterAus(g)
+      expect(r.HEADER_HEIGHT).toBeGreaterThanOrEqual(RASTER_MINDEST.HEADER_HEIGHT)
+      expect(r.HEADER_HEIGHT_WITH_IP).toBeGreaterThanOrEqual(RASTER_MINDEST.HEADER_HEIGHT_WITH_IP)
+      expect(r.PORT_ROW).toBeGreaterThanOrEqual(RASTER_MINDEST.PORT_ROW)
+      expect(r.PADDING).toBeGreaterThanOrEqual(RASTER_MINDEST.PADDING)
+      expect(r.DEFAULT_WIDTH).toBeGreaterThanOrEqual(RASTER_MINDEST.DEFAULT_WIDTH)
+    }
+  })
+
+  it('jede Buchse liegt bei JEDER Rastergroesse auf einem Gitterpunkt', () => {
+    // Nicht aus der Formel abgelesen, sondern aus dem fertigen Layout: Header,
+    // Untertitel-Zeile, IP-Zeile und Port-Reihe wirken hier zusammen, und
+    // genau dieses Zusammenwirken war der Fehler.
+    let geprueft = 0
+    for (const g of ALLE_RASTER) {
+      const r = rasterAus(g)
+      const rasten = (n: number) => Math.round(n / r.GRID_SIZE) * r.GRID_SIZE
+      for (const zusatz of [{}, { subtitle: 'Sub' }, { ipAddress: '10.0.0.1' },
+                            { ipAddress: '10.0.0.1', subtitle: 'Sub' }]) {
+        for (const ports of [1, 2, 5, 9]) {
+          const eq = { ...geraet('x', rasten(137), rasten(291), ports), ...zusatz } as EquipmentItem
+          const layout = computeEquipmentLayout(eq, undefined, r)
+          expect(layout.width % r.GRID_SIZE).toBe(0)
+          expect(layout.height % r.GRID_SIZE).toBe(0)
+          for (let i = 0; i < ports; i += 1) {
+            for (const [liste, art] of [[eq.inputs!, 'target'], [eq.outputs!, 'source']] as const) {
+              const p = layout.portPos(liste[i].id, art)!
+              expect(p.x % r.CELL_SIZE).toBe(0)
+              expect(p.y % r.CELL_SIZE).toBe(0)
+              geprueft += 1
+            }
+          }
+        }
+      }
+    }
+    // Ohne diese Zeile koennte die Schleife leer laufen und der Lauf waere
+    // gruen, ohne eine einzige Buchse angesehen zu haben.
+    expect(geprueft).toBeGreaterThan(3000)
+  })
+
+  it('die eingestellte Rastergroesse wird beim Laden geprueft, nicht verworfen', () => {
+    // Bis 2026-09-12 stand im uiStore-Hydrate `merged.gridSize =
+    // defaults.gridSize`. Die Einstellung unter Einstellungen > Bearbeiten
+    // wirkte dadurch bis zum naechsten Start und war danach weg.
+    const quelle = readFileSync(resolve(__dirname, '..', 'src/renderer/store/uiStore.ts'), 'utf8')
+    const codeZeilen = quelle
+      .split('\n')
+      .filter((z) => !z.trimStart().startsWith('//') && !z.trimStart().startsWith('*'))
+      .join('\n')
+    expect(codeZeilen).not.toContain('merged.gridSize = defaults.gridSize')
+    expect(codeZeilen).toContain('rasterGrenzen(merged.gridSize)')
+  })
+})


### PR DESCRIPTION
> **Nutzer-Meldung:** „Stattdessen solltest du besser die Berechnungsgrundlage des A\* von dem Raster abhängig machen. Das Raster kann man doch auch im Menü verändern. Da ist ein hart kodiertes 20px Zellen doch dumm. Ebenso das fest kodierte Raster der Geräte."

Zutreffend — und es waren **drei** Zahlen für dieselbe Frage, nicht zwei.

| Wer | Was | Wo |
|---|---|---|
| `uiStore.gridSize` | 11 | Menü: *Einstellungen → Bearbeiten → Raster* |
| `EQUIPMENT_LAYOUT` | 44 / 66 / 22 / 11 / 220 | als feste Zahlen in `layoutConstants.ts` |
| `CELL_SIZE` | 20 | als Konstante im Wegfinder |

20 ist kein Vielfaches von 11. Die Buchsen saßen also **per Konstruktion** zwischen zwei
Gitterpunkten des Wegfinders — das war die Ursache der Stufe vor dem Ziel-Port und der
Haken, die #859 nur an der Oberfläche korrigiert hat. Und wer im Menü etwas anderes als 11
einstellte, verschob nur das Einrasten der Geräte-*Position*; Kopfhöhe, Port-Reihen und
Wegfinder blieben, wo sie waren.

## Was jetzt gilt

`src/renderer/lib/raster.ts` ist der einzige Eingang. Aus der eingestellten Rastergröße
folgen Kopfhöhe, Port-Reihe, Polster, Vorgabebreite **und das Zellmaß des Wegfinders**.
Die Datei bleibt rein — `aktuellesRaster.ts` liest den Store, damit kein Importkreis entsteht.

Zwei Regeln tragen die Ausrichtung:

- **Das Zellmaß *ist* die Rastergröße.** Buchsen-Koordinaten sind Vielfache von `g`; ein
  Punkt liegt genau dann auf jedem Gitterpunkt, wenn das Zellmaß `g` **teilt**. Ein
  Vielfaches wie `2g` reicht nicht — dann fällt jede zweite Port-Reihe wieder dazwischen.
- **Die Port-Reihe ist ein GERADES Vielfaches**, weil die Buchse in ihrer Mitte sitzt.

Die Mindestmaße 44/66/22/11/220 bleiben als *Lesbarkeits*grenzen und werden aufs nächste
Vielfache gehoben. Bei der Vorgabe 11 ergibt das **exakt die alten Zahlen** — diese
Änderung verschiebt dort nichts.

Dazu: `pathfinding.ts` hat keine Konstante mehr (`computeEdgePath` verlangt `cellSize` als
Pflichtfeld, damit niemand versehentlich wieder auf einer stillen 20 landet), und der
Abstand um Hindernisse steht in Pixeln statt in Zellen — sonst hätte eine Rasteränderung
stillschweigend auch die sichtbare Lücke verändert.

## Das Menü lügt nicht mehr

Der uiStore zwang `gridSize` und `snapToGrid` bei **jedem** Hydrate auf die Vorgabe zurück
(v7.9.30, als der Toolbar-Knopf entfiel). Die *Einstellung* gab es aber weiter: wer dort
etwas eintrug, sah es wirken und nach dem Neustart wieder auf 11 stehen. Jetzt wird der
Wert geprüft statt verworfen, und das Zahlenfeld zieht seine Grenzen aus derselben Quelle
wie der Wegfinder.

## Gemessen

264 Wege, zwölf Geräte mit je vier Ein- und Ausgängen, Zeit je Weg:

| Raster | ms | Raster | ms |
|---|---|---|---|
| 2 px | 23,67 | 11 px (Vorgabe) | **0,45** |
| 3 px | 9,47 | 16 px | 0,32 |
| 4 px | 4,19 | 22 px | 0,22 |
| 6 px | 1,33 | 60 px | 0,13 |

Bei der Vorgabe ist das eine Raster **schneller** als die alten festen 20 px (0,45 gegen
0,86 ms): ein feineres Gitter lässt geradere Wege zu und spart die Umwege, die die
Drehstrafe teuer machte. Daraus die Grenzen `RASTER_MIN = 6` (bei 2 px braucht ein Plan mit
300 Kabeln rund sieben Sekunden) und `RASTER_MAX = 60`.

**Im Browser gegengeprüft**, Beispielprojekt über den echten Ladeweg:

| gridSize | Kartenmaße | alle Vielfache von |
|---|---|---|
| 11 | 253×77 · 330×143 · 242×77 | 11 ✓ |
| 22 | 264×110 · 330×242 · 242×110 | 22 ✓ |
| 44 | 264×176 · 352×440 · 264×176 | 44 ✓ |

Der Wert steht nach dem Neuladen noch da.

## Wächter

- **`tests/rasterAlsEineZahl.test.ts`** (neu, 7 Fälle): Vorgabe trägt exakt die alten
  Zahlen · `layoutConstants` schreibt sie nicht mehr hin · Zellmaß teilt die Rastergröße ·
  Port-Reihe gerade · keine Untergrenze verletzt · über 3000 Buchsen aus dem **fertigen**
  Layout liegen bei jeder Rastergröße von 6 bis 60 auf einem Gitterpunkt · der uiStore
  verwirft die Einstellung nicht mehr.
- **`tests/anfahrtAmPort.test.ts` umgeschrieben.** Seine bisherige Vorbedingung („die
  beiden Raster gehen nicht auf") ist durch diese Reparatur *falsch geworden* — er
  behauptet ab jetzt die Zusage statt der Krankheit, über vier Rastergrößen, mit der
  Gegenprobe gegen das alte feste 20-px-Gitter im selben Lauf. Die Szene wächst jetzt mit
  der Gerätegröße: bei 60 px Raster ist ein Gerät 600 px hoch, und die alten festen
  Zeilenabstände hätten die Karten ineinander gestapelt (gemessen: 12 Stufen, 12 Haken —
  aus der unmöglichen Szene, nicht aus dem Router).
- **`tests/autoRouteEinRouter.test.ts`** nimmt die oberste Sprosse jetzt vom Router
  (`obersteSprosse`) statt einer festen `2`. Mit der festen Zahl wäre die Kennzahl auf 0
  gefallen und der Wächter still grün geworden; so bleibt sie bei 342 von 1188, weil der
  Wunsch in Pixeln steht (früher 2 Zellen à 20, jetzt 4 à 11).

**Gegenproben gefahren:** Zellmaß auf fest 20 zurückgedreht → 8 Fälle rot · Port-Reihe auf
ungerades Vielfaches → 2 rot · uiStore verwirft die Einstellung wieder → 1 rot.

**NICHT gemessen:** ob eine Karte bei 60 px Raster im Fenster noch gut aussieht. Das ist
eine Geschmacksfrage, und kein Test hier behauptet etwas darüber.

## Nachgerechnet

- `npm test` — 274 Test-Dateien, 4114 Tests grün, 2 skipped
- `npx tsc -p tsconfig.app.json --noEmit` — Exit 0
- `npm run lint` — 0 Fehler, Warnung für Warnung **identisch zur Basis** (diff leer)
- `npm run build` — ohne Fehler · `npm run lang:check` — grün

Dokumentiert als **Invariante 24** in `docs/architecture.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT

---
_Generated by [Claude Code](https://claude.ai/code/session_016DYtHJAFkg4LUw7afKLMmT)_